### PR TITLE
release-2.1: changefeedccl: fix avro buglet

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -252,6 +252,7 @@ func tableToAvroSchema(tableDesc *sqlbase.TableDescriptor) (*avroSchemaRecord, e
 		colIdxByFieldIdx: make(map[int]int),
 	}
 	for colIdx, col := range tableDesc.Columns {
+		col := col
 		field, err := columnDescToAvroSchema(&col)
 		if err != nil {
 			return nil, err

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -190,6 +190,11 @@ func TestAvroSchema(t *testing.T) {
 			schema: `(a INT PRIMARY KEY, b STRING)`,
 			values: `(1, 'a')`,
 		},
+		{
+			name:   `MULTI_WIDTHS`,
+			schema: `(a INT PRIMARY KEY, b DECIMAL (3,2), c DECIMAL (2, 1))`,
+			values: `(1, 1.23, 4.5)`,
+		},
 	}
 	// Generate a test for each column type with a random datum of that type.
 	for semTypeID, semTypeName := range sqlbase.ColumnType_SemanticType_name {


### PR DESCRIPTION
Backport 1/1 commits from #32474.

/cc @cockroachdb/release

---

Classic "taking the address of a for-loop local variable buglet". Was
breaking any columns with width or precision set.

Closes #32471

Release note (bug fix): experimental_avro CHANGEFEEDs now work with
column WIDTHs and PRECISIONs
