### PR TITLE
sql: add automatic table stats collection

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -61,6 +61,7 @@
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
 <tr><td><code>sql.defaults.default_int_size</code></td><td>integer</td><td><code>8</code></td><td>the size, in bytes, of an INT type</td></tr>
 <tr><td><code>sql.defaults.distsql</code></td><td>enumeration</td><td><code>1</code></td><td>default distributed SQL execution mode [off = 0, auto = 1, on = 2, 2.0-off = 3, 2.0-auto = 4]</td></tr>
+<tr><td><code>sql.defaults.experimental_automatic_statistics</code></td><td>boolean</td><td><code>false</code></td><td>default experimental automatic statistics mode</td></tr>
 <tr><td><code>sql.defaults.experimental_optimizer_updates</code></td><td>boolean</td><td><code>false</code></td><td>default experimental_optimizer_updates mode</td></tr>
 <tr><td><code>sql.defaults.experimental_vectorize</code></td><td>enumeration</td><td><code>0</code></td><td>default experimental_vectorize mode [off = 0, on = 1, always = 2]</td></tr>
 <tr><td><code>sql.defaults.optimizer</code></td><td>enumeration</td><td><code>1</code></td><td>default cost-based optimizer mode [off = 0, on = 1, local = 2]</td></tr>

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -300,6 +300,13 @@ func (n *createTableNode) startExec(params runParams) error {
 			}
 			n.run.rowsAffected++
 		}
+
+		// Initiate a run of CREATE STATISTICS.
+		params.ExecCfg().StatsRefresher.NotifyMutation(
+			params.EvalContext(),
+			desc.ID,
+			n.run.rowsAffected,
+		)
 	}
 	return nil
 }

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -34,6 +34,10 @@ const histogramBuckets = 200
 func (dsp *DistSQLPlanner) createStatsPlan(
 	planCtx *PlanningCtx, desc *sqlbase.ImmutableTableDescriptor, stats []requestedStat,
 ) (PhysicalPlan, error) {
+	if len(stats) == 0 {
+		return PhysicalPlan{}, errors.New("no stats requested")
+	}
+
 	// Create the table readers; for this we initialize a dummy scanNode.
 	scan := scanNode{desc: desc}
 	err := scan.initDescDefaults(nil /* planDependencies */, publicColumnsCfg)
@@ -152,6 +156,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 		distsqlpb.PostProcessSpec{},
 		[]sqlbase.ColumnType{},
 	)
+
 	return p, nil
 }
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -801,4 +801,41 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 	}
 	dsp.FinalizePlan(planCtx, &physPlan)
 	dsp.Run(planCtx, txn, &physPlan, recv, evalCtx, nil /* finishedSetupFn */)
+	if recv.resultWriter.Err() == nil {
+		if err := dsp.logEvents(ctx, evalCtx, plan); err != nil {
+			recv.SetError(err)
+			return
+		}
+	}
+}
+
+// logEvents logs events in the system.eventlog table for successful completion
+// of some types of operations.
+func (dsp *DistSQLPlanner) logEvents(
+	ctx context.Context, evalCtx *extendedEvalContext, plan planNode,
+) error {
+	switch n := plan.(type) {
+	case *createStatsNode:
+		// Record this statistics creation in the event log.
+		// TODO(rytaft): This creates a new transaction for the CREATE STATISTICS
+		// event. It must be different from the CREATE STATISTICS transaction,
+		// because that transaction must be read-only. In the future we may want
+		// to use the transaction that inserted the new stats into the
+		// system.table_statistics table, but that would require calling
+		// MakeEventLogger from the distsqlrun package.
+		return evalCtx.ExecCfg.DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			return MakeEventLogger(evalCtx.ExecCfg).InsertEventRecord(
+				ctx,
+				txn,
+				EventLogCreateStatistics,
+				int32(n.tableDesc.ID),
+				int32(evalCtx.NodeID),
+				struct {
+					StatisticName string
+					Statement     string
+				}{n.Name.String(), n.String()},
+			)
+		})
+	}
+	return nil
 }

--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -232,6 +232,18 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 				columnIDs[i] = s.sampledCols[c]
 			}
 
+			// Delete old stats that have been superseded.
+			if err := stats.DeleteOldStatsForColumns(
+				ctx,
+				s.flowCtx.executor,
+				txn,
+				s.tableID,
+				columnIDs,
+			); err != nil {
+				return err
+			}
+
+			// Insert the new stat.
 			if err := stats.InsertNewStat(
 				ctx,
 				s.flowCtx.Gossip,
@@ -248,6 +260,7 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 				return err
 			}
 		}
+
 		return nil
 	})
 }

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -98,6 +98,10 @@ const (
 	EventLogSetZoneConfig EventLogType = "set_zone_config"
 	// EventLogRemoveZoneConfig is recorded when a zone config is removed.
 	EventLogRemoveZoneConfig EventLogType = "remove_zone_config"
+
+	// EventLogCreateStatistics is recorded when statistics are collected for a
+	// table.
+	EventLogCreateStatistics EventLogType = "create_statistics"
 )
 
 // EventLogSetClusterSettingDetail is the json details for a settings change.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -356,6 +356,7 @@ type ExecutorConfig struct {
 	VirtualSchemas   *VirtualSchemaHolder
 	DistSQLPlanner   *DistSQLPlanner
 	TableStatsCache  *stats.TableStatisticsCache
+	StatsRefresher   *stats.Refresher
 	ExecLogger       *log.SecondaryLogger
 	AuditLogger      *log.SecondaryLogger
 	InternalExecutor *InternalExecutor

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -508,6 +508,13 @@ func (n *insertNode) BatchedNext(params runParams) (bool, error) {
 		n.run.done = true
 	}
 
+	// Possibly initiate a run of CREATE STATISTICS.
+	params.ExecCfg().StatsRefresher.NotifyMutation(
+		params.EvalContext(),
+		n.run.ti.tableDesc().ID,
+		n.run.rowCount,
+	)
+
 	return n.run.rowCount > 0, nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -1,0 +1,117 @@
+# LogicTest: fakedist fakedist-opt fakedist-metadata
+
+statement ok
+CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c), INDEX d_idx (d))
+
+# Enable automatic stats
+statement ok
+SET CLUSTER SETTING sql.defaults.experimental_automatic_statistics = true
+
+# Generate all combinations of values 1 to 10.
+statement ok
+INSERT INTO data SELECT a, b, c::FLOAT, NULL FROM
+   generate_series(1, 10) AS a(a),
+   generate_series(1, 10) AS b(b),
+   generate_series(1, 10) AS c(c)
+
+query TTIII colnames,rowsort,retry
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {a}           1000       10              0
+__auto__         {d}           1000       0               1000
+
+# Disable automatic stats
+statement ok
+SET CLUSTER SETTING sql.defaults.experimental_automatic_statistics = false
+
+# Update more than 5% of the table.
+statement ok
+UPDATE data SET d = 11, a = 11 WHERE a = 1 AND b > 1
+
+# There should be no change to stats.
+query TTIII colnames,rowsort
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {a}           1000       10              0
+__auto__         {d}           1000       0               1000
+
+# Enable automatic stats
+statement ok
+SET CLUSTER SETTING sql.defaults.experimental_automatic_statistics = true
+
+# Update more than 5% of the table.
+statement ok
+UPDATE data SET d = 12, a = 12 WHERE a = 11
+
+query TTIII colnames,rowsort,retry
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {a}           1000       10              0
+__auto__         {a}           1000       11              0
+__auto__         {d}           1000       0               1000
+__auto__         {d}           1000       1               910
+
+# Upsert more than 5% of the table.
+statement ok
+UPSERT INTO data SELECT a, b, 1, 1 FROM
+generate_series(1, 11) AS a(a),
+generate_series(1, 10) AS b(b)
+
+query TTIII colnames,rowsort,retry
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {a}           1000       10              0
+__auto__         {a}           1000       11              0
+__auto__         {a}           1019       12              0
+__auto__         {d}           1000       0               1000
+__auto__         {d}           1000       1               910
+__auto__         {d}           1019       2               819
+
+# Delete more than 5% of the table.
+statement ok
+DELETE FROM data WHERE c > 5
+
+query TTIII colnames,rowsort,retry
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {a}           1000       10              0
+__auto__         {a}           1000       11              0
+__auto__         {a}           1019       12              0
+__auto__         {a}           519        12              0
+__auto__         {d}           1000       0               1000
+__auto__         {d}           1000       1               910
+__auto__         {d}           1019       2               819
+__auto__         {d}           519        2               364
+
+# Test CREATE TABLE ... AS
+statement ok
+CREATE TABLE copy AS SELECT * FROM data
+
+query TTIII colnames,rowsort,retry
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE copy] ORDER BY column_names::STRING, created
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {a}           519        12              0
+
+# Test fast path delete.
+statement ok
+DELETE FROM copy WHERE true
+
+query TTIII colnames,rowsort,retry
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE copy] ORDER BY column_names::STRING, created
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+__auto__         {a}           519        12              0
+__auto__         {a}           0          0               0

--- a/pkg/sql/logictest/testdata/logic_test/distsql_event_log
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_event_log
@@ -1,0 +1,28 @@
+# LogicTest: 5node-dist 5node-dist-opt 5node-dist-metadata
+
+###################
+# CREATE STATISTICS
+###################
+
+statement ok
+CREATE TABLE a (id INT PRIMARY KEY, x INT, y INT, INDEX x_idx (x, y))
+
+statement ok
+CREATE STATISTICS s1 ON id FROM a
+
+statement ok
+CREATE STATISTICS __auto__ FROM a
+
+# verify statistics creation is logged
+##################
+query IIT
+SELECT "targetID", "reportingID", "info"
+FROM system.eventlog
+WHERE "eventType" = 'create_statistics'
+ORDER BY "timestamp"
+----
+53  1  {"StatisticName":"s1","Statement":"CREATE STATISTICS s1 ON id FROM a"}
+53  1  {"StatisticName":"__auto__","Statement":"CREATE STATISTICS __auto__ FROM a"}
+
+statement ok
+DROP TABLE a

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -128,7 +128,6 @@ query TTIII colnames
 SELECT statistics_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-s1               {a}           10000      10              0
 NULL             {b}           10000      10              0
 s2               {a}           10000      10              0
 
@@ -229,15 +228,7 @@ SELECT statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data]
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-s1               {a}           10000      10              0
-NULL             {b}           10000      10              0
-s2               {a}           10000      10              0
-s3               {a}           10000      10              0
-s3               {c}           10000      10              0
-s4               {a}           10000      10              0
-s4               {b}           10000      10              0
 s4               {c}           10000      10              0
-s5               {a}           10000      10              0
 s5               {b}           10000      10              0
 s6               {a}           10000      10              0
 
@@ -253,6 +244,68 @@ WHERE statistics_name = '__auto__'
 column_names  row_count  distinct_count  null_count
 {a}           10000      10              0
 {b}           10000      10              0
+
+#
+# Test delete stats
+#
+
+statement ok
+DROP INDEX data@data_b_idx
+
+statement ok
+CREATE STATISTICS __auto__ FROM [53];
+CREATE STATISTICS __auto__ FROM [53];
+CREATE STATISTICS __auto__ FROM [53];
+CREATE STATISTICS __auto__ FROM [53];
+CREATE STATISTICS __auto__ FROM [53];
+CREATE STATISTICS __auto__ FROM [53];
+
+# Only the last 4-5 automatic stats should remain for each column.
+query TT colnames
+SELECT statistics_name, column_names
+FROM [SHOW STATISTICS FOR TABLE data]
+----
+statistics_name  column_names
+s4               {c}
+__auto__         {b}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+
+statement ok
+CREATE STATISTICS s7 ON a FROM [53]
+
+query TT colnames
+SELECT statistics_name, column_names
+FROM [SHOW STATISTICS FOR TABLE data]
+----
+statistics_name  column_names
+s4               {c}
+__auto__         {b}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+s7               {a}
+
+statement ok
+CREATE STATISTICS s8 ON a FROM [53]
+
+# s7 is deleted but the automatic stats remain.
+query TT colnames
+SELECT statistics_name, column_names
+FROM [SHOW STATISTICS FOR TABLE data]
+----
+statistics_name  column_names
+s4               {c}
+__auto__         {b}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+s8               {a}
 
 # Regression test for #33195.
 statement ok

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -93,6 +93,11 @@ func (r *runParams) SessionData() *sessiondata.SessionData {
 	return r.extendedEvalCtx.SessionData
 }
 
+// ExecCfg gives convenient access to the runParam's ExecutorConfig.
+func (r *runParams) ExecCfg() *ExecutorConfig {
+	return r.extendedEvalCtx.ExecCfg
+}
+
 // planNode defines the interface for executing a query or portion of a query.
 //
 // The following methods apply to planNodes and contain special cases

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -1,0 +1,406 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
+)
+
+// AutomaticStatisticsClusterMode controls the cluster default for when
+// automatic table statistics collection is enabled.
+var AutomaticStatisticsClusterMode = settings.RegisterBoolSetting(
+	"sql.defaults.experimental_automatic_statistics",
+	"default experimental automatic statistics mode",
+	false,
+)
+
+// DefaultRefreshInterval is the frequency at which the Refresher will check if
+// the stats for each table should be refreshed. It is mutable for testing.
+// NB: Updates to this value after Refresher.Start has been called will not
+// have any effect.
+var DefaultRefreshInterval = time.Second
+
+// DefaultAsOfTime is a duration which is used to define the AS OF time for
+// automatic runs of CREATE STATISTICS. It is mutable for testing.
+// NB: Updates to this value after MakeRefresher has been called will not have
+// any effect.
+var DefaultAsOfTime = 30 * time.Second
+
+// Constants for automatic statistics collection.
+// TODO(rytaft): Should these constants be configurable?
+const (
+	// targetFractionOfRowsUpdatedBeforeRefresh indicates the target fraction
+	// of rows in a table that should be updated before statistics on that table
+	// are refreshed.
+	targetFractionOfRowsUpdatedBeforeRefresh = 0.05
+
+	// defaultAverageTimeBetweenRefreshes is the default time to use as the
+	// "average" time between refreshes when there is no information for a given
+	// table.
+	defaultAverageTimeBetweenRefreshes = 12 * time.Hour
+
+	// autoStatsName is the name to use for statistics created automatically.
+	// The name is chosen to be something that users are unlikely to choose when
+	// running CREATE STATISTICS manually.
+	autoStatsName = "__auto__"
+
+	// refreshChanBufferLen is the length of the buffered channel used by the
+	// automatic statistics refresher. If the channel overflows, all SQL mutations
+	// will be ignored by the refresher until it processes some existing mutations
+	// in the buffer and makes space for new ones. SQL mutations will never block
+	// waiting on the refresher.
+	refreshChanBufferLen = 256
+)
+
+// Refresher is responsible for automatically refreshing the table statistics
+// that are used by the cost-based optimizer. It is necessary to periodically
+// refresh the statistics to prevent them from becoming stale as data in the
+// database changes.
+//
+// The Refresher is designed to schedule a CREATE STATISTICS refresh job after
+// approximately X% of total rows have been updated/inserted/deleted in a given
+// table. Currently, X is hardcoded to be 5%.
+//
+// The decision to refresh is based on a percentage rather than a fixed number
+// of rows because if a table is huge and rarely updated, we don't want to
+// waste time frequently refreshing stats. Likewise, if it's small and rapidly
+// updated, we want to update stats more often.
+//
+// To avoid contention on row update counters, we use a statistical approach.
+// For example, suppose we want to refresh stats after 5% of rows are updated
+// and there are currently 1M rows in the table. If a user updates 10 rows,
+// we use random number generation to refresh stats with probability
+// 10/(1M * 0.05) = 0.0002. The general formula is:
+//
+//                            # rows updated/inserted/deleted
+//    p =  --------------------------------------------------------------------
+//         (# rows in table) * (target fraction of rows updated before refresh)
+//
+// The existing statistics in the stats cache are used to get the number of
+// rows in the table.
+//
+// Refresher also implements some heuristic limits designed to corral
+// statistical outliers. If we haven't refreshed stats in 2x the average time
+// between the last few refreshes, we automatically trigger a refresh. The
+// existing statistics in the stats cache are used to calculate the average
+// time between refreshes as well as to determine when the stats were last
+// updated.
+//
+// If the decision is made to continue with the refresh, Refresher runs
+// CREATE STATISTICS on the given table with the default set of column
+// statistics. See comments in sql/create_stats.go for details about which
+// default columns are chosen. Refresher runs CREATE STATISTICS with
+// AS OF SYSTEM TIME ‘-30s’ to minimize performance impact on running
+// transactions.
+//
+// To avoid adding latency to SQL mutation operations, the Refresher is run
+// in one separate background thread per Server. SQL mutation operations signal
+// to the Refresher thread by calling NotifyMutation, which sends mutation
+// metadata to the Refresher thread over a non-blocking buffered channel. The
+// signaling is best-effort; if the channel is full, the metadata will not be
+// sent.
+//
+type Refresher struct {
+	ex      sqlutil.InternalExecutor
+	cache   *TableStatisticsCache
+	randGen autoStatsRand
+
+	// mutations is the buffered channel used to pass messages containing
+	// metadata about SQL mutations to the background Refresher thread.
+	mutations chan mutation
+
+	// asOfTime is a duration which is used to define the AS OF time for
+	// runs of CREATE STATISTICS by the Refresher.
+	asOfTime time.Duration
+
+	// extraTime is a small, random amount of extra time to add to the check for
+	// whether too much time has passed since the last statistics refresh. It is
+	// used to avoid having multiple nodes trying to create stats at the same
+	// time.
+	extraTime time.Duration
+
+	// mutationCounts contains aggregated mutation counts for each table that
+	// have yet to be processed by the refresher.
+	mutationCounts map[sqlbase.ID]int
+}
+
+// mutation contains metadata about a SQL mutation and is the message passed to
+// the background refresher thread to (possibly) trigger a statistics refresh.
+type mutation struct {
+	tableID      sqlbase.ID
+	rowsAffected int
+}
+
+// MakeRefresher creates a new Refresher.
+func MakeRefresher(
+	ex sqlutil.InternalExecutor, cache *TableStatisticsCache, asOfTime time.Duration,
+) *Refresher {
+	randSource := rand.NewSource(rand.Int63())
+
+	return &Refresher{
+		ex:             ex,
+		cache:          cache,
+		randGen:        makeAutoStatsRand(randSource),
+		mutations:      make(chan mutation, refreshChanBufferLen),
+		asOfTime:       asOfTime,
+		extraTime:      time.Duration(rand.Int63n(int64(time.Hour))),
+		mutationCounts: make(map[sqlbase.ID]int, 16),
+	}
+}
+
+// Start starts the stats refresher thread, which polls for messages about
+// new SQL mutations and refreshes the table statistics with probability
+// proportional to the percentage of rows affected.
+func (r *Refresher) Start(
+	ctx context.Context, stopper *stop.Stopper, refreshInterval time.Duration,
+) error {
+	stopper.RunWorker(context.Background(), func(ctx context.Context) {
+		timer := time.NewTimer(refreshInterval)
+
+		for {
+			select {
+			case <-timer.C:
+				mutationCounts := r.mutationCounts
+				if err := stopper.RunAsyncTask(
+					ctx, "stats.Refresher: maybeRefreshStats", func(ctx context.Context) {
+						for tableID, rowsAffected := range mutationCounts {
+							r.maybeRefreshStats(ctx, tableID, rowsAffected, r.asOfTime)
+						}
+						timer.Reset(refreshInterval)
+					}); err != nil {
+					log.Errorf(ctx, "failed to refresh stats: %v", err)
+				}
+				r.mutationCounts = make(map[sqlbase.ID]int, len(r.mutationCounts))
+
+			case mut := <-r.mutations:
+				r.mutationCounts[mut.tableID] += mut.rowsAffected
+
+			case <-stopper.ShouldStop():
+				return
+			}
+		}
+	})
+	return nil
+}
+
+// NotifyMutation is called by SQL mutation operations to signal to the
+// Refresher that a table has been mutated. It should be called after any
+// successful insert, update, upsert or delete. rowsAffected refers to the
+// number of rows written as part of the mutation operation.
+func (r *Refresher) NotifyMutation(
+	evalCtx *tree.EvalContext, tableID sqlbase.ID, rowsAffected int,
+) {
+	if !AutomaticStatisticsClusterMode.Get(&evalCtx.Settings.SV) {
+		// Automatic stats are disabled.
+		return
+	}
+
+	if sqlbase.IsReservedID(tableID) {
+		// Don't try to create statistics for system tables (most importantly,
+		// for table_statistics itself).
+		return
+	}
+	if tableID == keys.VirtualDescriptorID {
+		// Don't try to create statistics for virtual tables.
+		return
+	}
+
+	// Send mutation info to the refresher thread to avoid adding latency to
+	// the calling transaction.
+	select {
+	case r.mutations <- mutation{tableID: tableID, rowsAffected: rowsAffected}:
+	default:
+		// Don't block if there is no room in the buffered channel.
+		log.Warningf(context.TODO(),
+			"buffered channel is full. Unable to refresh stats for table %d with %d rows affected",
+			tableID, rowsAffected)
+	}
+}
+
+// maybeRefreshStats implements the core logic described in the comment for
+// Refresher. It is called by the background Refresher thread.
+func (r *Refresher) maybeRefreshStats(
+	ctx context.Context, tableID sqlbase.ID, rowsAffected int, asOf time.Duration,
+) {
+	tableStats, err := r.cache.GetTableStats(ctx, tableID)
+	if err != nil {
+		log.Errorf(ctx, "failed to get table statistics: %v", err)
+		return
+	}
+
+	var rowCount float64
+	mustRefresh := false
+	if stat := mostRecentAutomaticStat(tableStats); stat != nil {
+		// Check if too much time has passed since the last refresh.
+		// This check is in place to corral statistical outliers and avoid a
+		// case where a significant portion of the data in a table has changed but
+		// the stats haven't been refreshed. Randomly add some extra time to the
+		// limit check to avoid having multiple nodes trying to create stats at
+		// the same time.
+		//
+		// Note that this can cause some unnecessary runs of CREATE STATISTICS
+		// in the case where there is a heavy write load followed by a very light
+		// load. For example, suppose the average refresh time is 1 hour during
+		// the period of heavy writes, and the average refresh time should be 1
+		// week during the period of light load. It could take ~16 refreshes over
+		// 3-4 weeks before the average settles at around 1 week. (Assuming the
+		// refresh happens at exactly 2x the current average, and the average
+		// refresh time is calculated from the most recent 4 refreshes. See the
+		// comment in stats/delete_stats.go.)
+		maxTimeBetweenRefreshes := stat.CreatedAt.Add(2*avgRefreshTime(tableStats) + r.extraTime)
+		if timeutil.Now().After(maxTimeBetweenRefreshes) {
+			mustRefresh = true
+		}
+		rowCount = float64(stat.RowCount)
+	} else {
+		// If there are no statistics available on this table, we must perform a
+		// refresh.
+		mustRefresh = true
+	}
+
+	targetRows := int64(rowCount*targetFractionOfRowsUpdatedBeforeRefresh) + 1
+	if !mustRefresh && r.randGen.randInt(targetRows) >= int64(rowsAffected) {
+		// No refresh is happening this time.
+		return
+	}
+
+	// TODO(rytaft): Add logic to create a Job ID for this refresh and use the
+	// Job ID to lock automatic stats creation for this table with a lock
+	// manager. If the lock succeeds, check the stats cache one more time to
+	// make sure a new statistic was not just added. If not, proceed to the next
+	// step.
+
+	if err := r.refreshStats(ctx, tableID, asOf); err != nil {
+		pgerr, ok := errors.Cause(err).(*pgerror.Error)
+		if ok && pgerr.Code == pgerror.CodeUndefinedTableError {
+			// Sleep so that the latest changes will be reflected according to the
+			// AS OF time, then try again.
+			time.Sleep(asOf)
+			err = r.refreshStats(ctx, tableID, asOf)
+		}
+		if err != nil {
+			log.Errorf(ctx, "failed to create statistics: %v", err)
+			return
+		}
+	}
+}
+
+func (r *Refresher) refreshStats(
+	ctx context.Context, tableID sqlbase.ID, asOf time.Duration,
+) error {
+	// Create statistics for all default column sets on the given table.
+	_ /* rows */, err := r.ex.Exec(
+		ctx,
+		"create-stats",
+		nil, /* txn */
+		fmt.Sprintf("CREATE STATISTICS %s FROM [%d] AS OF SYSTEM TIME '-%s';",
+			autoStatsName, tableID, asOf.String(),
+		),
+	)
+	return err
+}
+
+// mostRecentAutomaticStat finds the most recent automatic statistic
+// (identified by the name autoStatsName).
+func mostRecentAutomaticStat(tableStats []*TableStatistic) *TableStatistic {
+	// Stats are sorted with the most recent first.
+	for _, stat := range tableStats {
+		if stat.Name == autoStatsName {
+			return stat
+		}
+	}
+	return nil
+}
+
+// avgRefreshTime returns the average time between automatic statistics
+// refreshes given a list of tableStats from one table. It does so by finding
+// the most recent automatically generated statistic (identified by the name
+// autoStatsName), and then finds all previously generated automatic stats on
+// those same columns. The average is calculated as the average time between
+// each consecutive stat.
+//
+// If there are not at least two automatically generated statistics on the same
+// columns, the default value defaultAverageTimeBetweenRefreshes is returned.
+func avgRefreshTime(tableStats []*TableStatistic) time.Duration {
+	var reference *TableStatistic
+	var sum time.Duration
+	var count int
+	for _, stat := range tableStats {
+		if stat.Name != autoStatsName {
+			continue
+		}
+		if reference == nil {
+			reference = stat
+			continue
+		}
+		if !areEqual(stat.ColumnIDs, reference.ColumnIDs) {
+			continue
+		}
+		// Stats are sorted with the most recent first.
+		sum += reference.CreatedAt.Sub(stat.CreatedAt)
+		count++
+		reference = stat
+	}
+	if count == 0 {
+		return defaultAverageTimeBetweenRefreshes
+	}
+	return sum / time.Duration(count)
+}
+
+func areEqual(a, b []sqlbase.ColumnID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// autoStatsRand pairs a rand.Rand with a mutex.
+type autoStatsRand struct {
+	*syncutil.Mutex
+	*rand.Rand
+}
+
+func makeAutoStatsRand(source rand.Source) autoStatsRand {
+	return autoStatsRand{
+		Mutex: &syncutil.Mutex{},
+		Rand:  rand.New(source),
+	}
+}
+
+func (r autoStatsRand) randInt(n int64) int64 {
+	r.Lock()
+	defer r.Unlock()
+	return r.Int63n(n)
+}

--- a/pkg/sql/stats/delete_stats.go
+++ b/pkg/sql/stats/delete_stats.go
@@ -1,0 +1,76 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+)
+
+const (
+	// keepCount is the number of automatic statistics to keep for a given
+	// table and set of columns when deleting old stats. The purpose of keeping
+	// several old automatic statistics is to be able to track the amount of
+	// time between refreshes. See comments in automatic_stats.go for more
+	// details.
+	keepCount = 4
+)
+
+// DeleteOldStatsForColumns deletes old statistics from the
+// system.table_statistics table. For the given tableID and columnIDs,
+// DeleteOldStatsForColumns keeps the most recent keepCount automatic
+// statistics and deletes all the others.
+func DeleteOldStatsForColumns(
+	ctx context.Context,
+	executor sqlutil.InternalExecutor,
+	txn *client.Txn,
+	tableID sqlbase.ID,
+	columnIDs []sqlbase.ColumnID,
+) error {
+	columnIDsVal := tree.NewDArray(types.Int)
+	for _, c := range columnIDs {
+		if err := columnIDsVal.Append(tree.NewDInt(tree.DInt(int(c)))); err != nil {
+			return err
+		}
+	}
+
+	// This will delete all old statistics for the given table and columns,
+	// including stats created manually (except for a few automatic statistics,
+	// which are identified by the name autoStatsName).
+	_, err := executor.Exec(
+		ctx, "delete-statistics", txn,
+		`DELETE FROM system.table_statistics
+               WHERE "tableID" = $1
+               AND "columnIDs" = $3
+               AND "statisticID" NOT IN (
+                   SELECT "statisticID" FROM system.table_statistics
+                   WHERE "tableID" = $1
+                   AND "name" = $2
+                   AND "columnIDs" = $3
+                   ORDER BY "createdAt" DESC
+                   LIMIT $4
+               )`,
+		tableID,
+		autoStatsName,
+		columnIDsVal,
+		keepCount,
+	)
+	return err
+}

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -1,0 +1,330 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func TestDeleteOldStatsForColumns(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	ex := s.InternalExecutor().(sqlutil.InternalExecutor)
+	cache := NewTableStatisticsCache(10 /* cacheSize */, s.Gossip(), db, ex)
+
+	// The test data must be ordered by CreatedAt DESC so the calculated set of
+	// expected deleted stats is correct.
+	testData := []TableStatistic{
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   1,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{1},
+			CreatedAt:     timeutil.Now().Add(-1 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     0,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   2,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{1},
+			CreatedAt:     timeutil.Now().Add(-2 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     0,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   3,
+			Name:          "stat_100_1",
+			ColumnIDs:     []sqlbase.ColumnID{1},
+			CreatedAt:     timeutil.Now().Add(-3 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     0,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   4,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{1},
+			CreatedAt:     timeutil.Now().Add(-4 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     0,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   5,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{1},
+			CreatedAt:     timeutil.Now().Add(-5 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     0,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   6,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{1},
+			CreatedAt:     timeutil.Now().Add(-6 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     0,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   7,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{2, 3},
+			CreatedAt:     timeutil.Now().Add(-7 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     5,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   8,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{2, 3},
+			CreatedAt:     timeutil.Now().Add(-8 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     5,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   9,
+			Name:          "stat_100_2_3",
+			ColumnIDs:     []sqlbase.ColumnID{2, 3},
+			CreatedAt:     timeutil.Now().Add(-9 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     5,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   10,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{2, 3},
+			CreatedAt:     timeutil.Now().Add(-10 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     5,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   11,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{2, 3},
+			CreatedAt:     timeutil.Now().Add(-11 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     5,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   12,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{2, 3},
+			CreatedAt:     timeutil.Now().Add(-12 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     5,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   13,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{2},
+			CreatedAt:     timeutil.Now().Add(-13 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     5,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   14,
+			Name:          "stat_100_1_3",
+			ColumnIDs:     []sqlbase.ColumnID{1, 3},
+			CreatedAt:     timeutil.Now().Add(-14 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     5,
+		},
+		{
+			TableID:       sqlbase.ID(100),
+			StatisticID:   15,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{3, 2},
+			CreatedAt:     timeutil.Now().Add(-15 * time.Hour),
+			RowCount:      1000,
+			DistinctCount: 1000,
+			NullCount:     5,
+		},
+		{
+			TableID:       sqlbase.ID(101),
+			StatisticID:   16,
+			Name:          "stat_101_1",
+			ColumnIDs:     []sqlbase.ColumnID{1},
+			CreatedAt:     timeutil.Now().Add(-16 * time.Hour),
+			RowCount:      320000,
+			DistinctCount: 300000,
+			NullCount:     100,
+		},
+		{
+			TableID:       sqlbase.ID(102),
+			StatisticID:   17,
+			Name:          autoStatsName,
+			ColumnIDs:     []sqlbase.ColumnID{2, 3},
+			CreatedAt:     timeutil.Now().Add(-17 * time.Hour),
+			RowCount:      0,
+			DistinctCount: 0,
+			NullCount:     0,
+		},
+	}
+
+	for i := range testData {
+		stat := &testData[i]
+		if err := insertTableStat(ctx, db, ex, stat); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// findStat searches for a statistic in the given list of stats and returns
+	// an error if expectDeleted is true but the statistic is found. Likewise, it
+	// returns an error if expectDeleted is false but the statistic is not found.
+	findStat := func(
+		stats []*TableStatistic, tableID sqlbase.ID, statisticID uint64, expectDeleted bool,
+	) error {
+		for j := range stats {
+			if stats[j].StatisticID == statisticID {
+				if expectDeleted {
+					return fmt.Errorf(
+						"expected statistic %d in table %d to be deleted, but it was not",
+						statisticID, tableID,
+					)
+				}
+				return nil
+			}
+		}
+
+		if !expectDeleted {
+			return fmt.Errorf(
+				"expected statistic %d in table %d not to be deleted, but it was",
+				statisticID, tableID,
+			)
+		}
+		return nil
+	}
+
+	// checkDelete deletes old statistics for the given table and column IDs and
+	// checks that only the statisticIDs contained in expectDeleted have been
+	// deleted.
+	checkDelete := func(
+		tableID sqlbase.ID, columnIDs []sqlbase.ColumnID, expectDeleted map[uint64]struct{},
+	) error {
+		if err := s.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			return DeleteOldStatsForColumns(ctx, ex, txn, tableID, columnIDs)
+		}); err != nil {
+			return err
+		}
+
+		cache.InvalidateTableStats(ctx, tableID)
+		tableStats, err := cache.GetTableStats(ctx, tableID)
+		if err != nil {
+			return err
+		}
+
+		for i := range testData {
+			stat := &testData[i]
+			if stat.TableID != tableID {
+				cache.InvalidateTableStats(ctx, stat.TableID)
+				stats, err := cache.GetTableStats(ctx, stat.TableID)
+				if err != nil {
+					return err
+				}
+				// No stats from other tables should be deleted.
+				if err := findStat(
+					stats, stat.TableID, stat.StatisticID, false, /* expectDeleted */
+				); err != nil {
+					return err
+				}
+				continue
+			}
+
+			// Check whether this stat should have been deleted.
+			_, expectDeleted := expectDeleted[stat.StatisticID]
+			if err := findStat(tableStats, tableID, stat.StatisticID, expectDeleted); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	expectDeleted := make(map[uint64]struct{}, len(testData))
+	getExpectDeleted := func(tableID sqlbase.ID, columnIDs []sqlbase.ColumnID) {
+		keptStats := 0
+		for i := range testData {
+			stat := &testData[i]
+			if stat.TableID != tableID {
+				continue
+			}
+			if !reflect.DeepEqual(stat.ColumnIDs, columnIDs) {
+				continue
+			}
+			if stat.Name == autoStatsName && keptStats < keepCount {
+				keptStats++
+				continue
+			}
+			expectDeleted[stat.StatisticID] = struct{}{}
+		}
+	}
+
+	// Delete stats for column 1 in table 100.
+	tableID := sqlbase.ID(100)
+	columnIDs := []sqlbase.ColumnID{1}
+	getExpectDeleted(tableID, columnIDs)
+	if err := checkDelete(tableID, columnIDs, expectDeleted); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete stats for columns {2, 3} in table 100.
+	tableID = sqlbase.ID(100)
+	columnIDs = []sqlbase.ColumnID{2, 3}
+	getExpectDeleted(tableID, columnIDs)
+	if err := checkDelete(tableID, columnIDs, expectDeleted); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -603,6 +603,13 @@ func (u *updateNode) BatchedNext(params runParams) (bool, error) {
 		u.run.done = true
 	}
 
+	// Possibly initiate a run of CREATE STATISTICS.
+	params.ExecCfg().StatsRefresher.NotifyMutation(
+		params.EvalContext(),
+		u.run.tu.tableDesc().ID,
+		u.run.rowCount,
+	)
+
 	return u.run.rowCount > 0, nil
 }
 

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -351,6 +351,13 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 		n.run.done = true
 	}
 
+	// Possibly initiate a run of CREATE STATISTICS.
+	params.ExecCfg().StatsRefresher.NotifyMutation(
+		params.EvalContext(),
+		n.run.tw.tableDesc().ID,
+		n.run.tw.batchedCount(),
+	)
+
 	return n.run.tw.batchedCount() > 0, nil
 }
 


### PR DESCRIPTION
This commit adds an initial version of automatic table statistics collection.
After every insert, update, upsert or delete, there is some probability
that the statistics for the affected table will be refreshed. The code
that triggers automatic statistics collection is controlled with the
cluster setting `sql.defaults.experimental_automatic_statistics` and is
currently off by default.

The core implementation of this feature is a function called `maybeRefreshStats`.
`maybeRefreshStats` is used to schedule a `CREATE STATISTICS` refresh job after
approximately X% of total rows have been updated/inserted/deleted in a given
table. Currently, X is hardcoded to be 5%.

The decision to refresh is based on a percentage rather than a fixed number
of rows because if a table is huge and rarely updated, we don't want to
waste time frequently refreshing stats. Likewise, if it's small and rapidly
updated, we want to update stats more often.

To avoid contention on row update counters, we use a statistical approach.
For example, suppose we want to refresh stats after 5% of rows are updated
and there are currently 1M rows in the table. If a user updates 10 rows,
we use random number generation to refresh stats with probability
10/(1M * 0.05) = 0.0002. The general formula is:
```
                           # rows updated/inserted/deleted
   p =  --------------------------------------------------------------------
        (# rows in table) * (target fraction of rows updated before refresh)
```
The existing statistics in the stats cache are used to get the number of
rows in the table.

`maybeRefreshStats` also implements some heuristic limits designed to corral
statistical outliers. If we haven't refreshed stats in 2x the average time
between the last few refreshes, we automatically trigger a refresh. The
existing statistics in the stats cache are used to calculate the average time
between refreshes as well as to determine when the stats were last updated.

If the decision is made to continue with the refresh, `maybeRefreshStats` runs
`CREATE STATISTICS` on the given table with the default set of column
statistics. `maybeRefreshStats` runs `CREATE STATISTICS` with
`AS OF SYSTEM TIME '-30s'` to minimize performance impact on running
transactions.

Release note: None