### PR TITLE
sql: support `COMMENT ON DATABASE`

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -45,7 +45,8 @@ copy_from_stmt ::=
 	'COPY' table_name opt_column_list 'FROM' 'STDIN'
 
 comment_stmt ::=
-	'COMMENT' 'ON' 'TABLE' table_name 'IS' comment_text
+	'COMMENT' 'ON' 'DATABASE' database_name 'IS' comment_text
+	| 'COMMENT' 'ON' 'TABLE' table_name 'IS' comment_text
 
 execute_stmt ::=
 	'EXECUTE' table_alias_name execute_param_clause
@@ -198,6 +199,9 @@ table_name ::=
 opt_column_list ::=
 	'(' name_list ')'
 	| 
+
+database_name ::=
+	name
 
 comment_text ::=
 	'SCONST'
@@ -1062,9 +1066,6 @@ var_name ::=
 opt_scrub_options_clause ::=
 	'WITH' 'OPTIONS' scrub_option_list
 	| 
-
-database_name ::=
-	name
 
 simple_select ::=
 	simple_select_clause

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -331,7 +331,7 @@ const (
 	CommentsTableID        = 24
 
 	// CommentType is type for system.comments
-	// DatabaseCommentType = 0
-	TableCommentType = 1
+	DatabaseCommentType = 0
+	TableCommentType    = 1
 	// ColumnCommentType   = 2
 )

--- a/pkg/sql/comment_on_database_test.go
+++ b/pkg/sql/comment_on_database_test.go
@@ -1,0 +1,109 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql_test
+
+import (
+	"context"
+	gosql "database/sql"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestCommentOnDatabase(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := tests.CreateTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+
+	if _, err := db.Exec(`
+		CREATE DATABASE d;
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		exec   string
+		query  string
+		expect gosql.NullString
+	}{
+		{
+			`COMMENT ON DATABASE d IS 'foo'`,
+			`SELECT obj_description(oid) FROM pg_database WHERE datname = 'd'`,
+			gosql.NullString{String: `foo`, Valid: true},
+		},
+		{
+			`ALTER DATABASE d RENAME TO d2`,
+			`SELECT obj_description(oid) FROM pg_database WHERE datname = 'd2'`,
+			gosql.NullString{String: `foo`, Valid: true},
+		},
+		{
+			`COMMENT ON DATABASE d2 IS NULL`,
+			`SELECT obj_description(oid) FROM pg_database WHERE datname = 'd2'`,
+			gosql.NullString{Valid: false},
+		},
+	}
+
+	for _, tc := range testCases {
+		if _, err := db.Exec(tc.exec); err != nil {
+			t.Fatal(err)
+		}
+
+		row := db.QueryRow(tc.query)
+		var comment gosql.NullString
+		if err := row.Scan(&comment); err != nil {
+			t.Fatal(err)
+		}
+		if tc.expect != comment {
+			t.Fatalf("expected comment %v, got %v", tc.expect, comment)
+		}
+	}
+}
+
+func TestCommentOnDatabaseWhenDrop(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := tests.CreateTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+
+	if _, err := db.Exec(`
+		CREATE DATABASE d;
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.Exec(`COMMENT ON DATABASE d IS 'foo'`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.Exec(`DROP DATABASE d`); err != nil {
+		t.Fatal(err)
+	}
+
+	row := db.QueryRow(`SELECT comment FROM system.comments LIMIT 1`)
+	var comment string
+	err := row.Scan(&comment)
+	if err != gosql.ErrNoRows {
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Fatal("dropped comment remain comment")
+	}
+}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -314,7 +314,7 @@ func (p *planner) dropTableImpl(
 		droppedViews = append(droppedViews, viewDesc.Name)
 	}
 
-	err := p.removeComment(ctx, tableDesc)
+	err := p.removeTableComment(ctx, tableDesc)
 	if err != nil {
 		return droppedViews, err
 	}
@@ -482,12 +482,12 @@ func removeMatchingReferences(
 	return updatedRefs
 }
 
-func (p *planner) removeComment(
+func (p *planner) removeTableComment(
 	ctx context.Context, tableDesc *sqlbase.MutableTableDescriptor,
 ) error {
 	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Exec(
 		ctx,
-		"delete-comment",
+		"delete-table-comment",
 		p.txn,
 		"DELETE FROM system.comments WHERE type=$1 AND object_id=$2 AND sub_id=0",
 		keys.TableCommentType,

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -44,6 +44,8 @@ const (
 	// EventLogAlterTable is recorded when a table is altered.
 	EventLogAlterTable EventLogType = "alter_table"
 	// EventLogCommentOnTable is recorded when a table is commented.
+	EventLogCommentOnDatabase EventLogType = "comment_on_database"
+	// EventLogCommentOnTable is recorded when a table is commented.
 	EventLogCommentOnTable EventLogType = "comment_on_table"
 
 	// EventLogCreateIndex is recorded when an index is created.

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -350,6 +350,7 @@ func doExpandPlan(
 	case *alterTableNode:
 	case *alterSequenceNode:
 	case *alterUserSetPasswordNode:
+	case *commentOnDatabaseNode:
 	case *commentOnTableNode:
 	case *renameColumnNode:
 	case *renameDatabaseNode:
@@ -861,6 +862,7 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 	case *alterTableNode:
 	case *alterSequenceNode:
 	case *alterUserSetPasswordNode:
+	case *commentOnDatabaseNode:
 	case *commentOnTableNode:
 	case *renameColumnNode:
 	case *renameDatabaseNode:

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -371,6 +371,7 @@ func (p *planner) propagateFilters(
 	case *renameTableNode:
 	case *scrubNode:
 	case *truncateNode:
+	case *commentOnDatabaseNode:
 	case *commentOnTableNode:
 	case *createDatabaseNode:
 	case *createIndexNode:

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -216,6 +216,7 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *renameTableNode:
 	case *scrubNode:
 	case *truncateNode:
+	case *commentOnDatabaseNode:
 	case *commentOnTableNode:
 	case *createDatabaseNode:
 	case *createIndexNode:

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -264,6 +264,7 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *renameTableNode:
 	case *scrubNode:
 	case *truncateNode:
+	case *commentOnDatabaseNode:
 	case *commentOnTableNode:
 	case *createDatabaseNode:
 	case *createIndexNode:

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1151,6 +1151,8 @@ func TestParse(t *testing.T) {
 
 		{`COMMENT ON TABLE foo IS 'a'`},
 		{`COMMENT ON TABLE foo IS NULL`},
+		{`COMMENT ON DATABASE foo IS 'a'`},
+		{`COMMENT ON DATABASE foo IS NULL`},
 
 		{`ALTER SEQUENCE a RENAME TO b`},
 		{`EXPLAIN ALTER SEQUENCE a RENAME TO b`},
@@ -2697,7 +2699,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`ALTER TABLE a RENAME CONSTRAINT b TO c`, 32555, ``},
 
 		{`COMMENT ON COLUMN a.b IS 'a'`, 19472, `column`},
-		{`COMMENT ON DATABASE a IS 'b'`, 19472, ``},
 
 		{`CREATE AGGREGATE a`, 0, `create aggregate`},
 		{`CREATE CAST a`, 0, `create cast`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1997,7 +1997,11 @@ cancel_sessions_stmt:
 | CANCEL SESSIONS error // SHOW HELP: CANCEL SESSIONS
 
 comment_stmt:
-  COMMENT ON TABLE table_name IS comment_text
+  COMMENT ON DATABASE database_name IS comment_text
+  {
+    $$.val = &tree.CommentOnDatabase{Name: tree.Name($4), Comment: $6.strPtr()}
+  }
+| COMMENT ON TABLE table_name IS comment_text
   {
     name, err := tree.NormalizeTableName($4.unresolvedName())
     if err != nil {

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1012,7 +1012,7 @@ CREATE TABLE pg_catalog.pg_description (
 		}
 
 		h := makeOidHasher()
-		return forEachTableDescWithTableLookup(
+		err = forEachTableDescWithTableLookup(
 			ctx,
 			p,
 			dbContext,
@@ -1032,6 +1032,21 @@ CREATE TABLE pg_catalog.pg_description (
 
 				return nil
 			})
+		if err != nil {
+			return err
+		}
+
+		return forEachDatabaseDesc(ctx, p, nil /*all databases*/, func(db *sqlbase.DatabaseDescriptor) error {
+			if comment, ok := commentMap[tree.DInt(db.ID)]; ok {
+				return addRow(
+					h.DBOid(db),
+					oidZero,
+					comment[1],
+					comment[2])
+			}
+
+			return nil
+		})
 	},
 }
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -849,6 +849,8 @@ func (p *planner) newPlan(
 		return p.CancelQueries(ctx, n)
 	case *tree.CancelSessions:
 		return p.CancelSessions(ctx, n)
+	case *tree.CommentOnDatabase:
+		return p.CommentOnDatabase(ctx, n)
 	case *tree.CommentOnTable:
 		return p.CommentOnTable(ctx, n)
 	case *tree.ControlJobs:

--- a/pkg/sql/sem/tree/comment_on_database.go
+++ b/pkg/sql/sem/tree/comment_on_database.go
@@ -1,0 +1,35 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree
+
+import "github.com/cockroachdb/cockroach/pkg/sql/lex"
+
+// CommentOnDatabase represents an COMMENT ON DATABASE statement.
+type CommentOnDatabase struct {
+	Name    Name
+	Comment *string
+}
+
+// Format implements the NodeFormatter interface.
+func (n *CommentOnDatabase) Format(ctx *FmtCtx) {
+	ctx.WriteString("COMMENT ON DATABASE ")
+	ctx.FormatNode(&n.Name)
+	ctx.WriteString(" IS ")
+	if n.Comment != nil {
+		lex.EncodeSQLStringWithFlags(ctx.Buffer, *n.Comment, ctx.flags.EncodeFlags())
+	} else {
+		ctx.WriteString("NULL")
+	}
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -178,6 +178,12 @@ func (*AlterTable) StatementTag() string { return "ALTER TABLE" }
 func (*AlterTable) hiddenFromShowQueries() {}
 
 // StatementType implements the Statement interface.
+func (*CommentOnDatabase) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*CommentOnDatabase) StatementTag() string { return "COMMENT ON DATABASE" }
+
+// StatementType implements the Statement interface.
 func (*CommentOnTable) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -801,6 +807,7 @@ func (n *AlterTableDropConstraint) String() string  { return AsString(n) }
 func (n *AlterTableDropNotNull) String() string     { return AsString(n) }
 func (n *AlterTableDropStored) String() string      { return AsString(n) }
 func (n *AlterTableSetDefault) String() string      { return AsString(n) }
+func (n *CommentOnDatabase) String() string         { return AsString(n) }
 func (n *CommentOnTable) String() string            { return AsString(n) }
 func (n *AlterUserSetPassword) String() string      { return AsString(n) }
 func (n *AlterSequence) String() string             { return AsString(n) }

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -386,7 +386,7 @@ func reassignReferencedTables(
 func reassignComment(ctx context.Context, p *planner, oldID, newID sqlbase.ID) error {
 	comment, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryRow(
 		ctx,
-		"select-comment",
+		"select-table-comment",
 		p.txn,
 		`SELECT comment FROM system.comments WHERE object_id=$1`,
 		oldID)
@@ -397,7 +397,7 @@ func reassignComment(ctx context.Context, p *planner, oldID, newID sqlbase.ID) e
 	if comment != nil {
 		_, err = p.ExtendedEvalContext().ExecCfg.InternalExecutor.Exec(
 			ctx,
-			"upsert-comment",
+			"set-table-comment",
 			p.txn,
 			"UPSERT INTO system.comments VALUES ($1, $2, 0, $3)",
 			keys.TableCommentType,
@@ -410,7 +410,7 @@ func reassignComment(ctx context.Context, p *planner, oldID, newID sqlbase.ID) e
 
 	_, err = p.ExtendedEvalContext().ExecCfg.InternalExecutor.Exec(
 		ctx,
-		"delete-comment",
+		"delete-table-comment",
 		p.txn,
 		"DELETE FROM system.comments WHERE type=$1 AND object_id=$2 AND sub_id=0",
 		keys.TableCommentType,

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -673,6 +673,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&alterSequenceNode{}):        "alter sequence",
 	reflect.TypeOf(&alterTableNode{}):           "alter table",
 	reflect.TypeOf(&alterUserSetPasswordNode{}): "alter user",
+	reflect.TypeOf(&commentOnDatabaseNode{}):    "comment on database",
 	reflect.TypeOf(&commentOnTableNode{}):       "comment on table",
 	reflect.TypeOf(&cancelQueriesNode{}):        "cancel queries",
 	reflect.TypeOf(&cancelSessionsNode{}):       "cancel sessions",


### PR DESCRIPTION
Informs #19472.

This patch introduces support for database comments.

The syntax to set or delete a comment is the same as postgres:
`COMMENT ON DATABASE ... IS ...`. See:
https://www.postgresql.org/docs/9.1/sql-comment.html

Release note (sql change): CockroachDB now supports associating
comments to SQL databases using PostgreSQL's `COMMENT ON DATABASE`
syntax. This also provides proper support for pg's
`pg_catalog.pg_description` and built-in function `obj_description()`.