### PR TITLE
opt: Update colorizer files

### DIFF
--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -248,6 +248,9 @@ define LookupJoinPrivate {
 	# join statistics.
 	Cols ColSet
 
+	# lookupProps caches relational properties for the "table" side of the lookup
+	# join, treating it as if it were another relational input. This makes the
+	# lookup join appear more like other join operators.
 	lookupProps RelProps
 }
 
@@ -699,4 +702,3 @@ define ProjectSet {
     Input RelExpr
     Zip   ZipExpr
 }
-

--- a/pkg/sql/opt/optgen/lang/support/textmate/OptGen.tmbundle/Syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/textmate/OptGen.tmbundle/Syntaxes/optgen.tmLanguage
@@ -55,7 +55,7 @@
 					<key>begin</key>
 					<string>(?x) # Enable free spacing mode
 							^(define)
-							\s*([[:alpha:]][[:alnum:]]*)
+							\s*((?:_|[[:alpha:]])(?:_|[[:alnum:]])*)
 							\s*\{</string>
 					<key>captures</key>
 					<dict>
@@ -77,6 +77,10 @@
 					<key>patterns</key>
 					<array>
 						<dict>
+							<key>include</key>
+							<string>#comment</string>
+						</dict>
+						<dict>
 							<key>captures</key>
 							<dict>
 								<key>2</key>
@@ -87,8 +91,8 @@
 							</dict>
 							<key>match</key>
 							<string>(?x) # Enable free spacing mode
-									\s*([[:alpha:]][[:alnum:]]*)
-									\s*([[:alpha:]][[:alnum:]]*)</string>
+									\s*((?:_|[[:alpha:]])(?:_|[[:alnum:]])*)
+									\s*((?:_|[[:alpha:]])(?:_|[[:alnum:]])*)</string>
 							<key>name</key>
 							<string>meta.define.field.optgen</string>
 						</dict>
@@ -103,85 +107,158 @@
 				<dict>
 					<key>match</key>
 					<string>(?x)\b( # Enable free spacing mode
-						Subquery | 
-						Variable | 
-						Const | 
-						Placeholder | 
-						List | 
-						OrderedList | 
-						Filters | 
-						Projections | 
-						Exists | 
-						And | 
-						Or | 
-						Not | 
-						Eq | 
-						Lt | 
-						Gt | 
-						Le | 
-						Ge | 
-						Ne | 
-						In | 
-						NotIn | 
-						Like | 
-						NotLike | 
-						ILike | 
-						NotILike | 
-						SimilarTo | 
-						NotSimilarTo | 
-						RegMatch | 
-						NotRegMatch | 
-						RegIMatch | 
-						NotRegIMatch | 
-						IsDistinctFrom | 
-						IsNotDistinctFrom | 
-						Is | 
-						IsNot | 
-						Any | 
-						Some | 
-						All | 
-						Bitand | 
-						Bitor | 
-						Bitxor | 
-						Plus | 
-						Minus | 
-						Mult | 
-						Div | 
-						FloorDiv | 
-						Mod | 
-						Pow | 
-						Concat | 
-						LShift | 
-						RShift | 
-						UnaryPlus | 
-						UnaryMinus | 
-						UnaryComplement | 
-						Function | 
-						True | 
-						False | 
-						Scan | 
-						Values | 
-						Select | 
-						Project | 
-						InnerJoin | 
-						LeftJoin | 
-						RightJoin | 
-						FullJoin | 
-						SemiJoin | 
-						AntiJoin | 
-						InnerJoinApply | 
-						LeftJoinApply | 
-						RightJoinApply | 
-						FullJoinApply | 
-						SemiJoinApply | 
-						AntiJoinApply | 
-						GroupBy | 
-						Union | 
-						Intersect | 
-						Except | 
-						Sort | 
-						Arrange |
-						OpName)\b</string>
+                        Subquery |
+                        SubqueryPrivate |
+                        Any |
+                        Exists |
+                        Variable |
+                        Const |
+                        Null |
+                        True |
+                        False |
+                        Placeholder |
+                        Tuple |
+                        Projections |
+                        ColPrivate |
+                        Aggregations |
+                        AggregationsItem |
+                        Filters |
+                        FiltersItem |
+                        Zip |
+                        ZipItem |
+                        ZipItemPrivate |
+                        And |
+                        Or |
+                        Not |
+                        Eq |
+                        Lt |
+                        Gt |
+                        Le |
+                        Ge |
+                        Ne |
+                        In |
+                        NotIn |
+                        Like |
+                        NotLike |
+                        ILike |
+                        NotILike |
+                        SimilarTo |
+                        NotSimilarTo |
+                        RegMatch |
+                        NotRegMatch |
+                        RegIMatch |
+                        NotRegIMatch |
+                        Is |
+                        IsNot |
+                        Contains |
+                        JsonExists |
+                        JsonAllExists |
+                        JsonSomeExists |
+                        AnyScalar |
+                        Bitand |
+                        Bitor |
+                        Bitxor |
+                        Plus |
+                        Minus |
+                        Mult |
+                        Div |
+                        FloorDiv |
+                        Mod |
+                        Pow |
+                        Concat |
+                        LShift |
+                        RShift |
+                        FetchVal |
+                        FetchText |
+                        FetchValPath |
+                        FetchTextPath |
+                        UnaryMinus |
+                        UnaryComplement |
+                        Cast |
+                        Case |
+                        When |
+                        Array |
+                        Indirection |
+                        Function |
+                        FunctionPrivate |
+                        Coalesce |
+                        ColumnAccess |
+                        UnsupportedExpr |
+                        Avg |
+                        BoolAnd |
+                        BoolOr |
+                        ConcatAgg |
+                        Count |
+                        CountRows |
+                        Max |
+                        Min |
+                        SumInt |
+                        Sum |
+                        SqrDiff |
+                        Variance |
+                        StdDev |
+                        XorAgg |
+                        JsonAgg |
+                        JsonbAgg |
+                        ConstAgg |
+                        ConstNotNullAgg |
+                        AnyNotNullAgg |
+                        FirstAgg |
+                        AggDistinct |
+                        ScalarList |
+                        Scan |
+                        ScanPrivate |
+                        VirtualScan |
+                        VirtualScanPrivate |
+                        Values |
+                        Select |
+                        Project |
+                        InnerJoin |
+                        LeftJoin |
+                        RightJoin |
+                        FullJoin |
+                        SemiJoin |
+                        AntiJoin |
+                        IndexJoin |
+                        IndexJoinPrivate |
+                        LookupJoin |
+                        LookupJoinPrivate |
+                        MergeJoin |
+                        MergeJoinPrivate |
+                        InnerJoinApply |
+                        LeftJoinApply |
+                        RightJoinApply |
+                        FullJoinApply |
+                        SemiJoinApply |
+                        AntiJoinApply |
+                        GroupBy |
+                        GroupingPrivate |
+                        ScalarGroupBy |
+                        DistinctOn |
+                        Union |
+                        SetPrivate |
+                        Intersect |
+                        Except |
+                        UnionAll |
+                        IntersectAll |
+                        ExceptAll |
+                        Limit |
+                        Offset |
+                        Max1Row |
+                        Explain |
+                        ExplainPrivate |
+                        ShowTraceForSession |
+                        ShowTracePrivate |
+                        RowNumber |
+                        RowNumberPrivate |
+                        ProjectSet |
+                        Sort |
+                        Insert |
+                        Update |
+                        Upsert |
+                        Delete |
+                        CreateTable |
+                        OpName)\b</string>
 					<key>name</key>
 					<string>keyword.other.optgen</string>
 				</dict>
@@ -237,7 +314,7 @@
 							<array>
 								<dict>
 									<key>match</key>
-									<string>[[:alpha:]][[:alnum:]]*</string>
+									<string>(?:_|[[:alpha:]])(?:_|[[:alnum:]])*</string>
 									<key>name</key>
 									<string>entity.name.tag</string>
 								</dict>
@@ -257,7 +334,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>[[:alpha:]][[:alnum:]]*</string>
+					<string>(?:_|[[:alpha:]])(?:_|[[:alnum:]])*</string>
 					<key>name</key>
 					<string>entity.name.function.optgen</string>
 				</dict>
@@ -269,7 +346,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\$[[:alpha:]][[:alnum:]]*</string>
+					<string>\$(?:_|[[:alpha:]])(?:_|[[:alnum:]])*</string>
 					<key>name</key>
 					<string>variable.other.optgen</string>
 				</dict>

--- a/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
+++ b/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
@@ -34,14 +34,28 @@ syn keyword define contained define
 
 syn match func contained '(A-Za-z0-9_)*'
 
-syn keyword operator Subquery Variable Const Placeholder List OrderedList Filters Projections Exists
-syn keyword operator And Or Not Eq Lt Gt Le Ge Ne In NotIn
-syn keyword operator Like NotLike ILike NotILike SimilarTo NotSimilarTo RegMatch NotRegMatch RegIMatch NotRegIMatch
-syn keyword operator IsDistinctFrom IsNotDistinctFrom Is IsNot Any Some All
-syn keyword operator Bitand Bitor Bitxor Plus Minus Mult Div FloorDiv Mod Pow Concat LShift RShift
-syn keyword operator UnaryPlus UnaryMinus UnaryComplement Function True False
-syn keyword operator Scan Values Select Project Join InnerJoin LeftJoin RightJoin FullJoin SemiJoin AntiJoin
-syn keyword operator JoinApply InnerJoinApply LeftJoinApply RightJoinApply FullJoinApply SemiJoinApply AntiJoinApply GroupBy
-syn keyword operator Union Intersect Except Sort Arrange OpName
+syn keyword operator Subquery SubqueryPrivate Any Exists Variable Const Null True False Placeholder
+syn keyword operator Tuple Projections ColPrivate Aggregations AggregationsItem Filters FiltersItem
+syn keyword operator Zip ZipItem ZipItemPrivate And Or Not Eq Lt Gt Le Ge Ne In NotIn
+syn keyword operator Like NotLike ILike NotILike SimilarTo NotSimilarTo RegMatch NotRegMatch
+syn keyword operator RegIMatch NotRegIMatch Is IsNot Contains JsonExists JsonAllExists
+syn keyword operator JsonSomeExists AnyScalar Bitand Bitor Bitxor Plus Minus Mult Div FloorDiv
+syn keyword operator Mod Pow Concat LShift RShift FetchVal FetchText FetchValPath FetchTextPath
+syn keyword operator UnaryMinus UnaryComplement Cast Case When Array Indirection
+syn keyword operator Function FunctionPrivate Coalesce ColumnAccess UnsupportedExpr
+syn keyword operator Avg BoolAnd BoolOr ConcatAgg Count CountRows Max Min SumInt Sum SqrDiff
+syn keyword operator Variance StdDev XorAgg JsonAgg JsonbAgg ConstAgg ConstNotNullAgg
+syn keyword operator AnyNotNullAgg FirstAgg AggDistinct ScalarList
+syn keyword operator Scan ScanPrivate VirtualScan VirtualScanPrivate Values Select Project
+syn keyword operator InnerJoin LeftJoin RightJoin FullJoin SemiJoin AntiJoin
+syn keyword operator IndexJoin IndexJoinPrivate LookupJoin LookupJoinPrivate
+syn keyword operator MergeJoin MergeJoinPrivate
+syn keyword operator InnerJoinApply LeftJoinApply RightJoinApply FullJoinApply
+syn keyword operator SemiJoinApply AntiJoinApply
+syn keyword operator GroupBy GroupingPrivate ScalarGroupBy DistinctOn
+syn keyword operator Union SetPrivate Intersect Except UnionAll IntersectAll ExceptAll
+syn keyword operator Limit Offset Max1Row Explain ExplainPrivate
+syn keyword operator ShowTraceForSession ShowTracePrivate RowNumber RowNumberPrivate ProjectSet
+syn keyword operator Sort Insert Update Upsert Delete CreateTable OpName
 
 let b:current_syntax = "cropt"

--- a/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
@@ -55,7 +55,7 @@
 					<key>begin</key>
 					<string>(?x) # Enable free spacing mode
 							^(define)
-							\s*([[:alpha:]][[:alnum:]]*)
+							\s*((?:_|[[:alpha:]])(?:_|[[:alnum:]])*)
 							\s*\{</string>
 					<key>captures</key>
 					<dict>
@@ -77,6 +77,10 @@
 					<key>patterns</key>
 					<array>
 						<dict>
+							<key>include</key>
+							<string>#comment</string>
+						</dict>
+						<dict>
 							<key>captures</key>
 							<dict>
 								<key>2</key>
@@ -87,8 +91,8 @@
 							</dict>
 							<key>match</key>
 							<string>(?x) # Enable free spacing mode
-									\s*([[:alpha:]][[:alnum:]]*)
-									\s*([[:alpha:]][[:alnum:]]*)</string>
+									\s*((?:_|[[:alpha:]])(?:_|[[:alnum:]])*)
+									\s*((?:_|[[:alpha:]])(?:_|[[:alnum:]])*)</string>
 							<key>name</key>
 							<string>meta.define.field.optgen</string>
 						</dict>
@@ -103,85 +107,158 @@
 				<dict>
 					<key>match</key>
 					<string>(?x)\b( # Enable free spacing mode
-						Subquery | 
-						Variable | 
-						Const | 
-						Placeholder | 
-						List | 
-						OrderedList | 
-						Filters | 
-						Projections | 
-						Exists | 
-						And | 
-						Or | 
-						Not | 
-						Eq | 
-						Lt | 
-						Gt | 
-						Le | 
-						Ge | 
-						Ne | 
-						In | 
-						NotIn | 
-						Like | 
-						NotLike | 
-						ILike | 
-						NotILike | 
-						SimilarTo | 
-						NotSimilarTo | 
-						RegMatch | 
-						NotRegMatch | 
-						RegIMatch | 
-						NotRegIMatch | 
-						IsDistinctFrom | 
-						IsNotDistinctFrom | 
-						Is | 
-						IsNot | 
-						Any | 
-						Some | 
-						All | 
-						Bitand | 
-						Bitor | 
-						Bitxor | 
-						Plus | 
-						Minus | 
-						Mult | 
-						Div | 
-						FloorDiv | 
-						Mod | 
-						Pow | 
-						Concat | 
-						LShift | 
-						RShift | 
-						UnaryPlus | 
-						UnaryMinus | 
-						UnaryComplement | 
-						Function | 
-						True | 
-						False | 
-						Scan | 
-						Values | 
-						Select | 
-						Project | 
-						InnerJoin | 
-						LeftJoin | 
-						RightJoin | 
-						FullJoin | 
-						SemiJoin | 
-						AntiJoin | 
-						InnerJoinApply | 
-						LeftJoinApply | 
-						RightJoinApply | 
-						FullJoinApply | 
-						SemiJoinApply | 
-						AntiJoinApply | 
-						GroupBy | 
-						Union | 
-						Intersect | 
-						Except | 
-						Sort | 
-						Arrange |
-						OpName)\b</string>
+                        Subquery |
+                        SubqueryPrivate |
+                        Any |
+                        Exists |
+                        Variable |
+                        Const |
+                        Null |
+                        True |
+                        False |
+                        Placeholder |
+                        Tuple |
+                        Projections |
+                        ColPrivate |
+                        Aggregations |
+                        AggregationsItem |
+                        Filters |
+                        FiltersItem |
+                        Zip |
+                        ZipItem |
+                        ZipItemPrivate |
+                        And |
+                        Or |
+                        Not |
+                        Eq |
+                        Lt |
+                        Gt |
+                        Le |
+                        Ge |
+                        Ne |
+                        In |
+                        NotIn |
+                        Like |
+                        NotLike |
+                        ILike |
+                        NotILike |
+                        SimilarTo |
+                        NotSimilarTo |
+                        RegMatch |
+                        NotRegMatch |
+                        RegIMatch |
+                        NotRegIMatch |
+                        Is |
+                        IsNot |
+                        Contains |
+                        JsonExists |
+                        JsonAllExists |
+                        JsonSomeExists |
+                        AnyScalar |
+                        Bitand |
+                        Bitor |
+                        Bitxor |
+                        Plus |
+                        Minus |
+                        Mult |
+                        Div |
+                        FloorDiv |
+                        Mod |
+                        Pow |
+                        Concat |
+                        LShift |
+                        RShift |
+                        FetchVal |
+                        FetchText |
+                        FetchValPath |
+                        FetchTextPath |
+                        UnaryMinus |
+                        UnaryComplement |
+                        Cast |
+                        Case |
+                        When |
+                        Array |
+                        Indirection |
+                        Function |
+                        FunctionPrivate |
+                        Coalesce |
+                        ColumnAccess |
+                        UnsupportedExpr |
+                        Avg |
+                        BoolAnd |
+                        BoolOr |
+                        ConcatAgg |
+                        Count |
+                        CountRows |
+                        Max |
+                        Min |
+                        SumInt |
+                        Sum |
+                        SqrDiff |
+                        Variance |
+                        StdDev |
+                        XorAgg |
+                        JsonAgg |
+                        JsonbAgg |
+                        ConstAgg |
+                        ConstNotNullAgg |
+                        AnyNotNullAgg |
+                        FirstAgg |
+                        AggDistinct |
+                        ScalarList |
+                        Scan |
+                        ScanPrivate |
+                        VirtualScan |
+                        VirtualScanPrivate |
+                        Values |
+                        Select |
+                        Project |
+                        InnerJoin |
+                        LeftJoin |
+                        RightJoin |
+                        FullJoin |
+                        SemiJoin |
+                        AntiJoin |
+                        IndexJoin |
+                        IndexJoinPrivate |
+                        LookupJoin |
+                        LookupJoinPrivate |
+                        MergeJoin |
+                        MergeJoinPrivate |
+                        InnerJoinApply |
+                        LeftJoinApply |
+                        RightJoinApply |
+                        FullJoinApply |
+                        SemiJoinApply |
+                        AntiJoinApply |
+                        GroupBy |
+                        GroupingPrivate |
+                        ScalarGroupBy |
+                        DistinctOn |
+                        Union |
+                        SetPrivate |
+                        Intersect |
+                        Except |
+                        UnionAll |
+                        IntersectAll |
+                        ExceptAll |
+                        Limit |
+                        Offset |
+                        Max1Row |
+                        Explain |
+                        ExplainPrivate |
+                        ShowTraceForSession |
+                        ShowTracePrivate |
+                        RowNumber |
+                        RowNumberPrivate |
+                        ProjectSet |
+                        Sort |
+                        Insert |
+                        Update |
+                        Upsert |
+                        Delete |
+                        CreateTable |
+                        OpName)\b</string>
 					<key>name</key>
 					<string>keyword.other.optgen</string>
 				</dict>
@@ -237,7 +314,7 @@
 							<array>
 								<dict>
 									<key>match</key>
-									<string>[[:alpha:]][[:alnum:]]*</string>
+									<string>(?:_|[[:alpha:]])(?:_|[[:alnum:]])*</string>
 									<key>name</key>
 									<string>entity.name.tag</string>
 								</dict>
@@ -257,7 +334,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>[[:alpha:]][[:alnum:]]*</string>
+					<string>(?:_|[[:alpha:]])(?:_|[[:alnum:]])*</string>
 					<key>name</key>
 					<string>entity.name.function.optgen</string>
 				</dict>
@@ -269,7 +346,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\$[[:alpha:]][[:alnum:]]*</string>
+					<string>\$(?:_|[[:alpha:]])(?:_|[[:alnum:]])*</string>
 					<key>name</key>
 					<string>variable.other.optgen</string>
 				</dict>


### PR DESCRIPTION
Update files for TextMate (used by GoLand), VSCode, and VIM to reflect
latest changes to Optgen, including additional operators and new syntax.

Release note: None