### PR TITLE
sql: remove unnecessary semicolons from system catalogs

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -98,8 +98,7 @@ CREATE TABLE crdb_internal.node_build_info (
   node_id INT NOT NULL,
   field   STRING NOT NULL,
   value   STRING NOT NULL
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		execCfg := p.ExecCfg()
 		nodeID := tree.NewDInt(tree.DInt(int64(execCfg.NodeID.Get())))
@@ -132,8 +131,7 @@ CREATE TABLE crdb_internal.node_runtime_info (
   component STRING NOT NULL,
   field     STRING NOT NULL,
   value     STRING NOT NULL
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		if err := p.RequireSuperUser(ctx, "access the node runtime information"); err != nil {
 			return err
@@ -200,8 +198,7 @@ CREATE TABLE crdb_internal.tables (
   sc_lease_expiration_time TIMESTAMP,
   drop_time                TIMESTAMP,
   audit_mode               STRING NOT NULL
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		descs, err := p.Tables().getAllDescriptors(ctx, p.txn)
 		if err != nil {
@@ -277,8 +274,7 @@ CREATE TABLE crdb_internal.schema_changes (
   target_name   STRING,
   state         STRING NOT NULL,
   direction     STRING NOT NULL
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		descs, err := p.Tables().getAllDescriptors(ctx, p.txn)
 		if err != nil {
@@ -335,8 +331,7 @@ CREATE TABLE crdb_internal.leases (
   parent_id   INT NOT NULL,
   expiration  TIMESTAMP NOT NULL,
   deleted     BOOL NOT NULL
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		leaseMgr := p.LeaseMgr()
 		nodeID := tree.NewDInt(tree.DInt(int64(leaseMgr.execCfg.NodeID.Get())))
@@ -412,8 +407,7 @@ CREATE TABLE crdb_internal.jobs (
 	high_water_timestamp	DECIMAL,
 	error              		STRING,
 	coordinator_id     		INT
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		query := `SELECT id, status, created, payload, progress FROM system.jobs`
 		rows, _ /* cols */, err :=
@@ -549,8 +543,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
   service_lat_var     FLOAT NOT NULL,
   overhead_lat_avg    FLOAT NOT NULL,
   overhead_lat_var    FLOAT NOT NULL
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		if err := p.RequireSuperUser(ctx, "access application statistics"); err != nil {
 			return err
@@ -652,8 +645,7 @@ CREATE TABLE crdb_internal.session_trace (
   tag         STRING NOT NULL,     -- The logging tag, if any.
   message     STRING NOT NULL,     -- The logged message.
   age         INTERVAL NOT NULL    -- The age of this message relative to the beginning of the trace.
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		rows, err := p.ExtendedEvalContext().Tracing.getSessionTrace()
 		if err != nil {
@@ -677,8 +669,7 @@ CREATE TABLE crdb_internal.cluster_settings (
   value         STRING NOT NULL,
   type          STRING NOT NULL,
   description   STRING NOT NULL
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		if err := p.RequireSuperUser(ctx, "read crdb_internal.cluster_settings"); err != nil {
 			return err
@@ -704,8 +695,7 @@ var crdbInternalSessionVariablesTable = virtualSchemaTable{
 CREATE TABLE crdb_internal.session_variables (
   variable STRING NOT NULL,
   value    STRING NOT NULL
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
@@ -732,8 +722,7 @@ CREATE TABLE crdb_internal.%s (
   application_name STRING,         -- the name of the application as per SET application_name
   distributed      BOOL,           -- whether the query is running distributed
   phase            STRING          -- the current execution phase
-);
-`
+)`
 
 func (p *planner) makeSessionsRequest(ctx context.Context) serverpb.ListSessionsRequest {
 	req := serverpb.ListSessionsRequest{Username: p.SessionData().User}
@@ -838,7 +827,7 @@ CREATE TABLE crdb_internal.%s (
   kv_txn             STRING,         -- the ID of the current KV transaction
   alloc_bytes        INT,            -- the number of bytes allocated by the session
   max_alloc_bytes    INT             -- the high water mark of bytes allocated by the session
-);
+)
 `
 
 // crdbInternalLocalSessionsTable exposes the list of running sessions
@@ -970,7 +959,7 @@ var crdbInternalLocalMetricsTable = virtualSchemaTable{
   store_id 	         INT NULL,         -- the store, if any, for this metric
   name               STRING NOT NULL,  -- name of the metric
   value							 FLOAT NOT NULL    -- value of the metric
-);`,
+)`,
 
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		if err := p.RequireSuperUser(ctx, "read crdb_internal.node_metrics"); err != nil {
@@ -1012,8 +1001,7 @@ CREATE TABLE crdb_internal.builtin_functions (
   signature STRING NOT NULL,
   category  STRING NOT NULL,
   details   STRING NOT NULL
-);
-`,
+)`,
 	populate: func(ctx context.Context, _ *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for _, name := range builtins.AllBuiltinNames {
 			props, overloads := builtins.GetBuiltinProperties(name)

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -329,8 +329,7 @@ var informationSchemaEnabledRoles = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.enabled_roles (
 	ROLE_NAME STRING NOT NULL
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		currentUser := p.SessionData().User
 		memberMap, err := p.MemberOfWithAdminOption(ctx, currentUser)
@@ -394,7 +393,7 @@ CREATE TABLE information_schema.constraint_column_usage (
 	CONSTRAINT_CATALOG STRING NOT NULL,
 	CONSTRAINT_SCHEMA  STRING NOT NULL,
 	CONSTRAINT_NAME    STRING NOT NULL
-);`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /*no constraints in virtual tables*/, func(
 			db *sqlbase.DatabaseDescriptor,
@@ -454,7 +453,7 @@ CREATE TABLE information_schema.key_column_usage (
 	COLUMN_NAME        STRING NOT NULL,
 	ORDINAL_POSITION   INT NOT NULL,
 	POSITION_IN_UNIQUE_CONSTRAINT INT
-);`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /*no constraints in virtual tables*/, func(
 			db *sqlbase.DatabaseDescriptor,
@@ -544,8 +543,7 @@ CREATE TABLE information_schema.parameters (
 	MAXIMUM_CARDINALITY INT,
 	DTD_IDENTIFIER STRING,
 	PARAMETER_DEFAULT STRING
-);
-`,
+)`,
 	// This is the same as information_schema.table_privileges. In postgres, this virtual table does
 	// not show tables with grants provided through PUBLIC, but table_privileges does.
 	// Since we don't have the PUBLIC concept, the two virtual tables are identical.
@@ -602,7 +600,7 @@ CREATE TABLE information_schema.referential_constraints (
 	DELETE_RULE               STRING NOT NULL,
 	TABLE_NAME                STRING NOT NULL,
 	REFERENCED_TABLE_NAME     STRING NOT NULL
-);`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /*no constraints in virtual tables*/, func(
 			db *sqlbase.DatabaseDescriptor,
@@ -659,8 +657,7 @@ CREATE TABLE information_schema.role_table_grants (
 	PRIVILEGE_TYPE STRING NOT NULL,
 	IS_GRANTABLE   STRING,
 	WITH_HIERARCHY STRING
-);
-`,
+)`,
 	// This is the same as information_schema.table_privileges. In postgres, this virtual table does
 	// not show tables with grants provided through PUBLIC, but table_privileges does.
 	// Since we don't have the PUBLIC concept, the two virtual tables are identical.
@@ -753,7 +750,7 @@ CREATE TABLE information_schema.routines (
 	RESULT_CAST_SCOPE_NAME STRING,
 	RESULT_CAST_MAXIMUM_CARDINALITY INT,
 	RESULT_CAST_DTD_IDENTIFIER STRING
-); `,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return nil
 	},
@@ -762,13 +759,7 @@ CREATE TABLE information_schema.routines (
 // Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-schemata.html
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/schemata-table.html
 var informationSchemaSchemataTable = virtualSchemaTable{
-	schema: `
-CREATE TABLE information_schema.schemata (
-	CATALOG_NAME               STRING NOT NULL,
-	SCHEMA_NAME                STRING NOT NULL,
-	DEFAULT_CHARACTER_SET_NAME STRING,
-	SQL_PATH                   STRING
-);`,
+	schema: vtable.InformationSchemaSchemata,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, dbContext, func(db *sqlbase.DatabaseDescriptor) error {
 			return forEachSchemaName(ctx, p, db, func(sc string) error {
@@ -793,8 +784,7 @@ CREATE TABLE information_schema.schema_privileges (
 	TABLE_SCHEMA    STRING NOT NULL,
 	PRIVILEGE_TYPE  STRING NOT NULL,
 	IS_GRANTABLE    STRING
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, dbContext, func(db *sqlbase.DatabaseDescriptor) error {
 			return forEachSchemaName(ctx, p, db, func(scName string) error {
@@ -854,7 +844,7 @@ CREATE TABLE information_schema.sequences (
     MAXIMUM_VALUE            STRING NOT NULL,
     INCREMENT                STRING NOT NULL,
     CYCLE_OPTION             STRING NOT NULL
-);`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /*no sequences in virtual schemas*/
 			func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {
@@ -897,7 +887,7 @@ CREATE TABLE information_schema.statistics (
 	DIRECTION     STRING NOT NULL,
 	STORING       STRING NOT NULL,
 	IMPLICIT      STRING NOT NULL
-);`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual tables have no indexes*/
 			func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {
@@ -992,7 +982,7 @@ CREATE TABLE information_schema.table_constraints (
 	CONSTRAINT_TYPE    STRING NOT NULL,
 	IS_DEFERRABLE      STRING NOT NULL,
 	INITIALLY_DEFERRED STRING NOT NULL
-);`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual, /* virtual tables have no constraints */
 			func(
@@ -1039,7 +1029,7 @@ CREATE TABLE information_schema.user_privileges (
 	TABLE_CATALOG  STRING NOT NULL,
 	PRIVILEGE_TYPE STRING NOT NULL,
 	IS_GRANTABLE   STRING
-);`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, dbContext, func(dbDesc *DatabaseDescriptor) error {
 			dbNameStr := tree.NewDString(dbDesc.Name)
@@ -1074,8 +1064,7 @@ CREATE TABLE information_schema.table_privileges (
 	PRIVILEGE_TYPE STRING NOT NULL,
 	IS_GRANTABLE   STRING,
 	WITH_HIERARCHY STRING
-);
-`,
+)`,
 	populate: populateTablePrivileges,
 }
 
@@ -1161,7 +1150,7 @@ CREATE TABLE information_schema.views (
     IS_TRIGGER_UPDATABLE       STRING,
     IS_TRIGGER_DELETABLE       STRING,
     IS_TRIGGER_INSERTABLE_INTO STRING
-);`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual schemas have no views */
 			func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -236,8 +236,7 @@ CREATE TABLE pg_catalog.pg_am (
 	amname NAME,
 	amhandler OID,
 	amtype CHAR
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		h.writeStr(cockroachIndexEncoding)
@@ -259,8 +258,7 @@ CREATE TABLE pg_catalog.pg_attrdef (
 	adnum INT,
 	adbin STRING,
 	adsrc STRING
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(ctx, p, dbContext, virtualMany,
@@ -310,8 +308,7 @@ CREATE TABLE pg_catalog.pg_attribute (
 	attacl STRING[],
 	attoptions STRING[],
 	attfdwoptions STRING[]
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(ctx, p, dbContext, virtualMany, func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {
@@ -376,8 +373,7 @@ CREATE TABLE pg_catalog.pg_auth_members (
 	member OID,
 	grantor OID,
 	admin_option BOOL
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachRoleMembership(ctx, p,
@@ -432,8 +428,7 @@ CREATE TABLE pg_catalog.pg_class (
 	relfrozenxid INT,
 	relacl STRING[],
 	reloptions STRING[]
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(ctx, p, dbContext, virtualMany,
@@ -532,8 +527,7 @@ CREATE TABLE pg_catalog.pg_collation (
   collencoding INT,
   collcollate STRING,
   collctype STRING
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, func(db *DatabaseDescriptor) error {
@@ -624,8 +618,7 @@ CREATE TABLE pg_catalog.pg_constraint (
 	-- condef is a CockroachDB extension that provides a SHOW CREATE CONSTRAINT
 	-- style string, for use by pg_get_constraintdef().
 	condef STRING
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual /*virtual tables have no constraints*/, func(
@@ -813,8 +806,7 @@ CREATE TABLE pg_catalog.pg_database (
 	datminmxid INT,
 	dattablespace OID,
 	datacl STRING[]
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, nil /*all databases*/, func(db *sqlbase.DatabaseDescriptor) error {
@@ -876,8 +868,7 @@ CREATE TABLE pg_catalog.pg_depend (
   refobjid OID,
   refobjsubid INT,
   deptype CHAR
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		vt := p.getVirtualTabler()
 		pgConstraintsDesc, err := vt.getVirtualTableDesc(&pgConstraintsTableName)
@@ -939,8 +930,7 @@ CREATE TABLE pg_catalog.pg_description (
 	classoid OID,
 	objsubid INT,
 	description STRING
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Comments on database objects are not currently supported.
 		return nil
@@ -954,8 +944,7 @@ CREATE TABLE pg_catalog.pg_shdescription (
 	objoid OID,
 	classoid OID,
 	description STRING
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Comments on database objects are not currently supported.
 		return nil
@@ -970,8 +959,7 @@ CREATE TABLE pg_catalog.pg_enum (
   enumtypid OID,
   enumsortorder FLOAT,
   enumlabel STRING
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Enum types are not currently supported.
 		return nil
@@ -989,8 +977,7 @@ CREATE TABLE pg_catalog.pg_extension (
   extversion STRING,
   extconfig STRING,
   extcondition STRING
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Extensions are not supported.
 		return nil
@@ -1008,8 +995,7 @@ CREATE TABLE pg_catalog.pg_foreign_data_wrapper (
   fdwvalidator OID,
   fdwacl STRING[],
   fdwoptions STRING[]
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Foreign data wrappers are not supported.
 		return nil
@@ -1028,8 +1014,7 @@ CREATE TABLE pg_catalog.pg_foreign_server (
   srvversion STRING,
   srvacl STRING[],
   srvoptions STRING[]
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Foreign servers are not supported.
 		return nil
@@ -1043,8 +1028,7 @@ CREATE TABLE pg_catalog.pg_foreign_table (
   ftrelid OID,
   ftserver OID,
   ftoptions STRING[]
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Foreign tables are not supported.
 		return nil
@@ -1094,8 +1078,7 @@ CREATE TABLE pg_catalog.pg_index (
     indoption INT2VECTOR,
     indexprs STRING,
     indpred STRING
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual tables do not have indexes */
@@ -1171,8 +1154,7 @@ CREATE TABLE pg_catalog.pg_indexes (
 	indexname NAME,
 	tablespace NAME,
 	indexdef STRING
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDescWithTableLookup(ctx, p, dbContext, hideVirtual, /* virtual tables do not have indexes */
@@ -1262,8 +1244,7 @@ CREATE TABLE pg_catalog.pg_inherits (
 	inhrelid OID,
 	inhparent OID,
 	inhseqno INT
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Table inheritance is not supported.
 		return nil
@@ -1283,8 +1264,7 @@ CREATE TABLE pg_catalog.pg_language (
 	laninline OID,
 	lanvalidator OID,
 	lanacl STRING[]
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Languages to write functions and stored procedures are not supported.
 		return nil
@@ -1299,8 +1279,7 @@ CREATE TABLE pg_catalog.pg_namespace (
 	nspname NAME NOT NULL,
 	nspowner OID,
 	nspacl STRING[]
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, func(db *sqlbase.DatabaseDescriptor) error {
@@ -1344,8 +1323,7 @@ CREATE TABLE pg_catalog.pg_operator (
 	oprcode OID,
 	oprrest OID,
 	oprjoin OID
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, db *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		nspOid := h.NamespaceOid(db, pgCatalogName)
@@ -1474,8 +1452,7 @@ CREATE TABLE pg_catalog.pg_proc (
 	probin STRING,
 	proconfig STRING[],
 	proacl STRING[]
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, func(db *DatabaseDescriptor) error {
@@ -1608,8 +1585,7 @@ CREATE TABLE pg_catalog.pg_range (
 	rngsubopc OID,
 	rngcanonical INT,
 	rngsubdiff INT
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// We currently do not support any range types, so this table is empty.
 		// This table should be populated when any range types are added to
@@ -1630,8 +1606,7 @@ CREATE TABLE pg_catalog.pg_rewrite (
 	is_instead BOOL,
 	ev_qual TEXT,
 	ev_action TEXT
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Rewrite rules are not supported.
 		return nil
@@ -1656,8 +1631,7 @@ CREATE TABLE pg_catalog.pg_roles (
 	rolvaliduntil TIMESTAMPTZ,
 	rolbypassrls BOOL,
 	rolconfig STRING[]
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// We intentionally do not check if the user has access to system.user.
 		// Because Postgres allows access to pg_roles by non-privileged users, we
@@ -1700,8 +1674,7 @@ CREATE TABLE pg_catalog.pg_sequence (
 	seqmin INT8,
 	seqcache INT8,
 	seqcycle BOOL
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual schemas do not have indexes */
@@ -1750,8 +1723,7 @@ CREATE TABLE pg_catalog.pg_settings (
     sourcefile STRING,
     sourceline INT,
     pending_restart BOOL
-);
-`,
+)`,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
@@ -1811,8 +1783,7 @@ CREATE TABLE pg_catalog.pg_tables (
 	hasrules BOOL,
 	hastriggers BOOL,
 	rowsecurity BOOL
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Note: pg_catalog.pg_tables is not well-defined if the dbContext is
 		// empty -- listing tables across databases can yield duplicate
@@ -1846,8 +1817,7 @@ CREATE TABLE pg_catalog.pg_tablespace (
 	spclocation TEXT,
 	spcacl TEXT[],
 	spcoptions TEXT[]
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return addRow(
 			oidZero, // oid
@@ -1882,8 +1852,7 @@ CREATE TABLE pg_catalog.pg_trigger (
 	tgqual TEXT,
 	tgoldtable NAME,
 	tgnewtable NAME
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Triggers are unsupported.
 		return nil
@@ -1968,8 +1937,7 @@ CREATE TABLE pg_catalog.pg_type (
 	typdefaultbin STRING,
 	typdefault STRING,
 	typacl STRING[]
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, func(db *DatabaseDescriptor) error {
@@ -2063,8 +2031,7 @@ CREATE TABLE pg_catalog.pg_user (
 	passwd TEXT,
 	valuntil TIMESTAMP,
 	useconfig TEXT[]
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachRole(ctx, p,
@@ -2096,8 +2063,7 @@ CREATE TABLE pg_catalog.pg_user_mapping (
 	umuser OID,
 	umserver OID,
 	umoptions TEXT[]
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// This table stores the mapping to foreign server users.
 		// Foreign servers are not supported.
@@ -2240,8 +2206,7 @@ CREATE TABLE pg_catalog.pg_views (
 	viewname NAME,
 	viewowner STRING,
 	definition STRING
-);
-`,
+)`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Note: pg_views is not well defined if the dbContext is empty,
 		// because it does not distinguish views in separate databases.

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -809,7 +809,7 @@ var pgBuiltins = map[string]builtinDefinition{
 					ctx.Ctx(), "pg_table_is_visible",
 					ctx.Txn,
 					"SELECT nspname FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace=n.oid "+
-						"WHERE c.oid=$1 AND nspname=ANY(current_schemas(true));", oid)
+						"WHERE c.oid=$1 AND nspname=ANY(current_schemas(true))", oid)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/vtable/information_schema.go
+++ b/pkg/sql/vtable/information_schema.go
@@ -40,7 +40,7 @@ CREATE TABLE information_schema.columns (
 	GENERATION_EXPRESSION    STRING,          -- MySQL/CockroachDB extension.
 	IS_HIDDEN                STRING NOT NULL, -- CockroachDB extension for SHOW COLUMNS / dump.
 	CRDB_SQL_TYPE            STRING NOT NULL  -- CockroachDB extension for SHOW COLUMNS / dump.
-);`
+)`
 
 // InformationSchemaAdministrableRoleAuthorizations describes the schema of the
 // information_schema.administrable_role_authorizations table.
@@ -51,7 +51,7 @@ CREATE TABLE information_schema.administrable_role_authorizations (
 	GRANTEE      STRING NOT NULL,
 	ROLE_NAME    STRING NOT NULL,
 	IS_GRANTABLE STRING NOT NULL
-);`
+)`
 
 // InformationSchemaApplicableRoles describes the schema of the
 // information_schema.applicable_roles table.
@@ -62,7 +62,7 @@ CREATE TABLE information_schema.applicable_roles (
 	GRANTEE      STRING NOT NULL,
 	ROLE_NAME    STRING NOT NULL,
 	IS_GRANTABLE STRING NOT NULL
-);`
+)`
 
 // InformationSchemaColumnPrivileges describes the schema of the
 // information_schema.column_privileges table.
@@ -78,7 +78,7 @@ CREATE TABLE information_schema.column_privileges (
 	COLUMN_NAME    STRING NOT NULL,
 	PRIVILEGE_TYPE STRING NOT NULL,
 	IS_GRANTABLE   STRING
-);`
+)`
 
 // InformationSchemaSchemata describes the schema of the
 // information_schema.schemata table.
@@ -88,7 +88,7 @@ CREATE TABLE information_schema.schemata (
 	SCHEMA_NAME                STRING NOT NULL,
 	DEFAULT_CHARACTER_SET_NAME STRING,
 	SQL_PATH                   STRING
-);`
+)`
 
 // InformationSchemaTables describes the schema of the
 // information_schema.tables table.
@@ -102,4 +102,4 @@ CREATE TABLE information_schema.tables (
 	TABLE_TYPE         STRING NOT NULL,
 	IS_INSERTABLE_INTO STRING NOT NULL,
 	VERSION            INT
-);`
+)`


### PR DESCRIPTION
Release note: None

For context - I was working on a parser change which incidentally made `ParseOne` not accept a semicolon, and I had to clean these up. I have since abandoned that change but figured why not do the cleanup anyway.