### PR TITLE
exec: add limit; bugfixes to cfetcher

### DIFF
--- a/pkg/sql/distsqlrun/colbatch_scan.go
+++ b/pkg/sql/distsqlrun/colbatch_scan.go
@@ -53,6 +53,7 @@ func (s *colBatchScan) Next() exec.ColBatch {
 	if err != nil {
 		panic(err)
 	}
+	bat.SetSelection(false)
 	return bat
 }
 

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -17,6 +17,8 @@ package distsqlrun
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -91,6 +93,7 @@ func newColOperator(
 	default:
 		return nil, errors.Errorf("unsupported processor core %s", core)
 	}
+	log.VEventf(ctx, 1, "Made op %T\n", op)
 
 	if err != nil {
 		return nil, err

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -106,6 +106,12 @@ func newColOperator(
 		// TODO(solon): plan renders
 		return nil, errors.New("renders unsupported")
 	}
+	if post.Offset != 0 {
+		return nil, errors.New("offset unsupported")
+	}
+	if post.Limit != 0 {
+		op = exec.NewLimitOp(op, post.Limit)
+	}
 	return op, nil
 }
 

--- a/pkg/sql/exec/limit.go
+++ b/pkg/sql/exec/limit.go
@@ -53,7 +53,7 @@ func (c *limitOp) Next() ColBatch {
 		return bat
 	}
 	newSeen := c.seen + uint64(length)
-	if newSeen > c.limit {
+	if newSeen >= c.limit {
 		c.done = true
 		bat.SetLength(uint16(c.limit - c.seen))
 		return bat

--- a/pkg/sql/exec/limit.go
+++ b/pkg/sql/exec/limit.go
@@ -1,0 +1,63 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+// limitOp is an operator that implements limit, returning only the first n
+// tuples from its input.
+type limitOp struct {
+	input Operator
+
+	internalBatch ColBatch
+	limit         uint64
+
+	// seen is the number of tuples seen so far.
+	seen uint64
+	// done is true if the limit has been reached.
+	done bool
+}
+
+// NewLimitOp returns a new limit operator with the given limit.
+func NewLimitOp(input Operator, limit uint64) Operator {
+	c := &limitOp{
+		input: input,
+		limit: limit,
+	}
+	return c
+}
+
+func (c *limitOp) Init() {
+	c.internalBatch = NewMemBatch(nil)
+	c.input.Init()
+}
+
+func (c *limitOp) Next() ColBatch {
+	if c.done {
+		c.internalBatch.SetLength(0)
+		return c.internalBatch
+	}
+	bat := c.input.Next()
+	length := bat.Length()
+	if length == 0 {
+		return bat
+	}
+	newSeen := c.seen + uint64(length)
+	if newSeen > c.limit {
+		c.done = true
+		bat.SetLength(uint16(c.limit - c.seen))
+		return bat
+	}
+	c.seen = newSeen
+	return bat
+}

--- a/pkg/sql/exec/limit_test.go
+++ b/pkg/sql/exec/limit_test.go
@@ -1,0 +1,76 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func TestLimit(t *testing.T) {
+	tcs := []struct {
+		limit    uint64
+		tuples   []tuple
+		expected []tuple
+	}{
+		{
+			limit:    2,
+			tuples:   tuples{{1}},
+			expected: tuples{{1}},
+		},
+		{
+			limit:    1,
+			tuples:   tuples{{1}},
+			expected: tuples{{1}},
+		},
+		{
+			limit:    0,
+			tuples:   tuples{{1}},
+			expected: tuples{},
+		},
+		{
+			limit:    100000,
+			tuples:   tuples{{1}, {2}, {3}, {4}},
+			expected: tuples{{1}, {2}, {3}, {4}},
+		},
+		{
+			limit:    2,
+			tuples:   tuples{{1}, {2}, {3}, {4}},
+			expected: tuples{{1}, {2}},
+		},
+		{
+			limit:    1,
+			tuples:   tuples{{1}, {2}, {3}, {4}},
+			expected: tuples{{1}},
+		},
+		{
+			limit:    0,
+			tuples:   tuples{{1}, {2}, {3}, {4}},
+			expected: tuples{},
+		},
+	}
+
+	for _, tc := range tcs {
+		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+			limit := NewLimitOp(input[0], tc.limit)
+			out := newOpTestOutput(limit, []int{0}, tc.expected)
+
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1,0 +1,49 @@
+# LogicTest: local local-vec
+
+statement ok
+CREATE TABLE a (a INT, b INT, PRIMARY KEY (a, b))
+
+statement ok
+INSERT INTO a SELECT g//2, g FROM generate_series(0,2000) g(g)
+
+# TODO(jordan): remove once #30000 is fixed.
+statement ok
+SET optimizer=off
+
+query I
+SELECT count(*) FROM a
+----
+2001
+
+query I
+SELECT count(*) FROM (SELECT DISTINCT a FROM a)
+----
+1001
+
+query II
+SELECT * FROM a LIMIT 10
+----
+0  0
+0  1
+1  2
+1  3
+2  4
+2  5
+3  6
+3  7
+4  8
+4  9
+
+query II
+SELECT DISTINCT(a), b FROM a LIMIT 10
+----
+0  0
+0  1
+1  2
+1  3
+2  4
+2  5
+3  6
+3  7
+4  8
+4  9


### PR DESCRIPTION
A couple of bugfixes to cfetcher that was producing incorrect results.

- make sure colbatch_scan resets the batch's selection vector to false.
- fix some confusing off-by-one errors in cfetcher. The fundamental problem here is that the fetcher state machine is hidden within a couple of different functions, and the interaction with that state machine and the batch size limit is a little tricky. When we get to the end of the batch, we have to do something special - since at the same time that we find out we are at a new row, we're also trying to decode the key into the next row's slot. If the batch is full, this will fail, so we have to stop the state machine half way through and resume later. 

I think the cfetcher and row fetcher are complex enough at this point that they need a rewrite with a more explicit state machine. I think we could likely find performance improvements by doing that as well.

Also, I added a basic limit op while trying to figure this problem out, so its included in the PR.