### PR TITLE
storage: improve raftDescribeMessage RejectHint handling

### DIFF
--- a/pkg/storage/raft.go
+++ b/pkg/storage/raft.go
@@ -147,10 +147,7 @@ func raftDescribeMessage(m raftpb.Message, f raft.EntryFormatter) string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%x->%x %v Term:%d Log:%d/%d", m.From, m.To, m.Type, m.Term, m.LogTerm, m.Index)
 	if m.Reject {
-		fmt.Fprintf(&buf, " Rejected")
-		if m.RejectHint != 0 {
-			fmt.Fprintf(&buf, "(Hint:%d)", m.RejectHint)
-		}
+		fmt.Fprintf(&buf, " Rejected (Hint: %d)", m.RejectHint)
 	}
 	if m.Commit != 0 {
 		fmt.Fprintf(&buf, " Commit:%d", m.Commit)


### PR DESCRIPTION
The RejectHint is always used. See:

https://github.com/cockroachdb/cockroach/pull/32533#issuecomment-441199252

Release note: None