### PR TITLE
storage: fix flake in TestContendedIntentChangesOnRetry

### DIFF
--- a/pkg/storage/intent_resolver_test.go
+++ b/pkg/storage/intent_resolver_test.go
@@ -538,6 +538,10 @@ func TestContendedIntentChangesOnRetry(t *testing.T) {
 		}
 	}
 	if err := <-txnCh5; err != nil {
-		t.Fatal(err)
+		// txn5 can end up being aborted due to a perceived deadlock. This
+		// is rare and isn't important to the test, so we allow it.
+		if _, ok := err.(*roachpb.UnhandledRetryableError); !ok {
+			t.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
Saw in CI of #32853.

We were ignoring deadlock errors on txn4, but not txn5.

Release note: None