### PR TITLE
storage: deflake Test...AbandonedFollowersAutomaticallyGarbageCollected

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2022,8 +2022,6 @@ func TestStoreRangeMergeAbandonedFollowers(t *testing.T) {
 func TestStoreRangeMergeAbandonedFollowersAutomaticallyGarbageCollected(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/32062")
-
 	ctx := context.Background()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableReplicateQueue = true
@@ -2038,8 +2036,19 @@ func TestStoreRangeMergeAbandonedFollowersAutomaticallyGarbageCollected(t *testi
 		t.Fatal(err)
 	}
 
-	// Make store2 the leaseholder for the RHS.
+	// Make store2 the leaseholder for the RHS and wait for the lease transfer to
+	// apply.
 	mtc.transferLease(ctx, rhsDesc.RangeID, 0, 2)
+	testutils.SucceedsSoon(t, func() error {
+		rhsRepl, err := store2.GetReplica(rhsDesc.RangeID)
+		if err != nil {
+			return err
+		}
+		if !rhsRepl.OwnsValidLease(mtc.clock.Now()) {
+			return errors.New("store2 does not own valid lease for rhs range")
+		}
+		return nil
+	})
 
 	// Start dropping all Raft traffic to the LHS replica on store2 so that it
 	// won't be aware that there is a merge in progress.


### PR DESCRIPTION
TestStoreRangeMergeAbandonedFollowersAutomaticallyGarbageCollected needs
to wait for the lease transfer to apply before shutting down Raft
traffic to the LHS.

Fixes #32062.

Release note: None