### PR TITLE
sql: catch invalid functions in the UPDATE SET RHS

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -469,3 +469,21 @@ ROLLBACK; BEGIN; ALTER TABLE t29494 ADD COLUMN y INT NOT NULL DEFAULT 123
 
 statement error column "y" is being backfilled
 UPDATE t29494 SET x = y
+
+statement ok
+COMMIT
+
+#regression test for #32477
+subtest reject_special_funcs_inset
+
+statement ok
+CREATE TABLE t32477(x) AS SELECT 1
+
+statement error aggregate functions are not allowed in UPDATE SET
+UPDATE t32477 SET x = count(x)
+
+statement error window functions are not allowed in UPDATE SET
+UPDATE t32477 SET x = rank(x) OVER ()
+
+statement error generator functions are not allowed in UPDATE SET
+UPDATE t32477 SET x = generate_series(1,2)

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -319,6 +319,13 @@ func (p *planner) Update(
 		columns = columns[:len(desc.Columns)]
 	}
 
+	// For the analysis below, we need to restrict the planning to only
+	// allow simple expressions. Before we restrict anything, we need to
+	// save the current context.
+	scalarProps := &p.semaCtx.Properties
+	defer scalarProps.Restore(*scalarProps)
+	p.semaCtx.Properties.Require("UPDATE SET", tree.RejectSpecial)
+
 	for _, setExpr := range setExprs {
 		if setExpr.Tuple {
 			switch t := setExpr.Expr.(type) {


### PR DESCRIPTION
Fixes #32477.
This is a leftover case from #26425.

Prior to this patch, an invalid scalar function in the RHS of UPDATE
... SET would not be rejected during planning and cause a crash during
execution.

This patch fixes this by ensuring the bad construct is rejected during
planning.

Release note (bug fix): CockroachDB now properly rejects queries
that use an invalid function in UPDATE SET (e.g., an aggregation).