### PR TITLE
storage: assert syscfg gossip

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -174,6 +174,15 @@ func createTestStoreWithEngine(
 		return nil
 	})
 
+	// Wait for the system config to be available in gossip. All sorts of things
+	// might not work properly while the system config is not available.
+	testutils.SucceedsSoon(t, func() error {
+		if cfg := store.Gossip().GetSystemConfig(); cfg == nil {
+			return errors.Errorf("system config not available in gossip yet")
+		}
+		return nil
+	})
+
 	return store
 }
 

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -79,6 +79,13 @@ func (s *Store) ComputeMVCCStats() (enginepb.MVCCStats, error) {
 }
 
 func forceScanAndProcess(s *Store, q *baseQueue) {
+	// Check that the system config is available. It is needed by many queues. If
+	// it's not available, some queues silently fail to process any replicas,
+	// which is undesirable for this method.
+	if cfg := s.Gossip().GetSystemConfig(); cfg == nil {
+		log.Fatalf(context.TODO(), "system config not available in gossip")
+	}
+
 	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
 		q.MaybeAdd(repl, s.cfg.Clock.Now())
 		return true


### PR DESCRIPTION
Before this patch, ForceSplitScanAndProcess() (for example) would
silently fail to do anything if the system config was not "available in
gossip". Never again; this patch adds an assertion that the sys cfg has
been gossipped.
To make the assertion not trigger, I've also added a wait for gossip to
a way of starting nodes specific to storage package tests.

Release note: None