### PR TITLE
roachprod: introduce a --local-ssd-no-ext4-barrier flag for create

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1336,8 +1336,12 @@ func main() {
 
 	createCmd.Flags().DurationVarP(&createVMOpts.Lifetime,
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
-	createCmd.Flags().BoolVar(&createVMOpts.UseLocalSSD,
+	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.UseLocalSSD,
 		"local-ssd", true, "Use local SSD")
+	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.NoExt4Barrier,
+		"local-ssd-no-ext4-barrier", false,
+		`Mount the local SSD with the "-o nobarrier" flag. `+
+			`Ignored if --local-ssd=false is specified.`)
 	createCmd.Flags().IntVarP(&numNodes,
 		"nodes", "n", 4, "Total number of nodes, distributed across all clouds")
 	createCmd.Flags().StringSliceVarP(&createVMOpts.VMProviders,

--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -223,15 +223,6 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 			"`roachprod gc --gce-project=%s` cronjob\n", p.opts.Project)
 	}
 
-	// Create GCE startup script file.
-	filename, err := writeStartupScript()
-	if err != nil {
-		return errors.Wrapf(err, "could not write GCE startup script to temp file")
-	}
-	defer func() {
-		_ = os.Remove(filename)
-	}()
-
 	if !opts.GeoDistributed {
 		p.opts.Zones = []string{p.opts.Zones[0]}
 	}
@@ -262,10 +253,24 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 		args = append(args, "--service-account", p.opts.ServiceAccount)
 	}
 
+	extraMountOpts := ""
 	// Dynamic args.
-	if opts.UseLocalSSD {
+	if opts.SSDOpts.UseLocalSSD {
 		args = append(args, "--local-ssd", "interface=SCSI")
+		if opts.SSDOpts.NoExt4Barrier {
+			extraMountOpts = "nobarrier"
+		}
 	}
+
+	// Create GCE startup script file.
+	filename, err := writeStartupScript(extraMountOpts)
+	if err != nil {
+		return errors.Wrapf(err, "could not write GCE startup script to temp file")
+	}
+	defer func() {
+		_ = os.Remove(filename)
+	}()
+
 	args = append(args, "--machine-type", p.opts.MachineType)
 	args = append(args, "--labels", fmt.Sprintf("lifetime=%s", opts.Lifetime))
 

--- a/pkg/cmd/roachprod/vm/vm.go
+++ b/pkg/cmd/roachprod/vm/vm.go
@@ -111,10 +111,15 @@ func (vl List) ProviderIDs() []string {
 
 // CreateOpts is the set of options when creating VMs.
 type CreateOpts struct {
-	UseLocalSSD    bool
 	Lifetime       time.Duration
 	GeoDistributed bool
 	VMProviders    []string
+	SSDOpts        struct {
+		UseLocalSSD bool
+		// NoExt4Barrier, if set, makes the "-o nobarrier" flag be used when
+		// mounting the SSD. Ignored if UseLocalSSD is not set.
+		NoExt4Barrier bool
+	}
 }
 
 // ProviderFlags is a hook point for Providers to supply additional,


### PR DESCRIPTION
Use of nobarrier is common for roachprod clusters. They might even
become the default for roachtest clusters. This patch bring first-class
support for them into roachprod, which learns to mount a drive
accrdingly.

Release note: None