### PR TITLE
bulkio: add SESSION_TOKEN to S3 config.

### DIFF
--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -50,6 +50,8 @@ const (
 	S3AccessKeyParam = "AWS_ACCESS_KEY_ID"
 	// S3SecretParam is the query parameter for the 'secret' in an S3 URI.
 	S3SecretParam = "AWS_SECRET_ACCESS_KEY"
+	// S3TempTokenParam is the query parameter for session_token in an S3 URI.
+	S3TempTokenParam = "AWS_SESSION_TOKEN"
 	// S3EndpointParam is the query parameter for the 'endpoint' in an S3 URI.
 	S3EndpointParam = "AWS_ENDPOINT"
 	// S3RegionParam is the query parameter for the 'endpoint' in an S3 URI.
@@ -100,6 +102,7 @@ func ExportStorageConfFromURI(path string) (roachpb.ExportStorage, error) {
 			Prefix:    uri.Path,
 			AccessKey: uri.Query().Get(S3AccessKeyParam),
 			Secret:    uri.Query().Get(S3SecretParam),
+			TempToken: uri.Query().Get(S3TempTokenParam),
 			Endpoint:  uri.Query().Get(S3EndpointParam),
 			Region:    uri.Query().Get(S3RegionParam),
 		}

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1084,7 +1084,7 @@ func (*RangeStatsRequest) flags() int { return isRead }
 // Keys returns credentials in an aws.Config.
 func (b *ExportStorage_S3) Keys() *aws.Config {
 	return &aws.Config{
-		Credentials: credentials.NewStaticCredentials(b.AccessKey, b.Secret, ""),
+		Credentials: credentials.NewStaticCredentials(b.AccessKey, b.Secret, b.TempToken),
 	}
 }
 


### PR DESCRIPTION
Allows the client to pass a SESSION_TOKEN query parameter with an S3 URL.

Fixes #32276