### PR TITLE
storage: add a metric to track number of RocksDB WAL syncs

### DIFF
--- a/c-deps/libroach/engine.cc
+++ b/c-deps/libroach/engine.cc
@@ -191,6 +191,7 @@ DBStatus DBImpl::GetStats(DBStatsResult* stats) {
   stats->bloom_filter_prefix_useful =
       (int64_t)s->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_USEFUL);
   stats->memtable_total_size = memtable_total_size;
+  stats->wal_syncs = (int64_t)s->getTickerCount(rocksdb::WAL_FILE_SYNCED);
   stats->flushes = (int64_t)event_listener->GetFlushes();
   stats->compactions = (int64_t)event_listener->GetCompactions();
   stats->table_readers_mem_estimate = table_readers_mem_estimate;

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -326,6 +326,7 @@ typedef struct {
   int64_t bloom_filter_prefix_checked;
   int64_t bloom_filter_prefix_useful;
   int64_t memtable_total_size;
+  int64_t wal_syncs;
   int64_t flushes;
   int64_t compactions;
   int64_t table_readers_mem_estimate;

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -372,6 +372,7 @@ type Stats struct {
 	BloomFilterPrefixChecked       int64
 	BloomFilterPrefixUseful        int64
 	MemtableTotalSize              int64
+	WALSyncs                       int64
 	Flushes                        int64
 	Compactions                    int64
 	TableReadersMemEstimate        int64

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1133,6 +1133,7 @@ func (r *RocksDB) GetStats() (*Stats, error) {
 		BloomFilterPrefixChecked:       int64(s.bloom_filter_prefix_checked),
 		BloomFilterPrefixUseful:        int64(s.bloom_filter_prefix_useful),
 		MemtableTotalSize:              int64(s.memtable_total_size),
+		WALSyncs:                       int64(s.wal_syncs),
 		Flushes:                        int64(s.flushes),
 		Compactions:                    int64(s.compactions),
 		TableReadersMemEstimate:        int64(s.table_readers_mem_estimate),

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -373,6 +373,12 @@ var (
 		Measurement: "Memory",
 		Unit:        metric.Unit_BYTES,
 	}
+	metaRdbWALSyncs = metric.Metadata{
+		Name:        "rocksdb.wal.syncs",
+		Help:        "Number of times the write-ahead log has been synced to disk",
+		Measurement: "Syncs",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaRdbFlushes = metric.Metadata{
 		Name:        "rocksdb.flushes",
 		Help:        "Number of table flushes",
@@ -1043,6 +1049,7 @@ type StoreMetrics struct {
 	RdbBloomFilterPrefixChecked *metric.Gauge
 	RdbBloomFilterPrefixUseful  *metric.Gauge
 	RdbMemtableTotalSize        *metric.Gauge
+	RdbWALSyncs                 *metric.Gauge
 	RdbFlushes                  *metric.Gauge
 	RdbCompactions              *metric.Gauge
 	RdbTableReadersMemEstimate  *metric.Gauge
@@ -1253,6 +1260,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RdbBloomFilterPrefixChecked: metric.NewGauge(metaRdbBloomFilterPrefixChecked),
 		RdbBloomFilterPrefixUseful:  metric.NewGauge(metaRdbBloomFilterPrefixUseful),
 		RdbMemtableTotalSize:        metric.NewGauge(metaRdbMemtableTotalSize),
+		RdbWALSyncs:                 metric.NewGauge(metaRdbWALSyncs),
 		RdbFlushes:                  metric.NewGauge(metaRdbFlushes),
 		RdbCompactions:              metric.NewGauge(metaRdbCompactions),
 		RdbTableReadersMemEstimate:  metric.NewGauge(metaRdbTableReadersMemEstimate),
@@ -1442,6 +1450,7 @@ func (sm *StoreMetrics) updateRocksDBStats(stats engine.Stats) {
 	sm.RdbBloomFilterPrefixUseful.Update(stats.BloomFilterPrefixUseful)
 	sm.RdbBloomFilterPrefixChecked.Update(stats.BloomFilterPrefixChecked)
 	sm.RdbMemtableTotalSize.Update(stats.MemtableTotalSize)
+	sm.RdbWALSyncs.Update(stats.WALSyncs)
 	sm.RdbFlushes.Update(stats.Flushes)
 	sm.RdbCompactions.Update(stats.Compactions)
 	sm.RdbTableReadersMemEstimate.Update(stats.TableReadersMemEstimate)


### PR DESCRIPTION
I found this PR lying around. @petermattis do you think this would be helpful?

Release note: None