### PR TITLE
release-2.1: opt: fix panic when ROWS FROM used with non-function

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -922,9 +922,9 @@ func (b *Builder) initZipBuild(
 			return nil, nil, nil, opt.ColMap{}, err
 		}
 
-		props := child.Private().(*memo.FuncOpDef).Properties
-		if props.Class == tree.GeneratorClass {
-			numColsPerGen[i] = len(props.ReturnLabels)
+		if def, ok := child.Private().(*memo.FuncOpDef); ok &&
+			def.Properties.Class == tree.GeneratorClass {
+			numColsPerGen[i] = len(def.Properties.ReturnLabels)
 		} else {
 			numColsPerGen[i] = 1
 		}

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -252,3 +252,11 @@ limit                                 ·            ·                          
                           └── scan    ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·
 ·                                     table        articles@primary           ·                                                                                        ·
 ·                                     spans        ALL                        ·                                                                                        ·
+
+# Regression test for #32162.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM ROWS FROM (IF(length('abc') = length('def'), 1, 0))
+----
+project set    ·         ·  ("if")  ·
+ │             render 0  1  ·       ·
+ └── emptyrow  ·         ·  ()      ·


### PR DESCRIPTION
Prior to this patch, the execbuilder was assuming that any expression
inside a ROWS FROM clause was a function. This caused a panic when a
non-function expression such as CAST or IF was used with ROWS FROM.
This commit fixes that assumption.

Fixes #32162

Release note (bug fix): Fixed a panic caused by an incorrect assumption
in the SQL optimizer code that ROWS FROM clauses contain only functions.