### PR TITLE
sql: fix the evaluation of CHECK after ON CONFLICT DO UPDATE SET

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -715,4 +715,16 @@ x
 2
 
 statement ok
-COMMIT;
+COMMIT
+
+subtest regression_32762
+
+statement ok
+CREATE TABLE t32762(x INT, y INT, UNIQUE (x,y), CONSTRAINT y_not_null CHECK (y IS NOT NULL))
+
+statement ok
+INSERT INTO t32762(x,y) VALUES (1,2) ON CONFLICT (x,y) DO UPDATE SET x = t32762.x;
+
+statement ok
+INSERT INTO t32762(x,y) VALUES (1,2) ON CONFLICT (x,y) DO UPDATE SET x = t32762.x
+


### PR DESCRIPTION
Fixes  #32762.

Release note (bug fix): CockroachDB now properly evaluates CHECK
constraints after a row conflict in INSERT ON CONFLICT, when the CHECK
constraint depends on a column not assigned by DO UPDATE SET.