### PR TITLE
exec: plan all sum types in orderedAggregator

### DIFF
--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -19,6 +19,7 @@ import (
 
 	"fmt"
 
+	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
@@ -27,6 +28,7 @@ var (
 	defaultGroupCols  = []uint32{0}
 	defaultGroupTypes = []types.T{types.Int64}
 	defaultAggCols    = [][]uint32{{1}}
+	defaultAggTypes   = [][]types.T{{types.Int64}}
 )
 
 type aggregatorTestCase struct {
@@ -35,6 +37,7 @@ type aggregatorTestCase struct {
 	groupCols  []uint32
 	groupTypes []types.T
 	aggCols    [][]uint32
+	aggTypes   [][]types.T
 	input      tuples
 	expected   tuples
 	// {output}BatchSize if not 0 are passed in to NewOrderedAggregator to
@@ -42,9 +45,29 @@ type aggregatorTestCase struct {
 	batchSize       int
 	outputBatchSize int
 	name            string
+
+	// convToDecimal will convert any float64s to apd.Decimal{}s.
+	convToDecimal bool
 }
 
-func (tc *aggregatorTestCase) init() {
+func (tc *aggregatorTestCase) init() error {
+	if tc.convToDecimal {
+		for _, tuples := range []tuples{tc.input, tc.expected} {
+			for _, tuple := range tuples {
+				for i, e := range tuple {
+					switch v := e.(type) {
+					case float64:
+						d := &apd.Decimal{}
+						d, err := d.SetFloat64(v)
+						if err != nil {
+							return err
+						}
+						tuple[i] = *d
+					}
+				}
+			}
+		}
+	}
 	groupCols := defaultGroupCols
 	if tc.groupCols == nil {
 		tc.groupCols = groupCols
@@ -57,6 +80,10 @@ func (tc *aggregatorTestCase) init() {
 	if tc.aggCols == nil {
 		tc.aggCols = aggCols
 	}
+	aggTypes := defaultAggTypes
+	if tc.aggTypes == nil {
+		tc.aggTypes = aggTypes
+	}
 	batchSize := ColBatchSize
 	if tc.batchSize == 0 {
 		tc.batchSize = batchSize
@@ -65,6 +92,7 @@ func (tc *aggregatorTestCase) init() {
 	if tc.outputBatchSize == 0 {
 		tc.outputBatchSize = outputBatchSize
 	}
+	return nil
 }
 
 func TestAggregatorOneFunc(t *testing.T) {
@@ -171,10 +199,12 @@ func TestAggregatorOneFunc(t *testing.T) {
 	// Run tests with deliberate batch sizes and no selection vectors.
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.init()
+			if err := tc.init(); err != nil {
+				t.Fatal(err)
+			}
 
 			tupleSource := newOpTestInput(uint16(tc.batchSize), tc.input)
-			a, err := NewOrderedAggregator(tupleSource, tc.groupCols, tc.aggCols, tc.groupTypes)
+			a, err := NewOrderedAggregator(tupleSource, tc.groupCols, tc.groupTypes, tc.aggCols, tc.aggTypes)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -190,7 +220,7 @@ func TestAggregatorOneFunc(t *testing.T) {
 			// Run randomized tests on this test case.
 			t.Run(fmt.Sprintf("Randomized"), func(t *testing.T) {
 				runTests(t, []tuples{tc.input}, nil, func(t *testing.T, input []Operator) {
-					a, err := NewOrderedAggregator(input[0], tc.groupCols, tc.aggCols, tc.groupTypes)
+					a, err := NewOrderedAggregator(input[0], tc.groupCols, tc.groupTypes, tc.aggCols, tc.aggTypes)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -210,6 +240,9 @@ func TestAggregatorMultiFunc(t *testing.T) {
 			aggCols: [][]uint32{
 				{2}, {1},
 			},
+			aggTypes: [][]types.T{
+				{types.Int64}, {types.Int64},
+			},
 			input: tuples{
 				{0, 1, 2},
 				{0, 1, 2},
@@ -219,13 +252,35 @@ func TestAggregatorMultiFunc(t *testing.T) {
 			},
 			name: "OutputOrder",
 		},
+		{
+			aggCols: [][]uint32{
+				{2}, {1},
+			},
+			aggTypes: [][]types.T{
+				{types.Decimal}, {types.Int64},
+			},
+			input: tuples{
+				{0, 1, 1.3},
+				{0, 1, 1.6},
+				{0, 1, 0.5},
+				{1, 1, 1.2},
+			},
+			expected: tuples{
+				{3.4, 3},
+				{1.2, 1},
+			},
+			name:          "SumMultiType",
+			convToDecimal: true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s/Randomized", tc.name), func(t *testing.T) {
-			tc.init()
+			if err := tc.init(); err != nil {
+				t.Fatal(err)
+			}
 			runTests(t, []tuples{tc.input}, nil, func(t *testing.T, input []Operator) {
-				a, err := NewOrderedAggregator(input[0], tc.groupCols, tc.aggCols, tc.groupTypes)
+				a, err := NewOrderedAggregator(input[0], tc.groupCols, tc.groupTypes, tc.aggCols, tc.aggTypes)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -256,7 +311,7 @@ func BenchmarkSumInt(b *testing.B) {
 			batch.SetLength(ColBatchSize)
 			source := newRepeatableBatchSource(batch)
 
-			a, err := NewOrderedAggregator(source, []uint32{0}, [][]uint32{{1}}, []types.T{types.Int64})
+			a, err := NewOrderedAggregator(source, []uint32{0}, []types.T{types.Int64}, [][]uint32{{1}}, [][]types.T{{types.Int64}})
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -66,6 +66,9 @@ type ColVec interface {
 	// maximum size of ColBatchSize, filtered by the given selection vector.
 	AppendWithSel(vec ColVec, sel []uint16, batchSize uint16, colType types.T, toLength uint64)
 
+	// Copy copies src[srcStartIdx:srcEndIdx] into this ColVec.
+	Copy(src ColVec, srcStartIdx, srcEndIdx int, typ types.T)
+
 	// CopyWithSelInt64 copies vec, filtered by sel, into this ColVec. It replaces
 	// the contents of this ColVec.
 	CopyWithSelInt64(vec ColVec, sel []uint64, nSel uint16, colType types.T)

--- a/pkg/sql/exec/execgen/cmd/execgen/colvec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/colvec_gen.go
@@ -64,6 +64,17 @@ func (m *memColumn) AppendWithSel(
 	}
 }
 
+func (m *memColumn) Copy(src ColVec, srcStartIdx, srcEndIdx int, typ types.T) {
+	switch typ {
+	{{range .}}
+	case types.{{.ExecType}}:
+		copy(m.{{.ExecType}}(), src.{{.ExecType}}()[srcStartIdx:srcEndIdx])
+	{{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", typ))
+	}
+}
+
 func (m *memColumn) CopyWithSelInt64(
 	vec ColVec, sel []uint64, nSel uint16, colType types.T,
 ) {


### PR DESCRIPTION
The first two commits are #32110 

Previously, the orderedAggregator would only plan int64 sum aggregations
on the input columns. This change modifies the orderedAggregator to plan
a sum aggregate for the types specified in the input aggTyps.