### PR TITLE
kv: dont wrap a MixedSuccessError within a MixedSuccessError

### DIFF
--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -647,7 +647,7 @@ func (e *MixedSuccessError) Error() string {
 }
 
 func (e *MixedSuccessError) message(_ *Error) string {
-	return "the batch experienced mixed success and failure"
+	return fmt.Sprintf("the batch experienced mixed success and failure: %s", e.Wrapped)
 }
 
 var _ ErrorDetailInterface = &MixedSuccessError{}


### PR DESCRIPTION
divideAndSendBatchToRanges can call sendPartialBatch, which in
turn can call divideAndSendBatchToRanges recursively. Therefore,
the error seen by divideAndSendBatchToRanges can already be a
MixedSuccessError returned from a recursive call.

Also add underlying error string to MixedSuccessError.message

fixes #32499

Release note: None