### PR TITLE
backport-2.1: fix Raft log size accounting for sideloaded entries

### DIFF
--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -19,6 +19,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft"
 
@@ -249,11 +251,12 @@ func (rlq *raftLogQueue) process(ctx context.Context, r *Replica, _ config.Syste
 	if shouldTruncate(truncatableIndexes, raftLogSize) {
 		r.mu.Lock()
 		raftLogSize := r.mu.raftLogSize
+		lastIndex := r.mu.lastIndex
 		r.mu.Unlock()
 
 		if log.V(1) {
-			log.Infof(ctx, "truncating raft log %d-%d: size=%d",
-				oldestIndex-truncatableIndexes, oldestIndex, raftLogSize)
+			log.Infof(ctx, "truncating raft log entries [%d-%d], resulting in log [%d,%d], reclaiming ~%s",
+				oldestIndex-truncatableIndexes, oldestIndex-1, oldestIndex, lastIndex, humanizeutil.IBytes(raftLogSize))
 		}
 		b := &client.Batch{}
 		b.AddRawRequest(&roachpb.TruncateLogRequest{

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4325,14 +4325,17 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		firstPurge := rd.Entries[0].Index // first new entry written
 		purgeTerm := rd.Entries[0].Term - 1
 		lastPurge := prevLastIndex // old end of the log, include in deletion
-		for i := firstPurge; i <= lastPurge; i++ {
-			size, err := r.raftMu.sideloaded.Purge(ctx, i, purgeTerm)
-			if err != nil && errors.Cause(err) != errSideloadedFileNotFound {
-				const expl = "while purging index %d"
-				return stats, expl, errors.Wrapf(err, expl, i)
-			}
-			raftLogSize -= size
+		purgedSize, err := maybePurgeSideloaded(ctx, r.raftMu.sideloaded, firstPurge, lastPurge, purgeTerm)
+		if err != nil {
+			const expl = "while purging sideloaded storage"
+			return stats, expl, err
 		}
+		raftLogSize -= purgedSize
+		if raftLogSize < 0 {
+			// Might have gone negative if node was recently restarted.
+			raftLogSize = 0
+		}
+
 	}
 
 	// Update protected state - last index, last term, raft log size, and raft
@@ -4340,11 +4343,6 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	r.mu.Lock()
 	r.mu.lastIndex = lastIndex
 	r.mu.lastTerm = lastTerm
-	if raftLogSize < 0 {
-		// Might have gone negative during sideloaded.Purge above if node was
-		// recently restarted.
-		raftLogSize = 0
-	}
 	r.mu.raftLogSize = raftLogSize
 	if r.mu.leaderID != leaderID {
 		r.mu.leaderID = leaderID

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -565,10 +565,12 @@ func (r *Replica) handleReplicatedEvalResult(
 			// could rot.
 			{
 				log.Eventf(ctx, "truncating sideloaded storage up to (and including) index %d", newTruncState.Index)
-				if err := r.raftMu.sideloaded.TruncateTo(ctx, newTruncState.Index+1); err != nil {
+				if size, err := r.raftMu.sideloaded.TruncateTo(ctx, newTruncState.Index+1); err != nil {
 					// We don't *have* to remove these entries for correctness. Log a
 					// loud error, but keep humming along.
 					log.Errorf(ctx, "while removing sideloaded files during log truncation: %s", err)
+				} else {
+					rResult.RaftLogDelta -= size
 				}
 			}
 		}

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -47,8 +47,8 @@ type sideloadStorage interface {
 	// Clear files that may have been written by this sideloadStorage.
 	Clear(context.Context) error
 	// TruncateTo removes all files belonging to an index strictly smaller than
-	// the given one.
-	TruncateTo(_ context.Context, index uint64) error
+	// the given one. Returns the number of bytes freed.
+	TruncateTo(_ context.Context, index uint64) (int64, error)
 	// Returns an absolute path to the file that Get() would return the contents
 	// of. Does not check whether the file actually exists.
 	Filename(_ context.Context, index, term uint64) (string, error)

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -43,7 +43,9 @@ type sideloadStorage interface {
 	// remove any leftover files at the same index and earlier terms, but
 	// is not required to do so. When no file at the given index and term
 	// exists, returns errSideloadedFileNotFound.
-	Purge(_ context.Context, index, term uint64) error
+	//
+	// Returns the total size of the purged payloads.
+	Purge(_ context.Context, index, term uint64) (int64, error)
 	// Clear files that may have been written by this sideloadStorage.
 	Clear(context.Context) error
 	// TruncateTo removes all files belonging to an index strictly smaller than

--- a/pkg/storage/replica_sideload_disk.go
+++ b/pkg/storage/replica_sideload_disk.go
@@ -109,18 +109,32 @@ func (ss *diskSideloadStorage) filename(ctx context.Context, index, term uint64)
 	return filepath.Join(ss.dir, fmt.Sprintf("i%d.t%d", index, term))
 }
 
-func (ss *diskSideloadStorage) Purge(ctx context.Context, index, term uint64) error {
+func (ss *diskSideloadStorage) Purge(ctx context.Context, index, term uint64) (int64, error) {
 	return ss.purgeFile(ctx, ss.filename(ctx, index, term))
 }
 
-func (ss *diskSideloadStorage) purgeFile(ctx context.Context, filename string) error {
+func (ss *diskSideloadStorage) purgeFile(ctx context.Context, filename string) (int64, error) {
+	// TODO(tschottdorf): this should all be done through the env. As written,
+	// the sizes returned here will be wrong if encryption is one. We want the
+	// size of the unencrypted payload.
+	//
+	// See #31913.
+	info, err := os.Stat(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, errSideloadedFileNotFound
+		}
+		return 0, err
+	}
+	size := info.Size()
+
 	if err := ss.eng.DeleteFile(filename); err != nil {
 		if os.IsNotExist(err) {
-			return errSideloadedFileNotFound
+			return 0, errSideloadedFileNotFound
 		}
-		return err
+		return 0, err
 	}
-	return nil
+	return size, nil
 }
 
 func (ss *diskSideloadStorage) Clear(_ context.Context) error {
@@ -150,15 +164,12 @@ func (ss *diskSideloadStorage) TruncateTo(ctx context.Context, index uint64) (in
 		if i >= index {
 			continue
 		}
-		var fi os.FileInfo
-		if fi, err = os.Stat(match); err != nil {
-			return size, errors.Wrapf(err, "while purging %q", match)
-		}
-		if err := ss.purgeFile(ctx, match); err != nil {
+		fileSize, err := ss.purgeFile(ctx, match)
+		if err != nil {
 			return size, errors.Wrapf(err, "while purging %q", match)
 		}
 		deleted++
-		size += fi.Size()
+		size += fileSize
 	}
 
 	if deleted == len(matches) {

--- a/pkg/storage/replica_sideload_disk.go
+++ b/pkg/storage/replica_sideload_disk.go
@@ -115,7 +115,7 @@ func (ss *diskSideloadStorage) Purge(ctx context.Context, index, term uint64) (i
 
 func (ss *diskSideloadStorage) purgeFile(ctx context.Context, filename string) (int64, error) {
 	// TODO(tschottdorf): this should all be done through the env. As written,
-	// the sizes returned here will be wrong if encryption is one. We want the
+	// the sizes returned here will be wrong if encryption is on. We want the
 	// size of the unencrypted payload.
 	//
 	// See #31913.

--- a/pkg/storage/replica_sideload_inmem.go
+++ b/pkg/storage/replica_sideload_inmem.go
@@ -85,13 +85,14 @@ func (ss *inMemSideloadStorage) Filename(_ context.Context, index, term uint64) 
 	return filepath.Join(ss.prefix, fmt.Sprintf("i%d.t%d", index, term)), nil
 }
 
-func (ss *inMemSideloadStorage) Purge(_ context.Context, index, term uint64) error {
+func (ss *inMemSideloadStorage) Purge(_ context.Context, index, term uint64) (int64, error) {
 	k := ss.key(index, term)
 	if _, ok := ss.m[k]; !ok {
-		return errSideloadedFileNotFound
+		return 0, errSideloadedFileNotFound
 	}
+	size := int64(len(ss.m[k]))
 	delete(ss.m, k)
-	return nil
+	return size, nil
 }
 
 func (ss *inMemSideloadStorage) Clear(_ context.Context) error {

--- a/pkg/storage/replica_sideload_inmem.go
+++ b/pkg/storage/replica_sideload_inmem.go
@@ -99,12 +99,14 @@ func (ss *inMemSideloadStorage) Clear(_ context.Context) error {
 	return nil
 }
 
-func (ss *inMemSideloadStorage) TruncateTo(_ context.Context, index uint64) error {
+func (ss *inMemSideloadStorage) TruncateTo(_ context.Context, index uint64) (int64, error) {
 	// Not efficient, but this storage is for testing purposes only anyway.
-	for k := range ss.m {
+	var size int64
+	for k, v := range ss.m {
 		if k.index < index {
+			size += int64(len(v))
 			delete(ss.m, k)
 		}
 	}
-	return nil
+	return size, nil
 }

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -361,6 +361,37 @@ func testSideloadingSideloadedStorage(
 	}
 
 	assertCreated(false)
+
+	// Repopulate with a few entries at indexes=1,2,4 and term 10 to test `maybePurgeSideloaded`
+	// with.
+	for index := uint64(1); index < 5; index++ {
+		if index == 3 {
+			continue
+		}
+		payload := []byte(strings.Repeat("x", 1+int(index)))
+		if err := ss.Put(ctx, index, 10, payload); err != nil {
+			t.Fatalf("%d: %s", index, err)
+		}
+	}
+
+	// Term too high and too low, respectively. Shouldn't delete anything.
+	for _, term := range []uint64{9, 11} {
+		if size, err := maybePurgeSideloaded(ctx, ss, 1, 10, term); err != nil || size != 0 {
+			t.Fatalf("expected noop for term %d, got (%d, %v)", term, size, err)
+		}
+	}
+	// This should delete 2 and 4. Index == size+1, so expect 6.
+	if size, err := maybePurgeSideloaded(ctx, ss, 2, 4, 10); err != nil || size != 8 {
+		t.Fatalf("unexpectedly got (%d, %v)", size, err)
+	}
+	// This should delete 1 (the lone survivor).
+	if size, err := maybePurgeSideloaded(ctx, ss, 0, 100, 10); err != nil || size != 2 {
+		t.Fatalf("unexpectedly got (%d, %v)", size, err)
+	}
+	// Nothing left.
+	if size, err := maybePurgeSideloaded(ctx, ss, 0, 100, 10); err != nil || size != 0 {
+		t.Fatalf("expected noop, got (%d, %v)", size, err)
+	}
 }
 
 func TestRaftSSTableSideloadingInline(t *testing.T) {

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -189,7 +189,8 @@ func testSideloadingSideloadedStorage(
 		{
 			err: nil,
 			fun: func() error {
-				return ss.TruncateTo(ctx, 123)
+				_, err := ss.TruncateTo(ctx, 123)
+				return err
 			},
 		},
 		{
@@ -260,7 +261,7 @@ func testSideloadingSideloadedStorage(
 
 	for n := range payloads {
 		// Truncate indexes <= payloads[n] (payloads is sorted in increasing order).
-		if err := ss.TruncateTo(ctx, payloads[n]); err != nil {
+		if _, err := ss.TruncateTo(ctx, payloads[n]); err != nil {
 			t.Fatalf("%d: %s", n, err)
 		}
 		// Index payloads[n] and above are still there (truncation is exclusive)
@@ -280,16 +281,20 @@ func testSideloadingSideloadedStorage(
 		}
 	}
 
-	if !isInMem {
+	func() {
+		if isInMem {
+			return
+		}
 		// First add a file that shouldn't be in the sideloaded storage to ensure
 		// sane behavior when directory can't be removed after full truncate.
 		nonRemovableFile := filepath.Join(ss.(*diskSideloadStorage).dir, "cantremove.xx")
-		_, err := os.Create(nonRemovableFile)
+		f, err := os.Create(nonRemovableFile)
 		if err != nil {
 			t.Fatalf("could not create non i*.t* file in sideloaded storage: %v", err)
 		}
+		defer f.Close()
 
-		err = ss.TruncateTo(ctx, math.MaxUint64)
+		_, err = ss.TruncateTo(ctx, math.MaxUint64)
 		if err == nil {
 			t.Fatalf("sideloaded directory should not have been removable due to extra file %s", nonRemovableFile)
 		}
@@ -304,7 +309,7 @@ func testSideloadingSideloadedStorage(
 		}
 
 		// Test that directory is removed when filepath.Glob returns 0 matches.
-		if err := ss.TruncateTo(ctx, math.MaxUint64); err != nil {
+		if _, err := ss.TruncateTo(ctx, math.MaxUint64); err != nil {
 			t.Fatal(err)
 		}
 		// Ensure directory is removed, now that all files should be gone.
@@ -328,7 +333,7 @@ func testSideloadingSideloadedStorage(
 			}
 		}
 		assertCreated(true)
-		if err := ss.TruncateTo(ctx, math.MaxUint64); err != nil {
+		if _, err := ss.TruncateTo(ctx, math.MaxUint64); err != nil {
 			t.Fatal(err)
 		}
 		// Ensure directory is removed when all records are removed.
@@ -341,7 +346,7 @@ func testSideloadingSideloadedStorage(
 				t.Fatalf("expected %q to be removed: %v", ss.(*diskSideloadStorage).dir, err)
 			}
 		}
-	}
+	}()
 
 	if err := ss.Clear(ctx); err != nil {
 		t.Fatal(err)
@@ -350,7 +355,7 @@ func testSideloadingSideloadedStorage(
 	assertCreated(false)
 
 	// Sanity check that we can call TruncateTo without the directory existing.
-	if err := ss.TruncateTo(ctx, 1); err != nil {
+	if _, err := ss.TruncateTo(ctx, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -620,10 +625,40 @@ func makeInMemSideloaded(repl *Replica) {
 // TestRaftSSTableSideloadingProposal runs a straightforward application of an `AddSSTable` command.
 func TestRaftSSTableSideloadingProposal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	testutils.RunTrueAndFalse(t, "engineInMem", func(t *testing.T, engineInMem bool) {
+		testutils.RunTrueAndFalse(t, "mockSideloaded", func(t *testing.T, mockSideloaded bool) {
+			if engineInMem && !mockSideloaded {
+				t.Skip("https://github.com/cockroachdb/cockroach/issues/31913")
+			}
+			testRaftSSTableSideloadingProposal(t, engineInMem, mockSideloaded)
+		})
+	})
+}
+
+// TestRaftSSTableSideloadingProposal runs a straightforward application of an `AddSSTable` command.
+func testRaftSSTableSideloadingProposal(t *testing.T, engineInMem, mockSideloaded bool) {
+	defer leaktest.AfterTest(t)()
 	defer SetMockAddSSTable()()
 
-	tc := testContext{}
+	dir, cleanup := testutils.TempDir(t)
+	defer cleanup()
 	stopper := stop.NewStopper()
+	tc := testContext{}
+	if !engineInMem {
+		cfg := engine.RocksDBConfig{
+			Dir:      dir,
+			Settings: cluster.MakeTestingClusterSettings(),
+		}
+		var err error
+		cache := engine.NewRocksDBCache(1 << 20)
+		defer cache.Release()
+		tc.engine, err = engine.NewRocksDB(cfg, cache)
+		if err != nil {
+			t.Fatal(err)
+		}
+		stopper.AddCloser(tc.engine)
+	}
 	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
@@ -631,11 +666,14 @@ func TestRaftSSTableSideloadingProposal(t *testing.T) {
 	defer cancel()
 
 	const (
-		key = "foo"
-		val = "bar"
+		key       = "foo"
+		entrySize = 128
 	)
+	val := strings.Repeat("x", entrySize)
 
-	makeInMemSideloaded(tc.repl)
+	if mockSideloaded {
+		makeInMemSideloaded(tc.repl)
+	}
 
 	ts := hlc.Timestamp{Logical: 1}
 
@@ -664,27 +702,57 @@ func TestRaftSSTableSideloadingProposal(t *testing.T) {
 		}
 	}
 
-	tc.repl.raftMu.Lock()
-	defer tc.repl.raftMu.Unlock()
-	if ss := tc.repl.raftMu.sideloaded.(*inMemSideloadStorage); len(ss.m) < 1 {
-		t.Fatal("sideloaded storage is empty")
+	func() {
+		tc.repl.raftMu.Lock()
+		defer tc.repl.raftMu.Unlock()
+		if ss, ok := tc.repl.raftMu.sideloaded.(*inMemSideloadStorage); ok && len(ss.m) < 1 {
+			t.Fatal("sideloaded storage is empty")
+		}
+
+		if err := testutils.MatchInOrder(tracing.FormatRecordedSpans(collect()), "sideloadable proposal detected", "ingested SSTable"); err != nil {
+			t.Fatal(err)
+		}
+
+		if n := tc.store.metrics.AddSSTableProposals.Count(); n == 0 {
+			t.Fatalf("expected metric to show at least one AddSSTable proposal, but got %d", n)
+		}
+
+		if n := tc.store.metrics.AddSSTableApplications.Count(); n == 0 {
+			t.Fatalf("expected metric to show at least one AddSSTable application, but got %d", n)
+		}
+		// We usually don't see copies because we hardlink and ingest the original SST. However, this
+		// depends on luck and the file system, so don't try to assert it. We should, however, see
+		// no more than one.
+		expMaxCopies := int64(1)
+		if engineInMem {
+			// We don't count in-memory env SST writes as copies.
+			expMaxCopies = 0
+		}
+		if n := tc.store.metrics.AddSSTableApplicationCopies.Count(); n > expMaxCopies {
+			t.Fatalf("expected metric to show <= %d AddSSTable copies, but got %d", expMaxCopies, n)
+		}
+	}()
+
+	// Force a log truncation followed by verification of the tracked raft log size. This exercises a
+	// former bug in which the raft log size took the sideloaded payload into account when adding
+	// to the log, but not when truncating.
+
+	// Write enough keys to the range to make sure that a truncation will happen.
+	for i := 0; i < RaftLogQueueStaleThreshold+1; i++ {
+		key := roachpb.Key(fmt.Sprintf("key%02d", i))
+		args := putArgs(key, []byte(fmt.Sprintf("value%02d", i)))
+		if _, err := client.SendWrapped(context.Background(), tc.store.TestSender(), &args); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	if err := testutils.MatchInOrder(tracing.FormatRecordedSpans(collect()), "sideloadable proposal detected", "ingested SSTable"); err != nil {
+	if _, err := tc.store.raftLogQueue.Add(tc.repl, 99.99 /* priority */); err != nil {
 		t.Fatal(err)
 	}
-
-	if n := tc.store.metrics.AddSSTableProposals.Count(); n == 0 {
-		t.Fatalf("expected metric to show at least one AddSSTable proposal, but got %d", n)
-	}
-
-	if n := tc.store.metrics.AddSSTableApplications.Count(); n == 0 {
-		t.Fatalf("expected metric to show at least one AddSSTable application, but got %d", n)
-	}
-	// We don't count in-memory env SST writes as copies.
-	if n := tc.store.metrics.AddSSTableApplicationCopies.Count(); n != 0 {
-		t.Fatalf("expected metric to show 0 AddSSTable copy, but got %d", n)
-	}
+	tc.store.ForceRaftLogScanAndProcess()
+	// SST is definitely truncated now, so recomputing the Raft log keys should match up with
+	// the tracked size.
+	verifyLogSizeInSync(t, tc.repl)
 }
 
 type mockSender struct {

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -183,7 +183,8 @@ func testSideloadingSideloadedStorage(
 		{
 			err: errSideloadedFileNotFound,
 			fun: func() error {
-				return ss.Purge(ctx, 123, 456)
+				_, err := ss.Purge(ctx, 123, 456)
+				return err
 			},
 		},
 		{


### PR DESCRIPTION
Backport:
  * 1/1 commits from "storage: fix Raft log size accounting" (#31914)
  * 3/3 commits from "storage: adjust raft log size correctly when replacing sideloaded entries" (#31926)

Please see individual PRs for details.

/cc @cockroachdb/release
