### PR TITLE
ui: render errors in Loading component

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/index.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/index.tsx
@@ -28,6 +28,7 @@ const NodeCanvasContent = swapByLicense(NeedEnterpriseLicense, NodeCanvasContain
 interface ClusterVisualizationProps {
   licenseDataExists: boolean;
   enterpriseEnabled: boolean;
+  clusterDataError: Error | null;
 }
 
 class ClusterVisualization extends React.Component<ClusterVisualizationProps & RouterState & { router: InjectedRouter }> {
@@ -78,6 +79,7 @@ class ClusterVisualization extends React.Component<ClusterVisualizationProps & R
         </div>
         <Loading
           loading={!this.props.licenseDataExists}
+          error={this.props.clusterDataError}
           render={() => <NodeCanvasContent tiers={tiers} />}
         />
       </div>
@@ -89,6 +91,7 @@ function mapStateToProps(state: AdminUIState) {
   return {
     licenseDataExists: !!state.cachedData.cluster.data,
     enterpriseEnabled: selectEnterpriseEnabled(state),
+    clusterDataError: state.cachedData.cluster.lastError,
   };
 }
 

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvasContainer.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvasContainer.tsx
@@ -41,6 +41,7 @@ interface NodeCanvasContainerProps {
   livenesses: { [id: string]: Liveness };
   dataExists: boolean;
   dataIsValid: boolean;
+  dataErrors: Error[];
   refreshNodes: typeof refreshNodes;
   refreshLiveness: typeof refreshLiveness;
   refreshLocations: typeof refreshLocations;
@@ -72,6 +73,7 @@ class NodeCanvasContainer extends React.Component<NodeCanvasContainerProps & Nod
     return (
       <Loading
         loading={!this.props.dataExists}
+        error={this.props.dataErrors}
         render={() => (
           <NodeCanvas
             localityTree={currentLocality}
@@ -100,6 +102,13 @@ const selectDataIsValid = createSelector(
   (nodes, locations, liveness) => nodes.valid && locations.valid && liveness.valid,
 );
 
+const dataErrors = createSelector(
+  selectNodeRequestStatus,
+  selectLocationsRequestStatus,
+  selectLivenessRequestStatus,
+  (nodes, locations, liveness) => [nodes.lastError, locations.lastError, liveness.lastError],
+);
+
 export default connect(
   (state: AdminUIState, _ownProps: NodeCanvasContainerOwnProps) => ({
     nodesSummary: nodesSummarySelector(state),
@@ -109,6 +118,7 @@ export default connect(
     livenesses: livenessByNodeIDSelector(state),
     dataIsValid: selectDataIsValid(state),
     dataExists: selectDataExists(state),
+    dataErrors: dataErrors(state),
   }),
   {
     refreshNodes,

--- a/pkg/ui/src/views/app/containers/layout/layout.styl
+++ b/pkg/ui/src/views/app/containers/layout/layout.styl
@@ -185,21 +185,3 @@ div.raft-filters
 
 .table-stats
   margin-bottom 50px
-
-.loading-image
-  height 100%
-  background-repeat no-repeat
-  background-position center 40%
-  padding 12px 24px
-
-  &__spinner
-    background-size 40px 40px
-    min-height 40px
-
-  &__spinner-left
-    background-size 40px 40px
-    min-height 40px
-    width 400px
-
-    &__padded
-      padding-top 100px

--- a/pkg/ui/src/views/reports/containers/certificates/index.tsx
+++ b/pkg/ui/src/views/reports/containers/certificates/index.tsx
@@ -204,11 +204,13 @@ class Certificates extends React.Component<CertificatesProps, {}> {
         </Helmet>
         <h1>Certificates</h1>
 
-        <Loading
-          loading={!this.props.certificates}
-          error={this.props.lastError}
-          render={this.renderContent}
-        />
+        <section className="section">
+          <Loading
+            loading={!this.props.certificates}
+            error={this.props.lastError}
+            render={this.renderContent}
+          />
+        </section>
       </div>
     );
   }

--- a/pkg/ui/src/views/reports/containers/certificates/index.tsx
+++ b/pkg/ui/src/views/reports/containers/certificates/index.tsx
@@ -23,6 +23,7 @@ import { certificatesRequestKey, refreshCertificates } from "src/redux/apiReduce
 import { AdminUIState } from "src/redux/state";
 import { nodeIDAttr } from "src/util/constants";
 import { LongToMoment } from "src/util/convert";
+import Loading from "src/views/shared/components/loading";
 
 interface CertificatesOwnProps {
   certificates: protos.cockroach.server.serverpb.CertificatesResponse;
@@ -164,41 +165,15 @@ class Certificates extends React.Component<CertificatesProps, {}> {
     );
   }
 
-  render() {
-    const nodeID = this.props.params[nodeIDAttr];
-    if (!_.isNil(this.props.lastError)) {
-      return (
-        <div className="section">
-          <Helmet>
-            <title>Certificates | Debug</title>
-          </Helmet>
-          <h1>Certificates</h1>
-          <h2>Error loading certificates for node {nodeID}</h2>
-        </div>
-      );
-    }
+  renderContent = () => {
     const { certificates } = this.props;
-    if (_.isEmpty(certificates)) {
-      return (
-        <div className="section">
-          <Helmet>
-            <title>Certificates | Debug</title>
-          </Helmet>
-          <h1>Certificates</h1>
-          <h2>Loading cluster status...</h2>
-        </div>
-      );
-    }
+    const nodeID = this.props.params[nodeIDAttr];
 
     if (_.isEmpty(certificates.certificates)) {
       return (
-        <div className="section">
-          <Helmet>
-            <title>Certificates | Debug</title>
-          </Helmet>
-          <h1>Certificates</h1>
+        <React.Fragment>
           <h2>No certificates were found on node {this.props.params[nodeIDAttr]}.</h2>
-        </div>
+        </React.Fragment>
       );
     }
 
@@ -210,17 +185,30 @@ class Certificates extends React.Component<CertificatesProps, {}> {
     }
 
     return (
-      <div className="section">
-        <Helmet>
-          <title>Certificates | Debug</title>
-        </Helmet>
-        <h1>Certificates</h1>
+      <React.Fragment>
         <h2>{header} certificates</h2>
         {
           _.map(certificates.certificates, (cert, key) => (
             this.renderCert(cert, key)
           ))
         }
+      </React.Fragment>
+    );
+  }
+
+  render() {
+    return (
+      <div className="section">
+        <Helmet>
+          <title>Certificates | Debug</title>
+        </Helmet>
+        <h1>Certificates</h1>
+
+        <Loading
+          loading={!this.props.certificates}
+          error={this.props.lastError}
+          render={this.renderContent}
+        />
       </div>
     );
   }

--- a/pkg/ui/src/views/reports/containers/commandQueue/index.tsx
+++ b/pkg/ui/src/views/reports/containers/commandQueue/index.tsx
@@ -122,6 +122,7 @@ class CommandQueue extends React.Component<CommandQueueProps, {}> {
         </h1>
         <Loading
           loading={!this.props.commandQueue || this.props.commandQueue.inFlight}
+          error={this.props.commandQueue && this.props.commandQueue.lastError}
           render={this.renderReportBody}
         />
       </div>

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -136,7 +136,7 @@ export default function Debug() {
         <DebugPanelLink
           name="Localities"
           url="#/reports/localities"
-          note="Check node localities for your cluster."
+          note="Check node localities and locations for your cluster."
         />
       </PanelSection>
       <DebugTable heading="Even More Advanced Debugging">

--- a/pkg/ui/src/views/reports/containers/localities/index.tsx
+++ b/pkg/ui/src/views/reports/containers/localities/index.tsx
@@ -111,6 +111,7 @@ class Localities extends React.Component<LocalitiesProps, {}> {
         <section className="section"><h1>Localities</h1></section>
         <Loading
           loading={ !this.props.localityStatus.data || !this.props.locationStatus.data }
+          error={ [this.props.localityStatus.lastError, this.props.locationStatus.lastError] }
           render={() => (
             <section className="section">
               <table className="locality-table">

--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -20,9 +20,16 @@ import React from "react";
 import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import { RouterState } from "react-router";
+import { createSelector } from "reselect";
 
 import { refreshLiveness, refreshNodes } from "src/redux/apiReducers";
-import { LivenessStatus, NodesSummary, nodesSummarySelector } from "src/redux/nodes";
+import {
+  LivenessStatus,
+  NodesSummary,
+  nodesSummarySelector,
+  selectLivenessRequestStatus,
+  selectNodeRequestStatus,
+} from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import { LongToMoment, NanoToMilli } from "src/util/convert";
 import { FixLong } from "src/util/fixLong";
@@ -36,6 +43,7 @@ import Loading from "src/views/shared/components/loading";
 
 interface NetworkOwnProps {
   nodesSummary: NodesSummary;
+  nodeSummaryErrors: Error[];
   refreshNodes: typeof refreshNodes;
   refreshLiveness: typeof refreshLiveness;
 }
@@ -456,6 +464,7 @@ class Network extends React.Component<NetworkProps, {}> {
         <h1>Network Diagnostics</h1>
         <Loading
           loading={!contentAvailable(nodesSummary)}
+          error={this.props.nodeSummaryErrors}
           className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
           render={() => (
             <div>
@@ -469,9 +478,16 @@ class Network extends React.Component<NetworkProps, {}> {
   }
 }
 
+const nodeSummaryErrors = createSelector(
+  selectNodeRequestStatus,
+  selectLivenessRequestStatus,
+  (nodes, liveness) => [nodes.lastError, liveness.lastError],
+);
+
 function mapStateToProps(state: AdminUIState) {
   return {
     nodesSummary: nodesSummarySelector(state),
+    nodeSummaryErrors: nodeSummaryErrors(state),
   };
 }
 

--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -198,7 +198,7 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
         <h1>Problem Ranges Report</h1>
         <Loading
           loading={isLoading(this.props.problemRanges)}
-          className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
+          error={this.props.problemRanges && this.props.problemRanges.lastError}
           render={() => (
             <div>
               {this.renderReportBody()}

--- a/pkg/ui/src/views/reports/containers/range/allocator.tsx
+++ b/pkg/ui/src/views/reports/containers/range/allocator.tsx
@@ -26,35 +26,48 @@ interface AllocatorOutputProps {
 }
 
 export default class AllocatorOutput extends React.Component<AllocatorOutputProps, {}> {
+  renderContent = () => {
+    const { allocator } = this.props;
+
+    if (allocator && (_.isEmpty(allocator.data) || _.isEmpty(allocator.data.dry_run))) {
+      return (
+        <div>
+          No simulated allocator output was returned.
+        </div>
+      );
+    }
+
+    return (
+      <table className="allocator-table">
+        <tbody>
+          <tr className="allocator-table__row allocator-table__row--header">
+            <th className="allocator-table__cell allocator-table__cell--header">Timestamp</th>
+            <th className="allocator-table__cell allocator-table__cell--header">Message</th>
+          </tr>
+          {
+            _.map(allocator.data.dry_run.events, (event, key) => (
+              <tr key={key} className="allocator-table__row">
+                <td className="allocator-table__cell allocator-table__cell--date">{Print.Timestamp(event.time)}</td>
+                <td className="allocator-table__cell">{event.message}</td>
+              </tr>
+            ))
+          }
+        </tbody>
+      </table>
+    );
+  }
+
   render() {
     const { allocator } = this.props;
 
     // TODO(couchand): This is a really myopic way to check for this particular
     // case, but making major changes to the CachedDataReducer or util.api seems
     // fraught at this point.  We should revisit this soon.
-    if (allocator.lastError && allocator.lastError.message === "Forbidden") {
+    if (allocator && allocator.lastError && allocator.lastError.message === "Forbidden") {
       return (
         <div>
           <h2>Simulated Allocator Output</h2>
           { REMOTE_DEBUGGING_ERROR_TEXT }
-        </div>
-      );
-    }
-
-    if (allocator && !_.isNil(allocator.lastError)) {
-      return (
-        <div>
-          <h2>Simulated Allocator Output</h2>
-          {allocator.lastError.toString()}
-        </div>
-      );
-    }
-
-    if (allocator && (_.isEmpty(allocator.data) || _.isEmpty(allocator.data.dry_run))) {
-      return (
-        <div>
-          <h2>Simulated Allocator Output</h2>
-          No simulated allocator output was returned.
         </div>
       );
     }
@@ -69,24 +82,8 @@ export default class AllocatorOutput extends React.Component<AllocatorOutputProp
         <h2>Simulated Allocator Output{fromNodeID}</h2>
         <Loading
           loading={!allocator || allocator.inFlight}
-          render={() => (
-            <table className="allocator-table">
-              <tbody>
-                <tr className="allocator-table__row allocator-table__row--header">
-                  <th className="allocator-table__cell allocator-table__cell--header">Timestamp</th>
-                  <th className="allocator-table__cell allocator-table__cell--header">Message</th>
-                </tr>
-                {
-                  _.map(allocator.data.dry_run.events, (event, key) => (
-                    <tr key={key} className="allocator-table__row">
-                      <td className="allocator-table__cell allocator-table__cell--date">{Print.Timestamp(event.time)}</td>
-                      <td className="allocator-table__cell">{event.message}</td>
-                    </tr>
-                  ))
-                }
-              </tbody>
-            </table>
-          )}
+          error={allocator && allocator.lastError}
+          render={this.renderContent}
         />
       </div>
     );

--- a/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
@@ -41,6 +41,7 @@ export default function ConnectionsTable(props: ConnectionsTableProps) {
       <h2>Connections {viaNodeID}</h2>
       <Loading
         loading={!range || range.inFlight}
+        error={range && range.lastError}
         render={() => (
           <table className="connections-table">
             <tbody>

--- a/pkg/ui/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/logTable.tsx
@@ -90,18 +90,8 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
     );
   }
 
-  render() {
+  renderContent = () => {
     const { log } = this.props;
-
-    if (log && !_.isEmpty(log.lastError)) {
-      return (
-        <div>
-          <h2>Range Log</h2>
-          There was an error retrieving the range log:
-          {log.lastError}
-        </div>
-      );
-    }
 
     // Sort by descending timestamp.
     const events = _.orderBy(
@@ -111,36 +101,43 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
     );
 
     return (
+      <table className="log-table">
+        <tbody>
+          <tr className="log-table__row log-table__row--header">
+            <th className="log-table__cell log-table__cell--header">Timestamp</th>
+            <th className="log-table__cell log-table__cell--header">Store</th>
+            <th className="log-table__cell log-table__cell--header">Event Type</th>
+            <th className="log-table__cell log-table__cell--header">Range</th>
+            <th className="log-table__cell log-table__cell--header">Other Range</th>
+            <th className="log-table__cell log-table__cell--header">Info</th>
+          </tr>
+          {_.map(events, (event, key) => (
+            <tr key={key} className="log-table__row">
+              <td className="log-table__cell log-table__cell--date">
+                {Print.Timestamp(event.event.timestamp)}
+              </td>
+              <td className="log-table__cell">s{event.event.store_id}</td>
+              <td className="log-table__cell">{printLogEventType(event.event.event_type)}</td>
+              <td className="log-table__cell">{this.renderRangeID(event.event.range_id)}</td>
+              <td className="log-table__cell">{this.renderRangeID(event.event.other_range_id)}</td>
+              <td className="log-table__cell">{this.renderLogInfo(event.pretty_info)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+
+  render() {
+    const { log } = this.props;
+
+    return (
       <div>
         <h2>Range Log</h2>
         <Loading
           loading={!log || log.inFlight}
-          render={() => (
-            <table className="log-table">
-              <tbody>
-                <tr className="log-table__row log-table__row--header">
-                  <th className="log-table__cell log-table__cell--header">Timestamp</th>
-                  <th className="log-table__cell log-table__cell--header">Store</th>
-                  <th className="log-table__cell log-table__cell--header">Event Type</th>
-                  <th className="log-table__cell log-table__cell--header">Range</th>
-                  <th className="log-table__cell log-table__cell--header">Other Range</th>
-                  <th className="log-table__cell log-table__cell--header">Info</th>
-                </tr>
-                {_.map(events, (event, key) => (
-                  <tr key={key} className="log-table__row">
-                    <td className="log-table__cell log-table__cell--date">
-                      {Print.Timestamp(event.event.timestamp)}
-                    </td>
-                    <td className="log-table__cell">s{event.event.store_id}</td>
-                    <td className="log-table__cell">{printLogEventType(event.event.event_type)}</td>
-                    <td className="log-table__cell">{this.renderRangeID(event.event.range_id)}</td>
-                    <td className="log-table__cell">{this.renderRangeID(event.event.other_range_id)}</td>
-                    <td className="log-table__cell">{this.renderLogInfo(event.pretty_info)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
+          error={log && log.lastError}
+          render={this.renderContent}
         />
       </div>
     );

--- a/pkg/ui/src/views/reports/containers/settings/index.styl
+++ b/pkg/ui/src/views/reports/containers/settings/index.styl
@@ -1,0 +1,16 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+.settings-note
+  padding 18px 0

--- a/pkg/ui/src/views/reports/containers/settings/index.tsx
+++ b/pkg/ui/src/views/reports/containers/settings/index.tsx
@@ -23,6 +23,8 @@ import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { AdminUIState } from "src/redux/state";
 import Loading from "src/views/shared/components/loading";
 
+import "./index.styl";
+
 interface SettingsOwnProps {
   settings: CachedDataReducerState<protos.cockroach.server.serverpb.SettingsResponse>;
   refreshSettings: typeof refreshSettings;
@@ -78,29 +80,18 @@ class Settings extends React.Component<SettingsProps, {}> {
   }
 
   render() {
-    if (!_.isNil(this.props.settings.lastError)) {
-      return (
-        <div className="section">
-          <h1>Cluster Settings</h1>
-          <h2>Error loading Cluster Settings</h2>
-          {this.props.settings.lastError}
-        </div>
-      );
-    }
-
     return (
       <div className="section">
         <Helmet>
           <title>Cluster Settings | Debug</title>
         </Helmet>
         <h1>Cluster Settings</h1>
-        <h2></h2>
         <Loading
           loading={!this.props.settings.data}
-          className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
+          error={this.props.settings.lastError}
           render={() => (
             <div>
-              <p>Note that some settings have been redacted for security purposes.</p>
+              <p className="settings-note">Note that some settings have been redacted for security purposes.</p>
               {this.renderTable()}
             </div>
           )}

--- a/pkg/ui/src/views/reports/containers/stores/index.tsx
+++ b/pkg/ui/src/views/reports/containers/stores/index.tsx
@@ -86,11 +86,6 @@ class Stores extends React.Component<StoresProps, {}> {
 
   renderContent = () => {
     const nodeID = this.props.params[nodeIDAttr];
-    if (!_.isNil(this.props.lastError)) {
-      return (
-        <h2>Error loading stores for node {nodeID}</h2>
-      );
-    }
 
     const { stores } = this.props;
     if (_.isEmpty(stores)) {
@@ -124,7 +119,7 @@ class Stores extends React.Component<StoresProps, {}> {
         <h2>{header} stores</h2>
         <Loading
           loading={this.props.loading}
-          className="loading-image loading-image__spinner"
+          error={this.props.lastError}
           render={this.renderContent}
         />
       </div>

--- a/pkg/ui/src/views/shared/components/loading/index.styl
+++ b/pkg/ui/src/views/shared/components/loading/index.styl
@@ -19,3 +19,21 @@
   border thin solid $notification-alert-border-color
   background $notification-alert-fill-color
   border-radius 5px
+
+.loading-image
+  height 100%
+  background-repeat no-repeat
+  background-position center 40%
+  padding 12px 24px
+
+  &__spinner
+    background-size 40px 40px
+    min-height 40px
+
+  &__spinner-left
+    background-size 40px 40px
+    min-height 40px
+    width 400px
+
+    &__padded
+      padding-top 100px

--- a/pkg/ui/src/views/shared/components/loading/index.tsx
+++ b/pkg/ui/src/views/shared/components/loading/index.tsx
@@ -19,10 +19,31 @@ import "./index.styl";
 
 interface LoadingProps {
   loading: boolean;
-  error?: Error | null;
+  error?: Error | Error[] | null;
   className?: string;
   image?: string;
   render: () => React.ReactNode;
+}
+
+/**
+ * getValidErrorsList eliminates any null Error values, and returns either
+ * null or a non-empty list of Errors.
+ */
+function getValidErrorsList (errors?: Error | Error[] | null): Error[] | null {
+  if (errors) {
+    if (!Array.isArray(errors)) {
+      // Put single Error into a list to simplify logic in main Loading component.
+      return [errors];
+    } else {
+      // Remove null values from Error[].
+      const validErrors = errors.filter(e => !!e);
+      if (validErrors.length === 0) {
+        return null;
+      }
+      return validErrors;
+    }
+  }
+  return null;
 }
 
 /**
@@ -30,18 +51,28 @@ interface LoadingProps {
  * loading prop is true.
  */
 export default function Loading(props: LoadingProps) {
-  const className = props.className || "loading-image loading-image__spinner-left";
+  const className = props.className || "loading-image loading-image__spinner";
   const imageURL = props.image || spinner;
   const image = {
     "backgroundImage": `url(${imageURL})`,
   };
+
+  const errors = getValidErrorsList(props.error);
+
   // Check for `error` before `loading`, since tests for `loading` often return
   // true even if CachedDataReducer has an error and is no longer really "loading".
-  if (props.error) {
+  if (errors) {
+    const errorCountMessage = (errors.length > 1) ? "Multiple errors occurred" : "An error was encountered";
     return (
       <div className="loading-error">
-        <p>An error was encountered while loading this data:</p>
-        <pre>{props.error.message}</pre>
+        <p>{errorCountMessage} while loading this data:</p>
+        <ul>
+          {errors.map((error, idx) => (
+            <li key={idx}>
+              <pre>{error.message}</pre>
+            </li>
+          ))}
+        </ul>
       </div>
     );
   }

--- a/pkg/ui/src/views/shared/components/loading/loading.spec.tsx
+++ b/pkg/ui/src/views/shared/components/loading/loading.spec.tsx
@@ -1,0 +1,185 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+import _ from "lodash";
+import React from "react";
+import { assert } from "chai";
+import {mount, ReactWrapper} from "enzyme";
+
+import "src/enzymeInit";
+import Loading from "src/views/shared/components/loading";
+
+const LOADING_CLASS_NAME = "loading-class-name";
+const RENDER_CLASS_NAME = "render-class-name";
+const ERROR_CLASS_NAME = "loading-error";
+const ALL_CLASS_NAMES = [LOADING_CLASS_NAME, ERROR_CLASS_NAME, RENDER_CLASS_NAME];
+
+interface MakeLoadingProps {
+  loading: boolean;
+  error?: Error | Error[] | null;
+  renderClassName?: string;
+}
+
+interface AssertExpectedProps {
+  onlyVisibleClass: string;
+  errorCount?: number;
+}
+
+describe("<Loading>", () => {
+
+  describe("when error is null", () => {
+    describe("when loading=false", () => {
+      it("renders content.", () => {
+        const wrapper = makeLoadingComponent({
+          loading: false, error: null,
+          renderClassName: "my-rendered-content",
+        });
+        assertExpectedState(wrapper, {
+          onlyVisibleClass: "my-rendered-content",
+        });
+      });
+    });
+
+    describe("when loading=true", () => {
+      it("renders loading spinner.", () => {
+        const wrapper = makeLoadingComponent({
+          loading: true, error: null,
+        });
+        assertExpectedState(wrapper, {
+          onlyVisibleClass: LOADING_CLASS_NAME,
+        });
+      });
+    });
+  });
+
+  describe("when error is a single error", () => {
+    describe("when loading=false", () => {
+      it("renders error, regardless of loading value.", () => {
+        const wrapper = makeLoadingComponent({
+          loading: false,
+          error: Error("some error message"),
+        });
+        assertExpectedState(wrapper, {
+          onlyVisibleClass: ERROR_CLASS_NAME,
+          errorCount: 1,
+        });
+      });
+    });
+
+    describe("when loading=true", () => {
+      it("renders error, regardless of loading value.", () => {
+        const wrapper = makeLoadingComponent({
+          loading: true,
+          error: Error("some error message"),
+        });
+        assertExpectedState(wrapper, {
+          onlyVisibleClass: ERROR_CLASS_NAME,
+          errorCount: 1,
+        });
+      });
+    });
+  });
+
+  describe("when error is a list of errors", () => {
+    describe("when no errors are null", () => {
+      it("renders all errors in list", () => {
+        const wrapper = makeLoadingComponent({
+          loading: false,
+          error: [
+            Error("error1"),
+            Error("error2"),
+            Error("error3"),
+          ],
+        });
+        assertExpectedState(wrapper, {
+          onlyVisibleClass: ERROR_CLASS_NAME,
+          errorCount: 3,
+        });
+      });
+    });
+
+    describe("when some errors are null", () => {
+      it("ignores null list values, rending only valid errors.", () => {
+        const wrapper = makeLoadingComponent({
+          loading: false,
+          error: [
+            null,
+            Error("error1"),
+            Error("error2"),
+            null,
+            Error("error3"),
+            null,
+          ],
+        });
+        assertExpectedState(wrapper, {
+          onlyVisibleClass: ERROR_CLASS_NAME,
+          errorCount: 3,
+        });
+      });
+    });
+
+    describe("when all errors are null", () => {
+      it("renders content, since there are no errors.", () => {
+        const wrapper = makeLoadingComponent({
+          loading: false,
+          error: [
+            null,
+            null,
+            null,
+          ],
+          renderClassName: "no-errors-so-should-render-me",
+        });
+        assertExpectedState(wrapper, {
+          onlyVisibleClass: "no-errors-so-should-render-me",
+        });
+      });
+    });
+  });
+});
+
+function assertExpectedState(
+  wrapper: ReactWrapper,
+  props: AssertExpectedProps,
+) {
+  // Assert that onlyVisibleClass is rendered, and that all classes are not.
+  _.map(ALL_CLASS_NAMES, (className) => {
+    const expectedVisibility = props.onlyVisibleClass === className;
+    const expectedLength = expectedVisibility ? 1 : 0;
+    const element = "div." + className;
+    assert.lengthOf(
+      wrapper.find(element),
+      expectedLength, "expected " + element +
+      (expectedVisibility ? " to be visible" : " to not be rendered"));
+  });
+
+  if (props.errorCount) {
+    assert.lengthOf(
+      wrapper.find("div." + ERROR_CLASS_NAME).find("li"),
+      props.errorCount,
+    );
+  }
+}
+
+function makeLoadingComponent(
+  props: MakeLoadingProps,
+) {
+  return mount(<Loading
+    loading={props.loading}
+    error={props.error}
+    className={LOADING_CLASS_NAME}
+    render={() => (
+      <div className={props.renderClassName || RENDER_CLASS_NAME}>Hello, world!</div>
+    )}
+    />);
+}

--- a/pkg/ui/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/src/views/statements/statementDetails.tsx
@@ -68,6 +68,7 @@ function AppLink(props: { app: string }) {
 
 interface StatementDetailsOwnProps {
   statement: SingleStatementStatistics;
+  statementsError: Error | null;
   nodeNames: { [nodeId: string]: string };
   refreshStatements: typeof refreshStatements;
 }
@@ -180,7 +181,7 @@ class StatementDetails extends React.Component<StatementDetailsProps, StatementD
         <section className="section section--container">
           <Loading
             loading={_.isNil(this.props.statement)}
-            className="loading-image loading-image__spinner"
+            error={this.props.statementsError}
             render={this.renderContent}
           />
         </section>
@@ -441,6 +442,7 @@ export const selectStatement = createSelector(
 const StatementDetailsConnected = connect(
   (state: AdminUIState, props: RouterState) => ({
     statement: selectStatement(state, props),
+    statementsError: state.cachedData.statements.lastError,
     nodeNames: nodeDisplayNameByIDSelector(state),
   }),
   {

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -44,6 +44,7 @@ type RouteProps = RouteComponentProps<any, any>;
 
 interface StatementsPageProps {
   statements: AggregateStatistics[];
+  statementsError: Error | null;
   apps: string[];
   totalFingerprints: number;
   lastReset: string;
@@ -157,7 +158,7 @@ class StatementsPage extends React.Component<StatementsPageProps & RouteProps, S
 
         <Loading
           loading={_.isNil(this.props.statements)}
-          className="loading-image loading-image__spinner"
+          error={this.props.statementsError}
           render={this.renderStatements}
         />
       </React.Fragment>
@@ -259,6 +260,7 @@ export const selectLastReset = createSelector(
 const StatementsPageConnected = connect(
   (state: StatementsState, props: RouteProps) => ({
     statements: selectStatements(state, props),
+    statementsError: state.cachedData.statements.lastError,
     apps: selectApps(state),
     totalFingerprints: selectTotalFingerprints(state),
     lastReset: selectLastReset(state),


### PR DESCRIPTION
Previously, data fetching errors were not being consistently surfaced to
the user. This commit updates all existing uses of the Loading component
to surface these errors:

 - Some parent components renders data from multiple sources,
   potentially having multiple errors to show the user. This commit also
   extends the Loading component to handle multiple errors.
 - The Certificates page had custom loading logic. This commit replaces
   logic with Loading component.

Also in this commit is some minor cleanup (copy, layout).

Fixes: #24011

Release note (admin ui change): This commit wires up data errors to all
existing uses of the Loading component. Previously, data errors weren't
consistently surfaced.