### PR TITLE
sql: release orphaned table leases at server startup

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1691,6 +1691,10 @@ func (s *Server) Start(ctx context.Context) error {
 	// executes a SQL query, this must be done after the SQL layer is ready.
 	s.node.recordJoinEvent()
 
+	// Delete all orphaned table leases created by a prior instance of this
+	// node.
+	s.leaseMgr.DeleteOrphanedLeases(startTime)
+
 	log.Event(ctx, "server ready")
 
 	return nil

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -215,7 +215,15 @@ func TestReportUsage(t *testing.T) {
 				{Key: "city", Value: "nyc"},
 			},
 		},
+		Knobs: base.TestingKnobs{
+			SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
+				// Disable SELECT called for delete orphaned leases to keep
+				// query stats stable.
+				DisableDeleteOrphanedLeases: true,
+			},
+		},
 	}
+
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO()) // stopper will wait for the update/report loop to finish too.
 	ts := s.(*TestServer)

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
@@ -52,6 +53,13 @@ func TestQueryCounts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
+			// Disable SELECT called for delete orphaned leases to keep
+			// query stats stable.
+			DisableDeleteOrphanedLeases: true,
+		},
+	}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1909,6 +1909,30 @@ func ParseDTimestamp(ctx ParseTimeContext, s string, precision time.Duration) (*
 	return MakeDTimestamp(t, precision), nil
 }
 
+// AsDTimestamp attempts to retrieve a DTimestamp from an Expr, returning a DTimestamp and
+// a flag signifying whether the assertion was successful. The function should
+// be used instead of direct type assertions wherever a *DTimestamp wrapped by a
+// *DOidWrapper is possible.
+func AsDTimestamp(e Expr) (DTimestamp, bool) {
+	switch t := e.(type) {
+	case *DTimestamp:
+		return *t, true
+	case *DOidWrapper:
+		return AsDTimestamp(t.Wrapped)
+	}
+	return DTimestamp{}, false
+}
+
+// MustBeDTimestamp attempts to retrieve a DTimestamp from an Expr, panicking if the
+// assertion fails.
+func MustBeDTimestamp(e Expr) DTimestamp {
+	t, ok := AsDTimestamp(e)
+	if !ok {
+		panic(pgerror.NewAssertionErrorf("expected *DTimestamp, found %T", e))
+	}
+	return t
+}
+
 // ResolvedType implements the TypedExpr interface.
 func (*DTimestamp) ResolvedType() types.T {
 	return types.Timestamp
@@ -2373,7 +2397,7 @@ func MakeDJSON(d interface{}) (Datum, error) {
 // AsDJSON attempts to retrieve a *DJSON from an Expr, returning a *DJSON and
 // a flag signifying whether the assertion was successful. The function should
 // be used instead of direct type assertions wherever a *DJSON wrapped by a
-// *DJSON is possible.
+// *DOidWrapper is possible.
 func AsDJSON(e Expr) (*DJSON, bool) {
 	switch t := e.(type) {
 	case *DJSON:


### PR DESCRIPTION
table leases created and not released when a node shuts down
ungracefully are orphaned leases. These orphaned leases can
block new schema changes run before the expiration time of
the lease. This change deletes such orphaned leases at
server startup.

This implementation is limited in that the orphaned leases are
deleted by the node when it restarts. In the future this
implementation can benefit from the leases holding
node liveness epoch in them, but that is part of a larger
future design to introduce node liveness epoch in leases.
For now, this is sufficient to maintain the current
implementation while providing for user impact in the most
common case of node restarts.

fixes #20485
fixes #32254
fixes #23244

Release note (sql change): Fix problem with schema change
getting stuck for 5 minutes when executed immediately after
a server restart.