### PR TITLE
release-2.1: various changefeed fixes

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -164,7 +164,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	// but only the first one is ever used.
 	ca.errCh = make(chan error, 2)
 	ca.pollerDoneCh = make(chan struct{})
-	go func(ctx context.Context) {
+	if err := ca.flowCtx.Stopper().RunAsyncTask(ctx, "changefeed-poller", func(ctx context.Context) {
 		defer close(ca.pollerDoneCh)
 		var err error
 		if storage.RangefeedEnabled.Get(&ca.flowCtx.Settings.SV) {
@@ -177,7 +177,10 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 		// state stateTrailingMeta`), so return the error via a channel.
 		ca.errCh <- err
 		ca.cancel()
-	}(ctx)
+	}); err != nil {
+		ca.errCh <- err
+		ca.cancel()
+	}
 
 	return ctx
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1250,125 +1250,137 @@ func TestChangefeedSchemaTTL(t *testing.T) {
 func TestChangefeedErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
-		sqlDB := sqlutils.MakeSQLRunner(db)
-		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+	sqlDB.Exec(t, `CREATE DATABASE d`)
 
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR foo WITH format=nope`,
-		); !testutils.IsError(err, `unknown format: nope`) {
-			t.Errorf(`expected 'unknown format: nope' error got: %+v`, err)
-		}
-
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR foo WITH envelope=diff`,
-		); !testutils.IsError(err, `envelope=diff is not yet supported`) {
-			t.Errorf(`expected 'envelope=diff is not yet supported' error got: %+v`, err)
-		}
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR foo WITH envelope=nope`,
-		); !testutils.IsError(err, `unknown envelope: nope`) {
-			t.Errorf(`expected 'unknown envelope: nope' error got: %+v`, err)
-		}
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR foo WITH resolved='-1s'`,
-		); !testutils.IsError(err, `negative durations are not accepted: resolved='-1s'`) {
-			t.Errorf(`expected 'negative durations are not accepted' error got: %+v`, err)
-		}
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR foo WITH cursor=$1`, timeutil.Now().Add(time.Hour),
-		); !testutils.IsError(err, `cannot specify timestamp in the future`) {
-			t.Errorf(`expected 'cannot specify timestamp in the future' error got: %+v`, err)
-		}
-
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR foo INTO ''`,
-		); !testutils.IsError(err, `omit the SINK clause`) {
-			t.Errorf(`expected 'omit the SINK clause' error got: %+v`, err)
-		}
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR foo INTO $1`, ``,
-		); !testutils.IsError(err, `omit the SINK clause`) {
-			t.Errorf(`expected 'omit the SINK clause' error got: %+v`, err)
-		}
-
-		enableEnterprise := utilccl.TestingDisableEnterprise()
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope`,
-		); !testutils.IsError(err, `CHANGEFEED requires an enterprise license`) {
-			t.Errorf(`expected 'CHANGEFEED requires an enterprise license' error got: %+v`, err)
-		}
-		enableEnterprise()
-
-		// Watching system.jobs would create a cycle, since the resolved timestamp
-		// high-water mark is saved in it.
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR system.jobs`,
-		); !testutils.IsError(err, `not supported on system tables`) {
-			t.Errorf(`expected 'not supported on system tables' error got: %+v`, err)
-		}
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR bar`,
-		); !testutils.IsError(err, `table "bar" does not exist`) {
-			t.Errorf(`expected 'table "bar" does not exist' error got: %+v`, err)
-		}
-		sqlDB.Exec(t, `CREATE SEQUENCE seq`)
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR seq`,
-		); !testutils.IsError(err, `CHANGEFEED cannot target sequences: seq`) {
-			t.Errorf(`expected 'CHANGEFEED cannot target sequences: seq' error got: %+v`, err)
-		}
-		sqlDB.Exec(t, `CREATE VIEW vw AS SELECT a, b FROM foo`)
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR vw`,
-		); !testutils.IsError(err, `CHANGEFEED cannot target views: vw`) {
-			t.Errorf(`expected 'CHANGEFEED cannot target views: vw' error got: %+v`, err)
-		}
-		// Backup has the same bad error message #28170.
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR information_schema.tables`,
-		); !testutils.IsError(err, `"information_schema.tables" does not exist`) {
-			t.Errorf(`expected '"information_schema.tables" does not exist' error got: %+v`, err)
-		}
-
-		// TODO(dan): These two tests shouldn't need initial data in the table
-		// to pass.
-		sqlDB.Exec(t, `CREATE TABLE dec (a DECIMAL PRIMARY KEY)`)
-		sqlDB.Exec(t, `INSERT INTO dec VALUES (1.0)`)
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR dec WITH format=$1, confluent_schema_registry=$2`,
-			optFormatAvro, `bar`,
-		); !testutils.IsError(err, `pq: column a: decimal with no precision`) {
-			t.Errorf(`expected 'pq: column a: decimal with no precision' error got: %+v`, err)
-		}
-		sqlDB.Exec(t, `CREATE TABLE "uuid" (a UUID PRIMARY KEY)`)
-		sqlDB.Exec(t, `INSERT INTO "uuid" VALUES (gen_random_uuid())`)
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR "uuid" WITH format=$1, confluent_schema_registry=$2`,
-			optFormatAvro, `bar`,
-		); !testutils.IsError(err, `pq: column a: type UUID not yet supported with avro`) {
-			t.Errorf(`expected 'pq: column a: type UUID' error got: %+v`, err)
-		}
-
-		// Check that confluent_schema_registry is only accepted if format is
-		// avro.
-		s := f.Server()
-		sink, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
-		defer cleanup()
-		sink.Scheme = sinkSchemeExperimentalSQL
-		sink.Path = `d`
-		q := sink.Query()
-		q.Set(optConfluentSchemaRegistry, `foo`)
-		sink.RawQuery = q.Encode()
-		if _, err := sqlDB.DB.Exec(
-			`CREATE CHANGEFEED FOR foo INTO $1`, sink.String(),
-		); !testutils.IsError(err, `unknown sink query parameter: confluent_schema_registry`) {
-			t.Errorf(`expected "unknown sink query parameter: confluent_schema_registry" error got: %v`, err)
-		}
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR foo WITH format=nope`,
+	); !testutils.IsError(err, `unknown format: nope`) {
+		t.Errorf(`expected 'unknown format: nope' error got: %+v`, err)
 	}
 
-	t.Run(`sinkless`, sinklessTest(testFn))
-	t.Run(`enterprise`, enterpriseTest(testFn))
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR foo WITH envelope=diff`,
+	); !testutils.IsError(err, `envelope=diff is not yet supported`) {
+		t.Errorf(`expected 'envelope=diff is not yet supported' error got: %+v`, err)
+	}
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR foo WITH envelope=nope`,
+	); !testutils.IsError(err, `unknown envelope: nope`) {
+		t.Errorf(`expected 'unknown envelope: nope' error got: %+v`, err)
+	}
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR foo WITH resolved='-1s'`,
+	); !testutils.IsError(err, `negative durations are not accepted: resolved='-1s'`) {
+		t.Errorf(`expected 'negative durations are not accepted' error got: %+v`, err)
+	}
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR foo WITH cursor=$1`, timeutil.Now().Add(time.Hour),
+	); !testutils.IsError(err, `cannot specify timestamp in the future`) {
+		t.Errorf(`expected 'cannot specify timestamp in the future' error got: %+v`, err)
+	}
+
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR foo INTO ''`,
+	); !testutils.IsError(err, `omit the SINK clause`) {
+		t.Errorf(`expected 'omit the SINK clause' error got: %+v`, err)
+	}
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR foo INTO $1`, ``,
+	); !testutils.IsError(err, `omit the SINK clause`) {
+		t.Errorf(`expected 'omit the SINK clause' error got: %+v`, err)
+	}
+
+	enableEnterprise := utilccl.TestingDisableEnterprise()
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope`,
+	); !testutils.IsError(err, `CHANGEFEED requires an enterprise license`) {
+		t.Errorf(`expected 'CHANGEFEED requires an enterprise license' error got: %+v`, err)
+	}
+	enableEnterprise()
+
+	// Watching system.jobs would create a cycle, since the resolved timestamp
+	// high-water mark is saved in it.
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR system.jobs`,
+	); !testutils.IsError(err, `not supported on system tables`) {
+		t.Errorf(`expected 'not supported on system tables' error got: %+v`, err)
+	}
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR bar`,
+	); !testutils.IsError(err, `table "bar" does not exist`) {
+		t.Errorf(`expected 'table "bar" does not exist' error got: %+v`, err)
+	}
+	sqlDB.Exec(t, `CREATE SEQUENCE seq`)
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR seq`,
+	); !testutils.IsError(err, `CHANGEFEED cannot target sequences: seq`) {
+		t.Errorf(`expected 'CHANGEFEED cannot target sequences: seq' error got: %+v`, err)
+	}
+	sqlDB.Exec(t, `CREATE VIEW vw AS SELECT a, b FROM foo`)
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR vw`,
+	); !testutils.IsError(err, `CHANGEFEED cannot target views: vw`) {
+		t.Errorf(`expected 'CHANGEFEED cannot target views: vw' error got: %+v`, err)
+	}
+	// Backup has the same bad error message #28170.
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR information_schema.tables`,
+	); !testutils.IsError(err, `"information_schema.tables" does not exist`) {
+		t.Errorf(`expected '"information_schema.tables" does not exist' error got: %+v`, err)
+	}
+
+	// TODO(dan): These two tests shouldn't need initial data in the table
+	// to pass.
+	sqlDB.Exec(t, `CREATE TABLE dec (a DECIMAL PRIMARY KEY)`)
+	sqlDB.Exec(t, `INSERT INTO dec VALUES (1.0)`)
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR dec WITH format=$1, confluent_schema_registry=$2`,
+		optFormatAvro, `bar`,
+	); !testutils.IsError(err, `pq: column a: decimal with no precision`) {
+		t.Errorf(`expected 'pq: column a: decimal with no precision' error got: %+v`, err)
+	}
+	sqlDB.Exec(t, `CREATE TABLE "uuid" (a UUID PRIMARY KEY)`)
+	sqlDB.Exec(t, `INSERT INTO "uuid" VALUES (gen_random_uuid())`)
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR "uuid" WITH format=$1, confluent_schema_registry=$2`,
+		optFormatAvro, `bar`,
+	); !testutils.IsError(err, `pq: column a: type UUID not yet supported with avro`) {
+		t.Errorf(`expected 'pq: column a: type UUID' error got: %+v`, err)
+	}
+
+	// Check that confluent_schema_registry is only accepted if format is avro.
+	if _, err := sqlDB.DB.Exec(
+		`CREATE CHANGEFEED FOR foo INTO $1`, `experimental-sql://d/?confluent_schema_registry=foo`,
+	); !testutils.IsError(err, `unknown sink query parameter: confluent_schema_registry`) {
+		t.Errorf(`expected 'unknown sink query parameter: confluent_schema_registry' error got: %+v`, err)
+	}
+
+	// Check unavailable kafka.
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope'`,
+	); !testutils.IsError(err, `client has run out of available brokers`) {
+		t.Errorf(`expected 'client has run out of available brokers' error got: %+v`, err)
+	}
+
+	// kafka_topic_prefix was referenced by an old version of the RFC, it's
+	// "topic_prefix" now.
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?kafka_topic_prefix=foo`,
+	); !testutils.IsError(err, `unknown sink query parameter: kafka_topic_prefix`) {
+		t.Errorf(`expected 'unknown sink query parameter: kafka_topic_prefix' error got: %+v`, err)
+	}
+
+	// schema_topic will be implemented but isn't yet.
+	if _, err := db.Exec(
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?schema_topic=foo`,
+	); !testutils.IsError(err, `schema_topic is not yet supported`) {
+		t.Errorf(`expected 'schema_topic is not yet supported' error got: %+v`, err)
+	}
 }
 
 func TestChangefeedPermissions(t *testing.T) {

--- a/pkg/ccl/changefeedccl/validations_test.go
+++ b/pkg/ccl/changefeedccl/validations_test.go
@@ -72,8 +72,7 @@ func TestValidations(t *testing.T) {
 
 			v := Validators{
 				NewOrderValidator(`bank`),
-				// TODO(mrtracy): Disabled by #30902. Re-enabling is tracked by #31110.
-				// NewFingerprintValidator(db, `bank`, `fprint`, bank.Partitions()),
+				NewFingerprintValidator(db, `bank`, `fprint`, bank.Partitions()),
 			}
 			sqlDB.Exec(t, `CREATE TABLE fprint (id INT PRIMARY KEY, balance INT, payload STRING)`)
 			for {

--- a/pkg/ccl/changefeedccl/validator_test.go
+++ b/pkg/ccl/changefeedccl/validator_test.go
@@ -167,6 +167,7 @@ func TestFingerprintValidator(t *testing.T) {
 	t.Run(`missed_initial`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE missed_initial (k INT PRIMARY KEY, v INT)`)
 		v := NewFingerprintValidator(sqlDB.DB, `foo`, `missed_initial`, []string{`p`})
+		noteResolved(t, v, `p`, ts[0])
 		// Intentionally missing {"k":1,"v":1} at ts[1].
 		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
 		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
@@ -179,6 +180,7 @@ func TestFingerprintValidator(t *testing.T) {
 	t.Run(`missed_middle`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE missed_middle (k INT PRIMARY KEY, v INT)`)
 		v := NewFingerprintValidator(sqlDB.DB, `foo`, `missed_middle`, []string{`p`})
+		noteResolved(t, v, `p`, ts[0])
 		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
 		// Intentionally missing {"k":1,"v":2} at ts[2].
 		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
@@ -190,6 +192,28 @@ func TestFingerprintValidator(t *testing.T) {
 			`fingerprints did not match at `+ts[3].Prev().AsOfSystemTime()+
 				`: 1099511631581 vs 1099511631582`,
 		)
+	})
+	t.Run(`missed_end`, func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE missed_end (k INT PRIMARY KEY, v INT)`)
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `missed_end`, []string{`p`})
+		noteResolved(t, v, `p`, ts[0])
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
+		// Intentionally missing {"k":1,"v":3} at ts[3].
+		noteResolved(t, v, `p`, ts[3])
+		assertValidatorFailures(t, v,
+			`fingerprints did not match at `+ts[3].AsOfSystemTime()+
+				`: 1099511631580 vs 1099511631581`,
+		)
+	})
+	t.Run(`initial_scan`, func(t *testing.T) {
+		sqlDB.Exec(t, `CREATE TABLE initial_scan (k INT PRIMARY KEY, v INT)`)
+		v := NewFingerprintValidator(sqlDB.DB, `foo`, `initial_scan`, []string{`p`})
+		v.NoteRow(ignored, `[1]`, `{"k":1,"v":3}`, ts[4])
+		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[4])
+		noteResolved(t, v, `p`, ts[4])
+		assertValidatorFailures(t, v)
 	})
 	t.Run(`unknown_partition`, func(t *testing.T) {
 		v := NewFingerprintValidator(sqlDB.DB, `foo`, `unknown_partition`, []string{`p`})

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -328,6 +328,14 @@ func (r *Registry) maybeCancelJobs(ctx context.Context, nl NodeLiveness) {
 	if !liveness.IsLive(r.lenientNow(), r.clock.MaxOffset()) {
 		r.cancelAll(ctx)
 		r.mu.epoch = liveness.Epoch
+		return
+	}
+
+	// Finally, we cancel all jobs if the stopper is quiescing.
+	select {
+	case <-r.stopper.ShouldQuiesce():
+		r.cancelAll(ctx)
+	default:
 	}
 }
 

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -139,6 +139,11 @@ func (ctx *FlowCtx) TestingKnobs() TestingKnobs {
 	return ctx.testingKnobs
 }
 
+// Stopper returns the stopper for this flowCtx.
+func (ctx *FlowCtx) Stopper() *stop.Stopper {
+	return ctx.stopper
+}
+
 type flowStatus int
 
 // Flow status indicators.

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -162,7 +162,7 @@ func (b *bank) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Que
 	updateStmt, err := db.Prepare(`
 		UPDATE bank
 		SET balance = CASE id WHEN $1 THEN balance-$3 WHEN $2 THEN balance+$3 END
-		WHERE id IN ($1, $2) AND (SELECT balance >= $3 FROM bank WHERE id = $1)
+		WHERE id IN ($1, $2)
 	`)
 	if err != nil {
 		return workload.QueryLoad{}, err


### PR DESCRIPTION
There were also some roachtest changes in these PRs, but they had all kinds of merge conflicts due to some refactoring that was happening at the same time. The roachtest code in the release branch isn't really used for anything, so I resolved them by stripping all pkg/roachtest changes from the commits (as well as build, pkg/acceptance, pkg/ccl/acceptanceccl).

In the future, we should probably split any roachtest changes we make into their own commit in the PR.

Backport:
  * 1/1 commits from "cdc: Re-enable Fingerprint Validator" (#31774)
  * 1/1 commits from "roachtest: port docker-based cdc tests to roachtest" (#31707)
  * 1/1 commits from "cdc: Fix/Roachtest for CRDB Chaos" (#32069)
  * 1/1 commits from "changefeedccl: more quickly notice new kafka partitions" (#32297)

Please see individual PRs for details.

/cc @cockroachdb/release
