### PR TITLE
server: remove unncecessary WaitForInitialSplits() from TestAuthentic…

### DIFF
--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -416,9 +416,6 @@ func TestAuthenticationAPIUserLogin(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
-	if err := ts.WaitForInitialSplits(); err != nil {
-		t.Fatal(err)
-	}
 
 	const (
 		validUsername = "testuser"


### PR DESCRIPTION
…ationAPIUserLogin

That wait is implied when starting servers.

Release note: None