### PR TITLE
sql: proprely record stmt stats for client-specified app names

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -503,9 +503,13 @@ func (s *Server) newConnExecutor(
 			log.Errorf(ctx, "error setting up client session: %v", err)
 			return nil, err
 		}
+	} else {
+		// It's possible there were no defaults, for example when the
+		// connEx is serving an internal executor. In that case we still
+		// need to populate appStats according to the configured
+		// application name.
+		ex.appStats = s.sqlStats.getStatsForApplication(ex.sessionData.ApplicationName)
 	}
-
-	ex.appStats = s.sqlStats.getStatsForApplication(sd.ApplicationName)
 
 	ex.phaseTimes[sessionInit] = timeutil.Now()
 	ex.extraTxnState.tables = TableCollection{


### PR DESCRIPTION
Fixes #31766

The initialization of `(*connExecutor).appStats` in `newConnExecutor`
was based off a temporary local variable (`sd`) unrelated to the object
actually holding the application name (`ex.sessionData`). This caused
the initial appStats to always be wrong when the initial application
name was not empty.

Meanwhile, the changes in #30702 have ensured that `appStats` is
initialized via `resetSessionVars` for normal client connections. The
extra initialization in `newConnExecutor` was not just wrong; it was
not needed any more except for internal executors.

This patch corrects/simplifies the situation.

Release note (bug fix): CockroachDB now properly records statistics
for sessions where the value of `application_name` is given by the
client during initialization instead of `SET`.