### PR TITLE
storage: TestStoreRangeMergeSlowUnabandonedFollower_NoSplit

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -1688,8 +1688,10 @@ func TestStoreRangeMergeSlowUnabandonedFollower_NoSplit(t *testing.T) {
 
 	// Wait for store2 to hear about the split.
 	testutils.SucceedsSoon(t, func() error {
-		_, err := store2.GetReplica(rhsDesc.RangeID)
-		return err
+		if rhsRepl2, err := store2.GetReplica(rhsDesc.RangeID); err != nil || !rhsRepl2.IsInitialized() {
+			return errors.New("store2 has not yet processed split")
+		}
+		return nil
 	})
 
 	// Block Raft traffic to the LHS replica on store2, by holding its raftMu, so


### PR DESCRIPTION
This test needs to wait for a split to occur. Doing so requires waiting
for the right-hand side replica to become initialized, not just to
exist.

Fix #32169.

Release note: None