### PR TITLE
sql: ensure orphaned lease deletion uses a post bootstrap timestamp

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1441,6 +1441,11 @@ func (s *Server) Start(ctx context.Context) error {
 		return errors.Wrap(err, "inspecting engines")
 	}
 
+	// Record a walltime that is lower than the lowest hlc timestamp this current
+	// instance of the node can use. We do not use startTime because it is lower
+	// than the timestamp used to create the bootstrap schema.
+	timeThreshold := s.clock.Now().WallTime
+
 	// Now that we have a monotonic HLC wrt previous incarnations of the process,
 	// init all the replicas. At this point *some* store has been bootstrapped or
 	// we're joining an existing cluster for the first time.
@@ -1693,7 +1698,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Delete all orphaned table leases created by a prior instance of this
 	// node.
-	s.leaseMgr.DeleteOrphanedLeases(startTime)
+	s.leaseMgr.DeleteOrphanedLeases(timeThreshold)
 
 	log.Event(ctx, "server ready")
 

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -1926,7 +1926,7 @@ CREATE TABLE t.after (k CHAR PRIMARY KEY, v CHAR);
 
 	// Assume server shuts down here and a new instance of the server starts up.
 	// All leases created prior to this time are declared orphaned.
-	now := timeutil.Now()
+	now := timeutil.Now().UnixNano()
 
 	// Acquire a lease on "after" by name after server startup.
 	afterTable, _, err := t.node(1).AcquireByName(ctx, t.server.Clock().Now(), dbID, "after")


### PR DESCRIPTION
This is to ensure that it doesn't see a system.lease table doesn't
exist error. Also retry orphaned lease request upto 30 times when
the request sees an error.

fixes #33121

Release note: None