### PR TITLE
engine: fix a comment

### DIFF
--- a/pkg/storage/engine/enginepb/mvcc.pb.go
+++ b/pkg/storage/engine/enginepb/mvcc.pb.go
@@ -18,6 +18,8 @@ var _ = fmt.Errorf
 var _ = math.Inf
 
 // MVCCMetadata holds MVCC metadata for a key. Used by storage/engine/mvcc.go.
+// An MVCCMetadata is stored for a versioned key while there is an intent on
+// that key.
 type MVCCMetadata struct {
 	Txn *TxnMeta `protobuf:"bytes,1,opt,name=txn" json:"txn,omitempty"`
 	// The timestamp of the most recent versioned value if this is a

--- a/pkg/storage/engine/enginepb/mvcc.proto
+++ b/pkg/storage/engine/enginepb/mvcc.proto
@@ -22,6 +22,8 @@ import "util/hlc/legacy_timestamp.proto";
 import "gogoproto/gogo.proto";
 
 // MVCCMetadata holds MVCC metadata for a key. Used by storage/engine/mvcc.go.
+// An MVCCMetadata is stored for a versioned key while there is an intent on
+// that key.
 message MVCCMetadata {
   option (gogoproto.populate) = true;
 


### PR DESCRIPTION
A misleading comment was suggesting that an MVCCMetadata is adjusted
when an intent is resolved. In fact, it is deleted.

Release note: None