### PR TITLE
 opt: query cache prototype

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -75,6 +75,7 @@
 <tr><td><code>sql.metrics.statement_details.dump_to_logs</code></td><td>boolean</td><td><code>false</code></td><td>dump collected statement statistics to node logs when periodically cleared</td></tr>
 <tr><td><code>sql.metrics.statement_details.enabled</code></td><td>boolean</td><td><code>true</code></td><td>collect per-statement query statistics</td></tr>
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statistics to be collected</td></tr>
+<tr><td><code>sql.query_cache.enabled</code></td><td>boolean</td><td><code>false</code></td><td>enable the query cache</td></tr>
 <tr><td><code>sql.tablecache.lease.refresh_limit</code></td><td>integer</td><td><code>50</code></td><td>maximum number of tables to periodically refresh leases for</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>
 <tr><td><code>sql.trace.session_eventlog.enabled</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable session tracing</td></tr>

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -73,6 +73,8 @@ const (
 	recommendedNetworkFileDescriptors = 5000
 
 	defaultSQLTableStatCacheSize = 256
+
+	defaultSQLQueryCacheSize = 1024 * 1024
 )
 
 var productionSettingsWebpage = fmt.Sprintf(
@@ -166,6 +168,9 @@ type Config struct {
 	// SQLTableStatCacheSize is the size (number of tables) of the table
 	// statistics cache.
 	SQLTableStatCacheSize int
+
+	// SQLQueryCacheSize is the memory size (in bytes) of the query plan cache.
+	SQLQueryCacheSize int
 
 	// HeapProfileDirName is the directory name for heap profiles using
 	// heapprofiler.
@@ -325,6 +330,7 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		CacheSize:                      DefaultCacheSize,
 		SQLMemoryPoolSize:              defaultSQLMemoryPoolSize,
 		SQLTableStatCacheSize:          defaultSQLTableStatCacheSize,
+		SQLQueryCacheSize:              defaultSQLQueryCacheSize,
 		ScanInterval:                   defaultScanInterval,
 		ScanMinIdleTime:                defaultScanMinIdleTime,
 		ScanMaxIdleTime:                defaultScanMaxIdleTime,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
+	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
@@ -632,6 +633,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		AuditLogger: log.NewSecondaryLogger(
 			s.cfg.SQLAuditLogDirName, "sql-audit", true /*enableGc*/, true, /*forceSyncWrites*/
 		),
+
+		QueryCache: querycache.New(s.cfg.SQLQueryCacheSize),
 	}
 
 	if sqlSchemaChangerTestingKnobs := s.cfg.TestingKnobs.SQLSchemaChanger; sqlSchemaChangerTestingKnobs != nil {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -577,6 +577,10 @@ var maxStmtStatReset = settings.RegisterNonNegativeDurationSetting(
 	time.Hour*2, // 2 x diagnosticReportFrequency
 )
 
+var queryCacheEnabled = settings.RegisterBoolSetting(
+	"sql.query_cache.enabled", "enable the query cache", false,
+)
+
 // PeriodicallyClearStmtStats runs a loop to ensure that sql stats are reset.
 // Usually we expect those stats to be reset by diagnostics reporting, after it
 // generates its reports. However if the diagnostics loop crashes and stops

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -319,6 +320,7 @@ type ExecutorConfig struct {
 	ExecLogger       *log.SecondaryLogger
 	AuditLogger      *log.SecondaryLogger
 	InternalExecutor *InternalExecutor
+	QueryCache       *querycache.C
 
 	TestingKnobs              *ExecutorTestingKnobs
 	SchemaChangerTestingKnobs *SchemaChangerTestingKnobs

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -73,6 +73,10 @@ type Builder struct {
 	// pulled from an outer scope, that is, if the query was found to be correlated.
 	IsCorrelated bool
 
+	// HadPlaceholders is set to true if we replaced any placeholders with their
+	// values.
+	HadPlaceholders bool
+
 	factory *norm.Factory
 	stmt    tree.Statement
 

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -283,6 +283,7 @@ func (b *Builder) buildScalar(
 
 	case *tree.Placeholder:
 		if !b.KeepPlaceholders && b.evalCtx.HasPlaceholders() {
+			b.HadPlaceholders = true
 			// Replace placeholders with their value.
 			d, err := t.Eval(b.evalCtx)
 			if err != nil {

--- a/pkg/sql/plan_test.go
+++ b/pkg/sql/plan_test.go
@@ -1,0 +1,182 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+	gosql "database/sql"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestQueryCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	conns := make([]*gosql.Conn, 4)
+	runners := make([]*sqlutils.SQLRunner, len(conns))
+	for i := range conns {
+		var err error
+		conns[i], err = db.Conn(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		runners[i] = sqlutils.MakeSQLRunner(conns[i])
+	}
+	r0, r1 := runners[0], runners[1]
+
+	r0.Exec(t, "SET CLUSTER SETTING sql.query_cache.enabled = true")
+
+	init := func(t *testing.T) {
+		r0.Exec(t, "DROP DATABASE IF EXISTS db1")
+		r0.Exec(t, "DROP DATABASE IF EXISTS db2")
+		r0.Exec(t, "CREATE DATABASE db1")
+		r0.Exec(t, "CREATE TABLE db1.t (a INT, b INT)")
+		r0.Exec(t, "INSERT INTO db1.t VALUES (1, 1)")
+		for _, r := range runners {
+			r.Exec(t, "SET DATABASE = db1")
+		}
+	}
+
+	t.Run("simple", func(t *testing.T) {
+		init(t)
+		// Alternate between the connections.
+		for i := 0; i < 5; i++ {
+			for _, r := range runners {
+				r.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
+			}
+		}
+	})
+
+	t.Run("parallel", func(t *testing.T) {
+		init(t)
+		var group errgroup.Group
+		for connIdx := range conns {
+			c := conns[connIdx]
+			group.Go(func() error {
+				for j := 0; j < 10; j++ {
+					rows, err := c.QueryContext(context.Background(), "SELECT * FROM t")
+					if err != nil {
+						return err
+					}
+					res, err := sqlutils.RowsToStrMatrix(rows)
+					if err != nil {
+						return err
+					}
+					if !reflect.DeepEqual(res, [][]string{{"1", "1"}}) {
+						return errors.Errorf("incorrect results %v", res)
+					}
+				}
+				return nil
+			})
+		}
+		if err := group.Wait(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Test connections running the same statement but under different databases.
+	t.Run("multidb", func(t *testing.T) {
+		init(t)
+		r0.Exec(t, "CREATE DATABASE db2")
+		r0.Exec(t, "CREATE TABLE db2.t (a INT)")
+		r0.Exec(t, "INSERT INTO db2.t VALUES (2)")
+		for i := range runners {
+			if i%2 == 1 {
+				runners[i].Exec(t, "SET DATABASE = db2")
+			}
+		}
+		// Alternate between the connections.
+		for i := 0; i < 5; i++ {
+			for i, r := range runners {
+				var res [][]string
+				if i%2 == 0 {
+					res = [][]string{{"1", "1"}}
+				} else {
+					res = [][]string{{"2"}}
+				}
+				r.CheckQueryResults(t, "SELECT * FROM t", res)
+			}
+		}
+	})
+
+	// Test that a schema change triggers cache invalidation.
+	t.Run("schemachange", func(t *testing.T) {
+		init(t)
+		r0.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
+		r1.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
+		r0.Exec(t, "ALTER TABLE t ADD COLUMN c INT AS (a+b) STORED")
+		r1.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1", "2"}})
+	})
+
+	// Test a schema change where the other connections are running the query in
+	// parallel.
+	t.Run("schemachange-parallel", func(t *testing.T) {
+		init(t)
+		var group errgroup.Group
+		for connIdx := 1; connIdx < len(conns); connIdx++ {
+			c := conns[connIdx]
+			group.Go(func() error {
+				sawChanged := false
+				doQuery := func() error {
+					rows, err := c.QueryContext(context.Background(), "SELECT * FROM t")
+					if err != nil {
+						return err
+					}
+					res, err := sqlutils.RowsToStrMatrix(rows)
+					if err != nil {
+						return err
+					}
+					if reflect.DeepEqual(res, [][]string{{"1", "1"}}) {
+						if sawChanged {
+							return errors.Errorf("Saw updated results, then older results")
+						}
+					} else if reflect.DeepEqual(res, [][]string{{"1", "1", "2"}}) {
+						sawChanged = true
+					} else {
+						return errors.Errorf("incorrect results %v", res)
+					}
+					return nil
+				}
+
+				// Run the query until we see an updated result.
+				for !sawChanged {
+					if err := doQuery(); err != nil {
+						return err
+					}
+				}
+
+				// Now run the query a bunch more times to make sure we keep reading the
+				// updated version.
+				for i := 0; i < 10; i++ {
+					if err := doQuery(); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		}
+		r0.Exec(t, "ALTER TABLE t ADD COLUMN c INT AS (a+b) STORED")
+	})
+}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -538,15 +538,15 @@ func (p *planner) optionallyUseOptimizer(
 	ctx context.Context, sd sessiondata.SessionData, stmt Statement,
 ) (bool, error) {
 	if sd.OptimizerMode == sessiondata.OptimizerOff {
-		log.VEvent(ctx, 1, "optimizer disabled")
+		log.VEvent(ctx, 2, "optimizer disabled")
 		return false, nil
 	}
 
-	log.VEvent(ctx, 1, "generating optimizer plan")
+	log.VEvent(ctx, 2, "generating optimizer plan")
 
 	err := p.makeOptimizerPlan(ctx, stmt)
 	if err == nil {
-		log.VEvent(ctx, 1, "optimizer plan succeeded")
+		log.VEvent(ctx, 2, "optimizer plan succeeded")
 		return true, nil
 	}
 	log.VEventf(ctx, 1, "optimizer plan failed: %v", err)

--- a/pkg/sql/querycache/query_cache.go
+++ b/pkg/sql/querycache/query_cache.go
@@ -1,0 +1,184 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package querycache
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// C is a query cache, keyed on SQL statement strings (which can contain
+// placeholders).
+type C struct {
+	mu struct {
+		syncutil.Mutex
+
+		// Sentinel list entry. Cache entries form a circular linked list, with the
+		// most recently used entry at the front (i.e. sentinel.next). All available
+		// entries are always part of the list; unused entries have SQL="".
+		sentinel entry
+
+		// Map with an entry for each used entry.
+		m map[string]*entry
+	}
+}
+
+// Currently we use a very crude memory management scheme: we never put in the
+// cache plans that use more memory than maxCachedSize and we only allocate
+// (totalCacheSize / maxCachedSize) cache entries.
+// TODO(radu): improve this.
+const maxCachedSize = 8192
+
+// CachedData is the data associated with a cache entry.
+type CachedData struct {
+	SQL  string
+	Memo *memo.Memo
+}
+
+func (cd *CachedData) memoryEstimate() int64 {
+	return int64(len(cd.SQL)) + cd.Memo.MemoryEstimate()
+}
+
+// entry in a circular linked list.
+type entry struct {
+	CachedData
+
+	// Linked list pointers.
+	prev, next *entry
+}
+
+// clear resets the CachedData in the entry.
+func (e *entry) clear() {
+	e.CachedData = CachedData{}
+}
+
+// remove removes the entry from the linked list.
+func (e *entry) remove() {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.prev = nil
+	e.next = nil
+}
+
+func (e *entry) insertAfter(a *entry) {
+	b := a.next
+
+	e.prev = a
+	e.next = b
+
+	a.next = e
+	b.prev = e
+}
+
+// New creates a query cache of the given size.
+func New(memorySize int) *C {
+	numEntries := memorySize / maxCachedSize
+	if numEntries == 0 {
+		numEntries = 1
+	}
+	c := &C{}
+	c.mu.m = make(map[string]*entry, numEntries)
+	entries := make([]entry, numEntries)
+	// Make a linked list of entries, starting with the sentinel.
+	c.mu.sentinel.next = &entries[0]
+	c.mu.sentinel.prev = &entries[numEntries-1]
+	for i := range entries {
+		if i > 0 {
+			entries[i].prev = &entries[i-1]
+		} else {
+			entries[i].prev = &c.mu.sentinel
+		}
+		if i+1 < len(entries) {
+			entries[i].next = &entries[i+1]
+		} else {
+			entries[i].next = &c.mu.sentinel
+		}
+	}
+	return c
+}
+
+// Find returns the entry for the given query, if it is in the cache.
+func (c *C) Find(sql string) (_ CachedData, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	res := c.mu.m[sql]
+	if res == nil {
+		return CachedData{}, false
+	}
+	c.moveToFrontLocked(res)
+	return res.CachedData, true
+}
+
+// Add adds an entry to the cache (possibly evicting some other entry). If the
+// cache already has a corresponding entry for d.SQL, it is updated.
+func (c *C) Add(d *CachedData) {
+	if d.memoryEstimate() > maxCachedSize {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if e, ok := c.mu.m[d.SQL]; ok {
+		c.moveToFrontLocked(e)
+		e.CachedData = *d
+		return
+	}
+
+	// Evict the least recently used entry.
+	e := c.mu.sentinel.prev
+	if e.SQL != "" {
+		delete(c.mu.m, e.SQL)
+	}
+	c.moveToFrontLocked(e)
+	e.CachedData = *d
+	c.mu.m[d.SQL] = e
+}
+
+// moveToFrontLocked moves the given entry to the front of the list (right after
+// the sentinel). Assumes c.mu is locked.
+func (c *C) moveToFrontLocked(e *entry) {
+	e.remove()
+	e.insertAfter(&c.mu.sentinel)
+}
+
+// Clear removes all the entries from the cache.
+func (c *C) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Clear the map.
+	for sql, e := range c.mu.m {
+		e.clear()
+		delete(c.mu.m, sql)
+	}
+}
+
+// Purge removes the entry for the given query, if it exists.
+func (c *C) Purge(sql string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	e := c.mu.m[sql]
+	if e == nil {
+		return
+	}
+	delete(c.mu.m, sql)
+	e.clear()
+	e.remove()
+	// Insert at the back of the list.
+	e.insertAfter(c.mu.sentinel.prev)
+}

--- a/pkg/sql/querycache/query_cache_test.go
+++ b/pkg/sql/querycache/query_cache_test.go
@@ -1,0 +1,141 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package querycache
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func toStr(c *C) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var b strings.Builder
+	for e := c.mu.sentinel.next; e != &c.mu.sentinel; e = e.next {
+		if e.SQL == "" {
+			continue
+		}
+		if b.Len() != 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(e.SQL)
+	}
+	return b.String()
+}
+
+func expect(t *testing.T, c *C, exp string) {
+	t.Helper()
+	if s := toStr(c); s != exp {
+		t.Errorf("expected %s, got %s", exp, s)
+	}
+}
+
+// TestCache tests the main operations of the cache.
+func TestCache(t *testing.T) {
+	sa := &memo.Memo{}
+	sb := &memo.Memo{}
+	sc := &memo.Memo{}
+	sd := &memo.Memo{}
+
+	c := New(3 * maxCachedSize)
+
+	expect(t, c, "")
+	c.Add(&CachedData{SQL: "a", Memo: sa})
+	expect(t, c, "a")
+	c.Add(&CachedData{SQL: "b", Memo: sb})
+	expect(t, c, "b,a")
+	c.Add(&CachedData{SQL: "c", Memo: sc})
+	expect(t, c, "c,b,a")
+	c.Add(&CachedData{SQL: "d", Memo: sd})
+	expect(t, c, "d,c,b")
+	if _, ok := c.Find("a"); ok {
+		t.Errorf("a shouldn't be in the cache")
+	}
+	if res, ok := c.Find("c"); !ok {
+		t.Errorf("c should be in the cache")
+	} else if res.Memo != sc {
+		t.Errorf("invalid Memo for c")
+	}
+	expect(t, c, "c,d,b")
+
+	if res, ok := c.Find("b"); !ok {
+		t.Errorf("b should be in the cache")
+	} else if res.Memo != sb {
+		t.Errorf("invalid Memo for b")
+	}
+	expect(t, c, "b,c,d")
+
+	c.Add(&CachedData{SQL: "a", Memo: sa})
+	expect(t, c, "a,b,c")
+
+	c.Purge("b")
+	expect(t, c, "a,c")
+	if _, ok := c.Find("b"); ok {
+		t.Errorf("b shouldn't be in the cache")
+	}
+
+	c.Purge("c")
+	expect(t, c, "a")
+
+	c.Add(&CachedData{SQL: "b", Memo: sb})
+	expect(t, c, "b,a")
+
+	c.Clear()
+	expect(t, c, "")
+	if _, ok := c.Find("b"); ok {
+		t.Errorf("b shouldn't be in the cache")
+	}
+}
+
+// TestSynchronization verifies that the cache doesn't crash (or cause a race
+// detector error) when multiple goroutines are using it in parallel.
+func TestSynchronization(t *testing.T) {
+	const size = 100
+	c := New(size * maxCachedSize)
+
+	var wg sync.WaitGroup
+	const goroutines = 20
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			rng, _ := randutil.NewPseudoRand()
+			for j := 0; j < 5000; j++ {
+				sql := fmt.Sprintf("%d", rng.Intn(2*size))
+				switch r := rng.Intn(100); {
+				case r == 0:
+					// 1% of the time, clear the entire cache.
+					c.Clear()
+				case r <= 10:
+					// 10% of the time, purge an entry.
+					c.Purge(sql)
+				case r <= 35:
+					// 25% of the time, add an entry.
+					c.Add(&CachedData{SQL: sql, Memo: &memo.Memo{}})
+				default:
+					// The rest of the time, find an entry.
+					_, _ = c.Find(sql)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/workload/connection.go
+++ b/pkg/workload/connection.go
@@ -40,7 +40,7 @@ func NewConnFlags(genFlags *Flags) *ConnFlags {
 		`Override for the SQL database to use. If empty, defaults to the generator name`)
 	c.IntVar(&c.Concurrency, `concurrency`, 2*runtime.NumCPU(),
 		`Number of concurrent workers`)
-	c.StringVar(&c.Method, `method`, `prepare`, `SQL issue method (prepare, noprepare)`)
+	c.StringVar(&c.Method, `method`, `prepare`, `SQL issue method (prepare, noprepare, simple)`)
 	genFlags.AddFlagSet(c.FlagSet)
 	if genFlags.Meta == nil {
 		genFlags.Meta = make(map[string]FlagMeta)


### PR DESCRIPTION
Initial implementation of a query plan cache. The cache is disabled by
default. Limitations:
 - the cache is only used for non-prepared statements ("simple query"
   pgwire message); using the cache for prepare involves other
   difficulties (we need to remember more information, e.g. argument
   type hints etc).

 - the cache has very simplistic memory management - it uses a fixed
   number of "slots" and rejects all plans above a certain size.

 - the cache uses a single global lock; as we run more experiments, we
   will decide if we need to shard it into multiple instances.

 - we don't invalidate a cached plan on new statistics.

 - tests are a work in progress.

I ran a KV workload with `simple` method and Zipfian distribution with
log messages on and confirmed we get cache hits.

Release note: None