### PR TITLE
scripts: fix unison ignore list

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -82,10 +82,15 @@ case "${cmd}" in
     gcloud compute config-ssh --ssh-config-file "$tmpfile" > /dev/null
     unison "$host" "ssh://${NAME}.${CLOUDSDK_COMPUTE_ZONE}.${CLOUDSDK_CORE_PROJECT}/$worker" \
       -sshargs "-F ${tmpfile}" -auto -prefer "$host" -repeat watch \
+      -ignore 'Path .git' \
       -ignore 'Path bin*' \
       -ignore 'Path build/builder_home' \
       -ignore 'Path pkg/sql/parser/gen' \
+      -ignore 'Path pkg/ui/node_modules' \
+      -ignore 'Path pkg/ui/.cache-loader' \
       -ignore 'Path cockroach-data' \
+      -ignore 'Name *.d' \
+      -ignore 'Name *.o' \
       -ignore 'Name zcgo_flags*.go'
     ;;
     *)


### PR DESCRIPTION
Make Unison less likely to corrupt your Git repository at the cost of not syncing your Git repository. Also omit some noisy build artifacts that don't need to be synced.

Release note: None