### PR TITLE
backport-2.1: opt,sql: fix correctness with JSON normalization

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -106,7 +106,9 @@ INSERT INTO foo VALUES
   ('1.000'),
   ('true'),
   ('false'),
-  (NULL)
+  (NULL),
+  ('{"x": [1, 2, 3]}'),
+  ('{"x": {"y": "z"}}')
 
 query T rowsort
 SELECT bar FROM foo
@@ -118,6 +120,8 @@ SELECT bar FROM foo
 true
 false
 NULL
+{"x": [1, 2, 3]}
+{"x": {"y": "z"}}
 
 query T
 SELECT bar FROM foo WHERE bar->>'a' = 'b'
@@ -175,6 +179,16 @@ NULL
 NULL
 NULL
 NULL
+NULL
+NULL
+
+query T
+SELECT * from foo where bar->'x' = '[1]'
+----
+
+query T
+SELECT * from foo where bar->'x' = '{}'
+----
 
 statement ok
 DELETE FROM foo

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -170,9 +170,8 @@
 # NormalizeJSONFieldAccess transforms field access into a containment with a
 # simpler LHS. This allows inverted index constraints to be generated in some
 # cases.
-# The FetchVal operator also has a version with
-# integers instead of strings, but this transformation is not valid in that
-# case.
+# The FetchVal operator also has an overload with integers instead of strings,
+# but this transformation is not valid in that case.
 # This transforms
 #
 #   a->'b' = '"c"'
@@ -181,13 +180,18 @@
 #
 #   a @> '{"b": "c"}'
 #
+# Note that we can't make this transformation in cases like
+#
+#   a->'b' = '["c"]',
+#
+# because containment is not equivalent to equality for non-scalar types.
 [NormalizeJSONFieldAccess, Normalize]
 (Eq
-  (FetchVal
-    $val:*
-    $key:(Const) & (IsString $key)
-  )
-  $right:(Const)
+    (FetchVal
+        $val:*
+        $key:(Const) & (IsString $key)
+    )
+    $right:(Const) & (IsJSONScalar $right)
 )
 =>
 (Contains

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -519,6 +519,19 @@ select
  └── filters [type=bool, outer=(5)]
       └── (j->'a') @> '"b"' [type=bool, outer=(5)]
 
+# The transformation is not valid in this case, since containment doesn't imply
+# equality for non-scalars.
+opt
+SELECT j->'a' = '["b"]'::JSON, j->'a' = '{"b": "c"}'::JSON FROM a
+----
+project
+ ├── columns: "?column?":7(bool) "?column?":8(bool)
+ ├── scan a
+ │    └── columns: j:5(jsonb)
+ └── projections [outer=(5)]
+      ├── (j->'a') = '["b"]' [type=bool, outer=(5)]
+      └── (j->'a') = '{"b": "c"}' [type=bool, outer=(5)]
+
 # --------------------------------------------------
 # NormalizeJSONContains
 # --------------------------------------------------

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -437,8 +437,19 @@ func (expr *ComparisonExpr) normalize(v *NormalizeVisitor) TypedExpr {
 					break
 				}
 
+				rjson := rhs.(*DJSON).JSON
+				t := rjson.Type()
+				if t == json.ObjectJSONType || t == json.ArrayJSONType {
+					// We can't make this transformation in cases like
+					//
+					//   a->'b' = '["c"]',
+					//
+					// because containment is not equivalent to equality for non-scalar types.
+					break
+				}
+
 				j := json.NewObjectBuilder(1)
-				j.Add(string(*str.(*DString)), rhs.(*DJSON).JSON)
+				j.Add(string(*str.(*DString)), rjson)
 
 				dj, err := MakeDJSON(j.Build())
 				if err != nil {


### PR DESCRIPTION
Prior to this commit, we would normalize expressions of the form
`a->'b' = c` to `a @> {"b": c}` unconditionally. This was valid in many
important cases because containment is equivalent to equality for scalar
values. However, it is *not* valid if `c` is a non-scalar, as this
example illustrates:

`'{"a": [1, 2, 3]}'->'a' = [1]` => `false`
=>
`'{"a": [1, 2, 3]}' @> {"a": [1]}` => `true`

Since this bug was present in 2.0 I think it's not urgent to get it into
2.1.0, but I will target backporting it to 2.1.1.

Release note (bug fix): Fixed a bug that would incorrectly cause JSON
field access equality comparisons to be true when they should be false.