### PR TITLE
roachtest: add disk-full roachtest

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -291,7 +291,7 @@ DBStatus DBSyncWAL(DBEngine* db) {
   options.sync = true;
   return ToDBStatus(db->rep->Write(options, &batch));
 #else
-  return ToDBStatus(db->rep->SyncWAL());
+  return ToDBStatus(db->rep->FlushWAL(true /* sync */));
 #endif
 }
 

--- a/c-deps/libroach/options.cc
+++ b/c-deps/libroach/options.cc
@@ -214,6 +214,7 @@ rocksdb::Options DBMakeOptions(DBOptions db_opts) {
   // of sstables.
   options.target_file_size_base = 4 << 20;  // 4 MB
   options.target_file_size_multiplier = 2;
+  options.manual_wal_flush = true;
 
   // Because we open a long running rocksdb instance, we do not want the
   // manifest file to grow unbounded. Assuming each manifest entry is about 1

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1425,6 +1425,10 @@ func (m *monitor) ExpectDeaths(count int32) {
 	atomic.AddInt32(&m.expDeaths, count)
 }
 
+func (m *monitor) ResetDeaths() {
+	atomic.StoreInt32(&m.expDeaths, 0)
+}
+
 var errGoexit = errors.New("Goexit() was called")
 
 func (m *monitor) Go(fn func(context.Context) error) {

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -1,0 +1,90 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func registerDiskFull(r *registry) {
+	r.Add(testSpec{
+		Name:       "disk-full",
+		MinVersion: `v2.1.0`,
+		Nodes:      nodes(5),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			if c.isLocal() {
+				t.spec.Skip = "you probably don't want to fill your local disk"
+				return
+			}
+
+			nodes := c.nodes - 1
+			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+			c.Start(ctx, t, c.Range(1, nodes))
+
+			t.Status("running workload")
+			m := newMonitor(ctx, c, c.Range(1, nodes))
+			m.Go(func(ctx context.Context) error {
+				cmd := fmt.Sprintf(
+					"./workload run kv --tolerate-errors --init --read-percent=0"+
+						" --concurrency=10 --duration=2m {pgurl:1-%d}",
+					nodes)
+				c.Run(ctx, c.Node(nodes+1), cmd)
+				return nil
+			})
+			m.Go(func(ctx context.Context) error {
+				time.Sleep(30 * time.Second)
+				const n = 1
+				m.ExpectDeath()
+				t.l.Printf("filling disk on %d\n", n)
+				// The 100% ballast size will cause the disk to fill up and the ballast
+				// command to exit with an error. The "|| true" is used to ignore that
+				// error.
+				c.Run(ctx, c.Node(n), "./cockroach debug ballast {store-dir}/ballast --size=100% || true")
+
+				// Restart cockroach in a loop for 30s.
+				for start := timeutil.Now(); timeutil.Since(start) < 30*time.Second; {
+					if t.Failed() {
+						return nil
+					}
+					t.l.Printf("starting %d when disk is full\n", n)
+					// We expect cockroach to die during startup, though it might get far
+					// enough along that the monitor detects the death.
+					m.ExpectDeath()
+					if err := c.StartE(ctx, c.Node(n)); err == nil {
+						t.Fatalf("node successfully started unexpectedly")
+					} else if strings.Contains(err.Error(), "a panic has occurred") {
+						t.Fatal(err)
+					}
+				}
+
+				// Clear the disk full condition and restart cockroach again.
+				t.l.Printf("clearing full disk on %d\n", n)
+				c.Run(ctx, c.Node(n), "rm -f {store-dir}/ballast")
+				// Clear any death expectations that did not occur.
+				m.ResetDeaths()
+				c.Start(ctx, t, c.Node(n))
+				return nil
+			})
+			m.Wait()
+		},
+	})
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -32,6 +32,7 @@ func registerTests(r *registry) {
 	registerDebugHeap(r)
 	registerDecommission(r)
 	registerDiskUsage(r)
+	registerDiskFull(r)
 	registerDrop(r)
 	registerElectionAfterRestart(r)
 	registerEncryption(r)

--- a/pkg/cmd/roachtest/synctest.go
+++ b/pkg/cmd/roachtest/synctest.go
@@ -22,7 +22,8 @@ import (
 	"path/filepath"
 )
 
-const nemesisScript = `#!/usr/bin/env bash
+func registerSyncTest(r *registry) {
+	const nemesisScript = `#!/usr/bin/env bash
 
 if [[ $1 == "on" ]]; then
   charybdefs-nemesis --probability
@@ -31,7 +32,6 @@ else
 fi
 `
 
-func registerSyncTest(r *registry) {
 	r.Add(testSpec{
 		Name:       "synctest",
 		MinVersion: `v2.2.0`,

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -1635,7 +1635,21 @@ func TestSstFileWriterTimeBound(t *testing.T) {
 func TestRocksDBWALFileEmptyBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	e := NewInMem(roachpb.Attributes{}, 1<<20)
+	dir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+
+	// NB: The in-mem RocksDB instance doesn't support syncing the WAL which is
+	// necessary for this test.
+	e, err := NewRocksDB(
+		RocksDBConfig{
+			Settings: cluster.MakeTestingClusterSettings(),
+			Dir:      dir,
+		},
+		RocksDBCache{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer e.Close()
 
 	// Commit a batch with one key.


### PR DESCRIPTION
RocksDB was missing some error checks on the code paths involved in `FlushWAL`. The result was that writes that failed when the disk is full were erroneously being considered success. 

Fixes #32631
Fixes #25173

Release note (performance improvement): Re-enable usage of RocksDB FlushWAL which is a minor performance improvement for synchronous RocksDB write operations.