### PR TITLE
release-2.1: sql: assorted telemetry fixes

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -2639,7 +2639,7 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`CREATE INDEX a ON b(c[d])`, 9682, ``},
 		{`CREATE INDEX a ON b(foo(c))`, 9682, ``},
 
-		{`INSERT INTO foo(a, a.b) VALUES (1,2)`, 8318, ``},
+		{`INSERT INTO foo(a, a.b) VALUES (1,2)`, 27792, ``},
 		{`INSERT INTO foo VALUES (1,2) ON CONFLICT ON CONSTRAINT a DO NOTHING`, 0, `on conflict on constraint`},
 
 		{`SELECT * FROM ab, LATERAL (SELECT * FROM kv)`, 24560, `select`},
@@ -2686,12 +2686,12 @@ func TestUnimplementedSyntax(t *testing.T) {
 
 		{`WITH RECURSIVE a AS (TABLE b) SELECT c`, 21085, ``},
 
-		{`UPDATE foo SET (a, a.b) = (1, 2)`, 8318, ``},
-		{`UPDATE foo SET a.b = 1`, 8318, ``},
+		{`UPDATE foo SET (a, a.b) = (1, 2)`, 27792, ``},
+		{`UPDATE foo SET a.b = 1`, 27792, ``},
 		{`UPDATE foo SET x = y FROM a, b`, 7841, ``},
-		{`UPDATE Foo SET x.y = z`, 8318, ``},
+		{`UPDATE Foo SET x.y = z`, 27792, ``},
 
-		{`UPSERT INTO foo(a, a.b) VALUES (1,2)`, 8318, ``},
+		{`UPSERT INTO foo(a, a.b) VALUES (1,2)`, 27792, ``},
 	}
 	for _, d := range testData {
 		_, err := parser.Parse(d.sql)

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4980,10 +4980,10 @@ insert_column_list:
 // position. The rule below can be extended to support a sequence of
 // field subscript or array indexing operators to designate a part of
 // a field, when partial updates are to be supported. This likely will
-// be needed together with support for compound types (#8318).
+// be needed together with support for composite types (#27792).
 insert_column_item:
   column_name
-| column_name '.' error { return unimplementedWithIssue(sqllex, 8318) }
+| column_name '.' error { return unimplementedWithIssue(sqllex, 27792) }
 
 on_conflict:
   ON CONFLICT opt_conf_expr DO UPDATE SET set_clause_list where_clause
@@ -5075,7 +5075,7 @@ single_set_clause:
   {
     $$.val = &tree.UpdateExpr{Names: tree.NameList{tree.Name($1)}, Expr: $3.expr()}
   }
-| column_name '.' error { return unimplementedWithIssue(sqllex, 8318) }
+| column_name '.' error { return unimplementedWithIssue(sqllex, 27792) }
 
 multiple_set_clause:
   '(' insert_column_list ')' '=' in_expr
@@ -7022,7 +7022,7 @@ c_expr:
 // Currently we support array indexing (see c_expr above).
 //
 // TODO(knz/jordan): this is the rule that can be extended to support
-// compound types (#8318) with e.g.:
+// composite types (#27792) with e.g.:
 //
 //     | '(' a_expr ')' field_access_ops
 //

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3243,7 +3243,7 @@ func (expr *IndirectionExpr) Eval(ctx *EvalContext) (Datum, error) {
 	var subscriptIdx int
 	for i, t := range expr.Indirection {
 		if t.Slice {
-			return nil, pgerror.UnimplementedWithIssueErrorf(2115, "ARRAY slicing in %s", expr)
+			return nil, pgerror.UnimplementedWithIssueErrorf(32551, "ARRAY slicing in %s", expr)
 		}
 		if i > 0 {
 			return nil, pgerror.UnimplementedWithIssueErrorf(2115, "multidimensional ARRAY %s", expr)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3246,7 +3246,7 @@ func (expr *IndirectionExpr) Eval(ctx *EvalContext) (Datum, error) {
 			return nil, pgerror.UnimplementedWithIssueErrorf(32551, "ARRAY slicing in %s", expr)
 		}
 		if i > 0 {
-			return nil, pgerror.UnimplementedWithIssueErrorf(2115, "multidimensional ARRAY %s", expr)
+			return nil, pgerror.UnimplementedWithIssueErrorf(32552, "multidimensional ARRAY %s", expr)
 		}
 
 		d, err := t.Begin.(TypedExpr).Eval(ctx)

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -462,7 +462,7 @@ func (expr *CastExpr) TypeCheck(ctx *SemaContext, _ types.T) (TypedExpr, error) 
 func (expr *IndirectionExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, error) {
 	for i, t := range expr.Indirection {
 		if t.Slice {
-			return nil, pgerror.UnimplementedWithIssueErrorf(2115, "ARRAY slicing in %s", expr)
+			return nil, pgerror.UnimplementedWithIssueErrorf(32551, "ARRAY slicing in %s", expr)
 		}
 		if i > 0 {
 			return nil, pgerror.UnimplementedWithIssueErrorf(2115, "multidimensional ARRAY %s", expr)

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -465,7 +465,7 @@ func (expr *IndirectionExpr) TypeCheck(ctx *SemaContext, desired types.T) (Typed
 			return nil, pgerror.UnimplementedWithIssueErrorf(32551, "ARRAY slicing in %s", expr)
 		}
 		if i > 0 {
-			return nil, pgerror.UnimplementedWithIssueErrorf(2115, "multidimensional ARRAY %s", expr)
+			return nil, pgerror.UnimplementedWithIssueErrorf(32552, "multidimensional ARRAY %s", expr)
 		}
 
 		beginExpr, err := typeCheckAndRequire(ctx, t.Begin, types.Int, "ARRAY subscript")


### PR DESCRIPTION
Backport 3/3 commits from #32553.

/cc @cockroachdb/release

---

Fixes #31989. Requested by @awoods187.
