### PR TITLE
roachtest: skip sysbench roachtest

### DIFF
--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -129,6 +129,7 @@ func registerSysbench(r *registry) {
 		}
 
 		r.Add(testSpec{
+			Skip:  "https://github.com/cockroachdb/cockroach/issues/32738",
 			Name:  fmt.Sprintf("sysbench/%s/nodes=%d", w, n),
 			Nodes: nodes(n+1, cpu(cpus)),
 			Run: func(ctx context.Context, t *test, c *cluster) {


### PR DESCRIPTION
This is flaky due to some core dump in the sysbench load gen. I haven't
been able to figure it out yet.

See #32738.

Release note: None