### PR TITLE
opt: move props.Physical to physical.Required

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -204,7 +204,7 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	if err != nil {
 		return execPlan{}, err
 	}
-	if p := e.Physical(); !p.Presentation.Any() {
+	if p := e.RequiredPhysical(); !p.Presentation.Any() {
 		ep, err = b.applyPresentation(ep, p)
 	}
 	return ep, err
@@ -305,8 +305,8 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		scan.Constraint,
 		scan.HardLimit.RowCount(),
 		// HardLimit.Reverse() is taken into account by ScanIsReverse.
-		ordering.ScanIsReverse(scan, &scan.Physical().Ordering),
-		res.reqOrdering(scan.Physical()),
+		ordering.ScanIsReverse(scan, &scan.RequiredPhysical().Ordering),
+		res.reqOrdering(scan.RequiredPhysical()),
 	)
 	if err != nil {
 		return execPlan{}, err
@@ -342,7 +342,7 @@ func (b *Builder) buildSelect(sel *memo.SelectExpr) (execPlan, error) {
 	}
 	// A filtering node does not modify the schema.
 	res := execPlan{outputCols: input.outputCols}
-	res.root, err = b.factory.ConstructFilter(input.root, filter, res.reqOrdering(sel.Physical()))
+	res.root, err = b.factory.ConstructFilter(input.root, filter, res.reqOrdering(sel.RequiredPhysical()))
 	if err != nil {
 		return execPlan{}, err
 	}
@@ -379,7 +379,7 @@ func (b *Builder) buildProject(prj *memo.ProjectExpr) (execPlan, error) {
 	projections := prj.Projections
 	if len(projections) == 0 {
 		// We have only pass-through columns.
-		return b.applySimpleProject(input, prj.Passthrough, prj.Physical())
+		return b.applySimpleProject(input, prj.Passthrough, prj.RequiredPhysical())
 	}
 
 	var res execPlan
@@ -402,7 +402,7 @@ func (b *Builder) buildProject(prj *memo.ProjectExpr) (execPlan, error) {
 		exprs = append(exprs, b.indexedVar(&ctx, md, colID))
 		colNames = append(colNames, md.ColumnLabel(colID))
 	})
-	reqOrdering := res.reqOrdering(prj.Physical())
+	reqOrdering := res.reqOrdering(prj.RequiredPhysical())
 	res.root, err = b.factory.ConstructRender(input.root, exprs, colNames, reqOrdering)
 	if err != nil {
 		return execPlan{}, err
@@ -441,7 +441,7 @@ func (b *Builder) buildMergeJoin(join *memo.MergeJoinExpr) (execPlan, error) {
 	leftOrd := left.sqlOrdering(join.LeftEq)
 	rightOrd := right.sqlOrdering(join.RightEq)
 	ep := execPlan{outputCols: outputCols}
-	reqOrd := ep.reqOrdering(join.Physical())
+	reqOrd := ep.reqOrdering(join.RequiredPhysical())
 	ep.root, err = b.factory.ConstructMergeJoin(
 		joinType, left.root, right.root, onExpr, leftOrd, rightOrd, reqOrd,
 	)
@@ -572,9 +572,9 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 	} else {
 		groupBy := groupBy.(*memo.GroupByExpr)
 		orderedInputCols := input.getColumnOrdinalSet(
-			ordering.StreamingGroupingCols(&groupBy.GroupingPrivate, &groupBy.Physical().Ordering),
+			ordering.StreamingGroupingCols(&groupBy.GroupingPrivate, &groupBy.RequiredPhysical().Ordering),
 		)
-		reqOrdering := ep.reqOrdering(groupBy.Physical())
+		reqOrdering := ep.reqOrdering(groupBy.RequiredPhysical())
 		ep.root, err = b.factory.ConstructGroupBy(
 			input.root, groupingColIdx, orderedInputCols, aggInfos, reqOrdering,
 		)
@@ -593,7 +593,7 @@ func (b *Builder) buildDistinct(distinct *memo.DistinctOnExpr) (execPlan, error)
 
 	distinctCols := input.getColumnOrdinalSet(distinct.GroupingCols)
 	orderedCols := input.getColumnOrdinalSet(
-		ordering.StreamingGroupingCols(&distinct.GroupingPrivate, &distinct.Physical().Ordering),
+		ordering.StreamingGroupingCols(&distinct.GroupingPrivate, &distinct.RequiredPhysical().Ordering),
 	)
 	node, err := b.factory.ConstructDistinct(input.root, distinctCols, orderedCols)
 	if err != nil {
@@ -639,7 +639,7 @@ func (b *Builder) buildGroupByInput(groupBy memo.RelExpr) (execPlan, error) {
 		}
 	})
 
-	reqOrdering := input.reqOrdering(groupBy.Physical())
+	reqOrdering := input.reqOrdering(groupBy.RequiredPhysical())
 	input.root, err = b.factory.ConstructSimpleProject(
 		input.root, cols, nil /* colNames */, reqOrdering,
 	)
@@ -683,11 +683,11 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 	// Note that (unless this is part of a larger query) the presentation property
 	// will ensure that the columns are presented correctly in the output (i.e. in
 	// the order `b, c, a`).
-	left, err = b.ensureColumns(left, private.LeftCols, nil /* colNames */, leftExpr.Physical())
+	left, err = b.ensureColumns(left, private.LeftCols, nil /* colNames */, leftExpr.RequiredPhysical())
 	if err != nil {
 		return execPlan{}, err
 	}
-	right, err = b.ensureColumns(right, private.RightCols, nil /* colNames */, rightExpr.Physical())
+	right, err = b.ensureColumns(right, private.RightCols, nil /* colNames */, rightExpr.RequiredPhysical())
 	if err != nil {
 		return execPlan{}, err
 	}
@@ -751,7 +751,7 @@ func (b *Builder) buildSort(sort *memo.SortExpr) (execPlan, error) {
 	if err != nil {
 		return execPlan{}, err
 	}
-	return b.buildSortedInput(input, &sort.Physical().Ordering)
+	return b.buildSortedInput(input, &sort.RequiredPhysical().Ordering)
 }
 
 func (b *Builder) buildRowNumber(rowNum *memo.RowNumberExpr) (execPlan, error) {
@@ -784,7 +784,7 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	var ordering *physical.OrderingChoice
 	child := join.Input
 	if child.Op() == opt.SortOp {
-		ordering = &child.Physical().Ordering
+		ordering = &child.RequiredPhysical().Ordering
 		child = child.Child(0).(memo.RelExpr)
 	}
 
@@ -804,7 +804,7 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	// be in the needed set, so no need to add anything further to that.
 	var reqOrdering exec.OutputOrdering
 	if ordering == nil {
-		reqOrdering = res.reqOrdering(join.Physical())
+		reqOrdering = res.reqOrdering(join.RequiredPhysical())
 	}
 
 	res.root, err = b.factory.ConstructIndexJoin(
@@ -862,7 +862,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		keyCols,
 		lookupOrdinals,
 		onExpr,
-		res.reqOrdering(join.Physical()),
+		res.reqOrdering(join.RequiredPhysical()),
 	)
 	if err != nil {
 		return execPlan{}, err
@@ -870,7 +870,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 
 	// Apply a post-projection if Cols doesn't contain all input columns.
 	if !inputCols.SubsetOf(join.Cols) {
-		return b.applySimpleProject(res, join.Cols, join.Physical())
+		return b.applySimpleProject(res, join.Cols, join.RequiredPhysical())
 	}
 	return res, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/ordering"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -92,14 +92,16 @@ func (ep *execPlan) getColumnOrdinalSet(cols opt.ColSet) exec.ColumnOrdinalSet {
 
 // reqOrdering converts the ordering in the physical props to an OutputOrdering
 // (according to the outputCols map).
-func (ep *execPlan) reqOrdering(p *props.Physical) exec.OutputOrdering {
+func (ep *execPlan) reqOrdering(p *physical.Required) exec.OutputOrdering {
 	return exec.OutputOrdering(ep.sqlOrderingFromChoice(&p.Ordering))
 }
 
 // sqlOrderingFromChoice converts an OrderingChoice to a ColumnOrdering
 // (according to the outputCols map). An arbitrary column is chosen from each
 // column ordering group.
-func (ep *execPlan) sqlOrderingFromChoice(ordering *props.OrderingChoice) sqlbase.ColumnOrdering {
+func (ep *execPlan) sqlOrderingFromChoice(
+	ordering *physical.OrderingChoice,
+) sqlbase.ColumnOrdering {
 	if ordering.Any() {
 		return nil
 	}
@@ -349,7 +351,7 @@ func (b *Builder) buildSelect(sel *memo.SelectExpr) (execPlan, error) {
 
 // applySimpleProject adds a simple projection on top of an existing plan.
 func (b *Builder) applySimpleProject(
-	input execPlan, cols opt.ColSet, props *props.Physical,
+	input execPlan, cols opt.ColSet, props *physical.Required,
 ) (execPlan, error) {
 	// We have only pass-through columns.
 	colList := make([]exec.ColumnOrdinal, 0, cols.Len())
@@ -779,7 +781,7 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	// sort is on top of the index join.
 	// TODO(radu): Remove this code once we have support for a more general
 	// lookup join execution path.
-	var ordering *props.OrderingChoice
+	var ordering *physical.OrderingChoice
 	child := join.Input
 	if child.Op() == opt.SortOp {
 		ordering = &child.Physical().Ordering
@@ -946,7 +948,7 @@ func (b *Builder) needProjection(
 // ensureColumns applies a projection as necessary to make the output match the
 // given list of columns; colNames is optional.
 func (b *Builder) ensureColumns(
-	input execPlan, colList opt.ColList, colNames []string, props *props.Physical,
+	input execPlan, colList opt.ColList, colNames []string, props *physical.Required,
 ) (execPlan, error) {
 	cols, needProj := b.needProjection(input, colList)
 	if !needProj {
@@ -972,7 +974,7 @@ func (b *Builder) ensureColumns(
 
 // applyPresentation adds a projection to a plan to satisfy a required
 // Presentation property.
-func (b *Builder) applyPresentation(input execPlan, p *props.Physical) (execPlan, error) {
+func (b *Builder) applyPresentation(input execPlan, p *physical.Required) (execPlan, error) {
 	pres := p.Presentation
 	colList := make(opt.ColList, len(pres))
 	colNames := make([]string, len(pres))
@@ -983,7 +985,7 @@ func (b *Builder) applyPresentation(input execPlan, p *props.Physical) (execPlan
 	// The required ordering is not useful for a top-level projection (it is used
 	// by the distsql planner for internal nodes); we might not even be able to
 	// represent it because it can refer to columns not in the presentation.
-	return b.ensureColumns(input, colList, colNames, props.MinPhysProps)
+	return b.ensureColumns(input, colList, colNames, physical.MinRequired)
 }
 
 func (b *Builder) buildExplain(explain *memo.ExplainExpr) (execPlan, error) {
@@ -1038,7 +1040,7 @@ func (b *Builder) buildShowTrace(show *memo.ShowTraceForSessionExpr) (execPlan, 
 // buildSortedInput is a helper method that can be reused to sort any input plan
 // by the given ordering.
 func (b *Builder) buildSortedInput(
-	input execPlan, ordering *props.OrderingChoice,
+	input execPlan, ordering *physical.OrderingChoice,
 ) (execPlan, error) {
 	colOrd := input.sqlOrderingFromChoice(ordering)
 	node, err := b.factory.ConstructSort(input.root, colOrd)

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -182,9 +183,9 @@ func (m *Memo) checkExpr(e opt.Expr) {
 func checkExprOrdering(e opt.Expr) {
 	// Verify that orderings stored in operators only refer to columns produced by
 	// their input.
-	var ordering props.OrderingChoice
+	var ordering physical.OrderingChoice
 	switch t := e.Private().(type) {
-	case *props.OrderingChoice:
+	case *physical.OrderingChoice:
 		ordering = *t
 	case *RowNumberPrivate:
 		ordering = t.Ordering

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -49,10 +49,10 @@ type RelExpr interface {
 	// characteristics of this expression's behavior and results.
 	Relational() *props.Relational
 
-	// Physical is the set of physical properties with respect to which this
-	// expression was optimized. Enforcers may be added to the expression tree
-	// to ensure the physical properties are provided.
-	Physical() *physical.Required
+	// RequiredPhysical is the set of required physical properties with respect to
+	// which this expression was optimized. Enforcers may be added to the
+	// expression tree to ensure the physical properties are provided.
+	RequiredPhysical() *physical.Required
 
 	// FirstExpr returns the first member expression in the memo group (could be
 	// this expression if it happens to be first in the group). Subsequent members

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
@@ -51,7 +52,7 @@ type RelExpr interface {
 	// Physical is the set of physical properties with respect to which this
 	// expression was optimized. Enforcers may be added to the expression tree
 	// to ensure the physical properties are provided.
-	Physical() *props.Physical
+	Physical() *physical.Required
 
 	// FirstExpr returns the first member expression in the memo group (could be
 	// this expression if it happens to be first in the group). Subsequent members

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
@@ -139,10 +140,10 @@ func (f *ExprFmtCtx) formatExpr(e opt.Expr, tp treeprinter.Node) {
 
 func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 	relational := e.Relational()
-	physical := e.Physical()
-	if physical == nil {
-		// Physical can be nil before optimization has taken place.
-		physical = props.MinPhysProps
+	required := e.Physical()
+	if required == nil {
+		// required can be nil before optimization has taken place.
+		required = physical.MinRequired
 	}
 
 	// Special cases for merge-join and lookup-join: we want the type of the join
@@ -154,12 +155,12 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 	case *LookupJoinExpr:
 		fmt.Fprintf(f.Buffer, "%v (lookup", t.JoinType)
-		FormatPrivate(f, e.Private(), physical)
+		FormatPrivate(f, e.Private(), required)
 		f.Buffer.WriteByte(')')
 
 	case *ScanExpr, *VirtualScanExpr, *IndexJoinExpr, *ShowTraceForSessionExpr:
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
-		FormatPrivate(f, e.Private(), physical)
+		FormatPrivate(f, e.Private(), required)
 
 	default:
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
@@ -197,7 +198,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		colList = opt.ColSetToList(e.Relational().OutputCols)
 	}
 
-	f.formatColumns(e, tp, colList, physical.Presentation)
+	f.formatColumns(e, tp, colList, required.Presentation)
 
 	switch t := e.(type) {
 	// Special-case handling for GroupBy private; print grouping columns
@@ -301,8 +302,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 	}
 
-	if !physical.Ordering.Any() {
-		tp.Childf("ordering: %s", physical.Ordering.String())
+	if !required.Ordering.Any() {
+		tp.Childf("ordering: %s", required.Ordering.String())
 	}
 
 	if !f.HasFlags(ExprFmtHideRuleProps) {
@@ -444,12 +445,12 @@ func (f *ExprFmtCtx) formatScalarPrivate(scalar opt.ScalarExpr) {
 
 	if private != nil {
 		f.Buffer.WriteRune(':')
-		FormatPrivate(f, private, &props.Physical{})
+		FormatPrivate(f, private, &physical.Required{})
 	}
 }
 
 func (f *ExprFmtCtx) formatColumns(
-	nd RelExpr, tp treeprinter.Node, cols opt.ColList, presentation props.Presentation,
+	nd RelExpr, tp treeprinter.Node, cols opt.ColList, presentation physical.Presentation,
 ) {
 	if presentation.Any() {
 		f.formatColList(nd, tp, "columns:", cols)
@@ -534,10 +535,10 @@ func formatCol(f *ExprFmtCtx, label string, id opt.ColumnID, notNullCols opt.Col
 // ScanIsReverseFn is a callback that is used to figure out if a scan needs to
 // happen in reverse (the code lives in the ordering package, and depending on
 // that directly would be a dependency loop).
-var ScanIsReverseFn func(md *opt.Metadata, s *ScanPrivate, required *props.OrderingChoice) bool
+var ScanIsReverseFn func(md *opt.Metadata, s *ScanPrivate, required *physical.OrderingChoice) bool
 
 // FormatPrivate outputs a description of the private to f.Buffer.
-func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *props.Physical) {
+func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Required) {
 	if private == nil {
 		return
 	}
@@ -595,7 +596,7 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *props.Physical
 	case *FunctionPrivate:
 		fmt.Fprintf(f.Buffer, " %s", t.Name)
 
-	case *props.OrderingChoice:
+	case *physical.OrderingChoice:
 		if !t.Any() {
 			fmt.Fprintf(f.Buffer, " ordering=%s", t)
 		}

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -140,7 +140,7 @@ func (f *ExprFmtCtx) formatExpr(e opt.Expr, tp treeprinter.Node) {
 
 func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 	relational := e.Relational()
-	required := e.Physical()
+	required := e.RequiredPhysical()
 	if required == nil {
 		// required can be nil before optimization has taken place.
 		required = physical.MinRequired

--- a/pkg/sql/opt/memo/group.go
+++ b/pkg/sql/opt/memo/group.go
@@ -16,6 +16,7 @@ package memo
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
 // exprGroup represents a group of relational query plans that are logically
@@ -52,7 +53,7 @@ type exprGroup interface {
 type bestProps struct {
 	// Required properties with respect to which the best expression was
 	// optimized.
-	required *props.Physical
+	required *physical.Required
 
 	// Cost of the best expression.
 	cost Cost

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -260,14 +260,14 @@ func TestInterner(t *testing.T) {
 		}},
 
 		{hashFn: in.hasher.HashOrderingChoice, eqFn: in.hasher.IsOrderingChoiceEqual, variations: []testVariation{
-			{val1: props.ParseOrderingChoice(""), val2: props.ParseOrderingChoice(""), equal: true},
-			{val1: props.ParseOrderingChoice("+1"), val2: props.ParseOrderingChoice("+1"), equal: true},
-			{val1: props.ParseOrderingChoice("+(1|2)"), val2: props.ParseOrderingChoice("+(2|1)"), equal: true},
-			{val1: props.ParseOrderingChoice("+1 opt(2)"), val2: props.ParseOrderingChoice("+1 opt(2)"), equal: true},
-			{val1: props.ParseOrderingChoice("+1"), val2: props.ParseOrderingChoice("-1"), equal: false},
-			{val1: props.ParseOrderingChoice("+1,+2"), val2: props.ParseOrderingChoice("+1"), equal: false},
-			{val1: props.ParseOrderingChoice("+(1|2)"), val2: props.ParseOrderingChoice("+1"), equal: false},
-			{val1: props.ParseOrderingChoice("+1 opt(2)"), val2: props.ParseOrderingChoice("+1"), equal: false},
+			{val1: physical.ParseOrderingChoice(""), val2: physical.ParseOrderingChoice(""), equal: true},
+			{val1: physical.ParseOrderingChoice("+1"), val2: physical.ParseOrderingChoice("+1"), equal: true},
+			{val1: physical.ParseOrderingChoice("+(1|2)"), val2: physical.ParseOrderingChoice("+(2|1)"), equal: true},
+			{val1: physical.ParseOrderingChoice("+1 opt(2)"), val2: physical.ParseOrderingChoice("+1 opt(2)"), equal: true},
+			{val1: physical.ParseOrderingChoice("+1"), val2: physical.ParseOrderingChoice("-1"), equal: false},
+			{val1: physical.ParseOrderingChoice("+1,+2"), val2: physical.ParseOrderingChoice("+1"), equal: false},
+			{val1: physical.ParseOrderingChoice("+(1|2)"), val2: physical.ParseOrderingChoice("+1"), equal: false},
+			{val1: physical.ParseOrderingChoice("+1 opt(2)"), val2: physical.ParseOrderingChoice("+1"), equal: false},
 		}},
 
 		{hashFn: in.hasher.HashTableID, eqFn: in.hasher.IsTableIDEqual, variations: []testVariation{
@@ -404,33 +404,33 @@ func TestInterner(t *testing.T) {
 func TestInternerPhysProps(t *testing.T) {
 	var in interner
 
-	physProps1 := props.Physical{
-		Presentation: props.Presentation{{Label: "c", ID: 1}},
-		Ordering:     props.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
+	physProps1 := physical.Required{
+		Presentation: physical.Presentation{{Label: "c", ID: 1}},
+		Ordering:     physical.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
 	}
-	physProps2 := props.Physical{
-		Presentation: props.Presentation{{Label: "c", ID: 1}},
-		Ordering:     props.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
+	physProps2 := physical.Required{
+		Presentation: physical.Presentation{{Label: "c", ID: 1}},
+		Ordering:     physical.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
 	}
-	physProps3 := props.Physical{
-		Presentation: props.Presentation{{Label: "d", ID: 1}},
-		Ordering:     props.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
+	physProps3 := physical.Required{
+		Presentation: physical.Presentation{{Label: "d", ID: 1}},
+		Ordering:     physical.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
 	}
-	physProps4 := props.Physical{
-		Presentation: props.Presentation{{Label: "d", ID: 2}},
-		Ordering:     props.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
+	physProps4 := physical.Required{
+		Presentation: physical.Presentation{{Label: "d", ID: 2}},
+		Ordering:     physical.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
 	}
-	physProps5 := props.Physical{
-		Presentation: props.Presentation{{Label: "d", ID: 2}, {Label: "e", ID: 3}},
-		Ordering:     props.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
+	physProps5 := physical.Required{
+		Presentation: physical.Presentation{{Label: "d", ID: 2}, {Label: "e", ID: 3}},
+		Ordering:     physical.ParseOrderingChoice("+(1|2),+3 opt(4,5)"),
 	}
-	physProps6 := props.Physical{
-		Presentation: props.Presentation{{Label: "d", ID: 2}, {Label: "e", ID: 3}},
-		Ordering:     props.ParseOrderingChoice("+(1|2),+3 opt(4,5,6)"),
+	physProps6 := physical.Required{
+		Presentation: physical.Presentation{{Label: "d", ID: 2}, {Label: "e", ID: 3}},
+		Ordering:     physical.ParseOrderingChoice("+(1|2),+3 opt(4,5,6)"),
 	}
 
 	testCases := []struct {
-		phys    *props.Physical
+		phys    *physical.Required
 		inCache bool
 	}{
 		{phys: &physProps1, inCache: false},
@@ -442,7 +442,7 @@ func TestInternerPhysProps(t *testing.T) {
 		{phys: &physProps6, inCache: false},
 	}
 
-	inCache := make(map[*props.Physical]bool)
+	inCache := make(map[*physical.Required]bool)
 
 	for _, tc := range testCases[:1] {
 		interned := in.InternPhysicalProps(tc.phys)

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -297,10 +297,10 @@ func (m *Memo) InternPhysicalProps(phys *physical.Required) *physical.Required {
 // expression's memo group. It is called by the optimizer once it determines
 // the lowest cost expression in a group.
 func (m *Memo) SetBestProps(e RelExpr, phys *physical.Required, cost Cost) {
-	if e.Physical() != nil {
-		if e.Physical() != phys || e.Cost() != cost {
+	if e.RequiredPhysical() != nil {
+		if e.RequiredPhysical() != phys || e.Cost() != cost {
 			panic(fmt.Sprintf("cannot overwrite %s (%.9g) with %s (%.9g)",
-				e.Physical(), e.Cost(), phys, cost))
+				e.RequiredPhysical(), e.Cost(), phys, cost))
 		}
 		return
 	}
@@ -314,5 +314,5 @@ func (m *Memo) IsOptimized() bool {
 	// The memo is optimized once the root expression has its physical properties
 	// assigned.
 	rel, ok := m.rootExpr.(RelExpr)
-	return ok && rel.Physical() != nil
+	return ok && rel.RequiredPhysical() != nil
 }

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
@@ -126,7 +126,7 @@ type Memo struct {
 
 	// rootProps are the physical properties required of the root memo expression.
 	// It is set via a call to SetRoot.
-	rootProps *props.Physical
+	rootProps *physical.Required
 
 	// memEstimate is the approximate memory usage of the memo, in bytes.
 	memEstimate int64
@@ -192,13 +192,13 @@ func (m *Memo) RootExpr() opt.Expr {
 
 // RootProps returns the physical properties required of the root memo group,
 // previously set via a call to SetRoot.
-func (m *Memo) RootProps() *props.Physical {
+func (m *Memo) RootProps() *physical.Required {
 	return m.rootProps
 }
 
 // SetRoot stores the root memo expression when it is a relational expression,
 // and also stores the physical properties required of the root group.
-func (m *Memo) SetRoot(e RelExpr, phys *props.Physical) {
+func (m *Memo) SetRoot(e RelExpr, phys *physical.Required) {
 	m.rootExpr = e
 	if m.rootProps != phys {
 		m.rootProps = m.InternPhysicalProps(phys)
@@ -285,18 +285,18 @@ func (m *Memo) IsStale(ctx context.Context, evalCtx *tree.EvalContext, catalog o
 // yet been added. If the same props was added previously, then return a pointer
 // to the previously added props. This allows interned physical props to be
 // compared for equality using simple pointer comparison.
-func (m *Memo) InternPhysicalProps(physical *props.Physical) *props.Physical {
+func (m *Memo) InternPhysicalProps(phys *physical.Required) *physical.Required {
 	// Special case physical properties that require nothing of operator.
-	if !physical.Defined() {
-		return props.MinPhysProps
+	if !phys.Defined() {
+		return physical.MinRequired
 	}
-	return m.interner.InternPhysicalProps(physical)
+	return m.interner.InternPhysicalProps(phys)
 }
 
 // SetBestProps updates the physical properties and cost of a relational
 // expression's memo group. It is called by the optimizer once it determines
 // the lowest cost expression in a group.
-func (m *Memo) SetBestProps(e RelExpr, phys *props.Physical, cost Cost) {
+func (m *Memo) SetBestProps(e RelExpr, phys *physical.Required, cost Cost) {
 	if e.Physical() != nil {
 		if e.Physical() != phys || e.Cost() != cost {
 			panic(fmt.Sprintf("cannot overwrite %s (%.9g) with %s (%.9g)",

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
@@ -327,13 +328,13 @@ func (c *CustomFuncs) sharedProps(e opt.Expr) *props.Shared {
 
 // HasColsInOrdering returns true if all columns that appear in an ordering are
 // output columns of the input expression.
-func (c *CustomFuncs) HasColsInOrdering(input memo.RelExpr, ordering props.OrderingChoice) bool {
+func (c *CustomFuncs) HasColsInOrdering(input memo.RelExpr, ordering physical.OrderingChoice) bool {
 	return ordering.CanProjectCols(input.Relational().OutputCols)
 }
 
 // OrderingCols returns all non-optional columns that are part of the given
 // OrderingChoice.
-func (c *CustomFuncs) OrderingCols(ordering props.OrderingChoice) opt.ColSet {
+func (c *CustomFuncs) OrderingCols(ordering physical.OrderingChoice) opt.ColSet {
 	return ordering.ColSet()
 }
 
@@ -341,8 +342,8 @@ func (c *CustomFuncs) OrderingCols(ordering props.OrderingChoice) opt.ColSet {
 // not part of the needed column set. Should only be called if HasColsInOrdering
 // is true.
 func (c *CustomFuncs) PruneOrdering(
-	ordering props.OrderingChoice, needed opt.ColSet,
-) props.OrderingChoice {
+	ordering physical.OrderingChoice, needed opt.ColSet,
+) physical.OrderingChoice {
 	if ordering.SubsetOfCols(needed) {
 		return ordering
 	}

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
@@ -632,14 +633,16 @@ func (c *CustomFuncs) MakeGrouping(groupingCols opt.ColSet) *memo.GroupingPrivat
 // MakeOrderedGrouping constructs a new GroupingPrivate using the given
 // grouping columns and OrderingChoice private.
 func (c *CustomFuncs) MakeOrderedGrouping(
-	groupingCols opt.ColSet, ordering props.OrderingChoice,
+	groupingCols opt.ColSet, ordering physical.OrderingChoice,
 ) *memo.GroupingPrivate {
 	return &memo.GroupingPrivate{GroupingCols: groupingCols, Ordering: ordering}
 }
 
 // ExtractGroupingOrdering returns the ordering associated with the input
 // GroupingPrivate.
-func (c *CustomFuncs) ExtractGroupingOrdering(private *memo.GroupingPrivate) props.OrderingChoice {
+func (c *CustomFuncs) ExtractGroupingOrdering(
+	private *memo.GroupingPrivate,
+) physical.OrderingChoice {
 	return private.Ordering
 }
 

--- a/pkg/sql/opt/norm/ordering.go
+++ b/pkg/sql/opt/norm/ordering.go
@@ -16,14 +16,14 @@ package norm
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
 // CanSimplifyLimitOffsetOrdering returns true if the ordering required by the
 // Limit or Offset operator can be made less restrictive, so that the input
 // operator has more ordering choices.
 func (c *CustomFuncs) CanSimplifyLimitOffsetOrdering(
-	in memo.RelExpr, ordering props.OrderingChoice,
+	in memo.RelExpr, ordering physical.OrderingChoice,
 ) bool {
 	return c.canSimplifyOrdering(in, ordering)
 }
@@ -32,8 +32,8 @@ func (c *CustomFuncs) CanSimplifyLimitOffsetOrdering(
 // Offset operator less restrictive by removing optional columns, adding
 // equivalent columns, and removing redundant columns.
 func (c *CustomFuncs) SimplifyLimitOffsetOrdering(
-	input memo.RelExpr, ordering props.OrderingChoice,
-) props.OrderingChoice {
+	input memo.RelExpr, ordering physical.OrderingChoice,
+) physical.OrderingChoice {
 	return c.simplifyOrdering(input, ordering)
 }
 
@@ -103,7 +103,7 @@ func (c *CustomFuncs) SimplifyExplainOrdering(
 	return &copy
 }
 
-func (c *CustomFuncs) canSimplifyOrdering(in memo.RelExpr, ordering props.OrderingChoice) bool {
+func (c *CustomFuncs) canSimplifyOrdering(in memo.RelExpr, ordering physical.OrderingChoice) bool {
 	// If any ordering is allowed, nothing to simplify.
 	if ordering.Any() {
 		return false
@@ -112,8 +112,8 @@ func (c *CustomFuncs) canSimplifyOrdering(in memo.RelExpr, ordering props.Orderi
 }
 
 func (c *CustomFuncs) simplifyOrdering(
-	in memo.RelExpr, ordering props.OrderingChoice,
-) props.OrderingChoice {
+	in memo.RelExpr, ordering physical.OrderingChoice,
+) physical.OrderingChoice {
 	simplified := ordering.Copy()
 	simplified.Simplify(&in.Relational().FuncDeps)
 	return simplified

--- a/pkg/sql/opt/norm/prune_cols.go
+++ b/pkg/sql/opt/norm/prune_cols.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
@@ -254,7 +255,7 @@ func DerivePruneCols(e memo.RelExpr) opt.ColSet {
 		// Any pruneable input columns can potentially be pruned, as long as
 		// they're not used as an ordering column.
 		inputPruneCols := DerivePruneCols(e.Child(0).(memo.RelExpr))
-		ordering := e.Private().(*props.OrderingChoice).ColSet()
+		ordering := e.Private().(*physical.OrderingChoice).ColSet()
 		relProps.Rule.PruneCols = inputPruneCols.Difference(ordering)
 
 	case opt.RowNumberOp:

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -593,7 +593,7 @@ define ExceptAll {
 
 # Limit returns a limited subset of the results in the input relation. The limit
 # expression is a scalar value; the operator returns at most this many rows. The
-# Orering field is a props.OrderingChoice which indicates the row ordering
+# Orering field is a physical.OrderingChoice which indicates the row ordering
 # required from the input (the first rows with respect to this ordering are
 # returned).
 [Relational]

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -145,7 +145,7 @@ func (b *Builder) buildScalar(
 			types.TArray{Typ: elemType},
 		)
 
-		var oc props.OrderingChoice
+		var oc physical.OrderingChoice
 		oc.FromOrdering(s.ordering)
 
 		out = b.factory.ConstructCoalesce(memo.ScalarListExpr{

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -212,19 +212,19 @@ func (s *scope) getColumn(col opt.ColumnID) *scopeColumn {
 }
 
 // makeOrderingChoice returns an OrderingChoice that corresponds to s.ordering.
-func (s *scope) makeOrderingChoice() props.OrderingChoice {
-	var oc props.OrderingChoice
+func (s *scope) makeOrderingChoice() physical.OrderingChoice {
+	var oc physical.OrderingChoice
 	oc.FromOrdering(s.ordering)
 	return oc
 }
 
 // makePhysicalProps constructs physical properties using the columns in the
 // scope for presentation and s.ordering for required ordering.
-func (s *scope) makePhysicalProps() *props.Physical {
-	p := &props.Physical{}
+func (s *scope) makePhysicalProps() *physical.Required {
+	p := &physical.Required{}
 
 	if len(s.cols) > 0 {
-		p.Presentation = make(props.Presentation, 0, len(s.cols))
+		p.Presentation = make(physical.Presentation, 0, len(s.cols))
 		for i := range s.cols {
 			col := &s.cols[i]
 			if !col.hidden {

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -329,8 +329,8 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 		fmt.Fprintf(g.w, "  return e.next\n")
 		fmt.Fprintf(g.w, "}\n\n")
 
-		// Generate the Physical method.
-		fmt.Fprintf(g.w, "func (e *%s) Physical() *physical.Required {\n", opTyp.name)
+		// Generate the RequiredPhysical method.
+		fmt.Fprintf(g.w, "func (e *%s) RequiredPhysical() *physical.Required {\n", opTyp.name)
 		fmt.Fprintf(g.w, "  return e.grp.bestProps().required\n")
 		fmt.Fprintf(g.w, "}\n\n")
 
@@ -432,8 +432,8 @@ func (g *exprsGen) genEnforcerFuncs(define *lang.DefineExpr) {
 	fmt.Fprintf(g.w, "  return nil\n")
 	fmt.Fprintf(g.w, "}\n\n")
 
-	// Generate the Physical method.
-	fmt.Fprintf(g.w, "func (e *%s) Physical() *physical.Required {\n", opTyp.name)
+	// Generate the RequiredPhysical method.
+	fmt.Fprintf(g.w, "func (e *%s) RequiredPhysical() *physical.Required {\n", opTyp.name)
 	fmt.Fprintf(g.w, "  return e.best.required\n")
 	fmt.Fprintf(g.w, "}\n\n")
 

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -44,6 +44,7 @@ func (g *exprsGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 	fmt.Fprintf(g.w, "  \"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint\"\n")
 	fmt.Fprintf(g.w, "  \"github.com/cockroachdb/cockroach/pkg/sql/opt\"\n")
 	fmt.Fprintf(g.w, "  \"github.com/cockroachdb/cockroach/pkg/sql/opt/props\"\n")
+	fmt.Fprintf(g.w, "  \"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical\"\n")
 	fmt.Fprintf(g.w, "  \"github.com/cockroachdb/cockroach/pkg/sql/sem/tree\"\n")
 	fmt.Fprintf(g.w, "  \"github.com/cockroachdb/cockroach/pkg/sql/sem/types\"\n")
 	fmt.Fprintf(g.w, ")\n\n")
@@ -329,7 +330,7 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 		fmt.Fprintf(g.w, "}\n\n")
 
 		// Generate the Physical method.
-		fmt.Fprintf(g.w, "func (e *%s) Physical() *props.Physical {\n", opTyp.name)
+		fmt.Fprintf(g.w, "func (e *%s) Physical() *physical.Required {\n", opTyp.name)
 		fmt.Fprintf(g.w, "  return e.grp.bestProps().required\n")
 		fmt.Fprintf(g.w, "}\n\n")
 
@@ -432,7 +433,7 @@ func (g *exprsGen) genEnforcerFuncs(define *lang.DefineExpr) {
 	fmt.Fprintf(g.w, "}\n\n")
 
 	// Generate the Physical method.
-	fmt.Fprintf(g.w, "func (e *%s) Physical() *props.Physical {\n", opTyp.name)
+	fmt.Fprintf(g.w, "func (e *%s) Physical() *physical.Required {\n", opTyp.name)
 	fmt.Fprintf(g.w, "  return e.best.required\n")
 	fmt.Fprintf(g.w, "}\n\n")
 

--- a/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
@@ -43,7 +43,7 @@ func (g *factoryGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/coltypes\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt/memo\"\n")
-	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt/props\"\n")
+	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/sem/tree\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/sem/types\"\n")
 	g.w.unnest(")\n\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -147,7 +147,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"ColList":        {fullName: "opt.ColList", passByVal: true},
 		"TableID":        {fullName: "opt.TableID", passByVal: true},
 		"Ordering":       {fullName: "opt.Ordering", passByVal: true},
-		"OrderingChoice": {fullName: "props.OrderingChoice", passByVal: true},
+		"OrderingChoice": {fullName: "physical.OrderingChoice", passByVal: true},
 		"TupleOrdinal":   {fullName: "memo.TupleOrdinal", passByVal: true},
 		"ScanLimit":      {fullName: "memo.ScanLimit", passByVal: true},
 		"ScanFlags":      {fullName: "memo.ScanFlags", passByVal: true},
@@ -164,7 +164,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"Constraint":     {fullName: "*constraint.Constraint", isPointer: true},
 		"FuncProps":      {fullName: "*tree.FunctionProperties", isPointer: true},
 		"FuncOverload":   {fullName: "*tree.Overload", isPointer: true},
-		"PhysProps":      {fullName: "*props.Physical", isPointer: true},
+		"PhysProps":      {fullName: "*physical.Required", isPointer: true},
 		"RelProps":       {fullName: "props.Relational"},
 		"ScalarProps":    {fullName: "props.Scalar"},
 	}

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -116,7 +116,7 @@ func (e *ProjectExpr) NextExpr() RelExpr {
 	return e.next
 }
 
-func (e *ProjectExpr) Physical() *physical.Required {
+func (e *ProjectExpr) RequiredPhysical() *physical.Required {
 	return e.grp.bestProps().required
 }
 
@@ -322,7 +322,7 @@ func (e *SortExpr) NextExpr() RelExpr {
 	return nil
 }
 
-func (e *SortExpr) Physical() *physical.Required {
+func (e *SortExpr) RequiredPhysical() *physical.Required {
 	return e.best.required
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
@@ -115,7 +116,7 @@ func (e *ProjectExpr) NextExpr() RelExpr {
 	return e.next
 }
 
-func (e *ProjectExpr) Physical() *props.Physical {
+func (e *ProjectExpr) Physical() *physical.Required {
 	return e.grp.bestProps().required
 }
 
@@ -321,7 +322,7 @@ func (e *SortExpr) NextExpr() RelExpr {
 	return nil
 }
 
-func (e *SortExpr) Physical() *props.Physical {
+func (e *SortExpr) Physical() *physical.Required {
 	return e.best.required
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -70,7 +70,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )

--- a/pkg/sql/opt/ordering/explain.go
+++ b/pkg/sql/opt/ordering/explain.go
@@ -16,11 +16,11 @@ package ordering
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
 func explainBuildChildReqOrdering(
-	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
-) props.OrderingChoice {
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
 	return parent.(*memo.ExplainExpr).Props.Ordering
 }

--- a/pkg/sql/opt/ordering/limit.go
+++ b/pkg/sql/opt/ordering/limit.go
@@ -16,23 +16,23 @@ package ordering
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
-func limitOrOffsetCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
+func limitOrOffsetCanProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {
 	// Limit/Offset require a certain ordering of their input, but can also pass
 	// through a stronger ordering. For example:
 	//   SELECT * FROM (SELECT x, y FROM t ORDER BY x LIMIT 10) ORDER BY x,y
 	// In this case the internal ordering is x+, but we can pass through x+,y+
 	// to satisfy both orderings.
-	return required.Intersects(expr.Private().(*props.OrderingChoice))
+	return required.Intersects(expr.Private().(*physical.OrderingChoice))
 }
 
 func limitOrOffsetBuildChildReqOrdering(
-	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
-) props.OrderingChoice {
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
 	if childIdx != 0 {
-		return props.OrderingChoice{}
+		return physical.OrderingChoice{}
 	}
-	return required.Intersection(parent.Private().(*props.OrderingChoice))
+	return required.Intersection(parent.Private().(*physical.OrderingChoice))
 }

--- a/pkg/sql/opt/ordering/lookup_join.go
+++ b/pkg/sql/opt/ordering/lookup_join.go
@@ -16,20 +16,22 @@ package ordering
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
-func lookupOrIndexJoinCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
+func lookupOrIndexJoinCanProvideOrdering(
+	expr memo.RelExpr, required *physical.OrderingChoice,
+) bool {
 	// LookupJoin and IndexJoin can pass through their ordering if the ordering
 	// depends only on columns present in the input.
 	return isOrderingBoundBy(expr.Child(0).(memo.RelExpr), required)
 }
 
 func lookupOrIndexJoinBuildChildReqOrdering(
-	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
-) props.OrderingChoice {
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
 	if childIdx != 0 {
-		return props.OrderingChoice{}
+		return physical.OrderingChoice{}
 	}
 
 	// We may need to remove ordering columns that are not output by the input

--- a/pkg/sql/opt/ordering/merge_join.go
+++ b/pkg/sql/opt/ordering/merge_join.go
@@ -17,10 +17,10 @@ package ordering
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
-func mergeJoinCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
+func mergeJoinCanProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {
 	m := expr.(*memo.MergeJoinExpr).MergeJoinPrivate
 	// TODO(radu): in principle, we could pass through an ordering that covers
 	// more than the equality columns. For example, if we have a merge join
@@ -44,14 +44,14 @@ func mergeJoinCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoi
 }
 
 func mergeJoinBuildChildReqOrdering(
-	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
-) props.OrderingChoice {
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
 	switch childIdx {
 	case 0:
 		return parent.(*memo.MergeJoinExpr).LeftOrdering
 	case 1:
 		return parent.(*memo.MergeJoinExpr).RightOrdering
 	default:
-		return props.OrderingChoice{}
+		return physical.OrderingChoice{}
 	}
 }

--- a/pkg/sql/opt/ordering/project.go
+++ b/pkg/sql/opt/ordering/project.go
@@ -16,20 +16,20 @@ package ordering
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
-func projectCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
+func projectCanProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {
 	// Project can pass through its ordering if the ordering depends only on
 	// columns present in the input.
 	return isOrderingBoundBy(expr.(*memo.ProjectExpr).Input, required)
 }
 
 func projectBuildChildReqOrdering(
-	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
-) props.OrderingChoice {
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
 	if childIdx != 0 {
-		return props.OrderingChoice{}
+		return physical.OrderingChoice{}
 	}
 
 	// We may need to remove ordering columns that are not output by the input
@@ -50,7 +50,7 @@ func projectBuildChildReqOrdering(
 
 // isOrderingBoundBy returns true if the given ordering can be satisfied using
 // only the columns produced by input.
-func isOrderingBoundBy(input memo.RelExpr, ordering *props.OrderingChoice) bool {
+func isOrderingBoundBy(input memo.RelExpr, ordering *physical.OrderingChoice) bool {
 	inputCols := input.Relational().OutputCols
 	return ordering.CanProjectCols(inputCols)
 }
@@ -59,8 +59,8 @@ func isOrderingBoundBy(input memo.RelExpr, ordering *props.OrderingChoice) bool 
 // can only be used if isOrderingBoundBy is true for the ordering. If projection
 // is not necessary, returns a shallow copy of the ordering.
 func projectOrderingToInput(
-	input memo.RelExpr, ordering *props.OrderingChoice,
-) props.OrderingChoice {
+	input memo.RelExpr, ordering *physical.OrderingChoice,
+) physical.OrderingChoice {
 	childOutCols := input.Relational().OutputCols
 	if ordering.SubsetOfCols(childOutCols) {
 		return *ordering

--- a/pkg/sql/opt/ordering/project_test.go
+++ b/pkg/sql/opt/ordering/project_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -64,7 +65,7 @@ func TestProject(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		req := props.ParseOrderingChoice(tc.req)
+		req := physical.ParseOrderingChoice(tc.req)
 		res := "no"
 		if projectCanProvideOrdering(project, &req) {
 			res = projectBuildChildReqOrdering(project, &req, 0).String()

--- a/pkg/sql/opt/ordering/row_number.go
+++ b/pkg/sql/opt/ordering/row_number.go
@@ -17,10 +17,10 @@ package ordering
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
-func rowNumberCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
+func rowNumberCanProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {
 	// By construction, any prefix of the ordering required of the input is also
 	// ordered by the ordinality column. For example, if the required input
 	// ordering is +a,+b, then any of these orderings can be provided:
@@ -56,10 +56,10 @@ func rowNumberCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoi
 }
 
 func rowNumberBuildChildReqOrdering(
-	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
-) props.OrderingChoice {
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
 	if childIdx != 0 {
-		return props.OrderingChoice{}
+		return physical.OrderingChoice{}
 	}
 	// RowNumber always requires its internal ordering.
 	return parent.(*memo.RowNumberExpr).Ordering

--- a/pkg/sql/opt/ordering/scan.go
+++ b/pkg/sql/opt/ordering/scan.go
@@ -17,10 +17,10 @@ package ordering
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
-func scanCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
+func scanCanProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {
 	ok, _ := ScanPrivateCanProvide(
 		expr.Memo().Metadata(),
 		&expr.(*memo.ScanExpr).ScanPrivate,
@@ -33,7 +33,7 @@ func scanCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) b
 // in order to satisfy the required ordering. If either direction is ok (e.g. no
 // required ordering), reutrns false. The scan must be able to satisfy the
 // required ordering, according to ScanCanProvideOrdering.
-func ScanIsReverse(scan *memo.ScanExpr, required *props.OrderingChoice) bool {
+func ScanIsReverse(scan *memo.ScanExpr, required *physical.OrderingChoice) bool {
 	ok, reverse := ScanPrivateCanProvide(
 		scan.Memo().Metadata(),
 		&scan.ScanPrivate,
@@ -49,7 +49,7 @@ func ScanIsReverse(scan *memo.ScanExpr, required *props.OrderingChoice) bool {
 // that satisfy the given required ordering; it also returns whether the scan
 // needs to be in reverse order to match the required ordering.
 func ScanPrivateCanProvide(
-	md *opt.Metadata, s *memo.ScanPrivate, required *props.OrderingChoice,
+	md *opt.Metadata, s *memo.ScanPrivate, required *physical.OrderingChoice,
 ) (ok bool, reverse bool) {
 	// Scan naturally orders according to scanned index's key columns. A scan can
 	// be executed either as a forward or as a reverse scan (unless it has a row
@@ -112,7 +112,7 @@ func ScanPrivateCanProvide(
 
 func init() {
 	memo.ScanIsReverseFn = func(
-		md *opt.Metadata, s *memo.ScanPrivate, required *props.OrderingChoice,
+		md *opt.Metadata, s *memo.ScanPrivate, required *physical.OrderingChoice,
 	) bool {
 		ok, reverse := ScanPrivateCanProvide(md, s, required)
 		if !ok {

--- a/pkg/sql/opt/ordering/scan_test.go
+++ b/pkg/sql/opt/ordering/scan_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -136,7 +136,7 @@ func TestScan(t *testing.T) {
 		t.Run(fmt.Sprintf("group%d", gIdx+1), func(t *testing.T) {
 			for tcIdx, tc := range g.cases {
 				t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
-					req := props.ParseOrderingChoice(tc.req)
+					req := physical.ParseOrderingChoice(tc.req)
 					ok, rev := ScanPrivateCanProvide(md, &g.p, &req)
 					res := "no"
 					if ok {

--- a/pkg/sql/opt/ordering/select.go
+++ b/pkg/sql/opt/ordering/select.go
@@ -17,18 +17,19 @@ package ordering
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
-func selectCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
+func selectCanProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {
 	// Select operator can always pass through ordering to its input.
 	return true
 }
 
 func selectBuildChildReqOrdering(
-	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
-) props.OrderingChoice {
+	parent memo.RelExpr, required *physical.OrderingChoice, childIdx int,
+) physical.OrderingChoice {
 	if childIdx != 0 {
-		return props.OrderingChoice{}
+		return physical.OrderingChoice{}
 	}
 	return trimColumnGroups(required, &parent.(*memo.SelectExpr).Input.Relational().FuncDeps)
 }
@@ -39,7 +40,9 @@ func selectBuildChildReqOrdering(
 // equivalences that the input expression does not (for example a Select with an
 // equality condition); the columns in a group must be equivalent at the level
 // of the operator where the ordering is required.
-func trimColumnGroups(required *props.OrderingChoice, fds *props.FuncDepSet) props.OrderingChoice {
+func trimColumnGroups(
+	required *physical.OrderingChoice, fds *props.FuncDepSet,
+) physical.OrderingChoice {
 	res := *required
 	copied := false
 	for i := range res.Columns {

--- a/pkg/sql/opt/props/physical/ordering_choice.go
+++ b/pkg/sql/opt/props/physical/ordering_choice.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package props
+package physical
 
 import (
 	"bytes"
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -476,7 +477,7 @@ func (oc *OrderingChoice) Copy() OrderingChoice {
 // groups, and additional equivalent columns. This is used to quickly check
 // whether Simplify needs to be called without requiring allocations in the
 // common case. This logic should be changed in concert with the Simplify logic.
-func (oc *OrderingChoice) CanSimplify(fdset *FuncDepSet) bool {
+func (oc *OrderingChoice) CanSimplify(fdset *props.FuncDepSet) bool {
 	if oc.Any() {
 		// Any ordering allowed, so can't simplify further.
 		return false
@@ -536,7 +537,7 @@ func (oc *OrderingChoice) CanSimplify(fdset *FuncDepSet) bool {
 //        https://cs.uwaterloo.ca/~gweddell/cs798/p57-simmen.pdf
 //
 // This logic should be changed in concert with the CanSimplify logic.
-func (oc *OrderingChoice) Simplify(fdset *FuncDepSet) {
+func (oc *OrderingChoice) Simplify(fdset *props.FuncDepSet) {
 	oc.Optional = fdset.ComputeClosure(oc.Optional)
 
 	closure := oc.Optional

--- a/pkg/sql/opt/props/physical/required.go
+++ b/pkg/sql/opt/props/physical/required.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package props
+package physical
 
 import (
 	"bytes"
@@ -21,7 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 )
 
-// Physical properties are interesting characteristics of an expression that
+// Required properties are interesting characteristics of an expression that
 // impact its layout, presentation, or location, but not its logical content.
 // Examples include row order, column naming, and data distribution (physical
 // location of data ranges). Physical properties exist outside of the relational
@@ -37,7 +37,7 @@ import (
 // is always with respect to a particular set of required physical properties.
 // The goal is to find the lowest cost expression that provides those
 // properties while still remaining logically equivalent.
-type Physical struct {
+type Required struct {
 	// Presentation specifies the naming, membership (including duplicates),
 	// and order of result columns. If Presentation is not defined, then no
 	// particular column presentation is required or provided.
@@ -50,18 +50,18 @@ type Physical struct {
 	Ordering OrderingChoice
 }
 
-// MinPhysProps are the default physical properties that require nothing and
+// MinRequired are the default physical properties that require nothing and
 // provide nothing.
-var MinPhysProps = &Physical{}
+var MinRequired = &Required{}
 
 // Defined is true if any physical property is defined. If none is defined, then
-// this is an instance of MinPhysProps.
-func (p *Physical) Defined() bool {
+// this is an instance of MinRequired.
+func (p *Required) Defined() bool {
 	return !p.Presentation.Any() || !p.Ordering.Any()
 }
 
 // ColSet returns the set of columns used by any of the physical properties.
-func (p *Physical) ColSet() opt.ColSet {
+func (p *Required) ColSet() opt.ColSet {
 	colSet := p.Ordering.ColSet()
 	for _, col := range p.Presentation {
 		colSet.Add(int(col.ID))
@@ -69,7 +69,7 @@ func (p *Physical) ColSet() opt.ColSet {
 	return colSet
 }
 
-func (p *Physical) String() string {
+func (p *Required) String() string {
 	hasProjection := !p.Presentation.Any()
 	hasOrdering := !p.Ordering.Any()
 
@@ -100,7 +100,7 @@ func (p *Physical) String() string {
 }
 
 // Equals returns true if the two physical properties are identical.
-func (p *Physical) Equals(rhs *Physical) bool {
+func (p *Required) Equals(rhs *Required) bool {
 	return p.Presentation.Equals(rhs.Presentation) && p.Ordering.Equals(&rhs.Ordering)
 }
 

--- a/pkg/sql/opt/props/physical/required.go
+++ b/pkg/sql/opt/props/physical/required.go
@@ -30,13 +30,12 @@ import (
 // optimization (e.g. a merge join requires the inputs to be sorted in a
 // particular order).
 //
-// Physical properties can be provided by an operator or required of it. Some
-// operators "naturally" provide a physical property such as ordering on a
-// particular column. Other operators require one or more of their operands to
-// provide a particular physical property. When an expression is optimized, it
-// is always with respect to a particular set of required physical properties.
-// The goal is to find the lowest cost expression that provides those
-// properties while still remaining logically equivalent.
+// Required properties are derived top-to-bottom - there is a required physical
+// property on the root, and each expression can require physical properties on
+// one or more of its operands. When an expression is optimized, it is always
+// with respect to a particular set of required physical properties.  The goal
+// is to find the lowest cost expression that provides those properties while
+// still remaining logically equivalent.
 type Required struct {
 	// Presentation specifies the naming, membership (including duplicates),
 	// and order of result columns. If Presentation is not defined, then no

--- a/pkg/sql/opt/props/physical/required_test.go
+++ b/pkg/sql/opt/props/physical/required_test.go
@@ -12,31 +12,31 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package props_test
+package physical_test
 
 import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
-func TestPhysicalProps(t *testing.T) {
+func TestRequiredProps(t *testing.T) {
 	// Empty props.
-	phys := &props.Physical{}
-	testPhysicalProps(t, phys, "[]")
+	phys := &physical.Required{}
+	testRequiredProps(t, phys, "[]")
 
 	if phys.Defined() {
 		t.Error("no props should be defined")
 	}
 
 	// Presentation props.
-	presentation := props.Presentation{
+	presentation := physical.Presentation{
 		opt.LabeledColumn{Label: "a", ID: 1},
 		opt.LabeledColumn{Label: "b", ID: 2},
 	}
-	phys = &props.Physical{Presentation: presentation}
-	testPhysicalProps(t, phys, "[presentation: a:1,b:2]")
+	phys = &physical.Required{Presentation: presentation}
+	testRequiredProps(t, phys, "[presentation: a:1,b:2]")
 
 	if presentation.Any() {
 		t.Error("presentation should not be empty")
@@ -46,17 +46,17 @@ func TestPhysicalProps(t *testing.T) {
 		t.Error("presentation should equal itself")
 	}
 
-	if presentation.Equals(props.Presentation{}) {
+	if presentation.Equals(physical.Presentation{}) {
 		t.Error("presentation should not equal the empty presentation")
 	}
 
 	// Add ordering props.
-	ordering := props.ParseOrderingChoice("+1,+5")
+	ordering := physical.ParseOrderingChoice("+1,+5")
 	phys.Ordering = ordering
-	testPhysicalProps(t, phys, "[presentation: a:1,b:2] [ordering: +1,+5]")
+	testRequiredProps(t, phys, "[presentation: a:1,b:2] [ordering: +1,+5]")
 }
 
-func testPhysicalProps(t *testing.T, physProps *props.Physical, expected string) {
+func testRequiredProps(t *testing.T, physProps *physical.Required, expected string) {
 	t.Helper()
 	actual := physProps.String()
 	if actual != expected {

--- a/pkg/sql/opt/testutils/forcing_opt.go
+++ b/pkg/sql/opt/testutils/forcing_opt.go
@@ -17,7 +17,7 @@ package testutils
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 )
 
@@ -143,7 +143,7 @@ func (fc *forcingCoster) AddAllowedPath(path exprPath) {
 }
 
 // ComputeCost is part of the xform.Coster interface.
-func (fc *forcingCoster) ComputeCost(e memo.RelExpr, required *props.Physical) memo.Cost {
+func (fc *forcingCoster) ComputeCost(e memo.RelExpr, required *physical.Required) memo.Cost {
 	// If no allowed paths have been added, allow all expressions.
 	if len(fc.allowed) != 0 {
 		// Derive the path of the expression in the tree.

--- a/pkg/sql/opt/xform/explorer.go
+++ b/pkg/sql/opt/xform/explorer.go
@@ -17,7 +17,7 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
@@ -201,13 +201,13 @@ func (e *explorer) exploreGroup(grp memo.RelExpr) *exploreState {
 // lookupExploreState returns the optState struct associated with the memo
 // group.
 func (e *explorer) lookupExploreState(grp memo.RelExpr) *exploreState {
-	return &e.o.lookupOptState(grp, props.MinPhysProps).explore
+	return &e.o.lookupOptState(grp, physical.MinRequired).explore
 }
 
 // ensureExploreState allocates the exploration state in the optState struct
 // associated with the memo group, with respect to the min physical props.
 func (e *explorer) ensureExploreState(grp memo.RelExpr) *exploreState {
-	return &e.o.ensureOptState(grp, props.MinPhysProps).explore
+	return &e.o.ensureOptState(grp, physical.MinRequired).explore
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/xform/interesting_orderings.go
+++ b/pkg/sql/opt/xform/interesting_orderings.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
 // DeriveInterestingOrderings calculates and returns the
@@ -119,7 +120,7 @@ func interestingOrderingsForGroupBy(rel memo.RelExpr) opt.OrderingSet {
 
 func interestingOrderingsForLimit(rel memo.RelExpr) opt.OrderingSet {
 	res := DeriveInterestingOrderings(rel.Child(0).(memo.RelExpr))
-	ord := rel.Private().(*props.OrderingChoice).ToOrdering()
+	ord := rel.Private().(*physical.OrderingChoice).ToOrdering()
 	if ord.Empty() {
 		return res
 	}

--- a/pkg/sql/opt/xform/memo_format.go
+++ b/pkg/sql/opt/xform/memo_format.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
@@ -236,11 +236,11 @@ func (mf *memoFormatter) formatExpr(e opt.Expr) {
 		}
 		fmt.Fprintf(mf.buf, " G%d", mf.group(child)+1)
 	}
-	mf.formatPrivate(e, &props.Physical{})
+	mf.formatPrivate(e, &physical.Required{})
 	mf.buf.WriteString(")")
 }
 
-func (mf *memoFormatter) formatBest(best memo.RelExpr, required *props.Physical) {
+func (mf *memoFormatter) formatBest(best memo.RelExpr, required *physical.Required) {
 	fmt.Fprintf(mf.buf, "(%s", best.Op())
 
 	for i := 0; i < best.ChildCount(); i++ {
@@ -257,7 +257,7 @@ func (mf *memoFormatter) formatBest(best memo.RelExpr, required *props.Physical)
 	mf.buf.WriteString(")")
 }
 
-func (mf *memoFormatter) formatPrivate(e opt.Expr, physProps *props.Physical) {
+func (mf *memoFormatter) formatPrivate(e opt.Expr, physProps *physical.Required) {
 	private := e.Private()
 	if private == nil {
 		return

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/ordering"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
 // canProvidePhysicalProps returns true if the given expression can provide the
@@ -32,7 +32,7 @@ import (
 // Operators that do this should return true from the appropriate canProvide
 // method and then pass through that property in the buildChildPhysicalProps
 // method.
-func (o *Optimizer) canProvidePhysicalProps(e memo.RelExpr, required *props.Physical) bool {
+func (o *Optimizer) canProvidePhysicalProps(e memo.RelExpr, required *physical.Required) bool {
 	// All operators can provide the Presentation property, so no need to check
 	// for that.
 	return ordering.CanProvide(e, &required.Ordering)
@@ -47,9 +47,9 @@ func (o *Optimizer) canProvidePhysicalProps(e memo.RelExpr, required *props.Phys
 // repeatedly as physical properties are derived for each child. On each call,
 // buildChildPhysicalProps updates the childProps argument.
 func (o *Optimizer) buildChildPhysicalProps(
-	parent memo.RelExpr, nth int, parentProps *props.Physical,
-) *props.Physical {
-	var childProps props.Physical
+	parent memo.RelExpr, nth int, parentProps *physical.Required,
+) *physical.Required {
+	var childProps physical.Required
 
 	// The only operation that requires a presentation of its input is Explain.
 	if parent.Op() == opt.ExplainOp {


### PR DESCRIPTION
For #32221, Andy suggested it would be more future-proof to add a separate "required" physical properties type, and we think this will make sense when we add more physical properties around distribution. This change is mechanical, except the comment update in the last commit.

#### opt: move props.Physical to physical.Required

Mechanical change to move Physical and OrderingChoice to a new
physical package (we will have physical.Requried and
physical.Provided).

Release note: None

#### opt: rename RelExpr.Physical to RequiredPhysical

Release note: None

#### opt: update comment on physical.Required

Release note: None
