### PR TITLE
release-2.1: Revert "libroach: use FlushWAL instead of SyncWAL"

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -291,7 +291,7 @@ DBStatus DBSyncWAL(DBEngine* db) {
   options.sync = true;
   return ToDBStatus(db->rep->Write(options, &batch));
 #else
-  return ToDBStatus(db->rep->FlushWAL(true /* sync */));
+  return ToDBStatus(db->rep->SyncWAL());
 #endif
 }
 

--- a/c-deps/libroach/options.cc
+++ b/c-deps/libroach/options.cc
@@ -210,7 +210,6 @@ rocksdb::Options DBMakeOptions(DBOptions db_opts) {
   // of sstables.
   options.target_file_size_base = 4 << 20;  // 4 MB
   options.target_file_size_multiplier = 2;
-  options.manual_wal_flush = true;
 
   // Because we open a long running rocksdb instance, we do not want the
   // manifest file to grow unbounded. Assuming each manifest entry is about 1


### PR DESCRIPTION
Backport 1/1 commits from #32605.

/cc @cockroachdb/release

---

This reverts commit a32142466b3e31f798df3ebb3d50eff73e5ed703.

We have a report with credible testing that using FlushWAL instead of
SyncWAL causes data loss in disk full situations. Presumably there is
some error that is not being propagated correctly.
Possibly related to #31948.

See #25173. Possibly unrelated, but the symptom is the same.

Release note (bug fix): Fix a node data loss bug that occurs when a disk
becomes temporarily full.
