### PR TITLE
sql/row: Implement MATCH SIMPLE for composite FK matching

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -3272,30 +3272,19 @@ statement ok
 INSERT INTO a VALUES (NULL, NULL), (NULL, 1), (2, NULL), (3, 3);
 INSERT INTO b VALUES (NULL, NULL), (NULL, 1), (2, NULL), (3, 3);
 
-# Note that these match our current incorrect style of MATCH FULL and allow
-# matching of NULLs if one exists in the referencing table.
+# Note that these matches use MATCH SIMPLE.
 
-statement ok
-DELETE FROM a WHERE y = 1;
-
+# What we start with.
 query II colnames
 SELECT * FROM b ORDER BY x, y;
 ----
 x    y
 NULL NULL
+NULL 1
 2    NULL
 3    3
 
-statement ok
-DELETE FROM a WHERE x = 2;
-
-query II colnames
-SELECT * FROM b ORDER BY x, y;
-----
-x    y
-NULL NULL
-3    3
-
+# Remove everything from a. x=3,y=3 should be the only cascading values.
 statement ok
 DELETE FROM a;
 
@@ -3305,7 +3294,10 @@ SELECT * FROM b ORDER BY x, y;
 ----
 x    y
 NULL NULL
+NULL 1
+2    NULL
 
+# Make sure that a is now empty.
 query II colnames
 SELECT * FROM a ORDER BY x;
 ----
@@ -3317,6 +3309,7 @@ TRUNCATE b, a;
 INSERT INTO a VALUES (NULL, NULL), (NULL, 4), (5, NULL), (6, 6);
 INSERT INTO b VALUES (NULL, NULL), (NULL, 4), (5, NULL), (6, 6);
 
+# For this, only x=6,y=6 should cascade.
 statement ok
 UPDATE a SET y = y*10 WHERE y > 0;
 UPDATE a SET x = x*10 WHERE x > 0;
@@ -3326,44 +3319,9 @@ SELECT * FROM b ORDER BY x, y;
 ----
 x    y
 NULL  NULL
-NULL  40
-50    NULL
+NULL  4
+5     NULL
 60    60
-
-statement ok
-UPDATE a SET y = 100 WHERE y IS NULL;
-UPDATE a SET x = 100 WHERE x IS NULL;
-
-query II colnames
-SELECT * FROM b ORDER BY x, y;
-----
-x    y
-NULL NULL
-50   100
-60   60
-100  40
-
-# Note that the double NULL should not get cascaded.
-statement ok
-UPDATE a SET (x,y) = (100, 100) WHERE y IS NULL AND x IS NULL;
-
-query II colnames
-SELECT * FROM b ORDER BY x, y;
-----
-x    y
-NULL NULL
-50   100
-60   60
-100  40
-
-query II colnames
-SELECT * FROM a ORDER BY x, y;
-----
-x    y
-50   100
-60   60
-100  40
-100  100
 
 # Clean up after the test.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -334,7 +334,8 @@ statement ok
 ALTER TABLE "user content"."customer reviews"
   ADD CONSTRAINT orderfk2 FOREIGN KEY ("order", shipment) REFERENCES orders (id, shipment)
 
-statement error missing value for column "shipment" in multi-part foreign key
+# This is allowed because we match using MATCH SIMPLE.
+statement ok
 INSERT INTO "user content"."customer reviews" (id, product, body, "order") VALUES (4, '780', 'i ordered 101 of them', 9)
 
 statement error pgcode 23503 foreign key violation: value \[9 1\] not found in orders@primary \[id shipment\]
@@ -1340,16 +1341,17 @@ CREATE TABLE b (
 statement ok
 INSERT INTO a (x, y) VALUES ('x1', 'y1')
 
-statement error pq: missing value for column "a_y" in multi-part foreign key
+# All of these are allowed because we do composite matching using MATCH SIMPLE.
+statement ok
 INSERT INTO b (a_x) VALUES ('x1')
 
-statement error pq: missing value for column "a_x" in multi-part foreign key
+statement ok
 INSERT INTO b (a_y) VALUES ('y1')
 
-statement error pq: foreign key violation: value \['y1' NULL\] not found in a@primary \[y x\]
+statement ok
 INSERT INTO b (a_y, a_x) VALUES ('y1', NULL)
 
-statement error pq: foreign key violation: value \[NULL 'x1'\] not found in a@primary \[y x\]
+statement ok
 INSERT INTO b (a_y, a_x) VALUES (NULL, 'x1')
 
 statement ok
@@ -1380,58 +1382,60 @@ CREATE TABLE b (
 statement ok
 INSERT INTO a (x, y, z) VALUES ('x1', 'y1', 'z1')
 
-statement error missing values for columns \["a_y" "a_z"\] in multi-part foreign key
+# All of these are allowed because we do composite matching using MATCH SIMPLE.
+
+statement ok
 INSERT INTO b (a_x) VALUES ('x1')
 
-statement error missing values for columns \["a_x" "a_z"\] in multi-part foreign key
+statement ok
 INSERT INTO b (a_y) VALUES ('y1')
 
-statement error missing values for columns \["a_x" "a_y"\] in multi-part foreign key
+statement ok
 INSERT INTO b (a_z) VALUES ('z1')
 
-statement error missing value for column "a_z" in multi-part foreign key
+statement ok
 INSERT INTO b (a_x, a_y) VALUES ('x1', 'y1')
 
-statement error missing value for column "a_z" in multi-part foreign key
+statement ok
 INSERT INTO b (a_x, a_y) VALUES (NULL, 'y1')
 
-statement error missing value for column "a_z" in multi-part foreign key
+statement ok
 INSERT INTO b (a_x, a_y) VALUES ('x1', NULL)
 
-statement error missing value for column "a_y" in multi-part foreign key
+statement ok
 INSERT INTO b (a_x, a_z) VALUES ('x1', 'z1')
 
-statement error missing value for column "a_y" in multi-part foreign key
+statement ok
 INSERT INTO b (a_x, a_z) VALUES (NULL, 'z1')
 
-statement error missing value for column "a_y" in multi-part foreign key
+statement ok
 INSERT INTO b (a_x, a_z) VALUES ('x1', NULL)
 
-statement error missing value for column "a_x" in multi-part foreign key
+statement ok
 INSERT INTO b (a_y, a_z) VALUES ('y1', 'z1')
 
-statement error missing value for column "a_x" in multi-part foreign key
+statement ok
 INSERT INTO b (a_y, a_z) VALUES (NULL, 'z1')
 
-statement error missing value for column "a_x" in multi-part foreign key
+statement ok
 INSERT INTO b (a_y, a_z) VALUES ('y1', NULL)
 
-statement error foreign key violation: value \[NULL NULL 'x1'\] not found in a@primary \[z y x\]
+statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', NULL, NULL)
 
-statement error foreign key violation: value \[NULL 'y1' NULL] not found in a@primary \[z y x\]
+statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y1', NULL)
 
-statement error foreign key violation: value \['z1' NULL NULL] not found in a@primary \[z y x\]
+statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, NULL, 'z1')
 
-statement error foreign key violation: value \[NULL 'y1' 'x1'\] not found in a@primary \[z y x\]
+statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', 'y1', NULL)
 
-statement error foreign key violation: value \['z1' NULL 'x1'\] not found in a@primary \[z y x\]
+statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', NULL, 'z1')
 
-statement error foreign key violation: value \['z1' 'y1' NULL\] not found in a@primary \[z y x\]
+statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y1', 'z1')
 
 statement ok
@@ -1569,3 +1573,26 @@ BEGIN; ALTER TABLE childid ADD id2 INT UNIQUE NOT NULL DEFAULT 0; ALTER TABLE ch
 
 statement ok
 ROLLBACK;
+
+subtest dont_check_nulls
+# Make sure that nulls are never checked while executing FK constraints.
+
+statement ok
+CREATE TABLE t1(x INT UNIQUE)
+
+statement ok
+INSERT INTO t1(x) VALUES (1), (null)
+
+statement ok
+CREATE TABLE t2(
+  x INT REFERENCES t1(x)
+)
+
+statement ok
+INSERT INTO t2(x) VALUES (1), (null)
+
+statement ok
+DELETE FROM t1 WHERE x IS NULL
+
+statement ok
+DROP TABLE t2, t2 CASCADE

--- a/pkg/sql/row/cascader.go
+++ b/pkg/sql/row/cascader.go
@@ -198,17 +198,13 @@ func spanForIndexValues(
 	values []tree.Datum,
 	keyPrefix []byte,
 ) (roachpb.Span, error) {
-	// Currently, we only offer MATCH FULL, so this checks to ensure that if a
-	// reference is composed of all NULLs, then we don't cascade it.
-	nulls := true
+	// This implements the check for MATCH SIMPLE.
+	// See https://github.com/cockroachdb/cockroach/issues/20305 or
+	// https://www.postgresql.org/docs/11/sql-createtable.html.
 	for _, rowIndex := range indexColIDs {
-		if values[rowIndex] != tree.DNull {
-			nulls = false
-			break
+		if values[rowIndex] == tree.DNull {
+			return roachpb.Span{}, nil
 		}
-	}
-	if nulls {
-		return roachpb.Span{}, nil
 	}
 	keyBytes, _, err := sqlbase.EncodePartialIndexKey(table.TableDesc(), index, prefixLen, indexColIDs, values, keyPrefix)
 	if err != nil {

--- a/pkg/sql/row/fk.go
+++ b/pkg/sql/row/fk.go
@@ -17,7 +17,6 @@ package row
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -467,20 +466,19 @@ func checkIdx(
 	idx sqlbase.IndexID,
 	row tree.Datums,
 ) error {
+outer:
 	for i, fk := range fks[idx] {
-		nulls := true
+		// This implements the check for MATCH SIMPLE.
+		// See https://github.com/cockroachdb/cockroach/issues/20305 or
+		// https://www.postgresql.org/docs/11/sql-createtable.html.
 		for _, colID := range fk.searchIdx.ColumnIDs[:fk.prefixLen] {
 			found, ok := fk.ids[colID]
 			if !ok {
 				panic(fmt.Sprintf("fk ids (%v) missing column id %d", fk.ids, colID))
 			}
-			if row[found] != tree.DNull {
-				nulls = false
-				break
+			if row[found] == tree.DNull {
+				continue outer
 			}
-		}
-		if nulls {
-			continue
 		}
 		if err := checker.addCheck(row, &fks[idx][i]); err != nil {
 			return err
@@ -678,32 +676,18 @@ func makeBaseFKHelper(
 		return b, err
 	}
 
-	// Check for all NULL values, since these can skip FK checking in MATCH FULL
-	// TODO(bram): add MATCH SIMPLE and fix MATCH FULL #30026
+	// This implements the check for MATCH SIMPLE.
+	// See https://github.com/cockroachdb/cockroach/issues/20305 or
+	// https://www.postgresql.org/docs/11/sql-createtable.html.
 	b.ids = make(map[sqlbase.ColumnID]int, len(writeIdx.ColumnIDs))
-	nulls := true
-	var missingColumns []string
 	for i, writeColID := range writeIdx.ColumnIDs[:b.prefixLen] {
 		if found, ok := colMap[writeColID]; ok {
 			b.ids[searchIdx.ColumnIDs[i]] = found
-			nulls = false
 		} else {
-			missingColumns = append(missingColumns, writeIdx.ColumnNames[i])
+			return b, errSkipUnusedFK
 		}
 	}
-	if nulls {
-		return b, errSkipUnusedFK
-	}
-
-	switch len(missingColumns) {
-	case 0:
-		return b, nil
-	case 1:
-		return b, errors.Errorf("missing value for column %q in multi-part foreign key", missingColumns[0])
-	default:
-		sort.Strings(missingColumns)
-		return b, errors.Errorf("missing values for columns %q in multi-part foreign key", missingColumns)
-	}
+	return b, nil
 }
 
 func (f baseFKHelper) spanForValues(values tree.Datums) (roachpb.Span, error) {


### PR DESCRIPTION
Up until now, we've been using a broken version of MATCH FULL. See #30026 for
more details on how we are non-compliant.
This is the first step to getting us to be SQL compliant and closer to Postgres
compatibility.

Postgres has a default composite matching of MATCH SIMPLE and allows specifying
of MATCH FULL.  MATCH PARTIAL is not supported.

For a full description of all the matching schemes, see #20305.

See the release notes below for further details.

Release note (backwards-incompatible change, sql change): We are changing the
way in which composite foreign key matches are evaluated. A composite foreign
key is a key with more than one column in it.

Up until now, we've claimed that our composite keys were matched using the
MATCH FULL method, which was almost correct.  For all matching methods, there
are two categories.  Keys that are 3 types of keys:

* valid - keys that can be used for matching foreign key relationships
* invalid - keys that will not be used for matching
* unacceptable - keys that cannot be inserted at all

If a key is not valid for matching, it will not be affected by any foreign key
checking and is allowed to violate the relationship.

MATCH FULL stipulates that valid keys can have no NULL values. And invalid keys
must have all NULL values. Keys with any combination of both values and NULLs
cannot are unacceptable.  Until now, we allowed explicit NULL values if there
was a corresponding NULL value. This was incorrect.

Of course, this can easily be corrected, but not without possibly making some
foreign key relationships invalid. To fix this, all matches going forward will
now use the MATCH SIMPLE method.

MATCH SIMPLE stipulates that valid keys have no NULL.  Invalid keys are ones
with one or more NULLs instead of the stricter no-NULLs allowed from MATCH
FULL. So now the presence of a single NULL will mean that the key will not
attempt to be matched in foreign key constraint relationships, including
cascading operations.

Please note that this now is same as the default Postgres matching method.
There is a chance that if your schema currently uses composite keys that this
may change your foreign key constraints and cascading so please inspect them.