### PR TITLE
storage: fix a lying test comment

### DIFF
--- a/pkg/storage/gossip_test.go
+++ b/pkg/storage/gossip_test.go
@@ -174,10 +174,7 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Take down a node other than the first node and replace it with a new one.
-	// Replacing the first node would be better from an adversarial testing
-	// perspective because it typically has the most leases on it, but that also
-	// causes the test to take significantly longer as a result.
+	// Take down the first node and replace it with a new one.
 	oldNodeIdx := 0
 	newServerArgs := serverArgs
 	newServerArgs.Addr = tc.Servers[oldNodeIdx].ServingAddr()


### PR DESCRIPTION
The comment was left over from a time where taking out the first node
was slow, but the test was subsequently tweaked to make that faster and
switched to shutting down the first node.

Release note: None