### PR TITLE
cli: Fix mix-up between under-replicated and unavailable range counts

### DIFF
--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -176,8 +176,8 @@ SELECT node_id AS id,
        sum((metrics->>'replicas.leaders')::DECIMAL)::INT AS replicas_leaders,
        sum((metrics->>'replicas.leaseholders')::DECIMAL)::INT AS replicas_leaseholders,
        sum((metrics->>'replicas')::DECIMAL)::INT AS ranges,
-       sum((metrics->>'ranges.underreplicated')::DECIMAL)::INT AS ranges_underreplicated,
-       sum((metrics->>'ranges.unavailable')::DECIMAL)::INT AS ranges_unavailable
+       sum((metrics->>'ranges.unavailable')::DECIMAL)::INT AS ranges_unavailable,
+       sum((metrics->>'ranges.underreplicated')::DECIMAL)::INT AS ranges_underreplicated
 FROM crdb_internal.kv_store_status
 GROUP BY node_id`
 


### PR DESCRIPTION
Release note (bug fix): `cockroach node status --ranges` previously
listed the count of under-replicated ranges in the `ranges_unavailable`
column and the number of unavailable ranges in the
`ranges_underreplicated` column. This fixes that mix-up.