### PR TITLE
sql/sqlbase: memoize parsed, type checked computed col expressions

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -405,7 +405,7 @@ func (sc *SchemaChanger) distBackfill(
 			if backfillType == columnBackfill {
 				fkTables, err := row.TablesNeededForFKs(
 					ctx,
-					*tableDesc,
+					tableDesc,
 					row.CheckUpdates,
 					row.NoLookup,
 					row.NoCheckPrivilege,
@@ -597,7 +597,7 @@ func columnBackfillInTxn(
 	var otherTableDescs []*sqlbase.ImmutableTableDescriptor
 	fkTables, err := row.TablesNeededForFKs(
 		ctx,
-		*tableDesc,
+		tableDesc,
 		row.CheckUpdates,
 		row.NoLookup,
 		row.NoCheckPrivilege,

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -142,7 +142,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 ) (roachpb.Key, error) {
 	fkTables, _ := row.TablesNeededForFKs(
 		ctx,
-		*tableDesc,
+		tableDesc,
 		row.CheckUpdates,
 		row.NoLookup,
 		row.NoCheckPrivilege,

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -100,7 +100,7 @@ func (p *planner) Delete(
 	// Determine what are the foreign key tables that are involved in the deletion.
 	fkTables, err := row.TablesNeededForFKs(
 		ctx,
-		*desc,
+		desc,
 		row.CheckDeletes,
 		p.LookupTableByID,
 		p.CheckPrivilege,

--- a/pkg/sql/delete_test.go
+++ b/pkg/sql/delete_test.go
@@ -129,7 +129,7 @@ CREATE TABLE IF NOT EXISTS child_with_index(
 
 			fkTables, err := row.TablesNeededForFKs(
 				context.TODO(),
-				*pd,
+				pd,
 				row.CheckDeletes,
 				lookup,
 				row.NoCheckPrivilege,

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -113,7 +113,7 @@ func (p *planner) Insert(
 	}
 	fkTables, err := row.TablesNeededForFKs(
 		ctx,
-		*desc,
+		desc,
 		fkCheckType,
 		p.LookupTableByID,
 		p.CheckPrivilege,

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -154,7 +154,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 
-	var tables []sqlbase.ImmutableTableDescriptor
+	var tables []sqlbase.TableDescriptor
 	var expiration hlc.Timestamp
 	getLeases := func() {
 		for i := 0; i < 3; i++ {
@@ -165,7 +165,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 			if err != nil {
 				t.Fatal(err)
 			}
-			tables = append(tables, *table)
+			tables = append(tables, *table.TableDesc())
 			expiration = exp
 			if err := leaseManager.Release(table); err != nil {
 				t.Fatal(err)
@@ -221,7 +221,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	// without a lease.
 	ts.mu.Lock()
 	tableVersion := &tableVersionState{
-		ImmutableTableDescriptor: tables[0],
+		ImmutableTableDescriptor: *sqlbase.NewImmutableTableDescriptor(tables[0]),
 		expiration:               tables[5].ModificationTime,
 	}
 	ts.mu.active.insert(tableVersion)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -876,7 +876,7 @@ func (ef *execFactory) ConstructInsert(
 	// Determine the foreign key tables involved in the update.
 	fkTables, err := row.TablesNeededForFKs(
 		ef.planner.extendedEvalCtx.Context,
-		*tabDesc,
+		tabDesc,
 		row.CheckInserts,
 		ef.planner.LookupTableByID,
 		ef.planner.CheckPrivilege,
@@ -950,7 +950,7 @@ func (ef *execFactory) ConstructUpdate(
 	// Determine the foreign key tables involved in the update.
 	fkTables, err := row.TablesNeededForFKs(
 		ef.planner.extendedEvalCtx.Context,
-		*tabDesc,
+		tabDesc,
 		row.CheckUpdates,
 		ef.planner.LookupTableByID,
 		ef.planner.CheckPrivilege,

--- a/pkg/sql/row/fk.go
+++ b/pkg/sql/row/fk.go
@@ -180,7 +180,7 @@ func (q *tableLookupQueue) dequeue() (TableLookup, FKCheck, bool) {
 // CheckHelpers are required.
 func TablesNeededForFKs(
 	ctx context.Context,
-	table sqlbase.ImmutableTableDescriptor,
+	table *sqlbase.ImmutableTableDescriptor,
 	usage FKCheck,
 	lookup TableLookupFunction,
 	checkPrivilege CheckPrivilegeFunction,
@@ -194,7 +194,7 @@ func TablesNeededForFKs(
 		analyzeExpr:    analyzeExpr,
 	}
 	// Add the passed in table descriptor to the table lookup.
-	baseTableLookup := TableLookup{Table: &table}
+	baseTableLookup := TableLookup{Table: table}
 	if err := baseTableLookup.addCheckHelper(ctx, analyzeExpr); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/row/fk_test.go
+++ b/pkg/sql/row/fk_test.go
@@ -186,7 +186,7 @@ func TestTablesNeededForFKs(t *testing.T) {
 	test := func(t *testing.T, usage FKCheck, expectedIDs []ID) {
 		tableLookups, err := TablesNeededForFKs(
 			context.TODO(),
-			*xDesc,
+			xDesc,
 			usage,
 			lookup,
 			NoCheckPrivilege,

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/pkg/errors"
 )
 
@@ -134,6 +135,19 @@ type ImmutableTableDescriptor struct {
 	// are all set to nullable while column backfilling is still in
 	// progress, as mutation columns may have NULL values.
 	ReadableColumns []ColumnDescriptor
+
+	// This mutex is for holding values that are evaluated after this struct has
+	// been created. It is important that any writes to this struct after
+	// creation should be guarded by this lock as it may be shared between multiple
+	// goroutines.
+	mu struct {
+		syncutil.Mutex
+
+		computedColumns []ColumnDescriptor
+
+		// Kept in parallel with computedColumns.
+		computedExprs tree.TypedExprs
+	}
 }
 
 // InvalidMutationID is the uninitialised mutation id.

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -102,7 +102,7 @@ func (p *planner) Update(
 	// Determine what are the foreign key tables that are involved in the update.
 	fkTables, err := row.TablesNeededForFKs(
 		ctx,
-		*desc,
+		desc,
 		row.CheckUpdates,
 		p.LookupTableByID,
 		p.CheckPrivilege,


### PR DESCRIPTION
Parse and type check computed column expressions at most once for the
duration of the lease on the table version. Reuse the results in
subsequent write commands.

Release note (performance improvement): Inserts and updates on tables
with computed columns skips the parsing stage of the computed
expressions.