### PR TITLE
roachtest: give clearrange a 90m timeout

### DIFF
--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -27,6 +27,7 @@ func registerClearRange(r *registry) {
 	for _, checks := range []bool{true, false} {
 		r.Add(testSpec{
 			Name:       fmt.Sprintf(`clearrange/checks=%t`, checks),
+			Timeout:    90 * time.Minute,
 			MinVersion: `v2.1.0`,
 			Nodes:      nodes(10),
 			Stable:     true, // DO NOT COPY to new tests


### PR DESCRIPTION
The clearrange/* tests pass in ~1h, but periodically they never
finish. Don't let them suck up resources for hours.

Release note: None