### PR TITLE
storage: remove data race caused by load based splitting

### DIFF
--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -223,7 +223,6 @@ func (sq *splitQueue) processAttempt(
 		); pErr != nil {
 			return errors.Wrapf(pErr, "unable to split %s at key %q", r, splitByLoadKey)
 		}
-		r.splitMu.splitFinder = nil
 		return nil
 	}
 	return nil


### PR DESCRIPTION
This line looks like it was moved under the lock above but accidentally
left in the code.

Fixes #32372.

Release note: None