### PR TITLE
[DNM/WIP] rangefeed - per registration buffer

### DIFF
--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -42,14 +42,7 @@ const (
 
 // newErrBufferCapacityExceeded creates an error that is returned to subscribers
 // if the rangefeed processor is not able to keep up with the flow of incoming
-// events and is forced to drop events in order to not block. The error is
-// usually associated with a slow consumer.
-// TODO(nvanbenschoten): currently a single slow consumer can cause all
-// rangefeeds on a Range to be shut down with this error. We should work
-// on isolating buffering for individual consumers so that a slow consumer
-// only affects itself. One idea for this is to replace Stream.Send with
-// Stream.SendAsync and give each stream its own individual buffer. If
-// an individual stream is unable to keep up, to should fail on its own.
+// events and is forced to drop events in order to not block.
 func newErrBufferCapacityExceeded() *roachpb.Error {
 	return roachpb.NewErrorf("rangefeed: buffer capacity exceeded due to slow consumer")
 }
@@ -117,19 +110,12 @@ type Processor struct {
 	rts resolvedTimestamp
 
 	regC     chan registration
-	catchUpC chan catchUpResult
+	unregC   chan *registration
 	lenReqC  chan struct{}
 	lenResC  chan int
 	eventC   chan event
 	stopC    chan *roachpb.Error
 	stoppedC chan struct{}
-}
-
-// catchUpResult is delivered to the Processor goroutine when a catch up scan
-// for a new registration has completed.
-type catchUpResult struct {
-	r    *registration
-	pErr *roachpb.Error
 }
 
 // event is a union of different event types that the Processor goroutine needs
@@ -153,7 +139,7 @@ func NewProcessor(cfg Config) *Processor {
 		rts:    makeResolvedTimestamp(),
 
 		regC:     make(chan registration),
-		catchUpC: make(chan catchUpResult),
+		unregC:   make(chan *registration),
 		lenReqC:  make(chan struct{}),
 		lenResC:  make(chan int),
 		eventC:   make(chan event, cfg.EventChanCap),
@@ -200,13 +186,9 @@ func (p *Processor) Start(stopper *stop.Stopper, rtsIter engine.SimpleIterator) 
 			defer txnPushTicker.Stop()
 		}
 
-		// checkStreamsTicker periodically checks whether any streams have
-		// disconnected. If so, the registration is unregistered.
-		checkStreamsTicker := time.NewTicker(p.CheckStreamsInterval)
-		defer checkStreamsTicker.Stop()
-
 		for {
 			select {
+
 			// Handle new registrations.
 			case r := <-p.regC:
 				if !p.Span.AsRawSpanWithNoLocals().Contains(r.span) {
@@ -216,21 +198,17 @@ func (p *Processor) Start(stopper *stop.Stopper, rtsIter engine.SimpleIterator) 
 				// Add the new registration to the registry.
 				p.reg.Register(&r)
 
-				// Launch an async catch-up scan for the new registration.
-				// Ignore error if quiescing.
-				if r.catchUpIter != nil {
-					catchUp := newCatchUpScan(p, &r)
-					err := stopper.RunAsyncTask(ctx, "rangefeed: catch-up scan", catchUp.Run)
-					if err != nil {
-						catchUp.Cancel()
-					}
-				} else {
-					p.handleCatchUpScanRes(ctx, catchUpResult{r: &r})
+				// Run an output loop for the registry.
+				loop := newRegistryOutputLoop(p, &r)
+				if err := stopper.RunAsyncTask(ctx, "rangefeed: output loop", loop.Run); err != nil {
+					r.disconnect(roachpb.NewError(err))
+					p.reg.Unregister(&r)
 				}
 
-			// React to registrations finishing their catch up scan.
-			case res := <-p.catchUpC:
-				p.handleCatchUpScanRes(ctx, res)
+			// Respond to unregistration requests; these come from registrations that
+			// encounter an error during their output loop.
+			case r := <-p.unregC:
+				p.reg.Unregister(r)
 
 			// Respond to answers about the processor goroutine state.
 			case <-p.lenReqC:
@@ -285,10 +263,6 @@ func (p *Processor) Start(stopper *stop.Stopper, rtsIter engine.SimpleIterator) 
 				txnPushTickerC = txnPushTicker.C
 				txnPushAttemptC = nil
 
-			// Check whether any streams have disconnected.
-			case <-checkStreamsTicker.C:
-				p.reg.CheckStreams()
-
 			// Close registrations and exit when signaled.
 			case pErr := <-p.stopC:
 				p.reg.DisconnectWithErr(all, pErr)
@@ -340,17 +314,17 @@ func (p *Processor) sendStop(pErr *roachpb.Error) {
 // events that are consumed concurrently with this call. The channel will be
 // provided an error when the registration closes.
 //
-// The provided iterator is used to catch the registration up from its starting
-// timestamp with value events for all committed values. It must obey the
-// contract of an iterator used for a catchUpScan. The Processor promises to
-// clean up the iterator by calling its Close method when it is finished. If the
-// iterator is nil then no catch-up scan will be performed.
+// The provided engine is used to instantiate "catch-up" iterators for this
+// registration as needed. Catch-up iterators are used if a registration
+// temporarily falls behind the "live" stream of output events; a catch-up phase
+// is also used immediately when a new registration is created with a non-empty
+// startTS.
 //
 // NOT safe to call on nil Processor.
 func (p *Processor) Register(
 	span roachpb.RSpan,
 	startTS hlc.Timestamp,
-	catchUpIter engine.SimpleIterator,
+	eng engine.Engine,
 	stream Stream,
 	errC chan<- *roachpb.Error,
 ) {
@@ -359,19 +333,10 @@ func (p *Processor) Register(
 	// it should see these events during its catch up scan.
 	p.syncEventC()
 
-	r := registration{
-		span:        span.AsRawSpanWithNoLocals(),
-		startTS:     startTS,
-		catchUpIter: catchUpIter,
-		stream:      stream,
-		errC:        errC,
-	}
+	r := newRegistration(span, startTS, eng, p.Config.EventChanCap, stream, errC)
 	select {
 	case p.regC <- r:
 	case <-p.stoppedC:
-		if catchUpIter != nil {
-			catchUpIter.Close() // clean up
-		}
 		errC <- roachpb.NewErrorf("rangefeed processor closed")
 	}
 }
@@ -389,16 +354,6 @@ func (p *Processor) Len() int {
 		return <-p.lenResC
 	case <-p.stoppedC:
 		return 0
-	}
-}
-
-// deliverCatchUpScanRes informs the Processor of the results of a catch-up scan
-// for a given registration.
-func (p *Processor) deliverCatchUpScanRes(r *registration, pErr *roachpb.Error) {
-	select {
-	case p.catchUpC <- catchUpResult{r: r, pErr: pErr}:
-	case <-p.stoppedC:
-		// Already stopped. Do nothing.
 	}
 }
 
@@ -489,25 +444,6 @@ func (p *Processor) syncEventC() {
 		}
 	case <-p.stoppedC:
 		// Already stopped. Do nothing.
-	}
-}
-
-//
-// Methods called from Processor goroutine.
-//
-
-func (p *Processor) handleCatchUpScanRes(ctx context.Context, res catchUpResult) {
-	if res.pErr == nil {
-		res.r.SetCaughtUp()
-
-		// Publish checkpoint to processor even if the resolved timestamp is
-		// not initialized. In that case, the timestamp will be empty but the
-		// checkpoint event is still useful to indicate that the catch-up scan
-		// has completed. This allows clients to rely on stronger ordering
-		// semantics once they observe the first checkpoint event.
-		p.reg.PublishToReg(res.r, p.newCheckpointEvent())
-	} else {
-		p.reg.DisconnectRegWithError(res.r, res.pErr)
 	}
 }
 

--- a/pkg/storage/rangefeed/registry.go
+++ b/pkg/storage/rangefeed/registry.go
@@ -18,10 +18,16 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 )
@@ -48,20 +54,210 @@ type Stream interface {
 // has finished.
 type registration struct {
 	// Internal.
-	id   int64
-	keys interval.Range
+	id               int64
+	keys             interval.Range
+	catchupTimestamp hlc.Timestamp
+
+	mu struct {
+		*syncutil.Mutex
+		needsCatchup       bool
+		outputLoopErr      error
+		outputLoopCancelFn func()
+		disconnected       bool
+	}
 
 	// Footprint.
-	span    roachpb.Span
-	startTS hlc.Timestamp // exclusive
+	span roachpb.Span
+	eng  engine.Engine
 
-	// Catch-up state.
-	catchUpIter engine.SimpleIterator
-	caughtUp    bool
+	// Buffer.
+	buf chan *roachpb.RangeFeedEvent
 
 	// Output.
 	stream Stream
 	errC   chan<- *roachpb.Error
+}
+
+func newRegistration(
+	span roachpb.RSpan,
+	startTS hlc.Timestamp,
+	eng engine.Engine,
+	bufferSz int,
+	stream Stream,
+	errC chan<- *roachpb.Error,
+) registration {
+	r := registration{
+		span:             span.AsRawSpanWithNoLocals(),
+		eng:              eng,
+		stream:           stream,
+		errC:             errC,
+		buf:              make(chan *roachpb.RangeFeedEvent, bufferSz),
+		catchupTimestamp: startTS,
+	}
+	r.mu.Mutex = &syncutil.Mutex{}
+	if !startTS.IsEmpty() {
+		r.mu.needsCatchup = true
+	}
+	return r
+}
+
+// publish attempts to send a single event to the output buffer for this
+// registration. If the output buffer is full, the needsCatchup flag is set,
+// indicating that live events were lost and a catchup scan should be initiated.
+// If needsCatchup is already set, events are ignored and not written to the
+// buffer.
+func (r *registration) publish(event *roachpb.RangeFeedEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.mu.needsCatchup {
+		return
+	}
+	select {
+	case r.buf <- event:
+	default:
+		r.mu.needsCatchup = true
+	}
+}
+
+// disconnect cancels the output loop context for the registration and passes an
+// error to the output error stream for the registration. This also sets the
+// disconnected flag on the registration, preventing it from being disconnected
+// again.
+func (r *registration) disconnect(pErr *roachpb.Error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.mu.disconnected {
+		if r.mu.outputLoopCancelFn != nil {
+			r.mu.outputLoopCancelFn()
+		}
+		r.mu.disconnected = true
+		r.errC <- pErr
+	}
+}
+
+// outputLoop is the operational loop for a single registration. The behavior
+// is as thus:
+//
+// 1. If a catch-up scan is indicated, run one. This can occur at start-up, or
+// if the buffer has been overfilled and the "needsCatchup" flag has been set.
+// 2. After catch-up is complete, Begin reading from the registration buffer
+// channel and writing to the output stream until the buffer is empty *and*
+// the needsCatchup flag has been set.
+//
+// The loop exits with any error encountered, or if the provided context is
+// canceled.
+func (r *registration) outputLoop(ctx context.Context) error {
+	for {
+		r.mu.Lock()
+		needsCatchup := r.mu.needsCatchup
+		r.mu.needsCatchup = false
+		r.mu.Unlock()
+
+		// Run a catch-up scan from the current start time.
+		if needsCatchup {
+			if err := r.runCatchupScan(); err != nil {
+				err = errors.Wrap(err, "catch-up scan failed")
+				log.Error(ctx, err)
+				return err
+			}
+		}
+
+		// Normal buffered output loop.
+		for {
+			if len(r.buf) == 0 {
+				r.mu.Lock()
+				needsCatchup := r.mu.needsCatchup
+				r.mu.Unlock()
+				if needsCatchup {
+					break
+				}
+			}
+
+			var nextEvent *roachpb.RangeFeedEvent
+			select {
+			case nextEvent = <-r.buf:
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-r.stream.Context().Done():
+				return r.stream.Context().Err()
+			}
+
+			if nextEvent.Checkpoint != nil {
+				r.catchupTimestamp = nextEvent.Checkpoint.ResolvedTS
+			}
+			if err := r.stream.Send(nextEvent); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// runCatchupScan starts a catchup scan which will output entries for all
+// recorded changes in the replica that are newer than the catchupTimeStamp.
+// This creates a single engine iterator immediately when this method
+// is called, and outputs records directly to the registration stream.
+func (r *registration) runCatchupScan() error {
+	it := r.eng.NewIterator(engine.IterOptions{
+		UpperBound:       r.span.EndKey,
+		MinTimestampHint: r.catchupTimestamp,
+	})
+	defer it.Close()
+
+	var a bufalloc.ByteAllocator
+	startKey := engine.MakeMVCCMetadataKey(r.span.Key)
+	endKey := engine.MakeMVCCMetadataKey(r.span.EndKey)
+
+	// Iterate though all keys using Next. We want to publish all committed
+	// versions of each key that are after the registration's startTS, so we
+	// can't use NextKey.
+	var meta enginepb.MVCCMetadata
+	for it.Seek(startKey); ; it.Next() {
+		if ok, err := it.Valid(); err != nil {
+			return err
+		} else if !ok || !it.UnsafeKey().Less(endKey) {
+			break
+		}
+
+		unsafeKey := it.UnsafeKey()
+		unsafeVal := it.UnsafeValue()
+		if !unsafeKey.IsValue() {
+			// Found a metadata key.
+			if err := protoutil.Unmarshal(unsafeVal, &meta); err != nil {
+				return errors.Wrapf(err, "unmarshaling mvcc meta: %v", unsafeKey)
+			}
+			if !meta.IsInline() {
+				// Not an inline value. Ignore.
+				continue
+			}
+
+			// If write is inline, it doesn't have a timestamp so we don't
+			// filter on the registration's starting timestamp. Instead, we
+			// return all inline writes.
+			unsafeVal = meta.RawBytes
+		} else if !r.catchupTimestamp.Less(unsafeKey.Timestamp) {
+			// At or before the registration's exclusive starting timestamp.
+			// Ignore.
+			continue
+		}
+
+		var key, val []byte
+		a, key = a.Copy(unsafeKey.Key, 0)
+		a, val = a.Copy(unsafeVal, 0)
+		ts := unsafeKey.Timestamp
+
+		var event roachpb.RangeFeedEvent
+		event.MustSetValue(&roachpb.RangeFeedValue{
+			Key: key,
+			Value: roachpb.Value{
+				RawBytes:  val,
+				Timestamp: ts,
+			},
+		})
+		if err := r.stream.Send(&event); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ID implements interval.Interface.
@@ -74,12 +270,8 @@ func (r *registration) Range() interval.Range {
 	return r.keys
 }
 
-func (r *registration) SetCaughtUp() {
-	r.caughtUp = true
-}
-
 func (r registration) String() string {
-	return fmt.Sprintf("[%s @ %s+]", r.span, r.startTS)
+	return fmt.Sprintf("[%s @ %s+]", r.span, r.catchupTimestamp)
 }
 
 // registry holds a set of registrations and manages their lifecycle.
@@ -113,22 +305,12 @@ func (reg *registry) nextID() int64 {
 	return reg.idAlloc
 }
 
-// PublishToReg publishes the provided event to the given registration. No
-// validation of whether the registration state is compatible with the event
-// is performed.
-func (reg *registry) PublishToReg(r *registration, event *roachpb.RangeFeedEvent) {
-	if err := r.stream.Send(event); err != nil {
-		reg.DisconnectRegWithError(r, roachpb.NewError(err))
-	}
-}
-
 // PublishToOverlapping publishes the provided event to all registrations whose
 // range overlaps the specified span.
 func (reg *registry) PublishToOverlapping(span roachpb.Span, event *roachpb.RangeFeedEvent) {
 	// Determine the earliest starting timestamp that a registration
 	// can have while still needing to hear about this event.
 	var minTS hlc.Timestamp
-	var requireCaughtUp bool
 	switch t := event.GetValue().(type) {
 	case *roachpb.RangeFeedValue:
 		// Only publish values to registrations with starting
@@ -138,31 +320,24 @@ func (reg *registry) PublishToOverlapping(span roachpb.Span, event *roachpb.Rang
 		// Always publish checkpoint notifications, regardless
 		// of a registration's starting timestamp.
 		minTS = hlc.MaxTimestamp
-		requireCaughtUp = true
 	default:
 		panic(fmt.Sprintf("unexpected RangeFeedEvent variant: %v", event))
 	}
 
 	reg.forOverlappingRegs(span, func(r *registration) (bool, *roachpb.Error) {
-		if !r.startTS.Less(minTS) {
+		if !r.catchupTimestamp.Less(minTS) {
 			// Don't publish events if they are equal to or less
 			// than the registration's starting timestamp.
 			return false, nil
 		}
-		if requireCaughtUp && !r.caughtUp {
-			// Don't publish event if it requires the registration
-			// to be caught up and this one is not.
-			return false, nil
-		}
 
-		err := r.stream.Send(event)
-		return err != nil, roachpb.NewError(err)
+		r.publish(event)
+		return false, nil
 	})
 }
 
 // DisconnectRegWithError disconnects a specific registration with a provided error.
-func (reg *registry) DisconnectRegWithError(r *registration, pErr *roachpb.Error) {
-	r.errC <- pErr
+func (reg *registry) Unregister(r *registration) {
 	if err := reg.tree.Delete(r, false /* fast */); err != nil {
 		panic(err)
 	}
@@ -182,15 +357,6 @@ func (reg *registry) DisconnectWithErr(span roachpb.Span, pErr *roachpb.Error) {
 	})
 }
 
-// CheckStreams checks the context of all streams in the registry and
-// unregisters any that have already disconnected.
-func (reg *registry) CheckStreams() {
-	reg.forOverlappingRegs(all, func(reg *registration) (bool, *roachpb.Error) {
-		err := errors.Wrap(reg.stream.Context().Err(), "check streams")
-		return err != nil, roachpb.NewError(err)
-	})
-}
-
 // all is a span that overlaps with all registrations.
 var all = roachpb.Span{Key: roachpb.KeyMin, EndKey: roachpb.KeyMax}
 
@@ -206,7 +372,7 @@ func (reg *registry) forOverlappingRegs(
 		r := i.(*registration)
 		dis, pErr := fn(r)
 		if dis {
-			r.errC <- pErr
+			r.disconnect(pErr)
 			toDelete = append(toDelete, i)
 		}
 		return false

--- a/pkg/storage/rangefeed/task.go
+++ b/pkg/storage/rangefeed/task.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -116,102 +115,29 @@ func (s *initResolvedTSScan) Cancel() {
 	s.it.Close()
 }
 
-// catchUpScan scans over the provided iterator and publishes committed values
-// to the registration's stream. This backfill allows a registration to request
-// a starting timestamp in the past and observe events for writes that have
-// already happened.
-//
-// Iterator Contract:
-//   Committed values beneath the registration's starting timestamp will be
-//   ignored, but all values above the registration's starting timestamp must be
-//   present. An important implication of this is that if the iterator is a
-//   TimeBoundIterator, its MinTimestamp cannot be above the registration's
-//   starting timestamp.
-//
-type catchUpScan struct {
-	p  *Processor
-	r  *registration
-	it engine.SimpleIterator
-	a  bufalloc.ByteAllocator
+// registryOutputLoop is responsible for managing the output goroutine for an
+// individual registration. It is responsible for telling the processor to
+// unregister a registration when the output loop encounters an error.
+type registryOutputLoop struct {
+	p *Processor
+	r *registration
 }
 
-func newCatchUpScan(p *Processor, r *registration) runnable {
-	s := catchUpScan{p: p, r: r, it: r.catchUpIter}
-	r.catchUpIter = nil // detach
-	return &s
-}
-
-func (s *catchUpScan) Run(ctx context.Context) {
-	defer s.Cancel()
-	if err := s.iterateAndSend(ctx); err != nil {
-		err = errors.Wrap(err, "catch-up scan failed")
-		log.Error(ctx, err)
-		s.p.deliverCatchUpScanRes(s.r, roachpb.NewError(err))
-	} else {
-		s.p.deliverCatchUpScanRes(s.r, nil)
+func newRegistryOutputLoop(p *Processor, r *registration) registryOutputLoop {
+	return registryOutputLoop{
+		p: p,
+		r: r,
 	}
 }
 
-func (s *catchUpScan) iterateAndSend(ctx context.Context) error {
-	startKey := engine.MakeMVCCMetadataKey(s.r.span.Key)
-	endKey := engine.MakeMVCCMetadataKey(s.r.span.EndKey)
-
-	// Iterate though all keys using Next. We want to publish all committed
-	// versions of each key that are after the registration's startTS, so we
-	// can't use NextKey.
-	var meta enginepb.MVCCMetadata
-	for s.it.Seek(startKey); ; s.it.Next() {
-		if ok, err := s.it.Valid(); err != nil {
-			return err
-		} else if !ok || !s.it.UnsafeKey().Less(endKey) {
-			break
-		}
-
-		unsafeKey := s.it.UnsafeKey()
-		unsafeVal := s.it.UnsafeValue()
-		if !unsafeKey.IsValue() {
-			// Found a metadata key.
-			if err := protoutil.Unmarshal(unsafeVal, &meta); err != nil {
-				return errors.Wrapf(err, "unmarshaling mvcc meta: %v", unsafeKey)
-			}
-			if !meta.IsInline() {
-				// Not an inline value. Ignore.
-				continue
-			}
-
-			// If write is inline, it doesn't have a timestamp so we don't
-			// filter on the registration's starting timestamp. Instead, we
-			// return all inline writes.
-			unsafeVal = meta.RawBytes
-		} else if !s.r.startTS.Less(unsafeKey.Timestamp) {
-			// At or before the registration's exclusive starting timestamp.
-			// Ignore.
-			continue
-		}
-
-		var key, val []byte
-		s.a, key = s.a.Copy(unsafeKey.Key, 0)
-		s.a, val = s.a.Copy(unsafeVal, 0)
-		ts := unsafeKey.Timestamp
-
-		var event roachpb.RangeFeedEvent
-		event.MustSetValue(&roachpb.RangeFeedValue{
-			Key: key,
-			Value: roachpb.Value{
-				RawBytes:  val,
-				Timestamp: ts,
-			},
-		})
-		if err := s.r.stream.Send(&event); err != nil {
-			return err
-		}
+func (rol *registryOutputLoop) Run(ctx context.Context) {
+	rol.r.mu.Lock()
+	ctx, rol.r.mu.outputLoopCancelFn = context.WithCancel(ctx)
+	rol.r.mu.Unlock()
+	if err := rol.r.outputLoop(ctx); err != nil {
+		rol.r.disconnect(roachpb.NewError(err))
+		rol.p.unregC <- rol.r
 	}
-	return nil
-}
-
-func (s *catchUpScan) Cancel() {
-	s.it.Close()
-	s.a = nil
 }
 
 // TxnPusher is capable of pushing transactions to a new timestamp and


### PR DESCRIPTION
Converts rangefeed to use an output buffer and dedicated goroutine for
each registration managed by a processor.

This has a few primary benefits:
1. A slow registration can no longer block other registration from
making progress, or put any backpressure on raft.
2. A slow registration will automatically fall back to a catch-up
iterator if it is unable to keep up with the processor.
3. As a result, the processor never needs to shut down as a result of a
slow registration.

Tests are not yet adjusted, this is a WIP to demonstrate the basic
approach.

Release note: None