### PR TITLE
roachprod: fix usage of local clusters

### DIFF
--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -64,7 +64,7 @@ func cockroachNodeBinary(c *SyncedCluster, i int) string {
 		}
 		// We're unable to find the binary in PATH and "binary" is a relative path:
 		// look in the cockroach repo.
-		gopath := envutil.EnvOrDefaultString("GOPATH", "")
+		gopath := os.Getenv("GOPATH")
 		if gopath == "" {
 			return config.Binary
 		}


### PR DESCRIPTION
Fix usage of local clusters when the cockroach binary is not explicitly
specified. `envutil.EnvOrDefaultString` requires the environment
variable starts with `COCKROACH_`.

Release note: None