### PR TITLE
changefeedccl: add logs for slow ExportRequests and frontier spans

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -300,6 +301,8 @@ type changeFrontier struct {
 	freqEmitResolved time.Duration
 	// lastEmitResolved is the last time a resolved timestamp was emitted.
 	lastEmitResolved time.Time
+	// lastSlowSpanLog is the last time a slow span from `sf` was logged.
+	lastSlowSpanLog time.Time
 
 	// jobProgressedFn, if non-nil, is called to checkpoint the changefeed's
 	// progress in the corresponding system job entry.
@@ -497,7 +500,9 @@ func (cf *changeFrontier) noteResolvedSpan(d sqlbase.EncDatum) error {
 	if err := protoutil.Unmarshal([]byte(*raw), &resolved); err != nil {
 		return errors.Wrapf(err, `unmarshalling resolved span: %x`, raw)
 	}
-	if cf.sf.Forward(resolved.Span, resolved.Timestamp) {
+
+	frontierChanged := cf.sf.Forward(resolved.Span, resolved.Timestamp)
+	if frontierChanged {
 		newResolved := cf.sf.Frontier()
 		cf.metrics.mu.Lock()
 		if cf.metricsID != -1 {
@@ -517,6 +522,25 @@ func (cf *changeFrontier) noteResolvedSpan(d sqlbase.EncDatum) error {
 			cf.lastEmitResolved = newResolved.GoTime()
 		}
 	}
+
+	// Potentially log the most behind span in the frontier for debugging.
+	slownessThreshold := 10 * changefeedPollInterval.Get(&cf.flowCtx.Settings.SV)
+	frontier := cf.sf.Frontier()
+	now := timeutil.Now()
+	if resolvedBehind := now.Sub(frontier.GoTime()); resolvedBehind > slownessThreshold {
+		if frontierChanged {
+			log.Infof(cf.Ctx, "job %d new resolved timestamp %s is behind by %s",
+				cf.spec.JobID, frontier, resolvedBehind)
+		}
+		const slowSpanMaxFrequency = 10 * time.Second
+		if now.Sub(cf.lastSlowSpanLog) > slowSpanMaxFrequency {
+			cf.lastSlowSpanLog = now
+			s := cf.sf.peekFrontierSpan()
+			log.Infof(cf.Ctx, "job %d span [%s,%s) is behind by %s",
+				cf.spec.JobID, s.Key, s.EndKey, resolvedBehind)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/ccl/changefeedccl/span_frontier.go
+++ b/pkg/ccl/changefeedccl/span_frontier.go
@@ -130,6 +130,13 @@ func (s *spanFrontier) Frontier() hlc.Timestamp {
 	return s.minHeap[0].ts
 }
 
+func (s *spanFrontier) peekFrontierSpan() roachpb.Span {
+	if s.minHeap.Len() == 0 {
+		return roachpb.Span{}
+	}
+	return s.minHeap[0].span
+}
+
 // Forward advances the timestamp for a span. Any part of the span that doesn't
 // overlap the tracked span set will be ignored. True is returned if the
 // frontier advanced as a result.


### PR DESCRIPTION
The metrics added in #32241 are great for monitoring the health of a
changefeed and roughly debugging performance issues. Many of the ones
I've been seeing in testing have been one or many spans being behind, so
add some debug logging with details on the keys and lag, which then
allows for more targeted investigation.

Release note: None