### PR TITLE
storage: write at provisional commit ts, not orig ts

### DIFF
--- a/pkg/ccl/storageccl/engineccl/mvcc_test.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc_test.go
@@ -161,25 +161,31 @@ func TestMVCCIterateIncremental(t *testing.T) {
 
 		// Exercise intent handling.
 		txn1ID := uuid.MakeV4()
-		txn1 := roachpb.Transaction{TxnMeta: enginepb.TxnMeta{
-			Key:       testKey1,
-			ID:        txn1ID,
-			Epoch:     1,
-			Timestamp: ts4,
-		}}
+		txn1 := roachpb.Transaction{
+			TxnMeta: enginepb.TxnMeta{
+				Key:       testKey1,
+				ID:        txn1ID,
+				Epoch:     1,
+				Timestamp: ts4,
+			},
+			OrigTimestamp: ts4,
+		}
 		txn1Val := roachpb.Value{RawBytes: testValue4}
-		if err := engine.MVCCPut(ctx, e, nil, txn1.TxnMeta.Key, txn1.TxnMeta.Timestamp, txn1Val, &txn1); err != nil {
+		if err := engine.MVCCPut(ctx, e, nil, txn1.TxnMeta.Key, txn1.OrigTimestamp, txn1Val, &txn1); err != nil {
 			t.Fatal(err)
 		}
 		txn2ID := uuid.MakeV4()
-		txn2 := roachpb.Transaction{TxnMeta: enginepb.TxnMeta{
-			Key:       testKey2,
-			ID:        txn2ID,
-			Epoch:     1,
-			Timestamp: ts4,
-		}}
+		txn2 := roachpb.Transaction{
+			TxnMeta: enginepb.TxnMeta{
+				Key:       testKey2,
+				ID:        txn2ID,
+				Epoch:     1,
+				Timestamp: ts4,
+			},
+			OrigTimestamp: ts4,
+		}
 		txn2Val := roachpb.Value{RawBytes: testValue4}
-		if err := engine.MVCCPut(ctx, e, nil, txn2.TxnMeta.Key, txn2.TxnMeta.Timestamp, txn2Val, &txn2); err != nil {
+		if err := engine.MVCCPut(ctx, e, nil, txn2.TxnMeta.Key, txn2.OrigTimestamp, txn2Val, &txn2); err != nil {
 			t.Fatal(err)
 		}
 		t.Run("intents1",
@@ -233,25 +239,31 @@ func TestMVCCIterateIncremental(t *testing.T) {
 
 		// Exercise intent handling.
 		txn1ID := uuid.MakeV4()
-		txn1 := roachpb.Transaction{TxnMeta: enginepb.TxnMeta{
-			Key:       testKey1,
-			ID:        txn1ID,
-			Epoch:     1,
-			Timestamp: ts4,
-		}}
+		txn1 := roachpb.Transaction{
+			TxnMeta: enginepb.TxnMeta{
+				Key:       testKey1,
+				ID:        txn1ID,
+				Epoch:     1,
+				Timestamp: ts4,
+			},
+			OrigTimestamp: ts4,
+		}
 		txn1Val := roachpb.Value{RawBytes: testValue4}
-		if err := engine.MVCCPut(ctx, e, nil, txn1.TxnMeta.Key, txn1.TxnMeta.Timestamp, txn1Val, &txn1); err != nil {
+		if err := engine.MVCCPut(ctx, e, nil, txn1.TxnMeta.Key, txn1.OrigTimestamp, txn1Val, &txn1); err != nil {
 			t.Fatal(err)
 		}
 		txn2ID := uuid.MakeV4()
-		txn2 := roachpb.Transaction{TxnMeta: enginepb.TxnMeta{
-			Key:       testKey2,
-			ID:        txn2ID,
-			Epoch:     1,
-			Timestamp: ts4,
-		}}
+		txn2 := roachpb.Transaction{
+			TxnMeta: enginepb.TxnMeta{
+				Key:       testKey2,
+				ID:        txn2ID,
+				Epoch:     1,
+				Timestamp: ts4,
+			},
+			OrigTimestamp: ts4,
+		}
 		txn2Val := roachpb.Value{RawBytes: testValue4}
-		if err := engine.MVCCPut(ctx, e, nil, txn2.TxnMeta.Key, txn2.TxnMeta.Timestamp, txn2Val, &txn2); err != nil {
+		if err := engine.MVCCPut(ctx, e, nil, txn2.TxnMeta.Key, txn2.OrigTimestamp, txn2Val, &txn2); err != nil {
 			t.Fatal(err)
 		}
 		t.Run("intents1",
@@ -370,6 +382,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 			Epoch:     1,
 			Timestamp: hlc.Timestamp{WallTime: 2},
 		},
+		OrigTimestamp: hlc.Timestamp{WallTime: 2},
 	})
 
 	// Create a second DB in which we'll create a specific SSTable structure: the
@@ -473,6 +486,7 @@ func TestMVCCIncrementalIteratorIntentDeletion(t *testing.T) {
 				Epoch:     1,
 				Timestamp: ts,
 			},
+			OrigTimestamp: ts,
 		}
 	}
 	intent := func(txn *roachpb.Transaction) roachpb.Intent {
@@ -542,9 +556,9 @@ func TestMVCCIncrementalIteratorIntentDeletion(t *testing.T) {
 	// kA:3 -> vA3
 	// kA:2 -> vA2
 	// kB -> (intent deletion)
-	require.NoError(t, engine.MVCCPut(ctx, db, nil, kA, txnA1.Timestamp, vA1, txnA1))
-	require.NoError(t, engine.MVCCPut(ctx, db, nil, kB, txnB1.Timestamp, vB1, txnB1))
-	require.NoError(t, engine.MVCCPut(ctx, db, nil, kC, txnC1.Timestamp, vC1, txnC1))
+	require.NoError(t, engine.MVCCPut(ctx, db, nil, kA, txnA1.OrigTimestamp, vA1, txnA1))
+	require.NoError(t, engine.MVCCPut(ctx, db, nil, kB, txnB1.OrigTimestamp, vB1, txnB1))
+	require.NoError(t, engine.MVCCPut(ctx, db, nil, kC, txnC1.OrigTimestamp, vC1, txnC1))
 	require.NoError(t, db.Flush())
 	require.NoError(t, db.Compact())
 	require.NoError(t, engine.MVCCResolveWriteIntent(ctx, db, nil, intent(txnA1)))

--- a/pkg/roachpb/data.pb.go
+++ b/pkg/roachpb/data.pb.go
@@ -352,42 +352,11 @@ type Transaction struct {
 	// transaction will retry unless we manage to "refresh the reads" - see
 	// refreshed_timestamp.
 	//
-	// This timestamp is the one at which all transactions will read, unless
-	// refreshed_timestamp is set. It is also, surprisingly, the timestamp at
-	// which transactions will provisionally _write_ (i.e. intents are written at
-	// this orig_timestamp and, after commit, when the intents are resolved,
-	// their timestamps are bumped to the to the commit timestamp), if
-	// refreshed_timestamp isn't set.
-	// This is ultimately because of correctness concerns around SNAPSHOT
-	// transactions.
+	// This timestamp is the one at which all reads occur, unless
+	// refreshed_timestamp is set.
 	//
-	// Intuitively, one could think that the timestamp at which intents should be
-	// written should be the provisional commit timestamp, and while this is
-	// morally true, consider the following scenario, where txn1 is a SNAPSHOT
-	// txn:
-	//
-	// - txn1 at orig_timestamp=5 reads key1: (value) 1.
-	// - txn1 writes elsewhere, has its commit timestamp increased to 20.
-	// - txn2 at orig_timestamp=10 reads key1: 1
-	// - txn2 increases the value by 5: key1: 6 and commits
-	// - txn1 increases the value by 1: key1: 2, attempts commit
-	//
-	// If txn1 uses its orig_timestamp for updating key1 (as it does), it
-	// conflicts with txn2's committed value (which is at timestamp 10, in the
-	// future of 5), and restarts.
-	// Using instead its candidate commit timestamp, it wouldn't see a conflict
-	// and commit, but this is not the expected outcome (the expected outcome is
-	// {key1: 6} (since txn1 is not expected to commit)) and we would be
-	// experiencing the Lost Update Anomaly.
-	//
-	// Note that in practice, before restarting, txn1 would still lay down an
-	// intent (just above the committed value) not with the intent to commit it,
-	// but to avoid being starved by short-lived transactions on that key which
-	// would otherwise not have to go through conflict resolution with txn1.
-	//
-	// Again, keep in mind that, when the transaction commits, all the intents are
-	// bumped to the commit timestamp (otherwise, pushing a transaction wouldn't
-	// achieve anything).
+	// Note that writes do not occur at this timestamp; they instead occur at the
+	// provisional commit timestamp, meta.Timestamp.
 	OrigTimestamp cockroach_util_hlc.Timestamp `protobuf:"bytes,6,opt,name=orig_timestamp,json=origTimestamp" json:"orig_timestamp"`
 	// Initial Timestamp + clock skew. Reads which encounter values with
 	// timestamps between timestamp and max_timestamp trigger a txn
@@ -400,9 +369,10 @@ type Transaction struct {
 	// can commit without necessitating a serializable restart. This
 	// value is forwarded to the transaction's current timestamp (meta.timestamp)
 	// if the transaction coordinator is able to refresh all refreshable spans
-	// encountered during the course of the txn. If set, this take precedence
-	// over orig_timestamp and is the timestamp at which the transaction both
-	// reads and writes going forward.
+	// encountered during the course of the txn. If set, this takes precedence
+	// over orig_timestamp and is the timestamp at which the transaction reads
+	// going forward.
+	//
 	// We need to keep track of both refresh_timestamp and orig_timestamp (instead
 	// of simply overwriting the orig_timestamp after refreshes) because the
 	// orig_timestamp needs to be used as a lower bound timestamp for the

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -262,42 +262,11 @@ message Transaction {
   // transaction will retry unless we manage to "refresh the reads" - see
   // refreshed_timestamp.
   //
-  // This timestamp is the one at which all transactions will read, unless
-  // refreshed_timestamp is set. It is also, surprisingly, the timestamp at
-  // which transactions will provisionally _write_ (i.e. intents are written at
-  // this orig_timestamp and, after commit, when the intents are resolved,
-  // their timestamps are bumped to the to the commit timestamp), if
-  // refreshed_timestamp isn't set.
-  // This is ultimately because of correctness concerns around SNAPSHOT
-  // transactions.
+  // This timestamp is the one at which all reads occur, unless
+  // refreshed_timestamp is set.
   //
-  // Intuitively, one could think that the timestamp at which intents should be
-  // written should be the provisional commit timestamp, and while this is
-  // morally true, consider the following scenario, where txn1 is a SNAPSHOT
-  // txn:
-  //
-  // - txn1 at orig_timestamp=5 reads key1: (value) 1.
-  // - txn1 writes elsewhere, has its commit timestamp increased to 20.
-  // - txn2 at orig_timestamp=10 reads key1: 1
-  // - txn2 increases the value by 5: key1: 6 and commits
-  // - txn1 increases the value by 1: key1: 2, attempts commit
-  //
-  // If txn1 uses its orig_timestamp for updating key1 (as it does), it
-  // conflicts with txn2's committed value (which is at timestamp 10, in the
-  // future of 5), and restarts.
-  // Using instead its candidate commit timestamp, it wouldn't see a conflict
-  // and commit, but this is not the expected outcome (the expected outcome is
-  // {key1: 6} (since txn1 is not expected to commit)) and we would be
-  // experiencing the Lost Update Anomaly.
-  //
-  // Note that in practice, before restarting, txn1 would still lay down an
-  // intent (just above the committed value) not with the intent to commit it,
-  // but to avoid being starved by short-lived transactions on that key which
-  // would otherwise not have to go through conflict resolution with txn1.
-  //
-  // Again, keep in mind that, when the transaction commits, all the intents are
-  // bumped to the commit timestamp (otherwise, pushing a transaction wouldn't
-  // achieve anything).
+  // Note that writes do not occur at this timestamp; they instead occur at the
+  // provisional commit timestamp, meta.Timestamp.
   util.hlc.Timestamp orig_timestamp = 6 [(gogoproto.nullable) = false];
   // Initial Timestamp + clock skew. Reads which encounter values with
   // timestamps between timestamp and max_timestamp trigger a txn
@@ -310,9 +279,10 @@ message Transaction {
   // can commit without necessitating a serializable restart. This
   // value is forwarded to the transaction's current timestamp (meta.timestamp)
   // if the transaction coordinator is able to refresh all refreshable spans
-  // encountered during the course of the txn. If set, this take precedence
-  // over orig_timestamp and is the timestamp at which the transaction both
-  // reads and writes going forward.
+  // encountered during the course of the txn. If set, this takes precedence
+  // over orig_timestamp and is the timestamp at which the transaction reads
+  // going forward.
+  //
   // We need to keep track of both refresh_timestamp and orig_timestamp (instead
   // of simply overwriting the orig_timestamp after refreshes) because the
   // orig_timestamp needs to be used as a lower bound timestamp for the

--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -129,7 +129,7 @@ func TestUpsertFastPath(t *testing.T) {
 	}
 }
 
-func TestConcurrentUpsertWithSnapshotIsolation(t *testing.T) {
+func TestConcurrentUpsert(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
@@ -138,9 +138,6 @@ func TestConcurrentUpsertWithSnapshotIsolation(t *testing.T) {
 
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE d.t (a INT PRIMARY KEY, b INT, INDEX b_idx (b))`)
-	// TODO(andrei): This test is probably broken: it's setting a default
-	// isolation on a random connection, not on all connections.
-	sqlDB.Exec(t, `SET DEFAULT_TRANSACTION_ISOLATION TO SNAPSHOT`)
 
 	testCases := []struct {
 		name       string

--- a/pkg/storage/batcheval/cmd_refresh_range_test.go
+++ b/pkg/storage/batcheval/cmd_refresh_range_test.go
@@ -69,8 +69,9 @@ func TestRefreshRangeTimeBoundIterator(t *testing.T) {
 			Epoch:     1,
 			Timestamp: ts1,
 		},
+		OrigTimestamp: ts1,
 	}
-	if err := engine.MVCCPut(ctx, db, nil, k, txn.Timestamp, v, txn); err != nil {
+	if err := engine.MVCCPut(ctx, db, nil, k, txn.OrigTimestamp, v, txn); err != nil {
 		t.Fatal(err)
 	}
 	if err := engine.MVCCPut(ctx, db, nil, roachpb.Key("unused1"), ts4, v, nil); err != nil {

--- a/pkg/storage/engine/enginepb/mvcc3.proto
+++ b/pkg/storage/engine/enginepb/mvcc3.proto
@@ -36,15 +36,61 @@ message TxnMeta {
   bytes key = 3; // TODO(tschottdorf): [(gogoproto.casttype) = "Key"];
   // Incremented on txn retry.
   uint32 epoch = 4;
-  // The proposed timestamp for the transaction. This starts as the
-  // current wall time on the txn coordinator. This is the timestamp
-  // at which all of the transaction's writes are performed: even if
-  // intents have been laid down at different timestamps, the process
-  // of resolving them (e.g. when the txn commits) will bump them to
-  // this timestamp. SERIALIZABLE transactions only commit when
-  // timestamp == orig_timestamp. SNAPSHOT transactions can commit
-  // even when they've performed their reads (at orig_timestamp) at a
-  // different timestamp than their writes (at timestamp).
+  // The proposed timestamp for the transaction. This starts as the current wall
+  // time on the txn coordinator, and is forwarded by the timestamp cache if the
+  // txn attempts to write "beneath" another txn's writes.
+  //
+  // Writes within the txn are performed using the most up-to-date value of this
+  // timestamp that is available. For example, suppose a txn starts at some
+  // timestamp, writes a key/value, and has its timestamp forwarded while doing
+  // so because a later version already exists at that key. As soon as the txn
+  // coordinator learns of the updated timestamp, it will begin performing
+  // writes at the updated timestamp. The coordinator may, however, continue
+  // issuing writes at the original timestamp before it learns about the
+  // forwarded timestamp. The process of resolving the intents when the txn
+  // commits will bump any intents written at an older timestamp to the final
+  // commit timestamp.
+  //
+  // Note that reads do not occur at this timestamp; they instead occur at
+  // OrigTimestamp, which is tracked in the containing roachpb.Transaction.
+  //
+  // Writes used to be performed at the txn's original timestamp, which was
+  // necessary to avoid lost update anomalies in snapshot isolation mode. We no
+  // longer support snapshot isolation mode, and there are now several important
+  // reasons that writes are performed at this timestamp instead of the txn's
+  // original timestamp:
+  //
+  //    1. This timestamp is forwarded by the timestamp cache when this
+  //       transaction attempts to write beneath a more recent read. Leaving the
+  //       intent at the original timestamp would write beneath that read, which
+  //       would violate an invariant that time-bound iterators rely on.
+  //
+  //       For example, consider a client that uses a time-bound iterator to
+  //       poll for changes to a key. The client reads (ts5, ts10], sees no
+  //       writes, and reports that no changes have occurred up to t10. Then a
+  //       txn writes an intent at its original timestamp ts7. The txn's
+  //       timestamp is forwarded to ts11 by the timestamp cache thanks to the
+  //       client's read. Meanwhile, the client reads (ts10, ts15] and, again
+  //       seeing no intents, reports that no changes have occurred to the key
+  //       up to t15. Now the txn commits at ts11 and bumps the intent to ts11.
+  //       But the client thinks it has seen all changes up to t15, and so never
+  //       sees the intent! We avoid this problem by writing intents at the
+  //       provisional commit timestamp insteadr. In this example, the intent
+  //       would instead be written at ts11 and picked up by the client's next
+  //       read from (ts10, ts15].
+  //
+  //    2. Unnecessary PushTxn roundtrips are avoided. If a transaction is
+  //       forwarded from ts5 to ts10, the rest of its intents will be written
+  //       at ts10. Reads at t < ts10 that encounter these intents can ignore
+  //       them; if the intents had instead been left at ts5, these reads would
+  //       have needed to send PushTxn requests just to find out that the txn
+  //       had, in fact, been forwarded to a non-conflicting time.
+  //
+  //    3. Unnecessary intent rewriting is avoided. Writing at the original
+  //       timestamp when this timestamp has been forwarded guarantees that the
+  //       value will need to be rewritten at the forwarded timestamp if the
+  //       transaction commits.
+  //
   util.hlc.Timestamp timestamp = 5 [(gogoproto.nullable) = false];
   int32 priority = 6;
   // A one-indexed sequence number which is increased on each request


### PR DESCRIPTION

The fact that transactions write at their original timestamp, and not
their provisional commit timestamp, allows leaving an intent under a
read. The timestamp cache will ensure that the transaction can't
actually commit unless it can bump its intents above the read, but it
will still leave an intent under the read in the meantime.

This can lead to starvation. Intents are meant to function as a sort of
lock on a key. Once a writer lays down an intent, no readers should be
allowed to read above that intent until that intent is resolved.
Otherwise a continual stream of readers could prevent the writer from
ever managing to commit by continually bumping the timestamp cache.

Now consider how CDC's poller works: it reads (tsmin, ts1], then (ts1,
ts2], then (ts2, ts3], and so on, in a tight loop. Since it uses a
time-bound iterator under the hood, reading (ts2, ts3], for example,
cannot return an intent written at ts2. But the idea was that we
inductively guranteed that we never read above an intent. If an intent
was written at ts2, even though the read from (ts2, ts3] would fail to
observe it, the previous read from (ts1, ts2] would have.

Of course, since transactions write at their original timestamp, a
transaction with an original timestamp of ts2 can write an intent at ts2
*after* the CDC poller has read (ts1, ts2]. (The transaction will be
forced to commit at ts3 or later to be sequenced after the CDC poller's
read, but it will leave the intent at ts2.) The CDC poller's next read,
from (ts2, ts3], thus won't see the intent, nor will any future reads at
higher timestamps. And so the CDC poller will continually bump the
timestamp cache, completely starving the writer.

Fix the problem by writing at the transaction's provisional commit
timestamp (i.e., the timestamp that has been forwarded by the timestamp
cache, if necessary) instead of the transaction's original timestamp.
Writing at the original timestamp was only necessary to prevent a lost
update in snapshot isolation mode, which is no longer supported. In
serializable mode, the anomaly is protected against by the read refresh
mechanism.

Besides fixing the starvation problem, the new behavior is more
intuitive than the old behavior. It also might have some performance
benefits, as it is less likely that intents will need to be bumped at
commit time, which saves on RocksDB writes.

Touches #32433.

Release note: None