### PR TITLE
opt: add perturb-cost flag to OptTester

### DIFF
--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -322,6 +322,12 @@ func (m *Memo) SetBestProps(
 	bp.cost = cost
 }
 
+// ResetCost updates the cost of a relational expression's memo group. It
+// should *only* be called by Optimizer.RecomputeCost() for testing purposes.
+func (m *Memo) ResetCost(e RelExpr, cost Cost) {
+	e.bestProps().cost = cost
+}
+
 // IsOptimized returns true if the memo has been fully optimized.
 func (m *Memo) IsOptimized() bool {
 	// The memo is optimized once the root expression has its physical properties

--- a/pkg/sql/opt/xform/main_test.go
+++ b/pkg/sql/opt/xform/main_test.go
@@ -1,0 +1,32 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	os.Exit(m.Run())
+}

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
@@ -33,6 +34,7 @@ import (
 )
 
 func TestDetachMemo(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	catalog := testcat.New()
 	_, err := catalog.ExecuteDDL("CREATE TABLE abc (a INT PRIMARY KEY, b INT, c STRING, INDEX (c))")
 	if err != nil {
@@ -105,6 +107,7 @@ func TestDetachMemo(t *testing.T) {
 //   make test PKG=./pkg/sql/opt/xform TESTS="TestCoster/scan"
 //   ...
 func TestCoster(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	runDataDrivenTest(
 		t, "testdata/coster/",
 		memo.ExprFmtHideRuleProps|memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars,
@@ -116,6 +119,7 @@ func TestCoster(t *testing.T) {
 //   make test PKG=./pkg/sql/opt/xform TESTS="TestPhysicalPropsFactory/presentation"
 //   ...
 func TestPhysicalProps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	runDataDrivenTest(t, "testdata/physprops/", memo.ExprFmtHideAll)
 }
 
@@ -123,6 +127,7 @@ func TestPhysicalProps(t *testing.T) {
 //   make test PKG=./pkg/sql/opt/xform TESTS="TestRuleProps/orderings"
 //   ...
 func TestRuleProps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	datadriven.Walk(t, "testdata/ruleprops", func(t *testing.T, path string) {
 		catalog := testcat.New()
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
@@ -139,6 +144,7 @@ func TestRuleProps(t *testing.T) {
 //   make test PKG=./pkg/sql/opt/xform TESTS="TestRules/select"
 //   ...
 func TestRules(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	runDataDrivenTest(
 		t,
 		"testdata/rules/",
@@ -163,6 +169,7 @@ var externalTestData = flag.String(
 //   make test PKG=./pkg/sql/opt/xform TESTS=TestExternal TESTFLAGS='-d /some-dir'
 //
 func TestExternal(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	runDataDrivenTest(
 		t,
 		*externalTestData,

--- a/pkg/sql/opt/xform/testdata/coster/perturb-cost
+++ b/pkg/sql/opt/xform/testdata/coster/perturb-cost
@@ -1,0 +1,94 @@
+# This file tests that the OptTester flag perturb-cost works. It's not possible
+# to include tests with the opt directive (other than for trivial scalar
+# queries), since by construction those tests will produce a random query plan
+# and we cannot predict the output in advance. For example,
+#   `SELECT * FROM a JOIN b ON a.x=b.x`
+# may produce one of at least 6 different plans.
+
+# For this reason, the perturb-cost flag is only intended for debugging at this
+# time, by using the "-rewrite=true" flag.
+
+exec-ddl
+CREATE TABLE a (x INT PRIMARY KEY, y INT)
+----
+TABLE a
+ ├── x int not null
+ ├── y int
+ └── INDEX primary
+      └── x int not null
+
+exec-ddl
+CREATE TABLE b (x INT PRIMARY KEY)
+----
+TABLE b
+ ├── x int not null
+ └── INDEX primary
+      └── x int not null
+
+norm perturb-cost=(0.5)
+SELECT * FROM a JOIN b ON a.x=b.x ORDER BY a.y
+----
+sort
+ ├── columns: x:1(int!null) y:2(int) x:3(int!null)
+ ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(3)=1000, null(3)=0]
+ ├── cost: 2319.35569
+ ├── key: (3)
+ ├── fd: (1)-->(2), (1)==(3), (3)==(1)
+ ├── ordering: +2
+ └── inner-join
+      ├── columns: a.x:1(int!null) y:2(int) b.x:3(int!null)
+      ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(3)=1000, null(3)=0]
+      ├── cost: 2100.03
+      ├── key: (3)
+      ├── fd: (1)-->(2), (1)==(3), (3)==(1)
+      ├── scan a
+      │    ├── columns: a.x:1(int!null) y:2(int)
+      │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+      │    ├── cost: 1040.01
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      ├── scan b
+      │    ├── columns: b.x:3(int!null)
+      │    ├── stats: [rows=1000, distinct(3)=1000, null(3)=0]
+      │    ├── cost: 1020.01
+      │    └── key: (3)
+      └── filters
+           └── a.x = b.x [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+
+opt perturb-cost=(0.9)
+SELECT 1
+----
+project
+ ├── columns: "?column?":1(int!null)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 0.05
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── cost: 0.02
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── const: 1 [type=int]
+
+opt perturb-cost=(2.5)
+SELECT 1
+----
+project
+ ├── columns: "?column?":1(int!null)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 0.05
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── cost: 0.02
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── const: 1 [type=int]


### PR DESCRIPTION
This PR builds on #31977, which added the flag `-optimizer-cost-perturbation`
to the logic tests. That flag was introduced to randomly perturb the
costs of expressions in the optimizer, allowing us to test that alternate
plans produced by the optimizer are logically equivalent.

This PR adds a similar flag to the `OptTester`, so that we can use the
cost-perturbation feature inside optimizer tests. It's not currently useful
to actually write tests with this new flag, since by construction those
tests will produce a random query plan and we cannot predict the output
in advance. However, it *is* useful for debugging, by using the
"-rewrite=true" flag.

This PR also includes new logic to recompute the cost of the plan after
optimization, so that the real cost of each expression is printed in the
output (rather than the perturbed cost).

Release note: None