### PR TITLE
exec: add support for non-distinct equality keys (n-n inner join)

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -190,7 +190,7 @@ func newColOperator(
 			}
 		}
 
-		op, err = exec.NewEqInnerDistinctHashJoiner(
+		op, err = exec.NewEqInnerHashJoiner(
 			inputs[0],
 			inputs[1],
 			core.HashJoiner.LeftEqColumns,
@@ -199,6 +199,8 @@ func newColOperator(
 			rightOutCols,
 			leftTypes,
 			rightTypes,
+			core.HashJoiner.RightEqColumnsAreKey,
+			core.HashJoiner.LeftEqColumnsAreKey || core.HashJoiner.RightEqColumnsAreKey,
 		)
 
 	default:

--- a/pkg/sql/exec/hashjoiner.go
+++ b/pkg/sql/exec/hashjoiner.go
@@ -48,6 +48,10 @@ type hashJoinerSpec struct {
 	// buildRightSide indicates whether or not the build table is the right side.
 	// By default, this flag is false and the build table is the left side.
 	buildRightSide bool
+
+	// buildDistinct indicates whether or not the build table equality column
+	// tuples are distinct. If they are distinct, performance can be optimized.
+	buildDistinct bool
 }
 
 type hashJoinerSourceSpec struct {
@@ -67,9 +71,9 @@ type hashJoinerSourceSpec struct {
 	source Operator
 }
 
-// hashJoinEqInnerDistinctOp performs a hash join on the input tables equality
-// columns. It requires that the build table's equality columns only contain
-// distinct values, otherwise the behavior is undefined. An inner join is
+// hashJoinEqInnerOp performs a hash join on the input tables equality columns.
+// It requires that the output for every input batch in the probe phase fits
+// within ColBatchSize, otherwise the behavior is undefined. An inner join is
 // performed and there is no guarantee on the ordering of the output columns.
 //
 // Before the build phase, all equality and output columns from the build table
@@ -84,8 +88,14 @@ type hashJoinerSourceSpec struct {
 // 3. The bucket-chaining hash table organization is prepared with the computed
 //    buckets.
 //
-// In the vectorized implementation of the probe phrase, the following tasks are
-// performed:
+// Depending on the value of the buildDistinct flag, there are two variations of
+// the probe phase. The planner will set buildDistinct to true if and only if
+// either the left equality columns or the right equality columns make a
+// distinct key. This corresponding table would then be used as the build table.
+//
+// In the vectorized implementation of the distinct build table probe phase, the
+// following tasks are performed by the fastProbe function:
+//
 // 1. Compute the bucket number for each probe rows key tuple and store the
 //    results into the buckets array.
 // 2. In order to find the position of these key tuples in the hash table:
@@ -105,8 +115,37 @@ type hashJoinerSourceSpec struct {
 // 3. Now, groupID for every probe's key tuple contains the index of the
 //    matching build's key tuple in the hash table. Use it to project output
 //    columns from the has table to build the resulting batch.
+//
+// In the vectorized implementation of the non-distinct build table probe phase,
+// the following tasks are performed by the probe function:
+//
+// 1. Compute the bucket number for each probe rows key tuple and store the
+//    results into the buckets array.
+// 2. In order to find the position of these key tuples in the hash table:
+// - First find the first element in the bucket's linked list for each key tuple
+//   and store it in the groupID array. Initialize the toCheck array with the
+//   full sequence of input indices (0...batchSize - 1).
+// - While toCheck is not empty, each element in toCheck represents a position
+//   of the key tuples for which the key has not yet been visited by any prior
+//   probe. Perform a multi-column equality check to see if the key columns
+//   match that of the build table's key columns at groupID.
+// - Update the differs array to store whether or not the probe's key tuple
+//   matched the corresponding build's key tuple.
+// - For the indices that did not differ, we can lazily update the hashTable's
+//   same linked list to store a list of all identical keys starting at head.
+//   Once a key has been added to ht.same, ht.visited is set to true. For the
+//   indices that have never been visited, we want to continue checking this
+//   bucket for identical values by adding this key to toCheck.
+// - Select the indices that differed and store them into toCheck since they
+//   need to be further processed.
+// - For the differing tuples, find the next ID in that bucket of the hash table
+//   and put it into the groupID array.
+// 3. Now, head stores the keyID of the first match in the build table for every
+//    probe table key. ht.same is used to select all build key matches for each
+//    probe key, which are added to the resulting batch. Output batching is done
+//    to ensure that each batch is at most ColBatchSize.
 
-type hashJoinEqInnerDistinctOp struct {
+type hashJoinEqInnerOp struct {
 	// spec, if not nil, holds the specification for the current hash joiner
 	// process.
 	spec hashJoinerSpec
@@ -114,6 +153,9 @@ type hashJoinEqInnerDistinctOp struct {
 	// ht holds the hashTable that is populated during the build
 	// phase and used during the probe phase.
 	ht *hashTable
+
+	// builder is used by the hashJoiner to execute the build phase.
+	builder *hashJoinBuilder
 
 	// prober, if not nil, stores the batch prober used by the hashJoiner in the
 	// probe phase.
@@ -123,44 +165,73 @@ type hashJoinEqInnerDistinctOp struct {
 	runningState hashJoinerState
 }
 
-var _ Operator = &hashJoinEqInnerDistinctOp{}
+var _ Operator = &hashJoinEqInnerOp{}
 
-func (hj *hashJoinEqInnerDistinctOp) Init() {
+func (hj *hashJoinEqInnerOp) Init() {
 	hj.spec.left.source.Init()
 	hj.spec.right.source.Init()
 
 	// Prepare the hashTable using the specified side as the build table. Prepare
 	// the prober using the other side as the probe table.
+	var build, probe hashJoinerSourceSpec
 	if hj.spec.buildRightSide {
-		hj.ht = makeHashTable(hashTableBucketSize, hj.spec.right.sourceTypes, hj.spec.right.eqCols, hj.spec.right.outCols)
-		hj.prober = makeHashJoinProber(hj.ht, hj.spec.left, hj.spec.right.sourceTypes, hj.spec.right.outCols, true)
+		build = hj.spec.right
+		probe = hj.spec.left
 	} else {
-		hj.ht = makeHashTable(hashTableBucketSize, hj.spec.left.sourceTypes, hj.spec.left.eqCols, hj.spec.left.outCols)
-		hj.prober = makeHashJoinProber(hj.ht, hj.spec.right, hj.spec.left.sourceTypes, hj.spec.left.outCols, false)
+		build = hj.spec.left
+		probe = hj.spec.right
 	}
+
+	hj.ht = makeHashTable(
+		hashTableBucketSize,
+		build.sourceTypes,
+		build.eqCols,
+		build.outCols,
+	)
+
+	hj.builder = makeHashJoinBuilder(
+		hj.ht,
+		build.source,
+		build.eqCols,
+		build.outCols,
+	)
+
+	hj.prober = makeHashJoinProber(
+		hj.ht, probe,
+		build.sourceTypes,
+		build.outCols,
+		hj.spec.buildRightSide,
+	)
 
 	hj.runningState = hjBuilding
 }
 
-func (hj *hashJoinEqInnerDistinctOp) Next() ColBatch {
+func (hj *hashJoinEqInnerOp) Next() ColBatch {
 	switch hj.runningState {
 	case hjBuilding:
 		hj.build()
 		fallthrough
 	case hjProbing:
+		if hj.spec.buildDistinct {
+			return hj.prober.distinctProbe()
+		}
 		return hj.prober.probe()
 	default:
 		panic("hash joiner in unhandled state")
 	}
 }
 
-func (hj *hashJoinEqInnerDistinctOp) build() {
-	builder := makeHashJoinBuilder(hj.ht)
+func (hj *hashJoinEqInnerOp) build() {
 
-	if hj.spec.buildRightSide {
-		builder.exec(hj.spec.right.source, hj.spec.right.eqCols, hj.spec.right.outCols)
-	} else {
-		builder.exec(hj.spec.left.source, hj.spec.left.eqCols, hj.spec.left.outCols)
+	hj.builder.exec()
+
+	if !hj.spec.buildDistinct {
+		hj.ht.same = make([]uint64, hj.ht.size+1)
+		hj.ht.visited = make([]bool, hj.ht.size+1)
+
+		// Since keyID = 0 is reserved for end of list, it can be marked as visited
+		// at the beginning.
+		hj.ht.visited[0] = true
 	}
 
 	hj.runningState = hjProbing
@@ -189,6 +260,15 @@ type hashTable struct {
 	// hash table bucket chain, where an id of 0 is reserved to represent end of
 	// chain.
 	next []uint64
+
+	// same is a densely-packed list that stores the keyID of the next key in the
+	// hash table that has the same value as the current key. The head of the key
+	// is the first key of that value found in the next linked list. This field
+	// will be lazily populated by the prober.
+	same []uint64
+	// visited represents whether each the corresponding key has been touched by
+	// the prober.
+	visited []bool
 
 	// vals stores the union of the equality and output columns of the left
 	// table. A key tuple is defined as the elements in each row of vals that
@@ -361,29 +441,43 @@ func (ht *hashTable) insertKeys(buckets []uint64) {
 // pre-loads all batches from the build relation before building the hash table.
 type hashJoinBuilder struct {
 	ht *hashTable
+
+	// source is the input operator used during the build phase of the hash join.
+	source Operator
+
+	// eqCols and outCols hold the equality and output column indices of the build
+	// table.
+	eqCols  []int
+	outCols []int
 }
 
-func makeHashJoinBuilder(ht *hashTable) *hashJoinBuilder {
+func makeHashJoinBuilder(
+	ht *hashTable, source Operator, eqCols []int, outCols []int,
+) *hashJoinBuilder {
 	return &hashJoinBuilder{
 		ht: ht,
+
+		source:  source,
+		eqCols:  eqCols,
+		outCols: outCols,
 	}
 }
 
 // exec executes the entirety of the hash table build phase using the source as
 // the build relation. The source operator is entirely consumed in the process.
-func (builder *hashJoinBuilder) exec(source Operator, eqCols []int, outCols []int) {
+func (builder *hashJoinBuilder) exec() {
 	for {
-		batch := source.Next()
+		batch := builder.source.Next()
 
 		if batch.Length() == 0 {
 			break
 		}
 
-		builder.ht.loadBatch(batch, eqCols, outCols)
+		builder.ht.loadBatch(batch, builder.eqCols, builder.outCols)
 	}
 
 	// buckets is used to store the computed hash value of each key.
-	nKeys := len(eqCols)
+	nKeys := len(builder.eqCols)
 	keyCols := make([]ColVec, nKeys)
 	for i := 0; i < nKeys; i++ {
 		keyCols[i] = builder.ht.vals[builder.ht.keyCols[i]]
@@ -394,7 +488,7 @@ func (builder *hashJoinBuilder) exec(source Operator, eqCols []int, outCols []in
 	builder.ht.insertKeys(buckets)
 }
 
-// hashJoinProber is used by the hashJoinEqInnerDistinctOp during the probe phase. It
+// hashJoinProber is used by the hashJoinEqInnerOp during the probe phase. It
 // operates on a single batch of obtained from the probe relation and probes the
 // hashTable to construct the resulting output batch.
 type hashJoinProber struct {
@@ -411,6 +505,10 @@ type hashJoinProber struct {
 	// toCheck stores the indices of the eqCol rows that have yet to be found or
 	// rejected.
 	toCheck []uint16
+
+	// head stores the first build table keyID that matched with the probe batch
+	// key at any given index.
+	head []uint64
 
 	// differs stores whether the key at any index differs with the build table
 	// key.
@@ -437,6 +535,10 @@ type hashJoinProber struct {
 	// probeLeftSide indicates whether the prober is probing on the left source or
 	// the right source.
 	probeLeftSide bool
+
+	// prevBatch, if not nil, indicates that the previous probe input batch has
+	// not been fully processed.
+	prevBatch ColBatch
 }
 
 func makeHashJoinProber(
@@ -463,6 +565,8 @@ func makeHashJoinProber(
 		toCheck: make([]uint16, ColBatchSize),
 		differs: make([]bool, ColBatchSize),
 
+		head: make([]uint64, ColBatchSize),
+
 		buildIdx: make([]uint64, ColBatchSize),
 		probeIdx: make([]uint16, ColBatchSize),
 
@@ -478,8 +582,9 @@ func makeHashJoinProber(
 	}
 }
 
-// probe returns a ColBatch with N + M columns where N is the number of left
-// source columns and M is the number of right source columns. The first N
+// probe is a general prober that works with non-distinct build table equality
+// columns. It returns a ColBatch with N + M columns where N is the number of
+// left source columns and M is the number of right source columns. The first N
 // columns correspond to the respective left source columns, followed by the
 // right source columns as the last M elements. Even though all the columns are
 // present in the result, only the specified output columns store relevant
@@ -488,43 +593,52 @@ func makeHashJoinProber(
 func (prober *hashJoinProber) probe() ColBatch {
 	prober.batch.SetLength(0)
 
-	for {
-		batch := prober.spec.source.Next()
+	if batch := prober.prevBatch; batch != nil {
+		prober.prevBatch = nil
 		batchSize := batch.Length()
-
-		if batchSize == 0 {
-			break
-		}
-
-		for i, colIdx := range prober.spec.eqCols {
-			prober.keys[i] = batch.ColVec(colIdx)
-		}
-
 		sel := batch.Selection()
 
-		// initialize groupID with the initial hash buckets and toCheck with all
-		// applicable indices.
-		prober.lookupInitial(batchSize, sel)
-		nToCheck := batchSize
-
-		// continue searching along the hash table next chains for the corresponding
-		// buckets. If the key is found or end of next chain is reached, the key is
-		// removed from the toCheck array.
-		for nToCheck > 0 {
-			nToCheck = prober.check(nToCheck, sel)
-			prober.findNext(nToCheck)
+		nResults := prober.collect(batch, batchSize, sel)
+		prober.congregate(nResults, batch, batchSize, sel)
+	} else {
+		// Reset each element of head to 0 to indicate that the probe key has not been
+		// found in the build table.
+		for i := range prober.head {
+			prober.head[i] = 0
 		}
 
-		prober.collectResults(batch, batchSize, sel)
+		for {
+			batch := prober.spec.source.Next()
+			batchSize := batch.Length()
 
-		// since is possible for the hash join to return an empty group, we should
-		// loop until we have a non-empty output batch, or an empty input batch.
-		// Otherwise, the client will assume that the ColBatch is completely
-		// consumed when it isn't.
-		if prober.batch.Length() > 0 {
-			// todo (changangela): add buffering to return batches of equal length on
-			// each call to Next()
-			break
+			if batchSize == 0 {
+				break
+			}
+
+			for i, colIdx := range prober.spec.eqCols {
+				prober.keys[i] = batch.ColVec(colIdx)
+			}
+
+			sel := batch.Selection()
+
+			// Initialize groupID with the initial hash buckets and toCheck with all
+			// applicable indices.
+			prober.lookupInitial(batchSize, sel)
+			nToCheck := batchSize
+
+			for nToCheck > 0 {
+				// Continue searching for the build table matching keys while the toCheck
+				// array is non-empty.
+				nToCheck = prober.check(nToCheck, sel)
+				prober.findNext(nToCheck)
+			}
+
+			nResults := prober.collect(batch, batchSize, sel)
+			prober.congregate(nResults, batch, batchSize, sel)
+
+			if prober.batch.Length() > 0 {
+				break
+			}
 		}
 	}
 
@@ -542,19 +656,47 @@ func (prober *hashJoinProber) lookupInitial(batchSize uint16, sel []uint16) {
 	}
 }
 
-// check determines if the current key in the groupID buckets matches the
-// equality column key. If there is a match, then the key is removed from
-// toCheck. If the bucket has reached the end, the key is rejected. The toCheck
-// list is reconstructed to only hold the indices of the eqCol keys that have
-// not been found. The new length of toCheck is returned by this function.
+// findNext determines the id of the next key inside the groupID buckets for
+// each equality column key in toCheck.
+func (prober *hashJoinProber) findNext(nToCheck uint16) {
+	for i := uint16(0); i < nToCheck; i++ {
+		prober.groupID[prober.toCheck[i]] = prober.ht.next[prober.groupID[prober.toCheck[i]]]
+	}
+}
+
+// check performs a equality check the current key in the groupID bucket with
+// the probe key at that index. If there is a match, the hashTable's same array
+// is updated to lazily populate the a linked list of identical build table
+// keys. The visited flag for corresponding build table key is also set. A key
+// is removed from toCheck if it has already been visited in a previous probe,
+// or the bucket has reached the end (key not found in build table). The new
+// length of toCheck is returned by this function.
 func (prober *hashJoinProber) check(nToCheck uint16, sel []uint16) uint16 {
 	for i, t := range prober.ht.keyTypes {
 		prober.checkCol(t, i, nToCheck, sel)
 	}
 
-	// select the indices that differ and put them into toCheck.
 	nDiffers := uint16(0)
 	for i := uint16(0); i < nToCheck; i++ {
+		if !prober.differs[prober.toCheck[i]] {
+			keyID := prober.groupID[prober.toCheck[i]]
+
+			if prober.head[prober.toCheck[i]] == 0 {
+				prober.head[prober.toCheck[i]] = keyID
+			}
+			headID := prober.head[prober.toCheck[i]]
+
+			if !prober.ht.visited[keyID] {
+				prober.differs[prober.toCheck[i]] = true
+				prober.ht.visited[keyID] = true
+
+				if headID != keyID {
+					prober.ht.same[keyID] = prober.ht.same[headID]
+					prober.ht.same[headID] = keyID
+				}
+			}
+		}
+
 		if prober.differs[prober.toCheck[i]] {
 			prober.differs[prober.toCheck[i]] = false
 			prober.toCheck[nDiffers] = prober.toCheck[i]
@@ -565,39 +707,51 @@ func (prober *hashJoinProber) check(nToCheck uint16, sel []uint16) uint16 {
 	return nDiffers
 }
 
-// findNext determines the id of the next key inside the groupID buckets for
-// each equality column key in toCheck.
-func (prober *hashJoinProber) findNext(nToCheck uint16) {
-	for i := uint16(0); i < nToCheck; i++ {
-		prober.groupID[prober.toCheck[i]] = prober.ht.next[prober.groupID[prober.toCheck[i]]]
-	}
-}
-
-// collectResults prepares the batch with the joined output columns where the
-// build row index for each probe row is given in the groupID slice.
-func (prober *hashJoinProber) collectResults(batch ColBatch, batchSize uint16, sel []uint16) {
+// collect prepares the buildIdx and probeIdx arrays where the buildIdx and
+// probeIdx at each index are joined to make an output row. The total number of
+// resulting rows is returned.
+func (prober *hashJoinProber) collect(batch ColBatch, batchSize uint16, sel []uint16) uint16 {
 	nResults := uint16(0)
-
 	if sel != nil {
 		for i := uint16(0); i < batchSize; i++ {
-			if prober.groupID[i] != 0 {
-				// Index of keys and outputs in the hash table is calculated as ID - 1.
-				prober.buildIdx[nResults] = prober.groupID[i] - 1
+			currentID := prober.head[i]
+			for currentID != 0 {
+				if nResults >= ColBatchSize {
+					// todo(changangela): use better method for output batching
+					prober.prevBatch = batch
+					return nResults
+				}
+				prober.buildIdx[nResults] = currentID - 1
 				prober.probeIdx[nResults] = sel[i]
+				currentID = prober.ht.same[currentID]
+				prober.head[i] = currentID
 				nResults++
 			}
 		}
 	} else {
 		for i := uint16(0); i < batchSize; i++ {
-			if prober.groupID[i] != 0 {
-				// Index of keys and outputs in the hash table is calculated as ID - 1.
-				prober.buildIdx[nResults] = prober.groupID[i] - 1
+			currentID := prober.head[i]
+			for currentID != 0 {
+				if nResults >= ColBatchSize {
+					// todo(changangela): use better method for output batching
+					prober.prevBatch = batch
+					return nResults
+				}
+				prober.buildIdx[nResults] = currentID - 1
 				prober.probeIdx[nResults] = i
+				currentID = prober.ht.same[currentID]
+				prober.head[i] = currentID
 				nResults++
 			}
 		}
 	}
 
+	return nResults
+}
+
+func (prober *hashJoinProber) congregate(
+	nResults uint16, batch ColBatch, batchSize uint16, sel []uint16,
+) {
 	// Stitch together the resulting inner join rows and add them to the output
 	// batch with the left table columns preceding right table columns.
 	var buildColOffset, probeColOffset int
@@ -626,11 +780,115 @@ func (prober *hashJoinProber) collectResults(batch ColBatch, batchSize uint16, s
 	prober.batch.SetLength(nResults)
 }
 
-// NewEqInnerDistinctHashJoiner creates a new inner equality hash join operator
+// distinctProbe is called if the build table equality columns are distinct. It
+// performs the same operation as the probe() function while taking a shortcut
+// to improve speed.
+func (prober *hashJoinProber) distinctProbe() ColBatch {
+	prober.batch.SetLength(0)
+
+	for {
+		batch := prober.spec.source.Next()
+		batchSize := batch.Length()
+
+		if batchSize == 0 {
+			break
+		}
+
+		for i, colIdx := range prober.spec.eqCols {
+			prober.keys[i] = batch.ColVec(colIdx)
+		}
+
+		sel := batch.Selection()
+
+		// Initialize groupID with the initial hash buckets and toCheck with all
+		// applicable indices.
+		prober.lookupInitial(batchSize, sel)
+		nToCheck := batchSize
+
+		// Continue searching along the hash table next chains for the corresponding
+		// buckets. If the key is found or end of next chain is reached, the key is
+		// removed from the toCheck array.
+		for nToCheck > 0 {
+			nToCheck = prober.distinctCheck(nToCheck, sel)
+			prober.findNext(nToCheck)
+		}
+
+		nResults := prober.distinctCollect(batch, batchSize, sel)
+		prober.congregate(nResults, batch, batchSize, sel)
+
+		// Since is possible for the hash join to return an empty group, we should
+		// loop until we have a non-empty output batch, or an empty input batch.
+		// Otherwise, the client will assume that the ColBatch is completely
+		// consumed when it isn't.
+		if prober.batch.Length() > 0 {
+			// todo (changangela): add buffering to return batches of equal length on
+			// each call to Next()
+			break
+		}
+	}
+
+	return prober.batch
+}
+
+// distinctCheck determines if the current key in the groupID buckets matches the
+// equality column key. If there is a match, then the key is removed from
+// toCheck. If the bucket has reached the end, the key is rejected. The toCheck
+// list is reconstructed to only hold the indices of the eqCol keys that have
+// not been found. The new length of toCheck is returned by this function.
+func (prober *hashJoinProber) distinctCheck(nToCheck uint16, sel []uint16) uint16 {
+	for i, t := range prober.ht.keyTypes {
+		prober.checkCol(t, i, nToCheck, sel)
+	}
+
+	// Select the indices that differ and put them into toCheck.
+	nDiffers := uint16(0)
+	for i := uint16(0); i < nToCheck; i++ {
+		if prober.differs[prober.toCheck[i]] {
+			prober.differs[prober.toCheck[i]] = false
+			prober.toCheck[nDiffers] = prober.toCheck[i]
+			nDiffers++
+		}
+	}
+
+	return nDiffers
+}
+
+// distinctCollect prepares the batch with the joined output columns where the build
+// row index for each probe row is given in the groupID slice. This function
+// requires assumes a 1-n hash join.
+func (prober *hashJoinProber) distinctCollect(
+	batch ColBatch, batchSize uint16, sel []uint16,
+) uint16 {
+	nResults := uint16(0)
+
+	if sel != nil {
+		for i := uint16(0); i < batchSize; i++ {
+			if prober.groupID[i] != 0 {
+				// Index of keys and outputs in the hash table is calculated as ID - 1.
+				prober.buildIdx[nResults] = prober.groupID[i] - 1
+				prober.probeIdx[nResults] = sel[i]
+				nResults++
+			}
+		}
+	} else {
+		for i := uint16(0); i < batchSize; i++ {
+			if prober.groupID[i] != 0 {
+				// Index of keys and outputs in the hash table is calculated as ID - 1.
+				prober.buildIdx[nResults] = prober.groupID[i] - 1
+				prober.probeIdx[nResults] = i
+				nResults++
+			}
+		}
+	}
+
+	return nResults
+}
+
+// NewEqInnerHashJoiner creates a new inner equality hash join operator
 // on the left and right input tables. leftEqCols and rightEqCols specify the
 // equality columns while leftOutCols and rightOutCols specifies the output
 // columns.
-func NewEqInnerDistinctHashJoiner(
+func NewEqInnerHashJoiner(
 	leftSource Operator,
 	rightSource Operator,
 	leftEqCols []uint32,
@@ -639,6 +897,8 @@ func NewEqInnerDistinctHashJoiner(
 	rightOutCols []uint32,
 	leftTypes []types.T,
 	rightTypes []types.T,
+	buildRightSide bool,
+	buildDistinct bool,
 ) (Operator, error) {
 	spec := hashJoinerSpec{
 		left: hashJoinerSourceSpec{
@@ -655,7 +915,8 @@ func NewEqInnerDistinctHashJoiner(
 			source:      rightSource,
 		},
 
-		buildRightSide: false,
+		buildRightSide: buildRightSide,
+		buildDistinct:  buildDistinct,
 	}
 
 	for i, col := range leftEqCols {
@@ -674,7 +935,7 @@ func NewEqInnerDistinctHashJoiner(
 		spec.right.outCols[i] = int(col)
 	}
 
-	return &hashJoinEqInnerDistinctOp{
+	return &hashJoinEqInnerOp{
 		spec: spec,
 	}, nil
 }

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -52,9 +52,47 @@ func TestHashJoinerInt64(t *testing.T) {
 		rightOutCols []int
 
 		buildRightSide bool
+		buildDistinct  bool
 
 		expectedTuples tuples
 	}{
+		{
+			// Test handling of duplicate equality keys.
+			leftTypes:  []types.T{types.Int64},
+			rightTypes: []types.T{types.Int64},
+
+			leftTuples: tuples{
+				{0},
+				{0},
+				{1},
+				{1},
+				{1},
+				{2},
+			},
+			rightTuples: tuples{
+				{1},
+				{0},
+				{2},
+				{2},
+			},
+
+			leftEqCols:   []int{0},
+			rightEqCols:  []int{0},
+			leftOutCols:  []int{0},
+			rightOutCols: []int{},
+
+			buildDistinct: false,
+
+			expectedTuples: tuples{
+				{1},
+				{1},
+				{1},
+				{0},
+				{0},
+				{2},
+				{2},
+			},
+		},
 		{
 			// Test handling of various output column types.
 			leftTypes:  []types.T{types.Bool, types.Int64, types.Bytes, types.Int64},
@@ -78,6 +116,8 @@ func TestHashJoinerInt64(t *testing.T) {
 			rightEqCols:  []int{0},
 			leftOutCols:  []int{1, 2},
 			rightOutCols: []int{0, 2},
+
+			buildDistinct: true,
 
 			expectedTuples: tuples{
 				{2, "foo", 2, int32(2)},
@@ -107,6 +147,8 @@ func TestHashJoinerInt64(t *testing.T) {
 			rightEqCols:  []int{0},
 			leftOutCols:  []int{0},
 			rightOutCols: []int{},
+
+			buildDistinct: true,
 
 			expectedTuples: tuples{
 				{0},
@@ -138,6 +180,8 @@ func TestHashJoinerInt64(t *testing.T) {
 			rightEqCols:  []int{0},
 			leftOutCols:  []int{0},
 			rightOutCols: []int{0},
+
+			buildDistinct: true,
 
 			expectedTuples: tuples{
 				{1, 1},
@@ -173,6 +217,8 @@ func TestHashJoinerInt64(t *testing.T) {
 			leftOutCols:  []int{0, 1, 2},
 			rightOutCols: []int{1},
 
+			buildDistinct: true,
+
 			expectedTuples: tuples{
 				{0, 2, 30, 100},
 				{1, 1, 40, 200},
@@ -204,6 +250,8 @@ func TestHashJoinerInt64(t *testing.T) {
 			rightEqCols:  []int{0, 1},
 			leftOutCols:  []int{0, 1, 2},
 			rightOutCols: []int{},
+
+			buildDistinct: true,
 
 			expectedTuples: tuples{
 				{20, 0, hashTableBucketSize},
@@ -238,6 +286,8 @@ func TestHashJoinerInt64(t *testing.T) {
 			leftOutCols:  []int{6},
 			rightOutCols: []int{},
 
+			buildDistinct: true,
+
 			expectedTuples: tuples{
 				{"ccc"},
 				{"aaa"},
@@ -267,6 +317,8 @@ func TestHashJoinerInt64(t *testing.T) {
 			leftOutCols:  []int{0, 1},
 			rightOutCols: []int{},
 
+			buildDistinct: true,
+
 			expectedTuples: tuples{
 				{float32(2.22), float64(44.4444)},
 				{float32(1.1), float64(33.333)},
@@ -295,6 +347,7 @@ func TestHashJoinerInt64(t *testing.T) {
 			rightOutCols: []int{0, 1, 2, 3},
 
 			buildRightSide: true,
+			buildDistinct:  true,
 
 			expectedTuples: tuples{
 				{3, 3, 2, 2, 1, 2, 3, 4},
@@ -323,6 +376,8 @@ func TestHashJoinerInt64(t *testing.T) {
 			leftOutCols:  []int{},
 			rightOutCols: []int{0},
 
+			buildDistinct: true,
+
 			expectedTuples: tuples{
 				{decs[2]},
 				{decs[0]},
@@ -332,48 +387,60 @@ func TestHashJoinerInt64(t *testing.T) {
 
 	for _, tc := range tcs {
 		inputs := []tuples{tc.leftTuples, tc.rightTuples}
-		runTests(t, inputs, []types.T{types.Bool}, func(t *testing.T, sources []Operator) {
-			leftSource, rightSource := sources[0], sources[1]
 
-			spec := hashJoinerSpec{
-				left: hashJoinerSourceSpec{
-					eqCols:      tc.leftEqCols,
-					outCols:     tc.leftOutCols,
-					sourceTypes: tc.leftTypes,
-					source:      leftSource,
-				},
+		buildFlags := []bool{false}
+		if tc.buildDistinct {
+			buildFlags = append(buildFlags, true)
+		}
 
-				right: hashJoinerSourceSpec{
-					eqCols:      tc.rightEqCols,
-					outCols:     tc.rightOutCols,
-					sourceTypes: tc.rightTypes,
-					source:      rightSource,
-				},
+		for _, buildDistinct := range buildFlags {
+			t.Run(fmt.Sprintf("buildDistinct=%v", buildDistinct), func(t *testing.T) {
+				runTests(t, inputs, []types.T{types.Bool}, func(t *testing.T, sources []Operator) {
+					leftSource, rightSource := sources[0], sources[1]
 
-				buildRightSide: tc.buildRightSide,
-			}
+					spec := hashJoinerSpec{
+						left: hashJoinerSourceSpec{
+							eqCols:      tc.leftEqCols,
+							outCols:     tc.leftOutCols,
+							sourceTypes: tc.leftTypes,
+							source:      leftSource,
+						},
 
-			hj := &hashJoinEqInnerDistinctOp{
-				spec: spec,
-			}
+						right: hashJoinerSourceSpec{
+							eqCols:      tc.rightEqCols,
+							outCols:     tc.rightOutCols,
+							sourceTypes: tc.rightTypes,
+							source:      rightSource,
+						},
 
-			nOutCols := len(tc.leftOutCols) + len(tc.rightOutCols)
-			nLeftOutCols := len(tc.leftOutCols)
-			nLeftCols := len(tc.leftTypes)
+						buildRightSide: tc.buildRightSide,
+						buildDistinct:  tc.buildDistinct,
+					}
 
-			cols := make([]int, nOutCols)
-			copy(cols, tc.leftOutCols)
+					hj := &hashJoinEqInnerOp{
+						spec: spec,
+					}
 
-			for i, colIdx := range tc.rightOutCols {
-				cols[i+nLeftOutCols] = colIdx + nLeftCols
-			}
+					nOutCols := len(tc.leftOutCols) + len(tc.rightOutCols)
+					nLeftOutCols := len(tc.leftOutCols)
+					nLeftCols := len(tc.leftTypes)
 
-			out := newOpTestOutput(hj, cols, tc.expectedTuples)
+					cols := make([]int, nOutCols)
+					copy(cols, tc.leftOutCols)
 
-			if err := out.Verify(); err != nil {
-				t.Fatal(err)
-			}
-		})
+					for i, colIdx := range tc.rightOutCols {
+						cols[i+nLeftOutCols] = colIdx + nLeftCols
+					}
+
+					out := newOpTestOutput(hj, cols, tc.expectedTuples)
+
+					if err := out.Verify(); err != nil {
+						t.Fatal(err)
+					}
+				})
+			})
+
+		}
 	}
 }
 
@@ -396,41 +463,49 @@ func BenchmarkHashJoiner(b *testing.B) {
 
 	batch.SetLength(ColBatchSize)
 
-	for _, nBatches := range []int{1 << 1, 1 << 2, 1 << 4, 1 << 8, 1 << 12, 1 << 16} {
-		b.Run(fmt.Sprintf("rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
-			// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
-			// batch) * nCols (number of columns / row) * 2 (number of sources).
-			b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols * 2))
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				leftSource := newFiniteBatchSource(batch, nBatches)
-				rightSource := newRepeatableBatchSource(batch)
+	for _, buildDistinct := range []bool{true, false} {
+		b.Run(fmt.Sprintf("distinct=%v", buildDistinct), func(b *testing.B) {
+			for _, nBatches := range []int{1 << 1, 1 << 2, 1 << 4, 1 << 8, 1 << 12, 1 << 16} {
+				b.Run(fmt.Sprintf("rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
+					// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+					// batch) * nCols (number of columns / row) * 2 (number of sources).
+					b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols * 2))
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						leftSource := newFiniteBatchSource(batch, nBatches)
+						rightSource := newRepeatableBatchSource(batch)
 
-				spec := hashJoinerSpec{
-					left: hashJoinerSourceSpec{
-						eqCols:      []int{0, 2},
-						outCols:     []int{0, 1},
-						sourceTypes: sourceTypes,
-						source:      leftSource,
-					},
+						spec := hashJoinerSpec{
+							left: hashJoinerSourceSpec{
+								eqCols:      []int{0, 2},
+								outCols:     []int{0, 1},
+								sourceTypes: sourceTypes,
+								source:      leftSource,
+							},
 
-					right: hashJoinerSourceSpec{
-						eqCols:      []int{1, 3},
-						outCols:     []int{2, 3},
-						sourceTypes: sourceTypes,
-						source:      rightSource,
-					},
-				}
+							right: hashJoinerSourceSpec{
+								eqCols:      []int{1, 3},
+								outCols:     []int{2, 3},
+								sourceTypes: sourceTypes,
+								source:      rightSource,
+							},
 
-				hj := &hashJoinEqInnerDistinctOp{
-					spec: spec,
-				}
+							buildDistinct: buildDistinct,
+						}
 
-				hj.Init()
+						hj := &hashJoinEqInnerOp{
+							spec: spec,
+						}
 
-				for i := 0; i < nBatches; i++ {
-					hj.Next()
-				}
+						hj.Init()
+
+						for i := 0; i < nBatches; i++ {
+							// Technically, the non-distinct hash join will produce much more
+							// than nBatches of output.
+							hj.Next()
+						}
+					}
+				})
 			}
 		})
 	}

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -28,7 +28,7 @@ statement ok
 CREATE TABLE b (a INT, b INT, c STRING)
 
 statement ok
-INSERT INTO b VALUES (0, 1, 'a'), (2, 1, 'b'), (0, 2, 'c')
+INSERT INTO b VALUES (0, 1, 'a'), (2, 1, 'b'), (0, 2, 'c'), (0, 1, 'd')
 
 statement ok
 CREATE TABLE c (a INT, b STRING)
@@ -61,6 +61,20 @@ SELECT t2.y, t1.v FROM t1 JOIN t2 ON t1.k = t2.x
 ----
 5  4
 2  4
+
+query IIII rowsort
+SELECT * FROM t1 JOIN t2 ON t1.v = t2.x
+----
+0  4  4  6
+2  1  1  3
+3  4  4  6
+5  4  4  6
+
+query IIT rowsort
+SELECT b.a, b.b, b.c FROM b JOIN a ON b.a = a.k AND a.v = b.b
+----
+0  1  a
+0  1  d
 
 query ITI
 SELECT b.a, b.c, c.a FROM b JOIN c ON b.b = c.a AND b.c = c.b


### PR DESCRIPTION
The planner will use the non-distinct hash joiner if and only if both the left and right equality columns are non-distinct.

In this modification, the build phase of the algorithm remains unchanged. This means that duplicate keys will simply be inserted as any other key into their corresponding buckets. We separate the `prober` into a `probe` and a `fastProbe`. 

- We store an additional densely-packed array, `same` that is used to store linked lists of duplicate keys (in the same fashion as the `next` array). For example, to store the keys [1, 1, 3, 5, 6] with a bucket size of 5, the final result looks like this:

```
first
----
4
5
0
3
0
```
```
id | next | same | visited |
0 | 0 | 0 | 1 |
1 | 0 | 0 | 1 |
2 | 1 | 1 | 1 |
3 | 0 | 0 | 1 |
4 | 0 | 0 | 1 |
5 | 2 | 0 | 1 |

```
- During the probe phase, this `same` array is lazily populated using a `visited` boolean array to keep track of which keys have processed. If a key has not been processed, then it will populate `same` with a linked list where the head of the list corresponds to the first key touched during the bucket probing.
- For example, consider probing for the key 1. The build table has this key at id 1 and 2. When we traverse the bucket for this key, we get 5 → 2 → 1. After rejecting 5, we can build the `same` linked list as 2 → 1.
- The next time we probe for the key 1, we can stop as soon as we find the first occurence (id 2), which will point us to the corresponding `same` linked list.
- In the end, for each probe key, we traverse the `same` linked list to find its build key pair in order to construct the results of the inner join.

During the `probe` phase, the following tasks are performed:
1. Compute the bucket number for each probe rows key tuple and store the
   results into the buckets array.
2. In order to find the position of these key tuples in the hash table:
- First find the first element in the bucket's linked list for each key tuple
  and store it in the groupID array. Initialize the toCheck array with the
  full sequence of input indices (0...batchSize - 1).
- While toCheck is not empty, each element in toCheck represents a position
  of the key tuples for which the key has not yet been visited by any prior
  probe. Perform a multi-column equality check to see if the key columns
  match that of the build table's key columns at groupID.
- Update the differs array to store whether or not the probe's key tuple
  matched the corresponding build's key tuple.
- For the indices that did not differ, we can lazily update the hashTable's
  same linked list to store a list of all identical keys starting at head.
  Once a key has been added to ht.same, ht.visited is set to true. For the
  indices that have never been visited, we want to continue checking this
  bucket for identical values by adding this key to toCheck.
- Select the indices that differed and store them into toCheck since they
  need to be further processed.
- For the differing tuples, find the next ID in that bucket of the hash table
  and put it into the groupID array.
3. Now, head for every probe key tuple contains the keyID of the first match
   in the build table. ht.same is used to select all build key matches for
   each probe key, which are added to the resulting batch.

Since the output of one input batch no longer fits within one ColBatch, output batching is added to fix this problem.

Benchmark for distinct vs non-distinct hash joiners:
```
pkg: github.com/cockroachdb/cockroach/pkg/sql/exec
BenchmarkHashJoiner/distinct=true/rows=2048-8         	   10000	    189043 ns/op	 693.34 MB/s
BenchmarkHashJoiner/distinct=true/rows=4096-8         	    5000	    282625 ns/op	 927.53 MB/s
BenchmarkHashJoiner/distinct=true/rows=16384-8        	    2000	    861720 ns/op	1216.84 MB/s
BenchmarkHashJoiner/distinct=true/rows=262144-8       	     100	  11753550 ns/op	1427.42 MB/s
BenchmarkHashJoiner/distinct=true/rows=4194304-8      	      10	 176007944 ns/op	1525.13 MB/s
BenchmarkHashJoiner/distinct=true/rows=67108864-8     	       1	6245771909 ns/op	 687.66 MB/s
BenchmarkHashJoiner/distinct=false/rows=2048-8        	    5000	    212938 ns/op	 615.54 MB/s
BenchmarkHashJoiner/distinct=false/rows=4096-8        	    5000	    328377 ns/op	 798.30 MB/s
BenchmarkHashJoiner/distinct=false/rows=16384-8       	    2000	   1031821 ns/op	1016.24 MB/s
BenchmarkHashJoiner/distinct=false/rows=262144-8      	     100	  19264249 ns/op	 870.90 MB/s
BenchmarkHashJoiner/distinct=false/rows=4194304-8     	       2	 667279770 ns/op	 402.28 MB/s
BenchmarkHashJoiner/distinct=false/rows=67108864-8    	       1	12406925071 ns/op	 346.18 MB/s
```