### PR TITLE
storage: exit process when disks are stalled

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -31,8 +31,7 @@ start_test "Check that a broken log file prints a message to stderr."
 system "mkdir -p logs"
 system "touch logs/broken"
 send "$argv start -s=path=logs/db --log-dir=logs/broken --insecure --logtostderr\r"
-eexpect "log: exiting because of error: log: cannot create log: open"
-eexpect "not a directory"
+eexpect "unable to create log directory"
 eexpect ":/# "
 end_test
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1004,6 +1004,11 @@ func setupAndInitializeLoggingAndProfiling(ctx context.Context) (*stop.Stopper, 
 			}
 		}
 
+		// Make sure the path exists.
+		if err := os.MkdirAll(logDir, 0755); err != nil {
+			return nil, errors.Wrap(err, "unable to create log directory")
+		}
+
 		// Note that we configured the --log-dir flag to set
 		// startContext.logDir. This is the point at which we set log-dir for the
 		// util/log package. We don't want to set it earlier to avoid spuriously
@@ -1014,11 +1019,10 @@ func setupAndInitializeLoggingAndProfiling(ctx context.Context) (*stop.Stopper, 
 			return nil, err
 		}
 
-		// Make sure the path exists.
-		if err := os.MkdirAll(logDir, 0755); err != nil {
-			return nil, err
-		}
-		log.Eventf(ctx, "created log directory %s", logDir)
+		// NB: this message is a crutch until #33458 is addressed. Without it,
+		// the calls to log.Shout below can be the first use of logging, hitting
+		// the bug described in the issue.
+		log.Infof(ctx, "logging to directory %s", logDir)
 
 		// Start the log file GC daemon to remove files that make the log
 		// directory too large.

--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -1,0 +1,141 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func registerDiskStalledDetection(r *registry) {
+	for _, affectsLogDir := range []bool{false, true} {
+		for _, affectsDataDir := range []bool{false, true} {
+			// Grab copies of the args because we'll pass them into a closure.
+			// Everyone's favorite bug to write in Go.
+			affectsLogDir := affectsLogDir
+			affectsDataDir := affectsDataDir
+			r.Add(testSpec{
+				Name: fmt.Sprintf(
+					"disk-stalled/log=%t,data=%t",
+					affectsLogDir, affectsDataDir,
+				),
+				MinVersion: `v2.2.0`,
+				Nodes:      nodes(1),
+				Run: func(ctx context.Context, t *test, c *cluster) {
+					runDiskStalledDetection(ctx, t, c, affectsLogDir, affectsDataDir)
+				},
+			})
+		}
+	}
+}
+
+func runDiskStalledDetection(
+	ctx context.Context, t *test, c *cluster, affectsLogDir bool, affectsDataDir bool,
+) {
+	n := c.Node(1)
+	tmpDir, err := ioutil.TempDir("", "stalled")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	c.Put(ctx, cockroach, "./cockroach")
+	c.Run(ctx, n, "sudo umount -f {store-dir}/faulty || true")
+	c.Run(ctx, n, "mkdir -p {store-dir}/{real,faulty} || true")
+	// Make sure the actual logs are downloaded as artifacts.
+	c.Run(ctx, n, "rm -f logs/real && ln -s {store-dir}/real/logs logs/real || true")
+
+	t.Status("setting up charybdefs")
+
+	if err := execCmd(ctx, t.l, roachprod, "install", c.makeNodes(n), "charybdefs"); err != nil {
+		t.Fatal(err)
+	}
+	c.Run(ctx, n, "sudo charybdefs {store-dir}/faulty -oallow_other,modules=subdir,subdir={store-dir}/real && chmod 777 {store-dir}/{real,faulty}")
+	l, err := t.l.ChildLogger("cockroach")
+	if err != nil {
+		t.Fatal(err)
+	}
+	type result struct {
+		err error
+		out string
+	}
+	errCh := make(chan result)
+
+	// NB: charybdefs' delay nemesis introduces 50ms per syscall. It would
+	// be nicer to introduce a longer delay, but this works.
+	tooShortSync := 40 * time.Millisecond
+
+	maxLogSync := time.Hour
+	logDir := "real/logs"
+	if affectsLogDir {
+		logDir = "faulty/logs"
+		maxLogSync = tooShortSync
+	}
+	maxDataSync := time.Hour
+	dataDir := "real"
+	if affectsDataDir {
+		maxDataSync = tooShortSync
+		dataDir = "faulty"
+	}
+
+	tStarted := timeutil.Now()
+	dur := 10 * time.Minute
+	if !affectsDataDir && !affectsLogDir {
+		dur = 30 * time.Second
+	}
+
+	go func() {
+		t.WorkerStatus("running server")
+		out, err := c.RunWithBuffer(ctx, l, n,
+			fmt.Sprintf("timeout --signal 9 %ds env COCKROACH_ENGINE_MAX_SYNC_DURATION=%s COCKROACH_LOG_MAX_SYNC_DURATION=%s "+
+				"./cockroach start --insecure --logtostderr=INFO --store {store-dir}/%s --log-dir {store-dir}/%s",
+				int(dur.Seconds()), maxDataSync, maxLogSync, dataDir, logDir,
+			),
+		)
+		errCh <- result{err, string(out)}
+	}()
+
+	time.Sleep(time.Duration(rand.Intn(5)) * time.Second)
+
+	t.Status("blocking storage")
+	c.Run(ctx, n, "charybdefs-nemesis --delay")
+
+	res := <-errCh
+	if res.err == nil {
+		t.Fatalf("expected an error: %s", res.out)
+	}
+
+	// This test can also run in sanity check mode to make sure it doesn't fail
+	// due to the aggressive env vars above.
+	expectMsg := affectsDataDir || affectsLogDir
+
+	if expectMsg != strings.Contains(res.out, "disk stall detected") {
+		t.Fatalf("unexpected output: %v %s", res.err, res.out)
+	} else if elapsed := timeutil.Since(tStarted); !expectMsg && elapsed < dur {
+		t.Fatalf("no disk stall injected, but process terminated too early after %s (expected >= %s)", elapsed, dur)
+	}
+
+	c.Run(ctx, n, "charybdefs-nemesis --clear")
+	c.Run(ctx, n, "sudo umount {store-dir}/faulty")
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -33,6 +33,7 @@ func registerTests(r *registry) {
 	registerDecommission(r)
 	registerDiskUsage(r)
 	registerDiskFull(r)
+	registerDiskStalledDetection(r)
 	registerDrop(r)
 	registerElectionAfterRestart(r)
 	registerEncryption(r)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1309,6 +1309,8 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 	s.stopper.AddCloser(&s.engines)
 
+	startAssertEngineHealth(ctx, s.stopper, s.engines)
+
 	// Write listener info files early in the startup sequence. `listenerInfo` has a comment.
 	listenerFiles := listenerInfo{
 		advertise: s.cfg.AdvertiseAddr,

--- a/pkg/server/server_engine_health.go
+++ b/pkg/server/server_engine_health.go
@@ -1,0 +1,72 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+var maxSyncDuration = envutil.EnvOrDefaultDuration("COCKROACH_ENGINE_MAX_SYNC_DURATION", 10*time.Second)
+
+// startAssertEngineHealth starts a goroutine that periodically verifies that
+// syncing the engines is possible within maxSyncDuration. If not,
+// the process is terminated (with an attempt at a descriptive message).
+func startAssertEngineHealth(ctx context.Context, stopper *stop.Stopper, engines []engine.Engine) {
+	stopper.RunWorker(ctx, func(ctx context.Context) {
+		t := timeutil.NewTimer()
+		t.Reset(0)
+
+		for {
+			select {
+			case <-t.C:
+				t.Read = true
+				t.Reset(10 * time.Second)
+				assertEngineHealth(ctx, engines, maxSyncDuration)
+			case <-stopper.ShouldQuiesce():
+				return
+			}
+		}
+	})
+}
+
+func guaranteedExitFatal(ctx context.Context, msg string, args ...interface{}) {
+	// NB: log.Shout sets up a timer that guarantees process termination.
+	log.Shout(ctx, log.Severity_FATAL, fmt.Sprintf(msg, args...))
+}
+
+func assertEngineHealth(ctx context.Context, engines []engine.Engine, maxDuration time.Duration) {
+	for _, eng := range engines {
+		func() {
+			t := time.AfterFunc(maxDuration, func() {
+				// NB: the disk-stall-detected roachtest matches on this message.
+				guaranteedExitFatal(ctx, "disk stall detected: unable to write to %s within %s",
+					eng, maxSyncDuration,
+				)
+			})
+			defer t.Stop()
+			if err := engine.WriteSyncNoop(ctx, eng); err != nil {
+				log.Fatal(ctx, err)
+			}
+		}()
+	}
+}

--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -39,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logtags"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/gogo/protobuf/proto"
@@ -1151,172 +1149,4 @@ func TestNodeLivenessLivenessStatus(t *testing.T) {
 			}
 		})
 	}
-}
-
-// TestUpdateLiveness verifies that a node always writes to its local RocksDB
-// before updating its liveness. If write is blocking, updateLiveness will also
-// block. It also tests the updateLiveness will fail if we inject the errors to
-// make write to disk fail.
-func TestUpdateLiveness(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	mtc := &multiTestContext{}
-	defer mtc.Stop()
-
-	engineStopper := stop.NewStopper()
-	mtc.engineStoppers = append(mtc.engineStoppers, engineStopper)
-	eng := &MockEngine{InMem: engine.NewInMem(roachpb.Attributes{}, 1<<20)}
-	engineStopper.AddCloser(eng)
-	mtc.engines = append(mtc.engines, eng)
-	mtc.injEngines = true
-	mtc.Start(t, 1)
-
-	// Verify liveness of all nodes for all nodes.
-	verifyLiveness(t, mtc)
-	pauseNodeLivenessHeartbeats(mtc, true)
-
-	// Advance clock past the liveness threshold to verify IsLive becomes false.
-	mtc.manualClock.Increment(mtc.nodeLivenesses[0].GetLivenessThreshold().Nanoseconds() + 1)
-	for idx, nl := range mtc.nodeLivenesses {
-		nodeID := mtc.gossips[idx].NodeID.Get()
-		live, err := nl.IsLive(nodeID)
-		if err != nil {
-			t.Error(err)
-		} else if live {
-			t.Errorf("expected node %d to be considered not-live after advancing node clock", nodeID)
-		}
-		testutils.SucceedsSoon(t, func() error {
-			if a, e := nl.Metrics().LiveNodes.Value(), int64(0); a != e {
-				return errors.Errorf("expected node %d's LiveNodes metric to be %d; got %d",
-					nodeID, e, a)
-			}
-			return nil
-		})
-	}
-
-	// Inject a customized error into engine and check the MockBatch's Commit()
-	// will fail with the exact same error.
-	const commitErr = "update liveness failed on commit"
-	errUpdateLiveness := errors.New(commitErr)
-	eng.mu.Lock()
-	eng.err = errUpdateLiveness
-	eng.mu.Unlock()
-	for idx, nl := range mtc.nodeLivenesses {
-		l, err := nl.Self()
-		if err != nil {
-			t.Fatal(err)
-		}
-		testutils.SucceedsSoon(t, func() error {
-			for {
-				nodeID := mtc.gossips[idx].NodeID.Get()
-				err := nl.Heartbeat(context.Background(), l)
-
-				if err == nil {
-					return errors.Errorf("expected node %d to fail to update its liveness because Commit() should fail", nodeID)
-				}
-
-				if testutils.IsError(err, commitErr) {
-					live, err := nl.IsLive(nodeID)
-					if err != nil {
-						return err
-					} else if live {
-						return errors.Errorf("expected node %d to be considered not live because updateLiveness should fail", nodeID)
-					}
-					break
-				}
-
-				if err == storage.ErrEpochIncremented {
-					log.Warningf(context.Background(), "retrying after %s", err)
-					continue
-				}
-
-				return err
-			}
-			return nil
-		})
-	}
-
-	// Trigger a manual heartbeat and check node is not alive within 5 ms because
-	// MockEngine's write will block for 5 ms before updating liveness.
-	// Then verify liveness is reestablished after 5 ms.
-	ch := make(chan bool)
-	eng.mu.Lock()
-	eng.ch = ch
-	eng.err = nil
-	eng.mu.Unlock()
-	for idx, nl := range mtc.nodeLivenesses {
-		l, err := nl.Self()
-		if err != nil {
-			t.Fatal(err)
-		}
-		testutils.SucceedsSoon(t, func() error {
-			for {
-				errCh := make(chan error)
-				go func() {
-					err := nl.Heartbeat(context.Background(), l)
-					errCh <- err
-				}()
-
-				nodeID := mtc.gossips[idx].NodeID.Get()
-				select {
-				case <-errCh:
-					return errors.Errorf("expected node %d to be considered not live within 5 milliseconds", nodeID)
-				case <-time.After(5 * time.Millisecond):
-					ch <- true
-					err = <-errCh
-				}
-
-				if err == nil {
-					live, err := nl.IsLive(nodeID)
-					if err != nil {
-						return err
-					} else if !live {
-						return errors.Errorf("expected node %d to be considered live after waiting 5 milliseconds", nodeID)
-					}
-					break
-				}
-
-				if err == storage.ErrEpochIncremented {
-					log.Warningf(context.Background(), "retrying after %s", err)
-					continue
-				}
-
-				return err
-			}
-			return nil
-		})
-	}
-}
-
-// *MockEngine implements engine.Engine interface.
-type MockEngine struct {
-	engine.InMem
-	mu  syncutil.Mutex
-	err error
-	ch  chan bool
-}
-
-func (m *MockEngine) NewBatch() engine.Batch {
-	return MockBatch{Batch: m.InMem.NewBatch(), engine: m}
-}
-
-// MockBatch implements engine.Batch interface.
-type MockBatch struct {
-	engine.Batch
-	engine *MockEngine
-}
-
-func (mb MockBatch) Commit(syncCommit bool) error {
-	mb.engine.mu.Lock()
-	ch := mb.engine.ch
-	err := mb.engine.err
-	mb.engine.mu.Unlock()
-
-	if ch != nil {
-		<-ch
-	}
-	if err != nil {
-		return err
-	}
-	err = mb.Batch.Commit(syncCommit)
-	return err
 }


### PR DESCRIPTION
We've had two recent incidents in which we saw clusters with disks
stalled  on a subset of nodes in the cluster. This is a fairly
treacherous failure mode since

- the symptoms are nondescript: from the UI it often looks like a Raft
problem, logspy will freeze up as well, and so you waste some time until
you end up looking at the goroutine dump and notice the writes stuck in
syscall
- the node is in some semi-live state that borders the byzantine and
can cause further trouble for the part of the cluster that isn't
affected (we have some mitigations against this in place but not
enough, and need to improve our defense mechanisms).
- it's sudden and often can't be gleaned from the logs (since everything
is fine and then nothing ever completes so no "alertable" metrics are
emitted).

This commit introduces a simple mechanism that periodically checks for
these conditions (both on the engines and logging) and invokes a fatal
error if necessary.

The accompanying roachtest exercises both a data and a logging disk
stall.

Fixes #7882.
Fixes #32736.

Touches #7646.

Release note (bug fix): CockroachDB will error with a fatal exit when
data or logging partitions become unresponsive. Previously, the process
would remain running, though in an unresponsive state.