### PR TITLE
opt: show columns hidden by presentation

### DIFF
--- a/pkg/sql/opt/metadata_column.go
+++ b/pkg/sql/opt/metadata_column.go
@@ -66,6 +66,15 @@ func (cl ColList) Equals(other ColList) bool {
 	return true
 }
 
+// ColSetToList converts a column id set to a list, in column id order.
+func ColSetToList(set ColSet) ColList {
+	res := make(ColList, 0, set.Len())
+	set.ForEach(func(x int) {
+		res = append(res, ColumnID(x))
+	})
+	return res
+}
+
 // ColMap provides a 1:1 mapping from one column id to another. It is used by
 // operators that need to match columns from its inputs.
 type ColMap = util.FastIntMap

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -237,7 +237,7 @@ opt expect=EliminateGroupByProject
 SELECT DISTINCT ON (i) s FROM (SELECT i, s, f FROM (SELECT * FROM a UNION SELECT * FROM a))
 ----
 distinct-on
- ├── columns: s:14(string)
+ ├── columns: s:14(string)  [hidden: i:12(int!null)]
  ├── grouping columns: i:12(int!null)
  ├── key: (12)
  ├── fd: (12)-->(14)
@@ -375,7 +375,7 @@ opt expect=ReduceGroupingCols
 SELECT DISTINCT ON (k, f, s) i, f, x FROM a JOIN xy ON i=y
 ----
 distinct-on
- ├── columns: i:2(int) f:3(float) x:6(int)
+ ├── columns: i:2(int) f:3(float) x:6(int)  [hidden: k:1(int!null)]
  ├── grouping columns: k:1(int!null)
  ├── key: (1)
  ├── fd: (1)-->(2,3,6), (2,3)~~>(1), (6)-->(2)

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -45,7 +45,7 @@ opt expect=SimplifyLimitOrdering
 SELECT b, c FROM abcde WHERE d=1 AND e=2 ORDER BY b, c, d, e, a LIMIT 10
 ----
 limit
- ├── columns: b:2(int) c:3(int)
+ ├── columns: b:2(int) c:3(int)  [hidden: a:1(int!null) d:4(int!null) e:5(int!null)]
  ├── internal-ordering: +2,+3,+1 opt(4,5)
  ├── cardinality: [0 - 10]
  ├── key: (1)
@@ -74,7 +74,7 @@ opt expect=SimplifyLimitOrdering
 SELECT c FROM abcde ORDER BY b, c, a, d LIMIT 10
 ----
 scan abcde@bc
- ├── columns: c:3(int)
+ ├── columns: c:3(int)  [hidden: a:1(int!null) b:2(int)]
  ├── limit: 10
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1548,7 +1548,7 @@ EXPLAIN SELECT a FROM abcde WHERE b=1 AND c IS NOT NULL ORDER BY c, d
 explain
  ├── columns: tree:6(string) field:7(string) description:8(string)
  └── project
-      ├── columns: a:1(int!null)
+      ├── columns: a:1(int!null)  [hidden: c:3(int!null)]
       ├── key: (1)
       ├── fd: (1)-->(3), (3)-->(1)
       ├── ordering: +3

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -35,7 +35,7 @@ opt
 SELECT * FROM a ORDER BY length('foo'), random()+1.0
 ----
 sort
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)  [hidden: column7:7(float)]
  ├── side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-5,7)

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -700,7 +700,7 @@ build
 SELECT v, count(k) FROM kv GROUP BY v ORDER BY v-count(k)
 ----
 sort
- ├── columns: v:2(int) count:5(int)
+ ├── columns: v:2(int) count:5(int)  [hidden: column6:6(int)]
  ├── ordering: +6
  └── project
       ├── columns: column6:6(int) v:2(int) count:5(int)
@@ -723,7 +723,7 @@ build
 SELECT v FROM kv GROUP BY v ORDER BY sum(k)
 ----
 sort
- ├── columns: v:2(int)
+ ├── columns: v:2(int)  [hidden: sum:5(decimal)]
  ├── ordering: +5
  └── group-by
       ├── columns: v:2(int) sum:5(decimal)
@@ -2798,7 +2798,7 @@ build
 SELECT 123 r FROM kv ORDER BY max(v)
 ----
 project
- ├── columns: r:6(int!null)
+ ├── columns: r:6(int!null)  [hidden: max:5(int)]
  ├── ordering: +5
  ├── scalar-group-by
  │    ├── columns: max:5(int)

--- a/pkg/sql/opt/optbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/optbuilder/testdata/distinct_on
@@ -58,7 +58,7 @@ build
 SELECT DISTINCT ON (z, x, y) x FROM xyz
 ----
 distinct-on
- ├── columns: x:1(int)
+ ├── columns: x:1(int)  [hidden: y:2(int) z:3(int)]
  ├── grouping columns: x:1(int) y:2(int) z:3(int)
  └── project
       ├── columns: x:1(int) y:2(int) z:3(int)
@@ -78,7 +78,7 @@ build
 SELECT DISTINCT ON (b, c, a) a FROM abc
 ----
 distinct-on
- ├── columns: a:1(string!null)
+ ├── columns: a:1(string!null)  [hidden: b:2(string!null) c:3(string!null)]
  ├── grouping columns: a:1(string!null) b:2(string!null) c:3(string!null)
  └── scan abc
       └── columns: a:1(string!null) b:2(string!null) c:3(string!null)
@@ -87,7 +87,7 @@ build
 SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
 ----
 distinct-on
- ├── columns: b:2(string!null)
+ ├── columns: b:2(string!null)  [hidden: a:1(string!null) c:3(string!null)]
  ├── grouping columns: a:1(string!null) b:2(string!null) c:3(string!null)
  ├── ordering: +2
  └── sort
@@ -114,7 +114,7 @@ build
 SELECT DISTINCT ON (y, x) x FROM xyz
 ----
 distinct-on
- ├── columns: x:1(int)
+ ├── columns: x:1(int)  [hidden: y:2(int)]
  ├── grouping columns: x:1(int) y:2(int)
  └── project
       ├── columns: x:1(int) y:2(int)
@@ -150,7 +150,7 @@ build
 SELECT DISTINCT ON (a, c) a, b FROM abc
 ----
 distinct-on
- ├── columns: a:1(string!null) b:2(string)
+ ├── columns: a:1(string!null) b:2(string)  [hidden: c:3(string!null)]
  ├── grouping columns: a:1(string!null) c:3(string!null)
  ├── scan abc
  │    └── columns: a:1(string!null) b:2(string!null) c:3(string!null)
@@ -237,7 +237,7 @@ build
 SELECT DISTINCT ON (max(y)) max(x) FROM xyz
 ----
 distinct-on
- ├── columns: max:6(int)
+ ├── columns: max:6(int)  [hidden: max:7(int)]
  ├── grouping columns: max:7(int)
  ├── scalar-group-by
  │    ├── columns: max:6(int) max:7(int)
@@ -258,7 +258,7 @@ build
 SELECT DISTINCT ON(min(a), max(b), min(c)) max(a) FROM abc
 ----
 distinct-on
- ├── columns: max:4(string)
+ ├── columns: max:4(string)  [hidden: min:5(string) max:6(string) min:7(string)]
  ├── grouping columns: min:5(string) max:6(string) min:7(string)
  ├── scalar-group-by
  │    ├── columns: max:4(string) min:5(string) max:6(string) min:7(string)
@@ -285,7 +285,7 @@ build
 SELECT DISTINCT ON(y) min(x) FROM xyz GROUP BY y
 ----
 distinct-on
- ├── columns: min:6(int)
+ ├── columns: min:6(int)  [hidden: y:2(int)]
  ├── grouping columns: y:2(int)
  ├── group-by
  │    ├── columns: y:2(int) min:6(int)
@@ -418,7 +418,7 @@ build
 SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
 ----
 sort
- ├── columns: x:1(int) y:2(int) z:3(int)
+ ├── columns: x:1(int) y:2(int) z:3(int)  [hidden: pk1:4(int!null) pk2:5(int!null)]
  ├── ordering: +1,+2
  └── distinct-on
       ├── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
@@ -433,7 +433,7 @@ build
 SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
 ----
 distinct-on
- ├── columns: pk1:4(int)
+ ├── columns: pk1:4(int)  [hidden: x:1(int) y:2(int) z:3(int)]
  ├── grouping columns: x:1(int) y:2(int) z:3(int)
  ├── ordering: +1
  ├── sort

--- a/pkg/sql/opt/optbuilder/testdata/explain
+++ b/pkg/sql/opt/optbuilder/testdata/explain
@@ -27,7 +27,7 @@ build
 EXPLAIN (TYPES) SELECT * FROM xy
 ----
 explain
- ├── columns: tree:3(string) field:6(string) description:7(string) columns:8(string) ordering:9(string)
+ ├── columns: tree:3(string) field:6(string) description:7(string) columns:8(string) ordering:9(string)  [hidden: level:4(int) node_type:5(string)]
  └── scan xy
       └── columns: x:1(int!null) y:2(int)
 
@@ -35,7 +35,7 @@ build
 EXPLAIN (VERBOSE) SELECT * FROM xy
 ----
 explain
- ├── columns: tree:3(string) field:6(string) description:7(string) columns:8(string) ordering:9(string)
+ ├── columns: tree:3(string) field:6(string) description:7(string) columns:8(string) ordering:9(string)  [hidden: level:4(int) node_type:5(string)]
  └── scan xy
       └── columns: x:1(int!null) y:2(int)
 
@@ -44,7 +44,7 @@ build
 EXPLAIN (VERBOSE) SELECT * FROM xy ORDER BY y
 ----
 explain
- ├── columns: tree:3(string) field:6(string) description:7(string) columns:8(string) ordering:9(string)
+ ├── columns: tree:3(string) field:6(string) description:7(string) columns:8(string) ordering:9(string)  [hidden: level:4(int) node_type:5(string)]
  └── sort
       ├── columns: x:1(int!null) y:2(int)
       ├── ordering: +2
@@ -55,7 +55,7 @@ build
 EXPLAIN (VERBOSE) SELECT * FROM xy INNER JOIN (VALUES (1, 2), (3, 4)) AS t(u,v) ON x=u
 ----
 explain
- ├── columns: tree:5(string) field:8(string) description:9(string) columns:10(string) ordering:11(string)
+ ├── columns: tree:5(string) field:8(string) description:9(string) columns:10(string) ordering:11(string)  [hidden: level:6(int) node_type:7(string)]
  └── inner-join
       ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
       ├── scan xy

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -134,7 +134,7 @@ build
 SELECT sum(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
 ----
 limit
- ├── columns: sum:4(decimal)
+ ├── columns: sum:4(decimal)  [hidden: v:2(int)]
  ├── internal-ordering: -2
  ├── ordering: -2
  ├── project

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -162,7 +162,7 @@ build
 SELECT b FROM t ORDER BY a DESC
 ----
 project
- ├── columns: b:2(int)
+ ├── columns: b:2(int)  [hidden: a:1(int!null)]
  ├── ordering: -1
  └── scan t,rev
       ├── columns: a:1(int!null) b:2(int) c:3(bool)
@@ -172,7 +172,7 @@ build
 SELECT b FROM t ORDER BY a LIMIT 1
 ----
 limit
- ├── columns: b:2(int)
+ ├── columns: b:2(int)  [hidden: a:1(int!null)]
  ├── internal-ordering: +1
  ├── ordering: +1
  ├── project
@@ -187,7 +187,7 @@ build
 SELECT b FROM t ORDER BY a DESC, b ASC
 ----
 project
- ├── columns: b:2(int)
+ ├── columns: b:2(int)  [hidden: a:1(int!null)]
  ├── ordering: -1,+2
  └── scan t,rev
       ├── columns: a:1(int!null) b:2(int) c:3(bool)
@@ -197,7 +197,7 @@ build
 SELECT b FROM t ORDER BY a DESC, b DESC
 ----
 project
- ├── columns: b:2(int)
+ ├── columns: b:2(int)  [hidden: a:1(int!null)]
  ├── ordering: -1,-2
  └── scan t,rev
       ├── columns: a:1(int!null) b:2(int) c:3(bool)
@@ -208,7 +208,7 @@ build
 SELECT a, b, b FROM t ORDER BY c
 ----
 sort
- ├── columns: a:1(int!null) b:2(int) b:2(int)
+ ├── columns: a:1(int!null) b:2(int) b:2(int)  [hidden: c:3(bool)]
  ├── ordering: +3
  └── scan t
       └── columns: a:1(int!null) b:2(int) c:3(bool)
@@ -302,7 +302,7 @@ build
 SELECT a FROM t ORDER BY a+b DESC, a
 ----
 sort
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: column4:4(int)]
  ├── ordering: -4,+1
  └── project
       ├── columns: column4:4(int) a:1(int!null)
@@ -451,7 +451,7 @@ build
 SELECT generate_series, ARRAY[generate_series] FROM generate_series(1, 1) ORDER BY -generate_series
 ----
 sort
- ├── columns: generate_series:1(int) array:2(int[])
+ ├── columns: generate_series:1(int) array:2(int[])  [hidden: column3:3(int)]
  ├── ordering: +3
  └── project
       ├── columns: array:2(int[]) column3:3(int) generate_series:1(int)
@@ -474,7 +474,7 @@ build
 SELECT * FROM t ORDER BY 1+2
 ----
 sort
- ├── columns: a:1(int!null) b:2(int) c:3(bool)
+ ├── columns: a:1(int!null) b:2(int) c:3(bool)  [hidden: column4:4(int!null)]
  ├── ordering: +4
  └── project
       ├── columns: column4:4(int!null) a:1(int!null) b:2(int) c:3(bool)
@@ -500,7 +500,7 @@ build
 SELECT * FROM t ORDER BY length('abc')
 ----
 sort
- ├── columns: a:1(int!null) b:2(int) c:3(bool)
+ ├── columns: a:1(int!null) b:2(int) c:3(bool)  [hidden: column4:4(int)]
  ├── ordering: +4
  └── project
       ├── columns: column4:4(int) a:1(int!null) b:2(int) c:3(bool)
@@ -560,7 +560,7 @@ build
 SELECT b, c FROM t ORDER BY @2
 ----
 sort
- ├── columns: b:2(int) c:3(bool)
+ ├── columns: b:2(int) c:3(bool)  [hidden: column4:4(int)]
  ├── ordering: +4
  └── project
       ├── columns: column4:4(int) b:2(int) c:3(bool)
@@ -615,7 +615,7 @@ build
 SELECT d FROM abc ORDER BY lower(d)
 ----
 sort
- ├── columns: d:4(string)
+ ├── columns: d:4(string)  [hidden: column5:5(string)]
  ├── ordering: +5
  └── project
       ├── columns: column5:5(string) d:4(string)
@@ -647,7 +647,7 @@ build
 SELECT a, b FROM abc ORDER BY b, c
 ----
 sort
- ├── columns: a:1(int!null) b:2(int!null)
+ ├── columns: a:1(int!null) b:2(int!null)  [hidden: c:3(int!null)]
  ├── ordering: +2,+3
  └── project
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -658,7 +658,7 @@ build
 SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
 project
- ├── columns: a:1(int!null) b:2(int!null)
+ ├── columns: a:1(int!null) b:2(int!null)  [hidden: c:3(int!null)]
  ├── ordering: +2,+3,-1
  └── sort
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
@@ -764,7 +764,7 @@ build
 SELECT a FROM abc ORDER BY INDEX abc@bc
 ----
 sort
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: b:2(int!null) c:3(int!null)]
  ├── ordering: +2,+3
  └── project
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -932,7 +932,7 @@ build
 SELECT a FROM abcd ORDER BY b, PRIMARY KEY abcd
 ----
 sort
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: b:2(int)]
  ├── ordering: +2,+1
  └── project
       ├── columns: a:1(int!null) b:2(int)
@@ -943,7 +943,7 @@ build
 SELECT a FROM abcd ORDER BY INDEX abcd@abc
 ----
 project
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: b:2(int) c:3(int)]
  ├── ordering: +1,+2,+3
  └── scan abcd
       ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
@@ -953,7 +953,7 @@ build
 SELECT a FROM abcd ORDER BY INDEX abcd@abc DESC
 ----
 project
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: b:2(int) c:3(int)]
  ├── ordering: -1,-2,-3
  └── scan abcd,rev
       ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
@@ -973,7 +973,7 @@ build
 SELECT a FROM abcd ORDER BY INDEX abcd@bcd
 ----
 sort
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: b:2(int) c:3(int) d:4(int)]
  ├── ordering: +2,-3,+4,+1
  └── scan abcd
       └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
@@ -982,7 +982,7 @@ build
 SELECT a FROM abcd ORDER BY INDEX abcd@bcd DESC
 ----
 sort
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: b:2(int) c:3(int) d:4(int)]
  ├── ordering: -2,+3,-4,-1
  └── scan abcd
       └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
@@ -997,7 +997,7 @@ build
 SELECT a FROM t.public.abcd ORDER BY INDEX t.public.abcd@bcd
 ----
 sort
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: b:2(int) c:3(int) d:4(int)]
  ├── ordering: +2,-3,+4,+1
  └── scan abcd
       └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
@@ -1006,7 +1006,7 @@ build
 SELECT a FROM t.abcd ORDER BY INDEX t.abcd@bcd
 ----
 sort
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: b:2(int) c:3(int) d:4(int)]
  ├── ordering: +2,-3,+4,+1
  └── scan abcd
       └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
@@ -1015,7 +1015,7 @@ build
 SELECT a FROM public.abcd ORDER BY INDEX public.abcd@bcd
 ----
 sort
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: b:2(int) c:3(int) d:4(int)]
  ├── ordering: +2,-3,+4,+1
  └── scan abcd
       └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
@@ -1050,7 +1050,7 @@ build
 SELECT a, b FROM abcd ORDER BY b, c
 ----
 sort
- ├── columns: a:1(int!null) b:2(int)
+ ├── columns: a:1(int!null) b:2(int)  [hidden: c:3(int)]
  ├── ordering: +2,+3
  └── project
       ├── columns: a:1(int!null) b:2(int) c:3(int)
@@ -1061,7 +1061,7 @@ build
 SELECT a FROM abcd ORDER BY b, c
 ----
 sort
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: b:2(int) c:3(int)]
  ├── ordering: +2,+3
  └── project
       ├── columns: a:1(int!null) b:2(int) c:3(int)
@@ -1072,7 +1072,7 @@ build
 SELECT a FROM abcd ORDER BY a, b, c
 ----
 project
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: b:2(int) c:3(int)]
  ├── ordering: +1,+2,+3
  └── scan abcd
       ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)

--- a/pkg/sql/opt/optbuilder/testdata/ordinality
+++ b/pkg/sql/opt/optbuilder/testdata/ordinality
@@ -69,7 +69,7 @@ build
 SELECT a FROM abcd WITH ORDINALITY ORDER BY ordinality
 ----
 project
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: ordinality:5(int!null)]
  ├── ordering: +5
  └── row-number
       ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int) ordinality:5(int!null)
@@ -81,7 +81,7 @@ build
 SELECT ordinality FROM abcd WITH ORDINALITY ORDER BY a
 ----
 sort
- ├── columns: ordinality:5(int!null)
+ ├── columns: ordinality:5(int!null)  [hidden: a:1(int!null)]
  ├── ordering: +1
  └── project
       ├── columns: a:1(int!null) ordinality:5(int!null)

--- a/pkg/sql/opt/optbuilder/testdata/where
+++ b/pkg/sql/opt/optbuilder/testdata/where
@@ -96,7 +96,7 @@ build
 SELECT 'hello' LIKE v AS r FROM kvString WHERE k LIKE 'like%' ORDER BY k
 ----
 project
- ├── columns: r:3(bool)
+ ├── columns: r:3(bool)  [hidden: k:1(string!null)]
  ├── ordering: +1
  ├── select
  │    ├── columns: k:1(string!null) v:2(string)
@@ -117,7 +117,7 @@ build
 SELECT 'hello' SIMILAR TO v AS r FROM kvString WHERE k SIMILAR TO 'like[1-2]' ORDER BY k
 ----
 project
- ├── columns: r:3(bool)
+ ├── columns: r:3(bool)  [hidden: k:1(string!null)]
  ├── ordering: +1
  ├── select
  │    ├── columns: k:1(string!null) v:2(string)
@@ -138,7 +138,7 @@ build
 SELECT 'hello' ~ replace(v, '%', '.*') AS r FROM kvString WHERE k ~ 'like[1-2]' ORDER BY k
 ----
 project
- ├── columns: r:3(bool)
+ ├── columns: r:3(bool)  [hidden: k:1(string!null)]
  ├── ordering: +1
  ├── select
  │    ├── columns: k:1(string!null) v:2(string)

--- a/pkg/sql/opt/xform/testdata/external/activerecord
+++ b/pkg/sql/opt/xform/testdata/external/activerecord
@@ -201,7 +201,7 @@ AND a.attnum > 0 AND NOT a.attisdropped
 ORDER BY a.attnum
 ----
 sort
- ├── columns: attname:2(string!null) format_type:65(string) pg_get_expr:66(string) attnotnull:13(bool!null) atttypid:3(oid!null) atttypmod:9(int!null) collname:67(string) comment:68(string)
+ ├── columns: attname:2(string!null) format_type:65(string) pg_get_expr:66(string) attnotnull:13(bool!null) atttypid:3(oid!null) atttypmod:9(int!null) collname:67(string) comment:68(string)  [hidden: attnum:6(int!null)]
  ├── fd: (3,9)-->(65)
  ├── ordering: +6
  └── project

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -297,7 +297,7 @@ ORDER BY score desc, updated_at_inverse DESC
 LIMIT 50
 ----
 project
- ├── columns: score:9(int!null) expires_at:15(int!null)
+ ├── columns: score:9(int!null) expires_at:15(int!null)  [hidden: updated_at_inverse:14(int!null)]
  ├── cardinality: [0 - 50]
  ├── fd: ()-->(15)
  ├── ordering: -9,-14 opt(15)

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -601,7 +601,7 @@ WHERE i_id IN (125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300)
 ORDER BY i_id
 ----
 scan item
- ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)
+ ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
  ├── stats: [rows=12, distinct(1)=12, null(1)=0]
  ├── cost: 13.08
@@ -618,7 +618,7 @@ WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
 ORDER BY s_i_id
 ----
 project
- ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)
+ ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)  [hidden: s_i_id:1(int!null)]
  ├── stats: [rows=5]
  ├── cost: 6.3
  ├── key: (1)
@@ -653,7 +653,7 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1(int!null)
+ ├── columns: c_id:1(int!null)  [hidden: c_first:4(string)]
  ├── stats: [rows=3.3e-05]
  ├── cost: 3.663e-05
  ├── key: (1)
@@ -1011,7 +1011,7 @@ FROM district
 ORDER BY d_w_id, d_id
 ----
 scan district
- ├── columns: d_next_o_id:11(int)
+ ├── columns: d_next_o_id:11(int)  [hidden: d_id:1(int!null) d_w_id:2(int!null)]
  ├── stats: [rows=100]
  ├── cost: 114
  ├── key: (1,2)
@@ -1027,7 +1027,7 @@ GROUP BY no_d_id, no_w_id
 ORDER BY no_w_id, no_d_id
 ----
 group-by
- ├── columns: max:4(int)
+ ├── columns: max:4(int)  [hidden: no_d_id:2(int!null) no_w_id:3(int!null)]
  ├── grouping columns: no_d_id:2(int!null) no_w_id:3(int!null)
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
  ├── cost: 98101
@@ -1055,7 +1055,7 @@ GROUP BY o_d_id, o_w_id
 ORDER BY o_w_id, o_d_id
 ----
 group-by
- ├── columns: max:9(int)
+ ├── columns: max:9(int)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
  ├── cost: 330001
@@ -1143,7 +1143,7 @@ GROUP BY o_w_id, o_d_id
 ORDER BY o_w_id, o_d_id
 ----
 group-by
- ├── columns: sum:9(decimal)
+ ├── columns: sum:9(decimal)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
  ├── cost: 342001
@@ -1170,7 +1170,7 @@ GROUP BY ol_w_id, ol_d_id
 ORDER BY ol_w_id, ol_d_id
 ----
 sort
- ├── columns: count:11(int)
+ ├── columns: count:11(int)  [hidden: ol_d_id:2(int!null) ol_w_id:3(int!null)]
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
  ├── cost: 1110017.05
  ├── key: (2,3)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -406,7 +406,7 @@ WHERE i_id IN (125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300)
 ORDER BY i_id
 ----
 scan item
- ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)
+ ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
  ├── stats: [rows=12, distinct(1)=12, null(1)=0]
  ├── cost: 13.08
@@ -423,7 +423,7 @@ WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
 ORDER BY s_i_id
 ----
 project
- ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)
+ ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)  [hidden: s_i_id:1(int!null)]
  ├── stats: [rows=0.5]
  ├── cost: 0.63
  ├── key: (1)
@@ -458,7 +458,7 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1(int!null)
+ ├── columns: c_id:1(int!null)  [hidden: c_first:4(string)]
  ├── stats: [rows=0.00099]
  ├── cost: 0.0010989
  ├── key: (1)
@@ -807,7 +807,7 @@ FROM district
 ORDER BY d_w_id, d_id
 ----
 scan district
- ├── columns: d_next_o_id:11(int)
+ ├── columns: d_next_o_id:11(int)  [hidden: d_id:1(int!null) d_w_id:2(int!null)]
  ├── stats: [rows=1000]
  ├── cost: 1140
  ├── key: (1,2)
@@ -823,7 +823,7 @@ GROUP BY no_d_id, no_w_id
 ORDER BY no_w_id, no_d_id
 ----
 group-by
- ├── columns: max:4(int)
+ ├── columns: max:4(int)  [hidden: no_d_id:2(int!null) no_w_id:3(int!null)]
  ├── grouping columns: no_d_id:2(int!null) no_w_id:3(int!null)
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
  ├── cost: 1100
@@ -851,7 +851,7 @@ GROUP BY o_d_id, o_w_id
 ORDER BY o_w_id, o_d_id
 ----
 group-by
- ├── columns: max:9(int)
+ ├── columns: max:9(int)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
  ├── cost: 1110
@@ -939,7 +939,7 @@ GROUP BY o_w_id, o_d_id
 ORDER BY o_w_id, o_d_id
 ----
 group-by
- ├── columns: sum:9(decimal)
+ ├── columns: sum:9(decimal)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
  ├── cost: 1150
@@ -966,7 +966,7 @@ GROUP BY ol_w_id, ol_d_id
 ORDER BY ol_w_id, ol_d_id
 ----
 group-by
- ├── columns: count:11(int)
+ ├── columns: count:11(int)  [hidden: ol_d_id:2(int!null) ol_w_id:3(int!null)]
  ├── grouping columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
  ├── cost: 1160

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -153,7 +153,7 @@ opt
 SELECT x+1 AS r, y FROM a ORDER BY x, y DESC
 ----
 project
- ├── columns: r:5(int) y:2(float!null)
+ ├── columns: r:5(int) y:2(float!null)  [hidden: x:1(int!null)]
  ├── ordering: +1,-2
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(float!null)
@@ -198,7 +198,7 @@ opt
 SELECT y, x-1 AS z FROM a WHERE x>y ORDER BY x, y DESC
 ----
 project
- ├── columns: y:2(float!null) z:5(int)
+ ├── columns: y:2(float!null) z:5(int)  [hidden: x:1(int!null)]
  ├── ordering: +1,-2
  ├── select
  │    ├── columns: x:1(int!null) y:2(float!null)
@@ -452,7 +452,7 @@ opt
 SELECT sum(c) FROM abc WHERE a = 1 GROUP BY b ORDER BY b
 ----
 group-by
- ├── columns: sum:4(decimal)
+ ├── columns: sum:4(decimal)  [hidden: b:2(int!null)]
  ├── grouping columns: b:2(int!null)
  ├── ordering: +2
  ├── scan abc
@@ -520,7 +520,7 @@ opt
 EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY y
 ----
 explain
- ├── columns: tree:5(string) field:8(string) description:9(string) columns:10(string) ordering:11(string)
+ ├── columns: tree:5(string) field:8(string) description:9(string) columns:10(string) ordering:11(string)  [hidden: level:6(int) node_type:7(string)]
  └── sort
       ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
       ├── ordering: +2

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -68,7 +68,7 @@ opt
 SELECT s FROM (SELECT s, i FROM a ORDER BY s LIMIT 10) a ORDER BY s, i LIMIT 1
 ----
 limit
- ├── columns: s:4(string)
+ ├── columns: s:4(string)  [hidden: i:2(int)]
  ├── internal-ordering: +4,+2
  ├── cardinality: [0 - 1]
  ├── key: ()
@@ -87,7 +87,7 @@ opt
 SELECT s FROM a ORDER BY f LIMIT 1
 ----
 limit
- ├── columns: s:4(string)
+ ├── columns: s:4(string)  [hidden: f:3(float)]
  ├── internal-ordering: +3
  ├── cardinality: [0 - 1]
  ├── key: ()

--- a/pkg/sql/opt/xform/testdata/rules/manual
+++ b/pkg/sql/opt/xform/testdata/rules/manual
@@ -54,7 +54,7 @@ opt
 SELECT a FROM abcde WHERE b=1 AND c IS NOT NULL ORDER BY c, d
 ----
 project
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: c:3(int!null)]
  ├── key: (1)
  ├── fd: (1)-->(3), (3)-->(1)
  ├── ordering: +3
@@ -70,7 +70,7 @@ opt
 SELECT a FROM abcde WHERE b=1 ORDER BY c, b, d
 ----
 sort
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: b:2(int!null) c:3(int) d:4(int)]
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3,4), (2,3)~~>(1,4)
  ├── ordering: +3,+4 opt(2)
@@ -94,7 +94,7 @@ opt
 SELECT c FROM abcde ORDER BY b, c, a, d LIMIT 10
 ----
 scan abcde@bc
- ├── columns: c:3(int)
+ ├── columns: c:3(int)  [hidden: a:1(int!null) b:2(int)]
  ├── limit: 10
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)~~>(1)
@@ -122,7 +122,7 @@ opt
 SELECT a FROM abcde WHERE b=1 ORDER BY c
 ----
 project
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: c:3(int)]
  ├── key: (1)
  ├── fd: (1)-->(3)
  ├── ordering: +3
@@ -139,7 +139,7 @@ opt
 SELECT a FROM abcde WHERE b=1 ORDER BY c, d
 ----
 sort
- ├── columns: a:1(int!null)
+ ├── columns: a:1(int!null)  [hidden: c:3(int) d:4(int)]
  ├── key: (1)
  ├── fd: (1)-->(3,4)
  ├── ordering: +3,+4

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -95,7 +95,7 @@ opt
 SELECT s FROM a ORDER BY k DESC
 ----
 scan a,rev
- ├── columns: s:4(string)
+ ├── columns: s:4(string)  [hidden: k:1(int!null)]
  ├── key: (1)
  ├── fd: (1)-->(4)
  └── ordering: -1
@@ -181,7 +181,7 @@ opt
 SELECT s, i, f FROM a ORDER BY s, k, i
 ----
 scan a@s_idx
- ├── columns: s:4(string) i:2(int) f:3(float)
+ ├── columns: s:4(string) i:2(int) f:3(float)  [hidden: k:1(int!null)]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  └── ordering: +4,+1
@@ -208,7 +208,7 @@ GenerateIndexScans
 ================================================================================
 Source expression:
   sort
-   ├── columns: s:4(string) i:2(int) f:3(float)
+   ├── columns: s:4(string) i:2(int) f:3(float)  [hidden: k:1(int!null)]
    ├── key: (1)
    ├── fd: (1)-->(2-4)
    ├── ordering: +4,+1
@@ -219,7 +219,7 @@ Source expression:
 
 New expression 1 of 1:
   scan a@s_idx
-   ├── columns: s:4(string) i:2(int) f:3(float)
+   ├── columns: s:4(string) i:2(int) f:3(float)  [hidden: k:1(int!null)]
    ├── key: (1)
    ├── fd: (1)-->(2-4)
    └── ordering: +4,+1
@@ -240,7 +240,7 @@ GenerateConstrainedScans
 ================================================================================
 Source expression:
   select
-   ├── columns: s:4(string!null) i:2(int) f:3(float)
+   ├── columns: s:4(string!null) i:2(int) f:3(float)  [hidden: k:1(int!null)]
    ├── key: (1)
    ├── fd: ()-->(4), (1)-->(2,3)
    ├── ordering: +1 opt(4)
@@ -254,7 +254,7 @@ Source expression:
 
 New expression 1 of 2:
   scan a@s_idx
-   ├── columns: s:4(string!null) i:2(int) f:3(float)
+   ├── columns: s:4(string!null) i:2(int) f:3(float)  [hidden: k:1(int!null)]
    ├── constraint: /4/1: [/'foo' - /'foo']
    ├── key: (1)
    ├── fd: ()-->(4), (1)-->(2,3)
@@ -262,7 +262,7 @@ New expression 1 of 2:
 
 New expression 2 of 2:
   sort
-   ├── columns: s:4(string!null) i:2(int) f:3(float)
+   ├── columns: s:4(string!null) i:2(int) f:3(float)  [hidden: k:1(int!null)]
    ├── key: (1)
    ├── fd: ()-->(4), (1)-->(2,3)
    ├── ordering: +1 opt(4)
@@ -428,7 +428,7 @@ opt
 SELECT s, i, f FROM a ORDER BY k, i, s
 ----
 scan a
- ├── columns: s:4(string) i:2(int) f:3(float)
+ ├── columns: s:4(string) i:2(int) f:3(float)  [hidden: k:1(int!null)]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  └── ordering: +1
@@ -470,7 +470,7 @@ opt
 SELECT i, k FROM a ORDER BY s DESC, i, k
 ----
 sort
- ├── columns: i:2(int) k:1(int!null)
+ ├── columns: i:2(int) k:1(int!null)  [hidden: s:4(string)]
  ├── key: (1)
  ├── fd: (1)-->(2,4)
  ├── ordering: -4,+2,+1


### PR DESCRIPTION
Example:
```
 group-by
 ├── columns: sum:4(decimal)  hidden: b:2(int!null)
```

Release note: None