### PR TITLE
storage: prettify error when change replicas races with a merge

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -195,11 +195,11 @@ func maybeDescriptorChangedError(desc *roachpb.RangeDescriptor, err error) (stri
 		// Provide a better message in the common case that the range being changed
 		// was already changed by a concurrent transaction.
 		var actualDesc roachpb.RangeDescriptor
-		if err := detail.ActualValue.GetProto(&actualDesc); err == nil {
-			if desc.RangeID == actualDesc.RangeID && !desc.Equal(actualDesc) {
-				return fmt.Sprintf("descriptor changed: [expected] %s != [actual] %s",
-					desc, actualDesc), true
-			}
+		if !detail.ActualValue.IsPresent() {
+			return fmt.Sprintf("descriptor changed: expected %s != [actual] nil (range subsumed)", desc), true
+		} else if err := detail.ActualValue.GetProto(&actualDesc); err == nil &&
+			desc.RangeID == actualDesc.RangeID && !desc.Equal(actualDesc) {
+			return fmt.Sprintf("descriptor changed: [expected] %s != [actual] %s", desc, actualDesc), true
 		}
 	}
 	return "", false


### PR DESCRIPTION
When a change replicas request races with a split or merge, the result
is an ugly ConditionFailedError that reads

    unexpected value: <gobleddygook>

We attempt to convert that ugly error into a prettier error of the form

    descriptor changed: [expected] <desc> != [actual] desc

but the prettification code was not handling the case where the actual
descriptor is nil, i.e., because the range in question has been
subsumed. This commit updates the code to produce the following prettier
error:

    descriptor changed: [expected] <desc> != [actual] nil (range subsumed)

This has the added benefit of fixing #32604, which sniffs out the
"descriptor changed" message to determine whether an error is expected
or not.

Release note: None