### PR TITLE
release-2.1: sqlbase: don't re-allocate index descriptor ids

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/storing
+++ b/pkg/sql/logictest/testdata/logic_test/storing
@@ -193,3 +193,23 @@ INSERT INTO t (a) VALUES (2)
 
 statement ok
 INSERT INTO t VALUES (3)
+
+# Regression test for #30984: indirectly ensure that index descriptors don't
+# get recreated every time any other schema change occurs.
+
+statement ok
+CREATE TABLE a(a INT, b INT, c INT, PRIMARY KEY(a, b))
+
+statement ok
+CREATE UNIQUE INDEX foo ON a(a) STORING(c)
+
+statement ok
+INSERT INTO a VALUES(1,2,3)
+
+statement ok
+CREATE UNIQUE INDEX ON a(a) STORING(c)
+
+query III
+SELECT * FROM a@foo
+----
+1 2 3

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -696,10 +696,13 @@ func (desc *TableDescriptor) allocateIndexIDs(columnNames map[string]ColumnID) e
 
 	// Populate IDs.
 	for _, index := range indexes {
-		if index.ID == 0 {
-			index.ID = desc.NextIndexID
-			desc.NextIndexID++
+		if index.ID != 0 {
+			// This index has already been populated. Nothing to do.
+			continue
 		}
+		index.ID = desc.NextIndexID
+		desc.NextIndexID++
+
 		for j, colName := range index.ColumnNames {
 			if len(index.ColumnIDs) <= j {
 				index.ColumnIDs = append(index.ColumnIDs, 0)


### PR DESCRIPTION
Backport 1/1 commits from #30998.

Fixes #32186.

cc @dt 

/cc @cockroachdb/release

---

Previously, the index descriptor id allocation code would always touch
all of the old index descriptors, re-generating all of their ids. This
was wasteful and caused at least one bug.

Fixes #30984.

Release note: None
