### PR TITLE
storage: skip TestStoreRangeMergeAbandonedFollowersAutomaticallyGarbageCollected

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -1966,6 +1966,8 @@ func TestStoreRangeMergeAbandonedFollowers(t *testing.T) {
 func TestStoreRangeMergeAbandonedFollowersAutomaticallyGarbageCollected(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/32062")
+
 	ctx := context.Background()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableReplicateQueue = true


### PR DESCRIPTION
It's probably a bit more involved to fix, and has been causing a few CI
flakes.

Release note: None