### PR TITLE
sql: add validation to cascading zone configs

### DIFF
--- a/docs/generated/sql/bnf/alter_zone_database_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_zone_database_stmt.bnf
@@ -1,3 +1,4 @@
 alter_zone_database_stmt ::=
-	'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value ) )*
+	'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'USING' variable '=' 'COPY' 'FROM' 'PARENT' ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
+	| 'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
 	| 'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'DISCARD'

--- a/docs/generated/sql/bnf/alter_zone_index_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_zone_index_stmt.bnf
@@ -1,5 +1,7 @@
 alter_zone_index_stmt ::=
-	'ALTER' 'INDEX' table_name '@' index_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value ) )*
+	'ALTER' 'INDEX' table_name '@' index_name 'CONFIGURE' 'ZONE' 'USING' variable '=' 'COPY' 'FROM' 'PARENT' ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
+	| 'ALTER' 'INDEX' table_name '@' index_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
 	| 'ALTER' 'INDEX' table_name '@' index_name 'CONFIGURE' 'ZONE' 'DISCARD'
-	| 'ALTER' 'INDEX' table_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value ) )*
+	| 'ALTER' 'INDEX' table_name 'CONFIGURE' 'ZONE' 'USING' variable '=' 'COPY' 'FROM' 'PARENT' ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
+	| 'ALTER' 'INDEX' table_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
 	| 'ALTER' 'INDEX' table_name 'CONFIGURE' 'ZONE' 'DISCARD'

--- a/docs/generated/sql/bnf/alter_zone_range_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_zone_range_stmt.bnf
@@ -1,3 +1,4 @@
 alter_zone_range_stmt ::=
-	'ALTER' 'RANGE' range_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value ) )*
+	'ALTER' 'RANGE' range_name 'CONFIGURE' 'ZONE' 'USING' variable '=' 'COPY' 'FROM' 'PARENT' ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
+	| 'ALTER' 'RANGE' range_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
 	| 'ALTER' 'RANGE' range_name 'CONFIGURE' 'ZONE' 'DISCARD'

--- a/docs/generated/sql/bnf/alter_zone_table_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_zone_table_stmt.bnf
@@ -1,5 +1,7 @@
 alter_zone_table_stmt ::=
-	'ALTER' 'TABLE' table_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value ) )*
+	'ALTER' 'TABLE' table_name 'CONFIGURE' 'ZONE' 'USING' variable '=' 'COPY' 'FROM' 'PARENT' ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
+	| 'ALTER' 'TABLE' table_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
 	| 'ALTER' 'TABLE' table_name 'CONFIGURE' 'ZONE' 'DISCARD'
-	| 'ALTER' 'PARTITION' partition_name 'OF' 'TABLE' table_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value ) )*
+	| 'ALTER' 'PARTITION' partition_name 'OF' 'TABLE' table_name 'CONFIGURE' 'ZONE' 'USING' variable '=' 'COPY' 'FROM' 'PARENT' ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
+	| 'ALTER' 'PARTITION' partition_name 'OF' 'TABLE' table_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
 	| 'ALTER' 'PARTITION' partition_name 'OF' 'TABLE' table_name 'CONFIGURE' 'ZONE' 'DISCARD'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1829,7 +1829,7 @@ alter_table_cmd ::=
 	| partition_by
 
 var_set_list ::=
-	( var_name '=' var_value ) ( ( ',' var_name '=' var_value ) )*
+	( var_name '=' 'COPY' 'FROM' 'PARENT' | var_name '=' var_value ) ( ( ',' var_name '=' var_value | ',' var_name '=' 'COPY' 'FROM' 'PARENT' ) )*
 
 alter_index_cmd ::=
 	partition_by

--- a/pkg/cli/testdata/zone_range_max_bytes.yaml
+++ b/pkg/cli/testdata/zone_range_max_bytes.yaml
@@ -1,2 +1,3 @@
 range_max_bytes: 134217728
+range_min_bytes: 16777216
 num_replicas: 3

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -138,8 +138,11 @@ func runLoadSplits(ctx context.Context, t *test, c *cluster, params splitParams)
 		}
 
 		t.Status("increasing range_max_bytes")
+		minBytes := 16 << 20 // 16 MB
 		setRangeMaxBytes := func(maxBytes int) {
-			stmtZone := fmt.Sprintf("ALTER RANGE default CONFIGURE ZONE USING range_max_bytes = %d", maxBytes)
+			stmtZone := fmt.Sprintf(
+				"ALTER RANGE default CONFIGURE ZONE USING range_max_bytes = %d, range_min_bytes = %d",
+				maxBytes, minBytes)
 			if _, err := db.Exec(stmtZone); err != nil {
 				t.Fatalf("failed to set range_max_bytes: %v", err)
 			}
@@ -252,8 +255,11 @@ func runLargeRangeSplits(ctx context.Context, t *test, c *cluster, size int) {
 		}
 
 		t.Status("increasing range_max_bytes")
+		minBytes := 16 << 20 // 16 MB
 		setRangeMaxBytes := func(maxBytes int) {
-			stmtZone := fmt.Sprintf("ALTER RANGE default CONFIGURE ZONE USING range_max_bytes = %d", maxBytes)
+			stmtZone := fmt.Sprintf(
+				"ALTER RANGE default CONFIGURE ZONE USING range_max_bytes = %d, range_min_bytes = %d",
+				maxBytes, minBytes)
 			_, err := db.Exec(stmtZone)
 			if err != nil && strings.Contains(err.Error(), "syntax error") {
 				// Pre-2.1 was EXPERIMENTAL.

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -510,6 +510,45 @@ func (z *ZoneConfig) InheritFromParent(parent ZoneConfig) {
 	}
 }
 
+// CopyFromZone copies over the specified fields from the other zone.
+func (z *ZoneConfig) CopyFromZone(other ZoneConfig, fieldList []tree.Name) {
+	for _, fieldName := range fieldList {
+		if fieldName == "num_replicas" {
+			z.NumReplicas = nil
+			if other.NumReplicas != nil {
+				z.NumReplicas = proto.Int32(*other.NumReplicas)
+			}
+		}
+		if fieldName == "range_min_bytes" {
+			z.RangeMinBytes = nil
+			if other.RangeMinBytes != nil {
+				z.RangeMinBytes = proto.Int64(*other.RangeMinBytes)
+			}
+		}
+		if fieldName == "range_max_bytes" {
+			z.RangeMaxBytes = nil
+			if other.RangeMaxBytes != nil {
+				z.RangeMaxBytes = proto.Int64(*other.RangeMaxBytes)
+			}
+		}
+		if fieldName == "gc.ttlseconds" {
+			z.GC = nil
+			if other.GC != nil {
+				tempGC := *other.GC
+				z.GC = &tempGC
+			}
+		}
+		if fieldName == "constraints" {
+			z.Constraints = other.Constraints
+			z.InheritedConstraints = other.InheritedConstraints
+		}
+		if fieldName == "lease_preferences" {
+			z.LeasePreferences = other.LeasePreferences
+			z.InheritedLeasePreferences = other.InheritedLeasePreferences
+		}
+	}
+}
+
 // StoreMatchesConstraint returns whether a store matches the given constraint.
 func StoreMatchesConstraint(store roachpb.StoreDescriptor, constraint Constraint) bool {
 	hasConstraint := storeHasConstraint(store, constraint)

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -358,7 +358,7 @@ statement ok
 CREATE TABLE a (id INT PRIMARY KEY)
 
 statement ok
-ALTER TABLE a CONFIGURE ZONE USING range_max_bytes = 67108865
+ALTER TABLE a CONFIGURE ZONE USING range_max_bytes = 67108865, range_min_bytes = 16777216
 
 statement ok
 ALTER TABLE a CONFIGURE ZONE DISCARD
@@ -371,7 +371,7 @@ FROM system.eventlog
 WHERE "eventType" = 'set_zone_config'
 ORDER BY "timestamp"
 ----
-60  1  {"Target":"test.a","Options":"range_max_bytes = 67108865","User":"root"}
+60  1  {"Target":"test.a","Options":"range_max_bytes = 67108865, range_min_bytes = 16777216","User":"root"}
 
 query IIT
 SELECT "targetID", "reportingID", "info"

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1102,6 +1102,10 @@ func TestParse(t *testing.T) {
 		{`ALTER INDEX db.t@i CONFIGURE ZONE USING foo = bar, baz = yay`},
 		{`ALTER INDEX t@i CONFIGURE ZONE USING foo = bar, baz = yay`},
 		{`ALTER INDEX i CONFIGURE ZONE USING foo = bar, baz = yay`},
+		{`ALTER INDEX i CONFIGURE ZONE USING foo = COPY FROM PARENT`},
+		{`ALTER INDEX i CONFIGURE ZONE USING foo = bar, baz = COPY FROM PARENT`},
+		{`ALTER INDEX i CONFIGURE ZONE USING foo = COPY FROM PARENT, baz = COPY FROM PARENT`},
+		{`ALTER INDEX i CONFIGURE ZONE USING foo = bar, other = COPY FROM PARENT, baz = yay`},
 
 		{`ALTER RANGE default CONFIGURE ZONE DISCARD`},
 		{`ALTER RANGE meta CONFIGURE ZONE DISCARD`},
@@ -1688,6 +1692,8 @@ func TestParse2(t *testing.T) {
 			`ALTER INDEX t@i CONFIGURE ZONE USING "foo.bar" = yay`},
 		{`ALTER INDEX i CONFIGURE ZONE USING foo.bar = yay`,
 			`ALTER INDEX i CONFIGURE ZONE USING "foo.bar" = yay`},
+		{`ALTER INDEX i CONFIGURE ZONE USING foo = COPY FROM PARENT`,
+			`ALTER INDEX i CONFIGURE ZONE USING "foo" = COPY FROM PARENT`},
 
 		// Alternative forms for table patterns.
 

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1693,7 +1693,7 @@ func TestParse2(t *testing.T) {
 		{`ALTER INDEX i CONFIGURE ZONE USING foo.bar = yay`,
 			`ALTER INDEX i CONFIGURE ZONE USING "foo.bar" = yay`},
 		{`ALTER INDEX i CONFIGURE ZONE USING foo = COPY FROM PARENT`,
-			`ALTER INDEX i CONFIGURE ZONE USING "foo" = COPY FROM PARENT`},
+			`ALTER INDEX i CONFIGURE ZONE USING foo = COPY FROM PARENT`},
 
 		// Alternative forms for table patterns.
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1123,6 +1123,7 @@ alter_ddl_stmt:
 // Zone configurations:
 //   DISCARD
 //   USING <var> = <expr> [, ...]
+//   USING <var> = COPY FROM PARENT [, ...]
 //   { TO | = } <expr>
 //
 // %SeeAlso: WEBDOCS/alter-table.html
@@ -1217,6 +1218,7 @@ alter_database_stmt:
 // Zone configurations:
 //   DISCARD
 //   USING <var> = <expr> [, ...]
+//   USING <var> = COPY FROM PARENT [, ...]
 //   { TO | = } <expr>
 //
 // %SeeAlso: ALTER TABLE
@@ -1412,13 +1414,21 @@ alter_zone_index_stmt:
   }
 
 var_set_list:
-  var_name '=' var_value
+  var_name '=' COPY FROM PARENT
+  {
+    $$.val = []tree.KVOption{tree.KVOption{Key: tree.Name(strings.Join($1.strs(), "."))}}
+  }
+| var_name '=' var_value
   {
     $$.val = []tree.KVOption{tree.KVOption{Key: tree.Name(strings.Join($1.strs(), ".")), Value: $3.expr()}}
   }
 | var_set_list ',' var_name '=' var_value
   {
     $$.val = append($1.kvOptions(), tree.KVOption{Key: tree.Name(strings.Join($3.strs(), ".")), Value: $5.expr()})
+  }
+| var_set_list ',' var_name '=' COPY FROM PARENT
+  {
+    $$.val = append($1.kvOptions(), tree.KVOption{Key: tree.Name(strings.Join($3.strs(), "."))})
   }
 
 alter_scatter_stmt:

--- a/pkg/sql/sem/tree/zone.go
+++ b/pkg/sql/sem/tree/zone.go
@@ -102,6 +102,18 @@ func (node *SetZoneConfig) Format(ctx *FmtCtx) {
 		}
 	} else {
 		ctx.WriteString("USING ")
-		ctx.FormatNode(&node.Options)
+		kvOptions := node.Options
+		comma := ""
+		for _, kv := range kvOptions {
+			ctx.WriteString(comma)
+			comma = ", "
+			ctx.FormatNode(&kv.Key)
+			if kv.Value != nil {
+				ctx.WriteString(` = `)
+				ctx.FormatNode(kv.Value)
+			} else {
+				ctx.WriteString(` = COPY FROM PARENT`)
+			}
+		}
 	}
 }

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/gogo/protobuf/proto"
-	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -117,7 +116,8 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 		case types.String:
 		case types.Bytes:
 		default:
-			return nil, fmt.Errorf("zone config must be of type string or bytes, not %s", typ)
+			return nil, pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError,
+				"zone config must be of type string or bytes, not %s", typ)
 		}
 	}
 
@@ -130,11 +130,13 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 		options = make(map[tree.Name]optionValue)
 		for _, opt := range n.Options {
 			if _, alreadyExists := options[opt.Key]; alreadyExists {
-				return nil, fmt.Errorf("duplicate zone config parameter: %q", tree.ErrString(&opt.Key))
+				return nil, pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError,
+					"duplicate zone config parameter: %q", tree.ErrString(&opt.Key))
 			}
 			req, ok := supportedZoneConfigOptions[opt.Key]
 			if !ok {
-				return nil, fmt.Errorf("unsupported zone config parameter: %q", tree.ErrString(&opt.Key))
+				return nil, pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError,
+					"unsupported zone config parameter: %q", tree.ErrString(&opt.Key))
 			}
 			if opt.Value == nil {
 				options[opt.Key] = optionValue{inheritValue: true, explicitValue: nil}
@@ -209,6 +211,10 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 			inheritVal, expr := val.inheritValue, val.explicitValue
 			if inheritVal {
 				copyFromParentList = append(copyFromParentList, *name)
+				if optionStr.Len() > 0 {
+					optionStr.WriteString(", ")
+				}
+				fmt.Fprintf(&optionStr, "%s = COPY FROM PARENT", name)
 				continue
 			}
 			datum, err := expr.Eval(params.EvalContext())
@@ -216,14 +222,15 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 				return err
 			}
 			if datum == tree.DNull {
-				return fmt.Errorf("unsupported NULL value for %q", tree.ErrString(name))
+				return pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError,
+					"unsupported NULL value for %q", tree.ErrString(name))
 			}
 			setter := supportedZoneConfigOptions[*name].setter
 			setters = append(setters, func(c *config.ZoneConfig) { setter(c, datum) })
 			if optionStr.Len() > 0 {
 				optionStr.WriteString(", ")
 			}
-			fmt.Fprintf(&optionStr, "%s = %s", string(*name), datum)
+			fmt.Fprintf(&optionStr, "%s = %s", name, datum)
 
 		}
 	}
@@ -361,12 +368,14 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		// empty, in which case the unmarshaling will be a no-op. This is
 		// innocuous.
 		if err := yaml.UnmarshalStrict([]byte(yamlConfig), &newZone); err != nil {
-			return fmt.Errorf("could not parse zone config: %v", err)
+			return pgerror.NewErrorf(pgerror.CodeCheckViolationError,
+				"could not parse zone config: %v", err)
 		}
 
 		// Load settings from YAML into the partial zone as well.
 		if err := yaml.UnmarshalStrict([]byte(yamlConfig), &finalZone); err != nil {
-			return fmt.Errorf("could not parse zone config: %v", err)
+			return pgerror.NewErrorf(pgerror.CodeCheckViolationError,
+				"could not parse zone config: %v", err)
 		}
 
 		// Load settings from var = val assignments. If there were no such
@@ -447,7 +456,8 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 
 		// Finally revalidate everything. Validate only the completeZone config.
 		if err := completeZone.Validate(); err != nil {
-			return fmt.Errorf("could not validate zone config: %s", err)
+			return pgerror.NewErrorf(pgerror.CodeCheckViolationError,
+				"could not validate zone config: %v", err)
 		}
 	}
 
@@ -469,7 +479,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 	// Per-replica constraints cannot be set unless num_replicas is explicitly set
 	if err := zoneToWrite.ValidateTandemFields(); err != nil {
 		return pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError,
-			fmt.Sprintf("could not validate zone config: %s", err)).SetHintf(
+			"could not validate zone config: %v", err).SetHintf(
 			"try ALTER ... CONFIGURE ZONE USING <field_name> = COPY FROM PARENT [, ...] so populate the field")
 	}
 	n.run.numAffected, err = writeZoneConfig(params.ctx, params.p.txn,
@@ -581,7 +591,7 @@ func validateZoneAttrsAndLocalities(
 			}
 		}
 		if !found {
-			return fmt.Errorf(
+			return pgerror.NewErrorf(pgerror.CodeCheckViolationError,
 				"constraint %q matches no existing nodes within the cluster - did you enter it correctly?",
 				constraint)
 		}
@@ -602,7 +612,8 @@ func writeZoneConfig(
 	if len(zone.Subzones) > 0 {
 		st := execCfg.Settings
 		if !st.Version.IsMinSupported(cluster.VersionPartitioning) {
-			return 0, errors.New("cluster version does not support zone configs on indexes or partitions")
+			return 0, pgerror.NewError(pgerror.CodeCheckViolationError,
+				"cluster version does not support zone configs on indexes or partitions")
 		}
 		zone.SubzoneSpans, err = GenerateSubzoneSpans(
 			st, execCfg.ClusterID(), table, zone.Subzones, hasNewSubzones)
@@ -616,14 +627,14 @@ func writeZoneConfig(
 	if len(zone.Constraints) > 1 || (len(zone.Constraints) == 1 && zone.Constraints[0].NumReplicas != 0) {
 		st := execCfg.Settings
 		if !st.Version.IsMinSupported(cluster.VersionPerReplicaZoneConstraints) {
-			return 0, errors.New(
+			return 0, pgerror.NewError(pgerror.CodeCheckViolationError,
 				"cluster version does not support zone configs with per-replica constraints")
 		}
 	}
 	if len(zone.LeasePreferences) > 0 {
 		st := execCfg.Settings
 		if !st.Version.IsMinSupported(cluster.VersionLeasePreferences) {
-			return 0, errors.New(
+			return 0, pgerror.NewError(pgerror.CodeCheckViolationError,
 				"cluster version does not support zone configs with lease placement preferences")
 		}
 	}
@@ -635,7 +646,8 @@ func writeZoneConfig(
 
 	buf, err := protoutil.Marshal(zone)
 	if err != nil {
-		return 0, fmt.Errorf("could not marshal zone config: %s", err)
+		return 0, pgerror.NewErrorf(pgerror.CodeCheckViolationError,
+			"could not marshal zone config: %v", err)
 	}
 	return execCfg.InternalExecutor.Exec(ctx, "update-zone", txn,
 		"UPSERT INTO system.zones (id, config) VALUES ($1, $2)", targetID, buf)

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -35,10 +35,15 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+type optionValue struct {
+	inheritValue  bool
+	explicitValue tree.TypedExpr
+}
+
 type setZoneConfigNode struct {
 	zoneSpecifier tree.ZoneSpecifier
 	yamlConfig    tree.TypedExpr
-	options       map[tree.Name]tree.TypedExpr
+	options       map[tree.Name]optionValue
 	setDefault    bool
 
 	run setZoneConfigRun
@@ -116,13 +121,13 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 		}
 	}
 
-	var options map[tree.Name]tree.TypedExpr
+	var options map[tree.Name]optionValue
 	if n.Options != nil {
 		// We have a CONFIGURE ZONE USING ... assignment.
 		// Here we are constrained by the supported ZoneConfig fields,
 		// as described by supportedZoneConfigOptions above.
 
-		options = make(map[tree.Name]tree.TypedExpr)
+		options = make(map[tree.Name]optionValue)
 		for _, opt := range n.Options {
 			if _, alreadyExists := options[opt.Key]; alreadyExists {
 				return nil, fmt.Errorf("duplicate zone config parameter: %q", tree.ErrString(&opt.Key))
@@ -131,12 +136,16 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 			if !ok {
 				return nil, fmt.Errorf("unsupported zone config parameter: %q", tree.ErrString(&opt.Key))
 			}
+			if opt.Value == nil {
+				options[opt.Key] = optionValue{inheritValue: true, explicitValue: nil}
+				continue
+			}
 			valExpr, err := p.analyzeExpr(
 				ctx, opt.Value, nil, tree.IndexedVarHelper{}, req.requiredType, true /*requireType*/, string(opt.Key))
 			if err != nil {
 				return nil, err
 			}
-			options[opt.Key] = valExpr
+			options[opt.Key] = optionValue{inheritValue: false, explicitValue: valExpr}
 		}
 	}
 
@@ -179,6 +188,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		yamlConfig = strings.TrimSpace(yamlConfig)
 	}
 	var optionStr strings.Builder
+	var copyFromParentList []tree.Name
 	if n.options != nil {
 		// Set from var = value attributes.
 		//
@@ -187,8 +197,18 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		// the event log remains deterministic.
 		for i := range zoneOptionKeys {
 			name := (*tree.Name)(&zoneOptionKeys[i])
-			expr, ok := n.options[*name]
+			val, ok := n.options[*name]
 			if !ok {
+				continue
+			}
+			// We don't add the setters for the fields that will copy values
+			// from the parents. These fields will be set by taking what
+			// value would apply to the zone and setting that value explicitly.
+			// Instead we add the fields to a list that we use at a later time
+			// to copy values over.
+			inheritVal, expr := val.inheritValue, val.explicitValue
+			if inheritVal {
+				copyFromParentList = append(copyFromParentList, *name)
 				continue
 			}
 			datum, err := expr.Eval(params.EvalContext())
@@ -204,6 +224,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 				optionStr.WriteString(", ")
 			}
 			fmt.Fprintf(&optionStr, "%s = %s", string(*name), datum)
+
 		}
 	}
 
@@ -288,6 +309,9 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 	} else if err != nil {
 		return err
 	}
+
+	// Copy the fields set by the INHERIT field command.
+	partialZone.CopyFromZone(*completeZone, copyFromParentList)
 
 	if deleteZone {
 		if index != nil {
@@ -435,6 +459,18 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 	zoneToWrite := partialZone
 	if !execConfig.Settings.Version.IsMinSupported(cluster.VersionCascadingZoneConfigs) {
 		zoneToWrite = completeZone
+	}
+
+	// Finally check for the extra protection partial zone configs would
+	// require from changes made to parent zones. The extra protections are:
+	//
+	// RangeMinBytes and RangeMaxBytes must be set together
+	// LeasePreferences cannot be set unless Constraints are explicitly set
+	// Per-replica constraints cannot be set unless num_replicas is explicitly set
+	if err := zoneToWrite.ValidateTandemFields(); err != nil {
+		return pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError,
+			fmt.Sprintf("could not validate zone config: %s", err)).SetHintf(
+			"try ALTER ... CONFIGURE ZONE USING <field_name> = COPY FROM PARENT [, ...] so populate the field")
 	}
 	n.run.numAffected, err = writeZoneConfig(params.ctx, params.p.txn,
 		targetID, table, zoneToWrite, execConfig, hasNewSubzones)

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -453,7 +453,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 
 	// If cluster version is below 2.2, just write the complete zone
 	// config instead of the partial for backwards compatibility reasons.
-	// Otherwise write the partial zone configutation.
+	// Otherwise write the partial zone configuration.
 	hasNewSubzones := !deleteZone && index != nil
 	execConfig := params.extendedEvalCtx.ExecCfg
 	zoneToWrite := partialZone

--- a/pkg/sql/set_zone_config_test.go
+++ b/pkg/sql/set_zone_config_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestValidateZoneAttrsAndLocalities(t *testing.T) {


### PR DESCRIPTION
I found a few hours free and so took a second stab at https://github.com/cockroachdb/cockroach/pull/32059. Thought it'd be fun and new to try adding something to SQL for this, so @knz please feel free to tell me if what I've done here makes no sense. 

There are to be two changes to be made: 
1) Allow for the `COPY FROM PARENT` command so users can do something like:
` ALTER ... CONFIGURE ZONE USING range_min_bytes = ..., range_max_bytes = COPY FROM PARENT`

2) Add validation to the zone configs so certain fields are written in tandem. The fields are:
      - `NumReplicas` and `Constraints` (Only when per-replica constraints are in use)
      - `RangeMinBytes` and `RangeMaxBytes`
      - `LeasePreferences` and `Constraints`

Each of the changes are contained in their own commits.