### PR TITLE
exec: plan sum aggregate

### DIFF
--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -194,6 +194,22 @@ func TestAggregatorOneFunc(t *testing.T) {
 			outputBatchSize: 1,
 			name:            "CarryBetweenInputAndOutputBatches",
 		},
+		{
+			input: tuples{
+				{0, 1},
+				{0, 2},
+				{0, 3},
+				{0, 4},
+			},
+			expected: tuples{
+				{10},
+			},
+			batchSize:       1,
+			outputBatchSize: 1,
+			name:            "NoGroupingCols",
+			groupCols:       []uint32{},
+			groupTypes:      []types.T{},
+		},
 	}
 
 	// Run tests with deliberate batch sizes and no selection vectors.

--- a/pkg/sql/exec/one_shot.go
+++ b/pkg/sql/exec/one_shot.go
@@ -1,0 +1,42 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+// oneShotOp is an operator that does an arbitrary operation on the first batch
+// that it gets, then deletes itself from the operator tree. This is useful for
+// first-Next initialization that has to happen in an operator.
+type oneShotOp struct {
+	input Operator
+
+	outputSourceRef *Operator
+
+	fn func(batch ColBatch)
+}
+
+func (o *oneShotOp) Init() {
+	o.input.Init()
+}
+
+func (o *oneShotOp) Next() ColBatch {
+	batch := o.input.Next()
+
+	// Do our one-time work.
+	o.fn(batch)
+	// Swap out our output's input with our input, so we don't have to get called
+	// anymore.
+	*o.outputSourceRef = o.input
+
+	return batch
+}


### PR DESCRIPTION
On top of #32120.

This adds planning for sum aggregates to experimental_vectorize.