### PR TITLE
sql: support CREATE STATISTICS with no columns and table refs

### DIFF
--- a/docs/generated/sql/bnf/create_stats_stmt.bnf
+++ b/docs/generated/sql/bnf/create_stats_stmt.bnf
@@ -1,2 +1,2 @@
 create_stats_stmt ::=
-	'CREATE' 'STATISTICS' statistics_name 'ON' column_name 'FROM' table_name opt_as_of_clause
+	'CREATE' 'STATISTICS' statistics_name opt_stats_columns 'FROM' create_stats_target opt_as_of_clause

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -328,7 +328,7 @@ create_ddl_stmt ::=
 	| create_sequence_stmt
 
 create_stats_stmt ::=
-	'CREATE' 'STATISTICS' statistics_name 'ON' name_list 'FROM' table_name opt_as_of_clause
+	'CREATE' 'STATISTICS' statistics_name opt_stats_columns 'FROM' create_stats_target opt_as_of_clause
 
 opt_with_clause ::=
 	with_clause
@@ -947,6 +947,13 @@ create_sequence_stmt ::=
 
 statistics_name ::=
 	name
+
+opt_stats_columns ::=
+	'ON' name_list
+	| 
+
+create_stats_target ::=
+	table_name
 
 with_clause ::=
 	'WITH' cte_list

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -21,22 +21,37 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/pkg/errors"
 )
 
 type createStatsNode struct {
 	tree.CreateStats
 	tableDesc *sqlbase.ImmutableTableDescriptor
-	columns   []sqlbase.ColumnID
+	columns   [][]sqlbase.ColumnID
 }
 
 func (p *planner) CreateStatistics(ctx context.Context, n *tree.CreateStats) (planNode, error) {
-	// TODO(anyone): if CREATE STATISTICS is meant to be able to operate
-	// within a transaction, then the following should probably run with
-	// caching disabled, like other DDL statements.
-	tableDesc, err := ResolveExistingObject(ctx, p, &n.Table, true /*required*/, requireTableDesc)
-	if err != nil {
-		return nil, err
+	var tableDesc *ImmutableTableDescriptor
+	var err error
+	switch t := n.Table.(type) {
+	case *tree.TableName:
+		// TODO(anyone): if CREATE STATISTICS is meant to be able to operate
+		// within a transaction, then the following should probably run with
+		// caching disabled, like other DDL statements.
+		tableDesc, err = ResolveExistingObject(ctx, p, t, true /*required*/, requireTableDesc)
+		if err != nil {
+			return nil, err
+		}
+
+	case *tree.TableRef:
+		flags := ObjectLookupFlags{CommonLookupFlags: CommonLookupFlags{
+			avoidCached: p.avoidCachedDescriptors,
+		}}
+		tableDesc, err = p.Tables().getTableVersionByID(ctx, p.txn, sqlbase.ID(t.TableID), flags)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if tableDesc.IsVirtualTable() {
@@ -48,7 +63,7 @@ func (p *planner) CreateStatistics(ctx context.Context, n *tree.CreateStats) (pl
 	}
 
 	if len(n.ColumnNames) == 0 {
-		return nil, errors.Errorf("no columns given for statistics")
+		return createStatsDefaultColumns(n, tableDesc)
 	}
 
 	columns, err := tableDesc.FindActiveColumnsByNames(n.ColumnNames)
@@ -63,8 +78,70 @@ func (p *planner) CreateStatistics(ctx context.Context, n *tree.CreateStats) (pl
 	return &createStatsNode{
 		CreateStats: *n,
 		tableDesc:   tableDesc,
-		columns:     columnIDs,
+		columns:     [][]sqlbase.ColumnID{columnIDs},
 	}, nil
+}
+
+// createStatsDefaultColumns creates column statistics on a default set of
+// columns when no columns were specified by the caller.
+//
+// To determine a useful set of default column statistics, we rely on
+// information provided by the schema. In particular, the presence of an index
+// on a particular set of columns indicates that the workload likely contains
+// queries that involve those columns (e.g., for filters), and it would be
+// useful to have statistics on prefixes of those columns. For example, if a
+// table abc contains indexes on (a ASC, b ASC) and (b ASC, c ASC), we will
+// collect statistics on a, {a, b}, b, and {b, c}.
+// TODO(rytaft): This currently only generates one single-column stat per
+// index. Add code to collect multi-column stats once they are supported.
+func createStatsDefaultColumns(
+	n *tree.CreateStats, desc *ImmutableTableDescriptor,
+) (planNode, error) {
+	pn := &createStatsNode{
+		CreateStats: *n,
+		tableDesc:   desc,
+		columns:     make([][]sqlbase.ColumnID, 0, len(desc.Indexes)+1),
+	}
+
+	var requestedCols util.FastIntSet
+
+	// If the primary key is not the hidden rowid column, collect stats on it.
+	pkCol := desc.PrimaryIndex.ColumnIDs[0]
+	if !isHidden(desc, pkCol) {
+		pn.columns = append(pn.columns, []sqlbase.ColumnID{pkCol})
+		requestedCols.Add(int(pkCol))
+	}
+
+	// Add columns for each secondary index.
+	for i := range desc.Indexes {
+		idxCol := desc.Indexes[i].ColumnIDs[0]
+		if !requestedCols.Contains(int(idxCol)) {
+			pn.columns = append(pn.columns, []sqlbase.ColumnID{idxCol})
+			requestedCols.Add(int(idxCol))
+		}
+	}
+
+	// If there are no non-hidden index columns, collect stats on the first
+	// non-hidden column in the table.
+	if len(pn.columns) == 0 {
+		for i := range desc.Columns {
+			if !desc.Columns[i].IsHidden() {
+				pn.columns = append(pn.columns, []sqlbase.ColumnID{desc.Columns[i].ID})
+				break
+			}
+		}
+	}
+
+	return pn, nil
+}
+
+func isHidden(desc *ImmutableTableDescriptor, columnID sqlbase.ColumnID) bool {
+	for i := range desc.Columns {
+		if desc.Columns[i].ID == columnID {
+			return desc.Columns[i].IsHidden()
+		}
+	}
+	panic("column not found in table")
 }
 
 func (*createStatsNode) Next(runParams) (bool, error) {

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -158,14 +158,14 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 func (dsp *DistSQLPlanner) createPlanForCreateStats(
 	planCtx *PlanningCtx, n *createStatsNode,
 ) (PhysicalPlan, error) {
-
-	stats := []requestedStat{
-		{
-			columns:             n.columns,
-			histogram:           len(n.ColumnNames) == 1,
+	stats := make([]requestedStat, len(n.columns))
+	for i := 0; i < len(stats); i++ {
+		stats[i] = requestedStat{
+			columns:             n.columns[i],
+			histogram:           len(n.columns[i]) == 1,
 			histogramMaxBuckets: histogramBuckets,
 			name:                string(n.Name),
-		},
+		}
 	}
 
 	return dsp.createStatsPlan(planCtx, n.tableDesc, stats)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1,7 +1,7 @@
 # LogicTest: 5node-dist 5node-dist-opt 5node-dist-metadata
 
 statement ok
-CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))
+CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d), INDEX c_idx (c, d))
 
 # Prevent the merge queue from immediately discarding our splits.
 statement ok
@@ -131,3 +131,125 @@ statistics_name  column_names  row_count  distinct_count  null_count
 s1               {a}           10000      10              0
 NULL             {b}           10000      10              0
 s2               {a}           10000      10              0
+
+#
+# Test default column statistics
+#
+
+statement ok
+CREATE STATISTICS s3 FROM data
+
+query TIII colnames
+SELECT column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data]
+WHERE statistics_name = 's3'
+----
+column_names  row_count  distinct_count  null_count
+{a}           10000      10              0
+{c}           10000      10              0
+
+# Add indexes, including duplicate index on column c.
+statement ok
+CREATE INDEX ON data (c DESC, b ASC); CREATE INDEX ON data (b DESC)
+
+statement ok
+CREATE STATISTICS s4 FROM data
+
+# Check that stats are only collected once per column.
+query TIII colnames
+SELECT column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data]
+WHERE statistics_name = 's4'
+----
+column_names  row_count  distinct_count  null_count
+{a}           10000      10              0
+{b}           10000      10              0
+{c}           10000      10              0
+
+statement ok
+DROP INDEX data@c_idx; DROP INDEX data@data_c_b_idx
+
+statement ok
+CREATE STATISTICS s5 FROM [53]
+
+# We should no longer get stats for column c.
+query TIII colnames
+SELECT column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data]
+WHERE statistics_name = 's5'
+----
+column_names  row_count  distinct_count  null_count
+{a}           10000      10              0
+{b}           10000      10              0
+
+# A table with a hidden primary key and no other indexes has default
+# column stats collected on the first non-hidden column.
+statement ok
+CREATE TABLE simple (x INT, y INT)
+
+statement ok
+CREATE STATISTICS default_stat1 FROM simple
+
+query TTIII colnames
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE simple]
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+default_stat1    {x}           0          0               0
+
+# Add one null row.
+statement ok
+INSERT INTO simple VALUES (DEFAULT, DEFAULT)
+
+# Add an index.
+statement ok
+CREATE UNIQUE INDEX ON simple (y) STORING (x)
+
+statement ok
+CREATE STATISTICS default_stat2 FROM simple
+
+# Now stats are only collected on the index column.
+query TTIII colnames
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE simple]
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+default_stat1    {x}           0          0               0
+default_stat2    {y}           1          0               1
+
+#
+# Test numeric references
+#
+
+statement ok
+CREATE STATISTICS s6 ON a FROM [53]
+
+query TTIII colnames
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data]
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+s1               {a}           10000      10              0
+NULL             {b}           10000      10              0
+s2               {a}           10000      10              0
+s3               {a}           10000      10              0
+s3               {c}           10000      10              0
+s4               {a}           10000      10              0
+s4               {b}           10000      10              0
+s4               {c}           10000      10              0
+s5               {a}           10000      10              0
+s5               {b}           10000      10              0
+s6               {a}           10000      10              0
+
+# Combine default columns and numeric reference.
+statement ok
+CREATE STATISTICS __auto__ FROM [53]
+
+query TIII colnames
+SELECT column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data]
+WHERE statistics_name = '__auto__'
+----
+column_names  row_count  distinct_count  null_count
+{a}           10000      10              0
+{b}           10000      10              0

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1129,7 +1129,7 @@ func (node *CreateView) Format(ctx *FmtCtx) {
 type CreateStats struct {
 	Name        Name
 	ColumnNames NameList
-	Table       TableName
+	Table       TableExpr
 	AsOf        AsOfClause
 }
 
@@ -1138,11 +1138,13 @@ func (node *CreateStats) Format(ctx *FmtCtx) {
 	ctx.WriteString("CREATE STATISTICS ")
 	ctx.FormatNode(&node.Name)
 
-	ctx.WriteString(" ON ")
-	ctx.FormatNode(&node.ColumnNames)
+	if len(node.ColumnNames) > 0 {
+		ctx.WriteString(" ON ")
+		ctx.FormatNode(&node.ColumnNames)
+	}
 
 	ctx.WriteString(" FROM ")
-	ctx.FormatNode(&node.Table)
+	ctx.FormatNode(node.Table)
 
 	if node.AsOf.Expr != nil {
 		ctx.WriteByte(' ')

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -33,7 +33,7 @@ func EquiDepthHistogram(
 ) (HistogramData, error) {
 	numSamples := len(samples)
 	if numSamples == 0 {
-		return HistogramData{}, errors.Errorf("no samples")
+		return HistogramData{}, nil
 	}
 	if numRows < int64(numSamples) {
 		return HistogramData{}, errors.Errorf("more samples than rows")


### PR DESCRIPTION
This commit adds support for calling `CREATE STATISTICS` with no
columns specified. In this case, a default set of columns is used
for the given table.

To determine a useful set of default column statistics, we rely on
information provided by the schema. In particular, the presence of
an index on a particular set of columns indicates that the workload
likely contains queries that involve those columns (e.g., for filters),
and it would be useful to have statistics on prefixes of those columns.
For example, if a table `abc` contains indexes on `(a ASC, b ASC)` and
`(b ASC, c ASC)`, we would like to collect statistics on `a`, `{a, b}`, `b`,
and `{b, c}`. Multi-column stats are not yet fully implemented, however,
so this commit only collects single-column stats.

This commit also adds support for using numeric table references
with `CREATE STATISTICS`. This will make it easier to run 
`CREATE STATISTICS` programmatically when only the TableID is available. 
It is not documented so not intended for external use. The syntax is
similar to the syntax for using numeric table references in `SELECT`
statements.

Both of these changes will be used by an upcoming PR to call
`CREATE STATISTICS` automatically after some percentage of the rows of
a table have been updated. For example, the following command will
automatically collect stats for the table with ID 53:
```
  CREATE STATISTICS __auto__ FROM [53];
```
Release note (sql change): Added support for collecting table
statistics on a default set of columns by calling CREATE STATISTICS
with no columns specified.