### PR TITLE
sql: separate "main" from "internal" metrics

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -77,9 +77,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/getsentry/raven-go"
+	raven "github.com/getsentry/raven-go"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
@@ -681,9 +681,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			return &ie
 		}
 
-	s.registry.AddMetricStruct(s.pgServer.Metrics())
-	s.registry.AddMetricStruct(s.pgServer.StatementCounters())
-	s.registry.AddMetricStruct(s.pgServer.EngineMetrics())
+	for _, m := range s.pgServer.Metrics() {
+		s.registry.AddMetricStruct(m)
+	}
 	*internalExecutor = sql.MakeInternalExecutor(
 		ctx, s.pgServer.SQLServer, s.internalMemMetrics, s.ClusterSettings(),
 	)

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/diagnosticspb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -976,6 +977,11 @@ func TestStatusAPIStatements(t *testing.T) {
 		if respStatement.Key.KeyData.Failed {
 			// We ignore failed statements here as the INSERT statement can fail and
 			// be automatically retried, confusing the test success check.
+			continue
+		}
+		if strings.HasPrefix(respStatement.Key.KeyData.App, sql.InternalAppNamePrefix) {
+			// We ignore internal queries, these are not relevant for the
+			// validity of this test.
 			continue
 		}
 		statementsInResponse = append(statementsInResponse, respStatement.Key.KeyData.Query)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	"github.com/cockroachdb/circuitbreaker"
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
@@ -593,7 +593,9 @@ func (ts *TestServer) MustGetSQLNetworkCounter(name string) int64 {
 	var found bool
 
 	reg := metric.NewRegistry()
-	reg.AddMetricStruct(ts.pgServer.Metrics())
+	for _, m := range ts.pgServer.Metrics() {
+		reg.AddMetricStruct(m)
+	}
 	reg.Each(func(n string, v interface{}) {
 		if name == n {
 			switch t := v.(type) {

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -655,7 +655,12 @@ func TestReportUsage(t *testing.T) {
 
 	var foundKeys []string
 	for _, s := range r.last.SqlStats {
-		foundKeys = append(foundKeys, fmt.Sprintf("[%v,%v,%v] %s", s.Key.Opt, s.Key.DistSQL, s.Key.Failed, s.Key.Query))
+		if strings.HasPrefix(s.Key.App, sql.InternalAppNamePrefix+"internal") {
+			// Let's ignore all internal queries for this test.
+			continue
+		}
+		foundKeys = append(foundKeys,
+			fmt.Sprintf("[%v,%v,%v] %s", s.Key.Opt, s.Key.DistSQL, s.Key.Failed, s.Key.Query))
 	}
 	sort.Strings(foundKeys)
 	expectedKeys := []string{
@@ -700,6 +705,10 @@ func TestReportUsage(t *testing.T) {
 
 	bucketByApp := make(map[string][]roachpb.CollectedStatementStatistics)
 	for _, s := range r.last.SqlStats {
+		if strings.HasPrefix(s.Key.App, sql.InternalAppNamePrefix+"internal") {
+			// Let's ignore all internal queries for this test.
+			continue
+		}
 		bucketByApp[s.Key.App] = append(bucketByApp[s.Key.App], s)
 	}
 

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -297,11 +297,16 @@ func (s *sqlStats) getUnscrubbedStmtStats(
 	return s.getStmtStats(vt, false /* scrub */)
 }
 
-// InternalAppNamePrefix designates that an application name is internal to
+// InternalAppNamePrefix indicates that the application name is internal to
 // CockroachDB and therefore can be reported without scrubbing. (Note this only
 // applies to the application name itself. Query data is still scrubbed as
 // usual.)
 const InternalAppNamePrefix = "$ "
+
+// DelegatedAppNamePrefix is added to a regular client application name
+// for SQL queries that are ran internally on behalf of other SQL queries
+// inside that application. The application name should be scrubbed in reporting.
+const DelegatedAppNamePrefix = "$$ "
 
 func (s *sqlStats) getStmtStats(
 	vt *VirtualSchemaHolder, scrub bool,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -305,6 +305,15 @@ var (
 	}
 )
 
+func getMetricMeta(meta metric.Metadata, internal bool) metric.Metadata {
+	if internal {
+		meta.Name += ".internal"
+		meta.Help += " (internal queries)"
+		meta.Measurement = "SQL Internal Statements"
+	}
+	return meta
+}
+
 // NodeInfo contains metadata about the executing node and cluster.
 type NodeInfo struct {
 	ClusterID func() uuid.UUID

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -100,12 +100,7 @@ func (ex *connExecutor) recordStatementSummary(
 	automaticRetryCount int,
 	rowsAffected int,
 	err error,
-	m *EngineMetrics,
 ) {
-	if ex.stmtCounterDisabled {
-		return
-	}
-
 	phaseTimes := planner.statsCollector.PhaseTimes()
 
 	// Compute the run latency. This is always recorded in the
@@ -130,6 +125,7 @@ func (ex *connExecutor) recordStatementSummary(
 	execOverhead := svcLat - processingLat
 
 	if automaticRetryCount == 0 {
+		m := &ex.metrics.EngineMetrics
 		if planFlags.IsSet(planFlagOptUsed) {
 			m.SQLOptCount.Inc(1)
 		} else if planFlags.IsSet(planFlagOptFallback) {

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -181,7 +181,8 @@ func (ie *internalExecutorImpl) initConnEx(
 			sp,
 			stmtBuf,
 			clientComm,
-			ie.memMetrics)
+			ie.memMetrics,
+			&ie.s.InternalMetrics)
 	} else {
 		ex, err = ie.s.newConnExecutorWithTxn(
 			ctx,
@@ -190,12 +191,12 @@ func (ie *internalExecutorImpl) initConnEx(
 			clientComm,
 			ie.mon,
 			ie.memMetrics,
+			&ie.s.InternalMetrics,
 			txn)
 	}
 	if err != nil {
 		return nil, nil, err
 	}
-	ex.stmtCounterDisabled = true
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -267,19 +267,15 @@ func (s *Server) IsDraining() bool {
 	return s.mu.draining
 }
 
-// Metrics returns the metrics struct.
-func (s *Server) Metrics() *ServerMetrics {
-	return &s.metrics
-}
-
-// StatementCounters returns the Server's StatementCounters.
-func (s *Server) StatementCounters() *sql.StatementCounters {
-	return &s.SQLServer.StatementCounters
-}
-
-// EngineMetrics returns the Server's EngineMetrics.
-func (s *Server) EngineMetrics() *sql.EngineMetrics {
-	return &s.SQLServer.EngineMetrics
+// Metrics returns the set of metrics structs.
+func (s *Server) Metrics() (res []interface{}) {
+	return []interface{}{
+		&s.metrics,
+		&s.SQLServer.Metrics.StatementCounters,
+		&s.SQLServer.Metrics.EngineMetrics,
+		&s.SQLServer.InternalMetrics.StatementCounters,
+		&s.SQLServer.InternalMetrics.EngineMetrics,
+	}
 }
 
 // Drain prevents new connections from being served and waits for drainWait for


### PR DESCRIPTION
Fixes #32153.
Helps with fixing #32187.

Prior to this patch, both the timeseries and the statement stats for
"internal" queries (leases, system events etc) were completely hidden,
due to a change in v2.1 by @andreimatei in May 2018.

This patch instead changes the behavior to redirect the metric
collection for internal queries into a separate set of metrics:

- separate timeseries counters;
- separate statement stats.

This only pertains to the collection of these stats. The UI page for
"statements" will subsequently allow users to filter on them using the
"application name" drop-down (we should have special app names for
internal queries). However there will not be any graph on the
dashboard for internal queries just yet; these need to be added separately.

Special allowance is made for "internal" queries ran on behalf of
another, client-specified query; for example `select
pg_table_is_visible()`. If the application_name for the outer query is
set, then this patch ensures the internal application name generated
for the inner query will be derived from the outer app name.

For example:

```
root@localhost:26257/defaultdb> select pg_table_is_visible('t'::regclass);
  pg_table_is_visible
+---------------------+
         true
(1 row)

root@localhost:26257/defaultdb> select application_name, substr(key, 1, 50)||'...' as key from crdb_internal.node_statement_statistics;
     application_name     |                          key
+-------------------------+-------------------------------------------------------+
  $ internal-lease-insert | INSERT INTO system.public.lease("descID", version,...
  $ internal-read-setting | SELECT value FROM system.settings WHERE name = $1...
  $ internal-show-version | SHOW CLUSTER SETTING version...
  $$ woo                  | SELECT nspname FROM pg_catalog.pg_class AS c JOIN ...
  $$ woo                  | SELECT pg_class.oid, relname FROM pg_catalog.pg_cl...
  woo                     | SHOW database...
  woo                     | SELECT pg_table_is_visible(_::REGCLASS)...
(7 rows)
```

Release note (sql change): CockroachDB now collects statistics for
statements executed "internally" (for system purposes). This is meant
to facilitate performance troubleshooting.

Release note (ui change): SQL queries issued internally by CockroachDB
are now visible in the statement page. They can be filtered using the
application name.