### PR TITLE
cli/sql: make the final time printer more informative

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1621,7 +1621,9 @@ func TestRenderHTML(t *testing.T) {
 		name := fmt.Sprintf("escape=%v/rowStats=%v", tc.reporter.escape, tc.reporter.rowStats)
 		t.Run(name, func(t *testing.T) {
 			var buf bytes.Buffer
-			err := render(&tc.reporter, &buf, cols, newRowSliceIter(rows, align), nil /* noRowsHook */)
+			err := render(&tc.reporter, &buf,
+				cols, newRowSliceIter(rows, align),
+				nil /* completedHook */, nil /* noRowsHook */)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -231,7 +231,8 @@ Output the list of cluster settings known to this binary.
 			hr.rowStats = false
 		}
 		cols := []string{"Setting", "Type", "Default", "Description"}
-		return render(reporter, os.Stdout, cols, newRowSliceIter(rows, "dddd"), nil /* noRowsHook*/)
+		return render(reporter, os.Stdout,
+			cols, newRowSliceIter(rows, "dddd"), nil /* completedHook */, nil /* noRowsHook*/)
 	},
 }
 


### PR DESCRIPTION
Fixes  #32656.

By default `cockroach sql` uses the `table` formatter which buffers
the input rows in memory and then takes *a lot* of time to format the
table and display it.

In addition, `cockroach sql` also prints the query/statement latency
at the end.

Prior to this patch, the printed latency included both the query
latency and also the time needed to print the results. This is
misleading because in many cases the formatter takes much more time to
print than the query spent executing.

This patch improves the UX by changing the latency display to exclude
the printing time. This reduces the discrepancy between the latency
observed with one formatter and that of another formatter.

In addition, if the printing time is larger than 1 second, an
informative message is displayed to inform the user why they may have
the impression the query ran for longer than the time displayed.

For example:

```
> select * from generate_series(1, 100000)
...
Time: 1.884819457s
Note: an additional delay of 4.073508214s was spent formatting the results.
```

Release note (cli change): `cockroach sql` and other commands that
print query results and query execution latency will now exclude the
time required to prepare the display client-side from the latency
measurement.