### PR TITLE
opt: remove temporary fix for column ordering groups issue

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -765,13 +765,11 @@ CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z,y))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyz WHERE z=1 AND x=y ORDER BY x;
 ----
-sort                  ·       ·                (x, y, z)              +x
- │                    order   +x               ·                      ·
- └── filter           ·       ·                (x, y, z)              ·
-      │               filter  x = y            ·                      ·
-      └── index-join  ·       ·                (x, y, z)              ·
-           ├── scan   ·       ·                (y, z, rowid[hidden])  ·
-           │          table   xyz@xyz_z_y_idx  ·                      ·
-           │          spans   /1/!NULL-/2      ·                      ·
-           └── scan   ·       ·                (x, y, z)              ·
-·                     table   xyz@primary      ·                      ·
+filter           ·       ·                (x, y, z)              +y
+ │               filter  x = y            ·                      ·
+ └── index-join  ·       ·                (x, y, z)              +y
+      ├── scan   ·       ·                (y, z, rowid[hidden])  +y
+      │          table   xyz@xyz_z_y_idx  ·                      ·
+      │          spans   /1/!NULL-/2      ·                      ·
+      └── scan   ·       ·                (x, y, z)              ·
+·                table   xyz@primary      ·                      ·

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -924,7 +924,7 @@ select
  │    │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(2,4)
- │    │    │    └── ordering: +1
+ │    │    │    └── ordering: +(1|2) [provided: +1]
  │    │    └── filters
  │    │         └── i = k [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
  │    └── aggregations

--- a/pkg/sql/opt/ordering/select.go
+++ b/pkg/sql/opt/ordering/select.go
@@ -17,7 +17,6 @@ package ordering
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
@@ -32,32 +31,7 @@ func selectBuildChildReqOrdering(
 	if childIdx != 0 {
 		return physical.OrderingChoice{}
 	}
-	return trimColumnGroups(required, &parent.(*memo.SelectExpr).Input.Relational().FuncDeps)
-}
-
-// trimColumnGroups removes columns from ColumnOrderingChoice groups as
-// necessary, so that all columns in each group are equivalent according to
-// the given FDs. It is used when the parent expression can have column
-// equivalences that the input expression does not (for example a Select with an
-// equality condition); the columns in a group must be equivalent at the level
-// of the operator where the ordering is required.
-func trimColumnGroups(
-	required *physical.OrderingChoice, fds *props.FuncDepSet,
-) physical.OrderingChoice {
-	res := *required
-	copied := false
-	for i := range res.Columns {
-		c := &res.Columns[i]
-		eqGroup := fds.ComputeEquivGroup(c.AnyID())
-		if !c.Group.SubsetOf(eqGroup) {
-			if !copied {
-				res = res.Copy()
-				copied = true
-			}
-			res.Columns[i].Group = c.Group.Intersection(eqGroup)
-		}
-	}
-	return res
+	return *required
 }
 
 func selectBuildProvided(expr memo.RelExpr, required *physical.OrderingChoice) opt.Ordering {

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -861,13 +861,13 @@ memo (optimized, ~8KB, required=[presentation: array_agg:5])
  ├── G3: (projections)
  ├── G4: (select G6 G7) (select G8 G7) (select G9 G7)
  │    ├── [ordering: +(2|3) opt(4)]
- │    │    ├── best: (select G8="[ordering: +2 opt(4)]" G7)
+ │    │    ├── best: (select G8="[ordering: +(2|3) opt(4)]" G7)
  │    │    └── cost: 1079.12
  │    ├── [ordering: +(2|3),+4]
- │    │    ├── best: (sort G4)
- │    │    └── cost: 1080.04
+ │    │    ├── best: (select G9="[ordering: +(2|3),+4]" G7)
+ │    │    └── cost: 1079.12
  │    ├── [ordering: +(2|3)]
- │    │    ├── best: (select G8="[ordering: +2]" G7)
+ │    │    ├── best: (select G8="[ordering: +(2|3)]" G7)
  │    │    └── cost: 1079.12
  │    ├── [ordering: +4,+(2|3)]
  │    │    ├── best: (sort G4)
@@ -877,49 +877,49 @@ memo (optimized, ~8KB, required=[presentation: array_agg:5])
  │         └── cost: 1079.12
  ├── G5: (aggregations G10)
  ├── G6: (scan kuvw) (scan kuvw@uvw) (scan kuvw@wvu) (scan kuvw@vw) (scan kuvw@w)
- │    ├── [ordering: +2 opt(4)]
+ │    ├── [ordering: +(2|3) opt(4)]
  │    │    ├── best: (scan kuvw@uvw)
  │    │    └── cost: 1080.01
- │    ├── [ordering: +2,+4]
- │    │    ├── best: (sort G6)
- │    │    └── cost: 1310.30
- │    ├── [ordering: +2]
+ │    ├── [ordering: +(2|3),+4]
+ │    │    ├── best: (scan kuvw@vw)
+ │    │    └── cost: 1080.01
+ │    ├── [ordering: +(2|3)]
  │    │    ├── best: (scan kuvw@uvw)
  │    │    └── cost: 1080.01
- │    ├── [ordering: +4,+2]
- │    │    ├── best: (sort G6)
- │    │    └── cost: 1310.30
+ │    ├── [ordering: +4,+(2|3)]
+ │    │    ├── best: (scan kuvw@wvu)
+ │    │    └── cost: 1080.01
  │    └── []
  │         ├── best: (scan kuvw)
  │         └── cost: 1080.01
  ├── G7: (filters G11)
  ├── G8: (scan kuvw@uvw,constrained)
- │    ├── [ordering: +2 opt(4)]
+ │    ├── [ordering: +(2|3) opt(4)]
  │    │    ├── best: (scan kuvw@uvw,constrained)
  │    │    └── cost: 1069.21
- │    ├── [ordering: +2,+4]
+ │    ├── [ordering: +(2|3),+4]
  │    │    ├── best: (sort G8)
  │    │    └── cost: 1296.90
- │    ├── [ordering: +2]
+ │    ├── [ordering: +(2|3)]
  │    │    ├── best: (scan kuvw@uvw,constrained)
  │    │    └── cost: 1069.21
- │    ├── [ordering: +4,+2]
+ │    ├── [ordering: +4,+(2|3)]
  │    │    ├── best: (sort G8)
  │    │    └── cost: 1296.90
  │    └── []
  │         ├── best: (scan kuvw@uvw,constrained)
  │         └── cost: 1069.21
  ├── G9: (scan kuvw@vw,constrained)
- │    ├── [ordering: +2 opt(4)]
- │    │    ├── best: (sort G9)
- │    │    └── cost: 1286.06
- │    ├── [ordering: +2,+4]
- │    │    ├── best: (sort G9)
- │    │    └── cost: 1296.90
- │    ├── [ordering: +2]
- │    │    ├── best: (sort G9)
- │    │    └── cost: 1286.06
- │    ├── [ordering: +4,+2]
+ │    ├── [ordering: +(2|3) opt(4)]
+ │    │    ├── best: (scan kuvw@vw,constrained)
+ │    │    └── cost: 1069.21
+ │    ├── [ordering: +(2|3),+4]
+ │    │    ├── best: (scan kuvw@vw,constrained)
+ │    │    └── cost: 1069.21
+ │    ├── [ordering: +(2|3)]
+ │    │    ├── best: (scan kuvw@vw,constrained)
+ │    │    └── cost: 1069.21
+ │    ├── [ordering: +4,+(2|3)]
  │    │    ├── best: (sort G9)
  │    │    └── cost: 1296.90
  │    └── []
@@ -946,7 +946,7 @@ memo (optimized, ~8KB, required=[presentation: sum:5])
  ├── G3: (projections)
  ├── G4: (select G6 G7) (select G8 G7) (select G9 G7)
  │    ├── [ordering: +(2|3)]
- │    │    ├── best: (select G8="[ordering: +2]" G7)
+ │    │    ├── best: (select G8="[ordering: +(2|3)]" G7)
  │    │    └── cost: 1079.12
  │    ├── [ordering: +4]
  │    │    ├── best: (sort G4)
@@ -956,7 +956,7 @@ memo (optimized, ~8KB, required=[presentation: sum:5])
  │         └── cost: 1079.12
  ├── G5: (aggregations G10)
  ├── G6: (scan kuvw) (scan kuvw@uvw) (scan kuvw@wvu) (scan kuvw@vw) (scan kuvw@w)
- │    ├── [ordering: +2]
+ │    ├── [ordering: +(2|3)]
  │    │    ├── best: (scan kuvw@uvw)
  │    │    └── cost: 1080.01
  │    ├── [ordering: +4]
@@ -967,7 +967,7 @@ memo (optimized, ~8KB, required=[presentation: sum:5])
  │         └── cost: 1080.01
  ├── G7: (filters G11)
  ├── G8: (scan kuvw@uvw,constrained)
- │    ├── [ordering: +2]
+ │    ├── [ordering: +(2|3)]
  │    │    ├── best: (scan kuvw@uvw,constrained)
  │    │    └── cost: 1069.21
  │    ├── [ordering: +4]
@@ -977,9 +977,9 @@ memo (optimized, ~8KB, required=[presentation: sum:5])
  │         ├── best: (scan kuvw@uvw,constrained)
  │         └── cost: 1069.21
  ├── G9: (scan kuvw@vw,constrained)
- │    ├── [ordering: +2]
- │    │    ├── best: (sort G9)
- │    │    └── cost: 1286.06
+ │    ├── [ordering: +(2|3)]
+ │    │    ├── best: (scan kuvw@vw,constrained)
+ │    │    └── cost: 1069.21
  │    ├── [ordering: +4]
  │    │    ├── best: (sort G9)
  │    │    └── cost: 1286.06


### PR DESCRIPTION
This reverts the fix made in #32190 which isn't necessary now that we
have provided orderings.

Release note: None