### PR TITLE
exec: outer join

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -159,10 +159,6 @@ func newColOperator(
 			return nil, errors.New("can't plan hash join with on expressions")
 		}
 
-		if core.HashJoiner.Type != sqlbase.JoinType_INNER {
-			return nil, errors.Errorf("hash join of type %s not supported", core.HashJoiner.Type)
-		}
-
 		leftTypes := types.FromColumnTypes(spec.Input[0].ColumnTypes)
 		rightTypes := types.FromColumnTypes(spec.Input[1].ColumnTypes)
 
@@ -190,7 +186,7 @@ func newColOperator(
 			}
 		}
 
-		op, err = exec.NewEqInnerHashJoiner(
+		op, err = exec.NewEqHashJoinerOp(
 			inputs[0],
 			inputs[1],
 			core.HashJoiner.LeftEqColumns,
@@ -201,6 +197,7 @@ func newColOperator(
 			rightTypes,
 			core.HashJoiner.RightEqColumnsAreKey,
 			core.HashJoiner.LeftEqColumnsAreKey || core.HashJoiner.RightEqColumnsAreKey,
+			core.HashJoiner.Type,
 		)
 
 	case core.Sorter != nil:

--- a/pkg/sql/exec/colvec_tmpl.go
+++ b/pkg/sql/exec/colvec_tmpl.go
@@ -35,6 +35,10 @@ import (
 // Dummy import to pull in "apd" package.
 var _ apd.Decimal
 
+// _TYPES_T is the template type variable for types.T. It will be replaced by
+// types.Foo for each type Foo in the types.T type.
+const _TYPES_T = types.Unhandled
+
 // */}}
 
 func (m *memColumn) Append(vec ColVec, colType types.T, toLength uint64, fromLength uint16) {

--- a/pkg/sql/exec/colvec_tmpl.go
+++ b/pkg/sql/exec/colvec_tmpl.go
@@ -157,6 +157,45 @@ func (m *memColumn) CopyWithSelInt16(vec ColVec, sel []uint16, nSel uint16, colT
 	}
 }
 
+func (m *memColumn) CopyWithSelAndNilsInt64(
+	vec ColVec, sel []uint64, nSel uint16, nils []bool, colType types.T,
+) {
+	m.UnsetNulls()
+
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		toCol := m._TemplateType()
+		fromCol := vec._TemplateType()
+
+		if vec.HasNulls() {
+			// TODO(jordan): copy the null arrays in batch.
+			for i := uint16(0); i < nSel; i++ {
+				if nils[i] {
+					m.SetNull(i)
+				} else {
+					if vec.NullAt64(sel[i]) {
+						m.SetNull(i)
+					} else {
+						toCol[i] = fromCol[sel[i]]
+					}
+				}
+			}
+		} else {
+			for i := uint16(0); i < nSel; i++ {
+				if nils[i] {
+					m.SetNull(i)
+				} else {
+					toCol[i] = fromCol[sel[i]]
+				}
+			}
+		}
+	// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
+
 func (m *memColumn) PrettyValueAt(colIdx uint16, colType types.T) string {
 	if m.NullAt(colIdx) {
 		return "NULL"

--- a/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
@@ -17,7 +17,6 @@ package main
 import (
 	"io"
 	"io/ioutil"
-	"regexp"
 	"strings"
 	"text/template"
 
@@ -37,37 +36,36 @@ func genHashJoiner(wr io.Writer) error {
 	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
 	s = strings.Replace(s, "_SEL_IND", "{{.SelInd}}", -1)
 
-	assignNeRe := regexp.MustCompile(`_ASSIGN_NE\((.*),(.*),(.*)\)`)
+	assignNeRe := makeFunctionRegex("_ASSIGN_NE", 3)
 	s = assignNeRe.ReplaceAllString(s, `{{.Global.Assign "$1" "$2" "$3"}}`)
 
-	assignHash := regexp.MustCompile(`_ASSIGN_HASH\((.*),(.*)\)`)
+	assignHash := makeFunctionRegex("_ASSIGN_HASH", 2)
 	s = assignHash.ReplaceAllString(s, `{{.Global.UnaryAssign "$1" "$2"}}`)
 
-	rehash := regexp.MustCompile(`_REHASH_BODY\(.*,(.*)\)`)
-	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "SelInd" $1}}`)
+	rehash := makeFunctionRegex("_REHASH_BODY", 4)
+	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "SelInd" $4}}`)
 
-	checkCol := regexp.MustCompile(`(?s)_CHECK_COL_WITH_NULLS\(.*?,.*?,.*?,.*?,.*?,.*?,\s*(.*?)\)`)
-	s = checkCol.ReplaceAllString(s, `{{template "checkColWithNulls" buildDict "Global" . "SelInd" $1}}`)
+	checkCol := makeFunctionRegex("_CHECK_COL_WITH_NULLS", 7)
+	s = checkCol.ReplaceAllString(s, `{{template "checkColWithNulls" buildDict "Global" . "SelInd" $7}}`)
 
-	distinctCollectRightOuter := regexp.MustCompile(`(?s)_DISTINCT_COLLECT_RIGHT_OUTER\(\s*(.*?),\s*(.*?),\s*(.*?)\)`)
+	distinctCollectRightOuter := makeFunctionRegex("_DISTINCT_COLLECT_RIGHT_OUTER", 3)
 	s = distinctCollectRightOuter.ReplaceAllString(s, `{{template "distinctCollectRightOuter" buildDict "Global" . "SelInd" $3}}`)
 
-	distinctCollectNoOuter := regexp.MustCompile(`(?s)_DISTINCT_COLLECT_NO_OUTER\(\s*(.*?),\s*(.*?),\s*(.*?),\s*(.*?)\)`)
+	distinctCollectNoOuter := makeFunctionRegex("_DISTINCT_COLLECT_NO_OUTER", 4)
 	s = distinctCollectNoOuter.ReplaceAllString(s, `{{template "distinctCollectNoOuter" buildDict "Global" . "SelInd" $4}}`)
 
-	collectRightOuter := regexp.MustCompile(`(?s)_COLLECT_RIGHT_OUTER\(\s*(.*?),\s*(.*?),\s*(.*?),\s*(.*?),\s*(.*?)\)`)
+	collectRightOuter := makeFunctionRegex("_COLLECT_RIGHT_OUTER", 5)
 	s = collectRightOuter.ReplaceAllString(s, `{{template "collectRightOuter" buildDict "Global" . "SelInd" $5}}`)
 
-	collectNoOuter := regexp.MustCompile(`(?s)_COLLECT_NO_OUTER\(\s*(.*?),\s*(.*?),\s*(.*?),\s*(.*?),\s*(.*?)\)`)
+	collectNoOuter := makeFunctionRegex("_COLLECT_NO_OUTER", 5)
 	s = collectNoOuter.ReplaceAllString(s, `{{template "collectNoOuter" buildDict "Global" . "SelInd" $5}}`)
 
-	checkColMain := regexp.MustCompile(`_CHECK_COL_MAIN\((.*\))`)
+	checkColMain := makeFunctionRegex("_CHECK_COL_MAIN", 1)
 	s = checkColMain.ReplaceAllString(s, `{{template "checkColMain" .}}`)
 
-	checkColBody := regexp.MustCompile(`_CHECK_COL_BODY\((.*),(.*),(.*)\)`)
-	s = checkColBody.ReplaceAllString(s, `{{template "checkColBody" buildDict "Global" .Global "SelInd" .SelInd "ProbeHasNulls" $2 "BuildHasNulls" $3}}`)
+	checkColBody := makeFunctionRegex("_CHECK_COL_BODY", 8)
+	s = checkColBody.ReplaceAllString(s, `{{template "checkColBody" buildDict "Global" .Global "SelInd" .SelInd "ProbeHasNulls" $7 "BuildHasNulls" $8}}`)
 
-	print(s)
 	tmpl, err := template.New("hashjoiner_op").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 
 	if err != nil {

--- a/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
@@ -49,12 +49,25 @@ func genHashJoiner(wr io.Writer) error {
 	checkCol := regexp.MustCompile(`(?s)_CHECK_COL_WITH_NULLS\(.*?,.*?,.*?,.*?,.*?,.*?,\s*(.*?)\)`)
 	s = checkCol.ReplaceAllString(s, `{{template "checkColWithNulls" buildDict "Global" . "SelInd" $1}}`)
 
+	distinctCollectRightOuter := regexp.MustCompile(`(?s)_DISTINCT_COLLECT_RIGHT_OUTER\(\s*(.*?),\s*(.*?),\s*(.*?)\)`)
+	s = distinctCollectRightOuter.ReplaceAllString(s, `{{template "distinctCollectRightOuter" buildDict "Global" . "SelInd" $3}}`)
+
+	distinctCollectNoOuter := regexp.MustCompile(`(?s)_DISTINCT_COLLECT_NO_OUTER\(\s*(.*?),\s*(.*?),\s*(.*?),\s*(.*?)\)`)
+	s = distinctCollectNoOuter.ReplaceAllString(s, `{{template "distinctCollectNoOuter" buildDict "Global" . "SelInd" $4}}`)
+
+	collectRightOuter := regexp.MustCompile(`(?s)_COLLECT_RIGHT_OUTER\(\s*(.*?),\s*(.*?),\s*(.*?),\s*(.*?),\s*(.*?)\)`)
+	s = collectRightOuter.ReplaceAllString(s, `{{template "collectRightOuter" buildDict "Global" . "SelInd" $5}}`)
+
+	collectNoOuter := regexp.MustCompile(`(?s)_COLLECT_NO_OUTER\(\s*(.*?),\s*(.*?),\s*(.*?),\s*(.*?),\s*(.*?)\)`)
+	s = collectNoOuter.ReplaceAllString(s, `{{template "collectNoOuter" buildDict "Global" . "SelInd" $5}}`)
+
 	checkColMain := regexp.MustCompile(`_CHECK_COL_MAIN\((.*\))`)
 	s = checkColMain.ReplaceAllString(s, `{{template "checkColMain" .}}`)
 
 	checkColBody := regexp.MustCompile(`_CHECK_COL_BODY\((.*),(.*),(.*)\)`)
 	s = checkColBody.ReplaceAllString(s, `{{template "checkColBody" buildDict "Global" .Global "SelInd" .SelInd "ProbeHasNulls" $2 "BuildHasNulls" $3}}`)
 
+	print(s)
 	tmpl, err := template.New("hashjoiner_op").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 
 	if err != nil {

--- a/pkg/sql/exec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/overloads.go
@@ -17,6 +17,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -404,4 +405,20 @@ func intersectOverloads(allOverloads ...[]*overload) [][]*overload {
 	}
 
 	return allOverloads
+}
+
+// makeFunctionRegex makes a regexp representing a function with a specified
+// number of arguments. For example, a function with 3 arguments looks like
+// `(?s)funcName\(\s*(.*?),\s*(.*?),\s*(.*?)\)`.
+func makeFunctionRegex(funcName string, numArgs int) *regexp.Regexp {
+	argsRegex := ""
+
+	for i := 0; i < numArgs; i++ {
+		if argsRegex != "" {
+			argsRegex += ","
+		}
+		argsRegex += `\s*(.*?)`
+	}
+
+	return regexp.MustCompile(`(?s)` + funcName + `\(` + argsRegex + `\)`)
 }

--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -136,7 +136,7 @@ func _CHECK_COL_WITH_NULLS(
 	// {{/*
 }
 
-func _REHASH_BODY(buckets []uint64, keys []interface{}, nKeys uint64, _ string) { // */}}
+func _REHASH_BODY(buckets []uint64, keys []interface{}, nKeys uint64, _SEL_STRING string) { // */}}
 	// {{define "rehashBody"}}
 	for i := uint64(0); i < nKeys; i++ {
 		v := keys[_SEL_IND]
@@ -150,7 +150,7 @@ func _REHASH_BODY(buckets []uint64, keys []interface{}, nKeys uint64, _ string) 
 }
 
 func _COLLECT_RIGHT_OUTER(
-	prober *hashJoinProber, batchSize uint16, nResults uint16, batch ColBatch, _ string,
+	prober *hashJoinProber, batchSize uint16, nResults uint16, batch ColBatch, _SEL_STRING string,
 ) uint16 { // */}}
 	// {{define "collectRightOuter"}}
 	for i := uint16(0); i < batchSize; i++ {
@@ -178,14 +178,13 @@ func _COLLECT_RIGHT_OUTER(
 		}
 	}
 	// {{end}}
-
+	// {{/*
 	// Dummy return value that is never used.
 	return 0
-	// {{/*
 }
 
 func _COLLECT_NO_OUTER(
-	prober *hashJoinProber, batchSize uint16, nResults uint16, batch ColBatch, _ string,
+	prober *hashJoinProber, batchSize uint16, nResults uint16, batch ColBatch, _SEL_STRING string,
 ) uint16 { // */}}
 	// {{define "collectNoOuter"}}
 	for i := uint16(0); i < batchSize; i++ {
@@ -204,13 +203,12 @@ func _COLLECT_NO_OUTER(
 		}
 	}
 	// {{end}}
-
+	// {{/*
 	// Dummy return value that is never used.
 	return 0
-	// {{/*
 }
 
-func _DISTINCT_COLLECT_RIGHT_OUTER(prober *hashJoinProber, batchSize uint16, _ string) { // */}}
+func _DISTINCT_COLLECT_RIGHT_OUTER(prober *hashJoinProber, batchSize uint16, _SEL_STRING string) { // */}}
 	// {{define "distinctCollectRightOuter"}}
 	for i := uint16(0); i < batchSize; i++ {
 		// Index of keys and outputs in the hash table is calculated as ID - 1.

--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -149,6 +149,96 @@ func _REHASH_BODY(buckets []uint64, keys []interface{}, nKeys uint64, _ string) 
 	// {{/*
 }
 
+func _COLLECT_RIGHT_OUTER(
+	prober *hashJoinProber, batchSize uint16, nResults uint16, batch ColBatch, _ string,
+) uint16 { // */}}
+	// {{define "collectRightOuter"}}
+	for i := uint16(0); i < batchSize; i++ {
+		currentID := prober.head[i]
+
+		if currentID == 0 {
+			prober.probeRowUnmatched[nResults] = true
+		}
+
+		for {
+			if nResults >= ColBatchSize {
+				prober.prevBatch = batch
+				return nResults
+			}
+
+			prober.buildIdx[nResults] = currentID - 1
+			prober.probeIdx[nResults] = _SEL_IND
+			currentID = prober.ht.same[currentID]
+			prober.head[i] = currentID
+			nResults++
+
+			if currentID == 0 {
+				break
+			}
+		}
+	}
+	// {{end}}
+
+	// Dummy return value that is never used.
+	return 0
+	// {{/*
+}
+
+func _COLLECT_NO_OUTER(
+	prober *hashJoinProber, batchSize uint16, nResults uint16, batch ColBatch, _ string,
+) uint16 { // */}}
+	// {{define "collectNoOuter"}}
+	for i := uint16(0); i < batchSize; i++ {
+		currentID := prober.head[i]
+		for currentID != 0 {
+			if nResults >= ColBatchSize {
+				prober.prevBatch = batch
+				return nResults
+			}
+
+			prober.buildIdx[nResults] = currentID - 1
+			prober.probeIdx[nResults] = _SEL_IND
+			currentID = prober.ht.same[currentID]
+			prober.head[i] = currentID
+			nResults++
+		}
+	}
+	// {{end}}
+
+	// Dummy return value that is never used.
+	return 0
+	// {{/*
+}
+
+func _DISTINCT_COLLECT_RIGHT_OUTER(prober *hashJoinProber, batchSize uint16, _ string) { // */}}
+	// {{define "distinctCollectRightOuter"}}
+	for i := uint16(0); i < batchSize; i++ {
+		// Index of keys and outputs in the hash table is calculated as ID - 1.
+		prober.buildIdx[i] = prober.groupID[i] - 1
+		prober.probeIdx[i] = _SEL_IND
+
+		prober.probeRowUnmatched[i] = prober.groupID[i] == 0
+	}
+	// {{end}}
+	// {{/*
+}
+
+func _DISTINCT_COLLECT_NO_OUTER(
+	prober *hashJoinProber, batchSize uint16, nResults uint16, _ string,
+) { // */}}
+	// {{define "distinctCollectNoOuter"}}
+	for i := uint16(0); i < batchSize; i++ {
+		if prober.groupID[i] != 0 {
+			// Index of keys and outputs in the hash table is calculated as ID - 1.
+			prober.buildIdx[nResults] = prober.groupID[i] - 1
+			prober.probeIdx[nResults] = _SEL_IND
+			nResults++
+		}
+	}
+	// {{end}}
+	// {{/*
+}
+
 // */}}
 
 // rehash takes a element of a key (tuple representing a row of equality
@@ -206,4 +296,54 @@ func (prober *hashJoinProber) checkCol(t types.T, keyColIdx int, nToCheck uint16
 	default:
 		panic(fmt.Sprintf("unhandled type %d", t))
 	}
+}
+
+// collect prepares the buildIdx and probeIdx arrays where the buildIdx and
+// probeIdx at each index are joined to make an output row. The total number of
+// resulting rows is returned.
+func (prober *hashJoinProber) collect(batch ColBatch, batchSize uint16, sel []uint16) uint16 {
+	nResults := uint16(0)
+
+	if prober.spec.outer {
+		if sel != nil {
+			_COLLECT_RIGHT_OUTER(prober, batchSize, nResults, batch, "sel[i]")
+		} else {
+			_COLLECT_RIGHT_OUTER(prober, batchSize, nResults, batch, "i")
+		}
+	} else {
+		if sel != nil {
+			_COLLECT_NO_OUTER(prober, batchSize, nResults, batch, "sel[i]")
+		} else {
+			_COLLECT_NO_OUTER(prober, batchSize, nResults, batch, "i")
+		}
+	}
+
+	return nResults
+}
+
+// distinctCollect prepares the batch with the joined output columns where the build
+// row index for each probe row is given in the groupID slice. This function
+// requires assumes a N-1 hash join.
+func (prober *hashJoinProber) distinctCollect(
+	batch ColBatch, batchSize uint16, sel []uint16,
+) uint16 {
+	nResults := uint16(0)
+
+	if prober.spec.outer {
+		nResults = batchSize
+
+		if sel != nil {
+			_DISTINCT_COLLECT_RIGHT_OUTER(prober, batchSize, "sel[i]")
+		} else {
+			_DISTINCT_COLLECT_RIGHT_OUTER(prober, batchSize, "i")
+		}
+	} else {
+		if sel != nil {
+			_DISTINCT_COLLECT_NO_OUTER(prober, batchSize, nResults, "sel[i]")
+		} else {
+			_DISTINCT_COLLECT_NO_OUTER(prober, batchSize, nResults, "i")
+		}
+	}
+
+	return nResults
 }

--- a/pkg/sql/logictest/testdata/logic_test/exec_hash_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_hash_join
@@ -10,7 +10,7 @@ statement ok
 CREATE TABLE  t1 (k INT PRIMARY KEY, v INT)
 
 statement ok
-INSERT INTO t1 VALUES (0, 4), (2, 1), (5, 4), (3, 4)
+INSERT INTO t1 VALUES (0, 4), (2, 1), (5, 4), (3, 4), (-1, -1)
 
 statement ok
 CREATE TABLE t2 (x INT PRIMARY KEY, y INT)
@@ -69,6 +69,36 @@ SELECT * FROM t1 JOIN t2 ON t1.v = t2.x
 2  1  1  3
 3  4  4  6
 5  4  4  6
+
+query IIII rowsort
+SELECT * FROM t1 LEFT JOIN t2 ON t1.v = t2.x
+----
+-1  -1  NULL  NULL
+0   4   4     6
+2   1   1     3
+3   4   4     6
+5   4   4     6
+
+query IIII rowsort
+SELECT * FROM t1 RIGHT JOIN t2 ON t1.v = t2.x
+----
+0     4     4  6
+2     1     1  3
+3     4     4  6
+5     4     4  6
+NULL  NULL  0  5
+NULL  NULL  3  2
+
+query IIII rowsort
+SELECT * FROM t1 FULL JOIN t2 ON t1.v = t2.x
+----
+-1    -1    NULL  NULL
+0     4     4     6
+2     1     1     3
+3     4     4     6
+5     4     4     6
+NULL  NULL  3     2
+NULL  NULL  0     5
 
 query IIT rowsort
 SELECT b.a, b.b, b.c FROM b JOIN a ON b.a = a.k AND a.v = b.b


### PR DESCRIPTION
This PR adds right and left outer join support. It builds off of #33237 (template hash joiner).

```
BenchmarkHashJoiner/nulls=false/fullOuter=false/distinct=true/rows=2048-8         	   10000	    190102 ns/op	 689.48 MB/s
BenchmarkHashJoiner/nulls=false/fullOuter=false/distinct=true/rows=262144-8       	     100	  12164518 ns/op	1379.19 MB/s
BenchmarkHashJoiner/nulls=false/fullOuter=false/distinct=true/rows=4194304-8      	      10	 176378822 ns/op	1521.93 MB/s
BenchmarkHashJoiner/nulls=false/fullOuter=false/distinct=false/rows=2048-8        	   10000	    208850 ns/op	 627.59 MB/s
BenchmarkHashJoiner/nulls=false/fullOuter=false/distinct=false/rows=262144-8      	     100	  18943393 ns/op	 885.65 MB/s
BenchmarkHashJoiner/nulls=false/fullOuter=false/distinct=false/rows=4194304-8     	       2	 666980843 ns/op	 402.46 MB/s
BenchmarkHashJoiner/nulls=false/fullOuter=true/distinct=true/rows=2048-8          	    5000	    275679 ns/op	 475.45 MB/s
BenchmarkHashJoiner/nulls=false/fullOuter=true/distinct=true/rows=262144-8        	     100	  16794993 ns/op	 998.94 MB/s
BenchmarkHashJoiner/nulls=false/fullOuter=true/distinct=true/rows=4194304-8       	       5	 278006221 ns/op	 965.57 MB/s
BenchmarkHashJoiner/nulls=false/fullOuter=true/distinct=false/rows=2048-8         	    5000	    347624 ns/op	 377.05 MB/s
BenchmarkHashJoiner/nulls=false/fullOuter=true/distinct=false/rows=262144-8       	      50	  26753077 ns/op	 627.11 MB/s
BenchmarkHashJoiner/nulls=false/fullOuter=true/distinct=false/rows=4194304-8      	       2	 510258632 ns/op	 526.08 MB/s
BenchmarkHashJoiner/nulls=true/fullOuter=false/distinct=true/rows=2048-8          	    3000	    384740 ns/op	 340.68 MB/s
BenchmarkHashJoiner/nulls=true/fullOuter=false/distinct=true/rows=262144-8        	      50	  33669674 ns/op	 498.29 MB/s
BenchmarkHashJoiner/nulls=true/fullOuter=false/distinct=true/rows=4194304-8       	       2	 528106688 ns/op	 508.30 MB/s
BenchmarkHashJoiner/nulls=true/fullOuter=false/distinct=false/rows=2048-8         	    3000	    437200 ns/op	 299.80 MB/s
BenchmarkHashJoiner/nulls=true/fullOuter=false/distinct=false/rows=262144-8       	      30	  41442007 ns/op	 404.84 MB/s
BenchmarkHashJoiner/nulls=true/fullOuter=false/distinct=false/rows=4194304-8      	       2	 970349145 ns/op	 276.64 MB/s
BenchmarkHashJoiner/nulls=true/fullOuter=true/distinct=true/rows=2048-8           	    5000	    337161 ns/op	 388.75 MB/s
BenchmarkHashJoiner/nulls=true/fullOuter=true/distinct=true/rows=262144-8         	      50	  28320695 ns/op	 592.40 MB/s
BenchmarkHashJoiner/nulls=true/fullOuter=true/distinct=true/rows=4194304-8        	       3	 431805131 ns/op	 621.66 MB/s
BenchmarkHashJoiner/nulls=true/fullOuter=true/distinct=false/rows=2048-8          	    5000	    344703 ns/op	 380.25 MB/s
BenchmarkHashJoiner/nulls=true/fullOuter=true/distinct=false/rows=262144-8        	      50	  34031242 ns/op	 492.99 MB/s
BenchmarkHashJoiner/nulls=true/fullOuter=true/distinct=false/rows=4194304-8       	       2	 848903163 ns/op	 316.21 MB/s
```