### PR TITLE
build/acceptance: remove the use of the nodes flag from accceptance tests

### DIFF
--- a/build/teamcity-publish-artifacts.sh
+++ b/build/teamcity-publish-artifacts.sh
@@ -28,7 +28,7 @@ if [ "$TEAMCITY_BUILDCONF_NAME" == 'Publish Releases' ]; then
   # For the acceptance tests that run without Docker.
   ln -s cockroach.linux-2.6.32-gnu-amd64 cockroach
   build/builder.sh mkrelease $TYPE testbuild TAGS=acceptance PKG=./pkg/acceptance
-  (cd pkg/acceptance && ./acceptance.test -l ./artifacts -i $image -b /cockroach/cockroach -nodes 4 -test.v -test.timeout -5m) &> ./artifacts/publish-acceptance.log
+  (cd pkg/acceptance && ./acceptance.test -l ./artifacts -i $image -b /cockroach/cockroach -test.v -test.timeout -5m) &> ./artifacts/publish-acceptance.log
 
   sed "s/<EMAIL>/$DOCKER_EMAIL/;s/<AUTH>/$DOCKER_AUTH/" < build/.dockercfg.in > ~/.dockercfg
   docker push "$image:latest"

--- a/pkg/acceptance/run.sh
+++ b/pkg/acceptance/run.sh
@@ -12,4 +12,4 @@ export TMPDIR=$PWD/artifacts/acceptance
 
 # For the acceptance tests that run without Docker.
 make build
-make test PKG=./pkg/acceptance TESTTIMEOUT="${TESTTIMEOUT-30m}" TAGS=acceptance TESTFLAGS="${TESTFLAGS--v -nodes 4} -l $TMPDIR"
+make test PKG=./pkg/acceptance TESTTIMEOUT="${TESTTIMEOUT-30m}" TAGS=acceptance TESTFLAGS="${TESTFLAGS--v} -l $TMPDIR"


### PR DESCRIPTION
This was left over and no longer exists.

Release note: None