### PR TITLE
opt: Rename and clean up internal IDs and fingerprints

### DIFF
--- a/pkg/sql/opt/catalog.go
+++ b/pkg/sql/opt/catalog.go
@@ -34,16 +34,33 @@ import (
 // index, even if it meant adding a hidden unique rowid column.
 const PrimaryIndex = 0
 
-// Fingerprint uniquely identifies a catalog data source. If the schema of the
-// data source changes in any way, then the fingerprint must also change. This
-// enables cached data sources (or other data structures dependent on the data
-// sources) to be invalidated when their schema changes.
+// StableID permanently and uniquely identifies a catalog object (table, view,
+// index, column, etc.) within its scope:
 //
-// For sqlbase data sources, the fingerprint is simply the concatenation of the
-// 32-bit descriptor ID and version fields. The version is incremented each time
-// a change to a table/view/sequence occurs, including changes to any associated
-// indexes.
-type Fingerprint uint64
+//   data source StableID: unique within database
+//   index StableID: unique within table
+//   column StableID: unique within table
+//
+// If a new catalog object is created, it will always be assigned a new StableID
+// that has never, and will never, be reused by a different object in the same
+// scope. This uniqueness guarantee is true even if the new object has the same
+// name and schema as an old (and possibly dropped) object. The StableID will
+// never change as long as the object exists.
+//
+// Note that while two instances of the same catalog object will always have the
+// same StableID, they can have different schema if the schema has changed over
+// time. See the Version type comments for more details.
+//
+// For sqlbase objects, the StableID is the 32-bit descriptor ID.
+type StableID uint32
+
+// Version is incremented any time the schema of a catalog data source (table,
+// view, etc.) is changed in any way, including changes to any associated
+// indexes. This enables cached data sources (or other data structures dependent
+// on the data sources) to be invalidated when their schema changes.
+//
+// For sqlbase data sources, the version is the 32-bit descriptor version.
+type Version uint32
 
 // Catalog is an interface to a database catalog, exposing only the information
 // needed by the query optimizer.
@@ -55,9 +72,9 @@ type Catalog interface {
 	ResolveDataSource(ctx context.Context, name *tree.TableName) (DataSource, error)
 
 	// ResolveDataSourceByID is similar to ResolveDataSource, except that it
-	// locates a data source by its unique identifier in the database. This id
-	// is stable as long as the data source exists.
-	ResolveDataSourceByID(ctx context.Context, dataSourceID int64) (DataSource, error)
+	// locates a data source by its StableID. See the comment for StableID for
+	// more details.
+	ResolveDataSourceByID(ctx context.Context, id StableID) (DataSource, error)
 
 	// CheckPrivilege verifies that the current user has the given privilege on
 	// the given data source. If not, then CheckPrivilege returns an error.
@@ -67,10 +84,15 @@ type Catalog interface {
 // DataSource is an interface to a database object that provides rows, like a
 // table, a view, or a sequence.
 type DataSource interface {
-	// Fingerprint uniquely identifies this data source. If the schema of this
-	// data source changes, then so will the value of this fingerprint. If two
-	// data sources have the same fingerprint, then they are identical.
-	Fingerprint() Fingerprint
+	// ID is the unique, stable identifier for this data source. See the comment
+	// for StableID for more detail.
+	ID() StableID
+
+	// Version uniquely identifies a particular iteration of the data source's
+	// schema. Each time the schema changes, the version will be incremented,
+	// which allows changes to be easily detected. See the comment for the Version
+	// type for more detail.
+	Version() Version
 
 	// Name returns the fully normalized, fully qualified, and fully resolved
 	// name of the data source. The ExplicitCatalog and ExplicitSchema fields
@@ -88,9 +110,6 @@ type Table interface {
 	// information_schema tables.
 	IsVirtualTable() bool
 
-	// InternalID returns the table's globally-unique ID.
-	InternalID() uint64
-
 	// ColumnCount returns the number of columns in the table.
 	ColumnCount() int
 
@@ -106,11 +125,6 @@ type Table interface {
 	// To determine if the column is a mutation column, try to cast it to
 	// *MutationColumn.
 	Column(i int) Column
-
-	// LookupColumnOrdinal returns the ordinal of the column with the given ID.
-	// Note that this takes the internal column ID, and has no relation to
-	// ColumnIDs in the optimizer.
-	LookupColumnOrdinal(colID uint32) (int, error)
 
 	// IndexCount returns the number of indexes defined on this table. This
 	// includes the primary index, so the count is always >= 1.
@@ -152,6 +166,13 @@ type View interface {
 // Column is an interface to a table column, exposing only the information
 // needed by the query optimizer.
 type Column interface {
+	// ColID is the unique, stable identifier for this column within its table.
+	// Each new column in the table will be assigned a new ID that is different
+	// than every column allocated before or after. This is true even if a column
+	// is dropped and then re-added with the same name; the new column will have
+	// a different ID. See the comment for StableID for more detail.
+	ColID() StableID
+
 	// ColName returns the name of the column.
 	ColName() tree.Name
 
@@ -227,12 +248,13 @@ type IndexColumn struct {
 // add an implicit primary key based on a hidden rowid column if a primary key
 // was not explicitly declared).
 type Index interface {
-	// IdxName is the name of the index.
-	IdxName() string
+	// ID is the stable identifier for this index that is guaranteed to be
+	// unique within the owning table. See the comment for StableID for more
+	// detail.
+	ID() StableID
 
-	// InternalID returns the internal identifier of the index. Only used
-	// when the query contains a numeric index reference.
-	InternalID() uint64
+	// Name is the name of the index.
+	Name() string
 
 	// Table returns a reference to the table this index is based on.
 	Table() Table
@@ -342,12 +364,12 @@ type TableStatistic interface {
 // ForeignKeyReference is a struct representing an outbound foreign key reference.
 // It has accessors for table and index IDs, as well as the prefix length.
 type ForeignKeyReference struct {
-	// Table contains the referenced table's internal ID.
-	TableID uint64
+	// Table contains the referenced table's stable identifier.
+	TableID StableID
 
-	// Index contains the ID of the index that represents the
+	// Index contains the stable identifier of the index that represents the
 	// destination table's side of the foreign key relation.
-	IndexID uint64
+	IndexID StableID
 
 	// PrefixLen contains the length of columns that form the foreign key
 	// relation in the current and destination indexes.
@@ -386,7 +408,7 @@ func formatCatalogIndex(idx Index, isPrimary bool, tp treeprinter.Node) {
 	if idx.IsInverted() {
 		inverted = "INVERTED "
 	}
-	child := tp.Childf("%sINDEX %s", inverted, idx.IdxName())
+	child := tp.Childf("%sINDEX %s", inverted, idx.Name())
 
 	var buf bytes.Buffer
 	colCount := idx.ColumnCount()
@@ -433,7 +455,7 @@ func formatColPrefix(idx Index, prefixLen int) string {
 func formatCatalogFKRef(
 	cat Catalog, tab Table, idx Index, fkRef ForeignKeyReference, tp treeprinter.Node,
 ) {
-	ds, err := cat.ResolveDataSourceByID(context.TODO(), int64(fkRef.TableID))
+	ds, err := cat.ResolveDataSourceByID(context.TODO(), fkRef.TableID)
 	if err != nil {
 		panic(err)
 	}
@@ -442,7 +464,7 @@ func formatCatalogFKRef(
 
 	var fkIndex Index
 	for j, cnt := 0, fkTable.IndexCount(); j < cnt; j++ {
-		if fkTable.Index(j).InternalID() == fkRef.IndexID {
+		if fkTable.Index(j).ID() == fkRef.IndexID {
 			fkIndex = fkTable.Index(j)
 			break
 		}

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -310,10 +310,10 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		idx := tab.Index(scan.Flags.Index)
 		var err error
 		if idx.IsInverted() {
-			err = fmt.Errorf("index \"%s\" is inverted and cannot be used for this query", idx.IdxName())
+			err = fmt.Errorf("index \"%s\" is inverted and cannot be used for this query", idx.Name())
 		} else {
 			// This should never happen.
-			err = fmt.Errorf("index \"%s\" cannot be used for this query", idx.IdxName())
+			err = fmt.Errorf("index \"%s\" cannot be used for this query", idx.Name())
 		}
 		return execPlan{}, err
 	}

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -249,7 +249,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 				tp.Childf("flags: no-index-join")
 			} else if t.Flags.ForceIndex {
 				idx := md.Table(t.Table).Index(t.Flags.Index)
-				tp.Childf("flags: force-index=%s", idx.IdxName())
+				tp.Childf("flags: force-index=%s", idx.Name())
 			}
 		}
 
@@ -647,7 +647,7 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		if t.Index == opt.PrimaryIndex {
 			fmt.Fprintf(f.Buffer, " %s", tab.Name().TableName)
 		} else {
-			fmt.Fprintf(f.Buffer, " %s@%s", tab.Name().TableName, tab.Index(t.Index).IdxName())
+			fmt.Fprintf(f.Buffer, " %s@%s", tab.Name().TableName, tab.Index(t.Index).Name())
 		}
 		if ScanIsReverseFn(f.Memo.Metadata(), t, &physProps.Ordering) {
 			f.Buffer.WriteString(",rev")
@@ -681,7 +681,7 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		if t.Index == opt.PrimaryIndex {
 			fmt.Fprintf(f.Buffer, " %s", tab.Name().TableName)
 		} else {
-			fmt.Fprintf(f.Buffer, " %s@%s", tab.Name().TableName, tab.Index(t.Index).IdxName())
+			fmt.Fprintf(f.Buffer, " %s@%s", tab.Name().TableName, tab.Index(t.Index).Name())
 		}
 
 	case *ZigzagJoinPrivate:
@@ -689,11 +689,11 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		rightTab := f.Memo.metadata.Table(t.RightTable)
 		fmt.Fprintf(f.Buffer, " %s", leftTab.Name().TableName)
 		if t.LeftIndex != opt.PrimaryIndex {
-			fmt.Fprintf(f.Buffer, "@%s", leftTab.Index(t.LeftIndex).IdxName())
+			fmt.Fprintf(f.Buffer, "@%s", leftTab.Index(t.LeftIndex).Name())
 		}
 		fmt.Fprintf(f.Buffer, " %s", rightTab.Name().TableName)
 		if t.RightIndex != opt.PrimaryIndex {
-			fmt.Fprintf(f.Buffer, "@%s", rightTab.Index(t.RightIndex).IdxName())
+			fmt.Fprintf(f.Buffer, "@%s", rightTab.Index(t.RightIndex).Name())
 		}
 
 	case *MergeJoinPrivate:

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -72,7 +72,7 @@ func TestMetadataTables(t *testing.T) {
 	var md opt.Metadata
 
 	// Add a table reference to the metadata.
-	a := &testcat.Table{TabFingerprint: 1}
+	a := &testcat.Table{StableID: 1}
 	a.TabName = tree.MakeUnqualifiedTableName(tree.Name("a"))
 	x := &testcat.Column{Name: "x"}
 	y := &testcat.Column{Name: "y"}
@@ -99,7 +99,7 @@ func TestMetadataTables(t *testing.T) {
 	}
 
 	// Add another table reference to the metadata.
-	b := &testcat.Table{TabFingerprint: 1}
+	b := &testcat.Table{StableID: 1}
 	b.TabName = tree.MakeUnqualifiedTableName(tree.Name("b"))
 	b.Columns = append(b.Columns, &testcat.Column{Name: "x"})
 

--- a/pkg/sql/opt/norm/join.go
+++ b/pkg/sql/opt/norm/join.go
@@ -425,12 +425,12 @@ func (c *CustomFuncs) JoinFiltersMatchAllLeftRows(
 			continue
 		}
 
-		fkTable := md.TableByDescID(fkRef.TableID)
+		fkTable := md.TableByStableID(fkRef.TableID)
 		fkPrefix := int(fkRef.PrefixLen)
 		if fkPrefix <= 0 {
 			panic("fkPrefix should always be positive")
 		}
-		if fkTable == nil || fkTable.Fingerprint() != rightTab.Fingerprint() {
+		if fkTable == nil || fkTable.ID() != rightTab.ID() {
 			continue
 		}
 
@@ -440,7 +440,7 @@ func (c *CustomFuncs) JoinFiltersMatchAllLeftRows(
 		var fkIndex opt.Index
 		found := false
 		for j, cnt2 := 0, fkTable.IndexCount(); j < cnt2; j++ {
-			if fkTable.Index(j).InternalID() == fkRef.IndexID {
+			if fkTable.Index(j).ID() == fkRef.IndexID {
 				found = true
 				fkIndex = fkTable.Index(j)
 				break

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -88,7 +88,7 @@ func (b *Builder) findIndexByName(table opt.Table, name tree.UnrestrictedName) (
 
 	for i, n := 0, table.IndexCount(); i < n; i++ {
 		idx := table.Index(i)
-		if string(name) == idx.IdxName() {
+		if string(name) == idx.Name() {
 			return idx, nil
 		}
 	}

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -420,7 +420,7 @@ func (b *Builder) resolveDataSource(tn *tree.TableName, priv privilege.Kind) opt
 // does not have the given privilege, then resolveDataSourceFromRef raises an
 // error.
 func (b *Builder) resolveDataSourceRef(ref *tree.TableRef, priv privilege.Kind) opt.DataSource {
-	ds, err := b.catalog.ResolveDataSourceByID(b.ctx, ref.TableID)
+	ds, err := b.catalog.ResolveDataSourceByID(b.ctx, opt.StableID(ref.TableID))
 	if err != nil {
 		panic(builderError{errors.Wrapf(err, "%s", tree.ErrString(ref))})
 	}

--- a/pkg/sql/opt/testutils/testcat/create_view.go
+++ b/pkg/sql/opt/testutils/testcat/create_view.go
@@ -31,10 +31,10 @@ func (tc *Catalog) CreateView(stmt *tree.CreateView) *View {
 	stmt.AsSource.Format(&fmtCtx)
 
 	view := &View{
-		ViewFingerprint: tc.nextFingerprint(),
-		ViewName:        stmt.Name,
-		QueryText:       buf.String(),
-		ColumnNames:     stmt.ColumnNames,
+		ViewID:      tc.nextStableID(),
+		ViewName:    stmt.Name,
+		QueryText:   buf.String(),
+		ColumnNames: stmt.ColumnNames,
 	}
 
 	// Add the new view to the catalog.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -66,14 +66,14 @@ func (oc *optCatalog) ResolveDataSource(
 
 // ResolveDataSourceByID is part of the opt.Catalog interface.
 func (oc *optCatalog) ResolveDataSourceByID(
-	ctx context.Context, dataSourceID int64,
+	ctx context.Context, dataSourceID opt.StableID,
 ) (opt.DataSource, error) {
 
 	tableLookup, err := oc.resolver.LookupTableByID(ctx, sqlbase.ID(dataSourceID))
 
 	if err != nil || tableLookup.IsAdding {
 		if err == sqlbase.ErrDescriptorNotFound || tableLookup.IsAdding {
-			return nil, sqlbase.NewUndefinedRelationError(&tree.TableRef{TableID: dataSourceID})
+			return nil, sqlbase.NewUndefinedRelationError(&tree.TableRef{TableID: int64(dataSourceID)})
 		}
 		return nil, err
 	}
@@ -145,8 +145,8 @@ func (oc *optCatalog) newDataSource(
 	return ds, nil
 }
 
-// optView is a wrapper around sqlbase.ImmutableTableDescriptor that implements the
-// opt.DataSource and opt.View interfaces.
+// optView is a wrapper around sqlbase.ImmutableTableDescriptor that implements
+// the opt.DataSource and opt.View interfaces.
 type optView struct {
 	desc *sqlbase.ImmutableTableDescriptor
 
@@ -167,9 +167,14 @@ func newOptView(desc *sqlbase.ImmutableTableDescriptor, name *tree.TableName) *o
 	return ov
 }
 
-// Fingerprint is part of the opt.DataSource interface.
-func (ov *optView) Fingerprint() opt.Fingerprint {
-	return opt.Fingerprint(ov.desc.ID)<<32 | opt.Fingerprint(ov.desc.Version)
+// ID is part of the opt.DataSource interface.
+func (ov *optView) ID() opt.StableID {
+	return opt.StableID(ov.desc.ID)
+}
+
+// Version is part of the opt.DataSource interface.
+func (ov *optView) Version() opt.Version {
+	return opt.Version(ov.desc.Version)
 }
 
 // Name is part of the opt.View interface.
@@ -216,9 +221,14 @@ func newOptSequence(desc *sqlbase.ImmutableTableDescriptor, name *tree.TableName
 	return ot
 }
 
-// Fingerprint is part of the opt.DataSource interface.
-func (os *optSequence) Fingerprint() opt.Fingerprint {
-	return opt.Fingerprint(os.desc.ID)<<32 | opt.Fingerprint(os.desc.Version)
+// ID is part of the opt.DataSource interface.
+func (os *optSequence) ID() opt.StableID {
+	return opt.StableID(os.desc.ID)
+}
+
+// Version is part of the opt.DataSource interface.
+func (os *optSequence) Version() opt.Version {
+	return opt.Version(os.desc.Version)
 }
 
 // Name is part of the opt.DataSource interface.
@@ -305,19 +315,19 @@ func (ot *optTable) prepareMutationColumns(desc *sqlbase.ImmutableTableDescripto
 	}
 }
 
-// Fingerprint is part of the opt.DataSource interface.
-func (ot *optTable) Fingerprint() opt.Fingerprint {
-	return opt.Fingerprint(ot.desc.ID)<<32 | opt.Fingerprint(ot.desc.Version)
+// ID is part of the opt.DataSource interface.
+func (ot *optTable) ID() opt.StableID {
+	return opt.StableID(ot.desc.ID)
+}
+
+// Version is part of the opt.DataSource interface.
+func (ot *optTable) Version() opt.Version {
+	return opt.Version(ot.desc.Version)
 }
 
 // Name is part of the opt.DataSource interface.
 func (ot *optTable) Name() *tree.TableName {
 	return &ot.name
-}
-
-// InternalID is part of the opt.Table interface.
-func (ot *optTable) InternalID() uint64 {
-	return uint64(ot.desc.ID)
 }
 
 // IsVirtualTable is part of the opt.Table interface.
@@ -386,17 +396,6 @@ func (ot *optTable) ensureColMap() {
 			ot.colMap[ot.desc.Columns[i].ID] = i
 		}
 	}
-}
-
-// LookupColumnOrdinal is part of the opt.Table interface
-func (ot *optTable) LookupColumnOrdinal(colID uint32) (int, error) {
-	// LookupColumnOrdinal exposes optTable.lookupColumnOrdinal.
-	// In order to preserve the argument type information
-	// on lookupColumnOrdinal, this wrapper function exists.
-	// colID as the sqlbase.ColumnID type would result in a
-	// circular dependency for catalog.Table - the interface this
-	// implements.
-	return ot.lookupColumnOrdinal(sqlbase.ColumnID(colID))
 }
 
 // lookupColumnOrdinal returns the ordinal of the column with the given ID. A
@@ -491,20 +490,20 @@ func (oi *optIndex) init(tab *optTable, desc *sqlbase.IndexDescriptor) {
 	}
 
 	if desc.ForeignKey.IsSet() {
-		oi.foreignKey.TableID = uint64(desc.ForeignKey.Table)
-		oi.foreignKey.IndexID = uint64(desc.ForeignKey.Index)
+		oi.foreignKey.TableID = opt.StableID(desc.ForeignKey.Table)
+		oi.foreignKey.IndexID = opt.StableID(desc.ForeignKey.Index)
 		oi.foreignKey.PrefixLen = desc.ForeignKey.SharedPrefixLen
 	}
 }
 
-// IdxName is part of the opt.Index interface.
-func (oi *optIndex) IdxName() string {
-	return oi.desc.Name
+// ID is part of the opt.Index interface.
+func (oi *optIndex) ID() opt.StableID {
+	return opt.StableID(oi.desc.ID)
 }
 
-// InternalID is part of the opt.Index interface.
-func (oi *optIndex) InternalID() uint64 {
-	return uint64(oi.desc.ID)
+// Name is part of the opt.Index interface.
+func (oi *optIndex) Name() string {
+	return oi.desc.Name
 }
 
 // IsInverted is part of the opt.Index interface.
@@ -555,8 +554,8 @@ func (oi *optIndex) Column(i int) opt.IndexColumn {
 func (oi *optIndex) ForeignKey() (opt.ForeignKeyReference, bool) {
 	desc := oi.desc
 	if desc.ForeignKey.IsSet() {
-		oi.foreignKey.TableID = uint64(desc.ForeignKey.Table)
-		oi.foreignKey.IndexID = uint64(desc.ForeignKey.Index)
+		oi.foreignKey.TableID = opt.StableID(desc.ForeignKey.Table)
+		oi.foreignKey.IndexID = opt.StableID(desc.ForeignKey.Index)
 		oi.foreignKey.PrefixLen = desc.ForeignKey.SharedPrefixLen
 	}
 	return oi.foreignKey, oi.desc.ForeignKey.IsSet()

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2549,6 +2549,11 @@ func (desc *ColumnDescriptor) IsNullable() bool {
 	return desc.Nullable
 }
 
+// ColID is part of the opt.Column interface.
+func (desc *ColumnDescriptor) ColID() opt.StableID {
+	return opt.StableID(desc.ID)
+}
+
 // ColName is part of the opt.Column interface.
 func (desc *ColumnDescriptor) ColName() tree.Name {
 	return tree.Name(desc.Name)


### PR DESCRIPTION
Currently, there is a bit of a mess developing. An opt.Fingerprint type
combines a unique stable object id with an incrementing version. At the
same time, unique stable object ids are directly used in other places,
usually referring to them as InternalID and typing them as int64. There
is also no consistency to how these IDs are exposed and manipulated.

This commit cleans this up by separating Fingerprint into new StableID
and Version types that mirror sqlbase.ID and sqlbase.DescriptorVersion,
respectively. These new types are now consistently used across the
various opt.Catalog interfaces and structs. In addition, methods that
don't fit well are renamed or done differently, like InternalID and
LookupColumnOrdinal.

Release note: None