### PR TITLE
build: tighten deps for execgen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1313,7 +1313,8 @@ $(SETTINGS_DOC_PAGE): $(settings-doc-gen)
 	@$(settings-doc-gen) gen settings-list --format=html > $@
 
 pkg/sql/exec/distinct.og.go: pkg/sql/exec/distinct_tmpl.go
-pkg/sql/exec/%.og.go: bin/execgen
+
+$(EXECGEN_TARGETS): bin/execgen
 	execgen $@
 
 optgen-defs := pkg/sql/opt/ops/*.opt


### PR DESCRIPTION
Instead of using a wildcard for all execgen .og.go files, use the static
EXECGEN_TARGETS we've already defined. That should prevent unwanted
errors when switching branches.

Release note: None