### PR TITLE
server: Don't let non-superusers see other user's sessions

### DIFF
--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -360,8 +360,8 @@ func newAuthenticationMux(s *authenticationServer, inner http.Handler) *authenti
 type webSessionUserKey struct{}
 type webSessionIDKey struct{}
 
-const webSessionUserKeyStr = "webSessionUser"
-const webSessionIDKeyStr = "webSessionID"
+const webSessionUserKeyStr = "websessionuser"
+const webSessionIDKeyStr = "websessionid"
 
 func (am *authenticationMux) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	username, cookie, err := am.getSession(w, req)


### PR DESCRIPTION
This effectively means that only the root user can see other user's
sessions except when the enterprise-only RBAC feature is enabled and a
user has been added to the "admin" role.

This also changes the behavior of ListSessions and ListLocalSessions to
list whatever sessions they can even if no username is provided, whereas
previously if no username was provided then no sessions would ever be
returned.

Release note (bug fix): Don't let non-superusers see other user's
sessions and queries via the ListSessions and ListLocalSessions status
server API methods.

---

This of course needs tests if we want to keep this approach. I've only manually tested it for now. I'd be fine just putting in a simpler version for v2.1.1 that skips the RBAC admin role check if we want to avoid the extra sql planner machinery.