### PR TITLE
changefeedccl: enable the RangeFeed version of more tests

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -208,6 +208,9 @@ func TestChangefeedTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		// HACK: remove this once #32495 is fixed.
+		maybeWaitForEpochLeases(t, f.Server())
+
 		ctx := context.Background()
 		sqlDB := sqlutils.MakeSQLRunner(db)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
@@ -290,13 +293,16 @@ func TestChangefeedTimestamps(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	// TODO(dan): t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
 }
 
 func TestChangefeedResolvedFrequency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		// HACK: remove this once #32495 is fixed.
+		maybeWaitForEpochLeases(t, f.Server())
+
 		sqlDB := sqlutils.MakeSQLRunner(db)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
 
@@ -313,7 +319,6 @@ func TestChangefeedResolvedFrequency(t *testing.T) {
 		}
 		sort.Slice(resolved, func(i, j int) bool { return resolved[i].Less(resolved[j]) })
 		first, last := resolved[0], resolved[len(resolved)-1]
-		fmt.Println(resolved)
 
 		if d := last.GoTime().Sub(first.GoTime()); d < freq {
 			t.Errorf(`expected %s between resolved timestamps, but got %s`, freq, d)
@@ -322,7 +327,7 @@ func TestChangefeedResolvedFrequency(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	// TODO(dan): t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
 }
 
 // Test how Changefeeds react to schema changes that do not require a backfill
@@ -573,6 +578,9 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		// HACK: remove this once #32495 is fixed.
+		maybeWaitForEpochLeases(t, f.Server())
+
 		sqlDB := sqlutils.MakeSQLRunner(db)
 
 		t.Run(`add column with default`, func(t *testing.T) {
@@ -697,7 +705,7 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	// TODO(dan): t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
 }
 
 func TestChangefeedInterleaved(t *testing.T) {
@@ -899,6 +907,9 @@ func TestChangefeedMonitoring(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		// HACK: remove this once #32495 is fixed.
+		maybeWaitForEpochLeases(t, f.Server())
+
 		beforeEmitRowCh := make(chan struct{}, 2)
 		knobs := f.Server().(*server.TestServer).Cfg.TestingKnobs.
 			DistSQL.(*distsqlrun.TestingKnobs).
@@ -1014,7 +1025,7 @@ func TestChangefeedMonitoring(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	// TODO(dan): t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
 }
 
 func TestChangefeedRetryableSinkError(t *testing.T) {
@@ -1122,6 +1133,9 @@ func TestChangefeedDataTTL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		// HACK: remove this once #32495 is fixed.
+		maybeWaitForEpochLeases(t, f.Server())
+
 		// Set a very simple channel-based, wait-and-resume function as the
 		// BeforeEmitRow hook.
 		var shouldWait int32

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 
 	"github.com/cockroachdb/apd"
@@ -277,12 +278,6 @@ func makeSinkless(s serverutils.TestServerInterface, db *gosql.DB) *sinklessFeed
 func (f *sinklessFeedFactory) Feed(t testing.TB, create string, args ...interface{}) testfeed {
 	t.Helper()
 
-	if _, err := f.db.Exec(
-		`SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`,
-	); err != nil {
-		t.Fatal(err)
-	}
-
 	s := &sinklessFeed{db: f.db, seen: make(map[string]struct{})}
 	now := timeutil.Now()
 	var err error
@@ -399,11 +394,6 @@ func (f *tableFeedFactory) Feed(t testing.TB, create string, args ...interface{}
 	c := &tableFeed{
 		db: db, urlCleanup: cleanup, sinkURI: sink.String(), flushCh: f.flushCh,
 		seen: make(map[string]struct{}),
-	}
-	if _, err := c.db.Exec(
-		`SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`,
-	); err != nil {
-		t.Fatal(err)
 	}
 	if _, err := c.db.Exec(`CREATE DATABASE ` + sink.Path); err != nil {
 		t.Fatal(err)
@@ -684,6 +674,62 @@ func expectResolvedTimestamp(t testing.TB, f testfeed) hlc.Timestamp {
 	return parseTimeToHLC(t, valueRaw.CRDB.Resolved)
 }
 
+// maybeWaitForEpochLeases waits until all ranges serving user table data have
+// epoch leases.
+//
+// Changefeed resolved timestamps rely on RangeFeed checkpoints which rely on
+// closed timestamps which only work with epoch leases. This means that any
+// changefeed test that _uses RangeFeed_ and _needs resolved timestamps_ should
+// first wait until all the relevant ranges have epoch-leases.
+//
+// We added this to unblock RangeFeed work, but it takes ~10s, so we should fix
+// it for real at some point. The permanent fix is being tracked in #32495.
+func maybeWaitForEpochLeases(t *testing.T, s serverutils.TestServerInterface) {
+	// If it's not a rangefeed test, don't bother waiting.
+	if !strings.Contains(t.Name(), `rangefeed`) {
+		return
+	}
+
+	userTablesSpan := roachpb.RSpan{
+		Key:    roachpb.RKey(keys.MakeTablePrefix(keys.MinUserDescID)),
+		EndKey: roachpb.RKeyMax,
+	}
+	testutils.SucceedsSoon(t, func() error {
+		ctx := context.Background()
+		var rangeDescs []roachpb.RangeDescriptor
+		if err := s.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			var err error
+			rangeDescs, err = allRangeDescriptors(ctx, txn)
+			return err
+		}); err != nil {
+			return err
+		}
+
+		// Force a lease acquisition so we don't get stuck waiting forever.
+		if _, err := s.DB().Scan(ctx, userTablesSpan.Key, userTablesSpan.EndKey, 0); err != nil {
+			return err
+		}
+
+		stores := s.GetStores().(*storage.Stores)
+		for _, rangeDesc := range rangeDescs {
+			if !rangeDesc.ContainsKeyRange(userTablesSpan.Key, userTablesSpan.EndKey) {
+				continue
+			}
+			replica, err := stores.GetReplicaForRangeID(rangeDesc.RangeID)
+			if err != nil {
+				return err
+			}
+			lease, _ := replica.GetLease()
+			if lease.Epoch == 0 {
+				err := errors.Errorf("%s does not have an epoch lease: should resolve in %s",
+					rangeDesc, lease.Expiration.GoTime().Sub(timeutil.Now()))
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 func sinklessTest(testFn func(*testing.T, *gosql.DB, testfeedFactory)) func(*testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
@@ -752,7 +798,16 @@ func rangefeedTest(
 ) func(*testing.T) {
 	return func(t *testing.T) {
 		metaTestFn(func(t *testing.T, db *gosql.DB, f testfeedFactory) {
-			sqlutils.MakeSQLRunner(db).Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+			sqlDB := sqlutils.MakeSQLRunner(db)
+			sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+			// TODO(dan): We currently have to set this to an extremely
+			// conservative value because otherwise schema changes become flaky
+			// (they don't commit their txn in time, get pushed by closed
+			// timestamps, and retry forever). This is more likely when the
+			// tests run slower (race builds or inside docker). The conservative
+			// value makes our tests take a long longer, though. Figure out some
+			// way to speed this up.
+			sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s'`)
 			testFn(t, db, f)
 		})(t)
 	}

--- a/pkg/ccl/changefeedccl/validations_test.go
+++ b/pkg/ccl/changefeedccl/validations_test.go
@@ -28,6 +28,9 @@ func TestValidations(t *testing.T) {
 	defer utilccl.TestingEnableEnterprise()()
 
 	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		// HACK: remove this once #32495 is fixed.
+		maybeWaitForEpochLeases(t, f.Server())
+
 		sqlDB := sqlutils.MakeSQLRunner(db)
 
 		t.Run("bank", func(t *testing.T) {
@@ -115,4 +118,5 @@ func TestValidations(t *testing.T) {
 	}
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
+	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
 }


### PR DESCRIPTION
Changefeed resolved timestamps rely on RangeFeed checkpoints which rely
on closed timestamps which only work with epoch leases. This means that
any changefeed test that _uses RangeFeed_ and _needs resolved
timestamps_ should first wait until all the relevant ranges have
epoch-leases.

This commit adds that waiting to unblock RangeFeed work, but it takes
~10s, so we should fix it for real at some point. The permanent fix is
being tracked in #32495.

Release note: None