### PR TITLE
release-2.1: opt: (non-index) constraints for LIKE, SIMILAR TO

### DIFF
--- a/pkg/sql/opt/idxconstraint/testdata/strings
+++ b/pkg/sql/opt/idxconstraint/testdata/strings
@@ -66,7 +66,13 @@ index-constraints vars=(string) index=(@1)
 [/'ABC' - /'ABC']
 
 index-constraints vars=(string) index=(@1)
-@1 SIMILAR TO '(ABC|ABCDEF)%'
+@1 SIMILAR TO '(ABC|ABCDEF).*'
 ----
 [/'ABC' - /'ABD')
-Remaining filter: @1 SIMILAR TO '(ABC|ABCDEF)%'
+Remaining filter: @1 SIMILAR TO '(ABC|ABCDEF).*'
+
+index-constraints vars=(string) index=(@1)
+@1 SIMILAR TO '.*'
+----
+[/'' - ]
+Remaining filter: @1 SIMILAR TO '.*'

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -16,6 +16,8 @@ package memo
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
@@ -76,7 +78,10 @@ func (cb *constraintsBuilder) buildSingleColumnConstraint(
 	}
 
 	if val.IsConstValue() || MatchesTupleOfConstants(val) {
-		return cb.buildSingleColumnConstraintConst(col, op, ExtractConstDatum(val))
+		res, tight := cb.buildSingleColumnConstraintConst(col, op, ExtractConstDatum(val))
+		if res != unconstrained {
+			return res, tight
+		}
 	}
 
 	// Try to at least deduce a not-null constraint.
@@ -161,7 +166,36 @@ func (cb *constraintsBuilder) buildSingleColumnConstraintConst(
 		}
 		return c, true
 
-		// TODO(radu): handle other ops.
+	case opt.LikeOp:
+		if s, ok := tree.AsDString(datum); ok {
+			if i := strings.IndexAny(string(s), "_%"); i >= 0 {
+				if i == 0 {
+					// Mask starts with _ or %.
+					return unconstrained, false
+				}
+				c := cb.makeStringPrefixSpan(col, string(s[:i]))
+				// A mask like ABC% is equivalent to restricting the prefix to ABC.
+				// A mask like ABC%Z requires restricting the prefix, but is a stronger
+				// condition.
+				tight := (i == len(s)-1) && s[i] == '%'
+				return c, tight
+			}
+			// No wildcard characters, this is an equality.
+			return cb.eqSpan(col, &s), true
+		}
+
+	case opt.SimilarToOp:
+		// a SIMILAR TO 'foo_*' -> prefix "foo"
+		if s, ok := tree.AsDString(datum); ok {
+			pattern := tree.SimilarEscape(string(s))
+			if re, err := regexp.Compile(pattern); err == nil {
+				prefix, complete := re.LiteralPrefix()
+				if complete {
+					return cb.eqSpan(col, tree.NewDString(prefix)), true
+				}
+				return cb.makeStringPrefixSpan(col, prefix), false
+			}
+		}
 	}
 	return unconstrained, false
 }
@@ -470,6 +504,33 @@ func (cb *constraintsBuilder) notNullSpan(col opt.ColumnID) *constraint.Set {
 func (cb *constraintsBuilder) eqSpan(col opt.ColumnID, value tree.Datum) *constraint.Set {
 	key := constraint.MakeKey(value)
 	return cb.singleSpan(col, key, includeBoundary, key, includeBoundary)
+}
+
+// makeStringPrefixSpan constraints a string column to strings having the given prefix.
+func (cb *constraintsBuilder) makeStringPrefixSpan(
+	col opt.ColumnID, prefix string,
+) *constraint.Set {
+	startKey, startBoundary := constraint.MakeKey(tree.NewDString(prefix)), includeBoundary
+	endKey, endBoundary := emptyKey, includeBoundary
+
+	i := len(prefix) - 1
+	for ; i >= 0 && prefix[i] == 0xFF; i-- {
+	}
+
+	// If i < 0, we have a prefix like "\xff\xff\xff"; there is no ending value.
+	if i >= 0 {
+		// A few examples:
+		//   prefix      -> endValue
+		//   ABC         -> ABD
+		//   ABC\xff     -> ABD
+		//   ABC\xff\xff -> ABD
+		endVal := []byte(prefix[:i+1])
+		endVal[i]++
+		endDatum := tree.NewDString(string(endVal))
+		endKey = constraint.MakeKey(endDatum)
+		endBoundary = excludeBoundary
+	}
+	return cb.singleSpan(col, startKey, startBoundary, endKey, endBoundary)
 }
 
 // verifyType checks that the type of column matches the given type. We disallow

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -195,13 +195,13 @@ opt
 SELECT * FROM a WHERE x > 1.5
 ----
 select
- ├── columns: x:1(int) y:2(int)
+ ├── columns: x:1(int!null) y:2(int)
  ├── prune: (2)
  ├── scan a
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
- └── filters [type=bool, outer=(1)]
-      └── gt [type=bool, outer=(1)]
+ └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      └── gt [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
            ├── variable: x [type=int, outer=(1)]
            └── const: 1.5 [type=decimal]
 
@@ -1014,3 +1014,224 @@ select
                 └── tuple [type=tuple{int, int}]
                      ├── const: 1 [type=int]
                      └── const: 2 [type=int]
+
+# Tests for string operators (LIKE, SIMILAR TO).
+opt
+SELECT * FROM kuv WHERE v LIKE 'ABC%'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'); tight)]
+      └── like [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'); tight)]
+           ├── variable: v [type=string, outer=(3)]
+           └── const: 'ABC%' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v LIKE 'ABC_'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+      └── like [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+           ├── variable: v [type=string, outer=(3)]
+           └── const: 'ABC_' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v LIKE 'ABC%Z'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+      └── like [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+           ├── variable: v [type=string, outer=(3)]
+           └── const: 'ABC%Z' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v LIKE 'ABC'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABC']; tight), fd=()-->(3)]
+      └── like [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABC']; tight)]
+           ├── variable: v [type=string, outer=(3)]
+           └── const: 'ABC' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v LIKE '%'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
+      └── like [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
+           ├── variable: v [type=string, outer=(3)]
+           └── const: '%' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v LIKE '%XY'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
+      └── like [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
+           ├── variable: v [type=string, outer=(3)]
+           └── const: '%XY' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v SIMILAR TO 'ABC.*'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+      └── similar-to [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+           ├── variable: v [type=string, outer=(3)]
+           └── const: 'ABC.*' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v SIMILAR TO 'ABC.*Z'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+      └── similar-to [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+           ├── variable: v [type=string, outer=(3)]
+           └── const: 'ABC.*Z' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v SIMILAR TO 'ABC'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABC']; tight), fd=()-->(3)]
+      └── similar-to [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABC']; tight)]
+           ├── variable: v [type=string, outer=(3)]
+           └── const: 'ABC' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v SIMILAR TO '(ABC|ABCDEF).*'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+      └── similar-to [type=bool, outer=(3), constraints=(/3: [/'ABC' - /'ABD'))]
+           ├── variable: v [type=string, outer=(3)]
+           └── const: '(ABC|ABCDEF).*' [type=string]
+
+opt
+SELECT * FROM kuv WHERE v SIMILAR TO '.*'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── prune: (1,2)
+ ├── interesting orderings: (+1)
+ ├── scan kuv
+ │    ├── columns: k:1(int!null) u:2(float) v:3(string)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+1)
+ └── filters [type=bool, outer=(3), constraints=(/3: [/'' - ])]
+      └── similar-to [type=bool, outer=(3), constraints=(/3: [/'' - ])]
+           ├── variable: v [type=string, outer=(3)]
+           └── const: '.*' [type=string]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -295,8 +295,8 @@ opt
 SELECT * FROM abcde WHERE b = 1 AND c LIKE '+1-1000%'
 ----
 index-join abcde
- ├── columns: a:1(int!null) b:2(int!null) c:3(string) d:4(int) e:5(int)
- ├── stats: [rows=3.33333333, distinct(2)=1]
+ ├── columns: a:1(int!null) b:2(int!null) c:3(string!null) d:4(int) e:5(int)
+ ├── stats: [rows=1.11111111, distinct(2)=1]
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3-5)
  └── scan abcde@good

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -318,25 +318,22 @@ select
       ├── d_id = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
       └── d_name = 'bobs_burgers' [type=bool, outer=(3), constraints=(/3: [/'bobs_burgers' - /'bobs_burgers']; tight)]
 
-# In this case we expect to use unknownFilterSelectivity
-# to estimate the selectivity on d_name, and use
-# the ratio of current/input distinct counts for d_id
 norm
 SELECT * FROM district WHERE d_id = 1 and d_name LIKE 'bob'
 ----
 select
- ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
- ├── stats: [rows=3.33333333, distinct(1)=1]
+ ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
+ ├── stats: [rows=0.1, distinct(1)=0.1, distinct(3)=0.1]
  ├── key: (2)
- ├── fd: ()-->(1), (2)-->(3)
+ ├── fd: ()-->(1,3)
  ├── scan district
  │    ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string)
- │    ├── stats: [rows=100, distinct(1)=10]
+ │    ├── stats: [rows=100, distinct(1)=10, distinct(3)=100]
  │    ├── key: (1,2)
  │    └── fd: (1,2)-->(3)
- └── filters [type=bool, outer=(1,3), constraints=(/1: [/1 - /1]), fd=()-->(1)]
+ └── filters [type=bool, outer=(1,3), constraints=(/1: [/1 - /1]; /3: [/'bob' - /'bob']; tight), fd=()-->(1,3)]
       ├── d_id = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
-      └── d_name LIKE 'bob' [type=bool, outer=(3)]
+      └── d_name LIKE 'bob' [type=bool, outer=(3), constraints=(/3: [/'bob' - /'bob']; tight)]
 
 # This tests selectivityFromReducedCols.
 # Since (1,2)-->(3) in order to use selectivityFromReducedCols,

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -396,52 +396,52 @@ FROM a
 WHERE NOT(s LIKE 'foo') AND NOT(s NOT LIKE 'foo') AND NOT(s ILIKE 'foo') AND NOT(s NOT ILIKE 'foo')
 ----
 select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
  ├── key: (1)
- ├── fd: (1)-->(2-5)
+ ├── fd: ()-->(4), (1)-->(2,3,5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
- └── filters [type=bool, outer=(4)]
-      ├── s NOT LIKE 'foo' [type=bool, outer=(4)]
-      ├── s LIKE 'foo' [type=bool, outer=(4)]
-      ├── s NOT ILIKE 'foo' [type=bool, outer=(4)]
-      └── s ILIKE 'foo' [type=bool, outer=(4)]
+ └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']), fd=()-->(4)]
+      ├── s NOT LIKE 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      ├── s LIKE 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
+      ├── s NOT ILIKE 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      └── s ILIKE 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
 
 # SimilarTo comparisons.
 opt
 SELECT * FROM a WHERE NOT(s SIMILAR TO 'foo') AND NOT(s NOT SIMILAR TO 'foo')
 ----
 select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
  ├── key: (1)
- ├── fd: (1)-->(2-5)
+ ├── fd: ()-->(4), (1)-->(2,3,5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
- └── filters [type=bool, outer=(4)]
-      ├── s NOT SIMILAR TO 'foo' [type=bool, outer=(4)]
-      └── s SIMILAR TO 'foo' [type=bool, outer=(4)]
+ └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']), fd=()-->(4)]
+      ├── s NOT SIMILAR TO 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      └── s SIMILAR TO 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
 
 # RegMatch comparisons.
 opt
 SELECT * FROM a WHERE NOT(s ~ 'foo') AND NOT(s !~ 'foo') AND NOT(s ~* 'foo') AND NOT (s !~* 'foo')
 ----
 select
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
- └── filters [type=bool, outer=(4)]
-      ├── s !~ 'foo' [type=bool, outer=(4)]
-      ├── s ~ 'foo' [type=bool, outer=(4)]
-      ├── s !~* 'foo' [type=bool, outer=(4)]
-      └── s ~* 'foo' [type=bool, outer=(4)]
+ └── filters [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      ├── s !~ 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      ├── s ~ 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      ├── s !~* 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+      └── s ~* 'foo' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
 
 opt
 SELECT * FROM a WHERE

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -776,8 +776,8 @@ select
  │    ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
- └── filters [type=bool, outer=(1)]
-      └── k > 1.0 [type=bool, outer=(1)]
+ └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      └── k > 1.0 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
 
 # Ensure the rest of normalization does its work and we move things around appropriately.
 opt expect=UnifyComparisonTypes
@@ -812,8 +812,8 @@ select
  │    ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
- └── filters [type=bool, outer=(1)]
-      └── k > 1.1 [type=bool, outer=(1)]
+ └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      └── k > 1.1 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
 
 # -0 can generate spans
 opt expect=UnifyComparisonTypes
@@ -837,8 +837,8 @@ select
  │    ├── columns: k:1(int!null) i:2(int) t:3(timestamp) tz:4(timestamptz) d:5(date)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
- └── filters [type=bool, outer=(1)]
-      └── k > NaN [type=bool, outer=(1)]
+ └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      └── k > NaN [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
 
 # IS/IS NOT
 # We do not do the unification here (the rule matches on Const and NULL is its
@@ -905,7 +905,7 @@ project
  ├── columns: k:1(int!null)
  ├── key: (1)
  └── select
-      ├── columns: k:1(int!null) tz:4(timestamptz)
+      ├── columns: k:1(int!null) tz:4(timestamptz!null)
       ├── key: (1)
       ├── fd: (1)-->(4)
       ├── scan e@secondary
@@ -913,8 +913,8 @@ project
       │    ├── constraint: /4/1: (/NULL - ]
       │    ├── key: (1)
       │    └── fd: (1)-->(4)
-      └── filters [type=bool, outer=(4)]
-           └── tz > '2017-11-12 07:35:01+00:00' [type=bool, outer=(4)]
+      └── filters [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
+           └── tz > '2017-11-12 07:35:01+00:00' [type=bool, outer=(4), constraints=(/4: (/NULL - ])]
 
 opt expect=UnifyComparisonTypes
 SELECT k FROM e WHERE tz > '2017-11-12 07:35:01+00:00'::TIMESTAMP
@@ -959,8 +959,8 @@ project
       │    ├── constraint: /5/1: [/'2018-07-02' - ]
       │    ├── key: (1)
       │    └── fd: (1)-->(5)
-      └── filters [type=bool, outer=(5)]
-           └── d < '2018-07-08 00:00:01+00:00' [type=bool, outer=(5)]
+      └── filters [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
+           └── d < '2018-07-08 00:00:01+00:00' [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
 
 # NULL value.
 opt

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -182,7 +182,7 @@ SELECT sum(kv.w) FROM kv GROUP BY lower(s) HAVING lower(kv.s) LIKE 'test%'
 project
  ├── columns: sum:5(decimal)
  └── select
-      ├── columns: sum:5(decimal) column6:6(string)
+      ├── columns: sum:5(decimal) column6:6(string!null)
       ├── group-by
       │    ├── columns: sum:5(decimal) column6:6(string)
       │    ├── grouping columns: column6:6(string)

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -530,9 +530,9 @@ project
       │         │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null)
       │         │    │    │    │    │    ├── key: (1)
       │         │    │    │    │    │    └── fd: (1)-->(3,5,6)
-      │         │    │    │    │    └── filters [type=bool, outer=(5,6), constraints=(/6: [/15 - /15]), fd=()-->(6)]
+      │         │    │    │    │    └── filters [type=bool, outer=(5,6), constraints=(/5: (/NULL - ]; /6: [/15 - /15]), fd=()-->(6)]
       │         │    │    │    │         ├── p_size = 15 [type=bool, outer=(6), constraints=(/6: [/15 - /15]; tight)]
-      │         │    │    │    │         └── p_type LIKE '%BRASS' [type=bool, outer=(5)]
+      │         │    │    │    │         └── p_type LIKE '%BRASS' [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
       │         │    │    │    └── filters [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
       │         │    │    │         └── p_partkey = partsupp.ps_partkey [type=bool, outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ])]
       │         │    │    └── filters [type=bool, outer=(1,29), constraints=(/1: (/NULL - ]; /29: (/NULL - ]), fd=(1)==(29), (29)==(1)]
@@ -1319,8 +1319,8 @@ sort
       │    │    │    └── filters [type=bool, outer=(10,13,19,47), constraints=(/10: (/NULL - ]; /13: (/NULL - ]; /19: (/NULL - ]; /47: (/NULL - ]), fd=(10)==(19), (19)==(10), (13)==(47), (47)==(13)]
       │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ])]
       │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(13,47), constraints=(/13: (/NULL - ]; /47: (/NULL - ])]
-      │    │    └── filters [type=bool, outer=(2)]
-      │    │         └── p_name LIKE '%green%' [type=bool, outer=(2)]
+      │    │    └── filters [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+      │    │         └── p_name LIKE '%green%' [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
       │    └── projections [outer=(21-23,36,42,48)]
       │         ├── extract('year', o_orderdate) [type=int, outer=(42)]
       │         └── (l_extendedprice * (1.0 - l_discount)) - (ps_supplycost * l_quantity) [type=float, outer=(21-23,36)]
@@ -1733,8 +1733,8 @@ sort
       │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(string!null)
       │    │    │    │    ├── key: (9)
       │    │    │    │    └── fd: (9)-->(10,17)
-      │    │    │    └── filters [type=bool, outer=(17)]
-      │    │    │         └── o_comment NOT LIKE '%special%requests%' [type=bool, outer=(17)]
+      │    │    │    └── filters [type=bool, outer=(17), constraints=(/17: (/NULL - ])]
+      │    │    │         └── o_comment NOT LIKE '%special%requests%' [type=bool, outer=(17), constraints=(/17: (/NULL - ])]
       │    │    └── filters [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
       │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ])]
       │    └── aggregations [outer=(9)]
@@ -2000,8 +2000,8 @@ sort
       │    │    │    │    ├── key: (15)
       │    │    │    │    ├── fd: (15)-->(21)
       │    │    │    │    └── ordering: +15
-      │    │    │    └── filters [type=bool, outer=(21)]
-      │    │    │         └── s_comment LIKE '%Customer%Complaints%' [type=bool, outer=(21)]
+      │    │    │    └── filters [type=bool, outer=(21), constraints=(/21: (/NULL - ])]
+      │    │    │         └── s_comment LIKE '%Customer%Complaints%' [type=bool, outer=(21), constraints=(/21: (/NULL - ])]
       │    │    └── merge-on
       │    │         ├── left ordering: +2
       │    │         ├── right ordering: +15
@@ -2014,9 +2014,9 @@ sort
       │    │    │    ├── columns: p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
       │    │    │    ├── key: (6)
       │    │    │    └── fd: (6)-->(9-11)
-      │    │    └── filters [type=bool, outer=(9-11), constraints=(/9: (/NULL - /'Brand#45') [/e'Brand#45\x00' - ]; /11: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49])]
+      │    │    └── filters [type=bool, outer=(9-11), constraints=(/9: (/NULL - /'Brand#45') [/e'Brand#45\x00' - ]; /10: (/NULL - ]; /11: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49])]
       │    │         ├── p_brand != 'Brand#45' [type=bool, outer=(9), constraints=(/9: (/NULL - /'Brand#45') [/e'Brand#45\x00' - ]; tight)]
-      │    │         ├── p_type NOT LIKE 'MEDIUM POLISHED %' [type=bool, outer=(10)]
+      │    │         ├── p_type NOT LIKE 'MEDIUM POLISHED %' [type=bool, outer=(10), constraints=(/10: (/NULL - ])]
       │    │         └── p_size IN (3, 9, 14, 19, 23, 36, 45, 49) [type=bool, outer=(11), constraints=(/11: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49]; tight)]
       │    └── filters [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       │         └── p_partkey = ps_partkey [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
@@ -2452,8 +2452,8 @@ sort
            │    │    │    │    ├── columns: p_partkey:17(int!null) p_name:18(string!null)
            │    │    │    │    ├── key: (17)
            │    │    │    │    └── fd: (17)-->(18)
-           │    │    │    └── filters [type=bool, outer=(18)]
-           │    │    │         └── p_name LIKE 'forest%' [type=bool, outer=(18)]
+           │    │    │    └── filters [type=bool, outer=(18), constraints=(/18: [/'forest' - /'foresu'); tight)]
+           │    │    │         └── p_name LIKE 'forest%' [type=bool, outer=(18), constraints=(/18: [/'forest' - /'foresu'); tight)]
            │    │    └── filters [type=bool, outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ]), fd=(12)==(17), (17)==(12)]
            │    │         └── ps_partkey = p_partkey [type=bool, outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ])]
            │    └── filters [type=bool, outer=(1,13), constraints=(/1: (/NULL - ]; /13: (/NULL - ]), fd=(1)==(13), (13)==(1)]


### PR DESCRIPTION
Backport of #31942 to 2.1. A customer ran into an issue that it fixes.

CC @cockroachdb/release 

Adding constraint builder support for `LikeOp` and `SimilarToOp`. Also
improving the logic to still try to determine not-null constraints if
`buildSingleColumnConstraintConst` fails to come up with a constraint.

Related to #31929.

Release note (performance improvement): Queries using LIKE get better
execution plans in some cases.