### PR TITLE
build: add Docker Compose to TeamCity agents

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -39,6 +39,7 @@ debconf-set-selections <<< "oracle-java8-installer shared/accepted-oracle-licens
 # Install the necessary dependencies. Keep this list small!
 apt-get install --yes \
   docker-ce \
+  docker-compose \
   git \
   golang-${GOVERS} \
   oracle-java8-installer \


### PR DESCRIPTION
This is used by the management console CI job to run tests that use both a database and a test container, e.g.: https://teamcity.cockroachdb.com/viewLog.html?buildId=1029115&buildTypeId=Internal_ManagementConsoleCi_Ci&tab=buildLog&_focus=89#_state=86,89

I've already built the new image with `packer build` and pointed TeamCity at it; seems to be working.

Release note: None