### PR TITLE
roachtest: disable load-based splitting in splits/largerange test

### DIFF
--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -100,12 +100,8 @@ func registerRebalanceLoad(r *registry) {
 			defer db.Close()
 
 			t.Status("disable load based splitting")
-			if _, err := db.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = false`); err != nil {
-				// If the cluster setting doesn't exist, the cluster version is < 2.2.0 and
-				// so Load based Splitting doesn't apply anyway and the error should be ignored.
-				if !strings.Contains(err.Error(), "unknown cluster setting") {
-					return err
-				}
+			if err := disableLoadBasedSplitting(ctx, db); err != nil {
+				return err
 			}
 
 			if _, err := db.ExecContext(


### PR DESCRIPTION
Fixes #32417.

Load-based splitting was causing the Range to split before we wanted
it to.

Release note: None