### PR TITLE
release-2.1: distsql: bugfix to distsql planning of subqueries

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -647,12 +647,24 @@ func (dsp *DistSQLPlanner) PlanAndRunSubqueries(
 		// TODO(arjun): #28264: We set up a row container, wrap it in a row
 		// receiver, and use it and serialize the results of the subquery. The type
 		// of the results stored in the container depends on the type of the subquery.
-		typ := sqlbase.ColTypeInfoFromColTypes(subqueryPhysPlan.ResultTypes)
 		subqueryRecv := recv.clone()
+		var typ sqlbase.ColTypeInfo
 		var rows *sqlbase.RowContainer
 		if subqueryPlan.execMode == distsqlrun.SubqueryExecModeExists {
 			subqueryRecv.noColsRequired = true
 			typ = sqlbase.ColTypeInfoFromColTypes([]sqlbase.ColumnType{})
+		} else {
+			// Apply the PlanToStreamColMap projection to the ResultTypes to get the
+			// final set of output types for the subquery. The reason this is necessary
+			// is that the output schema of a query sometimes contains columns necessary
+			// to merge the streams, but that aren't required by the final output of the
+			// query. These get projected out, so we need to similarly adjust the
+			// expected result types of the subquery here.
+			colTypes := make([]sqlbase.ColumnType, len(subqueryPhysPlan.PlanToStreamColMap))
+			for i, resIdx := range subqueryPhysPlan.PlanToStreamColMap {
+				colTypes[i] = subqueryPhysPlan.ResultTypes[resIdx]
+			}
+			typ = sqlbase.ColTypeInfoFromColTypes(colTypes)
 		}
 		rows = sqlbase.NewRowContainer(subqueryMemAccount, typ, 0)
 		defer rows.Close(evalCtx.Ctx())

--- a/pkg/sql/logictest/testdata/logic_test/distsql_subquery
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_subquery
@@ -1,0 +1,33 @@
+# LogicTest: 5node-dist
+
+# TODO(radu): re-add 5node-dist-opt when #32648 is fixed.
+
+# Regression test for #32652: make sure subqueries that have extra columns for
+# stream merges don't crash when executed.
+
+statement ok
+CREATE TABLE ab (a INT, b INT)
+
+statement ok
+INSERT INTO ab VALUES (1, 1), (1, 3), (2, 2)
+
+statement ok
+SET CLUSTER SETTING kv.range_merge.queue_enabled = false
+
+statement ok
+ALTER TABLE ab SPLIT AT VALUES (2)
+
+statement ok
+ALTER TABLE ab EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 1), (ARRAY[2], 2)
+
+query TTITI colnames
+SHOW EXPERIMENTAL_RANGES FROM TABLE ab
+----
+start_key  end_key  range_id  replicas  lease_holder
+NULL       /2       1         {1}       1
+/2         NULL     2         {2}       2
+
+query T
+SELECT ARRAY(SELECT a FROM ab ORDER BY b)
+----
+{1,2,1}


### PR DESCRIPTION
Backport 1/1 commits from #32652.

/cc @cockroachdb/release

---

Previously, some subqueries could crash the server when distributed,
because of incorrect accounting for the PlanToStreamColMap final
projection on the result types of the subquery. Now, that final
projection is properly applied.

Fixes #32650.

Release note (bug fix): prevent crash when running certain subqueries
that get planned in a distributed fashion.
