### PR TITLE
backport-2.1: Bump etcd/raft to pick up uncommitted log size fix

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1339,14 +1339,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b66436e3c460ee4a9fab4f7dc473c36c51d3263e04838756378e72cc90058b6c"
+  digest = "1:a489826ac91be264c6d903335fa7d3c9f460b32a973921b72e01208f69144788"
   name = "go.etcd.io/etcd"
   packages = [
     "raft",
     "raft/raftpb",
   ]
   pruneopts = "UT"
-  revision = "dac8c6fcc05ba42a8032d5b720f6c1704965c269"
+  revision = "a580ec4547563f85b923a0429893a887b6d73f32"
 
 [[projects]]
   digest = "1:f163a34487229f36dfdb298191d8e17c0e3e6a899aa2cddb020f2ac61ca364ab"
@@ -1711,6 +1711,7 @@
     "github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc",
     "github.com/hashicorp/go-version",
     "github.com/jackc/pgx",
+    "github.com/jackc/pgx/pgproto3",
     "github.com/jteeuwen/go-bindata/go-bindata",
     "github.com/kisielk/errcheck",
     "github.com/kisielk/gotool",


### PR DESCRIPTION
Picks up the bug fix https://github.com/etcd-io/etcd/pull/10199.
It also picks up these further small fixes (which is intentional,
I authored most of them):

5c209d66d raft: ensure leader is in ProgressStateReplicate
1569f4829 raft: print RejectHint of zero on MsgAppResp
966853612 raft: add a test case in TestStorageAppend
e4af2be5b raft: separate MaxCommittedSizePerReady config from MaxSizePerMsg
aa4313a55 *: fix github links
4aa72ca1d raft: Explain ReportSnapshot and Propose behavior
b7ed4165e raft: fix godoc in tests
10255cf19 raft: Fix comment on TestLeaderBcastBeat
c561f8310 OWNERS: experiment
ad49c8fd9 raft: fix bug in unbounded log growth prevention mechanism
de470991e raft: fix description in UT
73c20cc1b raft: Fix comment on sendHeartbeat
7be7ac5a5 raft: Fix spelling in doc.go

Fixes #32895.
Fixes #32900.
Fixes #32898.

Release note (bug fix): Prevent import/restore operations from getting stuck indefinitely.