### PR TITLE
storage: partially deflake TestSystemZoneConfigs

### DIFF
--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -1105,6 +1106,13 @@ func setupPartitioningTestCluster(ctx context.Context, t testing.TB) (*sqlutils.
 
 	tsArgs := func(attr string) base.TestServerArgs {
 		return base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &storage.StoreTestingKnobs{
+					// Disable LBS because when the scan is happening at the rate it's happening
+					// below, it's possible that one of the system ranges trigger a split.
+					DisableLoadBasedSplitting: true,
+				},
+			},
 			ScanInterval: 100 * time.Millisecond,
 			StoreSpecs: []base.StoreSpec{
 				{InMemory: true, Attributes: roachpb.Attributes{Attrs: []string{attr}}},

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1600,6 +1600,13 @@ func TestSystemZoneConfigs(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 7, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &storage.StoreTestingKnobs{
+					// Disable LBS because when the scan is happening at the rate it's happening
+					// below, it's possible that one of the system ranges trigger a split.
+					DisableLoadBasedSplitting: true,
+				},
+			},
 			// Scan like a bat out of hell to ensure replication and replica GC
 			// happen in a timely manner.
 			ScanInterval: 50 * time.Millisecond,

--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -785,6 +785,9 @@ func TestNodeLivenessStatusMap(t *testing.T) {
 				// Disable replica rebalancing to ensure that the liveness range
 				// does not get out of the first node (we'll be shutting down nodes).
 				DisableReplicaRebalancing: true,
+				// Disable LBS because when the scan is happening at the rate it's happening
+				// below, it's possible that one of the system ranges trigger a split.
+				DisableLoadBasedSplitting: true,
 			},
 		},
 		RaftConfig: base.RaftConfig{

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -7023,7 +7023,8 @@ func (r *Replica) SplitByLoadQPSThreshold() float64 {
 // SplitByLoadEnabled returns whether load based splitting is enabled.
 func (r *Replica) SplitByLoadEnabled() bool {
 	return SplitByLoadEnabled.Get(&r.store.cfg.Settings.SV) &&
-		r.store.ClusterSettings().Version.IsMinSupported(cluster.VersionLoadSplits)
+		r.store.ClusterSettings().Version.IsMinSupported(cluster.VersionLoadSplits) &&
+		!r.store.TestingKnobs().DisableLoadBasedSplitting
 }
 
 // needsSplitByLoadLocked returns two bools indicating first, whether

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -108,6 +108,8 @@ type StoreTestingKnobs struct {
 	// DisableReplicaRebalancing disables rebalancing of replicas but otherwise
 	// leaves the replicate queue operational.
 	DisableReplicaRebalancing bool
+	// DisableLoadBasedSplitting turns off LBS so no splits happen because of load.
+	DisableLoadBasedSplitting bool
 	// DisableSplitQueue disables the split queue.
 	DisableSplitQueue bool
 	// DisableTimeSeriesMaintenanceQueue disables the time series maintenance

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -264,6 +264,13 @@ func (tc *TestCluster) doAddServer(t testing.TB, serverArgs base.TestServerArgs)
 		}
 	}
 
+	// Disable LBS if the server being added has a scan interval arg this low.
+	if serverArgs.ScanInterval > 0 && serverArgs.ScanInterval <= 100*time.Millisecond {
+		if _, err := conn.Exec(`SET CLUSTER SETTING kv.range_split.by_load_enabled = false`); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	tc.Servers = append(tc.Servers, s.(*server.TestServer))
 	tc.Conns = append(tc.Conns, conn)
 	tc.mu.Lock()


### PR DESCRIPTION
I doubt this fixes #32511 completely, but this does address the
splits Andrei saw with the same test. With the scan interval
being so low, there are about 20 scans, each of which with ~ 20
replicas per scan, and they hit ~ 10 queues. If the queues do a meta
lookup or any other system lookup, it is possible that the QPS threshold
for splits is exceeded. To fix this, we turn off LBS in such tests

Release note: None