### PR TITLE
sql: fix INSERT results incorrectly including mutation column values

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -371,7 +371,8 @@ type insertRun struct {
 	// rowIdxToRetIdx is the mapping from the ordering of rows in
 	// insertCols to the ordering in the result rows, used when
 	// rowsNeeded is set to populate resultRowBuffer and the row
-	// container.
+	// container. The return index is -1 if the column for the row
+	// index is not public.
 	rowIdxToRetIdx []int
 
 	// autoCommit indicates whether the last KV batch processed by
@@ -423,7 +424,12 @@ func (n *insertNode) startExec(params runParams) error {
 
 		n.run.rowIdxToRetIdx = make([]int, len(n.run.insertCols))
 		for i, col := range n.run.insertCols {
-			n.run.rowIdxToRetIdx[i] = colIDToRetIndex[col.ID]
+			if idx, ok := colIDToRetIndex[col.ID]; !ok {
+				// Column must be write only and not public.
+				n.run.rowIdxToRetIdx[i] = -1
+			} else {
+				n.run.rowIdxToRetIdx[i] = idx
+			}
 		}
 	}
 
@@ -549,8 +555,11 @@ func (n *insertNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	if n.run.rows != nil {
 		for i, val := range rowVals {
 			// The downstream consumer will want the rows in the order of
-			// the table descriptor, not that of insertCols. Reorder them.
-			n.run.resultRowBuffer[n.run.rowIdxToRetIdx[i]] = val
+			// the table descriptor, not that of insertCols. Reorder them
+			// and ignore non-public columns.
+			if idx := n.run.rowIdxToRetIdx[i]; idx >= 0 {
+				n.run.resultRowBuffer[idx] = val
+			}
 		}
 		if _, err := n.run.rows.AddRow(params.ctx, n.run.resultRowBuffer); err != nil {
 			return err

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -619,3 +619,20 @@ INSERT INTO t29494(x) VALUES (123) RETURNING *
 
 statement ok
 COMMIT
+
+subtest regression_32759
+
+statement ok
+CREATE TABLE t32759(x INT, y INT NOT NULL DEFAULT(10), z INT)
+
+statement ok
+BEGIN; ALTER TABLE t32759 DROP COLUMN y
+
+query II colnames
+INSERT INTO t32759(x, z) VALUES (1, 4) RETURNING *
+----
+x  z
+1  4
+
+statement ok
+COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -698,3 +698,21 @@ ROLLBACK; BEGIN; ALTER TABLE t29497 ADD COLUMN y INT NOT NULL DEFAULT 123
 
 statement error column "y" does not exist
 INSERT INTO t29497(x) VALUES (1) ON CONFLICT (x) DO UPDATE SET y = 456
+
+statement ok
+ROLLBACK
+
+subtest visible_returning_columns
+
+statement ok
+BEGIN; ALTER TABLE tc DROP COLUMN y
+
+query I colnames rowsort
+UPSERT INTO tc VALUES (1), (2) RETURNING *
+----
+x
+1
+2
+
+statement ok
+COMMIT;


### PR DESCRIPTION
Prevent inserted rows with default or computed columns in write-only
state from overwriting the table's first column's value.

Fixes #32759.

Release note: None