### PR TITLE
sql: prevent a crash and add telemetry for an assertion

### DIFF
--- a/pkg/sql/cluster_wide_id.go
+++ b/pkg/sql/cluster_wide_id.go
@@ -47,6 +47,7 @@ func StringToClusterWideID(s string) (ClusterWideID, error) {
 }
 
 // BytesToClusterWideID converts raw bytes into a ClusterWideID.
+// The caller is responsible for ensuring the byte slice contains 16 bytes.
 func BytesToClusterWideID(b []byte) ClusterWideID {
 	id := uint128.FromBytes(b)
 	return ClusterWideID{Uint128: id}

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -158,6 +158,15 @@ func NewAssertionErrorf(format string, args ...interface{}) error {
 	return err
 }
 
+// NewInternalTrackingError instantiates an error
+// meant for use with telemetry.ReportError directly.
+func NewInternalTrackingError(issue int, detail string) error {
+	prefix := fmt.Sprintf("#%d.%s", issue, detail)
+	err := NewErrorWithDepthf(1, CodeInternalError, "internal error: %s", prefix)
+	err.InternalCommand = prefix + " " + captureTrace()
+	return err.SetHintf("See: https://github.com/cockroachdb/cockroach/issues/%d", issue)
+}
+
 func captureTrace() string {
 	var pc [50]uintptr
 	n := runtime.Callers(3, pc[:])

--- a/pkg/util/uint128/uint128.go
+++ b/pkg/util/uint128/uint128.go
@@ -94,6 +94,7 @@ func (u Uint128) Xor(o Uint128) Uint128 {
 }
 
 // FromBytes parses the byte slice as a 128 bit big-endian unsigned integer.
+// The caller is responsible for ensuring the byte slice contains 16 bytes.
 func FromBytes(b []byte) Uint128 {
 	hi := binary.BigEndian.Uint64(b[:8])
 	lo := binary.BigEndian.Uint64(b[8:])


### PR DESCRIPTION
Informs  #32517.

We got reports in the wild that CockroachDB crashes upon SHOW
SESSIONS/QUERIES due to an invalid session ID in a ListSessions
response.

An invalid session ID should never happen; also conceptually it makes
no sense because if a session exists (insofar that it gets reported by
Listsessions) it must hav ean ID.

However I was not able to find how an invalid session ID could be
created, if at all. So the root cause of the problem remains
uncovered.

In the meantime, this patch prevents a crash when encountering an
invalid session ID. nil entries are transformed to SQL NULLs, and
non-nil entries with a non-16 size are reported as `<invalid>`. Also
the values are recorded and reported in telemetry.

Release note (bug fix): CockroachDB does not longer crash when
encountering an internal error related to invalid entries in the
output of SHOW SESSIONs.