### PR TITLE
opt: implement use of sequences as data sources

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -92,9 +92,6 @@ SELECT job_id FROM crdb_internal.jobs
 ----
 
 statement ok
-CREATE SEQUENCE seq
-
-statement ok
 SET OPTIMIZER = ALWAYS
 
 query error pq: unsupported statement: \*tree\.AlterTable
@@ -103,9 +100,6 @@ ALTER TABLE test DROP COLUMN v;
 # Don't fall back to heuristic planner in ALWAYS mode.
 query error pq: aggregates with FILTER are not supported yet
 SELECT count(*) FILTER (WHERE v>10) FROM t
-
-query error pq: sequences are not supported
-SELECT * FROM seq
 
 statement ok
 SET OPTIMIZER = LOCAL

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -821,3 +821,30 @@ ROLLBACK TRANSACTION
 
 statement error no value provided for placeholder: \$1
 SELECT $1:::int
+
+statement ok
+CREATE SEQUENCE seq
+
+statement ok
+PREPARE seqsel AS SELECT * FROM seq
+
+query I
+SELECT nextval('seq')
+----
+1
+
+query IIB
+EXECUTE seqsel
+----
+1  0  true
+
+statement ok
+DROP SEQUENCE seq
+
+statement ok
+CREATE SEQUENCE seq
+
+query IIB
+EXECUTE seqsel
+----
+0  0  true

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -228,3 +228,7 @@ func (f *stubFactory) ConstructDelete(
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
+
+func (f *stubFactory) ConstructSequenceSelect(seq cat.Sequence) (exec.Node, error) {
+	return struct{}{}, nil
+}

--- a/pkg/sql/opt/cat/sequence.go
+++ b/pkg/sql/opt/cat/sequence.go
@@ -1,0 +1,37 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cat
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
+)
+
+// Sequence is an interface to a database sequence.
+type Sequence interface {
+	DataSource
+
+	// SequenceName returns the name of the sequence. This method should always
+	// return the same value as DataSource.Name(), but is included here as a
+	// safety measure so that every DataSource does not trivially implement
+	// Sequence.
+	SequenceName() *tree.TableName
+}
+
+// FormatCatalogSequence nicely formats a catalog sequence using a treeprinter for
+// debugging and testing.
+func FormatCatalogSequence(cat Catalog, seq Sequence, tp treeprinter.Node) {
+	tp.Childf("SEQUENCE %s", seq.Name())
+}

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -220,6 +220,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.CreateTableExpr:
 		ep, err = b.buildCreateTable(t)
 
+	case *memo.SequenceSelectExpr:
+		ep, err = b.buildSequenceSelect(t)
+
 	default:
 		if opt.IsSetOp(e) {
 			ep, err = b.buildSetOp(e)
@@ -1304,6 +1307,21 @@ func (b *Builder) buildCreateTable(ct *memo.CreateTableExpr) (execPlan, error) {
 	schema := b.mem.Metadata().Schema(ct.Schema)
 	root, err := b.factory.ConstructCreateTable(root, schema, ct.Syntax)
 	return execPlan{root: root}, err
+}
+
+func (b *Builder) buildSequenceSelect(seqSel *memo.SequenceSelectExpr) (execPlan, error) {
+	seq := b.mem.Metadata().Sequence(seqSel.Sequence)
+	node, err := b.factory.ConstructSequenceSelect(seq)
+	if err != nil {
+		return execPlan{}, err
+	}
+
+	ep := execPlan{root: node}
+	for i, c := range seqSel.Cols {
+		ep.outputCols.Set(int(c), i)
+	}
+
+	return ep, nil
 }
 
 // needProjection figures out what projection is needed on top of the input plan

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -316,6 +316,13 @@ EXPLAIN (VERBOSE) SELECT * FROM select_test
 tree             field  description  columns                           ordering
 sequence select  ·      ·            (last_value, log_cnt, is_called)  ·
 
+query TTTTT colnames
+EXPLAIN (VERBOSE) SELECT @1 FROM select_test
+----
+tree                  field     description  columns                           ordering
+render                ·         ·            ("?column?")                      ·
+ │                    render 0  last_value   ·                                 ·
+ └── sequence select  ·         ·            (last_value, log_cnt, is_called)  ·
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -312,6 +312,10 @@ type Factory interface {
 	// ConstructCreateTable returns a node that implements a CREATE TABLE
 	// statement.
 	ConstructCreateTable(input Node, schema cat.Schema, ct *tree.CreateTable) (Node, error)
+
+	// ConstructSequenceSelect creates a node that implements a scan of a sequence
+	// as a data source.
+	ConstructSequenceSelect(sequence cat.Sequence) (Node, error)
 }
 
 // OutputOrdering indicates the required output ordering on a Node that is being

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -167,7 +167,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		f.Buffer.WriteByte(')')
 
 	case *ScanExpr, *VirtualScanExpr, *IndexJoinExpr, *ShowTraceForSessionExpr,
-		*InsertExpr, *UpdateExpr, *UpsertExpr, *DeleteExpr:
+		*InsertExpr, *UpdateExpr, *UpsertExpr, *DeleteExpr, *SequenceSelectExpr:
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
 		FormatPrivate(f, e.Private(), required)
 
@@ -718,6 +718,10 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		// Always fully qualify virtual table names.
 		tabMeta := f.Memo.metadata.TableMeta(t.Table)
 		fmt.Fprintf(f.Buffer, " %s", tabMeta.Table.Name())
+
+	case *SequenceSelectPrivate:
+		seq := f.Memo.metadata.Sequence(t.Sequence)
+		fmt.Fprintf(f.Buffer, " %s", seq.Name())
 
 	case *MutationPrivate:
 		fmt.Fprintf(f.Buffer, " %s", tableName(f, t.Table))

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -443,6 +443,11 @@ func (h *hasher) HashTableID(val opt.TableID) {
 	h.hash *= prime64
 }
 
+func (h *hasher) HashSequenceID(val opt.SequenceID) {
+	h.hash ^= internHash(val)
+	h.hash *= prime64
+}
+
 func (h *hasher) HashScanLimit(val ScanLimit) {
 	h.hash ^= internHash(val)
 	h.hash *= prime64
@@ -677,6 +682,10 @@ func (h *hasher) IsSchemaIDEqual(l, r opt.SchemaID) bool {
 }
 
 func (h *hasher) IsTableIDEqual(l, r opt.TableID) bool {
+	return l == r
+}
+
+func (h *hasher) IsSequenceIDEqual(l, r opt.SequenceID) bool {
 	return l == r
 }
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -151,6 +151,38 @@ func (b *logicalPropsBuilder) buildVirtualScanProps(scan *VirtualScanExpr, rel *
 	b.sb.buildVirtualScan(scan, rel)
 }
 
+func (b *logicalPropsBuilder) buildSequenceSelectProps(
+	seq *SequenceSelectExpr, rel *props.Relational,
+) {
+	// Output Columns
+	// --------------
+	// Output columns are stored in the definition.
+	rel.OutputCols = seq.Cols.ToSet()
+
+	// Not Null Columns
+	// ----------------
+	// Every column is not null.
+	rel.NotNullCols = rel.OutputCols
+
+	// Outer Columns
+	// -------------
+	// The operator never has outer columns.
+
+	// Functional Dependencies
+	// -----------------------
+	rel.FuncDeps.MakeMax1Row(rel.OutputCols)
+
+	// Cardinality
+	// -----------
+	rel.Cardinality = props.OneCardinality
+
+	// Statistics
+	// ----------
+	if !b.disableStats {
+		b.sb.buildSequenceSelect(rel)
+	}
+}
+
 func (b *logicalPropsBuilder) buildSelectProps(sel *SelectExpr, rel *props.Relational) {
 	BuildSharedProps(b.mem, sel, &rel.Shared)
 

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -335,6 +335,9 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet, e RelExpr) *props.Column
 	case opt.InsertOp, opt.UpdateOp, opt.UpsertOp, opt.DeleteOp:
 		return sb.colStatMutation(colSet, e)
 
+	case opt.SequenceSelectOp:
+		return sb.colStatSequenceSelect(colSet, e.(*SequenceSelectExpr))
+
 	case opt.ExplainOp, opt.ShowTraceForSessionOp:
 		relProps := e.Relational()
 		return sb.colStatLeaf(colSet, &relProps.Stats, &relProps.FuncDeps, relProps.NotNullCols)
@@ -1909,6 +1912,27 @@ func (sb *statisticsBuilder) colStatMutation(
 	colStat, _ := s.ColStats.Add(colSet)
 	colStat.DistinctCount = inColStat.DistinctCount
 	colStat.NullCount = inColStat.NullCount
+	return colStat
+}
+
+// +-----------------+
+// | Sequence Select |
+// +-----------------+
+
+func (sb *statisticsBuilder) buildSequenceSelect(relProps *props.Relational) {
+	s := &relProps.Stats
+	s.RowCount = 1
+	sb.finalizeFromCardinality(relProps)
+}
+
+func (sb *statisticsBuilder) colStatSequenceSelect(
+	colSet opt.ColSet, seq *SequenceSelectExpr,
+) *props.ColumnStatistic {
+	s := &seq.Relational().Stats
+
+	colStat, _ := s.ColStats.Add(colSet)
+	colStat.DistinctCount = 1
+	colStat.NullCount = 0
 	return colStat
 }
 

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -356,3 +356,18 @@ project
                 │              └── aggregations
                 │                   └── count-rows [type=int]
                 └── const: 0 [type=int]
+
+# Sequences always have a single row when selected from.
+exec-ddl
+CREATE SEQUENCE x
+----
+SEQUENCE t.public.x
+
+build
+SELECT * FROM x
+----
+sequence-select t.public.x
+ ├── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ └── fd: ()-->(1-3)

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -466,3 +466,18 @@ index-join abcde
       ├── stats: [rows=1.089, distinct(1)=1.089, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1.089, null(3)=0]
       ├── key: (1)
       └── fd: ()-->(2), (1)-->(3,4)
+
+exec-ddl
+CREATE SEQUENCE seq
+----
+SEQUENCE t.public.seq
+
+opt
+SELECT * FROM seq
+----
+sequence-select t.public.seq
+ ├── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── key: ()
+ └── fd: ()-->(1-3)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -95,6 +95,24 @@ define VirtualScanPrivate {
 	Cols ColSet
 }
 
+# SequenceSelect represents a read from a sequence as a data source. It always returns
+# three columns, last_value, log_cnt, and is_called, with a single row. last_value is
+# the most recent value returned from the sequence and log_cnt and is_called are
+# always 0 and true, respectively.
+[Relational]
+define SequenceSelect {
+    _ SequenceSelectPrivate
+}
+
+[Private]
+define SequenceSelectPrivate {
+  # Sequence identifies the sequence to read from.
+  Sequence SequenceID
+
+  # Cols is the 3 element list of column IDs returned by the operator.
+  Cols ColList
+}
+
 # Values returns a manufactured result set containing a constant number of rows.
 # specified by the Rows list field. Each row must contain the same set of
 # columns in the same order.

--- a/pkg/sql/opt/optbuilder/testdata/sequence
+++ b/pkg/sql/opt/optbuilder/testdata/sequence
@@ -1,0 +1,129 @@
+exec-ddl
+CREATE SEQUENCE x
+----
+SEQUENCE t.public.x
+
+exec-ddl
+CREATE SEQUENCE y
+----
+SEQUENCE t.public.y
+
+build
+SELECT * FROM x
+----
+sequence-select t.public.x
+ └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+
+build
+SELECT z.last_value FROM x AS z
+----
+project
+ ├── columns: last_value:1(int!null)
+ └── sequence-select t.public.x
+      └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+
+build
+SELECT last_value FROM x
+----
+project
+ ├── columns: last_value:1(int!null)
+ └── sequence-select t.public.x
+      └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+
+build
+SELECT log_cnt FROM x
+----
+project
+ ├── columns: log_cnt:2(int!null)
+ └── sequence-select t.public.x
+      └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+
+# Multiple sequences in a query.
+build
+(SELECT * FROM x) UNION (SELECT * FROM y)
+----
+union
+ ├── columns: last_value:7(int!null) log_cnt:8(int!null) is_called:9(bool!null)
+ ├── left columns: last_value:1(int) log_cnt:2(int) is_called:3(bool)
+ ├── right columns: last_value:4(int) log_cnt:5(int) is_called:6(bool)
+ ├── sequence-select t.public.x
+ │    └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ └── sequence-select t.public.y
+      └── columns: last_value:4(int!null) log_cnt:5(int!null) is_called:6(bool!null)
+
+# Sequences occurring multiple times in a query.
+build
+(SELECT * FROM x)
+EXCEPT (SELECT * FROM x)
+EXCEPT (SELECT * FROM y)
+EXCEPT (SELECT * FROM x)
+EXCEPT (SELECT * FROM y)
+----
+except
+ ├── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ ├── left columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ ├── right columns: last_value:13(int) log_cnt:14(int) is_called:15(bool)
+ ├── except
+ │    ├── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ │    ├── left columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ │    ├── right columns: last_value:10(int) log_cnt:11(int) is_called:12(bool)
+ │    ├── except
+ │    │    ├── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ │    │    ├── left columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ │    │    ├── right columns: last_value:7(int) log_cnt:8(int) is_called:9(bool)
+ │    │    ├── except
+ │    │    │    ├── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ │    │    │    ├── left columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ │    │    │    ├── right columns: last_value:4(int) log_cnt:5(int) is_called:6(bool)
+ │    │    │    ├── sequence-select t.public.x
+ │    │    │    │    └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ │    │    │    └── sequence-select t.public.x
+ │    │    │         └── columns: last_value:4(int!null) log_cnt:5(int!null) is_called:6(bool!null)
+ │    │    └── sequence-select t.public.y
+ │    │         └── columns: last_value:7(int!null) log_cnt:8(int!null) is_called:9(bool!null)
+ │    └── sequence-select t.public.x
+ │         └── columns: last_value:10(int!null) log_cnt:11(int!null) is_called:12(bool!null)
+ └── sequence-select t.public.y
+      └── columns: last_value:13(int!null) log_cnt:14(int!null) is_called:15(bool!null)
+
+# Ensure index flags are ignored.
+build
+SELECT * FROM x@primary
+----
+sequence-select t.public.x
+ └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+
+build
+SELECT * FROM x@foobar
+----
+sequence-select t.public.x
+ └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+
+# Ordinal refs with a sequence.
+build
+SELECT @1 FROM x
+----
+project
+ ├── columns: "?column?":4(int)
+ ├── sequence-select t.public.x
+ │    └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ └── projections
+      └── variable: last_value [type=int]
+
+# Check a query with an extra operator.
+build
+SELECT * FROM x WHERE last_value = 0
+----
+select
+ ├── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ ├── sequence-select t.public.x
+ │    └── columns: last_value:1(int!null) log_cnt:2(int!null) is_called:3(bool!null)
+ └── filters
+      └── eq [type=bool]
+           ├── variable: last_value [type=int]
+           └── const: 0 [type=int]
+
+build
+INSERT INTO x VALUES (0, 0, false)
+----
+error (42809): "x" is not a table

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -152,6 +152,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"ColList":        {fullName: "opt.ColList", passByVal: true},
 		"TableID":        {fullName: "opt.TableID", passByVal: true},
 		"SchemaID":       {fullName: "opt.SchemaID", passByVal: true},
+		"SequenceID":     {fullName: "opt.SequenceID", passByVal: true},
 		"Ordering":       {fullName: "opt.Ordering", passByVal: true},
 		"OrderingChoice": {fullName: "physical.OrderingChoice", passByVal: true},
 		"TupleOrdinal":   {fullName: "memo.TupleOrdinal", passByVal: true},

--- a/pkg/sql/opt/testutils/testcat/create_sequence.go
+++ b/pkg/sql/opt/testutils/testcat/create_sequence.go
@@ -1,0 +1,33 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testcat
+
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
+// CreateSequence creates a test sequence from a parsed DDL statement and adds it
+// the catalog. This is intended for testing, and is not a complete (and
+// probably not fully correct) implementation. It just has to be "good enough".
+func (tc *Catalog) CreateSequence(stmt *tree.CreateSequence) *Sequence {
+	tc.qualifyTableName(&stmt.Name)
+
+	seq := &Sequence{
+		SeqID:   tc.nextStableID(),
+		SeqName: stmt.Name,
+		Catalog: tc,
+	}
+
+	tc.AddSequence(seq)
+	return seq
+}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -175,6 +175,10 @@ func (tc *Catalog) CheckPrivilege(ctx context.Context, o cat.Object, priv privil
 		if t.Revoked {
 			return fmt.Errorf("user does not have privilege to access %v", t.ViewName)
 		}
+	case *Sequence:
+		if t.Revoked {
+			return fmt.Errorf("user does not have privilege to access %v", t.SeqName)
+		}
 	default:
 		panic("invalid Object")
 	}
@@ -256,6 +260,15 @@ func (tc *Catalog) AddView(view *View) {
 	tc.dataSources[fq] = view
 }
 
+// AddSequence adds the given test sequence to the catalog.
+func (tc *Catalog) AddSequence(seq *Sequence) {
+	fq := seq.SeqName.FQString()
+	if _, ok := tc.dataSources[fq]; ok {
+		panic(fmt.Errorf("sequence %q already exists", tree.ErrString(&seq.SeqName)))
+	}
+	tc.dataSources[fq] = seq
+}
+
 // ExecuteDDL parses the given DDL SQL statement and creates objects in the test
 // catalog. This is used to test without spinning up a cluster.
 func (tc *Catalog) ExecuteDDL(sql string) (string, error) {
@@ -284,6 +297,10 @@ func (tc *Catalog) ExecuteDDL(sql string) (string, error) {
 	case *tree.DropTable:
 		tc.DropTable(stmt)
 		return "", nil
+
+	case *tree.CreateSequence:
+		seq := tc.CreateSequence(stmt)
+		return seq.String(), nil
 
 	default:
 		return "", fmt.Errorf("unsupported statement: %v", stmt)
@@ -709,4 +726,47 @@ func (ts TableStats) Less(i, j int) bool {
 // Swap is part of the Sorter interface.
 func (ts TableStats) Swap(i, j int) {
 	ts[i], ts[j] = ts[j], ts[i]
+}
+
+// Sequence implements the cat.Sequence interface for testing purposes.
+type Sequence struct {
+	SeqID      cat.StableID
+	SeqVersion int
+	SeqName    tree.TableName
+	Catalog    cat.Catalog
+
+	// If Revoked is true, then the user has had privileges on the sequence revoked.
+	Revoked bool
+}
+
+var _ cat.Sequence = &Sequence{}
+
+// ID is part of the cat.DataSource interface.
+func (ts *Sequence) ID() cat.StableID {
+	return ts.SeqID
+}
+
+// Equals is part of the cat.DataSource interface.
+func (ts *Sequence) Equals(other cat.DataSource) bool {
+	otherSequence, ok := other.(*Sequence)
+	if !ok {
+		return false
+	}
+	return ts.SeqID == otherSequence.SeqID && ts.SeqVersion == otherSequence.SeqVersion
+}
+
+// Name is part of the cat.DataSource interface.
+func (ts *Sequence) Name() *tree.TableName {
+	return &ts.SeqName
+}
+
+// SequenceName is part of the cat.Sequence interface.
+func (ts *Sequence) SequenceName() *tree.TableName {
+	return ts.Name()
+}
+
+func (ts *Sequence) String() string {
+	tp := treeprinter.New()
+	cat.FormatCatalogSequence(ts.Catalog, ts, tp)
+	return tp.String()
 }

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -252,8 +252,6 @@ func (ov *optView) ColumnName(i int) tree.Name {
 
 // optSequence is a wrapper around sqlbase.ImmutableTableDescriptor that
 // implements the cat.Object and cat.DataSource interfaces.
-//
-// TODO(andyk): This should implement cat.Sequence once we have it.
 type optSequence struct {
 	desc *sqlbase.ImmutableTableDescriptor
 
@@ -263,15 +261,16 @@ type optSequence struct {
 }
 
 var _ cat.DataSource = &optSequence{}
+var _ cat.Sequence = &optSequence{}
 
 func newOptSequence(desc *sqlbase.ImmutableTableDescriptor, name *cat.DataSourceName) *optSequence {
-	ot := &optSequence{desc: desc, name: *name}
+	os := &optSequence{desc: desc, name: *name}
 
 	// The cat.Sequence interface requires that table names be fully qualified.
-	ot.name.ExplicitSchema = true
-	ot.name.ExplicitCatalog = true
+	os.name.ExplicitSchema = true
+	os.name.ExplicitCatalog = true
 
-	return ot
+	return os
 }
 
 // ID is part of the cat.Object interface.
@@ -291,6 +290,11 @@ func (os *optSequence) Equals(other cat.DataSource) bool {
 // Name is part of the cat.DataSource interface.
 func (os *optSequence) Name() *cat.DataSourceName {
 	return &os.name
+}
+
+// SequenceName is part of the cat.Sequence interface.
+func (os *optSequence) SequenceName() *tree.TableName {
+	return os.Name()
 }
 
 // optTable is a wrapper around sqlbase.ImmutableTableDescriptor that caches

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1221,6 +1221,11 @@ func (ef *execFactory) ConstructCreateTable(
 	return nd, nil
 }
 
+// ConstructSequenceSelect is part of the exec.Factory interface.
+func (ef *execFactory) ConstructSequenceSelect(sequence cat.Sequence) (exec.Node, error) {
+	return ef.planner.SequenceSelectNode(sequence.(*optSequence).desc)
+}
+
 // renderBuilder encapsulates the code to build a renderNode.
 type renderBuilder struct {
 	r   *renderNode


### PR DESCRIPTION
This commit allows sequences to be selected from. It adds them as a
catalog item similar to tables.

Release note (sql change): Using a sequence as a SELECT target is now
supported by the cost-based optimizer.