### PR TITLE
opt: Plan zigzag joins on inverted indexes with 2 constraints

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -146,7 +146,8 @@ scan  ·       ·
 ·     spans   ALL
 ·     filter  b @> '{"a": {}}'
 
-## Multi-path contains queries
+## Multi-path contains queries. Should create zigzag joins with the respective
+## session flag enabled.
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
@@ -183,6 +184,60 @@ filter           ·       ·                                                    
       │          spans   /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
       └── scan   ·       ·                                                        (a, b)  ·
 ·                table   d@primary                                                ·       ·
+
+statement ok
+SET experimental_enable_zigzag_join = true
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
+----
+lookup-join       ·          ·                                    (a, b)  ·
+ │                type       inner                                ·       ·
+ │                pred       @2 @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
+ ├── zigzag-join  ·          ·                                    (a)     ·
+ │    │           type       inner                                ·       ·
+ │    ├── scan    ·          ·                                    (a)     ·
+ │    │           table      d@foo_inv                            ·       ·
+ │    │           fixedvals  1 column                             ·       ·
+ │    └── scan    ·          ·                                    ()      ·
+ │                table      d@foo_inv                            ·       ·
+ │                fixedvals  1 column                             ·       ·
+ └── scan         ·          ·                                    (b)     ·
+·                 table      d@primary                            ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+----
+lookup-join       ·          ·                                              (a, b)  ·
+ │                type       inner                                          ·       ·
+ │                pred       @2 @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
+ ├── zigzag-join  ·          ·                                              (a)     ·
+ │    │           type       inner                                          ·       ·
+ │    ├── scan    ·          ·                                              (a)     ·
+ │    │           table      d@foo_inv                                      ·       ·
+ │    │           fixedvals  1 column                                       ·       ·
+ │    └── scan    ·          ·                                              ()      ·
+ │                table      d@foo_inv                                      ·       ·
+ │                fixedvals  1 column                                       ·       ·
+ └── scan         ·          ·                                              (b)     ·
+·                 table      d@primary                                      ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
+----
+lookup-join       ·          ·                                   (a, b)  ·
+ │                type       inner                               ·       ·
+ │                pred       @2 @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
+ ├── zigzag-join  ·          ·                                   (a)     ·
+ │    │           type       inner                               ·       ·
+ │    ├── scan    ·          ·                                   (a)     ·
+ │    │           table      d@foo_inv                           ·       ·
+ │    │           fixedvals  1 column                            ·       ·
+ │    └── scan    ·          ·                                   ()      ·
+ │                table      d@foo_inv                           ·       ·
+ │                fixedvals  1 column                            ·       ·
+ └── scan         ·          ·                                   (b)     ·
+·                 table      d@primary                           ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -821,6 +821,8 @@ WHERE
 inner-join (zigzag lineitem@l_sd lineitem@l_cd)
  ├── columns: l_shipdate:11(date!null) l_commitdate:12(date!null) l_orderkey:1(int!null) l_linenumber:4(int!null)
  ├── eq columns: [1 4] = [1 4]
+ ├── left fixed columns: [11] = ['1995-09-01']
+ ├── right fixed columns: [12] = ['1995-08-01']
  ├── stats: [rows=0.1, distinct(1)=0.099955012, null(1)=0, distinct(4)=0.099955012, null(4)=0, distinct(11)=0.1, null(11)=0, distinct(12)=0.1, null(12)=0, distinct(11,12)=0.1, null(11,12)=0]
  ├── key: (1,4)
  ├── fd: ()-->(11,12)
@@ -871,6 +873,8 @@ inner-join (lookup lineitem)
  ├── inner-join (zigzag lineitem@l_sd lineitem@l_cd)
  │    ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null) l_commitdate:12(date!null)
  │    ├── eq columns: [1 4] = [1 4]
+ │    ├── left fixed columns: [11] = ['1995-09-01']
+ │    ├── right fixed columns: [12] = ['1995-08-01']
  │    ├── stats: [rows=0.1, distinct(1)=0.099955012, null(1)=0, distinct(4)=0.099955012, null(4)=0, distinct(11)=0.1, null(11)=0, distinct(12)=0.1, null(12)=0, distinct(11,12)=0.1, null(11,12)=0]
  │    ├── fd: ()-->(11,12)
  │    └── filters
@@ -898,6 +902,116 @@ select
  └── filters
       ├── l_shipdate = '1995-09-01' [type=bool, outer=(11), constraints=(/11: [/'1995-09-01' - /'1995-09-01']; tight), fd=()-->(11)]
       └── l_commitdate = '1995-08-01' [type=bool, outer=(12), constraints=(/12: [/'1995-08-01' - /'1995-08-01']; tight), fd=()-->(12)]
+
+# Create a table with an inverted index to test statistics around
+# JSON containment filter operators and zigzag joins.
+exec-ddl
+CREATE TABLE tjson (a INT PRIMARY KEY, b JSON, c JSON, INVERTED INDEX b_idx (b))
+----
+TABLE tjson
+ ├── a int not null
+ ├── b jsonb
+ ├── c jsonb
+ ├── INDEX primary
+ │    └── a int not null
+ └── INVERTED INDEX b_idx
+      ├── b jsonb
+      └── a int not null
+
+exec-ddl
+ALTER TABLE tjson INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 2:00:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 5000
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2018-01-01 2:00:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 2500
+  },
+  {
+    "columns": ["c"],
+    "created_at": "2018-01-01 2:00:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 2500
+  }
+]'
+----
+
+# Should generate a scan on the inverted index.
+opt
+SELECT * FROM tjson WHERE b @> '{"a":"b"}'
+----
+index-join tjson
+ ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ ├── stats: [rows=1666.66667, distinct(1)=1666.66667, null(1)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ └── scan tjson@b_idx
+      ├── columns: a:1(int!null)
+      ├── constraint: /2/1: [/'{"a": "b"}' - /'{"a": "b"}']
+      ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0]
+      └── key: (1)
+
+# Should generate a zigzag join on the inverted index. Row count should be
+# strictly lower than the above scan.
+opt
+SELECT * FROM tjson WHERE b @> '{"a":"b", "c":"d"}'
+----
+inner-join (lookup tjson)
+ ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ ├── key columns: [1] = [1]
+ ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── inner-join (zigzag tjson@b_idx tjson@b_idx)
+ │    ├── columns: a:1(int!null)
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [2] = ['{"a": "b"}']
+ │    ├── right fixed columns: [2] = ['{"c": "d"}']
+ │    ├── stats: [rows=61.7283951, distinct(1)=61.7283951, null(1)=0]
+ │    └── filters (true)
+ └── filters
+      └── b @> '{"a": "b", "c": "d"}' [type=bool, outer=(2)]
+
+# Should generate a select on the table with a JSON filter, since c does not
+# have an inverted index.
+opt
+SELECT * FROM tjson WHERE c @> '{"a":"b"}'
+----
+select
+ ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ ├── stats: [rows=1666.66667, distinct(1)=1666.66667, null(1)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan tjson
+ │    ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── c @> '{"a": "b"}' [type=bool, outer=(3)]
+
+# Should have a lower row count than the above case, due to a containment query
+# on 2 json paths.
+opt
+SELECT * FROM tjson WHERE c @> '{"a":"b", "c":"d"}'
+----
+select
+ ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan tjson
+ │    ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── c @> '{"a": "b", "c": "d"}' [type=bool, outer=(3)]
 
 # Bump up null counts.
 exec-ddl

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -295,17 +295,10 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 	}
 }
 
-// tryConstrainIndex tries to derive a constraint for the given index from the
-// specified filter. If a constraint is derived, it is returned along with any
-// filter remaining after extracting the constraint. If no constraint can be
-// derived, then tryConstrainIndex returns ok = false.
-func (c *CustomFuncs) tryConstrainIndex(
+func (c *CustomFuncs) initIdxConstraintForIndex(
 	filters memo.FiltersExpr, tabID opt.TableID, indexOrd int, isInverted bool,
-) (constraint *constraint.Constraint, remainingFilters memo.FiltersExpr, ok bool) {
-	// Start with fast check to rule out indexes that cannot be constrained.
-	if !isInverted && !c.canMaybeConstrainIndex(filters, tabID, indexOrd) {
-		return nil, nil, false
-	}
+) (ic *idxconstraint.Instance) {
+	ic = &idxconstraint.Instance{}
 
 	// Fill out data structures needed to initialize the idxconstraint library.
 	// Use LaxKeyColumnCount, since all columns <= LaxKeyColumnCount are
@@ -326,8 +319,23 @@ func (c *CustomFuncs) tryConstrainIndex(
 	}
 
 	// Generate index constraints.
-	var ic idxconstraint.Instance
 	ic.Init(filters, columns, notNullCols, isInverted, c.e.evalCtx, c.e.f)
+	return ic
+}
+
+// tryConstrainIndex tries to derive a constraint for the given index from the
+// specified filter. If a constraint is derived, it is returned along with any
+// filter remaining after extracting the constraint. If no constraint can be
+// derived, then tryConstrainIndex returns ok = false.
+func (c *CustomFuncs) tryConstrainIndex(
+	filters memo.FiltersExpr, tabID opt.TableID, indexOrd int, isInverted bool,
+) (constraint *constraint.Constraint, remainingFilters memo.FiltersExpr, ok bool) {
+	// Start with fast check to rule out indexes that cannot be constrained.
+	if !isInverted && !c.canMaybeConstrainIndex(filters, tabID, indexOrd) {
+		return nil, nil, false
+	}
+
+	ic := c.initIdxConstraintForIndex(filters, tabID, indexOrd, isInverted)
 	constraint = ic.Constraint()
 	if constraint.IsUnconstrained() {
 		return nil, nil, false
@@ -339,6 +347,28 @@ func (c *CustomFuncs) tryConstrainIndex(
 	// Make copy of constraint so that idxconstraint instance is not referenced.
 	copy := *constraint
 	return &copy, remaining, true
+}
+
+// allInvIndexConstraints tries to derive all constraints for the specified inverted
+// index that can be derived. If no constraint is derived, then it returns ok = false,
+// similar to tryConstrainIndex.
+func (c *CustomFuncs) allInvIndexConstraints(
+	filters memo.FiltersExpr, tabID opt.TableID, indexOrd int,
+) (constraints []*constraint.Constraint, ok bool) {
+	ic := c.initIdxConstraintForIndex(filters, tabID, indexOrd, true /* isInverted */)
+	constraints, err := ic.AllInvertedIndexConstraints()
+	if err != nil {
+		return nil, false
+	}
+	// As long as there was no error, AllInvertedIndexConstraints is guaranteed
+	// to add at least one constraint to the slice. It will be set to
+	// unconstrained if no constraints could be derived for this index.
+	constraint := constraints[0]
+	if constraint.IsUnconstrained() {
+		return constraints, false
+	}
+
+	return constraints, true
 }
 
 // canMaybeConstrainIndex performs two checks that can quickly rule out the
@@ -1056,6 +1086,172 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 			// original select.
 			c.e.mem.AddLookupJoinToGroup(&indexJoin, grp)
 		}
+	}
+}
+
+// GenerateInvertedIndexZigzagJoins generates zigzag joins for constraints on
+// inverted index. It looks for cases where one inverted index can satisfy
+// two constraints, and it produces zigzag joins with the same index on both
+// sides of the zigzag join for those cases, fixed on different constant values.
+func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
+	grp memo.RelExpr, scanPrivate *memo.ScanPrivate, filters memo.FiltersExpr,
+) {
+	// Short circuit unless zigzag joins are explicitly enabled.
+	if !c.e.evalCtx.SessionData.ZigzagJoinEnabled {
+		return
+	}
+
+	var sb indexScanBuilder
+	sb.init(c, scanPrivate.Table)
+
+	// Iterate over all inverted indexes.
+	var iter scanIndexIter
+	iter.init(c.e.mem, scanPrivate)
+	for iter.nextInverted() {
+		// See if there are two or more constraints that can be satisfied
+		// by this inverted index. This is possible with inverted indexes as
+		// opposed to secondary indexes, because one row in the primary index
+		// can often correspond to multiple rows in an inverted index. This
+		// function generates all constraints it can derive for this index;
+		// not all of which might get used in this function.
+		constraints, ok := c.allInvIndexConstraints(
+			filters, scanPrivate.Table, iter.indexOrdinal,
+		)
+		if !ok || len(constraints) < 2 {
+			continue
+		}
+		// In theory, we could explore zigzag joins on all constraint pairs.
+		// However, in the absence of stats on inverted indexes, we will not
+		// be able to distinguish more selective constraints from less
+		// selective ones anyway, so just pick the first two constraints.
+		//
+		// TODO(itsbilal): Use the remaining constraints to build a remaining
+		// filters expression, instead of just reusing filters from the scan.
+		constraint := constraints[0]
+		constraint2 := constraints[1]
+
+		minPrefix := constraint.ExactPrefix(c.e.evalCtx)
+		if otherPrefix := constraint2.ExactPrefix(c.e.evalCtx); otherPrefix < minPrefix {
+			minPrefix = otherPrefix
+		}
+
+		if minPrefix == 0 {
+			continue
+		}
+
+		zigzagJoin := memo.ZigzagJoinExpr{
+			On: filters,
+			ZigzagJoinPrivate: memo.ZigzagJoinPrivate{
+				LeftTable:  scanPrivate.Table,
+				LeftIndex:  iter.indexOrdinal,
+				RightTable: scanPrivate.Table,
+				RightIndex: iter.indexOrdinal,
+			},
+		}
+
+		// Get constant values from each constraint. Add them to FixedVals as
+		// tuples, with associated Column IDs in both {Left,Right}FixedCols.
+		leftVals := make(memo.ScalarListExpr, minPrefix)
+		leftTypes := make([]types.T, minPrefix)
+		rightVals := make(memo.ScalarListExpr, minPrefix)
+		rightTypes := make([]types.T, minPrefix)
+
+		zigzagJoin.LeftFixedCols = make(opt.ColList, minPrefix)
+		zigzagJoin.RightFixedCols = make(opt.ColList, minPrefix)
+		for i := 0; i < minPrefix; i++ {
+			leftVal := constraint.Spans.Get(0).StartKey().Value(i)
+			rightVal := constraint2.Spans.Get(0).StartKey().Value(i)
+
+			leftVals[i] = c.e.f.ConstructConstVal(leftVal)
+			leftTypes[i] = leftVal.ResolvedType()
+			rightVals[i] = c.e.f.ConstructConstVal(rightVal)
+			rightTypes[i] = rightVal.ResolvedType()
+			zigzagJoin.LeftFixedCols[i] = constraint.Columns.Get(i).ID()
+			zigzagJoin.RightFixedCols[i] = constraint.Columns.Get(i).ID()
+		}
+		zigzagJoin.FixedVals = memo.ScalarListExpr{
+			c.e.f.ConstructTuple(leftVals, types.TTuple{Types: leftTypes}),
+			c.e.f.ConstructTuple(rightVals, types.TTuple{Types: rightTypes}),
+		}
+
+		// Set equality columns - all remaining columns after the fixed prefix
+		// need to be equal.
+		eqColLen := iter.index.ColumnCount() - minPrefix
+		zigzagJoin.LeftEqCols = make(opt.ColList, eqColLen)
+		zigzagJoin.RightEqCols = make(opt.ColList, eqColLen)
+		for i := minPrefix; i < iter.index.ColumnCount(); i++ {
+			colID := scanPrivate.Table.ColumnID(iter.index.Column(i).Ordinal)
+			zigzagJoin.LeftEqCols[i-minPrefix] = colID
+			zigzagJoin.RightEqCols[i-minPrefix] = colID
+		}
+		zigzagJoin.On = filters
+
+		// Don't output the first column (i.e. the inverted index's JSON key
+		// col) from the zigzag join. It could contain partial values, so
+		// presenting it in the output or checking ON conditions against
+		// it makes little sense.
+		zigzagCols := iter.indexCols()
+		for i, cnt := 0, iter.index.KeyColumnCount(); i < cnt; i++ {
+			colID := scanPrivate.Table.ColumnID(iter.index.Column(i).Ordinal)
+			zigzagCols.Remove(int(colID))
+		}
+
+		pkIndex := iter.tab.Index(cat.PrimaryIndex)
+		pkCols := make(opt.ColList, pkIndex.KeyColumnCount())
+		for i := range pkCols {
+			pkCols[i] = scanPrivate.Table.ColumnID(pkIndex.Column(i).Ordinal)
+			// Ensure primary key columns are always retrieved from the zigzag
+			// join.
+			zigzagCols.Add(int(pkCols[i]))
+		}
+
+		// Case 1 (zigzagged indexes contain all requested columns).
+		if scanPrivate.Cols.SubsetOf(zigzagCols) {
+			zigzagJoin.Cols = scanPrivate.Cols
+			c.e.mem.AddZigzagJoinToGroup(&zigzagJoin, grp)
+			continue
+		}
+
+		if scanPrivate.Flags.NoIndexJoin {
+			continue
+		}
+
+		// Case 2 (wrap zigzag join in an index join).
+
+		var indexJoin memo.LookupJoinExpr
+		// Ensure the zigzag join returns pk columns.
+		zigzagJoin.Cols = scanPrivate.Cols.Intersection(zigzagCols)
+		for i := range pkCols {
+			zigzagJoin.Cols.Add(int(pkCols[i]))
+		}
+
+		if c.FiltersBoundBy(zigzagJoin.On, zigzagCols) {
+			// The ON condition refers only to the columns available in the zigzag
+			// indices.
+			indexJoin.On = memo.TrueFilter
+		} else {
+			// ON has some conditions that are bound by the columns in the index (at
+			// the very least, the equality conditions we used for EqCols and FixedCols),
+			// and some conditions that refer to other table columns. We can put
+			// the former in the lower ZigzagJoin and the latter in the index join.
+			conditions := zigzagJoin.On
+			zigzagJoin.On = c.ExtractBoundConditions(conditions, zigzagCols)
+			indexJoin.On = c.ExtractUnboundConditions(conditions, zigzagCols)
+		}
+
+		indexJoin.Input = c.e.f.ConstructZigzagJoin(
+			zigzagJoin.On,
+			&zigzagJoin.ZigzagJoinPrivate,
+		)
+		indexJoin.JoinType = opt.InnerJoinOp
+		indexJoin.Table = scanPrivate.Table
+		indexJoin.Index = cat.PrimaryIndex
+		indexJoin.KeyCols = pkCols
+		indexJoin.Cols = scanPrivate.Cols
+
+		// Create the LookupJoin for the index join in the same group as the
+		// original select.
+		c.e.mem.AddLookupJoinToGroup(&indexJoin, grp)
 	}
 }
 

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -67,6 +67,20 @@
 =>
 (GenerateZigzagJoins $scan $filters)
 
+# GenerateInvertedIndexZigzagJoins creates ZigzagJoin operators for inverted
+# indexes that can be constrained with two or more distinct constant values.
+# Inverted indexes contain one row for each path-to-leaf in a JSON value, so one
+# row in the primary index could generate multiple inverted index keys. This
+# property can be exploited by zigzag joining on the same inverted index, fixed
+# at any two of the JSON paths we are querying for.
+[GenerateInvertedIndexZigzagJoins, Explore]
+(Select
+    (Scan $scan:*) & (IsCanonicalScan $scan) & (HasInvertedIndexes $scan)
+    $filters:*
+)
+=>
+(GenerateInvertedIndexZigzagJoins $scan $filters)
+
 # GenerateLookupJoinWithFilter creates a LookupJoin alternative for a Join which
 # has a Select->Scan combination as its right input. The filter can get merged
 # with the ON condition (this is correct for both inner and left join).

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1297,6 +1297,8 @@ SELECT q,r FROM pqr WHERE q = 1 AND r = 2
 inner-join (zigzag pqr@q pqr@r)
  ├── columns: q:2(int!null) r:3(int!null)
  ├── eq columns: [1] = [1]
+ ├── left fixed columns: [2] = [1]
+ ├── right fixed columns: [3] = [2]
  ├── fd: ()-->(2,3)
  └── filters
       ├── q = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
@@ -1360,6 +1362,8 @@ inner-join (lookup pqr)
  ├── inner-join (zigzag pqr@q pqr@r)
  │    ├── columns: p:1(int!null) q:2(int!null) r:3(int!null)
  │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [2] = [1]
+ │    ├── right fixed columns: [3] = [2]
  │    ├── fd: ()-->(2,3)
  │    └── filters
  │         ├── q = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
@@ -1424,6 +1428,8 @@ SELECT q,s FROM pqr WHERE q = 1 AND s = 'foo'
 inner-join (zigzag pqr@q pqr@s)
  ├── columns: q:2(int!null) s:4(string!null)
  ├── eq columns: [1] = [1]
+ ├── left fixed columns: [2] = [1]
+ ├── right fixed columns: [4] = ['foo']
  ├── fd: ()-->(2,4)
  └── filters
       ├── q = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
@@ -1476,6 +1482,8 @@ SELECT r,t FROM pqr WHERE r = 1 AND t = 'foo'
 inner-join (zigzag pqr@rs pqr@ts)
  ├── columns: r:3(int!null) t:5(string!null)
  ├── eq columns: [4 1] = [4 1]
+ ├── left fixed columns: [3] = [1]
+ ├── right fixed columns: [5] = ['foo']
  ├── fd: ()-->(3,5)
  └── filters
       ├── r = 1 [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
@@ -1488,7 +1496,7 @@ memo (optimized, ~12KB, required=[presentation: r:3,t:5])
  ├── G1: (select G2 G3) (zigzag-join G3 pqr@rs pqr@ts) (select G4 G5) (select G6 G5) (select G7 G8)
  │    └── [presentation: r:3,t:5]
  │         ├── best: (zigzag-join G3 pqr@rs pqr@ts)
- │         └── cost: 0.21
+ │         └── cost: 0.22
  ├── G2: (scan pqr,cols=(3,5))
  │    └── []
  │         ├── best: (scan pqr,cols=(3,5))
@@ -1534,6 +1542,8 @@ SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 inner-join (zigzag pqr@q pqr@s)
  ├── columns: p:1(int!null) q:2(int!null) r:3(int!null) s:4(string!null)
  ├── eq columns: [1] = [1]
+ ├── left fixed columns: [2] = [1]
+ ├── right fixed columns: [4] = ['foo']
  ├── key: (1)
  ├── fd: ()-->(2-4)
  └── filters
@@ -1562,16 +1572,16 @@ memo (optimized, ~31KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G6: (zigzag-join G11 pqr@r pqr@s)
  │    └── []
  │         ├── best: (zigzag-join G11 pqr@r pqr@s)
- │         └── cost: 0.21
+ │         └── cost: 0.22
  ├── G7: (filters G16)
  ├── G8: (zigzag-join G11 pqr@r pqr@rs)
  │    └── []
  │         ├── best: (zigzag-join G11 pqr@r pqr@rs)
- │         └── cost: 0.21
+ │         └── cost: 0.22
  ├── G9: (zigzag-join G11 pqr@s pqr@rs)
  │    └── []
  │         ├── best: (zigzag-join G11 pqr@s pqr@rs)
- │         └── cost: 0.21
+ │         └── cost: 0.22
  ├── G10: (index-join G20 pqr,cols=(1-4))
  │    └── []
  │         ├── best: (index-join G20 pqr,cols=(1-4))
@@ -1678,3 +1688,121 @@ memo (optimized, ~8KB, required=[presentation: q:2,t:5])
  ├── G13: (const 1)
  ├── G14: (variable t)
  └── G15: (const 'foo')
+
+# --------------------------
+# GenerateInvertedIndexZigzagJoins
+# --------------------------
+
+exec-ddl
+CREATE TABLE t5 (
+    a INT PRIMARY KEY,
+    b JSONB,
+    c INT,
+    INVERTED INDEX b_idx(b)
+)
+----
+TABLE t5
+ ├── a int not null
+ ├── b jsonb
+ ├── c int
+ ├── INDEX primary
+ │    └── a int not null
+ └── INVERTED INDEX b_idx
+      ├── b jsonb
+      └── a int not null
+
+# One path. Should generate a scan constrained on the inverted index.
+opt
+SELECT b,a FROM t5 WHERE b @> '{"a":1}'
+----
+index-join t5
+ ├── columns: b:2(jsonb) a:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ └── scan t5@b_idx
+      ├── columns: a:1(int!null)
+      ├── constraint: /2/1: [/'{"a": 1}' - /'{"a": 1}']
+      └── key: (1)
+
+opt
+SELECT b,a FROM t5 WHERE b @> '{"a":[[{"b":{"c":[{"d":"e"}]}}]]}'
+----
+index-join t5
+ ├── columns: b:2(jsonb) a:1(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ └── scan t5@b_idx
+      ├── columns: a:1(int!null)
+      ├── constraint: /2/1: [/'{"a": [[{"b": {"c": [{"d": "e"}]}}]]}' - /'{"a": [[{"b": {"c": [{"d": "e"}]}}]]}']
+      └── key: (1)
+
+# Two paths. Should generate a zigzag join.
+opt
+SELECT b,a FROM t5 WHERE b @> '{"a":1, "c":2}'
+----
+inner-join (lookup t5)
+ ├── columns: b:2(jsonb) a:1(int!null)
+ ├── key columns: [1] = [1]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── inner-join (zigzag t5@b_idx t5@b_idx)
+ │    ├── columns: a:1(int!null)
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [2] = ['{"a": 1}']
+ │    ├── right fixed columns: [2] = ['{"c": 2}']
+ │    └── filters (true)
+ └── filters
+      └── b @> '{"a": 1, "c": 2}' [type=bool, outer=(2)]
+
+memo
+SELECT a FROM t5 WHERE b @> '{"a":1, "c":2}'
+----
+memo (optimized, ~10KB, required=[presentation: a:1])
+ ├── G1: (project G2 G3 a)
+ │    └── [presentation: a:1]
+ │         ├── best: (project G2 G3 a)
+ │         └── cost: 191.63
+ ├── G2: (select G4 G5) (lookup-join G6 G5 t5,keyCols=[1],outCols=(1,2)) (select G7 G5)
+ │    └── []
+ │         ├── best: (lookup-join G6 G5 t5,keyCols=[1],outCols=(1,2))
+ │         └── cost: 190.51
+ ├── G3: (projections)
+ ├── G4: (scan t5,cols=(1,2))
+ │    └── []
+ │         ├── best: (scan t5,cols=(1,2))
+ │         └── cost: 1050.01
+ ├── G5: (filters G8)
+ ├── G6: (zigzag-join G9 t5@b_idx t5@b_idx)
+ │    └── []
+ │         ├── best: (zigzag-join G9 t5@b_idx t5@b_idx)
+ │         └── cost: 25.57
+ ├── G7: (index-join G10 t5,cols=(1,2))
+ │    └── []
+ │         ├── best: (index-join G10 t5,cols=(1,2))
+ │         └── cost: 565.58
+ ├── G8: (contains G11 G12)
+ ├── G9: (filters)
+ ├── G10: (scan t5@b_idx,cols=(1),constrained)
+ │    └── []
+ │         ├── best: (scan t5@b_idx,cols=(1),constrained)
+ │         └── cost: 114.45
+ ├── G11: (variable b)
+ └── G12: (const '{"a": 1, "c": 2}')
+
+# Three or more paths. Should generate zigzag joins.
+opt
+SELECT b,a FROM t5 WHERE b @> '{"a":[{"b":"c", "d":3}, 5]}'
+----
+inner-join (lookup t5)
+ ├── columns: b:2(jsonb) a:1(int!null)
+ ├── key columns: [1] = [1]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── inner-join (zigzag t5@b_idx t5@b_idx)
+ │    ├── columns: a:1(int!null)
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [2] = ['{"a": [{"b": "c"}]}']
+ │    ├── right fixed columns: [2] = ['{"a": [{"d": 3}]}']
+ │    └── filters (true)
+ └── filters
+      └── b @> '{"a": [{"b": "c", "d": 3}, 5]}' [type=bool, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -222,6 +222,8 @@ project
  └── inner-join (zigzag a@u a@v)
       ├── columns: k:1(int!null) u:2(int!null) v:3(int!null)
       ├── eq columns: [1] = [1]
+      ├── left fixed columns: [2] = [1]
+      ├── right fixed columns: [3] = [5]
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1-3)
@@ -649,25 +651,51 @@ project
            ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
            └── key: (1)
 
-# Query only the primary key with a remaining filter.
+memo
+SELECT k FROM b WHERE j @> '{"a": "b"}'
+----
+memo (optimized, ~6KB, required=[presentation: k:1])
+ ├── G1: (project G2 G3 k)
+ │    └── [presentation: k:1]
+ │         ├── best: (project G2 G3 k)
+ │         └── cost: 570.03
+ ├── G2: (select G4 G5) (index-join G6 b,cols=(1,4))
+ │    └── []
+ │         ├── best: (index-join G6 b,cols=(1,4))
+ │         └── cost: 566.69
+ ├── G3: (projections)
+ ├── G4: (scan b,cols=(1,4))
+ │    └── []
+ │         ├── best: (scan b,cols=(1,4))
+ │         └── cost: 1060.01
+ ├── G5: (filters G7)
+ ├── G6: (scan b@inv_idx,cols=(1),constrained)
+ │    └── []
+ │         ├── best: (scan b@inv_idx,cols=(1),constrained)
+ │         └── cost: 114.45
+ ├── G7: (contains G8 G9)
+ ├── G8: (variable j)
+ └── G9: (const '{"a": "b"}')
+
+# Query only the primary key with a remaining filter. 2+ paths in containment
+# query should favor zigzag joins.
 opt
 SELECT k FROM b WHERE j @> '{"a": "b", "c": "d"}'
 ----
 project
  ├── columns: k:1(int!null)
  ├── key: (1)
- └── select
+ └── inner-join (lookup b)
       ├── columns: k:1(int!null) j:4(jsonb)
+      ├── key columns: [1] = [1]
       ├── key: (1)
       ├── fd: (1)-->(4)
-      ├── index-join b
-      │    ├── columns: k:1(int!null) j:4(jsonb)
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(4)
-      │    └── scan b@inv_idx
-      │         ├── columns: k:1(int!null)
-      │         ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
-      │         └── key: (1)
+      ├── inner-join (zigzag b@inv_idx b@inv_idx)
+      │    ├── columns: k:1(int!null)
+      │    ├── eq columns: [1] = [1]
+      │    ├── left fixed columns: [4] = ['{"a": "b"}']
+      │    ├── right fixed columns: [4] = ['{"c": "d"}']
+      │    └── filters (true)
       └── filters
            └── j @> '{"a": "b", "c": "d"}' [type=bool, outer=(4)]
 
@@ -712,40 +740,120 @@ index-join b
       ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
       └── key: (1)
 
-# Query requiring an index join with a remaining filter.
-# TODO(justin): push this filter into the index join.
+# Query requiring a zigzag join with a remaining filter.
+# TODO(itsbilal): remove filter from index join if zigzag join covers it.
 opt
 SELECT j, k FROM b WHERE j @> '{"a": "b", "c": "d"}'
 ----
-select
+inner-join (lookup b)
  ├── columns: j:4(jsonb) k:1(int!null)
+ ├── key columns: [1] = [1]
  ├── key: (1)
  ├── fd: (1)-->(4)
- ├── index-join b
- │    ├── columns: k:1(int!null) j:4(jsonb)
- │    ├── key: (1)
- │    ├── fd: (1)-->(4)
- │    └── scan b@inv_idx
- │         ├── columns: k:1(int!null)
- │         ├── constraint: /4/1: [/'{"a": "b"}' - /'{"a": "b"}']
- │         └── key: (1)
+ ├── inner-join (zigzag b@inv_idx b@inv_idx)
+ │    ├── columns: k:1(int!null)
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [4] = ['{"a": "b"}']
+ │    ├── right fixed columns: [4] = ['{"c": "d"}']
+ │    └── filters (true)
  └── filters
       └── j @> '{"a": "b", "c": "d"}' [type=bool, outer=(4)]
 
 opt
 SELECT * FROM b WHERE j @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
+inner-join (lookup b)
+ ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ ├── key columns: [1] = [1]
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── inner-join (zigzag b@inv_idx b@inv_idx)
+ │    ├── columns: k:1(int!null)
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [4] = ['{"a": {"b": "c"}}']
+ │    ├── right fixed columns: [4] = ['{"a": {"d": "e"}}']
+ │    └── filters (true)
+ └── filters
+      └── j @> '{"a": {"b": "c", "d": "e"}, "f": "g"}' [type=bool, outer=(4)]
+
+opt
+SELECT * FROM b WHERE j @> '{}'
+----
 select
  ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- ├── index-join b
+ ├── scan b
  │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- │    └── scan b@inv_idx
- │         ├── columns: k:1(int!null)
- │         ├── constraint: /4/1: [/'{"a": {"b": "c"}}' - /'{"a": {"b": "c"}}']
- │         └── key: (1)
+ │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
  └── filters
-      └── j @> '{"a": {"b": "c", "d": "e"}, "f": "g"}' [type=bool, outer=(4)]
+      └── j @> '{}' [type=bool, outer=(4)]
+
+opt
+SELECT * FROM b WHERE j @> '[]'
+----
+select
+ ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── scan b
+ │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ └── filters
+      └── j @> '[]' [type=bool, outer=(4)]
+
+opt
+SELECT * FROM b WHERE j @> '2'
+----
+index-join b
+ ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ └── scan b@inv_idx
+      ├── columns: k:1(int!null)
+      ├── constraint: /4/1: [/'2' - /'2'] [/'[2]' - /'[2]']
+      └── key: (1)
+
+opt
+SELECT * FROM b WHERE j @> '[{}]'
+----
+select
+ ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── scan b
+ │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ └── filters
+      └── j @> '[{}]' [type=bool, outer=(4)]
+
+opt
+SELECT * FROM b WHERE j @> '{"a": {}}'
+----
+select
+ ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── scan b
+ │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ └── filters
+      └── j @> '{"a": {}}' [type=bool, outer=(4)]
+
+opt
+SELECT * FROM b WHERE j @> '{"a": []}'
+----
+select
+ ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── scan b
+ │    ├── columns: k:1(int!null) u:2(int) v:3(int) j:4(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ └── filters
+      └── j @> '{"a": []}' [type=bool, outer=(4)]


### PR DESCRIPTION
This change adds an xform rule to plan zigzag joins whenever two or more
JSON paths-to-leaf exist in a JSON containment query, on a column with an
inverted index. Since inverted indexes could contain multiple keys for
each row in the primary index, zigzagging on the same inverted index
fixed at different constant values lets us effectively test for two JSON
paths at once.

Release note: None