### PR TITLE
storage: use correct threshold for in liveness status

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -395,7 +395,7 @@ func (nl *NodeLiveness) IsHealthy(nodeID roachpb.NodeID) (bool, error) {
 	}
 	ls := liveness.LivenessStatus(
 		nl.clock.Now().GoTime(),
-		nl.GetLivenessThreshold(),
+		TimeUntilStoreDead.Get(&nl.st.SV),
 		nl.clock.MaxOffset(),
 	)
 	return ls == storagepb.NodeLivenessStatus_LIVE, nil


### PR DESCRIPTION
The previous code wasn't passing in the right thing. The threshold
determines when the node is considered dead (as opposed to temporarily
unavailable or in unknown status).

I don't think this had any visible effects since the method just cares
about whether the status is a non-failing one.

Fixes #33219

Release note: None