### PR TITLE
sql: add request for MutableTableDescriptor in descriptor API

### DIFF
--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -71,8 +71,11 @@ func (r *descriptorResolver) LookupSchema(
 
 // LookupObject implements the tree.TableNameExistingResolver interface.
 func (r *descriptorResolver) LookupObject(
-	_ context.Context, dbName, scName, obName string,
+	_ context.Context, requireMutable bool, dbName, scName, obName string,
 ) (bool, tree.NameResolutionResult, error) {
+	if requireMutable {
+		panic("did not expect request for mutable descriptor")
+	}
 	if scName != tree.PublicSchema {
 		return false, nil, nil
 	}
@@ -201,7 +204,7 @@ func descriptorsMatchingTargets(
 
 		switch p := pattern.(type) {
 		case *tree.TableName:
-			found, descI, err := p.ResolveExisting(ctx, resolver, currentDatabase, searchPath)
+			found, descI, err := p.ResolveExisting(ctx, resolver, false /*requireMutable*/, currentDatabase, searchPath)
 			if err != nil {
 				return ret, err
 			}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -323,13 +323,15 @@ func (r fkResolver) CommonLookupFlags(ctx context.Context, required bool) sql.Co
 }
 
 // Implements the sql.SchemaResolver interface.
-func (r fkResolver) ObjectLookupFlags(ctx context.Context, required bool) sql.ObjectLookupFlags {
+func (r fkResolver) ObjectLookupFlags(
+	ctx context.Context, required bool, requireMutable bool,
+) sql.ObjectLookupFlags {
 	return sql.ObjectLookupFlags{}
 }
 
 // Implements the tree.TableNameExistingResolver interface.
 func (r fkResolver) LookupObject(
-	ctx context.Context, dbName, scName, obName string,
+	ctx context.Context, requireMutable bool, dbName, scName, obName string,
 ) (found bool, objMeta tree.NameResolutionResult, err error) {
 	if scName != "" {
 		obName = strings.TrimPrefix(obName, scName+".")

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -173,7 +173,7 @@ func TestMysqldumpSchemaReader(t *testing.T) {
 	referencedSimple := descForTable(t, readFile(t, `simple.cockroach-schema.sql`), expectedParent, 52, NoFKs)
 	fks := fkHandler{
 		allowed:  true,
-		resolver: fkResolver(map[string]*sqlbase.MutableTableDescriptor{referencedSimple.Name: sql.NewMutableTableDescriptor(*referencedSimple, sqlbase.TableDescriptor{})}),
+		resolver: fkResolver(map[string]*sqlbase.MutableTableDescriptor{referencedSimple.Name: sql.NewMutableCreatedTableDescriptor(*referencedSimple)}),
 	}
 
 	t.Run("simple", func(t *testing.T) {

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -174,7 +174,7 @@ func (p *planner) MemberOfWithAdminOption(
 ) (map[string]bool, error) {
 	// Lookup table version.
 	objDesc, _, err := p.PhysicalSchemaAccessor().GetObjectDesc(&roleMembersTableName,
-		p.ObjectLookupFlags(ctx, true /*required*/))
+		p.ObjectLookupFlags(ctx, true /*required*/, false /*requireMutable*/))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -193,7 +193,7 @@ func (sc *SchemaChanger) runBackfill(
 func (sc *SchemaChanger) getTableVersion(
 	ctx context.Context, txn *client.Txn, tc *TableCollection, version sqlbase.DescriptorVersion,
 ) (*sqlbase.TableDescriptor, error) {
-	flags := ObjectLookupFlags{CommonLookupFlags{txn: txn}}
+	flags := ObjectLookupFlags{CommonLookupFlags{txn: txn}, false /*requireMutable*/}
 	tableDesc, err := tc.getTableVersionByID(ctx, sc.tableID, flags)
 	if err != nil {
 		return nil, err
@@ -417,7 +417,7 @@ func (sc *SchemaChanger) distBackfill(
 					return err
 				}
 
-				flags := ObjectLookupFlags{CommonLookupFlags{txn: txn}}
+				flags := ObjectLookupFlags{CommonLookupFlags{txn: txn}, false /*requireMutable*/}
 				for k := range fkTables {
 					table, err := tc.getTableVersionByID(ctx, k, flags)
 					if err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -806,12 +806,20 @@ var CreatePartitioningCCL = func(
 		"creating or manipulating partitions requires a CCL binary"))
 }
 
-// NewMutableTableDescriptor returns a MutableTableDescriptor from the
-// given TableDescriptor and cluster version of the table.
-func NewMutableTableDescriptor(
-	tbl sqlbase.TableDescriptor, clusterVersion sqlbase.TableDescriptor,
+// NewMutableCreatedTableDescriptor returns a MutableTableDescriptor from the
+// given TableDescriptor with the cluster version being the zero table. This
+// is for a table that is created in the transaction.
+func NewMutableCreatedTableDescriptor(tbl sqlbase.TableDescriptor) *sqlbase.MutableTableDescriptor {
+	return &sqlbase.MutableTableDescriptor{TableDescriptor: tbl}
+}
+
+// NewMutableExistingTableDescriptor returns a MutableTableDescriptor from the
+// given TableDescriptor with the cluster version also set to the descriptor.
+// This is for an existing table.
+func NewMutableExistingTableDescriptor(
+	tbl sqlbase.TableDescriptor,
 ) *sqlbase.MutableTableDescriptor {
-	return &sqlbase.MutableTableDescriptor{TableDescriptor: tbl, ClusterVersion: clusterVersion}
+	return &sqlbase.MutableTableDescriptor{TableDescriptor: tbl, ClusterVersion: tbl}
 }
 
 // InitTableDescriptor returns a blank TableDescriptor.
@@ -821,7 +829,7 @@ func InitTableDescriptor(
 	creationTime hlc.Timestamp,
 	privileges *sqlbase.PrivilegeDescriptor,
 ) sqlbase.MutableTableDescriptor {
-	return *NewMutableTableDescriptor(sqlbase.TableDescriptor{
+	return *NewMutableCreatedTableDescriptor(sqlbase.TableDescriptor{
 		ID:               id,
 		Name:             name,
 		ParentID:         parentID,
@@ -829,7 +837,7 @@ func InitTableDescriptor(
 		Version:          1,
 		ModificationTime: creationTime,
 		Privileges:       privileges,
-	}, sqlbase.TableDescriptor{})
+	})
 }
 
 // makeTableDescIfAs is the MakeTableDesc method for when we have a table

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -157,7 +157,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		backrefID := updated.desc.ID
 		backRefMutable := params.p.Tables().getUncommittedTableByID(backrefID)
 		if backRefMutable == nil {
-			backRefMutable = NewMutableTableDescriptor(*updated.desc, *updated.desc)
+			backRefMutable = NewMutableExistingTableDescriptor(*updated.desc)
 		}
 		for _, dep := range updated.deps {
 			// The logical plan constructor merely registered the dependencies.

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -198,11 +198,10 @@ func (p *planner) getTableScanByRef(
 	indexFlags *tree.IndexFlags,
 	scanVisibility scanVisibility,
 ) (planDataSource, error) {
-	flags := ObjectLookupFlags{CommonLookupFlags{
+	flags := ObjectLookupFlags{CommonLookupFlags: CommonLookupFlags{
 		txn:         p.txn,
 		avoidCached: p.avoidCachedDescriptors,
-	},
-	}
+	}}
 	desc, err := p.Tables().getTableVersionByID(ctx, sqlbase.ID(tref.TableID), flags)
 	if err != nil {
 		return planDataSource{}, errors.Wrapf(err, "%s", tree.ErrString(tref))

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -123,17 +123,7 @@ func (p *planner) createDescriptorWithID(
 	b.CPut(idKey, descID, nil)
 	b.CPut(descKey, descDesc, nil)
 
-	isTable := false
-	var mutDesc *sqlbase.MutableTableDescriptor
-	switch d := descriptor.(type) {
-	case *sqlbase.MutableTableDescriptor:
-		mutDesc = d
-		isTable = true
-	case *sqlbase.TableDescriptor:
-		mutDesc = NewMutableTableDescriptor(*d, sqlbase.TableDescriptor{})
-		isTable = true
-	}
-
+	mutDesc, isTable := descriptor.(*sqlbase.MutableTableDescriptor)
 	if isTable {
 		if err := mutDesc.ValidateTable(st); err != nil {
 			return err

--- a/pkg/sql/logical_schema_accessors.go
+++ b/pkg/sql/logical_schema_accessors.go
@@ -70,6 +70,9 @@ func (l *LogicalSchemaAccessor) GetObjectDesc(
 	if scEntry, ok := l.vt.getVirtualSchemaEntry(name.Schema()); ok {
 		tableName := name.Table()
 		if t, ok := scEntry.defs[tableName]; ok {
+			if flags.requireMutable {
+				return NewMutableExistingTableDescriptor(*t.desc), nil, nil
+			}
 			return t.desc, nil, nil
 		}
 		if _, ok := scEntry.allTableNames[tableName]; ok {

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -127,4 +127,6 @@ type DatabaseListFlags struct {
 // ObjectLookupFlags is the flag struct suitable for GetObjectDesc().
 type ObjectLookupFlags struct {
 	CommonLookupFlags
+	// return a MutableTableDeescriptor
+	requireMutable bool
 }

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -178,7 +178,7 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 	for i := range tbNames {
 		tableName := &tbNames[i]
 		objDesc, _, err := p.LogicalSchemaAccessor().GetObjectDesc(
-			tableName, p.ObjectLookupFlags(ctx, true /*required*/))
+			tableName, p.ObjectLookupFlags(ctx, true /*required*/, false /*requireMutable*/))
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/sem/tree/name_resolution_test.go
+++ b/pkg/sql/sem/tree/name_resolution_test.go
@@ -497,7 +497,7 @@ func (fakeResResult) NameResolutionResult() {}
 
 // LookupObject implements the TableNameResolver interface.
 func (f *fakeMetadata) LookupObject(
-	_ context.Context, dbName, scName, tbName string,
+	_ context.Context, requireMutable bool, dbName, scName, tbName string,
 ) (found bool, obMeta tree.NameResolutionResult, err error) {
 	defer func() {
 		f.t.Logf("LookupObject(%s, %s, %s) -> found %v meta %v err %v",
@@ -768,7 +768,7 @@ func TestResolveTablePatternOrName(t *testing.T) {
 					ctPrefix = tpv.Catalog()
 				case *tree.TableName:
 					if tc.expected {
-						found, obMeta, err = tpv.ResolveExisting(ctx, fakeResolver, tc.curDb, tc.searchPath)
+						found, obMeta, err = tpv.ResolveExisting(ctx, fakeResolver, false /*requireMutable*/, tc.curDb, tc.searchPath)
 					} else {
 						found, scMeta, err = tpv.ResolveTarget(ctx, fakeResolver, tc.curDb, tc.searchPath)
 					}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -191,7 +191,7 @@ func (p *planner) truncateTable(
 		return err
 	}
 	tableDesc.DropJobID = dropJobID
-	newTableDesc := NewMutableTableDescriptor(tableDesc.TableDescriptor, sqlbase.TableDescriptor{})
+	newTableDesc := NewMutableCreatedTableDescriptor(tableDesc.TableDescriptor)
 	newTableDesc.ReplacementOf = sqlbase.TableDescriptor_Replacement{
 		ID: id, Time: p.txn.CommitTimestamp(),
 	}


### PR DESCRIPTION
This change sets up users of the descriptor resolution API to
clearly request a MutableTableDescriptor using a flag. It allows
the implementation for reading a TableDescriptor to be split away
from the one reading a MutableTableDescriptor. MutableTableDescriptor
is now created where it's needed.

The avoidCache flag now only affects the implementation of reading
a TableDescriptor, and can be used where transactions need to read
a const TableDescriptor from the store.

Release note: None