### PR TITLE
opt: add plan cache metrics

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -263,9 +263,12 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 	return &Server{
 		cfg: cfg,
 		EngineMetrics: EngineMetrics{
-			DistSQLSelectCount:  metric.NewCounter(MetaDistSQLSelect),
-			SQLOptCount:         metric.NewCounter(MetaSQLOpt),
-			SQLOptFallbackCount: metric.NewCounter(MetaSQLOptFallback),
+			DistSQLSelectCount:    metric.NewCounter(MetaDistSQLSelect),
+			SQLOptCount:           metric.NewCounter(MetaSQLOpt),
+			SQLOptFallbackCount:   metric.NewCounter(MetaSQLOptFallback),
+			SQLOptPlanCacheHits:   metric.NewCounter(MetaSQLOptPlanCacheHits),
+			SQLOptPlanCacheMisses: metric.NewCounter(MetaSQLOptPlanCacheMisses),
+
 			// TODO(mrtracy): See HistogramWindowInterval in server/config.go for the 6x factor.
 			DistSQLExecLatency: metric.NewLatency(MetaDistSQLExecLatency,
 				6*metricsSampleInterval),

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -209,9 +209,9 @@ func (ex *connExecutor) prepare(
 		// As of right now, the optimizer only works on SELECT statements and will
 		// fallback for all others, so this should be safe for the foreseeable
 		// future.
-		if optimizerPlanned, err := p.optionallyUseOptimizer(ctx, ex.sessionData, stmt); err != nil {
+		if flags, err := p.optionallyUseOptimizer(ctx, ex.sessionData, stmt); err != nil {
 			return err
-		} else if !optimizerPlanned {
+		} else if !flags.IsSet(planFlagOptUsed) {
 			isCorrelated := p.curPlan.isCorrelated
 			log.VEventf(ctx, 1, "query is correlated: %v", isCorrelated)
 			// Fallback if the optimizer was not enabled or used.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -59,7 +59,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -228,6 +228,18 @@ var (
 	MetaSQLOptFallback = metric.Metadata{
 		Name:        "sql.optimizer.fallback.count",
 		Help:        "Number of statements which the cost-based optimizer was unable to plan",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_COUNT,
+	}
+	MetaSQLOptPlanCacheHits = metric.Metadata{
+		Name:        "sql.optimizer.plan_cache.hits",
+		Help:        "Number of non-prepared statements for which a cached plan was used",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_COUNT,
+	}
+	MetaSQLOptPlanCacheMisses = metric.Metadata{
+		Name:        "sql.optimizer.plan_cache.misses",
+		Help:        "Number of non-prepared statements for which a cached plan was not used",
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_COUNT,
 	}

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -65,7 +65,7 @@ func TestQueryCounts(t *testing.T) {
 
 	var testcases = []queryCounter{
 		// The counts are deltas for each query.
-		{query: "SET OPTIMIZER = 'off'", miscCount: 1},
+		{query: "SET OPTIMIZER = 'off'", miscCount: 1, fallbackCount: 1},
 		{query: "SET DISTSQL = 'off'", miscCount: 1},
 		{query: "BEGIN; END", txnBeginCount: 1, txnCommitCount: 1},
 		{query: "SELECT 1", selectCount: 1, txnCommitCount: 1},
@@ -93,11 +93,11 @@ func TestQueryCounts(t *testing.T) {
 		{query: "SET DISTSQL = 'off'", miscCount: 1},
 		{query: "DROP TABLE mt.n", ddlCount: 1},
 		{query: "SET database = system", miscCount: 1},
-		{query: "SET OPTIMIZER = 'on'", miscCount: 1, fallbackCount: 1},
+		{query: "SET OPTIMIZER = 'on'", miscCount: 1},
 		{query: "SELECT 3", selectCount: 1, optCount: 1},
 		{query: "CREATE TABLE mt.n (num INTEGER PRIMARY KEY)", ddlCount: 1, fallbackCount: 1},
 		{query: "UPDATE mt.n SET num = num + 1", updateCount: 1, fallbackCount: 1},
-		{query: "SET OPTIMIZER = 'off'", miscCount: 1},
+		{query: "SET OPTIMIZER = 'off'", miscCount: 1, fallbackCount: 1},
 	}
 
 	accum := initializeQueryCounter(s)

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -252,18 +252,8 @@ func (m *Memo) IsStale(ctx context.Context, evalCtx *tree.EvalContext, catalog o
 		return true
 	}
 
-	// Memo is stale if the search path has changed. Assume it's changed if the
-	// slice length is different, or if it no longer points to the same underlying
-	// array. If two slices are the same length and point to the same underlying
-	// array, then they are guaranteed to be identical. Note that GetPathArray
-	// already specifies that the slice must not be modified, so its elements will
-	// never be modified in-place.
-	left := m.searchPath.GetPathArray()
-	right := evalCtx.SessionData.SearchPath.GetPathArray()
-	if len(left) != len(right) {
-		return true
-	}
-	if len(left) != 0 && &left[0] != &right[0] {
+	// Memo is stale if the search path has changed.
+	if !m.searchPath.Equals(&evalCtx.SessionData.SearchPath) {
 		return true
 	}
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -138,8 +138,8 @@ func TestMemoIsStale(t *testing.T) {
 		t.Errorf("expected stale search path")
 	}
 	evalCtx.SessionData.SearchPath = sessiondata.MakeSearchPath([]string{"path1", "path2"})
-	if !o.Memo().IsStale(ctx, &evalCtx, catalog) {
-		t.Errorf("expected stale search path")
+	if o.Memo().IsStale(ctx, &evalCtx, catalog) {
+		t.Errorf("memo should not be stale")
 	}
 	evalCtx.SessionData.SearchPath = sessiondata.MakeSearchPath(searchPath)
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -532,29 +532,36 @@ func (p *planner) prepareForDistSQLSupportCheck() {
 }
 
 // optionallyUseOptimizer will attempt to make an optimizer plan based on the
-// optimizerMode setting. If it is run, it will return true. If it returns false
-// and no error is returned, it is safe to fallback to a non-optimizer plan.
+// optimizerMode setting.
+//
+// If we are able to create a plan with the optimizer, the planFlagOptUsed is
+// set in the flags.
+//
+// If the optimizer is off or it is safe to fall back to the heuristic planner,
+// no error is returned and planFlagOptUsed is not set in the flags
+// (planFlagOptFallback is set in the latter case).
 func (p *planner) optionallyUseOptimizer(
 	ctx context.Context, sd sessiondata.SessionData, stmt Statement,
-) (bool, error) {
+) (planFlags, error) {
 	if sd.OptimizerMode == sessiondata.OptimizerOff {
 		log.VEvent(ctx, 2, "optimizer disabled")
-		return false, nil
+		return 0, nil
 	}
 
 	log.VEvent(ctx, 2, "generating optimizer plan")
 
-	err := p.makeOptimizerPlan(ctx, stmt)
-	if err == nil {
-		log.VEvent(ctx, 2, "optimizer plan succeeded")
-		return true, nil
+	flags, err := p.makeOptimizerPlan(ctx, stmt)
+	if err != nil {
+		log.VEventf(ctx, 1, "optimizer plan failed: %v", err)
+		if canFallbackFromOpt(err, sd.OptimizerMode, stmt) {
+			log.VEvent(ctx, 1, "optimizer falls back on heuristic planner")
+			return planFlagOptFallback, nil
+		}
+		return 0, err
 	}
-	log.VEventf(ctx, 1, "optimizer plan failed: %v", err)
-	if canFallbackFromOpt(err, sd.OptimizerMode, stmt) {
-		log.VEvent(ctx, 1, "optimizer falls back on heuristic planner")
-		return false, nil
-	}
-	return false, err
+
+	log.VEvent(ctx, 2, "optimizer plan succeeded")
+	return flags, nil
 }
 
 // txnModesSetter is an interface used by SQL execution to influence the current

--- a/pkg/sql/sessiondata/search_path.go
+++ b/pkg/sql/sessiondata/search_path.go
@@ -33,8 +33,8 @@ type SearchPath struct {
 	containsPgCatalog bool
 }
 
-// MakeSearchPath returns a new SearchPath struct. The paths slice must not be
-// modified after hand-off to MakeSearchPath.
+// MakeSearchPath returns a new immutable SearchPath struct. The paths slice
+// must not be modified after hand-off to MakeSearchPath.
 func MakeSearchPath(paths []string) SearchPath {
 	containsPgCatalog := false
 	for _, e := range paths {
@@ -74,6 +74,25 @@ func (s SearchPath) IterWithoutImplicitPGCatalog() SearchPathIter {
 // resultant slice is not to be modified.
 func (s SearchPath) GetPathArray() []string {
 	return s.paths
+}
+
+// Equals returns true if two SearchPaths are the same.
+func (s SearchPath) Equals(other *SearchPath) bool {
+	if s.containsPgCatalog != other.containsPgCatalog {
+		return false
+	}
+	if len(s.paths) != len(other.paths) {
+		return false
+	}
+	// Fast path: skip the check if it is the same slice.
+	if &s.paths[0] != &other.paths[0] {
+		for i := range s.paths {
+			if s.paths[i] != other.paths[i] {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (s SearchPath) String() string {

--- a/pkg/sql/sessiondata/search_path_test.go
+++ b/pkg/sql/sessiondata/search_path_test.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestImpliedSearchPath(t *testing.T) {
@@ -57,4 +59,25 @@ func TestImpliedSearchPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSearchPathEquals(t *testing.T) {
+	a1 := MakeSearchPath([]string{"x", "y", "z"})
+	a2 := MakeSearchPath([]string{"x", "y", "z"})
+	assert.True(t, a1.Equals(&a1))
+	assert.True(t, a2.Equals(&a2))
+
+	assert.True(t, a1.Equals(&a2))
+	assert.True(t, a2.Equals(&a1))
+
+	b := MakeSearchPath([]string{"x", "z", "y"})
+	assert.False(t, a1.Equals(&b))
+
+	c1 := MakeSearchPath([]string{"x", "y", "pg_catalog"})
+	c2 := MakeSearchPath([]string{"x", "y", "pg_catalog"})
+	assert.True(t, c1.Equals(&c2))
+	assert.False(t, a1.Equals(&c1))
+
+	d := MakeSearchPath([]string{"x"})
+	assert.False(t, a1.Equals(&d))
 }

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -54,9 +54,7 @@ type SessionData struct {
 	OptimizerUpdates bool
 	// SerialNormalizationMode indicates how to handle the SERIAL pseudo-type.
 	SerialNormalizationMode SerialNormalizationMode
-	// SearchPath is a list of databases that will be searched for a table name
-	// before the database. Currently, this is used only for SELECTs.
-	// Names in the search path must have been normalized already.
+	// SearchPath is a list of namespaces to search builtins in.
 	SearchPath SearchPath
 	// StmtTimeout is the duration a query is permitted to run before it is
 	// canceled by the session. If set to 0, there is no timeout.


### PR DESCRIPTION
This change adds metrics that count hits and misses of the query plan
cache. The simple cache test now checks these metrics.

We also make a fix to the cache invalidation logic which was found by
the new check (we were too strict when comparing search paths).

Release note: None