### PR TITLE
release-2.1: server: Don't let non-superusers see other user's sessions

### DIFF
--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -360,8 +360,8 @@ func newAuthenticationMux(s *authenticationServer, inner http.Handler) *authenti
 type webSessionUserKey struct{}
 type webSessionIDKey struct{}
 
-const webSessionUserKeyStr = "webSessionUser"
-const webSessionIDKeyStr = "webSessionID"
+const webSessionUserKeyStr = "websessionuser"
+const webSessionIDKeyStr = "websessionid"
 
 func (am *authenticationMux) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	username, cookie, err := am.getSession(w, req)

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1356,13 +1356,36 @@ func (s *statusServer) ListLocalSessions(
 		return nil, remoteDebuggingErr
 	}
 
+	var showAll bool
+	sessionUser, err := userFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// If the client is asking to see more than just their own sessions, verify
+	// that they should be allowed to.
+	if sessionUser != req.Username {
+		superuser := (sessionUser == security.RootUser || s.isSuperUser(ctx, sessionUser))
+		if req.Username != "" && !superuser {
+			return nil, grpcstatus.Errorf(
+				codes.PermissionDenied,
+				"client user %q does not have permission to view sessions from user %q",
+				sessionUser, req.Username)
+		}
+		// If the user isn't a superuser, then a request with an empty username is
+		// implicitly a request for the client's own sessions.
+		if req.Username == "" && !superuser {
+			req.Username = sessionUser
+		}
+		showAll = (req.Username == "" && superuser)
+	}
+
 	registry := s.sessionRegistry
 
 	sessions := registry.SerializeAll()
 	userSessions := make([]serverpb.Session, 0, len(sessions))
 
 	for _, session := range sessions {
-		if !(req.Username == security.RootUser || req.Username == session.Username) {
+		if req.Username != session.Username && !showAll {
 			continue
 		}
 
@@ -1696,4 +1719,43 @@ func marshalJSONResponse(value interface{}) (*serverpb.JSONResponse, error) {
 		return nil, err
 	}
 	return &serverpb.JSONResponse{Data: data}, nil
+}
+
+func userFromContext(ctx context.Context) (string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		// If the incoming context has metadata but no attached web session user,
+		// it's a gRPC / internal SQL connection which has root on the cluster.
+		return security.RootUser, nil
+	}
+	usernames, ok := md[webSessionUserKeyStr]
+	if !ok {
+		// If the incoming context has metadata but no attached web session user,
+		// it's a gRPC / internal SQL connection which has root on the cluster.
+		return security.RootUser, nil
+	}
+	if len(usernames) != 1 {
+		log.Warningf(ctx, "context's incoming metadata contains unexpected number of usernames: %+v ", md)
+		return "", fmt.Errorf(
+			"context's incoming metadata contains unexpected number of usernames: %+v ", md)
+	}
+	return usernames[0], nil
+}
+
+type superUserChecker interface {
+	RequireSuperUser(ctx context.Context, action string) error
+}
+
+func (s *statusServer) isSuperUser(ctx context.Context, username string) bool {
+	planner, cleanup := sql.NewInternalPlanner(
+		"check-superuser",
+		client.NewTxn(ctx, s.db, s.gossip.NodeID.Get(), client.RootTxn),
+		username,
+		&sql.MemoryMetrics{},
+		s.admin.server.execCfg)
+	defer cleanup()
+	if err := planner.(superUserChecker).RequireSuperUser(ctx, "access status server endpoint"); err != nil {
+		return false
+	}
+	return true
 }

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -985,3 +985,63 @@ func TestStatusAPIStatements(t *testing.T) {
 		t.Fatalf("expected queries\n\n%v\n\ngot queries\n\n%v", expectedStatements, statementsInResponse)
 	}
 }
+
+func TestListSessionsSecurity(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	ts := s.(*TestServer)
+	defer ts.Stopper().Stop(context.TODO())
+
+	// HTTP requests respect the authenticated username from the HTTP session.
+	testCases := []struct {
+		endpoint    string
+		expectedErr string
+	}{
+		{"local_sessions", ""},
+		{"sessions", ""},
+		{fmt.Sprintf("local_sessions?username=%s", authenticatedUserName), ""},
+		{fmt.Sprintf("sessions?username=%s", authenticatedUserName), ""},
+		{"local_sessions?username=root", "does not have permission to view sessions from user"},
+		{"sessions?username=root", "does not have permission to view sessions from user"},
+	}
+	for _, tc := range testCases {
+		var response serverpb.ListSessionsResponse
+		err := getStatusJSONProto(ts, tc.endpoint, &response)
+		if tc.expectedErr == "" {
+			if err != nil || len(response.Errors) > 0 {
+				t.Errorf("unexpected failure listing sessions from %s; error: %v; response errors: %v",
+					tc.endpoint, err, response.Errors)
+			}
+		} else {
+			if !testutils.IsError(err, tc.expectedErr) &&
+				!strings.Contains(response.Errors[0].Message, tc.expectedErr) {
+				t.Errorf("did not get expected error %q when listing sessions from %s: %v",
+					tc.expectedErr, tc.endpoint, err)
+			}
+		}
+	}
+
+	// gRPC requests behave as root and thus are always allowed.
+	rootConfig := testutils.NewTestBaseContext(security.RootUser)
+	rpcContext := rpc.NewContext(
+		log.AmbientContext{Tracer: ts.ClusterSettings().Tracer}, rootConfig, ts.Clock(), ts.Stopper(),
+		&ts.ClusterSettings().Version)
+	url := ts.ServingAddr()
+	conn, err := rpcContext.GRPCDial(url).Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := serverpb.NewStatusClient(conn)
+	ctx := context.Background()
+	for _, user := range []string{"", authenticatedUserName, "root"} {
+		request := &serverpb.ListSessionsRequest{Username: user}
+		if resp, err := client.ListLocalSessions(ctx, request); err != nil || len(resp.Errors) > 0 {
+			t.Errorf("unexpected failure listing local sessions for %q; error: %v; response errors: %v",
+				user, err, resp.Errors)
+		}
+		if resp, err := client.ListSessions(ctx, request); err != nil || len(resp.Errors) > 0 {
+			t.Errorf("unexpected failure listing sessions for %q; error: %v; response errors: %v",
+				user, err, resp.Errors)
+		}
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #32253.

/cc @cockroachdb/release

---

This effectively means that only the root user can see other user's
sessions except when the enterprise-only RBAC feature is enabled and a
user has been added to the "admin" role.

This also changes the behavior of ListSessions and ListLocalSessions to
list whatever sessions they can even if no username is provided, whereas
previously if no username was provided then no sessions would ever be
returned.

Release note (bug fix): Don't let non-superusers see other user's
sessions and queries via the ListSessions and ListLocalSessions status
server API methods.