### PR TITLE
build: run all opt packages in testrace if one changed

### DIFF
--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -24,6 +24,13 @@ else
 		echo "PR #$TC_BUILD_BRANCH has no changed packages; skipping race detector tests"
 		exit 0
 	fi
+  if [[ $pkgspec == *"./pkg/sql/opt"* ]]; then
+    # If one opt package was changed, run all opt packages (the optimizer puts
+    # various checks behind the race flag to keep them out of release builds).
+    echo "$pkgspec" | sed 's$./pkg/sql/opt/[^ ]*$$g'
+    pkgspec=$(echo "$pkgspec" | sed 's$./pkg/sql/opt[^ ]*$$g')
+    pkgspec="$pkgspec ./pkg/sql/opt/..."
+  fi
 	echo "PR #$TC_BUILD_BRANCH has changed packages; running race detector tests on $pkgspec"
 fi
 tc_end_block "Determine changed packages"


### PR DESCRIPTION
The optimizer puts some potentially expensive checks behind the race
flag. These checks can fail if any opt package is changed, but they
are only run in CI if the specific package that contains the check is
changed.

This change tweaks the `teamcity-testrace.sh` logic to run all opt
packages if any of them is changed.

Release note: None

I tested the new lines in isolation, not sure if there's a way to test the entire script.