### PR TITLE
opt: Generate comments taken from Optgen structs and fields

### DIFF
--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -62,6 +62,7 @@ define ScanPrivate {
 	# rows.
 	HardLimit ScanLimit
 
+	# Flags modify how the table is scanned, such as which index is used to scan.
 	Flags ScanFlags
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -64,7 +64,7 @@ func (g *exprsGen) genExprDef(define *lang.DefineExpr) {
 	opTyp := g.md.typeOf(define)
 
 	// Generate comment for the expression struct.
-	generateDefineComments(g.w, define, opTyp.name)
+	generateComments(g.w, define.Comments, string(define.Name), opTyp.name)
 
 	// Generate the struct and methods.
 	if define.Tags.Contains("List") {
@@ -147,7 +147,15 @@ func (g *exprsGen) genPrivateStruct(define *lang.DefineExpr) {
 	privTyp := g.md.typeOf(define)
 
 	fmt.Fprintf(g.w, "type %s struct {\n", privTyp.name)
-	for _, field := range define.Fields {
+	for i, field := range define.Fields {
+		// Generate comment for the struct field.
+		if len(field.Comments) != 0 {
+			if i != 0 {
+				fmt.Fprintf(g.w, "\n")
+			}
+			generateComments(g.w, field.Comments, string(field.Name), string(field.Name))
+		}
+
 		fmt.Fprintf(g.w, "  %s %s\n", field.Name, g.md.typeOf(field).name)
 	}
 	fmt.Fprintf(g.w, "}\n\n")
@@ -169,7 +177,15 @@ func (g *exprsGen) genExprStruct(define *lang.DefineExpr) {
 	fmt.Fprintf(g.w, "type %s struct {\n", opTyp.name)
 
 	// Generate child fields.
-	for _, field := range define.Fields {
+	for i, field := range define.Fields {
+		// Generate comment for the struct field.
+		if len(field.Comments) != 0 {
+			if i != 0 {
+				fmt.Fprintf(g.w, "\n")
+			}
+			generateComments(g.w, field.Comments, string(field.Name), string(field.Name))
+		}
+
 		// If field's name is "_", then use Go embedding syntax.
 		if isEmbeddedField(field) {
 			fmt.Fprintf(g.w, "  %s\n", g.md.typeOf(field).name)

--- a/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
@@ -80,7 +80,7 @@ func (g *factoryGen) genConstructFuncs() {
 		// Generate Construct method.
 		format := "// Construct%s constructs an expression for the %s operator.\n"
 		g.w.writeIndent(format, define.Name, define.Name)
-		generateDefineComments(g.w.writer, define, string(define.Name))
+		generateComments(g.w.writer, define.Comments, string(define.Name), string(define.Name))
 
 		g.w.nestIndent("func (_f *Factory) Construct%s(\n", define.Name)
 

--- a/pkg/sql/opt/optgen/cmd/optgen/ops_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/ops_gen.go
@@ -49,7 +49,7 @@ func (g *opsGen) genOperatorEnum() {
 
 	for _, define := range g.sorted {
 		fmt.Fprintf(g.w, "\n")
-		generateDefineComments(g.w, define, string(define.Name))
+		generateComments(g.w, define.Comments, string(define.Name), string(define.Name))
 		fmt.Fprintf(g.w, "  %sOp\n", define.Name)
 	}
 	fmt.Fprintf(g.w, "\nNumOperators\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/compile
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/compile
@@ -17,7 +17,7 @@ define Not {
 			Tags=(Tags)
 			Name="Not"
 			Fields=(DefineFields
-				(DefineField Name="Input" Type="Expr" Src=<test.opt:3:5>)
+				(DefineField Comments=(Comments) Name="Input" Type="Expr" Src=<test.opt:3:5>)
 			)
 			Src=<test.opt:2:1>
 		)
@@ -64,8 +64,8 @@ define Gt {
 			Tags=(Tags)
 			Name="Gt"
 			Fields=(DefineFields
-				(DefineField Name="left" Type="Expr" Src=<test.opt:2:5>)
-				(DefineField Name="right" Type="Expr" Src=<test.opt:3:5>)
+				(DefineField Comments=(Comments) Name="left" Type="Expr" Src=<test.opt:2:5>)
+				(DefineField Comments=(Comments) Name="right" Type="Expr" Src=<test.opt:3:5>)
 			)
 			Src=<test.opt:1:1>
 		)

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -2,9 +2,14 @@
 # Generate code for relational, scalar, enforcer, and private operators.
 #
 optgen exprs test.opt
+
+# Project is a projection operator.
 [Relational]
 define Project {
-    Input       RelExpr
+    # Input is a relational input.
+    Input RelExpr
+
+    # Projections are the projected columns.
     Projections ProjectionsExpr
 
     Passthrough ColSet
@@ -23,7 +28,10 @@ define ProjectionsItem {
 
 [Private]
 define ColPrivate {
-    Col    ColumnID
+    # Col is a column ID.
+    Col ColumnID
+
+    # scalar are props.
     scalar ScalarProps
 }
 
@@ -49,8 +57,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
+// ProjectExpr is a projection operator.
 type ProjectExpr struct {
-	Input       RelExpr
+	// Input is a relational input.
+	Input RelExpr
+
+	// Projections are the projected columns.
 	Projections ProjectionsExpr
 	Passthrough opt.ColSet
 
@@ -268,7 +280,10 @@ func (e *ProjectionsItem) ScalarProps(mem *Memo) *props.Scalar {
 }
 
 type ColPrivate struct {
-	Col    opt.ColumnID
+	// Col is a column ID.
+	Col opt.ColumnID
+
+	// scalar are props.
 	scalar props.Scalar
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/utils.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/utils.go
@@ -61,25 +61,24 @@ func expandFields(compiled *lang.CompiledExpr, define *lang.DefineExpr) lang.Def
 	return fields
 }
 
-// generateDefineComments is a helper function that generates a block of
-// op definition comments by converting the Optgen comment to a Go comment.
-// The comments are assumed to start with the name of the op and follow with a
-// description of the op, like this:
-//   # <opname> <description of what this op does>
+// generateComments is a helper function that generates a block of comments by
+// converting an Optgen comment to a Go comment. The comments are assumed to
+// start with the name of an op or field and follow with a description, similar
+// to this:
+//   # <name> <description of what this op or field does>
 //   # ...
 //
-// The initial opname is replaced with the given replaceName, in order to adapt
+// The initial name is replaced with the given replaceName, in order to adapt
 // it to different enums and structs that are generated.
-func generateDefineComments(w io.Writer, define *lang.DefineExpr, replaceName string) {
-	for i, comment := range define.Comments {
-		// Replace the # comment character used in Optgen with the Go
-		// comment character.
+func generateComments(w io.Writer, comments lang.CommentsExpr, findName, replaceName string) {
+	for i, comment := range comments {
+		// Replace the # comment character used in Optgen with the Go comment
+		// character.
 		s := strings.Replace(string(comment), "#", "//", 1)
 
-		// Replace the definition name if it is the first word in the first
-		// comment.
-		if i == 0 && strings.HasPrefix(string(comment), "# "+string(define.Name)) {
-			s = strings.Replace(s, string(define.Name), replaceName, 1)
+		// Replace the findName if it is the first word in the first comment.
+		if i == 0 && strings.HasPrefix(string(comment), "# "+findName) {
+			s = strings.Replace(s, findName, replaceName, 1)
 		}
 
 		fmt.Fprintf(w, "  %s\n", s)

--- a/pkg/sql/opt/optgen/lang/expr.og.go
+++ b/pkg/sql/opt/optgen/lang/expr.og.go
@@ -494,9 +494,10 @@ func (e *DefineFieldsExpr) Format(buf *bytes.Buffer, level int) {
 }
 
 type DefineFieldExpr struct {
-	Name StringExpr
-	Type StringExpr
-	Src  *SourceLoc
+	Comments CommentsExpr
+	Name     StringExpr
+	Type     StringExpr
+	Src      *SourceLoc
 }
 
 func (e *DefineFieldExpr) Op() Operator {
@@ -504,14 +505,16 @@ func (e *DefineFieldExpr) Op() Operator {
 }
 
 func (e *DefineFieldExpr) ChildCount() int {
-	return 2
+	return 3
 }
 
 func (e *DefineFieldExpr) Child(nth int) Expr {
 	switch nth {
 	case 0:
-		return &e.Name
+		return &e.Comments
 	case 1:
+		return &e.Name
+	case 2:
 		return &e.Type
 	}
 	panic(fmt.Sprintf("child index %d is out of range", nth))
@@ -520,8 +523,10 @@ func (e *DefineFieldExpr) Child(nth int) Expr {
 func (e *DefineFieldExpr) ChildName(nth int) string {
 	switch nth {
 	case 0:
-		return "Name"
+		return "Comments"
 	case 1:
+		return "Name"
+	case 2:
 		return "Type"
 	}
 	return ""
@@ -534,7 +539,7 @@ func (e *DefineFieldExpr) Value() interface{} {
 func (e *DefineFieldExpr) Visit(visit VisitFunc) Expr {
 	children := visitChildren(e, visit)
 	if children != nil {
-		return &DefineFieldExpr{Name: *children[0].(*StringExpr), Type: *children[1].(*StringExpr), Src: e.Source()}
+		return &DefineFieldExpr{Comments: *children[0].(*CommentsExpr), Name: *children[1].(*StringExpr), Type: *children[2].(*StringExpr), Src: e.Source()}
 	}
 	return e
 }

--- a/pkg/sql/opt/optgen/lang/lang.opt
+++ b/pkg/sql/opt/optgen/lang/lang.opt
@@ -80,8 +80,9 @@ define DefineFields {
 }
 
 define DefineField {
-    Name String
-    Type String
+    Comments Comments
+    Name     String
+    Type     String
 }
 
 define Rule {

--- a/pkg/sql/opt/optgen/lang/testdata/compiler
+++ b/pkg/sql/opt/optgen/lang/testdata/compiler
@@ -4,7 +4,10 @@
 compile
 # Join comment.
 define Join {
+    # Left comment.
     Left  Expr
+
+    # Right comment.
     Right Expr
 }
 
@@ -19,8 +22,18 @@ define Join {
 			Tags=(Tags)
 			Name="Join"
 			Fields=(DefineFields
-				(DefineField Name="Left" Type="Expr" Src=<test.opt:3:5>)
-				(DefineField Name="Right" Type="Expr" Src=<test.opt:4:5>)
+				(DefineField
+					Comments=(Comments # Left comment.)
+					Name="Left"
+					Type="Expr"
+					Src=<test.opt:4:5>
+				)
+				(DefineField
+					Comments=(Comments # Right comment.)
+					Name="Right"
+					Type="Expr"
+					Src=<test.opt:7:5>
+				)
 			)
 			Src=<test.opt:2:1>
 		)
@@ -33,22 +46,22 @@ define Join {
 			Match=(Func
 				Name=Join
 				Args=(Slice
-					(Bind Label="left" Target=(Any Typ=Expr) Typ=Expr Src=<test.opt:9:7>)
-					(Bind Label="right" Target=(Any Typ=Expr) Typ=Expr Src=<test.opt:9:15>)
+					(Bind Label="left" Target=(Any Typ=Expr) Typ=Expr Src=<test.opt:12:7>)
+					(Bind Label="right" Target=(Any Typ=Expr) Typ=Expr Src=<test.opt:12:15>)
 				)
 				Typ=Join
-				Src=<test.opt:9:1>
+				Src=<test.opt:12:1>
 			)
 			Replace=(Func
 				Name=Join
 				Args=(Slice
-					(Ref Label="right" Typ=Expr Src=<test.opt:9:34>)
-					(Ref Label="left" Typ=Expr Src=<test.opt:9:41>)
+					(Ref Label="right" Typ=Expr Src=<test.opt:12:34>)
+					(Ref Label="left" Typ=Expr Src=<test.opt:12:41>)
 				)
 				Typ=Join
-				Src=<test.opt:9:28>
+				Src=<test.opt:12:28>
 			)
-			Src=<test.opt:8:1>
+			Src=<test.opt:11:1>
 		)
 	)
 )
@@ -83,8 +96,8 @@ define Project {
 			Tags=(Tags Join)
 			Name="InnerJoin"
 			Fields=(DefineFields
-				(DefineField Name="Left" Type="Expr" Src=<test.opt:3:5>)
-				(DefineField Name="Right" Type="Expr" Src=<test.opt:4:5>)
+				(DefineField Comments=(Comments) Name="Left" Type="Expr" Src=<test.opt:3:5>)
+				(DefineField Comments=(Comments) Name="Right" Type="Expr" Src=<test.opt:4:5>)
 			)
 			Src=<test.opt:1:1>
 		)
@@ -93,8 +106,8 @@ define Project {
 			Tags=(Tags Join)
 			Name="LeftJoin"
 			Fields=(DefineFields
-				(DefineField Name="Left" Type="Expr" Src=<test.opt:8:5>)
-				(DefineField Name="Right" Type="Expr" Src=<test.opt:9:5>)
+				(DefineField Comments=(Comments) Name="Left" Type="Expr" Src=<test.opt:8:5>)
+				(DefineField Comments=(Comments) Name="Right" Type="Expr" Src=<test.opt:9:5>)
 			)
 			Src=<test.opt:6:1>
 		)
@@ -103,7 +116,7 @@ define Project {
 			Tags=(Tags)
 			Name="Project"
 			Fields=(DefineFields
-				(DefineField Name="Input" Type="Expr" Src=<test.opt:12:5>)
+				(DefineField Comments=(Comments) Name="Input" Type="Expr" Src=<test.opt:12:5>)
 			)
 			Src=<test.opt:11:1>
 		)
@@ -225,7 +238,7 @@ define SubOp2 {}
 			Tags=(Tags)
 			Name="Op"
 			Fields=(DefineFields
-				(DefineField Name="Input" Type="Expr" Src=<test.opt:2:5>)
+				(DefineField Comments=(Comments) Name="Input" Type="Expr" Src=<test.opt:2:5>)
 			)
 			Src=<test.opt:1:1>
 		)
@@ -350,7 +363,7 @@ define Op {
 			Tags=(Tags)
 			Name="Op"
 			Fields=(DefineFields
-				(DefineField Name="Input" Type="Expr" Src=<test.opt:2:5>)
+				(DefineField Comments=(Comments) Name="Input" Type="Expr" Src=<test.opt:2:5>)
 			)
 			Src=<test.opt:1:1>
 		)
@@ -417,7 +430,7 @@ define Op {
 			Tags=(Tags)
 			Name="Op"
 			Fields=(DefineFields
-				(DefineField Name="Input" Type="Expr" Src=<test.opt:2:5>)
+				(DefineField Comments=(Comments) Name="Input" Type="Expr" Src=<test.opt:2:5>)
 			)
 			Src=<test.opt:1:1>
 		)
@@ -505,12 +518,12 @@ define Op {
 			Tags=(Tags)
 			Name="Op"
 			Fields=(DefineFields
-				(DefineField Name="Input1" Type="Expr" Src=<test.opt:2:5>)
-				(DefineField Name="Input2" Type="Expr" Src=<test.opt:3:5>)
-				(DefineField Name="Input3" Type="Expr" Src=<test.opt:4:5>)
-				(DefineField Name="Input4" Type="Expr" Src=<test.opt:5:5>)
-				(DefineField Name="Input5" Type="Expr" Src=<test.opt:6:5>)
-				(DefineField Name="Input6" Type="Expr" Src=<test.opt:7:5>)
+				(DefineField Comments=(Comments) Name="Input1" Type="Expr" Src=<test.opt:2:5>)
+				(DefineField Comments=(Comments) Name="Input2" Type="Expr" Src=<test.opt:3:5>)
+				(DefineField Comments=(Comments) Name="Input3" Type="Expr" Src=<test.opt:4:5>)
+				(DefineField Comments=(Comments) Name="Input4" Type="Expr" Src=<test.opt:5:5>)
+				(DefineField Comments=(Comments) Name="Input5" Type="Expr" Src=<test.opt:6:5>)
+				(DefineField Comments=(Comments) Name="Input6" Type="Expr" Src=<test.opt:7:5>)
 			)
 			Src=<test.opt:1:1>
 		)
@@ -628,7 +641,7 @@ define Op {
 			Tags=(Tags)
 			Name="Op"
 			Fields=(DefineFields
-				(DefineField Name="Input" Type="Expr" Src=<test.opt:2:5>)
+				(DefineField Comments=(Comments) Name="Input" Type="Expr" Src=<test.opt:2:5>)
 			)
 			Src=<test.opt:1:1>
 		)
@@ -750,9 +763,9 @@ define LeftJoin {
 			Tags=(Tags Join)
 			Name="InnerJoin"
 			Fields=(DefineFields
-				(DefineField Name="Left" Type="Expr" Src=<test.opt:3:5>)
-				(DefineField Name="Right" Type="Expr" Src=<test.opt:4:5>)
-				(DefineField Name="On" Type="FiltersExpr" Src=<test.opt:5:5>)
+				(DefineField Comments=(Comments) Name="Left" Type="Expr" Src=<test.opt:3:5>)
+				(DefineField Comments=(Comments) Name="Right" Type="Expr" Src=<test.opt:4:5>)
+				(DefineField Comments=(Comments) Name="On" Type="FiltersExpr" Src=<test.opt:5:5>)
 			)
 			Src=<test.opt:1:1>
 		)
@@ -761,9 +774,9 @@ define LeftJoin {
 			Tags=(Tags Join)
 			Name="LeftJoin"
 			Fields=(DefineFields
-				(DefineField Name="Left" Type="Expr" Src=<test.opt:10:5>)
-				(DefineField Name="Right" Type="Expr" Src=<test.opt:11:5>)
-				(DefineField Name="On" Type="FiltersExpr" Src=<test.opt:12:5>)
+				(DefineField Comments=(Comments) Name="Left" Type="Expr" Src=<test.opt:10:5>)
+				(DefineField Comments=(Comments) Name="Right" Type="Expr" Src=<test.opt:11:5>)
+				(DefineField Comments=(Comments) Name="On" Type="FiltersExpr" Src=<test.opt:12:5>)
 			)
 			Src=<test.opt:8:1>
 		)

--- a/pkg/sql/opt/optgen/lang/testdata/parser
+++ b/pkg/sql/opt/optgen/lang/testdata/parser
@@ -8,7 +8,11 @@ parse
 # And another information-packed line about it as well.
 #
 define Lt {
+    # This is a field comment.
+    #
     Left  Expr
+
+    # And another field comment.
     Right Expr
 }
 ----
@@ -19,8 +23,18 @@ define Lt {
 			Tags=(Tags)
 			Name="Lt"
 			Fields=(DefineFields
-				(DefineField Name="Left" Type="Expr" Src=<test.opt:7:5>)
-				(DefineField Name="Right" Type="Expr" Src=<test.opt:8:5>)
+				(DefineField
+					Comments=(Comments # This is a field comment. #)
+					Name="Left"
+					Type="Expr"
+					Src=<test.opt:9:5>
+				)
+				(DefineField
+					Comments=(Comments # And another field comment.)
+					Name="Right"
+					Type="Expr"
+					Src=<test.opt:12:5>
+				)
 			)
 			Src=<test.opt:6:1>
 		)
@@ -45,7 +59,7 @@ define Not {
 			Tags=(Tags Tag1 Tag2)
 			Name="Not"
 			Fields=(DefineFields
-				(DefineField Name="Input" Type="Expr" Src=<test.opt:4:5>)
+				(DefineField Comments=(Comments) Name="Input" Type="Expr" Src=<test.opt:4:5>)
 			)
 			Src=<test.opt:2:1>
 		)


### PR DESCRIPTION
Our relational and scalar operators often have comments attached to
struct and field definitions. Change Optgen to attach these comments
to generated Go structs and fields.

Release note: None