### PR TITLE
roachtest: add and fix acceptance/replicagc-changed-peers

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -17,53 +17,58 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
 func registerAcceptance(r *registry) {
-	// The acceptance tests all share a 4-node cluster and run sequentially. In
+	// The acceptance tests all share a cluster and run sequentially. In
 	// local mode the acceptance tests should be configured to run within a
 	// minute or so as these tests are run on every merge to master.
-	spec := testSpec{
-		Name:  "acceptance",
-		Nodes: nodes(4),
-	}
 
-	testCases := []struct {
+	testCases := map[int][]struct {
 		name string
 		fn   func(ctx context.Context, t *test, c *cluster)
 	}{
-		// Sorted. Please keep it that way.
-		{"bank/cluster-recovery", runBankClusterRecovery},
-		{"bank/node-restart", runBankNodeRestart},
-		{"bank/zerosum-splits", runBankNodeZeroSum},
-		//TODO(masha) This is flaking for same reasons as bank/node-restart
-		// enable after #30064 is fixed.
-		//{"bank/zerosum-restart", runBankZeroSumRestart},
-		{"build-info", runBuildInfo},
-		{"cli/node-status", runCLINodeStatus},
-		{"decommission", runDecommissionAcceptance},
-		{"cluster-init", runClusterInit},
-		{"event-log", runEventLog},
-		{"gossip/peerings", runGossipPeerings},
-		{"gossip/restart", runGossipRestart},
-		{"gossip/restart-node-one", runGossipRestartNodeOne},
-		{"gossip/locality-address", runCheckLocalityIPAddress},
-		{"rapid-restart", runRapidRestart},
-		{"status-server", runStatusServer},
-		{"version-upgrade", runVersionUpgrade},
+		4: {
+			// Sorted. Please keep it that way.
+			{"bank/cluster-recovery", runBankClusterRecovery},
+			{"bank/node-restart", runBankNodeRestart},
+			{"bank/zerosum-splits", runBankNodeZeroSum},
+			//TODO(masha) This is flaking for same reasons as bank/node-restart
+			// enable after #30064 is fixed.
+			//{"bank/zerosum-restart", runBankZeroSumRestart},
+			{"build-info", runBuildInfo},
+			{"cli/node-status", runCLINodeStatus},
+			{"decommission", runDecommissionAcceptance},
+			{"cluster-init", runClusterInit},
+			{"event-log", runEventLog},
+			{"gossip/peerings", runGossipPeerings},
+			{"gossip/restart", runGossipRestart},
+			{"gossip/restart-node-one", runGossipRestartNodeOne},
+			{"gossip/locality-address", runCheckLocalityIPAddress},
+			{"rapid-restart", runRapidRestart},
+			{"status-server", runStatusServer},
+			{"version-upgrade", runVersionUpgrade},
+		},
 	}
-	for _, tc := range testCases {
-		tc := tc
-		spec.SubTests = append(spec.SubTests, testSpec{
-			Name:    tc.name,
-			Timeout: 10 * time.Minute,
-			Run: func(ctx context.Context, t *test, c *cluster) {
-				c.Wipe(ctx)
-				tc.fn(ctx, t, c)
-			},
-		})
-	}
+	for numNodes, cases := range testCases {
+		spec := testSpec{
+			Name:  fmt.Sprintf("acceptance/nodes=%d", numNodes),
+			Nodes: nodes(numNodes),
+		}
 
-	r.Add(spec)
+		for _, tc := range cases {
+			tc := tc
+			spec.SubTests = append(spec.SubTests, testSpec{
+				Name:    tc.name,
+				Timeout: 10 * time.Minute,
+				Run: func(ctx context.Context, t *test, c *cluster) {
+					c.Wipe(ctx)
+					tc.fn(ctx, t, c)
+				},
+			})
+		}
+		r.Add(spec)
+	}
 }

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -50,6 +50,7 @@ func registerTests(r *registry) {
 	registerLargeRange(r)
 	registerQueue(r)
 	registerRebalanceLoad(r)
+	registerReplicaGC(r)
 	registerRestore(r)
 	registerRoachmart(r)
 	registerScaleData(r)

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -1,0 +1,164 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func registerReplicaGC(r *registry) {
+
+	r.Add(testSpec{
+		Name:  "replicagc-changed-peers/withRestart",
+		Nodes: nodes(6),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runReplicaGCChangedPeers(ctx, t, c, true /* withRestart */)
+		},
+	})
+	r.Add(testSpec{
+		Name:  "replicagc-changed-peers/noRestart",
+		Nodes: nodes(6),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runReplicaGCChangedPeers(ctx, t, c, false /* withRestart */)
+		},
+	})
+}
+
+func runReplicaGCChangedPeers(ctx context.Context, t *test, c *cluster, withRestart bool) {
+	if c.nodes != 6 {
+		t.Fatal("test needs to be run with 6 nodes")
+	}
+
+	args := startArgs("--sequential", "--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
+	c.Put(ctx, cockroach, "./cockroach")
+	c.Put(ctx, workload, "./workload", c.Node(1))
+	c.Start(ctx, t, args, c.Range(1, 3))
+
+	t.Status("waiting for full replication")
+	func() {
+		db := c.Conn(ctx, 3)
+		defer func() {
+			_ = db.Close()
+		}()
+		for {
+			var fullReplicated bool
+			if err := db.QueryRow(
+				// Check if all ranges are fully replicated.
+				"SELECT min(array_length(replicas, 1)) >= 3 FROM crdb_internal.ranges",
+			).Scan(&fullReplicated); err != nil {
+				t.Fatal(err)
+			}
+			if fullReplicated {
+				break
+			}
+			time.Sleep(time.Second)
+		}
+	}()
+
+	c.Run(ctx, c.Node(1), "./workload run kv {pgurl:1} --init --max-ops=1 --splits 100")
+
+	// Kill the third node so it won't know that all of its replicas are moved
+	// elsewhere. (We don't use the first because that's what roachprod will
+	// join new nodes to).
+	c.Stop(ctx, c.Node(3))
+
+	// Start three new nodes that will take over all data.
+	c.Start(ctx, t, args, c.Range(4, 6))
+
+	if _, err := execCLI(ctx, t, c, 2, "node", "decommission", "1", "2", "3"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stop the remaining two old nodes.
+	c.Stop(ctx, c.Range(1, 2))
+
+	db4 := c.Conn(ctx, 4)
+	defer func() {
+		_ = db4.Close()
+	}()
+
+	for _, change := range []string{
+		"RANGE default", "RANGE meta", "RANGE system", "RANGE liveness", "DATABASE system", "TABLE system.jobs",
+	} {
+		stmt := `ALTER ` + change + ` CONFIGURE ZONE = 'constraints: {"-deadnode"}'`
+		c.l.Printf(stmt + "\n")
+		if _, err := db4.ExecContext(ctx, stmt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Recommission n3 so that when it starts again, it doesn't even know that
+	// it was decommissioned (being decommissioning basically lets the replica
+	// GC queue run wild). We also recommission the other nodes, for if we didn't,
+	// n3 would learn that they are decommissioned and would try to perform
+	// replication changes on its ranges, which acquires the lease, which hits
+	// the eager GC path since the Raft groups get initialized.
+	if _, err := execCLI(ctx, t, c, 4, "node", "recommission", "1", "2", "3"); err != nil {
+		t.Fatal(err)
+	}
+
+	if withRestart {
+		// Restart the remainder of the cluster. This makes sure there are lots of
+		// dormant ranges but also and importantly removes all trace of n1 and n2
+		// from the Gossip network. If n3 upon restarting learns that n1 and n2
+		// used to exist, the replicate queue wakes up a number of ranges due to
+		// rebalancing and repair attempts. Lacking this information it does not
+		// do that within the store dead interval (5m, i.e. too long for this
+		// test).
+		c.Stop(ctx, c.Range(4, 6))
+		c.Start(ctx, t, args, c.Range(4, 6))
+	}
+
+	// Restart n3. We have to manually tell it where to find a new node or it
+	// won't be able to connect. Give it the attribute that we've used as a
+	// negative constraint for "everything" so that no new replicas are added
+	// to this node.
+	addr4 := c.InternalAddr(ctx, c.Node(4))[0]
+	c.Start(ctx, t, c.Node(3), startArgs(
+		"--args=--join="+addr4,
+		"--args=--attrs=deadnode",
+		"--args=--vmodule=raft=5,replicate_queue=5,allocator=5",
+		"--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms",
+	))
+
+	db3 := c.Conn(ctx, 3)
+	defer func() {
+		_ = db3.Close()
+	}()
+
+	// Loop for two metric sample intervals (10s) to make sure n3 doesn't see any
+	// underreplicated ranges.
+	var sawNonzero bool
+	var n int
+	for tBegin := timeutil.Now(); timeutil.Since(tBegin) < 5*time.Minute; time.Sleep(time.Second) {
+		if err := db3.QueryRowContext(
+			ctx,
+			`SELECT value FROM crdb_internal.node_metrics WHERE name = 'replicas'`,
+		).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		c.l.Printf("%d replicas on n3\n", n)
+		if sawNonzero && n == 0 {
+			break
+		}
+		sawNonzero = true
+	}
+	if n != 0 {
+		t.Fatalf("replica count didn't drop to zero: %d", n)
+	}
+}

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -97,6 +97,7 @@ func newReplicaGCQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *repl
 		queueConfig{
 			maxSize:                  defaultQueueMaxSize,
 			needsLease:               false,
+			needsRaftInitialized:     true,
 			needsSystemConfig:        false,
 			acceptsUnsplitRanges:     true,
 			processDestroyedReplicas: true,


### PR DESCRIPTION
This fixes the failure of the acceptance test (see below)
since it will wake up dormant replicas, at which point they'll
become candidates and are checked for replicaGC aggressively.

This change also means that as a node restarts, all replicas are woken
up (once) over an interval of 10 minutes (default scan interval) when a
node restarts. This is a kind of "slow unquiescence storm" that should
not impact cluster performance significantly. For example, at 50k
ranges, we'd wake up ~83 ranges per second over the first ten minutes
after restarting a node (virtually all of these ranges are expected to
immediately quiesce again).

It's still unfortunate that this is sort of a side effect in the base
queue and driven by the scanner. Perhaps we could add a goroutine at
node start time that explicitly performs this task, and generates
appropriate output to indicate what's happening.

For the test:

Shut down a node, move all of its replicas to a completely disjoint set
of stores, and restart the node. Ensure that it replicaGCs the remaining
replicas reasonably fast (i.e. within minutes).

Note that #32843 would cause failures in this test as well, but this
problem has not been observed so far and are unlikely to occur in this
test since it leaves no freedom for replica placement at any time.

Fixes #25131.
Fixes #24067.

[1]: https://github.com/cockroachdb/cockroach/blob/cf617ba86cae5e6a8b7f977ebb49ea6f0afe6a95/pkg/storage/replica_gc_queue.go#L144-L155

Release note (bug fix): CockroachDB will no longer report erroneous under-replicated ranges corresponding to replicas that were waiting to be deleted.