### PR TITLE
 util/uuid: replace crypto/rand with math/rand in UUID generation, 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -743,6 +743,14 @@
   revision = "d723c7237b64c7871a69e4c411acb04245bcd23d"
 
 [[projects]]
+  digest = "1:3a26588bc48b96825977c1b3df964f8fd842cd6860cc26370588d3563433cf11"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:e145e9710a10bc114a6d3e2738aadf8de146adaa031854ffdf7bbfe15da85e63"
   name = "github.com/googleapis/gax-go"
   packages = ["."]
@@ -1251,14 +1259,6 @@
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:274f67cb6fed9588ea2521ecdac05a6d62a8c51c074c1fccc6a49a40ba80e925"
-  name = "github.com/satori/go.uuid"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
-
-[[projects]]
   branch = "master"
   digest = "1:3b2f0fcb35e10e0f7845f2182e4dd22f5a6fe3db5d1044ca815d646992a2444f"
   name = "github.com/sdboyer/constext"
@@ -1705,6 +1705,7 @@
     "github.com/google/go-github/github",
     "github.com/google/pprof/driver",
     "github.com/google/pprof/profile",
+    "github.com/google/uuid",
     "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
     "github.com/grpc-ecosystem/grpc-gateway/runtime",
     "github.com/grpc-ecosystem/grpc-gateway/utilities",
@@ -1745,7 +1746,6 @@
     "github.com/rcrowley/go-metrics",
     "github.com/rcrowley/go-metrics/exp",
     "github.com/sasha-s/go-deadlock",
-    "github.com/satori/go.uuid",
     "github.com/shirou/gopsutil/cpu",
     "github.com/shirou/gopsutil/disk",
     "github.com/shirou/gopsutil/host",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,14 +67,6 @@ ignored = [
   source = "https://github.com/cockroachdb/vitess"
   branch = "no-flag-names-parens"
 
-# The master version of go.uuid has an incompatible interface and (as
-# of 2018-06-06) a serious bug. Don't upgrade without making sure
-# that bug is fixed.
-# https://github.com/cockroachdb/cockroach/issues/26332
-[[constraint]]
-  name = "github.com/satori/go.uuid"
-  version = "v1.2.0"
-
 # We want https://github.com/go-yaml/yaml/pull/381
 [[constraint]]
   name = "gopkg.in/yaml.v2"

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -930,11 +930,11 @@ func TestLint(t *testing.T) {
 
 		// forbiddenImportPkg -> permittedReplacementPkg
 		forbiddenImports := map[string]string{
-			"golang.org/x/net/context": "context",
-			"log":  "util/log",
-			"path": "path/filepath",
+			"golang.org/x/net/context":         "context",
+			"log":                              "util/log",
+			"path":                             "path/filepath",
 			"github.com/golang/protobuf/proto": "github.com/gogo/protobuf/proto",
-			"github.com/satori/go.uuid":        "util/uuid",
+			"github.com/google/uuid":           "util/uuid",
 			"golang.org/x/sync/singleflight":   "github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight",
 			"syscall":                          "sysutil",
 		}
@@ -994,7 +994,7 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`cockroach/pkg/util/caller: path$`),
 			stream.GrepNot(`cockroach/pkg/ccl/storageccl: path$`),
 			stream.GrepNot(`cockroach/pkg/ccl/workloadccl: path$`),
-			stream.GrepNot(`cockroach/pkg/util/uuid: github\.com/satori/go\.uuid$`),
+			stream.GrepNot(`cockroach/pkg/util/uuid: github\.com/google/uuid$`),
 		), func(s string) {
 			pkgStr := strings.Split(s, ": ")
 			importingPkg, importedPkg := pkgStr[0], pkgStr[1]

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -2148,7 +2148,7 @@ func DecodeUntaggedBitArrayValue(b []byte) (remaining []byte, d bitarray.BitArra
 
 const uuidValueEncodedLength = 16
 
-var _ [uuidValueEncodedLength]byte = (uuid.UUID{}).UUID // Assert that "github.com/satori/go.uuid" is length 16.
+var _ [uuidValueEncodedLength]byte = (uuid.UUID{}).UUID // Assert that "github.com/google/uuid".UUID is length 16.
 
 // DecodeUUIDValue decodes a value encoded by EncodeUUIDValue.
 func DecodeUUIDValue(b []byte) (remaining []byte, u uuid.UUID, err error) {


### PR DESCRIPTION
Replace github.com/satori/go.uuid with github.com/google/uuid which supports injection of source of randomness. 
Fixes #30236
Release note (performance improvement): Stop using crypto/rand for UUID generation