### PR TITLE
storage: enable load based splitting by default

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -32,8 +32,8 @@
 <tr><td><code>kv.range.backpressure_range_size_multiplier</code></td><td>float</td><td><code>2</code></td><td>multiple of range_max_bytes that a range is allowed to grow to without splitting before writes to that range are blocked, or 0 to disable</td></tr>
 <tr><td><code>kv.range_descriptor_cache.size</code></td><td>integer</td><td><code>1000000</code></td><td>maximum number of entries in the range descriptor and leaseholder caches</td></tr>
 <tr><td><code>kv.range_merge.queue_enabled</code></td><td>boolean</td><td><code>true</code></td><td>whether the automatic merge queue is enabled</td></tr>
-<tr><td><code>kv.range_split.by_load_enabled</code></td><td>boolean</td><td><code>false</code></td><td>allow automatic splits of ranges based on where load is concentrated.</td></tr>
-<tr><td><code>kv.range_split.load_qps_threshold</code></td><td>integer</td><td><code>200</code></td><td>the QPS over which, the range becomes a candidate for load based splitting.</td></tr>
+<tr><td><code>kv.range_split.by_load_enabled</code></td><td>boolean</td><td><code>true</code></td><td>allow automatic splits of ranges based on where load is concentrated.</td></tr>
+<tr><td><code>kv.range_split.load_qps_threshold</code></td><td>integer</td><td><code>250</code></td><td>the QPS over which, the range becomes a candidate for load based splitting.</td></tr>
 <tr><td><code>kv.rangefeed.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, rangefeed registration is enabled</td></tr>
 <tr><td><code>kv.snapshot_rebalance.max_rate</code></td><td>byte size</td><td><code>2.0 MiB</code></td><td>the rate limit (bytes/sec) to use for rebalance snapshots</td></tr>
 <tr><td><code>kv.snapshot_recovery.max_rate</code></td><td>byte size</td><td><code>8.0 MiB</code></td><td>the rate limit (bytes/sec) to use for recovery snapshots</td></tr>

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/google/btree"
 	"github.com/kr/pretty"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -6871,14 +6871,14 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (*config.SystemConfigEnt
 var SplitByLoadEnabled = settings.RegisterBoolSetting(
 	"kv.range_split.by_load_enabled",
 	"allow automatic splits of ranges based on where load is concentrated.",
-	false,
+	true,
 )
 
 // SplitByLoadQPSThreshold wraps "kv.range_split.load_qps_threshold".
 var SplitByLoadQPSThreshold = settings.RegisterIntSetting(
 	"kv.range_split.load_qps_threshold",
 	"the QPS over which, the range becomes a candidate for load based splitting.",
-	200, // 200 req/s
+	250, // 250 req/s
 )
 
 // SplitByLoadQPSThreshold returns the QPS request rate for a given replica.


### PR DESCRIPTION
Load based splitting looks stable enough to enable by
default. This may break some tests that rely on specific
range counts. For all such tests, LBS should be turned off.

Release note (general change): Load based splitting enabled
by default.