### PR TITLE
roachtest: remove stable vs unstable distinction

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -25,9 +25,8 @@ func registerAcceptance(r *registry) {
 	// local mode the acceptance tests should be configured to run within a
 	// minute or so as these tests are run on every merge to master.
 	spec := testSpec{
-		Name:   "acceptance",
-		Nodes:  nodes(4),
-		Stable: true, // DO NOT COPY to new tests
+		Name:  "acceptance",
+		Nodes: nodes(4),
 	}
 
 	testCases := []struct {
@@ -59,7 +58,6 @@ func registerAcceptance(r *registry) {
 		spec.SubTests = append(spec.SubTests, testSpec{
 			Name:    tc.name,
 			Timeout: 10 * time.Minute,
-			Stable:  true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				c.Wipe(ctx)
 				tc.fn(ctx, t, c)

--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -76,17 +76,15 @@ func registerAllocator(r *registry) {
 	}
 
 	r.Add(testSpec{
-		Name:   `upreplicate/1to3`,
-		Nodes:  nodes(3),
-		Stable: true, // DO NOT COPY to new tests
+		Name:  `upreplicate/1to3`,
+		Nodes: nodes(3),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runAllocator(ctx, t, c, 1, 10.0)
 		},
 	})
 	r.Add(testSpec{
-		Name:   `rebalance/3to5`,
-		Nodes:  nodes(5),
-		Stable: true, // DO NOT COPY to new tests
+		Name:  `rebalance/3to5`,
+		Nodes: nodes(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runAllocator(ctx, t, c, 3, 42.0)
 		},

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -27,9 +27,8 @@ import (
 
 func registerBackup(r *registry) {
 	r.Add(testSpec{
-		Name:   `backup2TB`,
-		Nodes:  nodes(10),
-		Stable: true, // DO NOT COPY to new tests
+		Name:  `backup2TB`,
+		Nodes: nodes(10),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			nodes := c.nodes
 
@@ -62,7 +61,6 @@ func registerBackup(r *registry) {
 	r.Add(testSpec{
 		Name:    `backupTPCC`,
 		Nodes:   nodes(3),
-		Stable:  false,
 		Timeout: 1 * time.Hour,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			c.Put(ctx, cockroach, "./cockroach")

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -117,18 +117,16 @@ func registerCancel(r *registry) {
 	}
 
 	r.Add(testSpec{
-		Name:   fmt.Sprintf("cancel/tpcc/distsql/w=%d,nodes=%d", warehouses, numNodes),
-		Nodes:  nodes(numNodes),
-		Stable: true, // DO NOT COPY to new tests
+		Name:  fmt.Sprintf("cancel/tpcc/distsql/w=%d,nodes=%d", warehouses, numNodes),
+		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCancel(ctx, t, c, queries, warehouses, true /* useDistsql */)
 		},
 	})
 
 	r.Add(testSpec{
-		Name:   fmt.Sprintf("cancel/tpcc/local/w=%d,nodes=%d", warehouses, numNodes),
-		Nodes:  nodes(numNodes),
-		Stable: true, // DO NOT COPY to new tests
+		Name:  fmt.Sprintf("cancel/tpcc/local/w=%d,nodes=%d", warehouses, numNodes),
+		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCancel(ctx, t, c, queries, warehouses, false /* useDistsql */)
 		},

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -315,7 +315,6 @@ func registerCDC(r *registry) {
 		Name:       "cdc/tpcc-1000",
 		MinVersion: "2.1.0",
 		Nodes:      nodes(4, cpu(16)),
-		Stable:     false,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -332,7 +331,6 @@ func registerCDC(r *registry) {
 		Name:       "cdc/initial-scan",
 		MinVersion: "2.1.0",
 		Nodes:      nodes(4, cpu(16)),
-		Stable:     false,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -349,7 +347,6 @@ func registerCDC(r *registry) {
 		Name:       "cdc/sink-chaos",
 		MinVersion: "2.1.0",
 		Nodes:      nodes(4, cpu(16)),
-		Stable:     true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -366,7 +363,6 @@ func registerCDC(r *registry) {
 		Name:       "cdc/crdb-chaos",
 		MinVersion: "2.1.0",
 		Nodes:      nodes(4, cpu(16)),
-		Stable:     true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -386,8 +382,7 @@ func registerCDC(r *registry) {
 		// TODO(mrtracy): This workload is designed to be running on a 20CPU nodes,
 		// but this cannot be allocated without some sort of configuration outside
 		// of this test. Look into it.
-		Nodes:  nodes(4, cpu(16)),
-		Stable: true,
+		Nodes: nodes(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             ledgerWorkloadType,
@@ -411,7 +406,6 @@ func registerCDC(r *registry) {
 		Name:       "cdc/bank",
 		MinVersion: "2.1.0",
 		Nodes:      nodes(4),
-		Stable:     true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCDCBank(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -30,7 +30,6 @@ func registerClearRange(r *registry) {
 			Timeout:    90 * time.Minute,
 			MinVersion: `v2.1.0`,
 			Nodes:      nodes(10),
-			Stable:     true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runClearRange(ctx, t, c, checks)
 			},

--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -112,15 +112,13 @@ func makeClockJumpTests() testSpec {
 	}
 
 	spec := testSpec{
-		Name:   "jump",
-		Stable: true, // DO NOT COPY to new tests
+		Name: "jump",
 	}
 
 	for i := range testCases {
 		tc := testCases[i]
 		spec.SubTests = append(spec.SubTests, testSpec{
-			Name:   tc.name,
-			Stable: true, // DO NOT COPY to new tests
+			Name: tc.name,
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runClockJump(ctx, t, c, tc)
 			},
@@ -132,9 +130,8 @@ func makeClockJumpTests() testSpec {
 
 func registerClock(r *registry) {
 	r.Add(testSpec{
-		Name:   "clock",
-		Nodes:  nodes(1),
-		Stable: true, // DO NOT COPY to new tests
+		Name:  "clock",
+		Nodes: nodes(1),
 		SubTests: []testSpec{
 			makeClockJumpTests(),
 			makeClockMonotonicTests(),

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -114,15 +114,13 @@ func makeClockMonotonicTests() testSpec {
 	}
 
 	spec := testSpec{
-		Name:   "monotonic",
-		Stable: true, // DO NOT COPY to new tests
+		Name: "monotonic",
 	}
 
 	for i := range testCases {
 		tc := testCases[i]
 		spec.SubTests = append(spec.SubTests, testSpec{
-			Name:   tc.name,
-			Stable: true, // DO NOT COPY to new tests
+			Name: tc.name,
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runClockMonotonicity(ctx, t, c, tc)
 			},

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -139,9 +139,8 @@ func registerCopy(r *registry) {
 	for _, inTxn := range []bool{true, false} {
 		inTxn := inTxn
 		r.Add(testSpec{
-			Name:   fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", rows, numNodes, inTxn),
-			Nodes:  nodes(numNodes),
-			Stable: true, // DO NOT COPY to new tests
+			Name:  fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", rows, numNodes, inTxn),
+			Nodes: nodes(numNodes),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runCopy(ctx, t, c, rows, inTxn)
 			},

--- a/pkg/cmd/roachtest/debug.go
+++ b/pkg/cmd/roachtest/debug.go
@@ -80,9 +80,8 @@ func registerDebug(r *registry) {
 
 	for _, n := range []int{3} {
 		r.Add(testSpec{
-			Name:   fmt.Sprintf("debug/nodes=%d", n),
-			Nodes:  nodes(n),
-			Stable: true, // DO NOT COPY to new tests
+			Name:  fmt.Sprintf("debug/nodes=%d", n),
+			Nodes: nodes(n),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runDebug(ctx, t, c)
 			},
@@ -148,9 +147,8 @@ func registerDebugHeap(r *registry) {
 
 	for _, n := range []int{3} {
 		r.Add(testSpec{
-			Name:   fmt.Sprintf("debug/heap/nodes=%d", n),
-			Nodes:  nodes(n),
-			Stable: true, // DO NOT COPY to new tests
+			Name:  fmt.Sprintf("debug/heap/nodes=%d", n),
+			Nodes: nodes(n),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runDebug(ctx, t, c)
 			},

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -241,9 +241,8 @@ func registerDecommission(r *registry) {
 	duration := time.Hour
 
 	r.Add(testSpec{
-		Name:   fmt.Sprintf("decommission/nodes=%d/duration=%s", numNodes, duration),
-		Nodes:  nodes(numNodes),
-		Stable: true, // DO NOT COPY to new tests
+		Name:  fmt.Sprintf("decommission/nodes=%d/duration=%s", numNodes, duration),
+		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {
 				duration = 3 * time.Minute

--- a/pkg/cmd/roachtest/disk_space.go
+++ b/pkg/cmd/roachtest/disk_space.go
@@ -321,7 +321,6 @@ func registerDiskUsage(r *registry) {
 				Name:       fmt.Sprintf("disk_space/tc=%s", testCase.name),
 				Nodes:      nodes(numNodes),
 				MinVersion: "2.1", // cockroach debug ballast
-				Stable:     true,  // DO NOT COPY to new tests
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					if local {
 						duration = 30 * time.Minute

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -174,7 +174,6 @@ func registerDrop(r *registry) {
 		Name:       fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
 		MinVersion: `v2.1.0`,
 		Nodes:      nodes(numNodes),
-		Stable:     true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			// NB: this is likely not going to work out in `-local` mode. Edit the
 			// numbers during iteration.

--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -24,9 +24,8 @@ import (
 
 func registerElectionAfterRestart(r *registry) {
 	r.Add(testSpec{
-		Name:   "election-after-restart",
-		Nodes:  nodes(3),
-		Stable: true, // DO NOT COPY to new tests
+		Name:  "election-after-restart",
+		Nodes: nodes(3),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			t.Status("starting up")
 			c.Put(ctx, cockroach, "./cockroach")

--- a/pkg/cmd/roachtest/encryption.go
+++ b/pkg/cmd/roachtest/encryption.go
@@ -92,7 +92,6 @@ func registerEncryption(r *registry) {
 			Name:       fmt.Sprintf("encryption/nodes=%d", n),
 			MinVersion: "v2.1.0",
 			Nodes:      nodes(n),
-			Stable:     true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runEncryption(ctx, t, c)
 			},

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -292,9 +292,8 @@ echo "ext {
 	}
 
 	r.Add(testSpec{
-		Name:   "hibernate",
-		Nodes:  nodes(1),
-		Stable: false,
+		Name:  "hibernate",
+		Nodes: nodes(1),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runHibernate(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -101,9 +101,8 @@ func registerHotSpotSplits(r *registry) {
 	concurrency := 128
 
 	r.Add(testSpec{
-		Name:   fmt.Sprintf("hotspotsplits/nodes=%d", numNodes),
-		Nodes:  nodes(numNodes),
-		Stable: true, // DO NOT COPY to new tests
+		Name:  fmt.Sprintf("hotspotsplits/nodes=%d", numNodes),
+		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {
 				concurrency = 32

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -79,7 +79,6 @@ func registerImportTPCH(r *registry) {
 			Name:    fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),
 			Nodes:   nodes(item.nodes),
 			Timeout: item.timeout,
-			Stable:  true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				c.Put(ctx, cockroach, "./cockroach")
 				c.Start(ctx, t)

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -127,9 +127,8 @@ func registerInterleaved(r *registry) {
 	}
 
 	r.Add(testSpec{
-		Name:   "interleavedpartitioned",
-		Nodes:  nodes(12, geo(), zones("us-west1-b,us-east4-b,us-central1-a")),
-		Stable: false,
+		Name:  "interleavedpartitioned",
+		Nodes: nodes(12, geo(), zones("us-west1-b,us-east4-b,us-central1-a")),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runInterleaved(ctx, t, c,
 				config{

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -64,7 +64,6 @@ func registerKV(r *registry) {
 					Name:       fmt.Sprintf("kv%d/encrypt=%t/nodes=%d", p, e, n),
 					MinVersion: minVersion,
 					Nodes:      nodes(n+1, cpu(8)),
-					Stable:     true, // DO NOT COPY to new tests
 					Run: func(ctx context.Context, t *test, c *cluster) {
 						runKV(ctx, t, c, p, startArgs(fmt.Sprintf("--encrypt=%t", e)))
 					},
@@ -79,7 +78,6 @@ func registerKVQuiescenceDead(r *registry) {
 		Name:       "kv/quiescence/nodes=3",
 		Nodes:      nodes(4),
 		MinVersion: "2.1.0",
-		Stable:     false, // added 6/7/2018
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if !c.isLocal() {
 				c.RemountNoBarrier(ctx)
@@ -173,7 +171,6 @@ func registerKVSplits(r *registry) {
 			Name:    fmt.Sprintf("kv/splits/nodes=3/quiesce=%t", item.quiesce),
 			Timeout: item.timeout,
 			Nodes:   nodes(4),
-			Stable:  false, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				nodes := c.nodes - 1
 				c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -139,7 +139,6 @@ func registerRebalanceLoad(r *registry) {
 		Name:       `rebalance-leases-by-load`,
 		Nodes:      nodes(4), // the last node is just used to generate load
 		MinVersion: "2.1.0",
-		Stable:     true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {
 				concurrency = 32
@@ -152,7 +151,6 @@ func registerRebalanceLoad(r *registry) {
 		Name:       `rebalance-replicas-by-load`,
 		Nodes:      nodes(7), // the last node is just used to generate load
 		MinVersion: "2.1.0",
-		Stable:     false, // TODO(a-robinson): Promote to stable
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {
 				concurrency = 32

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -224,7 +224,6 @@ func registerRestore(r *registry) {
 			Name:    fmt.Sprintf("restore2TB/nodes=%d", item.nodes),
 			Nodes:   nodes(item.nodes),
 			Timeout: item.timeout,
-			Stable:  true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				c.Put(ctx, cockroach, "./cockroach")
 				c.Start(ctx, t)

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -74,9 +74,8 @@ func registerRoachmart(r *registry) {
 	for _, v := range []bool{true, false} {
 		v := v
 		r.Add(testSpec{
-			Name:   fmt.Sprintf("roachmart/partition=%v", v),
-			Nodes:  nodes(9, geo(), zones("us-central1-b,us-west1-b,europe-west2-b")),
-			Stable: true, // DO NOT COPY to new tests
+			Name:  fmt.Sprintf("roachmart/partition=%v", v),
+			Nodes: nodes(9, geo(), zones("us-central1-b,us-west1-b,europe-west2-b")),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runRoachmart(ctx, t, c, v)
 			},

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -49,7 +49,6 @@ func registerScaleData(r *registry) {
 				Name:    fmt.Sprintf("scaledata/%s/nodes=%d", app, n),
 				Timeout: 2 * duration,
 				Nodes:   nodes(n + 1),
-				Stable:  true, // DO NOT COPY to new tests
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runSqlapp(ctx, t, c, app, flags, duration)
 				},

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -27,9 +27,8 @@ import (
 
 func registerSchemaChangeKV(r *registry) {
 	r.Add(testSpec{
-		Name:   `schemachange/mixed/kv`,
-		Nodes:  nodes(5),
-		Stable: true, // DO NOT COPY to new tests
+		Name:  `schemachange/mixed/kv`,
+		Nodes: nodes(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup`
 

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -207,7 +207,6 @@ func registerLargeRange(r *registry) {
 		Name:    fmt.Sprintf("splits/largerange/size=%s,nodes=%d", bytesStr(size), numNodes),
 		Nodes:   nodes(numNodes),
 		Timeout: 5 * time.Hour,
-		Stable:  true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runLargeRangeSplits(ctx, t, c, size)
 		},

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -109,7 +109,6 @@ func registerSQLsmith(r *registry) {
 	r.Add(testSpec{
 		Name:       "sqlsmith",
 		Nodes:      nodes(1),
-		Stable:     false,
 		MinVersion: "2.2.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runSQLsmith(ctx, t, c)

--- a/pkg/cmd/roachtest/synctest.go
+++ b/pkg/cmd/roachtest/synctest.go
@@ -36,7 +36,6 @@ fi
 		Name:       "synctest",
 		MinVersion: `v2.2.0`,
 		Nodes:      nodes(1),
-		Stable:     true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			n := c.Node(1)
 			tmpDir, err := ioutil.TempDir("", "synctest")

--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -131,8 +131,6 @@ func registerSysbench(r *registry) {
 		r.Add(testSpec{
 			Name:  fmt.Sprintf("sysbench/%s/nodes=%d", w, n),
 			Nodes: nodes(n+1, cpu(cpus)),
-			// TODO(nvanbenschoten): Wait for this to stabilize.
-			Stable: false,
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runSysbench(ctx, t, c, opts)
 			},

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -38,21 +38,12 @@ func TestRegistryRun(t *testing.T) {
 	r := newRegistry()
 	r.out = ioutil.Discard
 	r.Add(testSpec{
-		Name:   "pass",
-		Stable: true,
+		Name: "pass",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 		},
 	})
 	r.Add(testSpec{
-		Name:   "fail",
-		Stable: true,
-		Run: func(ctx context.Context, t *test, c *cluster) {
-			t.Fatal("failed")
-		},
-	})
-	r.Add(testSpec{
-		Name:   "fail-unstable",
-		Stable: false,
+		Name: "fail",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			t.Fatal("failed")
 		},
@@ -105,8 +96,7 @@ func TestRegistryStatus(t *testing.T) {
 	r.out = &buf
 	r.statusInterval = 20 * time.Millisecond
 	r.Add(testSpec{
-		Name:   `status`,
-		Stable: true,
+		Name: `status`,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			t.Status("waiting")
 			var wg sync.WaitGroup
@@ -159,8 +149,7 @@ func TestRegistryStatusUnknown(t *testing.T) {
 	r.statusInterval = 20 * time.Millisecond
 
 	r.Add(testSpec{
-		Name:   `status`,
-		Stable: true,
+		Name: `status`,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			for i := 0; i < 100; i++ {
 				time.Sleep(r.statusInterval)
@@ -191,7 +180,6 @@ func TestRegistryRunTimeout(t *testing.T) {
 	r.Add(testSpec{
 		Name:    `timeout`,
 		Timeout: 10 * time.Millisecond,
-		Stable:  true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			<-ctx.Done()
 		},
@@ -211,11 +199,9 @@ func TestRegistryRunSubTestFailed(t *testing.T) {
 	r := newRegistry()
 	r.out = &buf
 	r.Add(testSpec{
-		Name:   "parent",
-		Stable: true,
+		Name: "parent",
 		SubTests: []testSpec{{
-			Name:   "child",
-			Stable: true,
+			Name: "child",
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				t.Fatal("failed")
 			},
@@ -244,9 +230,8 @@ func TestRegistryRunClusterExpired(t *testing.T) {
 	r.out = &buf
 
 	r.Add(testSpec{
-		Name:   `expired`,
-		Stable: true,
-		Nodes:  nodes(1, nodeLifetimeOption(time.Second)),
+		Name:  `expired`,
+		Nodes: nodes(1, nodeLifetimeOption(time.Second)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			panic("not reached")
 		},

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -132,7 +132,6 @@ func registerTPCC(r *registry) {
 		// releases will support on this hardware.
 		MinVersion: "2.1.0",
 		Nodes:      nodes(4, cpu(16)),
-		Stable:     false,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			warehouses := 1400
 			runTPCC(ctx, t, c, tpccOptions{
@@ -141,9 +140,8 @@ func registerTPCC(r *registry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:   "tpcc-nowait/nodes=3/w=1",
-		Nodes:  nodes(4, cpu(16)),
-		Stable: false,
+		Name:  "tpcc-nowait/nodes=3/w=1",
+		Nodes: nodes(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: 1,
@@ -154,9 +152,8 @@ func registerTPCC(r *registry) {
 	})
 
 	r.Add(testSpec{
-		Name:   "tpcc/w=100/nodes=3/chaos=true",
-		Nodes:  nodes(4),
-		Stable: false,
+		Name:  "tpcc/w=100/nodes=3/chaos=true",
+		Nodes: nodes(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			duration := 30 * time.Minute
 			runTPCC(ctx, t, c, tpccOptions{
@@ -339,9 +336,8 @@ func registerTPCCBenchSpec(r *registry, b tpccBenchSpec) {
 	nodes := nodes(numNodes, opts...)
 
 	r.Add(testSpec{
-		Name:   name,
-		Nodes:  nodes,
-		Stable: true, // DO NOT COPY to new tests
+		Name:  name,
+		Nodes: nodes,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCCBench(ctx, t, c, b)
 		},

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -230,7 +230,6 @@ func registerVersion(r *registry) {
 			Name:       fmt.Sprintf("version/mixedWith=%s/nodes=%d", version, n),
 			MinVersion: "v2.1.0",
 			Nodes:      nodes(n + 1),
-			Stable:     true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runVersion(ctx, t, c, version)
 			},


### PR DESCRIPTION
Remove the distinction between stable vs unstable tests. That
distinction had more value in the past when it was useful to delineate
which tests were stable and which weren't and when there were more
failures due to the test infrastructure. Now that most tests are stable
and the roachtest infrastruture is mature, the value has
lessened. Rather than keeping the burden of managing the "stable" tag,
we're just removing it.

Release note: None