### PR TITLE
server: deflake TestStatusAPIStatements

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -974,6 +974,11 @@ func TestStatusAPIStatements(t *testing.T) {
 
 	var statementsInResponse []string
 	for _, respStatement := range resp.Statements {
+		if respStatement.Key.KeyData.Failed {
+			// We ignore failed statements here as the INSERT statement can fail and
+			// be automatically retried, confusing the test success check.
+			continue
+		}
 		statementsInResponse = append(statementsInResponse, respStatement.Key.KeyData.Query)
 	}
 


### PR DESCRIPTION
We record statement statistics for the execution of a statement even if
the statement is automatically retried. Account for that in
`TestStatusAPIStatements` which was seeing the `INSERT` statement twice
where one of the occurrences was a failure.

Fixes #31995

Release note: None