### PR TITLE
opt: count number of execPlan columns correctly

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -982,3 +982,12 @@ SELECT parent_path FROM t32786 ORDER BY id
 ----
 3aaa2577-dbc3-47e7-9e85-9cc7e19cf48a/
 3aaa2577-dbc3-47e7-9e85-9cc7e19cf48a/5ae7eafd-8277-4f41-83de-0fd4b4482169/
+
+# Regression test for #32723.
+query I
+SELECT
+    generate_series(a + 1, a + 1)
+FROM
+    (SELECT a FROM ((SELECT 1 AS a, 1) EXCEPT ALL (SELECT 0, 0)))
+----
+2

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -54,19 +54,28 @@ type execPlan struct {
 	// example the output columns in increasing index order. However, this would
 	// require a lot of otherwise unnecessary projections.
 	//
-	// The number of entries set in the map is always the same with the number of
-	// columns emitted by Node.
-	//
 	// Note: conceptually, this could be a ColList; however, the map is more
 	// convenient when converting VariableOps to IndexedVars.
 	outputCols opt.ColMap
+}
+
+// numOutputCols returns the number of columns emitted by the execPlan's Node.
+// This will typically be equal to ep.outputCols.Len(), but might be different
+// if the node outputs the same optimizer ColumnID multiple times.
+// TODO(justin): we should keep track of this instead of computing it each time.
+func (ep *execPlan) numOutputCols() int {
+	max, ok := ep.outputCols.MaxValue()
+	if !ok {
+		return 0
+	}
+	return max + 1
 }
 
 // makeBuildScalarCtx returns a buildScalarCtx that can be used with expressions
 // that refer the output columns of this plan.
 func (ep *execPlan) makeBuildScalarCtx() buildScalarCtx {
 	return buildScalarCtx{
-		ivh:     tree.MakeIndexedVarHelper(nil /* container */, ep.outputCols.Len()),
+		ivh:     tree.MakeIndexedVarHelper(nil /* container */, ep.numOutputCols()),
 		ivarMap: ep.outputCols,
 	}
 }
@@ -1041,7 +1050,7 @@ func (b *Builder) buildProjectSet(projectSet *memo.ProjectSetExpr) (execPlan, er
 	numColsPerGen := make([]int, len(zip))
 
 	ep := execPlan{outputCols: input.outputCols}
-	n := ep.outputCols.Len()
+	n := ep.numOutputCols()
 
 	for i := range zip {
 		item := &zip[i]
@@ -1170,7 +1179,7 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (execPlan, error) {
 func (b *Builder) needProjection(
 	input execPlan, colList opt.ColList,
 ) (_ []exec.ColumnOrdinal, needProj bool) {
-	if input.outputCols.Len() == len(colList) {
+	if input.numOutputCols() == len(colList) {
 		identity := true
 		for i, col := range colList {
 			if ord, ok := input.outputCols.Get(int(col)); !ok || ord != i {

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -486,7 +486,7 @@ func (b *Builder) buildAny(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	}
 
 	// Construct tuple type of columns in the row.
-	types := types.TTuple{Types: make([]types.T, plan.outputCols.Len())}
+	types := types.TTuple{Types: make([]types.T, plan.numOutputCols())}
 	plan.outputCols.ForEach(func(key, val int) {
 		types.Types[val] = b.mem.Metadata().ColumnType(opt.ColumnID(key))
 	})

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -261,3 +261,29 @@ limit                                 ·            ·                          
                           └── scan    ·            ·                          (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)          ·
 ·                                     table        articles@primary           ·                                                                                        ·
 ·                                     spans        ALL                        ·                                                                                        ·
+
+# Regression test for #32723.
+query TTTTT
+EXPLAIN (VERBOSE)
+    SELECT
+        generate_series(a + 1, a + 1)
+    FROM
+        (SELECT a FROM ((SELECT 1 AS a, 1) EXCEPT ALL (SELECT 0, 0)))
+----
+render                      ·              ·                                (generate_series)         ·
+ │                          render 0       generate_series                  ·                         ·
+ └── project set            ·              ·                                (a, a, generate_series)   ·
+      │                     render 0       generate_series(@2 + 1, @2 + 1)  ·                         ·
+      └── union             ·              ·                                (a, a)                    ·
+           ├── render       ·              ·                                (a, a)                    ·
+           │    │           render 0       a                                ·                         ·
+           │    │           render 1       a                                ·                         ·
+           │    └── values  ·              ·                                (a)                       ·
+           │                size           1 column, 1 row                  ·                         ·
+           │                row 0, expr 0  1                                ·                         ·
+           └── render       ·              ·                                ("?column?", "?column?")  ·
+                │           render 0       "?column?"                       ·                         ·
+                │           render 1       "?column?"                       ·                         ·
+                └── values  ·              ·                                ("?column?")              ·
+·                           size           1 column, 1 row                  ·                         ·
+·                           row 0, expr 0  0                                ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -58,3 +58,46 @@ sort                 ·         ·            (a)     +a
            └── scan  ·         ·            (a, b)  ·
 ·                    table     abc@primary  ·       ·
 ·                    spans     ALL          ·       ·
+
+# Regression test for #32723.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT a FROM ((SELECT '' AS a , '') EXCEPT ALL (SELECT '', ''))
+----
+render                 ·              ·                (a)                       ·
+ │                     render 0       a                ·                         ·
+ └── union             ·              ·                (a, a)                    ·
+      ├── render       ·              ·                (a, a)                    ·
+      │    │           render 0       a                ·                         ·
+      │    │           render 1       a                ·                         ·
+      │    └── values  ·              ·                (a)                       ·
+      │                size           1 column, 1 row  ·                         ·
+      │                row 0, expr 0  ''               ·                         ·
+      └── render       ·              ·                ("?column?", "?column?")  ·
+           │           render 0       "?column?"       ·                         ·
+           │           render 1       "?column?"       ·                         ·
+           └── values  ·              ·                ("?column?")              ·
+·                      size           1 column, 1 row  ·                         ·
+·                      row 0, expr 0  ''               ·                         ·
+
+query TTTTT
+EXPLAIN (VERBOSE) ((SELECT '', '', 'x' WHERE false))
+UNION ALL ((SELECT '', '', 'x') EXCEPT (VALUES ('', '', 'x')))
+----
+render                 ·              ·                 ("?column?", "?column?", "?column?")  ·
+ │                     render 0       "?column?"        ·                                     ·
+ │                     render 1       "?column?"        ·                                     ·
+ │                     render 2       "?column?"        ·                                     ·
+ └── union             ·              ·                 ("?column?", "?column?", "?column?")  ·
+      ├── render       ·              ·                 ("?column?", "?column?", "?column?")  ·
+      │    │           render 0       "?column?"        ·                                     ·
+      │    │           render 1       "?column?"        ·                                     ·
+      │    │           render 2       "?column?"        ·                                     ·
+      │    └── values  ·              ·                 ("?column?", "?column?")              ·
+      │                size           2 columns, 1 row  ·                                     ·
+      │                row 0, expr 0  ''                ·                                     ·
+      │                row 0, expr 1  'x'               ·                                     ·
+      └── values       ·              ·                 (column1, column2, column3)           ·
+·                      size           3 columns, 1 row  ·                                     ·
+·                      row 0, expr 0  ''                ·                                     ·
+·                      row 0, expr 1  ''                ·                                     ·
+·                      row 0, expr 2  'x'               ·                                     ·


### PR DESCRIPTION
Fixes #32723.

Prior to this commit, we assumed that the number of columns output by
an execPlan was equal to the size of its outputCol map. This was untrue
in the case where we output a single column multiple times, which could
happen when we reuse projections in a query like `SELECT '', ''`.

I found two places where this was clearly causing a bug:
1. when we initialize a scalarBuildCtx we sized the ivarHelper to be the
   size of the outputCols map. This led to it being undersized and causing
   an out-of-bounds in some cases.
2. When we built a projectSet we used this count to offset our
   projections, leading to incorrect results.

We now take the highest value (column index) in the map to be the number
of output columns.

Here's before/after numbers for ExecBuild:
```
name                                 old time/op    new time/op    delta
Phases/kv-read/ExecBuild-8             12.0µs ± 2%    11.7µs ± 2%  -2.19%  (p=0.000 n=10+10)
Phases/kv-read-no-prep/ExecBuild-8     41.2µs ± 2%    42.2µs ± 4%  +2.49%  (p=0.003 n=9+10)
Phases/kv-read-const/ExecBuild-8        662ns ± 2%     660ns ± 2%    ~     (p=0.753 n=10+10)
Phases/tpcc-new-order/ExecBuild-8      41.8µs ± 3%    41.8µs ± 2%    ~     (p=0.968 n=10+9)
Phases/tpcc-delivery/ExecBuild-8       27.8µs ± 2%    28.4µs ± 2%  +2.38%  (p=0.001 n=10+10)
Phases/tpcc-stock-level/ExecBuild-8     141µs ± 0%     141µs ± 2%    ~     (p=0.965 n=8+10)
```

Release note (bug fix): Fixed a panic in the cost-based optimizer during
the planning of some queries.