### PR TITLE
sql: Add default_int_size to control INT alias

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -59,6 +59,7 @@
 <tr><td><code>server.shutdown.query_wait</code></td><td>duration</td><td><code>10s</code></td><td>the server will wait for at least this amount of time for active queries to finish</td></tr>
 <tr><td><code>server.time_until_store_dead</code></td><td>duration</td><td><code>5m0s</code></td><td>the time after which if there is no new gossiped information about a store, it is considered dead</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
+<tr><td><code>sql.defaults.default_int_size</code></td><td>integer</td><td><code>8</code></td><td>the size, in bytes, of an INT type</td></tr>
 <tr><td><code>sql.defaults.distsql</code></td><td>enumeration</td><td><code>1</code></td><td>default distributed SQL execution mode [off = 0, auto = 1, on = 2, 2.0-off = 3, 2.0-auto = 4]</td></tr>
 <tr><td><code>sql.defaults.experimental_optimizer_updates</code></td><td>boolean</td><td><code>false</code></td><td>default experimental_optimizer_updates mode</td></tr>
 <tr><td><code>sql.defaults.experimental_vectorize</code></td><td>boolean</td><td><code>false</code></td><td>default experimental_vectorize mode</td></tr>

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -81,6 +81,18 @@ var ClusterSecret = func() *settings.StringSetting {
 	return s
 }()
 
+// defaultIntSize controls how a "naked" INT type will be parsed.
+// TODO(bob): Change this to 4 in v2.3; https://github.com/cockroachdb/cockroach/issues/32534
+// TODO(bob): Remove or n-op this in v2.4: https://github.com/cockroachdb/cockroach/issues/32844
+var defaultIntSize = settings.RegisterValidatedIntSetting(
+	"sql.defaults.default_int_size",
+	"the size, in bytes, of an INT type", 8, func(i int64) error {
+		if i != 4 && i != 8 {
+			return errors.New("only 4 or 8 are valid values")
+		}
+		return nil
+	})
+
 // traceTxnThreshold can be used to log SQL transactions that take
 // longer than duration to complete. For example, traceTxnThreshold=1s
 // will log the trace for any transaction that takes 1s or longer. To
@@ -1612,6 +1624,10 @@ func (m *sessionDataMutator) SetExtraFloatDigits(val int) {
 
 func (m *sessionDataMutator) SetDatabase(dbName string) {
 	m.data.Database = dbName
+}
+
+func (m *sessionDataMutator) SetDefaultIntSize(size int) {
+	m.data.DefaultIntSize = size
 }
 
 func (m *sessionDataMutator) SetDefaultReadOnly(val bool) {

--- a/pkg/sql/logictest/testdata/logic_test/int_size
+++ b/pkg/sql/logictest/testdata/logic_test/int_size
@@ -1,0 +1,177 @@
+# LogicTest: local local-opt local-parallel-stmts fakedist fakedist-opt fakedist-metadata
+
+subtest defaults
+
+query T
+SHOW default_int_size
+----
+8
+
+subtest set_int4
+
+statement ok
+SET default_int_size=4
+
+query T
+SHOW default_int_size
+----
+4
+
+statement ok
+CREATE TABLE i4 (i4 INT)
+
+query TT
+SHOW CREATE TABLE i4
+----
+i4  CREATE TABLE i4 (
+    i4 INT4 NULL,
+    FAMILY "primary" (i4, rowid)
+)
+
+subtest set_int8
+
+statement ok
+SET default_int_size=8
+
+query T
+SHOW default_int_size
+----
+8
+
+statement ok
+CREATE TABLE i8 (i8 INT)
+
+query TT
+SHOW CREATE TABLE i8
+----
+i8  CREATE TABLE i8 (
+    i8 INT8 NULL,
+    FAMILY "primary" (i8, rowid)
+)
+
+# https://github.com/cockroachdb/cockroach/issues/32846
+subtest issue_32846
+
+statement ok
+SET default_int_size=8
+
+# Parsing and evaluation are async, so the setting won't take
+# effect until the next statement is evaluated.
+statement ok
+SET default_int_size=4; CREATE TABLE late4 (a INT)
+
+query TT
+SHOW CREATE TABLE late4
+----
+late4  CREATE TABLE late4 (
+       a INT8 NULL,
+       FAMILY "primary" (a, rowid)
+)
+
+query T
+SHOW default_int_size
+----
+4
+
+subtest set_bad_value
+
+statement error pq: only 4 or 8 are supported by default_int_size
+SET default_int_size=2
+
+# We want to check the combinations of default_int_size and
+# experimental_serialization_normalization.
+
+subtest serial_rowid
+# When using rowid, we should always see INT8, since that's the
+# return type of unique_rowid()
+
+statement ok
+SET default_int_size=4; SET experimental_serial_normalization='rowid';
+
+statement ok
+CREATE TABLE i4_rowid (a SERIAL)
+
+query TT
+SHOW CREATE TABLE i4_rowid
+----
+i4_rowid  CREATE TABLE i4_rowid (
+          a INT8 NOT NULL DEFAULT unique_rowid(),
+          FAMILY "primary" (a, rowid)
+)
+
+statement ok
+SET default_int_size=8; SET experimental_serial_normalization='rowid';
+
+statement ok
+CREATE TABLE i8_rowid (a SERIAL)
+
+query TT
+SHOW CREATE TABLE i8_rowid
+----
+i8_rowid  CREATE TABLE i8_rowid (
+          a INT8 NOT NULL DEFAULT unique_rowid(),
+          FAMILY "primary" (a, rowid)
+)
+
+subtest serial_sql_sequence
+# When using rowid, we should see an INTx that matches the current size setting.
+
+statement ok
+SET default_int_size=4; SET experimental_serial_normalization='sql_sequence';
+
+statement ok
+CREATE TABLE i4_sql_sequence (a SERIAL)
+
+query TT
+SHOW CREATE TABLE i4_sql_sequence
+----
+i4_sql_sequence  CREATE TABLE i4_sql_sequence (
+                 a INT4 NOT NULL DEFAULT nextval('i4_sql_sequence_a_seq':::STRING),
+                 FAMILY "primary" (a, rowid)
+)
+
+statement ok
+SET default_int_size=8; SET experimental_serial_normalization='sql_sequence';
+
+statement ok
+CREATE TABLE i8_sql_sequence (a SERIAL)
+
+query TT
+SHOW CREATE TABLE i8_sql_sequence
+----
+i8_sql_sequence  CREATE TABLE i8_sql_sequence (
+                 a INT8 NOT NULL DEFAULT nextval('i8_sql_sequence_a_seq':::STRING),
+                 FAMILY "primary" (a, rowid)
+)
+
+subtest serial_virtual_sequence
+# Virtual sequences are a wrapper around unique_rowid(), so they will also
+# return an INT8 value.
+
+statement ok
+SET default_int_size=4; SET experimental_serial_normalization='virtual_sequence';
+
+statement ok
+CREATE TABLE i4_virtual_sequence (a SERIAL)
+
+query TT
+SHOW CREATE TABLE i4_virtual_sequence
+----
+i4_virtual_sequence  CREATE TABLE i4_virtual_sequence (
+                     a INT8 NOT NULL DEFAULT nextval('i4_virtual_sequence_a_seq':::STRING),
+                     FAMILY "primary" (a, rowid)
+)
+
+statement ok
+SET default_int_size=8; SET experimental_serial_normalization='virtual_sequence';
+
+statement ok
+CREATE TABLE i8_virtual_sequence (a SERIAL)
+
+query TT
+SHOW CREATE TABLE i8_virtual_sequence
+----
+i8_virtual_sequence  CREATE TABLE i8_virtual_sequence (
+                     a INT8 NOT NULL DEFAULT nextval('i8_virtual_sequence_a_seq':::STRING),
+                     FAMILY "primary" (a, rowid)
+)

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1335,6 +1335,7 @@ client_encoding                    UTF8          NULL      NULL        NULL     
 client_min_messages                notice        NULL      NULL        NULL        string
 database                           test          NULL      NULL        NULL        string
 datestyle                          ISO, MDY      NULL      NULL        NULL        string
+default_int_size                   8             NULL      NULL        NULL        string
 default_transaction_isolation      serializable  NULL      NULL        NULL        string
 default_transaction_read_only      off           NULL      NULL        NULL        string
 distsql                            2.0-off       NULL      NULL        NULL        string
@@ -1379,6 +1380,7 @@ client_encoding                    UTF8          NULL  user     NULL      UTF8  
 client_min_messages                notice        NULL  user     NULL      notice        notice
 database                           test          NULL  user     NULL      ·             test
 datestyle                          ISO, MDY      NULL  user     NULL      ISO, MDY      ISO, MDY
+default_int_size                   8             NULL  user     NULL      8             8
 default_transaction_isolation      serializable  NULL  user     NULL      default       default
 default_transaction_read_only      off           NULL  user     NULL      off           off
 distsql                            2.0-off       NULL  user     NULL      2.0-off       2.0-off
@@ -1419,6 +1421,7 @@ client_min_messages                NULL    NULL     NULL     NULL        NULL
 crdb_version                       NULL    NULL     NULL     NULL        NULL
 database                           NULL    NULL     NULL     NULL        NULL
 datestyle                          NULL    NULL     NULL     NULL        NULL
+default_int_size                   NULL    NULL     NULL     NULL        NULL
 default_transaction_isolation      NULL    NULL     NULL     NULL        NULL
 default_transaction_read_only      NULL    NULL     NULL     NULL        NULL
 distsql                            NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -32,6 +32,7 @@ client_encoding                    UTF8
 client_min_messages                notice
 database                           test
 datestyle                          ISO, MDY
+default_int_size                   8
 default_transaction_isolation      serializable
 default_transaction_read_only      off
 distsql                            2.0-off

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -195,7 +195,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'database'
       └── values  ·       ·
-·                 size    2 columns, 37 rows
+·                 size    2 columns, 38 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -204,7 +204,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'timezone'
       └── values  ·       ·
-·                 size    2 columns, 37 rows
+·                 size    2 columns, 38 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -213,7 +213,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'default_transaction_isolation'
       └── values  ·       ·
-·                 size    2 columns, 37 rows
+·                 size    2 columns, 38 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -222,7 +222,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_isolation'
       └── values  ·       ·
-·                 size    2 columns, 37 rows
+·                 size    2 columns, 38 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -231,7 +231,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_priority'
       └── values  ·       ·
-·                 size    2 columns, 37 rows
+·                 size    2 columns, 38 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -186,7 +186,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'database'
       └── values  ·       ·
-·                 size    2 columns, 37 rows
+·                 size    2 columns, 38 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -195,7 +195,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'timezone'
       └── values  ·       ·
-·                 size    2 columns, 37 rows
+·                 size    2 columns, 38 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -204,7 +204,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'default_transaction_isolation'
       └── values  ·       ·
-·                 size    2 columns, 37 rows
+·                 size    2 columns, 38 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -213,7 +213,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_isolation'
       └── values  ·       ·
-·                 size    2 columns, 37 rows
+·                 size    2 columns, 38 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -222,7 +222,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_priority'
       └── values  ·       ·
-·                 size    2 columns, 37 rows
+·                 size    2 columns, 38 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6533,7 +6533,7 @@ const_typename:
   }
 | SERIAL
   {
-    $$.val = coltypes.Serial8
+    $$.val = sqllex.(*scanner).nakedSerialType
   }
 | SERIAL2
   {
@@ -6623,11 +6623,11 @@ opt_numeric_modifiers:
 numeric:
   INT
   {
-    $$.val = coltypes.Int8
+    $$.val = sqllex.(*scanner).nakedIntType
   }
 | INTEGER
   {
-    $$.val = coltypes.Int8
+    $$.val = sqllex.(*scanner).nakedIntType
   }
 | INT2
   {

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -87,6 +87,9 @@ type SessionData struct {
 	// identifier `cockroach_restart` in order use a restartable
 	// transaction.
 	ForceSavepointRestart bool
+	// DefaultIntSize specifies the size in bits or bytes (preferred)
+	// of how a "naked" INT type should be parsed.
+	DefaultIntSize int
 }
 
 // DataConversionConfig contains the parameters that influence


### PR DESCRIPTION
This is a follow-up from #32831 to support #26925.

The combination of `default_int_size` interacts with
`experimental_serial_normalization`. Sequence types that are ultimately based
on `unique_rowid()` must always be INT8 types in order to hold the returned
values.  Only in the case where `default_int_size=4
experimental_serial_normalization='sql_sequence'` will an INT4 column be
created in response to a SERIAL type.

Release note (sql change): A new session variable `default_int_size` and
cluster setting `sql.defaults.default_int_size` have been added to control how
the INT and SERIAL types are interpreted. The default value, 8, causes the INT
and SERIAL types to be interpreted as aliases for INT8 and SERIAL8, which have
been the historical defaults for CockroachDB.  PostgreSQL clients that expect
INT and SERIAL to be 32-bit values, can set `default_int_size` to 4, which will
cause INT and SERIAL to be aliases for INT4 and SERIAL4.  Please note that due
to issue #32846, `SET default_int_size` does not take effect until the next
statement batch is executed.

