### PR TITLE
json: allow ArrayBuilder to be reused

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -2958,3 +2958,18 @@ Laptop      Dell             800.00   NULL  800.00
 Tablet      iPad             700.00   NULL  700.00
 Tablet      Kindle Fire      150.00   NULL  150.00
 Tablet      Samsung          200.00   NULL  200.00
+
+# Test for #32702
+
+statement ok
+CREATE TABLE x (a INT)
+
+statement ok
+INSERT INTO x VALUES (1), (2), (3)
+
+query IT
+SELECT a, json_agg(a) OVER (ORDER BY a) FROM x ORDER BY a
+----
+1 [1]
+2 [1, 2]
+3 [1, 2, 3]

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -197,21 +197,15 @@ func NewArrayBuilder(numAddsHint int) *ArrayBuilder {
 
 // Add appends JSON to the sequence.
 func (b *ArrayBuilder) Add(j JSON) {
-	if b.jsons == nil {
-		panic(msgModifyAfterBuild)
-	}
 	b.jsons = append(b.jsons, j)
 }
 
-// Build returns a JSON array built from a JSON sequence. After that, it should
-// not be modified any longer.
+// Build returns the constructed JSON array. A caller may not modify the array,
+// and the ArrayBuilder reserves the right to re-use the array returned (though
+// the data will not be modified).  This is important in the case of a window
+// function, which might want to incrementally update an aggregation.
 func (b *ArrayBuilder) Build() JSON {
-	if b.jsons == nil {
-		panic(msgModifyAfterBuild)
-	}
-	arr := jsonArray(b.jsons)
-	b.jsons = nil
-	return arr
+	return jsonArray(b.jsons)
 }
 
 // ArrayBuilderWithCounter builds JSON Array by a JSON sequence with a size counter.


### PR DESCRIPTION
Fixes #32702.

json_agg previously assumed that once its value was requested, there
would be no more additions to the aggregation. Similarly,
json.ArrayBuilder would panic if values were added to an array after its
construction. This is actually not true in the case of window functions,
which might incrementally add to an aggregation as it gets output.

This commit changes json.ArrayBuilder to no longer panic in this case
and instead allow more values to be added.

However, it thus also modifies the contract of ArrayBuilder to state
that the called may not mutate the array themselves.

Release note (bug fix): fix a panic involving json_agg and window
functions.