### PR TITLE
release-2.1: sql: catch invalid functions in the UPDATE SET RHS

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -467,3 +467,21 @@ ROLLBACK; BEGIN; ALTER TABLE t29494 ADD COLUMN y INT NOT NULL DEFAULT 123
 
 statement error column "y" is being backfilled
 UPDATE t29494 SET x = y
+
+statement ok
+COMMIT
+
+#regression test for #32477
+subtest reject_special_funcs_inset
+
+statement ok
+CREATE TABLE t32477(x) AS SELECT 1
+
+statement error aggregate functions are not allowed in UPDATE SET
+UPDATE t32477 SET x = count(x)
+
+statement error window functions are not allowed in UPDATE SET
+UPDATE t32477 SET x = rank(x) OVER ()
+
+statement error generator functions are not allowed in UPDATE SET
+UPDATE t32477 SET x = generate_series(1,2)

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -287,6 +287,13 @@ func (p *planner) Update(
 		columns = columns[:len(desc.Columns)]
 	}
 
+	// For the analysis below, we need to restrict the planning to only
+	// allow simple expressions. Before we restrict anything, we need to
+	// save the current context.
+	scalarProps := &p.semaCtx.Properties
+	defer scalarProps.Restore(*scalarProps)
+	p.semaCtx.Properties.Require("UPDATE SET", tree.RejectSpecial)
+
 	for _, setExpr := range setExprs {
 		if setExpr.Tuple {
 			switch t := setExpr.Expr.(type) {


### PR DESCRIPTION
Backport 1/1 commits from #32505.

/cc @cockroachdb/release

