### PR TITLE
backport-2.1: various snapshot logging improvements

### DIFF
--- a/pkg/server/status/health_check.go
+++ b/pkg/server/status/health_check.go
@@ -77,6 +77,10 @@ var trackedMetrics = map[string]threshold{
 	"queue.raftsnapshot.process.failure":  counterZero,
 	"queue.tsmaintenance.process.failure": counterZero,
 	"queue.consistency.process.failure":   counterZero,
+
+	// When there are more than 100 pending items in the Raft snapshot queue,
+	// this is certainly worth pointing out.
+	"queue.raftsnapshot.pending": {gauge: true, min: 100},
 }
 
 type metricsMap map[roachpb.StoreID]map[string]float64

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -306,6 +306,7 @@ func replicas(storeIDs ...roachpb.StoreID) []roachpb.ReplicaDescriptor {
 	for i, storeID := range storeIDs {
 		res[i].NodeID = roachpb.NodeID(storeID)
 		res[i].StoreID = storeID
+		res[i].ReplicaID = roachpb.ReplicaID(i + 1)
 	}
 	return res
 }

--- a/pkg/storage/raft.go
+++ b/pkg/storage/raft.go
@@ -148,10 +148,7 @@ func raftDescribeMessage(m raftpb.Message, f raft.EntryFormatter) string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%x->%x %v Term:%d Log:%d/%d", m.From, m.To, m.Type, m.Term, m.LogTerm, m.Index)
 	if m.Reject {
-		fmt.Fprintf(&buf, " Rejected")
-		if m.RejectHint != 0 {
-			fmt.Fprintf(&buf, "(Hint:%d)", m.RejectHint)
-		}
+		fmt.Fprintf(&buf, " Rejected (Hint: %d)", m.RejectHint)
 	}
 	if m.Commit != 0 {
 		fmt.Fprintf(&buf, " Commit:%d", m.Commit)

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -22,9 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-	"go.etcd.io/etcd/raft/raftpb"
-
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -40,6 +37,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/raft"
+	"go.etcd.io/etcd/raft/raftpb"
 )
 
 // evaluateCommand delegates to the eval method for the given
@@ -197,6 +197,23 @@ func maybeDescriptorChangedError(desc *roachpb.RangeDescriptor, err error) (stri
 	return "", false
 }
 
+func splitSnapshotWarningStr(rangeID roachpb.RangeID, status *raft.Status) string {
+	var s string
+	if status != nil && status.RaftState == raft.StateLeader {
+		for replicaID, pr := range status.Progress {
+			if replicaID == status.Lead {
+				// TODO(tschottdorf): remove this line once we have picked up
+				// https://github.com/etcd-io/etcd/pull/10279
+				continue
+			}
+			if pr.State != raft.ProgressStateReplicate {
+				s += fmt.Sprintf("; may cause Raft snapshot to r%d/%d: %v", rangeID, replicaID, &pr)
+			}
+		}
+	}
+	return s
+}
+
 // adminSplitWithDescriptor divides the range into into two ranges, using
 // either args.SplitKey (if provided) or an internally computed key that aims
 // to roughly equipartition the range by size. The split is done inside of a
@@ -295,8 +312,10 @@ func (r *Replica) adminSplitWithDescriptor(
 	}
 	leftDesc.EndKey = splitKey
 
-	log.Infof(ctx, "initiating a split of this range at key %s [r%d]",
-		splitKey, rightDesc.RangeID)
+	extra := splitSnapshotWarningStr(r.RangeID, r.RaftStatus())
+
+	log.Infof(ctx, "initiating a split of this range at key %s [r%d]%s",
+		splitKey, rightDesc.RangeID, extra)
 
 	if err := r.store.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		log.Event(ctx, "split closure begins")

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
@@ -132,6 +133,22 @@ func leaseExpiry(repl *Replica) int64 {
 		panic("leaseExpiry only valid for expiration-based leases")
 	}
 	return l.Expiration.WallTime + 1
+}
+
+// Create a Raft status that shows everyone fully up to date.
+func upToDateRaftStatus(repls []roachpb.ReplicaDescriptor) *raft.Status {
+	prs := make(map[uint64]raft.Progress)
+	for _, repl := range repls {
+		prs[uint64(repl.ReplicaID)] = raft.Progress{
+			State: raft.ProgressStateReplicate,
+			Match: 100,
+		}
+	}
+	return &raft.Status{
+		HardState: raftpb.HardState{Commit: 100},
+		SoftState: raft.SoftState{Lead: 1, RaftState: raft.StateLeader},
+		Progress:  prs,
+	}
 }
 
 // testContext contains all the objects necessary to test a Range.
@@ -10855,4 +10872,22 @@ func TestRollbackMissingTxnRecordNoError(t *testing.T) {
 	if !testutils.IsPError(pErr, regexp.QuoteMeta(expErr)) {
 		t.Errorf("expected %s; got %v", expErr, pErr)
 	}
+}
+
+func TestSplitSnapshotWarningStr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	status := upToDateRaftStatus(replicas(1, 3, 5))
+	assert.Equal(t, "", splitSnapshotWarningStr(12, status))
+
+	pr := status.Progress[2]
+	pr.State = raft.ProgressStateProbe
+	status.Progress[2] = pr
+
+	assert.Equal(
+		t,
+		"; may cause Raft snapshot to r12/2: next = 0, match = 100, state = ProgressStateProbe,"+
+			" waiting = false, pendingSnapshot = 0",
+		splitSnapshotWarningStr(12, status),
+	)
 }


### PR DESCRIPTION
Backport:
  * 1/1 commits from "storage: emit health alert when >100 Raft snapshots are queued" (#32531)
  * 2/2 commits from "storage: log when rebalance-after-split causes snapshot" (#32549)
  * 1/1 commits from "storage: improve raftDescribeMessage RejectHint handling" (#32572)
  * 1/1 commits from "storage: indicate when a split causes a Raft snapshot" (#32588)

Please see individual PRs for details.

/cc @cockroachdb/release
