### PR TITLE
sql: ensure that internal executors have a valid application_name

### DIFF
--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -450,9 +450,11 @@ func TestCancelIfExists(t *testing.T) {
 }
 
 func isClientsideQueryCanceledErr(err error) bool {
-	pqErr, ok := err.(*pq.Error)
-	if !ok {
-		return false
+	if pgErr, ok := pgerror.GetPGCause(err); ok {
+		return pgErr.Code == pgerror.CodeQueryCanceledError
 	}
-	return pqErr.Code == pgerror.CodeQueryCanceledError
+	if pqErr, ok := err.(*pq.Error); ok {
+		return pqErr.Code == pgerror.CodeQueryCanceledError
+	}
+	return false
 }


### PR DESCRIPTION
Fixes #33086.
Fixes #31998.

Previously, there was a possibility for an internal conn executor to
have no application name set, leading to a potential panic during show
sessions, queries and other mechanisms that require a valid
application name.

This patch fixes it by ensuring the application name is reliably set.
It also adds a test that validates this on both kinds of internal
executors.

Release note (bug fix): CockroachDB does not crash upon running SHOW
SESSIONS, SHOW QUERIES and inspections of some `crdb_internal` tables
when certain SQL sessions are issuing internal SQL queries.
