### PR TITLE
storage: allow preemptive snapshots on empty replica with replicaID (again)

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2274,7 +2274,16 @@ func TestStoreRangeReadoptedLHSFollower(t *testing.T) {
 		var lhsRepl2 *storage.Replica
 		testutils.SucceedsSoon(t, func() error {
 			lhsRepl2, err = store2.GetReplica(lhsDesc.RangeID)
-			return err
+			if err != nil {
+				return err
+			}
+			if !lhsRepl2.IsInitialized() {
+				// Make sure the replica is initialized before unreplicating.
+				// Uninitialized replicas that have a replicaID are hard to
+				// GC (not implemented at the time of writing).
+				return errors.Errorf("%s not initialized", lhsRepl2)
+			}
+			return nil
 		})
 		mtc.unreplicateRange(lhsDesc.RangeID, 2)
 


### PR DESCRIPTION
This morally reverts #32436, though without deleting all the cleanup
that was done in that PR.

That PR introduced blocking preemptive snapshots that would apply on an
uninitialized replica (with a replicaID), that is, a blank Raft group
created in response to an incoming message.

It turns out that accepting these snapshots is the best we can do
because gc'ing a "blank" replica is actually unimplemented today: our
replicaGC hinges on being able to look up the correct descriptor from
the meta2 ranges, but an uninitialized replica doesn't know its start
key. This means that "blank" replicas are not gc'able and will never be
GC'ed, which caused test failures such as #32511 in which replication
cannot make progress.

Fixes #32511.

Release note: None