### PR TITLE
opt: use provided ordering in execbuilder, reenable groupby optimization

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -168,18 +168,17 @@ distinct   ·            ·            (pk1, pk2)  weak-key(pk1); +pk1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
-sort                      ·            ·            (a, c)     weak-key(a); +a
- │                        order        +a           ·          ·
- └── distinct             ·            ·            (a, c)     weak-key(a)
-      │                   distinct on  a            ·          ·
-      └── render          ·            ·            (a, c)     ·
-           │              render 0     a            ·          ·
-           │              render 1     c            ·          ·
-           └── sort       ·            ·            (a, b, c)  -c,+b
-                │         order        -c,+b        ·          ·
-                └── scan  ·            ·            (a, b, c)  ·
-·                         table        abc@primary  ·          ·
-·                         spans        ALL          ·          ·
+distinct             ·            ·            (a, c)     weak-key(a); +a
+ │                   distinct on  a            ·          ·
+ │                   order key    a            ·          ·
+ └── render          ·            ·            (a, c)     +a
+      │              render 0     a            ·          ·
+      │              render 1     c            ·          ·
+      └── sort       ·            ·            (a, b, c)  +a,-c,+b
+           │         order        +a,-c,+b     ·          ·
+           └── scan  ·            ·            (a, b, c)  ·
+·                    table        abc@primary  ·          ·
+·                    spans        ALL          ·          ·
 
 #################
 # With ORDER BY #
@@ -215,19 +214,18 @@ render               ·            ·            (y, z, x)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
 ----
-render                    ·            ·            (y, z, x)  ·
- │                        render 0     y            ·          ·
- │                        render 1     z            ·          ·
- │                        render 2     x            ·          ·
- └── sort                 ·            ·            (x, y, z)  weak-key(x); +x
-      │                   order        +x           ·          ·
-      └── distinct        ·            ·            (x, y, z)  weak-key(x); -z,-y
-           │              distinct on  x            ·          ·
-           └── sort       ·            ·            (x, y, z)  -z,-y
-                │         order        -z,-y        ·          ·
-                └── scan  ·            ·            (x, y, z)  ·
-·                         table        xyz@primary  ·          ·
-·                         spans        ALL          ·          ·
+render               ·            ·            (y, z, x)  ·
+ │                   render 0     y            ·          ·
+ │                   render 1     z            ·          ·
+ │                   render 2     x            ·          ·
+ └── distinct        ·            ·            (x, y, z)  weak-key(x); +x,-z,-y
+      │              distinct on  x            ·          ·
+      │              order key    x            ·          ·
+      └── sort       ·            ·            (x, y, z)  +x,-z,-y
+           │         order        +x,-z,-y     ·          ·
+           └── scan  ·            ·            (x, y, z)  ·
+·                    table        xyz@primary  ·          ·
+·                    spans        ALL          ·          ·
 
 #####################
 # With aggregations #

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -105,20 +105,19 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJy0lb9u2zAQh_c-RXBrCdhH0o
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x
 ----
-sort                 ·            ·            (x, y)  weak-key(y); +y
- │                   order        +y           ·       ·
- └── distinct        ·            ·            (x, y)  weak-key(y); +x
-      │              distinct on  y            ·       ·
-      └── sort       ·            ·            (x, y)  +x
-           │         order        +x           ·       ·
-           └── scan  ·            ·            (x, y)  ·
-·                    table        xyz@primary  ·       ·
-·                    spans        ALL          ·       ·
+distinct        ·            ·            (x, y)  weak-key(y); +y,+x
+ │              distinct on  y            ·       ·
+ │              order key    y            ·       ·
+ └── sort       ·            ·            (x, y)  +y,+x
+      │         order        +y,+x        ·       ·
+      └── scan  ·            ·            (x, y)  ·
+·               table        xyz@primary  ·       ·
+·               spans        ALL          ·       ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJyslUFvm0AQhe_9FdVcu5I9u2DHnDj0kktTpb1VPlB2FCE5rLW7lpJG_u-VAYmCwgwlHGH93pv5_LS8Qe0sfSueKUD2CxAUaFBgQEECClI4Kjh7V1IIzt9-0gru7QtkWwVVfb7E2-ujgtJ5guwNYhVPBBn8LH6f6JEKS36zBQWWYlGdmpizr54L_5q_vP4BBQ-XmH3OtcoNHK8K3CX2piEWTwQZXtX84B_OR_KbdJiZ45dJe_0_9l-rEKu6jBscbZXryQAzGdD7Om_Jk31vanaK8Z7TUyQLKOJubD-NMR344_x64Kr1EIK7xcZ7za6HYN__MbiwHno-OL0qOCG4A7dfCk6w78HpheDMfHBmVXBCcAfubik4wb4HZxaCS-aDS1YFJwR34A5LwQn2PbhkhZv8nYBHCmdXBxq4Tzlvb9c82SdqPwvBXXxJ370rm5j28aHRNS8shdieYvtwX7dHtwH_FSMr1rxYs2IzEONYbFhxwicn_M57Xp2y6h0v3rFiIXn_EWJ3rPjAJx94YluhJnzJhMGRbxkKNUO-Z2gEOd80aXahaqkQzncNhbIh37bx7Mfrp78BAAD__06g0ss=
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyslb9u2zAQh_c-RXFrCNhHyo6tSUOXLE2Rdis0qOIhEOCIAkkBSQO_e6E_gCq3OioQR0n-8bv77kC_Q200fS1eyEH6ExAESBCgQEACAg6QC2isKck5Y7ufDIEH_QrpXkBVN63vXucCSmMJ0nfwlb8QpPCj-HWhJyo02d0eBGjyRXXpMY2tXgr7lr2-_QYBj61PP2dSZAryqwDT-ulQ54tnghSvYj34u7Ge7O4wZ2byTmR4t4iQH0F8qZyv6tLvcH9L6RqymizprqlFnFrETRQznLPUB1vXP92vrCuZ1YXrR4xRRxwAjyM-bhlxADGpxCgjlutVyqgqA-BR5f0WlQHEpFJGUanWq1RRVQbAo8rTFpUBxKRSRVGZrFeZRFUZAI8qz1tUBhCTyiT6Hf4f3BO5xtSOZqylk_fd5U76mYY_BGdaW9I3a8oeMzw-9rn-hSbnh684PDzUw6euwL_DyIYlH5ZsWM3CeBtWfNlHHp2w6QMfPrDhAPm4pel7NnziySc2fObD5y1lY2DHQkvGbxkG1gw37RkGFi0JwPlNw8CqIb9rt7Xn109_AgAA__8Zbbvp
 
 # Distinct processors elided becaue of strong key.
 query TTTTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -792,7 +792,7 @@ DROP TABLE num
 # ANY, ALL tests.
 # ------------------------------------------------------------------------------
 statement ok
-CREATE TABLE abc (a INT, b INT, C INT)
+CREATE TABLE abc (a INT, b INT, c INT)
 
 statement ok
 INSERT INTO abc VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300)
@@ -1062,3 +1062,17 @@ render          ·         ·                    (a, x)     ·
 ·               table     abcd@primary         ·          ·
 ·               spans     ALL                  ·          ·
 ·               limit     10                   ·          ·
+
+statement ok
+CREATE TABLE xyz (x INT, y INT, z INT, INDEX(x,y,z))
+
+# Verify the scan is configured with the correct ordering +x,+y,+z (#31882).
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyz LIMIT 10) WHERE y = 1 ORDER BY x, y, z
+----
+filter     ·       ·                  (x, y, z)  +x,+z
+ │         filter  y = 1              ·          ·
+ └── scan  ·       ·                  (x, y, z)  +x,+y,+z
+·          table   xyz@xyz_x_y_z_idx  ·          ·
+·          spans   ALL                ·          ·
+·          limit   10                 ·          ·

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -145,7 +145,7 @@ SELECT DISTINCT ON (b, c) a, b, c FROM abcde ORDER BY b, c, a, d, e
 distinct-on
  ├── columns: a:1(int) b:2(int) c:3(int)
  ├── grouping columns: b:2(int) c:3(int)
- ├── internal-ordering: +2,+3,+1
+ ├── internal-ordering: +1 opt(2,3)
  ├── key: (1)
  ├── fd: (1)-->(2,3), (2,3)-->(1)
  ├── ordering: +2,+3

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -99,13 +99,6 @@ func (b *Builder) buildDistinctOn(distinctOnCols opt.ColSet, inScope *scope) (ou
 	// columns as optional.
 	private.Ordering.FromOrderingWithOptCols(inScope.ordering, distinctOnCols)
 
-	// TODO(radu): the execbuilder doesn't correctly handle orderings with
-	// optional columns that are not constant (#31882). The fix for that is
-	// involved; for now we don't set the grouping columns as optional. The
-	// exploration rule that looks at interesting orderings negates (or at least
-	// alleviates) the impact of restricting the Ordering in this way.
-	private.Ordering.Optional = opt.ColSet{}
-
 	// Set up a new scope for the output of DISTINCT ON. This scope differs from
 	// the input scope in that it doesn't have "extra" ORDER BY columns, e.g.
 	// column e in case 2 example:

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -161,13 +161,6 @@ func (b *Builder) constructGroupBy(
 	// ARRAY_AGG). So we add the grouping columns as optional columns.
 	private.Ordering.FromOrderingWithOptCols(ordering, groupingColSet)
 
-	// TODO(radu): the execbuilder doesn't correctly handle orderings with
-	// optional columns that are not constant (#31882). The fix for that is
-	// involved; for now we don't set the grouping columns as optional. The
-	// exploration rule that looks at interesting orderings negates (or at least
-	// alleviates) the impact of restricting the Ordering in this way.
-	private.Ordering.Optional = opt.ColSet{}
-
 	if groupingColSet.Empty() {
 		return b.factory.ConstructScalarGroupBy(input, aggs, &private)
 	}

--- a/pkg/sql/opt/optbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/optbuilder/testdata/distinct_on
@@ -209,25 +209,23 @@ distinct-on
 build
 SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
 ----
-sort
+distinct-on
  ├── columns: y:2(int) z:3(int) x:1(int)
+ ├── grouping columns: x:1(int)
+ ├── internal-ordering: -3,-2 opt(1)
  ├── ordering: +1
- └── distinct-on
-      ├── columns: x:1(int) y:2(int) z:3(int)
-      ├── grouping columns: x:1(int)
-      ├── internal-ordering: -3,-2
-      ├── sort
-      │    ├── columns: x:1(int) y:2(int) z:3(int)
-      │    ├── ordering: -3,-2
-      │    └── project
-      │         ├── columns: x:1(int) y:2(int) z:3(int)
-      │         └── scan xyz
-      │              └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
-      └── aggregations
-           ├── first-agg [type=int]
-           │    └── variable: y [type=int]
-           └── first-agg [type=int]
-                └── variable: z [type=int]
+ ├── sort
+ │    ├── columns: x:1(int) y:2(int) z:3(int)
+ │    ├── ordering: +1,-3,-2
+ │    └── project
+ │         ├── columns: x:1(int) y:2(int) z:3(int)
+ │         └── scan xyz
+ │              └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
+ └── aggregations
+      ├── first-agg [type=int]
+      │    └── variable: y [type=int]
+      └── first-agg [type=int]
+           └── variable: z [type=int]
 
 #####################
 # With aggregations #
@@ -469,20 +467,18 @@ distinct-on
 build
 SELECT DISTINCT ON (x, y) x, y, z FROM xyz ORDER BY x ASC, y DESC, z
 ----
-sort
+distinct-on
  ├── columns: x:1(int) y:2(int) z:3(int)
+ ├── grouping columns: x:1(int) y:2(int)
+ ├── internal-ordering: +3 opt(1,2)
  ├── ordering: +1,-2
- └── distinct-on
-      ├── columns: x:1(int) y:2(int) z:3(int)
-      ├── grouping columns: x:1(int) y:2(int)
-      ├── internal-ordering: +3
-      ├── sort
-      │    ├── columns: x:1(int) y:2(int) z:3(int)
-      │    ├── ordering: +3
-      │    └── project
-      │         ├── columns: x:1(int) y:2(int) z:3(int)
-      │         └── scan xyz
-      │              └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
-      └── aggregations
-           └── first-agg [type=int]
-                └── variable: z [type=int]
+ ├── sort
+ │    ├── columns: x:1(int) y:2(int) z:3(int)
+ │    ├── ordering: +1,-2,+3
+ │    └── project
+ │         ├── columns: x:1(int) y:2(int) z:3(int)
+ │         └── scan xyz
+ │              └── columns: x:1(int) y:2(int) z:3(int) pk1:4(int!null) pk2:5(int!null)
+ └── aggregations
+      └── first-agg [type=int]
+           └── variable: z [type=int]

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -760,15 +760,9 @@ func (c *CustomFuncs) GenerateLookupJoins(
 // IsCanonicalGroupBy returns true if the private is for the canonical version
 // of the grouping operator.
 func (c *CustomFuncs) IsCanonicalGroupBy(private *memo.GroupingPrivate) bool {
-	// Check that no grouping columns are part of the ordering.
-	// TODO(radu): when we address #31882 and grouping columns become optional, we
-	// can just check private.GroupingCols.SubsetOf(private.Ordering.Optional).
-	for i := range private.Ordering.Columns {
-		if private.GroupingCols.Intersects(private.Ordering.Columns[i].Group) {
-			return false
-		}
-	}
-	return true
+	// The canonical version always has all grouping columns as optional in the
+	// internal ordering.
+	return private.Ordering.Any() || private.GroupingCols.SubsetOf(private.Ordering.Optional)
 }
 
 // GenerateStreamingGroupBy generates variants of a GroupBy or DistinctOn

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -407,7 +407,7 @@ SELECT a, b, array_agg(c) FROM (SELECT * FROM abc ORDER BY c) GROUP BY a, b ORDE
 group-by
  ├── columns: a:1(int!null) b:2(int!null) array_agg:4(int[])
  ├── grouping columns: a:1(int!null) b:2(int!null)
- ├── internal-ordering: +1,+2,+3
+ ├── internal-ordering: +3 opt(1,2)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -422,7 +422,7 @@ SELECT a, b, array_agg(c) FROM (SELECT * FROM abc ORDER BY a, b, c) GROUP BY a, 
 group-by
  ├── columns: a:1(int!null) b:2(int!null) array_agg:4(int[])
  ├── grouping columns: a:1(int!null) b:2(int!null)
- ├── internal-ordering: +1,+2,+3
+ ├── internal-ordering: +3 opt(1,2)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -437,7 +437,7 @@ SELECT a, b, array_agg(c) FROM (SELECT * FROM abc ORDER BY b, c, a) GROUP BY b, 
 group-by
  ├── columns: a:1(int!null) b:2(int!null) array_agg:4(int[])
  ├── grouping columns: a:1(int!null) b:2(int!null)
- ├── internal-ordering: +1,+2,+3
+ ├── internal-ordering: +3 opt(1,2)
  ├── ordering: +1,+2
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -505,10 +505,10 @@ project
  └── group-by
       ├── columns: a:1(int) b:2(int) array_agg:6(int[])
       ├── grouping columns: a:1(int) b:2(int)
-      ├── internal-ordering: +3
+      ├── internal-ordering: +3 opt(1,2)
       ├── scan abcd@cd
       │    ├── columns: a:1(int) b:2(int) c:3(int) d:4(int)
-      │    └── ordering: +3
+      │    └── ordering: +3 opt(1,2)
       └── aggregations
            └── array-agg [type=int[]]
                 └── variable: d [type=int]
@@ -1050,38 +1050,36 @@ distinct-on
 opt
 SELECT DISTINCT ON (b, c) a, b, c FROM abc ORDER BY b, c, a
 ----
-sort
+distinct-on
  ├── columns: a:1(int) b:2(int!null) c:3(int!null)
+ ├── grouping columns: b:2(int!null) c:3(int!null)
+ ├── internal-ordering: +1 opt(2,3)
  ├── ordering: +2,+3
- └── distinct-on
-      ├── columns: a:1(int) b:2(int!null) c:3(int!null)
-      ├── grouping columns: b:2(int!null) c:3(int!null)
-      ├── internal-ordering: +1
-      ├── scan abc
-      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      │    └── ordering: +1
-      └── aggregations
-           └── first-agg [type=int]
-                └── variable: a [type=int]
+ ├── sort
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── ordering: +2,+3,+1
+ │    └── scan abc
+ │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ └── aggregations
+      └── first-agg [type=int]
+           └── variable: a [type=int]
 
 opt
 SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
-sort
+distinct-on
  ├── columns: a:1(int!null) c:3(int)
+ ├── grouping columns: a:1(int!null)
+ ├── internal-ordering: -3,+2 opt(1)
  ├── ordering: +1
- └── distinct-on
-      ├── columns: a:1(int!null) c:3(int)
-      ├── grouping columns: a:1(int!null)
-      ├── internal-ordering: -3,+2
-      ├── sort
-      │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      │    ├── ordering: -3,+2
-      │    └── scan abc
-      │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      └── aggregations
-           └── first-agg [type=int]
-                └── variable: c [type=int]
+ ├── sort
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    ├── ordering: +1,-3,+2
+ │    └── scan abc
+ │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ └── aggregations
+      └── first-agg [type=int]
+           └── variable: c [type=int]
 
 # Pass through the ordering from above.
 opt
@@ -1136,7 +1134,7 @@ SELECT * FROM (SELECT DISTINCT ON (b, c) a, b, c FROM abc ORDER BY c, b, a) ORDE
 distinct-on
  ├── columns: a:1(int) b:2(int!null) c:3(int!null)
  ├── grouping columns: b:2(int!null) c:3(int!null)
- ├── internal-ordering: +1
+ ├── internal-ordering: +1 opt(2,3)
  ├── ordering: +1
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
@@ -1156,10 +1154,10 @@ sort
  └── distinct-on
       ├── columns: a:1(int) b:2(int!null) c:3(int)
       ├── grouping columns: b:2(int!null)
-      ├── internal-ordering: +3
+      ├── internal-ordering: +3 opt(2)
       ├── sort
       │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
-      │    ├── ordering: +3
+      │    ├── ordering: +3 opt(2)
       │    └── scan abc
       │         └── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       └── aggregations

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -131,7 +131,7 @@ SELECT array_agg(a), b, c FROM (SELECT * FROM abc ORDER BY b, a) GROUP BY b, c
 group-by
  ├── columns: array_agg:5(int[]) b:2(int) c:3(int)
  ├── grouping columns: b:2(int) c:3(int)
- ├── internal-ordering: +1
+ ├── internal-ordering: +1 opt(2,3)
  ├── key: (2,3)
  ├── fd: (3)~~>(2), (2,3)-->(5)
  ├── prune: (5)
@@ -139,7 +139,7 @@ group-by
  │    ├── columns: a:1(int) b:2(int) c:3(int)
  │    ├── lax-key: (1-3)
  │    ├── fd: (3)~~>(1,2)
- │    ├── ordering: +1
+ │    ├── ordering: +1 opt(2,3) [provided: +1]
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+1,+2) (+3)
  │    └── scan abc

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -736,7 +736,7 @@ memo (optimized, ~5KB, required=[presentation: array_agg:5])
  │    └── [presentation: array_agg:5]
  │         ├── best: (project G2 G3 array_agg)
  │         └── cost: 1120.00
- ├── G2: (group-by G4 G5 cols=(2,3),ordering=+4) (group-by G4 G5 cols=(2,3),ordering=+2,+3,+4) (group-by G4 G5 cols=(2,3),ordering=+4,+3,+2) (group-by G4 G5 cols=(2,3),ordering=+3,+4)
+ ├── G2: (group-by G4 G5 cols=(2,3),ordering=+4 opt(2,3)) (group-by G4 G5 cols=(2,3),ordering=+2,+3,+4) (group-by G4 G5 cols=(2,3),ordering=+4,+3,+2) (group-by G4 G5 cols=(2,3),ordering=+3,+4)
  │    └── []
  │         ├── best: (group-by G4="[ordering: +2,+3,+4]" G5 cols=(2,3),ordering=+2,+3,+4)
  │         └── cost: 1110.00
@@ -748,10 +748,10 @@ memo (optimized, ~5KB, required=[presentation: array_agg:5])
  │    ├── [ordering: +3,+4]
  │    │    ├── best: (scan kuvw@vw,cols=(2-4))
  │    │    └── cost: 1070.00
- │    ├── [ordering: +4,+3,+2]
- │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
+ │    ├── [ordering: +4 opt(2,3)]
+ │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
  │    │    └── cost: 1070.00
- │    ├── [ordering: +4]
+ │    ├── [ordering: +4,+3,+2]
  │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
  │    │    └── cost: 1070.00
  │    └── []
@@ -826,18 +826,18 @@ memo (optimized, ~5KB, required=[presentation: array_agg:5])
  │    └── [presentation: array_agg:5]
  │         ├── best: (project G2 G3 array_agg)
  │         └── cost: 1102.00
- ├── G2: (group-by G4 G5 cols=(3),ordering=+2,+4) (group-by G4 G5 cols=(3),ordering=+2,+3,+4)
+ ├── G2: (group-by G4 G5 cols=(3),ordering=+2,+4 opt(3)) (group-by G4 G5 cols=(3),ordering=+2,+3,+4)
  │    └── []
- │         ├── best: (group-by G4="[ordering: +2,+3,+4]" G5 cols=(3),ordering=+2,+3,+4)
+ │         ├── best: (group-by G4="[ordering: +2,+4 opt(3)]" G5 cols=(3),ordering=+2,+4 opt(3))
  │         └── cost: 1101.00
  ├── G3: (projections)
  ├── G4: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,+3,+4]
  │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
  │    │    └── cost: 1070.00
- │    ├── [ordering: +2,+4]
- │    │    ├── best: (sort G4)
- │    │    └── cost: 1300.28
+ │    ├── [ordering: +2,+4 opt(3)]
+ │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
+ │    │    └── cost: 1070.00
  │    └── []
  │         ├── best: (scan kuvw,cols=(2-4))
  │         └── cost: 1070.00
@@ -854,12 +854,15 @@ memo (optimized, ~8KB, required=[presentation: array_agg:5])
  │    └── [presentation: array_agg:5]
  │         ├── best: (project G2 G3 array_agg)
  │         └── cost: 1079.59
- ├── G2: (group-by G4 G5 cols=(4),ordering=+(2|3)) (group-by G4 G5 cols=(4),ordering=+4,+(2|3)) (group-by G4 G5 cols=(4),ordering=+(2|3),+4)
+ ├── G2: (group-by G4 G5 cols=(4),ordering=+(2|3) opt(4)) (group-by G4 G5 cols=(4),ordering=+(2|3)) (group-by G4 G5 cols=(4),ordering=+4,+(2|3)) (group-by G4 G5 cols=(4),ordering=+(2|3),+4)
  │    └── []
- │         ├── best: (group-by G4="[ordering: +(2|3)]" G5 cols=(4),ordering=+(2|3))
+ │         ├── best: (group-by G4="[ordering: +(2|3) opt(4)]" G5 cols=(4),ordering=+(2|3) opt(4))
  │         └── cost: 1079.50
  ├── G3: (projections)
  ├── G4: (select G6 G7) (select G8 G7) (select G9 G7)
+ │    ├── [ordering: +(2|3) opt(4)]
+ │    │    ├── best: (select G8="[ordering: +2 opt(4)]" G7)
+ │    │    └── cost: 1079.10
  │    ├── [ordering: +(2|3),+4]
  │    │    ├── best: (sort G4)
  │    │    └── cost: 1080.01
@@ -874,6 +877,9 @@ memo (optimized, ~8KB, required=[presentation: array_agg:5])
  │         └── cost: 1079.10
  ├── G5: (aggregations G10)
  ├── G6: (scan kuvw) (scan kuvw@uvw) (scan kuvw@wvu) (scan kuvw@vw) (scan kuvw@w)
+ │    ├── [ordering: +2 opt(4)]
+ │    │    ├── best: (scan kuvw@uvw)
+ │    │    └── cost: 1080.00
  │    ├── [ordering: +2,+4]
  │    │    ├── best: (sort G6)
  │    │    └── cost: 1310.28
@@ -888,6 +894,9 @@ memo (optimized, ~8KB, required=[presentation: array_agg:5])
  │         └── cost: 1080.00
  ├── G7: (filters G11)
  ├── G8: (scan kuvw@uvw,constrained)
+ │    ├── [ordering: +2 opt(4)]
+ │    │    ├── best: (scan kuvw@uvw,constrained)
+ │    │    └── cost: 1069.20
  │    ├── [ordering: +2,+4]
  │    │    ├── best: (sort G8)
  │    │    └── cost: 1296.88
@@ -901,6 +910,9 @@ memo (optimized, ~8KB, required=[presentation: array_agg:5])
  │         ├── best: (scan kuvw@uvw,constrained)
  │         └── cost: 1069.20
  ├── G9: (scan kuvw@vw,constrained)
+ │    ├── [ordering: +2 opt(4)]
+ │    │    ├── best: (sort G9)
+ │    │    └── cost: 1286.04
  │    ├── [ordering: +2,+4]
  │    │    ├── best: (sort G9)
  │    │    └── cost: 1296.88
@@ -989,14 +1001,14 @@ memo (optimized, ~4KB, required=[presentation: array_agg:5])
  │    └── [presentation: array_agg:5]
  │         ├── best: (project G2 G3 array_agg)
  │         └── cost: 1229.66
- ├── G2: (group-by G4 G5 cols=(2,3),ordering=-4)
+ ├── G2: (group-by G4 G5 cols=(2,3),ordering=-4 opt(2,3))
  │    └── []
- │         ├── best: (group-by G4="[ordering: -4]" G5 cols=(2,3),ordering=-4)
+ │         ├── best: (group-by G4="[ordering: -4 opt(2,3)]" G5 cols=(2,3),ordering=-4 opt(2,3))
  │         └── cost: 1219.66
  ├── G3: (projections)
  ├── G4: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
- │    ├── [ordering: -4]
- │    │    ├── best: (scan kuvw@wvu,rev,cols=(2-4))
+ │    ├── [ordering: -4 opt(2,3)]
+ │    │    ├── best: (scan kuvw@uvw,rev,cols=(2-4))
  │    │    └── cost: 1169.66
  │    └── []
  │         ├── best: (scan kuvw,cols=(2-4))
@@ -1123,15 +1135,21 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (u) u, v, w FROM kuvw ORDER BY u, w
 ----
-memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
- ├── G1: (distinct-on G2 G3 cols=(2),ordering=+4)
+memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
+ ├── G1: (distinct-on G2 G3 cols=(2),ordering=+4 opt(2)) (distinct-on G2 G3 cols=(2),ordering=+4)
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +2]
  │    │    ├── best: (sort G1)
  │    │    └── cost: 1126.29
  │    └── []
- │         ├── best: (distinct-on G2="[ordering: +4]" G3 cols=(2),ordering=+4)
+ │         ├── best: (distinct-on G2="[ordering: +4 opt(2)]" G3 cols=(2),ordering=+4 opt(2))
  │         └── cost: 1111.00
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
+ │    ├── [ordering: +2,+4]
+ │    │    ├── best: (sort G2)
+ │    │    └── cost: 1300.28
+ │    ├── [ordering: +4 opt(2)]
+ │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
+ │    │    └── cost: 1070.00
  │    ├── [ordering: +4]
  │    │    ├── best: (scan kuvw@wvu,cols=(2-4))
  │    │    └── cost: 1070.00
@@ -1149,15 +1167,18 @@ memo
 SELECT DISTINCT ON (u) u, v, w FROM kuvw ORDER BY u, v, w
 ----
 memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
- ├── G1: (distinct-on G2 G3 cols=(2),ordering=+3,+4) (distinct-on G2 G3 cols=(2),ordering=+2,+3,+4)
+ ├── G1: (distinct-on G2 G3 cols=(2),ordering=+3,+4 opt(2)) (distinct-on G2 G3 cols=(2),ordering=+2,+3,+4) (distinct-on G2 G3 cols=(2),ordering=+3,+4)
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +2]
- │    │    ├── best: (distinct-on G2="[ordering: +2,+3,+4]" G3 cols=(2),ordering=+2,+3,+4)
+ │    │    ├── best: (distinct-on G2="[ordering: +2,+3,+4]" G3 cols=(2),ordering=+3,+4 opt(2))
  │    │    └── cost: 1101.00
  │    └── []
  │         ├── best: (distinct-on G2="[ordering: +2,+3,+4]" G3 cols=(2),ordering=+2,+3,+4)
  │         └── cost: 1101.00
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
  │    ├── [ordering: +2,+3,+4]
+ │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
+ │    │    └── cost: 1070.00
+ │    ├── [ordering: +3,+4 opt(2)]
  │    │    ├── best: (scan kuvw@uvw,cols=(2-4))
  │    │    └── cost: 1070.00
  │    ├── [ordering: +3,+4]
@@ -1177,16 +1198,19 @@ memo
 SELECT DISTINCT ON (w, u) u, v, w FROM kuvw ORDER BY w, u, v DESC
 ----
 memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4,+2])
- ├── G1: (distinct-on G2 G3 cols=(2,4),ordering=-3)
+ ├── G1: (distinct-on G2 G3 cols=(2,4),ordering=-3 opt(2,4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4,+2]
- │    │    ├── best: (sort G1)
- │    │    └── cost: 1449.94
+ │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(2,4),ordering=-3 opt(2,4))
+ │    │    └── cost: 1341.38
  │    └── []
- │         ├── best: (distinct-on G2="[ordering: -3]" G3 cols=(2,4),ordering=-3)
+ │         ├── best: (distinct-on G2="[ordering: -3 opt(2,4)]" G3 cols=(2,4),ordering=-3 opt(2,4))
  │         └── cost: 1219.66
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
- │    ├── [ordering: -3]
- │    │    ├── best: (scan kuvw@vw,rev,cols=(2-4))
+ │    ├── [ordering: +4,+2,-3]
+ │    │    ├── best: (sort G2)
+ │    │    └── cost: 1301.38
+ │    ├── [ordering: -3 opt(2,4)]
+ │    │    ├── best: (scan kuvw@uvw,rev,cols=(2-4))
  │    │    └── cost: 1169.66
  │    └── []
  │         ├── best: (scan kuvw,cols=(2-4))
@@ -1199,15 +1223,18 @@ memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw ORDER BY w, u DESC, v
 ----
 memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
- ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3)
+ ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
- │    │    ├── best: (sort G1)
- │    │    └── cost: 1356.57
+ │    │    ├── best: (distinct-on G2="[ordering: +4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
+ │    │    └── cost: 1332.38
  │    └── []
- │         ├── best: (distinct-on G2="[ordering: -2,+3]" G3 cols=(4),ordering=-2,+3)
+ │         ├── best: (distinct-on G2="[ordering: -2,+3 opt(4)]" G3 cols=(4),ordering=-2,+3 opt(4))
  │         └── cost: 1341.28
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
- │    ├── [ordering: -2,+3]
+ │    ├── [ordering: +4,-2,+3]
+ │    │    ├── best: (sort G2)
+ │    │    └── cost: 1301.38
+ │    ├── [ordering: -2,+3 opt(4)]
  │    │    ├── best: (sort G2)
  │    │    └── cost: 1300.28
  │    └── []
@@ -1223,17 +1250,20 @@ memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw ORDER BY w DESC, u DESC, v
 ----
 memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: -4])
- ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3)
+ ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: -4]
- │    │    ├── best: (sort G1)
- │    │    └── cost: 1356.57
+ │    │    ├── best: (distinct-on G2="[ordering: -4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
+ │    │    └── cost: 1332.38
  │    └── []
- │         ├── best: (distinct-on G2="[ordering: -2,+3]" G3 cols=(4),ordering=-2,+3)
+ │         ├── best: (distinct-on G2="[ordering: -2,+3 opt(4)]" G3 cols=(4),ordering=-2,+3 opt(4))
  │         └── cost: 1341.28
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
- │    ├── [ordering: -2,+3]
+ │    ├── [ordering: -2,+3 opt(4)]
  │    │    ├── best: (sort G2)
  │    │    └── cost: 1300.28
+ │    ├── [ordering: -4,-2,+3]
+ │    │    ├── best: (sort G2)
+ │    │    └── cost: 1301.38
  │    └── []
  │         ├── best: (scan kuvw,cols=(2-4))
  │         └── cost: 1070.00
@@ -1247,17 +1277,20 @@ memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw ORDER BY w, u, v DESC
 ----
 memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
- ├── G1: (distinct-on G2 G3 cols=(4),ordering=+2,-3)
+ ├── G1: (distinct-on G2 G3 cols=(4),ordering=+2,-3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
- │    │    ├── best: (sort G1)
- │    │    └── cost: 1356.57
+ │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(4),ordering=+2,-3 opt(4))
+ │    │    └── cost: 1332.38
  │    └── []
- │         ├── best: (distinct-on G2="[ordering: +2,-3]" G3 cols=(4),ordering=+2,-3)
+ │         ├── best: (distinct-on G2="[ordering: +2,-3 opt(4)]" G3 cols=(4),ordering=+2,-3 opt(4))
  │         └── cost: 1341.28
  ├── G2: (scan kuvw,cols=(2-4)) (scan kuvw@uvw,cols=(2-4)) (scan kuvw@wvu,cols=(2-4)) (scan kuvw@vw,cols=(2-4)) (scan kuvw@w,cols=(2-4))
- │    ├── [ordering: +2,-3]
+ │    ├── [ordering: +2,-3 opt(4)]
  │    │    ├── best: (sort G2)
  │    │    └── cost: 1300.28
+ │    ├── [ordering: +4,+2,-3]
+ │    │    ├── best: (sort G2)
+ │    │    └── cost: 1301.38
  │    └── []
  │         ├── best: (scan kuvw,cols=(2-4))
  │         └── cost: 1070.00


### PR DESCRIPTION
Note: this is on top of #32221, ignore that commit.

#### opt: use provided ordering in execbuilder

Use the `physical.Provided` ordering to correctly configure orderings
during execution.

Informs #31882.

Release note: None

#### opt: reenable GroupBy optional columns optimization

This change re-enables an optimization that sets grouping columns as
optional in the internal GroupBy/DistinctOn ordering. This improves
some cases where we don't have a relevant interesting ordering.

Fixes #31882.

Release note (performance improvement): More efficient execution for
some queries with GROUP BY or DISTINCT ON and an ORDER BY clause where
an index with a suitable ordering is not available.
