### PR TITLE
[wip] sql: pgwire support for limited result sets

### DIFF
--- a/pkg/acceptance/testdata/java/src/main/java/MainTest.java
+++ b/pkg/acceptance/testdata/java/src/main/java/MainTest.java
@@ -67,6 +67,29 @@ public class MainTest extends CockroachDBTest {
     }
 
     @Test
+    public void testLimit() throws Exception {
+        conn.setAutoCommit(false);
+        PreparedStatement stmt = conn.prepareStatement(
+                "SELECT generate_series(1,5)");
+
+        stmt.setFetchSize(2);
+
+        ResultSet rs = stmt.executeQuery();
+        rs.next();
+        Assert.assertEquals(1, rs.getInt(1));
+        rs.next();
+        Assert.assertEquals(2, rs.getInt(1));
+        rs.next();
+        Assert.assertEquals(3, rs.getInt(1));
+        rs.next();
+        Assert.assertEquals(4, rs.getInt(1));
+        rs.next();
+        Assert.assertEquals(5, rs.getInt(1));
+        conn.commit();
+        conn.setAutoCommit(true);
+    }
+
+    @Test
     public void testInsertWithParameters() throws Exception {
         PreparedStatement stmt = conn.prepareStatement(
                 "CREATE TABLE accounts (id INT PRIMARY KEY, balance INT, cdate DATE)"

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -204,16 +204,16 @@ func makeChangefeedResultWriter(rowsCh chan<- tree.Datums) *changefeedResultWrit
 	return &changefeedResultWriter{rowsCh: rowsCh}
 }
 
-func (w *changefeedResultWriter) AddRow(ctx context.Context, row tree.Datums) error {
+func (w *changefeedResultWriter) AddRow(ctx context.Context, row tree.Datums) (cont bool, _ error) {
 	// Copy the row because it's not guaranteed to exist after this function
 	// returns.
 	row = append(tree.Datums(nil), row...)
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return false, ctx.Err()
 	case w.rowsCh <- row:
-		return nil
+		return true, nil
 	}
 }
 func (w *changefeedResultWriter) IncrementRowsAffected(n int) {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1103,7 +1103,7 @@ func (ex *connExecutor) run(
 			return err
 		}
 
-		cmd, pos, err := ex.stmtBuf.curCmd()
+		cmd, pos, err := ex.stmtBuf.CurCmd()
 		if err != nil {
 			if err == io.EOF {
 				return nil
@@ -1127,9 +1127,7 @@ func (ex *connExecutor) run(
 			}
 			ex.curStmt = tcmd.Stmt
 
-			stmtRes := ex.clientComm.CreateStatementResult(
-				tcmd.Stmt, NeedRowDesc, pos, nil, /* formatCodes */
-				ex.sessionData.DataConversion)
+			stmtRes := ex.clientComm.CreateStatementResult(tcmd.Stmt, NeedRowDesc, pos, nil, ex.sessionData.DataConversion, 0)
 			res = stmtRes
 			curStmt := Statement{SQL: tcmd.SQL, AST: tcmd.Stmt}
 
@@ -1179,14 +1177,8 @@ func (ex *connExecutor) run(
 				break
 			}
 
-			stmtRes := ex.clientComm.CreateStatementResult(
-				portal.Stmt.Statement,
-				// The client is using the extended protocol, so no row description is
-				// needed.
-				DontNeedRowDesc,
-				pos, portal.OutFormats,
-				ex.sessionData.DataConversion)
-			stmtRes.SetLimit(tcmd.Limit)
+			stmtRes := ex.clientComm.CreateStatementResult(portal.Stmt.Statement, DontNeedRowDesc, pos, portal.OutFormats,
+				ex.sessionData.DataConversion, tcmd.Limit)
 			res = stmtRes
 			curStmt := Statement{
 				SQL:           portal.Stmt.Str,
@@ -1304,7 +1296,7 @@ func (ex *connExecutor) run(
 		// Move the cursor according to what the state transition told us to do.
 		switch advInfo.code {
 		case advanceOne:
-			ex.stmtBuf.advanceOne()
+			ex.stmtBuf.AdvanceOne()
 		case skipBatch:
 			// We'll flush whatever results we have to the network. The last one must
 			// be an error. This flush may seem unnecessary, as we generally only

--- a/pkg/sql/conn_io_test.go
+++ b/pkg/sql/conn_io_test.go
@@ -81,7 +81,7 @@ func TestStmtBuf(t *testing.T) {
 	// same statement.
 	expPos := CmdPos(0)
 	for i := 0; i < 2; i++ {
-		cmd, pos, err := buf.curCmd()
+		cmd, pos, err := buf.CurCmd()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -91,9 +91,9 @@ func TestStmtBuf(t *testing.T) {
 		assertStmt(t, cmd, "SELECT 1")
 	}
 
-	buf.advanceOne()
+	buf.AdvanceOne()
 	expPos++
-	cmd, pos, err := buf.curCmd()
+	cmd, pos, err := buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,9 +102,9 @@ func TestStmtBuf(t *testing.T) {
 	}
 	assertStmt(t, cmd, "SELECT 2")
 
-	buf.advanceOne()
+	buf.AdvanceOne()
 	expPos++
-	cmd, pos, err = buf.curCmd()
+	cmd, pos, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,9 +113,9 @@ func TestStmtBuf(t *testing.T) {
 	}
 	assertStmt(t, cmd, "SELECT 3")
 
-	buf.advanceOne()
+	buf.AdvanceOne()
 	expPos++
-	cmd, pos, err = buf.curCmd()
+	cmd, pos, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestStmtBuf(t *testing.T) {
 	// Now rewind.
 	expPos = 1
 	buf.rewind(ctx, expPos)
-	cmd, pos, err = buf.curCmd()
+	cmd, pos, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestStmtBufSignal(t *testing.T) {
 	}()
 
 	expPos := CmdPos(0)
-	cmd, pos, err := buf.curCmd()
+	cmd, pos, err := buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,8 +177,8 @@ func TestStmtBufLtrim(t *testing.T) {
 		mustPush(ctx, t, buf, ExecStmt{Stmt: stmt})
 	}
 	// Advance the cursor so that we can trim.
-	buf.advanceOne()
-	buf.advanceOne()
+	buf.AdvanceOne()
+	buf.AdvanceOne()
 	trimPos := CmdPos(2)
 	buf.ltrim(ctx, trimPos)
 	if l := len(buf.mu.data); l != 3 {
@@ -203,7 +203,7 @@ func TestStmtBufClose(t *testing.T) {
 	mustPush(ctx, t, buf, ExecStmt{Stmt: stmt})
 	buf.Close()
 
-	_, _, err = buf.curCmd()
+	_, _, err = buf.CurCmd()
 	if err != io.EOF {
 		t.Fatalf("expected EOF, got: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestStmtBufCloseUnblocksReader(t *testing.T) {
 		buf.Close()
 	}()
 
-	_, _, err := buf.curCmd()
+	_, _, err := buf.CurCmd()
 	if err != io.EOF {
 		t.Fatalf("expected EOF, got: %v", err)
 	}
@@ -241,21 +241,21 @@ func TestStmtBufPreparedStmt(t *testing.T) {
 	mustPush(ctx, t, buf, PrepareStmt{Name: "p1"})
 	mustPush(ctx, t, buf, PrepareStmt{Name: "p2"})
 
-	cmd, _, err := buf.curCmd()
+	cmd, _, err := buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
 	assertStmt(t, cmd, "SELECT 1")
 
-	buf.advanceOne()
-	cmd, _, err = buf.curCmd()
+	buf.AdvanceOne()
+	cmd, _, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
 	assertPrepareStmt(t, cmd, "p1")
 
-	buf.advanceOne()
-	cmd, _, err = buf.curCmd()
+	buf.AdvanceOne()
+	cmd, _, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +263,7 @@ func TestStmtBufPreparedStmt(t *testing.T) {
 
 	// Rewind to the first prepared stmt.
 	buf.rewind(ctx, CmdPos(1))
-	cmd, _, err = buf.curCmd()
+	cmd, _, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,7 +303,7 @@ func TestStmtBufBatching(t *testing.T) {
 	if err := buf.seekToNextBatch(); err != nil {
 		t.Fatal(err)
 	}
-	_, pos, err := buf.curCmd()
+	_, pos, err := buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestStmtBufBatching(t *testing.T) {
 	if err := buf.seekToNextBatch(); err != nil {
 		t.Fatal(err)
 	}
-	_, pos, err = buf.curCmd()
+	_, pos, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -333,7 +333,7 @@ func TestStmtBufBatching(t *testing.T) {
 	if err := buf.seekToNextBatch(); err != nil {
 		t.Fatal(err)
 	}
-	_, pos, err = buf.curCmd()
+	_, pos, err = buf.CurCmd()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -112,9 +112,11 @@ func (b *RowResultWriter) IncrementRowsAffected(n int) {
 }
 
 // AddRow implements the rowResultWriter interface.
-func (b *RowResultWriter) AddRow(ctx context.Context, row tree.Datums) error {
-	_, err := b.rowContainer.AddRow(ctx, row)
-	return err
+func (b *RowResultWriter) AddRow(ctx context.Context, row tree.Datums) (bool, error) {
+	if _, err := b.rowContainer.AddRow(ctx, row); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // SetError is part of the rowResultWriter interface.
@@ -148,8 +150,8 @@ func (c *callbackResultWriter) IncrementRowsAffected(n int) {
 	c.rowsAffected += n
 }
 
-func (c *callbackResultWriter) AddRow(ctx context.Context, row tree.Datums) error {
-	return c.fn(ctx, row)
+func (c *callbackResultWriter) AddRow(ctx context.Context, row tree.Datums) (cont bool, err error) {
+	return true, c.fn(ctx, row)
 }
 
 func (c *callbackResultWriter) SetError(err error) {

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -571,6 +571,7 @@ func (icc *internalClientComm) CreateStatementResult(
 	pos CmdPos,
 	_ []pgwirebase.FormatCode,
 	_ sessiondata.DataConversionConfig,
+	_ int,
 ) CommandResult {
 	return icc.createRes(pos, nil /* onClose */)
 }

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -954,6 +954,13 @@ func (c *conn) bufferCommandComplete(tag []byte) {
 	}
 }
 
+func (c *conn) bufferPortalSuspended() {
+	c.msgBuilder.initMsg(pgwirebase.ServerMsgPortalSuspended)
+	if err := c.msgBuilder.finishMsg(&c.writerState.buf); err != nil {
+		panic(fmt.Sprintf("unexpected err from buffer: %s", err))
+	}
+}
+
 func (c *conn) bufferErr(err error) {
 	if err := writeErr(err, &c.msgBuilder, &c.writerState.buf); err != nil {
 		panic(fmt.Sprintf("unexpected err from buffer: %s", err))
@@ -1173,9 +1180,9 @@ func (c *conn) CreateStatementResult(
 	pos sql.CmdPos,
 	formatCodes []pgwirebase.FormatCode,
 	conv sessiondata.DataConversionConfig,
+	limit int,
 ) sql.CommandResult {
-	res := c.makeCommandResult(descOpt, pos, stmt, formatCodes, conv)
-	return &res
+	return c.makeCommandResult(descOpt, pos, stmt, formatCodes, conv, limit)
 }
 
 // CreateSyncResult is part of the sql.ClientComm interface.

--- a/pkg/sql/pgwire/pgwirebase/msg.go
+++ b/pkg/sql/pgwire/pgwirebase/msg.go
@@ -52,6 +52,7 @@ const (
 	ServerMsgParameterDescription ServerMessageType = 't'
 	ServerMsgParameterStatus      ServerMessageType = 'S'
 	ServerMsgParseComplete        ServerMessageType = '1'
+	ServerMsgPortalSuspended      ServerMessageType = 's'
 	ServerMsgReady                ServerMessageType = 'Z'
 	ServerMsgRowDescription       ServerMessageType = 'T'
 )

--- a/pkg/sql/pgwire/pgwirebase/servermessagetype_string.go
+++ b/pkg/sql/pgwire/pgwirebase/servermessagetype_string.go
@@ -12,13 +12,14 @@ const (
 	_ServerMessageType_name_4 = "ServerMsgAuthServerMsgParameterStatusServerMsgRowDescription"
 	_ServerMessageType_name_5 = "ServerMsgReady"
 	_ServerMessageType_name_6 = "ServerMsgNoData"
-	_ServerMessageType_name_7 = "ServerMsgParameterDescription"
+	_ServerMessageType_name_7 = "ServerMsgPortalSuspendedServerMsgParameterDescription"
 )
 
 var (
 	_ServerMessageType_index_0 = [...]uint8{0, 22, 43, 65}
 	_ServerMessageType_index_1 = [...]uint8{0, 24, 40, 62}
 	_ServerMessageType_index_4 = [...]uint8{0, 13, 37, 60}
+	_ServerMessageType_index_7 = [...]uint8{0, 24, 53}
 )
 
 func (i ServerMessageType) String() string {
@@ -40,8 +41,9 @@ func (i ServerMessageType) String() string {
 		return _ServerMessageType_name_5
 	case i == 110:
 		return _ServerMessageType_name_6
-	case i == 116:
-		return _ServerMessageType_name_7
+	case 115 <= i && i <= 116:
+		i -= 115
+		return _ServerMessageType_name_7[_ServerMessageType_index_7[i]:_ServerMessageType_index_7[i+1]]
 	default:
 		return "ServerMessageType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -77,13 +77,13 @@ func MakeStmtBufReader(buf *StmtBuf) StmtBufReader {
 
 // CurCmd returns the current command in the buffer.
 func (r StmtBufReader) CurCmd() (Command, error) {
-	cmd, _ /* pos */, err := r.buf.curCmd()
+	cmd, _ /* pos */, err := r.buf.CurCmd()
 	return cmd, err
 }
 
 // AdvanceOne moves the cursor one position over.
 func (r *StmtBufReader) AdvanceOne() {
-	r.buf.advanceOne()
+	r.buf.AdvanceOne()
 }
 
 // SeekToNextBatch skips to the beginning of the next batch of commands.


### PR DESCRIPTION
This commit adds support for portal execution with limits, which is the
part of the pgwire protocol that JDBC uses if you use its native
pagination with `setFetchSize`.

Closes #4035.

Release note (sql change): add support for row limits in prepared
portals at the pgwire layer, enabling support for client-side pagination
with things like JDBC's `setFetchSize`.

Co-authored-by: Jordan Lewis <jordanthelewis@gmail.com>
Co-authored-by: Andrei Matei <andrei@cockroachlabs.com>