### PR TITLE
ccl/backupccl,ccl/importccl: disable merges during IMPORT and RESTORE

### DIFF
--- a/pkg/ccl/gossipccl/disable_merges.go
+++ b/pkg/ccl/gossipccl/disable_merges.go
@@ -1,0 +1,63 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package gossipccl
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+const (
+	disableMergesInterval = 10 * time.Second
+)
+
+// DisableMerges starts a goroutine which periodically gossips keys that
+// disable merging for the specified table IDs. The goroutine until the
+// associated context is done (usually via cancellation).
+func DisableMerges(ctx context.Context, g *gossip.Gossip, tableIDs []uint32) {
+	if len(tableIDs) == 0 {
+		// Nothing to do.
+		return
+	}
+
+	disable := func() {
+		for _, id := range tableIDs {
+			key := gossip.MakeTableDisableMergesKey(id)
+			err := g.AddInfo(key, nil /* value */, disableMergesInterval*2 /* ttl */)
+			if err != nil {
+				log.Infof(ctx, "failed to gossip: %s: %v", key, err)
+			}
+		}
+	}
+
+	// Disable merging synchronously before we start the periodic loop below.
+	disable()
+
+	s := g.Stopper()
+	// We don't care if this task can't be started as that only occurs if the
+	// stopper is stopping.
+	_ = s.RunAsyncTask(ctx, "disable-merges", func(ctx context.Context) {
+		ticker := time.NewTicker(disableMergesInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				disable()
+			case <-ctx.Done():
+				return
+			case <-s.ShouldQuiesce():
+				return
+			}
+		}
+	})
+}

--- a/pkg/ccl/gossipccl/disable_merges_test.go
+++ b/pkg/ccl/gossipccl/disable_merges_test.go
@@ -1,0 +1,49 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package gossipccl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+)
+
+func TestDisableMerges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	testCases := []struct {
+		tableIDs []uint32
+	}{
+		{tableIDs: nil},
+		{tableIDs: []uint32{0}},
+		{tableIDs: []uint32{1, 2, 9, 10}},
+	}
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			g := gossip.NewTest(1, nil /* rpcContext */, nil, /* grpcServer */
+				stopper, metric.NewRegistry())
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			DisableMerges(ctx, g, c.tableIDs)
+			for _, id := range c.tableIDs {
+				key := gossip.MakeTableDisableMergesKey(id)
+				if _, err := g.GetInfo(key); err != nil {
+					t.Fatalf("expected to find %s, but got %v", key, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -96,6 +96,13 @@ func registerImportTPCH(r *registry) {
 				m.Go(dul.Runner)
 				hc := NewHealthChecker(c, c.All())
 				m.Go(hc.Runner)
+				m.Go(func(ctx context.Context) error {
+					// Make sure the merge queue doesn't muck with our import.
+					return verifyMetrics(ctx, c, map[string]float64{
+						"cr.store.queue.merge.process.success": 10,
+						"cr.store.queue.merge.process.failure": 10,
+					})
+				})
 
 				m.Go(func(ctx context.Context) error {
 					defer dul.Done()

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1233,6 +1233,11 @@ func (g *Gossip) Start(advertAddr net.Addr, resolvers []resolver.Resolver) {
 	g.manage()                 // manage gossip clients
 }
 
+// Stopper returns the stopper for this gossip instance.
+func (g *Gossip) Stopper() *stop.Stopper {
+	return g.server.stopper
+}
+
 // hasIncomingLocked returns whether the server has an incoming gossip
 // client matching the provided node ID. Mutex should be held by
 // caller.

--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -90,6 +90,12 @@ const (
 	// the keys are used to notify nodes to invalidate table statistic caches.
 	KeyTableStatAddedPrefix = "table-stat-added"
 
+	// KeyTableDisableMergesPrefix is the prefix for keys that indicate range
+	// merges for the specified table ID should be disabled. This is used by
+	// IMPORT and RESTORE to disable range merging while those operations are in
+	// progress.
+	KeyTableDisableMergesPrefix = "table-disable-merges"
+
 	// KeyGossipClientsPrefix is the prefix for keys that indicate which gossip
 	// client connections a node has open. This is used by other nodes in the
 	// cluster to build a map of the gossip network.
@@ -208,6 +214,12 @@ func TableIDFromTableStatAddedKey(key string) (uint32, error) {
 		return 0, errors.Wrapf(err, "failed parsing table ID from key %q", key)
 	}
 	return uint32(tableID), nil
+}
+
+// MakeTableDisableMergesKey returns the gossip key used to disable merges for
+// the specified table ID.
+func MakeTableDisableMergesKey(tableID uint32) string {
+	return MakeKey(KeyTableDisableMergesPrefix, strconv.FormatUint(uint64(tableID), 10 /* base */))
 }
 
 // removePrefixFromKey removes the key prefix and separator and returns what's

--- a/pkg/gossip/keys_test.go
+++ b/pkg/gossip/keys_test.go
@@ -93,3 +93,21 @@ func TestStoreIDFromKey(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeTableDisableMergesKey(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		tableID  uint32
+		expected string
+	}{
+		{0, "table-disable-merges:0"},
+		{123, "table-disable-merges:123"},
+	}
+	for _, c := range testCases {
+		key := MakeTableDisableMergesKey(c.tableID)
+		if c.expected != key {
+			t.Fatalf("expected %s, but found %s", c.expected, key)
+		}
+	}
+}

--- a/pkg/storage/merge_queue.go
+++ b/pkg/storage/merge_queue.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -123,6 +124,25 @@ func (mq *mergeQueue) enabled() bool {
 	return st.Version.IsMinSupported(cluster.VersionRangeMerges) && storagebase.MergeQueueEnabled.Get(&st.SV)
 }
 
+func (mq *mergeQueue) mergesDisabledForRange(desc *roachpb.RangeDescriptor) bool {
+	_, tableID, err := keys.DecodeTablePrefix(desc.StartKey.AsRawKey())
+	if err == nil {
+		_, err = mq.gossip.GetInfo(gossip.MakeTableDisableMergesKey(uint32(tableID)))
+		if err == nil {
+			return true
+		}
+	}
+	_, tableID2, err := keys.DecodeTablePrefix(desc.EndKey.AsRawKey())
+	if err != nil {
+		return false
+	}
+	if tableID == tableID2 {
+		return false
+	}
+	_, err = mq.gossip.GetInfo(gossip.MakeTableDisableMergesKey(uint32(tableID2)))
+	return err == nil
+}
+
 func (mq *mergeQueue) shouldQueue(
 	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg *config.SystemConfig,
 ) (shouldQ bool, priority float64) {
@@ -141,6 +161,10 @@ func (mq *mergeQueue) shouldQueue(
 		// This range would need to be split if it extended just one key further.
 		// There is thus no possible right-hand neighbor that it could be merged
 		// with.
+		return false, 0
+	}
+
+	if mq.mergesDisabledForRange(desc) {
 		return false, 0
 	}
 
@@ -194,6 +218,12 @@ func (mq *mergeQueue) process(
 		return nil
 	}
 
+	lhsDesc := lhsRepl.Desc()
+	if mq.mergesDisabledForRange(lhsDesc) {
+		log.VEventf(ctx, 2, "skipping merge: merges are temporarily disabled for this table")
+		return nil
+	}
+
 	lhsStats := lhsRepl.GetMVCCStats()
 	minBytes := lhsRepl.GetMinBytes()
 	if lhsStats.Total() >= minBytes {
@@ -202,7 +232,6 @@ func (mq *mergeQueue) process(
 		return nil
 	}
 
-	lhsDesc := lhsRepl.Desc()
 	lhsQPS := lhsRepl.GetSplitQPS()
 	timeSinceLastReq := lhsRepl.store.Clock().PhysicalTime().Sub(lhsRepl.GetLastRequestTime())
 	rhsDesc, rhsStats, rhsQPS, err := mq.requestRangeStats(ctx, lhsDesc.EndKey.AsRawKey())


### PR DESCRIPTION
Add a facility for periodically gossiping keys which disable range
merges for a set of tables. This is used by IMPORT and RESTORE to
disable range merges on tables being imported / restored. This is done
to prevent the merge queue from fighting against the splitting performed
by IMPORT and RESTORE.

Fixes #29268

Release note: None