### PR TITLE
[wip] storage/engine: never delete MVCC metadata keys

### DIFF
--- a/c-deps/libroach/mvcc.h
+++ b/c-deps/libroach/mvcc.h
@@ -221,7 +221,11 @@ template <bool reverse> class mvccScanner {
     }
 
     if (!meta_.has_txn()) {
-      return setStatus(FmtStatus("intent without transaction"));
+      // Shh. This intent doesn't really exist.
+      if (check_uncertainty_) {
+        return seekVersion(txn_max_timestamp_, true);
+      }
+      return seekVersion(timestamp_, false);
     }
 
     const bool own_intent = (meta_.txn().id() == txn_id_);

--- a/pkg/ccl/storageccl/engineccl/mvcc.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc.go
@@ -168,6 +168,11 @@ func (i *MVCCIncrementalIterator) advance() {
 				i.valid = false
 				return
 			}
+			if !i.meta.IsInline() && i.meta.Txn == nil {
+				// Shh. This intent doesn't really exist.
+				i.iter.Next()
+				continue
+			}
 		}
 		if i.meta.IsInline() {
 			// Inline values are only used in non-user data. They're not needed

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -3076,10 +3076,11 @@ func TestMVCCAbortTxn(t *testing.T) {
 	} else if value != nil {
 		t.Fatalf("expected the value to be empty: %s", value)
 	}
-	if meta, err := engine.Get(mvccKey(testKey1)); err != nil {
+	var meta enginepb.MVCCMetadata
+	if ok, _, _, err := engine.GetProto(mvccKey(testKey1), &meta); err != nil {
 		t.Fatal(err)
-	} else if len(meta) != 0 {
-		t.Fatalf("expected no more MVCCMetadata, got: %s", meta)
+	} else if !ok || meta.Txn != nil {
+		t.Fatalf("expected deleted MVCCMetadata, got: %+v", meta)
 	}
 }
 
@@ -3111,10 +3112,11 @@ func TestMVCCAbortTxnWithPreviousVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if meta, err := engine.Get(mvccKey(testKey1)); err != nil {
+	var meta enginepb.MVCCMetadata
+	if ok, _, _, err := engine.GetProto(mvccKey(testKey1), &meta); err != nil {
 		t.Fatal(err)
-	} else if len(meta) != 0 {
-		t.Fatalf("expected no more MVCCMetadata, got: %s", meta)
+	} else if !ok || meta.Txn != nil {
+		t.Fatalf("expected deleted MVCCMetadata, got: %+v", meta)
 	}
 
 	if value, _, err := MVCCGet(ctx, engine, testKey1, hlc.Timestamp{WallTime: 3}, true, nil); err != nil {


### PR DESCRIPTION
Not asking for a review yet! Pushing this up as PoC for @danhhz.

---

This is a prototype of one of the proposed solutions to #28358, whereby
we never delete MVCCMetadata keys when resolving an intent. Instead, we
Put a new value that where Timestamp != nil (this is how the SST gets
the right bounds), Txn == nil (this indicates that this is the
resolution of an intent and not a new intent), and RawBytes == nil (to
indicate that this is not an inline value).

This has the downside of a) being extremely subtle, and b) wasting space
because writing a key transactionally now results in the metadata being
present forever. (We could probably work around b with a compaction
filter.)

Touches #28358.

Release note: None