### PR TITLE
changefeedccl: add metrics for performance debugging

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -150,7 +150,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	leaseMgr := ca.flowCtx.LeaseManager.(*sql.LeaseManager)
 	ca.poller = makePoller(
 		ca.flowCtx.Settings, ca.flowCtx.ClientDB, ca.flowCtx.ClientDB.Clock(), ca.flowCtx.Gossip,
-		spans, ca.spec.Feed, initialHighWater, buf, leaseMgr,
+		spans, ca.spec.Feed, initialHighWater, buf, leaseMgr, metrics,
 	)
 	rowsFn := kvsToRows(leaseMgr, ca.spec.Feed, buf.Get)
 
@@ -158,7 +158,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	if cfKnobs, ok := ca.flowCtx.TestingKnobs().Changefeed.(*TestingKnobs); ok {
 		knobs = *cfKnobs
 	}
-	ca.tickFn = emitEntries(ca.flowCtx.Settings, ca.spec.Feed, ca.encoder, ca.sink, rowsFn, knobs)
+	ca.tickFn = emitEntries(ca.flowCtx.Settings, ca.spec.Feed, ca.encoder, ca.sink, rowsFn, knobs, metrics)
 
 	// Give errCh enough buffer both possible errors from supporting goroutines,
 	// but only the first one is ever used.

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -14,7 +14,11 @@
 
 package jobs
 
-import "github.com/cockroachdb/cockroach/pkg/util/metric"
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+)
 
 // Metrics are for production monitoring of each job type.
 type Metrics struct {
@@ -25,12 +29,12 @@ type Metrics struct {
 func (Metrics) MetricStruct() {}
 
 // InitHooks initializes the metrics for job monitoring.
-func (m *Metrics) InitHooks() {
+func (m *Metrics) InitHooks(histogramWindowInterval time.Duration) {
 	if MakeChangefeedMetricsHook != nil {
-		m.Changefeed = MakeChangefeedMetricsHook()
+		m.Changefeed = MakeChangefeedMetricsHook(histogramWindowInterval)
 	}
 }
 
 // MakeChangefeedMetricsHook allows for registration of changefeed metrics from
 // ccl code.
-var MakeChangefeedMetricsHook func() metric.Struct
+var MakeChangefeedMetricsHook func(time.Duration) metric.Struct

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -139,6 +139,7 @@ func MakeRegistry(
 	ex sqlutil.InternalExecutor,
 	nodeID *base.NodeIDContainer,
 	settings *cluster.Settings,
+	histogramWindowInterval time.Duration,
 	planFn planHookMaker,
 ) *Registry {
 	r := &Registry{
@@ -153,7 +154,7 @@ func MakeRegistry(
 	}
 	r.mu.epoch = 1
 	r.mu.jobs = make(map[int64]context.CancelFunc)
-	r.metrics.InitHooks()
+	r.metrics.InitHooks(histogramWindowInterval)
 	return r
 }
 

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
@@ -91,7 +92,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 		nodeID.Reset(id)
 		r := jobs.MakeRegistry(
 			ac, s.Stopper(), clock, db, s.InternalExecutor().(sqlutil.InternalExecutor),
-			nodeID, s.ClusterSettings(), jobs.FakePHS,
+			nodeID, s.ClusterSettings(), server.DefaultHistogramWindowInterval, jobs.FakePHS,
 		)
 		if err := r.Start(ctx, s.Stopper(), nodeLiveness, cancelInterval, adoptInterval); err != nil {
 			t.Fatal(err)

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -39,13 +39,17 @@ func TestRegistryCancelation(t *testing.T) {
 	ctx, stopper := context.Background(), stop.NewStopper()
 	defer stopper.Stop(ctx)
 
+	// Not using the server.DefaultHistogramWindowInterval constant because
+	// of a dep cycle.
+	const histogramWindowInterval = 60 * time.Second
+
 	var db *client.DB
 	// Insulate this test from wall time.
 	mClock := hlc.NewManualClock(hlc.UnixNano())
 	clock := hlc.NewClock(mClock.UnixNano, time.Nanosecond)
 	registry := MakeRegistry(
 		log.AmbientContext{}, stopper, clock, db, nil /* ex */, FakeNodeID, cluster.NoSettings,
-		FakePHS)
+		histogramWindowInterval, FakePHS)
 
 	const nodeCount = 1
 	nodeLiveness := NewFakeNodeLiveness(nodeCount)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -58,8 +58,9 @@ const (
 	defaultScanMaxIdleTime   = 1 * time.Second
 	// NB: this can't easily become a variable as the UI hard-codes it to 10s.
 	// See https://github.com/cockroachdb/cockroach/issues/20310.
-	DefaultMetricsSampleInterval = 10 * time.Second
-	defaultStorePath             = "cockroach-data"
+	DefaultMetricsSampleInterval   = 10 * time.Second
+	DefaultHistogramWindowInterval = 6 * DefaultMetricsSampleInterval
+	defaultStorePath               = "cockroach-data"
 	// TempDirPrefix is the filename prefix of any temporary subdirectory
 	// created.
 	TempDirPrefix = "cockroach-temp"
@@ -277,7 +278,7 @@ type Config struct {
 // metrics. For more information on the issues underlying our histogram system
 // and the proposed fixes, please see issue #7896.
 func (cfg Config) HistogramWindowInterval() time.Duration {
-	hwi := DefaultMetricsSampleInterval * 6
+	hwi := DefaultHistogramWindowInterval
 
 	// Rudimentary overflow detection; this can result if
 	// DefaultMetricsSampleInterval is set to an extremely large number, likely

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -492,6 +492,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		internalExecutor,
 		&s.nodeIDContainer,
 		st,
+		s.cfg.HistogramWindowInterval(),
 		func(opName, user string) (interface{}, func()) {
 			// This is a hack to get around a Go package dependency cycle. See comment
 			// in sql/jobs/registry.go on planHookMaker.


### PR DESCRIPTION
I've been running a branch with a bunch of extra metrics while debugging
issue #32104. PR'ing the ones that have proven useful in case someone
has performance issues in the wild.

Release note (enterprise change): Added timeseries metrics for debugging
CHANGEFEED performance issues.