### PR TITLE
sql: disallow de-computing a non-computed column

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -740,6 +740,10 @@ func applyColumnMutation(
 		col.Nullable = true
 
 	case *tree.AlterTableDropStored:
+		if !col.IsComputed() {
+			return pgerror.NewErrorf(pgerror.CodeInvalidColumnDefinitionError,
+				"column %q is not a computed column", col.Name)
+		}
 		col.ComputeExpr = nil
 	}
 	return nil

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -689,6 +689,12 @@ INSERT INTO decomputed_column VALUES (3, NULL), (4, 99)
 statement ok
 ALTER TABLE decomputed_column ALTER COLUMN b DROP STORED
 
+statement error pq: column "a" is not a computed column
+ALTER TABLE decomputed_column ALTER COLUMN a DROP STORED
+
+statement error pq: column "b" is not a computed column
+ALTER TABLE decomputed_column ALTER COLUMN b DROP STORED
+
 # Verify that the computation is dropped and that we can mutate the column
 statement ok
 INSERT INTO decomputed_column VALUES (3, NULL), (4, 99)


### PR DESCRIPTION
The current code allows a user to `ALTER ... DROP STORED` on columns that are
not, or never were, computed columns. This change checks that a column is in
fact a computed column before de-computing it.

Fixes: #32275

Release note (sql change): It is now an error to run `ALTER TABLE ... DROP
STORED` on a column which is not actually a computed, stored column.
Previously, this statement would be a successful no-op.

@BramGruneir, this is a follow-up for your QA issue https://github.com/cockroachdb/cockroach/issues/28141#issuecomment-427970049

I'll also plan to back-port this to 2.1.