### PR TITLE
roachtest: add AS OF SYSTEM TIME to SCRUB test

### DIFF
--- a/pkg/cmd/roachtest/scrub.go
+++ b/pkg/cmd/roachtest/scrub.go
@@ -57,9 +57,9 @@ func makeScrubTPCCTest(
 	for i := 0; i < len(stmts); i += len(tpccTables) {
 		for j, t := range tpccTables {
 			if indexOnly {
-				stmts[i+j] = fmt.Sprintf(`EXPERIMENTAL SCRUB TABLE tpcc.%s WITH OPTIONS INDEX ALL`, t)
+				stmts[i+j] = fmt.Sprintf(`EXPERIMENTAL SCRUB TABLE tpcc.%s AS OF SYSTEM TIME '-0s' WITH OPTIONS INDEX ALL`, t)
 			} else {
-				stmts[i+j] = fmt.Sprintf(`EXPERIMENTAL SCRUB TABLE tpcc.%s`, t)
+				stmts[i+j] = fmt.Sprintf(`EXPERIMENTAL SCRUB TABLE tpcc.%s AS OF SYSTEM TIME '-0s'`, t)
 			}
 		}
 	}


### PR DESCRIPTION
Add `AS OF SYSTEM TIME` to the `SCRUB` roachtest to reduce contention. I ran
this version of the test and didn't get the deadlock that showed up in #33149.

Eventually we'll want to have `AS OF SYSTEM TIME` be present by default in the
`SELECT` query that is run during SCRUB instead of having it be manually added.

Release note: None