### PR TITLE
ui: remove chai from runtime bundle

### DIFF
--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@types/analytics-node": "^0.0.32",
+    "@types/assert": "^1.4.0",
     "@types/bytebuffer": "^5.0.33",
     "@types/chai": "^4.1.0",
     "@types/classnames": "^0.0.32",

--- a/pkg/ui/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/src/redux/cachedDataReducer.ts
@@ -20,7 +20,7 @@
 
 import _ from "lodash";
 import { Action, Dispatch } from "redux";
-import { assert } from "chai";
+import assert from "assert";
 import moment from "moment";
 import { hashHistory } from "react-router";
 import { push } from "react-router-redux";
@@ -78,7 +78,7 @@ export class CachedDataReducer<TRequest, TResponseMessage> {
     protected requestTimeout?: moment.Duration,
   ) {
     // check actionNamespace
-    assert.notProperty(CachedDataReducer.namespaces, actionNamespace, "Expected actionNamespace to be unique.");
+    assert(!CachedDataReducer.namespaces.hasOwnProperty(actionNamespace), "Expected actionNamespace to be unique.");
     CachedDataReducer.namespaces[actionNamespace] = true;
 
     this.REQUEST = `cockroachui/CachedDataReducer/${actionNamespace}/REQUEST`;

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -56,6 +56,10 @@
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/analytics-node/-/analytics-node-0.0.32.tgz#4bd500d2b63f519d9e180e4d3c02d187b55bab6d"
 
+"@types/assert@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@types/assert/-/assert-1.4.0.tgz#95a469cbb1bb94b21e9deb5fd1939859c613a87f"
+
 "@types/bytebuffer@^5.0.33":
   version "5.0.34"
   resolved "https://registry.yarnpkg.com/@types/bytebuffer/-/bytebuffer-5.0.34.tgz#43f7140503a593acc700f818fe23343ae911bcdf"


### PR DESCRIPTION
Previously, we were including all of chai in our runtime bundle due to
a single assertion in production code.  This changes the assertion to
use the native assert module, which is much more lightweight.

Release note: None