### PR TITLE
pgwire: decode bpchar OIDs

### DIFF
--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -520,7 +520,7 @@ func DecodeOidDatum(
 
 	// Types with identical text/binary handling.
 	switch id {
-	case oid.T_text, oid.T_varchar:
+	case oid.T_text, oid.T_varchar, oid.T_bpchar:
 		if err := validateStringBytes(b); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Using cmd/generate-binary I was able to verify that bpchar has the same
binary and text encodings as text and varchar, and so my best guess is
that it's correct to add it to this list.

No test has been added because the existing tests only test the T_text
decoding. That is: T_varchar was already untested, so having T_bpchar
also be untested is ok for now. I've opened #32653 to track this.

Fixes #32625

Release note (sql change): allow bpchar OIDs from client connections.