### PR TITLE
backport-2.1: sql: bump noteworthy internal mem usage threshold to 1mb

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -466,7 +466,7 @@ func (r *Registry) resume(
 	taskName := fmt.Sprintf(`job-%d`, *job.ID())
 	if err := r.stopper.RunAsyncTask(ctx, taskName, func(ctx context.Context) {
 		payload := job.Payload()
-		phs, cleanup := r.planFn("resume-job", payload.Username)
+		phs, cleanup := r.planFn("resume-"+taskName, payload.Username)
 		defer cleanup()
 		spanName := fmt.Sprintf(`%s-%d`, payload.Type(), *job.ID())
 		var span opentracing.Span

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -16,6 +16,7 @@ package sql
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -244,7 +245,7 @@ func newInternalPlanner(
 	p.semaCtx.SearchPath = sd.SearchPath
 
 	plannerMon := mon.MakeUnlimitedMonitor(ctx,
-		"internal-planner",
+		fmt.Sprintf("internal-planner.%s.%s", user, opName),
 		mon.MemoryResource,
 		memMetrics.CurBytesCount, memMetrics.MaxBytesHist,
 		noteworthyInternalMemoryUsageBytes, execCfg.Settings)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -171,7 +171,7 @@ type planner struct {
 // noteworthyInternalMemoryUsageBytes is the minimum size tracked by each
 // internal SQL pool before the pool starts explicitly logging overall usage
 // growth in the log.
-var noteworthyInternalMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_INTERNAL_MEMORY_USAGE", 100*1024)
+var noteworthyInternalMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_INTERNAL_MEMORY_USAGE", 1<<20 /* 1 MB */)
 
 // NewInternalPlanner is an exported version of newInternalPlanner. It
 // returns an interface{} so it can be used outside of the sql package.


### PR DESCRIPTION
Backport 2/2 commits from #32536.

/cc @cockroachdb/release

---

It was previously 100kb, which resulted in log spam during import. The
offending job was almost certainly the import.

Probably closes the below issu, but I don't know that yet, so:

Touches #32510.

Release note: None
