### PR TITLE
ui: add whitespace between text and links

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/needEnterpriseLicense.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/needEnterpriseLicense.tsx
@@ -21,10 +21,9 @@ export default class NeedEnterpriseLicense extends React.Component<NodeCanvasCon
             <p className="need-license-blurb__text">
               The Node Map shows the geographical layout of your cluster, along
               with metrics and health indicators. To enable the Node Map,
-              request an
-              <a href={docsURL.enterpriseLicensing} target="_blank">Enterprise trial license</a>
-              and refer to this
-              <a href={docsURL.enableNodeMap} target="_blank">configuration guide</a>.
+              request an <a href={docsURL.enterpriseLicensing} target="_blank">Enterprise trial
+              license</a> and refer to this <a href={docsURL.enableNodeMap} target="_blank">configuration
+              guide</a>.
             </p>
           </div>
           <a href={docsURL.startTrial} className="need-license-blurb__trial-link" target="_blank">


### PR DESCRIPTION
Previously copy and links were running into each other.
Rearranged blurb to force a space between copy and links.

Before:
![image](https://user-images.githubusercontent.com/3051672/48718885-39d5fd00-ebea-11e8-8175-69d69c3e837d.png)

After:
![image](https://user-images.githubusercontent.com/3051672/48718948-5bcf7f80-ebea-11e8-9ee1-87f3c29d8542.png)

Release note (admin ui change): Minor copy render fix.
