### PR TITLE
storage: bump collectChecksumTimeout from 5s to 15s

### DIFF
--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -51,7 +51,7 @@ const (
 	// because the checksum might never be computed for a replica if that replica
 	// is caught up via a snapshot and never performs the ComputeChecksum
 	// operation.
-	collectChecksumTimeout = 5 * time.Second
+	collectChecksumTimeout = 15 * time.Second
 )
 
 // CheckConsistency runs a consistency check on the range. It first applies a


### PR DESCRIPTION
In recent nightly import tests, I'm seeing the consistency checker
occasionally fail to collect the checksum from its local replica.

Arguably 5s ought to be enough for this operation, but it's
understandable that when a 32mb sstable needs to be shoved through many
Raft groups at the same time first, it may not be.

Release note: None