### PR TITLE
backport-2.1: various low-risk test/log improvements

### DIFF
--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -550,7 +550,7 @@ func getSummedDiskCounters(ctx context.Context) (diskStats, error) {
 }
 
 func getSummedNetStats(ctx context.Context) (net.IOCountersStat, error) {
-	netCounters, err := net.IOCountersWithContext(ctx, true /* idk what this bool means */)
+	netCounters, err := net.IOCountersWithContext(ctx, true /* per NIC */)
 	if err != nil {
 		return net.IOCountersStat{}, err
 	}

--- a/pkg/storage/raft.go
+++ b/pkg/storage/raft.go
@@ -106,34 +106,40 @@ func (r *raftLogger) Panicf(format string, v ...interface{}) {
 	panic(fmt.Sprintf(format, v...))
 }
 
+func verboseRaftLoggingEnabled() bool {
+	return log.V(5)
+}
+
 func logRaftReady(ctx context.Context, ready raft.Ready) {
-	if log.V(5) {
-		var buf bytes.Buffer
-		if ready.SoftState != nil {
-			fmt.Fprintf(&buf, "  SoftState updated: %+v\n", *ready.SoftState)
-		}
-		if !raft.IsEmptyHardState(ready.HardState) {
-			fmt.Fprintf(&buf, "  HardState updated: %+v\n", ready.HardState)
-		}
-		for i, e := range ready.Entries {
-			fmt.Fprintf(&buf, "  New Entry[%d]: %.200s\n",
-				i, raft.DescribeEntry(e, raftEntryFormatter))
-		}
-		for i, e := range ready.CommittedEntries {
-			fmt.Fprintf(&buf, "  Committed Entry[%d]: %.200s\n",
-				i, raft.DescribeEntry(e, raftEntryFormatter))
-		}
-		if !raft.IsEmptySnap(ready.Snapshot) {
-			snap := ready.Snapshot
-			snap.Data = nil
-			fmt.Fprintf(&buf, "  Snapshot updated: %v\n", snap)
-		}
-		for i, m := range ready.Messages {
-			fmt.Fprintf(&buf, "  Outgoing Message[%d]: %.200s\n",
-				i, raftDescribeMessage(m, raftEntryFormatter))
-		}
-		log.Infof(ctx, "raft ready (must-sync=%t)\n%s", ready.MustSync, buf.String())
+	if !verboseRaftLoggingEnabled() {
+		return
 	}
+
+	var buf bytes.Buffer
+	if ready.SoftState != nil {
+		fmt.Fprintf(&buf, "  SoftState updated: %+v\n", *ready.SoftState)
+	}
+	if !raft.IsEmptyHardState(ready.HardState) {
+		fmt.Fprintf(&buf, "  HardState updated: %+v\n", ready.HardState)
+	}
+	for i, e := range ready.Entries {
+		fmt.Fprintf(&buf, "  New Entry[%d]: %.200s\n",
+			i, raft.DescribeEntry(e, raftEntryFormatter))
+	}
+	for i, e := range ready.CommittedEntries {
+		fmt.Fprintf(&buf, "  Committed Entry[%d]: %.200s\n",
+			i, raft.DescribeEntry(e, raftEntryFormatter))
+	}
+	if !raft.IsEmptySnap(ready.Snapshot) {
+		snap := ready.Snapshot
+		snap.Data = nil
+		fmt.Fprintf(&buf, "  Snapshot updated: %v\n", snap)
+	}
+	for i, m := range ready.Messages {
+		fmt.Fprintf(&buf, "  Outgoing Message[%d]: %.200s\n",
+			i, raftDescribeMessage(m, raftEntryFormatter))
+	}
+	log.Infof(ctx, "raft ready (must-sync=%t)\n%s", ready.MustSync, buf.String())
 }
 
 // This is a fork of raft.DescribeMessage with a tweak to avoid logging

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1005,7 +1005,7 @@ func updateRangeDescriptor(
 	var newValue interface{}
 	if newDesc != nil {
 		if err := newDesc.Validate(); err != nil {
-			return err
+			return errors.Wrapf(err, "validating new descriptor %+v (old descriptor is %+v)", newDesc, oldDesc)
 		}
 		newBytes, err := protoutil.Marshal(newDesc)
 		if err != nil {

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -613,7 +613,7 @@ func TestRaftSSTableSideloadingSideload(t *testing.T) {
 
 func makeInMemSideloaded(repl *Replica) {
 	repl.raftMu.Lock()
-	repl.raftMu.sideloaded = mustNewInMemSideloadStorage(repl.RangeID, 0, "")
+	repl.raftMu.sideloaded = mustNewInMemSideloadStorage(repl.RangeID, 0, repl.store.engine.GetAuxiliaryDir())
 	repl.raftMu.Unlock()
 }
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -5588,8 +5588,8 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 
 	for i, test := range testCases {
 		key := roachpb.Key(fmt.Sprintf("key-%d", i))
-		pushee := newTransaction(fmt.Sprintf("test-%d", i), key, 1, enginepb.SERIALIZABLE, tc.Clock())
-		pusher := newTransaction("pusher", key, 1, enginepb.SERIALIZABLE, tc.Clock())
+		pushee := newTransaction(fmt.Sprintf("test-%d", i), key, roachpb.MaxUserPriority, enginepb.SERIALIZABLE, tc.Clock())
+		pusher := newTransaction("pusher", key, roachpb.MinUserPriority, enginepb.SERIALIZABLE, tc.Clock())
 
 		// First, establish "start" of existing pushee's txn via BeginTransaction.
 		if test.heartbeat != (hlc.Timestamp{}) {

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -672,8 +672,10 @@ func (rq *replicateQueue) purgatoryChan() <-chan time.Time {
 // rangeRaftStatus pretty-prints the Raft progress (i.e. Raft log position) of
 // the replicas.
 func rangeRaftProgress(raftStatus *raft.Status, replicas []roachpb.ReplicaDescriptor) string {
-	if raftStatus == nil || len(raftStatus.Progress) == 0 {
-		return "[raft progress unknown]"
+	if raftStatus == nil {
+		return "[no raft status]"
+	} else if len(raftStatus.Progress) == 0 {
+		return "[no raft progress]"
 	}
 	var buf bytes.Buffer
 	buf.WriteString("[")

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3508,6 +3508,10 @@ func (s *Store) withReplicaForRequest(
 func (s *Store) processRaftRequestWithReplica(
 	ctx context.Context, r *Replica, req *RaftMessageRequest,
 ) *roachpb.Error {
+	if verboseRaftLoggingEnabled() {
+		log.Infof(ctx, "incoming raft message:\n%s", raftDescribeMessage(req.Message, raftEntryFormatter))
+	}
+
 	if req.Message.Type == raftpb.MsgSnap {
 		log.Fatalf(ctx, "unexpected snapshot: %+v", req)
 	}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "status: fix a comment" (#31344)
  * 1/1 commits from "storage: disambiguate raft progress string" (#31727)
  * 1/1 commits from "storage: log(spy) incoming raft messages" (#31876)
  * 1/1 commits from "storage: add comment about snapshots refused due to overlap" (#31949)
  * 1/1 commits from "storage: de-flake TestPushTxnHeartbeatTimeout" (#31965)
  * 1/1 commits from "storage: add debug logging for #31918" (#31968)
  * 1/1 commits from "storage: deflake TestRaftSSTableSideloadingProposal" (#32001)

Please see individual PRs for details.

/cc @cockroachdb/release
