### PR TITLE
gossip: require node descriptors have non-empty addresses

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -106,7 +106,10 @@ func createTestStoreWithEngine(
 
 	rpcContext := rpc.NewContext(
 		ac, &base.Config{Insecure: true}, storeCfg.Clock, stopper, &storeCfg.Settings.Version)
-	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
+	nodeDesc := &roachpb.NodeDescriptor{
+		NodeID:  1,
+		Address: util.MakeUnresolvedAddr("tcp", "invalid.invalid:26257"),
+	}
 	server := rpc.NewServer(rpcContext) // never started
 	storeCfg.Gossip = gossip.NewTest(
 		nodeDesc.NodeID, rpcContext, server, stopper, metric.NewRegistry(),

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/tscache"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -92,7 +93,10 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	ambient.AddLogTag("n", nc)
 
 	nodeID := roachpb.NodeID(1)
-	nodeDesc := &roachpb.NodeDescriptor{NodeID: nodeID}
+	nodeDesc := &roachpb.NodeDescriptor{
+		NodeID:  nodeID,
+		Address: util.MakeUnresolvedAddr("tcp", "invalid.invalid:26257"),
+	}
 
 	ltc.tester = t
 	ltc.Stopper = stop.NewStopper()


### PR DESCRIPTION
This brings a slight bit of sanity to gossip, which previously had to
assume that a node descriptor could have an empty address for testing
purposes. We now ensure that node descriptors set via
`Gossip.SetNodeDescriptor` always have a non-empty address.

Unify the logic for detecting empty node descriptors to check for either
the zero node-id or an empty address.

See #29035

Release note: None