### PR TITLE
release-2.1: backport deflake TestLogGrowthWhenRefreshingPendingCommands

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1254,12 +1254,17 @@ func TestLogGrowthWhenRefreshingPendingCommands(t *testing.T) {
 					t.Fatalf("raft leader should be node 0, but got status %+v", status)
 				}
 
-				// Check raft log size.
+				// Check the raft log size. We allow GetRaftLogSize to grow up
+				// to twice RaftMaxUncommittedEntriesSize because its total
+				// includes a little more state (the roachpb.Value checksum,
+				// etc.). The important thing here is that the log doesn't grow
+				// forever.
+				logSizeLimit := int64(2 * sc.RaftMaxUncommittedEntriesSize)
 				curlogSize := leaderRepl.GetRaftLogSize()
 				logSize := curlogSize - initLogSize
 				logSizeStr := humanizeutil.IBytes(logSize)
 				// Note that logSize could be negative if something got truncated.
-				if logSize > int64(sc.RaftMaxUncommittedEntriesSize) {
+				if logSize > logSizeLimit {
 					t.Fatalf("raft log size grew to %s", logSizeStr)
 				}
 				t.Logf("raft log size grew to %s", logSizeStr)

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1258,7 +1258,8 @@ func TestLogGrowthWhenRefreshingPendingCommands(t *testing.T) {
 				curlogSize := leaderRepl.GetRaftLogSize()
 				logSize := curlogSize - initLogSize
 				logSizeStr := humanizeutil.IBytes(logSize)
-				if uint64(logSize) > sc.RaftMaxUncommittedEntriesSize {
+				// Note that logSize could be negative if something got truncated.
+				if logSize > int64(sc.RaftMaxUncommittedEntriesSize) {
 					t.Fatalf("raft log size grew to %s", logSizeStr)
 				}
 				t.Logf("raft log size grew to %s", logSizeStr)


### PR DESCRIPTION
Backport:
  * 1/1 commits from "storage: deflake TestLogGrowthWhenRefreshingPendingCommands" (#31583)
  * 1/1 commits from "storage: deflake TestLogGrowthWhenRefreshingPendingCommands" (#31660)

Please see individual PRs for details.

/cc @cockroachdb/release

Fixes #32683 