### PR TITLE
interval: don't use interval btree by default

### DIFF
--- a/pkg/util/interval/interval.go
+++ b/pkg/util/interval/interval.go
@@ -236,7 +236,7 @@ type TreeIterator interface {
 	Next() (Interface, bool)
 }
 
-var useBTreeImpl = envutil.EnvOrDefaultBool("COCKROACH_INTERVAL_BTREE", true)
+var useBTreeImpl = envutil.EnvOrDefaultBool("COCKROACH_INTERVAL_BTREE", false)
 
 // NewTree creates a new interval tree with the given overlapper function. It
 // uses the augmented Left-Leaning Red Black tree implementation.


### PR DESCRIPTION
This slipped into 5b1ad68, which was not the intention of the change.
There aren't any known issues with the btree implementation, but we
weren't intending on using it and should have been deliberate about
the change if we wanted to make it.

Release note: None