### PR TITLE
roachtest: disable the range-merge check in import/tpch/nodes=4

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -96,13 +96,17 @@ func registerImportTPCH(r *registry) {
 				m.Go(dul.Runner)
 				hc := NewHealthChecker(c, c.All())
 				m.Go(hc.Runner)
-				m.Go(func(ctx context.Context) error {
-					// Make sure the merge queue doesn't muck with our import.
-					return verifyMetrics(ctx, c, map[string]float64{
-						"cr.store.queue.merge.process.success": 10,
-						"cr.store.queue.merge.process.failure": 10,
-					})
-				})
+
+				// TODO(peter): This currently causes the test to fail because we see a
+				// flurry of valid merges when the import finishes.
+				//
+				// m.Go(func(ctx context.Context) error {
+				// 	// Make sure the merge queue doesn't muck with our import.
+				// 	return verifyMetrics(ctx, c, map[string]float64{
+				// 		"cr.store.queue.merge.process.success": 10,
+				// 		"cr.store.queue.merge.process.failure": 10,
+				// 	})
+				// })
 
 				m.Go(func(ctx context.Context) error {
 					defer dul.Done()

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -326,3 +326,6 @@ func verifyMetrics(ctx context.Context, c *cluster, m map[string]float64) error 
 		}
 	}
 }
+
+// TODO(peter): silence unused warning.
+var _ = verifyMetrics


### PR DESCRIPTION
The check is flaky because range merges can happen validly after the
import finishes.

Release note: None