### PR TITLE
release-2.1: build: add missing `env` and `stdbuf` invocations

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -175,6 +175,7 @@ docker run --privileged -i ${tty-} --rm \
   --env="TMPDIR=/go/src/github.com/cockroachdb/cockroach/artifacts" \
   --env="PAGER=cat" \
   --env="GOTRACEBACK=${GOTRACEBACK-all}" \
+  --env="TZ=America/New_York" \
   --env=COCKROACH_BUILDER_CCACHE \
   --env=COCKROACH_BUILDER_CCACHE_MAXSIZE \
   "${image}:${version}" "$@"

--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -30,7 +30,11 @@ tc_end_block "Compile acceptanceccl tests"
 
 tc_start_block "Run acceptance tests"
 run cd pkg/acceptance
-run ./acceptance.test -nodes 4 -l "$TMPDIR" -test.v -test.timeout 30m 2>&1 | tee "$TMPDIR/acceptance.log" | go-test-teamcity
+run env TZ=America/New_York \
+	stdbuf -eL -oL \
+	./acceptance.test -nodes 4 -l "$TMPDIR" -test.v -test.timeout 30m 2>&1 \
+	| tee "$TMPDIR/acceptance.log" \
+	| go-test-teamcity
 run cd ../..
 tc_end_block "Run acceptance tests"
 

--- a/build/teamcity-bench.sh
+++ b/build/teamcity-bench.sh
@@ -14,7 +14,9 @@ run build/builder.sh make -Otarget c-deps
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Benchmarks"
-run build/builder.sh env TZ=America/New_York make benchshort TESTFLAGS='-v' 2>&1 \
+run build/builder.sh \
+	stdbuf -oL -eL \
+	make benchshort TESTFLAGS='-v' 2>&1 \
 	| tee artifacts/bench.log \
 	| go-test-teamcity
 tc_end_block "Run Benchmarks"

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -31,7 +31,11 @@ tc_start_block "Lint"
 #
 # TODO(benesch): once GOPATH/pkg goes away because Go static analysis tools can
 # rebuild on demand, remove this. Upstream issue: golang/go#25650.
-COCKROACH_BUILDER_CCACHE= run build/builder.sh make lint 2>&1 | tee artifacts/lint.log | go-test-teamcity
+COCKROACH_BUILDER_CCACHE= build/builder.sh \
+	stdbuf -eL -oL \
+	make lint 2>&1 \
+	| tee artifacts/lint.log \
+	| go-test-teamcity
 tc_end_block "Lint"
 
 tc_start_block "Test web UI"

--- a/build/teamcity-local-roachtest.sh
+++ b/build/teamcity-local-roachtest.sh
@@ -23,10 +23,13 @@ tc_end_block "Compile workload/roachtest"
 
 tc_start_block "Run local roachtests"
 # TODO(peter,dan): curate a suite of the tests that works locally.
-run build/builder.sh ./bin/roachtest run '(acceptance|kv/splits)' \
+run build/builder.sh \
+	stdbuf -oL -eL \
+	./bin/roachtest run '(acceptance|kv/splits)' \
   --local \
   --cockroach "cockroach" \
   --workload "bin/workload" \
   --artifacts artifacts \
-  --teamcity 2>&1 | tee artifacts/roachtest.log
+  --teamcity 2>&1 \
+	| tee artifacts/roachtest.log
 tc_end_block "Run local roachtests"

--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -14,7 +14,8 @@ export BUILDER_HIDE_GOPATH_SRC=0
 # tests that do require correlated subquery support, but only with the cost-
 # based optimizer.
 for config in local local-opt fakedist fakedist-opt fakedist-disk; do
-    build/builder.sh env \
+    build/builder.sh \
+        stdbuf -oL -eL \
         make test TESTFLAGS="-v -bigtest -config ${config}" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteLogic$$' 2>&1 \
         | tee "artifacts/${config}.log" \
         | go-test-teamcity
@@ -23,7 +24,8 @@ done
 # Need to specify the flex-types flag in order to skip past variations that have
 # numeric typing differences.
 for config in local-opt fakedist-opt; do
-    build/builder.sh env \
+    build/builder.sh \
+        stdbuf -oL -eL \
         make test TESTFLAGS="-v -bigtest -config ${config} -flex-types" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteCorrelatedLogic$$' 2>&1 \
         | tee "artifacts/${config}.log" \
         | go-test-teamcity

--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -18,6 +18,7 @@ env=(
   "GOFLAGS=${GOFLAGS:-}"
   "TAGS=${TAGS:-}"
   "STRESSFLAGS=${STRESSFLAGS:-}"
+  "TZ=America/New_York"
 )
 
 build/builder.sh env "${env[@]}" bash <<'EOF'
@@ -44,7 +45,8 @@ go install ./pkg/cmd/github-post
 # We've set pipefail, so the exit status is going to come from stress if there
 # are test failures.
 # Use an `if` so that the `-e` option doesn't stop the script on error.
-if ! make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-maxruns 100 -maxfails 1 -stderr $STRESSFLAGS" 2>&1 \
+if ! stdbuf -oL -eL \
+  make stress PKG="$PKG" TESTTIMEOUT=40m GOFLAGS="$GOFLAGS" TAGS="$TAGS" STRESSFLAGS="-maxruns 100 -maxfails 1 -stderr $STRESSFLAGS" 2>&1 \
   | tee artifacts/stress.log; then
   exit_status=${PIPESTATUS[0]}
   go tool test2json -t < artifacts/stress.log | github-post

--- a/build/teamcity-test-deadlock.sh
+++ b/build/teamcity-test-deadlock.sh
@@ -15,7 +15,9 @@ run build/builder.sh make -Otarget c-deps
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Go tests with deadlock detection enabled"
-run build/builder.sh env TZ=America/New_York make test TAGS=deadlock TESTFLAGS='-v' 2>&1 \
+run build/builder.sh \
+	stdbuf -oL -eL \
+	make test TAGS=deadlock TESTFLAGS='-v' 2>&1 \
 	| tee artifacts/test.log \
 	| go-test-teamcity
 tc_end_block "Run Go tests with deadlock detection enabled"

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -19,7 +19,9 @@ run build/builder.sh make -Otarget c-deps
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Go tests"
-run build/builder.sh env TZ=America/New_York make test TESTFLAGS='-v' 2>&1 \
+run build/builder.sh \
+	stdbuf -oL -eL \
+	make test TESTFLAGS='-v' 2>&1 \
 	| tee artifacts/test.log \
 	| go-test-teamcity
 tc_end_block "Run Go tests"

--- a/build/teamcity-testlogic-verbose.sh
+++ b/build/teamcity-testlogic-verbose.sh
@@ -14,7 +14,9 @@ run build/builder.sh make -Otarget c-deps
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run TestLogic tests under verbose"
-run build/builder.sh env TZ=America/New_York make testlogic TESTTIMEOUT=1h TESTFLAGS='--vmodule=*=10 -show-sql -test.v' 2>&1 \
+run build/builder.sh \
+	stdbuf -oL -eL \
+	make testlogic TESTTIMEOUT=1h TESTFLAGS='--vmodule=*=10 -show-sql -test.v' 2>&1 \
 	| tee artifacts/test.log \
 	| go-test-teamcity
 tc_end_block "Run TestLogic tests under verbose"

--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -8,7 +8,8 @@ maybe_ccache
 
 mkdir -p artifacts
 
-build/builder.sh env \
+build/builder.sh \
+	stdbuf -oL -eL \
 	make testrace \
 	PKG=./pkg/sql/logictest \
 	TESTFLAGS='-v' \

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -35,6 +35,7 @@ tc_end_block "Compile C dependencies"
 tc_start_block "Run Go tests under race detector"
 run build/builder.sh env \
     COCKROACH_LOGIC_TESTS_SKIP=true \
+    stdbuf -oL -eL \
     make testrace \
     PKG="$pkgspec" \
     TESTTIMEOUT=45m \

--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -268,6 +268,7 @@ To repro, try:
 # controls concurrency.
 ./scripts/gceworker.sh start && ./scripts/gceworker.sh mosh
 cd ~/go/src/github.com/cockroachdb/cockroach && \
+stdbuf -oL -eL \
 make stress TESTS=%[5]s PKG=%[4]s TESTTIMEOUT=5m STRESSFLAGS='-stderr=false -maxtime 20m -timeout 10m'
 ` + "```" + `
 

--- a/pkg/cmd/internal/issues/issues_test.go
+++ b/pkg/cmd/internal/issues/issues_test.go
@@ -119,6 +119,7 @@ To repro, try:
 # controls concurrency.
 `+regexp.QuoteMeta(`./scripts/gceworker.sh start && ./scripts/gceworker.sh mosh
 cd ~/go/src/github.com/cockroachdb/cockroach && \
+stdbuf -oL -eL \
 make stress TESTS=%s PKG=%s TESTTIMEOUT=5m STRESSFLAGS='-stderr=false -maxtime 20m -timeout 10m'`)+`
 `+"```"+`
 


### PR DESCRIPTION
Backport 1/1 commits from #32587.

/cc @cockroachdb/release

