### PR TITLE
c-deps: fix an infinite loop in MVCCScan

### DIFF
--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -91,6 +91,7 @@ enable_testing()
 # List of tests to build and run. Tests in `ccl/` are linked against roachccl, all others
 # are linked against roach only.
 set(tests
+  chunked_buffer_test.cc
   db_test.cc
   encoding_test.cc
   file_registry_test.cc

--- a/c-deps/libroach/chunked_buffer_test.cc
+++ b/c-deps/libroach/chunked_buffer_test.cc
@@ -1,0 +1,40 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+#include <gtest/gtest.h>
+#include "chunked_buffer.h"
+
+// Verify we can a chunked buffer can hold more than 2GB of data when
+// writing in pieces that are smaller than the maximum chunk size (128
+// MB). See #32896.
+TEST(ChunkedBuffer, PutSmall) {
+  const std::string data(1 << 20, '.'); // 1 MB
+  const int64_t total = 3LL << 30;      // 3 GB
+  cockroach::chunkedBuffer buf;
+  for (int64_t sum = 0; sum < total; sum += data.size()) {
+    buf.Put(data, data);
+  }
+}
+
+// Verify we can a chunked buffer can hold more than 2GB of data when
+// writing in pieces that are larger than the maximum chunk size (128
+// MB). See #32896.
+TEST(ChunkedBuffer, PutLarge) {
+  const std::string data(256 << 20, '.'); // 256 MB
+  const int64_t total = 3LL << 30;        // 3 GB
+  cockroach::chunkedBuffer buf;
+  for (int64_t sum = 0; sum < total; sum += data.size()) {
+    buf.Put(data, data);
+  }
+}


### PR DESCRIPTION
MVCCScan would previously loop forever if asked to scan more than 2GB of
data. The root problem was in the calculation of the next buffer size to
use in `chunkedBuffer::put` which was not accounting for an `int` being
a signed 32-bit value. Changed the logic in `chunkedBuffer::put` to use
a maximum buffer size of 128 MB to avoid hitting this problem and avoid
wasting excessive space wasteage if only a tiny bit of additional space
is needed.

Fixes #32896

Release note (bug fix): Fix an infinite loop in a low-level scanning
routine that could be hit in unusual circumstances.