### PR TITLE
roachtest: update hibernate 2.1 blacklist

### DIFF
--- a/pkg/cmd/roachtest/hibernate_blacklist.go
+++ b/pkg/cmd/roachtest/hibernate_blacklist.go
@@ -570,7 +570,6 @@ var hibernateBlackList2_1 = blacklist{
 	"org.hibernate.test.jpa.lock.RepeatableReadTest.testStaleNonVersionedInstanceFoundOnLock":                                                                                        "31671",
 	"org.hibernate.test.jpa.lock.RepeatableReadTest.testStaleVersionedInstanceFoundOnLock":                                                                                           "6583",
 	"org.hibernate.test.legacy.ABCProxyTest.testSubclassing":                                                                                                                         "6583",
-	"org.hibernate.test.legacy.FooBarTest.testCollectionsInSelect":                                                                                                                   "31777",
 	"org.hibernate.test.legacy.FooBarTest.testOnCascadeDelete":                                                                                                                       "unknown",
 	"org.hibernate.test.legacy.FooBarTest.testQuery":                                                                                                                                 "unknown",
 	"org.hibernate.test.legacy.FooBarTest.testVersioning":                                                                                                                            "6583",


### PR DESCRIPTION
The fix for #31777 has now been backported to 2.1.

Fixes #32244.

Release note: None