### PR TITLE
sql: future-proof a test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -103,26 +103,19 @@ query TT
 SELECT operation,
        regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message
   FROM [SHOW KV TRACE FOR SESSION]
-WHERE message NOT LIKE '%Z/%'
+WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%intExec=%'
   AND tag NOT LIKE '%scExec%'
   AND tag NOT LIKE '%IndexBackfiller%'
 ----
-dist sender send  querying next range at /Table/2/1/0/"t"/3/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/54/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
 sql txn           Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-dist sender send  querying next range at /Table/3/1/54/2/1
 dist sender send  r1: sending batch 1 Put to (n1,s1):1
 sql txn           rows affected: 0
-dist sender send  querying next range at /Table/SystemConfigSpan/Start
 dist sender send  r1: sending batch 1 EndTxn, 9 QueryIntent to (n1,s1):1
 
 statement ok
@@ -312,36 +305,24 @@ query TT
 SELECT operation,
        regexp_replace(regexp_replace(regexp_replace(message, 'drop_job_id:[1-9]\d*', 'drop_job_id:...'), 'wall_time:\d+', 'wall_time:...'), 'drop_time:\d+', 'drop_time:...') as message
   FROM [SHOW KV TRACE FOR SESSION]
-WHERE message NOT LIKE '%Z/%'
+WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%intExec=%'
   AND tag NOT LIKE '%scExec%'
   AND tag NOT LIKE '%IndexBackfiller%'
 ----
-dist sender send  querying next range at /Table/2/1/0/"t"/3/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/55/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/5/1/55/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/55/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/5/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/5/1/0/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
 sql txn           Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... >
-dist sender send  querying next range at /Table/3/1/55/2/1
 dist sender send  r1: sending batch 1 Put to (n1,s1):1
 sql txn           rows affected: 0
-dist sender send  querying next range at /Table/SystemConfigSpan/Start
 dist sender send  r1: sending batch 1 EndTxn, 10 QueryIntent to (n1,s1):1
 
 statement ok
@@ -371,48 +352,30 @@ query TT
 SELECT operation,
        regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message
   FROM [SHOW KV TRACE FOR SESSION]
-WHERE message NOT LIKE '%Z/%'
+WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%intExec=%'
   AND tag NOT LIKE '%scExec%'
   AND tag NOT LIKE '%IndexBackfiller%'
 ----
-dist sender send  querying next range at /Table/2/1/0/"t"/3/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/54/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/0/"t"/3/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/54/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/5/1/54/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/54/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/5/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/5/1/0/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
 sql txn           Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-dist sender send  querying next range at /Table/3/1/54/2/1
 dist sender send  r1: sending batch 1 Put to (n1,s1):1
 sql txn           rows affected: 0
-dist sender send  querying next range at /Table/SystemConfigSpan/Start
 dist sender send  r1: sending batch 1 EndTxn, 9 QueryIntent to (n1,s1):1
 
 statement ok
@@ -421,36 +384,24 @@ SET tracing = on,kv,results; DROP TABLE t.kv; SET tracing = off
 query TT
 SELECT operation, regexp_replace(regexp_replace(regexp_replace(message, 'job_id:[1-9]\d*', 'job_id:...', 'g'), 'wall_time:\d+', 'wall_time:...'), 'drop_time:\d+', 'drop_time:...', 'g') as message
   FROM [SHOW KV TRACE FOR SESSION]
-WHERE message NOT LIKE '%Z/%'
+WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%intExec=%'
   AND tag NOT LIKE '%scExec%'
   AND tag NOT LIKE '%IndexBackfiller%'
 ----
-dist sender send  querying next range at /Table/2/1/0/"t"/3/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/54/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/5/1/54/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/54/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/5/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/5/1/0/2/1
 dist sender send  r1: sending batch 1 Get to (n1,s1):1
 sql txn           Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > >
-dist sender send  querying next range at /Table/3/1/54/2/1
 dist sender send  r1: sending batch 1 Put to (n1,s1):1
 sql txn           rows affected: 0
-dist sender send  querying next range at /Table/SystemConfigSpan/Start
 dist sender send  r1: sending batch 1 EndTxn, 14 QueryIntent to (n1,s1):1
 
 # Check that session tracing does not inhibit the fast path for inserts &


### PR DESCRIPTION
This patch eliminates range resolution messages from a test that traces
a create index. The reason is that an unrelated change that mucks with
the system ranges introduces an extra range lookup (cause there's no
longer a single system range in the cache which was eliminating the need
for a lookup on the jobs table), and even worse the lookup on the jobs
table is non-deterministic because primary keys there contain a
timestamp.

Release note: None