### PR TITLE
backport-2.1: storage: low-risk snapshot logging improvements

### DIFF
--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -224,7 +224,22 @@ type truncateDecision struct {
 func (td *truncateDecision) raftSnapshotsForIndex(index uint64) int {
 	var n int
 	for _, p := range td.Input.RaftStatus.Progress {
-		if p.Match < index {
+		if p.State != raft.ProgressStateReplicate {
+			// If the follower isn't replicating, we can't trust its Match in
+			// the first place. But note that this shouldn't matter in practice
+			// as we already take care to not cut off these followers when
+			// computing the truncate decision. See:
+			_ = truncatableIndexChosenViaProbingFollower // guru ref
+			continue
+		}
+
+		// When a log truncation happens at the "current log index" (i.e. the
+		// most recently committed index), it is often still in flight to the
+		// followers not required for quorum, and it is likely that they won't
+		// need a truncation to catch up. A follower in that state will have a
+		// Match equaling committed-1, but a Next of committed+1 (indicating that
+		// an append at 'committed' is already ongoing).
+		if p.Match < index && p.Next <= index {
 			n++
 		}
 	}

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -213,8 +213,25 @@ func splitSnapshotWarningStr(rangeID roachpb.RangeID, status *raft.Status) strin
 				// https://github.com/etcd-io/etcd/pull/10279
 				continue
 			}
-			if pr.State != raft.ProgressStateReplicate {
-				s += fmt.Sprintf("; may cause Raft snapshot to r%d/%d: %v", rangeID, replicaID, &pr)
+			if pr.State == raft.ProgressStateReplicate {
+				// This follower is in good working order.
+				continue
+			}
+			s += fmt.Sprintf("; r%d/%d is ", rangeID, replicaID)
+			switch pr.State {
+			case raft.ProgressStateSnapshot:
+				// If the Raft snapshot queue is backed up, replicas can spend
+				// minutes or worse until they are caught up.
+				s += "waiting for a Raft snapshot"
+			case raft.ProgressStateProbe:
+				// Assuming the split has already been delayed for a little bit,
+				// seeing a follower that is probing hints at some problem with
+				// Raft or Raft message delivery. (Of course it's possible that
+				// the follower *just* entered probing state).
+				s += "being probed (may or may not need a Raft snapshot)"
+			default:
+				// Future proofing.
+				s += "in unknown state " + pr.State.String()
 			}
 		}
 	}

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -264,6 +264,14 @@ func (rgcq *replicaGCQueue) process(
 			// look it up by RangeID) to disable the mechanism in #31875 for it.
 			// We should be able to use prefetching unconditionally to have this
 			// desc ready whenever we need it.
+			//
+			// NB: there's solid evidence that this phenomenon can actually lead
+			// to a large spike in Raft snapshots early in the life of a cluster
+			// (in particular when combined with a restore operation) when the
+			// removed replica has many pending splits and thus incurs a Raft
+			// snapshot for *each* of them. This typically happens for the last
+			// range:
+			// [n1,replicaGC,s1,r33/1:/{Table/53/1/3…-Max}] removing replica [...]
 			log.Infof(ctx, "removing replica with pending split; will incur Raft snapshot for right hand side")
 		}
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -10886,8 +10886,15 @@ func TestSplitSnapshotWarningStr(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"; may cause Raft snapshot to r12/2: next = 0, match = 100, state = ProgressStateProbe,"+
-			" waiting = false, pendingSnapshot = 0",
+		"; r12/2 is being probed (may or may not need a Raft snapshot)",
+		splitSnapshotWarningStr(12, status),
+	)
+
+	pr.State = raft.ProgressStateSnapshot
+
+	assert.Equal(
+		t,
+		"; r12/2 is being probed (may or may not need a Raft snapshot)",
 		splitSnapshotWarningStr(12, status),
 	)
 }

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -676,9 +676,9 @@ func sendSnapshot(
 	if err := stream.Send(&SnapshotRequest{Final: true}); err != nil {
 		return err
 	}
-	log.Infof(ctx, "streamed snapshot to %s: %s, rate-limit: %s/sec, %0.0fms",
+	log.Infof(ctx, "streamed snapshot to %s: %s, rate-limit: %s/sec, %.2fs",
 		to, ss.Status(), humanizeutil.IBytes(int64(targetRate)),
-		timeutil.Since(start).Seconds()*1000)
+		timeutil.Since(start).Seconds())
 
 	resp, err = stream.Recv()
 	if err != nil {


### PR DESCRIPTION
All applied cleanly.

Backport:
  * 1/1 commits from "storage: improve split-snapshot warning" (#32679)
  * 1/1 commits from "storage: improve snapshot info messages in log truncation" (#32672)
  * 1/1 commits from "storage: add comment to replicaGC with pending split" (#32710)
  * 1/1 commits from "storage: print snapshot send duration as %.2f" (#32711)
  * 1/1 commits from "storage: print log message when blocked on snapshot semaphore" (#32712)

Please see individual PRs for details.

/cc @cockroachdb/release
