### PR TITLE
release-2.1: importccl: don't return values during sampling

### DIFF
--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -507,10 +507,21 @@ func (cp *readImportDataProcessor) doRun(ctx context.Context, wg *sync.WaitGroup
 				if completedSpans.Contains(kv.Key) {
 					continue
 				}
-				if sampleAll || keys.IsDescriptorKey(kv.Key) || fn(kv) {
-					row := sqlbase.EncDatumRow{
-						sqlbase.DatumToEncDatum(typeBytes, tree.NewDBytes(tree.DBytes(kv.Key))),
-						sqlbase.DatumToEncDatum(typeBytes, tree.NewDBytes(tree.DBytes(kv.Value.RawBytes))),
+
+				rowRequired := sampleAll || keys.IsDescriptorKey(kv.Key)
+				if rowRequired || fn(kv) {
+					var row sqlbase.EncDatumRow
+					if rowRequired {
+						row = sqlbase.EncDatumRow{
+							sqlbase.DatumToEncDatum(typeBytes, tree.NewDBytes(tree.DBytes(kv.Key))),
+							sqlbase.DatumToEncDatum(typeBytes, tree.NewDBytes(tree.DBytes(kv.Value.RawBytes))),
+						}
+					} else {
+						// Don't send the value for rows returned for sampling
+						row = sqlbase.EncDatumRow{
+							sqlbase.DatumToEncDatum(typeBytes, tree.NewDBytes(tree.DBytes(kv.Key))),
+							sqlbase.DatumToEncDatum(typeBytes, tree.NewDBytes(tree.DBytes([]byte{}))),
+						}
 					}
 
 					cs, err := cp.out.EmitRow(ctx, row)


### PR DESCRIPTION
Backport 1/1 commits from #32390.

/cc @cockroachdb/release

---

During sampling, the values for the k-v pairs are needed to weight the sampling
probability but are not used later in the pipeline. This change replaces the
values to be returned with empty values, as a performance optimization.

I tested the change on roachprod on a sample data set and got an improvement of
about 10% (from ~11 min to ~10 min).

Fixes #32308

Release note: None
