### PR TITLE
storage/spanlatch: recycle btree root when count drops to 0

### DIFF
--- a/pkg/storage/spanlatch/interval_btree.go
+++ b/pkg/storage/spanlatch/interval_btree.go
@@ -678,9 +678,13 @@ func (t *btree) Delete(la *latch) {
 	if out, _ := mut(&t.root).remove(la); out != nil {
 		t.length--
 	}
-	if t.root.count == 0 && !t.root.leaf {
+	if t.root.count == 0 {
 		old := t.root
-		t.root = t.root.children[0]
+		if t.root.leaf {
+			t.root = nil
+		} else {
+			t.root = t.root.children[0]
+		}
 		old.decRef(false /* recursive */)
 	}
 }

--- a/pkg/storage/spanlatch/interval_btree_test.go
+++ b/pkg/storage/spanlatch/interval_btree_test.go
@@ -33,7 +33,8 @@ import (
 
 // Verify asserts that the tree's structural invariants all hold.
 func (t *btree) Verify(tt *testing.T) {
-	if t.root == nil {
+	if t.length == 0 {
+		require.Nil(tt, t.root)
 		return
 	}
 	t.verifyLeafSameDepth(tt)


### PR DESCRIPTION
The idea came out of a discussion about increased memory usage
compared to an LLRB tree. This change should help by making the
trees free when they are empty.

Release note: None