### PR TITLE
sql: eliminate direct usage of Mutations list in table schema

### DIFF
--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -34,7 +34,7 @@ import (
 func DecodeIndexKeyToCols(
 	vecs []exec.ColVec,
 	idx uint16,
-	desc *sqlbase.TableDescriptor,
+	desc *sqlbase.ImmutableTableDescriptor,
 	index *sqlbase.IndexDescriptor,
 	indexColIdx []int,
 	types []sqlbase.ColumnType,

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -224,10 +224,8 @@ func (p *planner) getTableScanByRef(
 	wantedColumns := tref.Columns
 	if scanVisibility == publicAndNonPublicColumns {
 		wantedColumns = wantedColumns[:len(wantedColumns):len(wantedColumns)]
-		for _, mutation := range desc.Mutations {
-			if c := mutation.GetColumn(); c != nil {
-				wantedColumns = append(wantedColumns, tree.ColumnID(c.ID))
-			}
+		for _, c := range desc.MutationColumns() {
+			wantedColumns = append(wantedColumns, tree.ColumnID(c.ID))
 		}
 	}
 

--- a/pkg/sql/distsqlrun/colbatch_scan.go
+++ b/pkg/sql/distsqlrun/colbatch_scan.go
@@ -67,15 +67,7 @@ func newColBatchScan(
 
 	limitHint := limitHint(spec.LimitHint, post)
 
-	numCols := len(spec.Table.Columns)
 	returnMutations := spec.Visibility == distsqlpb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC
-	if returnMutations {
-		for i := range spec.Table.Mutations {
-			if spec.Table.Mutations[i].GetColumn() != nil {
-				numCols++
-			}
-		}
-	}
 	typs := spec.Table.ColumnTypesWithMutations(returnMutations)
 	helper := ProcOutputHelper{}
 	if err := helper.Init(

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -87,15 +87,7 @@ func newTableReader(
 	tr.limitHint = limitHint(spec.LimitHint, post)
 	tr.maxResults = spec.MaxResults
 
-	numCols := len(spec.Table.Columns)
 	returnMutations := spec.Visibility == distsqlpb.ScanVisibility_PUBLIC_AND_NOT_PUBLIC
-	if returnMutations {
-		for i := range spec.Table.Mutations {
-			if spec.Table.Mutations[i].GetColumn() != nil {
-				numCols++
-			}
-		}
-	}
 	types := spec.Table.ColumnTypesWithMutations(returnMutations)
 	tr.ignoreMisplannedRanges = flowCtx.local
 	if err := tr.Init(

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -133,7 +133,7 @@ func (p *planner) Insert(
 		// not care: the backfill is also inserting defaults, and we do
 		// not provide guarantees about the evaluation order of default
 		// expressions.
-		insertCols = desc.WritableColumns
+		insertCols = desc.WritableColumns()
 	} else {
 		var err error
 		if insertCols, err = p.processColumns(desc, n.Columns,
@@ -649,7 +649,7 @@ func GenerateInsertRow(
 	}
 
 	// Check to see if NULL is being inserted into any non-nullable column.
-	for _, col := range tableDesc.WritableColumns {
+	for _, col := range tableDesc.WritableColumns() {
 		if !col.Nullable {
 			if i, ok := rowContainerForComputedVals.Mapping[col.ID]; !ok || rowVals[i] == tree.DNull {
 				return nil, sqlbase.NewNonNullViolationError(col.Name)

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -425,7 +425,7 @@ func (v *indexInfo) isCoveringIndex(scan *scanNode) bool {
 	for _, colIdx := range scan.valNeededForCol.Ordered() {
 		// This is possible during a schema change when we have
 		// additional mutation columns.
-		if colIdx >= len(v.desc.Columns) && len(v.desc.Mutations) > 0 {
+		if colIdx >= len(v.desc.Columns) && len(v.desc.MutationColumns()) > 0 {
 			return false
 		}
 		colID := v.desc.Columns[colIdx].ID

--- a/pkg/sql/sqlbase/default_exprs.go
+++ b/pkg/sql/sqlbase/default_exprs.go
@@ -101,7 +101,7 @@ func processColumnSet(
 
 	// Add all public or columns in DELETE_AND_WRITE_ONLY state
 	// that satisfy the condition.
-	for _, col := range tableDesc.WritableColumns {
+	for _, col := range tableDesc.WritableColumns() {
 		if inSet(col) {
 			if _, ok := colIDSet[col.ID]; !ok {
 				colIDSet[col.ID] = struct{}{}

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -189,7 +189,8 @@ func (p *planner) newUpsertNode(
 			// can't specify it, which means we need to do a lookup and so we can't use
 			// the fast path. When adding or removing an index, same result, so the fast
 			// path is disabled during all mutations.
-			len(desc.Mutations) == 0 &&
+			len(desc.MutationColumns()) == 0 &&
+			len(desc.MutationIndexes()) == 0 &&
 			// For the fast path, all columns must be specified in the insert.
 			len(ri.InsertCols) == len(desc.Columns) &&
 			// We cannot use the fast path if we also have a RETURNING clause, because


### PR DESCRIPTION
This change continues the work that was started in #32920 which removed
some instances in the sql codebase directly accessing the schema
mutations list in non-schema change related code.

Release note: None