### PR TITLE
roachtest: determine whether to encrypt clusters once per test

### DIFF
--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -270,6 +270,10 @@ func registerUpgrade(r *registry) {
 }
 
 func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
+	// This is ugly, but we can't pass `--encrypt=false` to old versions of
+	// Cockroach.
+	c.encryptDefault = false
+
 	nodes := c.Range(1, 3)
 	goos := ifLocal(runtime.GOOS, "linux")
 	const headVersion = "HEAD"


### PR DESCRIPTION
The `--encrypt=random` setting was determining whether to use
encryption-at-rest every time the cluster (or a node in the cluster) was
started. This was problematic for tests which restarted nodes multiple
times. Changed the logic so that we "roll the dice" once per test.

Fixes #32245

Release note: None