### PR TITLE
sql: remove maps from cfetcher hot path

### DIFF
--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -58,7 +58,7 @@ func (f *kvFetcher) nextKV(
 		var key []byte
 		var rawBytes []byte
 		var err error
-		key, _, rawBytes, f.batchResponse, err = enginepb.ScanDecodeKeyValue(f.batchResponse)
+		key, rawBytes, f.batchResponse, err = enginepb.ScanDecodeKeyValueNoTS(f.batchResponse)
 		if err != nil {
 			return false, kv, false, err
 		}

--- a/pkg/storage/engine/enginepb/decode_test.go
+++ b/pkg/storage/engine/enginepb/decode_test.go
@@ -1,0 +1,50 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package enginepb_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+var key []byte
+var ts []byte
+var val []byte
+var o []byte
+
+func BenchmarkScanDecodeKeyValue(b *testing.B) {
+	key := roachpb.Key("blah blah blah")
+	ts := hlc.Timestamp{WallTime: int64(1000000)}
+	value := []byte("foo foo foo")
+	rep := make([]byte, 8)
+	keyBytes := engine.EncodeKey(engine.MVCCKey{key, ts})
+	binary.LittleEndian.PutUint64(rep, uint64(len(keyBytes)<<32)|uint64(len(value)))
+	rep = append(rep, keyBytes...)
+	rep = append(rep, value...)
+	b.Run("getTs=true", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var err error
+			key, ts, val, o, err = enginepb.ScanDecodeKeyValue(rep)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/pkg/storage/engine/enginepb/decode_test.go
+++ b/pkg/storage/engine/enginepb/decode_test.go
@@ -24,24 +24,28 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
-var key []byte
-var ts []byte
-var val []byte
-var o []byte
-
 func BenchmarkScanDecodeKeyValue(b *testing.B) {
 	key := roachpb.Key("blah blah blah")
 	ts := hlc.Timestamp{WallTime: int64(1000000)}
 	value := []byte("foo foo foo")
 	rep := make([]byte, 8)
-	keyBytes := engine.EncodeKey(engine.MVCCKey{key, ts})
+	keyBytes := engine.EncodeKey(engine.MVCCKey{Key: key, Timestamp: ts})
 	binary.LittleEndian.PutUint64(rep, uint64(len(keyBytes)<<32)|uint64(len(value)))
 	rep = append(rep, keyBytes...)
 	rep = append(rep, value...)
 	b.Run("getTs=true", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			var err error
-			key, ts, val, o, err = enginepb.ScanDecodeKeyValue(rep)
+			_, _, _, _, err = enginepb.ScanDecodeKeyValue(rep)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("getTs=false", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var err error
+			_, _, _, err = enginepb.ScanDecodeKeyValueNoTS(rep)
 			if err != nil {
 				b.Fatal(err)
 			}


### PR DESCRIPTION
Closes #32968.

Previously, the cfetcher used a Go map to keep track of the relationship
between column id and column index, so that during decoding of value
columns, it could put the decoded value in the correct spot depending on
its column id. This was fairly expensive and showed up very heavily in
profiles.

This commit changes the approach used, by recognizing that within any
given key/value pair, the encountered column ids will be strictly
increasing. Thanks to this knowledge, it becomes cheap to use a regular
list for storage of the mapping - instead of an O(n) lookup for every
column value in a kv pair, it's O(n) for the whole kv pair, since we can
save our position within the sorted list of required column ids.

This reduces the time spent in the cfetcher's ProcessValueBytes method
from 30% to 10% for a large scan.

Release note: None