### PR TITLE
opt: fix factory Construct methods to return normalized expressions

### DIFF
--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -564,7 +564,11 @@ func (g *exprsGen) genMemoizeFuncs() {
 			fieldName := g.md.fieldName(field)
 			fmt.Fprintf(g.w, "  %s %s,\n", unTitle(fieldName), fieldTyp.asParam())
 		}
-		fmt.Fprintf(g.w, ") *%s {\n", opTyp.name)
+		if define.Tags.Contains("Scalar") {
+			fmt.Fprintf(g.w, ") *%s {\n", opTyp.name)
+		} else {
+			fmt.Fprintf(g.w, ") RelExpr {\n")
+		}
 
 		if len(define.Fields) == 0 {
 			fmt.Fprintf(g.w, "  return %sSingleton\n", define.Name)
@@ -615,7 +619,12 @@ func (g *exprsGen) genMemoizeFuncs() {
 		fmt.Fprintf(g.w, "    m.memEstimate += size\n")
 		fmt.Fprintf(g.w, "    m.checkExpr(e)\n")
 		fmt.Fprintf(g.w, "  }\n")
-		fmt.Fprintf(g.w, "  return interned\n")
+		if define.Tags.Contains("Scalar") {
+			fmt.Fprintf(g.w, "  return interned\n")
+		} else {
+			// Return the normalized expression if this is a relational expr.
+			fmt.Fprintf(g.w, "  return interned.FirstExpr()\n")
+		}
 
 		fmt.Fprintf(g.w, "}\n\n")
 	}
@@ -636,7 +645,7 @@ func (g *exprsGen) genAddToGroupFuncs() {
 		fmt.Fprintf(g.w, "    m.memEstimate += size\n")
 		fmt.Fprintf(g.w, "    m.checkExpr(e)\n")
 		fmt.Fprintf(g.w, "  } else if interned.group() != grp.group() {\n")
-		fmt.Fprintf(g.w, "    panic(fmt.Sprintf(\"%%s expression cannot be added to multiple groups: %%s\", e.Op(), e))\n")
+		fmt.Fprintf(g.w, "    panic(fmt.Sprintf(\"%%s expression cannot be added to multiple groups: %%s\", e.Op(), interned))\n")
 		fmt.Fprintf(g.w, "  }\n")
 		fmt.Fprintf(g.w, "  return interned\n")
 		fmt.Fprintf(g.w, "}\n\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -373,7 +373,7 @@ func (m *Memo) MemoizeProject(
 	input RelExpr,
 	projections ProjectionsExpr,
 	passthrough opt.ColSet,
-) *ProjectExpr {
+) RelExpr {
 	const size = int64(unsafe.Sizeof(projectGroup{}))
 	grp := &projectGroup{mem: m, first: ProjectExpr{
 		Input:       input,
@@ -388,7 +388,7 @@ func (m *Memo) MemoizeProject(
 		m.memEstimate += size
 		m.checkExpr(e)
 	}
-	return interned
+	return interned.FirstExpr()
 }
 
 func (m *Memo) AddProjectToGroup(e *ProjectExpr, grp RelExpr) *ProjectExpr {
@@ -399,7 +399,7 @@ func (m *Memo) AddProjectToGroup(e *ProjectExpr, grp RelExpr) *ProjectExpr {
 		m.memEstimate += size
 		m.checkExpr(e)
 	} else if interned.group() != grp.group() {
-		panic(fmt.Sprintf("%s expression cannot be added to multiple groups: %s", e.Op(), e))
+		panic(fmt.Sprintf("%s expression cannot be added to multiple groups: %s", e.Op(), interned))
 	}
 	return interned
 }


### PR DESCRIPTION
Prior to this patch, it was possible for factory Construct methods to
return non-normalized expressions. This could happen if Construct was
called on an expression that already existed as an alternate expression
in an existing memo group. This is a problem because it breaks the
abstraction of the memo. The children of a parent relational expression
should only refer to other memo groups, never to specific expressions
within a group.

For example, consider this simplified memo:
```
memo
SELECT * FROM a LIMIT 10
----
memo
 ├── G1: (limit G2 G3)
 ├── G2: (scan a) (scan a@s_idx) (scan a@si_idx)
 └── G3: (const 10)
```
It is important that the input of the limit expression in `G1` is the
entire memo group `G2`, not a specific instance of a scan expression.
However, this conflicts with the new representation for relational
expressions, which have a `RelExpr` as input, not an `exprGroup`.
The solution is to ensure that the input `RelExpr` is the *normalized*
expression in its memo group (i.e., the first expression).

This commit fixes the Construct methods to always return the first
expression in the memo group. It also fixes an error message which
was printing garbage due to a nil input.

Note that this bug was not visible because we do not currently have
any exploration rules that would trigger construction of non-normalized
expressions. It will become a problem when we try to add more complex
exploration rules such as `AssociateJoin` (see #31033).

Release note: None