### PR TITLE
release-2.1: insert fixes related to write-only mutation columns

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -370,7 +370,8 @@ type insertRun struct {
 	// rowIdxToRetIdx is the mapping from the ordering of rows in
 	// insertCols to the ordering in the result rows, used when
 	// rowsNeeded is set to populate resultRowBuffer and the row
-	// container.
+	// container. The return index is -1 if the column for the row
+	// index is not public.
 	rowIdxToRetIdx []int
 
 	// autoCommit indicates whether the last KV batch processed by
@@ -422,7 +423,12 @@ func (n *insertNode) startExec(params runParams) error {
 
 		n.run.rowIdxToRetIdx = make([]int, len(n.run.insertCols))
 		for i, col := range n.run.insertCols {
-			n.run.rowIdxToRetIdx[i] = colIDToRetIndex[col.ID]
+			if idx, ok := colIDToRetIndex[col.ID]; !ok {
+				// Column must be write only and not public.
+				n.run.rowIdxToRetIdx[i] = -1
+			} else {
+				n.run.rowIdxToRetIdx[i] = idx
+			}
 		}
 	}
 
@@ -548,8 +554,11 @@ func (n *insertNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	if n.run.rows != nil {
 		for i, val := range rowVals {
 			// The downstream consumer will want the rows in the order of
-			// the table descriptor, not that of insertCols. Reorder them.
-			n.run.resultRowBuffer[n.run.rowIdxToRetIdx[i]] = val
+			// the table descriptor, not that of insertCols. Reorder them
+			// and ignore non-public columns.
+			if idx := n.run.rowIdxToRetIdx[i]; idx >= 0 {
+				n.run.resultRowBuffer[idx] = val
+			}
 		}
 		if _, err := n.run.rows.AddRow(params.ctx, n.run.resultRowBuffer); err != nil {
 			return err

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -611,3 +611,20 @@ INSERT INTO t29494(x) VALUES (123) RETURNING *
 
 statement ok
 COMMIT
+
+subtest regression_32759
+
+statement ok
+CREATE TABLE t32759(x INT, y INT NOT NULL DEFAULT(10), z INT)
+
+statement ok
+BEGIN; ALTER TABLE t32759 DROP COLUMN y
+
+query II colnames
+INSERT INTO t32759(x, z) VALUES (1, 4) RETURNING *
+----
+x  z
+1  4
+
+statement ok
+COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -712,3 +712,18 @@ INSERT INTO t32762(x,y) VALUES (1,2) ON CONFLICT (x,y) DO UPDATE SET x = t32762.
 
 statement ok
 INSERT INTO t32762(x,y) VALUES (1,2) ON CONFLICT (x,y) DO UPDATE SET x = t32762.x
+
+subtest visible_returning_columns
+
+statement ok
+BEGIN; ALTER TABLE tc DROP COLUMN y
+
+query I colnames rowsort
+UPSERT INTO tc VALUES (1), (2) RETURNING *
+----
+x
+1
+2
+
+statement ok
+COMMIT;

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2227,7 +2227,10 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT UNIQUE DEFAULT 23 CREATE FAMILY F3
 func TestCRUDWhileColumnBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	backfillNotification := make(chan bool)
-	continueBackfillNotification := make(chan bool)
+
+	backfillCompleteNotification := make(chan bool)
+	continueSchemaChangeNotification := make(chan bool)
+
 	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		DistSQL: &distsqlrun.TestingKnobs{
@@ -2237,9 +2240,18 @@ func TestCRUDWhileColumnBackfill(t *testing.T) {
 					// been queued and the backfill has started.
 					close(backfillNotification)
 					backfillNotification = nil
-					<-continueBackfillNotification
+					<-continueSchemaChangeNotification
 				}
 				return nil
+			},
+			RunAfterBackfillChunk: func() {
+				if backfillCompleteNotification != nil {
+					// Close channel to notify that the schema change
+					// backfill is complete and not finalized.
+					close(backfillCompleteNotification)
+					backfillCompleteNotification = nil
+					<-continueSchemaChangeNotification
+				}
 			},
 		},
 		// Disable backfill migrations, we still need the jobs table migration.
@@ -2254,7 +2266,7 @@ func TestCRUDWhileColumnBackfill(t *testing.T) {
 CREATE DATABASE t;
 CREATE TABLE t.test (
     k INT NOT NULL,
-    v INT NOT NULL,
+    v INT,
     length INT NOT NULL,
     CONSTRAINT "primary" PRIMARY KEY (k),
     INDEX v_idx (v),
@@ -2269,10 +2281,11 @@ INSERT INTO t.test (k, v, length) VALUES (2, 3, 1);
 
 	// Run the column schema change in a separate goroutine.
 	notification := backfillNotification
+	doneNotification := backfillCompleteNotification
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD id INT NOT NULL DEFAULT 2;`); err != nil {
+		if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD id INT NOT NULL DEFAULT 2, ADD u INT NOT NULL AS (v+1) STORED;`); err != nil {
 			t.Error(err)
 		}
 		wg.Done()
@@ -2293,7 +2306,7 @@ INSERT INTO t.test (k, v, length) VALUES (2, 3, 1);
 	// Wait until both mutations are queued up.
 	testutils.SucceedsSoon(t, func() error {
 		tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
-		if l := len(tableDesc.Mutations); l != 2 {
+		if l := len(tableDesc.Mutations); l != 3 {
 			return errors.Errorf("number of mutations = %d", l)
 		}
 		return nil
@@ -2378,7 +2391,7 @@ INSERT INTO t.test (k, v, length) VALUES (2, 3, 1);
 	}
 	expect := `CREATE TABLE test (
 	k INT NOT NULL,
-	v INT NOT NULL,
+	v INT NULL,
 	length INT NOT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (k ASC),
 	INDEX v_idx (v ASC),
@@ -2389,11 +2402,24 @@ INSERT INTO t.test (k, v, length) VALUES (2, 3, 1);
 	}
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
-	if l := len(tableDesc.Mutations); l != 2 {
+	if l := len(tableDesc.Mutations); l != 3 {
 		t.Fatalf("number of mutations = %d", l)
 	}
 
-	close(continueBackfillNotification)
+	continueSchemaChangeNotification <- true
+
+	<-doneNotification
+
+	expectedErr := "\"u\" violates not-null constraint"
+	if _, err := sqlDB.Exec(`INSERT INTO t.test(k, v, length) VALUES (5, NULL, 8)`); !testutils.IsError(err, expectedErr) {
+		t.Fatal(err)
+	}
+
+	if _, err := sqlDB.Exec(`UPDATE t.test SET v = NULL WHERE k = 0`); !testutils.IsError(err, expectedErr) {
+		t.Fatal(err)
+	}
+
+	close(continueSchemaChangeNotification)
 
 	wg.Wait()
 
@@ -2401,26 +2427,26 @@ INSERT INTO t.test (k, v, length) VALUES (2, 3, 1);
 		t.Fatal(err)
 	}
 	// Check data!
-	rows, err := sqlDB.Query(`SELECT k, v, length, id, z FROM t.test`)
+	rows, err := sqlDB.Query(`SELECT k, v, length, id, u, z FROM t.test`)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer rows.Close()
 	expected := [][]int{
-		{0, 1, 27000, 2, 2},
-		{3, 1, 3, 2, 5},
-		{4, 5, 270, 2, 6},
+		{0, 1, 27000, 2, 2, 2},
+		{3, 1, 3, 2, 2, 5},
+		{4, 5, 270, 2, 6, 6},
 	}
 	count := 0
 	for ; rows.Next(); count++ {
-		var i1, i2, i3, i4, i5 *int
-		if err := rows.Scan(&i1, &i2, &i3, &i4, &i5); err != nil {
+		var i1, i2, i3, i4, i5, i6 *int
+		if err := rows.Scan(&i1, &i2, &i3, &i4, &i5, &i6); err != nil {
 			t.Errorf("row %d scan failed: %s", count, err)
 			continue
 		}
-		row := fmt.Sprintf("%d %d %d %d %d", *i1, *i2, *i3, *i4, *i5)
+		row := fmt.Sprintf("%d %d %d %d %d %d", *i1, *i2, *i3, *i4, *i5, *i6)
 		exp := expected[count]
-		expRow := fmt.Sprintf("%d %d %d %d %d", exp[0], exp[1], exp[2], exp[3], exp[4])
+		expRow := fmt.Sprintf("%d %d %d %d %d %d", exp[0], exp[1], exp[2], exp[3], exp[4], exp[5])
 		if row != expRow {
 			t.Errorf("expected %q but read %q", expRow, row)
 		}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: fix INSERT results incorrectly including mutation column values" (#32789)
  * 1/1 commits from "sql: fix race between backfill and insert on non-null column" (#32870)

Please see individual PRs for details.

/cc @cockroachdb/release
