### PR TITLE
roachtest: randomize enabling encryption-at-rest

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -17,13 +17,16 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"os/user"
 
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/spf13/cobra"
 )
 
 func main() {
+	rand.Seed(timeutil.Now().UnixNano())
 	username := os.Getenv("ROACHPROD_USER")
 	parallelism := 10
 	// Path to a local dir where the test logs and artifacts collected from
@@ -67,8 +70,9 @@ func main() {
 		&cockroach, "cockroach", "", "path to cockroach binary to use")
 	rootCmd.PersistentFlags().StringVar(
 		&workload, "workload", "", "path to workload binary to use")
-	rootCmd.PersistentFlags().BoolVarP(
-		&encrypt, "encrypt", "", encrypt, "start cluster with encryption at rest turned on")
+	f := rootCmd.PersistentFlags().VarPF(
+		&encrypt, "encrypt", "", "start cluster with encryption at rest turned on")
+	f.NoOptDefVal = "true"
 
 	var listCmd = &cobra.Command{
 		Use:   "list [tests]",


### PR DESCRIPTION
Change the `--encrypt` flag to support `--encrypt=random` which
randomizes whether encryption-at-rest is enabled for a particular
test. The default is still `--encrypt=false`. As before, if a test
explicitly asks for encryption to be enabled or disabled, that setting
overrides the command line setting.

Fixes #32224

Release note: None