### PR TITLE
opt: extract const cols from intersecting filter constraints

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -928,8 +928,8 @@ EXPLAIN (VERBOSE) SELECT x FROM xy WHERE y > 0 AND y < 2 ORDER BY y
 ----
 render           ·         ·            (x)                 ·
  │               render 0  x            ·                   ·
- └── index-join  ·         ·            (x, y)              +y
-      ├── scan   ·         ·            (y, rowid[hidden])  +y
+ └── index-join  ·         ·            (x, y)              ·
+      ├── scan   ·         ·            (y, rowid[hidden])  ·
       │          table     xy@xy_y_idx  ·                   ·
       │          spans     /1-/2        ·                   ·
       └── scan   ·         ·            (x, y)              ·

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -32,6 +32,26 @@ select
            ├── variable: x [type=int]
            └── const: 1 [type=int]
 
+# Verify that 1 is determined to be constant (from the intersection of the
+# constraints).
+opt
+SELECT * FROM a WHERE x > 0 AND x < 2
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── fd: ()-->(1)
+ ├── prune: (2)
+ ├── scan a
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── prune: (1,2)
+ └── filters
+      ├── gt [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
+      │    ├── variable: x [type=int]
+      │    └── const: 0 [type=int]
+      └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /1]; tight)]
+           ├── variable: x [type=int]
+           └── const: 2 [type=int]
+
 opt
 SELECT * FROM a WHERE x >= 1
 ----


### PR DESCRIPTION
Add logic to intersect the constraint sets for filters and extract
constant columns from the intersection. This improves constant column
detection for cases like `y > 0 AND y < 2`, removing a gap in the FDs
determined from a Select when compared to those determined from an
equivalent constrained Scan.

Informs #32320.

Release note: None