### PR TITLE
opt: add support for IFERROR/ISERROR

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -396,6 +396,23 @@ func (f *ExprFmtCtx) formatScalar(scalar opt.ScalarExpr, tp treeprinter.Node) {
 			tp.Child("filters (true)")
 			return
 		}
+
+	case opt.IfErrOp:
+		f.Buffer.Reset()
+		fmt.Fprintf(f.Buffer, "%v", scalar.Op())
+		f.FormatScalarProps(scalar)
+
+		tp = tp.Child(f.Buffer.String())
+
+		f.formatExpr(scalar.Child(0), tp)
+		if scalar.Child(1).ChildCount() > 0 {
+			f.formatExpr(scalar.Child(1), tp.Child("else"))
+		}
+		if scalar.Child(2).ChildCount() > 0 {
+			f.formatExpr(scalar.Child(2), tp.Child("err-code"))
+		}
+
+		return
 	}
 
 	// Don't show scalar-list, as it's redundant with its parent.

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -137,6 +137,7 @@ func init() {
 	typingFuncMap[opt.IndirectionOp] = typeIndirection
 	typingFuncMap[opt.CollateOp] = typeCollate
 	typingFuncMap[opt.ArrayFlattenOp] = typeArrayFlatten
+	typingFuncMap[opt.IfErrOp] = typeIfErr
 
 	// Override default typeAsAggregate behavior for aggregate functions with
 	// a large number of possible overloads or where ReturnType depends on
@@ -205,6 +206,15 @@ func typeArrayFlatten(e opt.ScalarExpr) types.T {
 	return types.TArray{
 		Typ: input.Memo().Metadata().ColumnType(opt.ColumnID(colID)),
 	}
+}
+
+// typeIfErr returns the type of the IfErrExpr. The type is boolean if
+// there is no OrElse, and the type of Cond/OrElse otherwise.
+func typeIfErr(e opt.ScalarExpr) types.T {
+	if e.(*IfErrExpr).OrElse.ChildCount() == 0 {
+		return types.Bool
+	}
+	return e.(*IfErrExpr).Cond.DataType()
 }
 
 // typeAsFirstArg returns the type of the expression's 0th argument.

--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -100,6 +100,15 @@ func (c *CustomFuncs) deriveHasHoistableSubquery(scalar opt.ScalarExpr) bool {
 					memo.BuildSharedProps(c.mem, child, &sharedProps)
 					hasHoistableSubquery = !sharedProps.CanHaveSideEffects
 				}
+
+			case *memo.IfErrExpr:
+				// Determine whether this is the Else child. Checking this how the
+				// other branches do is tricky because it's a list, but we know that
+				// it's at position 1.
+				if i == 1 {
+					memo.BuildSharedProps(c.mem, child, &sharedProps)
+					hasHoistableSubquery = !sharedProps.CanHaveSideEffects
+				}
 			}
 
 			if hasHoistableSubquery {

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -262,3 +262,84 @@ select
                                └── filters
                                     ├── x = i [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
                                     └── (5 / y) > 1 [type=bool, outer=(7), side-effects]
+
+
+# Don't decorrelate IFERROR branch if there are side effects
+norm
+SELECT * FROM a WHERE IFERROR(1/0, (SELECT y::DECIMAL FROM xy WHERE x = i AND 5/y>1))=k
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── side-effects
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── eq [type=bool, outer=(1,2), side-effects, constraints=(/1: (/NULL - ])]
+           ├── variable: k [type=int]
+           └── if-err [type=decimal]
+                ├── 1 / 0 [type=decimal]
+                └── else
+                     └── subquery [type=decimal]
+                          └── project
+                               ├── columns: y:8(decimal)
+                               ├── outer: (2)
+                               ├── cardinality: [0 - 1]
+                               ├── side-effects
+                               ├── key: ()
+                               ├── fd: ()-->(8)
+                               ├── select
+                               │    ├── columns: x:6(int!null) xy.y:7(int)
+                               │    ├── outer: (2)
+                               │    ├── cardinality: [0 - 1]
+                               │    ├── side-effects
+                               │    ├── key: ()
+                               │    ├── fd: ()-->(6,7)
+                               │    ├── scan xy
+                               │    │    ├── columns: x:6(int!null) xy.y:7(int)
+                               │    │    ├── key: (6)
+                               │    │    └── fd: (6)-->(7)
+                               │    └── filters
+                               │         ├── x = i [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+                               │         └── (5 / xy.y) > 1 [type=bool, outer=(7), side-effects]
+                               └── projections
+                                    └── xy.y::DECIMAL [type=decimal, outer=(7)]
+
+# Decorrelate IFERROR branch if there are no side effects
+norm
+SELECT * FROM a WHERE IFERROR(1/0, (SELECT y::DECIMAL FROM xy WHERE x = i))=k
+----
+project
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── side-effects
+ ├── fd: (1)-->(2-5)
+ └── select
+      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:8(decimal)
+      ├── side-effects
+      ├── key: (1,6)
+      ├── fd: (1)-->(2-5), (6)-->(8)
+      ├── left-join
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:8(decimal)
+      │    ├── key: (1,6)
+      │    ├── fd: (1)-->(2-5), (6)-->(8)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2-5)
+      │    ├── project
+      │    │    ├── columns: y:8(decimal) x:6(int!null)
+      │    │    ├── key: (6)
+      │    │    ├── fd: (6)-->(8)
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:6(int!null) xy.y:7(int)
+      │    │    │    ├── key: (6)
+      │    │    │    └── fd: (6)-->(7)
+      │    │    └── projections
+      │    │         └── xy.y::DECIMAL [type=decimal, outer=(7)]
+      │    └── filters
+      │         └── x = i [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+      └── filters
+           └── k = IFERROR(1 / 0, y) [type=bool, outer=(1,8), side-effects, constraints=(/1: (/NULL - ])]

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -592,6 +592,29 @@ define Cast {
     TargetTyp ColType
 }
 
+# IfErr is roughly a runtime try-catch operator. It has different semantics
+# depending on which of its fields are set.
+#
+# If ErrCode is set, only errors which match the given error code will be
+# caught. If ErrCode is not set, all errors will be caught.
+#
+# If OrElse is not set, IfErr evaluates to true or false indicating whether an
+# error was caught.  If OrElse is set, IfErr evaluates to Cond if no error was
+# caught and to OrElse if an error was caught.
+#
+# TODO(justin): The implementation here is a hack: ErrCode and OrElse are
+# optional, so we repurpose lists as an optional field (since it's not
+# valid to use nil). If this comes up again, we might want to consider
+# adding an explicit Option type.
+[Scalar]
+define IfErr {
+    Cond ScalarExpr
+    # OrElse and ErrCode will be lists with a single element if their respective
+    # values are set, and empty lists otherwise.
+    OrElse  ScalarListExpr
+    ErrCode ScalarListExpr
+}
+
 # Case is a CASE statement of the form:
 #
 #   CASE [ <Input> ]

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -159,6 +159,25 @@ func (b *Builder) buildScalar(
 			b.buildScalar(subscript.Begin.(tree.TypedExpr), inScope, nil, nil, colRefs),
 		)
 
+	case *tree.IfErrExpr:
+		cond := b.buildScalar(t.Cond.(tree.TypedExpr), inScope, nil, nil, colRefs)
+
+		orElse := memo.EmptyScalarListExpr
+		if t.Else != nil {
+			orElse = memo.ScalarListExpr{
+				b.buildScalar(t.Else.(tree.TypedExpr), inScope, nil, nil, colRefs),
+			}
+		}
+
+		errCode := memo.EmptyScalarListExpr
+		if t.ErrCode != nil {
+			errCode = memo.ScalarListExpr{
+				b.buildScalar(t.ErrCode.(tree.TypedExpr), inScope, nil, nil, colRefs),
+			}
+		}
+
+		out = b.factory.ConstructIfErr(cond, orElse, errCode)
+
 	case *tree.BinaryExpr:
 		// It's possible for an overload to be selected that expects different
 		// types than the TypedExpr arguments return:

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -1123,3 +1123,55 @@ build
 SELECT ARRAY(SELECT y FROM u ORDER BY x) FROM v
 ----
 error: can't execute a correlated ARRAY(...) over int[]
+
+build-scalar
+ISERROR(1/0)
+----
+if-err [type=bool]
+ └── div [type=decimal]
+      ├── const: 1 [type=int]
+      └── const: 0 [type=int]
+
+build-scalar
+ISERROR(1/0, '22012')
+----
+if-err [type=bool]
+ ├── div [type=decimal]
+ │    ├── const: 1 [type=int]
+ │    └── const: 0 [type=int]
+ └── err-code
+      └── const: '22012' [type=string]
+
+build-scalar vars=(decimal)
+IFERROR(1/0, @1)
+----
+if-err [type=decimal]
+ ├── div [type=decimal]
+ │    ├── const: 1 [type=int]
+ │    └── const: 0 [type=int]
+ └── else
+      └── variable: @1 [type=decimal]
+
+build-scalar vars=(decimal, string)
+IFERROR(1/0, @1, @2)
+----
+if-err [type=decimal]
+ ├── div [type=decimal]
+ │    ├── const: 1 [type=int]
+ │    └── const: 0 [type=int]
+ ├── else
+ │    └── variable: @1 [type=decimal]
+ └── err-code
+      └── variable: @2 [type=string]
+
+build-scalar vars=(decimal)
+IFERROR(1/0, @1, '10000')
+----
+if-err [type=decimal]
+ ├── div [type=decimal]
+ │    ├── const: 1 [type=int]
+ │    └── const: 0 [type=int]
+ ├── else
+ │    └── variable: @1 [type=decimal]
+ └── err-code
+      └── const: '10000' [type=string]

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -469,6 +469,21 @@ func NewTypedArrayFlattenExpr(input Expr) *ArrayFlatten {
 	return node
 }
 
+// NewTypedIfErrExpr returns a new IfErrExpr that is verified to be well-typed.
+func NewTypedIfErrExpr(cond, orElse, errCode TypedExpr) *IfErrExpr {
+	node := &IfErrExpr{
+		Cond:    cond,
+		Else:    orElse,
+		ErrCode: errCode,
+	}
+	if orElse == nil {
+		node.typ = types.Bool
+	} else {
+		node.typ = cond.ResolvedType()
+	}
+	return node
+}
+
 func (node *ComparisonExpr) memoizeFn() {
 	fOp, fLeft, fRight, _, _ := foldComparisonExpr(node.Operator, node.Left, node.Right)
 	leftRet, rightRet := fLeft.(TypedExpr).ResolvedType(), fRight.(TypedExpr).ResolvedType()

--- a/pkg/sql/sem/tree/testdata/eval/conditional
+++ b/pkg/sql/sem/tree/testdata/eval/conditional
@@ -36,6 +36,11 @@ ISERROR(2)
 false
 
 eval
+(ISERROR((1/0)::STRING, '22012'), IFERROR((1/0)::STRING, '22012'))
+----
+(true, '22012')
+
+eval
 ISERROR(1/0)
 ----
 true


### PR DESCRIPTION
This commit introduces the IFERROR/ISERROR scalar operators. See #25304
for more background on these operators.

Release note: None