### PR TITLE
sql: separate mutations by element and state

### DIFF
--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -175,29 +175,18 @@ func initRowFetcher(
 	alloc *sqlbase.DatumAlloc,
 	scanVisibility distsqlpb.ScanVisibility,
 ) (index *sqlbase.IndexDescriptor, isSecondaryIndex bool, err error) {
-	index, isSecondaryIndex, err = desc.FindIndexByIndexIdx(indexIdx)
+	immutDesc := sqlbase.NewImmutableTableDescriptor(*desc)
+	index, isSecondaryIndex, err = immutDesc.FindIndexByIndexIdx(indexIdx)
 	if err != nil {
 		return nil, false, err
 	}
 
-	cols := desc.Columns
+	cols := immutDesc.Columns
 	if scanVisibility == distsqlpb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC {
-		if len(desc.Mutations) > 0 {
-			cols = make([]sqlbase.ColumnDescriptor, 0, len(desc.Columns)+len(desc.Mutations))
-			cols = append(cols, desc.Columns...)
-			for _, mutation := range desc.Mutations {
-				if c := mutation.GetColumn(); c != nil {
-					col := *c
-					// Even if the column is non-nullable it can be null in the
-					// middle of a schema change.
-					col.Nullable = true
-					cols = append(cols, col)
-				}
-			}
-		}
+		cols = immutDesc.ReadableColumns
 	}
 	tableArgs := row.FetcherTableArgs{
-		Desc:             sqlbase.NewImmutableTableDescriptor(*desc),
+		Desc:             immutDesc,
 		Index:            index,
 		ColIdxMap:        colIdxMap,
 		IsSecondaryIndex: isSecondaryIndex,

--- a/pkg/sql/sqlbase/default_exprs.go
+++ b/pkg/sql/sqlbase/default_exprs.go
@@ -99,25 +99,14 @@ func processColumnSet(
 		colIDSet[col.ID] = struct{}{}
 	}
 
-	addIf := func(col ColumnDescriptor) {
+	// Add all public or columns in DELETE_AND_WRITE_ONLY state
+	// that satisfy the condition.
+	for _, col := range tableDesc.WritableColumns {
 		if inSet(col) {
 			if _, ok := colIDSet[col.ID]; !ok {
 				colIDSet[col.ID] = struct{}{}
 				cols = append(cols, col)
 			}
-		}
-	}
-
-	// Add all public columns that satisfy the condition.
-	for _, col := range tableDesc.Columns {
-		addIf(col)
-	}
-	// Also add any column in a mutation that is DELETE_AND_WRITE_ONLY that also
-	// satisfies the condition.
-	for _, m := range tableDesc.Mutations {
-		if col := m.GetColumn(); col != nil &&
-			m.State == DescriptorMutation_DELETE_AND_WRITE_ONLY {
-			addIf(*col)
 		}
 	}
 	return cols


### PR DESCRIPTION
Store mutation columns and indexes in separate slices separated by their
element type and state. This makes the usage of mutation columns and
indexes explicit.

Fixes #32586.

Release note: None