### PR TITLE
storage: remove decoy batch timestamp handler

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -176,10 +176,10 @@ func TestAsOfTime(t *testing.T) {
 		}
 	}
 
-	// Old queries shouldn't work.
-	if err := db.QueryRow("SELECT a FROM d.t AS OF SYSTEM TIME '1969-12-31'").Scan(&i); err == nil {
+	// Queries before the Unix epoch definitely shouldn't work.
+	if err := db.QueryRow("SELECT a FROM d.t AS OF SYSTEM TIME '1969-12-30'").Scan(&i); err == nil {
 		t.Fatal("expected error")
-	} else if !testutils.IsError(err, "pq: batch timestamp -86400.000000000,0 must be after GC threshold 0.000000000,0") {
+	} else if !testutils.IsError(err, "AS OF SYSTEM TIME: timestamp before 1970-01-01T00:00:00Z is invalid") {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/sem/tree/as_of.go
+++ b/pkg/sql/sem/tree/as_of.go
@@ -88,6 +88,8 @@ func EvalAsOfTimestamp(
 	var zero hlc.Timestamp
 	if ts == zero {
 		return ts, errors.Errorf("AS OF SYSTEM TIME: zero timestamp is invalid")
+	} else if ts.Less(zero) {
+		return ts, errors.Errorf("AS OF SYSTEM TIME: timestamp before 1970-01-01T00:00:00Z is invalid")
 	} else if max.Less(ts) {
 		return ts, errors.Errorf("AS OF SYSTEM TIME: cannot specify timestamp in the future")
 	}

--- a/pkg/storage/closed_timestamp_test.go
+++ b/pkg/storage/closed_timestamp_test.go
@@ -186,6 +186,9 @@ CREATE TABLE cttest.kv (id INT PRIMARY KEY, value STRING);
 		baWrite.Txn = &txn
 		baWrite.Add(r)
 		baWrite.RangeID = repls[0].RangeID
+		if err := baWrite.SetActiveTimestamp(tc.Server(0).Clock().Now); err != nil {
+			t.Fatal(err)
+		}
 
 		var found bool
 		for _, repl := range repls {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2166,14 +2166,19 @@ func (r *Replica) requestCanProceed(rspan roachpb.RSpan, ts hlc.Timestamp) error
 	return mismatchErr
 }
 
-// checkBatchRequest verifies BatchRequest validity requirements. In
-// particular, timestamp, user, user priority and transactions must
-// all be set to identical values between the batch request header and
-// all constituent batch requests. Also, either all requests must be
+// checkBatchRequest verifies BatchRequest validity requirements. In particular,
+// the batch must have an assigned timestamp, and either all requests must be
 // read-only, or none.
+//
 // TODO(tschottdorf): should check that request is contained in range
 // and that EndTransaction only occurs at the very end.
 func (r *Replica) checkBatchRequest(ba roachpb.BatchRequest, isReadOnly bool) error {
+	if ba.Timestamp == (hlc.Timestamp{}) {
+		// For transactional requests, Store.Send sets the timestamp. For non-
+		// transactional requests, the client sets the timestamp. Either way, we
+		// need to have a timestamp at this point.
+		return errors.New("Replica.checkBatchRequest: batch does not have timestamp assigned")
+	}
 	consistent := ba.ReadConsistency == roachpb.CONSISTENT
 	if isReadOnly {
 		if !consistent && ba.Txn != nil {
@@ -2451,22 +2456,6 @@ func (r *Replica) beginCmds(
 		}
 	} else {
 		log.Event(ctx, "operation accepts inconsistent results")
-	}
-
-	// Update the incoming timestamp if unset. Wait until after any
-	// preceding command(s) for key range are complete so that the node
-	// clock has been updated to the high water mark of any commands
-	// which might overlap this one in effect.
-	// TODO(spencer,tschottdorf): might remove this, but harder than it looks.
-	//   This isn't just unittests (which would require revamping the test
-	//   context sender), but also some of the scanner queues place batches
-	//   directly into the local range they're servicing.
-	if ba.Timestamp == (hlc.Timestamp{}) {
-		if txn := ba.Txn; txn != nil {
-			ba.Timestamp = txn.OrigTimestamp
-		} else {
-			ba.Timestamp = r.store.Clock().Now()
-		}
 	}
 
 	// Handle load-based splitting.


### PR DESCRIPTION
Replica.beginCmds pretended to be in charge of assigning a timestamp to
transactional batches. In fact, Store.Send has this responsibility;
there are only a few tests that send non-timestamped batches directly to
a Replica.

Avoid this confusing code by teaching the tests that send batches
directly to replicas to assign a sensible timestamp first.

This has been a major contributor to my confusion as I've been working on https://github.com/cockroachdb/cockroach/pull/32487.

Release note: None