### PR TITLE
release-2.1: sql: skip removed nodes in crdb_internal.gossip_nodes

### DIFF
--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -345,9 +345,8 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 		InitialBackoff: time.Second,
 		MaxBackoff:     5 * time.Second,
 		Multiplier:     1,
-		MaxRetries:     20,
 	}
-	for r := retry.Start(retryOpts); r.Next(); {
+	if err := retry.WithMaxAttempts(ctx, retryOpts, 20, func() error {
 		o, err := decommission(ctx, 2, c.Node(1),
 			"decommission", "--wait", "none", "--format", "csv")
 		if err != nil {
@@ -360,10 +359,9 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 			decommissionFooter,
 		}
 
-		if err := matchCSV(o, exp); err != nil {
-			continue
-		}
-		break
+		return matchCSV(o, exp)
+	}); err != nil {
+		t.Fatal(err)
 	}
 
 	// Check that even though the node is decommissioned, we still see it (since
@@ -595,6 +593,34 @@ func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
 			continue
 		}
 		break
+	}
+
+	// Wipe data of node 1 and start it as a new node.
+	// It will join the cluster with a node id of 5.
+	// This is done to verify that node status works when a new node is started
+	// with an address belonging to an old decommissioned node.
+	{
+		c.Wipe(ctx, c.Node(1))
+		c.Start(ctx, c.Node(1), startArgs(fmt.Sprintf("-a=--join %s",
+			c.InternalAddr(ctx, c.Node(2))[0])))
+	}
+
+	if err := retry.WithMaxAttempts(ctx, retryOpts, 20, func() error {
+		o, err := execCLI(ctx, 2, "node", "status", "--format", "csv")
+		if err != nil {
+			t.Fatalf("node-status failed: %v", err)
+		}
+
+		exp := [][]string{
+			statusHeader,
+			{`2`, `.*`, `.*`, `.*`, `.*`, `.*`, `.*`},
+			{`3`, `.*`, `.*`, `.*`, `.*`, `.*`, `.*`},
+			{`4`, `.*`, `.*`, `.*`, `.*`, `.*`, `.*`},
+			{`5`, `.*`, `.*`, `.*`, `.*`, `.*`, `.*`},
+		}
+		return matchCSV(o, exp)
+	}); err != nil {
+		t.Fatal(err)
 	}
 
 	if err := retry.ForDuration(time.Minute, func() error {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1777,7 +1777,12 @@ CREATE TABLE crdb_internal.gossip_nodes (
 			if err := protoutil.Unmarshal(bytes, &d); err != nil {
 				return errors.Wrapf(err, "failed to parse value for key %q", key)
 			}
-			descriptors = append(descriptors, d)
+
+			// Don't use node descriptors with NodeID 0, because that's meant to
+			// indicate that the node has been removed from the cluster.
+			if d.NodeID != 0 {
+				descriptors = append(descriptors, d)
+			}
 			return nil
 		}); err != nil {
 			return err


### PR DESCRIPTION
Removed nodes have empty info proto. Skip them while processing
rows in crdb_internal.gossip_nodes

Fixes #31696

Release note (bug fix): Fix an error returned by node status after
a new node is added to the cluster at a previous node's address.