### PR TITLE
opt: separate bestProps in exprGroup

### DIFF
--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -73,6 +73,10 @@ type RelExpr interface {
 	// the first member of the group.
 	group() exprGroup
 
+	// bestProps returns the instance of bestProps associated with this
+	// expression.
+	bestProps() *bestProps
+
 	// setNext sets this expression's next pointer to point to the given
 	// expression. setNext will panic if the next pointer has already been set.
 	setNext(e RelExpr)

--- a/pkg/sql/opt/memo/group.go
+++ b/pkg/sql/opt/memo/group.go
@@ -37,15 +37,23 @@ type exprGroup interface {
 	// relational are the relational properties shared by members of the group.
 	relational() *props.Relational
 
-	// physical are the physical properties with respect to which this group was
-	// optimized. This is nil before optimization is complete.
-	physical() *props.Physical
+	// bestProps returns a per-group instance of bestProps. This is the zero
+	// value until optimization is complete.
+	bestProps() *bestProps
+}
 
-	// cost is the estimated execution cost of the best (i.e. lowest cost)
-	// expression in the group. This is 0 before optimization is complete.
-	cost() Cost
+// bestProps contains the properties of the "best" expression in group. The best
+// expression is the expression which is part of the lowest-cost tree for the
+// overall query. It is well-defined because the lowest-cost tree does not
+// contain multiple expressions from the same group.
+//
+// These are not properties of the group per se but they are stored within each
+// group for efficiency.
+type bestProps struct {
+	// Required properties with respect to which the best expression was
+	// optimized.
+	required *props.Physical
 
-	// setBestProps is called at the end of optimization to update the physical
-	// props and cost of the best expression in the group.
-	setBestProps(physical *props.Physical, cost Cost)
+	// Cost of the best expression.
+	cost Cost
 }

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -304,16 +304,9 @@ func (m *Memo) SetBestProps(e RelExpr, phys *props.Physical, cost Cost) {
 		}
 		return
 	}
-
-	// Enforcer expressions keep their own copy of physical properties and cost.
-	switch t := e.(type) {
-	case *SortExpr:
-		t.phys = phys
-		t.cst = cost
-
-	default:
-		e.group().setBestProps(phys, cost)
-	}
+	bp := e.bestProps()
+	bp.required = phys
+	bp.cost = cost
 }
 
 // IsOptimized returns true if the memo has been fully optimized.

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -116,15 +116,19 @@ func (e *ProjectExpr) NextExpr() RelExpr {
 }
 
 func (e *ProjectExpr) Physical() *props.Physical {
-	return e.grp.physical()
+	return e.grp.bestProps().required
 }
 
 func (e *ProjectExpr) Cost() Cost {
-	return e.grp.cost()
+	return e.grp.bestProps().cost
 }
 
 func (e *ProjectExpr) group() exprGroup {
 	return e.grp
+}
+
+func (e *ProjectExpr) bestProps() *bestProps {
+	return e.grp.bestProps()
 }
 
 func (e *ProjectExpr) setNext(member RelExpr) {
@@ -145,9 +149,8 @@ func (e *ProjectExpr) setGroup(member RelExpr) {
 type projectGroup struct {
 	mem   *Memo
 	rel   props.Relational
-	phys  *props.Physical
-	cst   Cost
 	first ProjectExpr
+	best  bestProps
 }
 
 var _ exprGroup = &projectGroup{}
@@ -160,21 +163,12 @@ func (g *projectGroup) relational() *props.Relational {
 	return &g.rel
 }
 
-func (g *projectGroup) physical() *props.Physical {
-	return g.phys
-}
-
 func (g *projectGroup) firstExpr() RelExpr {
 	return &g.first
 }
 
-func (g *projectGroup) cost() Cost {
-	return g.cst
-}
-
-func (g *projectGroup) setBestProps(physical *props.Physical, cost Cost) {
-	g.phys = physical
-	g.cst = cost
+func (g *projectGroup) bestProps() *bestProps {
+	return &g.best
 }
 
 type ProjectionsExpr []ProjectionsItem
@@ -275,8 +269,7 @@ type ColPrivate struct {
 
 type SortExpr struct {
 	Input RelExpr
-	phys  *props.Physical
-	cst   Cost
+	best  bestProps
 }
 
 func (e *SortExpr) Op() opt.Operator {
@@ -329,11 +322,15 @@ func (e *SortExpr) NextExpr() RelExpr {
 }
 
 func (e *SortExpr) Physical() *props.Physical {
-	return e.phys
+	return e.best.required
 }
 
 func (e *SortExpr) Cost() Cost {
-	return e.cst
+	return e.best.cost
+}
+
+func (e *SortExpr) bestProps() *bestProps {
+	return &e.best
 }
 
 func (e *SortExpr) group() exprGroup {


### PR DESCRIPTION
The "best expression" descriptions in exprGroup are a bit misleading:
it is not the lowest-cost expression in the group (which is not even a
thing because expressions have costs only in the context of specific
required props) but the expression that appears in the lowest-cost
tree.

This change separates these properties into a `bestProps` struct
and clarifies the comments. `RelExpr` now contains a `bestProps()`
method.

Release note: None