### PR TITLE
opt: add regression test for using ROWS FROM with non-function

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -196,3 +196,11 @@ EXPLAIN (VERBOSE) SELECT
   jsonb_array_elements( (SELECT gg.data->'members' FROM groups gg WHERE gg.data->>'name' = g.data->>'name') )
 FROM
   groups g
+
+# Regression test for #32162.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM ROWS FROM (IF(length('abc') = length('def'), 1, 0))
+----
+project set    ·         ·  ("if")  ·
+ │             render 0  1  ·       ·
+ └── emptyrow  ·         ·  ()      ·


### PR DESCRIPTION
This commit adds a regression test for a panic in the execbuilder
caused by using a non-function expression such as `CAST` or `IF` with
`ROWS FROM`. The panic was already fixed in the master branch, but
was not fixed in the 2.1 release branch. PR #32168 fixes the panic
for the 2.1 release branch. This PR adds a regression test to master
to ensure the panic does not re-emerge.

Fixes #32162

Release note: None