### PR TITLE
storage/engine: extract an MVCCScanOptions struct

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -505,8 +505,7 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	var descs []roachpb.RangeDescriptor
 
 	if _, err := engine.MVCCIterate(context.Background(), db, start, end, hlc.MaxTimestamp,
-		false /* consistent */, false /* tombstones */, nil, /* txn */
-		false /* reverse */, func(kv roachpb.KeyValue) (bool, error) {
+		engine.MVCCScanOptions{Inconsistent: true}, func(kv roachpb.KeyValue) (bool, error) {
 			var desc roachpb.RangeDescriptor
 			_, suffix, _, err := keys.DecodeRangeKey(kv.Key)
 			if err != nil {
@@ -652,8 +651,7 @@ func runDebugCheckStoreRaft(ctx context.Context, db *engine.RocksDB) error {
 	var hasError bool
 
 	if _, err := engine.MVCCIterate(ctx, db, start, end, hlc.MaxTimestamp,
-		false /* consistent */, false /* tombstones */, nil, /* txn */
-		false /* reverse */, func(kv roachpb.KeyValue) (bool, error) {
+		engine.MVCCScanOptions{Inconsistent: true}, func(kv roachpb.KeyValue) (bool, error) {
 			rangeID, _, suffix, detail, err := keys.DecodeRangeIDKey(kv.Key)
 			if err != nil {
 				return false, err

--- a/pkg/kv/split_test.go
+++ b/pkg/kv/split_test.go
@@ -121,7 +121,7 @@ func TestRangeSplitMeta(t *testing.T) {
 	}
 
 	testutils.SucceedsSoon(t, func() error {
-		if _, _, _, err := engine.MVCCScan(ctx, s.Eng, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, true, nil); err != nil {
+		if _, _, _, err := engine.MVCCScan(ctx, s.Eng, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, engine.MVCCScanOptions{}); err != nil {
 			return errors.Errorf("failed to verify no dangling intents: %s", err)
 		}
 		return nil
@@ -229,7 +229,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 	// for timing of finishing the test writer and a possibly-ongoing
 	// asynchronous split.
 	testutils.SucceedsSoon(t, func() error {
-		if _, _, _, err := engine.MVCCScan(ctx, s.Eng, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, true, nil); err != nil {
+		if _, _, _, err := engine.MVCCScan(ctx, s.Eng, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, engine.MVCCScanOptions{}); err != nil {
 			return errors.Errorf("failed to verify no dangling intents: %s", err)
 		}
 		return nil

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -211,7 +211,7 @@ func TestBootstrapCluster(t *testing.T) {
 	}
 
 	// Scan the complete contents of the local database directly from the engine.
-	rows, _, _, err := engine.MVCCScan(context.Background(), e, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, true, nil)
+	rows, _, _, err := engine.MVCCScan(context.Background(), e, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, engine.MVCCScanOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/abortspan/abortspan.go
+++ b/pkg/storage/abortspan/abortspan.go
@@ -109,8 +109,7 @@ func (sc *AbortSpan) Get(
 func (sc *AbortSpan) Iterate(
 	ctx context.Context, e engine.Reader, f func(roachpb.Key, roachpb.AbortSpanEntry) error,
 ) error {
-	_, err := engine.MVCCIterate(ctx, e, sc.min(), sc.max(), hlc.Timestamp{},
-		true /* consistent */, false /* tombstones */, nil /* txn */, false, /* reverse */
+	_, err := engine.MVCCIterate(ctx, e, sc.min(), sc.max(), hlc.Timestamp{}, engine.MVCCScanOptions{},
 		func(kv roachpb.KeyValue) (bool, error) {
 			var entry roachpb.AbortSpanEntry
 			if _, err := keys.DecodeAbortSpanKey(kv.Key, nil); err != nil {

--- a/pkg/storage/addressing_test.go
+++ b/pkg/storage/addressing_test.go
@@ -162,7 +162,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Scan meta keys directly from engine.
-		kvs, _, _, err := engine.MVCCScan(ctx, store.Engine(), keys.MetaMin, keys.MetaMax, math.MaxInt64, hlc.MaxTimestamp, true, nil)
+		kvs, _, _, err := engine.MVCCScan(ctx, store.Engine(), keys.MetaMin, keys.MetaMax, math.MaxInt64, hlc.MaxTimestamp, engine.MVCCScanOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storage/batcheval/cmd_reverse_scan.go
+++ b/pkg/storage/batcheval/cmd_reverse_scan.go
@@ -47,9 +47,13 @@ func ReverseScan(
 	case roachpb.BATCH_RESPONSE:
 		var kvData []byte
 		var numKvs int64
-		kvData, numKvs, resumeSpan, intents, err = engine.MVCCReverseScanToBytes(
-			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys,
-			h.Timestamp, h.ReadConsistency == roachpb.CONSISTENT, h.Txn)
+		kvData, numKvs, resumeSpan, intents, err = engine.MVCCScanToBytes(
+			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp,
+			engine.MVCCScanOptions{
+				Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
+				Txn:          h.Txn,
+				Reverse:      true,
+			})
 		if err != nil {
 			return result.Result{}, err
 		}
@@ -57,8 +61,12 @@ func ReverseScan(
 		reply.BatchResponse = kvData
 	case roachpb.KEY_VALUES:
 		var rows []roachpb.KeyValue
-		rows, resumeSpan, intents, err = engine.MVCCReverseScan(ctx, batch, args.Key, args.EndKey,
-			cArgs.MaxKeys, h.Timestamp, h.ReadConsistency == roachpb.CONSISTENT, h.Txn)
+		rows, resumeSpan, intents, err = engine.MVCCScan(
+			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp, engine.MVCCScanOptions{
+				Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
+				Txn:          h.Txn,
+				Reverse:      true,
+			})
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/storage/batcheval/cmd_scan.go
+++ b/pkg/storage/batcheval/cmd_scan.go
@@ -48,8 +48,11 @@ func Scan(
 		var kvData []byte
 		var numKvs int64
 		kvData, numKvs, resumeSpan, intents, err = engine.MVCCScanToBytes(
-			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys,
-			h.Timestamp, h.ReadConsistency == roachpb.CONSISTENT, h.Txn)
+			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp,
+			engine.MVCCScanOptions{
+				Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
+				Txn:          h.Txn,
+			})
 		if err != nil {
 			return result.Result{}, err
 		}
@@ -57,8 +60,11 @@ func Scan(
 		reply.BatchResponse = kvData
 	case roachpb.KEY_VALUES:
 		var rows []roachpb.KeyValue
-		rows, resumeSpan, intents, err = engine.MVCCScan(ctx, batch, args.Key, args.EndKey,
-			cArgs.MaxKeys, h.Timestamp, h.ReadConsistency == roachpb.CONSISTENT, h.Txn)
+		rows, resumeSpan, intents, err = engine.MVCCScan(
+			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp, engine.MVCCScanOptions{
+				Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
+				Txn:          h.Txn,
+			})
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -160,10 +160,6 @@ func runMVCCScan(emk engineMaker, numRows, numVersions, valueSize int, reverse b
 		iter.Close()
 	}
 
-	scan := MVCCScan
-	if reverse {
-		scan = MVCCReverseScan
-	}
 	b.SetBytes(int64(numRows * valueSize))
 	b.ResetTimer()
 
@@ -177,7 +173,9 @@ func runMVCCScan(emk engineMaker, numRows, numVersions, valueSize int, reverse b
 		endKey = endKey.Next()
 		walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 		ts := hlc.Timestamp{WallTime: walltime}
-		kvs, _, _, err := scan(context.Background(), eng, startKey, endKey, int64(numRows), ts, true, nil)
+		kvs, _, _, err := MVCCScan(context.Background(), eng, startKey, endKey, int64(numRows), ts, MVCCScanOptions{
+			Reverse: reverse,
+		})
 		if err != nil {
 			b.Fatalf("failed scan: %s", err)
 		}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -112,16 +112,14 @@ type Iterator interface {
 		txn *roachpb.Transaction, consistent, tombstones bool,
 	) (*roachpb.Value, []roachpb.Intent, error)
 	// MVCCScan is the internal implementation of the family of package-level
-	// MVCCScan functions. There are two notable differences. The first is that
-	// key/value pairs are returned raw, as a buffer of varint-prefixed slices,
-	// alternating from key to value, where numKVs specifies the number of pairs
-	// in the buffer. The second is that the tombstones parameter allows returning
-	// deleted values, where the value portion will be empty.
+	// MVCCScan functions. The notable difference is that key/value pairs are
+	// returned raw, as a buffer of varint-prefixed slices, alternating from key
+	// to value, where numKVs specifies the number of pairs in the buffer.
 	//
 	// There is little reason to use this function directly. Use the package-level
 	// MVCCScan, or one of its variants, instead.
-	MVCCScan(start, end roachpb.Key, max int64, timestamp hlc.Timestamp,
-		txn *roachpb.Transaction, consistent, reverse, tombstone bool,
+	MVCCScan(
+		start, end roachpb.Key, max int64, timestamp hlc.Timestamp, opts MVCCScanOptions,
 	) (kvData []byte, numKVs int64, resumeSpan *roachpb.Span, intents []roachpb.Intent, err error)
 	// SetUpperBound installs a new upper bound for this iterator.
 	SetUpperBound(roachpb.Key)

--- a/pkg/storage/engine/rocksdb_iter_stats_test.go
+++ b/pkg/storage/engine/rocksdb_iter_stats_test.go
@@ -66,7 +66,7 @@ func TestIterStats(t *testing.T) {
 			// Scanning a key range containing the tombstone sees it.
 			for i := 0; i < 10; i++ {
 				if _, _, _, _, err := iter.MVCCScan(
-					roachpb.KeyMin, roachpb.KeyMax, math.MaxInt64, hlc.Timestamp{}, nil, true, false, false,
+					roachpb.KeyMin, roachpb.KeyMax, math.MaxInt64, hlc.Timestamp{}, MVCCScanOptions{},
 				); err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -425,9 +425,8 @@ func processLocalKeyRange(
 	startKey := keys.MakeRangeKeyPrefix(desc.StartKey)
 	endKey := keys.MakeRangeKeyPrefix(desc.EndKey)
 
-	_, err := engine.MVCCIterate(ctx, snap, startKey, endKey,
-		hlc.Timestamp{}, true /* consistent */, false /* tombstones */, nil, /* txn */
-		false /* reverse */, func(kv roachpb.KeyValue) (bool, error) {
+	_, err := engine.MVCCIterate(ctx, snap, startKey, endKey, hlc.Timestamp{}, engine.MVCCScanOptions{},
+		func(kv roachpb.KeyValue) (bool, error) {
 			return false, handleOne(kv)
 		})
 	return gcKeys, err

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -786,7 +786,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 	outsideTxnPrefixEnd := keys.TransactionKey(outsideKey.Next(), uuid.UUID{})
 	var count int
 	if _, err := engine.MVCCIterate(context.Background(), tc.store.Engine(), outsideTxnPrefix, outsideTxnPrefixEnd, hlc.Timestamp{},
-		true, false, nil, false, func(roachpb.KeyValue) (bool, error) {
+		engine.MVCCScanOptions{}, func(roachpb.KeyValue) (bool, error) {
 			count++
 			return false, nil
 		}); err != nil {

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -237,10 +237,7 @@ func iterateEntries(
 		keys.RaftLogKey(rangeID, lo),
 		keys.RaftLogKey(rangeID, hi),
 		hlc.Timestamp{},
-		true,  /* consistent */
-		false, /* tombstones */
-		nil,   /* txn */
-		false, /* reverse */
+		engine.MVCCScanOptions{},
 		scanFunc,
 	)
 	return err

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -181,16 +181,12 @@ func (s *Iterator) MVCCGet(
 
 // MVCCScan is part of the engine.Iterator interface.
 func (s *Iterator) MVCCScan(
-	start, end roachpb.Key,
-	max int64,
-	timestamp hlc.Timestamp,
-	txn *roachpb.Transaction,
-	consistent, reverse, tombstones bool,
+	start, end roachpb.Key, max int64, timestamp hlc.Timestamp, opts engine.MVCCScanOptions,
 ) (kvData []byte, numKVs int64, resumeSpan *roachpb.Span, intents []roachpb.Intent, err error) {
 	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
 		return nil, 0, nil, nil, err
 	}
-	return s.i.MVCCScan(start, end, max, timestamp, txn, consistent, reverse, tombstones)
+	return s.i.MVCCScan(start, end, max, timestamp, opts)
 }
 
 // SetUpperBound is part of the engine.Iterator interface.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1177,8 +1177,8 @@ func IterateRangeDescriptors(
 		return fn(desc)
 	}
 
-	_, err := engine.MVCCIterate(ctx, eng, start, end, hlc.MaxTimestamp, false /* consistent */, false, /* tombstones */
-		nil /* txn */, false /* reverse */, kvToDesc)
+	_, err := engine.MVCCIterate(ctx, eng, start, end, hlc.MaxTimestamp,
+		engine.MVCCScanOptions{Inconsistent: true}, kvToDesc)
 	log.Eventf(ctx, "iterated over %d keys to find %d range descriptors (by suffix: %v)",
 		allCount, matchCount, bySuffix)
 	return err

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -128,7 +128,7 @@ func (tm *testModelRunner) getActualData() map[string]roachpb.Value {
 	// Scan over all TS Keys stored in the engine
 	startKey := keys.TimeseriesPrefix
 	endKey := startKey.PrefixEnd()
-	keyValues, _, _, err := engine.MVCCScan(context.Background(), tm.Eng, startKey, endKey, math.MaxInt64, tm.Clock.Now(), true, nil)
+	keyValues, _, _, err := engine.MVCCScan(context.Background(), tm.Eng, startKey, endKey, math.MaxInt64, tm.Clock.Now(), engine.MVCCScanOptions{})
 	if err != nil {
 		tm.t.Fatalf("error scanning TS data from engine: %s", err)
 	}


### PR DESCRIPTION
The signatures of the functions in the MVCCScan family are extremely
unwieldy. Extract an MVCCScanOptions struct for the fields that have
reasonable default values.

We can immediately realize the benefits of this change by removing
MVCCReverseScan, MVCCReverseScanWithBytes, and MVCCIterateUsingIter,
as the functionality provided by those functions can be requested with
the appropriate option in the MVCCScanOptions struct.

This paves the way towards introducing additional parameters, like
minimum and maximum timestamp bounds.

Updates #28358.

Release note: None