### PR TITLE
[wip] c-deps: bump RocksDB to 5.17.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -551,6 +551,7 @@ $(ROCKSDB_DIR)/Makefile: $(C_DEPS_DIR)/rocksdb-rebuild | bin/.submodules-initial
 	  $(if $(findstring release,$(BUILDTYPE)),-DPORTABLE=ON) -DWITH_GFLAGS=OFF \
 	  -DSNAPPY_LIBRARIES=$(LIBSNAPPY) -DSNAPPY_INCLUDE_DIR="$(SNAPPY_SRC_DIR);$(SNAPPY_DIR)" -DWITH_SNAPPY=ON \
 	  $(if $(use-stdmalloc),,-DJEMALLOC_LIBRARIES=$(LIBJEMALLOC) -DJEMALLOC_INCLUDE_DIR=$(JEMALLOC_DIR)/include -DWITH_JEMALLOC=ON) \
+	  -DUSE_RTTI=ON \
 	  -DCMAKE_BUILD_TYPE=$(if $(ENABLE_ROCKSDB_ASSERTIONS),Debug,Release)
 
 $(SNAPPY_DIR)/Makefile: $(C_DEPS_DIR)/snappy-rebuild | bin/.submodules-initialized

--- a/c-deps/rocksdb-rebuild
+++ b/c-deps/rocksdb-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing rocksdb CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-10
+11

--- a/pkg/storage/engine/rocksdb_error_test.go
+++ b/pkg/storage/engine/rocksdb_error_test.go
@@ -63,7 +63,7 @@ func TestRocksDBErrorSafeMessage(t *testing.T) {
 		{
 			err: rErr,
 			// "locks" is redacted because this last part of the message is actually from `strerror` (ANSI-C).
-			expMsg: "io error while lock file <redacted> no <redacted> available",
+			expMsg: "io error lock <redacted> <redacted> no <redacted> available",
 		},
 		{
 			// A real-world example.


### PR DESCRIPTION
I haven't analyzed which of our patches might need to be applied to this new branch, but wanted to kick off a CI run in the meantime.

Release note: None