### PR TITLE
roachpb: avoid accidental MinTxnPriority due to rounding error

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -894,9 +894,9 @@ func MakePriority(userPriority UserPriority) int32 {
 	// For userPriority=MaxUserPriority, the probability of overflow is 0.7%.
 	// For userPriority=(MaxUserPriority/2), the probability of overflow is 0.005%.
 	val = (val / (5 * float64(MaxUserPriority))) * math.MaxInt32
-	if val <= MinTxnPriority {
+	if val < MinTxnPriority+1 {
 		return MinTxnPriority + 1
-	} else if val >= MaxTxnPriority {
+	} else if val > MaxTxnPriority-1 {
 		return MaxTxnPriority - 1
 	}
 	return int32(val)

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -598,8 +598,15 @@ func TestMakePriority(t *testing.T) {
 	const trials = 100000
 	values := make([][trials]int32, len(userPs))
 	for i, userPri := range userPs {
-		for t := 0; t < trials; t++ {
-			values[i][t] = MakePriority(userPri)
+		for tr := 0; tr < trials; tr++ {
+			p := MakePriority(userPri)
+			if p == MinTxnPriority {
+				t.Fatalf("unexpected min txn priority")
+			}
+			if p == MaxTxnPriority {
+				t.Fatalf("unexpected max txn priority")
+			}
+			values[i][tr] = p
 		}
 	}
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -5712,8 +5712,8 @@ func TestPushTxnHeartbeatTimeout(t *testing.T) {
 
 	for i, test := range testCases {
 		key := roachpb.Key(fmt.Sprintf("key-%d", i))
-		pushee := newTransaction(fmt.Sprintf("test-%d", i), key, roachpb.MaxUserPriority, enginepb.SERIALIZABLE, tc.Clock())
-		pusher := newTransaction("pusher", key, roachpb.MinUserPriority, enginepb.SERIALIZABLE, tc.Clock())
+		pushee := newTransaction(fmt.Sprintf("test-%d", i), key, 1, enginepb.SERIALIZABLE, tc.Clock())
+		pusher := newTransaction("pusher", key, 1, enginepb.SERIALIZABLE, tc.Clock())
 
 		// First, establish "start" of existing pushee's txn via BeginTransaction.
 		if test.heartbeat != (hlc.Timestamp{}) {


### PR DESCRIPTION
Fixes #32676.
Reverts #31965 since this was the (confirmed) underlying cause of #31859.

Before this change, it was possible for a non-minimum `UserPriority`
to result in `MinTxnPriority`. This was due to a rounding error in
`MakePriority`.

I stressed both `TestPushTxnHeartbeatTimeout` and `TestTxnWaitQueueUpdateNotPushedTxn`
for over 2,000,000 iterations each without a failure after this fix.

Release note: None