### PR TITLE
sql: introduce ImmutableTableDescriptor struct

### DIFF
--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -27,7 +27,7 @@ import (
 // column families of one row) into a row.
 type rowFetcherCache struct {
 	leaseMgr *sql.LeaseManager
-	fetchers map[*sqlbase.TableDescriptor]*row.Fetcher
+	fetchers map[*sqlbase.ImmutableTableDescriptor]*row.Fetcher
 
 	a sqlbase.DatumAlloc
 }
@@ -35,14 +35,14 @@ type rowFetcherCache struct {
 func newRowFetcherCache(leaseMgr *sql.LeaseManager) *rowFetcherCache {
 	return &rowFetcherCache{
 		leaseMgr: leaseMgr,
-		fetchers: make(map[*sqlbase.TableDescriptor]*row.Fetcher),
+		fetchers: make(map[*sqlbase.ImmutableTableDescriptor]*row.Fetcher),
 	}
 }
 
 func (c *rowFetcherCache) TableDescForKey(
 	ctx context.Context, key roachpb.Key, ts hlc.Timestamp,
-) (*sqlbase.TableDescriptor, error) {
-	var tableDesc *sqlbase.TableDescriptor
+) (*sqlbase.ImmutableTableDescriptor, error) {
+	var tableDesc *sqlbase.ImmutableTableDescriptor
 	for skippedCols := 0; ; {
 		remaining, tableID, _, err := sqlbase.DecodeTableIDIndexID(key)
 		if err != nil {
@@ -80,7 +80,7 @@ func (c *rowFetcherCache) TableDescForKey(
 }
 
 func (c *rowFetcherCache) RowFetcherForTableDesc(
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 ) (*row.Fetcher, error) {
 	if rf, ok := c.fetchers[tableDesc]; ok {
 		return rf, nil

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -94,14 +94,14 @@ func Load(
 
 	privs := dbDesc.GetPrivileges()
 
-	tableDescs := make(map[string]*sqlbase.TableDescriptor)
+	tableDescs := make(map[string]*sqlbase.ImmutableTableDescriptor)
 
 	var currentCmd bytes.Buffer
 	scanner := bufio.NewReader(r)
 	var ri row.Inserter
 	var defaultExprs []tree.TypedExpr
 	var cols []sqlbase.ColumnDescriptor
-	var tableDesc *sqlbase.TableDescriptor
+	var tableDesc *sqlbase.ImmutableTableDescriptor
 	var tableName string
 	var prevKey roachpb.Key
 	var kvs []engine.MVCCKeyValue
@@ -170,10 +170,10 @@ func Load(
 				return backupccl.BackupDescriptor{}, errors.Wrap(err, "make table desc")
 			}
 
-			tableDesc = desc.TableDesc()
+			tableDesc = sqlbase.NewImmutableTableDescriptor(*desc.TableDesc())
 			tableDescs[tableName] = tableDesc
 			backup.Descriptors = append(backup.Descriptors, sqlbase.Descriptor{
-				Union: &sqlbase.Descriptor_Table{Table: tableDesc},
+				Union: &sqlbase.Descriptor_Table{Table: desc.TableDesc()},
 			})
 
 			for _, col := range tableDesc.Columns {
@@ -253,7 +253,7 @@ func Load(
 
 func insertStmtToKVs(
 	ctx context.Context,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	defaultExprs []tree.TypedExpr,
 	cols []sqlbase.ColumnDescriptor,
 	evalCtx tree.EvalContext,

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -173,7 +173,7 @@ func TestMysqldumpSchemaReader(t *testing.T) {
 	referencedSimple := descForTable(t, readFile(t, `simple.cockroach-schema.sql`), expectedParent, 52, NoFKs)
 	fks := fkHandler{
 		allowed:  true,
-		resolver: fkResolver(map[string]*sqlbase.MutableTableDescriptor{referencedSimple.Name: sql.NewMutableCreatedTableDescriptor(*referencedSimple)}),
+		resolver: fkResolver(map[string]*sqlbase.MutableTableDescriptor{referencedSimple.Name: sqlbase.NewMutableCreatedTableDescriptor(*referencedSimple)}),
 	}
 
 	t.Run("simple", func(t *testing.T) {

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -26,7 +26,7 @@ import (
 
 type createStatsNode struct {
 	tree.CreateStats
-	tableDesc *sqlbase.TableDescriptor
+	tableDesc *sqlbase.ImmutableTableDescriptor
 	columns   []sqlbase.ColumnID
 }
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -830,22 +830,6 @@ var CreatePartitioningCCL = func(
 		"creating or manipulating partitions requires a CCL binary"))
 }
 
-// NewMutableCreatedTableDescriptor returns a MutableTableDescriptor from the
-// given TableDescriptor with the cluster version being the zero table. This
-// is for a table that is created in the transaction.
-func NewMutableCreatedTableDescriptor(tbl sqlbase.TableDescriptor) *sqlbase.MutableTableDescriptor {
-	return &sqlbase.MutableTableDescriptor{TableDescriptor: tbl}
-}
-
-// NewMutableExistingTableDescriptor returns a MutableTableDescriptor from the
-// given TableDescriptor with the cluster version also set to the descriptor.
-// This is for an existing table.
-func NewMutableExistingTableDescriptor(
-	tbl sqlbase.TableDescriptor,
-) *sqlbase.MutableTableDescriptor {
-	return &sqlbase.MutableTableDescriptor{TableDescriptor: tbl, ClusterVersion: tbl}
-}
-
 // InitTableDescriptor returns a blank TableDescriptor.
 func InitTableDescriptor(
 	id, parentID sqlbase.ID,
@@ -853,7 +837,7 @@ func InitTableDescriptor(
 	creationTime hlc.Timestamp,
 	privileges *sqlbase.PrivilegeDescriptor,
 ) sqlbase.MutableTableDescriptor {
-	return *NewMutableCreatedTableDescriptor(sqlbase.TableDescriptor{
+	return *sqlbase.NewMutableCreatedTableDescriptor(sqlbase.TableDescriptor{
 		ID:               id,
 		Name:             name,
 		ParentID:         parentID,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -138,7 +138,7 @@ func (n *createTableNode) startExec(params runParams) error {
 		}
 		var foundExternalReference bool
 		for id := range refs {
-			if t := params.p.Tables().getUncommittedTableByID(id); t == nil || !t.IsNewTable() {
+			if t := params.p.Tables().getUncommittedTableByID(id).MutableTableDescriptor; t == nil || !t.IsNewTable() {
 				foundExternalReference = true
 				break
 			}
@@ -197,7 +197,12 @@ func (n *createTableNode) startExec(params runParams) error {
 		// Instantiate a row inserter and table writer. It has a 1-1
 		// mapping to the definitions in the descriptor.
 		ri, err := row.MakeInserter(
-			params.p.txn, desc.TableDesc(), nil, desc.Columns, row.SkipFKs, &params.p.alloc)
+			params.p.txn,
+			sqlbase.NewImmutableTableDescriptor(*desc.TableDesc()),
+			nil,
+			desc.Columns,
+			row.SkipFKs,
+			&params.p.alloc)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -157,7 +157,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		backrefID := updated.desc.ID
 		backRefMutable := params.p.Tables().getUncommittedTableByID(backrefID)
 		if backRefMutable == nil {
-			backRefMutable = NewMutableExistingTableDescriptor(*updated.desc)
+			backRefMutable = sqlbase.NewMutableExistingTableDescriptor(*updated.desc)
 		}
 		for _, dep := range updated.deps {
 			// The logical plan constructor merely registered the dependencies.

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -155,9 +155,9 @@ func (n *createViewNode) startExec(params runParams) error {
 	// Persist the back-references in all referenced table descriptors.
 	for _, updated := range n.planDeps {
 		backrefID := updated.desc.ID
-		backRefMutable := params.p.Tables().getUncommittedTableByID(backrefID)
+		backRefMutable := params.p.Tables().getUncommittedTableByID(backrefID).MutableTableDescriptor
 		if backRefMutable == nil {
-			backRefMutable = sqlbase.NewMutableExistingTableDescriptor(*updated.desc)
+			backRefMutable = sqlbase.NewMutableExistingTableDescriptor(*updated.desc.TableDesc())
 		}
 		for _, dep := range updated.deps {
 			// The logical plan constructor merely registered the dependencies.

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -294,7 +294,7 @@ func renameSource(
 
 func (p *planner) getPlanForDesc(
 	ctx context.Context,
-	desc *sqlbase.TableDescriptor,
+	desc *sqlbase.ImmutableTableDescriptor,
 	tn *tree.TableName,
 	indexFlags *tree.IndexFlags,
 	colCfg scanColumnsConfig,
@@ -331,7 +331,7 @@ func (p *planner) getPlanForDesc(
 // getViewPlan builds a planDataSource for the view specified by the
 // table name and descriptor, expanding out its subquery plan.
 func (p *planner) getViewPlan(
-	ctx context.Context, tn *tree.TableName, desc *sqlbase.TableDescriptor,
+	ctx context.Context, tn *tree.TableName, desc *sqlbase.ImmutableTableDescriptor,
 ) (planDataSource, error) {
 	stmt, err := parser.ParseOne(desc.ViewQuery)
 	if err != nil {
@@ -411,7 +411,7 @@ func (p *planner) getPlanForRowsFrom(
 }
 
 func (p *planner) getSequenceSource(
-	ctx context.Context, tn tree.TableName, desc *sqlbase.TableDescriptor,
+	ctx context.Context, tn tree.TableName, desc *sqlbase.ImmutableTableDescriptor,
 ) (planDataSource, error) {
 	if err := p.CheckPrivilege(ctx, desc, privilege.SELECT); err != nil {
 		return planDataSource{}, err

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -168,7 +168,7 @@ func (p *planner) Delete(
 		},
 	}
 
-	dn.run.fastPathInterleaved = canDeleteFastInterleaved(*desc, fkTables)
+	dn.run.fastPathInterleaved = canDeleteFastInterleaved(desc, fkTables)
 
 	// Finally, handle RETURNING, if any.
 	r, err := p.Returning(ctx, dn, n.Returning, desiredTypes, alias)
@@ -356,7 +356,7 @@ func (d *deleteNode) FastPathResults() (int, bool) {
 	return d.run.rowCount, d.run.fastPath
 }
 
-func canDeleteFastInterleaved(table TableDescriptor, fkTables row.TableLookupsByID) bool {
+func canDeleteFastInterleaved(table *ImmutableTableDescriptor, fkTables row.TableLookupsByID) bool {
 	// If there are no interleaved tables then don't take the fast path.
 	// This avoids superfluous use of DelRange in cases where there isn't as much of a performance boost.
 	hasInterleaved := false

--- a/pkg/sql/delete_test.go
+++ b/pkg/sql/delete_test.go
@@ -109,13 +109,13 @@ CREATE TABLE IF NOT EXISTS child_with_index(
 			setup(tableNames...)
 			defer drop(tableNames...)
 
-			tablesByID := make(map[sqlbase.ID]*TableDescriptor)
-			pd := sqlbase.GetTableDescriptor(kvDB, "defaultdb", "parent")
+			tablesByID := make(map[sqlbase.ID]*ImmutableTableDescriptor)
+			pd := sqlbase.GetImmutableTableDescriptor(kvDB, "defaultdb", "parent")
 			tablesByID[pd.ID] = pd
 
 			for _, tableName := range tableNames {
 				if tableName != "parent" {
-					cd := sqlbase.GetTableDescriptor(kvDB, "defaultdb", tableName)
+					cd := sqlbase.GetImmutableTableDescriptor(kvDB, "defaultdb", tableName)
 					tablesByID[cd.ID] = cd
 				}
 			}
@@ -140,7 +140,7 @@ CREATE TABLE IF NOT EXISTS child_with_index(
 				t.Fatal(err)
 			}
 
-			if canDeleteFastInterleaved(*pd, fkTables) != expected {
+			if canDeleteFastInterleaved(pd, fkTables) != expected {
 				t.Fatalf("canDeleteFastInterleaved returned %t, expected %t", !expected, expected)
 			}
 		}

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -32,7 +32,7 @@ const histogramSamples = 10000
 const histogramBuckets = 200
 
 func (dsp *DistSQLPlanner) createStatsPlan(
-	planCtx *PlanningCtx, desc *sqlbase.TableDescriptor, stats []requestedStat,
+	planCtx *PlanningCtx, desc *sqlbase.ImmutableTableDescriptor, stats []requestedStat,
 ) (PhysicalPlan, error) {
 	// Create the table readers; for this we initialize a dummy scanNode.
 	scan := scanNode{desc: desc}

--- a/pkg/sql/distsqlrun/colbatch_scan.go
+++ b/pkg/sql/distsqlrun/colbatch_scan.go
@@ -144,7 +144,7 @@ func initCRowFetcher(
 		}
 	}
 	tableArgs := row.FetcherTableArgs{
-		Desc:             desc,
+		Desc:             sqlbase.NewImmutableTableDescriptor(*desc),
 		Index:            index,
 		ColIdxMap:        colIdxMap,
 		IsSecondaryIndex: isSecondaryIndex,

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -393,7 +393,7 @@ func (irj *interleavedReaderJoiner) initRowFetcher(
 	args := make([]row.FetcherTableArgs, len(tables))
 
 	for i, table := range tables {
-		desc := table.Desc
+		desc := sqlbase.NewImmutableTableDescriptor(table.Desc)
 		var err error
 		args[i].Index, args[i].IsSecondaryIndex, err = desc.FindIndexByIndexIdx(int(table.IndexIdx))
 		if err != nil {
@@ -405,7 +405,7 @@ func (irj *interleavedReaderJoiner) initRowFetcher(
 		// on a scan before a join.
 		args[i].ValNeededForCol.AddRange(0, len(desc.Columns)-1)
 		args[i].ColIdxMap = desc.ColumnIdxMap()
-		args[i].Desc = &desc
+		args[i].Desc = desc
 		args[i].Cols = desc.Columns
 		args[i].Spans = make(roachpb.Spans, len(table.Spans))
 		for j, trSpan := range table.Spans {

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -197,7 +197,7 @@ func initRowFetcher(
 		}
 	}
 	tableArgs := row.FetcherTableArgs{
-		Desc:             desc,
+		Desc:             sqlbase.NewImmutableTableDescriptor(*desc),
 		Index:            index,
 		ColIdxMap:        colIdxMap,
 		IsSecondaryIndex: isSecondaryIndex,

--- a/pkg/sql/helpers_test.go
+++ b/pkg/sql/helpers_test.go
@@ -56,7 +56,7 @@ func NewLeaseRemovalTracker() *LeaseRemovalTracker {
 // TrackRemoval starts monitoring lease removals for a particular lease.
 // This should be called before triggering the operation that (asynchronously)
 // removes the lease.
-func (w *LeaseRemovalTracker) TrackRemoval(table *sqlbase.TableDescriptor) RemovalTracker {
+func (w *LeaseRemovalTracker) TrackRemoval(table *sqlbase.ImmutableTableDescriptor) RemovalTracker {
 	id := tableVersionID{
 		id:      table.ID,
 		version: table.Version,
@@ -116,7 +116,7 @@ func (m *LeaseManager) AcquireAndAssertMinVersion(
 	timestamp hlc.Timestamp,
 	tableID sqlbase.ID,
 	minVersion sqlbase.DescriptorVersion,
-) (*sqlbase.TableDescriptor, hlc.Timestamp, error) {
+) (*sqlbase.ImmutableTableDescriptor, hlc.Timestamp, error) {
 	t := m.findTableState(tableID, true)
 	if err := ensureVersion(ctx, tableID, minVersion, m); err != nil {
 		return nil, hlc.Timestamp{}, err
@@ -125,5 +125,5 @@ func (m *LeaseManager) AcquireAndAssertMinVersion(
 	if err != nil {
 		return nil, hlc.Timestamp{}, err
 	}
-	return &table.TableDescriptor, table.expiration, nil
+	return &table.ImmutableTableDescriptor, table.expiration, nil
 }

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -203,7 +203,7 @@ func (p *planner) makeIndexJoin(
 	table.filter = table.filterVars.Rebind(table.filter, true /* alsoReset */, false /* normalizeToNonNil */)
 	indexScan.initOrdering(exactPrefix, p.EvalContext())
 
-	primaryKeyPrefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(table.desc, table.index.ID))
+	primaryKeyPrefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(table.desc.TableDesc(), table.index.ID))
 	node := &indexJoinNode{
 		index:             indexScan,
 		table:             table,
@@ -278,7 +278,7 @@ func (n *indexJoinNode) Next(params runParams) (bool, error) {
 			}
 			vals := n.index.Values()
 			primaryIndexKey, _, err := sqlbase.EncodeIndexKey(
-				n.table.desc, n.table.index, n.run.colIDtoRowIndex, vals, n.run.primaryKeyPrefix)
+				n.table.desc.TableDesc(), n.table.index, n.run.colIDtoRowIndex, vals, n.run.primaryKeyPrefix)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -603,7 +603,7 @@ func GenerateInsertRow(
 	insertCols []sqlbase.ColumnDescriptor,
 	computedCols []sqlbase.ColumnDescriptor,
 	evalCtx tree.EvalContext,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	rowVals tree.Datums,
 	rowContainerForComputedVals *sqlbase.RowIndexedVarContainer,
 ) (tree.Datums, error) {
@@ -677,7 +677,9 @@ func GenerateInsertRow(
 // are returned. If allowMutations is set, even columns undergoing
 // mutations are added.
 func (p *planner) processColumns(
-	tableDesc *sqlbase.TableDescriptor, nameList tree.NameList, ensureColumns, allowMutations bool,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
+	nameList tree.NameList,
+	ensureColumns, allowMutations bool,
 ) ([]sqlbase.ColumnDescriptor, error) {
 	if len(nameList) == 0 {
 		if ensureColumns {

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func newTestScanNode(kvDB *client.DB, tableName string) (*scanNode, error) {
-	desc := sqlbase.GetTableDescriptor(kvDB, sqlutils.TestDB, tableName)
+	desc := sqlbase.GetImmutableTableDescriptor(kvDB, sqlutils.TestDB, tableName)
 
 	p := planner{}
 	scan := p.Scan()

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -120,20 +120,20 @@ func (t *leaseTest) expectLeases(descID sqlbase.ID, expected string) {
 
 func (t *leaseTest) acquire(
 	nodeID uint32, descID sqlbase.ID,
-) (*sqlbase.TableDescriptor, hlc.Timestamp, error) {
+) (*sqlbase.ImmutableTableDescriptor, hlc.Timestamp, error) {
 	return t.node(nodeID).Acquire(context.TODO(), t.server.Clock().Now(), descID)
 }
 
 func (t *leaseTest) acquireMinVersion(
 	nodeID uint32, descID sqlbase.ID, minVersion sqlbase.DescriptorVersion,
-) (*sqlbase.TableDescriptor, hlc.Timestamp, error) {
+) (*sqlbase.ImmutableTableDescriptor, hlc.Timestamp, error) {
 	return t.node(nodeID).AcquireAndAssertMinVersion(
 		context.TODO(), t.server.Clock().Now(), descID, minVersion)
 }
 
 func (t *leaseTest) mustAcquire(
 	nodeID uint32, descID sqlbase.ID,
-) (*sqlbase.TableDescriptor, hlc.Timestamp) {
+) (*sqlbase.ImmutableTableDescriptor, hlc.Timestamp) {
 	table, expiration, err := t.acquire(nodeID, descID)
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +143,7 @@ func (t *leaseTest) mustAcquire(
 
 func (t *leaseTest) mustAcquireMinVersion(
 	nodeID uint32, descID sqlbase.ID, minVersion sqlbase.DescriptorVersion,
-) (*sqlbase.TableDescriptor, hlc.Timestamp) {
+) (*sqlbase.ImmutableTableDescriptor, hlc.Timestamp) {
 	table, expiration, err := t.acquireMinVersion(nodeID, descID, minVersion)
 	if err != nil {
 		t.Fatal(err)
@@ -151,7 +151,7 @@ func (t *leaseTest) mustAcquireMinVersion(
 	return table, expiration
 }
 
-func (t *leaseTest) release(nodeID uint32, table *sqlbase.TableDescriptor) error {
+func (t *leaseTest) release(nodeID uint32, table *sqlbase.ImmutableTableDescriptor) error {
 	return t.node(nodeID).Release(table)
 }
 
@@ -160,7 +160,9 @@ func (t *leaseTest) release(nodeID uint32, table *sqlbase.TableDescriptor) error
 // store (i.e. it's not expired and it's not for an old descriptor version),
 // this shouldn't be set.
 func (t *leaseTest) mustRelease(
-	nodeID uint32, table *sqlbase.TableDescriptor, leaseRemovalTracker *sql.LeaseRemovalTracker,
+	nodeID uint32,
+	table *sqlbase.ImmutableTableDescriptor,
+	leaseRemovalTracker *sql.LeaseRemovalTracker,
 ) {
 	var tracker sql.RemovalTracker
 	if leaseRemovalTracker != nil {
@@ -578,7 +580,7 @@ func isDeleted(tableID sqlbase.ID, cfg *config.SystemConfig) bool {
 
 func acquire(
 	ctx context.Context, s *server.TestServer, descID sqlbase.ID,
-) (*sqlbase.TableDescriptor, hlc.Timestamp, error) {
+) (*sqlbase.ImmutableTableDescriptor, hlc.Timestamp, error) {
 	return s.LeaseManager().(*sql.LeaseManager).Acquire(ctx, s.Clock().Now(), descID)
 }
 

--- a/pkg/sql/logical_schema_accessors.go
+++ b/pkg/sql/logical_schema_accessors.go
@@ -80,7 +80,7 @@ func (l *LogicalSchemaAccessor) GetObjectDesc(
 			if flags.requireMutable {
 				return sqlbase.NewMutableExistingTableDescriptor(*t.desc), nil, nil
 			}
-			return t.desc, nil, nil
+			return sqlbase.NewImmutableTableDescriptor(*t.desc), nil, nil
 		}
 		if _, ok := scEntry.allTableNames[tableName]; ok {
 			return nil, nil, pgerror.Unimplemented(name.Schema()+"."+tableName,

--- a/pkg/sql/logical_schema_accessors.go
+++ b/pkg/sql/logical_schema_accessors.go
@@ -78,7 +78,7 @@ func (l *LogicalSchemaAccessor) GetObjectDesc(
 		tableName := name.Table()
 		if t, ok := scEntry.defs[tableName]; ok {
 			if flags.requireMutable {
-				return NewMutableExistingTableDescriptor(*t.desc), nil, nil
+				return sqlbase.NewMutableExistingTableDescriptor(*t.desc), nil, nil
 			}
 			return t.desc, nil, nil
 		}

--- a/pkg/sql/opt_decompose_test.go
+++ b/pkg/sql/opt_decompose_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func testTableDesc() *sqlbase.TableDescriptor {
-	return &sqlbase.TableDescriptor{
+func testTableDesc() *sqlbase.ImmutableTableDescriptor {
+	return sqlbase.NewImmutableTableDescriptor(sqlbase.TableDescriptor{
 		Name:     "test",
 		ID:       1001,
 		ParentID: 1000,
@@ -56,7 +56,7 @@ func testTableDesc() *sqlbase.TableDescriptor {
 		},
 		Privileges:    sqlbase.NewDefaultPrivilegeDescriptor(),
 		FormatVersion: sqlbase.FamilyFormatVersion,
-	}
+	})
 }
 
 func makeSelectNode(t *testing.T, p *planner) *renderNode {

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -551,7 +551,7 @@ func (ef *execFactory) ConstructIndexJoin(
 	tableScan.disableBatchLimit()
 
 	primaryKeyColumns, colIDtoRowIndex := processIndexJoinColumns(tableScan, scan)
-	primaryKeyPrefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(tabDesc, tableScan.index.ID))
+	primaryKeyPrefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(tabDesc.TableDesc(), tableScan.index.ID))
 
 	return &indexJoinNode{
 		index:             scan,
@@ -624,7 +624,7 @@ func (ef *execFactory) ConstructLookupJoin(
 
 // Helper function to create a scanNode from just a table / index descriptor
 func (ef *execFactory) constructScanForZigzag(
-	indexDesc *sqlbase.IndexDescriptor, tableDesc *sqlbase.TableDescriptor,
+	indexDesc *sqlbase.IndexDescriptor, tableDesc *sqlbase.ImmutableTableDescriptor,
 ) (*scanNode, error) {
 	colCount := len(indexDesc.ColumnIDs) + len(indexDesc.ExtraColumnIDs)
 	colCount += len(indexDesc.StoreColumnIDs)

--- a/pkg/sql/opt_index_selection_test.go
+++ b/pkg/sql/opt_index_selection_test.go
@@ -37,7 +37,7 @@ import (
 
 func makeTestIndex(
 	t *testing.T, columns []string, dirs []encoding.Direction,
-) (*sqlbase.TableDescriptor, *sqlbase.IndexDescriptor) {
+) (*sqlbase.ImmutableTableDescriptor, *sqlbase.IndexDescriptor) {
 	desc := testTableDesc()
 	desc.Indexes = append(desc.Indexes, sqlbase.IndexDescriptor{
 		Name:        "foo",
@@ -66,7 +66,7 @@ func makeTestIndex(
 // it is descending.
 func makeTestIndexFromStr(
 	t *testing.T, columnsStr string,
-) (*sqlbase.TableDescriptor, *sqlbase.IndexDescriptor) {
+) (*sqlbase.ImmutableTableDescriptor, *sqlbase.IndexDescriptor) {
 	columns := strings.Split(columnsStr, ",")
 	dirs := make([]encoding.Direction, len(columns))
 	for i, c := range columns {
@@ -84,7 +84,7 @@ func makeSpans(
 	t *testing.T,
 	p *planner,
 	sql string,
-	desc *sqlbase.TableDescriptor,
+	desc *sqlbase.ImmutableTableDescriptor,
 	index *sqlbase.IndexDescriptor,
 	sel *renderNode,
 ) (_ *constraint.Constraint, spans roachpb.Spans) {
@@ -255,7 +255,7 @@ func TestMakeSpans(t *testing.T) {
 				span := spans[0]
 				d.expected = d.expected[4:]
 				// Trim the index prefix from the span.
-				prefix := string(sqlbase.MakeIndexKeyPrefix(desc, index.ID))
+				prefix := string(sqlbase.MakeIndexKeyPrefix(desc.TableDesc(), index.ID))
 				got = strings.TrimPrefix(string(span.Key), prefix) + "-" +
 					strings.TrimPrefix(string(span.EndKey), prefix)
 			} else {

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -147,11 +147,11 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 			// Immediately after a RENAME an old name still points to the
 			// descriptor during the drain phase for the name. Do not
 			// return a descriptor during draining.
-			if nameMatchesTable(desc, dbDesc.ID, name.Table()) {
+			if desc.Name == name.Table() {
 				if flags.requireMutable {
 					return sqlbase.NewMutableExistingTableDescriptor(*desc), dbDesc, nil
 				}
-				return desc, dbDesc, nil
+				return sqlbase.NewImmutableTableDescriptor(*desc), dbDesc, nil
 			}
 		}
 	}

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -149,7 +149,7 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 			// return a descriptor during draining.
 			if nameMatchesTable(desc, dbDesc.ID, name.Table()) {
 				if flags.requireMutable {
-					return NewMutableExistingTableDescriptor(*desc), dbDesc, nil
+					return sqlbase.NewMutableExistingTableDescriptor(*desc), dbDesc, nil
 				}
 				return desc, dbDesc, nil
 			}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -583,7 +583,7 @@ func (r *fkSelfResolver) LookupObject(
 		tbName == r.newTableName.Table() {
 		table := r.newTableDesc
 		if requireMutable {
-			return true, NewMutableExistingTableDescriptor(*table), nil
+			return true, sqlbase.NewMutableExistingTableDescriptor(*table), nil
 		}
 		return true, table, nil
 	}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -94,12 +94,12 @@ func GetObjectNames(
 // if no object is found.
 func ResolveExistingObject(
 	ctx context.Context, sc SchemaResolver, tn *ObjectName, required bool, requiredType requiredType,
-) (res *TableDescriptor, err error) {
+) (res *ImmutableTableDescriptor, err error) {
 	desc, err := resolveExistingObjectImpl(ctx, sc, tn, required, false /* requiredMutable */, requiredType)
 	if err != nil || desc == nil {
 		return nil, err
 	}
-	return desc.(*TableDescriptor), nil
+	return desc.(*ImmutableTableDescriptor), nil
 }
 
 // ResolveMutableExistingObject looks up an existing mutable object.
@@ -158,7 +158,7 @@ func resolveExistingObjectImpl(
 		return descI.(*MutableTableDescriptor), nil
 	}
 
-	return obj.TableDesc(), nil
+	return descI.(*ImmutableTableDescriptor), nil
 }
 
 // runWithOptions sets the provided resolution flags for the
@@ -193,11 +193,15 @@ func (p *planner) ResolveMutableTableDescriptor(
 
 func (p *planner) ResolveUncachedTableDescriptor(
 	ctx context.Context, tn *ObjectName, required bool, requiredType requiredType,
-) (table *UncachedTableDescriptor, err error) {
+) (_ *UncachedTableDescriptor, err error) {
+	var table *ImmutableTableDescriptor
 	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		table, err = ResolveExistingObject(ctx, p, tn, required, requiredType)
 	})
-	return table, err
+	if table == nil {
+		return nil, err
+	}
+	return table.TableDesc(), err
 }
 
 // ResolveTargetObject determines a valid target path for an object
@@ -585,7 +589,7 @@ func (r *fkSelfResolver) LookupObject(
 		if requireMutable {
 			return true, sqlbase.NewMutableExistingTableDescriptor(*table), nil
 		}
-		return true, table, nil
+		return true, sqlbase.NewImmutableTableDescriptor(*table), nil
 	}
 	return r.SchemaResolver.LookupObject(ctx, requireMutable, dbName, scName, tbName)
 }

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -234,7 +234,7 @@ func (rf *CFetcher) Init(
 
 		table := cTableInfo{
 			spans:            tableArgs.Spans,
-			desc:             tableArgs.Desc,
+			desc:             tableArgs.Desc.TableDesc(),
 			colIdxMap:        tableArgs.ColIdxMap,
 			index:            tableArgs.Index,
 			isSecondaryIndex: tableArgs.IsSecondaryIndex,

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -51,7 +51,7 @@ func (f *singleKVFetcher) getRangesInfo() []roachpb.RangeInfo {
 
 // ConvertBatchError returns a user friendly constraint violation error.
 func ConvertBatchError(
-	ctx context.Context, tableDesc *sqlbase.TableDescriptor, b *client.Batch,
+	ctx context.Context, tableDesc *sqlbase.ImmutableTableDescriptor, b *client.Batch,
 ) error {
 	origPErr := b.MustPErr()
 	if origPErr.Index == nil {
@@ -67,7 +67,7 @@ func ConvertBatchError(
 		// TODO(dan): There's too much internal knowledge of the sql table
 		// encoding here (and this callsite is the only reason
 		// DecodeIndexKeyPrefix is exported). Refactor this bit out.
-		indexID, _, err := sqlbase.DecodeIndexKeyPrefix(tableDesc, key)
+		indexID, _, err := sqlbase.DecodeIndexKeyPrefix(tableDesc.TableDesc(), key)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -76,10 +76,10 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 		e STRING, f STRING, PRIMARY KEY (e, f)
 	) INTERLEAVE IN PARENT parent (e)`)
 
-	parentDesc := sqlbase.GetTableDescriptor(kvDB, `d`, `parent`)
-	childDesc := sqlbase.GetTableDescriptor(kvDB, `d`, `child`)
+	parentDesc := sqlbase.GetImmutableTableDescriptor(kvDB, `d`, `parent`)
+	childDesc := sqlbase.GetImmutableTableDescriptor(kvDB, `d`, `child`)
 	var args []row.FetcherTableArgs
-	for _, desc := range []*sqlbase.TableDescriptor{parentDesc, childDesc} {
+	for _, desc := range []*sqlbase.ImmutableTableDescriptor{parentDesc, childDesc} {
 		colIdxMap := make(map[sqlbase.ColumnID]int)
 		var valNeededForCol util.FastIntSet
 		for colIdx, col := range desc.Columns {

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 type initFetcherArgs struct {
-	tableDesc       *sqlbase.TableDescriptor
+	tableDesc       *sqlbase.ImmutableTableDescriptor
 	indexIdx        int
 	valNeededForCol util.FastIntSet
 	spans           roachpb.Spans
@@ -143,7 +143,7 @@ func TestNextRowSingle(t *testing.T) {
 	// We try to read rows from each table.
 	for tableName, table := range tables {
 		t.Run(tableName, func(t *testing.T) {
-			tableDesc := sqlbase.GetTableDescriptor(kvDB, sqlutils.TestDB, tableName)
+			tableDesc := sqlbase.GetImmutableTableDescriptor(kvDB, sqlutils.TestDB, tableName)
 
 			var valNeededForCol util.FastIntSet
 			valNeededForCol.AddRange(0, table.nCols-1)
@@ -263,7 +263,7 @@ func TestNextRowBatchLimiting(t *testing.T) {
 	// We try to read rows from each table.
 	for tableName, table := range tables {
 		t.Run(tableName, func(t *testing.T) {
-			tableDesc := sqlbase.GetTableDescriptor(kvDB, sqlutils.TestDB, tableName)
+			tableDesc := sqlbase.GetImmutableTableDescriptor(kvDB, sqlutils.TestDB, tableName)
 
 			var valNeededForCol util.FastIntSet
 			valNeededForCol.AddRange(0, table.nCols-1)
@@ -375,7 +375,7 @@ INDEX(c)
 
 	alloc := &sqlbase.DatumAlloc{}
 
-	tableDesc := sqlbase.GetTableDescriptor(kvDB, sqlutils.TestDB, tableName)
+	tableDesc := sqlbase.GetImmutableTableDescriptor(kvDB, sqlutils.TestDB, tableName)
 
 	var valNeededForCol util.FastIntSet
 	valNeededForCol.AddRange(0, table.nCols-1)
@@ -542,7 +542,7 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 	// We try to read rows from each index.
 	for tableName, table := range tables {
 		t.Run(tableName, func(t *testing.T) {
-			tableDesc := sqlbase.GetTableDescriptor(kvDB, sqlutils.TestDB, tableName)
+			tableDesc := sqlbase.GetImmutableTableDescriptor(kvDB, sqlutils.TestDB, tableName)
 
 			var valNeededForCol util.FastIntSet
 			valNeededForCol.AddRange(0, table.nVals-1)
@@ -894,7 +894,7 @@ func TestNextRowInterleaved(t *testing.T) {
 			// RowFetcher.
 			idLookups := make(map[uint64]*fetcherEntryArgs, len(entries))
 			for i, entry := range entries {
-				tableDesc := sqlbase.GetTableDescriptor(kvDB, sqlutils.TestDB, entry.tableName)
+				tableDesc := sqlbase.GetImmutableTableDescriptor(kvDB, sqlutils.TestDB, entry.tableName)
 				var indexID sqlbase.IndexID
 				if entry.indexIdx == 0 {
 					indexID = tableDesc.PrimaryIndex.ID
@@ -1013,7 +1013,7 @@ func TestRowFetcherReset(t *testing.T) {
 		0,
 		sqlutils.ToRowFn(sqlutils.RowIdxFn, sqlutils.RowModuloFn(1)),
 	)
-	tableDesc := sqlbase.GetTableDescriptor(kvDB, sqlutils.TestDB, "foo")
+	tableDesc := sqlbase.GetImmutableTableDescriptor(kvDB, sqlutils.TestDB, "foo")
 	var valNeededForCol util.FastIntSet
 	valNeededForCol.AddRange(0, 1)
 	args := []initFetcherArgs{

--- a/pkg/sql/row/fk_test.go
+++ b/pkg/sql/row/fk_test.go
@@ -33,16 +33,16 @@ import (
 
 type testTables struct {
 	nextID       ID
-	tablesByID   map[ID]*sqlbase.TableDescriptor
-	tablesByName map[string]*sqlbase.TableDescriptor
+	tablesByID   map[ID]*sqlbase.ImmutableTableDescriptor
+	tablesByName map[string]*sqlbase.ImmutableTableDescriptor
 }
 
 func (t *testTables) createTestTable(name string) ID {
-	table := &sqlbase.TableDescriptor{
+	table := sqlbase.NewImmutableTableDescriptor(sqlbase.TableDescriptor{
 		Name:        name,
 		ID:          t.nextID,
 		NextIndexID: sqlbase.IndexID(1), // This must be 1 to avoid clashing with a primary index.
-	}
+	})
 	t.tablesByID[table.ID] = table
 	t.tablesByName[table.Name] = table
 	t.nextID++
@@ -99,8 +99,8 @@ func (t *testTables) createForeignKeyReference(
 func TestTablesNeededForFKs(t *testing.T) {
 	tables := testTables{
 		nextID:       ID(1),
-		tablesByID:   make(map[ID]*sqlbase.TableDescriptor),
-		tablesByName: make(map[string]*sqlbase.TableDescriptor),
+		tablesByID:   make(map[ID]*sqlbase.ImmutableTableDescriptor),
+		tablesByName: make(map[string]*sqlbase.ImmutableTableDescriptor),
 	}
 
 	// First setup the table we will be testing against.

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -58,7 +58,7 @@ type Inserter struct {
 // insertCols must contain every column in the primary key.
 func MakeInserter(
 	txn *client.Txn,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	fkTables TableLookupsByID,
 	insertCols []sqlbase.ColumnDescriptor,
 	checkFKs checkFKConstraints,
@@ -94,7 +94,7 @@ func MakeInserter(
 
 	if checkFKs == CheckFKs {
 		var err error
-		if ri.Fks, err = makeFKInsertHelper(txn, *tableDesc, fkTables,
+		if ri.Fks, err = makeFKInsertHelper(txn, tableDesc, fkTables,
 			ri.InsertColIDtoRowIndex, alloc); err != nil {
 			return ri, err
 		}
@@ -407,7 +407,7 @@ const (
 // passed in requestedCols will be included in FetchCols at the beginning.
 func MakeUpdater(
 	txn *client.Txn,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	fkTables TableLookupsByID,
 	updateCols []sqlbase.ColumnDescriptor,
 	requestedCols []sqlbase.ColumnDescriptor,
@@ -440,7 +440,7 @@ var returnTruePseudoError error = returnTrue{}
 // create a cascader.
 func makeUpdaterWithoutCascader(
 	txn *client.Txn,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	fkTables TableLookupsByID,
 	updateCols []sqlbase.ColumnDescriptor,
 	requestedCols []sqlbase.ColumnDescriptor,
@@ -607,7 +607,7 @@ func makeUpdaterWithoutCascader(
 	}
 
 	var err error
-	if ru.Fks, err = makeFKUpdateHelper(txn, *tableDesc, fkTables,
+	if ru.Fks, err = makeFKUpdateHelper(txn, tableDesc, fkTables,
 		ru.FetchColIDtoRowIndex, alloc); err != nil {
 		return Updater{}, err
 	}
@@ -871,7 +871,7 @@ type Deleter struct {
 // passed in requestedCols will be included in FetchCols.
 func MakeDeleter(
 	txn *client.Txn,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	fkTables TableLookupsByID,
 	requestedCols []sqlbase.ColumnDescriptor,
 	checkFKs checkFKConstraints,
@@ -898,7 +898,7 @@ func MakeDeleter(
 // additional cascader.
 func makeRowDeleterWithoutCascader(
 	txn *client.Txn,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	fkTables TableLookupsByID,
 	requestedCols []sqlbase.ColumnDescriptor,
 	checkFKs checkFKConstraints,
@@ -955,7 +955,7 @@ func makeRowDeleterWithoutCascader(
 	}
 	if checkFKs == CheckFKs {
 		var err error
-		if rd.Fks, err = makeFKDeleteHelper(txn, *tableDesc, fkTables,
+		if rd.Fks, err = makeFKDeleteHelper(txn, tableDesc, fkTables,
 			fetchColIDtoRowIndex, alloc); err != nil {
 			return Deleter{}, err
 		}
@@ -1043,7 +1043,7 @@ func (rd *Deleter) DeleteIndexRow(
 		}
 	}
 	secondaryIndexEntry, err := sqlbase.EncodeSecondaryIndex(
-		rd.Helper.TableDesc, idx, rd.FetchColIDtoRowIndex, values)
+		rd.Helper.TableDesc.TableDesc(), idx, rd.FetchColIDtoRowIndex, values)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -41,7 +41,7 @@ var scanNodePool = sync.Pool{
 // A scanNode handles scanning over the key/value pairs for a table and
 // reconstructing them into rows.
 type scanNode struct {
-	desc  *sqlbase.TableDescriptor
+	desc  *sqlbase.ImmutableTableDescriptor
 	index *sqlbase.IndexDescriptor
 
 	// Set if an index was explicitly specified.
@@ -294,7 +294,7 @@ func (n *scanNode) limitHint() int64 {
 func (n *scanNode) initTable(
 	ctx context.Context,
 	p *planner,
-	desc *sqlbase.TableDescriptor,
+	desc *sqlbase.ImmutableTableDescriptor,
 	indexFlags *tree.IndexFlags,
 	colCfg scanColumnsConfig,
 ) error {

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -48,6 +48,9 @@ type (
 	// MutableTableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	MutableTableDescriptor = sqlbase.MutableTableDescriptor
+	// ImmutableTableDescriptor is provided for convenience and to make the
+	// interface definitions below more intuitive.
+	ImmutableTableDescriptor = sqlbase.ImmutableTableDescriptor
 	// UncachedTableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	// It is an immutable descriptor read from the store.

--- a/pkg/sql/scrub_constraint.go
+++ b/pkg/sql/scrub_constraint.go
@@ -30,7 +30,7 @@ import (
 // CHECK constraint on a table.
 type sqlCheckConstraintCheckOperation struct {
 	tableName *tree.TableName
-	tableDesc *sqlbase.TableDescriptor
+	tableDesc *sqlbase.ImmutableTableDescriptor
 	checkDesc *sqlbase.TableDescriptor_CheckConstraint
 	asOf      hlc.Timestamp
 
@@ -54,7 +54,7 @@ type sqlCheckConstraintCheckRun struct {
 
 func newSQLCheckConstraintCheckOperation(
 	tableName *tree.TableName,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	checkDesc *sqlbase.TableDescriptor_CheckConstraint,
 	asOf hlc.Timestamp,
 ) *sqlCheckConstraintCheckOperation {

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -30,7 +30,7 @@ import (
 // sqlForeignKeyCheckOperation is a check on an indexes physical data.
 type sqlForeignKeyCheckOperation struct {
 	tableName  *tree.TableName
-	tableDesc  *sqlbase.TableDescriptor
+	tableDesc  *sqlbase.ImmutableTableDescriptor
 	constraint *sqlbase.ConstraintDetail
 	asOf       hlc.Timestamp
 
@@ -49,7 +49,7 @@ type sqlForeignKeyConstraintCheckRun struct {
 
 func newSQLForeignKeyCheckOperation(
 	tableName *tree.TableName,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	constraint sqlbase.ConstraintDetail,
 	asOf hlc.Timestamp,
 ) *sqlForeignKeyCheckOperation {
@@ -257,7 +257,7 @@ func (o *sqlForeignKeyCheckOperation) Close(ctx context.Context) {
 //
 func createFKCheckQuery(
 	database string,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	constraint *sqlbase.ConstraintDetail,
 	asOf hlc.Timestamp,
 ) (string, error) {

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -38,7 +38,7 @@ import (
 //    that refers to a primary index key that cannot be found.
 type indexCheckOperation struct {
 	tableName *tree.TableName
-	tableDesc *sqlbase.TableDescriptor
+	tableDesc *sqlbase.ImmutableTableDescriptor
 	indexDesc *sqlbase.IndexDescriptor
 	asOf      hlc.Timestamp
 
@@ -64,7 +64,7 @@ type indexCheckRun struct {
 
 func newIndexCheckOperation(
 	tableName *tree.TableName,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	indexDesc *sqlbase.IndexDescriptor,
 	asOf hlc.Timestamp,
 ) *indexCheckOperation {
@@ -291,7 +291,7 @@ func (o *indexCheckOperation) Close(ctx context.Context) {
 //
 func createIndexCheckQuery(
 	columnNames []string,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	tableName *tree.TableName,
 	indexDesc *sqlbase.IndexDescriptor,
 	asOf hlc.Timestamp,

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -31,7 +31,7 @@ var _ checkOperation = &physicalCheckOperation{}
 // physicalCheckOperation is a check on an indexes physical data.
 type physicalCheckOperation struct {
 	tableName *tree.TableName
-	tableDesc *sqlbase.TableDescriptor
+	tableDesc *sqlbase.ImmutableTableDescriptor
 	indexDesc *sqlbase.IndexDescriptor
 
 	// columns is a list of the columns returned in the query result
@@ -53,7 +53,9 @@ type physicalCheckRun struct {
 }
 
 func newPhysicalCheckOperation(
-	tableName *tree.TableName, tableDesc *sqlbase.TableDescriptor, indexDesc *sqlbase.IndexDescriptor,
+	tableName *tree.TableName,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
+	indexDesc *sqlbase.IndexDescriptor,
 ) *physicalCheckOperation {
 	return &physicalCheckOperation{
 		tableName: tableName,
@@ -136,7 +138,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 
 	planCtx := params.extendedEvalCtx.DistSQLPlanner.NewPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
 	physPlan, err := params.extendedEvalCtx.DistSQLPlanner.createScrubPhysicalCheck(
-		planCtx, scan, *o.tableDesc, *o.indexDesc, spans, params.p.ExecCfg().Clock.Now())
+		planCtx, scan, *o.tableDesc.TableDesc(), *o.indexDesc, spans, params.p.ExecCfg().Clock.Now())
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/select_name_resolution_test.go
+++ b/pkg/sql/select_name_resolution_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func testInitDummySelectNode(t *testing.T, p *planner, desc *TableDescriptor) *renderNode {
+func testInitDummySelectNode(t *testing.T, p *planner, desc *ImmutableTableDescriptor) *renderNode {
 	scan := &scanNode{}
 	scan.desc = desc
 	if err := scan.initDescDefaults(p.curPlan.deps, publicColumnsCfg); err != nil {

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -71,7 +71,7 @@ func (p *planner) IncrementSequence(ctx context.Context, seqName *tree.TableName
 	return val, nil
 }
 
-func boundsExceededError(descriptor *sqlbase.TableDescriptor) error {
+func boundsExceededError(descriptor *sqlbase.ImmutableTableDescriptor) error {
 	seqOpts := descriptor.SequenceOpts
 	isAscending := seqOpts.Increment > 0
 
@@ -135,7 +135,7 @@ func (p *planner) SetSequenceValue(
 			`cannot set the value of virtual sequence %q`, tree.ErrString(seqName))
 	}
 
-	seqValueKey, newVal, err := MakeSequenceKeyVal(descriptor, newVal, isCalled)
+	seqValueKey, newVal, err := MakeSequenceKeyVal(descriptor.TableDesc(), newVal, isCalled)
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func MakeSequenceKeyVal(
 
 // GetSequenceValue returns the current value of the sequence.
 func (p *planner) GetSequenceValue(
-	ctx context.Context, desc *sqlbase.TableDescriptor,
+	ctx context.Context, desc *sqlbase.ImmutableTableDescriptor,
 ) (int64, error) {
 	if desc.SequenceOpts == nil {
 		return 0, errors.New("descriptor is not a sequence")

--- a/pkg/sql/sequence_select.go
+++ b/pkg/sql/sequence_select.go
@@ -26,7 +26,7 @@ import (
 type sequenceSelectNode struct {
 	optColumnsSlot
 
-	desc *sqlbase.TableDescriptor
+	desc *sqlbase.ImmutableTableDescriptor
 
 	val  int64
 	done bool
@@ -34,7 +34,7 @@ type sequenceSelectNode struct {
 
 var _ planNode = &sequenceSelectNode{}
 
-func (p *planner) SequenceSelectNode(desc *sqlbase.TableDescriptor) (planNode, error) {
+func (p *planner) SequenceSelectNode(desc *sqlbase.ImmutableTableDescriptor) (planNode, error) {
 	if desc.SequenceOpts == nil {
 		return nil, errors.New("descriptor is not a sequence")
 	}

--- a/pkg/sql/sqlbase/check.go
+++ b/pkg/sql/sqlbase/check.go
@@ -52,7 +52,7 @@ func (c *CheckHelper) Init(
 	ctx context.Context,
 	analyzeExpr AnalyzeExprFunction,
 	tn *tree.TableName,
-	tableDesc *TableDescriptor,
+	tableDesc *ImmutableTableDescriptor,
 ) error {
 	if len(tableDesc.Checks) == 0 {
 		return nil

--- a/pkg/sql/sqlbase/computed_exprs.go
+++ b/pkg/sql/sqlbase/computed_exprs.go
@@ -99,7 +99,7 @@ func ProcessComputedColumns(
 	ctx context.Context,
 	cols []ColumnDescriptor,
 	tn *tree.TableName,
-	tableDesc *TableDescriptor,
+	tableDesc *ImmutableTableDescriptor,
 	txCtx *transform.ExprTransformContext,
 	evalCtx *tree.EvalContext,
 ) ([]ColumnDescriptor, []ColumnDescriptor, []tree.TypedExpr, error) {
@@ -125,7 +125,7 @@ func ProcessComputedColumns(
 // input columns earlier in the slice.
 func MakeComputedExprs(
 	cols []ColumnDescriptor,
-	tableDesc *TableDescriptor,
+	tableDesc *ImmutableTableDescriptor,
 	tn *tree.TableName,
 	txCtx *transform.ExprTransformContext,
 	evalCtx *tree.EvalContext,

--- a/pkg/sql/sqlbase/default_exprs.go
+++ b/pkg/sql/sqlbase/default_exprs.go
@@ -80,7 +80,7 @@ func MakeDefaultExprs(
 // and returns the defaultExprs for cols.
 func ProcessDefaultColumns(
 	cols []ColumnDescriptor,
-	tableDesc *TableDescriptor,
+	tableDesc *ImmutableTableDescriptor,
 	txCtx *transform.ExprTransformContext,
 	evalCtx *tree.EvalContext,
 ) ([]ColumnDescriptor, []tree.TypedExpr, error) {
@@ -92,7 +92,7 @@ func ProcessDefaultColumns(
 }
 
 func processColumnSet(
-	cols []ColumnDescriptor, tableDesc *TableDescriptor, inSet func(ColumnDescriptor) bool,
+	cols []ColumnDescriptor, tableDesc *ImmutableTableDescriptor, inSet func(ColumnDescriptor) bool,
 ) []ColumnDescriptor {
 	colIDSet := make(map[ColumnID]struct{}, len(cols))
 	for _, col := range cols {

--- a/pkg/sql/sqlbase/row_container.go
+++ b/pkg/sql/sqlbase/row_container.go
@@ -123,7 +123,7 @@ func (ti ColTypeInfo) Type(idx int) types.T {
 // MakeColTypeInfo returns a ColTypeInfo initialized from the given
 // TableDescriptor and map from column ID to row index.
 func MakeColTypeInfo(
-	tableDesc *TableDescriptor, colIDToRowIndex map[ColumnID]int,
+	tableDesc *ImmutableTableDescriptor, colIDToRowIndex map[ColumnID]int,
 ) (ColTypeInfo, error) {
 	colTypeInfo := ColTypeInfo{
 		colTypes: make([]ColumnType, len(colIDToRowIndex)),

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -105,12 +105,19 @@ const (
 type MutationID uint32
 
 // MutableTableDescriptor is a custom type for TableDescriptors
-// going through mutations.
+// going through schema mutations.
 type MutableTableDescriptor struct {
 	TableDescriptor
 
 	// ClusterVersion represents the version of the table descriptor read from the store.
 	ClusterVersion TableDescriptor
+}
+
+// ImmutableTableDescriptor is a custom type for TableDescriptors
+// It holds precomputed values and the underlying TableDescriptor
+// should be const.
+type ImmutableTableDescriptor struct {
+	TableDescriptor
 }
 
 // InvalidMutationID is the uninitialised mutation id.
@@ -168,6 +175,12 @@ func NewMutableCreatedTableDescriptor(tbl TableDescriptor) *MutableTableDescript
 // This is for an existing table.
 func NewMutableExistingTableDescriptor(tbl TableDescriptor) *MutableTableDescriptor {
 	return &MutableTableDescriptor{TableDescriptor: tbl, ClusterVersion: tbl}
+}
+
+// NewImmutableTableDescriptor returns a ImmutableTableDescriptor from the
+// given TableDescriptor.
+func NewImmutableTableDescriptor(tbl TableDescriptor) *ImmutableTableDescriptor {
+	return &ImmutableTableDescriptor{TableDescriptor: tbl}
 }
 
 // GetDatabaseDescFromID retrieves the database descriptor for the database
@@ -2548,11 +2561,11 @@ func (desc *TableDescriptor) FindAllReferences() (map[ID]struct{}, error) {
 }
 
 // TableDesc implements the ObjectDescriptor interface.
-func (desc *TableDescriptor) TableDesc() *TableDescriptor {
-	return desc
+func (desc *MutableTableDescriptor) TableDesc() *TableDescriptor {
+	return &desc.TableDescriptor
 }
 
 // TableDesc implements the ObjectDescriptor interface.
-func (desc *MutableTableDescriptor) TableDesc() *TableDescriptor {
+func (desc *ImmutableTableDescriptor) TableDesc() *TableDescriptor {
 	return &desc.TableDescriptor
 }

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -156,6 +156,20 @@ var ErrDescriptorNotFound = errors.New("descriptor not found")
 // collected mutations list.
 var ErrIndexGCMutationsList = errors.New("index in GC mutations list")
 
+// NewMutableCreatedTableDescriptor returns a MutableTableDescriptor from the
+// given TableDescriptor with the cluster version being the zero table. This
+// is for a table that is created in the transaction.
+func NewMutableCreatedTableDescriptor(tbl TableDescriptor) *MutableTableDescriptor {
+	return &MutableTableDescriptor{TableDescriptor: tbl}
+}
+
+// NewMutableExistingTableDescriptor returns a MutableTableDescriptor from the
+// given TableDescriptor with the cluster version also set to the descriptor.
+// This is for an existing table.
+func NewMutableExistingTableDescriptor(tbl TableDescriptor) *MutableTableDescriptor {
+	return &MutableTableDescriptor{TableDescriptor: tbl, ClusterVersion: tbl}
+}
+
 // GetDatabaseDescFromID retrieves the database descriptor for the database
 // ID passed in using an existing txn. Returns an error if the descriptor
 // doesn't exist or if it exists and is not a database.

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -74,6 +74,13 @@ func GetTableDescriptor(kvDB *client.DB, database string, table string) *TableDe
 	return desc.GetTable()
 }
 
+// GetImmutableTableDescriptor retrieves an immutable table descriptor directly from the KV layer.
+func GetImmutableTableDescriptor(
+	kvDB *client.DB, database string, table string,
+) *ImmutableTableDescriptor {
+	return NewImmutableTableDescriptor(*GetTableDescriptor(kvDB, database, table))
+}
+
 // RandDatum generates a random Datum of the given type.
 // If nullOk is true, the datum can be DNull.
 // Note that if typ.SemanticType is ColumnType_NULL, the datum will always be DNull,

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -133,6 +133,11 @@ type uncommittedDatabase struct {
 	dropped bool
 }
 
+type uncommittedTable struct {
+	*sqlbase.MutableTableDescriptor
+	*sqlbase.ImmutableTableDescriptor
+}
+
 // TableCollection is a collection of tables held by a single session that
 // serves SQL requests, or a background job using a table descriptor. The
 // collection is cleared using releaseTables() which is called at the
@@ -145,7 +150,7 @@ type TableCollection struct {
 	// They are released once the transaction using them is complete.
 	// If the transaction gets pushed and the timestamp changes,
 	// the tables are released.
-	leasedTables []*sqlbase.TableDescriptor
+	leasedTables []*sqlbase.ImmutableTableDescriptor
 	// Tables modified by the uncommitted transaction affiliated
 	// with this TableCollection. This allows a transaction to see
 	// its own modifications while bypassing the table lease mechanism.
@@ -154,7 +159,7 @@ type TableCollection struct {
 	// the table. These table descriptors are local to this
 	// TableCollection and invisible to other transactions. A dropped
 	// table is marked dropped.
-	uncommittedTables []*sqlbase.MutableTableDescriptor
+	uncommittedTables []uncommittedTable
 
 	// databaseCache is used as a cache for database names.
 	// TODO(andrei): get rid of it and replace it with a leasing system for
@@ -221,9 +226,9 @@ func (tc *TableCollection) getMutableTableDescriptor(
 
 	if refuseFurtherLookup, table, err := tc.getUncommittedTable(dbID, tn, flags.required); refuseFurtherLookup || err != nil {
 		return nil, nil, err
-	} else if table != nil {
-		log.VEventf(ctx, 2, "found uncommitted table %d", table.ID)
-		return table, nil, nil
+	} else if mut := table.MutableTableDescriptor; mut != nil {
+		log.VEventf(ctx, 2, "found uncommitted table %d", mut.ID)
+		return mut, nil, nil
 	}
 
 	phyAccessor := UncachedPhysicalAccessor{}
@@ -247,7 +252,7 @@ func (tc *TableCollection) getMutableTableDescriptor(
 //
 func (tc *TableCollection) getTableVersion(
 	ctx context.Context, txn *client.Txn, tn *tree.TableName, flags ObjectLookupFlags,
-) (*sqlbase.TableDescriptor, *sqlbase.DatabaseDescriptor, error) {
+) (*sqlbase.ImmutableTableDescriptor, *sqlbase.DatabaseDescriptor, error) {
 	if log.V(2) {
 		log.Infof(ctx, "planner acquiring lease on table '%s'", tn)
 	}
@@ -287,9 +292,9 @@ func (tc *TableCollection) getTableVersion(
 
 	if refuseFurtherLookup, table, err := tc.getUncommittedTable(dbID, tn, flags.required); refuseFurtherLookup || err != nil {
 		return nil, nil, err
-	} else if table != nil {
+	} else if immut := table.ImmutableTableDescriptor; immut != nil {
 		// If not forcing to resolve using KV, tables being added aren't visible.
-		if table.Adding() && !avoidCache {
+		if immut.Adding() && !avoidCache {
 			err := errTableAdding
 			if !flags.required {
 				err = nil
@@ -297,17 +302,17 @@ func (tc *TableCollection) getTableVersion(
 			return nil, nil, err
 		}
 
-		log.VEventf(ctx, 2, "found uncommitted table %d", table.ID)
-		return table.TableDesc(), nil, nil
+		log.VEventf(ctx, 2, "found uncommitted table %d", immut.ID)
+		return immut, nil, nil
 	}
 
-	readTableFromStore := func() (*sqlbase.TableDescriptor, *sqlbase.DatabaseDescriptor, error) {
+	readTableFromStore := func() (*sqlbase.ImmutableTableDescriptor, *sqlbase.DatabaseDescriptor, error) {
 		phyAccessor := UncachedPhysicalAccessor{}
 		obj, db, err := phyAccessor.GetObjectDesc(ctx, txn, tn, flags)
 		if obj == nil {
 			return nil, db, err
 		}
-		return obj.(*sqlbase.TableDescriptor), db, err
+		return obj.(*sqlbase.ImmutableTableDescriptor), db, err
 	}
 
 	if avoidCache {
@@ -358,7 +363,7 @@ func (tc *TableCollection) getTableVersion(
 // getTableVersionByID is a by-ID variant of getTableVersion (i.e. uses same cache).
 func (tc *TableCollection) getTableVersionByID(
 	ctx context.Context, txn *client.Txn, tableID sqlbase.ID, flags ObjectLookupFlags,
-) (*sqlbase.TableDescriptor, error) {
+) (*sqlbase.ImmutableTableDescriptor, error) {
 	log.VEventf(ctx, 2, "planner getting table on table ID %d", tableID)
 
 	if flags.avoidCached || testDisableTableLeases {
@@ -369,18 +374,18 @@ func (tc *TableCollection) getTableVersionByID(
 		if err := filterTableState(table); err != nil {
 			return nil, err
 		}
-		return table, nil
+		return sqlbase.NewImmutableTableDescriptor(*table), nil
 	}
 
 	for _, table := range tc.uncommittedTables {
-		if table.ID == tableID {
+		if immut := table.ImmutableTableDescriptor; immut.ID == tableID {
 			log.VEventf(ctx, 2, "found uncommitted table %d", tableID)
-			if table.Dropped() {
+			if immut.Dropped() {
 				return nil, sqlbase.NewUndefinedRelationError(
 					tree.NewUnqualifiedTableName(tree.Name(fmt.Sprintf("<id=%d>", tableID))),
 				)
 			}
-			return table.TableDesc(), nil
+			return immut, nil
 		}
 	}
 
@@ -427,7 +432,7 @@ func (tc *TableCollection) getMutableTableVersionByID(
 ) (*sqlbase.MutableTableDescriptor, error) {
 	log.VEventf(ctx, 2, "planner getting mutable table on table ID %d", tableID)
 
-	if table := tc.getUncommittedTableByID(tableID); table != nil {
+	if table := tc.getUncommittedTableByID(tableID).MutableTableDescriptor; table != nil {
 		log.VEventf(ctx, 2, "found uncommitted table %d", tableID)
 		return table, nil
 	}
@@ -496,13 +501,17 @@ func (tc *TableCollection) hasUncommittedTables() bool {
 }
 
 func (tc *TableCollection) addUncommittedTable(desc sqlbase.MutableTableDescriptor) {
+	tbl := uncommittedTable{
+		MutableTableDescriptor:   &desc,
+		ImmutableTableDescriptor: sqlbase.NewImmutableTableDescriptor(*desc.TableDesc()),
+	}
 	for i, table := range tc.uncommittedTables {
-		if table.ID == desc.ID {
-			tc.uncommittedTables[i] = &desc
+		if table.MutableTableDescriptor.ID == desc.ID {
+			tc.uncommittedTables[i] = tbl
 			return
 		}
 	}
-	tc.uncommittedTables = append(tc.uncommittedTables, &desc)
+	tc.uncommittedTables = append(tc.uncommittedTables, tbl)
 	tc.releaseAllDescriptors()
 }
 
@@ -514,13 +523,13 @@ func (tc *TableCollection) addUncommittedTable(desc sqlbase.MutableTableDescript
 func (tc *TableCollection) getTablesWithNewVersion() []IDVersion {
 	var tables []IDVersion
 	for _, table := range tc.uncommittedTables {
-		if !table.IsNewTable() {
+		if mut := table.MutableTableDescriptor; !mut.IsNewTable() {
 			tables = append(tables, IDVersion{
-				name: table.Name,
-				id:   table.ID,
+				name: mut.Name,
+				id:   mut.ID,
 				// Used to check that there are no leases at Version - 2.
 				// Note the version has already been incremented.
-				version: table.Version - 2,
+				version: mut.Version - 2,
 			})
 		}
 	}
@@ -574,17 +583,18 @@ func (tc *TableCollection) getUncommittedDatabaseID(
 // still exist).
 func (tc *TableCollection) getUncommittedTable(
 	dbID sqlbase.ID, tn *tree.TableName, required bool,
-) (refuseFurtherLookup bool, table *sqlbase.MutableTableDescriptor, err error) {
+) (refuseFurtherLookup bool, table uncommittedTable, err error) {
 	// Walk latest to earliest so that a DROP TABLE followed by a CREATE TABLE
 	// with the same name will result in the CREATE TABLE being seen.
 	for i := len(tc.uncommittedTables) - 1; i >= 0; i-- {
 		table := tc.uncommittedTables[i]
+		mutTbl := table.MutableTableDescriptor
 		// If a table has gotten renamed we'd like to disallow using the old names.
 		// The renames could have happened in another transaction but it's still okay
 		// to disallow the use of the old name in this transaction because the other
 		// transaction has already committed and this transaction is seeing the
 		// effect of it.
-		for _, drain := range table.DrainingNames {
+		for _, drain := range mutTbl.DrainingNames {
 			if drain.Name == string(tn.TableName) &&
 				drain.ParentID == dbID {
 				// Table name has gone away.
@@ -594,41 +604,41 @@ func (tc *TableCollection) getUncommittedTable(
 				}
 				// The table collection knows better; the caller has to avoid
 				// going to KV in any case: refuseFurtherLookup = true
-				return true, nil, err
+				return true, uncommittedTable{}, err
 			}
 		}
 
 		// Do we know about a table with this name?
-		if table.Name == string(tn.TableName) &&
-			table.ParentID == dbID {
+		if mutTbl.Name == string(tn.TableName) &&
+			mutTbl.ParentID == dbID {
 			// Right state?
-			if err = filterTableState(table.TableDesc()); err != nil && err != errTableAdding {
+			if err = filterTableState(mutTbl.TableDesc()); err != nil && err != errTableAdding {
 				if !required {
 					// If it's not required here, we simply say we don't have it.
 					err = nil
 				}
 				// The table collection knows better; the caller has to avoid
 				// going to KV in any case: refuseFurtherLookup = true
-				return true, nil, err
+				return true, uncommittedTable{}, err
 			}
 
 			// Got a table.
 			return false, table, nil
 		}
 	}
-	return false, nil, nil
+	return false, uncommittedTable{}, nil
 }
 
-func (tc *TableCollection) getUncommittedTableByID(id sqlbase.ID) *sqlbase.MutableTableDescriptor {
+func (tc *TableCollection) getUncommittedTableByID(id sqlbase.ID) uncommittedTable {
 	// Walk latest to earliest so that a DROP TABLE followed by a CREATE TABLE
 	// with the same name will result in the CREATE TABLE being seen.
 	for i := len(tc.uncommittedTables) - 1; i >= 0; i-- {
 		table := tc.uncommittedTables[i]
-		if table.ID == id {
+		if table.MutableTableDescriptor.ID == id {
 			return table
 		}
 	}
-	return nil
+	return uncommittedTable{}
 }
 
 // getAllDescriptors returns all descriptors visible by the transaction,
@@ -872,7 +882,7 @@ func (p *planner) writeTableDescToBatch(
 		// Only increment the table descriptor version once in this transaction.
 		// If the descriptor version had been incremented before it would have
 		// been placed in the uncommitted tables list.
-		if p.Tables().getUncommittedTableByID(tableDesc.ID) == nil {
+		if p.Tables().getUncommittedTableByID(tableDesc.ID).MutableTableDescriptor == nil {
 			if err := incrementVersion(ctx, tableDesc.TableDesc(), p.txn); err != nil {
 				return err
 			}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -435,7 +435,7 @@ func (tc *TableCollection) getMutableTableVersionByID(
 	if err != nil {
 		return nil, err
 	}
-	return NewMutableExistingTableDescriptor(*table), nil
+	return sqlbase.NewMutableExistingTableDescriptor(*table), nil
 }
 
 func (tc *TableCollection) releaseLeases(ctx context.Context) {

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -74,7 +74,7 @@ type tableWriter interface {
 
 	// tableDesc returns the TableDescriptor for the table that the tableWriter
 	// will modify.
-	tableDesc() *sqlbase.TableDescriptor
+	tableDesc() *sqlbase.ImmutableTableDescriptor
 
 	// fkSpanCollector returns the FkSpanCollector for the tableWriter.
 	fkSpanCollector() row.FkSpanCollector
@@ -137,7 +137,7 @@ func (tb *tableWriterBase) init(txn *client.Txn) {
 // flushAndStartNewBatch shares the common flushAndStartNewBatch()
 // code between extendedTableWriters.
 func (tb *tableWriterBase) flushAndStartNewBatch(
-	ctx context.Context, tableDesc *sqlbase.TableDescriptor,
+	ctx context.Context, tableDesc *sqlbase.ImmutableTableDescriptor,
 ) error {
 	if err := tb.txn.Run(ctx, tb.b); err != nil {
 		return row.ConvertBatchError(ctx, tableDesc, tb.b)
@@ -152,7 +152,7 @@ func (tb *tableWriterBase) curBatchSize() int { return tb.batchSize }
 
 // finalize shares the common finalize code between extendedTableWriters.
 func (tb *tableWriterBase) finalize(
-	ctx context.Context, autoCommit autoCommitOpt, tableDesc *sqlbase.TableDescriptor,
+	ctx context.Context, autoCommit autoCommitOpt, tableDesc *sqlbase.ImmutableTableDescriptor,
 ) (err error) {
 	if autoCommit == autoCommitEnabled {
 		// An auto-txn can commit the transaction with the batch. This is an

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -370,7 +370,7 @@ func (td *tableDeleter) deleteIndexScan(
 	return resume, err
 }
 
-func (td *tableDeleter) tableDesc() *sqlbase.TableDescriptor {
+func (td *tableDeleter) tableDesc() *sqlbase.ImmutableTableDescriptor {
 	return td.rd.Helper.TableDesc
 }
 

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -59,7 +59,7 @@ func (ti *tableInserter) finalize(
 }
 
 // tableDesc is part of the tableWriter interface.
-func (ti *tableInserter) tableDesc() *sqlbase.TableDescriptor {
+func (ti *tableInserter) tableDesc() *sqlbase.ImmutableTableDescriptor {
 	return ti.ri.Helper.TableDesc
 }
 

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -67,7 +67,7 @@ func (tu *tableUpdater) finalize(
 }
 
 // tableDesc is part of the tableWriter interface.
-func (tu *tableUpdater) tableDesc() *sqlbase.TableDescriptor {
+func (tu *tableUpdater) tableDesc() *sqlbase.ImmutableTableDescriptor {
 	return tu.ru.Helper.TableDesc
 }
 

--- a/pkg/sql/tablewriter_upsert_strict.go
+++ b/pkg/sql/tablewriter_upsert_strict.go
@@ -127,7 +127,7 @@ func (tu *strictTableUpserter) getConflictingRows(
 
 		// Get the primary key of the insert row.
 		upsertRowPK, _, err := sqlbase.EncodeIndexKey(
-			tableDesc, &tableDesc.PrimaryIndex, tu.ri.InsertColIDtoRowIndex, row, tu.indexKeyPrefix)
+			tableDesc.TableDesc(), &tableDesc.PrimaryIndex, tu.ri.InsertColIDtoRowIndex, row, tu.indexKeyPrefix)
 		if err != nil {
 			return nil, err
 		}
@@ -150,7 +150,7 @@ func (tu *strictTableUpserter) getConflictingRows(
 		// and if not, mark the key to be checked against the table.
 		for _, idx := range tu.conflictIndexes {
 			entries, err := sqlbase.EncodeSecondaryIndex(
-				tableDesc, &idx, tu.ri.InsertColIDtoRowIndex, row)
+				tableDesc.TableDesc(), &idx, tu.ri.InsertColIDtoRowIndex, row)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -399,7 +399,13 @@ func truncateTableInChunks(
 		}
 		if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 			rd, err := row.MakeDeleter(
-				txn, tableDesc, nil, nil, row.SkipFKs, nil /* *tree.EvalContext */, alloc,
+				txn,
+				sqlbase.NewImmutableTableDescriptor(*tableDesc),
+				nil,
+				nil,
+				row.SkipFKs,
+				nil, /* *tree.EvalContext */
+				alloc,
 			)
 			if err != nil {
 				return err

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -191,7 +191,7 @@ func (p *planner) truncateTable(
 		return err
 	}
 	tableDesc.DropJobID = dropJobID
-	newTableDesc := NewMutableCreatedTableDescriptor(tableDesc.TableDescriptor)
+	newTableDesc := sqlbase.NewMutableCreatedTableDescriptor(tableDesc.TableDescriptor)
 	newTableDesc.ReplacementOf = sqlbase.TableDescriptor_Replacement{
 		ID: id, Time: p.txn.CommitTimestamp(),
 	}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -219,7 +219,7 @@ func (p *planner) Update(
 			requestedColSet.Add(int(col.ID))
 		}
 		for _, ck := range desc.Checks {
-			cols, err := ck.ColumnsUsed(desc)
+			cols, err := ck.ColumnsUsed(desc.TableDesc())
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -50,7 +50,7 @@ var _ autoCommitNode = &upsertNode{}
 func (p *planner) newUpsertNode(
 	ctx context.Context,
 	n *tree.Insert,
-	desc *sqlbase.TableDescriptor,
+	desc *sqlbase.ImmutableTableDescriptor,
 	ri row.Inserter,
 	tn, alias *tree.TableName,
 	sourceRows planNode,
@@ -523,7 +523,7 @@ func (uh *upsertHelper) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 func (p *planner) newUpsertHelper(
 	ctx context.Context,
 	tn *tree.TableName,
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	insertCols []sqlbase.ColumnDescriptor,
 	updateCols []sqlbase.ColumnDescriptor,
 	updateExprs tree.UpdateExprs,
@@ -736,7 +736,7 @@ func (uh *upsertHelper) shouldUpdate(insertRow tree.Datums, existingRow tree.Dat
 //   or auto-generated assignments for UPSERT.
 // - conflictIdx: the conflicting index, if specified.
 func upsertExprsAndIndex(
-	tableDesc *sqlbase.TableDescriptor,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
 	onConflict tree.OnConflict,
 	insertCols []sqlbase.ColumnDescriptor,
 ) (

--- a/pkg/sql/views.go
+++ b/pkg/sql/views.go
@@ -30,7 +30,7 @@ import (
 type planDependencyInfo struct {
 	// desc is a reference to the descriptor for the table being
 	// depended on.
-	desc *sqlbase.TableDescriptor
+	desc *sqlbase.ImmutableTableDescriptor
 	// deps is the list of ways in which the current plan depends on
 	// that table. There can be more than one entries when the same
 	// table is used in different places. The entries can also be

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -257,13 +257,16 @@ func (p *planner) resolveTableForZone(
 			res = mutRes.TableDesc()
 		}
 	} else if zs.TargetsTable() {
+		var immutRes *ImmutableTableDescriptor
 		p.runWithOptions(resolveFlags{skipCache: true}, func() {
-			res, err = ResolveExistingObject(
+			immutRes, err = ResolveExistingObject(
 				ctx, p, &zs.TableOrIndex.Table, true /*required*/, anyDescType,
 			)
 		})
 		if err != nil {
 			return nil, err
+		} else if immutRes != nil {
+			res = immutRes.TableDesc()
 		}
 	}
 	return res, err


### PR DESCRIPTION
Create new ImmutableTableDescriptor struct which embeds a table schema
and increase usage of it. The ImmutableTableDescriptor will also contain
various data structures which will make the CRUD code path cleaner and
also improve lookup times for table schema elements (for example: col ID
to ordinal index map, compute exprs, col ID/name to descriptors).

Related to #22275.