### PR TITLE
storage/rangefeed: remove TODOs on TxnPusher

### DIFF
--- a/pkg/storage/rangefeed/task.go
+++ b/pkg/storage/rangefeed/task.go
@@ -219,16 +219,9 @@ func (s *catchUpScan) Cancel() {
 type TxnPusher interface {
 	// PushTxns attempts to push the specified transactions to a new
 	// timestamp. It returns the resulting transaction protos.
-	//
-	// TODO(nvanbenschoten): Implement by mapping calls
-	// intentResolver.maybePushTransactions with a PUSH_TIMESTAMP
-	// and a high-priority transaction.
 	PushTxns(context.Context, []enginepb.TxnMeta, hlc.Timestamp) ([]roachpb.Transaction, error)
 	// CleanupTxnIntentsAsync asynchronously cleans up intents owned
 	// by the specified transactions.
-	//
-	// TODO(nvanbenschoten): Implement by mapping calls
-	// intentResolver.cleanupTxnIntentsAsync.
 	CleanupTxnIntentsAsync(context.Context, []roachpb.Transaction) error
 }
 


### PR DESCRIPTION
This was addressed by c739363.

Release note: None