### PR TITLE
exec: added the hashed aggregator operator

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -77,13 +77,12 @@ func newColOperator(
 		for _, col := range aggSpec.OrderedGroupCols {
 			orderedCols.Add(int(col))
 		}
-		groupTyps := make([]types.T, len(aggSpec.GroupCols))
-		for i, col := range aggSpec.GroupCols {
+
+		for _, col := range aggSpec.GroupCols {
 			if !orderedCols.Contains(int(col)) {
 				return nil, errors.New("unsorted aggregation not supported")
 			}
 			groupCols.Add(int(col))
-			groupTyps[i] = types.FromColumnType(spec.Input[0].ColumnTypes[col])
 		}
 		if !orderedCols.SubsetOf(groupCols) {
 			return nil, pgerror.NewAssertionErrorf("ordered cols must be a subset of grouping cols")
@@ -120,7 +119,7 @@ func newColOperator(
 			}
 		}
 		op, err = exec.NewOrderedAggregator(
-			inputs[0], aggSpec.GroupCols, groupTyps, aggFns, aggCols, aggTyps,
+			inputs[0], types.FromColumnTypes(spec.Input[0].ColumnTypes), aggFns, aggSpec.GroupCols, aggCols,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -109,30 +109,29 @@ type orderedAggregator struct {
 var _ Operator = &orderedAggregator{}
 
 // NewOrderedAggregator creates an ordered aggregator on the given grouping
-// columns. aggCols is a slice where each index represents a new aggregation
-// function. The slice at that index specifies the columns of the input batch
-// that the aggregate function should work on. aggTyps specifies the associated
-// types of these input columns.
+// columns.
 // TODO(asubiotto): Take in distsqlrun.AggregatorSpec_Func. This is currently
 // impossible due to an import cycle so we hack around it by taking in the raw
 // integer specifier.
 func NewOrderedAggregator(
 	input Operator,
-	groupCols []uint32,
-	groupTyps []types.T,
+	colTypes []types.T,
 	aggFns []distsqlpb.AggregatorSpec_Func,
+	groupCols []uint32,
 	aggCols [][]uint32,
-	aggTyps [][]types.T,
 ) (Operator, error) {
-	if len(aggFns) != len(aggCols) || len(aggFns) != len(aggTyps) {
+	if len(aggFns) != len(aggCols) {
 		return nil,
 			errors.Errorf(
-				"mismatched aggregation spec lengths: aggFns(%d), aggCols(%d), aggTyps(%d)",
+				"mismatched aggregation lengths: aggFns(%d), aggCols(%d)",
 				len(aggFns),
 				len(aggCols),
-				len(aggTyps),
 			)
 	}
+
+	groupTyps := extractGroupTypes(groupCols, colTypes)
+	aggTyps := extractAggTypes(aggCols, colTypes)
+
 	op, groupCol, err := orderedDistinctColsToOperators(input, groupCols, groupTyps)
 	if err != nil {
 		return nil, err
@@ -159,30 +158,42 @@ func NewOrderedAggregator(
 		}
 	}
 
-	outputTyps := make([]types.T, len(aggCols))
-	aggregateFuncs := make([]aggregateFunc, len(aggCols))
 	*a = orderedAggregator{
 		input: op,
 
-		aggregateFuncs: aggregateFuncs,
-		aggCols:        aggCols,
-		aggTyps:        aggTyps,
-		outputTyps:     outputTyps,
-		groupCol:       groupCol,
+		aggCols:  aggCols,
+		aggTyps:  aggTyps,
+		groupCol: groupCol,
 	}
+
+	a.aggregateFuncs, a.outputTyps, err = makeAggregateFuncs(aggTyps, aggFns)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return a, nil
+}
+
+func makeAggregateFuncs(
+	aggTyps [][]types.T, aggFns []distsqlpb.AggregatorSpec_Func,
+) ([]aggregateFunc, []types.T, error) {
+	funcs := make([]aggregateFunc, len(aggFns))
+	outTyps := make([]types.T, len(aggFns))
+
 	for i := range aggFns {
 		var err error
 		switch aggFns[i] {
 		case distsqlpb.AggregatorSpec_ANY_NOT_NULL:
-			a.aggregateFuncs[i], err = newAnyNotNullAgg(aggTyps[i][0])
+			funcs[i], err = newAnyNotNullAgg(aggTyps[i][0])
 		case distsqlpb.AggregatorSpec_AVG:
-			a.aggregateFuncs[i], err = newAvgAgg(aggTyps[i][0])
+			funcs[i], err = newAvgAgg(aggTyps[i][0])
 		case distsqlpb.AggregatorSpec_SUM, distsqlpb.AggregatorSpec_SUM_INT:
-			a.aggregateFuncs[i], err = newSumAgg(aggTyps[i][0])
+			funcs[i], err = newSumAgg(aggTyps[i][0])
 		case distsqlpb.AggregatorSpec_COUNT_ROWS:
-			a.aggregateFuncs[i] = newCountAgg()
+			funcs[i] = newCountAgg()
 		default:
-			return nil, errors.Errorf("unsupported columnar aggregate function %d", aggFns[i])
+			return nil, nil, errors.Errorf("unsupported columnar aggregate function %d", aggFns[i])
 		}
 
 		// Set the output type of the aggregate.
@@ -190,18 +201,18 @@ func NewOrderedAggregator(
 		case distsqlpb.AggregatorSpec_COUNT_ROWS:
 			// TODO(jordan): this is a somewhat of a hack. The aggregate functions
 			// should come with their own output types, somehow.
-			a.outputTyps[i] = types.Int64
+			outTyps[i] = types.Int64
 		default:
 			// Output types are the input types for now.
-			a.outputTyps[i] = a.aggTyps[i][0]
+			outTyps[i] = aggTyps[i][0]
 		}
 
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return a, nil
+	return funcs, outTyps, nil
 }
 
 func (a *orderedAggregator) initWithBatchSize(inputSize, outputSize int) {
@@ -278,4 +289,291 @@ func (a *orderedAggregator) Reset() {
 	for _, fn := range a.aggregateFuncs {
 		fn.Reset()
 	}
+}
+
+// hashAggregator is an operator that performs an aggregation based on
+// specified grouping columns. This operator performs a hash table build at the
+// first call to `Next()` which consumes the entire build source. After the
+// build phase, the state of the hashAggregator is changed to isAggregating and
+// the grouped hash table buckets are then passed as input to an
+// orderedAggregator. The output row ordering of this aggregator is arbitrary.
+type hashAggregator struct {
+	spec aggregatorSpec
+
+	// isAggregating represents whether the hashAggregator is in the building or
+	// aggregating phase.
+	isAggregating bool
+
+	ht      *hashTable
+	builder *hashJoinBuilder
+
+	// orderedAgg is the underlying orderedAggregator used by this
+	// hashAggregator once the bucket-groups of the input has been determined.
+	orderedAgg *orderedAggregator
+}
+
+// NewHashAggregator creates a hashed aggregator on the given grouping
+// columns. The input specifications to this function are the same as that of
+// the NewOrderedAggregator function.
+func NewHashAggregator(
+	input Operator,
+	colTypes []types.T,
+	aggFns []distsqlpb.AggregatorSpec_Func,
+	groupCols []uint32,
+	aggCols [][]uint32,
+) (Operator, error) {
+	aggTyps := extractAggTypes(aggCols, colTypes)
+
+	// Only keep relevant output columns, those that are used as input to an
+	// aggregation.
+	nCols := uint32(len(colTypes))
+	keepCol := make([]bool, nCols)
+
+	// compressed represents a mapping between each original column and its index
+	// in the new compressed columns set. This is required since we are
+	// effectively compressing the original list of columns by only keeping the
+	// columns used as input to an aggregation function,
+	compressed := make([]uint32, nCols)
+	for _, cols := range aggCols {
+		for _, col := range cols {
+			keepCol[col] = true
+		}
+	}
+
+	// Map the corresponding aggCols to the new output column indices.
+	nOutCols := uint32(0)
+	outCols := make([]uint32, 0)
+	for i := range keepCol {
+		if keepCol[i] {
+			outCols = append(outCols, uint32(i))
+			compressed[i] = nOutCols
+			nOutCols++
+		}
+	}
+
+	mappedAggCols := make([][]uint32, len(aggCols))
+	for aggIdx := range aggCols {
+		mappedAggCols[aggIdx] = make([]uint32, len(aggCols[aggIdx]))
+		for i := range mappedAggCols[aggIdx] {
+			mappedAggCols[aggIdx][i] = compressed[aggCols[aggIdx][i]]
+		}
+	}
+
+	ht := makeHashTable(
+		hashTableBucketSize,
+		colTypes,
+		groupCols,
+		outCols,
+	)
+
+	builder := makeHashJoinBuilder(
+		ht,
+		hashJoinerSourceSpec{
+			source:      input,
+			eqCols:      groupCols,
+			outCols:     outCols,
+			sourceTypes: colTypes,
+		},
+	)
+
+	funcs, outTyps, err := makeAggregateFuncs(aggTyps, aggFns)
+	if err != nil {
+		return nil, err
+	}
+
+	distinctCol := make([]bool, ColBatchSize)
+
+	// op is the underlying batching operop.distinct[op.batchStart:batchEnd]ator used as input by the orderedAgg to
+	// create the batches of ColBatchSize from built hashTable.
+	op := makeHashAggregatorBatchOp(ht, distinctCol)
+
+	orderedAgg := &orderedAggregator{
+		input:          op,
+		aggCols:        mappedAggCols,
+		aggTyps:        aggTyps,
+		groupCol:       distinctCol,
+		aggregateFuncs: funcs,
+		outputTyps:     outTyps,
+	}
+
+	return &hashAggregator{
+		spec: aggregatorSpec{
+			input:     input,
+			colTypes:  colTypes,
+			aggFns:    aggFns,
+			groupCols: groupCols,
+			aggCols:   aggCols,
+		},
+
+		ht:      ht,
+		builder: builder,
+
+		orderedAgg: orderedAgg,
+	}, nil
+}
+
+func (ag *hashAggregator) Init() {
+	ag.spec.input.Init()
+	ag.orderedAgg.Init()
+}
+
+func (ag *hashAggregator) Next() ColBatch {
+	if !ag.isAggregating {
+		ag.build()
+	}
+
+	return ag.orderedAgg.Next()
+}
+
+// Reset resets the hashAggregator for another run. Primarily used for
+// benchmarks.
+func (ag *hashAggregator) Reset() {
+	ag.ht.size = 0
+	ag.isAggregating = false
+	ag.orderedAgg.Reset()
+}
+
+func (ag *hashAggregator) build() {
+	ag.builder.exec()
+	ag.isAggregating = true
+}
+
+var _ Operator = &hashAggregator{}
+
+// aggregatorSpec represents the specifications for the various aggregation
+// operators.
+type aggregatorSpec struct {
+	// input is the source Operator consumed by the aggregator.
+	input Operator
+	// colTypes represents the column types corresponding to the input columns.
+	colTypes []types.T
+
+	// aggFns represents the list of aggregation functions to be performed.
+	aggFns []distsqlpb.AggregatorSpec_Func
+
+	// aggCols is a slice where each index represents a new aggregation function.
+	// The slice at each index maps to the input column indices used as input to
+	// each corresponding aggregation function.
+	aggCols [][]uint32
+	// groupCols holds the list of group column indices.
+	groupCols []uint32
+}
+
+// hashAggregatorBatchOp is a helper operator used by the hashAggregator as
+// input to its orderedAggregator. Once the building of the hashTable is
+// completed, this batch operator exists to return the next batch of input to
+// the orderedAggregator based on the results of the pre-built hashTable.
+type hashAggregatorBatchOp struct {
+	ht *hashTable
+
+	// sel is an ordered list of indices to select representing the input rows.
+	// This selection vector is much bigger than ColBatchSize and should be
+	// batched with the hashAggregatorBatchOp operator.
+	sel []uint64
+	// distinct represents whether each corresponding row is part of a new group.
+	distinct []bool
+
+	// distinctCol is a reference to the slice that aggregateFuncs use to
+	// determine whether a value is part of the current aggregation group. See
+	// aggregateFunc.Init for more information.
+	distinctCol []bool
+
+	batchStart uint64
+	batch      ColBatch
+}
+
+func makeHashAggregatorBatchOp(ht *hashTable, distinctCol []bool) Operator {
+	return &hashAggregatorBatchOp{
+		distinctCol: distinctCol,
+		ht:          ht,
+		batch:       NewMemBatch(ht.outTypes),
+	}
+}
+
+func (op *hashAggregatorBatchOp) Init() {}
+
+func (op *hashAggregatorBatchOp) Next() ColBatch {
+	// The selection vector needs to be populated before any batching can be
+	// done.
+	if op.sel == nil {
+		// After the entire hashTable is built, we want to construct the selection
+		// vector. This vector would be an ordered list of indices indicating the
+		// ordering of the bucket-grouped rows of input. The same linked list is
+		// traversed from each head to form this ordered list.
+		headID := uint64(0)
+		curID := uint64(0)
+
+		// Since next is no longer useful and pre-allocated to the appropriate size,
+		// we can use it as the selection vector. This way we don't have to
+		// reallocate a huge array.
+		op.sel = op.ht.next
+		// Since visited is no longer used and pre-allocated to the appropriate
+		// size, we can use it for the distinct vector.
+		op.distinct = op.ht.visited
+
+		for i := uint64(0); i < op.ht.size; i++ {
+			op.distinct[i] = false
+			for !op.ht.head[headID] || curID == 0 {
+				op.distinct[i] = true
+				headID++
+				curID = headID
+			}
+			op.sel[i] = curID - 1
+			curID = op.ht.same[curID]
+		}
+	}
+
+	// Create and return the next batch of input to a maximum size of
+	// ColBatchSize. The rows in the new batch is specified by the corresponding
+	// slice in the selection vector.
+	nSelected := uint16(0)
+
+	batchEnd := op.batchStart + uint64(ColBatchSize)
+	if batchEnd > op.ht.size {
+		batchEnd = op.ht.size
+	}
+	nSelected = uint16(batchEnd - op.batchStart)
+
+	copy(op.distinctCol, op.distinct[op.batchStart:batchEnd])
+
+	for i, colIdx := range op.ht.outCols {
+		toCol := op.batch.ColVec(i)
+		fromCol := op.ht.vals[colIdx]
+		toCol.CopyWithSelInt64(fromCol, op.sel[op.batchStart:batchEnd], nSelected, op.ht.valTypes[op.ht.outCols[i]])
+	}
+
+	op.batchStart = batchEnd
+
+	op.batch.SetLength(nSelected)
+	return op.batch
+}
+
+var _ Operator = &hashAggregatorBatchOp{}
+
+// extractGroupTypes returns an array representing the type corresponding to
+// each group column. This information is extracted from the group column
+// indices and their corresponding column types.
+func extractGroupTypes(groupCols []uint32, colTypes []types.T) []types.T {
+	groupTyps := make([]types.T, len(groupCols))
+
+	for i, colIdx := range groupCols {
+		groupTyps[i] = colTypes[colIdx]
+	}
+
+	return groupTyps
+}
+
+// extractAggTypes returns a nested array representing the input types
+// corresponding to each aggregation function.
+func extractAggTypes(aggCols [][]uint32, colTypes []types.T) [][]types.T {
+	aggTyps := make([][]types.T, len(aggCols))
+
+	for aggIdx := range aggCols {
+		aggTyps[aggIdx] = make([]types.T, len(aggCols[aggIdx]))
+		for i, colIdx := range aggCols[aggIdx] {
+			aggTyps[aggIdx][i] = colTypes[colIdx]
+		}
+	}
+
+	return aggTyps
 }

--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -25,23 +25,21 @@ import (
 )
 
 var (
-	defaultGroupCols  = []uint32{0}
-	defaultGroupTypes = []types.T{types.Int64}
-	defaultAggCols    = [][]uint32{{1}}
-	defaultAggTypes   = [][]types.T{{types.Int64}}
-	defaultAggFns     = []distsqlpb.AggregatorSpec_Func{distsqlpb.AggregatorSpec_SUM}
+	defaultGroupCols = []uint32{0}
+	defaultAggCols   = [][]uint32{{1}}
+	defaultAggFns    = []distsqlpb.AggregatorSpec_Func{distsqlpb.AggregatorSpec_SUM}
+	defaultColTyps   = []types.T{types.Int64, types.Int64}
 )
 
 type aggregatorTestCase struct {
 	// groupCols, groupTypes, and aggCols will be set to their default values
 	// before running a test if nil.
-	groupCols  []uint32
-	groupTypes []types.T
-	aggFns     []distsqlpb.AggregatorSpec_Func
-	aggCols    [][]uint32
-	aggTypes   [][]types.T
-	input      tuples
-	expected   tuples
+	groupCols []uint32
+	colTypes  []types.T
+	aggFns    []distsqlpb.AggregatorSpec_Func
+	aggCols   [][]uint32
+	input     tuples
+	expected  tuples
 	// {output}BatchSize if not 0 are passed in to NewOrderedAggregator to
 	// divide input/output batches.
 	batchSize       int
@@ -84,17 +82,14 @@ func (tc *aggregatorTestCase) init() error {
 	if tc.groupCols == nil {
 		tc.groupCols = defaultGroupCols
 	}
-	if tc.groupTypes == nil {
-		tc.groupTypes = defaultGroupTypes
-	}
 	if tc.aggFns == nil {
 		tc.aggFns = defaultAggFns
 	}
 	if tc.aggCols == nil {
 		tc.aggCols = defaultAggCols
 	}
-	if tc.aggTypes == nil {
-		tc.aggTypes = defaultAggTypes
+	if tc.colTypes == nil {
+		tc.colTypes = defaultColTyps
 	}
 	if tc.batchSize == 0 {
 		tc.batchSize = ColBatchSize
@@ -218,7 +213,6 @@ func TestAggregatorOneFunc(t *testing.T) {
 			outputBatchSize: 1,
 			name:            "NoGroupingCols",
 			groupCols:       []uint32{},
-			groupTypes:      []types.T{},
 		},
 	}
 
@@ -231,7 +225,11 @@ func TestAggregatorOneFunc(t *testing.T) {
 
 			tupleSource := newOpTestInput(uint16(tc.batchSize), tc.input)
 			a, err := NewOrderedAggregator(
-				tupleSource, tc.groupCols, tc.groupTypes, tc.aggFns, tc.aggCols, tc.aggTypes,
+				tupleSource,
+				tc.colTypes,
+				tc.aggFns,
+				tc.groupCols,
+				tc.aggCols,
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -249,7 +247,11 @@ func TestAggregatorOneFunc(t *testing.T) {
 			t.Run(fmt.Sprintf("Randomized"), func(t *testing.T) {
 				runTests(t, []tuples{tc.input}, nil, func(t *testing.T, input []Operator) {
 					a, err := NewOrderedAggregator(
-						input[0], tc.groupCols, tc.groupTypes, tc.aggFns, tc.aggCols, tc.aggTypes,
+						input[0],
+						tc.colTypes,
+						tc.aggFns,
+						tc.groupCols,
+						tc.aggCols,
 					)
 					if err != nil {
 						t.Fatal(err)
@@ -271,13 +273,11 @@ func TestAggregatorMultiFunc(t *testing.T) {
 			aggCols: [][]uint32{
 				{2}, {1},
 			},
-			aggTypes: [][]types.T{
-				{types.Int64}, {types.Int64},
-			},
 			input: tuples{
 				{0, 1, 2},
 				{0, 1, 2},
 			},
+			colTypes: []types.T{types.Int64, types.Int64, types.Int64},
 			expected: tuples{
 				{4, 2},
 			},
@@ -288,15 +288,13 @@ func TestAggregatorMultiFunc(t *testing.T) {
 			aggCols: [][]uint32{
 				{2}, {1},
 			},
-			aggTypes: [][]types.T{
-				{types.Decimal}, {types.Int64},
-			},
 			input: tuples{
 				{0, 1, 1.3},
 				{0, 1, 1.6},
 				{0, 1, 0.5},
 				{1, 1, 1.2},
 			},
+			colTypes: []types.T{types.Int64, types.Int64, types.Decimal},
 			expected: tuples{
 				{3.4, 3},
 				{1.2, 1},
@@ -309,9 +307,6 @@ func TestAggregatorMultiFunc(t *testing.T) {
 			aggCols: [][]uint32{
 				{1}, {1},
 			},
-			aggTypes: [][]types.T{
-				{types.Decimal}, {types.Decimal},
-			},
 			input: tuples{
 				{0, 1.1},
 				{0, 1.2},
@@ -319,6 +314,7 @@ func TestAggregatorMultiFunc(t *testing.T) {
 				{1, 6.21},
 				{1, 2.43},
 			},
+			colTypes: []types.T{types.Int64, types.Decimal},
 			expected: tuples{
 				{"1.5333333333333333333", 4.6},
 				{4.32, 8.64},
@@ -335,7 +331,11 @@ func TestAggregatorMultiFunc(t *testing.T) {
 			}
 			runTests(t, []tuples{tc.input}, nil, func(t *testing.T, input []Operator) {
 				a, err := NewOrderedAggregator(
-					input[0], tc.groupCols, tc.groupTypes, tc.aggFns, tc.aggCols, tc.aggTypes,
+					input[0],
+					tc.colTypes,
+					tc.aggFns,
+					tc.groupCols,
+					tc.aggCols,
 				)
 				if err != nil {
 					t.Fatal(err)
@@ -359,7 +359,7 @@ func TestAggregatorKitchenSink(t *testing.T) {
 				distsqlpb.AggregatorSpec_SUM,
 			},
 			aggCols:  [][]uint32{{0}, {1}, {}, {2}},
-			aggTypes: [][]types.T{{types.Int64}, {types.Decimal}, {}, {types.Int64}},
+			colTypes: []types.T{types.Int64, types.Decimal, types.Int64},
 			input: tuples{
 				{0, 3.1, 2},
 				{0, 1.1, 3},
@@ -386,7 +386,7 @@ func TestAggregatorKitchenSink(t *testing.T) {
 			}
 			runTests(t, []tuples{tc.input}, nil, func(t *testing.T, input []Operator) {
 				a, err := NewOrderedAggregator(
-					input[0], tc.groupCols, tc.groupTypes, tc.aggFns, tc.aggCols, tc.aggTypes,
+					input[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols,
 				)
 				if err != nil {
 					t.Fatal(err)
@@ -427,11 +427,10 @@ func TestAggregatorRandomCountSum(t *testing.T) {
 					source.resetBatchesToReturn(numInputBatches)
 					a, err := NewOrderedAggregator(
 						source,
-						[]uint32{0},
-						[]types.T{types.Int64},
+						[]types.T{types.Int64, types.Int64},
 						[]distsqlpb.AggregatorSpec_Func{distsqlpb.AggregatorSpec_COUNT_ROWS, distsqlpb.AggregatorSpec_SUM_INT},
+						[]uint32{0},
 						[][]uint32{{}, {1}},
-						[][]types.T{{}, {types.Int64}},
 					)
 					if err != nil {
 						t.Fatal(err)
@@ -482,9 +481,10 @@ func BenchmarkAggregator(b *testing.B) {
 	} {
 		fName := distsqlpb.AggregatorSpec_Func_name[int32(aggFn)]
 		b.Run(fName, func(b *testing.B) {
-			for _, groupSize := range []int{1, ColBatchSize / 2, ColBatchSize} {
+			for _, groupSize := range []int{1, 2, ColBatchSize / 2, ColBatchSize} {
 				for _, numInputBatches := range []int{1, 2, 64} {
-					batch := NewMemBatch([]types.T{types.Int64, types.Decimal})
+					colTypes := []types.T{types.Int64, types.Decimal}
+					batch := NewMemBatch(colTypes)
 					groups, decimals := batch.ColVec(0).Int64(), batch.ColVec(1).Decimal()
 					curGroup := 0
 					for i := 0; i < ColBatchSize; i++ {
@@ -503,11 +503,10 @@ func BenchmarkAggregator(b *testing.B) {
 					}
 					a, err := NewOrderedAggregator(
 						source,
-						[]uint32{0},
-						[]types.T{types.Int64},
+						colTypes,
 						[]distsqlpb.AggregatorSpec_Func{aggFn},
+						[]uint32{0},
 						[][]uint32{[]uint32{1}[:nCols]},
-						[][]types.T{[]types.T{types.Decimal}[:nCols]},
 					)
 					if err != nil {
 						b.Fatal(err)
@@ -529,6 +528,185 @@ func BenchmarkAggregator(b *testing.B) {
 						},
 					)
 				}
+			}
+		})
+	}
+}
+
+func TestHashAggregator(t *testing.T) {
+	tcs := []aggregatorTestCase{
+		{
+			// Test carry between output batches.
+			input: tuples{
+				{0, 1},
+				{1, 5},
+				{0, 4},
+				{0, 2},
+				{2, 6},
+				{0, 3},
+				{0, 7},
+			},
+			colTypes:  []types.T{types.Int64, types.Int64},
+			groupCols: []uint32{0},
+			aggCols:   [][]uint32{{1}},
+
+			expected: tuples{
+				{5},
+				{6},
+				{17},
+			},
+
+			name: "carryBetweenBatches",
+		},
+		{
+			// Test a single row input source.
+			input: tuples{
+				{5},
+			},
+			colTypes:  []types.T{types.Int64},
+			groupCols: []uint32{0},
+			aggCols:   [][]uint32{{0}},
+
+			expected: tuples{
+				{5},
+			},
+
+			name: "singleRowInput",
+		},
+		{
+			// Test bucket collisions.
+			input: tuples{
+				{0, 3},
+				{0, 4},
+				{hashTableBucketSize, 6},
+				{0, 5},
+				{hashTableBucketSize, 7},
+			},
+			colTypes:  []types.T{types.Int64, types.Int64},
+			groupCols: []uint32{0},
+			aggCols:   [][]uint32{{1}},
+
+			expected: tuples{
+				{12},
+				{13},
+			},
+
+			name: "bucketCollision",
+		},
+		{
+			input: tuples{
+				{0, 1, 1.3},
+				{0, 1, 1.6},
+				{0, 1, 0.5},
+				{1, 1, 1.2},
+			},
+			colTypes:      []types.T{types.Int64, types.Int64, types.Decimal},
+			convToDecimal: true,
+
+			aggFns:    []distsqlpb.AggregatorSpec_Func{distsqlpb.AggregatorSpec_SUM, distsqlpb.AggregatorSpec_SUM},
+			groupCols: []uint32{0, 1},
+			aggCols: [][]uint32{
+				{2}, {1},
+			},
+
+			expected: tuples{
+				{3.4, 3},
+				{1.2, 1},
+			},
+
+			name: "decimalSums",
+		},
+		{
+			// Test unused input columns.
+			input: tuples{
+				{0, 1, 2, 3},
+				{0, 1, 4, 5},
+				{1, 1, 3, 7},
+				{1, 2, 4, 9},
+				{0, 1, 6, 11},
+				{1, 2, 6, 13},
+			},
+			colTypes:  []types.T{types.Int64, types.Int64, types.Int64, types.Int64},
+			groupCols: []uint32{0, 1},
+			aggCols:   [][]uint32{{3}},
+
+			expected: tuples{
+				{7},
+				{19},
+				{22},
+			},
+
+			name: "unusedInputCol",
+		},
+	}
+
+	for _, tc := range tcs {
+		tc.init()
+		runTests(t, []tuples{tc.input}, []types.T{types.Bool}, func(t *testing.T, sources []Operator) {
+			ag, err := NewHashAggregator(sources[0], tc.colTypes, tc.aggFns, tc.groupCols, tc.aggCols)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			nOutput := len(tc.aggCols)
+			cols := make([]int, nOutput)
+			for i := 0; i < nOutput; i++ {
+				cols[i] = i
+			}
+
+			out := newOpTestOutput(ag, cols, tc.expected)
+
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func BenchmarkHashAggregator(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+
+	nCols := 2
+	sourceTypes := []types.T{types.Int64, types.Decimal}
+
+	batch := NewMemBatch(sourceTypes)
+	groups, decimals := batch.ColVec(0).Int64(), batch.ColVec(1).Decimal()
+	for i := 0; i < ColBatchSize; i++ {
+		decimals[i].SetInt64(rng.Int63())
+		groups[i] = int64(i)
+	}
+
+	batch.SetLength(ColBatchSize)
+	source := newRepeatableBatchSource(batch)
+
+	for _, aggFn := range []distsqlpb.AggregatorSpec_Func{
+		distsqlpb.AggregatorSpec_ANY_NOT_NULL,
+		distsqlpb.AggregatorSpec_AVG,
+		distsqlpb.AggregatorSpec_COUNT_ROWS,
+		distsqlpb.AggregatorSpec_SUM,
+	} {
+		fName := distsqlpb.AggregatorSpec_Func_name[int32(aggFn)]
+		b.Run(fName, func(b *testing.B) {
+			for _, nBatches := range []int{1 << 1, 1 << 2, 1 << 4, 1 << 8} {
+				b.Run(fmt.Sprintf("rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
+					b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols))
+					b.ResetTimer()
+
+					agg, err := NewHashAggregator(source, sourceTypes, []distsqlpb.AggregatorSpec_Func{aggFn}, []uint32{0}, [][]uint32{{1}})
+					if err != nil {
+						b.Fatal(err)
+					}
+					agg.Init()
+
+					for i := 0; i < b.N; i++ {
+						agg.(*hashAggregator).Reset()
+						source.resetBatchesToReturn(nBatches)
+
+						for b := agg.Next(); b.Length() != 0; b = agg.Next() {
+						}
+					}
+				})
 			}
 		})
 	}

--- a/pkg/sql/exec/coalescer_test.go
+++ b/pkg/sql/exec/coalescer_test.go
@@ -27,7 +27,7 @@ func TestCoalescer(t *testing.T) {
 	large := make(tuples, nRows)
 	largeTypes := []types.T{types.Int64}
 
-	for i := 0; i < nRows; i++ {
+	for i := 0; i < int(nRows); i++ {
 		large[i] = tuple{int64(i)}
 	}
 
@@ -84,14 +84,14 @@ func BenchmarkCoalescer(b *testing.B) {
 
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		col := batch.ColVec(colIdx).Int64()
-		for i := 0; i < ColBatchSize; i++ {
+		for i := uint16(0); i < ColBatchSize; i++ {
 			col[i] = int64(i)
 		}
 	}
 
 	for _, nBatches := range []int{1 << 1, 1 << 2, 1 << 4, 1 << 8, 1 << 12, 1 << 16} {
-		b.Run(fmt.Sprintf("rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
-			b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols))
+		b.Run(fmt.Sprintf("rows=%d", nBatches*int(ColBatchSize)), func(b *testing.B) {
+			b.SetBytes(int64(8 * nBatches * int(ColBatchSize) * nCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				source := newRandomLengthBatchSource(batch)

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -74,10 +74,13 @@ type ColVec interface {
 	// CopyWithSelInt16 copies vec, filtered by sel, into this ColVec. It replaces
 	// the contents of this ColVec.
 	CopyWithSelInt16(vec ColVec, sel []uint16, nSel uint16, colType types.T)
-
 	// CopyWithSelAndNilsInt64 copies vec, filtered by sel, unless nils is set,
 	// into ColVec. It replaces the contents of this ColVec.
 	CopyWithSelAndNilsInt64(vec ColVec, sel []uint64, nSel uint16, nils []bool, colType types.T)
+
+	// Slice returns a new ColVec representing a slice of the current ColVec from
+	// [start, end).
+	Slice(colType types.T, start uint64, end uint64) ColVec
 
 	// PrettyValueAt returns a "pretty"value for the idx'th value in this ColVec.
 	// It uses the reflect package and is not suitable for calling in hot paths.

--- a/pkg/sql/exec/colvec_tmpl.go
+++ b/pkg/sql/exec/colvec_tmpl.go
@@ -200,6 +200,20 @@ func (m *memColumn) CopyWithSelAndNilsInt64(
 	}
 }
 
+func (m *memColumn) Slice(colType types.T, start uint64, end uint64) ColVec {
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		col := m._TemplateType()
+		return &memColumn{
+			col: col[start:end],
+		}
+	// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
+
 func (m *memColumn) PrettyValueAt(colIdx uint16, colType types.T) string {
 	if m.NullAt(colIdx) {
 		return "NULL"

--- a/pkg/sql/exec/hashjoiner.go
+++ b/pkg/sql/exec/hashjoiner.go
@@ -252,7 +252,7 @@ func (hj *hashJoinEqOp) Next() ColBatch {
 }
 
 func (hj *hashJoinEqOp) build() {
-	hj.builder.exec()
+	hj.builder.distinctExec()
 
 	if !hj.spec.buildDistinct {
 		hj.ht.same = make([]uint64, hj.ht.size+1)
@@ -326,13 +326,18 @@ type hashTable struct {
 	// keys.
 	//
 	// same is a densely-packed list that stores the keyID of the next key in the
-	// hash table that has the same value as the current key. The head of the key
+	// hash table that has the same value as the current key. The headID of the key
 	// is the first key of that value found in the next linked list. This field
 	// will be lazily populated by the prober.
 	same []uint64
 	// visited represents whether each of the corresponding keys have been touched
 	// by the prober.
 	visited []bool
+
+	// head indicates whether each of the corresponding key is the head of the
+	// linked list at same. This would allow us to eliminate keys that are not the
+	// head and thereby should not be traversed.
+	head []bool
 
 	// vals stores the union of the equality and output columns of the left
 	// table. A key tuple is defined as the elements in each row of vals that
@@ -343,18 +348,41 @@ type hashTable struct {
 	valTypes []types.T
 	// valCols stores the union of the keyCols and outCols.
 	valCols []uint32
-
 	// keyCols stores the indices of vals which are key columns.
 	keyCols []uint32
 
 	// outCols stores the indices of vals which are output columns.
 	outCols []uint32
+	// outTypes stores the types of the output columns.
+	outTypes []types.T
 
 	// size returns the total number of keyCols the hashTable currently stores.
 	size uint64
 	// bucketSize returns the number of buckets the hashTable employs. This is
 	// equivalent to the size of first.
 	bucketSize uint64
+
+	// keyCols stores the equality columns on the probe table for a single batch.
+	keys []ColVec
+	// buckets is used to store the computed hash value of each key in a single
+	// batch.
+	buckets []uint64
+
+	// groupID stores the keyID that maps to the joining rows of the build table.
+	// The ith element of groupID stores the keyID of the build table that
+	// corresponds to the ith key in the probe table.
+	groupID []uint64
+	// toCheck stores the indices of the eqCol rows that have yet to be found or
+	// rejected.
+	toCheck []uint16
+
+	// headID stores the first build table keyID that matched with the probe batch
+	// key at any given index.
+	headID []uint64
+
+	// differs stores whether the key at any index differs with the build table
+	// key.
+	differs []bool
 }
 
 func makeHashTable(
@@ -415,12 +443,20 @@ func makeHashTable(
 		vals:     cols,
 		valTypes: keepTypes,
 		valCols:  keepCols,
-
-		keyCols: keys,
-
-		outCols: outs,
+		keyCols:  keys,
+		outCols:  outs,
+		outTypes: outTypes,
 
 		bucketSize: bucketSize,
+
+		groupID: make([]uint64, ColBatchSize),
+		toCheck: make([]uint16, ColBatchSize),
+		differs: make([]bool, ColBatchSize),
+
+		headID: make([]uint64, ColBatchSize),
+
+		keys:    make([]ColVec, len(eqCols)),
+		buckets: make([]uint64, ColBatchSize),
 	}
 }
 
@@ -490,13 +526,12 @@ func (ht *hashTable) computeBuckets(buckets []uint64, keys []ColVec, nKeys uint6
 
 // insertKeys builds the hash map from the compute hash values.
 func (ht *hashTable) insertKeys(buckets []uint64) {
-	ht.next = make([]uint64, ht.size+1)
-
 	for id := uint64(1); id <= ht.size; id++ {
 		// keyID is stored into corresponding hash bucket at the front of the next
 		// chain.
-		ht.next[id] = ht.first[buckets[id-1]]
-		ht.first[buckets[id-1]] = id
+		hash := buckets[id]
+		ht.next[id] = ht.first[hash]
+		ht.first[hash] = id
 	}
 }
 
@@ -526,9 +561,59 @@ func makeHashJoinBuilder(ht *hashTable, spec hashJoinerSourceSpec) *hashJoinBuil
 	}
 }
 
-// exec executes the entirety of the hash table build phase using the source as
-// the build relation. The source operator is entirely consumed in the process.
+// exec executes distinctExec, and then eagerly populates the hashTable's same
+// array by probing the hashTable with every single input key.
 func (builder *hashJoinBuilder) exec() {
+	builder.distinctExec()
+
+	builder.ht.same = make([]uint64, builder.ht.size+1)
+	builder.ht.visited = make([]bool, builder.ht.size+1)
+	builder.ht.head = make([]bool, builder.ht.size+1)
+
+	// Since keyID = 0 is reserved for end of list, it can be marked as visited
+	// at the beginning.
+	builder.ht.visited[0] = true
+
+	nKeyCols := len(builder.spec.eqCols)
+	batchStart := uint64(0)
+	for batchStart < builder.ht.size {
+		batchEnd := batchStart + ColBatchSize
+		if batchEnd > builder.ht.size {
+			batchEnd = builder.ht.size
+		}
+
+		batchSize := uint16(batchEnd - batchStart)
+
+		for i := 0; i < nKeyCols; i++ {
+			builder.ht.keys[i] = builder.ht.vals[builder.ht.keyCols[i]].Slice(builder.ht.valTypes[builder.ht.keyCols[i]], batchStart, batchEnd)
+		}
+
+		builder.ht.lookupInitial(batchSize, nil)
+		nToCheck := batchSize
+
+		for nToCheck > 0 {
+			// Continue searching for the build table matching keys while the toCheck
+			// array is non-empty.
+			nToCheck = builder.ht.check(nToCheck, nil)
+			builder.ht.findNext(nToCheck)
+		}
+
+		// Reset each element of headID to 0 to indicate that the probe key has not
+		// been found in the build table. Also mark the corresponding indices as
+		// head of the linked list.
+		for i := uint16(0); i < batchSize; i++ {
+			builder.ht.head[builder.ht.headID[i]] = true
+			builder.ht.headID[i] = 0
+		}
+
+		batchStart = batchEnd
+	}
+}
+
+// distinctExec executes the entirety of the hash table build phase using the
+// source as the build relation. The source operator is entirely consumed in the
+// process.
+func (builder *hashJoinBuilder) distinctExec() {
 	for {
 		batch := builder.spec.source.Next()
 
@@ -540,15 +625,15 @@ func (builder *hashJoinBuilder) exec() {
 	}
 
 	// buckets is used to store the computed hash value of each key.
-	nKeys := len(builder.ht.keyCols)
-	keyCols := make([]ColVec, nKeys)
-	for i := 0; i < nKeys; i++ {
+	nKeyCols := len(builder.spec.eqCols)
+	keyCols := make([]ColVec, nKeyCols)
+	for i := 0; i < nKeyCols; i++ {
 		keyCols[i] = builder.ht.vals[builder.ht.keyCols[i]]
 	}
 
-	buckets := make([]uint64, builder.ht.size)
-	builder.ht.computeBuckets(buckets, keyCols, builder.ht.size, nil)
-	builder.ht.insertKeys(buckets)
+	builder.ht.next = make([]uint64, builder.ht.size+1)
+	builder.ht.computeBuckets(builder.ht.next[1:], keyCols, builder.ht.size, nil)
+	builder.ht.insertKeys(builder.ht.next)
 }
 
 // hashJoinProber is used by the hashJoinEqOp during the probe phase. It
@@ -560,22 +645,6 @@ type hashJoinProber struct {
 	// batch stores the resulting output batch that is constructed and returned
 	// for every input batch during the probe phase.
 	batch ColBatch
-
-	// groupID stores the keyID that maps to the joining rows of the build table.
-	// The ith element of groupID stores the keyID of the build table that
-	// corresponds to the ith key in the probe table.
-	groupID []uint64
-	// toCheck stores the indices of the eqCol rows that have yet to be found or
-	// rejected.
-	toCheck []uint16
-
-	// head stores the first build table keyID that matched with the probe batch
-	// key at any given index.
-	head []uint64
-
-	// differs stores whether the key at any index differs with the build table
-	// key.
-	differs []bool
 
 	// buildIdx and probeIdx represents the matching row indices that are used to
 	// stitch together the join results. Since probing is done on a per-batch
@@ -602,12 +671,6 @@ type hashJoinProber struct {
 	// build table is the left table.
 	buildColOffset uint32
 	probeColOffset uint32
-
-	// keyCols stores the equality columns on the probe table for a single batch.
-	keys []ColVec
-	// buckets is used to store the computed hash value of each key in a single
-	// batch.
-	buckets []uint64
 
 	// spec holds the specifications for the source operator used in the probe
 	// phase.
@@ -659,17 +722,8 @@ func makeHashJoinProber(
 
 		batch: NewMemBatch(outColTypes),
 
-		groupID: make([]uint64, ColBatchSize),
-		toCheck: make([]uint16, ColBatchSize),
-		differs: make([]bool, ColBatchSize),
-
-		head: make([]uint64, ColBatchSize),
-
 		buildIdx: make([]uint64, ColBatchSize),
 		probeIdx: make([]uint16, ColBatchSize),
-
-		keys:    make([]ColVec, len(probe.eqCols)),
-		buckets: make([]uint64, ColBatchSize),
 
 		spec:  probe,
 		build: build,
@@ -719,14 +773,14 @@ func (prober *hashJoinProber) exec() {
 			}
 
 			for i, colIdx := range prober.spec.eqCols {
-				prober.keys[i] = batch.ColVec(int(colIdx))
+				prober.ht.keys[i] = batch.ColVec(int(colIdx))
 			}
 
 			sel := batch.Selection()
 
 			// Initialize groupID with the initial hash buckets and toCheck with all
 			// applicable indices.
-			prober.lookupInitial(batchSize, sel)
+			prober.ht.lookupInitial(batchSize, sel)
 			nToCheck := batchSize
 
 			var nResults uint16
@@ -736,8 +790,11 @@ func (prober *hashJoinProber) exec() {
 				// buckets. If the key is found or end of next chain is reached, the key is
 				// removed from the toCheck array.
 				for nToCheck > 0 {
-					nToCheck = prober.distinctCheck(nToCheck, sel)
-					prober.findNext(nToCheck)
+					// Continue searching along the hash table next chains for the corresponding
+					// buckets. If the key is found or end of next chain is reached, the key is
+					// removed from the toCheck array.
+					nToCheck = prober.ht.distinctCheck(nToCheck, sel)
+					prober.ht.findNext(nToCheck)
 				}
 
 				nResults = prober.distinctCollect(batch, batchSize, sel)
@@ -745,8 +802,8 @@ func (prober *hashJoinProber) exec() {
 				for nToCheck > 0 {
 					// Continue searching for the build table matching keys while the toCheck
 					// array is non-empty.
-					nToCheck = prober.check(nToCheck, sel)
-					prober.findNext(nToCheck)
+					nToCheck = prober.ht.check(nToCheck, sel)
+					prober.ht.findNext(nToCheck)
 				}
 
 				nResults = prober.collect(batch, batchSize, sel)
@@ -764,26 +821,26 @@ func (prober *hashJoinProber) exec() {
 // lookupInitial finds the corresponding hash table buckets for the equality
 // column of the batch and stores the results in groupID. It also initializes
 // toCheck with all indices in the range [0, batchSize).
-func (prober *hashJoinProber) lookupInitial(batchSize uint16, sel []uint16) {
-	prober.ht.computeBuckets(prober.buckets, prober.keys, uint64(batchSize), sel)
+func (ht *hashTable) lookupInitial(batchSize uint16, sel []uint16) {
+	ht.computeBuckets(ht.buckets, ht.keys, uint64(batchSize), sel)
 	for i := uint16(0); i < batchSize; i++ {
-		prober.groupID[i] = prober.ht.first[prober.buckets[i]]
-		prober.toCheck[i] = i
+		ht.groupID[i] = ht.first[ht.buckets[i]]
+		ht.toCheck[i] = i
 	}
 }
 
 // findNext determines the id of the next key inside the groupID buckets for
 // each equality column key in toCheck.
-func (prober *hashJoinProber) findNext(nToCheck uint16) {
+func (ht *hashTable) findNext(nToCheck uint16) {
 	for i := uint16(0); i < nToCheck; i++ {
-		prober.groupID[prober.toCheck[i]] = prober.ht.next[prober.groupID[prober.toCheck[i]]]
+		ht.groupID[ht.toCheck[i]] = ht.next[ht.groupID[ht.toCheck[i]]]
 	}
 }
 
 // checkCols performs a column by columns checkCol on the key columns.
-func (prober *hashJoinProber) checkCols(nToCheck uint16, sel []uint16) {
-	for i, k := range prober.ht.keyCols {
-		prober.checkCol(prober.ht.valTypes[k], i, nToCheck, sel)
+func (ht *hashTable) checkCols(nToCheck uint16, sel []uint16) {
+	for i, k := range ht.keyCols {
+		ht.checkCol(ht.valTypes[k], i, nToCheck, sel)
 	}
 }
 
@@ -794,42 +851,40 @@ func (prober *hashJoinProber) checkCols(nToCheck uint16, sel []uint16) {
 // key is removed from toCheck if it has already been visited in a previous
 // probe, or the bucket has reached the end (key not found in build table). The
 // new length of toCheck is returned by this function.
-func (prober *hashJoinProber) check(nToCheck uint16, sel []uint16) uint16 {
-	prober.checkCols(nToCheck, sel)
-
+func (ht *hashTable) check(nToCheck uint16, sel []uint16) uint16 {
+	ht.checkCols(nToCheck, sel)
 	nDiffers := uint16(0)
 	for i := uint16(0); i < nToCheck; i++ {
-		if !prober.differs[prober.toCheck[i]] {
-			// If the current key matches with the probe key, we want to update head
+		if !ht.differs[ht.toCheck[i]] {
+			// If the current key matches with the probe key, we want to update headID
 			// with the current key if it has not been set yet.
-			keyID := prober.groupID[prober.toCheck[i]]
-
-			if prober.head[prober.toCheck[i]] == 0 {
-				prober.head[prober.toCheck[i]] = keyID
+			keyID := ht.groupID[ht.toCheck[i]]
+			if ht.headID[ht.toCheck[i]] == 0 {
+				ht.headID[ht.toCheck[i]] = keyID
 			}
-			headID := prober.head[prober.toCheck[i]]
+			firstID := ht.headID[ht.toCheck[i]]
 
-			if !prober.ht.visited[keyID] {
+			if !ht.visited[keyID] {
 				// We can then add this keyID into the same array at the end of the
 				// corresponding linked list and mark this ID as visited. Since there
 				// can be multiple keys that match this probe key, we want to mark
 				// differs at this position to be true. This way, the prober will
 				// continue probing for this key until it reaches the end of the next
 				// chain.
-				prober.differs[prober.toCheck[i]] = true
-				prober.ht.visited[keyID] = true
+				ht.differs[ht.toCheck[i]] = true
+				ht.visited[keyID] = true
 
-				if headID != keyID {
-					prober.ht.same[keyID] = prober.ht.same[headID]
-					prober.ht.same[headID] = keyID
+				if firstID != keyID {
+					ht.same[keyID] = ht.same[firstID]
+					ht.same[firstID] = keyID
 				}
 			}
 		}
 
-		if prober.differs[prober.toCheck[i]] {
+		if ht.differs[ht.toCheck[i]] {
 			// Continue probing in this next chain for the probe key.
-			prober.differs[prober.toCheck[i]] = false
-			prober.toCheck[nDiffers] = prober.toCheck[i]
+			ht.differs[ht.toCheck[i]] = false
+			ht.toCheck[nDiffers] = ht.toCheck[i]
 			nDiffers++
 		}
 	}
@@ -885,15 +940,15 @@ func (prober *hashJoinProber) congregate(nResults uint16, batch ColBatch, batchS
 // toCheck. If the bucket has reached the end, the key is rejected. The toCheck
 // list is reconstructed to only hold the indices of the eqCol keys that have
 // not been found. The new length of toCheck is returned by this function.
-func (prober *hashJoinProber) distinctCheck(nToCheck uint16, sel []uint16) uint16 {
-	prober.checkCols(nToCheck, sel)
+func (ht *hashTable) distinctCheck(nToCheck uint16, sel []uint16) uint16 {
+	ht.checkCols(nToCheck, sel)
 
 	// Select the indices that differ and put them into toCheck.
 	nDiffers := uint16(0)
 	for i := uint16(0); i < nToCheck; i++ {
-		if prober.differs[prober.toCheck[i]] {
-			prober.differs[prober.toCheck[i]] = false
-			prober.toCheck[nDiffers] = prober.toCheck[i]
+		if ht.differs[ht.toCheck[i]] {
+			ht.differs[ht.toCheck[i]] = false
+			ht.toCheck[nDiffers] = ht.toCheck[i]
 			nDiffers++
 		}
 	}

--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -63,9 +63,7 @@ const _TYPES_T = types.Unhandled
 // i or sel[i] depending on whether we're in a selection or not.
 const _SEL_IND = 0
 
-func _CHECK_COL_MAIN(
-	prober *hashJoinProber, buildKeys, probeKeys []interface{}, keyID uint64, i uint16,
-) { // */}}
+func _CHECK_COL_MAIN(ht *hashTable, buildKeys, probeKeys []interface{}, keyID uint64, i uint16) { // */}}
 	// {{define "checkColMain"}}
 	buildVal := buildKeys[keyID-1]
 	probeVal := probeKeys[_SEL_IND]
@@ -73,7 +71,7 @@ func _CHECK_COL_MAIN(
 	_ASSIGN_NE(unique, buildVal, probeVal)
 
 	if unique {
-		prober.differs[prober.toCheck[i]] = true
+		ht.differs[ht.toCheck[i]] = true
 	}
 	// {{end}}
 
@@ -81,7 +79,7 @@ func _CHECK_COL_MAIN(
 }
 
 func _CHECK_COL_BODY(
-	prober *hashJoinProber,
+	ht *hashTable,
 	probeVec, buildVec ColVec,
 	buildKeys, probeKeys []interface{},
 	nToCheck uint16,
@@ -92,18 +90,18 @@ func _CHECK_COL_BODY(
 	for i := uint16(0); i < nToCheck; i++ {
 		// keyID of 0 is reserved to represent the end of the next chain.
 
-		if keyID := prober.groupID[prober.toCheck[i]]; keyID != 0 {
+		if keyID := ht.groupID[ht.toCheck[i]]; keyID != 0 {
 			// the build table key (calculated using keys[keyID - 1] = key) is
 			// compared to the corresponding probe table to determine if a match is
 			// found.
 
 			/* {{if .ProbeHasNulls }} */
 			if probeVec.NullAt(_SEL_IND) {
-				prober.groupID[prober.toCheck[i]] = 0
+				ht.groupID[ht.toCheck[i]] = 0
 			} else /*{{end}} {{if .BuildHasNulls}} */ if buildVec.NullAt64(keyID - 1) {
-				prober.differs[prober.toCheck[i]] = true
+				ht.differs[ht.toCheck[i]] = true
 			} else /*{{end}} */ {
-				_CHECK_COL_MAIN(prober, buildKeys, probeKeys, keyID, i)
+				_CHECK_COL_MAIN(ht, buildKeys, probeKeys, keyID, i)
 			}
 		}
 	}
@@ -112,7 +110,7 @@ func _CHECK_COL_BODY(
 }
 
 func _CHECK_COL_WITH_NULLS(
-	prober *hashJoinProber,
+	ht *hashTable,
 	probeVec, buildVec ColVec,
 	buildKeys, probeKeys []interface{},
 	nToCheck uint16,
@@ -121,15 +119,15 @@ func _CHECK_COL_WITH_NULLS(
 	// {{define "checkColWithNulls"}}
 	if probeVec.HasNulls() {
 		if buildVec.HasNulls() {
-			_CHECK_COL_BODY(prober, probeVec, buildVec, buildKeys, probeKeys, nToCheck, true, true)
+			_CHECK_COL_BODY(ht, probeVec, buildVec, buildKeys, probeKeys, nToCheck, true, true)
 		} else {
-			_CHECK_COL_BODY(prober, probeVec, buildVec, buildKeys, probeKeys, nToCheck, true, false)
+			_CHECK_COL_BODY(ht, probeVec, buildVec, buildKeys, probeKeys, nToCheck, true, false)
 		}
 	} else {
 		if buildVec.HasNulls() {
-			_CHECK_COL_BODY(prober, probeVec, buildVec, buildKeys, probeKeys, nToCheck, false, true)
+			_CHECK_COL_BODY(ht, probeVec, buildVec, buildKeys, probeKeys, nToCheck, false, true)
 		} else {
-			_CHECK_COL_BODY(prober, probeVec, buildVec, buildKeys, probeKeys, nToCheck, false, false)
+			_CHECK_COL_BODY(ht, probeVec, buildVec, buildKeys, probeKeys, nToCheck, false, false)
 		}
 	}
 	// {{end}}
@@ -154,7 +152,7 @@ func _COLLECT_RIGHT_OUTER(
 ) uint16 { // */}}
 	// {{define "collectRightOuter"}}
 	for i := uint16(0); i < batchSize; i++ {
-		currentID := prober.head[i]
+		currentID := prober.ht.headID[i]
 
 		if currentID == 0 {
 			prober.probeRowUnmatched[nResults] = true
@@ -169,7 +167,7 @@ func _COLLECT_RIGHT_OUTER(
 			prober.buildIdx[nResults] = currentID - 1
 			prober.probeIdx[nResults] = _SEL_IND
 			currentID = prober.ht.same[currentID]
-			prober.head[i] = currentID
+			prober.ht.headID[i] = currentID
 			nResults++
 
 			if currentID == 0 {
@@ -188,7 +186,7 @@ func _COLLECT_NO_OUTER(
 ) uint16 { // */}}
 	// {{define "collectNoOuter"}}
 	for i := uint16(0); i < batchSize; i++ {
-		currentID := prober.head[i]
+		currentID := prober.ht.headID[i]
 		for currentID != 0 {
 			if nResults >= ColBatchSize {
 				prober.prevBatch = batch
@@ -198,7 +196,7 @@ func _COLLECT_NO_OUTER(
 			prober.buildIdx[nResults] = currentID - 1
 			prober.probeIdx[nResults] = _SEL_IND
 			currentID = prober.ht.same[currentID]
-			prober.head[i] = currentID
+			prober.ht.headID[i] = currentID
 			nResults++
 		}
 	}
@@ -212,10 +210,10 @@ func _DISTINCT_COLLECT_RIGHT_OUTER(prober *hashJoinProber, batchSize uint16, _SE
 	// {{define "distinctCollectRightOuter"}}
 	for i := uint16(0); i < batchSize; i++ {
 		// Index of keys and outputs in the hash table is calculated as ID - 1.
-		prober.buildIdx[i] = prober.groupID[i] - 1
+		prober.buildIdx[i] = prober.ht.groupID[i] - 1
 		prober.probeIdx[i] = _SEL_IND
 
-		prober.probeRowUnmatched[i] = prober.groupID[i] == 0
+		prober.probeRowUnmatched[i] = prober.ht.groupID[i] == 0
 	}
 	// {{end}}
 	// {{/*
@@ -226,9 +224,9 @@ func _DISTINCT_COLLECT_NO_OUTER(
 ) { // */}}
 	// {{define "distinctCollectNoOuter"}}
 	for i := uint16(0); i < batchSize; i++ {
-		if prober.groupID[i] != 0 {
+		if prober.ht.groupID[i] != 0 {
 			// Index of keys and outputs in the hash table is calculated as ID - 1.
-			prober.buildIdx[nResults] = prober.groupID[i] - 1
+			prober.buildIdx[nResults] = prober.ht.groupID[i] - 1
 			prober.probeIdx[nResults] = _SEL_IND
 			nResults++
 		}
@@ -265,30 +263,30 @@ func (ht *hashTable) rehash(
 // the specified equality column key. If there is a match, then the key is added
 // to differs. If the bucket has reached the end, the key is rejected. If any
 // element in the key is null, then there is no match.
-func (prober *hashJoinProber) checkCol(t types.T, keyColIdx int, nToCheck uint16, sel []uint16) {
+func (ht *hashTable) checkCol(t types.T, keyColIdx int, nToCheck uint16, sel []uint16) {
 	switch t {
 	// {{range $neType := .NETemplate}}
 	case _TYPES_T:
-		buildVec := prober.ht.vals[prober.ht.keyCols[keyColIdx]]
-		probeVec := prober.keys[keyColIdx]
+		buildVec := ht.vals[ht.keyCols[keyColIdx]]
+		probeVec := ht.keys[keyColIdx]
 
 		buildKeys := buildVec._TemplateType()
 		probeKeys := probeVec._TemplateType()
 
 		if sel != nil {
 			_CHECK_COL_WITH_NULLS(
-				prober,
+				ht,
 				probeVec, buildVec,
 				buildKeys, probeKeys,
 				nToCheck,
-				"sel[prober.toCheck[i]]")
+				"sel[ht.toCheck[i]]")
 		} else {
 			_CHECK_COL_WITH_NULLS(
-				prober,
+				ht,
 				probeVec, buildVec,
 				buildKeys, probeKeys,
 				nToCheck,
-				"prober.toCheck[i]")
+				"ht.toCheck[i]")
 		}
 	// {{end}}
 	default:

--- a/pkg/sql/exec/sort.go
+++ b/pkg/sql/exec/sort.go
@@ -143,7 +143,7 @@ func (p *sortOp) Next() ColBatch {
 		p.state = sortEmitting
 		fallthrough
 	case sortEmitting:
-		newEmitted := p.emitted + ColBatchSize
+		newEmitted := p.emitted + uint64(ColBatchSize)
 		if newEmitted > p.spooledTuples {
 			newEmitted = p.spooledTuples
 		}

--- a/pkg/sql/exec/sort_test.go
+++ b/pkg/sql/exec/sort_test.go
@@ -187,10 +187,10 @@ func BenchmarkSort(b *testing.B) {
 
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
 		for _, nCols := range []int{1, 2, 4} {
-			b.Run(fmt.Sprintf("rows=%d/cols=%d", nBatches*ColBatchSize, nCols), func(b *testing.B) {
+			b.Run(fmt.Sprintf("rows=%d/cols=%d", nBatches*int(ColBatchSize), nCols), func(b *testing.B) {
 				// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
 				// batch) * nCols (number of columns / row).
-				b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols))
+				b.SetBytes(int64(8 * nBatches * int(ColBatchSize) * nCols))
 				typs := make([]types.T, nCols)
 				for i := range typs {
 					typs[i] = types.Int64
@@ -203,7 +203,7 @@ func BenchmarkSort(b *testing.B) {
 					ordCols[i].Direction = distsqlpb.Ordering_Column_Direction(rng.Int() % 2)
 
 					col := batch.ColVec(i).Int64()
-					for j := 0; i < ColBatchSize; i++ {
+					for j := uint16(0); i < int(ColBatchSize); i++ {
 						col[j] = rng.Int63() % int64((j*1024)+1)
 					}
 				}


### PR DESCRIPTION
This PR adds on top of #32393 (non-distinct hash joiner) and #32277 (average aggregate function).

The `hashedAggregator` is an operator that performs an aggregation based on specified grouping columns. This operator performs a blocking hash table build at the beginning and then the grouped buckets are then passed as input to an orderedAggregator. The output row ordering of this aggregator is arbitrary.

Benchmark results:
```
BenchmarkHashAggregator/SUM/rows=2048-8         	   20000	     76442 ns/op	 428.66 MB/s
BenchmarkHashAggregator/SUM/rows=4096-8         	   10000	    157631 ns/op	 415.76 MB/s
BenchmarkHashAggregator/SUM/rows=16384-8        	    2000	    595084 ns/op	 440.52 MB/s
BenchmarkHashAggregator/SUM/rows=262144-8       	     100	  11238965 ns/op	 373.19 MB/s
BenchmarkHashAggregator/AVG/rows=2048-8         	   20000	     81449 ns/op	 402.31 MB/s
BenchmarkHashAggregator/AVG/rows=4096-8         	   10000	    162980 ns/op	 402.11 MB/s
BenchmarkHashAggregator/AVG/rows=16384-8        	    2000	    641285 ns/op	 408.78 MB/s
BenchmarkHashAggregator/AVG/rows=262144-8       	       1	1106932049 ns/op	   3.79 MB/s
```