### PR TITLE
sql,server: fix the listing of sessions for admin/root users

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1352,31 +1352,32 @@ func (s *statusServer) ListLocalSessions(
 		return nil, remoteDebuggingErr
 	}
 
-	var showAll bool
 	sessionUser, err := userFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	// If the client is asking to see more than just their own sessions, verify
-	// that they should be allowed to.
-	if sessionUser != req.Username {
-		superuser := (sessionUser == security.RootUser || s.isSuperUser(ctx, sessionUser))
-		if req.Username != "" && !superuser {
+
+	superuser := s.isSuperUser(ctx, sessionUser)
+	if !superuser {
+		// For non-superusers, requests with an empty username is
+		// implicitly a request for the client's own sessions.
+		if req.Username == "" {
+			req.Username = sessionUser
+		}
+
+		// Non-superusers are not allowed to query sessions others than their own.
+		if sessionUser != req.Username {
 			return nil, grpcstatus.Errorf(
 				codes.PermissionDenied,
 				"client user %q does not have permission to view sessions from user %q",
 				sessionUser, req.Username)
 		}
-		// If the user isn't a superuser, then a request with an empty username is
-		// implicitly a request for the client's own sessions.
-		if req.Username == "" && !superuser {
-			req.Username = sessionUser
-		}
-		showAll = (req.Username == "" && superuser)
 	}
 
-	registry := s.sessionRegistry
+	// The empty username means "all sessions".
+	showAll := req.Username == ""
 
+	registry := s.sessionRegistry
 	sessions := registry.SerializeAll()
 	userSessions := make([]serverpb.Session, 0, len(sessions))
 
@@ -1743,6 +1744,9 @@ type superUserChecker interface {
 }
 
 func (s *statusServer) isSuperUser(ctx context.Context, username string) bool {
+	if username == security.RootUser {
+		return true
+	}
 	planner, cleanup := sql.NewInternalPlanner(
 		"check-superuser",
 		client.NewTxn(ctx, s.db, s.gossip.NodeID.Get(), client.RootTxn),

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -254,6 +254,10 @@ func (c *conn) serveImpl(
 		if err := sendStatusParam("session_authorization", c.sessionArgs.User); err != nil {
 			return err
 		}
+
+		// TODO(knz): this should retrieve the admin status during
+		// authentication using the roles table, instead of using a
+		// simple/naive username match.
 		isSuperUser := c.sessionArgs.User == security.RootUser
 		superUserVal := "off"
 		if isSuperUser {

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -19,12 +19,14 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"math"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
 
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 
 	"github.com/cockroachdb/apd"
@@ -734,6 +736,76 @@ func TestShowSessions(t *testing.T) {
 	if errcount != 1 {
 		t.Fatalf("expected 1 error row, got %d", errcount)
 	}
+}
+
+func TestShowSessionPrivileges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := tests.CreateTestServerParams()
+	params.Insecure = true
+	s, rawSQLDBroot, _ := serverutils.StartServer(t, params)
+	sqlDBroot := sqlutils.MakeSQLRunner(rawSQLDBroot)
+	defer s.Stopper().Stop(context.TODO())
+
+	// Prepare a non-root session.
+	_ = sqlDBroot.Exec(t, `CREATE USER nonroot`)
+	pgURL := url.URL{
+		Scheme:   "postgres",
+		User:     url.User("nonroot"),
+		Host:     s.ServingAddr(),
+		RawQuery: "sslmode=disable",
+	}
+	rawSQLDBnonroot, err := gosql.Open("postgres", pgURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rawSQLDBnonroot.Close()
+	sqlDBnonroot := sqlutils.MakeSQLRunner(rawSQLDBnonroot)
+
+	// Ensure the non-root session is open.
+	sqlDBnonroot.Exec(t, `SELECT version()`)
+
+	t.Run("root", func(t *testing.T) {
+		// Verify that the root session can use SHOW SESSIONS properly and
+		// can observe other sessions than its own.
+		rows := sqlDBroot.Query(t, `SELECT user_name FROM [SHOW CLUSTER SESSIONS]`)
+		defer rows.Close()
+		counts := map[string]int{}
+		for rows.Next() {
+			var userName string
+			if err := rows.Scan(&userName); err != nil {
+				t.Fatal(err)
+			}
+			counts[userName]++
+		}
+		if counts[security.RootUser] == 0 {
+			t.Fatalf("root session is unable to see its own session: %+v", counts)
+		}
+		if counts["nonroot"] == 0 {
+			t.Fatal("root session is unable to see non-root session")
+		}
+	})
+
+	t.Run("non-root", func(t *testing.T) {
+		// Verify that the non-root session can use SHOW SESSIONS properly
+		// and cannot observe other sessions than its own.
+		rows := sqlDBnonroot.Query(t, `SELECT user_name FROM [SHOW CLUSTER SESSIONS]`)
+		defer rows.Close()
+		counts := map[string]int{}
+		for rows.Next() {
+			var userName string
+			if err := rows.Scan(&userName); err != nil {
+				t.Fatal(err)
+			}
+			counts[userName]++
+		}
+		if counts["nonroot"] == 0 {
+			t.Fatal("non-root session is unable to see its own session")
+		}
+		if len(counts) > 1 {
+			t.Fatalf("non-root session is able to see other sessions: %+v", counts)
+		}
+	})
 }
 
 // TestShowJobs manually inserts a row into system.jobs and checks that the


### PR DESCRIPTION
Fixes #32599.

Admin users should be able to list all sessions not just their own.
This was broken in #32253 and thus in 2.1.1 (was ok in 2.1.0 and
prior). This patch fixes this and also clarifies the code responsible.

Release note (bug fix): CockroachDB now again enables admin users,
including `root`, to list all user sessions besides their own.