### PR TITLE
backport-2.1: storage: improve logging and log Raft truncation

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -27,9 +27,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
-	"github.com/pkg/errors"
-
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -37,11 +34,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
 	"github.com/rubyist/circuitbreaker"
 )
 
@@ -358,7 +358,7 @@ func (r *Replica) QuotaReleaseQueueLen() int {
 func (r *Replica) IsFollowerActive(ctx context.Context, followerID roachpb.ReplicaID) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.isFollowerActiveLocked(ctx, followerID)
+	return r.mu.lastUpdateTimes.isFollowerActive(ctx, followerID, timeutil.Now())
 }
 
 func (r *Replica) CommandSizesLen() int {

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -786,6 +786,16 @@ func isBenign(err error) bool {
 	})
 }
 
+func isPurgatoryError(err error) (purgatoryError, bool) {
+	var purgErr purgatoryError
+	ok := causer.Visit(err, func(err error) bool {
+		var ok bool
+		purgErr, ok = err.(purgatoryError)
+		return ok
+	})
+	return purgErr, ok
+}
+
 // finishProcessingReplica handles the completion of a replica process attempt.
 // It removes the replica from the replica set and may re-enqueue the replica or
 // add it to purgatory.
@@ -819,7 +829,7 @@ func (bq *baseQueue) finishProcessingReplica(
 		// the failing replica to purgatory. Note that even if the item was
 		// scheduled to be requeued, we ignore this if we add the replica to
 		// purgatory.
-		if purgErr, ok := errors.Cause(err).(purgatoryError); ok {
+		if purgErr, ok := isPurgatoryError(err); ok {
 			bq.addToPurgatoryLocked(ctx, stopper, repl, purgErr)
 			return
 		}

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/causer"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -768,6 +769,23 @@ func (bq *baseQueue) processReplica(queueCtx context.Context, repl *Replica) err
 	return nil
 }
 
+type benignError struct {
+	error
+}
+
+var _ causer.Causer = &benignError{}
+
+func (be *benignError) Cause() error {
+	return be.error
+}
+
+func isBenign(err error) bool {
+	return causer.Visit(err, func(err error) bool {
+		_, ok := err.(*benignError)
+		return ok
+	})
+}
+
 // finishProcessingReplica handles the completion of a replica process attempt.
 // It removes the replica from the replica set and may re-enqueue the replica or
 // add it to purgatory.
@@ -789,7 +807,12 @@ func (bq *baseQueue) finishProcessingReplica(
 
 	// Handle failures.
 	if err != nil {
-		// Increment failures metric to capture all error.
+		benign := isBenign(err)
+
+		// Increment failures metric.
+		//
+		// TODO(tschottdorf): once we start asserting zero failures in tests
+		// (and production), move benign failures into a dedicated category.
 		bq.failures.Inc(1)
 
 		// Determine whether a failure is a purgatory error. If it is, add
@@ -801,8 +824,10 @@ func (bq *baseQueue) finishProcessingReplica(
 			return
 		}
 
-		// If not a purgatory error, log.
-		log.Error(ctx, err)
+		// If not a benign or purgatory error, log.
+		if !benign {
+			log.Error(ctx, err)
+		}
 	}
 
 	// Maybe add replica back into queue, if requested.

--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -96,6 +96,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (*truncateDecision, er
 	rangeID := r.RangeID
 	now := timeutil.Now()
 
+	// NB: we need an exclusive lock due to grabbing the first index.
 	r.mu.Lock()
 	raftLogSize := r.mu.raftLogSize
 	// A "cooperative" truncation (i.e. one that does not cut off followers from
@@ -138,6 +139,21 @@ func newTruncateDecision(ctx context.Context, r *Replica) (*truncateDecision, er
 		return &truncateDecision{}, nil
 	}
 
+	// For all our followers, overwrite the RecentActive field (which is always
+	// true since we don't use CheckQuorum) with our own activity check.
+	r.mu.RLock()
+	updateRaftProgressFromActivity(
+		ctx, raftStatus.Progress, r.descRLocked().Replicas, r.mu.lastUpdateTimes, now,
+	)
+	r.mu.RUnlock()
+
+	if pr, ok := raftStatus.Progress[raftStatus.Lead]; ok {
+		// TODO(tschottdorf): remove this line once we have picked up
+		// https://github.com/etcd-io/etcd/pull/10279
+		pr.State = raft.ProgressStateReplicate
+		raftStatus.Progress[raftStatus.Lead] = pr
+	}
+
 	input := truncateDecisionInput{
 		RaftStatus:                     raftStatus,
 		LogSize:                        raftLogSize,
@@ -151,12 +167,39 @@ func newTruncateDecision(ctx context.Context, r *Replica) (*truncateDecision, er
 	return &decision, nil
 }
 
+func updateRaftProgressFromActivity(
+	ctx context.Context,
+	prs map[uint64]raft.Progress,
+	replicas []roachpb.ReplicaDescriptor,
+	lastUpdate lastUpdateTimesMap,
+	now time.Time,
+) {
+	for _, replDesc := range replicas {
+		replicaID := replDesc.ReplicaID
+		pr, ok := prs[uint64(replicaID)]
+		if !ok {
+			continue
+		}
+		pr.RecentActive = lastUpdate.isFollowerActive(ctx, replicaID, now)
+		// Override this field for safety since we don't use it. Instead, we use
+		// pendingSnapshotIndex from above which is also populated for
+		// preemptive snapshots.
+		//
+		// TODO(tschottdorf): if we used Raft learners instead of preemptive
+		// snapshots, I think this value would do exactly the right tracking
+		// (including only resetting when the follower resumes replicating).
+		pr.PendingSnapshot = 0
+		prs[uint64(replicaID)] = pr
+	}
+}
+
 const (
-	truncatableIndexChosenViaQuorumIndex = "quorum"
-	truncatableIndexChosenViaFollowers   = "followers"
-	truncatableIndexChosenViaPendingSnap = "pending snapshot"
-	truncatableIndexChosenViaFirstIndex  = "first index"
-	truncatableIndexChosenViaLastIndex   = "last index"
+	truncatableIndexChosenViaQuorumIndex     = "quorum"
+	truncatableIndexChosenViaFollowers       = "followers"
+	truncatableIndexChosenViaProbingFollower = "probing follower"
+	truncatableIndexChosenViaPendingSnap     = "pending snapshot"
+	truncatableIndexChosenViaFirstIndex      = "first index"
+	truncatableIndexChosenViaLastIndex       = "last index"
 )
 
 type truncateDecisionInput struct {
@@ -260,16 +303,33 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 	decision.NewFirstIndex = decision.QuorumIndex
 	decision.ChosenVia = truncatableIndexChosenViaQuorumIndex
 
-	if !input.LogTooLarge() {
-		// Only truncate to one of the follower indexes if the raft log is less
-		// than the target size. If the raft log is greater than the target size we
-		// always truncate to the quorum commit index.
-		for _, progress := range input.RaftStatus.Progress {
-			index := progress.Match
-			if decision.NewFirstIndex > index {
-				decision.NewFirstIndex = index
-				decision.ChosenVia = truncatableIndexChosenViaFollowers
-			}
+	for _, progress := range input.RaftStatus.Progress {
+		// Generally we truncate to the quorum commit index when the log becomes
+		// too large, but we make an exception for live followers which are
+		// being probed (i.e. the leader doesn't know how far they've caught
+		// up). In that case the Match index is too large, and so the quorum
+		// index can be, too. We don't want these followers to require a
+		// snapshot since they are most likely going to be caught up very soon
+		// (they respond with the "right index" to the first probe or don't
+		// respond, in which case they should end up as not recently active).
+		// But we also don't know their index, so we can't possible make a
+		// truncation decision that avoids that at this point and make the
+		// truncation a no-op.
+		//
+		// The scenario in which this is most relevant is during restores, where
+		// we split off new ranges that rapidly receive very large log entries
+		// while the Raft group is still in a state of discovery (a new leader
+		// starts probing followers at its own last index). Additionally, these
+		// ranges will be split many times over, resulting in a flurry of
+		// snapshots with overlapping bounds that put significant stress on the
+		// Raft snapshot queue.
+		probing := (progress.RecentActive && progress.State == raft.ProgressStateProbe)
+		if probing && decision.NewFirstIndex > decision.Input.FirstIndex {
+			decision.NewFirstIndex = decision.Input.FirstIndex
+			decision.ChosenVia = truncatableIndexChosenViaProbingFollower
+		} else if !input.LogTooLarge() && decision.NewFirstIndex > progress.Match {
+			decision.NewFirstIndex = progress.Match
+			decision.ChosenVia = truncatableIndexChosenViaFollowers
 		}
 	}
 

--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -16,20 +16,22 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"strings"
 	"time"
-
-	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
-
-	"github.com/pkg/errors"
-	"go.etcd.io/etcd/raft"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/raft"
 )
 
 const (
@@ -55,12 +57,15 @@ const (
 type raftLogQueue struct {
 	*baseQueue
 	db *client.DB
+
+	logSnapshots util.EveryN
 }
 
 // newRaftLogQueue returns a new instance of raftLogQueue.
 func newRaftLogQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *raftLogQueue {
 	rlq := &raftLogQueue{
-		db: db,
+		db:           db,
+		logSnapshots: util.Every(10 * time.Second),
 	}
 	rlq.baseQueue = newBaseQueue(
 		"raftlog", rlq, store, gossip,
@@ -79,29 +84,11 @@ func newRaftLogQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *raftLo
 	return rlq
 }
 
-func shouldTruncate(truncatableIndexes uint64, raftLogSize int64) bool {
-	return truncatableIndexes >= RaftLogQueueStaleThreshold ||
-		(truncatableIndexes > 0 && raftLogSize >= RaftLogQueueStaleSize)
-}
-
-// getTruncatableIndexes returns the number of truncatable indexes, the oldest
-// index that cannot be truncated, and the current Raft log size. See
-// computeTruncatableIndex.
-func getTruncatableIndexes(ctx context.Context, r *Replica) (uint64, uint64, int64, error) {
+// newTruncateDecision returns a truncateDecision for the given Replica if no
+// error occurs. If no truncation can be carried out, a zero decision is
+// returned.
+func newTruncateDecision(ctx context.Context, r *Replica) (*truncateDecision, error) {
 	rangeID := r.RangeID
-	raftStatus := r.RaftStatus()
-	if raftStatus == nil {
-		if log.V(6) {
-			log.Infof(ctx, "the raft group doesn't exist for r%d", rangeID)
-		}
-		return 0, 0, 0, nil
-	}
-
-	// Is this the raft leader? We only perform log truncation on the raft leader
-	// which has the up to date info on followers.
-	if raftStatus.RaftState != raft.StateLeader {
-		return 0, 0, 0, nil
-	}
 
 	r.mu.Lock()
 	raftLogSize := r.mu.raftLogSize
@@ -119,21 +106,129 @@ func getTruncatableIndexes(ctx context.Context, r *Replica) (uint64, uint64, int
 	if targetSize > r.store.cfg.RaftLogTruncationThreshold {
 		targetSize = r.store.cfg.RaftLogTruncationThreshold
 	}
+	raftStatus := r.raftStatusRLocked()
+
 	firstIndex, err := r.raftFirstIndexLocked()
 	pendingSnapshotIndex := r.mu.pendingSnapshotIndex
 	lastIndex := r.mu.lastIndex
 	r.mu.Unlock()
+
 	if err != nil {
-		return 0, 0, 0, errors.Errorf("error retrieving first index for r%d: %s", rangeID, err)
+		return nil, errors.Errorf("error retrieving first index for r%d: %s", rangeID, err)
 	}
 
-	truncatableIndex := computeTruncatableIndex(
-		raftStatus, raftLogSize, targetSize, firstIndex, lastIndex, pendingSnapshotIndex)
-	// Return the number of truncatable indexes.
-	return truncatableIndex - firstIndex, truncatableIndex, raftLogSize, nil
+	if raftStatus == nil {
+		if log.V(6) {
+			log.Infof(ctx, "the raft group doesn't exist for r%d", rangeID)
+		}
+		return &truncateDecision{}, nil
+	}
+
+	// Is this the raft leader? We only perform log truncation on the raft leader
+	// which has the up to date info on followers.
+	if raftStatus.RaftState != raft.StateLeader {
+		return &truncateDecision{}, nil
+	}
+
+	input := truncateDecisionInput{
+		RaftStatus:                     raftStatus,
+		LogSize:                        raftLogSize,
+		MaxLogSize:                     targetSize,
+		FirstIndex:                     firstIndex,
+		LastIndex:                      lastIndex,
+		PendingPreemptiveSnapshotIndex: pendingSnapshotIndex,
+	}
+
+	decision := computeTruncateDecision(input)
+	return &decision, nil
 }
 
-// computeTruncatableIndex returns the oldest index that cannot be
+const (
+	truncatableIndexChosenViaQuorumIndex = "quorum"
+	truncatableIndexChosenViaFollowers   = "followers"
+	truncatableIndexChosenViaPendingSnap = "pending snapshot"
+	truncatableIndexChosenViaFirstIndex  = "first index"
+	truncatableIndexChosenViaLastIndex   = "last index"
+)
+
+type truncateDecisionInput struct {
+	RaftStatus                     *raft.Status // never nil
+	LogSize, MaxLogSize            int64
+	FirstIndex, LastIndex          uint64
+	PendingPreemptiveSnapshotIndex uint64
+}
+
+func (input truncateDecisionInput) LogTooLarge() bool {
+	return input.LogSize > input.MaxLogSize
+}
+
+type truncateDecision struct {
+	Input       truncateDecisionInput
+	QuorumIndex uint64 // largest index known to be present on quorum
+
+	NewFirstIndex uint64 // first index of the resulting log after truncation
+	ChosenVia     string
+}
+
+func (td *truncateDecision) raftSnapshotsForIndex(index uint64) int {
+	var n int
+	for _, p := range td.Input.RaftStatus.Progress {
+		if p.Match < index {
+			n++
+		}
+	}
+	if td.Input.PendingPreemptiveSnapshotIndex != 0 && td.Input.PendingPreemptiveSnapshotIndex < index {
+		n++
+	}
+
+	return n
+}
+
+func (td *truncateDecision) NumNewRaftSnapshots() int {
+	return td.raftSnapshotsForIndex(td.NewFirstIndex) - td.raftSnapshotsForIndex(td.Input.FirstIndex)
+}
+
+func (td *truncateDecision) String() string {
+	var buf strings.Builder
+	_, _ = fmt.Fprintf(
+		&buf,
+		"truncate %d entries to first index %d (chosen via: %s)",
+		td.NumTruncatableIndexes(), td.NewFirstIndex, td.ChosenVia,
+	)
+	if td.Input.LogTooLarge() {
+		_, _ = fmt.Fprintf(
+			&buf,
+			"; log too large (%s > %s)",
+			humanizeutil.IBytes(td.Input.LogSize),
+			humanizeutil.IBytes(td.Input.MaxLogSize),
+		)
+	}
+	if n := td.NumNewRaftSnapshots(); n > 0 {
+		_, _ = fmt.Fprintf(&buf, "; implies %d Raft snapshot%s", n, util.Pluralize(int64(n)))
+	}
+
+	return buf.String()
+}
+
+func (td *truncateDecision) NumTruncatableIndexes() int {
+	if td.NewFirstIndex < td.Input.FirstIndex {
+		log.Fatalf(
+			context.Background(),
+			"invalid truncate decision: first index would move from %d to %d",
+			td.Input.FirstIndex,
+			td.NewFirstIndex,
+		)
+	}
+	return int(td.NewFirstIndex - td.Input.FirstIndex)
+}
+
+func (td *truncateDecision) ShouldTruncate() bool {
+	n := td.NumTruncatableIndexes()
+	return n >= RaftLogQueueStaleThreshold ||
+		(n > 0 && td.Input.LogSize >= RaftLogQueueStaleSize)
+}
+
+// computeTruncateDecision returns the oldest index that cannot be
 // truncated. If there is a behind node, we want to keep old raft logs so it
 // can catch up without having to send a full snapshot. However, if a node down
 // is down long enough, sending a snapshot is more efficient and we should
@@ -150,53 +245,57 @@ func getTruncatableIndexes(ctx context.Context, r *Replica) (uint64, uint64, int
 // the behind node will be caught up to a point behind the current first index
 // and thus require another snapshot, likely entering a never ending loop of
 // snapshots. See #8629.
-func computeTruncatableIndex(
-	raftStatus *raft.Status,
-	raftLogSize int64,
-	targetSize int64,
-	firstIndex uint64,
-	lastIndex uint64,
-	pendingSnapshotIndex uint64,
-) uint64 {
-	quorumIndex := getQuorumIndex(raftStatus, pendingSnapshotIndex)
-	truncatableIndex := quorumIndex
+func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
+	decision := truncateDecision{Input: input}
+	decision.QuorumIndex = getQuorumIndex(input.RaftStatus, input.PendingPreemptiveSnapshotIndex)
 
-	if raftLogSize <= targetSize {
+	decision.NewFirstIndex = decision.QuorumIndex
+	decision.ChosenVia = truncatableIndexChosenViaQuorumIndex
+
+	if !input.LogTooLarge() {
 		// Only truncate to one of the follower indexes if the raft log is less
 		// than the target size. If the raft log is greater than the target size we
 		// always truncate to the quorum commit index.
-		for _, progress := range raftStatus.Progress {
+		for _, progress := range input.RaftStatus.Progress {
 			index := progress.Match
-			if truncatableIndex > index {
-				truncatableIndex = index
+			if decision.NewFirstIndex > index {
+				decision.NewFirstIndex = index
+				decision.ChosenVia = truncatableIndexChosenViaFollowers
 			}
 		}
 		// The pending snapshot index acts as a placeholder for a replica that is
 		// about to be added to the range. We don't want to truncate the log in a
 		// way that will require that new replica to be caught up via a Raft
 		// snapshot.
-		if pendingSnapshotIndex > 0 && truncatableIndex > pendingSnapshotIndex {
-			truncatableIndex = pendingSnapshotIndex
+		if input.PendingPreemptiveSnapshotIndex > 0 && decision.NewFirstIndex > input.PendingPreemptiveSnapshotIndex {
+			decision.NewFirstIndex = input.PendingPreemptiveSnapshotIndex
+			decision.ChosenVia = truncatableIndexChosenViaPendingSnap
 		}
 	}
 
-	if truncatableIndex < firstIndex {
-		truncatableIndex = firstIndex
-	}
-	// Never truncate past the quorum commit index (this can only occur if
-	// firstIndex > quorumIndex).
-	if truncatableIndex > quorumIndex {
-		truncatableIndex = quorumIndex
+	// Advance to the first index, but never truncate past the quorum commit
+	// index.
+	if decision.NewFirstIndex < input.FirstIndex && input.FirstIndex <= decision.QuorumIndex {
+		decision.NewFirstIndex = input.FirstIndex
+		decision.ChosenVia = truncatableIndexChosenViaFirstIndex
 	}
 	// Never truncate past the last index. Naively, you would expect lastIndex to
 	// never be smaller than quorumIndex, but RaftStatus.Progress.Match is
 	// updated on the leader when a command is proposed and in a single replica
 	// Raft group this also means that RaftStatus.Commit is updated at propose
 	// time.
-	if truncatableIndex > lastIndex {
-		truncatableIndex = lastIndex
+	if decision.NewFirstIndex > input.LastIndex {
+		decision.NewFirstIndex = input.LastIndex
+		decision.ChosenVia = truncatableIndexChosenViaLastIndex
 	}
-	return truncatableIndex
+
+	// If new first index dropped below first index, make them equal (resulting
+	// in a no-op).
+	if decision.NewFirstIndex < decision.Input.FirstIndex {
+		decision.NewFirstIndex = decision.Input.FirstIndex
+		decision.ChosenVia = truncatableIndexChosenViaFirstIndex
+	}
+	return decision
 }
 
 // getQuorumIndex returns the index which a quorum of the nodes have
@@ -229,45 +328,40 @@ func getQuorumIndex(raftStatus *raft.Status, pendingSnapshotIndex uint64) uint64
 func (rlq *raftLogQueue) shouldQueue(
 	ctx context.Context, now hlc.Timestamp, r *Replica, _ config.SystemConfig,
 ) (shouldQ bool, priority float64) {
-	truncatableIndexes, _, raftLogSize, err := getTruncatableIndexes(ctx, r)
+	decision, err := newTruncateDecision(ctx, r)
 	if err != nil {
 		log.Warning(ctx, err)
 		return false, 0
 	}
-
-	return shouldTruncate(truncatableIndexes, raftLogSize), float64(raftLogSize)
+	return decision.ShouldTruncate(), float64(decision.Input.LogSize)
 }
 
 // process truncates the raft log of the range if the replica is the raft
 // leader and if the total number of the range's raft log's stale entries
 // exceeds RaftLogQueueStaleThreshold.
 func (rlq *raftLogQueue) process(ctx context.Context, r *Replica, _ config.SystemConfig) error {
-	truncatableIndexes, oldestIndex, raftLogSize, err := getTruncatableIndexes(ctx, r)
+	decision, err := newTruncateDecision(ctx, r)
 	if err != nil {
 		return err
 	}
 
 	// Can and should the raft logs be truncated?
-	if shouldTruncate(truncatableIndexes, raftLogSize) {
-		r.mu.Lock()
-		raftLogSize := r.mu.raftLogSize
-		lastIndex := r.mu.lastIndex
-		r.mu.Unlock()
-
-		if log.V(1) {
-			log.Infof(ctx, "truncating raft log entries [%d-%d], resulting in log [%d,%d], reclaiming ~%s",
-				oldestIndex-truncatableIndexes, oldestIndex-1, oldestIndex, lastIndex, humanizeutil.IBytes(raftLogSize))
+	if decision.ShouldTruncate() {
+		if n := decision.NumNewRaftSnapshots(); log.V(1) || n > 0 && rlq.logSnapshots.ShouldProcess(timeutil.Now()) {
+			log.Info(ctx, decision)
+		} else {
+			log.VEvent(ctx, 1, decision.String())
 		}
 		b := &client.Batch{}
 		b.AddRawRequest(&roachpb.TruncateLogRequest{
 			RequestHeader: roachpb.RequestHeader{Key: r.Desc().StartKey.AsRawKey()},
-			Index:         oldestIndex,
+			Index:         decision.NewFirstIndex,
 			RangeID:       r.RangeID,
 		})
 		if err := rlq.db.Run(ctx, b); err != nil {
 			return err
 		}
-		r.store.metrics.RaftLogTruncated.Inc(int64(truncatableIndexes))
+		r.store.metrics.RaftLogTruncated.Inc(int64(decision.NumTruncatableIndexes()))
 	}
 	return nil
 }

--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -92,19 +92,21 @@ func newTruncateDecision(ctx context.Context, r *Replica) (*truncateDecision, er
 
 	r.mu.Lock()
 	raftLogSize := r.mu.raftLogSize
-	// We target the raft log size at the size of the replicated data. When
-	// writing to a replica, it is common for the raft log to become larger than
-	// the replicated data as the raft log contains the overhead of the
-	// BatchRequest which includes the full transaction state as well as begin
-	// and end transaction operations. If the estimated raft log size becomes
-	// larger than the replica size, we're better off recovering the replica
-	// using a snapshot.
+	// A "cooperative" truncation (i.e. one that does not cut off followers from
+	// the log) takes place whenever there are more than
+	// RaftLogQueueStaleThreshold entries or the log's estimated size is above
+	// RaftLogQueueStaleSize bytes. This is fairly aggressive, so under normal
+	// conditions, the log is very small.
+	//
+	// If followers start falling behind, at some point the logs still need to
+	// be truncated. We do this either when the size of the log exceeds
+	// RaftLogTruncationThreshold (or, in eccentric configurations, the zone's
+	// RangeMaxBytes). This captures the heuristic that at some point, it's more
+	// efficient to catch up via a snapshot than via applying a long tail of log
+	// entries.
 	targetSize := r.mu.state.Stats.Total()
 	if targetSize > r.mu.maxBytes {
 		targetSize = r.mu.maxBytes
-	}
-	if targetSize > r.store.cfg.RaftLogTruncationThreshold {
-		targetSize = r.store.cfg.RaftLogTruncationThreshold
 	}
 	raftStatus := r.raftStatusRLocked()
 

--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -50,6 +50,11 @@ const (
 	// Allow a limited number of Raft log truncations to be processed
 	// concurrently.
 	raftLogQueueConcurrency = 4
+	// While a snapshot is in flight, we won't truncate past the snapshot's log
+	// index. This behavior is extended to a grace period after the snapshot is
+	// marked as completed as it is applied at the receiver only a little later,
+	// leaving a window for a truncation that requires another snapshot.
+	raftLogQueuePendingSnapshotGracePeriod = 3 * time.Second
 )
 
 // raftLogQueue manages a queue of replicas slated to have their raft logs
@@ -89,6 +94,7 @@ func newRaftLogQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *raftLo
 // returned.
 func newTruncateDecision(ctx context.Context, r *Replica) (*truncateDecision, error) {
 	rangeID := r.RangeID
+	now := timeutil.Now()
 
 	r.mu.Lock()
 	raftLogSize := r.mu.raftLogSize
@@ -111,7 +117,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (*truncateDecision, er
 	raftStatus := r.raftStatusRLocked()
 
 	firstIndex, err := r.raftFirstIndexLocked()
-	pendingSnapshotIndex := r.mu.pendingSnapshotIndex
+	pendingSnapshotIndex := r.getAndGCSnapshotLogTruncationConstraintsLocked(now)
 	lastIndex := r.mu.lastIndex
 	r.mu.Unlock()
 
@@ -249,7 +255,7 @@ func (td *truncateDecision) ShouldTruncate() bool {
 // snapshots. See #8629.
 func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 	decision := truncateDecision{Input: input}
-	decision.QuorumIndex = getQuorumIndex(input.RaftStatus, input.PendingPreemptiveSnapshotIndex)
+	decision.QuorumIndex = getQuorumIndex(input.RaftStatus)
 
 	decision.NewFirstIndex = decision.QuorumIndex
 	decision.ChosenVia = truncatableIndexChosenViaQuorumIndex
@@ -265,14 +271,15 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 				decision.ChosenVia = truncatableIndexChosenViaFollowers
 			}
 		}
-		// The pending snapshot index acts as a placeholder for a replica that is
-		// about to be added to the range. We don't want to truncate the log in a
-		// way that will require that new replica to be caught up via a Raft
-		// snapshot.
-		if input.PendingPreemptiveSnapshotIndex > 0 && decision.NewFirstIndex > input.PendingPreemptiveSnapshotIndex {
-			decision.NewFirstIndex = input.PendingPreemptiveSnapshotIndex
-			decision.ChosenVia = truncatableIndexChosenViaPendingSnap
-		}
+	}
+
+	// The pending snapshot index acts as a placeholder for a replica that is
+	// about to be added to the range (or is in Raft recovery). We don't want to
+	// truncate the log in a way that will require that new replica to be caught
+	// up via yet another Raft snapshot.
+	if input.PendingPreemptiveSnapshotIndex > 0 && decision.NewFirstIndex > input.PendingPreemptiveSnapshotIndex {
+		decision.NewFirstIndex = input.PendingPreemptiveSnapshotIndex
+		decision.ChosenVia = truncatableIndexChosenViaPendingSnap
 	}
 
 	// Advance to the first index, but never truncate past the quorum commit
@@ -301,7 +308,7 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 }
 
 // getQuorumIndex returns the index which a quorum of the nodes have
-// committed. The pendingSnapshotIndex indicates the index of a pending
+// committed. The snapshotLogTruncationConstraints indicates the index of a pending
 // snapshot which is considered part of the Raft group even though it hasn't
 // been added yet. Note that getQuorumIndex may return 0 if the progress map
 // doesn't contain information for a sufficient number of followers (e.g. the
@@ -311,13 +318,10 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 // quorum was determined at the time the index was written. If you're thinking
 // of using getQuorumIndex for some purpose, consider that raftStatus.Commit
 // might be more appropriate (e.g. determining if a replica is up to date).
-func getQuorumIndex(raftStatus *raft.Status, pendingSnapshotIndex uint64) uint64 {
-	match := make([]uint64, 0, len(raftStatus.Progress)+1)
+func getQuorumIndex(raftStatus *raft.Status) uint64 {
+	match := make([]uint64, 0, len(raftStatus.Progress))
 	for _, progress := range raftStatus.Progress {
 		match = append(match, progress.Match)
-	}
-	if pendingSnapshotIndex != 0 {
-		match = append(match, pendingSnapshotIndex)
 	}
 	sort.Sort(uint64Slice(match))
 	quorum := computeQuorum(len(match))

--- a/pkg/storage/raft_log_queue_test.go
+++ b/pkg/storage/raft_log_queue_test.go
@@ -18,19 +18,17 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -52,7 +50,11 @@ func TestShouldTruncate(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			v := shouldTruncate(c.truncatableIndexes, c.raftLogSize)
+			var d truncateDecision
+			d.Input.LogSize = c.raftLogSize
+			d.Input.FirstIndex = 123
+			d.NewFirstIndex = d.Input.FirstIndex + c.truncatableIndexes
+			v := d.ShouldTruncate()
 			if c.expected != v {
 				t.Fatalf("expected %v, but found %v", c.expected, v)
 			}
@@ -96,7 +98,7 @@ func TestGetQuorumIndex(t *testing.T) {
 	}
 }
 
-func TestComputeTruncatableIndex(t *testing.T) {
+func TestComputeTruncateDecision(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const targetSize = 1000
@@ -107,27 +109,90 @@ func TestComputeTruncatableIndex(t *testing.T) {
 		firstIndex      uint64
 		lastIndex       uint64
 		pendingSnapshot uint64
-		expected        uint64
+		exp             string
 	}{
-		{[]uint64{1, 2}, 100, 1, 1, 0, 1},
-		{[]uint64{1, 5, 5}, 100, 1, 1, 0, 1},
-		{[]uint64{1, 5, 5}, 100, 2, 2, 0, 2},
-		{[]uint64{5, 5, 5}, 100, 2, 5, 0, 5},
-		{[]uint64{5, 5, 5}, 100, 2, 2, 1, 2},
-		{[]uint64{5, 5, 5}, 100, 2, 3, 3, 3},
-		{[]uint64{1, 2, 3, 4}, 100, 1, 1, 0, 1},
-		{[]uint64{1, 2, 3, 4}, 100, 2, 2, 0, 2},
-		// If over targetSize, should truncate to quorum committed index.
-		{[]uint64{1, 3, 3, 4}, 2000, 1, 3, 0, 3},
-		{[]uint64{1, 3, 3, 4}, 2000, 2, 3, 0, 3},
-		{[]uint64{1, 3, 3, 4}, 2000, 3, 3, 0, 3},
+		{
+			// Nothing to truncate.
+			[]uint64{1, 2}, 100, 1, 1, 0,
+			"truncate 0 entries to first index 1 (chosen via: quorum)"},
+		{
+			// Nothing to truncate on this replica, though a quorum elsewhere has more progress.
+			// NB this couldn't happen if we're truly the Raft leader, unless we appended to our
+			// own log asynchronously.
+			[]uint64{1, 5, 5}, 100, 1, 1, 0,
+			"truncate 0 entries to first index 1 (chosen via: followers)",
+		},
+		{
+			// We're not truncating anything, but one follower is already cut off. There's no pending
+			// snapshot so we shouldn't be causing any additional snapshots.
+			[]uint64{1, 5, 5}, 100, 2, 2, 0,
+			"truncate 0 entries to first index 2 (chosen via: first index)",
+		},
+		{
+			// The happy case.
+			[]uint64{5, 5, 5}, 100, 2, 5, 0,
+			"truncate 3 entries to first index 5 (chosen via: quorum)",
+		},
+		{
+			// No truncation, but the outstanding snapshot is made obsolete by the truncation. However
+			// it was already obsolete before. (This example is also not one you could manufacture in
+			// a real system).
+			[]uint64{5, 5, 5}, 100, 2, 2, 1,
+			"truncate 0 entries to first index 2 (chosen via: first index)",
+		},
+		{
+			// Respecting the pending snapshot.
+			[]uint64{5, 5, 5}, 100, 2, 5, 3,
+			"truncate 1 entries to first index 3 (chosen via: pending snapshot)",
+		},
+		{
+			// Log is below target size, so respecting the slowest follower.
+			[]uint64{1, 2, 3, 4}, 100, 1, 5, 0,
+			"truncate 0 entries to first index 1 (chosen via: followers)",
+		},
+		{
+			// Truncating since local log starts at 2. One follower is already cut off without a pending
+			// snapshot.
+			[]uint64{1, 2, 3, 4}, 100, 2, 2, 0,
+			"truncate 0 entries to first index 2 (chosen via: first index)",
+		},
+		// If over targetSize, should truncate to quorum committed index. Minority will need snapshots.
+		{
+			[]uint64{1, 3, 3, 4}, 2000, 1, 3, 0,
+			"truncate 2 entries to first index 3 (chosen via: quorum); log too large (2.0 KiB > 1000 B); implies 1 Raft snapshot",
+		},
+		{
+			[]uint64{100, 100}, 2000, 1, 100, 50,
+			"truncate 99 entries to first index 100 (chosen via: quorum); log too large (2.0 KiB > 1000 B); implies 1 Raft snapshot",
+		},
+		{
+			[]uint64{1, 3, 3, 4}, 2000, 2, 3, 0,
+			"truncate 1 entries to first index 3 (chosen via: quorum); log too large (2.0 KiB > 1000 B)",
+		},
+		{
+			[]uint64{1, 3, 3, 4}, 2000, 3, 3, 0,
+			"truncate 0 entries to first index 3 (chosen via: quorum); log too large (2.0 KiB > 1000 B)",
+		},
 		// The pending snapshot index affects the quorum commit index.
-		{[]uint64{4}, 2000, 1, 1, 1, 1},
+		{
+			[]uint64{4}, 2000, 1, 7, 1,
+			"truncate 0 entries to first index 1 (chosen via: quorum); log too large (2.0 KiB > 1000 B)",
+		},
 		// Never truncate past the quorum commit index.
-		{[]uint64{3, 3, 6}, 100, 4, 4, 0, 3},
+		{
+			[]uint64{3, 3, 6}, 100, 2, 7, 0,
+			"truncate 1 entries to first index 3 (chosen via: quorum)",
+		},
 		// Never truncate past the last index.
-		{[]uint64{5}, 100, 1, 3, 0, 3},
-	}
+		{
+			[]uint64{5}, 100, 1, 3, 0,
+			"truncate 2 entries to first index 3 (chosen via: last index)",
+		},
+		// Never truncate "before the first index".
+		{
+			[]uint64{5}, 100, 2, 3, 1,
+			"truncate 0 entries to first index 2 (chosen via: first index)",
+		}}
 	for i, c := range testCases {
 		status := &raft.Status{
 			Progress: make(map[uint64]raft.Progress),
@@ -135,10 +200,16 @@ func TestComputeTruncatableIndex(t *testing.T) {
 		for j, v := range c.progress {
 			status.Progress[uint64(j)] = raft.Progress{Match: v}
 		}
-		out := computeTruncatableIndex(status, c.raftLogSize, targetSize,
-			c.firstIndex, c.lastIndex, c.pendingSnapshot)
-		if !reflect.DeepEqual(c.expected, out) {
-			t.Errorf("%d: computeTruncatableIndex(...) expected %d, but got %d", i, c.expected, out)
+		decision := computeTruncateDecision(truncateDecisionInput{
+			RaftStatus:                     status,
+			LogSize:                        c.raftLogSize,
+			MaxLogSize:                     targetSize,
+			FirstIndex:                     c.firstIndex,
+			LastIndex:                      c.lastIndex,
+			PendingPreemptiveSnapshotIndex: c.pendingSnapshot,
+		})
+		if act, exp := decision.String(), c.exp; act != exp {
+			t.Errorf("%d: got:\n%s\nwanted:\n%s", i, act, exp)
 		}
 	}
 }
@@ -165,9 +236,9 @@ func verifyLogSizeInSync(t *testing.T, r *Replica) {
 	}
 }
 
-// TestGetTruncatableIndexes verifies that old raft log entries are correctly
+// TestNewTruncateDecision verifies that old raft log entries are correctly
 // removed.
-func TestGetTruncatableIndexes(t *testing.T) {
+func TestNewTruncateDecision(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
@@ -179,18 +250,12 @@ func TestGetTruncatableIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	getIndexes := func() (uint64, uint64, uint64, error) {
-		r.mu.Lock()
-		firstIndex, err := r.raftFirstIndexLocked()
-		r.mu.Unlock()
+	getIndexes := func() (uint64, int, uint64, error) {
+		d, err := newTruncateDecision(context.Background(), r)
 		if err != nil {
 			return 0, 0, 0, err
 		}
-		truncatableIndexes, oldestIndex, _, err := getTruncatableIndexes(context.Background(), r)
-		if err != nil {
-			return 0, 0, 0, err
-		}
-		return firstIndex, truncatableIndexes, oldestIndex, nil
+		return d.Input.FirstIndex, d.NumTruncatableIndexes(), d.NewFirstIndex, nil
 	}
 
 	aFirst, aTruncatable, aOldest, err := getIndexes()
@@ -215,13 +280,13 @@ func TestGetTruncatableIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 	if aFirst != bFirst {
-		t.Errorf("expected firstIndex to not change, instead it changed from %d -> %d", aFirst, bFirst)
+		t.Fatalf("expected firstIndex to not change, instead it changed from %d -> %d", aFirst, bFirst)
 	}
 	if aTruncatable >= bTruncatable {
-		t.Errorf("expected truncatableIndexes to increase, instead it changed from %d -> %d", aTruncatable, bTruncatable)
+		t.Fatalf("expected truncatableIndexes to increase, instead it changed from %d -> %d", aTruncatable, bTruncatable)
 	}
 	if aOldest >= bOldest {
-		t.Errorf("expected oldestIndex to increase, instead it changed from %d -> %d", aOldest, bOldest)
+		t.Fatalf("expected oldestIndex to increase, instead it changed from %d -> %d", aOldest, bOldest)
 	}
 
 	// Enable the raft log scanner and and force a truncation.
@@ -231,10 +296,11 @@ func TestGetTruncatableIndexes(t *testing.T) {
 
 	// There can be a delay from when the truncation command is issued and the
 	// indexes updating.
-	var cFirst, cTruncatable, cOldest uint64
+	var cFirst, cOldest uint64
+	var numTruncatable int
 	testutils.SucceedsSoon(t, func() error {
 		var err error
-		cFirst, cTruncatable, cOldest, err = getIndexes()
+		cFirst, numTruncatable, cOldest, err = getIndexes()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -243,8 +309,8 @@ func TestGetTruncatableIndexes(t *testing.T) {
 		}
 		return nil
 	})
-	if bTruncatable < cTruncatable {
-		t.Errorf("expected truncatableIndexes to decrease, instead it changed from %d -> %d", bTruncatable, cTruncatable)
+	if bTruncatable < numTruncatable {
+		t.Errorf("expected numTruncatable to decrease, instead it changed from %d -> %d", bTruncatable, numTruncatable)
 	}
 	if bOldest >= cOldest {
 		t.Errorf("expected oldestIndex to increase, instead it changed from %d -> %d", bOldest, cOldest)
@@ -261,7 +327,7 @@ func TestGetTruncatableIndexes(t *testing.T) {
 	// Unlike the last iteration, where we expect a truncation and can wait on
 	// it with succeedsSoon, we can't do that here. This check is fragile in
 	// that the truncation triggered here may lose the race against the call to
-	// GetFirstIndex or getTruncatableIndexes, giving a false negative. Fixing
+	// GetFirstIndex or newTruncateDecision, giving a false negative. Fixing
 	// this requires additional instrumentation of the queues, which was deemed
 	// to require too much work at the time of this writing.
 	dFirst, dTruncatable, dOldest, err := getIndexes()
@@ -271,8 +337,8 @@ func TestGetTruncatableIndexes(t *testing.T) {
 	if cFirst != dFirst {
 		t.Errorf("truncation should not have occurred, but firstIndex changed from %d -> %d", cFirst, dFirst)
 	}
-	if cTruncatable != dTruncatable {
-		t.Errorf("truncation should not have occurred, but truncatableIndexes changed from %d -> %d", cTruncatable, dTruncatable)
+	if numTruncatable != dTruncatable {
+		t.Errorf("truncation should not have occurred, but truncatableIndexes changed from %d -> %d", numTruncatable, dTruncatable)
 	}
 	if cOldest != dOldest {
 		t.Errorf("truncation should not have occurred, but oldestIndex changed from %d -> %d", cOldest, dOldest)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -6733,9 +6733,12 @@ func (r *Replica) setPendingSnapshotIndex(index uint64) error {
 	// snapshots on the same replica which is disallowed.
 	if (index == 1 && r.mu.pendingSnapshotIndex != 0) ||
 		(index > 1 && r.mu.pendingSnapshotIndex != 1) {
-		return errors.Errorf(
+		// NB: this path can be hit if the replicate queue and scatter work
+		// concurrently. It's still good to return an error to avoid duplicating
+		// work, but we make it a benign one (so that it isn't logged).
+		return &benignError{errors.Errorf(
 			"%s: can't set pending snapshot index to %d; pending snapshot already present: %d",
-			r, index, r.mu.pendingSnapshotIndex)
+			r, index, r.mu.pendingSnapshotIndex)}
 	}
 	r.mu.pendingSnapshotIndex = index
 	return nil

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -446,6 +446,14 @@ type Replica struct {
 		// Progress of a RaftStatus, which has a RecentActive field. However, that field
 		// is always true unless CheckQuorum is active, which at the time of writing in
 		// CockroachDB is not the case.
+		//
+		// TODO(tschottdorf): keeping a map on each replica seems to be
+		// overdoing it. We should map the replicaID to a NodeID and then use
+		// node liveness (or any sensible measure of the peer being around).
+		// The danger in doing so is that a single stuck replica on an otherwise
+		// functioning node could fill up the quota pool. We are already taking
+		// this kind of risk though: a replica that gets stuck on an otherwise
+		// live node will not lose leaseholdership.
 		lastUpdateTimes lastUpdateTimesMap
 
 		// The last seen replica descriptors from incoming Raft messages. These are
@@ -1156,6 +1164,10 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 			// hands.
 			r.mu.proposalQuota = newQuotaPool(r.store.cfg.RaftProposalQuota)
 			r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]time.Time)
+			now := timeutil.Now()
+			for _, desc := range r.mu.state.Desc.Replicas {
+				r.mu.lastUpdateTimes.update(desc.ReplicaID, now)
+			}
 			r.mu.commandSizes = make(map[storagebase.CmdIDKey]int)
 		} else if r.mu.proposalQuota != nil {
 			// We're becoming a follower.
@@ -4989,6 +5001,16 @@ func (r *Replica) sendRaftMessage(ctx context.Context, msg raftpb.Message) {
 	r.mu.Lock()
 	fromReplica, fromErr := r.getReplicaDescriptorByIDRLocked(roachpb.ReplicaID(msg.From), r.mu.lastToReplica)
 	toReplica, toErr := r.getReplicaDescriptorByIDRLocked(roachpb.ReplicaID(msg.To), r.mu.lastFromReplica)
+	if msg.Type == raftpb.MsgHeartbeat {
+		if r.mu.replicaID == 0 {
+			log.Fatalf(ctx, "preemptive snapshot attempted to send a heartbeat: %+v", msg)
+		}
+		// For followers, we update lastUpdateTimes when we step a message from
+		// them into the local Raft group. The leader won't hit that path, so we
+		// update it whenever it sends a heartbeat. In effect, this makes sure
+		// it always sees itself as alive.
+		r.mu.lastUpdateTimes.update(r.mu.replicaID, timeutil.Now())
+	}
 	r.mu.Unlock()
 
 	if fromErr != nil {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -245,6 +245,33 @@ func (s *destroyStatus) Reset() {
 	s.Set(nil, destroyReasonAlive)
 }
 
+// a lastUpdateTimesMap is maintained on the Raft leader to keep track of the
+// last communication received from followers, which in turn informs the quota
+// pool and log truncations.
+type lastUpdateTimesMap map[roachpb.ReplicaID]time.Time
+
+func (m lastUpdateTimesMap) update(replicaID roachpb.ReplicaID, now time.Time) {
+	if m == nil {
+		return
+	}
+	m[replicaID] = now
+}
+
+// isFollowerActive returns whether the specified follower has made
+// communication with the leader in the last MaxQuotaReplicaLivenessDuration.
+func (m lastUpdateTimesMap) isFollowerActive(
+	ctx context.Context, replicaID roachpb.ReplicaID, now time.Time,
+) bool {
+	lastUpdateTime, ok := m[replicaID]
+	if !ok {
+		// If the follower has no entry in lastUpdateTimes, it has not been
+		// updated since r became the leader (at which point all then-existing
+		// replicas were updated).
+		return false
+	}
+	return now.Sub(lastUpdateTime) <= MaxQuotaReplicaLivenessDuration
+}
+
 // A Replica is a contiguous keyspace with writes managed via an
 // instance of the Raft consensus algorithm. Many ranges may exist
 // in a store and they are unlikely to be contiguous. Ranges are
@@ -404,8 +431,13 @@ type Replica struct {
 		lastReplicaAdded     roachpb.ReplicaID
 		lastReplicaAddedTime time.Time
 
-		// The most recently updated time for each follower of this range.
-		lastUpdateTimes map[roachpb.ReplicaID]time.Time
+		// The most recently updated time for each follower of this range. This is updated
+		// every time a Raft message is received from a peer.
+		// Note that superficially it seems that similar information is contained in the
+		// Progress of a RaftStatus, which has a RecentActive field. However, that field
+		// is always true unless CheckQuorum is active, which at the time of writing in
+		// CockroachDB is not the case.
+		lastUpdateTimes lastUpdateTimesMap
 
 		// The last seen replica descriptors from incoming Raft messages. These are
 		// stored so that the replica still knows the replica descriptors for itself
@@ -1148,6 +1180,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	}
 
 	// Find the minimum index that active followers have acknowledged.
+	now := timeutil.Now()
 	minIndex := status.Commit
 	for _, rep := range r.mu.state.Desc.Replicas {
 		// Only consider followers that that have "healthy" RPC connections.
@@ -1157,7 +1190,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 		}
 
 		// Only consider followers that are active.
-		if !r.isFollowerActiveLocked(ctx, rep.ReplicaID) {
+		if !r.mu.lastUpdateTimes.isFollowerActive(ctx, rep.ReplicaID, now) {
 			continue
 		}
 		if progress, ok := status.Progress[uint64(rep.ReplicaID)]; ok {
@@ -1827,37 +1860,6 @@ func (r *Replica) setQueueLastProcessed(
 ) error {
 	key := keys.QueueLastProcessedKey(r.Desc().StartKey, queue)
 	return r.store.DB().PutInline(ctx, key, &timestamp)
-}
-
-func (r *Replica) refreshLastUpdateTimeForReplicaLocked(replicaID roachpb.ReplicaID) {
-	if r.mu.lastUpdateTimes != nil {
-		r.mu.lastUpdateTimes[replicaID] = r.store.Clock().PhysicalTime()
-	}
-}
-
-func (r *Replica) refreshLastUpdateTimeForAllReplicasLocked() {
-	if r.mu.lastUpdateTimes != nil {
-		now := r.store.Clock().PhysicalTime()
-		for _, rep := range r.mu.state.Desc.Replicas {
-			r.mu.lastUpdateTimes[rep.ReplicaID] = now
-		}
-	}
-}
-
-// isFollowerActiveLocked returns whether the specified follower has made
-// communication with the leader in the last MaxQuotaReplicaLivenessDuration.
-func (r *Replica) isFollowerActiveLocked(ctx context.Context, followerID roachpb.ReplicaID) bool {
-	if r.mu.lastUpdateTimes == nil {
-		log.Fatalf(ctx, "replica %d has uninitialized lastUpdateTimes map", r.mu.replicaID)
-	}
-	lastUpdateTime, ok := r.mu.lastUpdateTimes[followerID]
-	if !ok {
-		// If the follower has no entry in lastUpdateTimes, it has not been
-		// updated since r became the leader.
-		return false
-	}
-	now := r.store.Clock().PhysicalTime()
-	return now.Sub(lastUpdateTime) <= MaxQuotaReplicaLivenessDuration
 }
 
 // RaftStatus returns the current raft status of the replica. It returns nil
@@ -3929,7 +3931,10 @@ func (r *Replica) unquiesceWithOptionsLocked(campaignOnWake bool) {
 		if campaignOnWake {
 			r.maybeCampaignOnWakeLocked(ctx)
 		}
-		r.refreshLastUpdateTimeForAllReplicasLocked()
+		now := timeutil.Now()
+		for _, desc := range r.mu.state.Desc.Replicas {
+			r.mu.lastUpdateTimes.update(desc.ReplicaID, now)
+		}
 	}
 }
 
@@ -3962,7 +3967,7 @@ func (r *Replica) stepRaftGroup(req *RaftMessageRequest) error {
 		// Note that we avoid campaigning when receiving raft messages, because
 		// we expect the originator to campaign instead.
 		r.unquiesceWithOptionsLocked(false /* campaignOnWake */)
-		r.refreshLastUpdateTimeForReplicaLocked(req.FromReplica.ReplicaID)
+		r.mu.lastUpdateTimes.update(req.FromReplica.ReplicaID, timeutil.Now())
 		err := raftGroup.Step(req.Message)
 		if err == raft.ErrProposalDropped {
 			// A proposal was forwarded to this replica but we couldn't propose it.

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -367,10 +367,19 @@ type Replica struct {
 		// from the Raft log entry. Use the invalidLastTerm constant for this
 		// case.
 		lastIndex, lastTerm uint64
-		// The raft log index of a pending preemptive snapshot. Used to prohibit
-		// raft log truncation while a preemptive snapshot is in flight. A value of
-		// 0 indicates that there is no pending snapshot.
-		pendingSnapshotIndex uint64
+		// A map of raft log index of pending preemptive snapshots to deadlines.
+		// Used to prohibit raft log truncations that would leave a gap between
+		// the snapshot and the new first index. The map entry has a zero
+		// deadline while the snapshot is being sent and turns nonzero when the
+		// snapshot has completed, preventing truncation for a grace period
+		// (since there is a race between the snapshot completing and its being
+		// reflected in the raft status used to make truncation decisions).
+		//
+		// NB: If we kept only one value, we could end up in situations in which
+		// we're either giving some snapshots no grace period, or keep an
+		// already finished snapshot "pending" for extended periods of time
+		// (preventing log truncation).
+		snapshotLogTruncationConstraints map[uuid.UUID]snapTruncationInfo
 		// raftLogSize is the approximate size in bytes of the persisted raft log.
 		// On server restart, this value is assumed to be zero to avoid costly scans
 		// of the raft log. This will be correct when all log entries predating this
@@ -6730,29 +6739,67 @@ func (r *Replica) exceedsMultipleOfSplitSizeRLocked(mult float64) bool {
 	return maxBytes > 0 && float64(size) > float64(maxBytes)*mult
 }
 
-func (r *Replica) setPendingSnapshotIndex(index uint64) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	// We allow the pendingSnapshotIndex to change from 0 to 1 and then from 1 to
-	// a value greater than 1. Any other change indicates 2 current preemptive
-	// snapshots on the same replica which is disallowed.
-	if (index == 1 && r.mu.pendingSnapshotIndex != 0) ||
-		(index > 1 && r.mu.pendingSnapshotIndex != 1) {
-		// NB: this path can be hit if the replicate queue and scatter work
-		// concurrently. It's still good to return an error to avoid duplicating
-		// work, but we make it a benign one (so that it isn't logged).
-		return &benignError{errors.Errorf(
-			"%s: can't set pending snapshot index to %d; pending snapshot already present: %d",
-			r, index, r.mu.pendingSnapshotIndex)}
-	}
-	r.mu.pendingSnapshotIndex = index
-	return nil
+type snapTruncationInfo struct {
+	index    uint64
+	deadline time.Time
 }
 
-func (r *Replica) clearPendingSnapshotIndex() {
+func (r *Replica) addSnapshotLogTruncationConstraintLocked(
+	ctx context.Context, snapUUID uuid.UUID, index uint64,
+) {
+	if r.mu.snapshotLogTruncationConstraints == nil {
+		r.mu.snapshotLogTruncationConstraints = make(map[uuid.UUID]snapTruncationInfo)
+	}
+	item, ok := r.mu.snapshotLogTruncationConstraints[snapUUID]
+	if ok {
+		// Uh-oh, there's either a programming error (resulting in the same snapshot
+		// fed into this method twice) or a UUID collision. We discard the update
+		// (which is benign) but log it loudly. If the index is the same, it's
+		// likely the former, otherwise the latter.
+		log.Warningf(ctx, "UUID collision at %s for %+v (index %d)", snapUUID, item, index)
+		return
+	}
+
+	r.mu.snapshotLogTruncationConstraints[snapUUID] = snapTruncationInfo{index: index}
+}
+
+func (r *Replica) completeSnapshotLogTruncationConstraint(
+	ctx context.Context, snapUUID uuid.UUID, now time.Time,
+) {
+	deadline := now.Add(raftLogQueuePendingSnapshotGracePeriod)
+
 	r.mu.Lock()
-	r.mu.pendingSnapshotIndex = 0
-	r.mu.Unlock()
+	defer r.mu.Unlock()
+	item, ok := r.mu.snapshotLogTruncationConstraints[snapUUID]
+	if !ok {
+		// UUID collision while adding the snapshot in originally. Nothing
+		// else to do.
+		return
+	}
+
+	item.deadline = deadline
+	r.mu.snapshotLogTruncationConstraints[snapUUID] = item
+}
+
+func (r *Replica) getAndGCSnapshotLogTruncationConstraintsLocked(
+	now time.Time,
+) (minSnapIndex uint64) {
+	for snapUUID, item := range r.mu.snapshotLogTruncationConstraints {
+		if item.deadline != (time.Time{}) && item.deadline.Before(now) {
+			// The snapshot has finished and its grace period has passed.
+			// Ignore it when making truncation decisions.
+			delete(r.mu.snapshotLogTruncationConstraints, snapUUID)
+			continue
+		}
+		if minSnapIndex == 0 || minSnapIndex > item.index {
+			minSnapIndex = item.index
+		}
+	}
+	if len(r.mu.snapshotLogTruncationConstraints) == 0 {
+		// Save a little bit of memory.
+		r.mu.snapshotLogTruncationConstraints = nil
+	}
+	return minSnapIndex
 }
 
 func (r *Replica) startKey() roachpb.RKey {
@@ -6842,7 +6889,7 @@ func HasRaftLeader(raftStatus *raft.Status) bool {
 
 func calcReplicaMetrics(
 	ctx context.Context,
-	now hlc.Timestamp,
+	_ hlc.Timestamp,
 	raftCfg *base.RaftConfig,
 	cfg config.SystemConfig,
 	livenessMap map[roachpb.NodeID]bool,

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -172,10 +172,16 @@ func (r *Replica) AdminSplit(
 		reply, lastErr = r.adminSplitWithDescriptor(ctx, args, r.Desc())
 		// On seeing a ConditionFailedError or an AmbiguousResultError, retry
 		// the command with the updated descriptor.
-		switch errors.Cause(lastErr).(type) {
-		case *roachpb.ConditionFailedError:
-		case *roachpb.AmbiguousResultError:
-		default:
+		if retry := causer.Visit(lastErr, func(err error) bool {
+			switch err.(type) {
+			case *roachpb.ConditionFailedError:
+				return true
+			case *roachpb.AmbiguousResultError:
+				return true
+			default:
+				return false
+			}
+		}); !retry {
 			return reply, roachpb.NewError(lastErr)
 		}
 	}

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -817,15 +817,6 @@ func (r *Replica) changeReplicas(
 			return errors.Errorf("%s: unable to add replica %v; node already has a replica", r, repDesc)
 		}
 
-		// Prohibit premature raft log truncation. We set the pending index to 1
-		// here until we determine what it is below. This removes a small window of
-		// opportunity for the raft log to get truncated after the snapshot is
-		// generated.
-		if err := r.setPendingSnapshotIndex(1); err != nil {
-			return err
-		}
-		defer r.clearPendingSnapshotIndex()
-
 		// Send a pre-emptive snapshot. Note that the replica to which this
 		// snapshot is addressed has not yet had its replica ID initialized; this
 		// is intentional, and serves to avoid the following race with the replica
@@ -974,12 +965,6 @@ func (r *Replica) sendSnapshot(
 	fromRepDesc, err := r.GetReplicaDescriptor()
 	if err != nil {
 		return errors.Wrapf(err, "%s: change replicas failed", r)
-	}
-
-	if snapType == snapTypePreemptive {
-		if err := r.setPendingSnapshotIndex(snap.RaftSnap.Metadata.Index); err != nil {
-			return err
-		}
 	}
 
 	status := r.RaftStatus()

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/util/causer"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -169,8 +170,8 @@ func (r *Replica) AdminSplit(
 		}
 
 		reply, lastErr = r.adminSplitWithDescriptor(ctx, args, r.Desc())
-		// On seeing a ConditionFailedError or an AmbiguousResultError, retry the
-		// command with the updated descriptor.
+		// On seeing a ConditionFailedError or an AmbiguousResultError, retry
+		// the command with the updated descriptor.
 		switch errors.Cause(lastErr).(type) {
 		case *roachpb.ConditionFailedError:
 		case *roachpb.AmbiguousResultError:
@@ -393,7 +394,9 @@ func (r *Replica) adminSplitWithDescriptor(
 		// ConditionFailedError in the error detail so that the command can be
 		// retried.
 		if msg, ok := maybeDescriptorChangedError(desc, err); ok {
-			err = errors.Wrap(err, msg)
+			// NB: we have to wrap the existing error here as consumers of this
+			// code look at the root cause to sniff out the changed descriptor.
+			err = &benignError{errors.Wrap(err, msg)}
 		}
 		return reply, errors.Wrapf(err, "split at key %s failed", splitKey)
 	}
@@ -665,6 +668,7 @@ func waitForReplicasInit(
 }
 
 type snapshotError struct {
+	// NB: don't implement Cause() on this type without also updating IsSnapshotError.
 	cause error
 }
 
@@ -675,8 +679,10 @@ func (s *snapshotError) Error() string {
 // IsSnapshotError returns true iff the error indicates a preemptive
 // snapshot failed.
 func IsSnapshotError(err error) bool {
-	_, ok := err.(*snapshotError)
-	return ok
+	return causer.Visit(err, func(err error) bool {
+		_, ok := errors.Cause(err).(*snapshotError)
+		return ok
+	})
 }
 
 // ChangeReplicas adds or removes a replica of a range. The change is performed
@@ -931,7 +937,7 @@ func (r *Replica) changeReplicas(
 	}); err != nil {
 		log.Event(ctx, err.Error())
 		if msg, ok := maybeDescriptorChangedError(desc, err); ok {
-			return errors.Wrapf(err, "change replicas of r%d failed: %s", rangeID, msg)
+			err = &benignError{errors.New(msg)}
 		}
 		return errors.Wrapf(err, "change replicas of r%d failed", rangeID)
 	}
@@ -972,7 +978,9 @@ func (r *Replica) sendSnapshot(
 
 	status := r.RaftStatus()
 	if status == nil {
-		return errors.New("raft status not initialized")
+		// This code path is sometimes hit during scatter for replicas that
+		// haven't woken up yet.
+		return &benignError{errors.New("raft status not initialized")}
 	}
 
 	req := SnapshotRequest_Header{

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -397,15 +397,25 @@ func (r *Replica) raftSnapshotLocked() (raftpb.Snapshot, error) {
 func (r *Replica) GetSnapshot(
 	ctx context.Context, snapType string,
 ) (_ *OutgoingSnapshot, err error) {
+	snapUUID := uuid.MakeV4()
 	// Get a snapshot while holding raftMu to make sure we're not seeing "half
 	// an AddSSTable" (i.e. a state in which an SSTable has been linked in, but
 	// the corresponding Raft command not applied yet).
 	r.raftMu.Lock()
 	snap := r.store.engine.NewSnapshot()
+	r.mu.Lock()
+	appliedIndex := r.mu.state.RaftAppliedIndex
+	r.addSnapshotLogTruncationConstraintLocked(ctx, snapUUID, appliedIndex) // cleared when OutgoingSnapshot closes
+	r.mu.Unlock()
 	r.raftMu.Unlock()
+
+	release := func() {
+		r.completeSnapshotLogTruncationConstraint(ctx, snapUUID, timeutil.Now())
+	}
 
 	defer func() {
 		if err != nil {
+			release()
 			snap.Close()
 		}
 	}()
@@ -432,13 +442,14 @@ func (r *Replica) GetSnapshot(
 	// to use Replica.mu.stateLoader. This call is not performance sensitive, so
 	// create a new state loader.
 	snapData, err := snapshot(
-		ctx, stateloader.Make(r.store.cfg.Settings, rangeID), snapType,
+		ctx, snapUUID, stateloader.Make(r.store.cfg.Settings, rangeID), snapType,
 		snap, rangeID, r.store.raftEntryCache, withSideloaded, startKey,
 	)
 	if err != nil {
 		log.Errorf(ctx, "error generating snapshot: %s", err)
 		return nil, err
 	}
+	snapData.onClose = release
 	return &snapData, nil
 }
 
@@ -462,6 +473,7 @@ type OutgoingSnapshot struct {
 	WithSideloaded func(func(sideloadStorage) error) error
 	RaftEntryCache *raftEntryCache
 	snapType       string
+	onClose        func()
 }
 
 func (s *OutgoingSnapshot) String() string {
@@ -472,6 +484,9 @@ func (s *OutgoingSnapshot) String() string {
 func (s *OutgoingSnapshot) Close() {
 	s.Iter.Close()
 	s.EngineSnap.Close()
+	if s.onClose != nil {
+		s.onClose()
+	}
 }
 
 // IncomingSnapshot contains the data for an incoming streaming snapshot message.
@@ -490,6 +505,7 @@ type IncomingSnapshot struct {
 // given range. Note that snapshot() is called without Replica.raftMu held.
 func snapshot(
 	ctx context.Context,
+	snapUUID uuid.UUID,
 	rsl stateloader.StateLoader,
 	snapType string,
 	snap engine.Reader,
@@ -541,7 +557,6 @@ func snapshot(
 	// Intentionally let this iterator and the snapshot escape so that the
 	// streamer can send chunks from it bit by bit.
 	iter := rditer.NewReplicaDataIterator(&desc, snap, true /* replicatedOnly */)
-	snapUUID := uuid.MakeV4()
 
 	return OutgoingSnapshot{
 		RaftEntryCache: eCache,

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -381,8 +381,10 @@ func (rq *replicateQueue) processOneChange(
 		log.VEventf(ctx, 3, "filtered unremovable replicas from %v to get %v as candidates for removal",
 			desc.Replicas, candidates)
 		if len(candidates) == 0 {
-			return false, errors.Errorf("no removable replicas from range that needs a removal: %s",
-				rangeRaftProgress(repl.RaftStatus(), desc.Replicas))
+			// After rapid upreplication, the candidates for removal could still be catching up.
+			// Mark this error as benign so it doesn't create confusion in the logs.
+			return false, &benignError{errors.Errorf("no removable replicas from range that needs a removal: %s",
+				rangeRaftProgress(repl.RaftStatus(), desc.Replicas))}
 		}
 		removeReplica, details, err := rq.allocator.RemoveTarget(ctx, zone, candidates, rangeInfo)
 		if err != nil {

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -616,7 +616,7 @@ func sendSnapshot(
 			if len(resp.Message) > 0 {
 				declinedMsg = resp.Message
 			}
-			return errors.Errorf("%s: remote declined %s: %s", to, snap, declinedMsg)
+			return &benignError{errors.Errorf("%s: remote declined %s: %s", to, snap, declinedMsg)}
 		}
 		storePool.throttle(throttleFailed, to.StoreID)
 		return errors.Errorf("%s: programming error: remote declined required %s: %s",

--- a/pkg/util/causer/causer.go
+++ b/pkg/util/causer/causer.go
@@ -1,0 +1,42 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package causer
+
+// A Causer is an error that wraps a causing error (which in turn could be
+// another Causer). A Causer is usually constructed via errors.Wrap or Wrapf.
+type Causer interface {
+	error
+	Cause() error
+}
+
+// Visit walks along the chain of errors until it encounters the first one that
+// does not implement Causer. The visitor is invoked with each error visited
+// until there are no more errors to visit or the visitor returns true (which is
+// then the return value of Visit as well). Returns false when the visitor never
+// returns true or if the initial error is nil.
+// Calling this method on a cyclic error chain results in an infinite loop.
+func Visit(err error, f func(error) bool) bool {
+	for err != nil {
+		if f(err) {
+			return true
+		}
+		cause, ok := err.(Causer)
+		if !ok {
+			return false
+		}
+		err = cause.Cause()
+	}
+	return false
+}

--- a/pkg/util/causer/causer_test.go
+++ b/pkg/util/causer/causer_test.go
@@ -1,0 +1,53 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package causer
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/pkg/errors"
+)
+
+type fooErr struct {
+	error
+}
+
+func isFoo(err error) bool {
+	return Visit(err, func(err error) bool {
+		_, ok := err.(*fooErr)
+		return ok
+	})
+}
+
+func TestCauserVisit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	loudErr := errors.Wrap(errors.New("root cause"), "this happened")
+	quietErr := errors.Wrap(errors.Wrap(&fooErr{loudErr}, "foo"), "bar")
+
+	if isFoo(loudErr) {
+		t.Fatal("non-benign error marked as benign")
+	}
+	if !isFoo(&fooErr{errors.New("foo")}) {
+		t.Fatal("foo error not recognized as such")
+	}
+	if !isFoo(quietErr) {
+		t.Fatal("wrapped foo error not recognized as such")
+	}
+	if isFoo(nil) {
+		t.Fatal("nil error should not be foo")
+	}
+}


### PR DESCRIPTION
Backport:
  * 4/4 commits from "storage: don't log benign queue errors" (#31728)
  * 1/1 commits from "storage: refactor log truncation index computation" (#32137)
  * 1/1 commits from "storage: truncate aggressively only after 4mb of logs" (#32437)
  * 2/2 commits from "storage: don't truncate when probing active followers are present" (#32439)
  * 1/2 commits from "storage: avoid errant Raft snapshots during splits" (#31875)


Note that this does not backport the other commit from #31875 which solved the splittrigger-snapshot-race in an unfortunate way which is currently reworked in #32782 (but itself may not get backported).

Please see individual PRs for details.

/cc @cockroachdb/release
