### PR TITLE
storage: change init order for multiTestContext

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -832,7 +832,6 @@ func (m *multiTestContext) addStore(idx int) {
 	if err := m.gossipNodeDesc(m.gossips[idx], nodeID); err != nil {
 		m.t.Fatal(err)
 	}
-	store.WaitForInit()
 
 	ran := struct {
 		sync.Once
@@ -849,6 +848,8 @@ func (m *multiTestContext) addStore(idx int) {
 			close(ran.ch)
 		})
 	})
+
+	store.WaitForInit()
 	// Wait until we see the first heartbeat by waiting for the callback (which
 	// fires *after* the node becomes live).
 	<-ran.ch


### PR DESCRIPTION
Switch the order in which liveness heartbeats are started for stores in
a multiTestContext. It used to be started after a store was otherwise
initialized. This patch moves it up, as heartbeats are necessary for
gossiping the system config if some of the system ranges have
epoch-based leases. Currently, in multiTestContexts, there's a single
range at startup (with expiration-based lease), but I'm mulling starting
up with more ranges.

Release note: None