### PR TITLE
sql: allow check constraints on adding columns

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -478,6 +478,13 @@ func (n *alterTableNode) startExec(params runParams) error {
 					panic("constraint returned by GetConstraintInfo not found")
 				}
 				ck := n.tableDesc.Checks[idx]
+
+				if active, err := ck.IsActive(&n.tableDesc.TableDescriptor); err != nil {
+					return err
+				} else if !active {
+					return fmt.Errorf("constraint %q not active", t.Constraint)
+				}
+
 				if err := params.p.validateCheckExpr(
 					params.ctx, ck.Expr, &n.n.Table, n.tableDesc.TableDesc(),
 				); err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1428,8 +1428,8 @@ func replaceVars(
 			return nil, true, expr
 		}
 
-		col, err := desc.FindActiveColumnByName(string(c.ColumnName))
-		if err != nil {
+		col, dropped, err := desc.FindColumnByName(c.ColumnName)
+		if err != nil || dropped {
 			return fmt.Errorf("column %q not found for constraint %q",
 				c.ColumnName, expr.String()), false, nil
 		}
@@ -1478,7 +1478,7 @@ func MakeCheckConstraint(
 	sort.Sort(sqlbase.ColumnIDs(colIDs))
 
 	sourceInfo := sqlbase.NewSourceInfoForSingleTable(
-		tableName, sqlbase.ResultColumnsFromColDescs(desc.Columns),
+		tableName, sqlbase.ResultColumnsFromColDescs(desc.AllNonDropColumns()),
 	)
 	sources := sqlbase.MultiSourceInfo{sourceInfo}
 

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -499,3 +499,20 @@ INSERT INTO customers (k) VALUES ('b')
 
 statement ok
 COMMIT;
+
+subtest check_on_add_col
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE forlater ADD d INT
+
+statement ok
+ALTER TABLE forlater ADD CONSTRAINT d_0 CHECK (d > 0)
+
+statement ok
+COMMIT;
+
+statement error pq: failed to satisfy CHECK constraint \(d > 0\)
+INSERT INTO forlater (k, v, d) VALUES ('z', 'x', 0)

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -502,12 +502,16 @@ func createConstraintCheckOperations(
 	for _, constraint := range constraints {
 		switch constraint.Kind {
 		case sqlbase.ConstraintTypeCheck:
-			results = append(results, newSQLCheckConstraintCheckOperation(
-				tableName,
-				tableDesc,
-				constraint.CheckConstraint,
-				asOf,
-			))
+			if active, err := constraint.CheckConstraint.IsActive(tableDesc); err != nil {
+				return nil, err
+			} else if active {
+				results = append(results, newSQLCheckConstraintCheckOperation(
+					tableName,
+					tableDesc,
+					constraint.CheckConstraint,
+					asOf,
+				))
+			}
 		case sqlbase.ConstraintTypeFK:
 			results = append(results, newSQLForeignKeyCheckOperation(
 				tableName,

--- a/pkg/sql/sqlbase/check.go
+++ b/pkg/sql/sqlbase/check.go
@@ -63,11 +63,15 @@ func (c *CheckHelper) Init(
 		*tn, ResultColumnsFromColDescs(tableDesc.Columns),
 	)
 
-	c.Exprs = make([]tree.TypedExpr, len(tableDesc.Checks))
-	exprStrings := make([]string, len(tableDesc.Checks))
-	for i, check := range tableDesc.Checks {
-		exprStrings[i] = check.Expr
+	var exprStrings []string
+	for _, check := range tableDesc.Checks {
+		if active, err := check.IsActive(tableDesc); err != nil {
+			return err
+		} else if active {
+			exprStrings = append(exprStrings, check.Expr)
+		}
 	}
+	c.Exprs = make([]tree.TypedExpr, len(exprStrings))
 	exprs, err := parser.ParseExprs(exprStrings)
 	if err != nil {
 		return err


### PR DESCRIPTION
Add check constraints to the table descriptor immediately if any columns
are currently being added. Check validation does not get turned on until
all used columns are public.

Related to #29639 #26508.

Release note: None