### PR TITLE
opt: fix panic in CREATE STATISTICS for table with no columns

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -132,6 +132,11 @@ func createStatsDefaultColumns(
 		}
 	}
 
+	// If there are still no columns, return an error.
+	if len(pn.columns) == 0 {
+		return nil, errors.New("CREATE STATISTICS called on a table with no visible columns")
+	}
+
 	return pn, nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -253,3 +253,11 @@ WHERE statistics_name = '__auto__'
 column_names  row_count  distinct_count  null_count
 {a}           10000      10              0
 {b}           10000      10              0
+
+# Regression test for #33195.
+statement ok
+CREATE TABLE t (x int); INSERT INTO t VALUES (1); ALTER TABLE t DROP COLUMN x
+
+# Ensure that creating stats on a table with no columns does not cause a panic.
+statement error pq: CREATE STATISTICS called on a table with no visible columns
+CREATE STATISTICS s FROM t


### PR DESCRIPTION
This commit fixes a panic that happened when `CREATE STATISTICS` was
called on a table that had no columns. Now we return an error instead
of panicking.

Fixes #33195

Release note: None