### PR TITLE
release-2.1: opt: fix issue with GroupBy not using input ordering in some cases

### DIFF
--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -200,6 +200,12 @@ func (o *Optimizer) buildChildPhysicalProps(
 			}
 
 			childProps.Ordering = parentOrdering.Intersection(&def.Ordering)
+
+			// The FD set of the input doesn't "pass through" to the GroupBy FD set;
+			// check the ordering to see if it can be simplified with respect to the
+			// input FD set.
+			inputProps := o.mem.GroupProperties(mexpr.ChildGroup(o.mem, nth))
+			childProps.Ordering.Simplify(&inputProps.Relational.FuncDeps)
 		}
 
 	case opt.ExplainOp:

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -506,45 +506,34 @@ sort
       │         │    │         │    ├── has-placeholder
       │         │    │         │    ├── key: (1)
       │         │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    ├── right-join
+      │         │    │         │    ├── left-join (merge)
       │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true:31(bool)
       │         │    │         │    │    ├── has-placeholder
       │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(31)
-      │         │    │         │    │    ├── project
-      │         │    │         │    │    │    ├── columns: true:31(bool!null) flavor_projects.flavor_id:23(int!null)
-      │         │    │         │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    ├── fd: ()-->(31)
-      │         │    │         │    │    │    ├── select
-      │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
-      │         │    │         │    │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    │    ├── key: (23,24)
-      │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
-      │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
-      │         │    │         │    │    │    │    │    └── key: (23,24)
-      │         │    │         │    │    │    │    └── filters [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
-      │         │    │         │    │    │    │         └── flavor_projects.project_id = $2 [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
-      │         │    │         │    │    │    └── projections [outer=(23)]
-      │         │    │         │    │    │         └── true [type=bool]
       │         │    │         │    │    ├── project
       │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── key: (1)
       │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    │    │    ├── ordering: +1 opt(11)
       │         │    │         │    │    │    └── select
       │         │    │         │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
       │         │    │         │    │    │         ├── has-placeholder
       │         │    │         │    │    │         ├── key: (1)
       │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    │    │         ├── ordering: +1 opt(11)
       │         │    │         │    │    │         ├── group-by
       │         │    │         │    │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
       │         │    │         │    │    │         │    ├── grouping columns: flavors.id:1(int!null)
       │         │    │         │    │    │         │    ├── has-placeholder
       │         │    │         │    │    │         │    ├── key: (1)
       │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+      │         │    │         │    │    │         │    ├── ordering: +1 opt(11)
       │         │    │         │    │    │         │    ├── left-join (merge)
       │         │    │         │    │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:28(bool)
       │         │    │         │    │    │         │    │    ├── has-placeholder
       │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(28)
+      │         │    │         │    │    │         │    │    ├── ordering: +1 opt(11)
       │         │    │         │    │    │         │    │    ├── select
       │         │    │         │    │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
       │         │    │         │    │    │         │    │    │    ├── key: (1)
@@ -610,8 +599,28 @@ sort
       │         │    │         │    │    │         │              └── variable: flavors.updated_at [type=timestamp, outer=(15)]
       │         │    │         │    │    │         └── filters [type=bool, outer=(12,29)]
       │         │    │         │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,29)]
-      │         │    │         │    │    └── filters [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
-      │         │    │         │    │         └── flavor_projects.flavor_id = flavors.id [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ])]
+      │         │    │         │    │    ├── project
+      │         │    │         │    │    │    ├── columns: true:31(bool!null) flavor_projects.flavor_id:23(int!null)
+      │         │    │         │    │    │    ├── has-placeholder
+      │         │    │         │    │    │    ├── fd: ()-->(31)
+      │         │    │         │    │    │    ├── ordering: +23 opt(31)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
+      │         │    │         │    │    │    │    ├── has-placeholder
+      │         │    │         │    │    │    │    ├── key: (23,24)
+      │         │    │         │    │    │    │    ├── ordering: +23
+      │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
+      │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
+      │         │    │         │    │    │    │    │    ├── key: (23,24)
+      │         │    │         │    │    │    │    │    └── ordering: +23
+      │         │    │         │    │    │    │    └── filters [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
+      │         │    │         │    │    │    │         └── flavor_projects.project_id = $2 [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
+      │         │    │         │    │    │    └── projections [outer=(23)]
+      │         │    │         │    │    │         └── true [type=bool]
+      │         │    │         │    │    └── merge-on
+      │         │    │         │    │         ├── left ordering: +1
+      │         │    │         │    │         ├── right ordering: +23
+      │         │    │         │    │         └── true [type=bool]
       │         │    │         │    └── aggregations [outer=(2-12,14,15,31)]
       │         │    │         │         ├── const-not-null-agg [type=bool, outer=(31)]
       │         │    │         │         │    └── variable: true [type=bool, outer=(31)]
@@ -2869,7 +2878,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    ├── has-placeholder
  │    │         │    │         │    ├── key: (1)
  │    │         │    │         │    ├── fd: ()-->(11), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    ├── left-join
+ │    │         │    │         │    ├── left-join (merge)
  │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true:36(bool)
  │    │         │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(36)
@@ -2878,21 +2887,25 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── key: (1)
  │    │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         │    │         │    │    │    ├── ordering: +1 opt(11)
  │    │         │    │         │    │    │    └── select
  │    │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
  │    │         │    │         │    │    │         ├── has-placeholder
  │    │         │    │         │    │    │         ├── key: (1)
  │    │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         │    │         │    │    │         ├── ordering: +1 opt(11)
  │    │         │    │         │    │    │         ├── group-by
  │    │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
  │    │         │    │         │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
  │    │         │    │         │    │    │         │    ├── has-placeholder
  │    │         │    │         │    │    │         │    ├── key: (1)
  │    │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+ │    │         │    │         │    │    │         │    ├── ordering: +1 opt(11)
  │    │         │    │         │    │    │         │    ├── left-join (merge)
  │    │         │    │         │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:33(bool)
  │    │         │    │         │    │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(33)
+ │    │         │    │         │    │    │         │    │    ├── ordering: +1 opt(11)
  │    │         │    │         │    │    │         │    │    ├── select
  │    │         │    │         │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
  │    │         │    │         │    │    │         │    │    │    ├── has-placeholder
@@ -2969,21 +2982,26 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │    ├── columns: true:36(bool!null) instance_type_projects.instance_type_id:26(int!null)
  │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(36)
+ │    │         │    │         │    │    │    ├── ordering: +26 opt(36)
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
  │    │         │    │         │    │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    │    ├── key: (26-28)
+ │    │         │    │         │    │    │    │    ├── ordering: +26
  │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
  │    │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string) instance_type_projects.deleted:28(bool)
- │    │         │    │         │    │    │    │    │    └── lax-key: (26-28)
+ │    │         │    │         │    │    │    │    │    ├── lax-key: (26-28)
+ │    │         │    │         │    │    │    │    │    └── ordering: +26
  │    │         │    │         │    │    │    │    └── filters [type=bool, outer=(27,28), constraints=(/27: (/NULL - ]; /28: (/NULL - ])]
  │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $4 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
  │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $5 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
  │    │         │    │         │    │    │    │         └── instance_type_projects.project_id = $6 [type=bool, outer=(27), constraints=(/27: (/NULL - ])]
  │    │         │    │         │    │    │    └── projections [outer=(26)]
  │    │         │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    └── filters [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ]), fd=(1)==(26), (26)==(1)]
- │    │         │    │         │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,26), constraints=(/1: (/NULL - ]; /26: (/NULL - ])]
+ │    │         │    │         │    │    └── merge-on
+ │    │         │    │         │    │         ├── left ordering: +1
+ │    │         │    │         │    │         ├── right ordering: +26
+ │    │         │    │         │    │         └── true [type=bool]
  │    │         │    │         │    └── aggregations [outer=(2-16,36)]
  │    │         │    │         │         ├── const-not-null-agg [type=bool, outer=(36)]
  │    │         │    │         │         │    └── variable: true [type=bool, outer=(36)]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -419,6 +419,23 @@ group-by
       └── array-agg [type=int[]]
            └── variable: c [type=int]
 
+# Verify that the GroupBy child ordering is simplified according to the child's
+# FD set.
+opt
+SELECT sum(c) FROM abc WHERE a = 1 GROUP BY b ORDER BY b
+----
+group-by
+ ├── columns: sum:4(decimal)
+ ├── grouping columns: b:2(int!null)
+ ├── ordering: +2
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── constraint: /1/2/3: [/1 - /1]
+ │    └── ordering: +2 opt(1)
+ └── aggregations
+      └── sum [type=decimal]
+           └── variable: c [type=int]
+
 # --------------------------------------------------
 # Explain operator.
 # --------------------------------------------------


### PR DESCRIPTION
Backport 1/1 commits from #31754.

/cc @cockroachdb/sql-ui 

---

Similar to Project, the FDs of the input aren't in general reflected
by the GroupBy expression. We need to reduce a required ordering
according to the input FDs.

This fixes some cases where GroupBy wasn't using an input ordering.

Release note (bug fix): fixed a bug in the optimizer that prevented
passing through ordering requirements through aggregations (in some
cases).
