### PR TITLE
util: add version library, replace hashicorp/go-version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -827,14 +827,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ada37ea3db98b606d2b61577fbd87c0aabaa95e03b409033ebf58c6e5420b033"
-  name = "github.com/hashicorp/go-version"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "fc61389e27c71d120f87031ca8c88a3428f372dd"
-
-[[projects]]
-  branch = "master"
   digest = "1:e345ab0697f8f63d0ff3cc4c4c90fa470fa79c8d3c0b461a1d16df2f5b0c1fd1"
   name = "github.com/ianlancetaylor/cgosymbolizer"
   packages = ["."]
@@ -1755,7 +1747,6 @@
     "github.com/grpc-ecosystem/grpc-gateway/runtime",
     "github.com/grpc-ecosystem/grpc-gateway/utilities",
     "github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc",
-    "github.com/hashicorp/go-version",
     "github.com/jackc/pgx",
     "github.com/jackc/pgx/pgproto3",
     "github.com/jackc/pgx/pgtype",

--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	version "github.com/hashicorp/go-version"
+	"github.com/cockroachdb/cockroach/pkg/util/version"
 )
 
 // TimeFormat is the reference format for build.Time. Make sure it stays in sync
@@ -55,12 +55,11 @@ func SeemsOfficial() bool {
 
 // VersionPrefix returns the version prefix of the current build.
 func VersionPrefix() string {
-	v, err := version.NewVersion(tag)
+	v, err := version.Parse(tag)
 	if err != nil {
 		return "dev"
 	}
-	semVer := v.Segments()[:2]
-	return fmt.Sprintf("v%d.%d", semVer[0], semVer[1])
+	return fmt.Sprintf("v%d.%d", v.Major(), v.Minor())
 }
 
 func init() {

--- a/pkg/ccl/cliccl/main_test.go
+++ b/pkg/ccl/cliccl/main_test.go
@@ -21,7 +21,7 @@ import (
 func TestMain(m *testing.M) {
 	// CLI tests are sensitive to the server version, but test binaries don't have
 	// a version injected. Pretend to be a very up-to-date version.
-	defer build.TestingOverrideTag("v999")()
+	defer build.TestingOverrideTag("v999.0.0")()
 
 	defer utilccl.TestingEnableEnterprise()()
 	serverutils.InitTestServerFactory(server.TestServerFactory)

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
+	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -46,6 +47,10 @@ is omitted, dump all tables in the database.
 	RunE: MaybeDecorateGRPCError(runDump),
 }
 
+// We accept versions that are strictly newer than v2.1.0-alpha.20180416
+// (hence the "-0" at the end).
+var verDump = version.MustParse("v2.1.0-alpha.20180416-0")
+
 // runDumps performs a dump of a table or database.
 //
 // The approach here and its current flaws are summarized
@@ -57,7 +62,7 @@ func runDump(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 
-	if err := conn.requireServerVersion(">v2.1.0-alpha.20180416"); err != nil {
+	if err := conn.requireServerVersion(verDump); err != nil {
 		return err
 	}
 

--- a/pkg/cli/interactive_tests/test_version_reporting.tcl
+++ b/pkg/cli/interactive_tests/test_version_reporting.tcl
@@ -68,9 +68,9 @@ eexpect eof
 stop_server $argv
 
 start_test "Check that the client picks up a new server version, and warns about lower versions."
-set env(COCKROACH_TESTING_VERSION_TAG) "v0.1-fakever"
+set env(COCKROACH_TESTING_VERSION_TAG) "v0.1.0-fakever"
 start_server $argv
-set env(COCKROACH_TESTING_VERSION_TAG) "v0.2-fakever"
+set env(COCKROACH_TESTING_VERSION_TAG) "v0.2.0-fakever"
 spawn $argv sql
 send "select 1;\r"
 eexpect "# Client version: CockroachDB"

--- a/pkg/cli/main_test.go
+++ b/pkg/cli/main_test.go
@@ -32,7 +32,7 @@ func init() {
 func TestMain(m *testing.M) {
 	// CLI tests are sensitive to the server version, but test binaries don't have
 	// a version injected. Pretend to be a very up-to-date version.
-	defer build.TestingOverrideTag("v999")()
+	defer build.TestingOverrideTag("v999.0.0")()
 
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	os.Exit(m.Run())

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/lib/pq"
 	"github.com/spf13/cobra"
 )
@@ -36,6 +37,10 @@ Fetches and displays the user for <username>.
 	RunE: MaybeDecorateGRPCError(runGetUser),
 }
 
+var verGetUser = version.MustParse("v2.0.0-alpha.20180116")
+var verRmUser = version.MustParse("v1.1.0-alpha.20170622")
+var verSetUser = version.MustParse("v1.2.0-alpha.20171113")
+
 func runGetUser(cmd *cobra.Command, args []string) error {
 	conn, err := getPasswordAndMakeSQLClient("cockroach user")
 	if err != nil {
@@ -45,7 +50,7 @@ func runGetUser(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v2.0-alpha.20180116"); err != nil {
+	if err := conn.requireServerVersion(verGetUser); err != nil {
 		return err
 	}
 	return runQueryAndFormatResults(conn, os.Stdout,
@@ -97,7 +102,7 @@ func runRmUser(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v1.1-alpha.20170622"); err != nil {
+	if err := conn.requireServerVersion(verRmUser); err != nil {
 		return err
 	}
 	return runQueryAndFormatResults(conn, os.Stdout,
@@ -143,7 +148,7 @@ func runSetUser(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v1.2-alpha.20171113"); err != nil {
+	if err := conn.requireServerVersion(verSetUser); err != nil {
 		return err
 	}
 

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -25,10 +25,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/spf13/cobra"
 )
 
 type runQueryRawFn func(q string, parameters ...driver.Value) ([]string, [][]string, error)
+
+var verZones = version.MustParse("v1.2.0-alpha.20171026")
 
 // runQueryRawMaybeExperimental tries to run the query without the
 // experimental keyword, and if that fails with a syntax error, with
@@ -82,7 +85,7 @@ func runGetZone(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v1.2-alpha.20171026"); err != nil {
+	if err := conn.requireServerVersion(verZones); err != nil {
 		return err
 	}
 
@@ -141,7 +144,7 @@ func runLsZones(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v1.2-alpha.20171026"); err != nil {
+	if err := conn.requireServerVersion(verZones); err != nil {
 		return err
 	}
 
@@ -195,7 +198,7 @@ func runRmZone(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v1.2-alpha.20171026"); err != nil {
+	if err := conn.requireServerVersion(verZones); err != nil {
 		return err
 	}
 
@@ -274,7 +277,7 @@ func runSetZone(cmd *cobra.Command, args []string) error {
 	// NOTE: We too aggressively broke backwards compatibility in this command.
 	// Future changes should maintain compatibility with the last two released
 	// versions of CockroachDB.
-	if err := conn.requireServerVersion(">=v1.2-alpha.20171026"); err != nil {
+	if err := conn.requireServerVersion(verZones); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/google/go-github/github"
-	version "github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 )
@@ -161,17 +161,13 @@ func getProbableMilestone(
 		return nil
 	}
 
-	v, err := version.NewVersion(tag)
+	v, err := version.Parse(tag)
 	if err != nil {
 		log.Printf("unable to parse version from tag: %s", err)
 		log.Printf("issues will be posted without milestone")
 		return nil
 	}
-	if len(v.Segments()) < 2 {
-		log.Printf("version %s has less than two components; issues will be posted without milestone", tag)
-		return nil
-	}
-	vstring := fmt.Sprintf("%d.%d", v.Segments()[0], v.Segments()[1])
+	vstring := fmt.Sprintf("%d.%d", v.Major(), v.Minor())
 
 	milestones, _, err := listMilestones(ctx, githubUser, githubRepo, &github.MilestoneListOptions{
 		State: "open",

--- a/pkg/cmd/internal/issues/issues_test.go
+++ b/pkg/cmd/internal/issues/issues_test.go
@@ -246,7 +246,7 @@ Failed test: %s`,
 					}, nil, nil
 				}
 
-				p.getLatestTag = func() (string, error) { return "3.3", nil }
+				p.getLatestTag = func() (string, error) { return "v3.3.0", nil }
 
 				p.init()
 

--- a/pkg/cmd/publish-artifacts/main.go
+++ b/pkg/cmd/publish-artifacts/main.go
@@ -35,7 +35,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	version "github.com/hashicorp/go-version"
+	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/kr/pretty"
 )
 
@@ -110,13 +110,13 @@ func main() {
 	var versionStr string
 	var isStableRelease bool
 	if *isRelease {
-		ver, err := version.NewVersion(branch)
+		ver, err := version.Parse(branch)
 		if err != nil {
 			log.Fatalf("refusing to build release with invalid version name '%s' (err: %s)", branch, err)
 		}
 
 		// Prerelease returns anything after the `-` and before metadata. eg: `beta` for `1.0.1-beta+metadata`
-		if ver.Prerelease() == "" {
+		if ver.PreRelease() == "" {
 			isStableRelease = true
 		}
 		versionStr = branch

--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/hashicorp/go-version"
+	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/pkg/errors"
 )
 
@@ -100,11 +100,7 @@ func getCockroachVersion(c *SyncedCluster, i int) (*version.Version, error) {
 		return nil, fmt.Errorf("unable to parse cockroach version output:%s", out)
 	}
 
-	version, err := version.NewVersion(string(matches[1]))
-	if err != nil {
-		return nil, err
-	}
-	return version, nil
+	return version.Parse(string(matches[1]))
 }
 
 // GetAdminUIPort returns the admin UI port for ths specified RPC port.
@@ -320,7 +316,7 @@ tar cvf certs.tar certs
 		}
 		args = append(args, "--log-dir="+logDir)
 		args = append(args, "--background")
-		if VersionSatifies(vers, ">=1.1") {
+		if vers.AtLeast(version.MustParse("v1.1.0")) {
 			cache := 25
 			if c.IsLocal() {
 				cache /= len(nodes)
@@ -333,7 +329,7 @@ tar cvf certs.tar certs
 		}
 		if c.IsLocal() {
 			// This avoids annoying firewall prompts on Mac OS X.
-			if VersionSatifies(vers, ">=2.1") {
+			if vers.AtLeast(version.MustParse("v2.1.0")) {
 				args = append(args, "--listen-addr=127.0.0.1")
 			} else {
 				args = append(args, "--host=127.0.0.1")

--- a/pkg/cmd/roachprod/install/install.go
+++ b/pkg/cmd/roachprod/install/install.go
@@ -19,8 +19,6 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-
-	"github.com/hashicorp/go-version"
 )
 
 // Clusters memoizes cluster info for install operations
@@ -188,13 +186,4 @@ func Install(c *SyncedCluster, args []string) error {
 		}
 	}
 	return nil
-}
-
-// VersionSatifies TODO(peter): document
-func VersionSatifies(v *version.Version, constraintString string) bool {
-	constraints, err := version.NewConstraint(constraintString)
-	if err != nil {
-		panic(err)
-	}
-	return constraints.Check(v)
 }

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -319,7 +319,7 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 func registerCDC(r *registry) {
 	r.Add(testSpec{
 		Name:       "cdc/tpcc-1000",
-		MinVersion: "2.1.0",
+		MinVersion: "v2.1.0",
 		Nodes:      nodes(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -335,7 +335,7 @@ func registerCDC(r *registry) {
 	})
 	r.Add(testSpec{
 		Name:       "cdc/initial-scan",
-		MinVersion: "2.1.0",
+		MinVersion: "v2.1.0",
 		Nodes:      nodes(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -352,7 +352,7 @@ func registerCDC(r *registry) {
 	r.Add(testSpec{
 		Name:       "cdc/rangefeed-unstable",
 		Skip:       `resolved timestamps are not yet reliable with RangeFeed`,
-		MinVersion: "2.2.0",
+		MinVersion: "v2.2.0",
 		Nodes:      nodes(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -369,7 +369,7 @@ func registerCDC(r *registry) {
 	})
 	r.Add(testSpec{
 		Name:       "cdc/sink-chaos",
-		MinVersion: "2.1.0",
+		MinVersion: "v2.1.0",
 		Nodes:      nodes(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -385,7 +385,7 @@ func registerCDC(r *registry) {
 	})
 	r.Add(testSpec{
 		Name:       "cdc/crdb-chaos",
-		MinVersion: "2.1.0",
+		MinVersion: "v2.1.0",
 		Nodes:      nodes(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
@@ -402,7 +402,7 @@ func registerCDC(r *registry) {
 	})
 	r.Add(testSpec{
 		Name:       "cdc/ledger",
-		MinVersion: "2.1.0",
+		MinVersion: "v2.1.0",
 		// TODO(mrtracy): This workload is designed to be running on a 20CPU nodes,
 		// but this cannot be allocated without some sort of configuration outside
 		// of this test. Look into it.
@@ -428,7 +428,7 @@ func registerCDC(r *registry) {
 	// without potentially leaking secrets.
 	r.Add(testSpec{
 		Name:       "cdc/bank",
-		MinVersion: "2.1.0",
+		MinVersion: "v2.1.0",
 		Nodes:      nodes(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCDCBank(ctx, t, c)

--- a/pkg/cmd/roachtest/disk_space.go
+++ b/pkg/cmd/roachtest/disk_space.go
@@ -319,7 +319,7 @@ func registerDiskUsage(r *registry) {
 			testSpec{
 				Name:       fmt.Sprintf("disk_space/tc=%s", testCase.name),
 				Nodes:      nodes(numNodes),
-				MinVersion: "2.1", // cockroach debug ballast
+				MinVersion: "v2.1.0", // cockroach debug ballast
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					if local {
 						duration = 30 * time.Minute

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -56,9 +56,9 @@ func registerKV(r *registry) {
 		for _, n := range []int{1, 3} {
 			for _, e := range []bool{false, true} {
 				e := e
-				minVersion := "2.0.0"
+				minVersion := "v2.0.0"
 				if e {
-					minVersion = "2.1.0"
+					minVersion = "v2.1.0"
 				}
 				r.Add(testSpec{
 					Name:       fmt.Sprintf("kv%d/encrypt=%t/nodes=%d", p, e, n),
@@ -77,7 +77,7 @@ func registerKVQuiescenceDead(r *registry) {
 	r.Add(testSpec{
 		Name:       "kv/quiescence/nodes=3",
 		Nodes:      nodes(4),
-		MinVersion: "2.1.0",
+		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if !c.isLocal() {
 				c.RemountNoBarrier(ctx)

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -138,7 +138,7 @@ func registerRebalanceLoad(r *registry) {
 	r.Add(testSpec{
 		Name:       `rebalance-leases-by-load`,
 		Nodes:      nodes(4), // the last node is just used to generate load
-		MinVersion: "2.1.0",
+		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {
 				concurrency = 32
@@ -150,7 +150,7 @@ func registerRebalanceLoad(r *registry) {
 	r.Add(testSpec{
 		Name:       `rebalance-replicas-by-load`,
 		Nodes:      nodes(7), // the last node is just used to generate load
-		MinVersion: "2.1.0",
+		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {
 				concurrency = 32

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -47,7 +47,7 @@ func registerLoadSplits(r *registry) {
 
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("splits/load/uniform/nodes=%d", numNodes),
-		MinVersion: "2.2.0",
+		MinVersion: "v2.2.0",
 		Nodes:      nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			// After load based splitting is turned on, from experiments
@@ -85,7 +85,7 @@ func registerLoadSplits(r *registry) {
 	})
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("splits/load/sequential/nodes=%d", numNodes),
-		MinVersion: "2.2.0",
+		MinVersion: "v2.2.0",
 		Nodes:      nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
@@ -102,7 +102,7 @@ func registerLoadSplits(r *registry) {
 	})
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("splits/load/spanning/nodes=%d", numNodes),
-		MinVersion: "2.2.0",
+		MinVersion: "v2.2.0",
 		Nodes:      nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runLoadSplits(ctx, t, c, splitParams{

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -109,7 +109,7 @@ func registerSQLsmith(r *registry) {
 	r.Add(testSpec{
 		Name:       "sqlsmith",
 		Nodes:      nodes(1),
-		MinVersion: "2.2.0",
+		MinVersion: "v2.2.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runSQLsmith(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -370,7 +370,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 				MinVersion: "v2.1.0-foo",
 				Run:        dummyRun,
 			},
-			regexp.QuoteMeta(`invalid version 2.1.0-foo, cannot specify a prerelease (-xxx)`),
+			regexp.QuoteMeta(`invalid version v2.1.0-foo, cannot specify a prerelease (-xxx)`),
 			nil,
 		},
 		{
@@ -379,7 +379,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 				MinVersion: "foo",
 				Run:        dummyRun,
 			},
-			"a: unable to parse min-version: foo",
+			"a: unable to parse min-version: invalid version string 'foo'",
 			nil,
 		},
 		{
@@ -419,9 +419,9 @@ func TestRegistryMinVersion(t *testing.T) {
 		expectedA    bool
 		expectedB    bool
 	}{
-		{"1.1.0", false, false},
-		{"2.0.0", true, false},
-		{"2.1.0", true, true},
+		{"v1.1.0", false, false},
+		{"v2.0.0", true, false},
+		{"v2.1.0", true, true},
 	}
 	for _, c := range testCases {
 		t.Run(c.buildVersion, func(t *testing.T) {
@@ -431,14 +431,14 @@ func TestRegistryMinVersion(t *testing.T) {
 			r.out = &buf
 			r.Add(testSpec{
 				Name:       "a",
-				MinVersion: "2.0.0",
+				MinVersion: "v2.0.0",
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runA = true
 				},
 			})
 			r.Add(testSpec{
 				Name:       "b",
-				MinVersion: "2.1.0",
+				MinVersion: "v2.1.0",
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runB = true
 				},

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -129,7 +129,7 @@ func registerTPCC(r *registry) {
 		// TODO(dan): Instead of MinVersion, adjust the warehouses below to
 		// match our expectation for the max tpcc warehouses that previous
 		// releases will support on this hardware.
-		MinVersion: "2.1.0",
+		MinVersion: "v2.1.0",
 		Nodes:      nodes(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			warehouses := 1400

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -1,0 +1,238 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Version represents a semantic version; see
+// https://semver.org/spec/v2.0.0.html.
+type Version struct {
+	major      int32
+	minor      int32
+	patch      int32
+	preRelease string
+	metadata   string
+}
+
+// Major returns the major (first) version number.
+func (v *Version) Major() int {
+	return int(v.major)
+}
+
+// Minor returns the minor (second) version number.
+func (v *Version) Minor() int {
+	return int(v.minor)
+}
+
+// Patch returns the patch (third) version number.
+func (v *Version) Patch() int {
+	return int(v.patch)
+}
+
+// PreRelease returns the pre-release version (if present).
+func (v *Version) PreRelease() string {
+	return v.preRelease
+}
+
+// Metadata returns the metadata (if present).
+func (v *Version) Metadata() string {
+	return v.metadata
+}
+
+// String returns the string representation, in the format:
+//   "v1.2.3-beta+md"
+func (v Version) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "v%d.%d.%d", v.major, v.minor, v.patch)
+	if v.preRelease != "" {
+		fmt.Fprintf(&b, "-%s", v.preRelease)
+	}
+	if v.metadata != "" {
+		fmt.Fprintf(&b, "+%s", v.metadata)
+	}
+	return b.String()
+}
+
+// versionRE is the regexp that is used to verify that a version string is
+// of the form "vMAJOR.MINOR.PATCH[-PRERELEASE][+METADATA]". This
+// conforms to https://semver.org/spec/v2.0.0.html
+var versionRE = regexp.MustCompile(
+	`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-.]+)?(\+[0-9A-Za-z-.]+|)?$`,
+	// ^major           ^minor           ^patch         ^preRelease       ^metadata
+)
+
+// numericRE is the regexp used to check if an identifier is numeric.
+var numericRE = regexp.MustCompile(`^(0|[1-9][0-9]*)$`)
+
+// Parse creates a version from a string. The string must be a valid semantic
+// version (as per https://semver.org/spec/v2.0.0.html) in the format:
+//   "vMINOR.MAJOR.PATCH[-PRERELEASE][+METADATA]".
+// MINOR, MAJOR, and PATCH are numeric values (without any leading 0s).
+// PRERELEASE and METADATA can contain ASCII characters and digits, hyphens and
+// dots.
+func Parse(str string) (*Version, error) {
+	if !versionRE.MatchString(str) {
+		return nil, errors.Errorf("invalid version string '%s'", str)
+	}
+
+	var v Version
+	r := strings.NewReader(str)
+	// Read the major.minor.patch part.
+	_, err := fmt.Fscanf(r, "v%d.%d.%d", &v.major, &v.minor, &v.patch)
+	if err != nil {
+		panic(fmt.Sprintf("invalid version '%s' passed the regex: %s", str, err))
+	}
+	remaining := str[len(str)-r.Len():]
+	// Read the pre-release, if present.
+	if len(remaining) > 0 && remaining[0] == '-' {
+		p := strings.IndexRune(remaining, '+')
+		if p == -1 {
+			p = len(remaining)
+		}
+		v.preRelease = remaining[1:p]
+		remaining = remaining[p:]
+	}
+	// Read the metadata, if present.
+	if len(remaining) > 0 {
+		if remaining[0] != '+' {
+			panic(fmt.Sprintf("invalid version '%s' passed the regex", str))
+		}
+		v.metadata = remaining[1:]
+	}
+	return &v, nil
+}
+
+// MustParse is like Parse but panics on any error. Recommended as an
+// initializer for global values.
+func MustParse(str string) *Version {
+	v, err := Parse(str)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func cmpVal(a, b int32) int {
+	if a > b {
+		return +1
+	}
+	if a < b {
+		return -1
+	}
+	return 0
+}
+
+// Compare returns -1, 0, or +1 indicating the relative ordering of versions.
+func (v *Version) Compare(w *Version) int {
+	if v := cmpVal(v.major, w.major); v != 0 {
+		return v
+	}
+	if v := cmpVal(v.minor, w.minor); v != 0 {
+		return v
+	}
+	if v := cmpVal(v.patch, w.patch); v != 0 {
+		return v
+	}
+	if v.preRelease != w.preRelease {
+		if v.preRelease == "" && w.preRelease != "" {
+			// 1.0.0 is greater than 1.0.0-alpha.
+			return 1
+		}
+		if v.preRelease != "" && w.preRelease == "" {
+			// 1.0.0-alpha is less than 1.0.0.
+			return -1
+		}
+
+		// Quoting from https://semver.org/spec/v2.0.0.html:
+		//   Precedence for two pre-release versions with the same major, minor, and
+		//   patch version MUST be determined by comparing each dot separated
+		//   identifier from left to right until a difference is found as follows:
+		//    (1) Identifiers consisting of only digits are compared numerically.
+		//    (2) identifiers with letters or hyphens are compared lexically in ASCII
+		//        sort order.
+		//    (3) Numeric identifiers always have lower precedence than non-numeric
+		//        identifiers.
+		//    (4) A larger set of pre-release fields has a higher precedence than a
+		//        smaller set, if all of the preceding identifiers are equal.
+		//
+		vs := strings.Split(v.preRelease, ".")
+		ws := strings.Split(w.preRelease, ".")
+		for ; len(vs) > 0 && len(ws) > 0; vs, ws = vs[1:], ws[1:] {
+			vStr, wStr := vs[0], ws[0]
+			if vStr == wStr {
+				continue
+			}
+			vNumeric := numericRE.MatchString(vStr)
+			wNumeric := numericRE.MatchString(wStr)
+			switch {
+			case vNumeric && wNumeric:
+				// Case 1.
+				vVal, err := strconv.Atoi(vStr)
+				if err != nil {
+					panic(err)
+				}
+				wVal, err := strconv.Atoi(wStr)
+				if err != nil {
+					panic(err)
+				}
+				if vVal == wVal {
+					panic("different strings yield the same numbers")
+				}
+				if vVal < wVal {
+					return -1
+				}
+				return 1
+
+			case vNumeric:
+				// Case 3.
+				return -1
+
+			case wNumeric:
+				// Case 3.
+				return 1
+
+			default:
+				// Case 2.
+				if vStr < wStr {
+					return -1
+				}
+				return 1
+			}
+		}
+
+		if len(vs) > 0 {
+			// Case 4.
+			return +1
+		}
+		if len(ws) > 0 {
+			// Case 4.
+			return -1
+		}
+	}
+
+	return 0
+}
+
+// AtLeast returns true if v >= w.
+func (v *Version) AtLeast(w *Version) bool {
+	return v.Compare(w) > 0
+}

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -1,0 +1,181 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetters(t *testing.T) {
+	v, err := Parse("v1.2.3-beta+md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	str := fmt.Sprintf(
+		"%d %d %d %s %s", v.Major(), v.Minor(), v.Patch(), v.PreRelease(), v.Metadata(),
+	)
+	exp := "1 2 3 beta md"
+	if str != exp {
+		t.Errorf("got '%s', expected '%s'", str, exp)
+	}
+}
+
+func TestValid(t *testing.T) {
+	testData := []string{
+		"v0.0.0",
+		"v0.0.1",
+		"v0.1.0",
+		"v1.0.0",
+		"v1.0.0-alpha",
+		"v1.0.0-beta.20190101",
+		"v1.0.0-rc1-with-hyphen",
+		"v1.0.0-rc2.dot.dot",
+		"v1.2.3+metadata",
+		"v1.2.3+metadata-with-hyphen",
+		"v1.2.3+metadata.with.dots",
+		"v1.1.2-beta.20190101+metadata",
+		"v1.2.3-rc1-with-hyphen+metadata-with-hyphen",
+	}
+	for _, str := range testData {
+		v, err := Parse(str)
+		if err != nil {
+			t.Errorf("%s: %s", str, err)
+		}
+		if v.String() != str {
+			t.Errorf("%s roundtripped to %s", str, v.String())
+		}
+	}
+}
+
+func TestInvalid(t *testing.T) {
+	testData := []string{
+		"v1",
+		"v1.2",
+		"v1.2-beta",
+		"v1x2.3",
+		"v1.2x3",
+		"1.0.0",
+		" v1.0.0",
+		"v1.0.0  ",
+		"v1.2.beta",
+		"v1.2-beta",
+		"v1.2.3.beta",
+		"v1.2.3-beta$",
+		"v1.2.3-bet;a",
+		"v1.2.3+metadata%",
+		"v01.2.3",
+		"v1.02.3",
+		"v1.2.03",
+	}
+	for _, str := range testData {
+		if _, err := Parse(str); err == nil {
+			t.Errorf("expected error for %s", str)
+		}
+	}
+}
+
+func TestCompare(t *testing.T) {
+	testData := []struct {
+		a, b string
+		cmp  int
+	}{
+		{"v1.0.0", "v1.0.0", 0},
+		{"v1.0.0", "v1.0.1", -1},
+		{"v1.2.3", "v1.3.0", -1},
+		{"v1.2.3", "v2.0.0", -1},
+		{"v1.0.0+metadata", "v1.0.0", 0},
+		{"v1.0.0+metadata", "v1.0.0+other.metadata", 0},
+		{"v1.0.1+metadata", "v1.0.0+other.metadata", +1},
+		{"v1.0.0", "v1.0.0-alpha", +1},
+		{"v1.0.0", "v1.0.0-rc2", +1},
+		{"v1.0.0-alpha", "v1.0.0-beta", -1},
+		{"v1.0.0-beta", "v1.0.0-rc.2", -1},
+		{"v1.0.0-rc.2", "v1.0.0-rc.10", -1},
+		{"v1.0.1", "v1.0.0-alpha", +1},
+
+		// Tests below taken from coreos/go-semver, which carries the following
+		// copyright:
+		//
+		// Copyright 2013-2015 CoreOS, Inc.
+		// Copyright 2018 The Cockroach Authors.
+		//
+		// Licensed under the Apache License, Version 2.0 (the "License");
+		// you may not use this file except in compliance with the License.
+		// You may obtain a copy of the License at
+		//
+		//     http://www.apache.org/licenses/LICENSE-2.0
+		//
+		// Unless required by applicable law or agreed to in writing, software
+		// distributed under the License is distributed on an "AS IS" BASIS,
+		// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+		// See the License for the specific language governing permissions and
+		// limitations under the License.
+		{"v0.0.0", "v0.0.0-foo", +1},
+		{"v0.0.1", "v0.0.0", +1},
+		{"v1.0.0", "v0.9.9", +1},
+		{"v0.10.0", "v0.9.0", +1},
+		{"v0.99.0", "v0.10.0", +1},
+		{"v2.0.0", "v1.2.3", +1},
+		{"v0.0.0", "v0.0.0-foo", +1},
+		{"v0.0.1", "v0.0.0", +1},
+		{"v1.0.0", "v0.9.9", +1},
+		{"v0.10.0", "v0.9.0", +1},
+		{"v0.99.0", "v0.10.0", +1},
+		{"v2.0.0", "v1.2.3", +1},
+		{"v0.0.0", "v0.0.0-foo", +1},
+		{"v0.0.1", "v0.0.0", +1},
+		{"v1.0.0", "v0.9.9", +1},
+		{"v0.10.0", "v0.9.0", +1},
+		{"v0.99.0", "v0.10.0", +1},
+		{"v2.0.0", "v1.2.3", +1},
+		{"v1.2.3", "v1.2.3-asdf", +1},
+		{"v1.2.3", "v1.2.3-4", +1},
+		{"v1.2.3", "v1.2.3-4-foo", +1},
+		{"v1.2.3-5-foo", "v1.2.3-5", +1},
+		{"v1.2.3-5", "v1.2.3-4", +1},
+		{"v1.2.3-5-foo", "v1.2.3-5-Foo", +1},
+		{"v3.0.0", "v2.7.2+asdf", +1},
+		{"v3.0.0+foobar", "v2.7.2", +1},
+		{"v1.2.3-a.10", "v1.2.3-a.5", +1},
+		{"v1.2.3-a.b", "v1.2.3-a.5", +1},
+		{"v1.2.3-a.b", "v1.2.3-a", +1},
+		{"v1.2.3-a.b.c.10.d.5", "v1.2.3-a.b.c.5.d.100", +1},
+		{"v1.0.0", "v1.0.0-rc.1", +1},
+		{"v1.0.0-rc.2", "v1.0.0-rc.1", +1},
+		{"v1.0.0-rc.1", "v1.0.0-beta.11", +1},
+		{"v1.0.0-beta.11", "v1.0.0-beta.2", +1},
+		{"v1.0.0-beta.2", "v1.0.0-beta", +1},
+		{"v1.0.0-beta", "v1.0.0-alpha.beta", +1},
+		{"v1.0.0-alpha.beta", "v1.0.0-alpha.1", +1},
+		{"v1.0.0-alpha.1", "v1.0.0-alpha", +1},
+	}
+	for _, tc := range testData {
+		a, err := Parse(tc.a)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := Parse(tc.b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cmp := a.Compare(b); cmp != tc.cmp {
+			t.Errorf("'%s' vs '%s': expected %d, got %d", tc.a, tc.b, tc.cmp, cmp)
+		}
+		if cmp := b.Compare(a); cmp != -tc.cmp {
+			t.Errorf("'%s' vs '%s': expected %d, got %d", tc.b, tc.a, -tc.cmp, cmp)
+		}
+	}
+}


### PR DESCRIPTION
The go-version library has made changes that break our current usage.
The library does not conform with the semantic versioning standard and
the constraint interface is error-prone.

This change replaces uses of this library with a new implementation.

Release note: None