### PR TITLE
ui: CachedQuery implementation + initial set of queries

### DIFF
--- a/pkg/ui/src/redux/apiQueries.ts
+++ b/pkg/ui/src/redux/apiQueries.ts
@@ -1,0 +1,200 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+import _ from "lodash";
+import moment from "moment";
+import { call, put } from "redux-saga/effects";
+import { hashHistory } from "react-router";
+import { push } from "react-router-redux";
+
+import { CachedQuery, keyedQuery } from "./cachedQuery";
+import { getLoginPage } from "src/redux/login";
+import * as api from "src/util/api";
+import { versionCheck } from "src/util/cockroachlabsAPI";
+import { INodeStatus, RollupStoreMetrics } from "src/util/proto";
+import * as protos from "src/js/protos";
+
+// Simple API Queries with default settings.
+
+export const clusterQuery = new CachedQuery("cluster", () => api.getCluster(null));
+export const eventsQuery = new CachedQuery("events", () => api.getEvents(null));
+export const raftQuery = new CachedQuery("raft", () => api.raftDebug(null));
+export const versionQuery = new CachedQuery("version", () => versionCheck(null));
+export const locationsQuery = new CachedQuery("locations", () => api.getLocations(null));
+export const databasesQuery = new CachedQuery("databases", () => api.getDatabaseList(null));
+export const nonTableStatsQuery = new CachedQuery("nonTableStats", () => api.getNonTableStats(null));
+export const livenessQuery = new CachedQuery("liveness", () => api.getLiveness(null));
+
+// The health query, executed every 2 seconds as a sort of canary check, is
+// also responsible for detecting unauthorized errors and redirecting to the
+// login page.
+export const healthQuery = new CachedQuery<protos.cockroach.server.serverpb.HealthResponse>(
+  "health",
+  function *(): any {
+    try {
+      return yield call(api.getHealth, null);
+    } catch (e) {
+      if (e instanceof Error) {
+        if (e.message === "Unauthorized") {
+          const location = hashHistory.getCurrentLocation();
+          if (location && !location.pathname.startsWith("/login")) {
+                put(push(getLoginPage(location)));
+          }
+        }
+      }
+      // Rethrow error to query manager.
+      throw e;
+    }
+  },
+  {
+    refreshInterval: moment.duration(2, "s"),
+  },
+);
+
+// Nodes query processes the raw response from the server before caching.
+export const nodesQuery = new CachedQuery<INodeStatus[]>("nodes", function *() {
+  const response: api.NodesResponseMessage = yield api.getNodes(null);
+  return _.map(response.nodes, (n) => {
+    RollupStoreMetrics(n);
+    return n;
+  });
+});
+
+// Queries with non-default timing options.
+
+export const settingsQuery = new CachedQuery(
+  "settings",
+  () => api.getSettings(null, moment.duration(1, "m")),
+);
+
+export const statementsQuery = new CachedQuery(
+  "statements",
+  () => api.getStatements(moment.duration(1, "m")),
+  {
+    refreshInterval: moment.duration(5, "m"),
+  },
+);
+
+export const dataDistributionQuery = new CachedQuery(
+  "dataDistribution",
+  () => api.getDataDistribution(),
+  {
+    refreshInterval: moment.duration(2, "m"),
+  },
+);
+
+export function databaseDetailsQuery(dbName: string) {
+  return keyedQuery(
+    "databaseDetails." + dbName,
+    () => {
+      const request = new protos.cockroach.server.serverpb.DatabaseDetailsRequest({
+        database: dbName,
+      });
+      return api.getDatabaseDetails(request);
+    },
+  );
+}
+
+export function tableDetailsQuery(dbName: string, tblName: string) {
+  return keyedQuery(
+    `tableDetails.${encodeURIComponent(dbName)}.${encodeURIComponent(tblName)}`,
+    () => {
+      const request = new protos.cockroach.server.serverpb.TableDetailsRequest({
+        database: dbName,
+        table: tblName,
+      });
+      return api.getTableDetails(request);
+    },
+  );
+}
+
+export function tableStatsQuery(dbName: string, tblName: string) {
+  return keyedQuery(
+    `tableStats.${encodeURIComponent(dbName)}.${encodeURIComponent(tblName)}`,
+    () => {
+      const request = new protos.cockroach.server.serverpb.TableStatsRequest({
+        database: dbName,
+        table: tblName,
+      });
+      api.getTableStats(request);
+    },
+  );
+}
+
+export const jobsKey = (status: string, type: protos.cockroach.sql.jobs.jobspb.Type, limit: number) =>
+  `${encodeURIComponent(status)}/${encodeURIComponent(type.toString())}/${encodeURIComponent(limit.toString())}`;
+
+export function jobsQuery(request: api.JobsRequestMessage) {
+  return keyedQuery(
+    "jobs." + jobsKey(request.status, request.type, request.limit),
+    () => api.getJobs(request),
+  );
+}
+
+export function problemRangesQuery(nodeID: string) {
+  return keyedQuery(
+    "problemRanges." + _.isEmpty(nodeID) ? "all" : nodeID,
+    () => {
+      const req = new protos.cockroach.server.serverpb.ProblemRangesRequest({
+        node_id: nodeID,
+      });
+      return api.getProblemRanges(req, moment.duration(1, "m"));
+    },
+  );
+}
+
+export function certificatesQuery(req: api.CertificatesRequestMessage) {
+  return keyedQuery(
+    "certificates." + _.isEmpty(req.node_id) ? "none" : req.node_id,
+    () => api.getCertificates(req),
+    {
+      refreshInterval: moment.duration(1, "m"),
+    },
+  );
+}
+
+export function rangeQuery(req: api.RangeRequestMessage) {
+  return keyedQuery(
+    "range." + _.isNil(req.range_id) ? "none" : req.range_id.toString(),
+    () => api.getRange(req, moment.duration(1, "m")),
+  );
+}
+
+export function allocatorRangeQuery(req: api.AllocatorRangeRequestMessage) {
+  return keyedQuery(
+    "allocatorRange." + _.isNil(req.range_id) ? "none" : req.range_id.toString(),
+    () => api.getAllocatorRange(req, moment.duration(1, "m")),
+  );
+}
+
+export function rangeLogQuery(req: api.RangeLogRequestMessage) {
+  return keyedQuery(
+    "rangeLog." + _.isNil(req.range_id) ? "none" : req.range_id.toString(),
+    () => api.getRangeLog(req, moment.duration(5, "m")),
+  );
+}
+
+export function commandQueueQuery(req: api.CommandQueueRequestMessage) {
+  return keyedQuery(
+    "commandQueue." + _.isNil(req.range_id) ? "none" : req.range_id.toString(),
+    () => api.getCommandQueue(req, moment.duration(1, "m")),
+  );
+}
+
+export function storesQuery(req: api.StoresRequestMessage) {
+  return keyedQuery(
+    "stores." + _.isNil(req.node_id) ? "none" : req.node_id.toString(),
+    () => api.getStores(req, moment.duration(1, "m")),
+  );
+}

--- a/pkg/ui/src/redux/cachedQuery.spec.ts
+++ b/pkg/ui/src/redux/cachedQuery.spec.ts
@@ -1,0 +1,145 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+import { assert } from "chai";
+import _ from "lodash";
+import { combineReducers } from "redux";
+import { queryManagerSaga } from "./queryManager/saga";
+import { defaultCachedQueryOptions, CachedQuery, cachedQueryResultReducer, keyedQuery } from "./cachedQuery";
+import { refresh } from "./queryManager/saga";
+import { delay } from "redux-saga";
+import { call } from "redux-saga/effects";
+
+import { expectSaga } from "redux-saga-test-plan";
+import { queryManagerReducer } from "./queryManager/reducer";
+import * as moment from "moment";
+
+describe("cachedQuery", function() {
+  it("has correct defaults for refreshInterval/retryDelay", function () {
+    const query = new CachedQuery("test", () => null);
+    assert.equal(query.refreshInterval, defaultCachedQueryOptions.refreshInterval);
+    assert.equal(query.retryDelay, defaultCachedQueryOptions.retryDelay);
+  });
+
+  it("correctly assigns refreshInterval/retryDelay", function () {
+    const query = new CachedQuery("test", () => null, {
+      refreshInterval: moment.duration(50, "s"),
+      retryDelay: moment.duration(75, "s"),
+    });
+    assert.equal(query.refreshInterval.asMilliseconds(), 50000);
+    assert.equal(query.retryDelay.asMilliseconds(), 75000);
+  });
+
+  it("correctly overwrites values", function() {
+    let x = 0;
+    const countQ = new CachedQuery("count", () => {
+      x++;
+      return x;
+    });
+    return expectSaga(queryManagerSaga)
+      .withReducer(combineReducers({
+        cachedDataNew: cachedQueryResultReducer,
+        queryManager: queryManagerReducer,
+      }))
+      .dispatch(refresh(countQ))
+      .dispatch(refresh(countQ))
+      .dispatch(refresh(countQ))
+      .run()
+      .then(runResult => {
+        assert.equal(countQ.selectResult(runResult.storeState), 3);
+      });
+  });
+
+  it("correctly sets and selects results and errors", function() {
+    const genQ = new CachedQuery<string>(
+      "id1",
+      function *() {
+        yield call(delay, 0);
+        return "value";
+      },
+    );
+
+    const promiseQ = new CachedQuery(
+      "id2",
+      function() {
+        return new Promise((resolve, _reject) => setTimeout(() => resolve("fulfilled"), 1));
+      },
+    );
+
+    const testErr = new Error("error");
+    const errorQ = new CachedQuery(
+      "id3",
+      function() {
+        throw testErr;
+      },
+    );
+
+    const errorPromiseQ = new CachedQuery(
+      "id4",
+      function() {
+        return new Promise((_resolve, reject) => setTimeout(() => reject(testErr), 1));
+      },
+    );
+
+    return expectSaga(queryManagerSaga)
+      .withReducer(combineReducers({
+        cachedDataNew: cachedQueryResultReducer,
+        queryManager: queryManagerReducer,
+      }))
+      .dispatch(refresh(genQ))
+      .dispatch(refresh(errorQ))
+      .dispatch(refresh(promiseQ))
+      .dispatch(refresh(errorPromiseQ))
+      .delay(5)
+      .run()
+      .then(runResult => {
+        assert.equal(genQ.selectResult(runResult.storeState), "value");
+        assert.isNull(genQ.selectError(runResult.storeState));
+
+        assert.equal(promiseQ.selectResult(runResult.storeState), "fulfilled");
+        assert.isNull(promiseQ.selectError(runResult.storeState));
+
+        assert.isUndefined(errorQ.selectResult(runResult.storeState));
+        assert.equal(errorQ.selectError(runResult.storeState), testErr);
+
+        assert.isUndefined(errorPromiseQ.selectResult(runResult.storeState));
+        assert.equal(errorPromiseQ.selectError(runResult.storeState), testErr);
+      });
+  });
+});
+
+describe("keyedQuery", function() {
+  it("correctly memoizes queries", function() {
+    const kq1 = keyedQuery("testkey.1", () => "val1");
+    const kq2 = keyedQuery("testkey.2", () => "val2");
+    const kq3 = keyedQuery("testkey.1", () => "val1");
+    assert.equal(kq1, kq3);
+    assert.notEqual(kq1, kq2);
+  });
+
+  it("has correct defaults for refreshInterval/retryDelay", function () {
+    const query = keyedQuery("testkey.defaultoptions", () => "val1");
+    assert.equal(query.refreshInterval, defaultCachedQueryOptions.refreshInterval);
+    assert.equal(query.retryDelay, defaultCachedQueryOptions.retryDelay);
+  });
+
+  it("correctly assigns refreshInterval/retryDelay", function () {
+    const query = keyedQuery("testkey.customoptions", () => "val2", {
+      refreshInterval: moment.duration(50, "s"),
+      retryDelay: moment.duration(75, "s"),
+    });
+    assert.equal(query.refreshInterval.asMilliseconds(), 50000);
+    assert.equal(query.retryDelay.asMilliseconds(), 75000);
+  });
+});

--- a/pkg/ui/src/redux/cachedQuery.ts
+++ b/pkg/ui/src/redux/cachedQuery.ts
@@ -1,0 +1,152 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+/**
+ * This module maintains the state of read-only data fetched from the cluster.
+ * Data is fetched from an API endpoint in either 'util/api' or
+ * 'util/cockroachlabsAPI'
+ */
+
+import _ from "lodash";
+import { Action } from "redux";
+import moment from "moment";
+import { call, put, select } from "redux-saga/effects";
+
+import { ManagedQuery } from "src/redux/queryManager/saga";
+import nextState from "src/util/nextState";
+import { AdminUIState } from "./state";
+
+import { PayloadAction } from "src/interfaces/action";
+
+const SET_STATE = "cockroachui/CachedQueryState/SET_STATE";
+
+export interface CachedQueryResultState {
+  [key: string]: any;
+}
+
+export interface CachedQueryPayload {
+  key: string;
+  result: any;
+}
+
+// Reducer that handles updates to cached query results.
+export function cachedQueryResultReducer(
+  state: CachedQueryResultState = {}, action: Action,
+): CachedQueryResultState {
+  if (_.isNil(action)) {
+    return state;
+  }
+
+  switch (action.type) {
+    case SET_STATE:
+      const { payload } = action as PayloadAction<CachedQueryPayload>;
+      return nextState(state, {
+        [payload.key]: payload.result,
+      });
+    default:
+      return state;
+  }
+}
+
+export function setResult<TResult>(
+  query: CachedQuery<TResult>, result: any,
+): PayloadAction<CachedQueryPayload> {
+  return {
+    type: SET_STATE,
+    payload: {
+      key: query.id,
+      result,
+    },
+  };
+}
+
+interface CachedQueryOptions {
+  // The interval at which this query should be refreshed if it is being
+  // auto-refreshed. Default is ten seconds.
+  refreshInterval?: moment.Duration;
+  // The delay after which an auto-refreshing query will be retried after
+  // a failure. Default is two seconds.
+  retryDelay?: moment.Duration;
+}
+
+export const defaultCachedQueryOptions: CachedQueryOptions = {
+  refreshInterval: moment.duration(10, "s"),
+  retryDelay: moment.duration(2, "s"),
+};
+
+// CachedQuery represents the simplest expression of a ManagedQuery: a function
+// which makes one remote request and stores the result of that request without
+// modification. The function provided to CachedQuery can return either a plain
+// result, a promise for a result, or can be generator function which eventully
+// returns the result
+//
+// CachedQuery also provides two selectors which can be used to select (from
+// AdminUIState) either the currently cached result of the query *or* the most
+// recently encountered error when trying to query.
+export class CachedQuery<TResult> implements ManagedQuery {
+  // The interval at which this query should be refreshed if it is being
+  // auto-refreshed. Default is ten seconds.
+  public refreshInterval: moment.Duration;
+  // The delay after which an auto-refreshing query will be retried after
+  // a failure. Default is two seconds.
+  public retryDelay: moment.Duration;
+
+  public querySaga = (() => {
+    const self = this;
+    return function *(): any {
+      const result = yield call(self.query);=
+      yield put(setResult(self, result));
+    };
+  })();
+
+  public selectResult = (state: AdminUIState): TResult => {
+    return state.cachedQueries[this.id];
+  }
+
+  public selectError = (state: AdminUIState) => {
+    const queryData = state.queryManager[this.id];
+    return queryData ? queryData.lastError : undefined;
+  }
+
+  constructor(
+    public id: string,
+    private query: () => IterableIterator<any> | Promise<TResult> | TResult,
+    options?: CachedQueryOptions,
+  ) {
+    options = _.assign({}, defaultCachedQueryOptions, options);
+    this.refreshInterval = options.refreshInterval;
+    this.retryDelay = options.retryDelay;
+  }
+}
+
+// Keyed queries, where several related queries are maintained which hit the
+// same endpoint with different requests.
+// NOTE: This memoization function is the intersection of performance and
+// convenience; it uses a global variable. Its intention is to be used similarly
+// to template instantiation; that is, when calling keyedQuery with a specific
+// key, the expected result *must* be deterministic.
+const keyedQueryMemo: {[key: string]: CachedQuery<any>} = {};
+
+export function keyedQuery<TResult>(
+  key: string,
+  fn: () => IterableIterator<any> | Promise<TResult> | TResult,
+  options?: CachedQueryOptions,
+): CachedQuery<TResult> {
+  if (keyedQueryMemo[key]) {
+    return keyedQueryMemo[key];
+  }
+  const newQuery = new CachedQuery(key, fn, options);
+  keyedQueryMemo[key] = newQuery;
+  return newQuery;
+}

--- a/pkg/ui/src/redux/queryManager/saga.ts
+++ b/pkg/ui/src/redux/queryManager/saga.ts
@@ -24,7 +24,7 @@ export const DEFAULT_RETRY_DELAY = moment.duration(2, "s");
  * query will refresh as long as there is at least one auto_refresh() action
  * that has not been canceled by a stop_auto_refresh().
  */
-interface ManagedQuery {
+export interface ManagedQuery {
     // A string ID that distinguishes this query from all other queries.
     id: string;
     // The interval at which this query should be refreshed if it is being

--- a/pkg/ui/src/redux/state.ts
+++ b/pkg/ui/src/redux/state.ts
@@ -20,16 +20,19 @@ import createSagaMiddleware from "redux-saga";
 import thunk from "redux-thunk";
 
 import { apiReducersReducer, APIReducersState } from "./apiReducers";
+import { CachedQueryResultState, cachedQueryResultReducer } from "./cachedQuery";
 import { hoverReducer, HoverState } from "./hover";
 import { localSettingsReducer, LocalSettingsState } from "./localsettings";
 import { metricsReducer, MetricsState, queryMetricsSaga } from "./metrics";
 import { queryManagerReducer, QueryManagerState } from "./queryManager/reducer";
+import { queryManagerSaga} from "./queryManager/saga";
 import { timeWindowReducer, TimeWindowState } from "./timewindow";
 import { uiDataReducer, UIDataState } from "./uiData";
 import { loginReducer, LoginAPIState } from "./login";
 
 export interface AdminUIState {
     cachedData: APIReducersState;
+    cachedQueries: CachedQueryResultState;
     hover: HoverState;
     localSettings: LocalSettingsState;
     metrics: MetricsState;
@@ -48,6 +51,7 @@ export function createAdminUIStore() {
   const s: Store<AdminUIState> = createStore(
     combineReducers<AdminUIState>({
       cachedData: apiReducersReducer,
+      cachedQueries: cachedQueryResultReducer,
       hover: hoverReducer,
       localSettings: localSettingsReducer,
       metrics: metricsReducer,
@@ -75,6 +79,7 @@ export function createAdminUIStore() {
   );
 
   sagaMiddleware.run(queryMetricsSaga);
+  sagaMiddleware.run(queryManagerSaga);
   return s;
 }
 


### PR DESCRIPTION
Two commits:

+ First commit implements CachedQuery, which will be used to replace cachedDataReducers.
+ Second commit recreates existing cachedDataReducers in terms of CachedQueries, although that system is not yet replaced.