### PR TITLE
log: repeat header for multi-line messages

### DIFF
--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -589,10 +589,13 @@ func (buf *buffer) someDigits(i, d int) int {
 func formatLogEntry(entry Entry, stacks []byte, cp ttycolor.Profile) *buffer {
 	buf := formatHeader(entry.Severity, timeutil.Unix(0, entry.Time),
 		int(entry.Goroutine), entry.File, int(entry.Line), cp)
-	_, _ = buf.WriteString(entry.Message)
-	if buf.Bytes()[buf.Len()-1] != '\n' {
-		_ = buf.WriteByte('\n')
+	msg := entry.Message
+	if n := len(msg); n != 0 && msg[n-1] == '\n' {
+		msg = msg[:n-1]
 	}
+	msg = strings.Replace(msg, "\n", "\n"+buf.String(), -1)
+	_, _ = buf.WriteString(msg)
+	_ = buf.WriteByte('\n')
 	if len(stacks) > 0 {
 		buf.Write(stacks)
 	}


### PR DESCRIPTION
Unpolished since I wrote it up due to sorely needing it, but I think this is a
good idea.

----

Without this, it's a lot more painful to merge these log files "the unix
way". I type a variation of this ~100x daily:

    roachprod ssh tobias-test:1-4 -- cat 'logs/cockroach.*.log' | cut -c 2- | sort | less

But without the repeating headers only the first line of multi-line
messages is preserved.

Release note: None