### PR TITLE
opt: Remove types from mutation mappings

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/insert
+++ b/pkg/sql/opt/memo/testdata/logprops/insert
@@ -38,12 +38,12 @@ INSERT INTO abcde (a, b) SELECT y, y FROM xyz ORDER BY y, z
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  y:8(int) => a:1(int)
- │    ├──  y:8(int) => b:2(int)
- │    ├──  column10:10(int) => c:3(int)
- │    ├──  column13:13(int) => d:4(int)
- │    ├──  column11:11(int) => rowid:5(int)
- │    └──  column12:12(unknown) => e:6(int)
+ │    ├──  y:8 => a:1
+ │    ├──  y:8 => b:2
+ │    ├──  column10:10 => c:3
+ │    ├──  column13:13 => d:4
+ │    ├──  column11:11 => rowid:5
+ │    └──  column12:12 => e:6
  ├── internal-ordering: +8,+9
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
@@ -93,12 +93,12 @@ project
  └── insert abcde
       ├── columns: y:8(int!null) column10:10(int!null) column11:11(int!null) column13:13(int)
       ├── insert-mapping:
-      │    ├──  y:8(int!null) => a:1(int)
-      │    ├──  y:8(int!null) => b:2(int)
-      │    ├──  column10:10(int!null) => c:3(int)
-      │    ├──  column13:13(int) => d:4(int)
-      │    ├──  column11:11(int!null) => rowid:5(int)
-      │    └──  column12:12(unknown) => e:6(int)
+      │    ├──  y:8 => a:1
+      │    ├──  y:8 => b:2
+      │    ├──  column10:10 => c:3
+      │    ├──  column13:13 => d:4
+      │    ├──  column11:11 => rowid:5
+      │    └──  column12:12 => e:6
       ├── internal-ordering: +8,+9
       ├── side-effects, mutations
       ├── fd: ()-->(10), (8)-->(13)
@@ -143,12 +143,12 @@ INSERT INTO abcde (a, b) (VALUES (1, 2)) RETURNING *, rowid;
 insert abcde
  ├── columns: a:7(int!null) b:8(int) c:9(int!null) d:12(int) rowid:10(int!null)
  ├── insert-mapping:
- │    ├──  column1:7(int!null) => a:1(int)
- │    ├──  column2:8(int) => b:2(int)
- │    ├──  column9:9(int!null) => c:3(int)
- │    ├──  column12:12(int) => d:4(int)
- │    ├──  column10:10(int!null) => rowid:5(int)
- │    └──  column11:11(unknown) => e:6(int)
+ │    ├──  column1:7 => a:1
+ │    ├──  column2:8 => b:2
+ │    ├──  column9:9 => c:3
+ │    ├──  column12:12 => d:4
+ │    ├──  column10:10 => rowid:5
+ │    └──  column11:11 => e:6
  ├── cardinality: [1 - 1]
  ├── side-effects, mutations
  ├── key: ()
@@ -199,12 +199,12 @@ project
  └── insert abcde
       ├── columns: y:8(int!null) int8:10(int) column11:11(int!null) column12:12(int!null) column14:14(int)
       ├── insert-mapping:
-      │    ├──  y:8(int!null) => a:1(int)
-      │    ├──  int8:10(int) => b:2(int)
-      │    ├──  column11:11(int!null) => c:3(int)
-      │    ├──  column14:14(int) => d:4(int)
-      │    ├──  column12:12(int!null) => rowid:5(int)
-      │    └──  column13:13(unknown) => e:6(int)
+      │    ├──  y:8 => a:1
+      │    ├──  int8:10 => b:2
+      │    ├──  column11:11 => c:3
+      │    ├──  column14:14 => d:4
+      │    ├──  column12:12 => rowid:5
+      │    └──  column13:13 => e:6
       ├── side-effects, mutations
       ├── fd: ()-->(8,11), (10)-->(14)
       └── project

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -39,8 +39,8 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) rowid:11(int) e:12(int)
  ├── update-mapping:
- │    ├──  column13:13(int) => b:2(int)
- │    └──  column14:14(int) => d:4(int)
+ │    ├──  column13:13 => b:2
+ │    └──  column14:14 => d:4
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
@@ -93,8 +93,8 @@ project
       ├── columns: a:7(int!null) c:9(int!null) rowid:11(int!null) column13:13(int!null) column14:14(int)
       ├── fetch columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
       ├── update-mapping:
-      │    ├──  column13:13(int!null) => b:2(int)
-      │    └──  column14:14(int) => d:4(int)
+      │    ├──  column13:13 => b:2
+      │    └──  column14:14 => d:4
       ├── side-effects, mutations
       ├── key: (11)
       ├── fd: ()-->(7,13), (11)-->(9,14), (9)-->(14)
@@ -150,8 +150,8 @@ project
       ├── columns: a:7(int!null) c:9(int!null) rowid:11(int!null) column13:13(int!null) column14:14(int)
       ├── fetch columns: a:7(int!null) b:8(int) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
       ├── update-mapping:
-      │    ├──  column13:13(int!null) => b:2(int)
-      │    └──  column14:14(int) => d:4(int)
+      │    ├──  column13:13 => b:2
+      │    └──  column14:14 => d:4
       ├── cardinality: [0 - 1]
       ├── side-effects, mutations
       ├── key: ()
@@ -209,8 +209,8 @@ project
       ├── columns: b:8(int!null) c:9(int!null) rowid:11(int!null) column13:13(int!null) column14:14(int)
       ├── fetch columns: a:7(int) b:8(int!null) c:9(int!null) d:10(int) rowid:11(int!null) e:12(int)
       ├── update-mapping:
-      │    ├──  column13:13(int!null) => a:1(int)
-      │    └──  column14:14(int) => d:4(int)
+      │    ├──  column13:13 => a:1
+      │    └──  column14:14 => d:4
       ├── side-effects, mutations
       ├── key: (11)
       ├── fd: ()-->(13), (11)-->(8,9,14), (8)==(9), (9)==(8), (8,9)-->(14)

--- a/pkg/sql/opt/memo/testdata/stats/insert
+++ b/pkg/sql/opt/memo/testdata/stats/insert
@@ -59,9 +59,9 @@ select
  ├── insert xyz
  │    ├── columns: a:4(int!null) b:5(string!null) c:6(float)
  │    ├── insert-mapping:
- │    │    ├──  b:5(string!null) => x:1(string)
- │    │    ├──  a:4(int!null) => y:2(int)
- │    │    └──  c:6(float) => z:3(float)
+ │    │    ├──  b:5 => x:1
+ │    │    ├──  a:4 => y:2
+ │    │    └──  c:6 => z:3
  │    ├── side-effects, mutations
  │    ├── stats: [rows=200]
  │    ├── fd: ()-->(5)
@@ -91,9 +91,9 @@ INSERT INTO xyz (x, y, z) SELECT b, a, c FROM abc WHERE False RETURNING *
 insert xyz
  ├── columns: x:5(string!null) y:4(int!null) z:6(float)
  ├── insert-mapping:
- │    ├──  b:5(string!null) => x:1(string)
- │    ├──  a:4(int!null) => y:2(int)
- │    └──  c:6(float) => z:3(float)
+ │    ├──  b:5 => x:1
+ │    ├──  a:4 => y:2
+ │    └──  c:6 => z:3
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  ├── stats: [rows=0]

--- a/pkg/sql/opt/memo/testdata/stats/update
+++ b/pkg/sql/opt/memo/testdata/stats/update
@@ -61,7 +61,7 @@ select
  │    ├── columns: x:4(string!null) z:6(float!null) column7:7(int!null)
  │    ├── fetch columns: x:4(string!null) y:5(int) z:6(float!null)
  │    ├── update-mapping:
- │    │    └──  column7:7(int!null) => y:2(int)
+ │    │    └──  column7:7 => y:2
  │    ├── side-effects, mutations
  │    ├── stats: [rows=9.9]
  │    ├── key: (4)
@@ -96,7 +96,7 @@ update xyz
  ├── columns: x:7(string!null) y:5(int!null) z:6(float)
  ├── fetch columns: x:4(string) y:5(int!null) z:6(float)
  ├── update-mapping:
- │    └──  column7:7(string!null) => x:1(string)
+ │    └──  column7:7 => x:1
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  ├── stats: [rows=0]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -89,8 +89,8 @@ update xy
  ├── columns: <none>
  ├── fetch columns: x:3(int) y:4(int)
  ├── update-mapping:
- │    ├──  u:5(int) => x:1(int)
- │    └──  v:6(int) => y:2(int)
+ │    ├──  u:5 => x:1
+ │    └──  v:6 => y:2
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── left-join (merge)

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -245,11 +245,11 @@ INSERT INTO abcde (a, b, c, d) SELECT y, 1, y+1, 2 FROM xyz ORDER BY y, x, z
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  y:7(int) => a:1(int)
- │    ├──  "?column?":9(int) => b:2(int)
- │    ├──  "?column?":10(int) => c:3(int)
- │    ├──  "?column?":11(int) => d:4(int)
- │    └──  column12:12(int) => e:5(int)
+ │    ├──  y:7 => a:1
+ │    ├──  "?column?":9 => b:2
+ │    ├──  "?column?":10 => c:3
+ │    ├──  "?column?":11 => d:4
+ │    └──  column12:12 => e:5
  ├── internal-ordering: +7,+6 opt(9,11,12)
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
@@ -279,7 +279,7 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:6(int) b:7(int) c:8(int) d:9(int) e:10(int)
  ├── update-mapping:
- │    └──  column11:11(int) => b:2(int)
+ │    └──  column11:11 => b:2
  ├── internal-ordering: +8 opt(7,11)
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -79,12 +79,12 @@ INSERT INTO abcde VALUES (1, 2, 3)
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column1:7(int) => a:1(int)
- │    ├──  column2:8(int) => b:2(int)
- │    ├──  column3:9(int) => c:3(int)
- │    ├──  column11:11(int) => d:4(int)
- │    ├──  column1:7(int) => e:5(int)
- │    └──  column10:10(int) => rowid:6(int)
+ │    ├──  column1:7 => a:1
+ │    ├──  column2:8 => b:2
+ │    ├──  column3:9 => c:3
+ │    ├──  column11:11 => d:4
+ │    ├──  column1:7 => e:5
+ │    └──  column10:10 => rowid:6
  └── project
       ├── columns: column11:11(int) column1:7(int) column2:8(int) column3:9(int) column10:10(int)
       ├── project
@@ -111,12 +111,12 @@ INSERT INTO abcde VALUES (1)
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column1:7(int) => a:1(int)
- │    ├──  column8:8(unknown) => b:2(int)
- │    ├──  column9:9(int) => c:3(int)
- │    ├──  column8:8(unknown) => d:4(int)
- │    ├──  column1:7(int) => e:5(int)
- │    └──  column10:10(int) => rowid:6(int)
+ │    ├──  column1:7 => a:1
+ │    ├──  column8:8 => b:2
+ │    ├──  column9:9 => c:3
+ │    ├──  column8:8 => d:4
+ │    ├──  column1:7 => e:5
+ │    └──  column10:10 => rowid:6
  └── project
       ├── columns: column8:8(unknown) column9:9(int!null) column10:10(int) column1:7(int)
       ├── values
@@ -135,12 +135,12 @@ INSERT INTO abcde SELECT y FROM xyz ORDER BY y, z
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  y:8(int) => a:1(int)
- │    ├──  column10:10(unknown) => b:2(int)
- │    ├──  column11:11(int) => c:3(int)
- │    ├──  column10:10(unknown) => d:4(int)
- │    ├──  y:8(int) => e:5(int)
- │    └──  column12:12(int) => rowid:6(int)
+ │    ├──  y:8 => a:1
+ │    ├──  column10:10 => b:2
+ │    ├──  column11:11 => c:3
+ │    ├──  column10:10 => d:4
+ │    ├──  y:8 => e:5
+ │    └──  column12:12 => rowid:6
  ├── internal-ordering: +8,+9
  └── sort
       ├── columns: y:8(int) z:9(float) column10:10(unknown) column11:11(int!null) column12:12(int)
@@ -163,9 +163,9 @@ INSERT INTO xyz VALUES ($1, $2, $3)
 insert xyz
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column1:4(string) => x:1(string)
- │    ├──  column2:5(int) => y:2(int)
- │    └──  column3:6(float) => z:3(float)
+ │    ├──  column1:4 => x:1
+ │    ├──  column2:5 => y:2
+ │    └──  column3:6 => z:3
  └── values
       ├── columns: column1:4(string) column2:5(int) column3:6(float)
       └── tuple [type=tuple{string, int, float}]
@@ -180,12 +180,12 @@ INSERT INTO abcde VALUES (2, null, null)
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column1:7(int) => a:1(int)
- │    ├──  column2:8(unknown) => b:2(int)
- │    ├──  column3:9(unknown) => c:3(int)
- │    ├──  column11:11(unknown) => d:4(int)
- │    ├──  column1:7(int) => e:5(int)
- │    └──  column10:10(int) => rowid:6(int)
+ │    ├──  column1:7 => a:1
+ │    ├──  column2:8 => b:2
+ │    ├──  column3:9 => c:3
+ │    ├──  column11:11 => d:4
+ │    ├──  column1:7 => e:5
+ │    └──  column10:10 => rowid:6
  └── project
       ├── columns: column11:11(unknown) column1:7(int) column2:8(unknown) column3:9(unknown) column10:10(int)
       ├── project
@@ -208,12 +208,12 @@ INSERT INTO abcde SELECT 2, $1 + 1, $1 + 1
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  "?column?":7(int) => a:1(int)
- │    ├──  "?column?":8(int) => b:2(int)
- │    ├──  "?column?":8(int) => c:3(int)
- │    ├──  column10:10(int) => d:4(int)
- │    ├──  "?column?":7(int) => e:5(int)
- │    └──  column9:9(int) => rowid:6(int)
+ │    ├──  "?column?":7 => a:1
+ │    ├──  "?column?":8 => b:2
+ │    ├──  "?column?":8 => c:3
+ │    ├──  column10:10 => d:4
+ │    ├──  "?column?":7 => e:5
+ │    └──  column9:9 => rowid:6
  └── project
       ├── columns: column10:10(int) "?column?":7(int!null) "?column?":8(int) column9:9(int)
       ├── project
@@ -243,9 +243,9 @@ INSERT INTO uv DEFAULT VALUES
 insert uv
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column4:4(unknown) => u:1(decimal)
- │    ├──  column4:4(unknown) => v:2(bytes)
- │    └──  column5:5(int) => rowid:3(int)
+ │    ├──  column4:4 => u:1
+ │    ├──  column4:4 => v:2
+ │    └──  column5:5 => rowid:3
  └── project
       ├── columns: column4:4(unknown) column5:5(int)
       ├── values
@@ -261,12 +261,12 @@ INSERT INTO abcde ((VALUES (1, DEFAULT, 2), (2, 3, 4), (3, 2, DEFAULT), (4, DEFA
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column1:7(int) => a:1(int)
- │    ├──  column2:8(int) => b:2(int)
- │    ├──  column3:9(int) => c:3(int)
- │    ├──  column11:11(int) => d:4(int)
- │    ├──  column1:7(int) => e:5(int)
- │    └──  column10:10(int) => rowid:6(int)
+ │    ├──  column1:7 => a:1
+ │    ├──  column2:8 => b:2
+ │    ├──  column3:9 => c:3
+ │    ├──  column11:11 => d:4
+ │    ├──  column1:7 => e:5
+ │    └──  column10:10 => rowid:6
  └── project
       ├── columns: column11:11(int) column1:7(int) column2:8(int) column3:9(int) column10:10(int)
       ├── project
@@ -319,12 +319,12 @@ project
  └── insert abcde
       ├── columns: "?column?":7(int!null) column8:8(unknown) column9:9(int!null) column10:10(int!null)
       ├── insert-mapping:
-      │    ├──  "?column?":7(int!null) => a:1(int)
-      │    ├──  column8:8(unknown) => b:2(int)
-      │    ├──  column9:9(int!null) => c:3(int)
-      │    ├──  column8:8(unknown) => d:4(int)
-      │    ├──  "?column?":7(int!null) => e:5(int)
-      │    └──  column10:10(int!null) => rowid:6(int)
+      │    ├──  "?column?":7 => a:1
+      │    ├──  column8:8 => b:2
+      │    ├──  column9:9 => c:3
+      │    ├──  column8:8 => d:4
+      │    ├──  "?column?":7 => e:5
+      │    └──  column10:10 => rowid:6
       └── project
            ├── columns: column8:8(unknown) column9:9(int!null) column10:10(int) "?column?":7(int!null)
            ├── project
@@ -347,12 +347,12 @@ project
  ├── insert abcde
  │    ├── columns: "?column?":7(int!null) column8:8(unknown) column9:9(int!null) column10:10(int!null)
  │    ├── insert-mapping:
- │    │    ├──  "?column?":7(int!null) => a:1(int)
- │    │    ├──  column8:8(unknown) => b:2(int)
- │    │    ├──  column9:9(int!null) => c:3(int)
- │    │    ├──  column8:8(unknown) => d:4(int)
- │    │    ├──  "?column?":7(int!null) => e:5(int)
- │    │    └──  column10:10(int!null) => rowid:6(int)
+ │    │    ├──  "?column?":7 => a:1
+ │    │    ├──  column8:8 => b:2
+ │    │    ├──  column9:9 => c:3
+ │    │    ├──  column8:8 => d:4
+ │    │    ├──  "?column?":7 => e:5
+ │    │    └──  column10:10 => rowid:6
  │    └── project
  │         ├── columns: column8:8(unknown) column9:9(int!null) column10:10(int) "?column?":7(int!null)
  │         ├── project
@@ -380,12 +380,12 @@ project
  └── insert abcde
       ├── columns: column1:7(int!null) column8:8(unknown) column9:9(int!null) column10:10(int!null)
       ├── insert-mapping:
-      │    ├──  column1:7(int!null) => a:1(int)
-      │    ├──  column8:8(unknown) => b:2(int)
-      │    ├──  column9:9(int!null) => c:3(int)
-      │    ├──  column8:8(unknown) => d:4(int)
-      │    ├──  column1:7(int!null) => e:5(int)
-      │    └──  column10:10(int!null) => rowid:6(int)
+      │    ├──  column1:7 => a:1
+      │    ├──  column8:8 => b:2
+      │    ├──  column9:9 => c:3
+      │    ├──  column8:8 => d:4
+      │    ├──  column1:7 => e:5
+      │    └──  column10:10 => rowid:6
       └── project
            ├── columns: column8:8(unknown) column9:9(int!null) column10:10(int) column1:7(int)
            ├── values
@@ -422,12 +422,12 @@ WITH a AS (SELECT y, y+1 FROM xyz) INSERT INTO abcde SELECT * FROM a
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  y:2(int) => a:5(int)
- │    ├──  "?column?":4(int) => b:6(int)
- │    ├──  column11:11(int) => c:7(int)
- │    ├──  column13:13(int) => d:8(int)
- │    ├──  y:2(int) => e:9(int)
- │    └──  column12:12(int) => rowid:10(int)
+ │    ├──  y:2 => a:5
+ │    ├──  "?column?":4 => b:6
+ │    ├──  column11:11 => c:7
+ │    ├──  column13:13 => d:8
+ │    ├──  y:2 => e:9
+ │    └──  column12:12 => rowid:10
  └── project
       ├── columns: column13:13(int) y:2(int) "?column?":4(int) column11:11(int!null) column12:12(int)
       ├── project
@@ -458,12 +458,12 @@ INSERT INTO abcde TABLE a UNION TABLE b
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  y:15(int) => a:9(int)
- │    ├──  "?column?":16(int) => b:10(int)
- │    ├──  column17:17(int) => c:11(int)
- │    ├──  column19:19(int) => d:12(int)
- │    ├──  y:15(int) => e:13(int)
- │    └──  column18:18(int) => rowid:14(int)
+ │    ├──  y:15 => a:9
+ │    ├──  "?column?":16 => b:10
+ │    ├──  column17:17 => c:11
+ │    ├──  column19:19 => d:12
+ │    ├──  y:15 => e:13
+ │    └──  column18:18 => rowid:14
  └── project
       ├── columns: column19:19(int) y:15(int) "?column?":16(int) column17:17(int!null) column18:18(int)
       ├── project
@@ -531,12 +531,12 @@ select
                 └── insert abcde
                      ├── columns: column1:10(int!null) column2:11(int) column12:12(int!null) column13:13(int!null) column14:14(int)
                      ├── insert-mapping:
-                     │    ├──  column1:10(int!null) => a:4(int)
-                     │    ├──  column2:11(int) => b:5(int)
-                     │    ├──  column12:12(int!null) => c:6(int)
-                     │    ├──  column14:14(int) => d:7(int)
-                     │    ├──  column1:10(int!null) => e:8(int)
-                     │    └──  column13:13(int!null) => rowid:9(int)
+                     │    ├──  column1:10 => a:4
+                     │    ├──  column2:11 => b:5
+                     │    ├──  column12:12 => c:6
+                     │    ├──  column14:14 => d:7
+                     │    ├──  column1:10 => e:8
+                     │    └──  column13:13 => rowid:9
                      └── project
                           ├── columns: column14:14(int) column1:10(int) column2:11(int) column12:12(int!null) column13:13(int)
                           ├── project
@@ -569,12 +569,12 @@ INSERT INTO abcde (c, b, a) VALUES (1, 2, 3)
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column3:9(int) => a:1(int)
- │    ├──  column2:8(int) => b:2(int)
- │    ├──  column1:7(int) => c:3(int)
- │    ├──  column11:11(int) => d:4(int)
- │    ├──  column3:9(int) => e:5(int)
- │    └──  column10:10(int) => rowid:6(int)
+ │    ├──  column3:9 => a:1
+ │    ├──  column2:8 => b:2
+ │    ├──  column1:7 => c:3
+ │    ├──  column11:11 => d:4
+ │    ├──  column3:9 => e:5
+ │    └──  column10:10 => rowid:6
  └── project
       ├── columns: column11:11(int) column1:7(int) column2:8(int) column3:9(int) column10:10(int)
       ├── project
@@ -601,12 +601,12 @@ INSERT INTO abcde (a) VALUES (1)
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column1:7(int) => a:1(int)
- │    ├──  column8:8(unknown) => b:2(int)
- │    ├──  column9:9(int) => c:3(int)
- │    ├──  column8:8(unknown) => d:4(int)
- │    ├──  column1:7(int) => e:5(int)
- │    └──  column10:10(int) => rowid:6(int)
+ │    ├──  column1:7 => a:1
+ │    ├──  column8:8 => b:2
+ │    ├──  column9:9 => c:3
+ │    ├──  column8:8 => d:4
+ │    ├──  column1:7 => e:5
+ │    └──  column10:10 => rowid:6
  └── project
       ├── columns: column8:8(unknown) column9:9(int!null) column10:10(int) column1:7(int)
       ├── values
@@ -627,12 +627,12 @@ project
  └── insert abcde
       ├── columns: column1:7(int!null) column2:8(int!null) column9:9(unknown) column10:10(int!null)
       ├── insert-mapping:
-      │    ├──  column1:7(int!null) => a:1(int)
-      │    ├──  column9:9(unknown) => b:2(int)
-      │    ├──  column10:10(int!null) => c:3(int)
-      │    ├──  column9:9(unknown) => d:4(int)
-      │    ├──  column1:7(int!null) => e:5(int)
-      │    └──  column2:8(int!null) => rowid:6(int)
+      │    ├──  column1:7 => a:1
+      │    ├──  column9:9 => b:2
+      │    ├──  column10:10 => c:3
+      │    ├──  column9:9 => d:4
+      │    ├──  column1:7 => e:5
+      │    └──  column2:8 => rowid:6
       └── project
            ├── columns: column9:9(unknown) column10:10(int!null) column1:7(int) column2:8(int)
            ├── values
@@ -653,12 +653,12 @@ RETURNING *, rowid
 insert abcde
  ├── columns: a:9(int!null) b:8(int) c:7(int) d:11(int) e:9(int!null) rowid:10(int!null)
  ├── insert-mapping:
- │    ├──  column3:9(int!null) => a:1(int)
- │    ├──  column2:8(int) => b:2(int)
- │    ├──  column1:7(int) => c:3(int)
- │    ├──  column11:11(int) => d:4(int)
- │    ├──  column3:9(int!null) => e:5(int)
- │    └──  column4:10(int!null) => rowid:6(int)
+ │    ├──  column3:9 => a:1
+ │    ├──  column2:8 => b:2
+ │    ├──  column1:7 => c:3
+ │    ├──  column11:11 => d:4
+ │    ├──  column3:9 => e:5
+ │    └──  column4:10 => rowid:6
  └── project
       ├── columns: column11:11(int) column1:7(int) column2:8(int) column3:9(int) column4:10(int)
       ├── values
@@ -693,12 +693,12 @@ INSERT INTO abcde (a) VALUES (DEFAULT)
 insert abcde
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column1:7(unknown) => a:1(int)
- │    ├──  column8:8(unknown) => b:2(int)
- │    ├──  column9:9(int) => c:3(int)
- │    ├──  column8:8(unknown) => d:4(int)
- │    ├──  column1:7(unknown) => e:5(int)
- │    └──  column10:10(int) => rowid:6(int)
+ │    ├──  column1:7 => a:1
+ │    ├──  column8:8 => b:2
+ │    ├──  column9:9 => c:3
+ │    ├──  column8:8 => d:4
+ │    ├──  column1:7 => e:5
+ │    └──  column10:10 => rowid:6
  └── project
       ├── columns: column8:8(unknown) column9:9(int!null) column10:10(int) column1:7(unknown)
       ├── values
@@ -761,12 +761,12 @@ project
  └── insert abcde
       ├── columns: y:8(int!null) x:10(int) column11:11(int!null) column12:12(int!null) column13:13(int)
       ├── insert-mapping:
-      │    ├──  y:8(int!null) => a:1(int)
-      │    ├──  x:10(int) => b:2(int)
-      │    ├──  column11:11(int!null) => c:3(int)
-      │    ├──  column13:13(int) => d:4(int)
-      │    ├──  y:8(int!null) => e:5(int)
-      │    └──  column12:12(int!null) => rowid:6(int)
+      │    ├──  y:8 => a:1
+      │    ├──  x:10 => b:2
+      │    ├──  column11:11 => c:3
+      │    ├──  column13:13 => d:4
+      │    ├──  y:8 => e:5
+      │    └──  column12:12 => rowid:6
       └── project
            ├── columns: column13:13(int) y:8(int) x:10(int) column11:11(int!null) column12:12(int)
            ├── project
@@ -795,12 +795,12 @@ INSERT INTO abcde (rowid, a) VALUES (1, 2) RETURNING *, rowid
 insert abcde
  ├── columns: a:8(int!null) b:9(unknown) c:10(int!null) d:9(unknown) e:8(int!null) rowid:7(int!null)
  ├── insert-mapping:
- │    ├──  column2:8(int!null) => a:1(int)
- │    ├──  column9:9(unknown) => b:2(int)
- │    ├──  column10:10(int!null) => c:3(int)
- │    ├──  column9:9(unknown) => d:4(int)
- │    ├──  column2:8(int!null) => e:5(int)
- │    └──  column1:7(int!null) => rowid:6(int)
+ │    ├──  column2:8 => a:1
+ │    ├──  column9:9 => b:2
+ │    ├──  column10:10 => c:3
+ │    ├──  column9:9 => d:4
+ │    ├──  column2:8 => e:5
+ │    └──  column1:7 => rowid:6
  └── project
       ├── columns: column9:9(unknown) column10:10(int!null) column1:7(int) column2:8(int)
       ├── values
@@ -821,12 +821,12 @@ project
  └── insert abcde
       ├── columns: y:8(int) "?column?":10(int!null) column11:11(int!null) column12:12(int!null) column13:13(int)
       ├── insert-mapping:
-      │    ├──  "?column?":10(int!null) => a:1(int)
-      │    ├──  y:8(int) => b:2(int)
-      │    ├──  column11:11(int!null) => c:3(int)
-      │    ├──  column13:13(int) => d:4(int)
-      │    ├──  "?column?":10(int!null) => e:5(int)
-      │    └──  column12:12(int!null) => rowid:6(int)
+      │    ├──  "?column?":10 => a:1
+      │    ├──  y:8 => b:2
+      │    ├──  column11:11 => c:3
+      │    ├──  column13:13 => d:4
+      │    ├──  "?column?":10 => e:5
+      │    └──  column12:12 => rowid:6
       └── project
            ├── columns: column13:13(int) y:8(int) "?column?":10(int) column11:11(int!null) column12:12(int)
            ├── project
@@ -860,9 +860,9 @@ INSERT INTO xyz VALUES ($1, $2 + 1, $3 + 1)
 insert xyz
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column1:4(string) => x:1(string)
- │    ├──  column2:5(int) => y:2(int)
- │    └──  column3:6(float) => z:3(float)
+ │    ├──  column1:4 => x:1
+ │    ├──  column2:5 => y:2
+ │    └──  column3:6 => z:3
  └── values
       ├── columns: column1:4(string) column2:5(int) column3:6(float)
       └── tuple [type=tuple{string, int, float}]
@@ -881,9 +881,9 @@ INSERT INTO xyz (z, y, x) VALUES ($1 + 1, $2 + 1, $3)
 insert xyz
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column3:6(string) => x:1(string)
- │    ├──  column2:5(int) => y:2(int)
- │    └──  column1:4(float) => z:3(float)
+ │    ├──  column3:6 => x:1
+ │    ├──  column2:5 => y:2
+ │    └──  column1:4 => z:3
  └── values
       ├── columns: column1:4(float) column2:5(int) column3:6(string)
       └── tuple [type=tuple{float, int, string}]
@@ -902,9 +902,9 @@ INSERT INTO xyz ((SELECT $1, $2 + 1, $3 + 1))
 insert xyz
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  "?column?":4(string) => x:1(string)
- │    ├──  "?column?":5(int) => y:2(int)
- │    └──  "?column?":6(float) => z:3(float)
+ │    ├──  "?column?":4 => x:1
+ │    ├──  "?column?":5 => y:2
+ │    └──  "?column?":6 => z:3
  └── project
       ├── columns: "?column?":4(string) "?column?":5(int) "?column?":6(float)
       ├── values
@@ -925,9 +925,9 @@ INSERT INTO xyz (x, y, z) SELECT $1, $2 + 1, $3 + 1
 insert xyz
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  "?column?":4(string) => x:1(string)
- │    ├──  "?column?":5(int) => y:2(int)
- │    └──  "?column?":6(float) => z:3(float)
+ │    ├──  "?column?":4 => x:1
+ │    ├──  "?column?":5 => y:2
+ │    └──  "?column?":6 => z:3
  └── project
       ├── columns: "?column?":4(string) "?column?":5(int) "?column?":6(float)
       ├── values
@@ -948,9 +948,9 @@ INSERT INTO xyz (SELECT $1, $2 + 1, $3 + 1) UNION ALL (SELECT $1, $2 + 1, $3 + 1
 insert xyz
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  "?column?":10(string) => x:1(string)
- │    ├──  "?column?":11(int) => y:2(int)
- │    └──  "?column?":12(float) => z:3(float)
+ │    ├──  "?column?":10 => x:1
+ │    ├──  "?column?":11 => y:2
+ │    └──  "?column?":12 => z:3
  └── union-all
       ├── columns: "?column?":10(string) "?column?":11(int) "?column?":12(float)
       ├── left columns: "?column?":4(string) "?column?":5(int) "?column?":6(float)
@@ -987,9 +987,9 @@ INSERT INTO xyz (x, z, y) SELECT $1, $2 + 1, $3 + 1 UNION ALL SELECT $1, $2 + 1,
 insert xyz
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  "?column?":10(string) => x:1(string)
- │    ├──  "?column?":12(int) => y:2(int)
- │    └──  "?column?":11(float) => z:3(float)
+ │    ├──  "?column?":10 => x:1
+ │    ├──  "?column?":12 => y:2
+ │    └──  "?column?":11 => z:3
  └── union-all
       ├── columns: "?column?":10(string) "?column?":11(float) "?column?":12(int)
       ├── left columns: "?column?":4(string) "?column?":5(float) "?column?":6(int)
@@ -1030,10 +1030,10 @@ INSERT INTO mutation (m, n) VALUES (1, 2)
 insert mutation
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  column1:6(int) => m:1(int)
- │    ├──  column2:7(int) => n:2(int)
- │    ├──  column8:8(int) => o:3(int)
- │    └──  column9:9(int) => q:5(int)
+ │    ├──  column1:6 => m:1
+ │    ├──  column2:7 => n:2
+ │    ├──  column8:8 => o:3
+ │    └──  column9:9 => q:5
  └── project
       ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
       ├── project
@@ -1057,10 +1057,10 @@ INSERT INTO mutation (m, n) VALUES (1, 2) RETURNING *
 insert mutation
  ├── columns: m:6(int!null) n:7(int)
  ├── insert-mapping:
- │    ├──  column1:6(int!null) => m:1(int)
- │    ├──  column2:7(int) => n:2(int)
- │    ├──  column8:8(int) => o:3(int)
- │    └──  column9:9(int) => q:5(int)
+ │    ├──  column1:6 => m:1
+ │    ├──  column2:7 => n:2
+ │    ├──  column8:8 => o:3
+ │    └──  column9:9 => q:5
  └── project
       ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
       ├── project

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -72,9 +72,9 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column13:13(int) => a:1(int)
- │    ├──  column14:14(int) => d:4(int)
- │    └──  column13:13(int) => e:5(int)
+ │    ├──  column13:13 => a:1
+ │    ├──  column14:14 => d:4
+ │    └──  column13:13 => e:5
  └── project
       ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int!null)
       ├── project
@@ -104,12 +104,12 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column13:13(int) => a:1(int)
- │    ├──  column14:14(int) => b:2(int)
- │    ├──  column15:15(int) => c:3(int)
- │    ├──  column17:17(int) => d:4(int)
- │    ├──  column13:13(int) => e:5(int)
- │    └──  column16:16(int) => rowid:6(int)
+ │    ├──  column13:13 => a:1
+ │    ├──  column14:14 => b:2
+ │    ├──  column15:15 => c:3
+ │    ├──  column17:17 => d:4
+ │    ├──  column13:13 => e:5
+ │    └──  column16:16 => rowid:6
  └── project
       ├── columns: column17:17(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int!null) column14:14(int!null) column15:15(int!null) column16:16(int!null)
       ├── project
@@ -136,12 +136,12 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column16:16(int) => a:1(int)
- │    ├──  column15:15(int) => b:2(int)
- │    ├──  column14:14(int) => c:3(int)
- │    ├──  column17:17(int) => d:4(int)
- │    ├──  column16:16(int) => e:5(int)
- │    └──  column13:13(int) => rowid:6(int)
+ │    ├──  column16:16 => a:1
+ │    ├──  column15:15 => b:2
+ │    ├──  column14:14 => c:3
+ │    ├──  column17:17 => d:4
+ │    ├──  column16:16 => e:5
+ │    └──  column13:13 => rowid:6
  └── project
       ├── columns: column17:17(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int!null) column14:14(int!null) column15:15(int!null) column16:16(int!null)
       ├── project
@@ -168,12 +168,12 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column13:13(unknown) => a:1(int)
- │    ├──  column13:13(unknown) => b:2(int)
- │    ├──  column13:13(unknown) => c:3(int)
- │    ├──  column13:13(unknown) => d:4(int)
- │    ├──  column13:13(unknown) => e:5(int)
- │    └──  column13:13(unknown) => rowid:6(int)
+ │    ├──  column13:13 => a:1
+ │    ├──  column13:13 => b:2
+ │    ├──  column13:13 => c:3
+ │    ├──  column13:13 => d:4
+ │    ├──  column13:13 => e:5
+ │    └──  column13:13 => rowid:6
  └── project
       ├── columns: column13:13(unknown) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       ├── scan abcde
@@ -189,10 +189,10 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column13:13(int) => a:1(int)
- │    ├──  column14:14(int) => b:2(int)
- │    ├──  column15:15(int) => d:4(int)
- │    └──  column13:13(int) => e:5(int)
+ │    ├──  column13:13 => a:1
+ │    ├──  column14:14 => b:2
+ │    ├──  column15:15 => d:4
+ │    └──  column13:13 => e:5
  └── project
       ├── columns: column15:15(int) a:7(int!null) b:8(int!null) c:9(int) d:10(int) e:11(int!null) rowid:12(int!null) column13:13(int) column14:14(int)
       ├── project
@@ -227,10 +227,10 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  b:8(int) => a:1(int)
- │    ├──  c:9(int) => b:2(int)
- │    ├──  column13:13(int) => d:4(int)
- │    └──  b:8(int) => e:5(int)
+ │    ├──  b:8 => a:1
+ │    ├──  c:9 => b:2
+ │    ├──  column13:13 => d:4
+ │    └──  b:8 => e:5
  └── project
       ├── columns: column13:13(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       ├── scan abcde
@@ -250,9 +250,9 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column13:13(int) => b:2(int)
- │    ├──  column14:14(int) => d:4(int)
- │    └──  a:7(int) => e:5(int)
+ │    ├──  column13:13 => b:2
+ │    ├──  column14:14 => d:4
+ │    └──  a:7 => e:5
  ├── internal-ordering: +7
  └── project
       ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int!null)
@@ -293,8 +293,8 @@ update xyz
  ├── columns: <none>
  ├── fetch columns: x:4(string) y:5(int) z:6(float)
  ├── update-mapping:
- │    ├──  column7:7(int) => y:2(int)
- │    └──  column8:8(float) => z:3(float)
+ │    ├──  column7:7 => y:2
+ │    └──  column8:8 => z:3
  └── project
       ├── columns: column7:7(int!null) column8:8(float!null) x:4(string!null) y:5(int) z:6(float)
       ├── scan xyz
@@ -311,9 +311,9 @@ update xyz
  ├── columns: <none>
  ├── fetch columns: x:4(string) y:5(int) z:6(float)
  ├── update-mapping:
- │    ├──  column7:7(string) => x:1(string)
- │    ├──  column8:8(int) => y:2(int)
- │    └──  column9:9(float) => z:3(float)
+ │    ├──  column7:7 => x:1
+ │    ├──  column8:8 => y:2
+ │    └──  column9:9 => z:3
  └── project
       ├── columns: column7:7(string) column8:8(int) column9:9(float) x:4(string!null) y:5(int) z:6(float)
       ├── scan xyz
@@ -331,10 +331,10 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column13:13(int) => a:1(int)
- │    ├──  column13:13(int) => b:2(int)
- │    ├──  column14:14(int) => d:4(int)
- │    └──  column13:13(int) => e:5(int)
+ │    ├──  column13:13 => a:1
+ │    ├──  column13:13 => b:2
+ │    ├──  column14:14 => d:4
+ │    └──  column13:13 => e:5
  └── project
       ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int!null) d:10(int) e:11(int) rowid:12(int!null) column13:13(int)
       ├── project
@@ -374,10 +374,10 @@ select
                      ├── columns: a:10(int!null) rowid:15(int!null) y:16(int) column17:17(int) column18:18(int)
                      ├── fetch columns: a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null)
                      ├── update-mapping:
-                     │    ├──  y:16(int) => b:5(int)
-                     │    ├──  column17:17(int) => c:6(int)
-                     │    ├──  column18:18(int) => d:7(int)
-                     │    └──  a:10(int!null) => e:8(int)
+                     │    ├──  y:16 => b:5
+                     │    ├──  column17:17 => c:6
+                     │    ├──  column18:18 => d:7
+                     │    └──  a:10 => e:8
                      └── project
                           ├── columns: column18:18(int) a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null) y:16(int) column17:17(int)
                           ├── project
@@ -447,9 +447,9 @@ project
       ├── columns: b:8(int) c:9(int) rowid:12(int!null) column13:13(int!null) column14:14(int)
       ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       ├── update-mapping:
-      │    ├──  column13:13(int!null) => a:1(int)
-      │    ├──  column14:14(int) => d:4(int)
-      │    └──  column13:13(int!null) => e:5(int)
+      │    ├──  column13:13 => a:1
+      │    ├──  column14:14 => d:4
+      │    └──  column13:13 => e:5
       └── project
            ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int!null)
            ├── project
@@ -481,9 +481,9 @@ project
  │    ├── columns: b:8(int) c:9(int) rowid:12(int!null) column13:13(int!null) column14:14(int)
  │    ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
  │    ├── update-mapping:
- │    │    ├──  column13:13(int!null) => a:1(int)
- │    │    ├──  column14:14(int) => d:4(int)
- │    │    └──  column13:13(int!null) => e:5(int)
+ │    │    ├──  column13:13 => a:1
+ │    │    ├──  column14:14 => d:4
+ │    │    └──  column13:13 => e:5
  │    └── project
  │         ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int!null)
  │         ├── project
@@ -524,9 +524,9 @@ project
            ├── columns: b:8(int) c:9(int) rowid:12(int!null) column13:13(int!null) column14:14(int)
            ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
            ├── update-mapping:
-           │    ├──  column13:13(int!null) => a:1(int)
-           │    ├──  column14:14(int) => d:4(int)
-           │    └──  column13:13(int!null) => e:5(int)
+           │    ├──  column13:13 => a:1
+           │    ├──  column14:14 => d:4
+           │    └──  column13:13 => e:5
            ├── internal-ordering: +8
            └── sort
                 ├── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int!null) column14:14(int)
@@ -562,9 +562,9 @@ project
       ├── columns: a:7(int!null) b:8(int) c:9(int) column13:13(int!null) column14:14(int)
       ├── fetch columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
       ├── update-mapping:
-      │    ├──  column14:14(int) => d:4(int)
-      │    ├──  a:7(int!null) => e:5(int)
-      │    └──  column13:13(int!null) => rowid:6(int)
+      │    ├──  column14:14 => d:4
+      │    ├──  a:7 => e:5
+      │    └──  column13:13 => rowid:6
       └── project
            ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int)
            ├── project
@@ -606,10 +606,10 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column13:13(unknown) => b:2(int)
- │    ├──  column14:14(int) => c:3(int)
- │    ├──  column13:13(unknown) => d:4(int)
- │    └──  a:7(int) => e:5(int)
+ │    ├──  column13:13 => b:2
+ │    ├──  column14:14 => c:3
+ │    ├──  column13:13 => d:4
+ │    └──  a:7 => e:5
  └── project
       ├── columns: column13:13(unknown) column14:14(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       ├── scan abcde
@@ -627,9 +627,9 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column13:13(unknown) => a:1(int)
- │    ├──  column14:14(int) => d:4(int)
- │    └──  column13:13(unknown) => e:5(int)
+ │    ├──  column13:13 => a:1
+ │    ├──  column14:14 => d:4
+ │    └──  column13:13 => e:5
  └── project
       ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(unknown)
       ├── project
@@ -661,11 +661,11 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column13:13(int) => a:1(int)
- │    ├──  column14:14(int) => b:2(int)
- │    ├──  column15:15(int) => c:3(int)
- │    ├──  column16:16(int) => d:4(int)
- │    └──  column13:13(int) => e:5(int)
+ │    ├──  column13:13 => a:1
+ │    ├──  column14:14 => b:2
+ │    ├──  column15:15 => c:3
+ │    ├──  column16:16 => d:4
+ │    └──  column13:13 => e:5
  └── project
       ├── columns: column16:16(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int!null) column14:14(int!null) column15:15(int!null)
       ├── project
@@ -690,11 +690,11 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column15:15(int) => a:1(int)
- │    ├──  column14:14(int) => b:2(int)
- │    ├──  column13:13(unknown) => c:3(int)
- │    ├──  column13:13(unknown) => d:4(int)
- │    └──  column15:15(int) => e:5(int)
+ │    ├──  column15:15 => a:1
+ │    ├──  column14:14 => b:2
+ │    ├──  column13:13 => c:3
+ │    ├──  column13:13 => d:4
+ │    └──  column15:15 => e:5
  └── project
       ├── columns: column13:13(unknown) column14:14(int!null) column15:15(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       ├── scan abcde
@@ -712,10 +712,10 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column13:13(unknown) => b:2(int)
- │    ├──  column14:14(int) => c:3(int)
- │    ├──  column13:13(unknown) => d:4(int)
- │    └──  a:7(int) => e:5(int)
+ │    ├──  column13:13 => b:2
+ │    ├──  column14:14 => c:3
+ │    ├──  column13:13 => d:4
+ │    └──  a:7 => e:5
  └── project
       ├── columns: column13:13(unknown) column14:14(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       ├── scan abcde
@@ -732,10 +732,10 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column13:13(unknown) => a:1(int)
- │    ├──  column13:13(unknown) => b:2(int)
- │    ├──  column13:13(unknown) => d:4(int)
- │    └──  column13:13(unknown) => e:5(int)
+ │    ├──  column13:13 => a:1
+ │    ├──  column13:13 => b:2
+ │    ├──  column13:13 => d:4
+ │    └──  column13:13 => e:5
  └── project
       ├── columns: column13:13(unknown) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       ├── scan abcde
@@ -775,9 +775,9 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  one:13(int) => a:1(int)
- │    ├──  column14:14(int) => d:4(int)
- │    └──  one:13(int) => e:5(int)
+ │    ├──  one:13 => a:1
+ │    ├──  column14:14 => d:4
+ │    └──  one:13 => e:5
  └── project
       ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) one:13(int)
       ├── left-join-apply
@@ -808,12 +808,12 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  x:16(int) => a:1(int)
- │    ├──  y:14(int) => b:2(int)
- │    ├──  z:17(int) => c:3(int)
- │    ├──  column19:19(int) => d:4(int)
- │    ├──  x:16(int) => e:5(int)
- │    └──  y1:18(int) => rowid:6(int)
+ │    ├──  x:16 => a:1
+ │    ├──  y:14 => b:2
+ │    ├──  z:17 => c:3
+ │    ├──  column19:19 => d:4
+ │    ├──  x:16 => e:5
+ │    └──  y1:18 => rowid:6
  └── project
       ├── columns: column19:19(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) y:14(int) x:16(int) z:17(int) y1:18(int)
       ├── left-join-apply
@@ -850,12 +850,12 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  y:14(int) => a:1(int)
- │    ├──  y1:16(int) => b:2(int)
- │    ├──  column17:17(int) => c:3(int)
- │    ├──  column19:19(int) => d:4(int)
- │    ├──  y:14(int) => e:5(int)
- │    └──  column18:18(int) => rowid:6(int)
+ │    ├──  y:14 => a:1
+ │    ├──  y1:16 => b:2
+ │    ├──  column17:17 => c:3
+ │    ├──  column19:19 => d:4
+ │    ├──  y:14 => e:5
+ │    └──  column18:18 => rowid:6
  └── project
       ├── columns: column19:19(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) y:14(int) y1:16(int) column17:17(int!null) column18:18(int!null)
       ├── project
@@ -893,12 +893,12 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column17:17(int) => a:1(int)
- │    ├──  column18:18(int) => b:2(int)
- │    ├──  y:14(int) => c:3(int)
- │    ├──  column19:19(int) => d:4(int)
- │    ├──  column17:17(int) => e:5(int)
- │    └──  y1:16(int) => rowid:6(int)
+ │    ├──  column17:17 => a:1
+ │    ├──  column18:18 => b:2
+ │    ├──  y:14 => c:3
+ │    ├──  column19:19 => d:4
+ │    ├──  column17:17 => e:5
+ │    └──  y1:16 => rowid:6
  └── project
       ├── columns: column19:19(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) y:14(int) y1:16(int) column17:17(int!null) column18:18(int!null)
       ├── project
@@ -936,12 +936,12 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  y1:16(int) => a:1(int)
- │    ├──  y:14(int) => b:2(int)
- │    ├──  one:17(int) => c:3(int)
- │    ├──  column19:19(int) => d:4(int)
- │    ├──  y1:16(int) => e:5(int)
- │    └──  two:18(int) => rowid:6(int)
+ │    ├──  y1:16 => a:1
+ │    ├──  y:14 => b:2
+ │    ├──  one:17 => c:3
+ │    ├──  column19:19 => d:4
+ │    ├──  y1:16 => e:5
+ │    └──  two:18 => rowid:6
  └── project
       ├── columns: column19:19(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) y:14(int) y1:16(int) one:17(int) two:18(int)
       ├── left-join-apply
@@ -986,9 +986,9 @@ update xyz
  ├── columns: <none>
  ├── fetch columns: x:4(string) y:5(int) z:6(float)
  ├── update-mapping:
- │    ├──  column9:9(string) => x:1(string)
- │    ├──  three:8(int) => y:2(int)
- │    └──  two:7(float) => z:3(float)
+ │    ├──  column9:9 => x:1
+ │    ├──  three:8 => y:2
+ │    └──  two:7 => z:3
  └── project
       ├── columns: column9:9(string!null) x:4(string!null) y:5(int) z:6(float) two:7(float) three:8(int)
       ├── left-join-apply
@@ -1016,9 +1016,9 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:7(int) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int)
  ├── update-mapping:
- │    ├──  column19:19(int) => b:2(int)
- │    ├──  column20:20(int) => d:4(int)
- │    └──  a:7(int) => e:5(int)
+ │    ├──  column19:19 => b:2
+ │    ├──  column20:20 => d:4
+ │    └──  a:7 => e:5
  └── project
       ├── columns: column20:20(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column19:19(int)
       ├── project
@@ -1082,9 +1082,9 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:10(int) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int)
  ├── update-mapping:
- │    ├──  b:11(int) => a:4(int)
- │    ├──  column16:16(int) => d:7(int)
- │    └──  b:11(int) => e:8(int)
+ │    ├──  b:11 => a:4
+ │    ├──  column16:16 => d:7
+ │    └──  b:11 => e:8
  └── project
       ├── columns: column16:16(int) a:10(int!null) b:11(int) c:12(int) d:13(int) e:14(int) rowid:15(int!null)
       ├── select
@@ -1112,10 +1112,10 @@ update abcde
  ├── columns: <none>
  ├── fetch columns: a:11(int) b:12(int) c:13(int) d:14(int) e:15(int) rowid:16(int)
  ├── update-mapping:
- │    ├──  y:2(int) => a:5(int)
- │    ├──  y1:4(int) => b:6(int)
- │    ├──  column17:17(int) => d:8(int)
- │    └──  y:2(int) => e:9(int)
+ │    ├──  y:2 => a:5
+ │    ├──  y1:4 => b:6
+ │    ├──  column17:17 => d:8
+ │    └──  y:2 => e:9
  └── project
       ├── columns: column17:17(int) y:2(int) y1:4(int) a:11(int!null) b:12(int) c:13(int) d:14(int) e:15(int) rowid:16(int!null)
       ├── left-join-apply
@@ -1152,8 +1152,8 @@ update mutation
  ├── columns: <none>
  ├── fetch columns: m:5(int) n:6(int) o:7(int) p:8(int)
  ├── update-mapping:
- │    ├──  column9:9(int) => m:1(int)
- │    └──  column10:10(int) => p:4(int)
+ │    ├──  column9:9 => m:1
+ │    └──  column10:10 => p:4
  └── project
       ├── columns: column10:10(int) m:5(int!null) n:6(int) o:7(int) p:8(int) column9:9(int!null)
       ├── project
@@ -1175,9 +1175,9 @@ update mutation
  ├── columns: <none>
  ├── fetch columns: m:5(int) n:6(int) o:7(int) p:8(int)
  ├── update-mapping:
- │    ├──  column9:9(int) => m:1(int)
- │    ├──  column10:10(int) => n:2(int)
- │    └──  column11:11(int) => p:4(int)
+ │    ├──  column9:9 => m:1
+ │    ├──  column10:10 => n:2
+ │    └──  column11:11 => p:4
  └── project
       ├── columns: column11:11(int) m:5(int!null) n:6(int) o:7(int) p:8(int) column9:9(int!null) column10:10(int!null)
       ├── project
@@ -1200,8 +1200,8 @@ update mutation
  ├── columns: <none>
  ├── fetch columns: m:5(int) n:6(int) o:7(int) p:8(int)
  ├── update-mapping:
- │    ├──  column9:9(int) => m:1(int)
- │    └──  column10:10(int) => p:4(int)
+ │    ├──  column9:9 => m:1
+ │    └──  column10:10 => p:4
  ├── internal-ordering: +5,+6
  └── project
       ├── columns: column10:10(int) m:5(int!null) n:6(int) o:7(int) p:8(int) column9:9(int!null)
@@ -1235,8 +1235,8 @@ project
                      ├── columns: n:12(int) o:15(int!null)
                      ├── fetch columns: m:11(int) n:12(int) mutation.o:13(int) p:14(int)
                      ├── update-mapping:
-                     │    ├──  o:15(int!null) => m:7(int)
-                     │    └──  column16:16(int) => p:10(int)
+                     │    ├──  o:15 => m:7
+                     │    └──  column16:16 => p:10
                      └── project
                           ├── columns: column16:16(int) m:11(int!null) n:12(int) mutation.o:13(int) p:14(int) o:15(int)
                           ├── project

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1197,10 +1197,10 @@ INSERT INTO a SELECT a, b::float, c::decimal, 'foo' FROM abc ORDER BY b
 insert a
  ├── columns: <none>
  ├── insert-mapping:
- │    ├──  a:5(int) => x:1(int)
- │    ├──  b:8(float) => y:2(float)
- │    ├──  c:9(decimal) => z:3(decimal)
- │    └──  "?column?":10(string) => s:4(string)
+ │    ├──  a:5 => x:1
+ │    ├──  b:8 => y:2
+ │    ├──  c:9 => z:3
+ │    └──  "?column?":10 => s:4
  ├── internal-ordering: +8 opt(10)
  └── sort
       ├── columns: a:5(int!null) b:8(float) c:9(decimal) "?column?":10(string!null)
@@ -1221,9 +1221,9 @@ SELECT * FROM [INSERT INTO abc SELECT * FROM xyz ORDER BY y, z RETURNING *] ORDE
 insert abc
  ├── columns: a:4(int!null) b:5(int!null) c:6(int!null)
  ├── insert-mapping:
- │    ├──  x:4(int!null) => a:1(int)
- │    ├──  y:5(int!null) => b:2(int)
- │    └──  z:6(int!null) => c:3(int)
+ │    ├──  x:4 => a:1
+ │    ├──  y:5 => b:2
+ │    └──  z:6 => c:3
  ├── internal-ordering: +5,+6
  ├── ordering: +5
  └── sort
@@ -1240,9 +1240,9 @@ SELECT * FROM [INSERT INTO abc SELECT * FROM xyz WHERE y=z ORDER BY z RETURNING 
 insert abc
  ├── columns: a:4(int!null) b:5(int!null) c:6(int!null)
  ├── insert-mapping:
- │    ├──  x:4(int!null) => a:1(int)
- │    ├──  y:5(int!null) => b:2(int)
- │    └──  z:6(int!null) => c:3(int)
+ │    ├──  x:4 => a:1
+ │    ├──  y:5 => b:2
+ │    └──  z:6 => c:3
  ├── internal-ordering: +(5|6)
  ├── side-effects, mutations
  ├── key: (4,6)
@@ -1277,10 +1277,10 @@ update a
  ├── columns: <none>
  ├── fetch columns: x:5(int) y:6(float) z:7(decimal) s:8(string)
  ├── update-mapping:
- │    ├──  a:9(int) => x:1(int)
- │    ├──  b:12(float) => y:2(float)
- │    ├──  c:13(decimal) => z:3(decimal)
- │    └──  "?column?":14(string) => s:4(string)
+ │    ├──  a:9 => x:1
+ │    ├──  b:12 => y:2
+ │    ├──  c:13 => z:3
+ │    └──  "?column?":14 => s:4
  ├── internal-ordering: +6
  └── sort
       ├── columns: x:5(int!null) y:6(float!null) z:7(decimal) s:8(string!null) a:9(int) b:12(float) c:13(decimal) "?column?":14(string)
@@ -1309,7 +1309,7 @@ update abc
  ├── columns: a:4(int!null) b:7(int!null) c:6(int!null)
  ├── fetch columns: a:4(int!null) b:5(int) c:6(int!null)
  ├── update-mapping:
- │    └──  column7:7(int!null) => b:2(int)
+ │    └──  column7:7 => b:2
  ├── internal-ordering: +5,+6 opt(7)
  └── sort
       ├── columns: a:4(int!null) b:5(int!null) c:6(int!null) column7:7(int!null)
@@ -1332,9 +1332,9 @@ update abc
  ├── columns: a:7(int!null) b:8(int!null) c:9(int!null)
  ├── fetch columns: a:4(int) b:5(int) c:6(int)
  ├── update-mapping:
- │    ├──  column7:7(int!null) => a:1(int)
- │    ├──  column8:8(int!null) => b:2(int)
- │    └──  column9:9(int!null) => c:3(int)
+ │    ├──  column7:7 => a:1
+ │    ├──  column8:8 => b:2
+ │    └──  column9:9 => c:3
  ├── internal-ordering: +(5|6) opt(7-9)
  ├── side-effects, mutations
  ├── fd: ()-->(7-9)


### PR DESCRIPTION
The types make the mappings harder to read without adding much useful
information:

├── insert-mapping:
│    ├──  y:8(int) => a:1(int)
│    ├──  y:8(int) => b:2(int)

becomes:

├── insert-mapping:
│    ├──  y:8 => a:1
│    ├──  y:8 => b:2

Release note: None