### PR TITLE
debug/logspy: allow grepping for goroutine ids

### DIFF
--- a/pkg/server/debug/logspy_test.go
+++ b/pkg/server/debug/logspy_test.go
@@ -53,7 +53,21 @@ func TestDebugLogSpyOptions(t *testing.T) {
 			expOpts: logSpyOptions{
 				Count:    123,
 				Duration: durationAsString(9 * time.Second),
-				Grep:     regexpAsString{regexp.MustCompile(`^foo$`)},
+				Grep:     regexpAsString{re: regexp.MustCompile(`^foo$`)},
+			},
+		},
+		{
+			// Example where everything is specified (and parsed) and where grep is an integer.
+			vals: map[string][]string{
+				"NonexistentOptionIsIgnored": {"banana"},
+				"Count":    {"123"},
+				"Duration": {"9s"},
+				"Grep":     {`123`},
+			},
+			expOpts: logSpyOptions{
+				Count:    123,
+				Duration: durationAsString(9 * time.Second),
+				Grep:     regexpAsString{re: regexp.MustCompile(`123`), i: 123},
 			},
 		},
 		{


### PR DESCRIPTION
This change makes it possible to watch a single goroutine as it moves
around the system.

This would have helped in the current adriatic debug session.

Release note: None