### PR TITLE
roachtest: disable various import and restore tests

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -72,8 +72,9 @@ func registerImportTPCH(r *registry) {
 		timeout time.Duration
 	}{
 		{4, 6 * time.Hour},
-		{8, 4 * time.Hour},
-		{32, 3 * time.Hour},
+		// TODO(peter,tschottdorf): re-enable
+		// {8, 4 * time.Hour},
+		// {32, 3 * time.Hour},
 	} {
 		r.Add(testSpec{
 			Name:    fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -215,7 +215,8 @@ func registerRestore(r *registry) {
 		timeout time.Duration
 	}{
 		{10, 6 * time.Hour},
-		{32, 3 * time.Hour},
+		// TODO(peter,tschottdorf): re-enable
+		// {32, 3 * time.Hour},
 	} {
 		r.Add(testSpec{
 			Name:    fmt.Sprintf("restore2TB/nodes=%d", item.nodes),


### PR DESCRIPTION
Give the kv/splits tests a timeout.