### PR TITLE
backport-2.1: sql: set mutation columns to nullable while backfilling

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -142,7 +142,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 			// We're checking to see if a user is trying add a non-nullable column without a default to a
 			// non empty table by scanning the primary index span with a limit of 1 to see if any key exists.
-			if !col.Nullable && col.DefaultExpr == nil {
+			if !col.Nullable && (col.DefaultExpr == nil && !col.IsComputed()) {
 				kvs, err := params.p.txn.Scan(params.ctx, n.tableDesc.PrimaryIndexSpan().Key, n.tableDesc.PrimaryIndexSpan().EndKey, 1)
 				if err != nil {
 					return err

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -652,7 +652,7 @@ INSERT INTO x VALUES (3)
 
 # Verify computed columns work.
 statement ok
-ALTER TABLE x ADD COLUMN c INT AS (a + 4) STORED
+ALTER TABLE x ADD COLUMN c INT NOT NULL AS (a + 4) STORED
 
 query TT
 SHOW CREATE TABLE x
@@ -660,7 +660,7 @@ SHOW CREATE TABLE x
 x  CREATE TABLE x (
     a INT NULL,
     b INT NULL AS (a * 2) STORED,
-    c INT NULL AS (a + 4) STORED,
+    c INT NOT NULL AS (a + 4) STORED,
     FAMILY "primary" (a, b, rowid, c)
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1468,3 +1468,38 @@ INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, NULL, NULL)
 
 statement ok
 DROP TABLE b, a
+
+# Check that a FK cannot be added to a column being backfilled.
+# If this behavior is changed you should create a test similar to
+# TestCRUDWhileColumnBackfill to test that CRUD operations operating
+# with FK relationships work correctly over NON NULL columns that
+# are still being backfilled.
+subtest cannot_add_fk_on_col_needing_backfill
+
+statement ok
+CREATE TABLE parentid (
+    k INT NOT NULL PRIMARY KEY,
+    v INT NOT NULL
+);
+
+statement ok
+CREATE TABLE childid (
+    id INT NOT NULL PRIMARY KEY
+);
+
+# Make tables non-empty.
+statement ok
+INSERT INTO parentid (k, v) VALUES (0, 1); INSERT INTO childid (id) VALUES (2);
+
+statement error column \"id\" does not exist
+BEGIN; ALTER TABLE parentid ADD id INT NOT NULL AS (k + 2) STORED; ALTER TABLE childid ADD CONSTRAINT fk_id FOREIGN KEY (id) REFERENCES parentid (id);
+
+statement ok
+ROLLBACK;
+
+statement error column \"id2\" does not exist
+BEGIN; ALTER TABLE childid ADD id2 INT UNIQUE NOT NULL DEFAULT 0; ALTER TABLE childid ADD CONSTRAINT fk_id FOREIGN KEY (id2) REFERENCES parentid (k);
+
+statement ok
+ROLLBACK;
+

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -507,8 +507,14 @@ func runSchemaChangeWithOperations(
 
 	// Reupdate updated values back to what they were before.
 	for _, k := range updatedKeys {
-		if _, err := sqlDB.Exec(`UPDATE t.test SET v = $1 WHERE k = $2`, maxValue-k, k); err != nil {
-			t.Error(err)
+		if rand.Float32() < 0.5 {
+			if _, err := sqlDB.Exec(`UPDATE t.test SET v = $1 WHERE k = $2`, maxValue-k, k); err != nil {
+				t.Error(err)
+			}
+		} else {
+			if _, err := sqlDB.Exec(`UPSERT INTO t.test (k,v) VALUES ($1, $2)`, k, maxValue-k); err != nil {
+				t.Error(err)
+			}
 		}
 	}
 
@@ -522,8 +528,14 @@ func runSchemaChangeWithOperations(
 	// Reinsert deleted rows.
 	for i := 0; i < 10; i++ {
 		k := deleteStartKey + i
-		if _, err := sqlDB.Exec(`INSERT INTO t.test VALUES($1, $2)`, k, maxValue-k); err != nil {
-			t.Error(err)
+		if rand.Float32() < 0.5 {
+			if _, err := sqlDB.Exec(`INSERT INTO t.test VALUES($1, $2)`, k, maxValue-k); err != nil {
+				t.Error(err)
+			}
+		} else {
+			if _, err := sqlDB.Exec(`UPSERT INTO t.test VALUES($1, $2)`, k, maxValue-k); err != nil {
+				t.Error(err)
+			}
 		}
 	}
 

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2222,9 +2222,9 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT UNIQUE DEFAULT 23 CREATE FAMILY F3
 	}
 }
 
-// Test an UPDATE using a primary and a secondary index in the middle
-// of a column backfill.
-func TestUpdateDuringColumnBackfill(t *testing.T) {
+// Test CRUD operations can read NULL values for NOT NULL columns
+// in the middle of a column backfill.
+func TestCRUDWhileColumnBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	backfillNotification := make(chan bool)
 	continueBackfillNotification := make(chan bool)
@@ -2247,7 +2247,7 @@ func TestUpdateDuringColumnBackfill(t *testing.T) {
 			DisableBackfillMigrations: true,
 		},
 	}
-	server, sqlDB, _ := serverutils.StartServer(t, params)
+	server, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer server.Stopper().Stop(context.TODO())
 
 	if _, err := sqlDB.Exec(`
@@ -2261,6 +2261,8 @@ CREATE TABLE t.test (
     FAMILY "primary" (k, v, length)
 );
 INSERT INTO t.test (k, v, length) VALUES (0, 1, 1);
+INSERT INTO t.test (k, v, length) VALUES (1, 2, 1);
+INSERT INTO t.test (k, v, length) VALUES (2, 3, 1);
 `); err != nil {
 		t.Fatal(err)
 	}
@@ -2268,15 +2270,34 @@ INSERT INTO t.test (k, v, length) VALUES (0, 1, 1);
 	// Run the column schema change in a separate goroutine.
 	notification := backfillNotification
 	var wg sync.WaitGroup
-	wg.Add(1)
+	wg.Add(2)
 	go func() {
-		if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD id int NOT NULL DEFAULT 0;`); err != nil {
+		if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD id INT NOT NULL DEFAULT 2;`); err != nil {
 			t.Error(err)
 		}
 		wg.Done()
 	}()
 
+	// Wait until the first mutation has processed through the state machine
+	// and has started backfilling.
 	<-notification
+
+	go func() {
+		// Create a column that uses the above column in an expression.
+		if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD z INT AS (k + id) STORED;`); err != nil {
+			t.Error(err)
+		}
+		wg.Done()
+	}()
+
+	// Wait until both mutations are queued up.
+	testutils.SucceedsSoon(t, func() error {
+		tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+		if l := len(tableDesc.Mutations); l != 2 {
+			return errors.Errorf("number of mutations = %d", l)
+		}
+		return nil
+	})
 
 	// UPDATE the row using the secondary index.
 	if _, err := sqlDB.Exec(`UPDATE t.test SET length = 27000 WHERE v = 1`); err != nil {
@@ -2284,8 +2305,92 @@ INSERT INTO t.test (k, v, length) VALUES (0, 1, 1);
 	}
 
 	// UPDATE the row using the primary index.
-	if _, err := sqlDB.Exec(`UPDATE t.test SET length = 27001 WHERE k = 0`); err != nil {
+	if _, err := sqlDB.Exec(`UPDATE t.test SET length = 27001 WHERE k = 1`); err != nil {
 		t.Error(err)
+	}
+
+	// Use UPSERT instead of UPDATE.
+	if _, err := sqlDB.Exec(`UPSERT INTO t.test(k, v, length) VALUES (2, 3, 27000)`); err != nil {
+		t.Error(err)
+	}
+
+	// UPSERT inserts a new row.
+	if _, err := sqlDB.Exec(`UPSERT INTO t.test(k, v, length) VALUES (3, 4, 27000)`); err != nil {
+		t.Error(err)
+	}
+
+	// INSERT inserts a new row.
+	if _, err := sqlDB.Exec(`INSERT INTO t.test(k, v, length) VALUES (4, 5, 270)`); err != nil {
+		t.Error(err)
+	}
+
+	// DELETE.
+	if _, err := sqlDB.Exec(`DELETE FROM t.test WHERE k = 1`); err != nil {
+		t.Error(err)
+	}
+
+	// DELETE using the secondary index.
+	if _, err := sqlDB.Exec(`DELETE FROM t.test WHERE v = 4`); err != nil {
+		t.Error(err)
+	}
+
+	// Ensure that the newly added column cannot be supplied with any values.
+	if _, err := sqlDB.Exec(`UPDATE t.test SET id = 27000 WHERE k = 2`); !testutils.IsError(err,
+		`column "id" does not exist`) {
+		t.Errorf("err = %+v", err)
+	}
+	if _, err := sqlDB.Exec(`UPDATE t.test SET id = NULL WHERE k = 2`); !testutils.IsError(err,
+		`column "id" does not exist`) {
+		t.Errorf("err = %+v", err)
+	}
+	if _, err := sqlDB.Exec(`UPSERT INTO t.test(k, v, id) VALUES (2, 3, 234)`); !testutils.IsError(
+		err, `column "id" does not exist`) {
+		t.Errorf("err = %+v", err)
+	}
+	if _, err := sqlDB.Exec(`UPSERT INTO t.test(k, v, id) VALUES (2, 3, NULL)`); !testutils.IsError(
+		err, `column "id" does not exist`) {
+		t.Errorf("err = %+v", err)
+	}
+	if _, err := sqlDB.Exec(`INSERT INTO t.test(k, v, id) VALUES (4, 5, 270)`); !testutils.IsError(
+		err, `column "id" does not exist`) {
+		t.Errorf("err = %+v", err)
+	}
+	if _, err := sqlDB.Exec(`INSERT INTO t.test(k, v, id) VALUES (4, 5, NULL)`); !testutils.IsError(
+		err, `column "id" does not exist`) {
+		t.Errorf("err = %+v", err)
+	}
+
+	// Use column in an expression.
+	if _, err := sqlDB.Exec(
+		`INSERT INTO t.test (k, v, length) VALUES (2, 1, 3) ON CONFLICT (k) DO UPDATE SET (k, v, length) = (id + 1, 1, 3)`,
+	); err != nil {
+		t.Error(err)
+	}
+
+	// SHOW CREATE TABLE doesn't show new columns.
+	row := sqlDB.QueryRow(`SHOW CREATE TABLE t.test`)
+	var scanName, create string
+	if err := row.Scan(&scanName, &create); err != nil {
+		t.Fatal(err)
+	}
+	if scanName != `t.public.test` {
+		t.Fatalf("expected table name %s, got %s", `test`, scanName)
+	}
+	expect := `CREATE TABLE test (
+	k INT NOT NULL,
+	v INT NOT NULL,
+	length INT NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (k ASC),
+	INDEX v_idx (v ASC),
+	FAMILY "primary" (k, v, length)
+)`
+	if create != expect {
+		t.Fatalf("got: %s\nexpected: %s", create, expect)
+	}
+
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	if l := len(tableDesc.Mutations); l != 2 {
+		t.Fatalf("number of mutations = %d", l)
 	}
 
 	close(continueBackfillNotification)
@@ -2294,6 +2399,36 @@ INSERT INTO t.test (k, v, length) VALUES (0, 1, 1);
 
 	if err := sqlutils.RunScrub(sqlDB, "t", "test"); err != nil {
 		t.Fatal(err)
+	}
+	// Check data!
+	rows, err := sqlDB.Query(`SELECT k, v, length, id, z FROM t.test`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	expected := [][]int{
+		{0, 1, 27000, 2, 2},
+		{3, 1, 3, 2, 5},
+		{4, 5, 270, 2, 6},
+	}
+	count := 0
+	for ; rows.Next(); count++ {
+		var i1, i2, i3, i4, i5 *int
+		if err := rows.Scan(&i1, &i2, &i3, &i4, &i5); err != nil {
+			t.Errorf("row %d scan failed: %s", count, err)
+			continue
+		}
+		row := fmt.Sprintf("%d %d %d %d %d", *i1, *i2, *i3, *i4, *i5)
+		exp := expected[count]
+		expRow := fmt.Sprintf("%d %d %d %d %d", exp[0], exp[1], exp[2], exp[3], exp[4])
+		if row != expRow {
+			t.Errorf("expected %q but read %q", expRow, row)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Error(err)
+	} else if count != 3 {
+		t.Errorf("expected 3 rows but read %d", count)
 	}
 }
 

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1871,6 +1871,18 @@ func (desc *TableDescriptor) FindActiveColumnByID(id ColumnID) (*ColumnDescripto
 	return nil, fmt.Errorf("column-id \"%d\" does not exist", id)
 }
 
+// FindInactiveColumnByID finds the inactive column with specified ID.
+func (desc *TableDescriptor) FindInactiveColumnByID(id ColumnID) (*ColumnDescriptor, error) {
+	for _, m := range desc.Mutations {
+		if c := m.GetColumn(); c != nil {
+			if c.ID == id {
+				return c, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("column-id \"%d\" does not exist", id)
+}
+
 // FindFamilyByID finds the family with specified ID.
 func (desc *TableDescriptor) FindFamilyByID(id FamilyID) (*ColumnFamilyDescriptor, error) {
 	for i, f := range desc.Families {


### PR DESCRIPTION
Backport 4/4 commits from #32585.

/cc @cockroachdb/release

---

Also added the missing UPSERT tests.

The better way to fix this in the future is to always set
mutable columns to non-nullable in the yet to be introduced
ImmutableTableDescriptor (the opposite of MutableTableDescriptor)

fixes #32530

Release note (sql change): Fix crash in UPSERT in the middle of
a schema change adding a non-nullable column.
