### PR TITLE
build: pass --init to `docker run`

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -168,7 +168,7 @@ gid=$(id -g)
 # a pager, so we override $PAGER to disable.
 
 # shellcheck disable=SC2086
-docker run --privileged -i ${tty-} --rm \
+docker run --init --privileged -i ${tty-} --rm \
   -u "$uid:$gid" \
   ${vols} \
   --workdir="/go/src/github.com/cockroachdb/cockroach" \


### PR DESCRIPTION
The `--init` flag causes docker to "run an init inside the container
that forwards signals and reaps processes". This is necessary to
properly reap cockroach processes created by roachtest and roachprod as
done for the roachtest acceptance tests.

Release note: None