### PR TITLE
backport-2.1: ui: fix "slow request" graphs

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
@@ -25,19 +25,19 @@ export default function (props: GraphDashboardProps) {
   return [
     <LineGraph title="Slow Raft Proposals" sources={storeSources}>
       <Axis label="proposals">
-        <Metric name="cr.store.requests.slow.raft" title="Slow Raft Proposals" nonNegativeRate />
+        <Metric name="cr.store.requests.slow.raft" title="Slow Raft Proposals" downsampleMax />
       </Axis>
     </LineGraph>,
 
     <LineGraph title="Slow Lease Acquisitions" sources={storeSources}>
       <Axis label="lease acquisitions">
-        <Metric name="cr.store.requests.slow.lease" title="Slow Lease Acquisitions" nonNegativeRate />
+        <Metric name="cr.store.requests.slow.lease" title="Slow Lease Acquisitions" downsampleMax />
       </Axis>
     </LineGraph>,
 
     <LineGraph title="Slow Command Queue Entries" sources={storeSources}>
       <Axis label="queue entries">
-        <Metric name="cr.store.requests.slow.commandqueue" title="Slow Command Queue Entries" nonNegativeRate />
+        <Metric name="cr.store.requests.slow.commandqueue" title="Slow Command Queue Entries" downsampleMax />
       </Axis>
     </LineGraph>,
   ];


### PR DESCRIPTION
Backport 1/1 commits from #32305.

/cc @cockroachdb/release

---

They were plotting a gauge as a rate, meaning that there'd be a
temporary tiny bump when it should be a fat long line.

Closes #32304.

Release note: None
