### PR TITLE
exec: add planning from filter and render exprs to operators

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -16,17 +16,16 @@ package distsqlrun
 
 import (
 	"context"
-
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util"
-
-	"github.com/pkg/errors"
+	"reflect"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
 )
 
 func checkNumIn(inputs []exec.Operator, numIn int) error {
@@ -43,12 +42,22 @@ func newColOperator(
 	post := &spec.Post
 	var err error
 	var op exec.Operator
+
+	// Planning additional operators for the PostProcessSpec (filters and render
+	// expressions) requires knowing the operator's output column types. Currently
+	// this must be set for any core spec which might require post-processing. In
+	// the future we may want to make these column types part of the Operator
+	// interface.
+	var columnTypes []sqlbase.ColumnType
+
 	switch {
 	case core.TableReader != nil:
 		if err := checkNumIn(inputs, 0); err != nil {
 			return nil, err
 		}
 		op, err = newColBatchScan(flowCtx, core.TableReader, post)
+		returnMutations := core.TableReader.Visibility == ScanVisibility_PUBLIC_AND_NOT_PUBLIC
+		columnTypes = core.TableReader.Table.ColumnTypesWithMutations(returnMutations)
 	case core.Aggregator != nil:
 		if err := checkNumIn(inputs, 1); err != nil {
 			return nil, err
@@ -61,6 +70,7 @@ func newColOperator(
 			!spec.Aggregations[0].Distinct {
 			return exec.NewCountOp(inputs[0]), nil
 		}
+
 		return nil, errors.Errorf("unsupported aggregator %+v", core.Aggregator)
 
 	case core.Distinct != nil:
@@ -87,7 +97,8 @@ func newColOperator(
 			return nil, errors.New("unsorted distinct not supported")
 		}
 
-		typs := types.FromColumnTypes(spec.Input[0].ColumnTypes)
+		columnTypes = spec.Input[0].ColumnTypes
+		typs := types.FromColumnTypes(columnTypes)
 		op, err = exec.NewOrderedDistinct(inputs[0], core.Distinct.OrderedColumns, typs)
 
 	case core.HashJoiner != nil:
@@ -151,14 +162,54 @@ func newColOperator(
 	}
 
 	if !post.Filter.Empty() {
-		// TODO(solon): plan selection op
-		return nil, errors.New("filters unsupported")
+		if columnTypes == nil {
+			return nil, errors.Errorf(
+				"unable to columnarize filter expression %q: columnTypes is unset", post.Filter.Expr)
+		}
+		var helper exprHelper
+		err := helper.init(post.Filter, columnTypes, flowCtx.EvalCtx)
+		if err != nil {
+			return nil, err
+		}
+		var filterColumnTypes []sqlbase.ColumnType
+		op, _, filterColumnTypes, err = planExpressionOperators(helper.expr, columnTypes, op)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to columnarize filter expression %q", post.Filter.Expr)
+		}
+		if len(filterColumnTypes) > len(columnTypes) {
+			// Additional columns were appended to store projection results while
+			// evaluating the filter. Project them away.
+			var outputColumns []uint32
+			for i := range columnTypes {
+				outputColumns = append(outputColumns, uint32(i))
+			}
+			op = exec.NewSimpleProjectOp(op, outputColumns)
+		}
 	}
 	if post.Projection {
 		op = exec.NewSimpleProjectOp(op, post.OutputColumns)
 	} else if post.RenderExprs != nil {
-		// TODO(solon): plan renders
-		return nil, errors.New("renders unsupported")
+		if columnTypes == nil {
+			return nil, errors.New("unable to columnarize projection. columnTypes is unset")
+		}
+		var renderedCols []uint32
+		for _, expr := range post.RenderExprs {
+			var helper exprHelper
+			err := helper.init(expr, columnTypes, flowCtx.EvalCtx)
+			if err != nil {
+				return nil, err
+			}
+			var outputIdx int
+			op, outputIdx, columnTypes, err = planExpressionOperators(helper.expr, columnTypes, op)
+			if err != nil {
+				return nil, errors.Wrapf(err, "unable to columnarize render expression %q", expr)
+			}
+			if outputIdx < 0 {
+				return nil, errors.New("missing outputIdx")
+			}
+			renderedCols = append(renderedCols, uint32(outputIdx))
+		}
+		op = exec.NewSimpleProjectOp(op, renderedCols)
 	}
 	if post.Offset != 0 {
 		return nil, errors.New("offset unsupported")
@@ -167,6 +218,76 @@ func newColOperator(
 		op = exec.NewLimitOp(op, post.Limit)
 	}
 	return op, nil
+}
+
+// planExpressionOperators plans a chain of operators to execute the provided
+// expression. It returns the the tail of the chain, as well as the column index
+// of the expression's result (if any, otherwise -1) and the column types of the
+// resulting batches.
+func planExpressionOperators(
+	expr tree.TypedExpr, columnTypes []sqlbase.ColumnType, input exec.Operator,
+) (op exec.Operator, resultIdx int, ct []sqlbase.ColumnType, err error) {
+	resultIdx = -1
+	switch t := expr.(type) {
+	case *tree.IndexedVar:
+		return input, t.Idx, columnTypes, nil
+	case *tree.ComparisonExpr:
+		// TODO(solon): Handle the case where a ComparisonExpr is a projection,
+		// e.g. SELECT a > b FROM t. Currently we assume it is a selection.
+		cmpOp := t.Operator
+		leftOp, leftIdx, ct, err := planExpressionOperators(t.TypedLeft(), columnTypes, input)
+		if err != nil {
+			return nil, resultIdx, ct, err
+		}
+		typ := ct[leftIdx]
+		if constArg, ok := t.Right.(tree.Datum); ok {
+			op, err := exec.GetSelectionConstOperator(typ, cmpOp, leftOp, leftIdx, constArg)
+			return op, resultIdx, ct, err
+		}
+		rightOp, rightIdx, ct, err := planExpressionOperators(t.TypedRight(), ct, leftOp)
+		if err != nil {
+			return nil, resultIdx, ct, err
+		}
+		if !ct[leftIdx].Equal(ct[rightIdx]) {
+			err = errors.Errorf(
+				"comparison between %s and %s is unhandled", ct[leftIdx].SemanticType,
+				ct[rightIdx].SemanticType)
+			return nil, resultIdx, ct, err
+		}
+		op, err := exec.GetSelectionOperator(typ, cmpOp, rightOp, leftIdx, rightIdx)
+		return op, resultIdx, ct, err
+	case *tree.BinaryExpr:
+		binOp := t.Operator
+		leftOp, leftIdx, ct, err := planExpressionOperators(t.TypedLeft(), columnTypes, input)
+		if err != nil {
+			return nil, resultIdx, ct, err
+		}
+		typ := ct[leftIdx]
+		if constArg, ok := t.Right.(tree.Datum); ok {
+			// The projection result will be outputted to a new column which is appended
+			// to the input batch.
+			resultIdx = len(ct)
+			op, err := exec.GetProjectionConstOperator(typ, binOp, leftOp, leftIdx, constArg, resultIdx)
+			ct = append(ct, typ)
+			return op, resultIdx, ct, err
+		}
+		rightOp, rightIdx, ct, err := planExpressionOperators(t.TypedRight(), ct, leftOp)
+		if err != nil {
+			return nil, resultIdx, nil, err
+		}
+		if !ct[leftIdx].Equal(ct[rightIdx]) {
+			err = errors.Errorf(
+				"projection on %s and %s is unhandled", ct[leftIdx].SemanticType,
+				ct[rightIdx].SemanticType)
+			return nil, resultIdx, ct, err
+		}
+		resultIdx = len(ct)
+		op, err := exec.GetProjectionOperator(typ, binOp, rightOp, leftIdx, rightIdx, resultIdx)
+		ct = append(ct, typ)
+		return op, resultIdx, ct, err
+	default:
+		return nil, resultIdx, nil, errors.Errorf("unhandled expression type: %s", reflect.TypeOf(t))
+	}
 }
 
 func (f *Flow) setupVectorized(ctx context.Context) error {

--- a/pkg/sql/exec/colbatch.go
+++ b/pkg/sql/exec/colbatch.go
@@ -37,6 +37,8 @@ type ColBatch interface {
 	Selection() []uint16
 	// SetSelection sets whether this batch is using its selection vector or not.
 	SetSelection(bool)
+	// AppendCol appends a ColVec with the specified type to this batch.
+	AppendCol(types.T)
 }
 
 var _ ColBatch = &memBatch{}
@@ -109,6 +111,10 @@ func (m *memBatch) SetSelection(b bool) {
 
 func (m *memBatch) SetLength(n uint16) {
 	m.n = n
+}
+
+func (m *memBatch) AppendCol(t types.T) {
+	m.b = append(m.b, newMemColumn(t, ColBatchSize))
 }
 
 // projectingBatch is a ColBatch that applies a simple projection to another,

--- a/pkg/sql/exec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/overloads.go
@@ -74,6 +74,11 @@ type overload struct {
 	RetTyp  types.T
 
 	AssignFunc assignFunc
+
+	// TODO(solon): These would not be necessary if we changed the zero values of
+	// ComparisonOperator and BinaryOperator to be invalid.
+	IsCmpOp bool
+	IsBinOp bool
 }
 
 type assignFunc func(op overload, target, l, r string) string
@@ -124,6 +129,7 @@ func init() {
 			ov := &overload{
 				Name:    binaryOpName[op],
 				BinOp:   op,
+				IsBinOp: true,
 				OpStr:   binaryOpInfix[op],
 				LTyp:    t,
 				RTyp:    t,
@@ -143,6 +149,7 @@ func init() {
 			ov := &overload{
 				Name:    comparisonOpName[op],
 				CmpOp:   op,
+				IsCmpOp: true,
 				OpStr:   opStr,
 				LTyp:    t,
 				RTyp:    t,

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -47,3 +47,60 @@ SELECT DISTINCT(a), b FROM a LIMIT 10
 3  7
 4  8
 4  9
+
+# Simple filter.
+query I
+SELECT b FROM a WHERE b < 3
+----
+0
+1
+2
+
+# Filter on the result of a projection.
+query II
+SELECT a, b FROM a WHERE a * 2 < b LIMIT 5
+----
+0  1
+1  3
+2  5
+3  7
+4  9
+
+# Simple projection.
+query I
+SELECT b + 1 FROM a WHERE b < 3
+----
+1
+2
+3
+
+# Multiple step projection.
+query III
+SELECT a, b, (a + 1) * (b + 2) FROM a WHERE a < 3
+----
+0  0  2
+0  1  3
+1  2  8
+1  3  10
+2  4  18
+2  5  21
+
+# Mismatched constant type in projection. Not handled yet but should fall back
+# gracefully.
+query I
+SELECT (a + 1.0::DECIMAL)::INT FROM a LIMIT 1
+----
+1
+
+# Mismatched column types in projection. Not handled yet but should fall back
+# gracefully.
+statement ok
+CREATE TABLE intdec (a INT, b DECIMAL)
+
+statement ok
+INSERT INTO intdec VALUES (1, 2.0)
+
+query I
+SELECT (a + b)::INT FROM intdec
+----
+3


### PR DESCRIPTION
I added planning logic to convert tree.Exprs to chains of operators.
This allows us to plan render expressions, like `SELECT (x + 1) *
(y + 2) FROM t`, and filters expressions, like `SELECT * FROM t WHERE
x + 1 < y`.

To do this, we recursively traverse the expression tree. ComparisonExprs
are converted to selection operators. BinaryExprs are converted to
projection operators, each of which writes its output to a new column,
appended to the end of the input ColBatch. Finally, a SimpleProjectOp is
planned to filter out any unneeded columns.

This also required templating additional functions for retrieving the
appropriate selection or projection operator given a column type and
operation.

Many expressions are still not handled. Some examples:
- ANDs and ORs
- ComparisonExprs and BinaryExprs with heterogeneous input types
- BinaryExprs where the left side is a constant (e.g. `1 - x`)
- Projections which use comparison operators (e.g. `SELECT x > y`)

Fixes #31514

Release note: None