### PR TITLE
sql: catch invalid functions in the UPDATE SET RHS (v2.0.x)

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -529,3 +529,24 @@ query IIII rowsort
 SELECT * FROM tu
 ----
 1 NULL NULL NULL
+
+#regression test for #32477
+subtest reject_special_funcs_inset
+
+statement ok
+CREATE TABLE t32477(x, y, z) AS SELECT 1, 2, 3
+
+statement error aggregate functions are not allowed in UPDATE SET
+UPDATE t32477 SET x = count(x)
+
+statement error aggregate functions are not allowed in UPDATE SET
+UPDATE t32477 SET (y,z) = (count(y), count(z))
+
+statement error window functions are not allowed in UPDATE SET
+UPDATE t32477 SET x = rank() OVER ();
+
+statement error window functions are not allowed in UPDATE SET
+UPDATE t32477 SET (y,z) = (rank() OVER (), rank() OVER ())
+
+statement error value type setof tuple{int} doesn't match type INT of column "x"
+UPDATE t32477 SET x = generate_series(1, 2)


### PR DESCRIPTION
Fixes #32477 for v2.0.x.
This is not a back-port - the change is different from #32505.

Not sure whether we want to fix this? The other bugs fixed by the original PR #26425 still exist in v2.0.x, I think.

cc @cockroachdb/release 
