### PR TITLE
sql: skip removed nodes in crdb_internal.gossip_nodes

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1836,7 +1836,12 @@ CREATE TABLE crdb_internal.gossip_nodes (
 			if err := protoutil.Unmarshal(bytes, &d); err != nil {
 				return errors.Wrapf(err, "failed to parse value for key %q", key)
 			}
-			descriptors = append(descriptors, d)
+
+			// Don't use node descriptors with NodeID 0, because that's meant to
+			// indicate that the node has been removed from the cluster.
+			if d.NodeID != 0 {
+				descriptors = append(descriptors, d)
+			}
 			return nil
 		}); err != nil {
 			return err


### PR DESCRIPTION
Removed nodes have empty info proto. Skip them while processing
rows in crdb_internal.gossip_nodes

Fixes #31696

Release note (bug fix): Fix an error returned by `node status` after a new node is added to the cluster at a previous node's address. 