### PR TITLE
build: link libncurses statically

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20181019-161416
+version=20181128-142752
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -102,8 +102,8 @@ RUN mkdir ncurses \
        CXX=/x-tools/x86_64-unknown-linux-musl/bin/x86_64-unknown-linux-musl-c++ \
        ../configure --prefix=/x-tools/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/sysroot/usr \
          --host=x86_64-unknown-linux-musl \
-         $(cat /ncurses.conf) --without-shared --without-dlsym \
-    && (cd ncurses && make all && make install)) \
+         $(cat /ncurses.conf) \
+    && make install.libs) \
  && mkdir build-x86_64-unknown-linux-gnu \
  && (cd build-x86_64-unknown-linux-gnu \
     && CC=/x-tools/x86_64-unknown-linux-gnu/bin/x86_64-unknown-linux-gnu-cc \
@@ -111,7 +111,7 @@ RUN mkdir ncurses \
        ../configure --prefix=/x-tools/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot/usr \
          --host=x86_64-unknown-linux-gnu \
          $(cat /ncurses.conf) \
-    && (cd ncurses && make all && make install)) \
+    && make install.libs) \
  && mkdir build-aarch64-unknown-linux-gnueabi \
  && (cd build-aarch64-unknown-linux-gnueabi \
     && CC=/x-tools/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-cc \
@@ -119,7 +119,7 @@ RUN mkdir ncurses \
        ../configure --prefix=/x-tools/aarch64-unknown-linux-gnueabi/aarch64-unknown-linux-gnueabi/sysroot/usr \
          --host=aarch64-unknown-linux-gnueabi \
          $(cat /ncurses.conf) \
-    && (cd ncurses && make all && make install)) \
+    && make install.libs) \
  && cd .. \
  && rm -rf ncurses ncurses.conf ncurses.patch
 

--- a/build/builder/ncurses.conf
+++ b/build/builder/ncurses.conf
@@ -1,7 +1,8 @@
 --with-abi-version=5
---with-shared
+--without-shared --without-dlsym
 --without-profile --without-debug
 --disable-rpath --enable-echo
+--enable-overwrite
 --enable-const
 --without-gpm
 --without-ada

--- a/pkg/cmd/publish-artifacts/main.go
+++ b/pkg/cmd/publish-artifacts/main.go
@@ -66,8 +66,6 @@ var libsRe = func() *regexp.Regexp {
 		regexp.QuoteMeta("librt.so."),
 		regexp.QuoteMeta("libpthread.so."),
 		regexp.QuoteMeta("libdl.so."),
-		regexp.QuoteMeta("libtinfo.so."),
-		regexp.QuoteMeta("libncurses.so."),
 		regexp.QuoteMeta("libm.so."),
 		regexp.QuoteMeta("libc.so."),
 		strings.Replace(regexp.QuoteMeta("ld-linux-ARCH.so."), "ARCH", ".*", -1),


### PR DESCRIPTION
(this is a patch authored by @benesch - I am extracting this from  #32623 which needs more work) 

The Unix world is in the process of upgrading from libncurses ABI 5.0 to
libncurses ABI 6.0. The ABIs are incompatible in both directions, so we
can't support systems that ship libncurses 5.0 and systems that ship
libncurses 6.0 at the same time.

Link libncurses statically to sidestep the issue.

Note that we don't bother vendoring ncurses like we do for our other
C/C++ dependencies, because we don't particularly care about what
version of ncurses we link. Nearly all extant versions of ncurses
(5.0-6.1) are source compatible, and bug fixes in recent releases rarely
affect the low-level terminfo APIs that we depend upon.

Take the opportunity to upgrade to ncurses 6.1 as well. It doesn't fix
any bugs we know of, but it's good to stay up to date.

Fix #32281.

Release note (build change): ncurses is now linked statically so that
the cockroach binary no longer requires a particular version of the
ncurses shared library to be available on deployment machines.