### PR TITLE
roachtest: reenable skipped import tests

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -71,10 +71,9 @@ func registerImportTPCH(r *registry) {
 		nodes   int
 		timeout time.Duration
 	}{
-		{4, 6 * time.Hour},
-		// TODO(peter,tschottdorf): re-enable
-		// {8, 4 * time.Hour},
-		// {32, 3 * time.Hour},
+		{4, 6 * time.Hour}, // typically 4-5h
+		{8, 4 * time.Hour}, // typically 3h
+		{32, 3 * time.Hour},
 	} {
 		r.Add(testSpec{
 			Name:    fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -218,8 +218,7 @@ func registerRestore(r *registry) {
 		timeout time.Duration
 	}{
 		{10, 6 * time.Hour},
-		// TODO(peter,tschottdorf): re-enable
-		// {32, 3 * time.Hour},
+		{32, 3 * time.Hour},
 	} {
 		r.Add(testSpec{
 			Name:    fmt.Sprintf("restore2TB/nodes=%d", item.nodes),


### PR DESCRIPTION
With #31875 in, import/tpch/nodes=4 has been passing reliably, and the
expectation is that the nodes=8,32 versions will follow suit (at least
they passed just now).

Release note: None