### PR TITLE
backupccl: return better error on failed backup

### DIFF
--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -810,8 +810,8 @@ func splitAndScatter(
 			}
 
 			select {
-			case <-g.Done:
-				return g.Err()
+			case <-ctx.Done():
+				return ctx.Err()
 			case importSpanChunksCh <- importSpanChunk:
 			}
 		}
@@ -854,8 +854,8 @@ func splitAndScatter(
 					}
 
 					select {
-					case <-g.Done:
-						return g.Err()
+					case <-ctx.Done():
+						return ctx.Err()
 					case readyForImportCh <- importSpan:
 					}
 				}

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -573,8 +573,8 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, bmd basicMetada
 				return err
 			}
 			select {
-			case <-g.Done:
-				return g.Err()
+			case <-ctx.Done():
+				return ctx.Err()
 			case valsCh <- vals:
 			}
 		}
@@ -671,8 +671,8 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, bmd basicMetada
 				d.Format(&f.FmtCtx)
 			}
 			select {
-			case <-g.Done:
-				return g.Err()
+			case <-ctx.Done():
+				return ctx.Err()
 			case stringsCh <- f.String():
 			}
 		}

--- a/pkg/cmd/cmp-protocol/pgconnect/pgconnect.go
+++ b/pkg/cmd/cmp-protocol/pgconnect/pgconnect.go
@@ -56,8 +56,8 @@ func Connect(
 		defer close(send)
 		for {
 			select {
-			case <-g.Done:
-				return g.Err()
+			case <-ctx.Done():
+				return ctx.Err()
 			case msg := <-send:
 				err := fe.Send(msg)
 				if err != nil {
@@ -83,8 +83,8 @@ func Connect(
 			dup := y.Interface().(pgproto3.BackendMessage)
 
 			select {
-			case <-g.Done:
-				return g.Err()
+			case <-ctx.Done():
+				return ctx.Err()
 			case recv <- dup:
 			}
 		}

--- a/pkg/util/ctxgroup/ctxgroup.go
+++ b/pkg/util/ctxgroup/ctxgroup.go
@@ -162,32 +162,51 @@ import (
 
 // Group wraps errgroup.
 type Group struct {
-	*errgroup.Group
-	// Done is set to ctx.Done().
+	// Done is the context cancellation channel (i.e. ctx.Done()) for a context
+	// which is canceled when the Group is canceled (i.e. either the incoming
+	// context is canceled, or a method passed to Go returns with an error, or
+	// Wait returns).
 	Done <-chan struct{}
-	ctx  context.Context
+
+	wrapped *errgroup.Group
+	ctx     context.Context
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them. If Wait() is invoked
+// after the context (originally supplied to WithContext) is canceled, Wait
+// returns an error, even if no Go invocation did. In particular, calling
+// Wait() after Done has been closed is guaranteed to return an error.
+func (g Group) Wait() error {
+	ctxErr := g.ctx.Err()
+	err := g.wrapped.Wait()
+	if err != nil {
+		return err
+	}
+	return ctxErr
 }
 
 // WithContext returns a new Group and an associated Context derived from ctx.
 func WithContext(ctx context.Context) Group {
 	grp, ctx := errgroup.WithContext(ctx)
 	return Group{
-		Group: grp,
-		Done:  ctx.Done(),
-		ctx:   ctx,
+		Done: ctx.Done(),
+
+		wrapped: grp,
+		ctx:     ctx,
 	}
+}
+
+// Go calls the given function in a new goroutine.
+func (g Group) Go(f func() error) {
+	g.wrapped.Go(f)
 }
 
 // GoCtx calls the given function in a new goroutine.
 func (g Group) GoCtx(f func(ctx context.Context) error) {
-	g.Group.Go(func() error {
+	g.wrapped.Go(func() error {
 		return f(g.ctx)
 	})
-}
-
-// Err returns the Group's ctx.Err().
-func (g Group) Err() error {
-	return g.ctx.Err()
 }
 
 // GroupWorkers runs num worker go routines in an errgroup.

--- a/pkg/util/ctxgroup/ctxgroup_test.go
+++ b/pkg/util/ctxgroup/ctxgroup_test.go
@@ -1,0 +1,48 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ctxgroup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestErrorAfterCancel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testutils.RunTrueAndFalse(t, "canceled", func(t *testing.T, canceled bool) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		g := WithContext(ctx)
+		g.Go(func() error {
+			return nil
+		})
+		expErr := context.Canceled
+		if !canceled {
+			expErr = nil
+		} else {
+			cancel()
+		}
+
+		if err := g.Wait(); err != expErr {
+			t.Errorf("expected %v, got %v", expErr, err)
+		}
+	})
+}


### PR DESCRIPTION
The previous code would tend to return a context cancellation error when
a backup operation failed due to an error originating from an
ExportRequest, leaving no clue about the original failure condition
(this cost us a few hours today to discover when a user ran into it).

The root problem here is that `g.Err()` isn't supposed to exist and The
methods invoked by `Go` already have a `ctx` which they should use
instead, and outside of that you almost certainly want to check `Wait()`
to get a better error. Correspondingly, `g.Err()` has been removed to
avoid this pitfall in the future. This affected some other locations in
the codebase.

Release note: None