### PR TITLE
backport-2.1: sql: deflake TestIdleCancelSession

### DIFF
--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -302,7 +302,7 @@ func testCancelSession(t *testing.T, hasActiveSession bool) {
 	}
 
 	// Wait for node 2 to know about both sessions.
-	if err := retry.ForDuration(250*time.Millisecond, func() error {
+	if err := retry.ForDuration(10*time.Second, func() error {
 		rows, err := conn2.QueryContext(ctx, "SHOW CLUSTER SESSIONS")
 		if err != nil {
 			return err


### PR DESCRIPTION
Backport 1/1 commits from #31953.

See https://github.com/cockroachdb/cockroach/issues/32119#issuecomment-435416631

Fixes #32119.


/cc @cockroachdb/release

---

250ms is insufficient to wait for an event to happen under stress or
stressrace testing.

Fixes #31916

Release note: None
