### PR TITLE
opt: implement Provided orderings

### DIFF
--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -52,7 +52,21 @@ type RelExpr interface {
 	// RequiredPhysical is the set of required physical properties with respect to
 	// which this expression was optimized. Enforcers may be added to the
 	// expression tree to ensure the physical properties are provided.
+	//
+	// Set when optimization is complete, only for the expressions in the final
+	// tree.
 	RequiredPhysical() *physical.Required
+
+	// ProvidedPhysical is the set of provided physical properties (which must be
+	// compatible with the set of required physical properties).
+	//
+	// Set when optimization is complete, only for the expressions in the final
+	// tree.
+	ProvidedPhysical() *physical.Provided
+
+	// Cost is an estimate of the cost of executing this expression tree. Set
+	// when optimization is complete, only for the expressions in the final tree.
+	Cost() Cost
 
 	// FirstExpr returns the first member expression in the memo group (could be
 	// this expression if it happens to be first in the group). Subsequent members
@@ -63,10 +77,6 @@ type RelExpr interface {
 	// NextExpr returns the next member expression in the memo group, or nil if
 	// there are no further members in the group.
 	NextExpr() RelExpr
-
-	// Cost is an estimate of the cost of executing this expression tree. Before
-	// optimization, this cost will always be 0.
-	Cost() Cost
 
 	// group returns the memo group that contains this expression and any other
 	// logically equivalent expressions. There is one group struct for each memo

--- a/pkg/sql/opt/memo/group.go
+++ b/pkg/sql/opt/memo/group.go
@@ -55,6 +55,13 @@ type bestProps struct {
 	// optimized.
 	required *physical.Required
 
+	// Provided properties, which must be compatible with the required properties.
+	//
+	// We store these properties in-place because the structure is very small; if
+	// that changes we will want to intern them, similar to the required
+	// properties.
+	provided physical.Provided
+
 	// Cost of the best expression.
 	cost Cost
 }

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -297,7 +297,7 @@ memo (optimized, ~4KB, required=[presentation: x:7,y:8])
 memo
 SELECT array_agg(x) FROM (SELECT * FROM a)
 ----
-memo (optimized, ~2KB, required=[presentation: array_agg:3])
+memo (optimized, ~3KB, required=[presentation: array_agg:3])
  ├── G1: (scalar-group-by G2 G3 cols=())
  │    └── [presentation: array_agg:3]
  │         ├── best: (scalar-group-by G2 G3 cols=())
@@ -313,7 +313,7 @@ memo (optimized, ~2KB, required=[presentation: array_agg:3])
 memo
 SELECT array_agg(x) FROM (SELECT * FROM a) GROUP BY y
 ----
-memo (optimized, ~2KB, required=[presentation: array_agg:3])
+memo (optimized, ~3KB, required=[presentation: array_agg:3])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:3]
  │         ├── best: (project G2 G3 array_agg)

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -355,13 +355,13 @@ GenerateMergeJoins
          │    ├── columns: k:1(int!null) i:2(int!null) s:4(string)
          │    ├── key: (1)
          │    ├── fd: ()-->(2), (1)-->(4)
-  +      │    ├── ordering: +1 opt(2)
+  +      │    ├── ordering: +1 opt(2) [provided: +1]
          │    ├── scan a
          │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
          │    │    ├── key: (1)
   -      │    │    └── fd: (1)-->(2,4)
   +      │    │    ├── fd: (1)-->(2,4)
-  +      │    │    └── ordering: +1 opt(2)
+  +      │    │    └── ordering: +1 opt(2) [provided: +1]
          │    └── filters
          │         └── i = 9 [type=bool, outer=(2), constraints=(/2: [/9 - /9]; tight), fd=()-->(2)]
   -      └── filters
@@ -389,12 +389,12 @@ GenerateLookupJoins
          │    ├── columns: k:1(int!null) i:2(int!null) s:4(string)
          │    ├── key: (1)
          │    ├── fd: ()-->(2), (1)-->(4)
-  -      │    ├── ordering: +1 opt(2)
+  -      │    ├── ordering: +1 opt(2) [provided: +1]
          │    ├── scan a
          │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
          │    │    ├── key: (1)
   -      │    │    ├── fd: (1)-->(2,4)
-  -      │    │    └── ordering: +1 opt(2)
+  -      │    │    └── ordering: +1 opt(2) [provided: +1]
   +      │    │    └── fd: (1)-->(2,4)
          │    └── filters
          │         └── i = 9 [type=bool, outer=(2), constraints=(/2: [/9 - /9]; tight), fd=()-->(2)]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -847,7 +847,7 @@ project
  │    │    │    │    ├── right ordering: +8
  │    │    │    │    ├── key: (8)
  │    │    │    │    ├── fd: (6)-->(7), (8)-->(9), (6)==(8), (8)==(6)
- │    │    │    │    ├── ordering: +(6|8)
+ │    │    │    │    ├── ordering: +(6|8) [provided: +6]
  │    │    │    │    ├── scan xy
  │    │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    │    ├── key: (6)
@@ -894,7 +894,7 @@ semi-join (merge)
  │    ├── right ordering: +8
  │    ├── key: (8)
  │    ├── fd: (6)-->(7), (8)-->(9), (6)==(8), (8)==(6)
- │    ├── ordering: +(6|8)
+ │    ├── ordering: +(6|8) [provided: +6]
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
@@ -931,7 +931,7 @@ anti-join (merge)
  │    ├── right ordering: +8
  │    ├── key: (8)
  │    ├── fd: (6)-->(7), (8)-->(9), (6)==(8), (8)==(6)
- │    ├── ordering: +(6|8)
+ │    ├── ordering: +(6|8) [provided: +6]
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
@@ -986,7 +986,7 @@ project
       │    │    │    ├── right ordering: +8
       │    │    │    ├── key: (8)
       │    │    │    ├── fd: (6)==(8), (8)==(6)
-      │    │    │    ├── ordering: +(6|8)
+      │    │    │    ├── ordering: +(6|8) [provided: +6]
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:6(int!null)
       │    │    │    │    ├── key: (6)
@@ -2505,7 +2505,7 @@ project
       │    │    ├── columns: x:1(int!null) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string)
       │    │    ├── key: (1,3)
       │    │    ├── fd: (1)-->(2), (3)-->(4-6)
-      │    │    ├── ordering: +5,+6 opt(4)
+      │    │    ├── ordering: +5,+6 opt(4) [provided: +5,+6]
       │    │    └── left-join
       │    │         ├── columns: x:1(int!null) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string)
       │    │         ├── key: (1,3)
@@ -2566,12 +2566,12 @@ semi-join (merge)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
- │    ├── ordering: +1 opt(4)
+ │    ├── ordering: +1 opt(4) [provided: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1 opt(4)
+ │    │    └── ordering: +1 opt(4) [provided: +1]
  │    └── filters
  │         ├── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  │         └── i > 1 [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
@@ -2703,12 +2703,12 @@ anti-join (merge)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
- │    ├── ordering: +1 opt(4)
+ │    ├── ordering: +1 opt(4) [provided: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1 opt(4)
+ │    │    └── ordering: +1 opt(4) [provided: +1]
  │    └── filters
  │         ├── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  │         └── i > 1 [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -172,12 +172,12 @@ right-join (merge)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string!null) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
- │    ├── ordering: +1 opt(4)
+ │    ├── ordering: +1 opt(4) [provided: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1 opt(4)
+ │    │    └── ordering: +1 opt(4) [provided: +1]
  │    └── filters
  │         ├── (i < 0) OR (i > 10) [type=bool, outer=(2)]
  │         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
@@ -226,12 +226,12 @@ semi-join (merge)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string!null) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
- │    ├── ordering: +1 opt(4)
+ │    ├── ordering: +1 opt(4) [provided: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1 opt(4)
+ │    │    └── ordering: +1 opt(4) [provided: +1]
  │    └── filters
  │         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  ├── scan b
@@ -305,12 +305,12 @@ left-join (merge)
  │    ├── columns: k:3(int!null) i:4(int) f:5(float!null) s:6(string!null) j:7(jsonb)
  │    ├── key: (3)
  │    ├── fd: ()-->(6), (3)-->(4,5,7)
- │    ├── ordering: +3 opt(6)
+ │    ├── ordering: +3 opt(6) [provided: +3]
  │    ├── scan a
  │    │    ├── columns: k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
  │    │    ├── key: (3)
  │    │    ├── fd: (3)-->(4-7)
- │    │    └── ordering: +3 opt(6)
+ │    │    └── ordering: +3 opt(6) [provided: +3]
  │    └── filters
  │         ├── (i < 0) OR (i > 10) [type=bool, outer=(4)]
  │         └── s = 'foo' [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight), fd=()-->(6)]
@@ -1965,12 +1965,12 @@ project
       │    ├── columns: x:6(int!null) y:7(int!null)
       │    ├── key: (6)
       │    ├── fd: ()-->(7)
-      │    ├── ordering: +6 opt(7)
+      │    ├── ordering: +6 opt(7) [provided: +6]
       │    ├── scan b
       │    │    ├── columns: x:6(int!null) y:7(int)
       │    │    ├── key: (6)
       │    │    ├── fd: (6)-->(7)
-      │    │    └── ordering: +6 opt(7)
+      │    │    └── ordering: +6 opt(7) [provided: +6]
       │    └── filters
       │         └── y = 10 [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
       └── filters (true)

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -50,12 +50,12 @@ limit
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: ()-->(4,5), (1)-->(2,3), (2,3)~~>(1)
- ├── ordering: +2,+3,+1 opt(4,5)
+ ├── ordering: +2,+3,+1 opt(4,5) [provided: +2,+3,+1]
  ├── sort
  │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int!null) e:5(int!null)
  │    ├── key: (1)
  │    ├── fd: ()-->(4,5), (1)-->(2,3), (2,3)~~>(1)
- │    ├── ordering: +2,+3,+1 opt(4,5)
+ │    ├── ordering: +2,+3,+1 opt(4,5) [provided: +2,+3,+1]
  │    └── select
  │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int!null) e:5(int!null)
  │         ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1557,7 +1557,7 @@ explain
            ├── constraint: /2/3: (/1/NULL - /1]
            ├── key: (1)
            ├── fd: ()-->(2), (1)-->(3), (3)-->(1)
-           └── ordering: +3 opt(2)
+           └── ordering: +3 opt(2) [provided: +3]
 
 # --------------------------------------------------
 # PruneProjectSetCols

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -442,7 +442,7 @@ project
       │    │    ├── right ordering: +5
       │    │    ├── key: (5)
       │    │    ├── fd: (1)-->(2-4), (1)==(5), (5)==(1)
-      │    │    ├── ordering: +(1|5)
+      │    │    ├── ordering: +(1|5) [provided: +1]
       │    │    ├── scan a
       │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
       │    │    │    ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -527,12 +527,12 @@ semi-join (merge)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(2), (1)-->(3-5)
- │    ├── ordering: +1 opt(2)
+ │    ├── ordering: +1 opt(2) [provided: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1 opt(2)
+ │    │    └── ordering: +1 opt(2) [provided: +1]
  │    └── filters
  │         └── i = 0 [type=bool, outer=(2), constraints=(/2: [/0 - /0]; tight), fd=()-->(2)]
  ├── scan xy
@@ -556,12 +556,12 @@ anti-join (merge)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(2), (1)-->(3-5)
- │    ├── ordering: +1 opt(2)
+ │    ├── ordering: +1 opt(2) [provided: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1 opt(2)
+ │    │    └── ordering: +1 opt(2) [provided: +1]
  │    └── filters
  │         └── i = 0 [type=bool, outer=(2), constraints=(/2: [/0 - /0]; tight), fd=()-->(2)]
  ├── scan xy
@@ -919,7 +919,7 @@ select
  │    │    ├── columns: k:1(int!null) i:2(int!null) s:4(string)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(4), (1)==(2), (2)==(1)
- │    │    ├── ordering: +(1|2)
+ │    │    ├── ordering: +(1|2) [provided: +1]
  │    │    ├── scan a
  │    │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
  │    │    │    ├── key: (1)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -245,7 +245,7 @@ define LookupJoinPrivate {
 	# just a LookupCols set indicating which columns we should add from the
 	# index. However, this requires extra Project operators in the lookup join
 	# exploration transforms which currently leads to problems related to lookup
-    # join statistics.
+	# join statistics.
 	Cols ColSet
 
 	lookupProps RelProps

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -334,6 +334,11 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 		fmt.Fprintf(g.w, "  return e.grp.bestProps().required\n")
 		fmt.Fprintf(g.w, "}\n\n")
 
+		// Generate the ProvidedPhysical method.
+		fmt.Fprintf(g.w, "func (e *%s) ProvidedPhysical() *physical.Provided {\n", opTyp.name)
+		fmt.Fprintf(g.w, "  return &e.grp.bestProps().provided\n")
+		fmt.Fprintf(g.w, "}\n\n")
+
 		// Generate the Cost method.
 		fmt.Fprintf(g.w, "func (e *%s) Cost() Cost {\n", opTyp.name)
 		fmt.Fprintf(g.w, "  return e.grp.bestProps().cost\n")
@@ -435,6 +440,11 @@ func (g *exprsGen) genEnforcerFuncs(define *lang.DefineExpr) {
 	// Generate the RequiredPhysical method.
 	fmt.Fprintf(g.w, "func (e *%s) RequiredPhysical() *physical.Required {\n", opTyp.name)
 	fmt.Fprintf(g.w, "  return e.best.required\n")
+	fmt.Fprintf(g.w, "}\n\n")
+
+	// Generate the ProvidedPhysical method.
+	fmt.Fprintf(g.w, "func (e *%s) ProvidedPhysical() *physical.Provided {\n", opTyp.name)
+	fmt.Fprintf(g.w, "  return &e.best.provided\n")
 	fmt.Fprintf(g.w, "}\n\n")
 
 	// Generate the Cost method.

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -120,6 +120,10 @@ func (e *ProjectExpr) RequiredPhysical() *physical.Required {
 	return e.grp.bestProps().required
 }
 
+func (e *ProjectExpr) ProvidedPhysical() *physical.Provided {
+	return &e.grp.bestProps().provided
+}
+
 func (e *ProjectExpr) Cost() Cost {
 	return e.grp.bestProps().cost
 }
@@ -324,6 +328,10 @@ func (e *SortExpr) NextExpr() RelExpr {
 
 func (e *SortExpr) RequiredPhysical() *physical.Required {
 	return e.best.required
+}
+
+func (e *SortExpr) ProvidedPhysical() *physical.Provided {
+	return &e.best.provided
 }
 
 func (e *SortExpr) Cost() Cost {

--- a/pkg/sql/opt/ordering/doc.go
+++ b/pkg/sql/opt/ordering/doc.go
@@ -19,5 +19,55 @@ their children, etc.
 
 The package provides generic APIs that can be called on any RelExpr, as well as
 operator-specific APIs in some cases.
+
+Required orderings
+
+A Required ordering is part of the physical properties with respect to which an
+expression was optimized. It effectively describes a set of orderings, any of
+which are acceptable. See OrderingChoice for more information on how this set is
+represented.
+
+An operator can provide a Required ordering if it can guarantee its results
+respect at least one ordering in the OrderingChoice set, perhaps by requiring
+specific orderings of its inputs and/or configuring its execution in a specific
+way. This package implements the logic that decides whether each operator can
+provide a Required ordering, as well as what Required orderings on its input(s)
+are necessary.
+
+Provided orderings
+
+In a single-node serial execution model, the Required ordering would be
+sufficient to configure execution. But in a distributed setting, even if an
+operator logically has a natural ordering, when multiple instances of that
+operator are running on multiple nodes we must do some extra work (row
+comparisons) to maintain their natural orderings when their results merge into a
+single node. We must know exactly what order must be maintained on the streams
+(i.e. along which columns we should perform the comparisons).
+
+Consider a Scan operator that is scanning an index on a,b. In query:
+  SELECT a, b FROM abc ORDER BY a, b
+the Scan has Required ordering "+a,+b". Now consider another case where (as part
+of some more complicated query) we have the same Scan operator but with Required
+ordering "+b opt(a)"¹, which means that any of "+b", "+b,±a", "±a,+b" are
+acceptable. Execution would still need to be configured with "+a,+b" because
+that is the ordering for the rows that are produced², but this information is
+not available from the Required ordering "+b opt(a)".
+
+¹This could for example happen under a Select with filter "a=1".
+²For example, imagine that node A produces rows (1,4), (2,1) and node B produces
+rows (1,2), (2,3). If these results need to be merged on a single node and we
+configure execution to "maintain" an ordering of +b, it will cause an incorrect
+ordering or a runtime error.
+
+To address this issue, this package implements logic to calculate Provided
+orderings for each expression in the lowest-cost tree. Provided orderings are
+calculated bottom-up, in conjunction with the Required ordering at the level of
+each operator.
+
+The Provided ordering is a specific opt.Ordering which describes the ordering
+produced by the operator, and which intersects the Required OrderingChoice (when
+the operator's FDs are taken into account). A best-effort attempt is made to
+keep the Provided ordering as simple as possible, to minimize the comparisons
+that are necessary to maintain it.
 */
 package ordering

--- a/pkg/sql/opt/ordering/limit.go
+++ b/pkg/sql/opt/ordering/limit.go
@@ -15,6 +15,7 @@
 package ordering
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
@@ -35,4 +36,11 @@ func limitOrOffsetBuildChildReqOrdering(
 		return physical.OrderingChoice{}
 	}
 	return required.Intersection(parent.Private().(*physical.OrderingChoice))
+}
+
+func limitOrOffsetBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt.Ordering {
+	childProvided := expr.Child(0).(memo.RelExpr).ProvidedPhysical().Ordering
+	// The child's provided ordering satisfies both <required> and the
+	// Limit/Offset internal ordering; it may need to be trimmed.
+	return trimProvided(childProvided, required, &expr.Relational().FuncDeps)
 }

--- a/pkg/sql/opt/ordering/lookup_join_test.go
+++ b/pkg/sql/opt/ordering/lookup_join_test.go
@@ -1,0 +1,122 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ordering
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+func TestLookupJoinProvided(t *testing.T) {
+	tc := testcat.New()
+	if _, err := tc.ExecuteDDL(
+		"CREATE TABLE t (c1 INT, c2 INT, c3 INT, c4 INT, PRIMARY KEY(c1, c2))",
+	); err != nil {
+		t.Fatal(err)
+	}
+	evalCtx := tree.NewTestingEvalContext(nil /* st */)
+	var f norm.Factory
+	f.Init(evalCtx)
+	md := f.Metadata()
+	tab := md.AddTable(tc.Table(tree.NewUnqualifiedTableName("t")))
+
+	if c1 := tab.ColumnID(0); c1 != 1 {
+		t.Fatalf("unexpected ID for column c1: %d\n", c1)
+	}
+
+	c := func(cols ...int) opt.ColSet {
+		return util.MakeFastIntSet(cols...)
+	}
+
+	testCases := []struct {
+		keyCols  opt.ColList
+		outCols  opt.ColSet
+		required string
+		input    string
+		provided string
+	}{
+		// In these tests, the input (left side of the join) has columns 5,6 and the
+		// table (right side) has columns 1,2,3,4 and the join has condition
+		// (c5, c6) = (c1, c2).
+		//
+		{ // case 1: the lookup join adds columns 3,4 from the table and retains the
+			// input columns.
+			keyCols:  opt.ColList{5, 6},
+			outCols:  c(3, 4, 5, 6),
+			required: "+5,+6",
+			input:    "+5,+6",
+			provided: "+5,+6",
+		},
+		{ // case 2: the lookup join produces all columns. The provided ordering
+			// on 5,6 is equivalent to an ordering on 1,2.
+			keyCols:  opt.ColList{5, 6},
+			outCols:  c(1, 2, 3, 4, 5, 6),
+			required: "-1,+2",
+			input:    "-5,+6",
+			provided: "-5,+6",
+		},
+		{ // case 3: the lookup join does not produce input columns 5,6; we must
+			// remap the input ordering to refer to output columns 1,2 instead.
+			keyCols:  opt.ColList{5, 6},
+			outCols:  c(1, 2, 3, 4),
+			required: "+1,-2",
+			input:    "+5,-6",
+			provided: "+1,-2",
+		},
+		{ // case 4: a hybrid of the two cases above (we need to remap column 6).
+			keyCols:  opt.ColList{5, 6},
+			outCols:  c(1, 2, 3, 4, 5),
+			required: "-1,-2",
+			input:    "-5,-6",
+			provided: "-5,-2",
+		},
+	}
+
+	for tcIdx, tc := range testCases {
+		t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
+			input := &testexpr.Instance{
+				Rel: &props.Relational{},
+				Provided: &physical.Provided{
+					Ordering: parseOrdering(tc.input),
+				},
+			}
+			lookupJoin := f.Memo().MemoizeLookupJoin(
+				input,
+				nil, /* FiltersExpr */
+				&memo.LookupJoinPrivate{
+					Table:   tab,
+					Index:   opt.PrimaryIndex,
+					KeyCols: tc.keyCols,
+					Cols:    tc.outCols,
+				},
+			)
+			req := physical.ParseOrderingChoice(tc.required)
+			res := lookupJoinBuildProvided(lookupJoin, &req).String()
+			if res != tc.provided {
+				t.Errorf("expected '%s', got '%s'", tc.provided, res)
+			}
+		})
+	}
+}

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
@@ -48,12 +49,44 @@ func BuildChildRequired(
 	return result
 }
 
+// BuildProvided returns a specific ordering that the operator provides (and which
+// must be maintained on the results during distributed execution).
+//
+// The returned ordering, in conjunction with the operator's functional
+// dependencies, must intersect the required ordering.
+//
+// A best-effort attempt is made to make the provided orderings as simple as
+// possible (while still satisfying the required ordering).
+//
+// For example, if we scan an index on x,y,z with required ordering "+y opt(x)",
+// the provided ordering is "+x,+y". If we scan the same index with constraint
+// x=1, the provided ordering is "+y".
+//
+// This function assumes that the provided orderings have already been set in
+// the children of the expression.
+func BuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt.Ordering {
+	if required.Any() {
+		return nil
+	}
+	provided := funcMap[expr.Op()].buildProvidedOrdering(expr, required)
+
+	if util.RaceEnabled {
+		checkProvided(expr, required, provided)
+	}
+
+	return provided
+}
+
 type funcs struct {
 	canProvideOrdering func(expr memo.RelExpr, required *physical.OrderingChoice) bool
 
 	buildChildReqOrdering func(
 		parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
 	) physical.OrderingChoice
+
+	buildProvidedOrdering func(
+		expr memo.RelExpr, required *physical.OrderingChoice,
+	) opt.Ordering
 }
 
 var funcMap [opt.NumOperators]funcs
@@ -63,65 +96,80 @@ func init() {
 		funcMap[op] = funcs{
 			canProvideOrdering:    canNeverProvideOrdering,
 			buildChildReqOrdering: noChildReqOrdering,
+			buildProvidedOrdering: noProvidedOrdering,
 		}
 	}
 	funcMap[opt.ScanOp] = funcs{
 		canProvideOrdering:    scanCanProvideOrdering,
 		buildChildReqOrdering: noChildReqOrdering,
+		buildProvidedOrdering: scanBuildProvided,
 	}
 	funcMap[opt.SelectOp] = funcs{
 		canProvideOrdering:    selectCanProvideOrdering,
 		buildChildReqOrdering: selectBuildChildReqOrdering,
+		buildProvidedOrdering: selectBuildProvided,
 	}
 	funcMap[opt.ProjectOp] = funcs{
 		canProvideOrdering:    projectCanProvideOrdering,
 		buildChildReqOrdering: projectBuildChildReqOrdering,
+		buildProvidedOrdering: projectBuildProvided,
 	}
 	funcMap[opt.IndexJoinOp] = funcs{
 		canProvideOrdering:    lookupOrIndexJoinCanProvideOrdering,
 		buildChildReqOrdering: lookupOrIndexJoinBuildChildReqOrdering,
+		buildProvidedOrdering: indexJoinBuildProvided,
 	}
 	funcMap[opt.LookupJoinOp] = funcs{
 		canProvideOrdering:    lookupOrIndexJoinCanProvideOrdering,
 		buildChildReqOrdering: lookupOrIndexJoinBuildChildReqOrdering,
+		buildProvidedOrdering: lookupJoinBuildProvided,
 	}
 	funcMap[opt.RowNumberOp] = funcs{
 		canProvideOrdering:    rowNumberCanProvideOrdering,
 		buildChildReqOrdering: rowNumberBuildChildReqOrdering,
+		buildProvidedOrdering: rowNumberBuildProvided,
 	}
 	funcMap[opt.MergeJoinOp] = funcs{
 		canProvideOrdering:    mergeJoinCanProvideOrdering,
 		buildChildReqOrdering: mergeJoinBuildChildReqOrdering,
+		buildProvidedOrdering: mergeJoinBuildProvided,
 	}
 	funcMap[opt.LimitOp] = funcs{
 		canProvideOrdering:    limitOrOffsetCanProvideOrdering,
 		buildChildReqOrdering: limitOrOffsetBuildChildReqOrdering,
+		buildProvidedOrdering: limitOrOffsetBuildProvided,
 	}
 	funcMap[opt.OffsetOp] = funcs{
 		canProvideOrdering:    limitOrOffsetCanProvideOrdering,
 		buildChildReqOrdering: limitOrOffsetBuildChildReqOrdering,
+		buildProvidedOrdering: limitOrOffsetBuildProvided,
 	}
 	funcMap[opt.ExplainOp] = funcs{
 		canProvideOrdering:    canNeverProvideOrdering,
 		buildChildReqOrdering: explainBuildChildReqOrdering,
+		buildProvidedOrdering: noProvidedOrdering,
 	}
 	funcMap[opt.ScalarGroupByOp] = funcs{
 		// ScalarGroupBy always has exactly one result; any required ordering should
 		// have been simplified to Any (unless normalization rules are disabled).
 		canProvideOrdering:    canNeverProvideOrdering,
 		buildChildReqOrdering: scalarGroupByBuildChildReqOrdering,
+		buildProvidedOrdering: noProvidedOrdering,
 	}
 	funcMap[opt.GroupByOp] = funcs{
 		canProvideOrdering:    groupByCanProvideOrdering,
 		buildChildReqOrdering: groupByBuildChildReqOrdering,
+		buildProvidedOrdering: groupByBuildProvided,
 	}
 	funcMap[opt.DistinctOnOp] = funcs{
 		canProvideOrdering:    distinctOnCanProvideOrdering,
 		buildChildReqOrdering: distinctOnBuildChildReqOrdering,
+		buildProvidedOrdering: distinctOnBuildProvided,
 	}
 	funcMap[opt.SortOp] = funcs{
 		canProvideOrdering:    nil, // should never get called
 		buildChildReqOrdering: noChildReqOrdering,
+		buildProvidedOrdering: sortBuildProvided,
 	}
 }
 
@@ -133,6 +181,94 @@ func noChildReqOrdering(
 	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
 ) physical.OrderingChoice {
 	return physical.OrderingChoice{}
+}
+
+func noProvidedOrdering(expr memo.RelExpr, required *physical.OrderingChoice) opt.Ordering {
+	return nil
+}
+
+// remapProvided remaps columns in a provided ordering (according to the given
+// FDs) so that it only refers to columns in the given outCols set. It also
+// removes any columns that are redundant according to the FDs.
+//
+// Can only be called if the provided ordering can be remapped.
+//
+// Does not modify <provided> in place, but it can return the same slice.
+func remapProvided(provided opt.Ordering, fds *props.FuncDepSet, outCols opt.ColSet) opt.Ordering {
+	if len(provided) == 0 {
+		return nil
+	}
+
+	// result is nil until we determine that we need to make a copy.
+	var result opt.Ordering
+
+	// closure is the set of columns that are functionally determined by the
+	// columns in provided[:i].
+	closure := fds.ComputeClosure(opt.ColSet{})
+	for i := range provided {
+		col := provided[i].ID()
+		if closure.Contains(int(col)) {
+			// At the level of the new operator, this column is redundant.
+			if result == nil {
+				result = make(opt.Ordering, i, len(provided))
+				copy(result, provided)
+			}
+			continue
+		}
+		if outCols.Contains(int(col)) {
+			if result != nil {
+				result = append(result, provided[i])
+			}
+		} else {
+			equivCols := fds.ComputeEquivClosure(util.MakeFastIntSet(int(col)))
+			remappedCol, ok := equivCols.Intersection(outCols).Next(0)
+			if !ok {
+				panic(fmt.Sprintf("no output column equivalent to %d", col))
+			}
+			if result == nil {
+				result = make(opt.Ordering, i, len(provided))
+				copy(result, provided)
+			}
+			result = append(result, opt.MakeOrderingColumn(
+				opt.ColumnID(remappedCol), provided[i].Descending(),
+			))
+		}
+		closure.Add(int(col))
+		closure = fds.ComputeClosure(closure)
+	}
+	if result == nil {
+		return provided
+	}
+	return result
+}
+
+// trimProvided returns the smallest prefix of <provided> that is sufficient to
+// satisfy <required> (in conjunction with the FDs).
+//
+// This is useful because in a distributed setting execution is configured to
+// maintain the provided ordering when merging results from multiple nodes, and
+// we don't want to make needless comparisons.
+func trimProvided(
+	provided opt.Ordering, required *physical.OrderingChoice, fds *props.FuncDepSet,
+) opt.Ordering {
+	// closure is the set of columns that are functionally determined by the
+	// columns in provided[:provIdx].
+	closure := fds.ComputeClosure(opt.ColSet{})
+	provIdx := 0
+	for reqIdx := range required.Columns {
+		c := &required.Columns[reqIdx]
+		// Consume columns from the provided ordering until their closure intersects
+		// the required group.
+		for !closure.Intersects(c.Group) {
+			if provIdx == len(provided) {
+				panic("provided does not intersect required")
+			}
+			closure.Add(int(provided[provIdx].ID()))
+			closure = fds.ComputeClosure(closure)
+			provIdx++
+		}
+	}
+	return provided[:provIdx]
 }
 
 // checkRequired runs sanity checks on the ordering required of an operator.
@@ -153,5 +289,34 @@ func checkRequired(expr memo.RelExpr, required *physical.OrderingChoice) {
 				c.Group, expr.Op(),
 			))
 		}
+	}
+}
+
+// checkProvided runs sanity checks on a provided ordering.
+func checkProvided(expr memo.RelExpr, required *physical.OrderingChoice, provided opt.Ordering) {
+	// The provided ordering must refer only to output columns.
+	if outCols := expr.Relational().OutputCols; !provided.ColSet().SubsetOf(outCols) {
+		panic(fmt.Sprintf(
+			"provided %s must refer only to output columns %s", provided, outCols,
+		))
+	}
+
+	// The provided ordering must intersect the required ordering, after FDs are
+	// applied.
+	fds := &expr.Relational().FuncDeps
+	r := required.Copy()
+	r.Simplify(fds)
+	var p physical.OrderingChoice
+	p.FromOrdering(provided)
+	p.Simplify(fds)
+	if !r.Any() && (p.Any() || !p.Intersects(&r)) {
+		panic(fmt.Sprintf(
+			"provided %s does not intersect required %s (FDs: %s)", provided, required, fds,
+		))
+	}
+
+	// The provided ordering should not have unnecessary columns.
+	if trimmed := trimProvided(provided, required, fds); len(trimmed) != len(provided) {
+		panic(fmt.Sprintf("provided %s can be trimmed to %s (FDs: %s)", provided, trimmed, fds))
 	}
 }

--- a/pkg/sql/opt/ordering/ordering_test.go
+++ b/pkg/sql/opt/ordering/ordering_test.go
@@ -1,0 +1,149 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ordering
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+func TestTrimProvided(t *testing.T) {
+	emptyFD, equivFD, constFD := testFDs()
+	testCases := []struct {
+		req, prov string
+		fds       props.FuncDepSet
+		exp       string
+	}{
+		{ // case 1
+			req:  "+1 opt(2)",
+			prov: "+1,+2,+3",
+			fds:  emptyFD,
+			exp:  "+1",
+		},
+		{ // case 2
+			req:  "+1,+3 opt(2)",
+			prov: "+1,+2,+3",
+			fds:  emptyFD,
+			exp:  "+1,+2,+3",
+		},
+		{ // case 3
+			req:  "+4,-5 opt(1,2,3)",
+			prov: "-2,+4,-5,+7",
+			fds:  constFD,
+			exp:  "-2,+4,-5",
+		},
+		{ // case 4
+			req:  "+(1|2),-(3|4) opt(5)",
+			prov: "+2,-5,-3,+4",
+			fds:  equivFD,
+			exp:  "+2,-5,-3",
+		},
+	}
+	for tcIdx, tc := range testCases {
+		t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
+			req := physical.ParseOrderingChoice(tc.req)
+			prov := parseOrdering(tc.prov)
+			res := trimProvided(prov, &req, &tc.fds).String()
+			if res != tc.exp {
+				t.Errorf("expected %s, got %s", tc.exp, res)
+			}
+		})
+	}
+}
+
+func TestRemapProvided(t *testing.T) {
+	emptyFD, equivFD, constFD := testFDs()
+	c := func(cols ...int) opt.ColSet {
+		return util.MakeFastIntSet(cols...)
+	}
+	testCases := []struct {
+		prov string
+		fds  props.FuncDepSet
+		cols opt.ColSet
+		exp  string
+	}{
+		{ // case 1
+			prov: "+1,+2,+3",
+			fds:  emptyFD,
+			cols: c(1, 2, 3),
+			exp:  "+1,+2,+3",
+		},
+		{ // case 2
+			prov: "-1,+2,+3",
+			fds:  equivFD,
+			cols: c(1, 2, 3),
+			exp:  "-1,+3",
+		},
+		{ // case 3
+			prov: "+1,-2,+3",
+			fds:  equivFD,
+			cols: c(1, 3),
+			exp:  "+1,+3",
+		},
+		{ // case 4
+			prov: "-1,+2,+3",
+			fds:  equivFD,
+			cols: c(2, 4),
+			exp:  "-2,+4",
+		},
+		{ // case 5
+			prov: "+4,-1,-5,+2",
+			fds:  constFD,
+			cols: c(1, 2, 3, 4, 5),
+			exp:  "+4,-5",
+		},
+	}
+	for tcIdx, tc := range testCases {
+		t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
+			prov := parseOrdering(tc.prov)
+			res := remapProvided(prov, &tc.fds, tc.cols).String()
+			if res != tc.exp {
+				t.Errorf("expected %s, got %s", tc.exp, res)
+			}
+		})
+	}
+}
+
+// parseOrdering parses a simple opt.Ordering.
+func parseOrdering(str string) opt.Ordering {
+	prov := physical.ParseOrderingChoice(str)
+	if !prov.Optional.Empty() {
+		panic(fmt.Sprintf("invalid ordering %s", str))
+	}
+	for i := range prov.Columns {
+		if prov.Columns[i].Group.Len() != 1 {
+			panic(fmt.Sprintf("invalid ordering %s", str))
+		}
+	}
+	return prov.ToOrdering()
+}
+
+// testFDs returns FDs that can be used for testing:
+//   - emptyFD
+//   - equivFD: (1)==(2), (2)==(1), (3)==(4), (4)==(3)
+//   - constFD: ()-->(1,2)
+func testFDs() (emptyFD, equivFD, constFD props.FuncDepSet) {
+	equivFD.AddEquivalency(1, 2)
+	equivFD.AddEquivalency(3, 4)
+
+	constFD.AddConstants(util.MakeFastIntSet(1, 2))
+
+	return emptyFD, equivFD, constFD
+}

--- a/pkg/sql/opt/ordering/project_test.go
+++ b/pkg/sql/opt/ordering/project_test.go
@@ -20,18 +20,22 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testexpr"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 func TestProject(t *testing.T) {
-	var inProps props.Relational
-	inProps.OutputCols = util.MakeFastIntSet(1, 2, 3, 4)
-	fd := &inProps.FuncDeps
-	fd.AddEquivalency(2, 3)
-	fd.AddConstants(util.MakeFastIntSet(4))
+	var fds props.FuncDepSet
+	fds.AddEquivalency(2, 3)
+	fds.AddConstants(util.MakeFastIntSet(4))
 
 	project := &memo.ProjectExpr{
-		Input: newDummyRelExpr(inProps),
+		Input: &testexpr.Instance{
+			Rel: &props.Relational{
+				OutputCols: util.MakeFastIntSet(1, 2, 3, 4),
+				FuncDeps:   fds,
+			},
+		},
 	}
 
 	type testCase struct {

--- a/pkg/sql/opt/ordering/row_number_test.go
+++ b/pkg/sql/opt/ordering/row_number_test.go
@@ -1,0 +1,97 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ordering
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+func TestRowNumberProvided(t *testing.T) {
+	emptyFD, equivFD, constFD := testFDs()
+	// The ordinality column is 10.
+	testCases := []struct {
+		required string
+		input    string
+		fds      props.FuncDepSet
+		provided string
+	}{
+		{ // case 1
+			required: "+10",
+			input:    "+1,+2",
+			fds:      emptyFD,
+			provided: "+10",
+		},
+		{ // case 2
+			required: "+1,+10",
+			input:    "+1,+2,+3",
+			fds:      emptyFD,
+			provided: "+1,+10",
+		},
+		{ // case 3
+			required: "+1,+10,+5",
+			input:    "+1,+2",
+			fds:      emptyFD,
+			provided: "+1,+10",
+		},
+		{ // case 4
+			required: "+(1|2),+(3|10)",
+			input:    "+1,+4,+5",
+			fds:      emptyFD,
+			provided: "+1,+10",
+		},
+		{ // case 5
+			required: "+1",
+			input:    "",
+			fds:      constFD,
+			provided: "",
+		},
+		{ // case 6
+			required: "-1,+10",
+			input:    "-2",
+			fds:      equivFD,
+			provided: "-2,+10",
+		},
+	}
+
+	for tcIdx, tc := range testCases {
+		t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
+			evalCtx := tree.NewTestingEvalContext(nil /* st */)
+			var f norm.Factory
+			f.Init(evalCtx)
+			input := &testexpr.Instance{
+				Rel: &props.Relational{OutputCols: util.MakeFastIntSet(1, 2, 3, 4, 5)},
+				Provided: &physical.Provided{
+					Ordering: parseOrdering(tc.input),
+				},
+			}
+			r := f.Memo().MemoizeRowNumber(input, &memo.RowNumberPrivate{ColID: 10})
+			r.Relational().FuncDeps = tc.fds
+			req := physical.ParseOrderingChoice(tc.required)
+			res := rowNumberBuildProvided(r, &req).String()
+			if res != tc.provided {
+				t.Errorf("expected '%s', got '%s'", tc.provided, res)
+			}
+		})
+	}
+}

--- a/pkg/sql/opt/ordering/scan_test.go
+++ b/pkg/sql/opt/ordering/scan_test.go
@@ -19,7 +19,9 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -33,17 +35,35 @@ func TestScan(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	md := &opt.Metadata{}
+	evalCtx := tree.NewTestingEvalContext(nil /* st */)
+	var f norm.Factory
+	f.Init(evalCtx)
+	md := f.Metadata()
 	tab := md.AddTable(tc.Table(tree.NewUnqualifiedTableName("t")))
 
-	if a := tab.ColumnID(0); a != 1 {
-		t.Fatalf("unexpected ID for column a: %d\n", a)
+	if c1 := tab.ColumnID(0); c1 != 1 {
+		t.Fatalf("unexpected ID for column c1: %d\n", c1)
 	}
+
+	// Make a constraint for the index.
+	var columns constraint.Columns
+	columns.Init([]opt.OrderingColumn{-3, +4, +1, +2})
+	var c constraint.Constraint
+	keyCtx := constraint.MakeKeyContext(&columns, evalCtx)
+	var span constraint.Span
+	span.Init(
+		constraint.MakeCompositeKey(tree.NewDInt(1), tree.NewDInt(10)),
+		constraint.IncludeBoundary,
+		constraint.MakeCompositeKey(tree.NewDInt(1), tree.NewDInt(20)),
+		constraint.IncludeBoundary,
+	)
+	c.InitSingleSpan(&keyCtx, &span)
 
 	// We have groups of test cases for various ScanPrivates.
 	type testCase struct {
-		req string // required ordering
-		exp string // "no", "fwd", or "rev"
+		req  string // required ordering
+		exp  string // "no", "fwd", or "rev"
+		prov string // provided ordering
 	}
 
 	type testGroup struct {
@@ -59,16 +79,16 @@ func TestScan(t *testing.T) {
 				Cols:  util.MakeFastIntSet(1, 2, 3, 4),
 			},
 			cases: []testCase{
-				{req: "", exp: "fwd"},          // case 1
-				{req: "+1", exp: "fwd"},        // case 2
-				{req: "-1", exp: "rev"},        // case 3
-				{req: "+2", exp: "no"},         // case 4
-				{req: "+1,+2", exp: "fwd"},     // case 5
-				{req: "-1,-2", exp: "rev"},     // case 6
-				{req: "+1,-2", exp: "no"},      // case 7
-				{req: "+(1|2)", exp: "fwd"},    // case 8
-				{req: "+2 opt(1)", exp: "fwd"}, // case 9
-				{req: "-2 opt(1)", exp: "rev"}, // case 10
+				{req: "", exp: "fwd", prov: ""},               // case 1
+				{req: "+1", exp: "fwd", prov: "+1"},           // case 2
+				{req: "-1", exp: "rev", prov: "-1"},           // case 3
+				{req: "+2", exp: "no"},                        // case 4
+				{req: "+1,+2", exp: "fwd", prov: "+1,+2"},     // case 5
+				{req: "-1,-2", exp: "rev", prov: "-1,-2"},     // case 6
+				{req: "+1,-2", exp: "no", prov: "+1,-2"},      // case 7
+				{req: "+(1|2)", exp: "fwd", prov: "+1"},       // case 8
+				{req: "+2 opt(1)", exp: "fwd", prov: "+1,+2"}, // case 9
+				{req: "-2 opt(1)", exp: "rev", prov: "-1,-2"}, // case 10
 			},
 		},
 		{ // group 2: secondary index scan.
@@ -78,19 +98,19 @@ func TestScan(t *testing.T) {
 				Cols:  util.MakeFastIntSet(1, 2, 3, 4),
 			},
 			cases: []testCase{
-				{req: "", exp: "fwd"},               // case 1
-				{req: "-3", exp: "fwd"},             // case 2
-				{req: "+3", exp: "rev"},             // case 3
-				{req: "-3,+4", exp: "fwd"},          // case 4
-				{req: "+3,-4", exp: "rev"},          // case 5
-				{req: "+3,+4", exp: "no"},           // case 6
-				{req: "-3,+4,+1", exp: "fwd"},       // case 7
-				{req: "-3,+4,+1,+2", exp: "fwd"},    // case 8
-				{req: "-3,+2 opt(1,4)", exp: "fwd"}, // case 9
-				{req: "+3,-2 opt(1,4)", exp: "rev"}, // case 10
+				{req: "", exp: "fwd", prov: ""},                          // case 1
+				{req: "-3", exp: "fwd", prov: "-3"},                      // case 2
+				{req: "+3", exp: "rev", prov: "+3"},                      // case 3
+				{req: "-3,+4", exp: "fwd", prov: "-3,+4"},                // case 4
+				{req: "+3,-4", exp: "rev", prov: "+3,-4"},                // case 5
+				{req: "+3,+4", exp: "no"},                                // case 6
+				{req: "-3,+4,+1", exp: "fwd", prov: "-3,+4,+1"},          // case 7
+				{req: "-3,+4,+1,+2", exp: "fwd", prov: "-3,+4,+1,+2"},    // case 8
+				{req: "-3,+2 opt(1,4)", exp: "fwd", prov: "-3,+4,+1,+2"}, // case 9
+				{req: "+3,-2 opt(1,4)", exp: "rev", prov: "+3,-4,-1,-2"}, // case 10
 			},
 		},
-		{ // group 3: scan with limit (forces forward scan)
+		{ // group 3: scan with limit (forces forward scan).
 			p: memo.ScanPrivate{
 				Table:     tab,
 				Index:     opt.PrimaryIndex,
@@ -98,19 +118,19 @@ func TestScan(t *testing.T) {
 				HardLimit: +10,
 			},
 			cases: []testCase{
-				{req: "", exp: "fwd"},          // case 1
-				{req: "+1", exp: "fwd"},        // case 2
-				{req: "-1", exp: "no"},         // case 3
-				{req: "+2", exp: "no"},         // case 4
-				{req: "+1,+2", exp: "fwd"},     // case 5
-				{req: "-1,-2", exp: "no"},      // case 6
-				{req: "+1,-2", exp: "no"},      // case 7
-				{req: "+(1|2)", exp: "fwd"},    // case 8
-				{req: "+2 opt(1)", exp: "fwd"}, // case 9
-				{req: "-2 opt(1)", exp: "no"},  // case 10
+				{req: "", exp: "fwd", prov: ""},               // case 1
+				{req: "+1", exp: "fwd", prov: "+1"},           // case 2
+				{req: "-1", exp: "no"},                        // case 3
+				{req: "+2", exp: "no"},                        // case 4
+				{req: "+1,+2", exp: "fwd", prov: "+1,+2"},     // case 5
+				{req: "-1,-2", exp: "no"},                     // case 6
+				{req: "+1,-2", exp: "no"},                     // case 7
+				{req: "+(1|2)", exp: "fwd", prov: "+1"},       // case 8
+				{req: "+2 opt(1)", exp: "fwd", prov: "+1,+2"}, // case 9
+				{req: "-2 opt(1)", exp: "no"},                 // case 10
 			},
 		},
-		{ // group 4: scan with reverse limit
+		{ // group 4: scan with reverse limit.
 			p: memo.ScanPrivate{
 				Table:     tab,
 				Index:     opt.PrimaryIndex,
@@ -118,16 +138,31 @@ func TestScan(t *testing.T) {
 				HardLimit: -10,
 			},
 			cases: []testCase{
-				{req: "", exp: "rev"},          // case 1
-				{req: "+1", exp: "no"},         // case 2
-				{req: "-1", exp: "rev"},        // case 3
-				{req: "+2", exp: "no"},         // case 4
-				{req: "+1,+2", exp: "no"},      // case 5
-				{req: "-1,-2", exp: "rev"},     // case 6
-				{req: "+1,-2", exp: "no"},      // case 7
-				{req: "+(1|2)", exp: "no"},     // case 8
-				{req: "+2 opt(1)", exp: "no"},  // case 9
-				{req: "-2 opt(1)", exp: "rev"}, // case 10
+				{req: "", exp: "rev", prov: ""},               // case 1
+				{req: "+1", exp: "no"},                        // case 2
+				{req: "-1", exp: "rev", prov: "-1"},           // case 3
+				{req: "+2", exp: "no"},                        // case 4
+				{req: "+1,+2", exp: "no"},                     // case 5
+				{req: "-1,-2", exp: "rev", prov: "-1,-2"},     // case 6
+				{req: "+1,-2", exp: "no"},                     // case 7
+				{req: "+(1|2)", exp: "no"},                    // case 8
+				{req: "+2 opt(1)", exp: "no"},                 // case 9
+				{req: "-2 opt(1)", exp: "rev", prov: "-1,-2"}, // case 10
+			},
+		},
+		{ // group 5: scan with constraint.
+			p: memo.ScanPrivate{
+				Table:      tab,
+				Index:      1,
+				Cols:       util.MakeFastIntSet(1, 2, 3, 4),
+				Constraint: &c,
+			},
+			cases: []testCase{
+				{req: "-3", exp: "fwd", prov: ""},                   // case 1
+				{req: "-3,+4", exp: "fwd", prov: "+4"},              // case 2
+				{req: "-1 opt(3,4)", exp: "rev", prov: "-4,-1"},     // case 3
+				{req: "+1 opt(3)", exp: "no"},                       // case 4
+				{req: "-(1|2) opt(3,4)", exp: "rev", prov: "-4,-1"}, // case 5
 			},
 		},
 	}
@@ -148,6 +183,13 @@ func TestScan(t *testing.T) {
 					}
 					if res != tc.exp {
 						t.Errorf("expected %s, got %s", tc.exp, res)
+					}
+					if ok {
+						scan := f.ConstructScan(&g.p)
+						prov := scanBuildProvided(scan, &req).String()
+						if prov != tc.prov {
+							t.Errorf("expected provided '%s', got '%s'", tc.prov, prov)
+						}
 					}
 				})
 			}

--- a/pkg/sql/opt/ordering/select.go
+++ b/pkg/sql/opt/ordering/select.go
@@ -15,6 +15,7 @@
 package ordering
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
@@ -57,4 +58,12 @@ func trimColumnGroups(
 		}
 	}
 	return res
+}
+
+func selectBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt.Ordering {
+	s := expr.(*memo.SelectExpr)
+	rel := s.Relational()
+	// We don't need to remap columns, but we want to remove columns that are now
+	// unnecessary (e.g. because the Select constrains them to be constant).
+	return remapProvided(s.Input.ProvidedPhysical().Ordering, &rel.FuncDeps, rel.OutputCols)
 }

--- a/pkg/sql/opt/ordering/sort.go
+++ b/pkg/sql/opt/ordering/sort.go
@@ -15,24 +15,14 @@
 package ordering
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
-type dummyRelExpr struct {
-	// We embed a nil memo.RelExpr, which causes any methods that are not
-	// specifically overridden to panic.
-	memo.RelExpr
-
-	r props.Relational
-}
-
-var _ memo.RelExpr = &dummyRelExpr{}
-
-func newDummyRelExpr(r props.Relational) memo.RelExpr {
-	return &dummyRelExpr{r: r}
-}
-
-func (d *dummyRelExpr) Relational() *props.Relational {
-	return &d.r
+func sortBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt.Ordering {
+	provided := required.ToOrdering()
+	// The required ordering might not have been simplified (if normalization
+	// rules are off) so we may need to trim.
+	return trimProvided(provided, required, &expr.Relational().FuncDeps)
 }

--- a/pkg/sql/opt/props/physical/provided.go
+++ b/pkg/sql/opt/props/physical/provided.go
@@ -1,0 +1,63 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package physical
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+)
+
+// Provided physical properties of an operator. An operator might be able to
+// satisfy a required property in multiple ways, and additional information is
+// necessary for execution. For example, the required properties may allow
+// multiple ordering choices; the provided properties would describe the
+// specific ordering that has to be respected during execution.
+//
+// Provided properties are derived bottom-up (on the lowest cost tree).
+type Provided struct {
+	// Ordering is an ordering that needs to be maintained on the rows produced by
+	// this operator in order to satisfy its required ordering. This is useful for
+	// configuring execution in a distributed setting, where results from multiple
+	// nodes may need to be merged. A best-effort attempt is made to have as few
+	// columns as possible.
+	//
+	// The ordering, in conjunction with the functional dependencies (in the
+	// logical properties), must intersect the required ordering.
+	//
+	// See the documentation for the opt/ordering package for some examples.
+	Ordering opt.Ordering
+
+	// Note: we store a Provided structure in-place within each group because the
+	// struct is very small (see memo.bestProps). If we add more fields here, that
+	// decision needs to be revisited.
+}
+
+// Equals returns true if the two sets of provided properties are identical.
+func (p *Provided) Equals(other *Provided) bool {
+	return p.Ordering.Equals(other.Ordering)
+}
+
+func (p *Provided) String() string {
+	var buf bytes.Buffer
+
+	if len(p.Ordering) > 0 {
+		buf.WriteString("[ordering: ")
+		p.Ordering.Format(&buf)
+		buf.WriteByte(']')
+	}
+
+	return buf.String()
+}

--- a/pkg/sql/opt/testutils/testexpr/test_expr.go
+++ b/pkg/sql/opt/testutils/testexpr/test_expr.go
@@ -1,0 +1,91 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testexpr
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+)
+
+// Instance is a dummy RelExpr that contains various properties that can be
+// extracted via that interface. It can be initialized with whatever subset of
+// fields are required for the particular test; for example:
+//
+//   e := &testexpr.Instance{
+//     Rel: &props.Relational{...},
+//     Provided: &physical.Provided{...},
+//   }
+//
+type Instance struct {
+	Rel      *props.Relational
+	Required *physical.Required
+	Provided *physical.Provided
+	Priv     interface{}
+
+	// We embed a RelExpr to provide implementation for the unexported methods of
+	// RelExpr. This should not be initialized (resulting in a panic if any of
+	// those methods are called).
+	memo.RelExpr
+}
+
+var _ memo.RelExpr = &Instance{}
+
+// Relational is part of the RelExpr interface.
+func (e *Instance) Relational() *props.Relational { return e.Rel }
+
+// RequiredPhysical is part of the RelExpr interface.
+func (e *Instance) RequiredPhysical() *physical.Required { return e.Required }
+
+// ProvidedPhysical is part of the RelExpr interface.
+func (e *Instance) ProvidedPhysical() *physical.Provided { return e.Provided }
+
+// Private is part of the RelExpr interface.
+func (e *Instance) Private() interface{} { return e.Priv }
+
+// Op is part of the RelExpr interface.
+func (e *Instance) Op() opt.Operator {
+	// We implement this to keep checkExpr happy. It shouldn't match a real
+	// operator.
+	return 0xFFFF
+}
+
+// The rest of the methods are not implemented. Fields can be added to Instance
+// to implement these as necessary.
+
+// ChildCount is part of the RelExpr interface.
+func (e *Instance) ChildCount() int { panic("not implemented") }
+
+// Child is part of the RelExpr interface.
+func (e *Instance) Child(nth int) opt.Expr { panic("not implemented") }
+
+// String is part of the RelExpr interface.
+func (e *Instance) String() string { panic("not implemented") }
+
+// SetChild is part of the RelExpr interface.
+func (e *Instance) SetChild(nth int, child opt.Expr) { panic("not implemented") }
+
+// Memo is part of the RelExpr interface.
+func (e *Instance) Memo() *memo.Memo { panic("not implemented") }
+
+// FirstExpr is part of the RelExpr interface.
+func (e *Instance) FirstExpr() memo.RelExpr { panic("not implemented") }
+
+// NextExpr is part of the RelExpr interface.
+func (e *Instance) NextExpr() memo.RelExpr { panic("not implemented") }
+
+// Cost is part of the RelExpr interface.
+func (e *Instance) Cost() memo.Cost { panic("not implemented") }

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -139,23 +139,23 @@ project
       ├── cardinality: [0 - 50]
       ├── key: (1)
       ├── fd: ()-->(9), (1)-->(2,3,5-8,10)
-      ├── ordering: +1 opt(9)
+      ├── ordering: +1 opt(9) [provided: +1]
       ├── index-join article
       │    ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) title:5(string) summary:6(string) content:7(string) link:8(string) read:9(bool!null) date:10(timestamptz)
       │    ├── key: (1)
       │    ├── fd: ()-->(9), (1)-->(2,3,5-8,10)
-      │    ├── ordering: +1 opt(9)
+      │    ├── ordering: +1 opt(9) [provided: +1]
       │    └── select
       │         ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) read:9(bool!null)
       │         ├── key: (1)
       │         ├── fd: ()-->(9), (1)-->(2,3)
-      │         ├── ordering: +1 opt(9)
+      │         ├── ordering: +1 opt(9) [provided: +1]
       │         ├── scan article@article_idx_read_key
       │         │    ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) read:9(bool)
       │         │    ├── constraint: /1: [/1 - ]
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2,3,9)
-      │         │    └── ordering: +1 opt(9)
+      │         │    └── ordering: +1 opt(9) [provided: +1]
       │         └── filters
       │              └── NOT read [type=bool, outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
       └── const: 50 [type=int]
@@ -178,24 +178,24 @@ project
       ├── cardinality: [0 - 50]
       ├── key: (1)
       ├── fd: ()-->(9), (1)-->(2,3,5-8,10)
-      ├── ordering: +1 opt(9)
+      ├── ordering: +1 opt(9) [provided: +1]
       ├── index-join article
       │    ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) title:5(string) summary:6(string) content:7(string) link:8(string) read:9(bool!null) date:10(timestamptz)
       │    ├── key: (1)
       │    ├── fd: ()-->(9), (1)-->(2,3,5-8,10)
-      │    ├── ordering: +1 opt(9)
+      │    ├── ordering: +1 opt(9) [provided: +1]
       │    └── select
       │         ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) read:9(bool!null)
       │         ├── key: (1)
       │         ├── fd: ()-->(9), (1)-->(2,3)
-      │         ├── ordering: +1 opt(9)
+      │         ├── ordering: +1 opt(9) [provided: +1]
       │         ├── scan article@article_idx_read_key
       │         │    ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) read:9(bool)
       │         │    ├── constraint: /1: [/1 - ]
       │         │    ├── flags: force-index=article_idx_read_key
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2,3,9)
-      │         │    └── ordering: +1 opt(9)
+      │         │    └── ordering: +1 opt(9) [provided: +1]
       │         └── filters
       │              └── NOT read [type=bool, outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
       └── const: 50 [type=int]
@@ -210,18 +210,18 @@ limit
  ├── cardinality: [0 - 5]
  ├── key: (1)
  ├── fd: ()-->(9)
- ├── ordering: +1 opt(9)
+ ├── ordering: +1 opt(9) [provided: +1]
  ├── select
  │    ├── columns: id:1(int!null) read:9(bool!null)
  │    ├── key: (1)
  │    ├── fd: ()-->(9)
- │    ├── ordering: +1 opt(9)
+ │    ├── ordering: +1 opt(9) [provided: +1]
  │    ├── scan article@article_idx_read_key
  │    │    ├── columns: id:1(int!null) read:9(bool)
  │    │    ├── constraint: /1: [/1 - ]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
- │    │    └── ordering: +1 opt(9)
+ │    │    └── ordering: +1 opt(9) [provided: +1]
  │    └── filters
  │         └── NOT read [type=bool, outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
  └── const: 5 [type=int]
@@ -300,13 +300,13 @@ project
  ├── columns: score:9(int!null) expires_at:15(int!null)  [hidden: updated_at_inverse:14(int!null)]
  ├── cardinality: [0 - 50]
  ├── fd: ()-->(15)
- ├── ordering: -9,-14 opt(15)
+ ├── ordering: -9,-14 opt(15) [provided: -9,-14]
  └── scan leaderboard_record@test_idx,rev
       ├── columns: id:1(bytes!null) leaderboard_id:2(bytes!null) score:9(int!null) updated_at_inverse:14(int!null) expires_at:15(int!null)
       ├── constraint: /2/15/9/14/1/3: [/'\x74657374'/0 - /'\x74657374'/0/100/500/'\x736f6d655f6964')
       ├── limit: 50(rev)
       ├── fd: ()-->(2,15)
-      └── ordering: -9,-14 opt(2,15)
+      └── ordering: -9,-14 opt(2,15) [provided: -9,-14]
 
 # ------------------------------------------------------------------------------
 # Github Issue 26444: Ensure that optimizer uses a merge join using the
@@ -530,12 +530,12 @@ limit
  ├── cardinality: [0 - 50]
  ├── key: (1)
  ├── fd: ()-->(3,5), (1)-->(2,4,6-11)
- ├── ordering: +4 opt(3,5)
+ ├── ordering: +4 opt(3,5) [provided: +4]
  ├── sort
  │    ├── columns: remote_id:1(uuid!null) conflict_remote_id:2(uuid) user_id:3(uuid!null) last_sync_id:4(int!null) data_type:5(string!null) sync_data:6(string) deleted:7(bool!null) create_device_id:8(string!null) original_data_id:9(string!null) create_time:10(int!null) last_update_time:11(int!null)
  │    ├── key: (1)
  │    ├── fd: ()-->(3,5), (1)-->(2,4,6-11)
- │    ├── ordering: +4 opt(3,5)
+ │    ├── ordering: +4 opt(3,5) [provided: +4]
  │    └── select
  │         ├── columns: remote_id:1(uuid!null) conflict_remote_id:2(uuid) user_id:3(uuid!null) last_sync_id:4(int!null) data_type:5(string!null) sync_data:6(string) deleted:7(bool!null) create_device_id:8(string!null) original_data_id:9(string!null) create_time:10(int!null) last_update_time:11(int!null)
  │         ├── key: (1)

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -1260,7 +1260,7 @@ semi-join (merge)
  ├── sort
  │    ├── columns: person_id:10(int) order_id:11(int!null)
  │    ├── fd: ()-->(11)
- │    ├── ordering: +10 opt(11)
+ │    ├── ordering: +10 opt(11) [provided: +10]
  │    └── select
  │         ├── columns: person_id:10(int) order_id:11(int!null)
  │         ├── fd: ()-->(11)
@@ -1486,10 +1486,10 @@ semi-join (merge)
  ├── select
  │    ├── columns: person_id:7(int!null) addresses:8(string!null)
  │    ├── fd: ()-->(8)
- │    ├── ordering: +7 opt(8)
+ │    ├── ordering: +7 opt(8) [provided: +7]
  │    ├── scan person_addresses
  │    │    ├── columns: person_id:7(int!null) addresses:8(string)
- │    │    └── ordering: +7 opt(8)
+ │    │    └── ordering: +7 opt(8) [provided: +7]
  │    └── filters
  │         └── addresses = 'Home address' [type=bool, outer=(8), constraints=(/8: [/'Home address' - /'Home address']; tight), fd=()-->(8)]
  └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -278,7 +278,7 @@ ORDER BY schemaname, tablename
 sort
  ├── columns: oid:1(oid) schemaname:29(string) tablename:2(string) relacl:26(string[]) tableowner:133(string) description:134(string) relkind:17(string) cluster:92(string) hasoids:20(bool) hasindexes:13(bool) hasrules:22(bool) tablespace:33(string) param:27(string[]) hastriggers:23(bool) unlogged:15(string) ftoptions:120(string[]) srvname:122(string) reltuples:10(float) inhtable:135(bool) inhschemaname:69(string) inhtablename:42(string)
  ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,133,134)
- ├── ordering: +2 opt(29)
+ ├── ordering: +2 opt(29) [provided: +2]
  └── project
       ├── columns: tableowner:133(string) description:134(string) inhtable:135(bool) pg_class.oid:1(oid) pg_class.relname:2(string) pg_class.reltuples:10(float) pg_class.relhasindex:13(bool) pg_class.relpersistence:15(string) pg_class.relkind:17(string) pg_class.relhasoids:20(bool) pg_class.relhasrules:22(bool) pg_class.relhastriggers:23(bool) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.nspname:29(string) spcname:33(string) pg_class.relname:42(string) pg_namespace.nspname:69(string) pg_class.relname:92(string) ftoptions:120(string[]) srvname:122(string)
       ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,133,134)

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -340,7 +340,7 @@ left-join (merge)
  │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
  │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── fd: ()-->(22)
- │         │    │    │    │    │    ├── ordering: +17 opt(22)
+ │         │    │    │    │    │    ├── ordering: +17 opt(22) [provided: +17]
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
  │         │    │    │    │    │    │    ├── has-placeholder
@@ -460,7 +460,7 @@ sort
  ├── has-placeholder
  ├── key: (1,34)
  ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
- ├── ordering: +7 opt(11)
+ ├── ordering: +7 opt(11) [provided: +7]
  └── right-join
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs.id:34(int) key:35(string) value:36(string) flavor_extra_specs.flavor_id:37(int) flavor_extra_specs.created_at:38(timestamp) flavor_extra_specs.updated_at:39(timestamp)
       ├── side-effects
@@ -490,13 +490,13 @@ sort
       │         │    ├── has-placeholder
       │         │    ├── key: (1)
       │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    ├── ordering: +7 opt(11)
+      │         │    ├── ordering: +7 opt(11) [provided: +7]
       │         │    ├── sort
       │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
       │         │    │    ├── has-placeholder
       │         │    │    ├── key: (1)
       │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │    ├── ordering: +7 opt(11)
+      │         │    │    ├── ordering: +7 opt(11) [provided: +7]
       │         │    │    └── select
       │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
       │         │    │         ├── has-placeholder
@@ -515,50 +515,50 @@ sort
       │         │    │         │    │    ├── right ordering: +23
       │         │    │         │    │    ├── has-placeholder
       │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(31)
-      │         │    │         │    │    ├── ordering: +1 opt(11)
+      │         │    │         │    │    ├── ordering: +1 opt(11) [provided: +1]
       │         │    │         │    │    ├── project
       │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── key: (1)
       │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │    ├── ordering: +1 opt(11)
+      │         │    │         │    │    │    ├── ordering: +1 opt(11) [provided: +1]
       │         │    │         │    │    │    └── select
       │         │    │         │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
       │         │    │         │    │    │         ├── has-placeholder
       │         │    │         │    │    │         ├── key: (1)
       │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │         ├── ordering: +1 opt(11)
+      │         │    │         │    │    │         ├── ordering: +1 opt(11) [provided: +1]
       │         │    │         │    │    │         ├── group-by
       │         │    │         │    │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
       │         │    │         │    │    │         │    ├── grouping columns: flavors.id:1(int!null)
       │         │    │         │    │    │         │    ├── has-placeholder
       │         │    │         │    │    │         │    ├── key: (1)
       │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │         │    ├── ordering: +1 opt(11)
+      │         │    │         │    │    │         │    ├── ordering: +1 opt(11) [provided: +1]
       │         │    │         │    │    │         │    ├── left-join (merge)
       │         │    │         │    │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:28(bool)
       │         │    │         │    │    │         │    │    ├── left ordering: +1
       │         │    │         │    │    │         │    │    ├── right ordering: +17
       │         │    │         │    │    │         │    │    ├── has-placeholder
       │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(28)
-      │         │    │         │    │    │         │    │    ├── ordering: +1 opt(11)
+      │         │    │         │    │    │         │    │    ├── ordering: +1 opt(11) [provided: +1]
       │         │    │         │    │    │         │    │    ├── select
       │         │    │         │    │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
       │         │    │         │    │    │         │    │    │    ├── key: (1)
       │         │    │         │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11)
+      │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11) [provided: +1]
       │         │    │         │    │    │         │    │    │    ├── scan flavors
       │         │    │         │    │    │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
       │         │    │         │    │    │         │    │    │    │    ├── key: (1)
       │         │    │         │    │    │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11)
+      │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11) [provided: +1]
       │         │    │         │    │    │         │    │    │    └── filters
       │         │    │         │    │    │         │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
       │         │    │         │    │    │         │    │    ├── project
       │         │    │         │    │    │         │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:17(int!null)
       │         │    │         │    │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │         │    │    │    ├── fd: ()-->(28)
-      │         │    │         │    │    │         │    │    │    ├── ordering: +17 opt(28)
+      │         │    │         │    │    │         │    │    │    ├── ordering: +17 opt(28) [provided: +17]
       │         │    │         │    │    │         │    │    │    ├── select
       │         │    │         │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) flavor_projects.project_id:18(string!null)
       │         │    │         │    │    │         │    │    │    │    ├── has-placeholder
@@ -608,7 +608,7 @@ sort
       │         │    │         │    │    │    ├── columns: true:31(bool!null) flavor_projects.flavor_id:23(int!null)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── fd: ()-->(31)
-      │         │    │         │    │    │    ├── ordering: +23 opt(31)
+      │         │    │         │    │    │    ├── ordering: +23 opt(31) [provided: +23]
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) flavor_projects.project_id:24(string!null)
       │         │    │         │    │    │    │    ├── has-placeholder
@@ -805,7 +805,7 @@ sort
       │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── fd: ()-->(25)
-      │         │    │         │    │    │    ├── ordering: +18 opt(25)
+      │         │    │         │    │    │    ├── ordering: +18 opt(25) [provided: +18]
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
       │         │    │         │    │    │    │    ├── has-placeholder
@@ -963,7 +963,7 @@ sort
       │         │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:26(int!null)
       │         │    │    │    ├── has-placeholder
       │         │    │    │    ├── fd: ()-->(33)
-      │         │    │    │    ├── ordering: +26 opt(33)
+      │         │    │    │    ├── ordering: +26 opt(33) [provided: +26]
       │         │    │    │    ├── select
       │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
       │         │    │    │    │    ├── has-placeholder
@@ -1142,7 +1142,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
  │    │         │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    ├── fd: ()-->(25)
- │    │         │    │    │    │    │    ├── ordering: +18 opt(25)
+ │    │         │    │    │    │    │    ├── ordering: +18 opt(25) [provided: +18]
  │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │    │    │    │    │    ├── has-placeholder
@@ -1324,7 +1324,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
  │    │         │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    ├── fd: ()-->(25)
- │    │         │    │    │    │    │    ├── ordering: +18 opt(25)
+ │    │         │    │    │    │    │    ├── ordering: +18 opt(25) [provided: +18]
  │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │    │    │    │    │    ├── has-placeholder
@@ -1493,7 +1493,7 @@ right-join
  │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
  │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── fd: ()-->(22)
- │         │    │    │    │    │    ├── ordering: +17 opt(22)
+ │         │    │    │    │    │    ├── ordering: +17 opt(22) [provided: +17]
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
  │         │    │    │    │    │    │    ├── has-placeholder
@@ -1655,7 +1655,7 @@ right-join
  │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
  │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── fd: ()-->(22)
- │         │    │    │    │    │    ├── ordering: +17 opt(22)
+ │         │    │    │    │    │    ├── ordering: +17 opt(22) [provided: +17]
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
  │         │    │    │    │    │    │    ├── has-placeholder
@@ -1837,7 +1837,7 @@ sort
       │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── fd: ()-->(22)
-      │         │    │         │    │    │    ├── ordering: +17 opt(22)
+      │         │    │         │    │    │    ├── ordering: +17 opt(22) [provided: +17]
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
       │         │    │         │    │    │    │    ├── has-placeholder
@@ -2033,7 +2033,7 @@ sort
       │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── fd: ()-->(25)
-      │         │    │         │    │    │    ├── ordering: +18 opt(25)
+      │         │    │         │    │    │    ├── ordering: +18 opt(25) [provided: +18]
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
       │         │    │         │    │    │    │    ├── has-placeholder
@@ -2214,7 +2214,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
  │    │         │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    ├── fd: ()-->(25)
- │    │         │    │    │    │    │    ├── ordering: +18 opt(25)
+ │    │         │    │    │    │    │    ├── ordering: +18 opt(25) [provided: +18]
  │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │    │    │    │    │    ├── has-placeholder
@@ -2350,7 +2350,7 @@ sort
       │         │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:23(int!null)
       │         │    │    │    ├── has-placeholder
       │         │    │    │    ├── fd: ()-->(28)
-      │         │    │    │    ├── ordering: +23 opt(28)
+      │         │    │    │    ├── ordering: +23 opt(28) [provided: +23]
       │         │    │    │    ├── select
       │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
       │         │    │    │    │    ├── has-placeholder
@@ -2542,7 +2542,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
  │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(25)
- │    │         │    │         │    │    │    ├── ordering: +18 opt(25)
+ │    │         │    │         │    │    │    ├── ordering: +18 opt(25) [provided: +18]
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │         │    │    │    │    ├── has-placeholder
@@ -2719,7 +2719,7 @@ sort
       │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── fd: ()-->(22)
-      │         │    │         │    │    │    ├── ordering: +17 opt(22)
+      │         │    │         │    │    │    ├── ordering: +17 opt(22) [provided: +17]
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
       │         │    │         │    │    │    │    ├── has-placeholder
@@ -2844,7 +2844,7 @@ left-join (lookup instance_type_extra_specs)
  ├── has-placeholder
  ├── key: (1,39)
  ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
- ├── ordering: +7,+1 opt(11)
+ ├── ordering: +7,+1 opt(11) [provided: +7,+1]
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs.id:39(int) key:40(string) instance_type_extra_specs.instance_type_id:42(int) instance_type_extra_specs.deleted:43(bool)
  │    ├── key columns: [1] = [42]
@@ -2852,14 +2852,14 @@ left-join (lookup instance_type_extra_specs)
  │    ├── has-placeholder
  │    ├── key: (1,39)
  │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40,42,43), (40,42,43)~~>(39)
- │    ├── ordering: +7,+1 opt(11)
+ │    ├── ordering: +7,+1 opt(11) [provided: +7,+1]
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
  │    │    ├── side-effects
  │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │    ├── ordering: +7,+1 opt(11)
+ │    │    ├── ordering: +7,+1 opt(11) [provided: +7,+1]
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
  │    │         ├── internal-ordering: +7,+1 opt(11)
@@ -2867,20 +2867,20 @@ left-join (lookup instance_type_extra_specs)
  │    │         ├── has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         ├── ordering: +7,+1 opt(11)
+ │    │         ├── ordering: +7,+1 opt(11) [provided: +7,+1]
  │    │         ├── offset
  │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
  │    │         │    ├── internal-ordering: +7,+1 opt(11)
  │    │         │    ├── has-placeholder
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    ├── ordering: +7,+1 opt(11)
+ │    │         │    ├── ordering: +7,+1 opt(11) [provided: +7,+1]
  │    │         │    ├── sort
  │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
  │    │         │    │    ├── has-placeholder
  │    │         │    │    ├── key: (1)
  │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │    ├── ordering: +7,+1 opt(11)
+ │    │         │    │    ├── ordering: +7,+1 opt(11) [provided: +7,+1]
  │    │         │    │    └── select
  │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
  │    │         │    │         ├── has-placeholder
@@ -2899,44 +2899,44 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    ├── right ordering: +26
  │    │         │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(36)
- │    │         │    │         │    │    ├── ordering: +1 opt(11)
+ │    │         │    │         │    │    ├── ordering: +1 opt(11) [provided: +1]
  │    │         │    │         │    │    ├── project
  │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
  │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── key: (1)
  │    │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │    ├── ordering: +1 opt(11)
+ │    │         │    │         │    │    │    ├── ordering: +1 opt(11) [provided: +1]
  │    │         │    │         │    │    │    └── select
  │    │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
  │    │         │    │         │    │    │         ├── has-placeholder
  │    │         │    │         │    │    │         ├── key: (1)
  │    │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │         ├── ordering: +1 opt(11)
+ │    │         │    │         │    │    │         ├── ordering: +1 opt(11) [provided: +1]
  │    │         │    │         │    │    │         ├── group-by
  │    │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
  │    │         │    │         │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
  │    │         │    │         │    │    │         │    ├── has-placeholder
  │    │         │    │         │    │    │         │    ├── key: (1)
  │    │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │         │    ├── ordering: +1 opt(11)
+ │    │         │    │         │    │    │         │    ├── ordering: +1 opt(11) [provided: +1]
  │    │         │    │         │    │    │         │    ├── left-join (merge)
  │    │         │    │         │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:33(bool)
  │    │         │    │         │    │    │         │    │    ├── left ordering: +1
  │    │         │    │         │    │    │         │    │    ├── right ordering: +18
  │    │         │    │         │    │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(33)
- │    │         │    │         │    │    │         │    │    ├── ordering: +1 opt(11)
+ │    │         │    │         │    │    │         │    │    ├── ordering: +1 opt(11) [provided: +1]
  │    │         │    │         │    │    │         │    │    ├── select
  │    │         │    │         │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
  │    │         │    │         │    │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    │    ├── key: (1)
  │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11)
+ │    │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11) [provided: +1]
  │    │         │    │         │    │    │         │    │    │    ├── scan instance_types
  │    │         │    │         │    │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
  │    │         │    │         │    │    │         │    │    │    │    ├── key: (1)
  │    │         │    │         │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11)
+ │    │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11) [provided: +1]
  │    │         │    │         │    │    │         │    │    │    └── filters
  │    │         │    │         │    │    │         │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
  │    │         │    │         │    │    │         │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
@@ -2944,7 +2944,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │         │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:18(int!null)
  │    │         │    │         │    │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(33)
- │    │         │    │         │    │    │         │    │    │    ├── ordering: +18 opt(33)
+ │    │         │    │         │    │    │         │    │    │    ├── ordering: +18 opt(33) [provided: +18]
  │    │         │    │         │    │    │         │    │    │    ├── select
  │    │         │    │         │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) instance_type_projects.project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │         │    │    │         │    │    │    │    ├── has-placeholder
@@ -2999,7 +2999,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │    ├── columns: true:36(bool!null) instance_type_projects.instance_type_id:26(int!null)
  │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(36)
- │    │         │    │         │    │    │    ├── ordering: +26 opt(36)
+ │    │         │    │         │    │    │    ├── ordering: +26 opt(36) [provided: +26]
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) instance_type_projects.project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
  │    │         │    │         │    │    │    │    ├── has-placeholder
@@ -3198,7 +3198,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
  │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(25)
- │    │         │    │         │    │    │    ├── ordering: +18 opt(25)
+ │    │         │    │         │    │    │    ├── ordering: +18 opt(25) [provided: +18]
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │         │    │    │    │    ├── has-placeholder
@@ -3366,7 +3366,7 @@ right-join
  │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
  │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── fd: ()-->(22)
- │         │    │    │    │    │    ├── ordering: +17 opt(22)
+ │         │    │    │    │    │    ├── ordering: +17 opt(22) [provided: +17]
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
  │         │    │    │    │    │    │    ├── has-placeholder
@@ -3532,7 +3532,7 @@ sort
       │         │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
       │         │         │    │    │    ├── has-placeholder
       │         │         │    │    │    ├── fd: ()-->(22)
-      │         │         │    │    │    ├── ordering: +17 opt(22)
+      │         │         │    │    │    ├── ordering: +17 opt(22) [provided: +17]
       │         │         │    │    │    ├── select
       │         │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
       │         │         │    │    │    │    ├── has-placeholder

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -633,7 +633,7 @@ project
       ├── cost: 6.25
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
-      ├── ordering: +1 opt(2)
+      ├── ordering: +1 opt(2) [provided: +1]
       ├── prune: (1-3,8,14-17)
       └── interesting orderings: (+2,+1) (+1,+2)
 
@@ -667,7 +667,7 @@ project
       ├── cost: 3.63e-05
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4)
-      ├── ordering: +4 opt(2,3,6)
+      ├── ordering: +4 opt(2,3,6) [provided: +4]
       ├── prune: (1-4,6)
       └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
 
@@ -724,7 +724,7 @@ project
       ├── cost: 0.00017787
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
-      ├── ordering: +4 opt(2,3,6)
+      ├── ordering: +4 opt(2,3,6) [provided: +4]
       ├── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
       └── scan customer@customer_idx
            ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
@@ -733,7 +733,7 @@ project
            ├── cost: 3.63e-05
            ├── key: (1)
            ├── fd: ()-->(2,3,6), (1)-->(4)
-           ├── ordering: +4 opt(2,3,6)
+           ├── ordering: +4 opt(2,3,6) [provided: +4]
            ├── prune: (1-4,6)
            └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -438,7 +438,7 @@ project
       ├── cost: 0.625
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
-      ├── ordering: +1 opt(2)
+      ├── ordering: +1 opt(2) [provided: +1]
       ├── prune: (1-3,8,14-17)
       └── interesting orderings: (+2,+1) (+1,+2)
 
@@ -472,7 +472,7 @@ project
       ├── cost: 0.001089
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4)
-      ├── ordering: +4 opt(2,3,6)
+      ├── ordering: +4 opt(2,3,6) [provided: +4]
       ├── prune: (1-4,6)
       └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
 
@@ -529,7 +529,7 @@ project
       ├── cost: 0.0053361
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
-      ├── ordering: +4 opt(2,3,6)
+      ├── ordering: +4 opt(2,3,6) [provided: +4]
       ├── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
       └── scan customer@customer_idx
            ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
@@ -538,7 +538,7 @@ project
            ├── cost: 0.001089
            ├── key: (1)
            ├── fd: ()-->(2,3,6), (1)-->(4)
-           ├── ordering: +4 opt(2,3,6)
+           ├── ordering: +4 opt(2,3,6) [provided: +4]
            ├── prune: (1-4,6)
            └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
 

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -431,12 +431,12 @@ project
       ├── cardinality: [0 - 100]
       ├── key: (17,18)
       ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
-      ├── ordering: -15,+23,+11,+(1|17)
+      ├── ordering: -15,+23,+11,+(1|17) [provided: -15,+23,+11,+1]
       ├── sort
       │    ├── columns: p_partkey:1(int) p_mfgr:3(string) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float!null) nation.n_name:23(string) min:48(float!null)
       │    ├── key: (17,18)
       │    ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
-      │    ├── ordering: -15,+23,+11,+(1|17)
+      │    ├── ordering: -15,+23,+11,+(1|17) [provided: -15,+23,+11,+1]
       │    └── select
       │         ├── columns: p_partkey:1(int) p_mfgr:3(string) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_partkey:17(int!null) partsupp.ps_suppkey:18(int!null) partsupp.ps_supplycost:20(float!null) nation.n_name:23(string) min:48(float!null)
       │         ├── key: (17,18)
@@ -2102,23 +2102,23 @@ project
  │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null) lineitem.l_partkey:27(int) lineitem.l_quantity:30(float)
  │    │    │    │    │    │    ├── key columns: [26 29] = [26 29]
  │    │    │    │    │    │    ├── fd: ()-->(20,23)
- │    │    │    │    │    │    ├── ordering: +17 opt(20,23)
+ │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [provided: +17]
  │    │    │    │    │    │    ├── left-join (lookup lineitem@l_pk)
  │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null) lineitem.l_orderkey:26(int) lineitem.l_partkey:27(int) lineitem.l_linenumber:29(int)
  │    │    │    │    │    │    │    ├── key columns: [17] = [27]
  │    │    │    │    │    │    │    ├── key: (17,26,29)
  │    │    │    │    │    │    │    ├── fd: ()-->(20,23), (26,29)-->(27)
- │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23)
+ │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [provided: +17]
  │    │    │    │    │    │    │    ├── select
  │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null)
  │    │    │    │    │    │    │    │    ├── key: (17)
  │    │    │    │    │    │    │    │    ├── fd: ()-->(20,23)
- │    │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23)
+ │    │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [provided: +17]
  │    │    │    │    │    │    │    │    ├── scan part
  │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null)
  │    │    │    │    │    │    │    │    │    ├── key: (17)
  │    │    │    │    │    │    │    │    │    ├── fd: (17)-->(20,23)
- │    │    │    │    │    │    │    │    │    └── ordering: +17 opt(20,23)
+ │    │    │    │    │    │    │    │    │    └── ordering: +17 opt(20,23) [provided: +17]
  │    │    │    │    │    │    │    │    └── filters
  │    │    │    │    │    │    │    │         ├── p_brand = 'Brand#23' [type=bool, outer=(20), constraints=(/20: [/'Brand#23' - /'Brand#23']; tight), fd=()-->(20)]
  │    │    │    │    │    │    │    │         └── p_container = 'MED BOX' [type=bool, outer=(23), constraints=(/23: [/'MED BOX' - /'MED BOX']; tight), fd=()-->(23)]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -214,7 +214,7 @@ project
 memo
 SELECT y, x-1 AS z FROM a WHERE x>y ORDER BY x, y DESC
 ----
-memo (optimized, ~4KB, required=[presentation: y:2,z:5] [ordering: +1,-2])
+memo (optimized, ~5KB, required=[presentation: y:2,z:5] [ordering: +1,-2])
  ├── G1: (project G2 G3 x y)
  │    ├── [presentation: y:2,z:5] [ordering: +1,-2]
  │    │    ├── best: (project G2="[ordering: +1,-2]" G3 x y)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -796,7 +796,7 @@ memo (optimized, ~5KB, required=[presentation: sum:5])
 memo
 SELECT sum(w) FROM kuvw GROUP BY v
 ----
-memo (optimized, ~4KB, required=[presentation: sum:5])
+memo (optimized, ~5KB, required=[presentation: sum:5])
  ├── G1: (project G2 G3 sum)
  │    └── [presentation: sum:5]
  │         ├── best: (project G2 G3 sum)
@@ -821,7 +821,7 @@ memo (optimized, ~4KB, required=[presentation: sum:5])
 memo
 SELECT array_agg(w) FROM (SELECT * FROM kuvw ORDER BY u,w) GROUP BY v
 ----
-memo (optimized, ~4KB, required=[presentation: array_agg:5])
+memo (optimized, ~5KB, required=[presentation: array_agg:5])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:5]
  │         ├── best: (project G2 G3 array_agg)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -86,7 +86,7 @@ TABLE xyz
 memo
 SELECT * FROM abc JOIN xyz ON a=z
 ----
-memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~9KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+7) (lookup-join G3 G5 abc@ab,keyCols=[7],outCols=(1-3,5-7))
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (inner-join G2 G3 G4)
@@ -114,7 +114,7 @@ memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
 memo
 SELECT * FROM abc FULL OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~7KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (full-join G2 G3 G4) (full-join G3 G2 G4) (merge-join G2 G3 G5 full-join,+1,+7)
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (full-join G2 G3 G4)
@@ -181,7 +181,7 @@ full-join
 memo
 SELECT * FROM abc LEFT OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~7KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (left-join G2 G3 G4) (right-join G3 G2 G4) (merge-join G2 G3 G5 left-join,+1,+7)
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (left-join G2 G3 G4)
@@ -228,7 +228,7 @@ right-join
 memo
 SELECT * FROM abc RIGHT OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~9KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (right-join G2 G3 G4) (left-join G3 G2 G4) (merge-join G2 G3 G5 right-join,+1,+7) (lookup-join G3 G5 abc@ab,keyCols=[7],outCols=(1-3,5-7))
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (right-join G2 G3 G4)
@@ -667,7 +667,7 @@ right-join (merge)
  │    ├── left ordering: +1,+2
  │    ├── right ordering: +5,+6
  │    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
- │    ├── ordering: +(1|5)
+ │    ├── ordering: +(1|5) [provided: +1]
  │    ├── scan abc@ab
  │    │    ├── columns: a:1(int) b:2(int) c:3(int)
  │    │    └── ordering: +1,+2
@@ -698,7 +698,7 @@ left-join (merge)
  │    ├── left ordering: +1,+2
  │    ├── right ordering: +5,+6
  │    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
- │    ├── ordering: +(1|5),+(2|6)
+ │    ├── ordering: +(1|5),+(2|6) [provided: +1,+2]
  │    ├── scan abc@ab
  │    │    ├── columns: a:1(int) b:2(int) c:3(int)
  │    │    └── ordering: +1,+2

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -118,7 +118,7 @@ limit
 memo
 SELECT s FROM a WHERE s='foo' LIMIT 1
 ----
-memo (optimized, ~5KB, required=[presentation: s:4])
+memo (optimized, ~6KB, required=[presentation: s:4])
  ├── G1: (limit G2 G3) (scan a@s_idx,cols=(4),constrained,lim=1) (scan a@si_idx,cols=(4),constrained,lim=1)
  │    └── [presentation: s:4]
  │         ├── best: (scan a@s_idx,cols=(4),constrained,lim=1)

--- a/pkg/sql/opt/xform/testdata/rules/manual
+++ b/pkg/sql/opt/xform/testdata/rules/manual
@@ -63,7 +63,7 @@ project
       ├── constraint: /2/3: (/1/NULL - /1]
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3), (3)-->(1)
-      └── ordering: +3 opt(2)
+      └── ordering: +3 opt(2) [provided: +3]
 
 # d is required for the ordering, so requires a lookup-join.
 opt
@@ -73,7 +73,7 @@ sort
  ├── columns: a:1(int!null)  [hidden: b:2(int!null) c:3(int) d:4(int)]
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3,4), (2,3)~~>(1,4)
- ├── ordering: +3,+4 opt(2)
+ ├── ordering: +3,+4 opt(2) [provided: +3,+4]
  └── index-join abcde
       ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int)
       ├── key: (1)
@@ -131,7 +131,7 @@ project
       ├── constraint: /2/3: [/1 - /1]
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3), (2,3)~~>(1)
-      └── ordering: +3 opt(2)
+      └── ordering: +3 opt(2) [provided: +3]
 
 # Filter "b", but do not use it in the projection or ORDER BY. Add an additional
 # column to the ordering that triggers lookup-join.

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -243,12 +243,12 @@ Source expression:
    ├── columns: s:4(string!null) i:2(int) f:3(float)  [hidden: k:1(int!null)]
    ├── key: (1)
    ├── fd: ()-->(4), (1)-->(2,3)
-   ├── ordering: +1 opt(4)
+   ├── ordering: +1 opt(4) [provided: +1]
    ├── scan a@s_idx
    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
    │    ├── key: (1)
    │    ├── fd: (1)-->(2-4)
-   │    └── ordering: +1 opt(4)
+   │    └── ordering: +1 opt(4) [provided: +4,+1]
    └── filters
         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
@@ -258,14 +258,14 @@ New expression 1 of 2:
    ├── constraint: /4/1: [/'foo' - /'foo']
    ├── key: (1)
    ├── fd: ()-->(4), (1)-->(2,3)
-   └── ordering: +1 opt(4)
+   └── ordering: +1 opt(4) [provided: +1]
 
 New expression 2 of 2:
   sort
    ├── columns: s:4(string!null) i:2(int) f:3(float)  [hidden: k:1(int!null)]
    ├── key: (1)
    ├── fd: ()-->(4), (1)-->(2,3)
-   ├── ordering: +1 opt(4)
+   ├── ordering: +1 opt(4) [provided: +1]
    └── index-join a
         ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null)
         ├── key: (1)
@@ -380,7 +380,7 @@ TABLE abc
 memo
 SELECT d FROM abc ORDER BY lower(d)
 ----
-memo (optimized, ~2KB, required=[presentation: d:4] [ordering: +5])
+memo (optimized, ~3KB, required=[presentation: d:4] [ordering: +5])
  ├── G1: (project G2 G3 d)
  │    ├── [presentation: d:4] [ordering: +5]
  │    │    ├── best: (sort G1)


### PR DESCRIPTION
This change implements logic to determine specific Provided orderings
that can be used to configure distsql correctly. See #31882 and the
description in `ordering/doc.go`.

In a follow-up change we will modify the execbuilder to use
`ProvidedOrdering` and re-enable the group-by optimization where we
set all grouping columns as optionals in the required ordering.

Informs #31882.

Release note: None