### PR TITLE
storage/batcheval: decouple TestRefreshRangeTimeBoundIterator

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1139,9 +1139,9 @@ func (r *RocksDB) GetSortedWALFiles() ([]WALFileInfo, error) {
 	return res, nil
 }
 
-// getUserProperties fetches the user properties stored in each sstable's
+// GetUserProperties fetches the user properties stored in each sstable's
 // metadata.
-func (r *RocksDB) getUserProperties() (enginepb.SSTUserPropertiesCollection, error) {
+func (r *RocksDB) GetUserProperties() (enginepb.SSTUserPropertiesCollection, error) {
 	buf := cStringToGoBytes(C.DBGetUserProperties(r.rdb))
 	var ssts enginepb.SSTUserPropertiesCollection
 	if err := protoutil.Unmarshal(buf, &ssts); err != nil {

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -875,7 +875,7 @@ func TestRocksDBTimeBound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ssts, err := rocksdb.getUserProperties()
+	ssts, err := rocksdb.GetUserProperties()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This way the test continues to be applicable even after we teach MVCCResolveIntent to write out merges instead of deletions (or whatever approach we end up with).

---

Decouple TestRefreshRangeTimeBoundIterator from MVCC internals by
avoiding hardcoding the knowledge of intent resolution. Instead, use
strategic calls to rocksDB.Flush to create the desired SST structure.
This approach is inspired by RocksDB's internal tests.

Release note: None