### PR TITLE
uuid: excise support for UUID V2 from util/uuid

### DIFF
--- a/pkg/util/uuid/generator.go
+++ b/pkg/util/uuid/generator.go
@@ -15,7 +15,6 @@ import (
 	"hash"
 	"io"
 	"net"
-	"os"
 	"sync"
 	"time"
 
@@ -35,19 +34,9 @@ type HWAddrFunc func() (net.HardwareAddr, error)
 // DefaultGenerator is the default UUID Generator used by this package.
 var DefaultGenerator Generator = NewGen()
 
-var (
-	posixUID = uint32(os.Getuid())
-	posixGID = uint32(os.Getgid())
-)
-
 // NewV1 returns a UUID based on the current timestamp and MAC address.
 func NewV1() (UUID, error) {
 	return DefaultGenerator.NewV1()
-}
-
-// NewV2 returns a DCE Security UUID based on the POSIX UID/GID.
-func NewV2(domain byte) (UUID, error) {
-	return DefaultGenerator.NewV2(domain)
 }
 
 // NewV3 returns a UUID based on the MD5 hash of the namespace UUID and name.
@@ -68,7 +57,7 @@ func NewV5(ns UUID, name string) UUID {
 // Generator provides an interface for generating UUIDs.
 type Generator interface {
 	NewV1() (UUID, error)
-	NewV2(domain byte) (UUID, error)
+	// NewV2(domain byte) (UUID, error) // CRL: Removed support for V2.
 	NewV3(ns UUID, name string) UUID
 	NewV4() (UUID, error)
 	NewV5(ns UUID, name string) UUID
@@ -156,28 +145,6 @@ func (g *Gen) NewV1() (UUID, error) {
 	copy(u[10:], hardwareAddr)
 
 	u.SetVersion(V1)
-	u.SetVariant(VariantRFC4122)
-
-	return u, nil
-}
-
-// NewV2 returns a DCE Security UUID based on the POSIX UID/GID.
-func (g *Gen) NewV2(domain byte) (UUID, error) {
-	u, err := g.NewV1()
-	if err != nil {
-		return Nil, err
-	}
-
-	switch domain {
-	case DomainPerson:
-		binary.BigEndian.PutUint32(u[:], posixUID)
-	case DomainGroup:
-		binary.BigEndian.PutUint32(u[:], posixGID)
-	}
-
-	u[9] = domain
-
-	u.SetVersion(V2)
 	u.SetVariant(VariantRFC4122)
 
 	return u, nil

--- a/pkg/util/uuid/generator_test.go
+++ b/pkg/util/uuid/generator_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestGenerator(t *testing.T) {
 	t.Run("NewV1", testNewV1)
-	t.Run("NewV2", testNewV2)
 	t.Run("NewV3", testNewV3)
 	t.Run("NewV4", testNewV4)
 	t.Run("NewV5", testNewV5)
@@ -155,63 +154,6 @@ func testNewV1MissingNetworkFaultyRand(t *testing.T) {
 	u, err := g.NewV1()
 	if err == nil {
 		t.Errorf("did not error on faulty reader and missing network, got %v", u)
-	}
-}
-
-func testNewV2(t *testing.T) {
-	t.Run("Basic", testNewV2Basic)
-	t.Run("DifferentAcrossCalls", testNewV2DifferentAcrossCalls)
-	t.Run("FaultyRand", testNewV2FaultyRand)
-}
-
-func testNewV2Basic(t *testing.T) {
-	domains := []byte{
-		DomainPerson,
-		DomainGroup,
-		DomainOrg,
-	}
-	for _, domain := range domains {
-		u, err := NewV2(domain)
-		if err != nil {
-			t.Errorf("NewV2(%d): %v", domain, err)
-		}
-		if got, want := u.Version(), V2; got != want {
-			t.Errorf("NewV2(%d) generated UUID with version %d, want %d", domain, got, want)
-		}
-		if got, want := u.Variant(), VariantRFC4122; got != want {
-			t.Errorf("NewV2(%d) generated UUID with variant %d, want %d", domain, got, want)
-		}
-	}
-}
-
-func testNewV2DifferentAcrossCalls(t *testing.T) {
-	u1, err := NewV2(DomainOrg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	u2, err := NewV2(DomainOrg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if u1 == u2 {
-		t.Errorf("generated identical UUIDs across calls: %v", u1)
-	}
-}
-
-func testNewV2FaultyRand(t *testing.T) {
-	g := &Gen{
-		epochFunc:  time.Now,
-		hwAddrFunc: defaultHWAddrFunc,
-		rand: &faultyReader{
-			readToFail: 0, // fail immediately
-		},
-	}
-	u, err := g.NewV2(DomainPerson)
-	if err == nil {
-		t.Fatalf("got %v, want error", u)
-	}
-	if u != Nil {
-		t.Fatalf("got %v on error, want Nil", u)
 	}
 }
 
@@ -373,11 +315,6 @@ func BenchmarkGenerator(b *testing.B) {
 	b.Run("NewV1", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			Must(NewV1())
-		}
-	})
-	b.Run("NewV2", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			Must(NewV2(DomainOrg))
 		}
 	})
 	b.Run("NewV3", func(b *testing.B) {

--- a/pkg/util/uuid/uuid.go
+++ b/pkg/util/uuid/uuid.go
@@ -25,7 +25,7 @@ type UUID [Size]byte
 const (
 	_  byte = iota
 	V1      // Version 1 (date-time and MAC address)
-	V2      // Version 2 (date-time and MAC address, DCE security version)
+	_       // Version 2 (date-time and MAC address, DCE security version)
 	V3      // Version 3 (namespace name-based)
 	V4      // Version 4 (random)
 	V5      // Version 5 (namespace name-based)
@@ -37,13 +37,6 @@ const (
 	VariantRFC4122
 	VariantMicrosoft
 	VariantFuture
-)
-
-// UUID DCE domains.
-const (
-	DomainPerson = iota
-	DomainGroup
-	DomainOrg
 )
 
 // Timestamp is the count of 100-nanosecond intervals since 00:00:00.00,


### PR DESCRIPTION
The code in util/uuid derived from github.com/gofrs/uuid contains a faulty test
for the V2 variant of the the UUID which can fail on MacOS. In general UUID V2
is not the most useful UUID due to the small number of bits used to ensure
uniqueness for a given domain.

```
with the clock value truncated to the 28 most significant bits, compared to 60
bits in version 1, the clock in a version 2 UUID will "tick" only once every
429.49 seconds, a little more than 7 minutes, as opposed to every 100
nanoseconds for version 1.
```
[Wikipedia UUID V2](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_2_(date-time_and_MAC_address,_DCE_security_version))

CockroachDB exclusively uses V1 UUIDs. Rather than fix the test, this PR chooses
to remove support for V2 UUIDs.

Release note: None