### PR TITLE
storage/tscache: improve debug info in panic msg for inverted range

### DIFF
--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/interval"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -239,8 +239,17 @@ func (s *intervalSkl) AddRange(from, to []byte, opt rangeOptions, val cacheValue
 
 		switch {
 		case cmp > 0:
-			// Starting key is after ending key. This shouldn't happen.
-			panic(interval.ErrInvertedRange)
+			// Starting key is after ending key. This shouldn't happen. Determine
+			// the index where the keys diverged and panic.
+			d := 0
+			for d < len(from) && d < len(to) {
+				if from[d] != to[d] {
+					break
+				}
+				d++
+			}
+			panic(log.Safe(fmt.Sprintf("inverted range: key lens = [%d,%d), diff @ index %d",
+				len(from), len(to), d)))
 		case cmp == 0:
 			// Starting key is same as ending key, so just add single node.
 			if opt == (excludeFrom | excludeTo) {


### PR DESCRIPTION
Closes #32149 as unactionable past this point.

Release note: None