### PR TITLE
storage/spanlatch: return NodeUnavailableError on stopper Quiesce

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -748,7 +748,7 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(
 		return errors.Errorf("replicaID must be 0 when creating an initialized replica")
 	}
 
-	r.latchMgr.Init(r.store.metrics.SlowLatchRequests)
+	r.latchMgr = spanlatch.Make(r.store.stopper, r.store.metrics.SlowLatchRequests)
 	r.mu.proposals = map[storagebase.CmdIDKey]*ProposalData{}
 	r.mu.checksums = map[uuid.UUID]ReplicaChecksum{}
 	// Clear the internal raft group in case we're being reset. Since we're


### PR DESCRIPTION
Fixes #32970.
Fixes #32976.
Fixes #32953.

The `CommandQueue` used to have this condition, but it was inadvertently
dropped when we switched to the spanlatch.Manager. This commit revives it.

Release note: None