### PR TITLE
storage/engine: improve MVCCScan

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -314,6 +314,7 @@ typedef struct {
   DBChunkedBuffer data;
   DBSlice intents;
   DBTimestamp uncertainty_timestamp;
+  DBSlice resume_key;
 } DBScanResults;
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,

--- a/c-deps/libroach/mvcc.cc
+++ b/c-deps/libroach/mvcc.cc
@@ -275,17 +275,12 @@ DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_sp
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
                       bool consistent, bool tombstones) {
-  // Get is implemented as a scan where we retrieve a single key. Note
-  // that the semantics of max_keys is that we retrieve one more key
-  // than is specified in order to maintain the existing semantics of
-  // resume span. See storage/engine/mvcc.go:MVCCScan.
-  //
-  // We specify an empty key for the end key which will ensure we
-  // don't retrieve a key different than the start key. This is a bit
-  // of a hack.
+  // Get is implemented as a scan where we retrieve a single key. We specify an
+  // empty key for the end key which will ensure we don't retrieve a key
+  // different than the start key. This is a bit of a hack.
   const DBSlice end = {0, 0};
   ScopedStats scoped_iter(iter);
-  mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent,
+  mvccForwardScanner scanner(iter, key, end, timestamp, 1 /* max_keys */, txn, consistent,
                              tombstones);
   return scanner.get();
 }

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -119,7 +119,7 @@ type Iterator interface {
 	// will be empty).
 	MVCCScan(start, end roachpb.Key, max int64, timestamp hlc.Timestamp,
 		txn *roachpb.Transaction, consistent, reverse, tombstone bool,
-	) (kvs []byte, numKvs int64, intents []byte, err error)
+	) (kvData []byte, numKVs int64, resumeSpan *roachpb.Span, intents []roachpb.Intent, err error)
 	// SetUpperBound installs a new upper bound for this iterator.
 	SetUpperBound(roachpb.Key)
 

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1695,7 +1695,7 @@ func mvccScanToKvs(
 	var k MVCCKey
 	var rawBytes []byte
 	for i := range kvs {
-		k, rawBytes, kvData, err = MVCCScanDecodeKeyValue(res.KVData)
+		k, rawBytes, kvData, err = MVCCScanDecodeKeyValue(kvData)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -1756,29 +1756,6 @@ func resumeKeyToSpan(key, endKey, resumeKey roachpb.Key, reverse bool) (resumeSp
 		}
 	}
 	return resumeSpan
-}
-
-func buildScanResumeKey(kvData []byte, numKvs int64, max int64) ([]byte, int, error) {
-	kvLen := len(kvData)
-	if kvLen == 0 {
-		return nil, 0, nil
-	}
-	if numKvs <= max {
-		return nil, 0, nil
-	}
-	var err error
-	for i := int64(0); i < max; i++ {
-		kvData, err = mvccScanSkipKeyValue(kvData)
-		if err != nil {
-			return nil, 0, err
-		}
-	}
-	offset := kvLen - len(kvData)
-	key, _, _, err := MVCCScanDecodeKeyValue(kvData)
-	if err != nil {
-		return nil, 0, err
-	}
-	return key.Key, offset, nil
 }
 
 // MVCCScan scans the key range [key,endKey) key up to some maximum number of

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1739,25 +1739,6 @@ func buildScanIntents(data []byte) ([]roachpb.Intent, error) {
 	return intents, nil
 }
 
-// resumeKeyToSpan creates a resumeSpan suitable for returning in a ScanResponse
-// out of a resumeKey (the last key in a batch that exceeded a limit).
-func resumeKeyToSpan(key, endKey, resumeKey roachpb.Key, reverse bool) (resumeSpan *roachpb.Span) {
-	if resumeKey != nil {
-		// NB: we copy the resume key here to ensure that it doesn't point to the
-		// same shared buffer as the main results. Higher levels of the code may
-		// cache the resume key and we don't want them pinning excessive amounts of
-		// memory.
-		if reverse {
-			resumeKey = resumeKey[:len(resumeKey):len(resumeKey)]
-			resumeSpan = &roachpb.Span{Key: key, EndKey: resumeKey.Next()}
-		} else {
-			resumeKey = append(roachpb.Key(nil), resumeKey...)
-			resumeSpan = &roachpb.Span{Key: resumeKey, EndKey: endKey}
-		}
-	}
-	return resumeSpan
-}
-
 // MVCCScan scans the key range [key,endKey) key up to some maximum number of
 // results in ascending order. If it hits max, it returns a span to be used in
 // the next call to this function. Use MaxInt64 for not limit. If the limit is

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -41,7 +41,7 @@ const (
 
 var (
 	// MVCCKeyMax is a maximum mvcc-encoded key value which sorts after
-	// all other keys.`
+	// all other keys.
 	MVCCKeyMax = MakeMVCCMetadataKey(roachpb.KeyMax)
 	// NilKey is the nil MVCCKey.
 	NilKey = MVCCKey{}

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1689,10 +1689,6 @@ func mvccScanInternal(
 	txn *roachpb.Transaction,
 	reverse bool,
 ) ([]byte, int64, *roachpb.Span, []roachpb.Intent, error) {
-	if len(endKey) == 0 {
-		return nil, 0, nil, nil, emptyKeyError()
-	}
-
 	kvData, numKvs, intentData, err := iter.MVCCScan(
 		key, endKey, max, timestamp, txn, consistent, reverse, tombstones)
 	if err != nil {

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1470,7 +1470,7 @@ func (r *batchIterator) MVCCScan(
 	timestamp hlc.Timestamp,
 	txn *roachpb.Transaction,
 	consistent, reverse, tombstones bool,
-) (kvs []byte, numKvs int64, intents []byte, err error) {
+) (kvData []byte, numKVs int64, resumeSpan *roachpb.Span, intents []roachpb.Intent, err error) {
 	r.batch.flushMutations()
 	return r.iter.MVCCScan(start, end, max, timestamp, txn, consistent, reverse, tombstones)
 }
@@ -2297,12 +2297,16 @@ func (r *rocksDBIterator) MVCCScan(
 	timestamp hlc.Timestamp,
 	txn *roachpb.Transaction,
 	consistent, reverse, tombstones bool,
-) (kvs []byte, numKvs int64, intents []byte, err error) {
+) (kvData []byte, numKVs int64, resumeSpan *roachpb.Span, intents []roachpb.Intent, err error) {
 	if !consistent && txn != nil {
-		return nil, 0, nil, errors.Errorf("cannot allow inconsistent reads within a transaction")
+		return nil, 0, nil, nil, errors.Errorf("cannot allow inconsistent reads within a transaction")
 	}
 	if len(end) == 0 {
-		return nil, 0, nil, emptyKeyError()
+		return nil, 0, nil, nil, emptyKeyError()
+	}
+	if max == 0 {
+		resumeSpan = &roachpb.Span{Key: start, EndKey: end}
+		return nil, 0, resumeSpan, nil, nil
 	}
 
 	r.clearState()
@@ -2313,13 +2317,40 @@ func (r *rocksDBIterator) MVCCScan(
 	)
 
 	if err := statusToError(state.status); err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
 	if err := uncertaintyToError(timestamp, state.uncertainty_timestamp, txn); err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
-	kvs = copyFromSliceVector(state.data.bufs, state.data.len)
-	return kvs, int64(state.data.count), cSliceToGoBytes(state.intents), nil
+
+	kvData = copyFromSliceVector(state.data.bufs, state.data.len)
+	numKVs = int64(state.data.count)
+
+	intents, err = buildScanIntents(cSliceToGoBytes(state.intents))
+	if err != nil {
+		return nil, 0, nil, nil, err
+	}
+	if consistent && len(intents) > 0 {
+		// When encountering intents during a consistent scan we still need to
+		// return the resume key.
+		resumeKey, _, err := buildScanResumeKey(kvData, numKVs, max)
+		if err != nil {
+			return nil, 0, nil, nil, err
+		}
+		resumeSpan = resumeKeyToSpan(start, end, resumeKey, reverse)
+		return nil, 0, resumeSpan, nil, &roachpb.WriteIntentError{Intents: intents}
+	}
+
+	resumeKey, offset, err := buildScanResumeKey(kvData, numKVs, max)
+	if err != nil {
+		return nil, 0, nil, nil, nil
+	}
+	if resumeKey != nil {
+		kvData = kvData[:offset]
+		numKVs = max
+		resumeSpan = resumeKeyToSpan(start, end, resumeKey, reverse)
+	}
+	return kvData, numKVs, resumeSpan, intents, nil
 }
 
 func (r *rocksDBIterator) SetUpperBound(key roachpb.Key) {

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2325,7 +2325,14 @@ func (r *rocksDBIterator) MVCCScan(
 
 	kvData = copyFromSliceVector(state.data.bufs, state.data.len)
 	numKVs = int64(state.data.count)
-	resumeSpan = resumeKeyToSpan(start, end, cSliceToGoBytes(state.resume_key), reverse)
+
+	if resumeKey := cSliceToGoBytes(state.resume_key); resumeKey != nil {
+		if reverse {
+			resumeSpan = &roachpb.Span{Key: start, EndKey: roachpb.Key(resumeKey).Next()}
+		} else {
+			resumeSpan = &roachpb.Span{Key: resumeKey, EndKey: end}
+		}
+	}
 
 	intents, err = buildScanIntents(cSliceToGoBytes(state.intents))
 	if err != nil {

--- a/pkg/storage/engine/rocksdb_iter_stats_test.go
+++ b/pkg/storage/engine/rocksdb_iter_stats_test.go
@@ -15,6 +15,7 @@
 package engine
 
 import (
+	"math"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -64,8 +65,8 @@ func TestIterStats(t *testing.T) {
 			}
 			// Scanning a key range containing the tombstone sees it.
 			for i := 0; i < 10; i++ {
-				if _, _, _, err := iter.MVCCScan(
-					roachpb.KeyMin, roachpb.KeyMax, 0, hlc.Timestamp{}, nil, true, false, false,
+				if _, _, _, _, err := iter.MVCCScan(
+					roachpb.KeyMin, roachpb.KeyMax, math.MaxInt64, hlc.Timestamp{}, nil, true, false, false,
 				); err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -186,9 +186,9 @@ func (s *Iterator) MVCCScan(
 	timestamp hlc.Timestamp,
 	txn *roachpb.Transaction,
 	consistent, reverse, tombstones bool,
-) (kvs []byte, numKvs int64, intents []byte, err error) {
+) (kvData []byte, numKVs int64, resumeSpan *roachpb.Span, intents []roachpb.Intent, err error) {
 	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
 	return s.i.MVCCScan(start, end, max, timestamp, txn, consistent, reverse, tombstones)
 }


### PR DESCRIPTION
See commits for details. The primary goal was to make these code paths understandable enough that we can realize the perf gains from #31909. I accidentally knocked out #32239 in the process.

Note that the perf gains are currently somewhat offset by returning a struct instead of separate values (see this commit: https://github.com/cockroachdb/cockroach/commit/952bbc0ea3dadad544574d72ea87e2ceee640a94). Still trying to figure out why that has such a performance hit.