### PR TITLE
backport-2.1: sql: release orphaned table leases at server startup

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1686,6 +1686,10 @@ func (s *Server) Start(ctx context.Context) error {
 	// executes a SQL query, this must be done after the SQL layer is ready.
 	s.node.recordJoinEvent()
 
+	// Delete all orphaned table leases created by a prior instance of this
+	// node.
+	s.leaseMgr.DeleteOrphanedLeases(startTime)
+
 	log.Event(ctx, "server ready")
 
 	return nil

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -216,7 +216,15 @@ func TestReportUsage(t *testing.T) {
 				{Key: "city", Value: "nyc"},
 			},
 		},
+		Knobs: base.TestingKnobs{
+			SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
+				// Disable SELECT called for delete orphaned leases to keep
+				// query stats stable.
+				DisableDeleteOrphanedLeases: true,
+			},
+		},
 	}
+
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO()) // stopper will wait for the update/report loop to finish too.
 	ts := s.(*TestServer)

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -1172,8 +1172,9 @@ type LeaseManagerTestingKnobs struct {
 	GossipUpdateEvent func(config.SystemConfig) error
 	// A callback called after the leases are refreshed as a result of a gossip update.
 	TestingLeasesRefreshedEvent func(config.SystemConfig)
-
-	LeaseStoreTestingKnobs LeaseStoreTestingKnobs
+	// To disable the deletion of orphaned leases at server startup.
+	DisableDeleteOrphanedLeases bool
+	LeaseStoreTestingKnobs      LeaseStoreTestingKnobs
 }
 
 var _ base.ModuleTestingKnobs = &LeaseManagerTestingKnobs{}
@@ -1752,4 +1753,63 @@ func (m *LeaseManager) refreshSomeLeases(ctx context.Context) {
 		}
 	}
 	wg.Wait()
+}
+
+// DeleteOrphanedLeases releases all orphaned leases created by a prior
+// instance of this node.
+func (m *LeaseManager) DeleteOrphanedLeases(startTime time.Time) {
+	if m.testingKnobs.DisableDeleteOrphanedLeases {
+		return
+	}
+	nodeID := m.LeaseStore.execCfg.NodeID.Get()
+	if nodeID == 0 {
+		panic("zero nodeID")
+	}
+
+	// Run as async worker to prevent blocking the main server Start method.
+	// Exit after releasing all the orphaned leases.
+	m.stopper.RunWorker(context.Background(), func(ctx context.Context) {
+		// This could have been implemented using DELETE WHERE, but DELETE WHERE
+		// doesn't implement AS OF SYSTEM TIME.
+
+		// Read orphaned leases.
+		sqlQuery := fmt.Sprintf(`
+SELECT "descID", version, expiration FROM system.lease AS OF SYSTEM TIME %d WHERE "nodeID" = %d
+`, startTime.UnixNano(), nodeID)
+		rows, _, err := m.LeaseStore.execCfg.InternalExecutor.Query(
+			ctx, "read orphaned table leases", nil /*txn*/, sqlQuery)
+		if err != nil {
+			log.Warningf(ctx, "unable to read orphaned leases: %+v", err)
+			return
+		}
+		// Limit the number of concurrent lease releases.
+		sem := make(chan struct{}, 5)
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		for i := range rows {
+			// Early exit?
+			select {
+			case <-m.stopper.ShouldQuiesce():
+				return
+			default:
+			}
+
+			row := rows[i]
+			wg.Add(1)
+			lease := storedTableLease{
+				id:         sqlbase.ID(tree.MustBeDInt(row[0])),
+				version:    int(tree.MustBeDInt(row[1])),
+				expiration: tree.MustBeDTimestamp(row[2]),
+			}
+			if err := m.stopper.RunLimitedAsyncTask(
+				ctx, fmt.Sprintf("release table lease %+v", lease), sem, true /*wait*/, func(ctx context.Context) {
+					m.LeaseStore.release(ctx, m.stopper, &lease)
+					log.Infof(ctx, "released orphaned table lease: %+v", lease)
+					wg.Done()
+				}); err != nil {
+				log.Warningf(ctx, "did not release orphaned table lease: %+v, err = %s", lease, err)
+				wg.Done()
+			}
+		}
+	})
 }

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -1727,3 +1727,57 @@ CREATE TABLE t.test2 ();
 		t.Fatalf("expected lease acquisition to not block, but blockCount is: %d", blockCount)
 	}
 }
+
+// Tests that DeleteOrphanedLeases() deletes only orphaned leases.
+func TestDeleteOrphanedLeases(testingT *testing.T) {
+	defer leaktest.AfterTest(testingT)()
+
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLLeaseManager: &sql.LeaseManagerTestingKnobs{},
+	}
+
+	ctx := context.Background()
+	t := newLeaseTest(testingT, params)
+	defer t.cleanup()
+
+	if _, err := t.db.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.before (k CHAR PRIMARY KEY, v CHAR);
+CREATE TABLE t.after (k CHAR PRIMARY KEY, v CHAR);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	beforeDesc := sqlbase.GetTableDescriptor(t.kvDB, "t", "before")
+	afterDesc := sqlbase.GetTableDescriptor(t.kvDB, "t", "after")
+	dbID := beforeDesc.ParentID
+
+	// Acquire a lease on "before" by name.
+	beforeTable, _, err := t.node(1).AcquireByName(ctx, t.server.Clock().Now(), dbID, "before")
+	if err != nil {
+		t.Fatal(err)
+	} else if err := t.release(1, beforeTable); err != nil {
+		t.Fatal(err)
+	}
+
+	// Assume server shuts down here and a new instance of the server starts up.
+	// All leases created prior to this time are declared orphaned.
+	now := timeutil.Now()
+
+	// Acquire a lease on "after" by name after server startup.
+	afterTable, _, err := t.node(1).AcquireByName(ctx, t.server.Clock().Now(), dbID, "after")
+	if err != nil {
+		t.Fatal(err)
+	} else if err := t.release(1, afterTable); err != nil {
+		t.Fatal(err)
+	}
+	t.expectLeases(beforeDesc.ID, "/1/1")
+	t.expectLeases(afterDesc.ID, "/1/1")
+
+	// Call DeleteOrphanedLeases() with the server startup time.
+	t.node(1).DeleteOrphanedLeases(now)
+	// Orphaned lease is gone.
+	t.expectLeases(beforeDesc.ID, "")
+	t.expectLeases(afterDesc.ID, "/1/1")
+}

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
@@ -52,6 +53,13 @@ func TestQueryCounts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
+			// Disable SELECT called for delete orphaned leases to keep
+			// query stats stable.
+			DisableDeleteOrphanedLeases: true,
+		},
+	}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1800,6 +1800,30 @@ func ParseDTimestamp(s string, precision time.Duration) (*DTimestamp, error) {
 	return MakeDTimestamp(t, precision), nil
 }
 
+// AsDTimestamp attempts to retrieve a DTimestamp from an Expr, returning a DTimestamp and
+// a flag signifying whether the assertion was successful. The function should
+// be used instead of direct type assertions wherever a *DTimestamp wrapped by a
+// *DOidWrapper is possible.
+func AsDTimestamp(e Expr) (DTimestamp, bool) {
+	switch t := e.(type) {
+	case *DTimestamp:
+		return *t, true
+	case *DOidWrapper:
+		return AsDTimestamp(t.Wrapped)
+	}
+	return DTimestamp{}, false
+}
+
+// MustBeDTimestamp attempts to retrieve a DTimestamp from an Expr, panicking if the
+// assertion fails.
+func MustBeDTimestamp(e Expr) DTimestamp {
+	t, ok := AsDTimestamp(e)
+	if !ok {
+		panic(pgerror.NewAssertionErrorf("expected *DTimestamp, found %T", e))
+	}
+	return t
+}
+
 // ResolvedType implements the TypedExpr interface.
 func (*DTimestamp) ResolvedType() types.T {
 	return types.Timestamp
@@ -2263,7 +2287,7 @@ func MakeDJSON(d interface{}) (Datum, error) {
 // AsDJSON attempts to retrieve a *DJSON from an Expr, returning a *DJSON and
 // a flag signifying whether the assertion was successful. The function should
 // be used instead of direct type assertions wherever a *DJSON wrapped by a
-// *DJSON is possible.
+// *DOidWrapper is possible.
 func AsDJSON(e Expr) (*DJSON, bool) {
 	switch t := e.(type) {
 	case *DJSON:


### PR DESCRIPTION
Backport 1/1 commits from #32988.

/cc @cockroachdb/release

---

table leases created and not released when a node shuts down
ungracefully are orphaned leases. These orphaned leases can
block new schema changes run before the expiration time of
the lease. This change deletes such orphaned leases at
server startup.

This implementation is limited in that the orphaned leases are
deleted by the node when it restarts. In the future this
implementation can benefit from the leases holding
node liveness epoch in them, but that is part of a larger
future design to introduce node liveness epoch in leases.
For now, this is sufficient to maintain the current
implementation while providing for user impact in the most
common case of node restarts.

fixes #20485
fixes #32254
fixes #23244

Release note (sql change): Fix problem with schema change
getting stuck for 5 minutes when executed immediately after
a server restart.
