### PR TITLE
roachprod: fix order of regions when using create with AWS

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -348,7 +348,9 @@ func (p *Provider) Name() string {
 // allRegions returns the regions that have been configured with
 // AMI and SecurityGroup instances.
 func (p *Provider) allRegions() ([]string, error) {
-	amiMap, err := splitMap(p.opts.AMI)
+	// We're using an ordered list instead of a map here to guarantee
+	// the same ordering between calls.
+	regionList, err := orderedKeyList(p.opts.AMI)
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +361,7 @@ func (p *Provider) allRegions() ([]string, error) {
 	}
 
 	var keys []string
-	for region := range amiMap {
+	for _, region := range regionList {
 		if _, ok := securityMap[region]; ok {
 			keys = append(keys, region)
 		} else {

--- a/pkg/cmd/roachprod/vm/aws/support.go
+++ b/pkg/cmd/roachprod/vm/aws/support.go
@@ -115,15 +115,38 @@ func runJSONCommand(args []string, parsed interface{}) error {
 	return nil
 }
 
+// split returns a key and value for 'key:value' pairs.
+func split(data string) (key, value string, err error) {
+	parts := strings.Split(data, ":")
+	if len(parts) != 2 {
+		return "", "", errors.Errorf("Could not split: %s", data)
+	}
+
+	return parts[0], parts[1], nil
+}
+
 // splitMap splits a list of `key:value` pairs into a map.
 func splitMap(data []string) (map[string]string, error) {
 	ret := make(map[string]string, len(data))
 	for _, part := range data {
-		parts := strings.Split(part, ":")
-		if len(parts) != 2 {
-			return nil, errors.Errorf("Could not split Region:AMI: %s", part)
+		key, value, err := split(part)
+		if err != nil {
+			return nil, err
 		}
-		ret[parts[0]] = parts[1]
+		ret[key] = value
+	}
+	return ret, nil
+}
+
+// orderedKeyList returns just the ordered keys of a list of 'key:value' pairs.
+func orderedKeyList(data []string) ([]string, error) {
+	ret := make([]string, 0, len(data))
+	for _, part := range data {
+		key, _, err := split(part)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, key)
 	}
 	return ret, nil
 }


### PR DESCRIPTION
The allRegions() function returns a list of all valid regions. Before
it would read a mapping of regions to AMIs into a hashmap
and would use that to generate a list. This resulted in callers getting
regions in different orders between calls. For a function like Create
which uses the first region from this list for a non geo distributed
cluster, it means that the cluster would get started in a random region
unless explicitly specified.

Now we're going to read the AMI list in order so we can ensure
a consistent ordering between calls.

Release note: None