### PR TITLE
sql: remove MetadataSchema.AddConfigDescriptor

### DIFF
--- a/pkg/sql/sqlbase/metadata.go
+++ b/pkg/sql/sqlbase/metadata.go
@@ -72,7 +72,6 @@ func WrapDescriptor(descriptor DescriptorProto) *Descriptor {
 // start running correctly, thus requiring this special initialization.
 type MetadataSchema struct {
 	descs   []metadataDescriptor
-	configs int
 	otherKV []roachpb.KeyValue
 }
 
@@ -101,13 +100,6 @@ func (ms *MetadataSchema) AddDescriptor(parentID ID, desc DescriptorProto) {
 		}
 	}
 	ms.descs = append(ms.descs, metadataDescriptor{parentID, desc})
-}
-
-// AddConfigDescriptor adds a new descriptor to the system schema. Used only for
-// SystemConfig tables and databases.
-func (ms *MetadataSchema) AddConfigDescriptor(parentID ID, desc DescriptorProto) {
-	ms.AddDescriptor(parentID, desc)
-	ms.configs++
 }
 
 // SystemDescriptorCount returns the number of descriptors that will be created by

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -841,13 +841,13 @@ func createZoneConfigKV(keyID int, zoneConfig *config.ZoneConfig) roachpb.KeyVal
 // descriptors to the cockroach store.
 func addSystemDatabaseToSchema(target *MetadataSchema) {
 	// Add system database.
-	target.AddConfigDescriptor(keys.RootNamespaceID, &SystemDB)
+	target.AddDescriptor(keys.RootNamespaceID, &SystemDB)
 
 	// Add system config tables.
-	target.AddConfigDescriptor(keys.SystemDatabaseID, &NamespaceTable)
-	target.AddConfigDescriptor(keys.SystemDatabaseID, &DescriptorTable)
-	target.AddConfigDescriptor(keys.SystemDatabaseID, &UsersTable)
-	target.AddConfigDescriptor(keys.SystemDatabaseID, &ZonesTable)
+	target.AddDescriptor(keys.SystemDatabaseID, &NamespaceTable)
+	target.AddDescriptor(keys.SystemDatabaseID, &DescriptorTable)
+	target.AddDescriptor(keys.SystemDatabaseID, &UsersTable)
+	target.AddDescriptor(keys.SystemDatabaseID, &ZonesTable)
 
 	// Add all the other system tables.
 	target.AddDescriptor(keys.SystemDatabaseID, &LeaseTable)


### PR DESCRIPTION
The distinction between "system config" versus non-system config system
tables used to be useful at some point, but it has since become
unused.

Release note: None