### PR TITLE
sql: sometimes skip TestCopyTransaction

### DIFF
--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
@@ -416,7 +417,12 @@ func TestCopyTransaction(t *testing.T) {
 	}
 
 	if err = stmt.Close(); err != nil {
-		t.Fatal(err)
+		if testutils.IsError(err,
+			"TransactionAbortedError(ABORT_REASON_TIMESTAMP_CACHE_REJECTED_POSSIBLE_REPLAY)") {
+			t.Skip("sometimes skipped on 2.1. #32778")
+		} else {
+			t.Fatal(err)
+		}
 	}
 
 	var i int


### PR DESCRIPTION
The test sometimes gets a retriable error. The root cause is worked on
as #32495. On master the test was fixed by adding a retry loop (not
backported to 2.1), but I hope to get rid of it once the cause goes
away.
This patch skips the test on 2.1 if the error is detected.

This is original work on 2.1.
Fixes #32778

Release note: None