### PR TITLE
backport-2.1: engine: return ErrNotExist from DeleteFile on Windows

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2974,7 +2974,10 @@ func MVCCScanDecodeKeyValue(repr []byte) (key MVCCKey, value []byte, orepr []byt
 }
 
 func notFoundErrOrDefault(err error) error {
-	if strings.Contains(err.Error(), "No such file or directory") || strings.Contains(err.Error(), "File not found") {
+	errStr := err.Error()
+	if strings.Contains(errStr, "No such file or directory") ||
+		strings.Contains(errStr, "File not found") ||
+		strings.Contains(errStr, "The system cannot find the path specified") {
 		return os.ErrNotExist
 	}
 	return err


### PR DESCRIPTION
Backport 1/1 commits from #32664.

/cc @cockroachdb/release

---

Fixes #32593.

Release note (bug fix): Fixed a crash that could occur during or after a
data import on Windows.
