### PR TITLE
sql: fix race between backfill and insert on non-null column

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -660,10 +660,21 @@ func GenerateInsertRow(
 	}
 
 	// Check to see if NULL is being inserted into any non-nullable column.
+	checkNullViolation := func(col *sqlbase.ColumnDescriptor) error {
+		if i, ok := rowContainerForComputedVals.Mapping[col.ID]; !col.Nullable && (!ok || rowVals[i] == tree.DNull) {
+			return sqlbase.NewNonNullViolationError(col.Name)
+		}
+		return nil
+	}
 	for _, col := range tableDesc.Columns {
-		if !col.Nullable {
-			if i, ok := rowContainerForComputedVals.Mapping[col.ID]; !ok || rowVals[i] == tree.DNull {
-				return nil, sqlbase.NewNonNullViolationError(col.Name)
+		if err := checkNullViolation(&col); err != nil {
+			return nil, err
+		}
+	}
+	for _, m := range tableDesc.Mutations {
+		if c := m.GetColumn(); c != nil && m.State == sqlbase.DescriptorMutation_DELETE_AND_WRITE_ONLY {
+			if err := checkNullViolation(c); err != nil {
+				return nil, err
 			}
 		}
 	}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2197,7 +2197,10 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT UNIQUE DEFAULT 23 CREATE FAMILY F3
 func TestCRUDWhileColumnBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	backfillNotification := make(chan bool)
-	continueBackfillNotification := make(chan bool)
+
+	backfillCompleteNotification := make(chan bool)
+	continueSchemaChangeNotification := make(chan bool)
+
 	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		DistSQL: &distsqlrun.TestingKnobs{
@@ -2207,9 +2210,18 @@ func TestCRUDWhileColumnBackfill(t *testing.T) {
 					// been queued and the backfill has started.
 					close(backfillNotification)
 					backfillNotification = nil
-					<-continueBackfillNotification
+					<-continueSchemaChangeNotification
 				}
 				return nil
+			},
+			RunAfterBackfillChunk: func() {
+				if backfillCompleteNotification != nil {
+					// Close channel to notify that the schema change
+					// backfill is complete and not finalized.
+					close(backfillCompleteNotification)
+					backfillCompleteNotification = nil
+					<-continueSchemaChangeNotification
+				}
 			},
 		},
 		// Disable backfill migrations, we still need the jobs table migration.
@@ -2224,7 +2236,7 @@ func TestCRUDWhileColumnBackfill(t *testing.T) {
 CREATE DATABASE t;
 CREATE TABLE t.test (
     k INT NOT NULL,
-    v INT NOT NULL,
+    v INT,
     length INT NOT NULL,
     CONSTRAINT "primary" PRIMARY KEY (k),
     INDEX v_idx (v),
@@ -2239,10 +2251,11 @@ INSERT INTO t.test (k, v, length) VALUES (2, 3, 1);
 
 	// Run the column schema change in a separate goroutine.
 	notification := backfillNotification
+	doneNotification := backfillCompleteNotification
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD id INT NOT NULL DEFAULT 2;`); err != nil {
+		if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD id INT NOT NULL DEFAULT 2, ADD u INT NOT NULL AS (v+1) STORED;`); err != nil {
 			t.Error(err)
 		}
 		wg.Done()
@@ -2263,7 +2276,7 @@ INSERT INTO t.test (k, v, length) VALUES (2, 3, 1);
 	// Wait until both mutations are queued up.
 	testutils.SucceedsSoon(t, func() error {
 		tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
-		if l := len(tableDesc.Mutations); l != 2 {
+		if l := len(tableDesc.Mutations); l != 3 {
 			return errors.Errorf("number of mutations = %d", l)
 		}
 		return nil
@@ -2348,7 +2361,7 @@ INSERT INTO t.test (k, v, length) VALUES (2, 3, 1);
 	}
 	expect := `CREATE TABLE test (
 	k INT NOT NULL,
-	v INT NOT NULL,
+	v INT NULL,
 	length INT NOT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (k ASC),
 	INDEX v_idx (v ASC),
@@ -2359,11 +2372,24 @@ INSERT INTO t.test (k, v, length) VALUES (2, 3, 1);
 	}
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
-	if l := len(tableDesc.Mutations); l != 2 {
+	if l := len(tableDesc.Mutations); l != 3 {
 		t.Fatalf("number of mutations = %d", l)
 	}
 
-	close(continueBackfillNotification)
+	continueSchemaChangeNotification <- true
+
+	<-doneNotification
+
+	expectedErr := "\"u\" violates not-null constraint"
+	if _, err := sqlDB.Exec(`INSERT INTO t.test(k, v, length) VALUES (5, NULL, 8)`); !testutils.IsError(err, expectedErr) {
+		t.Fatal(err)
+	}
+
+	if _, err := sqlDB.Exec(`UPDATE t.test SET v = NULL WHERE k = 0`); !testutils.IsError(err, expectedErr) {
+		t.Fatal(err)
+	}
+
+	close(continueSchemaChangeNotification)
 
 	wg.Wait()
 
@@ -2371,26 +2397,26 @@ INSERT INTO t.test (k, v, length) VALUES (2, 3, 1);
 		t.Fatal(err)
 	}
 	// Check data!
-	rows, err := sqlDB.Query(`SELECT k, v, length, id, z FROM t.test`)
+	rows, err := sqlDB.Query(`SELECT k, v, length, id, u, z FROM t.test`)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer rows.Close()
 	expected := [][]int{
-		{0, 1, 27000, 2, 2},
-		{3, 1, 3, 2, 5},
-		{4, 5, 270, 2, 6},
+		{0, 1, 27000, 2, 2, 2},
+		{3, 1, 3, 2, 2, 5},
+		{4, 5, 270, 2, 6, 6},
 	}
 	count := 0
 	for ; rows.Next(); count++ {
-		var i1, i2, i3, i4, i5 *int
-		if err := rows.Scan(&i1, &i2, &i3, &i4, &i5); err != nil {
+		var i1, i2, i3, i4, i5, i6 *int
+		if err := rows.Scan(&i1, &i2, &i3, &i4, &i5, &i6); err != nil {
 			t.Errorf("row %d scan failed: %s", count, err)
 			continue
 		}
-		row := fmt.Sprintf("%d %d %d %d %d", *i1, *i2, *i3, *i4, *i5)
+		row := fmt.Sprintf("%d %d %d %d %d %d", *i1, *i2, *i3, *i4, *i5, *i6)
 		exp := expected[count]
-		expRow := fmt.Sprintf("%d %d %d %d %d", exp[0], exp[1], exp[2], exp[3], exp[4])
+		expRow := fmt.Sprintf("%d %d %d %d %d %d", exp[0], exp[1], exp[2], exp[3], exp[4], exp[5])
 		if row != expRow {
 			t.Errorf("expected %q but read %q", expRow, row)
 		}


### PR DESCRIPTION
A non-null computed column's expression can potentially evaluate to null
values. If the backfill for an inserted row's chunk is already
completed, a data anomaly can be inserted into the table and cause a
panic when the column is eventually public.

Fix this by checking non-null constraints for write-only columns during
insertion.

Release note: None