### PR TITLE
sqlutils: generalize SQLRunner

### DIFF
--- a/pkg/ccl/backupccl/bench_test.go
+++ b/pkg/ccl/backupccl/bench_test.go
@@ -10,6 +10,7 @@ package backupccl_test
 
 import (
 	"bytes"
+	gosql "database/sql"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -109,7 +110,7 @@ func BenchmarkLoadRestore(b *testing.B) {
 	b.SetBytes(int64(buf.Len() / b.N))
 	ts := hlc.Timestamp{WallTime: hlc.UnixNano()}
 	b.ResetTimer()
-	if _, err := importccl.Load(ctx, sqlDB.DB, buf, "data", dir, ts, 0, dir); err != nil {
+	if _, err := importccl.Load(ctx, sqlDB.DB.(*gosql.DB), buf, "data", dir, ts, 0, dir); err != nil {
 		b.Fatalf("%+v", err)
 	}
 	sqlDB.Exec(b, fmt.Sprintf(`RESTORE data.* FROM '%s'`, dir))

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -39,7 +39,7 @@ func BenchmarkChangefeedTicks(b *testing.B) {
 		numRows = 100
 	}
 	bankTable := bank.FromRows(numRows).Tables()[0]
-	timestamps, _, err := loadWorkloadBatches(sqlDB.DB, bankTable)
+	timestamps, _, err := loadWorkloadBatches(sqlDBRaw, bankTable)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -36,11 +36,12 @@ func setupExportableBank(t *testing.T, nodes, rows int) (*sqlutils.SQLRunner, st
 	tc := testcluster.StartTestCluster(t, nodes,
 		base.TestClusterArgs{ServerArgs: base.TestServerArgs{ExternalIODir: dir, UseDatabase: "test"}},
 	)
-	db := sqlutils.MakeSQLRunner(tc.Conns[0])
+	conn := tc.Conns[0]
+	db := sqlutils.MakeSQLRunner(conn)
 	db.Exec(t, "CREATE DATABASE test")
 
 	wk := bank.FromRows(rows)
-	if _, err := workload.Setup(ctx, db.DB, wk, 100, 3); err != nil {
+	if _, err := workload.Setup(ctx, conn, wk, 100, 3); err != nil {
 		t.Fatal(err)
 	}
 
@@ -53,7 +54,7 @@ func setupExportableBank(t *testing.T, nodes, rows int) (*sqlutils.SQLRunner, st
 	zoneConfig := config.DefaultZoneConfig()
 	zoneConfig.RangeMaxBytes = proto.Int64(5000)
 	config.TestingSetZoneConfig(last+1, zoneConfig)
-	if err := workload.Split(ctx, db.DB, wk.Tables()[0], 1 /* concurrency */); err != nil {
+	if err := workload.Split(ctx, conn, wk.Tables()[0], 1 /* concurrency */); err != nil {
 		t.Fatal(err)
 	}
 	db.Exec(t, "ALTER TABLE bank SCATTER")

--- a/pkg/ccl/partitionccl/drop_test.go
+++ b/pkg/ccl/partitionccl/drop_test.go
@@ -58,7 +58,7 @@ func TestDropIndexWithZoneConfigCCL(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 
 	// Create a test table with a partitioned secondary index.
-	if err := tests.CreateKVTable(sqlDB.DB, "kv", numRows); err != nil {
+	if err := tests.CreateKVTable(sqlDBRaw, "kv", numRows); err != nil {
 		t.Fatal(err)
 	}
 	sqlDB.Exec(t, `CREATE INDEX i ON t.kv (v) PARTITION BY LIST (v) (

--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -50,8 +50,8 @@ func TestValidIndexPartitionSetShowZones(t *testing.T) {
 	partialZoneOverride := *config.NewZoneConfig()
 	partialZoneOverride.GC = &config.GCPolicy{TTLSeconds: 42}
 
-	dbID := sqlutils.QueryDatabaseID(t, sqlDB.DB, "d")
-	tableID := sqlutils.QueryTableID(t, sqlDB.DB, "d", "t")
+	dbID := sqlutils.QueryDatabaseID(t, db, "d")
+	tableID := sqlutils.QueryTableID(t, db, "d", "t")
 
 	defaultRow := sqlutils.ZoneRow{
 		ID:           keys.RootNamespaceID,

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -124,12 +124,12 @@ func TestFixture(t *testing.T) {
 		t.Errorf(`expected no fixtures but got: %+v`, fixtures)
 	}
 
-	fixture, err := MakeFixture(ctx, sqlDB.DB, gcs, config, gen)
+	fixture, err := MakeFixture(ctx, db, gcs, config, gen)
 	if err != nil {
 		t.Fatalf(`%+v`, err)
 	}
 
-	_, err = MakeFixture(ctx, sqlDB.DB, gcs, config, gen)
+	_, err = MakeFixture(ctx, db, gcs, config, gen)
 	if !testutils.IsError(err, `already exists`) {
 		t.Fatalf(`expected 'already exists' error got: %+v`, err)
 	}
@@ -143,7 +143,7 @@ func TestFixture(t *testing.T) {
 	}
 
 	sqlDB.Exec(t, `CREATE DATABASE test`)
-	if err := RestoreFixture(ctx, sqlDB.DB, fixture, `test`); err != nil {
+	if err := RestoreFixture(ctx, db, fixture, `test`); err != nil {
 		t.Fatalf(`%+v`, err)
 	}
 	sqlDB.CheckQueryResults(t,

--- a/pkg/ccl/workloadccl/workload_test.go
+++ b/pkg/ccl/workloadccl/workload_test.go
@@ -65,7 +65,7 @@ func TestSetup(t *testing.T) {
 				}
 			}
 
-			if _, err := workload.Setup(ctx, sqlDB.DB, gen, test.batchSize, test.concurrency); err != nil {
+			if _, err := workload.Setup(ctx, db, gen, test.batchSize, test.concurrency); err != nil {
 				t.Fatalf("%+v", err)
 			}
 

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -324,7 +324,7 @@ func TestRegistryLifecycle(t *testing.T) {
 		check(t)
 		// Rollback a CANCEL.
 		{
-			txn, err := sqlDB.DB.Begin()
+			txn, err := outerDB.Begin()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -342,7 +342,7 @@ func TestRegistryLifecycle(t *testing.T) {
 		}
 		// Rollback a PAUSE.
 		{
-			txn, err := sqlDB.DB.Begin()
+			txn, err := outerDB.Begin()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -358,7 +358,7 @@ func TestRegistryLifecycle(t *testing.T) {
 		}
 		// Now pause it for reals.
 		{
-			txn, err := sqlDB.DB.Begin()
+			txn, err := outerDB.Begin()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -380,7 +380,7 @@ func TestRegistryLifecycle(t *testing.T) {
 		check(t)
 		// Rollback a RESUME.
 		{
-			txn, err := sqlDB.DB.Begin()
+			txn, err := outerDB.Begin()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -394,7 +394,7 @@ func TestRegistryLifecycle(t *testing.T) {
 		}
 		// Commit a RESUME.
 		{
-			txn, err := sqlDB.DB.Begin()
+			txn, err := outerDB.Begin()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/distsql_plan_backfill_test.go
+++ b/pkg/sql/distsql_plan_backfill_test.go
@@ -85,8 +85,9 @@ func TestDistBackfill(t *testing.T) {
 		SplitTable(t, tc, descNumToStr, i, n*n/numNodes*i)
 	}
 
-	r := sqlutils.MakeSQLRunner(tc.ServerConn(0))
-	r.DB.SetMaxOpenConns(1)
+	db := tc.ServerConn(0)
+	db.SetMaxOpenConns(1)
+	r := sqlutils.MakeSQLRunner(db)
 	r.Exec(t, "SET DISTSQL = OFF")
 	if _, err := tc.ServerConn(0).Exec(`CREATE INDEX foo ON numtostr (str)`); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -447,7 +447,7 @@ func (h *harness) prepareUsingServer(tb testing.TB) {
 
 	if h.query.prepare {
 		var err error
-		h.prepared, err = h.sr.DB.Prepare(h.query.query)
+		h.prepared, err = h.db.Prepare(h.query.query)
 		if err != nil {
 			tb.Fatalf("%v", err)
 		}

--- a/pkg/sql/partition_test.go
+++ b/pkg/sql/partition_test.go
@@ -38,7 +38,7 @@ func TestRemovePartitioningOSS(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	const numRows = 100
-	if err := tests.CreateKVTable(sqlDB.DB, "kv", numRows); err != nil {
+	if err := tests.CreateKVTable(sqlDBRaw, "kv", numRows); err != nil {
 		t.Fatal(err)
 	}
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "kv")

--- a/pkg/sql/schemachange/alter_column_type_test.go
+++ b/pkg/sql/schemachange/alter_column_type_test.go
@@ -326,7 +326,7 @@ func TestColumnConversions(t *testing.T) {
 					}
 
 					// Insert the test data.
-					if tx, err := sqlDB.DB.Begin(); err != nil {
+					if tx, err := db.Begin(); err != nil {
 						t.Fatal(err)
 					} else {
 						for i, v := range insert {

--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -101,7 +101,7 @@ func TestUpsertFastPath(t *testing.T) {
 	// transaction.
 	atomic.StoreUint64(&scans, 0)
 	atomic.StoreUint64(&beginTxn, 0)
-	tx, err := sqlDB.DB.Begin()
+	tx, err := conn.Begin()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/zone_test.go
+++ b/pkg/sql/zone_test.go
@@ -72,8 +72,8 @@ func TestValidSetShowZones(t *testing.T) {
 		Config:       zoneOverride,
 	}
 
-	dbID := sqlutils.QueryDatabaseID(t, sqlDB.DB, "d")
-	tableID := sqlutils.QueryTableID(t, sqlDB.DB, "d", "t")
+	dbID := sqlutils.QueryDatabaseID(t, db, "d")
+	tableID := sqlutils.QueryTableID(t, db, "d", "t")
 
 	dbRow := sqlutils.ZoneRow{
 		ID:           dbID,
@@ -236,7 +236,7 @@ func TestValidSetShowZones(t *testing.T) {
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", tableRow)
 
 	sqlDB.Exec(t, "DROP TABLE d.t")
-	_, err = sqlDB.DB.Exec("SHOW ZONE CONFIGURATION FOR TABLE d.t")
+	_, err = db.Exec("SHOW ZONE CONFIGURATION FOR TABLE d.t")
 	if !testutils.IsError(err, `relation "d.t" does not exist`) {
 		t.Errorf("expected SHOW ZONE CONFIGURATION to fail on dropped table, but got %q", err)
 	}

--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -28,18 +28,31 @@ import (
 // SQLRunner wraps a testing.TB and *gosql.DB connection and provides
 // convenience functions to run SQL statements and fail the test on any errors.
 type SQLRunner struct {
-	DB *gosql.DB
+	DB DBHandle
 }
 
+// DBHandle is an interface that applies to *gosql.DB, *gosql.Conn, and
+// *gosql.Tx.
+type DBHandle interface {
+	ExecContext(ctx context.Context, query string, args ...interface{}) (gosql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*gosql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *gosql.Row
+}
+
+var _ DBHandle = &gosql.DB{}
+var _ DBHandle = &gosql.Conn{}
+var _ DBHandle = &gosql.Tx{}
+
 // MakeSQLRunner returns a SQLRunner for the given database connection.
-func MakeSQLRunner(db *gosql.DB) *SQLRunner {
+// The argument can be a *gosql.DB, *gosql.Conn, or *gosql.Tx object.
+func MakeSQLRunner(db DBHandle) *SQLRunner {
 	return &SQLRunner{DB: db}
 }
 
 // Exec is a wrapper around gosql.Exec that kills the test on error.
 func (sr *SQLRunner) Exec(t testing.TB, query string, args ...interface{}) gosql.Result {
 	t.Helper()
-	r, err := sr.DB.Exec(query, args...)
+	r, err := sr.DB.ExecContext(context.Background(), query, args...)
 	if err != nil {
 		t.Fatalf("error executing '%s': %s", query, err)
 	}
@@ -75,7 +88,7 @@ func (sr *SQLRunner) ExpectErr(t testing.TB, errRE string, query string, args ..
 // Query is a wrapper around gosql.Query that kills the test on error.
 func (sr *SQLRunner) Query(t testing.TB, query string, args ...interface{}) *gosql.Rows {
 	t.Helper()
-	r, err := sr.DB.Query(query, args...)
+	r, err := sr.DB.QueryContext(context.Background(), query, args...)
 	if err != nil {
 		t.Fatalf("error executing '%s': %s", query, err)
 	}
@@ -99,7 +112,7 @@ func (r *Row) Scan(dest ...interface{}) {
 // QueryRow is a wrapper around gosql.QueryRow that kills the test on error.
 func (sr *SQLRunner) QueryRow(t testing.TB, query string, args ...interface{}) *Row {
 	t.Helper()
-	return &Row{t, sr.DB.QueryRow(query, args...)}
+	return &Row{t, sr.DB.QueryRowContext(context.Background(), query, args...)}
 }
 
 // QueryStr runs a Query and converts the result using RowsToStrMatrix. Kills

--- a/pkg/testutils/sqlutils/table_id.go
+++ b/pkg/testutils/sqlutils/table_id.go
@@ -15,16 +15,16 @@
 package sqlutils
 
 import (
-	gosql "database/sql"
+	"context"
 	"testing"
 )
 
 // QueryDatabaseID returns the database ID of the specified database using the
 // system.namespace table.
-func QueryDatabaseID(t testing.TB, sqlDB *gosql.DB, dbName string) uint32 {
+func QueryDatabaseID(t testing.TB, sqlDB DBHandle, dbName string) uint32 {
 	dbIDQuery := `SELECT id FROM system.namespace WHERE name = $1 AND "parentID" = 0`
 	var dbID uint32
-	result := sqlDB.QueryRow(dbIDQuery, dbName)
+	result := sqlDB.QueryRowContext(context.Background(), dbIDQuery, dbName)
 	if err := result.Scan(&dbID); err != nil {
 		t.Fatal(err)
 	}
@@ -33,14 +33,14 @@ func QueryDatabaseID(t testing.TB, sqlDB *gosql.DB, dbName string) uint32 {
 
 // QueryTableID returns the table ID of the specified database.table
 // using the system.namespace table.
-func QueryTableID(t testing.TB, sqlDB *gosql.DB, dbName, tableName string) uint32 {
+func QueryTableID(t testing.TB, sqlDB DBHandle, dbName, tableName string) uint32 {
 	tableIDQuery := `
  SELECT tables.id FROM system.namespace tables
    JOIN system.namespace dbs ON dbs.id = tables."parentID"
    WHERE dbs.name = $1 AND tables.name = $2
  `
 	var tableID uint32
-	result := sqlDB.QueryRow(tableIDQuery, dbName, tableName)
+	result := sqlDB.QueryRowContext(context.Background(), tableIDQuery, dbName, tableName)
 	if err := result.Scan(&tableID); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/workload/bank/bank_test.go
+++ b/pkg/workload/bank/bank_test.go
@@ -55,7 +55,7 @@ func TestBank(t *testing.T) {
 			bankTable := bank.Tables()[0]
 			sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE %s %s`, bankTable.Name, bankTable.Schema))
 
-			if err := workload.Split(ctx, sqlDB.DB, bankTable, 1 /* concurrency */); err != nil {
+			if err := workload.Split(ctx, db, bankTable, 1 /* concurrency */); err != nil {
 				t.Fatalf("%+v", err)
 			}
 

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -67,7 +67,7 @@ func TestSetup(t *testing.T) {
 			sqlDB.Exec(t, `DROP TABLE IF EXISTS bank`)
 
 			gen := bank.FromRows(test.rows)
-			if _, err := workload.Setup(ctx, sqlDB.DB, gen, test.batchSize, test.concurrency); err != nil {
+			if _, err := workload.Setup(ctx, db, gen, test.batchSize, test.concurrency); err != nil {
 				t.Fatalf("%+v", err)
 			}
 
@@ -103,7 +103,7 @@ func TestSplits(t *testing.T) {
 			table := gen.Tables()[0]
 			sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE %s %s`, table.Name, table.Schema))
 
-			if err := workload.Split(ctx, sqlDB.DB, table, concurrency); err != nil {
+			if err := workload.Split(ctx, db, table, concurrency); err != nil {
 				t.Fatalf("%+v", err)
 			}
 


### PR DESCRIPTION
This change generalizes SQLRunner so that it can work on top of not
just a `gosql.DB`, but also a `gosql.Conn` or `gosql.Tx`.

Unfortunately a lot of code was using `SQLRunner.DB` directly and had
to be cleaned up.

Release note: None