### PR TITLE
opt: fix column equivalency groups in required orderings

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -764,11 +764,13 @@ CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z,y))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyz WHERE z=1 AND x=y ORDER BY x;
 ----
-filter           ·       ·                (x, y, z)              +x
- │               filter  x = y            ·                      ·
- └── index-join  ·       ·                (x, y, z)              +x
-      ├── scan   ·       ·                (y, z, rowid[hidden])  +y
-      │          table   xyz@xyz_z_y_idx  ·                      ·
-      │          spans   /1/!NULL-/2      ·                      ·
-      └── scan   ·       ·                (x, y, z)              ·
-·                table   xyz@primary      ·                      ·
+sort                  ·       ·                (x, y, z)              +x
+ │                    order   +x               ·                      ·
+ └── filter           ·       ·                (x, y, z)              ·
+      │               filter  x = y            ·                      ·
+      └── index-join  ·       ·                (x, y, z)              ·
+           ├── scan   ·       ·                (y, z, rowid[hidden])  ·
+           │          table   xyz@xyz_z_y_idx  ·                      ·
+           │          spans   /1/!NULL-/2      ·                      ·
+           └── scan   ·       ·                (x, y, z)              ·
+·                     table   xyz@primary      ·                      ·

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -32,7 +32,7 @@ limit
  ├── columns: d:4(int) e:5(int)
  ├── internal-ordering: +4,+5
  ├── cardinality: [0 - 10]
- ├── ordering: +4,+5 opt(6)
+ ├── ordering: +4,+5
  ├── sort
  │    ├── columns: d:4(int) e:5(int)
  │    ├── ordering: +4,+5

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -924,7 +924,7 @@ select
  │    │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(2,4)
- │    │    │    └── ordering: +(1|2)
+ │    │    │    └── ordering: +1
  │    │    └── filters
  │    │         └── i = k [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
  │    └── aggregations

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -39,7 +39,7 @@ sort
  ├── side-effects
  ├── key: (1)
  ├── fd: (1)-->(2-5,7)
- ├── ordering: +7 opt(6)
+ ├── ordering: +7
  └── project
       ├── columns: column7:7(float) k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
       ├── side-effects

--- a/pkg/sql/opt/ordering/project_test.go
+++ b/pkg/sql/opt/ordering/project_test.go
@@ -66,8 +66,8 @@ func TestProject(t *testing.T) {
 	for _, tc := range testCases {
 		req := props.ParseOrderingChoice(tc.req)
 		res := "no"
-		if CanProvide(project, &req) {
-			res = BuildChildRequired(project, &req, 0).String()
+		if projectCanProvideOrdering(project, &req) {
+			res = projectBuildChildReqOrdering(project, &req, 0).String()
 		}
 		if res != tc.exp {
 			t.Errorf("req: %s  expected: %s  got: %s\n", tc.req, tc.exp, res)

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -15,13 +15,10 @@
 package xform
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/ordering"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // canProvidePhysicalProps returns true if the given expression can provide the
@@ -60,15 +57,6 @@ func (o *Optimizer) buildChildPhysicalProps(
 	}
 
 	childProps.Ordering = ordering.BuildChildRequired(parent, &parentProps.Ordering, nth)
-
-	// RaceEnabled ensures that checks are run on every change (as part of make
-	// testrace) while keeping the check code out of non-test builds.
-	if util.RaceEnabled && !childProps.Ordering.Any() {
-		outCols := parent.Child(nth).(memo.RelExpr).Relational().OutputCols
-		if !childProps.Ordering.SubsetOfCols(outCols) {
-			panic(fmt.Sprintf("OrderingChoice refers to non-output columns (op: %s)", parent.Op()))
-		}
-	}
 
 	// If properties haven't changed, no need to re-intern them.
 	if childProps.Equals(parentProps) {

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -861,10 +861,10 @@ memo (optimized, ~8KB, required=[presentation: array_agg:5])
  ├── G3: (projections)
  ├── G4: (select G6 G7) (select G8 G7) (select G9 G7)
  │    ├── [ordering: +(2|3),+4]
- │    │    ├── best: (select G9="[ordering: +(2|3),+4]" G7)
- │    │    └── cost: 1079.10
+ │    │    ├── best: (sort G4)
+ │    │    └── cost: 1080.01
  │    ├── [ordering: +(2|3)]
- │    │    ├── best: (select G8="[ordering: +(2|3)]" G7)
+ │    │    ├── best: (select G8="[ordering: +2]" G7)
  │    │    └── cost: 1079.10
  │    ├── [ordering: +4,+(2|3)]
  │    │    ├── best: (sort G4)
@@ -874,40 +874,40 @@ memo (optimized, ~8KB, required=[presentation: array_agg:5])
  │         └── cost: 1079.10
  ├── G5: (aggregations G10)
  ├── G6: (scan kuvw) (scan kuvw@uvw) (scan kuvw@wvu) (scan kuvw@vw) (scan kuvw@w)
- │    ├── [ordering: +(2|3),+4]
- │    │    ├── best: (scan kuvw@vw)
- │    │    └── cost: 1080.00
- │    ├── [ordering: +(2|3)]
+ │    ├── [ordering: +2,+4]
+ │    │    ├── best: (sort G6)
+ │    │    └── cost: 1310.28
+ │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw)
  │    │    └── cost: 1080.00
- │    ├── [ordering: +4,+(2|3)]
- │    │    ├── best: (scan kuvw@wvu)
- │    │    └── cost: 1080.00
+ │    ├── [ordering: +4,+2]
+ │    │    ├── best: (sort G6)
+ │    │    └── cost: 1310.28
  │    └── []
  │         ├── best: (scan kuvw)
  │         └── cost: 1080.00
  ├── G7: (filters G11)
  ├── G8: (scan kuvw@uvw,constrained)
- │    ├── [ordering: +(2|3),+4]
+ │    ├── [ordering: +2,+4]
  │    │    ├── best: (sort G8)
  │    │    └── cost: 1296.88
- │    ├── [ordering: +(2|3)]
+ │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw,constrained)
  │    │    └── cost: 1069.20
- │    ├── [ordering: +4,+(2|3)]
+ │    ├── [ordering: +4,+2]
  │    │    ├── best: (sort G8)
  │    │    └── cost: 1296.88
  │    └── []
  │         ├── best: (scan kuvw@uvw,constrained)
  │         └── cost: 1069.20
  ├── G9: (scan kuvw@vw,constrained)
- │    ├── [ordering: +(2|3),+4]
- │    │    ├── best: (scan kuvw@vw,constrained)
- │    │    └── cost: 1069.20
- │    ├── [ordering: +(2|3)]
- │    │    ├── best: (scan kuvw@vw,constrained)
- │    │    └── cost: 1069.20
- │    ├── [ordering: +4,+(2|3)]
+ │    ├── [ordering: +2,+4]
+ │    │    ├── best: (sort G9)
+ │    │    └── cost: 1296.88
+ │    ├── [ordering: +2]
+ │    │    ├── best: (sort G9)
+ │    │    └── cost: 1286.04
+ │    ├── [ordering: +4,+2]
  │    │    ├── best: (sort G9)
  │    │    └── cost: 1296.88
  │    └── []
@@ -934,7 +934,7 @@ memo (optimized, ~8KB, required=[presentation: sum:5])
  ├── G3: (projections)
  ├── G4: (select G6 G7) (select G8 G7) (select G9 G7)
  │    ├── [ordering: +(2|3)]
- │    │    ├── best: (select G8="[ordering: +(2|3)]" G7)
+ │    │    ├── best: (select G8="[ordering: +2]" G7)
  │    │    └── cost: 1079.10
  │    ├── [ordering: +4]
  │    │    ├── best: (sort G4)
@@ -944,7 +944,7 @@ memo (optimized, ~8KB, required=[presentation: sum:5])
  │         └── cost: 1079.10
  ├── G5: (aggregations G10)
  ├── G6: (scan kuvw) (scan kuvw@uvw) (scan kuvw@wvu) (scan kuvw@vw) (scan kuvw@w)
- │    ├── [ordering: +(2|3)]
+ │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw)
  │    │    └── cost: 1080.00
  │    ├── [ordering: +4]
@@ -955,7 +955,7 @@ memo (optimized, ~8KB, required=[presentation: sum:5])
  │         └── cost: 1080.00
  ├── G7: (filters G11)
  ├── G8: (scan kuvw@uvw,constrained)
- │    ├── [ordering: +(2|3)]
+ │    ├── [ordering: +2]
  │    │    ├── best: (scan kuvw@uvw,constrained)
  │    │    └── cost: 1069.20
  │    ├── [ordering: +4]
@@ -965,9 +965,9 @@ memo (optimized, ~8KB, required=[presentation: sum:5])
  │         ├── best: (scan kuvw@uvw,constrained)
  │         └── cost: 1069.20
  ├── G9: (scan kuvw@vw,constrained)
- │    ├── [ordering: +(2|3)]
- │    │    ├── best: (scan kuvw@vw,constrained)
- │    │    └── cost: 1069.20
+ │    ├── [ordering: +2]
+ │    │    ├── best: (sort G9)
+ │    │    └── cost: 1286.04
  │    ├── [ordering: +4]
  │    │    ├── best: (sort G9)
  │    │    └── cost: 1286.04

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -653,39 +653,6 @@ inner-join (merge)
  └── filters
       └── a = y [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
-# Verify that the required orderings are simplified: the equality columns are
-# (u,t)=(x,z) but we are able to utilize indexes on s,t,u and y,z.
-opt
-SELECT * FROM (SELECT * FROM stu WHERE s = u) FULL OUTER JOIN (SELECT * FROM xyz WHERE x = y) ON u=x AND t=z
-----
-full-join (merge)
- ├── columns: s:1(int) t:2(int) u:3(int) x:4(int) y:5(int) z:6(int)
- ├── left ordering: +3,+2
- ├── right ordering: +4,+6
- ├── fd: (1)==(3), (3)==(1), (4)==(5), (5)==(4)
- ├── select
- │    ├── columns: s:1(int!null) t:2(int!null) u:3(int!null)
- │    ├── key: (2,3)
- │    ├── fd: (1)==(3), (3)==(1)
- │    ├── ordering: +(1|3),+2
- │    ├── scan stu
- │    │    ├── columns: s:1(int!null) t:2(int!null) u:3(int!null)
- │    │    ├── key: (1-3)
- │    │    └── ordering: +(1|3),+2
- │    └── filters
- │         └── s = u [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
- ├── select
- │    ├── columns: x:4(int!null) y:5(int!null) z:6(int)
- │    ├── fd: (4)==(5), (5)==(4)
- │    ├── ordering: +(4|5),+6
- │    ├── scan xyz@yz
- │    │    ├── columns: x:4(int) y:5(int!null) z:6(int)
- │    │    ├── constraint: /5/6/7: (/NULL - ]
- │    │    └── ordering: +(4|5),+6
- │    └── filters
- │         └── x = y [type=bool, outer=(4,5), constraints=(/4: (/NULL - ]; /5: (/NULL - ]), fd=(4)==(5), (5)==(4)]
- └── filters (true)
-
 # Verify multiple merge-joins can be chained.
 opt
 SELECT * FROM abc JOIN xyz ON a=x AND b=y RIGHT OUTER JOIN stu ON a=s


### PR DESCRIPTION
`OrderingChoice` requires that the columns in a `Group` are
equivalent. In particular, this is required for `Simplify` to work
correctly: for example, if we have `+a,+(b|k),+c` and `k` is a key,
the ordering gets simplified to `+a,+(b|k)`. If `b` and `k` are not
equal, the operator might provide ordering `+a,+b` which is weaker
than the original ordering; consider rows
```
a b c k
1 1 2 2
1 1 1 1
```

This requirement is violated under a Select with an equality filter.
Consider `SELECT a,b,c FROM t WHERE a=b ORDER BY a`. At the level of
the Select, the required ordering is `+(a|b)`; but if we pass this
down to the Scan unchanged, the columns are not equal (at the level of
that operator).

Violating this requirement can lead to problems determining an
ordering for DistSQL: we could be scanning an index on `a,b` but try
to "maintain" a `+b` ordering which would be incorrect (at the level
of the scan). Fortunately, in practice this does not currently lead to
problems because any filtering always happens on the node that is
generating the data.

This change fixes this issue by trimming down column groups under a
Select. We choose an arbitrary subset of each group that has only
equivalent columns. While this can lead to worse plans in some cases,
equality filters that are not pushed down are rare in practice.

We also add more race-only sanity checks on required orderings. This
found a problem with the `PruneRootCols` rule which now also removes
the pruned columns from the root required ordering.

Release note: None