### PR TITLE
opt: Add SimplifyMutationOrdering rule for Update operator

### DIFF
--- a/pkg/sql/opt/norm/rules/ordering.opt
+++ b/pkg/sql/opt/norm/rules/ordering.opt
@@ -72,9 +72,9 @@
 # SimplifyMutationOrdering removes redundant columns from a mutation operator's
 # (Insert, Update, etc) input ordering.
 [SimplifyMutationOrdering, Normalize]
-(Insert
+(Insert | Update
     $input:*
     $mutationPrivate:* & (CanSimplifyMutationOrdering $input $mutationPrivate)
 )
 =>
-(Insert $input (SimplifyMutationOrdering $input $mutationPrivate))
+((OpName) $input (SimplifyMutationOrdering $input $mutationPrivate))

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -271,3 +271,33 @@ insert abcde
                 ├── const: 1 [type=int]
                 ├── y + 1 [type=int, outer=(7)]
                 └── const: 2 [type=int]
+
+opt expect=SimplifyMutationOrdering
+UPDATE abcde SET b=2 WHERE b=1 ORDER BY b, c
+----
+update abcde
+ ├── columns: <none>
+ ├── fetch columns: a:6(int) b:7(int) c:8(int) d:9(int) e:10(int)
+ ├── update-mapping:
+ │    └──  column11:11(int) => b:2(int)
+ ├── internal-ordering: +8 opt(7,11)
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── project
+      ├── columns: column11:11(int!null) a:6(int!null) b:7(int!null) c:8(int) d:9(int) e:10(int)
+      ├── key: (6)
+      ├── fd: ()-->(7,11), (6)-->(8-10), (7,8)~~>(6,9,10)
+      ├── ordering: +8 opt(7,11) [provided: +8]
+      ├── index-join abcde
+      │    ├── columns: a:6(int!null) b:7(int!null) c:8(int) d:9(int) e:10(int)
+      │    ├── key: (6)
+      │    ├── fd: ()-->(7), (6)-->(8-10), (7,8)~~>(6,9,10)
+      │    ├── ordering: +8 opt(7) [provided: +8]
+      │    └── scan abcde@bc
+      │         ├── columns: a:6(int!null) b:7(int!null) c:8(int)
+      │         ├── constraint: /7/8: [/1 - /1]
+      │         ├── key: (6)
+      │         ├── fd: ()-->(7), (6)-->(8), (7,8)~~>(6)
+      │         └── ordering: +8 opt(7) [provided: +8]
+      └── projections
+           └── const: 2 [type=int]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1310,10 +1310,10 @@ update abc
  ├── fetch columns: a:4(int!null) b:5(int) c:6(int!null)
  ├── update-mapping:
  │    └──  column7:7(int!null) => b:2(int)
- ├── internal-ordering: +5,+6
+ ├── internal-ordering: +5,+6 opt(7)
  └── sort
       ├── columns: a:4(int!null) b:5(int!null) c:6(int!null) column7:7(int!null)
-      ├── ordering: +5,+6
+      ├── ordering: +5,+6 opt(7)
       └── project
            ├── columns: column7:7(int!null) a:4(int!null) b:5(int!null) c:6(int!null)
            ├── scan abc
@@ -1335,14 +1335,14 @@ update abc
  │    ├──  column7:7(int!null) => a:1(int)
  │    ├──  column8:8(int!null) => b:2(int)
  │    └──  column9:9(int!null) => c:3(int)
- ├── internal-ordering: +6
+ ├── internal-ordering: +(5|6) opt(7-9)
  ├── side-effects, mutations
  ├── fd: ()-->(7-9)
  └── sort
       ├── columns: a:4(int!null) b:5(int!null) c:6(int!null) column7:7(int!null) column8:8(int!null) column9:9(int!null)
       ├── key: (4,6)
       ├── fd: ()-->(7-9), (5)==(6), (6)==(5)
-      ├── ordering: +6
+      ├── ordering: +(5|6) opt(7-9) [provided: +5]
       └── project
            ├── columns: column7:7(int!null) column8:8(int!null) column9:9(int!null) a:4(int!null) b:5(int!null) c:6(int!null)
            ├── key: (4,6)


### PR DESCRIPTION
Add Update to the list of operators that the SimplifyMutationOrdering
rule handles, so that the Update's internal ordering will be simplified.

Release note: None