### PR TITLE
exec: handle more types in materializer

### DIFF
--- a/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
@@ -151,8 +151,10 @@ func getDatumToPhysicalFn(ct sqlbase.ColumnType) string {
 		return "float64(*datum.(*tree.DFloat))"
 	case sqlbase.ColumnType_OID:
 		return "int64(datum.(*tree.DOid).DInt)"
-	case sqlbase.ColumnType_STRING, sqlbase.ColumnType_NAME:
+	case sqlbase.ColumnType_STRING:
 		return "encoding.UnsafeConvertStringToBytes(string(*datum.(*tree.DString)))"
+	case sqlbase.ColumnType_NAME:
+		return "encoding.UnsafeConvertStringToBytes(string(*datum.(*tree.DOidWrapper).Wrapped.(*tree.DString)))"
 	case sqlbase.ColumnType_DECIMAL:
 		return "datum.(*tree.DDecimal).Decimal"
 	}


### PR DESCRIPTION
The materializer wasn't handling all the types which are handled
elsewhere. I brought it up to speed and added a basic test for all
types.

Release note: None