### PR TITLE
testcluster: Also wait for all nodes to start

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4151,7 +4151,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	if s.cfg.NodeLiveness != nil {
 		livenessMap = s.cfg.NodeLiveness.GetIsLiveMap()
 	}
-	availableNodes := s.cfg.StorePool.AvailableNodeCount()
+	availableNodes := s.AvailableNodeCount()
 
 	newStoreReplicaVisitor(s).Visit(func(rep *Replica) bool {
 		metrics := rep.Metrics(ctx, timestamp, livenessMap, availableNodes)
@@ -4315,6 +4315,17 @@ func (s *Store) ComputeMetrics(ctx context.Context, tick int) error {
 		}
 	}
 	return nil
+}
+
+// AvailableNodeCount returns this store's view of the number of nodes
+// in the cluster. This is the metric used for adapative zone configs;
+// ranges will not be reported as underreplicated if it is low. Tests
+// that wait for full replication by tracking the underreplicated
+// metric must also check for the expected AvailableNodeCount to avoid
+// catching the cluster while the first node is initialized but the
+// other nodes are not.
+func (s *Store) AvailableNodeCount() int {
+	return s.cfg.StorePool.AvailableNodeCount()
 }
 
 // StoreKeySpanStats carries the result of a stats computation over a key range.

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -553,6 +553,11 @@ func (tc *TestCluster) WaitForFullReplication() error {
 		notReplicated = false
 		for _, s := range tc.Servers {
 			err := s.Stores().VisitStores(func(s *storage.Store) error {
+				if n := s.AvailableNodeCount(); n != len(tc.Servers) {
+					log.Infof(context.TODO(), "%s only sees %d/%d available nodes", s, n, len(tc.Servers))
+					notReplicated = true
+					return nil
+				}
 				if err := s.ComputeMetrics(context.TODO(), 0); err != nil {
 					// This can sometimes fail since ComputeMetrics calls
 					// updateReplicationGauges which needs the system config gossiped.


### PR DESCRIPTION
Adaptive zone configs introduced a potential false positive to
TestCluster.WaitForReplication: the first node won't report any
underreplicated ranges if the other nodes haven't started yet.
cli.TestRemoveDeadReplicas was most sensitive to this since it
restarts a cluster with an already-initialized first node.

Fix this by only considering the TestCluster fully replicated when all
nodes see each other as available.

Fixes #32777

Release note: None