### PR TITLE
workload/cli: stop including data-only generators in workload run

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2365,7 +2365,7 @@ func TestWorkload(t *testing.T) {
 	c := newCLITest(cliTestParams{noServer: true})
 	defer c.cleanup()
 
-	out, err := c.RunWithCapture("workload run --help")
+	out, err := c.RunWithCapture("workload init --help")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -95,6 +95,12 @@ func init() {
 		})
 		for _, meta := range workload.Registered() {
 			gen := meta.New()
+			if _, ok := gen.(workload.Opser); !ok {
+				// If Opser is not implemented, this would just fail at runtime,
+				// so omit it.
+				continue
+			}
+
 			var genFlags *pflag.FlagSet
 			if f, ok := gen.(workload.Flagser); ok {
 				genFlags = f.Flags().FlagSet


### PR DESCRIPTION
Release note(bug fix): `cockroach workload run` no longer includes
data-only generators