### PR TITLE
opt: support string_agg

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -844,11 +844,15 @@ func (ag *orderedAggregator) accumulateRow(row sqlbase.EncDatumRow) error {
 }
 
 type aggregateFuncHolder struct {
-	create    func(*tree.EvalContext, tree.Datums) tree.AggregateFunc
+	create func(*tree.EvalContext, tree.Datums) tree.AggregateFunc
+
+	// arguments is the list of constant (non-aggregated) arguments to the
+	// aggregate, for instance, the separator in string_agg.
 	arguments tree.Datums
-	group     *aggregatorBase
-	seen      map[string]struct{}
-	arena     *stringarena.Arena
+
+	group *aggregatorBase
+	seen  map[string]struct{}
+	arena *stringarena.Arena
 }
 
 const sizeOfAggregateFunc = int64(unsafe.Sizeof(tree.AggregateFunc(nil)))

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1242,6 +1242,18 @@ company_id  string_agg
 4           D,D,D,D
 
 query IT colnames
+SELECT company_id, string_agg(DISTINCT employee, ',')
+FROM string_agg_test
+GROUP BY company_id
+ORDER BY company_id;
+----
+company_id  string_agg
+1           A
+2           B
+3           C
+4           D
+
+query IT colnames
 SELECT company_id, string_agg(employee::BYTES, b',')
 FROM string_agg_test
 GROUP BY company_id

--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -861,6 +861,34 @@ WY
 NULL
 WA
 
+query T
+SELECT (SELECT string_agg(ship, ', ')
+  FROM
+  (SELECT c_id AS o_c_id, ship FROM o ORDER BY ship)
+  WHERE o_c_id=c.c_id)
+FROM c ORDER BY c_id
+----
+CA, CA, CA
+CA, TX
+NULL
+WY
+NULL
+WA
+
+query T
+SELECT (SELECT string_agg(DISTINCT ship, ', ')
+  FROM
+  (SELECT c_id AS o_c_id, ship FROM o ORDER BY ship)
+  WHERE o_c_id=c.c_id)
+FROM c ORDER BY c_id
+----
+CA
+CA, TX
+NULL
+WY
+NULL
+WA
+
 # ------------------------------------------------------------------------------
 # Subqueries in other interesting locations.
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -599,9 +599,10 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 		name, overload := memo.FindAggregateOverload(item.Agg)
 
 		distinct := false
-		argIdx := make([]exec.ColumnOrdinal, item.Agg.ChildCount())
-		for j := range argIdx {
-			child := item.Agg.Child(j)
+		var argIdx []exec.ColumnOrdinal
+
+		if item.Agg.ChildCount() > 0 {
+			child := item.Agg.Child(0)
 
 			if aggDistinct, ok := child.(*memo.AggDistinctExpr); ok {
 				distinct = true
@@ -611,8 +612,10 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 			if !ok {
 				return execPlan{}, errors.Errorf("only VariableOp args supported")
 			}
-			argIdx[j] = input.getColumnOrdinal(v.Col)
+			argIdx = []exec.ColumnOrdinal{input.getColumnOrdinal(v.Col)}
 		}
+
+		constArgs := b.extractAggregateConstArgs(item.Agg)
 
 		aggInfos[i] = exec.AggInfo{
 			FuncName:   name,
@@ -620,6 +623,7 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 			Distinct:   distinct,
 			ResultType: item.Agg.DataType(),
 			ArgCols:    argIdx,
+			ConstArgs:  constArgs,
 		}
 		ep.outputCols.Set(int(item.Col), len(groupingColIdx)+i)
 	}
@@ -640,6 +644,17 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 		return execPlan{}, err
 	}
 	return ep, nil
+}
+
+// extractAggregateConstArgs returns the list of constant arguments associated with a given aggregate
+// expression.
+func (b *Builder) extractAggregateConstArgs(agg opt.ScalarExpr) tree.Datums {
+	switch agg.Op() {
+	case opt.StringAggOp:
+		return tree.Datums{memo.ExtractConstDatum(agg.Child(1))}
+	default:
+		return nil
+	}
 }
 
 func (b *Builder) buildDistinct(distinct *memo.DistinctOnExpr) (execPlan, error) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -964,17 +964,14 @@ group                ·            ·             (array_agg)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT string_agg(s, ',') FROM (SELECT s FROM kv ORDER BY k)
 ----
-group                ·            ·                 (string_agg)                    ·
- │                   aggregate 0  string_agg(s)     ·                               ·
- │                   scalar       ·                 ·                               ·
- └── nosort          ·            ·                 (s)                             ·
-      │              order        +k                ·                               ·
-      └── render     ·            ·                 (s, k)                          k!=NULL; key(k); +k
-           │         render 0     test.public.kv.s  ·                               ·
-           │         render 1     test.public.kv.k  ·                               ·
-           └── scan  ·            ·                 (k, v[omitted], w[omitted], s)  k!=NULL; key(k); +k
-·                    table        kv@primary        ·                               ·
-·                    spans        ALL               ·                               ·
+group           ·            ·              (string_agg)  ·
+ │              aggregate 0  string_agg(s)  ·             ·
+ │              scalar       ·              ·             ·
+ └── render     ·            ·              (s)           ·
+      │         render 0     s              ·             ·
+      └── scan  ·            ·              (k, s)        +k
+·               table        kv@primary     ·             ·
+·               spans        ALL            ·             ·
 
 # Verify that we project away all input columns for count(*).
 query TTTTT
@@ -1012,3 +1009,112 @@ group      ·            ·             (u, v, s)  ·
  └── scan  ·            ·             (u, v, w)  +u,+v,+w
 ·          table        uvw@uvw       ·          ·
 ·          spans        ALL           ·          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT string_agg(s, ', ') FROM kv
+----
+group           ·            ·              (string_agg)  ·
+ │              aggregate 0  string_agg(s)  ·             ·
+ │              scalar       ·              ·             ·
+ └── render     ·            ·              (s)           ·
+      │         render 0     s              ·             ·
+      └── scan  ·            ·              (s)           ·
+·               table        kv@primary     ·             ·
+·               spans        ALL            ·             ·
+
+statement ok
+CREATE TABLE string_agg_test (
+  id INT PRIMARY KEY,
+  company_id INT,
+  employee STRING
+)
+
+query TTTTT
+EXPLAIN (VERBOSE)
+    SELECT
+        company_id, string_agg(employee, ',')
+    FROM
+        string_agg_test
+    GROUP BY
+        company_id
+    ORDER BY
+        company_id
+----
+sort            ·            ·                        (company_id, string_agg)  +company_id
+ │              order        +company_id              ·                         ·
+ └── group      ·            ·                        (company_id, string_agg)  ·
+      │         aggregate 0  company_id               ·                         ·
+      │         aggregate 1  string_agg(employee)     ·                         ·
+      │         group by     @1                       ·                         ·
+      └── scan  ·            ·                        (company_id, employee)    ·
+·               table        string_agg_test@primary  ·                         ·
+·               spans        ALL                      ·                         ·
+
+query TTTTT
+EXPLAIN (VERBOSE)
+    SELECT
+        company_id, string_agg(employee::BYTES, b',')
+    FROM
+        string_agg_test
+    GROUP BY
+        company_id
+    ORDER BY
+        company_id
+----
+sort                 ·            ·                        (company_id, string_agg)  +company_id
+ │                   order        +company_id              ·                         ·
+ └── group           ·            ·                        (company_id, string_agg)  ·
+      │              aggregate 0  company_id               ·                         ·
+      │              aggregate 1  string_agg(column4)      ·                         ·
+      │              group by     @2                       ·                         ·
+      └── render     ·            ·                        (column4, company_id)     ·
+           │         render 0     employee::BYTES          ·                         ·
+           │         render 1     company_id               ·                         ·
+           └── scan  ·            ·                        (company_id, employee)    ·
+·                    table        string_agg_test@primary  ·                         ·
+·                    spans        ALL                      ·                         ·
+
+query TTTTT
+EXPLAIN (VERBOSE)
+    SELECT
+        company_id, string_agg(employee, NULL)
+    FROM
+        string_agg_test
+    GROUP BY
+        company_id
+    ORDER BY
+        company_id
+----
+sort            ·            ·                        (company_id, string_agg)  +company_id
+ │              order        +company_id              ·                         ·
+ └── group      ·            ·                        (company_id, string_agg)  ·
+      │         aggregate 0  company_id               ·                         ·
+      │         aggregate 1  string_agg(employee)     ·                         ·
+      │         group by     @1                       ·                         ·
+      └── scan  ·            ·                        (company_id, employee)    ·
+·               table        string_agg_test@primary  ·                         ·
+·               spans        ALL                      ·                         ·
+
+query TTTTT
+EXPLAIN (VERBOSE)
+    SELECT
+        company_id, string_agg(employee::BYTES, NULL)
+    FROM
+        string_agg_test
+    GROUP BY
+        company_id
+    ORDER BY
+        company_id
+----
+sort                 ·            ·                        (company_id, string_agg)  +company_id
+ │                   order        +company_id              ·                         ·
+ └── group           ·            ·                        (company_id, string_agg)  ·
+      │              aggregate 0  company_id               ·                         ·
+      │              aggregate 1  string_agg(column4)      ·                         ·
+      │              group by     @2                       ·                         ·
+      └── render     ·            ·                        (column4, company_id)     ·
+           │         render 0     employee::BYTES          ·                         ·
+           │         render 1     company_id               ·                         ·
+           └── scan  ·            ·                        (company_id, employee)    ·
+·                    table        string_agg_test@primary  ·                         ·
+·                    spans        ALL                      ·                         ·

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -322,4 +322,8 @@ type AggInfo struct {
 	Distinct   bool
 	ResultType types.T
 	ArgCols    []ColumnOrdinal
+
+	// ConstArgs is the list of any constant arguments to the aggregate,
+	// for instance, the separator in string_agg.
+	ConstArgs []tree.Datum
 }

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -207,6 +207,10 @@ func (m *Memo) checkExpr(e opt.Expr) {
 			}
 		}
 
+		if e.Op() == opt.StringAggOp && !CanExtractConstDatum(e.Child(1)) {
+			panic(fmt.Sprintf("second argument to StringAggOp must always be constant, but got %s", e.Child(1).Op()))
+		}
+
 		if opt.IsJoinOp(e) {
 			checkFilters(*e.Child(2).(*FiltersExpr))
 		}

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -148,10 +148,6 @@ var ScalarListWithEmptyTuple = ScalarListExpr{EmptyTuple}
 // grouping columns and no ordering.
 var EmptyGroupingPrivate = GroupingPrivate{}
 
-// MaxAggChildren is the maximum number of children that any aggregate operator
-// can have.
-const MaxAggChildren = 3
-
 // LastGroupMember returns the last member in the same memo group of the given
 // relational expression.
 func LastGroupMember(e RelExpr) RelExpr {

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -117,9 +117,10 @@ func ExtractAggInputColumns(e opt.ScalarExpr) opt.ColSet {
 	if !opt.IsAggregateOp(e) {
 		panic("not an Aggregate")
 	}
+
 	var res opt.ColSet
-	for i, n := 0, e.ChildCount(); i < n; i++ {
-		res.Add(int(ExtractVarFromAggInput(e.Child(i).(opt.ScalarExpr)).Col))
+	if e.ChildCount() > 0 {
+		res.Add(int(ExtractVarFromAggInput(e.Child(0).(opt.ScalarExpr)).Col))
 	}
 	return res
 }

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -88,6 +88,16 @@ TABLE uvwz
       ├── w int not null
       └── rowid int not null (hidden) (storing)
 
+exec-ddl
+CREATE TABLE s (
+    s STRING PRIMARY KEY
+)
+----
+TABLE s
+ ├── s string not null
+ └── INDEX primary
+      └── s string not null
+
 # --------------------------------------------------
 # ConvertGroupByToDistinct
 # --------------------------------------------------
@@ -425,6 +435,28 @@ scalar-group-by
       └── sum [type=decimal, outer=(2)]
            └── agg-distinct [type=int]
                 └── variable: i [type=int]
+
+opt expect=EliminateAggDistinctForKeys
+SELECT string_agg(DISTINCT s, ', ') FROM s
+----
+scalar-group-by
+ ├── columns: string_agg:3(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(3)
+ ├── project
+ │    ├── columns: column2:2(string!null) s:1(string!null)
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2)
+ │    ├── scan s
+ │    │    ├── columns: s:1(string!null)
+ │    │    └── key: (1)
+ │    └── projections
+ │         └── const: ', ' [type=string]
+ └── aggregations
+      └── string-agg [type=string, outer=(1)]
+           ├── variable: s [type=string]
+           └── const: ', ' [type=string]
 
 # GroupBy with key argument.
 opt expect=EliminateAggDistinctForKeys

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -183,6 +183,7 @@ var AggregateOpReverseMap = map[Operator]string{
 	XorAggOp:          "xor_agg",
 	JsonAggOp:         "json_agg",
 	JsonbAggOp:        "jsonb_agg",
+	StringAggOp:       "string_agg",
 	ConstAggOp:        "any_not_null",
 	ConstNotNullAggOp: "any_not_null",
 	AnyNotNullAggOp:   "any_not_null",
@@ -232,7 +233,7 @@ func BoolOperatorRequiresNotNullArgs(op Operator) bool {
 // values are fed to it.
 func AggregateIsOrderingSensitive(op Operator) bool {
 	switch op {
-	case ArrayAggOp, ConcatAggOp, JsonAggOp, JsonbAggOp:
+	case ArrayAggOp, ConcatAggOp, JsonAggOp, JsonbAggOp, StringAggOp:
 		return true
 	}
 	return false
@@ -245,7 +246,7 @@ func AggregateIgnoresNulls(op Operator) bool {
 	switch op {
 	case AvgOp, BoolAndOp, BoolOrOp, CountOp, MaxOp, MinOp, SumIntOp, SumOp,
 		SqrDiffOp, VarianceOp, StdDevOp, XorAggOp, ConstNotNullAggOp,
-		AnyNotNullAggOp:
+		AnyNotNullAggOp, StringAggOp:
 		return true
 	}
 	return false
@@ -260,7 +261,7 @@ func AggregateIsNullOnEmpty(op Operator) bool {
 	switch op {
 	case AvgOp, BoolAndOp, BoolOrOp, MaxOp, MinOp, SumIntOp, SumOp, SqrDiffOp,
 		VarianceOp, StdDevOp, XorAggOp, ConstAggOp, ConstNotNullAggOp, ArrayAggOp,
-		ConcatAggOp, JsonAggOp, JsonbAggOp, AnyNotNullAggOp:
+		ConcatAggOp, JsonAggOp, JsonbAggOp, AnyNotNullAggOp, StringAggOp:
 		return true
 	}
 	return false

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -790,6 +790,15 @@ define JsonbAgg {
     Input ScalarExpr
 }
 
+[Scalar, Aggregate]
+define StringAgg {
+    Input ScalarExpr
+
+    # Sep is the constant expression which separates the input strings.
+    # Note that it must always be a constant expression.
+    Sep   ScalarExpr
+}
+
 # ConstAgg is used in the special case when the value of a column is known to be
 # constant within a grouping set; it returns that value. If there are no rows
 # in the grouping set, then ConstAgg returns NULL.

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -95,6 +95,11 @@ scalar-group-by
            └── variable: column16 [type=bytes]
 
 build
+SELECT min(1, 2)
+----
+error (42883): unknown signature: min(int, int)
+
+build
 SELECT min(1), count(1), max(1), sum_int(1), avg(1)::float, sum(1), stddev(1),
   variance(1)::float, bool_and(true), bool_or(true), to_hex(xor_agg(b'\x01'))
 ----
@@ -2792,6 +2797,114 @@ project
       └── aggregations
            └── max [type=decimal]
                 └── variable: column5 [type=decimal]
+
+# Tests for string_agg.
+
+build
+SELECT string_agg(s, 'separator') FROM kv
+----
+scalar-group-by
+ ├── columns: string_agg:6(string)
+ ├── project
+ │    ├── columns: column5:5(string!null) s:4(string)
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         └── const: 'separator' [type=string]
+ └── aggregations
+      └── string-agg [type=string]
+           ├── variable: s [type=string]
+           └── const: 'separator' [type=string]
+
+build
+SELECT string_agg(s) FROM kv
+----
+error (42883): unknown signature: string_agg(string)
+
+build
+SELECT string_agg(s, 'x', 'y') FROM kv
+----
+error (42883): unknown signature: string_agg(string, string, string)
+
+build
+SELECT string_agg(DISTINCT s, 'separator') FROM kv
+----
+scalar-group-by
+ ├── columns: string_agg:6(string)
+ ├── project
+ │    ├── columns: column5:5(string!null) s:4(string)
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         └── const: 'separator' [type=string]
+ └── aggregations
+      └── string-agg [type=string]
+           ├── agg-distinct [type=string]
+           │    └── variable: s [type=string]
+           └── const: 'separator' [type=string]
+
+build
+SELECT max(s), string_agg(s, 'sep1'), string_agg(s, 'sep2'), min(s) FROM kv
+----
+scalar-group-by
+ ├── columns: max:5(string) string_agg:7(string) string_agg:9(string) min:10(string)
+ ├── project
+ │    ├── columns: column6:6(string!null) column8:8(string!null) s:4(string)
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         ├── const: 'sep1' [type=string]
+ │         └── const: 'sep2' [type=string]
+ └── aggregations
+      ├── max [type=string]
+      │    └── variable: s [type=string]
+      ├── string-agg [type=string]
+      │    ├── variable: s [type=string]
+      │    └── const: 'sep1' [type=string]
+      ├── string-agg [type=string]
+      │    ├── variable: s [type=string]
+      │    └── const: 'sep2' [type=string]
+      └── min [type=string]
+           └── variable: s [type=string]
+
+# The separator must be constant, but it need not be a literal - any constant (as
+# determined by tree.IsConst) is valid.
+build
+SELECT string_agg(s, 'abc' || 'xyz') FROM kv
+----
+scalar-group-by
+ ├── columns: string_agg:6(string)
+ ├── project
+ │    ├── columns: column5:5(string!null) s:4(string)
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         └── const: 'abcxyz' [type=string]
+ └── aggregations
+      └── string-agg [type=string]
+           ├── variable: s [type=string]
+           └── const: 'abcxyz' [type=string]
+
+build
+SELECT string_agg(s, NULL) FROM kv
+----
+scalar-group-by
+ ├── columns: string_agg:6(string)
+ ├── project
+ │    ├── columns: column5:5(unknown) s:4(string)
+ │    ├── scan kv
+ │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
+ │    └── projections
+ │         └── null [type=unknown]
+ └── aggregations
+      └── string-agg [type=string]
+           ├── variable: s [type=string]
+           └── null [type=unknown]
+
+build
+SELECT string_agg('foo', s) FROM kv
+----
+error: unimplemented: aggregate functions with multiple non-constant expressions are not supported
 
 # Regression test for #26419
 build

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -432,7 +432,7 @@ func (ef *execFactory) addAggregations(n *groupNode, aggregations []exec.AggInfo
 			agg.ResultType,
 			renderIdx,
 			aggFn,
-			nil, /* arguments */
+			agg.ConstArgs,
 			ef.planner.EvalContext().Mon.MakeBoundAccount(),
 		)
 		if agg.Distinct {


### PR DESCRIPTION
This commit adds support for the string_agg aggregate. What makes
string_agg special is that it has a second argument, but as a
CRDB-specific limitation the second argument must be constant.

There are conceivably other multi-argument aggregates we could add in
the future which wouldn't have this restriction (json_object_agg) so
I've tried to include sufficiently many assertions that someone lifting
the constant restriction in the future won't have to hunt around too
much.

Release note (sql change): the string_agg aggregate is now supported by
the cost-based optimizer.