### PR TITLE
opt: extract const cols from intersecting filter constraints

### DIFF
--- a/pkg/sql/opt/constraint/columns.go
+++ b/pkg/sql/opt/constraint/columns.go
@@ -115,6 +115,16 @@ func (c *Columns) IsStrictSuffixOf(other *Columns) bool {
 	return true
 }
 
+// ColSet returns the columns as a ColSet.
+func (c *Columns) ColSet() opt.ColSet {
+	var r opt.ColSet
+	r.Add(int(c.firstCol.ID()))
+	for _, c := range c.otherCols {
+		r.Add(int(c.ID()))
+	}
+	return r
+}
+
 func (c Columns) String() string {
 	var b strings.Builder
 

--- a/pkg/sql/opt/constraint/constraint_set.go
+++ b/pkg/sql/opt/constraint/constraint_set.go
@@ -253,6 +253,19 @@ func (s *Set) Union(evalCtx *tree.EvalContext, other *Set) *Set {
 	return mergeSet
 }
 
+// ExtractCols returns all columns involved in the constraints in this set.
+func (s *Set) ExtractCols() opt.ColSet {
+	var res opt.ColSet
+	if s.length == 0 {
+		return res
+	}
+	res = s.firstConstraint.Columns.ColSet()
+	for i := int32(1); i < s.length; i++ {
+		res.UnionWith(s.otherConstraints[i-1].Columns.ColSet())
+	}
+	return res
+}
+
 // ExtractNotNullCols returns a set of columns that cannot be NULL for the
 // constraints in the set to hold.
 func (s *Set) ExtractNotNullCols(evalCtx *tree.EvalContext) opt.ColSet {

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -928,8 +928,8 @@ EXPLAIN (VERBOSE) SELECT x FROM xy WHERE y > 0 AND y < 2 ORDER BY y
 ----
 render           ·         ·            (x)                 ·
  │               render 0  x            ·                   ·
- └── index-join  ·         ·            (x, y)              +y
-      ├── scan   ·         ·            (y, rowid[hidden])  +y
+ └── index-join  ·         ·            (x, y)              ·
+      ├── scan   ·         ·            (y, rowid[hidden])  ·
       │          table     xy@xy_y_idx  ·                   ·
       │          spans     /1-/2        ·                   ·
       └── scan   ·         ·            (x, y)              ·

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -32,6 +32,26 @@ select
            ├── variable: x [type=int]
            └── const: 1 [type=int]
 
+# Verify that 1 is determined to be constant (from the intersection of the
+# constraints).
+opt
+SELECT * FROM a WHERE x > 0 AND x < 2
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── fd: ()-->(1)
+ ├── prune: (2)
+ ├── scan a
+ │    ├── columns: x:1(int) y:2(int)
+ │    └── prune: (1,2)
+ └── filters
+      ├── gt [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
+      │    ├── variable: x [type=int]
+      │    └── const: 0 [type=int]
+      └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /1]; tight)]
+           ├── variable: x [type=int]
+           └── const: 2 [type=int]
+
 opt
 SELECT * FROM a WHERE x >= 1
 ----


### PR DESCRIPTION
Add logic to intersect the constraint sets for filters and extract
constant columns from the intersection. This improves constant column
detection for cases like `y > 0 AND y < 2`, removing a gap in the FDs
determined from a Select when compared to those determined from an
equivalent constrained Scan.

Informs #32320.

Release note: None