### PR TITLE
sql: fix deadlock in VALIDATE CONSTRAINT

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -54,6 +54,8 @@ func (p *planner) validateCheckExpr(
 	if err != nil {
 		return err
 	}
+	defer rows.Close(ctx)
+
 	params := runParams{
 		ctx:             ctx,
 		extendedEvalCtx: &p.extendedEvalCtx,
@@ -125,20 +127,38 @@ func (p *planner) validateForeignKey(
 		query,
 	)
 
-	values, _ /* cols */, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Query(
-		ctx, "validate-fk", p.txn, query,
-	)
+	rows, err := p.delegateQuery(ctx, "ALTER TABLE VALIDATE", query, nil, nil)
 	if err != nil {
 		return err
 	}
 
-	if len(values) > 0 {
+	rows, err = p.optimizePlan(ctx, rows, allColumns(rows))
+	if err != nil {
+		return err
+	}
+	defer rows.Close(ctx)
+
+	params := runParams{
+		ctx:             ctx,
+		extendedEvalCtx: &p.extendedEvalCtx,
+		p:               p,
+	}
+	if err := startPlan(params, rows); err != nil {
+		return err
+	}
+	next, err := rows.Next(params)
+	if err != nil {
+		return err
+	}
+
+	if next {
+		values := rows.Values()
 		var pairs bytes.Buffer
-		for i := range values[0] {
+		for i := range values {
 			if i > 0 {
 				pairs.WriteString(", ")
 			}
-			pairs.WriteString(fmt.Sprintf("%s=%v", srcIdx.ColumnNames[i], values[0][i]))
+			pairs.WriteString(fmt.Sprintf("%s=%v", srcIdx.ColumnNames[i], values[i]))
 		}
 		return pgerror.NewErrorf(pgerror.CodeForeignKeyViolationError,
 			"foreign key violation: %q row %s has no match in %q",

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -751,3 +751,29 @@ query TT
 SELECT status, description FROM [SHOW JOBS] ORDER BY job_id DESC LIMIT 1
 ----
 succeeded  ALTER TABLE test.public.customers ADD COLUMN i INT DEFAULT 5;ALTER TABLE test.public.customers ADD COLUMN j INT AS (i - 1) STORED;ALTER TABLE test.public.customers ADD COLUMN d INT DEFAULT 15, ADD COLUMN e INT AS (d + j) STORED
+
+# VALIDATE CONSTRAINT will not hang when executed in the same txn as
+# a schema change in the same txn #32118
+subtest validate_in_schema_change_txn
+
+statement ok
+CREATE TABLE products (sku STRING PRIMARY KEY, upc STRING UNIQUE, vendor STRING)
+
+statement ok
+CREATE TABLE orders2 (
+  id INT PRIMARY KEY,
+  product STRING DEFAULT 'sprockets',
+  INDEX (product)
+)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE orders2 ADD FOREIGN KEY (product) REFERENCES products
+
+statement ok
+ALTER TABLE orders2 VALIDATE CONSTRAINT fk_product_ref_products
+
+statement ok
+COMMIT


### PR DESCRIPTION
This is present because of the call to the InternalExecutor
which has a limitation that while it can reuse a user transaction
it cannot reuse a TableCollection associated with a transaction.
Therefore if a user runs a schema change before a VALIDATE
in the same transaction the transaction can get deadlocked on:
the transaction having an outstanding intent on the table, and
the InternalExecutor triggering a table lease acquisition on the
table.

Stop using the InternalExecutor in VALIDATE CONSTRAINT.

Added the missing call to rows.Close() in validateCheckExpr()

related to #32118

Release note (sql change): Fix deadlock when using
ALTER TABLE VALIDATE CONSTRAINT in a transaction with a schema change.