### PR TITLE
opt: remove reference to catalog from data sources

### DIFF
--- a/pkg/sql/opt/catalog.go
+++ b/pkg/sql/opt/catalog.go
@@ -58,6 +58,10 @@ type Catalog interface {
 	// locates a data source by its unique identifier in the database. This id
 	// is stable as long as the data source exists.
 	ResolveDataSourceByID(ctx context.Context, dataSourceID int64) (DataSource, error)
+
+	// CheckPrivilege verifies that the current user has the given privilege on
+	// the given data source. If not, then CheckPrivilege returns an error.
+	CheckPrivilege(ctx context.Context, ds DataSource, priv privilege.Kind) error
 }
 
 // DataSource is an interface to a database object that provides rows, like a
@@ -72,10 +76,6 @@ type DataSource interface {
 	// name of the data source. The ExplicitCatalog and ExplicitSchema fields
 	// will always be true, since all parts of the name are always specified.
 	Name() *tree.TableName
-
-	// CheckPrivilege verifies that the current user has the given privilege on
-	// this data source. If not, then CheckPrivilege returns an error.
-	CheckPrivilege(ctx context.Context, priv privilege.Kind) error
 }
 
 // Table is an interface to a database table, exposing only the information

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -215,7 +215,7 @@ func (md *Metadata) CheckDependencies(ctx context.Context, catalog Catalog) bool
 			return false
 		}
 		if dep.priv != 0 {
-			if err = ds.CheckPrivilege(ctx, dep.priv); err != nil {
+			if err = catalog.CheckPrivilege(ctx, ds, dep.priv); err != nil {
 				return false
 			}
 		}

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -417,7 +417,7 @@ func (b *Builder) checkPrivilege(ds opt.DataSource) {
 	var priv privilege.Kind
 	if !b.skipSelectPrivilegeChecks {
 		priv = privilege.SELECT
-		err := ds.CheckPrivilege(b.ctx, priv)
+		err := b.catalog.CheckPrivilege(b.ctx, ds, priv)
 		if err != nil {
 			panic(builderError{err})
 		}


### PR DESCRIPTION
This change removes the reference to `optCatalog` from `optTable`,
`optView`, `optSequence`. The `CheckPrivilege` method is now a method
on the catalog. Also, we now pre-initialize the table statistics; the
lazy initialization wasn't buying us anything since the optimizer
always checks for statistics anyway.

This change will allow the plan cache to indirectly hold on to these
objects arbitrarily long.

Release note: None