### PR TITLE
roachtest: Add test of graceful draining during shutdown

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -18,9 +18,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -153,6 +157,120 @@ func registerKVQuiescenceDead(r *registry) {
 				)
 			}
 			t.l.Printf("QPS went from %.2f to %2.f with one node down\n", qpsAllUp, qpsOneDown)
+		},
+	})
+}
+
+func registerKVGracefulDraining(r *registry) {
+	r.Add(testSpec{
+		Name:  "kv/gracefuldraining/nodes=3",
+		Nodes: nodes(4),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			if !c.isLocal() {
+				c.RemountNoBarrier(ctx)
+			}
+
+			nodes := c.nodes - 1
+			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+			c.Start(ctx, t, c.Range(1, nodes))
+
+			db := c.Conn(ctx, 1)
+			defer db.Close()
+
+			waitForFullReplication(t, db)
+
+			// Initialize the database with a lot of ranges so that there are
+			// definitely a large number of leases on the node that we shut down
+			// before it starts draining.
+			splitCmd := "./workload run kv --init --max-ops=1 --splits 100 {pgurl:1}"
+			c.Run(ctx, c.Node(nodes+1), splitCmd)
+
+			m := newMonitor(ctx, c, c.Range(1, nodes))
+
+			// Run kv for 5 minutes, during which we can gracefully kill nodes and
+			// determine whether doing so affects the cluster-wide qps.
+			const expectedQPS = 1000
+			m.Go(func(ctx context.Context) error {
+				cmd := fmt.Sprintf(
+					"./workload run kv --duration=5m --read-percent=0 --tolerate-errors --max-rate=%d {pgurl:1-%d}",
+					expectedQPS, nodes-1)
+				t.WorkerStatus(cmd)
+				defer t.WorkerStatus()
+				return c.RunE(ctx, c.Node(nodes+1), cmd)
+			})
+
+			m.Go(func(ctx context.Context) error {
+				// Gracefully shut down the third node, let the cluster run for a
+				// while, then restart it. Then repeat for good measure.
+				for i := 0; i < 2; i++ {
+					select {
+					case <-ctx.Done():
+						return nil
+					case <-time.After(1 * time.Minute):
+					}
+					c.Run(ctx, c.Node(nodes), "./cockroach quit --insecure --host=:{pgport:3}")
+					c.Stop(ctx, c.Node(nodes))
+					select {
+					case <-ctx.Done():
+						return nil
+					case <-time.After(1 * time.Minute):
+					}
+					c.Start(ctx, t, c.Node(nodes))
+				}
+				return nil
+			})
+
+			// Let the test run for nearly the entire duration of the kv command.
+			runDuration := 4*time.Minute + 30*time.Second
+			time.Sleep(runDuration)
+
+			// Check that the QPS has been at the expected max rate for the entire
+			// test duration, even as one of the nodes was being stopped and started.
+			adminURLs := c.ExternalAdminUIAddr(ctx, c.Node(1))
+			url := "http://" + adminURLs[0] + "/ts/query"
+			now := timeutil.Now()
+			request := tspb.TimeSeriesQueryRequest{
+				StartNanos: now.Add(-runDuration).UnixNano(),
+				EndNanos:   now.UnixNano(),
+				// Check the performance in each timeseries sample interval.
+				SampleNanos: server.DefaultMetricsSampleInterval.Nanoseconds(),
+				Queries: []tspb.Query{
+					{
+						Name:             "cr.node.sql.query.count",
+						Downsampler:      tspb.TimeSeriesQueryAggregator_AVG.Enum(),
+						SourceAggregator: tspb.TimeSeriesQueryAggregator_SUM.Enum(),
+						Derivative:       tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE.Enum(),
+					},
+				},
+			}
+			var response tspb.TimeSeriesQueryResponse
+			if err := httputil.PostJSON(http.Client{}, url, &request, &response); err != nil {
+				t.Fatal(err)
+			}
+			if len(response.Results[0].Datapoints) <= 1 {
+				t.Fatalf("not enough datapoints in timeseries query response: %+v", response)
+			}
+			datapoints := response.Results[0].Datapoints
+
+			// Because we're specifying a --max-rate well less than what cockroach
+			// should be capable of, draining one of the three nodes should have no
+			// effect on performance at all, meaning that a fairly aggressive
+			// threshold here should be ok.
+			minQPS := expectedQPS * 0.9
+
+			// Examine every data point except the first one, because at that time
+			// splits may still have been happening or the cluster may still have
+			// been initializing.
+			for i := 1; i < len(datapoints); i++ {
+				if qps := datapoints[i].Value; qps < minQPS {
+					t.Fatalf(
+						"QPS of %.2f at time %v is below minimum allowable QPS of %.2f; entire timeseries: %+v",
+						qps, timeutil.Unix(0, datapoints[i].TimestampNanos), minQPS, datapoints)
+				}
+			}
+
+			m.Wait()
 		},
 	})
 }

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -45,6 +45,7 @@ func registerTests(r *registry) {
 	registerJepsen(r)
 	registerKV(r)
 	registerKVQuiescenceDead(r)
+	registerKVGracefulDraining(r)
 	registerKVScalability(r)
 	registerKVSplits(r)
 	registerLargeRange(r)


### PR DESCRIPTION
The test verifies that QPS isn't affected by a node being gracefully
drained and shut down.

Fixes #23274

Release note: None