### PR TITLE
release-2.1: cli: add kv workload generator

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -36,6 +36,7 @@ import (
 	// intentionally not all the workloads in pkg/ccl/workloadccl/allccl
 	_ "github.com/cockroachdb/cockroach/pkg/workload/bank"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/examples"
+	_ "github.com/cockroachdb/cockroach/pkg/workload/kv"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcc"
 )
 


### PR DESCRIPTION
Backport 1/2 commits from #32719.

/cc @cockroachdb/release

---

The docs team would like kv. Intentionally not backporting ycsb.
