### PR TITLE
release-2.1: backport 32387 and 32429

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -102,10 +102,16 @@ var (
 	defaultRaftLogTruncationThreshold = envutil.EnvOrDefaultInt64(
 		"COCKROACH_RAFT_LOG_TRUNCATION_THRESHOLD", 4<<20 /* 4 MB */)
 
-	// defaultRaftMaxSizePerMsg specifies the maximum number of Raft log entries
-	// that a leader will send to followers in a single MsgApp.
+	// defaultRaftMaxSizePerMsg specifies the maximum aggregate byte size of Raft
+	// log entries that a leader will send to followers in a single MsgApp.
 	defaultRaftMaxSizePerMsg = envutil.EnvOrDefaultInt(
 		"COCKROACH_RAFT_MAX_SIZE_PER_MSG", 16<<10 /* 16 KB */)
+
+	// defaultRaftMaxSizeCommittedSizePerReady specifies the maximum aggregate
+	// byte size of the committed log entries which a node will receive in a
+	// single Ready.
+	defaultRaftMaxCommittedSizePerReady = envutil.EnvOrDefaultInt(
+		"COCKROACH_RAFT_MAX_COMMITTED_SIZE_PER_READY", 64<<20 /* 64 MB */)
 
 	// defaultRaftMaxSizePerMsg specifies how many "inflight" messages a leader
 	// will send to a follower without hearing a response.
@@ -464,9 +470,13 @@ type RaftConfig struct {
 	// committed but continue to be proposed.
 	RaftMaxUncommittedEntriesSize uint64
 
-	// RaftMaxSizePerMsg controls how many Raft log entries the leader will send to
-	// followers in a single MsgApp.
+	// RaftMaxSizePerMsg controls the maximum aggregate byte size of Raft log
+	// entries the leader will send to followers in a single MsgApp.
 	RaftMaxSizePerMsg uint64
+
+	// RaftMaxCommittedSizePerReady controls the maximum aggregate byte size of
+	// committed Raft log entries a replica will receive in a single Ready.
+	RaftMaxCommittedSizePerReady uint64
 
 	// RaftMaxInflightMsgs controls how many "inflight" messages Raft will send
 	// to a follower without hearing a response. The total number of Raft log
@@ -514,6 +524,9 @@ func (cfg *RaftConfig) SetDefaults() {
 	}
 	if cfg.RaftMaxSizePerMsg == 0 {
 		cfg.RaftMaxSizePerMsg = uint64(defaultRaftMaxSizePerMsg)
+	}
+	if cfg.RaftMaxCommittedSizePerReady == 0 {
+		cfg.RaftMaxCommittedSizePerReady = uint64(defaultRaftMaxCommittedSizePerReady)
 	}
 	if cfg.RaftMaxInflightMsgs == 0 {
 		cfg.RaftMaxInflightMsgs = defaultRaftMaxInflightMsgs

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -9579,11 +9579,9 @@ func TestApplyPaginatedCommittedEntries(t *testing.T) {
 	tc := testContext{}
 	tsc := TestStoreConfig(nil)
 
-	// Drop the RaftMaxSizePerMsg so that even small Raft entries have their
-	// application paginated.
-	// TODO(nvanbenschoten): Switch this to using the new MaxCommitedSizePerReady
-	// configuration once #31511 is addressed.
-	tsc.RaftMaxSizePerMsg = 128
+	// Drop the RaftMaxCommittedSizePerReady so that even small Raft entries
+	// trigger pagination during entry application.
+	tsc.RaftMaxCommittedSizePerReady = 128
 	// Slow down the tick interval dramatically so that Raft groups can't rely
 	// on ticks to trigger Raft ready iterations.
 	tsc.RaftTickInterval = 5 * time.Second
@@ -9630,7 +9628,7 @@ func TestApplyPaginatedCommittedEntries(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var ba2 roachpb.BatchRequest
 		key := roachpb.Key("a")
-		put := putArgs(key, make([]byte, 2*tsc.RaftMaxSizePerMsg))
+		put := putArgs(key, make([]byte, 2*tsc.RaftMaxCommittedSizePerReady))
 		ba2.Add(&put)
 		ba2.Timestamp = tc.Clock().Now()
 
@@ -9643,7 +9641,7 @@ func TestApplyPaginatedCommittedEntries(t *testing.T) {
 
 	// Stop blocking Raft application. All of the proposals should quickly
 	// commit and apply, even if their application is paginated due to the
-	// small RaftMaxSizePerMsg.
+	// small RaftMaxCommittedSizePerReady.
 	close(blockRaftApplication)
 	const maxWait = 10 * time.Second
 	select {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -172,6 +172,7 @@ func newRaftConfig(
 		ElectionTick:              storeCfg.RaftElectionTimeoutTicks,
 		HeartbeatTick:             storeCfg.RaftHeartbeatIntervalTicks,
 		MaxUncommittedEntriesSize: storeCfg.RaftMaxUncommittedEntriesSize,
+		MaxCommittedSizePerReady:  storeCfg.RaftMaxCommittedSizePerReady,
 		MaxSizePerMsg:             storeCfg.RaftMaxSizePerMsg,
 		MaxInflightMsgs:           storeCfg.RaftMaxInflightMsgs,
 		Storage:                   strg,


### PR DESCRIPTION
Backport:
  * 1/1 commits from "storage: adopt new raft MaxCommittedSizePerReady config parameter" (#32387)
  * 1/1 commits from "storage: fix TestApplyPaginatedCommittedEntries, use MaxCommittedSizePerReady" (#32429)

Please see individual PRs for details.

/cc @cockroachdb/release
