### PR TITLE
sql: refactor context and txn out of resolver flags

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -318,14 +318,12 @@ func (r fkResolver) CurrentSearchPath() sessiondata.SearchPath {
 }
 
 // Implements the sql.SchemaResolver interface.
-func (r fkResolver) CommonLookupFlags(ctx context.Context, required bool) sql.CommonLookupFlags {
+func (r fkResolver) CommonLookupFlags(required bool) sql.CommonLookupFlags {
 	return sql.CommonLookupFlags{}
 }
 
 // Implements the sql.SchemaResolver interface.
-func (r fkResolver) ObjectLookupFlags(
-	ctx context.Context, required bool, requireMutable bool,
-) sql.ObjectLookupFlags {
+func (r fkResolver) ObjectLookupFlags(required bool, requireMutable bool) sql.ObjectLookupFlags {
 	return sql.ObjectLookupFlags{}
 }
 

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -173,8 +173,8 @@ func (p *planner) MemberOfWithAdminOption(
 	ctx context.Context, member string,
 ) (map[string]bool, error) {
 	// Lookup table version.
-	objDesc, _, err := p.PhysicalSchemaAccessor().GetObjectDesc(&roleMembersTableName,
-		p.ObjectLookupFlags(ctx, true /*required*/, false /*requireMutable*/))
+	objDesc, _, err := p.PhysicalSchemaAccessor().GetObjectDesc(ctx, p.txn, &roleMembersTableName,
+		p.ObjectLookupFlags(true /*required*/, false /*requireMutable*/))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -193,8 +193,7 @@ func (sc *SchemaChanger) runBackfill(
 func (sc *SchemaChanger) getTableVersion(
 	ctx context.Context, txn *client.Txn, tc *TableCollection, version sqlbase.DescriptorVersion,
 ) (*sqlbase.TableDescriptor, error) {
-	flags := ObjectLookupFlags{CommonLookupFlags{txn: txn}, false /*requireMutable*/}
-	tableDesc, err := tc.getTableVersionByID(ctx, sc.tableID, flags)
+	tableDesc, err := tc.getTableVersionByID(ctx, txn, sc.tableID, ObjectLookupFlags{})
 	if err != nil {
 		return nil, err
 	}
@@ -417,9 +416,8 @@ func (sc *SchemaChanger) distBackfill(
 					return err
 				}
 
-				flags := ObjectLookupFlags{CommonLookupFlags{txn: txn}, false /*requireMutable*/}
 				for k := range fkTables {
-					table, err := tc.getTableVersionByID(ctx, k, flags)
+					table, err := tc.getTableVersionByID(ctx, txn, k, ObjectLookupFlags{})
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -199,10 +199,9 @@ func (p *planner) getTableScanByRef(
 	scanVisibility scanVisibility,
 ) (planDataSource, error) {
 	flags := ObjectLookupFlags{CommonLookupFlags: CommonLookupFlags{
-		txn:         p.txn,
 		avoidCached: p.avoidCachedDescriptors,
 	}}
-	desc, err := p.Tables().getTableVersionByID(ctx, sqlbase.ID(tref.TableID), flags)
+	desc, err := p.Tables().getTableVersionByID(ctx, p.txn, sqlbase.ID(tref.TableID), flags)
 	if err != nil {
 		return planDataSource{}, errors.Wrapf(err, "%s", tree.ErrString(tref))
 	}

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -207,8 +207,8 @@ func (dc *databaseCache) getDatabaseDesc(
 	if desc == nil {
 		if err := txnRunner(ctx, func(ctx context.Context, txn *client.Txn) error {
 			a := UncachedPhysicalAccessor{}
-			desc, err = a.GetDatabaseDesc(name,
-				DatabaseLookupFlags{ctx: ctx, txn: txn, required: required})
+			desc, err = a.GetDatabaseDesc(ctx, txn, name,
+				DatabaseLookupFlags{required: required})
 			return err
 		}); err != nil {
 			return nil, err

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -64,7 +64,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 		return nil, err
 	}
 
-	tbNames, err := GetObjectNames(ctx, p, dbDesc, tree.PublicSchema, true /*explicitPrefix*/)
+	tbNames, err := GetObjectNames(ctx, p.txn, p, dbDesc, tree.PublicSchema, true /*explicitPrefix*/)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logical_schema_accessors.go
+++ b/pkg/sql/logical_schema_accessors.go
@@ -15,6 +15,9 @@
 package sql
 
 import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -45,7 +48,11 @@ func (l *LogicalSchemaAccessor) IsValidSchema(dbDesc *DatabaseDescriptor, scName
 
 // GetObjectNames implements the DatabaseLister interface.
 func (l *LogicalSchemaAccessor) GetObjectNames(
-	dbDesc *DatabaseDescriptor, scName string, flags DatabaseListFlags,
+	ctx context.Context,
+	txn *client.Txn,
+	dbDesc *DatabaseDescriptor,
+	scName string,
+	flags DatabaseListFlags,
 ) (TableNames, error) {
 	if entry, ok := l.vt.getVirtualSchemaEntry(scName); ok {
 		names := make(TableNames, len(entry.orderedDefNames))
@@ -60,12 +67,12 @@ func (l *LogicalSchemaAccessor) GetObjectNames(
 	}
 
 	// Fallthrough.
-	return l.SchemaAccessor.GetObjectNames(dbDesc, scName, flags)
+	return l.SchemaAccessor.GetObjectNames(ctx, txn, dbDesc, scName, flags)
 }
 
 // GetObjectDesc implements the ObjectAccessor interface.
 func (l *LogicalSchemaAccessor) GetObjectDesc(
-	name *ObjectName, flags ObjectLookupFlags,
+	ctx context.Context, txn *client.Txn, name *ObjectName, flags ObjectLookupFlags,
 ) (ObjectDescriptor, *DatabaseDescriptor, error) {
 	if scEntry, ok := l.vt.getVirtualSchemaEntry(name.Schema()); ok {
 		tableName := name.Table()
@@ -87,5 +94,5 @@ func (l *LogicalSchemaAccessor) GetObjectDesc(
 	}
 
 	// Fallthrough.
-	return l.SchemaAccessor.GetObjectDesc(name, flags)
+	return l.SchemaAccessor.GetObjectDesc(ctx, txn, name, flags)
 }

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -392,9 +392,8 @@ func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) erro
 func (p *planner) LookupTableByID(
 	ctx context.Context, tableID sqlbase.ID,
 ) (row.TableLookup, error) {
-	flags := ObjectLookupFlags{
-		CommonLookupFlags{txn: p.txn, avoidCached: p.avoidCachedDescriptors}, false /*requireMutable*/}
-	table, err := p.Tables().getTableVersionByID(ctx, tableID, flags)
+	flags := ObjectLookupFlags{CommonLookupFlags: CommonLookupFlags{avoidCached: p.avoidCachedDescriptors}}
+	table, err := p.Tables().getTableVersionByID(ctx, p.txn, tableID, flags)
 	if err != nil {
 		if err == errTableAdding {
 			return row.TableLookup{IsAdding: true}, nil

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -77,11 +77,11 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 	// name. Rather than trying to rewrite them with the changed DB name, we
 	// simply disallow such renames for now.
 	phyAccessor := p.PhysicalSchemaAccessor()
-	lookupFlags := p.CommonLookupFlags(ctx, true /*required*/)
+	lookupFlags := p.CommonLookupFlags(true /*required*/)
 	// DDL statements bypass the cache.
 	lookupFlags.avoidCached = true
 	tbNames, err := phyAccessor.GetObjectNames(
-		dbDesc, tree.PublicSchema, DatabaseListFlags{
+		ctx, p.txn, dbDesc, tree.PublicSchema, DatabaseListFlags{
 			CommonLookupFlags: lookupFlags,
 			explicitPrefix:    true,
 		})
@@ -90,7 +90,7 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 	}
 	lookupFlags.required = false
 	for i := range tbNames {
-		objDesc, _, err := phyAccessor.GetObjectDesc(&tbNames[i],
+		objDesc, _, err := phyAccessor.GetObjectDesc(ctx, p.txn, &tbNames[i],
 			ObjectLookupFlags{CommonLookupFlags: lookupFlags})
 		if err != nil {
 			return err

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -79,7 +79,7 @@ type SchemaAccessor interface {
 	// GetDatabaseDesc looks up a database by name and returns its
 	// descriptor. If the database is not found and required is true,
 	// an error is returned; otherwise a nil reference is returned.
-	GetDatabaseDesc(dbName string, flags DatabaseLookupFlags) (*DatabaseDescriptor, error)
+	GetDatabaseDesc(ctx context.Context, txn *client.Txn, dbName string, flags DatabaseLookupFlags) (*DatabaseDescriptor, error)
 
 	// IsValidSchema returns true if the given schema name is valid for the given database.
 	IsValidSchema(db *DatabaseDescriptor, scName string) bool
@@ -88,7 +88,7 @@ type SchemaAccessor interface {
 	// database and schema.
 	// TODO(whomever): when separate schemas are supported, this
 	// API should be extended to use schema descriptors.
-	GetObjectNames(db *DatabaseDescriptor, scName string, flags DatabaseListFlags) (TableNames, error)
+	GetObjectNames(ctx context.Context, txn *client.Txn, db *DatabaseDescriptor, scName string, flags DatabaseListFlags) (TableNames, error)
 
 	// GetObjectDesc looks up an objcet by name and returns both its
 	// descriptor and that of its parent database. If the object is not
@@ -100,13 +100,11 @@ type SchemaAccessor interface {
 	// It is not guaranteed to be non-nil even if the first return value
 	// is non-nil.  Callers that need a database descriptor can use that
 	// to avoid an extra roundtrip through a DatabaseAccessor.
-	GetObjectDesc(name *ObjectName, flags ObjectLookupFlags) (ObjectDescriptor, *DatabaseDescriptor, error)
+	GetObjectDesc(ctx context.Context, txn *client.Txn, name *ObjectName, flags ObjectLookupFlags) (ObjectDescriptor, *DatabaseDescriptor, error)
 }
 
 // CommonLookupFlags is the common set of flags for the various accessor interfaces.
 type CommonLookupFlags struct {
-	ctx context.Context
-	txn *client.Txn
 	// if required is set, lookup will return an error if the item is not found.
 	required bool
 	// if avoidCached is set, lookup will avoid the cache (if any).

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -170,15 +170,15 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 	if err != nil {
 		return err
 	}
-	tbNames, err := GetObjectNames(ctx, p, dbDesc, tree.PublicSchema, true /*explicitPrefix*/)
+	tbNames, err := GetObjectNames(ctx, p.txn, p, dbDesc, tree.PublicSchema, true /*explicitPrefix*/)
 	if err != nil {
 		return err
 	}
 
 	for i := range tbNames {
 		tableName := &tbNames[i]
-		objDesc, _, err := p.LogicalSchemaAccessor().GetObjectDesc(
-			tableName, p.ObjectLookupFlags(ctx, true /*required*/, false /*requireMutable*/))
+		objDesc, _, err := p.LogicalSchemaAccessor().GetObjectDesc(ctx, p.txn,
+			tableName, p.ObjectLookupFlags(true /*required*/, false /*requireMutable*/))
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/show_grants.go
+++ b/pkg/sql/show_grants.go
@@ -97,7 +97,7 @@ FROM "".information_schema.table_privileges`
 				//
 				// TODO(vivek): check if the cache can be used.
 				p.runWithOptions(resolveFlags{skipCache: true}, func() {
-					tables, err = expandTableGlob(ctx, p, tableGlob)
+					tables, err = expandTableGlob(ctx, p.txn, p, tableGlob)
 				})
 				if err != nil {
 					return nil, err

--- a/pkg/sql/show_table.go
+++ b/pkg/sql/show_table.go
@@ -57,7 +57,7 @@ func (p *planner) showTableDetails(
 
 // checkDBExists checks if the database exists by using the security.RootUser.
 func checkDBExists(ctx context.Context, p *planner, db string) error {
-	_, err := p.PhysicalSchemaAccessor().GetDatabaseDesc(db,
-		p.CommonLookupFlags(ctx, true /*required*/))
+	_, err := p.PhysicalSchemaAccessor().GetDatabaseDesc(ctx, p.txn, db,
+		p.CommonLookupFlags(true /*required*/))
 	return err
 }

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -181,8 +181,8 @@ var varGen = map[string]sessionVar{
 
 			if len(dbName) != 0 {
 				// Verify database descriptor exists.
-				if _, err := evalCtx.schemaAccessors.logical.GetDatabaseDesc(dbName,
-					DatabaseLookupFlags{ctx: ctx, txn: evalCtx.Txn, required: true}); err != nil {
+				if _, err := evalCtx.schemaAccessors.logical.GetDatabaseDesc(ctx, evalCtx.Txn, dbName,
+					DatabaseLookupFlags{required: true}); err != nil {
 					return "", err
 				}
 			}

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -226,8 +226,8 @@ func (e virtualDefEntry) getPlanInfo() (sqlbase.ResultColumns, virtualTableConst
 		var dbDesc *DatabaseDescriptor
 		if dbName != "" {
 			var err error
-			dbDesc, err = p.LogicalSchemaAccessor().GetDatabaseDesc(dbName,
-				DatabaseLookupFlags{ctx: ctx, txn: p.Txn(), required: true})
+			dbDesc, err = p.LogicalSchemaAccessor().GetDatabaseDesc(ctx, p.txn, dbName,
+				DatabaseLookupFlags{required: true})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Because flags should just be flags!

Release note: None