### PR TITLE
storage/bulk: move addsst helper and rowcounter to oss

### DIFF
--- a/pkg/ccl/importccl/sst_writer_proc.go
+++ b/pkg/ccl/importccl/sst_writer_proc.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -192,7 +193,7 @@ func (sp *sstWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
 							// throughput.
 							log.Errorf(ctx, "failed to scatter span %s: %s", roachpb.PrettyPrintKey(nil, end), pErr)
 						}
-						if err := storageccl.AddSSTable(ctx, sp.db, sst.span.Key, sst.span.EndKey, sst.data); err != nil {
+						if err := bulk.AddSSTable(ctx, sp.db, sst.span.Key, sst.span.EndKey, sst.data); err != nil {
 							return err
 						}
 					} else {
@@ -343,7 +344,7 @@ func makeSSTs(
 	}
 	defer sst.Close()
 
-	var counts storageccl.RowCounter
+	var counts bulk.RowCounter
 	var writtenKVs int
 	writeSST := func(key, endKey roachpb.Key, more bool) error {
 		data, err := sst.Finish()

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -17,12 +17,12 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -65,165 +65,6 @@ func MaxImportBatchSize(st *cluster.Settings) int64 {
 		return maxCommandSize - commandMetadataEstimate
 	}
 	return desiredSize
-}
-
-type sstBatcher struct {
-	maxSize int64
-	// rows written in the current batch.
-	rowCounter RowCounter
-	totalRows  roachpb.BulkOpSummary
-
-	sstWriter     engine.RocksDBSstFileWriter
-	batchStartKey []byte
-	batchEndKey   []byte
-}
-
-func (b *sstBatcher) add(key engine.MVCCKey, value []byte) error {
-	// Update the range currently represented in this batch, as
-	// necessary.
-	if len(b.batchStartKey) == 0 || bytes.Compare(key.Key, b.batchStartKey) < 0 {
-		b.batchStartKey = append(b.batchStartKey[:0], key.Key...)
-	}
-	if len(b.batchEndKey) == 0 || bytes.Compare(key.Key, b.batchEndKey) > 0 {
-		b.batchEndKey = append(b.batchEndKey[:0], key.Key...)
-	}
-	if err := b.rowCounter.Count(key.Key); err != nil {
-		return err
-	}
-	return b.sstWriter.Add(engine.MVCCKeyValue{Key: key, Value: value})
-}
-
-func (b *sstBatcher) reset() error {
-	b.sstWriter.Close()
-	w, err := engine.MakeRocksDBSstFileWriter()
-	if err != nil {
-		return err
-	}
-	b.sstWriter = w
-	b.batchStartKey = b.batchStartKey[:0]
-	b.batchEndKey = b.batchEndKey[:0]
-	b.rowCounter.BulkOpSummary.Reset()
-	return nil
-}
-
-func (b *sstBatcher) shouldFlush(nextKey roachpb.Key) bool {
-	return b.sstWriter.DataSize >= b.maxSize
-}
-
-func (b *sstBatcher) flush(ctx context.Context, db *client.DB) error {
-	if b.sstWriter.DataSize == 0 {
-		return nil
-	}
-	start := roachpb.Key(append([]byte(nil), b.batchStartKey...))
-	// The end key of the WriteBatch request is exclusive, but batchEndKey is
-	// currently the largest key in the batch. Increment it.
-	end := roachpb.Key(append([]byte(nil), b.batchEndKey...)).Next()
-
-	sstBytes, err := b.sstWriter.Finish()
-	if err != nil {
-		return errors.Wrapf(err, "finishing constructed sstable")
-	}
-	if err := AddSSTable(ctx, db, start, end, sstBytes); err != nil {
-		// TODO(dt): if we get a RangeKeyMismatchError, update batching split points
-		// and then tell the caller to try again.
-		return err
-	}
-	b.rowCounter.DataSize = b.sstWriter.DataSize
-	b.totalRows.Add(b.rowCounter.BulkOpSummary)
-	return nil
-}
-
-func (b *sstBatcher) Close() {
-	b.sstWriter.Close()
-}
-
-// AddSSTable retries db.AddSSTable if retryable errors occur.
-func AddSSTable(ctx context.Context, db *client.DB, start, end roachpb.Key, sstBytes []byte) error {
-	const maxAddSSTableRetries = 10
-	for i := 0; ; i++ {
-		log.VEventf(ctx, 2, "sending AddSSTable [%s,%s)", start, end)
-		// TODO(dan): This will fail if the range has split.
-		err := db.AddSSTable(ctx, start, end, sstBytes)
-		if err == nil {
-			return nil
-		}
-		if m, ok := errors.Cause(err).(*roachpb.RangeKeyMismatchError); ok {
-			return addSplitSSTable(ctx, db, sstBytes, start, m.MismatchedRange.EndKey.AsRawKey())
-		}
-		if _, ok := err.(*roachpb.AmbiguousResultError); i == maxAddSSTableRetries || !ok {
-			return errors.Wrapf(err, "addsstable [%s,%s)", start, end)
-		}
-
-		log.Warningf(ctx, "addsstable [%s,%s) attempt %d failed: %+v",
-			start, end, i, err)
-		continue
-	}
-}
-
-func addSplitSSTable(
-	ctx context.Context, db *client.DB, sstBytes []byte, start, splitKey roachpb.Key,
-) error {
-	iter, err := engine.NewMemSSTIterator(sstBytes, false)
-	if err != nil {
-		return err
-	}
-	defer iter.Close()
-
-	w, err := engine.MakeRocksDBSstFileWriter()
-	if err != nil {
-		return err
-	}
-	defer w.Close()
-
-	split := false
-	var first, last roachpb.Key
-
-	iter.Seek(engine.MVCCKey{Key: start})
-	for {
-		if ok, err := iter.Valid(); err != nil {
-			return err
-		} else if !ok {
-			break
-		}
-
-		key := iter.UnsafeKey()
-
-		if !split && key.Key.Compare(splitKey) >= 0 {
-			res, err := w.Finish()
-			if err != nil {
-				return err
-			}
-			if err := AddSSTable(ctx, db, first, last.PrefixEnd(), res); err != nil {
-				return err
-			}
-			w.Close()
-			w, err = engine.MakeRocksDBSstFileWriter()
-			if err != nil {
-				return err
-			}
-
-			split = true
-			first = nil
-			last = nil
-		}
-
-		if len(first) == 0 {
-			first = append(first[:0], key.Key...)
-		}
-		last = append(last[:0], key.Key...)
-
-		if err := w.Add(engine.MVCCKeyValue{Key: key, Value: iter.UnsafeValue()}); err != nil {
-			return err
-		}
-
-		iter.Next()
-	}
-
-	res, err := w.Finish()
-	if err != nil {
-		return err
-	}
-	return AddSSTable(ctx, db, first, last.PrefixEnd(), res)
 }
 
 // evalImport bulk loads key/value entries.
@@ -289,8 +130,8 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 		iters = append(iters, iter)
 	}
 
-	batcher := &sstBatcher{maxSize: MaxImportBatchSize(cArgs.EvalCtx.ClusterSettings())}
-	if err := batcher.reset(); err != nil {
+	batcher, err := bulk.MakeSSTBatcher(ctx, db, MaxImportBatchSize(cArgs.EvalCtx.ClusterSettings()))
+	if err != nil {
 		return nil, err
 	}
 	defer batcher.Close()
@@ -346,18 +187,6 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 			continue
 		}
 
-		// Check if we need to flush current batch *before* adding the next k/v --
-		// the batcher may want to flush the keys it already has, either because it
-		// is full or because it wants this key in a separate batch due to splits.
-		if batcher.shouldFlush(key.Key) {
-			if err := batcher.flush(ctx, db); err != nil {
-				return nil, errors.Wrapf(err, "import [%s, %s)", startKeyMVCC.Key, endKeyMVCC.Key)
-			}
-			if err := batcher.reset(); err != nil {
-				return nil, err
-			}
-		}
-
 		// Rewriting the key means the checksum needs to be updated.
 		value.ClearChecksum()
 		value.InitChecksum(key.Key)
@@ -365,14 +194,14 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 		if log.V(3) {
 			log.Infof(ctx, "Put %s -> %s", key.Key, value.PrettyPrint())
 		}
-		if err := batcher.add(key, value.RawBytes); err != nil {
+		if err := batcher.AddMVCCKey(ctx, key, value.RawBytes); err != nil {
 			return nil, errors.Wrapf(err, "adding to batch: %s -> %s", key, value.PrettyPrint())
 		}
 	}
 	// Flush out the last batch.
-	if err := batcher.flush(ctx, db); err != nil {
+	if err := batcher.Flush(ctx); err != nil {
 		return nil, err
 	}
 	log.Event(ctx, "done")
-	return &roachpb.ImportResponse{Imported: batcher.totalRows}, nil
+	return &roachpb.ImportResponse{Imported: batcher.GetSummary()}, nil
 }

--- a/pkg/storage/bulk/main_test.go
+++ b/pkg/storage/bulk/main_test.go
@@ -1,0 +1,42 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package bulk
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go
+
+func init() {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+}
+func TestMain(m *testing.M) {
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+
+	code := m.Run()
+
+	os.Exit(code)
+}

--- a/pkg/storage/bulk/row_counter.go
+++ b/pkg/storage/bulk/row_counter.go
@@ -1,0 +1,70 @@
+// Copyright 2017 The Cockroach Authors.
+//
+/// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package bulk
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+)
+
+// RowCounter is a helper that counts how many distinct rows appear in the KVs
+// that is is shown via `Count`. Note: the `DataSize` field of the BulkOpSummary
+// is *not* populated by this and should be set separately.
+type RowCounter struct {
+	roachpb.BulkOpSummary
+	prev roachpb.Key
+}
+
+// Count examines each key passed to it and increments the running count when it
+// sees a key that belongs to a new row.
+func (r *RowCounter) Count(key roachpb.Key) error {
+	// EnsureSafeSplitKey is usually used to avoid splitting a row across ranges,
+	// by returning the row's key prefix.
+	// We reuse it here to count "rows" by counting when it changes.
+	// Non-SQL keys are returned unchanged or may error -- we ignore them, since
+	// non-SQL keys are obviously thus not SQL rows.
+	row, err := keys.EnsureSafeSplitKey(key)
+	if err != nil || len(key) == len(row) {
+		return nil
+	}
+
+	// no change key prefix => no new row.
+	if bytes.Equal(row, r.prev) {
+		return nil
+	}
+	r.prev = append(r.prev[:0], row...)
+
+	rest, tbl, err := keys.DecodeTablePrefix(row)
+	if err != nil {
+		return err
+	}
+
+	if tbl < keys.MaxReservedDescID {
+		r.SystemRecords++
+	} else {
+		if _, indexID, err := encoding.DecodeUvarintAscending(rest); err != nil {
+			return err
+		} else if indexID == 1 {
+			r.Rows++
+		} else {
+			r.IndexEntries++
+		}
+	}
+
+	return nil
+}

--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -1,0 +1,253 @@
+// Copyright 2017 The Cockroach Authors.
+//
+/// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package bulk
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
+)
+
+// FixedTimestampSSTBatcher is a wrapper for SSTBatcher that assigns a fixed
+// timestamp to all the added keys.
+type FixedTimestampSSTBatcher struct {
+	timestamp hlc.Timestamp
+	SSTBatcher
+}
+
+// MakeFixedTimestampSSTBatcher makes a ready-to-use SSTBatcher
+func MakeFixedTimestampSSTBatcher(
+	ctx context.Context, db *client.DB, flushBytes int64, timestamp hlc.Timestamp,
+) (*FixedTimestampSSTBatcher, error) {
+	b := &FixedTimestampSSTBatcher{timestamp, SSTBatcher{db: db, maxSize: flushBytes}}
+	err := b.reset()
+	return b, err
+}
+
+// Add a key/value pair with the batcher's timestamp, flushing if needed.
+// Keys must be added in order.
+func (b *FixedTimestampSSTBatcher) Add(ctx context.Context, key roachpb.Key, value []byte) error {
+	return b.AddMVCCKey(ctx, engine.MVCCKey{Key: key, Timestamp: b.timestamp}, value)
+}
+
+// SSTBatcher is a helper for bulk-adding many KVs in chunks via AddSSTable. An
+// SSTBatcher can be handed KVs repeatedly and will make them into SSTs that are
+// added when they reach the configured size, tracking the total added rows,
+// bytes, etc.
+//
+// TODO(dt): this currently handles adding keys that span multiple ranges less
+// than ideally -- if a flush fails due to spanning a range boundary, it will
+// have to regenerate SSTs for each side of the reported split and retry. This
+// could in worst-case result in many expensive regeneration/retry loops.
+// Ideally the batcher should be aware of split points and try to flush before
+// crossing a split boundary (though it will still need to handle a mismatched
+// error on new splits).
+type SSTBatcher struct {
+	db *client.DB
+
+	maxSize int64
+	// rows written in the current batch.
+	rowCounter RowCounter
+	totalRows  roachpb.BulkOpSummary
+
+	sstWriter     engine.RocksDBSstFileWriter
+	batchStartKey []byte
+	batchEndKey   []byte
+}
+
+// MakeSSTBatcher makes a ready-to-use SSTBatcher.
+func MakeSSTBatcher(ctx context.Context, db *client.DB, flushBytes int64) (*SSTBatcher, error) {
+	b := &SSTBatcher{db: db, maxSize: flushBytes}
+	err := b.reset()
+	return b, err
+}
+
+// AddMVCCKey adds a key+timestamp/value pair to the batch (flushing if needed).
+// This is only for callers that want to control the timestamp on individual
+// keys -- like RESTORE where we want the restored data to look the like backup.
+// Keys must be added in order.
+func (b *SSTBatcher) AddMVCCKey(ctx context.Context, key engine.MVCCKey, value []byte) error {
+	// Check if we need to flush current batch *before* adding the next k/v --
+	// the batcher may want to flush the keys it already has, either because it
+	// is full or because it wants this key in a separate batch due to splits.
+	if b.shouldFlush(key.Key) {
+		if err := b.Flush(ctx); err != nil {
+			return err
+		}
+		if err := b.reset(); err != nil {
+			return err
+		}
+	}
+
+	// Update the range currently represented in this batch, as necessary.
+	if len(b.batchStartKey) == 0 || bytes.Compare(key.Key, b.batchStartKey) < 0 {
+		b.batchStartKey = append(b.batchStartKey[:0], key.Key...)
+	}
+	if len(b.batchEndKey) == 0 || bytes.Compare(key.Key, b.batchEndKey) > 0 {
+		b.batchEndKey = append(b.batchEndKey[:0], key.Key...)
+	}
+	if err := b.rowCounter.Count(key.Key); err != nil {
+		return err
+	}
+	return b.sstWriter.Add(engine.MVCCKeyValue{Key: key, Value: value})
+}
+
+func (b *SSTBatcher) reset() error {
+	b.sstWriter.Close()
+	w, err := engine.MakeRocksDBSstFileWriter()
+	if err != nil {
+		return err
+	}
+	b.sstWriter = w
+	b.batchStartKey = b.batchStartKey[:0]
+	b.batchEndKey = b.batchEndKey[:0]
+	b.rowCounter.BulkOpSummary.Reset()
+	return nil
+}
+
+func (b *SSTBatcher) shouldFlush(nextKey roachpb.Key) bool {
+	return b.sstWriter.DataSize >= b.maxSize
+}
+
+// Flush sends the current batch, if any.
+func (b *SSTBatcher) Flush(ctx context.Context) error {
+	if b.sstWriter.DataSize == 0 {
+		return nil
+	}
+	start := roachpb.Key(append([]byte(nil), b.batchStartKey...))
+	// The end key of the WriteBatch request is exclusive, but batchEndKey is
+	// currently the largest key in the batch. Increment it.
+	end := roachpb.Key(append([]byte(nil), b.batchEndKey...)).Next()
+
+	sstBytes, err := b.sstWriter.Finish()
+	if err != nil {
+		return errors.Wrapf(err, "finishing constructed sstable")
+	}
+	if err := AddSSTable(ctx, b.db, start, end, sstBytes); err != nil {
+		return err
+	}
+	b.totalRows.Add(b.rowCounter.BulkOpSummary)
+	b.totalRows.DataSize += b.sstWriter.DataSize
+	return nil
+}
+
+// Close closes the underlying SST builder.
+func (b *SSTBatcher) Close() {
+	b.sstWriter.Close()
+}
+
+// GetSummary returns this batcher's total added rows/bytes/etc.
+func (b *SSTBatcher) GetSummary() roachpb.BulkOpSummary {
+	return b.totalRows
+}
+
+// AddSSTable retries db.AddSSTable if retryable errors occur, including if the
+// SST spans a split, in which case it is iterated and split into two SSTs, one
+// for each side of the split in the error, and each are retried.
+func AddSSTable(ctx context.Context, db *client.DB, start, end roachpb.Key, sstBytes []byte) error {
+	const maxAddSSTableRetries = 10
+	var err error
+	for i := 0; i < maxAddSSTableRetries; i++ {
+		log.VEventf(ctx, 2, "sending AddSSTable [%s,%s)", start, end)
+		// This will fail if the range has split but we'll check for that below.
+		err = db.AddSSTable(ctx, start, end, sstBytes)
+		if err == nil {
+			return nil
+		}
+		// This range has split -- we need to split the SST to try again.
+		if m, ok := errors.Cause(err).(*roachpb.RangeKeyMismatchError); ok {
+			return addSplitSSTable(ctx, db, sstBytes, start, m.MismatchedRange.EndKey.AsRawKey())
+		}
+		// Retry on AmbiguousResult.
+		if _, ok := err.(*roachpb.AmbiguousResultError); ok {
+			log.Warningf(ctx, "addsstable [%s,%s) attempt %d failed: %+v", start, end, i, err)
+			continue
+		}
+	}
+	return errors.Wrapf(err, "addsstable [%s,%s)", start, end)
+}
+
+// addSplitSSTable is a helper for splitting up and retrying AddSStable calls.
+func addSplitSSTable(
+	ctx context.Context, db *client.DB, sstBytes []byte, start, splitKey roachpb.Key,
+) error {
+	iter, err := engine.NewMemSSTIterator(sstBytes, false)
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+
+	w, err := engine.MakeRocksDBSstFileWriter()
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	split := false
+	var first, last roachpb.Key
+
+	iter.Seek(engine.MVCCKey{Key: start})
+	for {
+		if ok, err := iter.Valid(); err != nil {
+			return err
+		} else if !ok {
+			break
+		}
+
+		key := iter.UnsafeKey()
+
+		if !split && key.Key.Compare(splitKey) >= 0 {
+			res, err := w.Finish()
+			if err != nil {
+				return err
+			}
+			if err := AddSSTable(ctx, db, first, last.PrefixEnd(), res); err != nil {
+				return err
+			}
+			w.Close()
+			w, err = engine.MakeRocksDBSstFileWriter()
+			if err != nil {
+				return err
+			}
+
+			split = true
+			first = nil
+			last = nil
+		}
+
+		if len(first) == 0 {
+			first = append(first[:0], key.Key...)
+		}
+		last = append(last[:0], key.Key...)
+
+		if err := w.Add(engine.MVCCKeyValue{Key: key, Value: iter.UnsafeValue()}); err != nil {
+			return err
+		}
+
+		iter.Next()
+	}
+
+	res, err := w.Finish()
+	if err != nil {
+		return err
+	}
+	return AddSSTable(ctx, db, first, last.PrefixEnd(), res)
+}

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -1,0 +1,160 @@
+// Copyright 2018 The Cockroach Authors.
+//
+/// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package bulk
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestAddBatched(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	t.Run("batch=default", func(t *testing.T) {
+		runTestImport(t, 32<<20)
+	})
+	t.Run("batch=1", func(t *testing.T) {
+		runTestImport(t, 1)
+	})
+}
+
+func runTestImport(t *testing.T, batchSize int64) {
+
+	ctx := context.Background()
+	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	const split1, split2 = 3, 5
+	// Each test case consists of some number of batches of keys, represented as
+	// ints [0, 8). Splits are at 3 and 5.
+	for i, testCase := range [][][]int{
+		// Simple cases, no spanning splits, try first, last, middle, etc in each.
+		// r1
+		{{0}},
+		{{1}},
+		{{2}},
+		{{0, 1, 2}},
+		{{0}, {1}, {2}},
+
+		// r2
+		{{3}},
+		{{4}},
+		{{3, 4}},
+		{{3}, {4}},
+
+		// r3
+		{{5}},
+		{{5, 6, 7}},
+		{{6}},
+
+		// batches exactly matching spans.
+		{{0, 1, 2}, {3, 4}, {5, 6, 7}},
+
+		// every key, in its own batch.
+		{{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}},
+
+		// every key in one big batch.
+		{{0, 1, 2, 3, 4, 5, 6, 7}},
+
+		// Look for off-by-ones on and around the splits.
+		{{2, 3}},
+		{{1, 3}},
+		{{2, 4}},
+		{{1, 4}},
+		{{1, 5}},
+		{{2, 5}},
+
+		// Mixture of split-aligned and non-aligned batches.
+		{{1}, {5}, {6}},
+		{{1, 2, 3}, {4, 5}, {6, 7}},
+		{{0}, {2, 3, 5}, {7}},
+		{{0, 4}, {5, 7}},
+		{{0, 3}, {4}},
+	} {
+		t.Run(fmt.Sprintf("%d-%v", i, testCase), func(t *testing.T) {
+			prefix := encoding.EncodeUvarintAscending(keys.MakeTablePrefix(uint32(100+i)), uint64(1))
+			key := func(i int) roachpb.Key {
+				return encoding.EncodeStringAscending(append([]byte{}, prefix...), fmt.Sprintf("k%d", i))
+			}
+
+			if err := kvDB.AdminSplit(ctx, key(split1), key(split1)); err != nil {
+				t.Fatal(err)
+			}
+			if err := kvDB.AdminSplit(ctx, key(split2), key(split2)); err != nil {
+				t.Fatal(err)
+			}
+
+			ts := hlc.Timestamp{WallTime: 100}
+			b, err := MakeFixedTimestampSSTBatcher(ctx, kvDB, batchSize, ts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			defer b.Close()
+
+			var expected []client.KeyValue
+
+			for _, batch := range testCase {
+				for _, x := range batch {
+					k := key(x)
+					v := roachpb.MakeValueFromString(fmt.Sprintf("value-%d", x))
+					v.Timestamp = ts
+					v.InitChecksum(k)
+					t.Logf("adding: %v", k)
+					if err := b.Add(ctx, k, v.RawBytes); err != nil {
+						t.Fatal(err)
+					}
+					t.Logf("batch: %d", b.sstWriter.DataSize)
+					expected = append(expected, client.KeyValue{Key: k, Value: &v})
+				}
+			}
+			if err := b.Flush(ctx); err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("flushed batch: %d", b.sstWriter.DataSize)
+
+			added := b.GetSummary()
+			t.Logf("Wrote %d total", added.DataSize)
+
+			got, err := kvDB.Scan(ctx, key(0), key(8), 0)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+
+			if !reflect.DeepEqual(got, expected) {
+				for i := 0; i < len(got) || i < len(expected); i++ {
+					if i < len(expected) {
+						t.Logf("expected %d\t%v\t%v", i, expected[i].Key, expected[i].Value)
+					}
+					if i < len(got) {
+						t.Logf("got      %d\t%v\t%v", i, got[i].Key, got[i].Value)
+					}
+				}
+				t.Fatalf("got %+v expected %+v", got, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This moves the batching-sst-maker-and-adder helper to the OSS codebase.
This helper can be created with a configured batch size and then just handed KVs.
If its outstanding batch of KVs grows beyond the configured batch size it will
flush them as an SSTable and start a new batch.
AddSSTable calls that end up spanning a range are split and retried.

Also moved it the row-counting helper that keeps track of rows/indexes/bytes added.

Release note: none.