### PR TITLE
exec: plan the hash joiner

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -1,0 +1,70 @@
+# LogicTest: local local-vec
+
+# Test that the exec HashJoiner follows SQL NULL semantics for ON predicate
+# equivilance. The use of sorts here force the planning of merge join.
+
+statement ok
+SET experimental_vectorize = true;
+
+statement ok
+CREATE TABLE  t1 (k INT PRIMARY KEY, v INT)
+
+statement ok
+INSERT INTO t1 VALUES (0, 4), (2, 1), (5, 4), (3, 4)
+
+statement ok
+CREATE TABLE t2 (x INT PRIMARY KEY, y INT)
+
+statement ok
+INSERT INTO t2 VALUES (1, 3), (4, 6), (0, 5), (3, 2)
+
+statement ok
+CREATE TABLE a (k INT, v INT)
+
+statement ok
+INSERT INTO a VALUES (0, 1), (1, 2), (2, 0)
+
+statement ok
+CREATE TABLE b (a INT, b INT, c STRING)
+
+statement ok
+INSERT INTO b VALUES (0, 1, 'a'), (2, 1, 'b'), (0, 2, 'c')
+
+statement ok
+CREATE TABLE c (a INT, b STRING)
+
+statement ok
+INSERT INTO c VALUES (1, 'a'), (1, 'b'), (2, 'c')
+
+query IIII
+SELECT * FROM t1 JOIN t2 ON t1.k = t2.x
+----
+0  4  0  5
+3  4  3  2
+
+query IIII rowsort
+SELECT * FROM a AS a1 JOIN a AS a2 ON a1.k = a2.v
+----
+0  1  2  0
+1  2  0  1
+2  0  1  2
+
+query IIII rowsort
+SELECT * FROM a AS a2 JOIN a AS a1 ON a1.k = a2.v
+----
+0  1  1  2
+1  2  2  0
+2  0  0  1
+
+query II
+SELECT t2.y, t1.v FROM t1 JOIN t2 ON t1.k = t2.x
+----
+5  4
+2  4
+
+query ITI
+SELECT b.a, b.c, c.a FROM b JOIN c ON b.b = c.a AND b.c = c.b
+----
+0  a  1
+2  b  1
+0  c  2


### PR DESCRIPTION
This adds planning for hash joins to `experimental_vectorize`. Joins in this experiment only work if the left join table is distinct.

```
root@:26257/tpch> set experimental_vectorize=false;                                                                                                                                  SET

Time: 351µs

root@:26257/tpch> select count(*) from supplier join partsupp on ps_suppkey=s_suppkey;                                                                                                 count
+--------+
  800000
(1 row)

Time: 546.155ms

root@:26257/tpch> set experimental_vectorize=true;
SET

Time: 357µs

root@:26257/tpch> select count(*) from supplier join partsupp on ps_suppkey=s_suppkey;                                                                                                 count
+--------+
  800000
(1 row)

Time: 309.745ms
```