### PR TITLE
distsql: bugfix to distsql planning of subqueries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_subquery
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_subquery
@@ -1,0 +1,33 @@
+# LogicTest: 5node-dist
+
+# TODO(radu): re-add 5node-dist-opt when #32648 is fixed.
+
+# Regression test for #32652: make sure subqueries that have extra columns for
+# stream merges don't crash when executed.
+
+statement ok
+CREATE TABLE ab (a INT, b INT)
+
+statement ok
+INSERT INTO ab VALUES (1, 1), (1, 3), (2, 2)
+
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false
+
+statement ok
+ALTER TABLE ab SPLIT AT VALUES (2)
+
+statement ok
+ALTER TABLE ab EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 1), (ARRAY[2], 2)
+
+query TTITI colnames
+SHOW EXPERIMENTAL_RANGES FROM TABLE ab
+----
+start_key  end_key  range_id  replicas  lease_holder
+NULL       /2       1         {1}       1
+/2         NULL     2         {2}       2
+
+query T
+SELECT ARRAY(SELECT a FROM ab ORDER BY b)
+----
+{1,2,1}


### PR DESCRIPTION
Previously, some subqueries could crash the server when distributed,
because of incorrect accounting for the PlanToStreamColMap final
projection on the result types of the subquery. Now, that final
projection is properly applied.

Fixes #32650.

Release note (bug fix): prevent crash when running certain subqueries
that get planned in a distributed fashion.