### PR TITLE
libroach: ensure correct lifetime for resume_key on reverse iteration

### DIFF
--- a/c-deps/libroach/iterator.h
+++ b/c-deps/libroach/iterator.h
@@ -31,6 +31,7 @@ struct DBIterator {
   std::unique_ptr<cockroach::chunkedBuffer> kvs;
   std::unique_ptr<rocksdb::WriteBatch> intents;
   std::unique_ptr<IteratorStats> stats;
+  std::string rev_resume_key;
 
   rocksdb::ReadOptions read_opts;
   std::string lower_bound_str;


### PR DESCRIPTION
Fixes #32149.

Before this change, it was possible for `DBScanResults.resume_key` to
point into memory owned by `mvccScanner`, which went out of scope after
`MVCCScan` returned. This allowed for memory corruption when returning
the key to Go.

This change fixes this corruption by copying the memory to the `DBIterator`
before returning, which should have a lifetime which exceeds that of the
`DBScanResults`.

Release note: None