### PR TITLE
release-2.1: engineccl/mvcc: work around time-bound iterator bug

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1138,9 +1138,9 @@ func (r *RocksDB) GetSortedWALFiles() ([]WALFileInfo, error) {
 	return res, nil
 }
 
-// getUserProperties fetches the user properties stored in each sstable's
+// GetUserProperties fetches the user properties stored in each sstable's
 // metadata.
-func (r *RocksDB) getUserProperties() (enginepb.SSTUserPropertiesCollection, error) {
+func (r *RocksDB) GetUserProperties() (enginepb.SSTUserPropertiesCollection, error) {
 	buf := cStringToGoBytes(C.DBGetUserProperties(r.rdb))
 	var ssts enginepb.SSTUserPropertiesCollection
 	if err := protoutil.Unmarshal(buf, &ssts); err != nil {

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -833,7 +833,7 @@ func TestRocksDBTimeBound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ssts, err := rocksdb.getUserProperties()
+	ssts, err := rocksdb.GetUserProperties()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Backport 1/1 commits from #32909.

/cc @cockroachdb/release

---

For reasons described in #28358, a time-bound iterator will sometimes
see an unresolved intent where there is none. A normal iterator doesn't
have this problem, so we work around it in MVCCIncrementalIterator by
double checking all non-value keys. If the normal iterator has a
different value for the key, it's used instead. If the normal iterator
doesn't have that key, it's skipped.

This fixes both changefeeds and incremental backup.

Closes #32104
Closes #32799

Release note (bug fix): `CHANGEFEED`s and incremental `BACKUP`s no
longer indefinitely hang under an infrequent condition.
