### PR TITLE
parser: remove some unnecessary allocations

### DIFF
--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -41,7 +41,7 @@ type Parser struct {
 
 // Parse parses the sql and returns a list of statements.
 func (p *Parser) Parse(sql string) (stmts tree.StatementList, err error) {
-	return parseWithDepth(1, sql)
+	return p.parseWithDepth(1, sql)
 }
 
 func (p *Parser) parseWithDepth(depth int, sql string) (stmts tree.StatementList, err error) {

--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf8"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -677,7 +678,7 @@ func (s *Scanner) scanIdent(lval *sqlSymType) {
 			}
 			b[i] = byte(c)
 		}
-		lval.str = string(b)
+		lval.str = *(*string)(unsafe.Pointer(&b))
 	} else {
 		// The string has unicode in it. No choice but to run Normalize.
 		lval.str = lex.NormalizeName(s.in[start:s.pos])
@@ -859,7 +860,7 @@ outer:
 	}
 
 	lval.id = BCONST
-	lval.str = string(buf)
+	lval.str = *(*string)(unsafe.Pointer(&buf))
 	return true
 }
 
@@ -895,7 +896,7 @@ outer:
 	}
 
 	lval.id = BITCONST
-	lval.str = string(buf)
+	lval.str = *(*string)(unsafe.Pointer(&buf))
 	return true
 }
 
@@ -994,6 +995,6 @@ outer:
 		return false
 	}
 
-	lval.str = string(buf)
+	lval.str = *(*string)(unsafe.Pointer(&buf))
 	return true
 }


### PR DESCRIPTION
Use an unsafe byte-slice-to-string conversion to avoid an extra
allocations during scanning.

```
name   old time/op    new time/op    delta
Parse    33.7µs ± 1%    33.7µs ± 3%     ~     (p=0.886 n=4+4)

name   old alloc/op   new alloc/op   delta
Parse    5.62kB ± 0%    5.54kB ± 0%   -1.56%  (p=0.029 n=4+4)

name   old allocs/op  new allocs/op  delta
Parse       104 ± 0%        92 ± 0%  -11.54%  (p=0.029 n=4+4)
```

Release note: None