### PR TITLE
sql: plumb bulk-adder support to index backfill

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -42,6 +42,8 @@
 <tr><td><code>kv.transaction.write_pipelining_enabled</code></td><td>boolean</td><td><code>true</code></td><td>if enabled, transactional writes are pipelined through Raft consensus</td></tr>
 <tr><td><code>kv.transaction.write_pipelining_max_batch_size</code></td><td>integer</td><td><code>128</code></td><td>if non-zero, defines that maximum size batch that will be pipelined through Raft consensus</td></tr>
 <tr><td><code>rocksdb.min_wal_sync_interval</code></td><td>duration</td><td><code>0s</code></td><td>minimum duration between syncs of the RocksDB WAL</td></tr>
+<tr><td><code>schemachanger.bulk_index_backfill.batch_size</code></td><td>integer</td><td><code>1000000</code></td><td>number of rows to process at a time during bulk index backfill</td></tr>
+<tr><td><code>schemachanger.bulk_index_backfill.enabled</code></td><td>boolean</td><td><code>false</code></td><td>backfill indexes in bulk via addsstable</td></tr>
 <tr><td><code>schemachanger.lease.duration</code></td><td>duration</td><td><code>5m0s</code></td><td>the duration of a schema change lease</td></tr>
 <tr><td><code>schemachanger.lease.renew_fraction</code></td><td>float</td><td><code>0.5</code></td><td>the fraction of schemachanger.lease_duration remaining to trigger a renew of the lease</td></tr>
 <tr><td><code>server.clock.forward_jump_check_enabled</code></td><td>boolean</td><td><code>false</code></td><td>if enabled, forward clock jumps > max_offset/2 will cause a panic.</td></tr>

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -57,8 +57,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sqlmigrations"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/bulk"
 	"github.com/cockroachdb/cockroach/pkg/storage/closedts/container"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/ui"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -518,6 +520,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		ClusterID:      &s.rpcContext.ClusterID,
 
 		TempStorage: tempEngine,
+		BulkAdder: func(ctx context.Context, db *client.DB, size int64, ts hlc.Timestamp) (storagebase.BulkAdder, error) {
+			return bulk.MakeFixedTimestampSSTBatcher(db, s.distSender.RangeDescriptorCache(), size, ts)
+		},
 		DiskMonitor: s.cfg.TempStorageConfig.Mon,
 
 		ParentMemoryMonitor: &rootSQLMemoryMonitor,

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -47,17 +48,23 @@ const (
 	// DeleteRange().
 	indexTruncateChunkSize = 600
 
-	// indexBackfillChunkSize is the maximum number index entries backfilled
-	// per chunk during an index backfill. The index backfill involves a table
-	// scan, and a number of individual ops presented in a batch. This value
-	// is smaller than ColumnTruncateAndBackfillChunkSize, because it involves
-	// a number of individual index row updates that can be scattered over
-	// many ranges.
-	indexBackfillChunkSize = 100
+	// indexTxnBackfillChunkSize is the maximum number index entries backfilled
+	// per chunk during an index backfill done in a txn. The index backfill
+	// involves a table scan, and a number of individual ops presented in a batch.
+	// This value is smaller than ColumnTruncateAndBackfillChunkSize, because it
+	// involves a number of individual index row updates that can be scattered
+	// over many ranges.
+	indexTxnBackfillChunkSize = 100
 
 	// checkpointInterval is the interval after which a checkpoint of the
 	// schema change is posted.
 	checkpointInterval = 2 * time.Minute
+)
+
+var indexBulkBackfillChunkSize = settings.RegisterIntSetting(
+	"schemachanger.bulk_index_backfill.batch_size",
+	"number of rows to process at a time during bulk index backfill",
+	1000000,
 )
 
 var _ sort.Interface = columnsByID{}
@@ -181,6 +188,7 @@ func (sc *SchemaChanger) runBackfill(
 
 	// Add new indexes.
 	if len(addedIndexDescs) > 0 {
+		// Check if bulk-adding is enabled and supported by indexes (ie non-unique).
 		if err := sc.backfillIndexes(ctx, evalCtx, lease, version); err != nil {
 			return err
 		}
@@ -468,8 +476,14 @@ func (sc *SchemaChanger) backfillIndexes(
 		fn()
 	}
 
+	chunkSize := int64(indexTxnBackfillChunkSize)
+	bulk := backfill.BulkWriteIndex.Get(&sc.settings.SV)
+	if bulk {
+		chunkSize = indexBulkBackfillChunkSize.Get(&sc.settings.SV)
+	}
+
 	return sc.distBackfill(
-		ctx, evalCtx, lease, version, indexBackfill, indexBackfillChunkSize,
+		ctx, evalCtx, lease, version, indexBackfill, chunkSize,
 		backfill.IndexMutationFilter)
 }
 
@@ -640,7 +654,7 @@ func indexBackfillInTxn(
 	for sp.Key != nil {
 		var err error
 		sp.Key, err = backfiller.RunIndexBackfillChunk(ctx,
-			txn, tableDesc, sp, indexBackfillChunkSize, false /* alsoCommit */, traceKV)
+			txn, tableDesc, sp, indexTxnBackfillChunkSize, false /* alsoCommit */, traceKV)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -358,6 +359,11 @@ func (ib *IndexBackfiller) Init(desc *sqlbase.ImmutableTableDescriptor) error {
 		false /* reverse */, false /* returnRangeInfo */, false /* isCheck */, &ib.alloc, tableArgs,
 	)
 }
+
+// BulkWriteIndex enables experimental bulk-ingestion of index entries.
+var BulkWriteIndex = settings.RegisterBoolSetting(
+	"schemachanger.bulk_index_backfill.enabled", "backfill indexes in bulk via addsstable", false,
+)
 
 // BuildIndexEntriesChunk reads a chunk of rows from a table using the span sp
 // provided, and builds all the added indexes.

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -98,6 +99,11 @@ type FlowCtx struct {
 	// This is not supposed to be used as a general engine.Engine and thus
 	// one should sparingly use the set of features offered by it.
 	TempStorage diskmap.Factory
+
+	// BulkAdder is used by backfill/bulk-ingestion processors to ingest large
+	// amounts of data in bulk as SSTs.
+	BullkAdder storagebase.BulkAdderFactory
+
 	// diskMonitor is used to monitor temporary storage disk usage.
 	diskMonitor *mon.BytesMonitor
 

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -136,6 +137,10 @@ type ServerConfig struct {
 	// TempStorage is used by some DistSQL processors to store rows when the
 	// working set is larger than can be stored in memory.
 	TempStorage diskmap.Factory
+
+	// BulkAdder is used by some processors to bulk-ingest data as SSTs.
+	BulkAdder storagebase.BulkAdderFactory
+
 	// DiskMonitor is used to monitor temporary storage disk usage. Actual disk
 	// space used will be a small multiple (~1.1) of this because of RocksDB
 	// space amplification.
@@ -442,6 +447,7 @@ func (ds *ServerImpl) setupFlow(
 		testingKnobs:   ds.TestingKnobs,
 		nodeID:         nodeID,
 		TempStorage:    ds.TempStorage,
+		BullkAdder:     ds.BulkAdder,
 		diskMonitor:    ds.DiskMonitor,
 		JobRegistry:    ds.ServerConfig.JobRegistry,
 		traceKV:        req.TraceKV,

--- a/pkg/storage/bulk/main_test.go
+++ b/pkg/storage/bulk/main_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package bulk
+package bulk_test
 
 import (
 	"os"

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -184,17 +184,11 @@ func runTestImport(t *testing.T, batchSize int64) {
 					}
 				}
 			}
-<<<<<<< HEAD
 			if splitRetries != expectedSplitRetries {
 				t.Fatalf("expected %d split-caused retries, got %d", expectedSplitRetries, splitRetries)
 			}
 			cancel()
-||||||| merged common ancestors
-			t.Logf("flushed batch: %d", b.sstWriter.DataSize)
 
-=======
-
->>>>>>> sql: plumb BulkAdder though distsql
 			added := b.GetSummary()
 			t.Logf("Wrote %d total", added.DataSize)
 

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -184,10 +184,17 @@ func runTestImport(t *testing.T, batchSize int64) {
 					}
 				}
 			}
+<<<<<<< HEAD
 			if splitRetries != expectedSplitRetries {
 				t.Fatalf("expected %d split-caused retries, got %d", expectedSplitRetries, splitRetries)
 			}
 			cancel()
+||||||| merged common ancestors
+			t.Logf("flushed batch: %d", b.sstWriter.DataSize)
+
+=======
+
+>>>>>>> sql: plumb BulkAdder though distsql
 			added := b.GetSummary()
 			t.Logf("Wrote %d total", added.DataSize)
 

--- a/pkg/storage/storagebase/bulk_adder.go
+++ b/pkg/storage/storagebase/bulk_adder.go
@@ -1,0 +1,40 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storagebase
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// BulkAdderFactory describes a factory function for BulkAdders.
+type BulkAdderFactory func(
+	ctx context.Context, db *client.DB, flushBytes int64, timestamp hlc.Timestamp,
+) (BulkAdder, error)
+
+// BulkAdder describes a bulk-adding helper that can be used to add lots of KVs.
+type BulkAdder interface {
+	// Add adds a KV pair to the adder's buffer, potentially flushing if needed.
+	Add(ctx context.Context, key roachpb.Key, value []byte) error
+	// Flush explicitly flushes anything remaining in the adder's buffer.
+	Flush(ctx context.Context) error
+	// GetSummary returns a summary of rows/bytes/etc written by this batcher.
+	GetSummary() roachpb.BulkOpSummary
+	// Close closes the underlying buffers/writers.
+	Close()
+}


### PR DESCRIPTION
This adds support for adding indexes in bulk, via `AddSSTable`, gated by a default-off setting for now.

This is still a WIP and requires more testing (and support for unique indexes) before it can be enabled.
