### PR TITLE
sql: add optional AS OF SYSTEM TIME with CREATE STATISTICS

### DIFF
--- a/docs/generated/sql/bnf/create_stats_stmt.bnf
+++ b/docs/generated/sql/bnf/create_stats_stmt.bnf
@@ -1,2 +1,2 @@
 create_stats_stmt ::=
-	'CREATE' 'STATISTICS' statistics_name 'ON' column_name 'FROM' table_name
+	'CREATE' 'STATISTICS' statistics_name 'ON' column_name 'FROM' table_name opt_as_of_clause

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -320,7 +320,7 @@ create_ddl_stmt ::=
 	| create_sequence_stmt
 
 create_stats_stmt ::=
-	'CREATE' 'STATISTICS' statistics_name 'ON' name_list 'FROM' table_name
+	'CREATE' 'STATISTICS' statistics_name 'ON' name_list 'FROM' table_name opt_as_of_clause
 
 opt_with_clause ::=
 	with_clause

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -663,7 +663,7 @@ func ParseHLC(s string) (hlc.Timestamp, error) {
 // that requires the transaction to be started already. If the returned
 // timestamp is not nil, it is the timestamp to which a transaction
 // should be set. The statements that will be checked are Select,
-// ShowTrace (of a Select statement), and Scrub.
+// ShowTrace (of a Select statement), Scrub, Export, and CreateStats.
 //
 // max is a lower bound on what the transaction's timestamp will be.
 // Used to check that the user didn't specify a timestamp in the future.
@@ -694,6 +694,11 @@ func (p *planner) isAsOf(stmt tree.Statement, max hlc.Timestamp) (*hlc.Timestamp
 		asOf = s.AsOf
 	case *tree.Export:
 		return p.isAsOf(s.Query, max)
+	case *tree.CreateStats:
+		if s.AsOf.Expr == nil {
+			return nil, nil
+		}
+		asOf = s.AsOf
 	default:
 		return nil, nil
 	}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -115,3 +115,19 @@ SELECT statistics_name, column_names, row_count, distinct_count, null_count FROM
 statistics_name  column_names  row_count  distinct_count  null_count
 s1               {"a"}         10000      10              0
 NULL             {"b"}         10000      10              0
+
+# Test AS OF SYSTEM TIME
+
+statement error pgcode 42P01 relation "data" does not exist
+CREATE STATISTICS s2 ON a FROM data AS OF SYSTEM TIME '2017'
+
+statement ok
+CREATE STATISTICS s2 ON a FROM data AS OF SYSTEM TIME '-1ns'
+
+query TTIII colnames
+SELECT statistics_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+s1               {"a"}         10000      10              0
+NULL             {"b"}         10000      10              0
+s2               {"a"}         10000      10              0

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2111,9 +2111,9 @@ create_ddl_stmt:
 // %Text:
 // CREATE STATISTICS <statisticname>
 //   ON <colname> [, ...]
-//   FROM <tablename>
+//   FROM <tablename> [AS OF SYSTEM TIME <expr>]
 create_stats_stmt:
-  CREATE STATISTICS statistics_name ON name_list FROM table_name
+  CREATE STATISTICS statistics_name ON name_list FROM table_name opt_as_of_clause
   {
     name, err := tree.NormalizeTableName($7.unresolvedName())
     if err != nil {
@@ -2124,6 +2124,7 @@ create_stats_stmt:
       Name: tree.Name($3),
       ColumnNames: $5.nameList(),
       Table: name,
+      AsOf: $8.asOfClause(),
     }
   }
 | CREATE STATISTICS error // SHOW HELP: CREATE STATISTICS

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1126,6 +1126,7 @@ type CreateStats struct {
 	Name        Name
 	ColumnNames NameList
 	Table       TableName
+	AsOf        AsOfClause
 }
 
 // Format implements the NodeFormatter interface.
@@ -1138,4 +1139,9 @@ func (node *CreateStats) Format(ctx *FmtCtx) {
 
 	ctx.WriteString(" FROM ")
 	ctx.FormatNode(&node.Table)
+
+	if node.AsOf.Expr != nil {
+		ctx.WriteByte(' ')
+		ctx.FormatNode(&node.AsOf)
+	}
 }


### PR DESCRIPTION
This commit adds support for using `AS OF SYSTEM TIME` with the
`CREATE STATISTICS` statement. This will allow users and automated
stats collection to avoid contention with running transactions.

Release note (sql change): Added support for AS OF SYSTEM TIME with
the CREATE STATISTICS statement.