### PR TITLE
sql: Uopdate unimplemented reference

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -98,11 +98,11 @@ func (n *alterTableNode) startExec(params runParams) error {
 			d := t.ColumnDef
 			if len(d.CheckExprs) > 0 {
 				return pgerror.UnimplementedWithIssueError(29639,
-					"adding a CHECK constraint via ALTER not supported")
+					"adding a CHECK constraint while also adding a column via ALTER not supported")
 			}
 			if d.HasFKConstraint() {
-				return pgerror.UnimplementedWithIssueError(8855,
-					"adding a REFERENCES constraint via ALTER not supported")
+				return pgerror.UnimplementedWithIssueError(32917,
+					"adding a REFERENCES constraint while also adding a column via ALTER not supported")
 			}
 
 			newDef, seqDbDesc, seqName, seqOpts, err := params.p.processSerialInColumnDef(params.ctx, d, tn)

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -349,10 +349,10 @@ ALTER TABLE o DROP COLUMN h
 statement ok
 ALTER TABLE o DROP COLUMN h CASCADE
 
-statement error adding a CHECK constraint via ALTER not supported
+statement error adding a CHECK constraint while also adding a column via ALTER not supported
 ALTER TABLE t ADD f INT CHECK (f>1)
 
-statement error adding a REFERENCES constraint via ALTER not supported
+statement error adding a REFERENCES constraint while also adding a column via ALTER not supported
 ALTER TABLE t ADD f INT UNIQUE REFERENCES other
 
 # Test that more than one column with constraints can be added in the same


### PR DESCRIPTION
And also clean up the wording to be more explicit.

The error for not being able to add a reference via alter was pointing to the
incorrect github ID #8855. It's been updated to point to #32917 instead.

Release note: None