### PR TITLE
server: fix a bug in a test

### DIFF
--- a/pkg/server/server_systemlog_gc_test.go
+++ b/pkg/server/server_systemlog_gc_test.go
@@ -66,7 +66,7 @@ func TestLogGC(t *testing.T) {
 				timestamp,
 				testRangeID,
 				1, // storeID
-				storagepb.RangeLogEventType_add,
+				storagepb.RangeLogEventType_add.String(),
 			)
 			a.NoError(err)
 		}


### PR DESCRIPTION
An int was being inserted in a table instead of the string
representation of an enum, which is what the respective col is supposed
to contain. The bug was benign; it only manifests itself if the admin
endpoints try to read the rangelog. But it was bad and it should feel
bad.

Release note: None