### PR TITLE
cli: fix version checks, update hashicorp/go-version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -798,12 +798,12 @@
   revision = "8e809c8a86450a29b90dcc9efbf062d0fe6d9746"
 
 [[projects]]
-  branch = "master"
-  digest = "1:ada37ea3db98b606d2b61577fbd87c0aabaa95e03b409033ebf58c6e5420b033"
+  digest = "1:77395dd3847dac9c45118c668f5dab85aedf0163dc3b38aea6578c5cf0d502f9"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
   pruneopts = "UT"
-  revision = "fc61389e27c71d120f87031ca8c88a3428f372dd"
+  revision = "b5a281d3160aa11950a6182bd9a9dc2cb1e02d50"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -57,7 +57,7 @@ func runDump(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 
-	if err := conn.requireServerVersion(">v2.1.0-alpha.20180416"); err != nil {
+	if err := conn.requireServerVersion("> 2.1.0-alpha.20180416"); err != nil {
 		return err
 	}
 

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -257,7 +257,7 @@ func (c *sqlConn) requireServerVersion(constraintString string) error {
 	}
 	vers, err := version.NewVersion(versionString)
 	if err != nil {
-		return fmt.Errorf("unable to parse server version %q", c.serverVersion)
+		return fmt.Errorf("unable to parse server version %q", versionString)
 	}
 	if !constraints.Check(vers) {
 		return fmt.Errorf("incompatible client and server versions (detected server version: %s, required: %s)",

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -45,7 +45,7 @@ func runGetUser(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v2.0-alpha.20180116"); err != nil {
+	if err := conn.requireServerVersion(">= 2.0.0-alpha.20180116"); err != nil {
 		return err
 	}
 	return runQueryAndFormatResults(conn, os.Stdout,
@@ -97,7 +97,7 @@ func runRmUser(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v1.1-alpha.20170622"); err != nil {
+	if err := conn.requireServerVersion(">= 1.1.0-alpha.20170622"); err != nil {
 		return err
 	}
 	return runQueryAndFormatResults(conn, os.Stdout,
@@ -143,7 +143,7 @@ func runSetUser(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v1.2-alpha.20171113"); err != nil {
+	if err := conn.requireServerVersion(">= 1.2.0-alpha.20171113"); err != nil {
 		return err
 	}
 

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -82,7 +82,7 @@ func runGetZone(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v1.2-alpha.20171026"); err != nil {
+	if err := conn.requireServerVersion(">= 1.2.0-alpha.20171026"); err != nil {
 		return err
 	}
 
@@ -141,7 +141,7 @@ func runLsZones(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v1.2-alpha.20171026"); err != nil {
+	if err := conn.requireServerVersion(">= 1.2.0-alpha.20171026"); err != nil {
 		return err
 	}
 
@@ -195,7 +195,7 @@ func runRmZone(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v1.2-alpha.20171026"); err != nil {
+	if err := conn.requireServerVersion(">= 1.2.0-alpha.20171026"); err != nil {
 		return err
 	}
 
@@ -274,7 +274,7 @@ func runSetZone(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v1.2-alpha.20171026"); err != nil {
+	if err := conn.requireServerVersion(">= 1.2.0-alpha.20171026"); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -320,7 +320,7 @@ tar cvf certs.tar certs
 		}
 		args = append(args, "--log-dir="+logDir)
 		args = append(args, "--background")
-		if VersionSatifies(vers, ">=1.1") {
+		if VersionSatifies(vers, ">=1.1.0") {
 			cache := 25
 			if c.IsLocal() {
 				cache /= len(nodes)
@@ -333,7 +333,7 @@ tar cvf certs.tar certs
 		}
 		if c.IsLocal() {
 			// This avoids annoying firewall prompts on Mac OS X.
-			if VersionSatifies(vers, ">=2.1") {
+			if VersionSatifies(vers, ">=2.1.0") {
 				args = append(args, "--listen-addr=127.0.0.1")
 			} else {
 				args = append(args, "--host=127.0.0.1")


### PR DESCRIPTION
Fixing version checks (which no longer work with the latest
`go-version`). The versions are not supposed to contain `v` and they
must always start with three numbers.

Release note: None