### PR TITLE
sql: Do not truncate Decimal values in-place

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -661,10 +661,11 @@ func GenerateInsertRow(
 
 	// Ensure that the values honor the specified column widths.
 	for i := range rowVals {
-		if err := sqlbase.CheckValueWidth(
-			insertCols[i].Type, rowVals[i], &insertCols[i].Name); err != nil {
+		outVal, err := sqlbase.LimitValueWidth(insertCols[i].Type, rowVals[i], &insertCols[i].Name)
+		if err != nil {
 			return nil, err
 		}
+		rowVals[i] = outVal
 	}
 	return rowVals, nil
 }

--- a/pkg/sql/sem/tree/decimal.go
+++ b/pkg/sql/sem/tree/decimal.go
@@ -55,7 +55,8 @@ var (
 )
 
 // LimitDecimalWidth limits d's precision (total number of digits) and scale
-// (number of digits after the decimal point).
+// (number of digits after the decimal point). Note that this any limiting will
+// modify the decimal in-place.
 func LimitDecimalWidth(d *apd.Decimal, precision, scale int) error {
 	if d.Form != apd.Finite || precision <= 0 {
 		return nil

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3040,7 +3040,7 @@ func PerformCast(ctx *EvalContext, d Datum, t coltypes.CastTargetType) (Datum, e
 			if typ.Prec == 0 {
 				return d, nil
 			}
-			dd = *v
+			dd.Set(&v.Decimal)
 		case *DString:
 			err = dd.SetString(string(*v))
 		case *DCollatedString:

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -676,9 +676,11 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 			}
 		} else {
 			// Verify that the data width matches the column constraint.
-			if err := sqlbase.CheckValueWidth(col.Type, val, &col.Name); err != nil {
+			newVal, err := sqlbase.LimitValueWidth(col.Type, val, &col.Name)
+			if err != nil {
 				return err
 			}
+			u.run.updateValues[i] = newVal
 		}
 	}
 


### PR DESCRIPTION
Currently, the CheckValueWidth method truncates the incoming Decimal value
if it doesn't fit in the prescribed column type. Currently, the truncation
modifies the value in-place. In the INSERT/UPDATE code paths, this results
in the original AST DDecimal Datum node being modified. While this is not
currently a bug, since the AST is only used on a single thread, it will
be a problem for the query cache, which can read Datum values on multiple
threads. In addition, it breaks interning assumptions in the optimizer,
because the same Datum object cannot be reused when the query contains
duplicate values, because its value can unexpectedly change.

The fix is to make a copy of the Decimal when it doesn't fit the target
column type. This commit renames CheckValueWidth to LimitValueWidth and
adds an output value that will be a copy of the value in the truncation
case.

Release note: None