### PR TITLE
build: better capture the output of tests into artifacts

### DIFF
--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -21,15 +21,15 @@ run ln -s cockroach-linux-2.6.32-gnu-amd64 cockroach  # For the tests that run w
 tc_end_block "Compile CockroachDB"
 
 tc_start_block "Compile acceptance tests"
-run build/builder.sh mkrelease "$type" -Otarget testbuild TAGS=acceptance PKG=./pkg/acceptance
+run script -t5 "$TMPDIR/acceptance-build.log" \
+	build/builder.sh mkrelease "$type" -Otarget testbuild TAGS=acceptance PKG=./pkg/acceptance
 tc_end_block "Compile acceptance tests"
 
 tc_start_block "Run acceptance tests"
 run cd pkg/acceptance
-run env TZ=America/New_York \
-	stdbuf -eL -oL \
-	./acceptance.test -l "$TMPDIR" -test.v -test.timeout 30m 2>&1 \
-	| tee "$TMPDIR/acceptance.log" \
+run script -t5 "$TMPDIR/acceptance.log" \
+	env TZ=America/New_York \
+	./acceptance.test -l "$TMPDIR" -test.v -test.timeout 30m \
 	| go-test-teamcity
 run cd ../..
 tc_end_block "Run acceptance tests"

--- a/build/teamcity-bench.sh
+++ b/build/teamcity-bench.sh
@@ -10,13 +10,14 @@ export TMPDIR=$PWD/artifacts/bench
 mkdir -p "$TMPDIR"
 
 tc_start_block "Compile C dependencies"
-run build/builder.sh make -Otarget c-deps
+run script -t5 artifacts/bench-build.log \
+	build/builder.sh \
+	make -Otarget c-deps
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Benchmarks"
-run build/builder.sh \
-	stdbuf -oL -eL \
-	make benchshort TESTFLAGS='-v' 2>&1 \
-	| tee artifacts/bench.log \
+run script -t5 artifacts/bench.log \
+	build/builder.sh \
+	make benchshort TESTFLAGS='-v' \
 	| go-test-teamcity
 tc_end_block "Run Benchmarks"

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -31,10 +31,10 @@ tc_start_block "Lint"
 #
 # TODO(benesch): once GOPATH/pkg goes away because Go static analysis tools can
 # rebuild on demand, remove this. Upstream issue: golang/go#25650.
-COCKROACH_BUILDER_CCACHE= build/builder.sh \
-	stdbuf -eL -oL \
-	make lint 2>&1 \
-	| tee artifacts/lint.log \
+run script -t5 artifacts/lint.log \
+    env COCKROACH_BUILDER_CCACHE= \
+    build/builder.sh \
+	make lint
 	| go-test-teamcity
 tc_end_block "Lint"
 
@@ -42,5 +42,7 @@ tc_start_block "Test web UI"
 # Run the UI tests. This logically belongs in teamcity-test.sh, but we do it
 # here to minimize total build time since this build has already generated the
 # UI.
-run build/builder.sh make -C pkg/ui
+run script -t5 artifacts/webui-check.log \
+	build/builder.sh \
+	make -C pkg/ui
 tc_end_block "Test web UI"

--- a/build/teamcity-local-roachtest.sh
+++ b/build/teamcity-local-roachtest.sh
@@ -10,23 +10,26 @@ maybe_ccache
 tc_end_block "Prepare environment"
 
 tc_start_block "Compile CockroachDB"
-run build/builder.sh make build
+run script -t5 artifacts/roachtest-compile-cockroach.log \
+	build/builder.sh \
+	make build
 tc_end_block "Compile CockroachDB"
 
 tc_start_block "Compile roachprod/workload/roachtest"
-run build/builder.sh make bin/roachprod bin/workload bin/roachtest
+run script -t5 artifacts/roachtest-compile.log \
+	build/builder.sh \
+	make bin/roachprod bin/workload bin/roachtest
 tc_end_block "Compile roachprod/workload/roachtest"
 
 tc_start_block "Run local roachtests"
 # TODO(peter,dan): curate a suite of the tests that works locally.
-run build/builder.sh \
-	stdbuf -oL -eL \
+run script -t5 artifacts/roachtest.log \
+	build/builder.sh \
 	./bin/roachtest run '(acceptance|kv/splits)' \
   --local \
   --cockroach "cockroach" \
   --roachprod "bin/roachprod" \
   --workload "bin/workload" \
   --artifacts artifacts \
-  --teamcity 2>&1 \
-	| tee artifacts/roachtest.log
+  --teamcity
 tc_end_block "Run local roachtests"

--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -14,19 +14,18 @@ export BUILDER_HIDE_GOPATH_SRC=0
 # tests that do require correlated subquery support, but only with the cost-
 # based optimizer.
 for config in local local-opt fakedist fakedist-opt fakedist-disk; do
-    build/builder.sh \
-        stdbuf -oL -eL \
-        make test TESTFLAGS="-v -bigtest -config ${config}" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteLogic$$' 2>&1 \
-        | tee "artifacts/${config}.log" \
+    script -t5 "artifacts/${config}.log" \
+		build/builder.sh \
+        make test TESTFLAGS="-v -bigtest -config ${config}" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteLogic$$' \
         | go-test-teamcity
 done
 
 # Need to specify the flex-types flag in order to skip past variations that have
 # numeric typing differences.
 for config in local-opt fakedist-opt; do
-    build/builder.sh \
-        stdbuf -oL -eL \
-        make test TESTFLAGS="-v -bigtest -config ${config} -flex-types" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteCorrelatedLogic$$' 2>&1 \
-        | tee "artifacts/${config}.log" \
+	# Note: we need -a here because the log files already exist after the executions above.
+	script -t5 -a "artifacts/${config}.log" \
+		build/builder.sh \
+        make test TESTFLAGS="-v -bigtest -config ${config} -flex-types" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteCorrelatedLogic$$' \
         | go-test-teamcity
 done

--- a/build/teamcity-test-deadlock.sh
+++ b/build/teamcity-test-deadlock.sh
@@ -15,9 +15,8 @@ run build/builder.sh make -Otarget c-deps
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Go tests with deadlock detection enabled"
-run build/builder.sh \
-	stdbuf -oL -eL \
-	make test TAGS=deadlock TESTFLAGS='-v' 2>&1 \
-	| tee artifacts/test.log \
+run script -t5 artifacts/test.log \
+	build/builder.sh \
+	make test TAGS=deadlock TESTFLAGS='-v' \
 	| go-test-teamcity
 tc_end_block "Run Go tests with deadlock detection enabled"

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -15,17 +15,19 @@ run build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=stress gith
 tc_end_block "Maybe stress pull request"
 
 tc_start_block "Compile C dependencies"
-run build/builder.sh make -Otarget c-deps
+run script -t5 artifacts/test-deps.log \
+	build/builder.sh make -Otarget c-deps
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Go tests"
-run build/builder.sh \
-	stdbuf -oL -eL \
-	make test TESTFLAGS='-v' 2>&1 \
-	| tee artifacts/test.log \
+run script -t5 artifacts/test.log \
+	build/builder.sh \
+	make test TESTFLAGS='-v' \
 	| go-test-teamcity
 tc_end_block "Run Go tests"
 
 tc_start_block "Run C++ tests"
-run build/builder.sh make check-libroach
+run script -t5 artifacts/test-cpp.log \
+	build/builder.sh \
+	make check-libroach
 tc_end_block "Run C++ tests"

--- a/build/teamcity-testlogic-verbose.sh
+++ b/build/teamcity-testlogic-verbose.sh
@@ -10,13 +10,14 @@ export TMPDIR=$PWD/artifacts/test
 mkdir -p "$TMPDIR"
 
 tc_start_block "Compile C dependencies"
-run build/builder.sh make -Otarget c-deps
+run script -t5 artifacts/test-deps.log \
+	build/builder.sh \
+	make -Otarget c-deps
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run TestLogic tests under verbose"
-run build/builder.sh \
-	stdbuf -oL -eL \
-	make testlogic TESTTIMEOUT=1h TESTFLAGS='--vmodule=*=10 -show-sql -test.v' 2>&1 \
-	| tee artifacts/test.log \
+run script -t5 artifacts/test.log \
+	build/builder.sh \
+	make testlogic TESTTIMEOUT=1h TESTFLAGS='--vmodule=*=10 -show-sql -test.v' \
 	| go-test-teamcity
 tc_end_block "Run TestLogic tests under verbose"

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -29,18 +29,19 @@ fi
 tc_end_block "Determine changed packages"
 
 tc_start_block "Compile C dependencies"
-run build/builder.sh make -Otarget c-deps GOFLAGS=-race
+run script -t5 artifacts/testrace-deps.log \
+	build/builder.sh \
+	make -Otarget c-deps GOFLAGS=-race
 tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Go tests under race detector"
-run build/builder.sh env \
-    COCKROACH_LOGIC_TESTS_SKIP=true \
-    stdbuf -oL -eL \
+run script -t5 artifacts/testrace.log \
+	build/builder.sh \
+	env COCKROACH_LOGIC_TESTS_SKIP=true \
     make testrace \
     PKG="$pkgspec" \
     TESTTIMEOUT=45m \
     TESTFLAGS='-v' \
-    USE_ROCKSDB_ASSERTIONS=1 2>&1 \
-	| tee artifacts/testrace.log \
+    USE_ROCKSDB_ASSERTIONS=1 \
 	| go-test-teamcity
 tc_end_block "Run Go tests under race detector"


### PR DESCRIPTION
Fixes #32399.

The previous code was not capturing the stdout/stderr interleaving in
a way compatible with `go-test-teamcity`. This patch improves the
situation by capturing the interleaving directly to artifacts via
`script`, and pass only stdout to `go-test-teamcity`.

Release note: None