### PR TITLE
exec: add count and any not null aggs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -700,6 +700,7 @@ PROTOBUF_TARGETS := bin/.go_protobuf_sources bin/.gw_protobuf_sources bin/.cpp_p
 DOCGEN_TARGETS := bin/.docgen_bnfs bin/.docgen_functions
 
 EXECGEN_TARGETS = \
+  pkg/sql/exec/any_not_null_agg.eg.go \
   pkg/sql/exec/avg_agg.eg.go \
   pkg/sql/exec/colvec.eg.go \
   pkg/sql/exec/distinct.eg.go \
@@ -1331,6 +1332,7 @@ settings-doc-gen := $(if $(filter buildshort,$(MAKECMDGOALS)),$(COCKROACHSHORT),
 $(SETTINGS_DOC_PAGE): $(settings-doc-gen)
 	@$(settings-doc-gen) gen settings-list --format=html > $@
 
+pkg/sql/exec/any_not_null_agg.eg.go: pkg/sql/exec/any_not_null_agg_tmpl.go
 pkg/sql/exec/avg_agg.eg.go: pkg/sql/exec/avg_agg_tmpl.go
 pkg/sql/exec/distinct.eg.go: pkg/sql/exec/distinct_tmpl.go
 pkg/sql/exec/quicksort.eg.go: pkg/sql/exec/quicksort_tmpl.go

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -83,7 +83,7 @@ func newColOperator(
 				return nil, errors.New("unsorted aggregation not supported")
 			}
 			groupCols.Add(int(col))
-			groupTyps[i] = types.FromColumnType(spec.Input[0].ColumnTypes[i])
+			groupTyps[i] = types.FromColumnType(spec.Input[0].ColumnTypes[col])
 		}
 		if !orderedCols.SubsetOf(groupCols) {
 			return nil, pgerror.NewAssertionErrorf("ordered cols must be a subset of grouping cols")

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -91,7 +91,7 @@ func newColOperator(
 
 		aggTyps := make([][]types.T, len(aggSpec.Aggregations))
 		aggCols := make([][]uint32, len(aggSpec.Aggregations))
-		aggFns := make([]int, len(aggSpec.Aggregations))
+		aggFns := make([]distsqlpb.AggregatorSpec_Func, len(aggSpec.Aggregations))
 		for i, agg := range aggSpec.Aggregations {
 			if agg.Distinct {
 				return nil, errors.New("distinct aggregation not supported")
@@ -102,16 +102,13 @@ func newColOperator(
 			if len(agg.Arguments) > 0 {
 				return nil, errors.New("aggregates with arguments not supported")
 			}
-			if len(agg.ColIdx) != 1 {
-				return nil, errors.New("non-single-arg aggregates not supported")
+			aggTyps[i] = make([]types.T, len(agg.ColIdx))
+			for j, colIdx := range agg.ColIdx {
+				aggTyps[i][j] = types.FromColumnType(spec.Input[0].ColumnTypes[colIdx])
 			}
-			colIdx := agg.ColIdx[0]
-			aggTyps[i] = []types.T{types.FromColumnType(spec.Input[0].ColumnTypes[colIdx])}
-			aggCols[i] = aggSpec.Aggregations[i].ColIdx
-
+			aggCols[i] = agg.ColIdx
+			aggFns[i] = agg.Func
 			switch agg.Func {
-			case distsqlpb.AggregatorSpec_AVG:
-			case distsqlpb.AggregatorSpec_SUM_INT:
 			case distsqlpb.AggregatorSpec_SUM:
 				switch aggTyps[i][0] {
 				case types.Int8, types.Int16, types.Int32, types.Int64:
@@ -120,10 +117,7 @@ func newColOperator(
 					// issues, at first, we could plan SUM for all types besides Int64.
 					return nil, errors.New("sum on int cols not supported (use sum_int)")
 				}
-			default:
-				return nil, errors.Errorf("non-sum aggregation %s not supported", agg.Func)
 			}
-			aggFns[i] = int(agg.Func)
 		}
 		op, err = exec.NewOrderedAggregator(
 			inputs[0], aggSpec.GroupCols, groupTyps, aggFns, aggCols, aggTyps,

--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -167,6 +167,8 @@ func NewOrderedAggregator(
 	for i := range aggFns {
 		var err error
 		switch aggFns[i] {
+		case distsqlpb.AggregatorSpec_ANY_NOT_NULL:
+			a.aggregateFuncs[i], err = newAnyNotNullAgg(aggTyps[i][0])
 		case distsqlpb.AggregatorSpec_AVG:
 			a.aggregateFuncs[i], err = newAvgAgg(aggTyps[i][0])
 		case distsqlpb.AggregatorSpec_SUM, distsqlpb.AggregatorSpec_SUM_INT:

--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -85,6 +85,8 @@ type orderedAggregator struct {
 	aggCols [][]uint32
 	aggTyps [][]types.T
 
+	outputTyps []types.T
+
 	// scratch is the ColBatch to output and variables related to it. Aggregate
 	// function operators write directly to this output batch.
 	scratch struct {
@@ -157,13 +159,17 @@ func NewOrderedAggregator(
 		}
 	}
 
+	outputTyps := make([]types.T, len(aggCols))
+	aggregateFuncs := make([]aggregateFunc, len(aggCols))
 	*a = orderedAggregator{
-		input:    op,
-		aggCols:  aggCols,
-		aggTyps:  aggTyps,
-		groupCol: groupCol,
+		input: op,
+
+		aggregateFuncs: aggregateFuncs,
+		aggCols:        aggCols,
+		aggTyps:        aggTyps,
+		outputTyps:     outputTyps,
+		groupCol:       groupCol,
 	}
-	a.aggregateFuncs = make([]aggregateFunc, len(aggCols))
 	for i := range aggFns {
 		var err error
 		switch aggFns[i] {
@@ -173,9 +179,23 @@ func NewOrderedAggregator(
 			a.aggregateFuncs[i], err = newAvgAgg(aggTyps[i][0])
 		case distsqlpb.AggregatorSpec_SUM, distsqlpb.AggregatorSpec_SUM_INT:
 			a.aggregateFuncs[i], err = newSumAgg(aggTyps[i][0])
+		case distsqlpb.AggregatorSpec_COUNT_ROWS:
+			a.aggregateFuncs[i] = newCountAgg()
 		default:
 			return nil, errors.Errorf("unsupported columnar aggregate function %d", aggFns[i])
 		}
+
+		// Set the output type of the aggregate.
+		switch aggFns[i] {
+		case distsqlpb.AggregatorSpec_COUNT_ROWS:
+			// TODO(jordan): this is a somewhat of a hack. The aggregate functions
+			// should come with their own output types, somehow.
+			a.outputTyps[i] = types.Int64
+		default:
+			// Output types are the input types for now.
+			a.outputTyps[i] = a.aggTyps[i][0]
+		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -187,15 +207,10 @@ func NewOrderedAggregator(
 func (a *orderedAggregator) initWithBatchSize(inputSize, outputSize int) {
 	a.input.Init()
 
-	// Output types are the input types for now.
-	oTypes := make([]types.T, len(a.aggregateFuncs))
-	for i := range oTypes {
-		oTypes[i] = a.aggTyps[i][0]
-	}
 	// Twice the input batchSize is allocated to avoid having to check for
 	// overflow when outputting.
-	a.scratch.ColBatch = NewMemBatchWithSize(oTypes, inputSize*2)
-	for i := 0; i < len(oTypes); i++ {
+	a.scratch.ColBatch = NewMemBatchWithSize(a.outputTyps, inputSize*2)
+	for i := 0; i < len(a.outputTyps); i++ {
 		vec := a.scratch.ColVec(i)
 		a.aggregateFuncs[i].Init(a.groupCol, vec)
 	}
@@ -214,20 +229,19 @@ func (a *orderedAggregator) Next() ColBatch {
 	if a.scratch.resumeIdx >= a.scratch.outputSize {
 		// Copy the second part of the output batch into the first and resume from
 		// there.
-		for i := 0; i < len(a.aggTyps); i++ {
+		newResumeIdx := a.scratch.resumeIdx - a.scratch.outputSize
+		for i := 0; i < len(a.outputTyps); i++ {
 			// According to the aggregate function interface contract, the value at
 			// the current index must also be copied.
-			a.scratch.ColVec(i).Copy(a.scratch.ColVec(i),
-				uint64(a.scratch.outputSize),
-				uint64(a.scratch.resumeIdx)+1,
-				a.aggTyps[i][0])
-			a.scratch.resumeIdx = a.scratch.resumeIdx - a.scratch.outputSize
-			if a.scratch.resumeIdx >= a.scratch.outputSize {
-				// We still have overflow output values.
-				a.scratch.SetLength(uint16(a.scratch.outputSize))
-				return a.scratch
-			}
-			a.aggregateFuncs[i].SetOutputIndex(a.scratch.resumeIdx)
+			a.scratch.ColVec(i).Copy(a.scratch.ColVec(i), uint64(a.scratch.outputSize),
+				uint64(a.scratch.resumeIdx+1), a.outputTyps[i])
+			a.aggregateFuncs[i].SetOutputIndex(newResumeIdx)
+		}
+		a.scratch.resumeIdx = newResumeIdx
+		if a.scratch.resumeIdx >= a.scratch.outputSize {
+			// We still have overflow output values.
+			a.scratch.SetLength(uint16(a.scratch.outputSize))
+			return a.scratch
 		}
 	}
 

--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -349,22 +349,33 @@ func TestAggregatorMultiFunc(t *testing.T) {
 	}
 }
 
-func TestAggregatorAnyNotNull(t *testing.T) {
+func TestAggregatorKitchenSink(t *testing.T) {
 	testCases := []aggregatorTestCase{
 		{
-			aggFns:   []distsqlpb.AggregatorSpec_Func{distsqlpb.AggregatorSpec_SUM, distsqlpb.AggregatorSpec_ANY_NOT_NULL},
-			aggCols:  [][]uint32{{2}, {1}},
-			aggTypes: [][]types.T{{types.Int64}, {types.Int64}},
+			aggFns: []distsqlpb.AggregatorSpec_Func{
+				distsqlpb.AggregatorSpec_ANY_NOT_NULL,
+				distsqlpb.AggregatorSpec_AVG,
+				distsqlpb.AggregatorSpec_COUNT_ROWS,
+				distsqlpb.AggregatorSpec_SUM,
+			},
+			aggCols:  [][]uint32{{0}, {1}, {}, {2}},
+			aggTypes: [][]types.T{{types.Int64}, {types.Decimal}, {}, {types.Int64}},
 			input: tuples{
-				{0, 3, 2},
-				{0, 1, 3},
-				{1, 1, 1},
-				{1, 4, 0},
+				{0, 3.1, 2},
+				{0, 1.1, 3},
+				{1, 1.1, 1},
+				{1, 4.1, 0},
+				{2, 1.1, 1},
+				{3, 4.1, 0},
+				{3, 5.1, 0},
 			},
 			expected: tuples{
-				{5, 3},
-				{1, 1},
+				{0, 2.1, 2, 5},
+				{1, 2.6, 2, 1},
+				{2, 1.1, 1, 1},
+				{3, 4.6, 2, 0},
 			},
+			convToDecimal: true,
 		},
 	}
 
@@ -380,12 +391,83 @@ func TestAggregatorAnyNotNull(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				out := newOpTestOutput(a, []int{0, 1}, tc.expected)
+				out := newOpTestOutput(a, []int{0, 1, 2, 3}, tc.expected)
 				if err := out.Verify(); err != nil {
 					t.Fatal(err)
 				}
 			})
 		})
+	}
+}
+
+func TestAggregatorRandomCountSum(t *testing.T) {
+	// This test sums and counts random inputs, keeping track of the expected
+	// results to make sure the aggregations are correct.
+	rng, _ := randutil.NewPseudoRand()
+	for _, groupSize := range []int{1, 2, ColBatchSize / 4, ColBatchSize / 2} {
+		for _, numInputBatches := range []int{1, 2, 64} {
+			t.Run(fmt.Sprintf("groupSize=%d/numInputBatches=%d", groupSize, numInputBatches),
+				func(t *testing.T) {
+					batch := NewMemBatch([]types.T{types.Int64, types.Int64})
+					groups, col := batch.ColVec(0).Int64(), batch.ColVec(1).Int64()
+					var expCounts, expSums []int64
+					curGroup := -1
+					for i := 0; i < ColBatchSize; i++ {
+						if i%groupSize == 0 {
+							expCounts = append(expCounts, int64(groupSize))
+							expSums = append(expSums, 0)
+							curGroup++
+						}
+						col[i] = rng.Int63() % 1024
+						expSums[len(expSums)-1] += col[i]
+						groups[i] = int64(curGroup)
+					}
+					batch.SetLength(ColBatchSize)
+					source := newRepeatableBatchSource(batch)
+					source.resetBatchesToReturn(numInputBatches)
+					a, err := NewOrderedAggregator(
+						source,
+						[]uint32{0},
+						[]types.T{types.Int64},
+						[]distsqlpb.AggregatorSpec_Func{distsqlpb.AggregatorSpec_COUNT_ROWS, distsqlpb.AggregatorSpec_SUM_INT},
+						[][]uint32{{}, {1}},
+						[][]types.T{{}, {types.Int64}},
+					)
+					if err != nil {
+						t.Fatal(err)
+					}
+					a.Init()
+
+					// Exhaust aggregator until all batches have been read.
+					i := 0
+					for b := a.Next(); b.Length() != 0; b = a.Next() {
+						countCol := b.ColVec(0).Int64()
+						sumCol := b.ColVec(1).Int64()
+						for j := uint16(0); j < b.Length(); j++ {
+							count := countCol[j]
+							sum := sumCol[j]
+							expCount := expCounts[int(j)%len(expCounts)]
+							if count != expCount {
+								t.Fatalf("Found count %d, expected %d, idx %d of batch %d", count, expCount, j, i)
+							}
+							expSum := expSums[int(j)%len(expSums)]
+							if sum != expSum {
+								t.Fatalf("Found sum %d, expected %d, idx %d of batch %d", sum, expSum, j, i)
+							}
+						}
+						i++
+					}
+					totalInputRows := numInputBatches * ColBatchSize
+					nOutputRows := totalInputRows / groupSize
+					expBatches := (nOutputRows / ColBatchSize)
+					if nOutputRows%ColBatchSize != 0 {
+						expBatches++
+					}
+					if i != expBatches {
+						t.Fatalf("expected %d batches, found %d", expBatches, i)
+					}
+				})
+		}
 	}
 }
 
@@ -395,6 +477,7 @@ func BenchmarkAggregator(b *testing.B) {
 	for _, aggFn := range []distsqlpb.AggregatorSpec_Func{
 		distsqlpb.AggregatorSpec_ANY_NOT_NULL,
 		distsqlpb.AggregatorSpec_AVG,
+		distsqlpb.AggregatorSpec_COUNT_ROWS,
 		distsqlpb.AggregatorSpec_SUM,
 	} {
 		fName := distsqlpb.AggregatorSpec_Func_name[int32(aggFn)]
@@ -414,13 +497,17 @@ func BenchmarkAggregator(b *testing.B) {
 					batch.SetLength(ColBatchSize)
 					source := newRepeatableBatchSource(batch)
 
+					nCols := 1
+					if aggFn == distsqlpb.AggregatorSpec_COUNT_ROWS {
+						nCols = 0
+					}
 					a, err := NewOrderedAggregator(
 						source,
 						[]uint32{0},
 						[]types.T{types.Int64},
 						[]distsqlpb.AggregatorSpec_Func{aggFn},
-						[][]uint32{{1}},
-						[][]types.T{{types.Decimal}},
+						[][]uint32{[]uint32{1}[:nCols]},
+						[][]types.T{[]types.T{types.Decimal}[:nCols]},
 					)
 					if err != nil {
 						b.Fatal(err)

--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -19,15 +19,9 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-)
-
-// Mirrors AggregatorSpec_Func until we can import without a distsqlrun
-// dependency.
-const (
-	AVG = 1
-	SUM = 10
 )
 
 var (
@@ -35,7 +29,7 @@ var (
 	defaultGroupTypes = []types.T{types.Int64}
 	defaultAggCols    = [][]uint32{{1}}
 	defaultAggTypes   = [][]types.T{{types.Int64}}
-	defaultAggFns     = []int{SUM}
+	defaultAggFns     = []distsqlpb.AggregatorSpec_Func{distsqlpb.AggregatorSpec_SUM}
 )
 
 type aggregatorTestCase struct {
@@ -43,7 +37,7 @@ type aggregatorTestCase struct {
 	// before running a test if nil.
 	groupCols  []uint32
 	groupTypes []types.T
-	aggFns     []int
+	aggFns     []distsqlpb.AggregatorSpec_Func
 	aggCols    [][]uint32
 	aggTypes   [][]types.T
 	input      tuples
@@ -273,7 +267,7 @@ func TestAggregatorOneFunc(t *testing.T) {
 func TestAggregatorMultiFunc(t *testing.T) {
 	testCases := []aggregatorTestCase{
 		{
-			aggFns: []int{SUM, SUM},
+			aggFns: []distsqlpb.AggregatorSpec_Func{distsqlpb.AggregatorSpec_SUM, distsqlpb.AggregatorSpec_SUM},
 			aggCols: [][]uint32{
 				{2}, {1},
 			},
@@ -290,7 +284,7 @@ func TestAggregatorMultiFunc(t *testing.T) {
 			name: "OutputOrder",
 		},
 		{
-			aggFns: []int{SUM, SUM},
+			aggFns: []distsqlpb.AggregatorSpec_Func{distsqlpb.AggregatorSpec_SUM, distsqlpb.AggregatorSpec_SUM},
 			aggCols: [][]uint32{
 				{2}, {1},
 			},
@@ -311,7 +305,7 @@ func TestAggregatorMultiFunc(t *testing.T) {
 			convToDecimal: true,
 		},
 		{
-			aggFns: []int{AVG, SUM},
+			aggFns: []distsqlpb.AggregatorSpec_Func{distsqlpb.AggregatorSpec_AVG, distsqlpb.AggregatorSpec_SUM},
 			aggCols: [][]uint32{
 				{1}, {1},
 			},
@@ -358,14 +352,8 @@ func TestAggregatorMultiFunc(t *testing.T) {
 func BenchmarkAggregator(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 
-	for _, aggFn := range []int{SUM, AVG} {
-		fName := ""
-		switch aggFn {
-		case AVG:
-			fName = "AVG"
-		case SUM:
-			fName = "SUM"
-		}
+	for _, aggFn := range []distsqlpb.AggregatorSpec_Func{distsqlpb.AggregatorSpec_SUM, distsqlpb.AggregatorSpec_AVG} {
+		fName := distsqlpb.AggregatorSpec_Func_name[int32(aggFn)]
 		b.Run(fName, func(b *testing.B) {
 			for _, groupSize := range []int{1, 2, ColBatchSize / 2, ColBatchSize} {
 				for _, numInputBatches := range []int{1, 2, 32, 64} {
@@ -386,7 +374,7 @@ func BenchmarkAggregator(b *testing.B) {
 						source,
 						[]uint32{0},
 						[]types.T{types.Int64},
-						[]int{aggFn},
+						[]distsqlpb.AggregatorSpec_Func{aggFn},
 						[][]uint32{{1}},
 						[][]types.T{{types.Decimal}},
 					)

--- a/pkg/sql/exec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/exec/any_not_null_agg_tmpl.go
@@ -1,0 +1,123 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for distinct.eg.go. It's formatted in a
+// special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package exec
+
+import (
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/pkg/errors"
+)
+
+func newAnyNotNullAgg(t types.T) (aggregateFunc, error) {
+	switch t {
+	// {{range .}}
+	case _TYPES_T:
+		return &anyNotNull_TYPEAgg{}, nil
+		// {{end}}
+	default:
+		return nil, errors.Errorf("unsupported any not null agg type %s", t)
+	}
+}
+
+// {{/*
+
+// Declarations to make the template compile properly.
+
+// Dummy import to pull in "apd" package.
+var _ apd.Decimal
+
+// _GOTYPE is the template Go type variable for this operator. It will be
+// replaced by the Go type equivalent for each type in types.T, for example
+// int64 for types.Int64.
+type _GOTYPE interface{}
+
+// _TYPES_T is the template type variable for types.T. It will be replaced by
+// types.Foo for each type Foo in the types.T type.
+const _TYPES_T = types.Unhandled
+
+// */}}
+
+// {{range .}}
+
+// anyNotNull_TYPEAgg implements the ANY_NOT_NULL aggregate, returning the
+// first non-null value in the input column.
+// TODO(jordan): this needs to have null handling when it's added!
+type anyNotNull_TYPEAgg struct {
+	done   bool
+	groups []bool
+	vec    []_GOTYPE
+	curIdx int
+}
+
+func (a *anyNotNull_TYPEAgg) Init(groups []bool, vec ColVec) {
+	a.groups = groups
+	a.vec = vec._TemplateType()
+	a.Reset()
+}
+
+func (a *anyNotNull_TYPEAgg) Reset() {
+	a.curIdx = -1
+}
+
+func (a *anyNotNull_TYPEAgg) CurrentOutputIndex() int {
+	return a.curIdx
+}
+
+func (a *anyNotNull_TYPEAgg) SetOutputIndex(idx int) {
+	if a.curIdx != -1 {
+		a.curIdx = idx
+	}
+}
+
+func (a *anyNotNull_TYPEAgg) Compute(b ColBatch, inputIdxs []uint32) {
+	if a.done {
+		return
+	}
+	inputLen := b.Length()
+	if inputLen == 0 {
+		a.curIdx++
+		a.done = true
+		return
+	}
+	col, sel := b.ColVec(int(inputIdxs[0]))._TemplateType(), b.Selection()
+	if sel != nil {
+		sel = sel[:inputLen]
+		for _, i := range sel {
+			if a.groups[i] {
+				a.curIdx++
+				a.vec[a.curIdx] = col[i]
+			}
+		}
+	} else {
+		col = col[:inputLen]
+		for i := range col {
+			if a.groups[i] {
+				a.curIdx++
+				a.vec[a.curIdx] = col[i]
+			}
+		}
+	}
+}
+
+// {{end}}

--- a/pkg/sql/exec/count_agg.go
+++ b/pkg/sql/exec/count_agg.go
@@ -1,0 +1,82 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+func newCountAgg() *countAgg {
+	return &countAgg{}
+}
+
+// countAgg is the COUNT(*) aggregate - it takes no arguments.
+type countAgg struct {
+	groups []bool
+	vec    []int64
+	curIdx int
+	done   bool
+}
+
+func (a *countAgg) Init(groups []bool, vec ColVec) {
+	a.groups = groups
+	a.vec = vec.Int64()
+	a.Reset()
+}
+
+func (a *countAgg) Reset() {
+	a.curIdx = -1
+	copy(a.vec, zeroInt64Batch)
+}
+
+func (a *countAgg) CurrentOutputIndex() int {
+	return a.curIdx
+}
+
+func (a *countAgg) SetOutputIndex(idx int) {
+	if a.curIdx != -1 {
+		a.curIdx = idx
+		copy(a.vec[idx+1:], zeroInt64Batch)
+	}
+}
+
+func (a *countAgg) Compute(b ColBatch, _ []uint32) {
+	if a.done {
+		return
+	}
+	inputLen := b.Length()
+	if inputLen == 0 {
+		a.curIdx++
+		a.done = true
+		return
+	}
+	sel := b.Selection()
+	if sel != nil {
+		sel = sel[:inputLen]
+		for _, i := range sel {
+			x := 0
+			if a.groups[i] {
+				x = 1
+			}
+			a.curIdx += x
+			a.vec[a.curIdx]++
+		}
+	} else {
+		for i := uint16(0); i < inputLen; i++ {
+			x := 0
+			if a.groups[i] {
+				x = 1
+			}
+			a.curIdx += x
+			a.vec[a.curIdx]++
+		}
+	}
+}

--- a/pkg/sql/exec/execgen/cmd/execgen/any_not_null_agg_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/any_not_null_agg_gen.go
@@ -1,0 +1,49 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func genAnyNotNullAgg(wr io.Writer) error {
+	t, err := ioutil.ReadFile("pkg/sql/exec/any_not_null_agg_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(t)
+
+	s = strings.Replace(s, "_GOTYPE", "{{.GoTypeName}}", -1)
+	s = strings.Replace(s, "_TYPES_T", "types.{{.}}", -1)
+	s = strings.Replace(s, "_TYPE", "{{.}}", -1)
+	s = strings.Replace(s, "_TemplateType", "{{.}}", -1)
+
+	tmpl, err := template.New("any_not_null_agg").Parse(s)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, types.AllTypes)
+}
+
+func init() {
+	registerGenerator(genAnyNotNullAgg, "any_not_null_agg.eg.go")
+}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -6,10 +6,6 @@ CREATE TABLE a (a INT, b INT, PRIMARY KEY (a, b))
 statement ok
 INSERT INTO a SELECT g//2, g FROM generate_series(0,2000) g(g)
 
-# TODO(jordan): remove once #30000 is fixed.
-statement ok
-SET optimizer=off
-
 query I
 SELECT count(*) FROM a
 ----
@@ -119,3 +115,19 @@ SELECT a, b FROM a WHERE a < 2 AND b > 0 AND a * b != 3
 ----
 0  1
 1  2
+
+statement ok
+CREATE TABLE b (a INT, b STRING, PRIMARY KEY (b,a))
+
+statement ok
+INSERT INTO b VALUES
+  (0, 'a'),
+  (1, 'a'),
+  (0, 'b'),
+  (1, 'b')
+
+query IT
+SELECT sum_int(a), b from b group by b
+----
+1 a
+1 b


### PR DESCRIPTION
Add 2 new aggregates - COUNT(*) and ANY_NOT_NULL. The latter is required for most group bys.

Once this and #32673 are merged, we'll be able to fully run TPC-H q1.

Previously, since exec couldn't import distsqlrun directly, it had to
duplicate the aggregator func enum. Now that the protos have been moved
to distsqlpb, exec can import them and use rather than having to mimic
the enum.

```
BenchmarkAggregator/ANY_NOT_NULL/groupSize=1/numInputBatches=1-8                 1000000              1093 ns/op        7492.63 MB/s
BenchmarkAggregator/ANY_NOT_NULL/groupSize=1/numInputBatches=2-8                 1000000              1964 ns/op        8341.59 MB/s
BenchmarkAggregator/ANY_NOT_NULL/groupSize=1/numInputBatches=64-8                  30000             57372 ns/op        9138.24 MB/s
BenchmarkAggregator/ANY_NOT_NULL/groupSize=512/numInputBatches=1-8               1000000              1058 ns/op        7741.03 MB/s
BenchmarkAggregator/ANY_NOT_NULL/groupSize=512/numInputBatches=2-8               1000000              1961 ns/op        8354.28 MB/s
BenchmarkAggregator/ANY_NOT_NULL/groupSize=512/numInputBatches=64-8                30000             57550 ns/op        9110.11 MB/s
BenchmarkAggregator/ANY_NOT_NULL/groupSize=1024/numInputBatches=1-8              1000000              1058 ns/op        7737.66 MB/s
BenchmarkAggregator/ANY_NOT_NULL/groupSize=1024/numInputBatches=2-8              1000000              1961 ns/op        8354.85 MB/s
BenchmarkAggregator/ANY_NOT_NULL/groupSize=1024/numInputBatches=64-8               30000             57410 ns/op        9132.34 MB/s
BenchmarkAggregator/COUNT_ROWS/groupSize=1/numInputBatches=1-8                   1000000              1263 ns/op        6484.39 MB/s
BenchmarkAggregator/COUNT_ROWS/groupSize=1/numInputBatches=2-8                   1000000              2128 ns/op        7697.26 MB/s
BenchmarkAggregator/COUNT_ROWS/groupSize=1/numInputBatches=64-8                    30000             57414 ns/op        9131.67 MB/s
BenchmarkAggregator/COUNT_ROWS/groupSize=512/numInputBatches=1-8                 1000000              1223 ns/op        6697.72 MB/s
BenchmarkAggregator/COUNT_ROWS/groupSize=512/numInputBatches=2-8                 1000000              2116 ns/op        7739.48 MB/s
BenchmarkAggregator/COUNT_ROWS/groupSize=512/numInputBatches=64-8                  30000             57648 ns/op        9094.49 MB/s
BenchmarkAggregator/COUNT_ROWS/groupSize=1024/numInputBatches=1-8                1000000              1225 ns/op        6683.79 MB/s
BenchmarkAggregator/COUNT_ROWS/groupSize=1024/numInputBatches=2-8                1000000              2157 ns/op        7592.34 MB/s
BenchmarkAggregator/COUNT_ROWS/groupSize=1024/numInputBatches=64-8                 30000             58543 ns/op        8955.46 MB/s
```

Also, fix a couple of small bugs in aggregation.