### PR TITLE
roachprod,cli: add roachprod logs command and improve debug merge-logs 

### DIFF
--- a/pkg/cli/debug_merge_logs_test.go
+++ b/pkg/cli/debug_merge_logs_test.go
@@ -41,7 +41,7 @@ var cases = []testCase{
 	{
 		name:  "1.filter-program",
 		args:  []string{"testdata/merge_logs/1/*/*"},
-		flags: []string{"--program", "not-cockroach"},
+		flags: []string{"--program-filter", "not-cockroach"},
 	},
 	{
 		name:  "1.seek-past-end-of-file",
@@ -73,6 +73,11 @@ var cases = []testCase{
 			"testdata/merge_logs/2/2.logs/roachprod.log",
 		},
 		flags: []string{"--from", "181130 22:15:07.525316"},
+	},
+	{
+		name:  "3.non-standard",
+		args:  []string{"testdata/merge_logs/3/*/*"},
+		flags: []string{"--file-pattern", ".*", "--prefix", ""},
 	},
 }
 

--- a/pkg/cli/testdata/merge_logs/3/1/not_standard.log
+++ b/pkg/cli/testdata/merge_logs/3/1/not_standard.log
@@ -1,0 +1,10 @@
+I181130 22:14:34.828612 740 storage/store_rebalancer.go:277  [n1,s1,store-rebalancer] load-based lease transfers successfully brought s1 down to 37128.65 qps (mean=29834.62, upperThreshold=37293.27)
+I181130 22:14:37.516378 441 server/status/runtime.go:465  [n1] runtime stats: 900 MiB RSS, 1509 goroutines, 421 MiB/144 MiB/777 MiB GO alloc/idle/total, 96 MiB/144 MiB CGO alloc/total, 154632.4 CGO/sec, 2206.9/216.0 %(u/s)time, 0.4 %gc (43x), 182 MiB/204 MiB (r/w)net
+I181130 22:14:47.400515 437 gossip/gossip.go:555  [n1] gossip status (ok, 3 nodes)
+gossip client (0/3 cur/max conns)
+gossip server (2/3 cur/max conns, infos 4077/2242 sent/received, bytes 1275332B/555352B sent/received)
+  2: ajwerner-test-0002:26257 (8m0s)
+  3: ajwerner-test-0003:26257 (8m0s)
+I181130 22:14:47.519324 441 server/status/runtime.go:465  [n1] runtime stats: 957 MiB RSS, 1690 goroutines, 420 MiB/173 MiB/777 MiB GO alloc/idle/total, 124 MiB/174 MiB CGO alloc/total, 143837.6 CGO/sec, 2245.9/218.3 %(u/s)time, 0.5 %gc (47x), 199 MiB/210 MiB (r/w)net
+I181130 22:14:57.522236 441 server/status/runtime.go:465  [n1] runtime stats: 986 MiB RSS, 1332 goroutines, 438 MiB/140 MiB/777 MiB GO alloc/idle/total, 151 MiB/203 MiB CGO alloc/total, 137663.6 CGO/sec, 2168.3/222.8 %(u/s)time, 0.4 %gc (45x), 192 MiB/203 MiB (r/w)net
+I181130 22:15:07.525316 441 server/status/runtime.go:465  [n1] runtime stats: 952 MiB RSS, 1422 goroutines, 397 MiB/165 MiB/777 MiB GO alloc/idle/total, 112 MiB/164 MiB CGO alloc/total, 133359.9 CGO/sec, 2137.8/225.1 %(u/s)time, 0.4 %gc (43x), 187 MiB/198 MiB (r/w)net

--- a/pkg/cli/testdata/merge_logs/3/2/also_not_standard.log
+++ b/pkg/cli/testdata/merge_logs/3/2/also_not_standard.log
@@ -1,0 +1,10 @@
+I181130 22:14:49.706516 6152567 storage/split_queue.go:213  [n2,split,s2,r163/3:/Table/53/1/-36{84178…-35915…}] initiating a split based on load at key /Table/53/1/-3661595080111255049
+I181130 22:14:49.706563 6152567 storage/replica_command.go:342  [n2,split,s2,r163/3:/Table/53/1/-36{84178…-35915…}] initiating a split of this range at key /Table/53/1/-3661595080111255049 [r586]
+I181130 22:14:49.732930 6153357 storage/split_queue.go:213  [n2,split,s2,r269/3:/Table/53/1/-81{56147…-10716…}] initiating a split based on load at key /Table/53/1/-8134885765915906309
+I181130 22:14:49.732976 6153357 storage/replica_command.go:342  [n2,split,s2,r269/3:/Table/53/1/-81{56147…-10716…}] initiating a split of this range at key /Table/53/1/-8134885765915906309 [r587]
+I181130 22:14:50.203263 6163815 storage/split_queue.go:213  [n2,split,s2,r171/3:/Table/53/1/-87{94402…-45781…}] initiating a split based on load at key /Table/53/1/-8768249731886885702
+I181130 22:14:50.203299 6163815 storage/replica_command.go:342  [n2,split,s2,r171/3:/Table/53/1/-87{94402…-45781…}] initiating a split of this range at key /Table/53/1/-8768249731886885702 [r588]
+I181130 22:14:57.650774 499 server/status/runtime.go:465  [n2] runtime stats: 729 MiB RSS, 1127 goroutines, 416 MiB/91 MiB/584 MiB GO alloc/idle/total, 75 MiB/128 MiB CGO alloc/total, 111534.7 CGO/sec, 2013.0/232.3 %(u/s)time, 0.4 %gc (56x), 189 MiB/189 MiB (r/w)net
+I181130 22:15:05.892547 6507691 storage/split_queue.go:213  [n2,split,s2,r129/3:/Table/53/1/-{722633…-673989…}] initiating a split based on load at key /Table/53/1/-698671514117501959
+I181130 22:15:05.892592 6507691 storage/replica_command.go:342  [n2,split,s2,r129/3:/Table/53/1/-{722633…-673989…}] initiating a split of this range at key /Table/53/1/-698671514117501959 [r589]
+I181130 22:15:07.653821 499 server/status/runtime.go:465  [n2] runtime stats: 756 MiB RSS, 1127 goroutines, 338 MiB/113 MiB/584 MiB GO alloc/idle/total, 94 MiB/149 MiB CGO alloc/total, 108469.2 CGO/sec, 1964.7/227.0 %(u/s)time, 0.4 %gc (54x), 185 MiB/184 MiB (r/w)net

--- a/pkg/cli/testdata/merge_logs/results/3.non-standard
+++ b/pkg/cli/testdata/merge_logs/results/3.non-standard
@@ -1,0 +1,20 @@
+I181130 22:14:34.828612 740 storage/store_rebalancer.go:277  [n1,s1,store-rebalancer] load-based lease transfers successfully brought s1 down to 37128.65 qps (mean=29834.62, upperThreshold=37293.27)
+I181130 22:14:37.516378 441 server/status/runtime.go:465  [n1] runtime stats: 900 MiB RSS, 1509 goroutines, 421 MiB/144 MiB/777 MiB GO alloc/idle/total, 96 MiB/144 MiB CGO alloc/total, 154632.4 CGO/sec, 2206.9/216.0 %(u/s)time, 0.4 %gc (43x), 182 MiB/204 MiB (r/w)net
+I181130 22:14:47.400515 437 gossip/gossip.go:555  [n1] gossip status (ok, 3 nodes)
+gossip client (0/3 cur/max conns)
+gossip server (2/3 cur/max conns, infos 4077/2242 sent/received, bytes 1275332B/555352B sent/received)
+  2: ajwerner-test-0002:26257 (8m0s)
+  3: ajwerner-test-0003:26257 (8m0s)
+I181130 22:14:47.519324 441 server/status/runtime.go:465  [n1] runtime stats: 957 MiB RSS, 1690 goroutines, 420 MiB/173 MiB/777 MiB GO alloc/idle/total, 124 MiB/174 MiB CGO alloc/total, 143837.6 CGO/sec, 2245.9/218.3 %(u/s)time, 0.5 %gc (47x), 199 MiB/210 MiB (r/w)net
+I181130 22:14:49.706516 6152567 storage/split_queue.go:213  [n2,split,s2,r163/3:/Table/53/1/-36{84178…-35915…}] initiating a split based on load at key /Table/53/1/-3661595080111255049
+I181130 22:14:49.706563 6152567 storage/replica_command.go:342  [n2,split,s2,r163/3:/Table/53/1/-36{84178…-35915…}] initiating a split of this range at key /Table/53/1/-3661595080111255049 [r586]
+I181130 22:14:49.732930 6153357 storage/split_queue.go:213  [n2,split,s2,r269/3:/Table/53/1/-81{56147…-10716…}] initiating a split based on load at key /Table/53/1/-8134885765915906309
+I181130 22:14:49.732976 6153357 storage/replica_command.go:342  [n2,split,s2,r269/3:/Table/53/1/-81{56147…-10716…}] initiating a split of this range at key /Table/53/1/-8134885765915906309 [r587]
+I181130 22:14:50.203263 6163815 storage/split_queue.go:213  [n2,split,s2,r171/3:/Table/53/1/-87{94402…-45781…}] initiating a split based on load at key /Table/53/1/-8768249731886885702
+I181130 22:14:50.203299 6163815 storage/replica_command.go:342  [n2,split,s2,r171/3:/Table/53/1/-87{94402…-45781…}] initiating a split of this range at key /Table/53/1/-8768249731886885702 [r588]
+I181130 22:14:57.522236 441 server/status/runtime.go:465  [n1] runtime stats: 986 MiB RSS, 1332 goroutines, 438 MiB/140 MiB/777 MiB GO alloc/idle/total, 151 MiB/203 MiB CGO alloc/total, 137663.6 CGO/sec, 2168.3/222.8 %(u/s)time, 0.4 %gc (45x), 192 MiB/203 MiB (r/w)net
+I181130 22:14:57.650774 499 server/status/runtime.go:465  [n2] runtime stats: 729 MiB RSS, 1127 goroutines, 416 MiB/91 MiB/584 MiB GO alloc/idle/total, 75 MiB/128 MiB CGO alloc/total, 111534.7 CGO/sec, 2013.0/232.3 %(u/s)time, 0.4 %gc (56x), 189 MiB/189 MiB (r/w)net
+I181130 22:15:05.892547 6507691 storage/split_queue.go:213  [n2,split,s2,r129/3:/Table/53/1/-{722633…-673989…}] initiating a split based on load at key /Table/53/1/-698671514117501959
+I181130 22:15:05.892592 6507691 storage/replica_command.go:342  [n2,split,s2,r129/3:/Table/53/1/-{722633…-673989…}] initiating a split of this range at key /Table/53/1/-698671514117501959 [r589]
+I181130 22:15:07.525316 441 server/status/runtime.go:465  [n1] runtime stats: 952 MiB RSS, 1422 goroutines, 397 MiB/165 MiB/777 MiB GO alloc/idle/total, 112 MiB/164 MiB CGO alloc/total, 133359.9 CGO/sec, 2137.8/225.1 %(u/s)time, 0.4 %gc (43x), 187 MiB/198 MiB (r/w)net
+I181130 22:15:07.653821 499 server/status/runtime.go:465  [n2] runtime stats: 756 MiB RSS, 1127 goroutines, 338 MiB/113 MiB/584 MiB GO alloc/idle/total, 94 MiB/149 MiB CGO alloc/total, 108469.2 CGO/sec, 1964.7/227.0 %(u/s)time, 0.4 %gc (54x), 185 MiB/184 MiB (r/w)net

--- a/pkg/util/flagutil/flagutil.go
+++ b/pkg/util/flagutil/flagutil.go
@@ -1,0 +1,136 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+// Package flagutil facilitates creation of rich flag types.
+package flagutil
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/spf13/pflag"
+)
+
+// TimeFormats are the time formats which a time flag accepts for parsing time
+// as described in time.Parse.
+var TimeFormats = []string{
+	log.MessageTimeFormat,
+	log.FileTimeFormat,
+	time.RFC3339Nano,
+	time.RFC3339,
+	time.Kitchen,
+	"15:04:00.999999Z",
+	"15:04:00.999999",
+	"15:04Z",
+	"15:04",
+}
+
+// Time returns a value which can be used with pflag.Var to create flags for
+// time variables. The flag attempts to parse its in a variety of formats.
+// The first is as a duration using time.ParseDuration and subtracting the
+// result from Now() and then by using the values in Formats for parsing using
+// time.Parse. An empty flag sets t to the zero value.
+func Time(t *time.Time) pflag.Value {
+	return (*timeFlag)(t)
+}
+
+// Regexp returns a value which can be used with pflag.Var to create flags
+// for regexp variables. The flag attempts to compile its input to a regular
+// expression and assigns the result to *r.
+// If the flag is empty, r is set to nil.
+func Regexp(r **regexp.Regexp) pflag.Value {
+	return re{re: r}
+}
+
+// timeFlag implements pflag.Value and enables easy creation of time flags.
+type timeFlag time.Time
+
+func (f *timeFlag) String() string {
+	if (*time.Time)(f).IsZero() {
+		return ""
+	}
+	return (*time.Time)(f).Format(log.MessageTimeFormat)
+}
+
+func (f *timeFlag) Type() string { return "time" }
+
+func (f *timeFlag) Set(s string) error {
+	if s == "" {
+		*f = (timeFlag)(time.Time{})
+		return nil
+	}
+	for _, p := range parsers {
+		if t, err := p.parseTime(s); err == nil {
+			*f = timeFlag(t.UTC())
+			return nil
+		}
+	}
+	return fmt.Errorf("failed to parse %q as time", s)
+}
+
+var parsers = func() (parsers []interface {
+	parseTime(s string) (time.Time, error)
+}) {
+	parsers = append(parsers, durationParser(time.ParseDuration))
+	for _, p := range TimeFormats {
+		parsers = append(parsers, formatParser(p))
+	}
+	return parsers
+}()
+
+type formatParser string
+
+func (f formatParser) parseTime(s string) (time.Time, error) {
+	return time.Parse(string(f), s)
+}
+
+type durationParser func(string) (time.Duration, error)
+
+func (f durationParser) parseTime(s string) (time.Time, error) {
+	d, err := f(s)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return timeutil.Now().Add(-1 * d), nil
+}
+
+type re struct {
+	re **regexp.Regexp
+}
+
+func (r re) String() string {
+	if *r.re == nil {
+		return ""
+	}
+	return (*r.re).String()
+}
+
+func (r re) Set(s string) error {
+	if s == "" {
+		*r.re = nil
+		return nil
+	}
+	re, err := regexp.Compile(s)
+	if err != nil {
+		return err
+	}
+	*r.re = re
+	return nil
+}
+
+func (r re) Type() string { return "regexp" }

--- a/pkg/util/flagutil/flagutil_test.go
+++ b/pkg/util/flagutil/flagutil_test.go
@@ -1,0 +1,169 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package flagutil
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/spf13/pflag"
+)
+
+func Example() {
+	var when time.Time
+	var re *regexp.Regexp
+	flags := pflag.NewFlagSet("flags", pflag.PanicOnError)
+	flags.Var(Time(&when), "when", "sets the time when it happens")
+	flags.Var(Regexp(&re), "re", "pattern to tell if it's a match")
+	if err := flags.Parse([]string{
+		"--when", "13:02",
+		"--re", "a match$",
+	}); err != nil {
+		panic(err)
+	}
+	fmt.Println("it happens at", when.Format(time.Kitchen), re.MatchString("it's a match"))
+	// Output:
+	// it happens at 1:02PM true
+}
+
+func TestZeroValueEmptyString(t *testing.T) {
+	if got := Time(&time.Time{}).String(); got != "" {
+		t.Fatalf("got unexpected %v from empty timeFlag.String()", got)
+	}
+	var r *regexp.Regexp
+	if got := Regexp(&r).String(); got != "" {
+		t.Fatalf("unexpected value %v from empty regexp string", got)
+	}
+}
+
+func TestDuration(t *testing.T) {
+	got := parseTime(t, "1m")
+	if then := timeutil.Now().Add(-1 * time.Minute); then.Sub(got) > 50*time.Millisecond {
+		t.Fatalf("Parsed duration is not near now less a minute: got %v, expected near %v, delta %v",
+			got, then, then.Sub(got))
+	}
+}
+
+func TestTimeNegative(t *testing.T) {
+	var when time.Time
+	flags := pflag.NewFlagSet("test", pflag.PanicOnError)
+	flags.Var(Time(&when), "time", "it's a test")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("did not panic during Parse")
+		}
+	}()
+	if err := flags.Parse([]string{"--time", "junk"}); err != nil {
+		t.Fatalf("error parsing flags: %v", err)
+	}
+}
+
+func TestType(t *testing.T) {
+	Regexp(nil).Type()
+	Time(nil).Type()
+}
+
+func TestTimeFlag(t *testing.T) {
+	for _, c := range []timeCase{
+		{"12:01", mustParse(time.Kitchen, "12:01PM")},
+		{"00:01", mustParse(time.Kitchen, "12:01AM")},
+		{"07:01Z", mustParse("15:04:05.999999999Z07:00", "07:01:00.0Z")},
+	} {
+		c.run(t)
+	}
+}
+
+type timeCase struct {
+	flag     string
+	expected time.Time
+}
+
+func (c *timeCase) run(t *testing.T) {
+	when := parseTime(t, c.flag)
+	if !when.Equal(c.expected) {
+		t.Errorf("parsing of %v did not equal %v, got %v", c.flag, c.expected, when)
+	}
+	s := Time(&when).String()
+	expected := when.Format(log.MessageTimeFormat)
+	if s != expected {
+		t.Errorf("String() method returned unexpected %q, expected %q", s, expected)
+	}
+}
+
+func mustParse(format, s string) time.Time {
+	t, err := time.Parse(format, s)
+	if err != nil {
+		panic(err)
+	}
+	return t.UTC()
+}
+
+func parseTime(t *testing.T, flag string) time.Time {
+	var when time.Time
+	flags := pflag.NewFlagSet("test", pflag.PanicOnError)
+	flags.Var(Time(&when), "time", "it's a test")
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked during Parse: %v", r)
+		}
+	}()
+	if err := flags.Parse([]string{"--time", flag}); err != nil {
+		t.Fatalf("unexpected error from flag.Parse: %v", err)
+	}
+	return when
+}
+
+func TestRegexpNegative(t *testing.T) {
+	var re *regexp.Regexp
+	flags := pflag.NewFlagSet("test", pflag.PanicOnError)
+	flags.Var(Regexp(&re), "re", "it's a test")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("did not panic during Parse")
+		}
+	}()
+	if err := flags.Parse([]string{"--re", "a+*"}); err != nil {
+		t.Fatalf("shouldn't have gotten to this code")
+	}
+}
+
+func TestRegexpString(t *testing.T) {
+	re := regexp.MustCompile(".*")
+	if Regexp(&re).String() != re.String() {
+		t.Fatalf("unexpected string value from non-empty Regexp")
+	}
+}
+
+func TestEmptyStringZeroes(t *testing.T) {
+	now := timeutil.Now()
+	re := regexp.MustCompile(".*")
+	flags := pflag.NewFlagSet("test", pflag.PanicOnError)
+	flags.Var(Time(&now), "time", "it's a test")
+	flags.Var(Regexp(&re), "re", "it's a test")
+	if err := flags.Parse([]string{"--time", "", "--re", ""}); err != nil {
+		t.Fatalf("error parsing flags: %v", err)
+	}
+	if re != nil {
+		t.Errorf("expected empty string to zero regexp")
+	}
+	if !now.IsZero() {
+		t.Errorf("expected empty string to zero time")
+	}
+}

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -361,6 +361,10 @@ func NewEntryDecoder(in io.Reader) *EntryDecoder {
 	return d
 }
 
+// MessageTimeFormat is the format of the timestamp in log message headers as
+// used in go's time.Parse and time.Format.
+const MessageTimeFormat = "060102 15:04:05.999999"
+
 // Decode decodes the next log entry into the provided protobuf message.
 func (d *EntryDecoder) Decode(entry *Entry) error {
 	for {
@@ -376,7 +380,7 @@ func (d *EntryDecoder) Decode(entry *Entry) error {
 			continue
 		}
 		entry.Severity = Severity(strings.IndexByte(severityChar, m[1][0]) + 1)
-		t, err := time.Parse("060102 15:04:05.999999", string(m[2]))
+		t, err := time.Parse(MessageTimeFormat, string(m[2]))
 		if err != nil {
 			return err
 		}

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -362,7 +362,7 @@ func NewEntryDecoder(in io.Reader) *EntryDecoder {
 }
 
 // MessageTimeFormat is the format of the timestamp in log message headers as
-// used in go's time.Parse and time.Format.
+// used in time.Parse and time.Format.
 const MessageTimeFormat = "060102 15:04:05.999999"
 
 // Decode decodes the next log entry into the provided protobuf message.

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -167,18 +167,19 @@ func removePeriods(s string) string {
 	return strings.Replace(s, ".", "", -1)
 }
 
+// FileTimeFormat is RFC3339 with the colons replaced with underscores.
+// It is the format used for timestamps in log file names.
+// This removal of colons creates log files safe for Windows file systems.
+const FileTimeFormat = "2006-01-02T15_04_05Z07:00"
+
 // logName returns a new log file name with start time t, and the name
 // for the symlink.
 func logName(prefix string, t time.Time) (name, link string) {
-	// Replace the ':'s in the time format with '_'s to allow for log files in
-	// Windows.
-	tFormatted := strings.Replace(t.Format(time.RFC3339), ":", "_", -1)
-
 	name = fmt.Sprintf("%s.%s.%s.%s.%06d.log",
 		removePeriods(prefix),
 		removePeriods(host),
 		removePeriods(userName),
-		tFormatted,
+		t.Format(FileTimeFormat),
 		pid)
 	return name, removePeriods(prefix) + ".log"
 }
@@ -194,9 +195,7 @@ func ParseLogFilename(filename string) (FileDetails, error) {
 		return FileDetails{}, errMalformedName
 	}
 
-	// Replace the '_'s with ':'s to restore the correct time format.
-	fixTime := strings.Replace(matches[4], "_", ":", -1)
-	time, err := time.Parse(time.RFC3339, fixTime)
+	time, err := time.Parse(FileTimeFormat, matches[4])
 	if err != nil {
 		return FileDetails{}, err
 	}


### PR DESCRIPTION
This PR comes in three commits. The first adds a new util/flagutil package which make it easy to create regular expression and time flags. The next adopts these flags and modestly evolves the behavior of debug merge-logs to allow it to be used with non-standard file names. Lastly it adds a roachprod command which can stream logs to the terminal. 