### PR TITLE
sql: deflake partition test again

### DIFF
--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -292,7 +292,7 @@ func (ctx *FmtCtx) FormatNode(n NodeFormatter) {
 			ctx.WriteString(":::")
 			colType, err := coltypes.DatumTypeToColumnType(typ)
 			if err != nil {
-				panic(err)
+				panic(fmt.Sprintf("invalid datatype %v", typ))
 			}
 			colType.Format(ctx.Buffer, f.EncodeFlags())
 		}


### PR DESCRIPTION
The RandDatum function could still occasionally return datums with
invalid column types, such as arrays with unknown-typed elements. This
should fix things once and for all, and cleans up the code a bit as
well.

Closes #32889.

Release note: None