### PR TITLE
sql: automatically add index for fk constraint on empty table

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -17,10 +17,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-	mysqltypes "vitess.io/vitess/go/sqltypes"
-	mysql "vitess.io/vitess/go/vt/sqlparser"
-
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
@@ -32,6 +28,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
+	mysqltypes "vitess.io/vitess/go/sqltypes"
+	mysql "vitess.io/vitess/go/vt/sqlparser"
 )
 
 // mysqldumpReader reads the default output of `mysqldump`, which consists of
@@ -481,7 +480,7 @@ type delayedFK struct {
 func addDelayedFKs(ctx context.Context, defs []delayedFK, resolver fkResolver) error {
 	for _, def := range defs {
 		if err := sql.ResolveFK(
-			ctx, nil, resolver, def.tbl, def.def, map[sqlbase.ID]*sqlbase.MutableTableDescriptor{}, sqlbase.ConstraintValidity_Validated,
+			ctx, nil, resolver, def.tbl, def.def, map[sqlbase.ID]*sqlbase.MutableTableDescriptor{}, sql.NewTable,
 		); err != nil {
 			return err
 		}

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -268,7 +268,7 @@ func readPostgresCreateTable(
 					continue
 				}
 				for _, constraint := range constraints {
-					if err := sql.ResolveFK(evalCtx.Ctx(), nil /* txn */, fks.resolver, desc, constraint, backrefs, sqlbase.ConstraintValidity_Validated); err != nil {
+					if err := sql.ResolveFK(evalCtx.Ctx(), nil /* txn */, fks.resolver, desc, constraint, backrefs, sql.NewTable); err != nil {
 						return nil, err
 					}
 				}

--- a/pkg/cmd/roachtest/hibernate_blacklist.go
+++ b/pkg/cmd/roachtest/hibernate_blacklist.go
@@ -15,9 +15,7 @@
 
 package main
 
-import (
-	"strings"
-)
+import "strings"
 
 type blacklist map[string]string
 
@@ -66,7 +64,6 @@ var hibernateBlackList2_2 = blacklist{
 	"org.hibernate.jpa.test.criteria.basic.CastTest.testCastToString":                                                                                                                "5807",
 	"org.hibernate.jpa.test.criteria.basic.PredicateTest.testQuotientConversion":                                                                                                     "26732",
 	"org.hibernate.jpa.test.emops.RemoveTest.testUpdatedAndRemove":                                                                                                                   "6583",
-	"org.hibernate.jpa.test.exception.ExceptionTest.testConstraintViolationException":                                                                                                "26738",
 	"org.hibernate.jpa.test.indetifier.AssignedInitialValueTableGeneratorConfiguredTest.testTheFirstGeneratedIdIsEqualToTableGeneratorInitialValuePlusOne":                           "6583",
 	"org.hibernate.jpa.test.indetifier.AssignedInitialValueTableGeneratorConfiguredTest.testTheGeneratedIdValuesAreCorrect":                                                          "6583",
 	"org.hibernate.jpa.test.indetifier.DefaultInitialValueTableGeneratorConfiguredTest.testTheFirstGeneratedIdIsEqualToTableGeneratorInitialValuePlusOne":                            "6583",
@@ -128,7 +125,6 @@ var hibernateBlackList2_2 = blacklist{
 	"org.hibernate.test.annotations.naturalid.ImmutableNaturalKeyLookupTest.testNaturalKeyLookupWithConstraint":                                                                      "6583",
 	"org.hibernate.test.annotations.naturalid.ImmutableNaturalKeyLookupTest.testSimpleImmutableNaturalKeyLookup":                                                                     "6583",
 	"org.hibernate.test.annotations.naturalid.ImmutableNaturalKeyLookupTest.testSubCriteriaOneToOneJoin":                                                                             "6583",
-	"org.hibernate.test.annotations.onetomany.OneToManyTest.testCascadeDeleteWithUnidirectionalAssociation":                                                                          "26738",
 	"org.hibernate.test.annotations.onetoone.hhh9798.OneToOneJoinTableTest.storeNonUniqueRelationship":                                                                               "5807",
 	"org.hibernate.test.annotations.tableperclass.TablePerClassTest.testUnionSubClass":                                                                                               "6583",
 	"org.hibernate.test.annotations.xml.hbm.HbmWithIdentityTest.testManyToOneAndInterface":                                                                                           "24062",
@@ -228,8 +224,8 @@ var hibernateBlackList2_2 = blacklist{
 	"org.hibernate.test.immutable.entitywithmutablecollection.noninverse.VersionedEntityWithNonInverseOneToManyJoinTest.testOneToManyCollectionOptimisticLockingWithUpdate":          "5807",
 	"org.hibernate.test.insertordering.InsertOrderingWithCascadeOnPersist.testInsertOrderingAvoidingForeignKeyConstraintViolation":                                                   "6583",
 	"org.hibernate.test.insertordering.InsertOrderingWithJoinedTableInheritance.testBatchOrdering":                                                                                   "5807",
-	"org.hibernate.test.insertordering.InsertOrderingWithJoinedTableInheritance.testBatchingAmongstSubClasses":                                                                       "26738",
-	"org.hibernate.test.insertordering.InsertOrderingWithJoinedTableMultiLevelInheritance.testBatchingAmongstSubClasses":                                                             "26738",
+	"org.hibernate.test.insertordering.InsertOrderingWithJoinedTableInheritance.testBatchingAmongstSubClasses":                                                                       "5807",
+	"org.hibernate.test.insertordering.InsertOrderingWithJoinedTableMultiLevelInheritance.testBatchingAmongstSubClasses":                                                             "5807",
 	"org.hibernate.test.insertordering.InsertOrderingWithTablePerClassInheritance.testBatchOrdering":                                                                                 "5807",
 	"org.hibernate.test.insertordering.InsertOrderingWithTablePerClassInheritance.testBatchingAmongstSubClasses":                                                                     "5807",
 	"org.hibernate.test.interfaceproxy.InterfaceProxyTest.testInterfaceProxies":                                                                                                      "26725",
@@ -270,7 +266,7 @@ var hibernateBlackList2_2 = blacklist{
 	"org.hibernate.test.legacy.MultiTableTest.testMultiTable":                                                                                                                        "6583",
 	"org.hibernate.test.legacy.MultiTableTest.testMultiTableGeneratedId":                                                                                                             "6583",
 	"org.hibernate.test.legacy.ParentChildTest.testComplexCriteria":                                                                                                                  "6583",
-	"org.hibernate.test.legacy.ParentChildTest.testLoadAfterNonExists":                                                                                                               "26738",
+	"org.hibernate.test.legacy.ParentChildTest.testLoadAfterNonExists":                                                                                                               "unknown",
 	"org.hibernate.test.legacy.ParentChildTest.testLocking":                                                                                                                          "6583",
 	"org.hibernate.test.legacy.SQLFunctionsTest.testBlobClob":                                                                                                                        "26725",
 	"org.hibernate.test.loadplans.process.inheritance.Test.basicTest":                                                                                                                "5807",
@@ -301,7 +297,6 @@ var hibernateBlackList2_2 = blacklist{
 	"org.hibernate.test.locking.paging.PagingAndLockingTest.testCriteria":                                                                                                            "6583",
 	"org.hibernate.test.locking.paging.PagingAndLockingTest.testHql":                                                                                                                 "6583",
 	"org.hibernate.test.locking.paging.PagingAndLockingTest.testNativeSql":                                                                                                           "6583",
-	"org.hibernate.test.manytomany.ManyToManyBidirectionalTest.testRemoveMappedBySide":                                                                                               "26738",
 	"org.hibernate.test.mixed.MixedTest.testMixedInheritance":                                                                                                                        "26725",
 	"org.hibernate.test.naturalid.mutable.cached.CachedMutableNaturalIdNonStrictReadWriteTest.testReattachementUnmodifiedInstance":                                                   "6583",
 	"org.hibernate.test.naturalid.mutable.cached.CachedMutableNaturalIdStrictReadWriteTest.testReattachementUnmodifiedInstance":                                                      "6583",
@@ -332,8 +327,8 @@ var hibernateBlackList2_2 = blacklist{
 	"org.hibernate.test.quote.TableGeneratorQuotingTest.testTableGeneratorQuoting":                                                                                                   "16769",
 	"org.hibernate.test.schemaupdate.MigrationTest.testIndexCreationViaSchemaUpdate":                                                                                                 "31761",
 	"org.hibernate.test.schemaupdate.PostgreSQLMultipleSchemaSequenceTest.test":                                                                                                      "26443",
-	"org.hibernate.test.schemaupdate.SchemaUpdateTest.testSchemaUpdateAndValidation[0]":                                                                                              "26738",
-	"org.hibernate.test.schemaupdate.SchemaUpdateTest.testSchemaUpdateAndValidation[1]":                                                                                              "26738",
+	"org.hibernate.test.schemaupdate.SchemaUpdateTest.testSchemaUpdateAndValidation[0]":                                                                                              "24062",
+	"org.hibernate.test.schemaupdate.SchemaUpdateTest.testSchemaUpdateAndValidation[1]":                                                                                              "24062",
 	"org.hibernate.test.schemaupdate.SchemaUpdateWithFunctionIndexTest.testUpdateSchema":                                                                                             "9682",
 	"org.hibernate.test.schemaupdate.SchemaUpdateWithViewsTest.testUpdateSchema":                                                                                                     "24897",
 	"org.hibernate.test.schemaupdate.foreignkeys.crossschema.CrossSchemaForeignKeyGenerationTest.testImprovedSchemaMigrationForeignKeysAreGeneratedAfterAllTheTablesAreCreated":      "26443",

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -725,22 +725,11 @@ CREATE TABLE a (id SERIAL NOT NULL, self_id INT, b_id INT NOT NULL, PRIMARY KEY 
 statement ok
 CREATE TABLE b (id SERIAL NOT NULL, PRIMARY KEY (id))
 
-# Adding a self-ref FK to an _existing_ table also works.
-statement error foreign key requires an existing index on columns \("self_id"\)
-ALTER TABLE a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES a;
-
-statement ok
-CREATE INDEX ON a (self_id);
-
+# The index needed for the fk constraint is automatically added because the table is empty
 statement ok
 ALTER TABLE a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES a;
 
-statement error foreign key requires an existing index on columns \("b_id"\)
-ALTER TABLE a ADD CONSTRAINT fk_b FOREIGN KEY (b_id) REFERENCES b;
-
-statement ok
-CREATE INDEX ON a (b_id);
-
+# The index needed for the fk constraint is automatically added because the table is empty
 statement ok
 ALTER TABLE a ADD CONSTRAINT fk_b FOREIGN KEY (b_id) REFERENCES b;
 
@@ -852,24 +841,6 @@ DROP TABLE refers1
 
 statement ok
 COMMIT
-
-statement ok
-CREATE TABLE a (id BIGSERIAL NOT NULL, self_id INT, b_id INT UNIQUE NOT NULL, PRIMARY KEY (id));
-
-statement error foreign key requires an existing index on columns \("self_id"\)
-ALTER TABLE a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES a(b_id);
-
-statement ok
-DROP TABLE a;
-
-statement ok
-CREATE TABLE a (id BIGSERIAL NOT NULL, self_id INT, b_id INT UNIQUE NOT NULL, PRIMARY KEY (id));
-
-statement error foreign key requires an existing index on columns \("self_id"\)
-ALTER TABLE a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES a(b_id);
-
-statement ok
-DROP TABLE a;
 
 # Check that removing self-ref FK correctly removed backref too, #16070.
 statement ok
@@ -1468,3 +1439,99 @@ INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, NULL, NULL)
 
 statement ok
 DROP TABLE b, a
+
+subtest auto_add_fk_with_composite_index_to_empty_table
+
+statement ok
+CREATE TABLE parent_composite_index (a_id INT NOT NULL, b_id INT NOT NULL, PRIMARY KEY (a_id, b_id))
+
+statement ok
+CREATE TABLE child_composite_index (id SERIAL NOT NULL, parent_a_id INT, parent_b_id INT, PRIMARY KEY (id))
+
+# The (composite) index needed for the fk constraint is automatically added because the table is empty
+statement ok
+ALTER TABLE child_composite_index ADD CONSTRAINT fk_id FOREIGN KEY (parent_a_id, parent_b_id) REFERENCES parent_composite_index;
+
+statement ok
+INSERT INTO parent_composite_index VALUES (100, 200)
+
+statement ok
+INSERT INTO child_composite_index VALUES (1, 100, 200)
+
+statement error foreign key violation: value \[100 300\] not found in parent_composite_index@primary \[a_id b_id\]
+INSERT INTO child_composite_index VALUES (2, 100, 300)
+
+statement ok
+DROP TABLE child_composite_index, parent_composite_index
+
+subtest auto_add_fk_to_nonempty_table_error
+
+statement ok
+CREATE TABLE nonempty_a (id SERIAL NOT NULL, self_id INT, b_id INT NOT NULL, PRIMARY KEY (id))
+
+statement ok
+CREATE TABLE nonempty_b (id SERIAL NOT NULL, PRIMARY KEY (id))
+
+statement ok
+INSERT INTO nonempty_b VALUES (1), (2), (3);
+
+statement ok
+INSERT INTO nonempty_a VALUES (1, NULL, 1)
+
+# Fails because self_id is not indexed, and an index will not be automatically created because the table is nonempty
+statement error foreign key requires an existing index on columns \("self_id"\)
+ALTER TABLE nonempty_a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES nonempty_a;
+
+statement ok
+CREATE INDEX ON nonempty_a (self_id)
+
+# This now succeeds with the manually added index
+statement ok
+ALTER TABLE nonempty_a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES nonempty_a;
+
+# Fails because b_id is not indexed, and an index will not be automatically created because the table is nonempty
+statement error foreign key requires an existing index on columns \("b_id"\)
+ALTER TABLE nonempty_a ADD CONSTRAINT fk_b FOREIGN KEY (b_id) REFERENCES nonempty_b;
+
+statement ok
+CREATE INDEX ON nonempty_a (b_id)
+
+# This now succeeds with the manually added index
+statement ok
+ALTER TABLE nonempty_a ADD CONSTRAINT fk_b FOREIGN KEY (b_id) REFERENCES nonempty_b;
+
+statement ok
+DROP TABLE nonempty_a, nonempty_b
+
+subtest auto_add_fk_index_name_collision
+
+statement ok
+CREATE TABLE parent_name_collision (id SERIAL NOT NULL, PRIMARY KEY (id))
+
+statement ok
+CREATE TABLE child_name_collision (id SERIAL NOT NULL, parent_id INT, other_col INT)
+
+statement ok
+CREATE INDEX child_name_collision_auto_index_fk_id ON child_name_collision (other_col)
+
+# Testing the unusual case where an index already exists that has the same name
+# as the index to be auto-generated when adding a fk constraint to an empty
+# table (but the existing index is not on the referencing column), in which
+# case the ALTER TABLE will fail due to the name collision.
+statement error duplicate index name: "child_name_collision_auto_index_fk_id"
+ALTER TABLE child_name_collision ADD CONSTRAINT fk_id FOREIGN KEY (parent_id) references parent_name_collision
+
+subtest auto_add_fk_duplicate_cols_error
+
+statement ok
+CREATE TABLE parent (a_id INT, b_id INT, PRIMARY KEY (a_id, b_id))
+
+statement ok
+CREATE TABLE child_duplicate_cols (id INT, parent_id INT, PRIMARY KEY (id))
+
+# The fk constraint is invalid because it has duplicate columns, so automatically adding the index fails
+statement error index \"child_duplicate_cols_auto_index_fk\" contains duplicate column \"parent_id\"
+ALTER TABLE child_duplicate_cols ADD CONSTRAINT fk FOREIGN KEY (parent_id, parent_id) references parent
+
+statement ok
+DROP TABLE parent, child_duplicate_cols

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1,5 +1,170 @@
 # LogicTest: local local-opt local-parallel-stmts fakedist fakedist-opt fakedist-metadata
 
+subtest create_and_add_fk_in_same_txn
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE test.parent (id int primary key)
+
+statement ok
+INSERT INTO test.parent values (1)
+
+statement ok
+CREATE TABLE test.child (id int primary key, parent_id int)
+
+# The index on parent_id is added automatically because test.child is empty
+statement ok
+ALTER TABLE test.child ADD CONSTRAINT fk_child_parent_id FOREIGN KEY (parent_id) REFERENCES test.parent (id);
+
+statement ok
+INSERT INTO test.child VALUES (1, 1)
+
+# Check that the auto-created index is visible
+query II rowsort
+SELECT * FROM test.child@child_auto_index_fk_child_parent_id
+----
+1 1
+
+statement ok
+COMMIT
+
+statement ok
+DROP TABLE test.child, test.parent
+
+subtest create_and_add_fk_in_separate_txns
+
+statement ok
+CREATE TABLE test.parent (id int primary key)
+
+statement ok
+INSERT INTO test.parent values (1)
+
+statement ok
+CREATE TABLE test.child (id int primary key, parent_id int)
+
+statement ok
+BEGIN
+
+# The index on parent_id is added automatically because test.child is empty
+statement ok
+ALTER TABLE test.child ADD CONSTRAINT fk_child_parent_id FOREIGN KEY (parent_id) REFERENCES test.parent (id);
+
+statement ok
+INSERT INTO test.child VALUES (1, 1)
+
+statement ok
+COMMIT
+
+# Check that the auto-created index is visible
+query II rowsort
+SELECT * FROM test.child@child_auto_index_fk_child_parent_id
+----
+1 1
+
+statement ok
+DROP TABLE test.child, test.parent
+
+subtest auto_add_fk_with_composite_index_to_empty_table
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE parent_composite_index (a_id INT NOT NULL, b_id INT NOT NULL, PRIMARY KEY (a_id, b_id))
+
+statement ok
+CREATE TABLE child_composite_index (id SERIAL NOT NULL, parent_a_id INT, parent_b_id INT, PRIMARY KEY (id))
+
+# The (composite) index needed for the fk constraint is automatically added because the table is empty
+statement ok
+ALTER TABLE child_composite_index ADD CONSTRAINT fk_id FOREIGN KEY (parent_a_id, parent_b_id) REFERENCES parent_composite_index;
+
+statement ok
+INSERT INTO parent_composite_index VALUES (100, 200)
+
+statement ok
+INSERT INTO child_composite_index VALUES (1, 100, 200)
+
+# Check that the auto-created index is visible
+query III rowsort
+SELECT * FROM child_composite_index@child_composite_index_auto_index_fk_id
+----
+1 100 200
+
+statement ok
+COMMIT
+
+statement ok
+DROP TABLE parent_composite_index, child_composite_index
+
+subtest auto_add_fk_to_nonempty_table_error
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE nonempty_a (id SERIAL NOT NULL, self_id INT, b_id INT NOT NULL, PRIMARY KEY (id))
+
+statement ok
+CREATE TABLE nonempty_b (id SERIAL NOT NULL, PRIMARY KEY (id))
+
+statement ok
+INSERT INTO nonempty_b VALUES (1), (2), (3);
+
+statement ok
+INSERT INTO nonempty_a VALUES (1, NULL, 1)
+
+# Fails because self_id is not indexed, and an index will not be automatically created because the table is nonempty
+statement error foreign key requires an existing index on columns \("self_id"\)
+ALTER TABLE nonempty_a ADD CONSTRAINT fk_self_id FOREIGN KEY (self_id) REFERENCES nonempty_a;
+
+statement ok
+COMMIT
+
+subtest auto_add_fk_index_name_collision
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE parent_name_collision (id SERIAL NOT NULL, PRIMARY KEY (id))
+
+statement ok
+CREATE TABLE child_name_collision (id SERIAL NOT NULL, parent_id INT, other_col INT)
+
+statement ok
+CREATE INDEX child_name_collision_auto_index_fk_id ON child_name_collision (other_col)
+
+# Testing the unusual case where an index already exists that has the same name
+# as the index to be auto-generated when adding a fk constraint to an empty
+# table (but the existing index is not on the referencing column), in which
+# case the ALTER TABLE will fail due to the name collision.
+statement error duplicate index name: "child_name_collision_auto_index_fk_id"
+ALTER TABLE child_name_collision ADD CONSTRAINT fk_id FOREIGN KEY (parent_id) references parent_name_collision
+
+statement ok
+COMMIT
+
+subtest auto_add_fk_duplicate_cols_error
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE parent (a_id INT, b_id INT, PRIMARY KEY (a_id, b_id))
+
+statement ok
+CREATE TABLE child_duplicate_cols (id INT, parent_id INT, PRIMARY KEY (id))
+
+# The fk constraint is invalid because it has duplicate columns, so automatically adding the index fails
+statement error index \"child_duplicate_cols_auto_index_fk\" contains duplicate column \"parent_id\"
+ALTER TABLE child_duplicate_cols ADD CONSTRAINT fk FOREIGN KEY (parent_id, parent_id) references parent
+
+statement ok
+COMMIT
+
 subtest create_with_other_commands_in_txn
 
 statement count 3


### PR DESCRIPTION
Adding a foreign key constraint requires that the referencing column(s)
be indexed, so previously, an ALTER TABLE statement to add a foreign key
constraint for an existing table would always fail, even if the
referencing table were empty. This change automatically adds the needed
index for the foreign key constraint when the table is empty. This will
improve compatibility with some ORMs, which create tables before adding
foreign key constraints.

Fixes #26738

Release note (sql change): An ALTER TABLE statement to add a foreign key
constraint now automatically creates the necessary index if the
referencing table is empty, if the index does not already exist.