### PR TITLE
distsqlrun: swallow uncertainty errors when draining

### DIFF
--- a/pkg/sql/distsqlrun/processors_test.go
+++ b/pkg/sql/distsqlrun/processors_test.go
@@ -16,13 +16,24 @@ package distsqlrun
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/jackc/pgx"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -466,5 +477,182 @@ func TestProcessorBaseContext(t *testing.T) {
 			noop.ConsumerClosed()
 			noop.ConsumerClosed()
 		})
+	})
+}
+
+// Test that processors swallow ReadWithinUncertaintyIntervalErrors once they
+// started draining. The code that this test is checking is in ProcessorBase.
+// The test is written using high-level interfaces since what's truly
+// interesting to test is the integration between DistSQL and KV.
+func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// We're going to test by running a query that selects rows 1..10 with limit
+	// 5. Out of these, rows 1..5 are on node 2, 6..10 on node 1. We're going to
+	// block the read on node 1 until the client gets the 5 rows from node 2. Then
+	// we're going to inject an uncertainty error in the blocked read. The point
+	// of the test is to check that the error is swallowed, because the processor
+	// on the gateway is already draining.
+	// We need to construct this scenario with multiple nodes since you can't have
+	// uncertainty errors if all the data is on the gateway. Then, we'll use a
+	// UNION query to force DistSQL to plan multiple TableReaders (otherwise it
+	// plans just one for LIMIT queries). The point of the test is to force one
+	// extra batch to be read without its rows actually being needed. This is not
+	// entirely easy to cause given the current implementation details.
+
+	// trapRead is set, atomically, once the test wants to block a read on the
+	// first node.
+	var trapRead int64
+	blockedRead := make(chan roachpb.BatchRequest)
+	unblockRead := make(chan *roachpb.Error)
+
+	tc := serverutils.StartTestCluster(t, 3, /* numNodes */
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+			ServerArgs: base.TestServerArgs{
+				UseDatabase: "test",
+				// Andrei is too lazy to figure out the incantation for telling pgx about
+				// our test certs.
+				Insecure: true,
+			},
+			ServerArgsPerNode: map[int]base.TestServerArgs{
+				0: {
+					Knobs: base.TestingKnobs{
+						Store: &storage.StoreTestingKnobs{
+							TestingRequestFilter: func(ba roachpb.BatchRequest) *roachpb.Error {
+								if atomic.LoadInt64(&trapRead) == 0 {
+									return nil
+								}
+								// We're going to trap a read for the rows [1,5].
+								req, ok := ba.GetArg(roachpb.Scan)
+								if !ok {
+									return nil
+								}
+								key := req.(*roachpb.ScanRequest).Key.String()
+								endKey := req.(*roachpb.ScanRequest).EndKey.String()
+								if strings.Contains(key, "/1") && strings.Contains(endKey, "5/") {
+									blockedRead <- ba
+									return <-unblockRead
+								}
+								return nil
+							},
+						},
+					},
+					UseDatabase: "test",
+					// Andrei is too lazy to figure out the incantation for telling pgx about
+					// our test certs.
+					Insecure: true,
+				},
+			},
+		})
+	defer tc.Stopper().Stop(context.TODO())
+
+	origDB0 := tc.ServerConn(0)
+	sqlutils.CreateTable(t, origDB0, "t",
+		"x INT PRIMARY KEY",
+		10, /* numRows */
+		sqlutils.ToRowFn(sqlutils.RowIdxFn))
+
+	// Split the table and move half of the rows to the 2nd node. We'll block the
+	// read on the first node, and so the rows we're going to be expecting are the
+	// ones from the second node.
+	_, err := origDB0.Exec(fmt.Sprintf(`
+	ALTER TABLE "t" SPLIT AT VALUES (6);
+	ALTER TABLE "t" EXPERIMENTAL_RELOCATE VALUES (ARRAY[%d], 0), (ARRAY[%d], 6);
+	`,
+		tc.Server(0).GetFirstStoreID(),
+		tc.Server(1).GetFirstStoreID()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure that the range cache is populated.
+	if _, err = origDB0.Exec(`SELECT count(1) FROM t`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Disable results buffering - we want to ensure that the server doesn't do
+	// any automatic retries, and also we use the client to know when to unblock
+	// the read.
+	if _, err := origDB0.Exec(
+		`SET CLUSTER SETTING sql.defaults.results_buffer.size = '0'`,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	host, ports, err := net.SplitHostPort(tc.Server(0).ServingAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(ports)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := pgx.Connect(
+		pgx.ConnConfig{
+			Host:     host,
+			Port:     uint16(port),
+			User:     "root",
+			Database: "test",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	atomic.StoreInt64(&trapRead, 1)
+
+	// We're going to run the test twice. Once in "dummy" node, which just
+	// verifies that the test is not fooling itself by increasing the limit from 5
+	// to 6 and checking that we get the injected error in that case.
+	testutils.RunTrueAndFalse(t, "dummy", func(t *testing.T, dummy bool) {
+		// Force DistSQL to distribute the query. Otherwise, as of Nov 2018, it's hard
+		// to convince it to distribute a query that uses an index.
+		if _, err := conn.Exec("set distsql='always'"); err != nil {
+			t.Fatal(err)
+		}
+		limit := 5
+		if dummy {
+			limit = 6
+		}
+		query := fmt.Sprintf(
+			"select x from t where x <= 5 union all select x from t where x > 5 limit %d",
+			limit)
+		rows, err := conn.Query(query)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		i := 6
+		for rows.Next() {
+			var n int
+			if err := rows.Scan(&n); err != nil {
+				t.Fatal(err)
+			}
+			if n != i {
+				t.Fatalf("expected row: %d but got: %d", i, n)
+			}
+			i++
+			// After we've gotten all the rows from the second node, let the first node
+			// return an uncertainty error.
+			if n == 10 {
+				ba := <-blockedRead
+				unblockRead <- roachpb.NewError(
+					roachpb.NewReadWithinUncertaintyIntervalError(
+						ba.Timestamp,           /* readTs */
+						ba.Timestamp.Add(1, 0), /* existingTs */
+						ba.Txn))
+			}
+		}
+		err = rows.Err()
+		if !dummy {
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			if !testutils.IsError(err, "ReadWithinUncertaintyIntervalError") {
+				t.Fatalf("expected injected error, got: %v", err)
+			}
+		}
 	})
 }


### PR DESCRIPTION
For the motivation, quoting from the patch:

We're already draining, so we don't care about whatever data generated
this uncertainty error. Besides generally seeming like a good idea,
doing this allows us to offer a nice guarantee to SQL clients: a
read-only query that produces at most one row, run as an implicit txn,
never produces retriable errors, regardless of the size of the row being
returned (in relation to the size of the result buffer on the
connection). One would naively expect that to be true: either the error
happens before any rows have been delivered to the client, in which case
the auto-retries kick in, or, if a row has been delivered, then the
query is done and so how can there be an error? What our naive friend is
ignoring is that, if it weren't for this code, it'd be possible for a
retriable error to sneak in after the query's limit has been satisfied
but while processors are still draining. Note that uncertainty errors
are not retried automatically by the leaf TxnCoordSenders (i.e. by
refresh txn interceptor).

Release note: None