### PR TITLE
sql: add max1row planNode

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"sync/atomic"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+
 	"fmt"
 
 	"sync"
@@ -769,7 +771,8 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 				subqueryPlans[planIdx].result = &tree.DTuple{D: rows.At(0)}
 			}
 		default:
-			return fmt.Errorf("more than one row returned by a subquery used as an expression")
+			return pgerror.NewErrorf(pgerror.CodeCardinalityViolationError,
+				"more than one row returned by a subquery used as an expression")
 		}
 	default:
 		return fmt.Errorf("unexpected subqueryExecMode: %d", subqueryPlan.execMode)

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -283,6 +283,9 @@ func doExpandPlan(
 	case *windowNode:
 		n.plan, err = doExpandPlan(ctx, p, noParams, n.plan)
 
+	case *max1RowNode:
+		n.plan, err = doExpandPlan(ctx, p, noParams, n.plan)
+
 	case *sortNode:
 		if !n.ordering.IsPrefixOf(params.desiredOrdering) {
 			params.desiredOrdering = n.ordering
@@ -750,6 +753,9 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 		n.source = p.simplifyOrderings(n.source, n.restrictOrdering(usefulOrdering))
 
 	case *limitNode:
+		n.plan = p.simplifyOrderings(n.plan, usefulOrdering)
+
+	case *max1RowNode:
 		n.plan = p.simplifyOrderings(n.plan, usefulOrdering)
 
 	case *spoolNode:

--- a/pkg/sql/logictest/testdata/planner_test/needed_columns
+++ b/pkg/sql/logictest/testdata/planner_test/needed_columns
@@ -121,21 +121,22 @@ nosort                   ·         ·     (x)                 x=CONST
 query TTTTT
 EXPLAIN (VERBOSE) SELECT 1 = (SELECT 2 AS x FROM (SELECT 3 AS s)) AS y
 ----
-root                               ·             ·                                     (y)           y=CONST
- ├── render                        ·             ·                                     (y)           y=CONST
- │    │                            render 0      @S1 = 1                               ·             ·
- │    └── emptyrow                 ·             ·                                     ()            ·
- └── subquery                      ·             ·                                     (y)           y=CONST
-      │                            id            @S1                                   ·             ·
-      │                            original sql  (SELECT 2 AS x FROM (SELECT 3 AS s))  ·             ·
-      │                            exec mode     one row                               ·             ·
-      └── limit                    ·             ·                                     (x)           x=CONST
-           │                       count         2                                     ·             ·
-           └── render              ·             ·                                     (x)           x=CONST
-                │                  render 0      2                                     ·             ·
-                └── render         ·             ·                                     (s[omitted])  ·
-                     │             render 0      NULL                                  ·             ·
-                     └── emptyrow  ·             ·                                     ()            ·
+root                                    ·             ·                                     (y)           y=CONST
+ ├── render                             ·             ·                                     (y)           y=CONST
+ │    │                                 render 0      @S1 = 1                               ·             ·
+ │    └── emptyrow                      ·             ·                                     ()            ·
+ └── subquery                           ·             ·                                     (y)           y=CONST
+      │                                 id            @S1                                   ·             ·
+      │                                 original sql  (SELECT 2 AS x FROM (SELECT 3 AS s))  ·             ·
+      │                                 exec mode     one row                               ·             ·
+      └── limit                         ·             ·                                     (x)           x=CONST
+           │                            count         2                                     ·             ·
+           └── max1row                  ·             ·                                     (x)           x=CONST
+                └── render              ·             ·                                     (x)           x=CONST
+                     │                  render 0      2                                     ·             ·
+                     └── render         ·             ·                                     (s[omitted])  ·
+                          │             render 0      NULL                                  ·             ·
+                          └── emptyrow  ·             ·                                     ()            ·
 
 # Propagation through table scans.
 statement ok

--- a/pkg/sql/logictest/testdata/planner_test/subquery
+++ b/pkg/sql/logictest/testdata/planner_test/subquery
@@ -2,6 +2,22 @@
 
 # Tests for subqueries (SELECT statements which are part of a bigger statement).
 
+query TTT
+EXPLAIN SELECT (SELECT 1)
+----
+root                               ·             ·
+ ├── render                        ·             ·
+ │    └── emptyrow                 ·             ·
+ └── subquery                      ·             ·
+      │                            id            @S1
+      │                            original sql  (SELECT 1)
+      │                            exec mode     one row
+      └── limit                    ·             ·
+           │                       count         2
+           └── max1row             ·             ·
+                └── render         ·             ·
+                     └── emptyrow  ·             ·
+
 statement ok
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 
@@ -12,18 +28,19 @@ SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 query TTT
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----
-root                          ·             ·
- ├── split                    ·             ·
- │    └── values              ·             ·
- │                            size          1 column, 1 row
- └── subquery                 ·             ·
-      │                       id            @S1
-      │                       original sql  (SELECT 42)
-      │                       exec mode     one row
-      └── limit               ·             ·
-           │                  count         2
-           └── render         ·             ·
-                └── emptyrow  ·             ·
+root                               ·             ·
+ ├── split                         ·             ·
+ │    └── values                   ·             ·
+ │                                 size          1 column, 1 row
+ └── subquery                      ·             ·
+      │                            id            @S1
+      │                            original sql  (SELECT 42)
+      │                            exec mode     one row
+      └── limit                    ·             ·
+           │                       count         2
+           └── max1row             ·             ·
+                └── render         ·             ·
+                     └── emptyrow  ·             ·
 
 statement ok
 ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
@@ -46,39 +63,58 @@ root                      ·             ·
 ·                         spans         ALL
 ·                         limit         1
 
+query TTT
+EXPLAIN SELECT (SELECT a FROM abc)
+----
+root                           ·             ·
+ ├── render                    ·             ·
+ │    └── emptyrow             ·             ·
+ └── subquery                  ·             ·
+      │                        id            @S1
+      │                        original sql  (SELECT a FROM abc)
+      │                        exec mode     one row
+      └── limit                ·             ·
+           │                   count         2
+           └── max1row         ·             ·
+                └── render     ·             ·
+                     └── scan  ·             ·
+·                              table         abc@primary
+·                              spans         ALL
+
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))
 ----
-root                              ·             ·                                                                            (a, b, c)                    a!=NULL; key(a)
- ├── scan                         ·             ·                                                                            (a, b, c)                    a!=NULL; key(a)
- │                                table         abc@primary                                                                  ·                            ·
- │                                spans         ALL                                                                          ·                            ·
- │                                filter        a = @S2                                                                      ·                            ·
- ├── subquery                     ·             ·                                                                            (a, b, c)                    a!=NULL; key(a)
- │    │                           id            @S1                                                                          ·                            ·
- │    │                           original sql  EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·                            ·
- │    │                           exec mode     exists                                                                       ·                            ·
- │    └── limit                   ·             ·                                                                            (a, b[omitted], c)           a!=NULL; c!=NULL; key(a)
- │         │                      count         1                                                                            ·                            ·
- │         └── scan               ·             ·                                                                            (a, b[omitted], c)           a!=NULL; c!=NULL; key(a)
- │                                table         abc@primary                                                                  ·                            ·
- │                                spans         ALL                                                                          ·                            ·
- │                                filter        c = (a + 3)                                                                  ·                            ·
- └── subquery                     ·             ·                                                                            (a, b, c)                    a!=NULL; key(a)
-      │                           id            @S2                                                                          ·                            ·
-      │                           original sql  (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·                            ·
-      │                           exec mode     one row                                                                      ·                            ·
-      └── limit                   ·             ·                                                                            (max)                        ·
-           │                      count         2                                                                            ·                            ·
-           └── group              ·             ·                                                                            (max)                        ·
-                │                 aggregate 0   max(a)                                                                       ·                            ·
-                │                 scalar        ·                                                                            ·                            ·
-                └── render        ·             ·                                                                            (a)                          a!=NULL; key(a); -a
-                     │            render 0      test.public.abc.a                                                            ·                            ·
-                     └── revscan  ·             ·                                                                            (a, b[omitted], c[omitted])  a!=NULL; key(a); -a
-·                                 table         abc@primary                                                                  ·                            ·
-·                                 spans         ALL                                                                          ·                            ·
-·                                 filter        @S1 AND (a IS NOT NULL)                                                      ·                            ·
+root                                   ·             ·                                                                            (a, b, c)                    a!=NULL; key(a)
+ ├── scan                              ·             ·                                                                            (a, b, c)                    a!=NULL; key(a)
+ │                                     table         abc@primary                                                                  ·                            ·
+ │                                     spans         ALL                                                                          ·                            ·
+ │                                     filter        a = @S2                                                                      ·                            ·
+ ├── subquery                          ·             ·                                                                            (a, b, c)                    a!=NULL; key(a)
+ │    │                                id            @S1                                                                          ·                            ·
+ │    │                                original sql  EXISTS (SELECT * FROM abc WHERE c = (a + 3))                                 ·                            ·
+ │    │                                exec mode     exists                                                                       ·                            ·
+ │    └── limit                        ·             ·                                                                            (a, b[omitted], c)           a!=NULL; c!=NULL; key(a)
+ │         │                           count         1                                                                            ·                            ·
+ │         └── scan                    ·             ·                                                                            (a, b[omitted], c)           a!=NULL; c!=NULL; key(a)
+ │                                     table         abc@primary                                                                  ·                            ·
+ │                                     spans         ALL                                                                          ·                            ·
+ │                                     filter        c = (a + 3)                                                                  ·                            ·
+ └── subquery                          ·             ·                                                                            (a, b, c)                    a!=NULL; key(a)
+      │                                id            @S2                                                                          ·                            ·
+      │                                original sql  (SELECT max(a) FROM abc WHERE EXISTS (SELECT * FROM abc WHERE c = (a + 3)))  ·                            ·
+      │                                exec mode     one row                                                                      ·                            ·
+      └── limit                        ·             ·                                                                            (max)                        ·
+           │                           count         2                                                                            ·                            ·
+           └── max1row                 ·             ·                                                                            (max)                        ·
+                └── group              ·             ·                                                                            (max)                        ·
+                     │                 aggregate 0   max(a)                                                                       ·                            ·
+                     │                 scalar        ·                                                                            ·                            ·
+                     └── render        ·             ·                                                                            (a)                          a!=NULL; key(a); -a
+                          │            render 0      test.public.abc.a                                                            ·                            ·
+                          └── revscan  ·             ·                                                                            (a, b[omitted], c[omitted])  a!=NULL; key(a); -a
+·                                      table         abc@primary                                                                  ·                            ·
+·                                      spans         ALL                                                                          ·                            ·
+·                                      filter        @S1 AND (a IS NOT NULL)                                                      ·                            ·
 
 # check that residual filters are not expanded twice
 query TTTTT
@@ -113,17 +149,18 @@ sort         ·      ·
 query TTT
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
-root                          ·             ·
- ├── values                   ·             ·
- │                            size          1 column, 2 rows
- └── subquery                 ·             ·
-      │                       id            @S1
-      │                       original sql  (SELECT 2)
-      │                       exec mode     one row
-      └── limit               ·             ·
-           │                  count         2
-           └── render         ·             ·
-                └── emptyrow  ·             ·
+root                               ·             ·
+ ├── values                        ·             ·
+ │                                 size          1 column, 2 rows
+ └── subquery                      ·             ·
+      │                            id            @S1
+      │                            original sql  (SELECT 2)
+      │                            exec mode     one row
+      └── limit                    ·             ·
+           │                       count         2
+           └── max1row             ·             ·
+                └── render         ·             ·
+                     └── emptyrow  ·             ·
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not

--- a/pkg/sql/max_one_row.go
+++ b/pkg/sql/max_one_row.go
@@ -1,0 +1,72 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// max1RowNode wraps another planNode, returning at most 1 row from the wrapped
+// node. If the wrapped node produces more than 1 row, this planNode returns an
+// error.
+//
+// This node is useful for constructing subqueries. Some ways of using
+// subqueries in SQL, such as using a subquery as an expression, expect that
+// the subquery can return at most 1 row - that expectation must be enforced at
+// runtime.
+type max1RowNode struct {
+	plan planNode
+
+	nexted bool
+	values tree.Datums
+}
+
+func (m *max1RowNode) Next(params runParams) (bool, error) {
+	if m.nexted {
+		return false, nil
+	}
+	m.nexted = true
+
+	ok, err := m.plan.Next(params)
+	if !ok || err != nil {
+		return ok, err
+	}
+	if ok {
+		// We need to eagerly check our parent plan for a new row, to ensure that
+		// we return an error as per the contract of this node if the parent plan
+		// isn't exhausted after a single row.
+		m.values = make(tree.Datums, len(m.plan.Values()))
+		copy(m.values, m.plan.Values())
+		var secondOk bool
+		secondOk, err = m.plan.Next(params)
+		if secondOk {
+			return false, pgerror.NewErrorf(pgerror.CodeCardinalityViolationError,
+				"more than one row returned by a subquery used as an expression")
+		}
+	}
+	return ok, err
+}
+
+func (m *max1RowNode) Values() tree.Datums {
+	return m.values
+}
+
+func (m *max1RowNode) Close(ctx context.Context) {
+	m.plan.Close(ctx)
+}

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -164,6 +164,10 @@ func (f *stubFactory) ConstructLimit(
 	return struct{}{}, nil
 }
 
+func (f *stubFactory) ConstructMax1Row(input exec.Node) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
 func (f *stubFactory) ConstructProjectSet(
 	n exec.Node, exprs tree.TypedExprs, zipCols sqlbase.ResultColumns, numColsPerGen []int,
 ) (exec.Node, error) {

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -176,6 +176,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.MergeJoinExpr:
 		ep, err = b.buildMergeJoin(t)
 
+	case *memo.Max1RowExpr:
+		ep, err = b.buildMax1Row(t)
+
 	case *memo.ProjectSetExpr:
 		ep, err = b.buildProjectSet(t)
 
@@ -982,6 +985,20 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 	}
 
 	return res, nil
+}
+
+func (b *Builder) buildMax1Row(max1Row *memo.Max1RowExpr) (execPlan, error) {
+	input, err := b.buildRelational(max1Row.Input)
+	if err != nil {
+		return execPlan{}, err
+	}
+
+	node, err := b.factory.ConstructMax1Row(input.root)
+	if err != nil {
+		return execPlan{}, err
+	}
+	return execPlan{root: node, outputCols: input.outputCols}, nil
+
 }
 
 func (b *Builder) buildProjectSet(projectSet *memo.ProjectSetExpr) (execPlan, error) {

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -477,11 +477,6 @@ func (b *Builder) buildSubquery(
 ) (tree.TypedExpr, error) {
 	subquery := scalar.(*memo.SubqueryExpr)
 	input := subquery.Input
-	// Typically, the input is a Max1RowOp; it might be elided if the optimizer
-	// proves that more than 1 result is not possible.
-	if subquery.Input.Op() == opt.Max1RowOp {
-		input = input.Child(0).(memo.RelExpr)
-	}
 
 	// TODO(radu): for now we only support the trivial projection.
 	cols := input.Relational().OutputCols

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -162,25 +162,26 @@ render               ·               ·                                        
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series((SELECT unnest(ARRAY[x, y]) FROM xy), z) FROM xz
 ----
-root                        ·             ·                                     (generate_series)     ·
- ├── render                 ·             ·                                     (generate_series)     ·
- │    │                     render 0      generate_series                       ·                     ·
- │    └── project set       ·             ·                                     (z, generate_series)  ·
- │         │                render 0      generate_series(@S1, @1)              ·                     ·
- │         └── scan         ·             ·                                     (z)                   ·
- │                          table         xz@primary                            ·                     ·
- │                          spans         ALL                                   ·                     ·
- └── subquery               ·             ·                                     (generate_series)     ·
-      │                     id            @S1                                   ·                     ·
-      │                     original sql  (SELECT unnest(ARRAY[x, y]) FROM xy)  ·                     ·
-      │                     exec mode     one row                               ·                     ·
-      └── render            ·             ·                                     (unnest)              ·
-           │                render 0      unnest                                ·                     ·
-           └── project set  ·             ·                                     (x, y, unnest)        ·
-                │           render 0      unnest(ARRAY[@1, @2])                 ·                     ·
-                └── scan    ·             ·                                     (x, y)                ·
-·                           table         xy@primary                            ·                     ·
-·                           spans         ALL                                   ·                     ·
+root                             ·             ·                                     (generate_series)     ·
+ ├── render                      ·             ·                                     (generate_series)     ·
+ │    │                          render 0      generate_series                       ·                     ·
+ │    └── project set            ·             ·                                     (z, generate_series)  ·
+ │         │                     render 0      generate_series(@S1, @1)              ·                     ·
+ │         └── scan              ·             ·                                     (z)                   ·
+ │                               table         xz@primary                            ·                     ·
+ │                               spans         ALL                                   ·                     ·
+ └── subquery                    ·             ·                                     (generate_series)     ·
+      │                          id            @S1                                   ·                     ·
+      │                          original sql  (SELECT unnest(ARRAY[x, y]) FROM xy)  ·                     ·
+      │                          exec mode     one row                               ·                     ·
+      └── max1row                ·             ·                                     (unnest)              ·
+           └── render            ·             ·                                     (unnest)              ·
+                │                render 0      unnest                                ·                     ·
+                └── project set  ·             ·                                     (x, y, unnest)        ·
+                     │           render 0      unnest(ARRAY[@1, @2])                 ·                     ·
+                     └── scan    ·             ·                                     (x, y)                ·
+·                                table         xy@primary                            ·                     ·
+·                                spans         ALL                                   ·                     ·
 
 # Regression test for #24676.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -13,18 +13,19 @@ SET CLUSTER SETTING kv.range_merge.queue_enabled = false;
 query TTT
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----
-root                          ·             ·
- ├── split                    ·             ·
- │    └── values              ·             ·
- │                            size          1 column, 1 row
- └── subquery                 ·             ·
-      │                       id            @S1
-      │                       original sql  (SELECT 42)
-      │                       exec mode     one row
-      └── limit               ·             ·
-           │                  count         2
-           └── render         ·             ·
-                └── emptyrow  ·             ·
+root                               ·             ·
+ ├── split                         ·             ·
+ │    └── values                   ·             ·
+ │                                 size          1 column, 1 row
+ └── subquery                      ·             ·
+      │                            id            @S1
+      │                            original sql  (SELECT 42)
+      │                            exec mode     one row
+      └── limit                    ·             ·
+           │                       count         2
+           └── max1row             ·             ·
+                └── render         ·             ·
+                     └── emptyrow  ·             ·
 
 statement ok
 ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -206,6 +206,11 @@ type Factory interface {
 	// set to nil.
 	ConstructLimit(input Node, limit, offset tree.TypedExpr) (Node, error)
 
+	// ConstructMax1Row returns a node that permits at most one row from the
+	// given input node, returning an error at runtime if the node tries to return
+	// more than one row.
+	ConstructMax1Row(input Node) (Node, error)
+
 	// ConstructProjectSet returns a node that performs a lateral cross join
 	// between the output of the given node and the functional zip of the given
 	// expressions.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -742,6 +742,14 @@ func (ef *execFactory) ConstructLimit(
 	}, nil
 }
 
+// ConstructMax1Row is part of the exec.Factory interface.
+func (ef *execFactory) ConstructMax1Row(input exec.Node) (exec.Node, error) {
+	plan := input.(planNode)
+	return &max1RowNode{
+		plan: plan,
+	}, nil
+}
+
 // ConstructProjectSet is part of the exec.Factory interface.
 func (ef *execFactory) ConstructProjectSet(
 	n exec.Node, exprs tree.TypedExprs, zipCols sqlbase.ResultColumns, numColsPerGen []int,

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -244,6 +244,11 @@ func (p *planner) propagateFilters(
 			return plan, extraFilter, err
 		}
 
+	case *max1RowNode:
+		if n.plan, err = p.triggerFilterPropagation(ctx, n.plan); err != nil {
+			return plan, extraFilter, err
+		}
+
 	case *windowNode:
 		if n.plan, err = p.triggerFilterPropagation(ctx, n.plan); err != nil {
 			return plan, extraFilter, err

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -124,6 +124,9 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *windowNode:
 		p.setUnlimited(n.plan)
 
+	case *max1RowNode:
+		p.setUnlimited(n.plan)
+
 	case *joinNode:
 		p.setUnlimited(n.left.plan)
 		p.setUnlimited(n.right.plan)

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -45,6 +45,9 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *limitNode:
 		setNeededColumns(n.plan, needed)
 
+	case *max1RowNode:
+		setNeededColumns(n.plan, needed)
+
 	case *spoolNode:
 		setNeededColumns(n.source, needed)
 

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -124,6 +124,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return getPlanColumns(n.plan, mut)
 	case *filterNode:
 		return getPlanColumns(n.source.plan, mut)
+	case *max1RowNode:
+		return getPlanColumns(n.plan, mut)
 	case *limitNode:
 		return getPlanColumns(n.plan, mut)
 	case *spoolNode:

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -35,6 +35,8 @@ func planPhysicalProps(plan planNode) physicalProps {
 		return planPhysicalProps(n.run.results)
 	case *limitNode:
 		return planPhysicalProps(n.plan)
+	case *max1RowNode:
+		return planPhysicalProps(n.plan)
 	case *spoolNode:
 		return planPhysicalProps(n.source)
 	case *indexJoinNode:

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -74,6 +74,8 @@ func collectSpans(params runParams, plan planNode) (reads, writes roachpb.Spans,
 		return collectSpans(params, n.plan)
 	case *limitNode:
 		return collectSpans(params, n.plan)
+	case *max1RowNode:
+		return collectSpans(params, n.plan)
 	case *spoolNode:
 		return collectSpans(params, n.source)
 	case *sortNode:

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -156,14 +156,6 @@ func (s *subquery) doEval(params runParams) (result tree.Datum, err error) {
 			copy(valuesCopy.D, values)
 			result = valuesCopy
 		}
-		another, err := s.plan.Next(params)
-		if err != nil {
-			return nil, err
-		}
-		if another {
-			err := fmt.Errorf("more than one row returned by a subquery used as an expression")
-			return nil, err
-		}
 		return result, nil
 
 	default:
@@ -289,6 +281,7 @@ func (v *subqueryVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.E
 			result.execMode = distsqlrun.SubqueryExecModeExists
 			t.SetType(types.Bool)
 		} else {
+			result.plan = &max1RowNode{plan: result.plan}
 			result.execMode = distsqlrun.SubqueryExecModeOneRow
 		}
 

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -290,6 +290,9 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		}
 		n.plan = v.visit(n.plan)
 
+	case *max1RowNode:
+		n.plan = v.visit(n.plan)
+
 	case *distinctNode:
 		if v.observer.attr == nil {
 			n.plan = v.visit(n.plan)
@@ -692,7 +695,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&joinNode{}):                 "join",
 	reflect.TypeOf(&limitNode{}):                "limit",
 	reflect.TypeOf(&lookupJoinNode{}):           "lookup-join",
-	reflect.TypeOf(&zigzagJoinNode{}):           "zigzag-join",
+	reflect.TypeOf(&max1RowNode{}):              "max1row",
 	reflect.TypeOf(&ordinalityNode{}):           "ordinality",
 	reflect.TypeOf(&projectSetNode{}):           "project set",
 	reflect.TypeOf(&relocateNode{}):             "relocate",
@@ -728,4 +731,5 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&virtualTableNode{}):         "virtual table values",
 	reflect.TypeOf(&windowNode{}):               "window",
 	reflect.TypeOf(&zeroNode{}):                 "norows",
+	reflect.TypeOf(&zigzagJoinNode{}):           "zigzag-join",
 }


### PR DESCRIPTION
This planNode replaces the custom logic that max-1-row subqueries had at
the end, that returns an error if the subquery returned more than 1 row.
The heuristic planner and the optimizer both now plan the new node on
top of the appropriate subqueries, and the custom logic is removed.

Release note: None