### PR TITLE
sql: plumb SQL string alongside statements

### DIFF
--- a/pkg/cli/interactive_tests/test_auto_trace.tcl
+++ b/pkg/cli/interactive_tests/test_auto_trace.tcl
@@ -15,7 +15,7 @@ send "select 1;\r"
 eexpect "1 row"
 # trace result
 eexpect "session recording"
-eexpect "executing: SELECT 1"
+eexpect "executing: select 1"
 eexpect "rows affected: 1"
 eexpect root@
 end_test
@@ -26,7 +26,7 @@ send "select woo;\r"
 eexpect "column \"woo\" does not exist"
 # trace result
 eexpect "session recording"
-eexpect "executing: SELECT woo"
+eexpect "executing: select woo"
 eexpect "does not exist"
 eexpect root@
 end_test
@@ -43,7 +43,7 @@ send "select * from t;\r"
 eexpect "2 rows"
 # trace result
 eexpect "session recording"
-eexpect "executing: SELECT \* FROM t"
+eexpect "executing: select \* from t"
 eexpect "output row:"
 eexpect "output row:"
 eexpect "rows affected: 2"

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1103,7 +1103,7 @@ func (ex *connExecutor) run(
 				tcmd.Stmt, NeedRowDesc, pos, nil, /* formatCodes */
 				ex.sessionData.DataConversion)
 			res = stmtRes
-			curStmt := Statement{AST: tcmd.Stmt}
+			curStmt := Statement{SQL: tcmd.SQL, AST: tcmd.Stmt}
 
 			ex.phaseTimes[sessionQueryReceived] = tcmd.TimeReceived
 			ex.phaseTimes[sessionStartParse] = tcmd.ParseStart
@@ -1161,6 +1161,7 @@ func (ex *connExecutor) run(
 			stmtRes.SetLimit(tcmd.Limit)
 			res = stmtRes
 			curStmt := Statement{
+				SQL:           portal.Stmt.Str,
 				AST:           portal.Stmt.Statement,
 				Prepared:      portal.Stmt,
 				ExpectedTypes: portal.Stmt.Columns,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -295,7 +295,9 @@ func (ex *connExecutor) execStmtInOpenState(
 		for i, t := range s.Types {
 			typeHints[strconv.Itoa(i+1)] = coltypes.CastTargetToDatumType(t)
 		}
-		if _, err := ex.addPreparedStmt(ctx, name, Statement{AST: s.Statement}, typeHints); err != nil {
+		if _, err := ex.addPreparedStmt(
+			ctx, name, Statement{SQL: s.Statement.String(), AST: s.Statement}, typeHints,
+		); err != nil {
 			return makeErrEvent(err)
 		}
 		return nil, nil, nil

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -53,7 +53,7 @@ func (ex *connExecutor) execPrepare(
 	}
 
 	ps, err := ex.addPreparedStmt(
-		ctx, parseCmd.Name, Statement{AST: parseCmd.Stmt}, parseCmd.TypeHints,
+		ctx, parseCmd.Name, Statement{SQL: parseCmd.SQL, AST: parseCmd.Stmt}, parseCmd.TypeHints,
 	)
 	if err != nil {
 		return retErr(err)

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -70,11 +70,12 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 	)
 	defer cleanup()
 	p := internalPlanner.(*planner)
-	stmt, err := parser.ParseOne("select * from test.t")
+	query := "select * from test.t"
+	stmt, err := parser.ParseOne(query)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.makePlan(ctx, Statement{AST: stmt}); err != nil {
+	if err := p.makePlan(ctx, Statement{SQL: query, AST: stmt}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -514,6 +514,7 @@ func (ie *internalExecutorImpl) execInternal(
 		if err := stmtBuf.Push(
 			ctx,
 			ExecStmt{
+				SQL:          stmt,
 				Stmt:         s,
 				TimeReceived: timeReceived,
 				ParseStart:   parseStart,
@@ -526,6 +527,7 @@ func (ie *internalExecutorImpl) execInternal(
 		if err := stmtBuf.Push(
 			ctx,
 			PrepareStmt{
+				SQL:        stmt,
 				Stmt:       s,
 				ParseStart: parseStart,
 				ParseEnd:   parseEnd,

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -333,7 +333,7 @@ func planQuery(t *testing.T, s serverutils.TestServerInterface, sql string) (*pl
 		t.Fatalf("expected to parse 1 statement, got: %d", len(stmts))
 	}
 	stmt := stmts[0]
-	if err := p.makePlan(context.TODO(), Statement{AST: stmt}); err != nil {
+	if err := p.makePlan(context.TODO(), Statement{SQL: sql, AST: stmt}); err != nil {
 		t.Fatal(err)
 	}
 	return p, func() {

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -457,6 +457,7 @@ func (c *conn) handleSimpleQuery(
 	if len(stmts) == 0 {
 		return c.stmtBuf.Push(
 			ctx, sql.ExecStmt{
+				SQL:          "",
 				Stmt:         nil,
 				TimeReceived: timeReceived,
 				ParseStart:   startParse,
@@ -490,9 +491,21 @@ func (c *conn) handleSimpleQuery(
 			return nil
 		}
 
+		var sqlStr string
+		if len(stmts) == 1 {
+			// TODO(radu): the string could potentially contain a trailing semicolon.
+			// It's not trivial to trim the semicolon as it can be surrounded by
+			// whitespace, newlines, and/or comments.
+			sqlStr = query
+		} else {
+			// TODO(radu): return this information from the parser instead of using
+			// String.
+			sqlStr = stmt.String()
+		}
 		if err := c.stmtBuf.Push(
 			ctx,
 			sql.ExecStmt{
+				SQL:          sqlStr,
 				Stmt:         stmt,
 				TimeReceived: timeReceived,
 				ParseStart:   startParse,
@@ -576,6 +589,7 @@ func (c *conn) handleParse(ctx context.Context, buf *pgwirebase.ReadBuffer) erro
 	return c.stmtBuf.Push(
 		ctx,
 		sql.PrepareStmt{
+			SQL:          query,
 			Name:         name,
 			Stmt:         stmt,
 			TypeHints:    sqlTypeHints,

--- a/pkg/sql/statement.go
+++ b/pkg/sql/statement.go
@@ -21,6 +21,7 @@ import (
 
 // Statement contains a statement with optional expected result columns and metadata.
 type Statement struct {
+	SQL           string
 	AST           tree.Statement
 	ExpectedTypes sqlbase.ResultColumns
 	AnonymizedStr string
@@ -40,5 +41,5 @@ type Statement struct {
 }
 
 func (s Statement) String() string {
-	return s.AST.String()
+	return s.SQL
 }

--- a/pkg/sql/subquery_test.go
+++ b/pkg/sql/subquery_test.go
@@ -36,7 +36,7 @@ func TestStartSubqueriesReturnsError(t *testing.T) {
 		t.Fatalf("expected to parse 1 statement, got: %d", len(stmts))
 	}
 	stmt := stmts[0]
-	if err := p.makePlan(context.TODO(), Statement{AST: stmt}); err != nil {
+	if err := p.makePlan(context.TODO(), Statement{SQL: sql, AST: stmt}); err != nil {
 		t.Fatal(err)
 	}
 	params := runParams{ctx: context.TODO(), p: p, extendedEvalCtx: &p.extendedEvalCtx}

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -102,7 +102,7 @@ func (dsp *DistSQLPlanner) Exec(
 		return err
 	}
 	p := localPlanner.(*planner)
-	if err := p.makePlan(ctx, Statement{AST: stmt}); err != nil {
+	if err := p.makePlan(ctx, Statement{SQL: sql, AST: stmt}); err != nil {
 		return err
 	}
 	rw := newCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {


### PR DESCRIPTION
This change keeps track of the SQL string that corresponds to a
statement (to be used as a "key" for the query cache).

We use the query string directly for a single statement (which
unfortunately includes any trailing `;`), and we use the AST `String`
method for multiple statements. In a future change, the parser will be
modified to return the "splits" so we can use them directly.

Release note: None