### PR TITLE
engine: skip WAL for temp rocks store

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -250,7 +250,7 @@ DBStatus DBOpen(DBEngine** db, DBSlice dir, DBOptions db_opts) {
     return ToDBStatus(status);
   }
   *db = new DBImpl(db_ptr, std::move(env_mgr),
-                   db_opts.cache != nullptr ? db_opts.cache->rep : nullptr, event_listener);
+                   db_opts.cache != nullptr ? db_opts.cache->rep : nullptr, event_listener, db_opts.skip_wal);
   return kSuccess;
 }
 

--- a/c-deps/libroach/engine.h
+++ b/c-deps/libroach/engine.h
@@ -68,12 +68,13 @@ struct DBImpl : public DBEngine {
   std::shared_ptr<rocksdb::Cache> block_cache;
   std::shared_ptr<DBEventListener> event_listener;
   std::atomic<int64_t> iters_count;
+  bool skip_wal;
 
   // Construct a new DBImpl from the specified DB.
   // The DB and passed Envs will be deleted when the DBImpl is deleted.
   // Either env can be NULL.
   DBImpl(rocksdb::DB* r, std::unique_ptr<EnvManager> e, std::shared_ptr<rocksdb::Cache> bc,
-         std::shared_ptr<DBEventListener> event_listener);
+         std::shared_ptr<DBEventListener> event_listener, bool skip_wal);
   virtual ~DBImpl();
 
   virtual DBStatus AssertPreClose();

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -80,6 +80,7 @@ typedef struct {
   bool use_file_registry;
   bool must_exist;
   bool read_only;
+  bool skip_wal;
   DBSlice rocksdb_options;
   DBSlice extra_options;
 } DBOptions;

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -448,6 +448,8 @@ type RocksDBConfig struct {
 	// MaxOpenFiles controls the maximum number of file descriptors RocksDB
 	// creates. If MaxOpenFiles is zero, this is set to DefaultMaxOpenFiles.
 	MaxOpenFiles uint64
+	// SkipWAL causes write batches to be applied without writing to the WAL.
+	SkipWAL bool
 	// WarnLargeBatchThreshold controls if a log message is printed when a
 	// WriteBatch takes longer than WarnLargeBatchThreshold. If it is set to
 	// zero, no log messages are ever printed.
@@ -620,6 +622,7 @@ func (r *RocksDB) open() error {
 			use_file_registry: C.bool(newVersion == versionCurrent),
 			must_exist:        C.bool(r.cfg.MustExist),
 			read_only:         C.bool(r.cfg.ReadOnly),
+			skip_wal:          C.bool(r.cfg.SkipWAL),
 			rocksdb_options:   goToCSlice([]byte(r.cfg.RocksDBOptions)),
 			extra_options:     goToCSlice(r.cfg.ExtraOptions),
 		})

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -39,6 +39,7 @@ func NewTempEngine(
 		MaxOpenFiles:    128, // TODO(arjun): Revisit this.
 		UseFileRegistry: storeSpec.UseFileRegistry,
 		ExtraOptions:    storeSpec.ExtraOptions,
+		SkipWAL:         true,
 	}
 	rocksDBCache := NewRocksDBCache(0)
 	rocksdb, err := NewRocksDB(rocksDBCfg, rocksDBCache)


### PR DESCRIPTION
The "temp" engine is used by some SQL processors and IMPORT to buffer
data that is too large to fit in memory. It is deleted and recreated on
startup, so writing to the WAL is pointless overhead.

Importing the TPC-H lineitem table at scale-factor 10 (~7.2GB in CSV) on
an otherwise unused, uncontended 4 node cluster, this cut the averge
completion time from 31m15s to 27m52s. Gains are likely more pronounced
in the presense of more IPOS or disk bandwidth contention.

RocksDB is still likely overkill for our usage here and additional gains
seem likely by replacing it entirely, but this seems like a quick win
for now.

Release note: None