### PR TITLE
exec: template hash join

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1336,6 +1336,7 @@ pkg/sql/exec/any_not_null_agg.eg.go: pkg/sql/exec/any_not_null_agg_tmpl.go
 pkg/sql/exec/avg_agg.eg.go: pkg/sql/exec/avg_agg_tmpl.go
 pkg/sql/exec/colvec.eg.go: pkg/sql/exec/colvec_tmpl.go
 pkg/sql/exec/distinct.eg.go: pkg/sql/exec/distinct_tmpl.go
+pkg/sql/exec/hashjoiner.eg.go: pkg/sql/exec/hashjoiner_tmpl.go
 pkg/sql/exec/quicksort.eg.go: pkg/sql/exec/quicksort_tmpl.go
 pkg/sql/exec/sort.eg.go: pkg/sql/exec/sort_tmpl.go
 pkg/sql/exec/sum_agg.eg.go: pkg/sql/exec/sum_agg_tmpl.go

--- a/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
@@ -38,16 +38,16 @@ func genHashJoiner(wr io.Writer) error {
 	s = strings.Replace(s, "_SEL_IND", "{{.SelInd}}", -1)
 
 	assignNeRe := regexp.MustCompile(`_ASSIGN_NE\((.*),(.*),(.*)\)`)
-	s = assignNeRe.ReplaceAllString(s, "{{.Global.Assign $1 $2 $3}}")
+	s = assignNeRe.ReplaceAllString(s, `{{.Global.Assign "$1" "$2" "$3"}}`)
 
 	assignHash := regexp.MustCompile(`_ASSIGN_HASH\((.*),(.*)\)`)
-	s = assignHash.ReplaceAllString(s, "{{.Global.UnaryAssign $1 $2}}")
+	s = assignHash.ReplaceAllString(s, `{{.Global.UnaryAssign "$1" "$2"}}`)
 
-	rehash := regexp.MustCompile(`_REHASH_BODY\((.*)\)`)
-	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "SelInd" "$1"}}`)
+	rehash := regexp.MustCompile(`_REHASH_BODY\(.*,(.*)\)`)
+	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "SelInd" $1}}`)
 
-	checkCol := regexp.MustCompile(`_CHECK_COL_WITH_NULLS\((.*)\)`)
-	s = checkCol.ReplaceAllString(s, `{{template "checkColWithNulls" buildDict "Global" . "SelInd" "$1"}}`)
+	checkCol := regexp.MustCompile(`(?s)_CHECK_COL_WITH_NULLS\(.*?,.*?,.*?,.*?,.*?,.*?,\s*(.*?)\)`)
+	s = checkCol.ReplaceAllString(s, `{{template "checkColWithNulls" buildDict "Global" . "SelInd" $1}}`)
 
 	checkColMain := regexp.MustCompile(`_CHECK_COL_MAIN\((.*\))`)
 	s = checkColMain.ReplaceAllString(s, `{{template "checkColMain" .}}`)

--- a/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
@@ -16,195 +16,62 @@ package main
 
 import (
 	"io"
+	"io/ioutil"
+	"regexp"
+	"strings"
 	"text/template"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-const hashJoinerTemplate = `
-package exec
-
-import (
-  "fmt"
-	"bytes"
-	"math"
-	
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
-)
-
-// rehash takes a element of a key (tuple representing a row of equality
-// column values) at a given column and computes a new hash by applying a
-// transformation to the existing hash.
-func (ht *hashTable) rehash(
-	buckets []uint64, keyIdx int, t types.T, col ColVec, nKeys uint64, sel []uint16,
-) {
-	switch t {
-	{{range .}}
-		case types.{{.ExecType}}:
-			keys := col.{{.ExecType}}()
-			if sel != nil {
-		  	for i := uint64(0); i < nKeys; i++ {
-					{{if eq .ExecType "Bool"}}
-						if keys[sel[i]] {
-							buckets[i] = buckets[i]*31 + 1
-						}
-					{{else if eq .ExecType "Bytes"}}
-					  hash := 1
-					  for b := range keys[sel[i]] {
-					  	hash = hash*31 + b
-					  }
-					  buckets[i] = buckets[i]*31 + uint64(hash)
-					{{else if (eq .ExecType "Float32")}}
-						buckets[i] = buckets[i]*31 + uint64(math.Float32bits(keys[sel[i]]))
-					{{else if (eq .ExecType "Float64")}}
-						buckets[i] = buckets[i]*31 + math.Float64bits(keys[sel[i]])
-					{{else if (eq .ExecType "Decimal")}}
-						d, err := keys[sel[i]].Float64()
-						if err != nil {
-							panic(fmt.Sprintf("%v", err))
-						}
-						buckets[i] = buckets[i]*31 + math.Float64bits(d)
-					{{else}}
-					  buckets[i] = buckets[i]*31 + uint64(keys[sel[i]])
-					{{end}}
-				}
-			} else {
-		  	for i := uint64(0); i < nKeys; i++ {
-					{{if eq .ExecType "Bool"}}
-						if keys[i] {
-							buckets[i] = buckets[i]*31 + 1
-						}
-					{{else if eq .ExecType "Bytes"}}
-						hash := 1
-						for b := range keys[i] {
-							hash = hash*31 + b
-						}
-						buckets[i] = buckets[i]*31 + uint64(hash)
-					{{else if (eq .ExecType "Float32")}}
-						buckets[i] = buckets[i]*31 + uint64(math.Float32bits(keys[i]))
-					{{else if (eq .ExecType "Float64")}}
-						buckets[i] = buckets[i]*31 + math.Float64bits(keys[i])
-					{{else if (eq .ExecType "Decimal")}}
-						d, err := keys[i].Float64()
-						if err != nil {
-							panic(fmt.Sprintf("%v", err))
-						}
-						buckets[i] = buckets[i]*31 + math.Float64bits(d)
-					{{else}}
-						buckets[i] = buckets[i]*31 + uint64(keys[i])
-					{{end}}
-				}
-			}
-	{{end}}
-	default:
-		panic(fmt.Sprintf("unhandled type %d", t))
-	}
-}
-
-// checkCol determines if the current key column in the groupID buckets matches
-// the specified equality column key. If there is a match, then the key is added
-// to differs. If the bucket has reached the end, the key is rejected. If any
-// element in the key is null, then there is no match.
-func (prober *hashJoinProber) checkCol(t types.T, keyColIdx int, nToCheck uint16, sel []uint16) {
-	switch t {
-	{{range .}}
-		case types.{{.ExecType}}:
-			buildVec := prober.ht.vals[prober.ht.keyCols[keyColIdx]]
-			probeVec := prober.keys[keyColIdx]
-
-			buildKeys := buildVec.{{.ExecType}}()
-			probeKeys := probeVec.{{.ExecType}}()
-
-			if sel != nil {
-				for i := uint16(0); i < nToCheck; i++ {
-					// keyID of 0 is reserved to represent the end of the next chain.
-					if keyID := prober.groupID[prober.toCheck[i]]; keyID != 0 {
-						// the build table key (calculated using keys[keyID - 1] = key) is
-						// compared to the corresponding probe table to determine if a match is
-						// found.
-
-						if probeVec.NullAt(sel[prober.toCheck[i]]) {
-							prober.groupID[prober.toCheck[i]] = 0
-						} else if buildVec.NullAt64(keyID-1) {
-							prober.differs[prober.toCheck[i]] = true
-						} else {
-						{{if eq .ExecType "Bytes"}}
-							if !bytes.Equal(buildKeys[keyID-1], probeKeys[sel[prober.toCheck[i]]]) {
-								prober.differs[prober.toCheck[i]] = true
-							}
-						{{else if (eq .ExecType "Decimal")}}
-							if buildKeys[keyID-1].Cmp(&probeKeys[sel[prober.toCheck[i]]]) != 0 {
-								prober.differs[prober.toCheck[i]] = true
-							}
-						{{else}}
-							if buildKeys[keyID-1] != probeKeys[sel[prober.toCheck[i]]] {
-								prober.differs[prober.toCheck[i]] = true
-							}
-						{{end}}
-						}
-					}
-				}
-			} else {
-				for i := uint16(0); i < nToCheck; i++ {
-					// keyID of 0 is reserved to represent the end of the next chain.
-					if keyID := prober.groupID[prober.toCheck[i]]; keyID != 0 {
-						// the build table key (calculated using keys[keyID - 1] = key) is
-						// compared to the corresponding probe table to determine if a match is
-						// found.
-
-						if probeVec.NullAt(prober.toCheck[i]) {
-							prober.groupID[prober.toCheck[i]] = 0
-						} else if buildVec.NullAt64(keyID-1) {
-							prober.differs[prober.toCheck[i]] = true
-						} else {
-						{{if eq .ExecType "Bytes"}}
-							if !bytes.Equal(buildKeys[keyID-1], probeKeys[prober.toCheck[i]]) {
-								prober.differs[prober.toCheck[i]] = true
-							}
-						{{else if (eq .ExecType "Decimal")}}
-							if buildKeys[keyID-1].Cmp(&probeKeys[prober.toCheck[i]]) != 0 {
-								prober.differs[prober.toCheck[i]] = true
-							}
-						{{else}}
-							if buildKeys[keyID-1] != probeKeys[prober.toCheck[i]] {
-								prober.differs[prober.toCheck[i]] = true
-							}
-						{{end}}
-						}
-					}
-				}
-			}
-	{{end}}
-	default:
-		panic(fmt.Sprintf("unhandled type %d", t))
-	}
-}
-`
-
-type hashJoinerGen struct {
-	ExecType string
-	GoType   string
-}
-
-func genHashJoinerDistinct(wr io.Writer) error {
-	// Build list of all exec types.
-	var gens []hashJoinerGen
-	for _, t := range types.AllTypes {
-		gen := hashJoinerGen{
-			ExecType: t.String(),
-			GoType:   t.GoTypeName(),
-		}
-		gens = append(gens, gen)
-	}
-
-	tmpl, err := template.New("hashJoinerTemplate").Parse(hashJoinerTemplate)
+func genHashJoiner(wr io.Writer) error {
+	t, err := ioutil.ReadFile("pkg/sql/exec/hashjoiner_tmpl.go")
 	if err != nil {
 		return err
 	}
 
-	return tmpl.Execute(wr, gens)
+	s := string(t)
+
+	s = strings.Replace(s, "_TYPES_T", "types.{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "_SEL_IND", "{{.SelInd}}", -1)
+
+	assignNeRe := regexp.MustCompile(`_ASSIGN_NE\((.*),(.*),(.*)\)`)
+	s = assignNeRe.ReplaceAllString(s, "{{.Global.Assign $1 $2 $3}}")
+
+	assignHash := regexp.MustCompile(`_ASSIGN_HASH\((.*),(.*)\)`)
+	s = assignHash.ReplaceAllString(s, "{{.Global.UnaryAssign $1 $2}}")
+
+	rehash := regexp.MustCompile(`_REHASH_BODY\((.*)\)`)
+	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "SelInd" "$1"}}`)
+
+	checkCol := regexp.MustCompile(`_CHECK_COL_WITH_NULLS\((.*)\)`)
+	s = checkCol.ReplaceAllString(s, `{{template "checkColWithNulls" buildDict "Global" . "SelInd" "$1"}}`)
+
+	checkColMain := regexp.MustCompile(`_CHECK_COL_MAIN\((.*\))`)
+	s = checkColMain.ReplaceAllString(s, `{{template "checkColMain" .}}`)
+
+	checkColBody := regexp.MustCompile(`_CHECK_COL_BODY\((.*),(.*),(.*)\)`)
+	s = checkColBody.ReplaceAllString(s, `{{template "checkColBody" buildDict "Global" .Global "SelInd" .SelInd "ProbeHasNulls" $2 "BuildHasNulls" $3}}`)
+
+	tmpl, err := template.New("hashjoiner_op").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
+
+	if err != nil {
+		return err
+	}
+
+	allOverloads := intersectOverloads(comparisonOpToOverloads[tree.NE], hashOverloads)
+
+	return tmpl.Execute(wr, struct {
+		NETemplate   interface{}
+		HashTemplate interface{}
+	}{
+		NETemplate:   allOverloads[0],
+		HashTemplate: allOverloads[1],
+	})
 }
 
 func init() {
-	registerGenerator(genHashJoinerDistinct, "hashjoiner.eg.go")
+	registerGenerator(genHashJoiner, "hashjoiner.eg.go")
 }

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -55,6 +55,54 @@ func TestHashJoinerInt64(t *testing.T) {
 		expectedTuples tuples
 	}{
 		{
+			leftTypes:  []types.T{types.Int64},
+			rightTypes: []types.T{types.Int64},
+
+			// Test null handling only on probe column.
+			leftTuples: tuples{
+				{0},
+			},
+			rightTuples: tuples{
+				{nil},
+				{0},
+			},
+
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			leftOutCols:  []uint32{0},
+			rightOutCols: []uint32{},
+
+			expectedTuples: tuples{
+				{0},
+			},
+		},
+		{
+			leftTypes:  []types.T{types.Int64},
+			rightTypes: []types.T{types.Int64},
+
+			// Test null handling only on build column.
+			leftTuples: tuples{
+				{nil},
+				{nil},
+				{1},
+				{0},
+			},
+			rightTuples: tuples{
+				{1},
+				{0},
+			},
+
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			leftOutCols:  []uint32{0},
+			rightOutCols: []uint32{},
+
+			expectedTuples: tuples{
+				{1},
+				{0},
+			},
+		},
+		{
 			leftTypes:  []types.T{types.Int64, types.Int64},
 			rightTypes: []types.T{types.Int64, types.Int64},
 

--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -1,0 +1,170 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for hashjoiner.eg.go. It's formatted in a
+// special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package exec
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// {{/*
+
+// Dummy import to pull in "tree" package.
+var _ tree.Datum
+
+// Dummy import to pull in "math" package
+var _ = math.Pi
+
+// Dummy import to pull in "bytes" package.
+var _ bytes.Buffer
+
+// _ASSIGN_HASH is the template equality function for assigning the first input
+// to the result of the hash value of the second input.
+func _ASSIGN_HASH(_, _ string) uint64 {
+	panic("")
+}
+
+func _CHECK_COL_MAIN(_SEL_IND uin64) { // */}}
+	// {{define "checkColMain"}}
+	buildVal := buildKeys[keyID-1]
+	probeVal := probeKeys[_SEL_IND]
+	var unique bool
+	_ASSIGN_NE("unique", "buildVal", "probeVal")
+
+	if unique {
+		prober.differs[prober.toCheck[i]] = true
+	}
+	// {{end}}
+
+	// {{/*
+}
+
+func _CHECK_COL_BODY(_SEL_IND uint64, _PROBE_HAS_NULLS bool, BUILD_HAS_NULLS bool) { // */}}
+	// {{define "checkColBody"}}
+	for i := uint16(0); i < nToCheck; i++ {
+		// keyID of 0 is reserved to represent the end of the next chain.
+
+		if keyID := prober.groupID[prober.toCheck[i]]; keyID != 0 {
+			// the build table key (calculated using keys[keyID - 1] = key) is
+			// compared to the corresponding probe table to determine if a match is
+			// found.
+
+			/* {{if .ProbeHasNulls }} */
+			if probeVec.NullAt(_SEL_IND) {
+				prober.groupID[prober.toCheck[i]] = 0
+			} else /*{{end}} {{if .BuildHasNulls}} */ if buildVec.NullAt64(keyID - 1) {
+				prober.differs[prober.toCheck[i]] = true
+			} else /*{{end}} */ {
+				_CHECK_COL_MAIN(_SEL_IND)
+			}
+		}
+	}
+	// {{end}}
+	// {{/*
+}
+
+func _CHECK_COL_WITH_NULLS(_SEL_IND uint64) { // */}}
+	// {{define "checkColWithNulls"}}
+	if probeVec.HasNulls() {
+		if buildVec.HasNulls() {
+			_CHECK_COL_BODY(_SEL_IND, true, true)
+		} else {
+			_CHECK_COL_BODY(_SEL_IND, true, false)
+		}
+	} else {
+		if buildVec.HasNulls() {
+			_CHECK_COL_BODY(_SEL_IND, false, true)
+		} else {
+			_CHECK_COL_BODY(_SEL_IND, false, false)
+		}
+	}
+	// {{end}}
+	// {{/*
+}
+
+func _REHASH_BODY(_ string) { // */}}
+	// {{define "rehashBody"}}
+	for i := uint64(0); i < nKeys; i++ {
+		v := keys[_SEL_IND]
+		var hash uint64
+		_ASSIGN_HASH("hash", "v")
+		buckets[i] = buckets[i]*31 + hash
+	}
+	// {{end}}
+
+	// {{/*
+}
+
+// */}}
+
+// rehash takes a element of a key (tuple representing a row of equality
+// column values) at a given column and computes a new hash by applying a
+// transformation to the existing hash.
+func (ht *hashTable) rehash(
+	buckets []uint64, keyIdx int, t types.T, col ColVec, nKeys uint64, sel []uint16,
+) {
+	switch t {
+	// {{range $hashType := .HashTemplate}}
+	case _TYPES_T:
+		keys := col._TemplateType()
+		if sel != nil {
+			_REHASH_BODY(sel[i])
+		} else {
+			_REHASH_BODY(i)
+		}
+
+	// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", t))
+	}
+}
+
+// checkCol determines if the current key column in the groupID buckets matches
+// the specified equality column key. If there is a match, then the key is added
+// to differs. If the bucket has reached the end, the key is rejected. If any
+// element in the key is null, then there is no match.
+func (prober *hashJoinProber) checkCol(t types.T, keyColIdx int, nToCheck uint16, sel []uint16) {
+	switch t {
+	// {{range $neType := .NETemplate}}
+	case _TYPES_T:
+		buildVec := prober.ht.vals[prober.ht.keyCols[keyColIdx]]
+		probeVec := prober.keys[keyColIdx]
+
+		buildKeys := buildVec._TemplateType()
+		probeKeys := probeVec._TemplateType()
+
+		if sel != nil {
+			_CHECK_COL_WITH_NULLS(sel[prober.toCheck[i]])
+		} else {
+			_CHECK_COL_WITH_NULLS(prober.toCheck[i])
+		}
+		// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", t))
+	}
+}


### PR DESCRIPTION
This commit pulls the hash join execgen templating string into the `hashjoiner_tmpl.go` file. We also added some more advanced templating techniques using the `{{define}}` semantics. This allows us to easily template out duplicate code and selection vector duplication.

This PR builds off of #32836.