### PR TITLE
roachprod: bump xenial image used on GCE

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -241,7 +241,7 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 		"--subnet", "default",
 		"--maintenance-policy", "MIGRATE",
 		"--scopes", "default,storage-rw",
-		"--image", "ubuntu-1604-xenial-v20181030",
+		"--image", "ubuntu-1604-xenial-v20181204",
 		"--image-project", "ubuntu-os-cloud",
 		"--boot-disk-size", "10",
 		"--boot-disk-type", "pd-ssd",


### PR DESCRIPTION
Many roachtests failed due to a warning about the previous image being
deprecated, though strangely that doesn't reproduce when running
manually.

Release note: None