### PR TITLE
chore: update debian to 8.11

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8.9
+FROM debian:8.11
 
 # Install root CAs so we can make SSL connections to phone home and
 # do backups to GCE/AWS/Azure.


### PR DESCRIPTION
we are currently seeing this [vulnerability](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-1126) pop up when using [microscanner](https://github.com/aquasecurity/microscanner) to scan this image.

upgrading to 8.11 fixes this issue
