### PR TITLE
exec: handle AndExpr in filter planning

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -280,6 +280,12 @@ func planExpressionOperators(
 	switch t := expr.(type) {
 	case *tree.IndexedVar:
 		return input, t.Idx, columnTypes, nil
+	case *tree.AndExpr:
+		leftOp, _, ct, err := planExpressionOperators(t.TypedLeft(), columnTypes, input)
+		if err != nil {
+			return nil, resultIdx, ct, err
+		}
+		return planExpressionOperators(t.TypedRight(), ct, leftOp)
 	case *tree.ComparisonExpr:
 		// TODO(solon): Handle the case where a ComparisonExpr is a projection,
 		// e.g. SELECT a > b FROM t. Currently we assume it is a selection.

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -104,3 +104,10 @@ query I
 SELECT (a + b)::INT FROM intdec
 ----
 3
+
+# AND expressions.
+query II
+SELECT a, b FROM a WHERE a < 2 AND b > 0 AND a * b != 3
+----
+0  1
+1  2


### PR DESCRIPTION
planExpressionOperators now handles `AndExpr`s simply by concatenating
two selection operators.

Release note: None