### PR TITLE
telemetry: make sure test starts with clean slate

### DIFF
--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -228,6 +228,9 @@ func TestReportUsage(t *testing.T) {
 	defer s.Stopper().Stop(context.TODO()) // stopper will wait for the update/report loop to finish too.
 	ts := s.(*TestServer)
 
+	// make sure the test's generated activity is the only activity we measure.
+	telemetry.GetAndResetFeatureCounts(false)
+
 	if _, err := db.Exec(fmt.Sprintf(`CREATE DATABASE %s`, elemName)); err != nil {
 		t.Fatal(err)
 	}
@@ -546,6 +549,7 @@ func TestReportUsage(t *testing.T) {
 		"errorcodes." + pgerror.CodeFeatureNotSupportedError: 10,
 		"errorcodes." + pgerror.CodeDivisionByZeroError:      10,
 	}
+
 	if expected, actual := len(expectedFeatureUsage), len(r.last.FeatureUsage); expected != actual {
 		t.Fatalf("expected %d feature usage counts, got %d: %v", expected, actual, r.last.FeatureUsage)
 	}


### PR DESCRIPTION
The test expects certain activity to be what is measured and reported. Sometimes the test fails when the
reported activity includes extra errors that were not part of the intentionally generated activity.

During the activity generation, we make sure we're getting the errors, and only the errors, we expect,
however if errors were encountered earlier, during startup, records of them may linger and then be mixed
with the record of the generated activity, throwing off our measurements.

Avoid this by resetting the recorder's counts before starting to generate the activities we actually want
to measure.

Fixes #31778.

Release note: none.