### PR TITLE
opt: Disable race-only asserts when -race flag isn't specified

### DIFF
--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // CheckExpr does sanity checking on an Expr. This code is called in testrace
@@ -30,9 +31,9 @@ import (
 func (m *Memo) checkExpr(e opt.Expr) {
 	// RaceEnabled ensures that checks are run on every PR (as part of make
 	// testrace) while keeping the check code out of non-test builds.
-	//if !util.RaceEnabled {
-	//	return
-	//}
+	if !util.RaceEnabled {
+		return
+	}
 
 	// Check properties.
 	switch t := e.(type) {


### PR DESCRIPTION
A previous PR accidentally enabled asserts that should only run when
the -race flag is specified. Running them slows down performance, so
they need to be disabled if the flag isn't specified.

Release note: None