### PR TITLE
sql: move uncommitted-tables check alongside the other consistency checks

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1162,7 +1162,7 @@ func (ex *connExecutor) run(
 			res = stmtRes
 			curStmt := Statement{
 				AST:           portal.Stmt.Statement,
-				Prepared:      ex.tryReusePreparedState(portal.Stmt),
+				Prepared:      portal.Stmt,
 				ExpectedTypes: portal.Stmt.Columns,
 				AnonymizedStr: portal.Stmt.AnonymizedStr,
 			}
@@ -1414,18 +1414,6 @@ func (ex *connExecutor) setTxnRewindPos(ctx context.Context, pos CmdPos) {
 func (ex *connExecutor) stmtDoesntNeedRetry(stmt tree.Statement) bool {
 	wrap := Statement{AST: stmt}
 	return isSavepoint(wrap) || isSetTransaction(wrap)
-}
-
-// tryReusePreparedState checks whether it's possible to reuse information that
-// was previously prepared. If the current transaction has uncommitted DDL
-// statements, then assume they may have changed schema on which the prepared
-// state depends, and don't reuse it. If the prepared state can be reused, then
-// tryReusePreparedState returns it, else returns nil.
-func (ex *connExecutor) tryReusePreparedState(prepStmt *PreparedStatement) *PreparedStatement {
-	if ex.extraTxnState.tables.hasUncommittedTables() {
-		return nil
-	}
-	return prepStmt
 }
 
 func stateToTxnStatusIndicator(s fsm.State) TransactionStatusIndicator {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -319,7 +319,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		}
 
 		stmt.AST = ps.Statement
-		stmt.Prepared = ex.tryReusePreparedState(ps.PreparedStatement)
+		stmt.Prepared = ps.PreparedStatement
 		stmt.ExpectedTypes = ps.Columns
 		stmt.AnonymizedStr = ps.AnonymizedStr
 		res.ResetStmtType(ps.Statement)

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -746,5 +746,17 @@ EXECUTE change_schema_uncommitted
 a  c
 1  10
 
+# Change the schema again and verify that the previously prepared plan is not
+# reused. Testing this is important because the second schema change won't
+# bump the table descriptor version again.
+statement ok
+ALTER TABLE othertable RENAME COLUMN c TO d
+
+query II colnames
+EXECUTE change_schema_uncommitted
+----
+a  d
+1  10
+
 statement ok
 ROLLBACK TRANSACTION

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -380,11 +380,24 @@ func (p *planner) makeOptimizerPlan(ctx context.Context, stmt Statement) error {
 	p.optimizer.Init(p.EvalContext())
 	f := p.optimizer.Factory()
 
+	// If the current transaction has uncommitted DDL statements, we cannot rely
+	// on descriptor versions for detecting a "stale" memo. This is because
+	// descriptor versions are bumped at most once per transaction, even if there
+	// are multiple DDL operations; and transactions can be aborted leading to
+	// potential reuse of versions. To avoid these issues, we prevent saving a
+	// memo (for prepare) or reusing a saved memo (for execute).
+	noMemoReuse := p.Tables().hasUncommittedTables()
+
 	// We have three distinct code paths:
 	//   1. Prepare
 	//   2. Execute a previously prepared statement
 	//   3. Execute without prior Prepare
 	//
+	// A note on the hasUncommittedTables checks below. If the current transaction
+	// has uncommitted DDL statements, then we assume they may have changed schema
+	// on which the prepared state depends; this is a separate check because the
+	// descriptor versions are bumped at most once per transaction, even if there
+	// are multiple DDL operations.
 	if p.EvalContext().PrepareOnly {
 		// 1. We are preparing a statement.
 		//
@@ -392,7 +405,9 @@ func (p *planner) makeOptimizerPlan(ctx context.Context, stmt Statement) error {
 		if err != nil {
 			return err
 		}
-		stmt.Prepared.Memo = memo
+		if !noMemoReuse {
+			stmt.Prepared.Memo = memo
+		}
 
 		// Construct a dummy plan that has correct output columns. Only output
 		// columns and placeholder types are needed.
@@ -408,7 +423,7 @@ func (p *planner) makeOptimizerPlan(ctx context.Context, stmt Statement) error {
 	}
 
 	var execMemo *memo.Memo
-	if stmt.Prepared != nil && stmt.Prepared.Memo != nil {
+	if stmt.Prepared != nil && stmt.Prepared.Memo != nil && !noMemoReuse {
 		// 2. We are executing a previously prepared statement.
 
 		// If the prepared memo has been invalidated by schema or other changes,
@@ -437,9 +452,9 @@ func (p *planner) makeOptimizerPlan(ctx context.Context, stmt Statement) error {
 			execMemo = preparedMemo
 		}
 	} else {
-		// 3. We are executing a statement that was not prepared, or we fell back to
-		// the heuristic planner during prepare, or we decided that the prepared
-		// state cannot be reused (see tryReusePreparedState).
+		// 3. We are executing a statement that was not prepared, we fell back to
+		// the heuristic planner during prepare, or this transaction is changing a
+		// schema.
 		bld := optbuilder.New(ctx, &p.semaCtx, p.EvalContext(), &catalog, f, stmt.AST)
 		if err := bld.Build(); err != nil {
 			// isCorrelated is used in the fallback case to create a better error.


### PR DESCRIPTION
Moving the code to check for uncommitted tables before reusing a
prepared plan into `makeOptimizerPlan`, alongside the other
consistency checks. Also improving a testcase to verify this code
path.

Release note: None