### PR TITLE
parser: unexport Scanner

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -120,7 +120,7 @@ func Load(
 			return backupccl.BackupDescriptor{}, errors.Wrap(err, "read line")
 		}
 		currentCmd.WriteString(line)
-		if !isEndOfStatement(currentCmd.String()) {
+		if !parser.EndsInSemicolon(currentCmd.String()) {
 			currentCmd.WriteByte('\n')
 			continue
 		}
@@ -352,16 +352,6 @@ func (i inserter) InitPut(key, value interface{}, failOnTombstones bool) {
 		Key:   *key.(*roachpb.Key),
 		Value: *value.(*roachpb.Value),
 	})
-}
-
-// isEndOfStatement returns true if stmt ends with a semicolon.
-func isEndOfStatement(stmt string) bool {
-	sc := parser.MakeScanner(stmt)
-	var last int
-	sc.Tokens(func(t int) {
-		last = t
-	})
-	return last == ';'
 }
 
 func writeSST(

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -58,8 +58,7 @@ func splitSQLSemicolon(data []byte, atEOF bool) (advance int, token []byte, err 
 		return 0, nil, nil
 	}
 
-	sc := parser.MakeScanner(string(data))
-	if pos := sc.Until(';'); pos > 0 {
+	if pos, ok := parser.SplitFirstStatement(string(data)); ok {
 		return pos, data[:pos], nil
 	}
 	// If we're at EOF, we have a final, non-terminated line. Return it.

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -458,17 +458,6 @@ func (c *cliState) handleUnset(args []string, nextState, errState cliStateEnum) 
 	return nextState
 }
 
-func checkTokens(fullStmt string) (isEmpty bool, lastTok int) {
-	sc := parser.MakeScanner(fullStmt)
-	isEmpty = true
-	var last int
-	sc.Tokens(func(t int) {
-		isEmpty = false
-		last = t
-	})
-	return isEmpty, last
-}
-
 func isEndOfStatement(lastTok int) bool {
 	return lastTok == ';' || lastTok == parser.HELPTOKEN
 }
@@ -1059,9 +1048,9 @@ func (c *cliState) doPrepareStatementLine(
 		return startState
 	}
 
-	isEmpty, lastTok := checkTokens(c.concatLines)
+	lastTok, ok := parser.LastLexicalToken(c.concatLines)
 	endOfStmt := isEndOfStatement(lastTok)
-	if c.partialStmtsLen == 0 && isEmpty {
+	if c.partialStmtsLen == 0 && !ok {
 		// More whitespace, or comments. Still nothing to do. However
 		// if the syntax was non-trivial to arrive here,
 		// keep it for history.

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -18,10 +18,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 // Example_sql_lex tests the usage of the lexer in the sql subcommand.
@@ -124,52 +122,4 @@ select '''
 	// +---+
 	//   1
 	// (1 row)
-}
-
-func TestIsEndOfStatement(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	tests := []struct {
-		in      string
-		isEnd   bool
-		isEmpty bool
-	}{
-		{
-			in:    ";",
-			isEnd: true,
-		},
-		{
-			in:    "; /* comment */",
-			isEnd: true,
-		},
-		{
-			in: "; SELECT",
-		},
-		{
-			in: "SELECT",
-		},
-		{
-			in:    "SET; SELECT 1;",
-			isEnd: true,
-		},
-		{
-			in:    "SELECT ''''; SET;",
-			isEnd: true,
-		},
-		{
-			in:      "  -- hello",
-			isEmpty: true,
-		},
-	}
-
-	for _, test := range tests {
-		isEmpty, lastTok := checkTokens(test.in)
-		if isEmpty != test.isEmpty {
-			t.Errorf("%q: isEmpty expected %v, got %v", test.in, test.isEmpty, isEmpty)
-		}
-		isEnd := isEndOfStatement(lastTok)
-		if isEnd != test.isEnd {
-			t.Errorf("%q: isEnd expected %v, got %v", test.in, test.isEnd, isEnd)
-		}
-	}
 }

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -73,7 +73,7 @@ func (h *HelpMessage) Format(w io.Writer) {
 // error", with the error set to a contextual help message about the
 // current statement.
 func helpWith(sqllex sqlLexer, helpText string) int {
-	scan := sqllex.(*Scanner)
+	scan := sqllex.(*scanner)
 	if helpText == "" {
 		scan.populateHelpMsg("help:\n" + AllHelp)
 		return 1
@@ -127,7 +127,7 @@ func helpWithFunction(sqllex sqlLexer, f tree.ResolvableFunctionReference) int {
 	_ = w.Flush()
 	msg.Text = buf.String()
 
-	sqllex.(*Scanner).SetHelp(msg)
+	sqllex.(*scanner).SetHelp(msg)
 	return 1
 }
 

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -35,7 +35,7 @@ import (
 // Parser wraps a scanner, parser and other utilities present in the parser
 // package.
 type Parser struct {
-	scanner    Scanner
+	scanner    scanner
 	parserImpl sqlParserImpl
 }
 
@@ -57,7 +57,7 @@ func (p *Parser) parseWithDepth(depth int, sql string) (stmts tree.StatementList
 			err = pgerror.NewErrorWithDepth(depth+1, pgerror.CodeSyntaxError, p.scanner.lastError.msg)
 		}
 		if p.scanner.lastError.hint != "" {
-			// If lastError.hint is not set, e.g. from (*Scanner).Unimplemented(),
+			// If lastError.hint is not set, e.g. from (*scanner).Unimplemented(),
 			// we're OK with the default hint. Otherwise, override it.
 			err.Hint = p.scanner.lastError.hint
 		}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -41,17 +41,17 @@ const MaxUint = ^uint(0)
 const MaxInt = int(MaxUint >> 1)
 
 func unimplemented(sqllex sqlLexer, feature string) int {
-    sqllex.(*Scanner).Unimplemented(feature)
+    sqllex.(*scanner).Unimplemented(feature)
     return 1
 }
 
 func unimplementedWithIssue(sqllex sqlLexer, issue int) int {
-    sqllex.(*Scanner).UnimplementedWithIssue(issue)
+    sqllex.(*scanner).UnimplementedWithIssue(issue)
     return 1
 }
 
 func unimplementedWithIssueDetail(sqllex sqlLexer, issue int, detail string) int {
-    sqllex.(*Scanner).UnimplementedWithIssueDetail(issue, detail)
+    sqllex.(*scanner).UnimplementedWithIssueDetail(issue, detail)
     return 1
 }
 %}
@@ -1028,7 +1028,7 @@ func newNameFromStr(s string) *tree.Name {
 stmt_block:
   stmt_list
   {
-    sqllex.(*Scanner).stmts = $1.stmts()
+    sqllex.(*scanner).stmts = $1.stmts()
   }
 
 stmt_list:


### PR DESCRIPTION
This change unexports `Scanner` and exports some helper functions
instead.

Release note: None