### PR TITLE
engine: add benchmark for scanning transactional data

### DIFF
--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -107,6 +107,18 @@ func BenchmarkMVCCReverseScan_RocksDB(b *testing.B) {
 	}
 }
 
+func BenchmarkMVCCScanTransactionalData_RocksDB(b *testing.B) {
+	ctx := context.Background()
+	runMVCCScan(ctx, b, setupMVCCRocksDB, benchScanOptions{
+		numRows: 10000,
+		benchDataOptions: benchDataOptions{
+			numVersions:   2,
+			valueBytes:    8,
+			transactional: true,
+		},
+	})
+}
+
 func BenchmarkMVCCGet_RocksDB(b *testing.B) {
 	ctx := context.Background()
 	for _, numVersions := range []int{1, 10, 100} {


### PR DESCRIPTION
This benchmark will allow us to evaluate the true effect of something like #32391, which fixes the TBI bug by changing how we write and resolve intents.

--

Data written by transactions often involves leaving an intent, which notably results in RocksDB tombstones when the intent is later resolved. This has a noticeable effect on scan performance. 

Add a low-level scan benchmark that loads data by leaving and resolving intents so that this effect can be measured. 

Benchmark results included below. 

    BenchmarkMVCCScan_RocksDB/rows=10000/versions=2/valueSize=8-8         	     500	   2739607 ns/op	  29.20 MB/s
    BenchmarkMVCCScan_RocksDB/rows=10000/versions=2/valueSize=8-8         	     500	   2708700 ns/op	  29.53 MB/s
    BenchmarkMVCCScan_RocksDB/rows=10000/versions=2/valueSize=8-8         	     500	   2766667 ns/op	  28.92 MB/s
    BenchmarkMVCCScan_RocksDB/rows=10000/versions=2/valueSize=8-8         	     500	   2734249 ns/op	  29.26 MB/s
    BenchmarkMVCCScan_RocksDB/rows=10000/versions=2/valueSize=8-8         	     500	   2707341 ns/op	  29.55 MB/s


    BenchmarkMVCCScanTransactionalData_RocksDB-8   	     300	   4649502 ns/op	  17.21 MB/s
    BenchmarkMVCCScanTransactionalData_RocksDB-8   	     300	   4705422 ns/op	  17.00 MB/s
    BenchmarkMVCCScanTransactionalData_RocksDB-8   	     300	   4779081 ns/op	  16.74 MB/s
    BenchmarkMVCCScanTransactionalData_RocksDB-8   	     300	   4587257 ns/op	  17.44 MB/s
    BenchmarkMVCCScanTransactionalData_RocksDB-8   	     300	   4848584 ns/op	  16.50 MB/s


    old time/op    new time/op    delta
    2.73ms ± 1%    4.71ms ± 3%  +72.59%  (p=0.008 n=5+5)


    old speed      new speed      delta
    29.3MB/s ± 1%  17.0MB/s ± 3%  -42.04%  (p=0.008 n=5+5)


Release note: None 
