### PR TITLE
storage: improve split-snapshot warning

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -11007,8 +11007,15 @@ func TestSplitSnapshotWarningStr(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"; may cause Raft snapshot to r12/2: next = 0, match = 100, state = ProgressStateProbe,"+
-			" waiting = false, pendingSnapshot = 0",
+		"; r12/2 is being probed (may or may not need a Raft snapshot)",
+		splitSnapshotWarningStr(12, status),
+	)
+
+	pr.State = raft.ProgressStateSnapshot
+
+	assert.Equal(
+		t,
+		"; r12/2 is being probed (may or may not need a Raft snapshot)",
 		splitSnapshotWarningStr(12, status),
 	)
 }


### PR DESCRIPTION
It now differentiates between the case in which the follower needs a
snapshot vs the one in which it is still being probed. We're not
expecting the probing case once the bug described here is fixed:

https://github.com/cockroachdb/cockroach/pull/32594#issuecomment-442433217

Release note: None