### PR TITLE
storage: deflake TestStoreRangeMergeSlowAbandonedFollower

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -1815,8 +1815,10 @@ func TestStoreRangeMergeSlowAbandonedFollower(t *testing.T) {
 	// Wait for store2 to hear about the split.
 	var rhsRepl2 *storage.Replica
 	testutils.SucceedsSoon(t, func() error {
-		rhsRepl2, err = store2.GetReplica(rhsDesc.RangeID)
-		return err
+		if rhsRepl2, err = store2.GetReplica(rhsDesc.RangeID); err != nil || !rhsRepl2.IsInitialized() {
+			return errors.New("store2 has not yet processed split")
+		}
+		return nil
 	})
 
 	// Block Raft traffic to the LHS replica on store2, by holding its raftMu, so


### PR DESCRIPTION
This test needs to wait for store2 to process the split before it blocks
traffic to the LHS of the merge. The old approach admitted a race where
it would proceed before store2's replica of the RHS was initialized.

Fix #32590.

Release note: None