### PR TITLE
exec: add arithmetic ops with const on left

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -321,19 +321,41 @@ func planExpressionOperators(
 		return op, resultIdx, ct, err
 	case *tree.BinaryExpr:
 		binOp := t.Operator
+		// There are 3 cases. Either the left is constant, the right is constant,
+		// or neither are constant.
+		lConstArg, lConst := t.Left.(tree.Datum)
+		if lConst {
+			// Case one: The left is constant.
+			// Normally, the optimizer normalizes binary exprs so that the constant
+			// argument is on the right side. This doesn't happen for non-commutative
+			// operators such as - and /, though, so we still need this case.
+			rightOp, rightIdx, ct, err := planExpressionOperators(t.TypedRight(), columnTypes, input)
+			if err != nil {
+				return nil, resultIdx, ct, err
+			}
+			resultIdx = len(ct)
+			typ := ct[rightIdx]
+			// The projection result will be outputted to a new column which is appended
+			// to the input batch.
+			op, err := exec.GetProjectionLConstOperator(typ, binOp, rightOp, rightIdx, lConstArg, resultIdx)
+			ct = append(ct, typ)
+			return op, resultIdx, ct, err
+		}
 		leftOp, leftIdx, ct, err := planExpressionOperators(t.TypedLeft(), columnTypes, input)
 		if err != nil {
 			return nil, resultIdx, ct, err
 		}
 		typ := ct[leftIdx]
-		if constArg, ok := t.Right.(tree.Datum); ok {
+		if rConstArg, rConst := t.Right.(tree.Datum); rConst {
+			// Case 2: The right is constant.
 			// The projection result will be outputted to a new column which is appended
 			// to the input batch.
 			resultIdx = len(ct)
-			op, err := exec.GetProjectionConstOperator(typ, binOp, leftOp, leftIdx, constArg, resultIdx)
+			op, err := exec.GetProjectionRConstOperator(typ, binOp, leftOp, leftIdx, rConstArg, resultIdx)
 			ct = append(ct, typ)
 			return op, resultIdx, ct, err
 		}
+		// Case 3: neither are constant.
 		rightOp, rightIdx, ct, err := planExpressionOperators(t.TypedRight(), ct, leftOp)
 		if err != nil {
 			return nil, resultIdx, nil, err

--- a/pkg/sql/exec/colbatch.go
+++ b/pkg/sql/exec/colbatch.go
@@ -25,6 +25,8 @@ type ColBatch interface {
 	Length() uint16
 	// SetLength sets the number of values in the columns in the batch.
 	SetLength(uint16)
+	// Width returns the number of columns in the batch.
+	Width() int
 	// ColVec returns the ith ColVec in this batch.
 	ColVec(i int) ColVec
 	// ColVecs returns all of the underlying ColVecs in this batch.
@@ -88,6 +90,10 @@ func (m *memBatch) Length() uint16 {
 	return m.n
 }
 
+func (m *memBatch) Width() int {
+	return len(m.b)
+}
+
 func (m *memBatch) ColVec(i int) ColVec {
 	return m.b[i]
 }
@@ -132,4 +138,17 @@ func newProjectionBatch(projection []uint32) *projectingBatch {
 
 func (b *projectingBatch) ColVec(i int) ColVec {
 	return b.ColBatch.ColVec(int(b.projection[i]))
+}
+
+func (b *projectingBatch) ColVecs() []ColVec {
+	panic("projectingBatch doesn't support ColVecs()")
+}
+
+func (b *projectingBatch) Width() int {
+	return len(b.projection)
+}
+
+func (b *projectingBatch) AppendCol(t types.T) {
+	b.ColBatch.AppendCol(t)
+	b.projection = append(b.projection, uint32(b.ColBatch.Width())-1)
 }

--- a/pkg/sql/exec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/overloads.go
@@ -70,6 +70,7 @@ type overload struct {
 	OpStr   string
 	LTyp    types.T
 	RTyp    types.T
+	LGoType string
 	RGoType string
 	RetTyp  types.T
 
@@ -133,6 +134,7 @@ func init() {
 				OpStr:   binaryOpInfix[op],
 				LTyp:    t,
 				RTyp:    t,
+				LGoType: t.GoTypeName(),
 				RGoType: t.GoTypeName(),
 				RetTyp:  t,
 			}
@@ -153,6 +155,7 @@ func init() {
 				OpStr:   opStr,
 				LTyp:    t,
 				RTyp:    t,
+				LGoType: t.GoTypeName(),
 				RGoType: t.GoTypeName(),
 				RetTyp:  types.Bool,
 			}

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -53,7 +53,7 @@ type {{template "opConstName" .}} struct {
 
 func (p *{{template "opConstName" .}}) Next() ColBatch {
 	batch := p.input.Next()
-	if p.outputIdx == len(batch.ColVecs()) {
+	if p.outputIdx == batch.Width() {
 		batch.AppendCol(types.{{.RetTyp}})
 	}
 	projCol := batch.ColVec(p.outputIdx).{{.RetTyp}}()[:ColBatchSize]
@@ -87,7 +87,7 @@ type {{template "opName" .}} struct {
 
 func (p *{{template "opName" .}}) Next() ColBatch {
 	batch := p.input.Next()
-	if p.outputIdx == len(batch.ColVecs()) {
+	if p.outputIdx == batch.Width() {
 		batch.AppendCol(types.{{.RetTyp}})
 	}
 	projCol := batch.ColVec(p.outputIdx).{{.RetTyp}}()[:ColBatchSize]

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -34,15 +34,16 @@ import (
 	"github.com/pkg/errors"
 )
 
-{{define "opConstName"}}proj{{.Name}}{{.LTyp}}{{.RTyp}}ConstOp{{end}}
+{{define "opRConstName"}}proj{{.Name}}{{.LTyp}}{{.RTyp}}ConstOp{{end}}
+{{define "opLConstName"}}proj{{.Name}}{{.LTyp}}Const{{.RTyp}}Op{{end}}
 {{define "opName"}}proj{{.Name}}{{.LTyp}}{{.RTyp}}Op{{end}}
 
 {{/* The outer range is a types.T, and the inner is the overloads associated
      with that type. */}}
-{{range .}}
+{{range .TypToOverloads}}
 {{range .}}
 
-type {{template "opConstName" .}} struct {
+type {{template "opRConstName" .}} struct {
 	input Operator
 
 	colIdx   int
@@ -51,7 +52,7 @@ type {{template "opConstName" .}} struct {
 	outputIdx int
 }
 
-func (p *{{template "opConstName" .}}) Next() ColBatch {
+func (p *{{template "opRConstName" .}}) Next() ColBatch {
 	batch := p.input.Next()
 	if p.outputIdx == batch.Width() {
 		batch.AppendCol(types.{{.RetTyp}})
@@ -72,7 +73,41 @@ func (p *{{template "opConstName" .}}) Next() ColBatch {
 	return batch
 }
 
-func (p {{template "opConstName" .}}) Init() {
+func (p {{template "opRConstName" .}}) Init() {
+	p.input.Init()
+}
+
+type {{template "opLConstName" .}} struct {
+	input Operator
+
+	colIdx   int
+	constArg {{.LGoType}}
+
+	outputIdx int
+}
+
+func (p *{{template "opLConstName" .}}) Next() ColBatch {
+	batch := p.input.Next()
+	if p.outputIdx == batch.Width() {
+		batch.AppendCol(types.{{.RetTyp}})
+	}
+	projCol := batch.ColVec(p.outputIdx).{{.RetTyp}}()[:ColBatchSize]
+	col := batch.ColVec(p.colIdx).{{.RTyp}}()[:ColBatchSize]
+	n := batch.Length()
+	if sel := batch.Selection(); sel != nil {
+		for _, i := range sel {
+			{{(.Assign "projCol[i]" "p.constArg" "col[i]")}}
+		}
+	} else {
+		col = col[:n]
+		for i := range col {
+			{{(.Assign "projCol[i]" "p.constArg" "col[i]")}}
+		}
+	}
+	return batch
+}
+
+func (p {{template "opLConstName" .}}) Init() {
 	p.input.Init()
 }
 
@@ -114,9 +149,12 @@ func (p {{template "opName" .}}) Init() {
 {{end}}
 {{end}}
 
+{{/* Range over true and false. $left will be true when outputting a left-const
+     operator, and false when outputting a right-const operator. */}}
+{{range $left := .ConstSides}}
 // GetProjectionConstOperator returns the appropriate constant projection
 // operator for the given column type and comparison.
-func GetProjectionConstOperator(
+func GetProjection{{if $left}}L{{else}}R{{end}}ConstOperator(
 	ct sqlbase.ColumnType,
 	op tree.Operator,
 	input Operator,
@@ -129,7 +167,7 @@ func GetProjectionConstOperator(
 		return nil, err
 	}
 	switch t := types.FromColumnType(ct); t {
-	{{range $typ, $overloads := .}}
+	{{range $typ, $overloads := $.TypToOverloads}}
 	case types.{{$typ}}:
 		switch op.(type) {
 		case tree.BinaryOperator:
@@ -137,10 +175,10 @@ func GetProjectionConstOperator(
 			{{range $overloads}}
 			{{if .IsBinOp}}
 			case tree.{{.Name}}:
-				return &{{template "opConstName" .}}{
+				return &{{if $left}}{{template "opLConstName" .}}{{else}}{{template "opRConstName" .}}{{end}}{
 					input:    input,
 					colIdx:   colIdx,
-					constArg: c.({{.RGoType}}),
+					constArg: c.({{if $left}}{{.LGoType}}{{else}}{{.RGoType}}{{end}}),
 					outputIdx: outputIdx,
 				}, nil
 			{{end}}
@@ -153,10 +191,10 @@ func GetProjectionConstOperator(
 			{{range $overloads}}
 			{{if .IsCmpOp}}
 			case tree.{{.Name}}:
-				return &{{template "opConstName" .}}{
+				return &{{if $left}}{{template "opLConstName" .}}{{else}}{{template "opRConstName" .}}{{end}}{
 					input:    input,
 					colIdx:   colIdx,
-					constArg: c.({{.RGoType}}),
+					constArg: c.({{if $left}}{{.LGoType}}{{else}}{{.RGoType}}{{end}}),
 					outputIdx: outputIdx,
 				}, nil
 			{{end}}
@@ -172,6 +210,7 @@ func GetProjectionConstOperator(
 		return nil, errors.Errorf("unhandled type: %s", t)
 	}
 }
+{{end}}
 
 // GetProjectionOperator returns the appropriate projection operator for the
 // given column type and comparison.
@@ -184,7 +223,7 @@ func GetProjectionOperator(
   outputIdx int,
 ) (Operator, error) {
 	switch t := types.FromColumnType(ct); t {
-	{{range $typ, $overloads := .}}
+	{{range $typ, $overloads := .TypToOverloads}}
 	case types.{{$typ}}:
 		switch op.(type) {
 		case tree.BinaryOperator:
@@ -229,6 +268,14 @@ func GetProjectionOperator(
 }
 `
 
+type genInput struct {
+	TypToOverloads map[types.T][]*overload
+	// ConstSides is a boolean array that contains two elements, true and false.
+	// It's used by the template to generate both variants of the const projection
+	// op - once where the left is const, and one where the right is const.
+	ConstSides []bool
+}
+
 func genProjectionOps(wr io.Writer) error {
 	tmpl, err := template.New("projection_ops").Parse(projTemplate)
 	if err != nil {
@@ -244,7 +291,7 @@ func genProjectionOps(wr io.Writer) error {
 		typ := overload.LTyp
 		typToOverloads[typ] = append(typToOverloads[typ], overload)
 	}
-	return tmpl.Execute(wr, typToOverloads)
+	return tmpl.Execute(wr, genInput{typToOverloads, []bool{false, true}})
 }
 
 func init() {

--- a/pkg/sql/exec/projection_ops_test.go
+++ b/pkg/sql/exec/projection_ops_test.go
@@ -90,7 +90,7 @@ func TestGetProjectionConstOperator(t *testing.T) {
 	constVal := float64(31.37)
 	constArg := tree.NewDFloat(tree.DFloat(constVal))
 	outputIdx := 5
-	op, err := GetProjectionConstOperator(ct, binOp, input, colIdx, constArg, outputIdx)
+	op, err := GetProjectionRConstOperator(ct, binOp, input, colIdx, constArg, outputIdx)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -92,6 +92,14 @@ SELECT (a + 1.0::DECIMAL)::INT FROM a LIMIT 1
 ----
 1
 
+# Operations with constants on the left work.
+query I
+SELECT 5 - a FROM a LIMIT 3
+----
+5
+5
+4
+
 # Mismatched column types in projection. Not handled yet but should fall back
 # gracefully.
 statement ok


### PR DESCRIPTION
Normally, arithmetic ops with constants are normalized so that the
constant is on the right. However, this is only possible with
commutative arithmetic ops - ops like `-` and `/` can't get normalized
in that way.

So, we need to be able to plan either direction. This commit adds
support for doing so. All arithmetic ops are templated in both
directions and can be planned either way as well.

This is necessary for planning of TPCH q1.

Release note: None