### PR TITLE
exec: template out colvec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1334,6 +1334,7 @@ $(SETTINGS_DOC_PAGE): $(settings-doc-gen)
 
 pkg/sql/exec/any_not_null_agg.eg.go: pkg/sql/exec/any_not_null_agg_tmpl.go
 pkg/sql/exec/avg_agg.eg.go: pkg/sql/exec/avg_agg_tmpl.go
+pkg/sql/exec/colvec.eg.go: pkg/sql/exec/colvec_tmpl.go
 pkg/sql/exec/distinct.eg.go: pkg/sql/exec/distinct_tmpl.go
 pkg/sql/exec/quicksort.eg.go: pkg/sql/exec/quicksort_tmpl.go
 pkg/sql/exec/sort.eg.go: pkg/sql/exec/sort_tmpl.go

--- a/pkg/sql/exec/colvec_tmpl.go
+++ b/pkg/sql/exec/colvec_tmpl.go
@@ -1,0 +1,113 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for colvec.eg.go. It's formatted in a
+// special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package exec
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+// {{/*
+
+// Dummy import to pull in "apd" package.
+var _ apd.Decimal
+
+// */}}
+
+func (m *memColumn) Append(vec ColVec, colType types.T, toLength uint64, fromLength uint16) {
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		m.col = append(m._TemplateType()[:toLength], vec._TemplateType()[:fromLength]...)
+		// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
+
+func (m *memColumn) AppendWithSel(
+	vec ColVec, sel []uint16, batchSize uint16, colType types.T, toLength uint64,
+) {
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		toCol := append(m._TemplateType()[:toLength], make([]_GOTYPE, batchSize)...)
+		fromCol := vec._TemplateType()
+
+		for i := uint16(0); i < batchSize; i++ {
+			toCol[uint64(i)+toLength] = fromCol[sel[i]]
+		}
+
+		m.col = toCol
+		// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
+
+func (m *memColumn) Copy(src ColVec, srcStartIdx, srcEndIdx uint64, typ types.T) {
+	switch typ {
+	// {{range .}}
+	case _TYPES_T:
+		copy(m._TemplateType(), src._TemplateType()[srcStartIdx:srcEndIdx])
+		// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", typ))
+	}
+}
+
+func (m *memColumn) CopyWithSelInt64(vec ColVec, sel []uint64, nSel uint16, colType types.T) {
+	// todo (changangela): handle the case when nSel > ColBatchSize
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		toCol := m._TemplateType()
+		fromCol := vec._TemplateType()
+
+		for i := uint16(0); i < nSel; i++ {
+			toCol[i] = fromCol[sel[i]]
+		}
+		// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
+
+func (m *memColumn) CopyWithSelInt16(vec ColVec, sel []uint16, nSel uint16, colType types.T) {
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		toCol := m._TemplateType()
+		fromCol := vec._TemplateType()
+
+		for i := uint16(0); i < nSel; i++ {
+			toCol[i] = fromCol[sel[i]]
+		}
+		// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}

--- a/pkg/sql/exec/execgen/cmd/execgen/colvec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/colvec_gen.go
@@ -16,123 +16,34 @@ package main
 
 import (
 	"io"
+	"io/ioutil"
+	"strings"
 	"text/template"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-const colVecTemplate = `
-package exec
-
-import (
-  "fmt"
-	
-	"github.com/cockroachdb/apd"
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
-)
-
-func (m *memColumn) Append(
-	vec ColVec, colType types.T, toLength uint64, fromLength uint16,
-) {
-	switch colType {
-		{{range .}}
-		case types.{{.ExecType}}:
-			m.col = append(m.{{.ExecType}}()[:toLength], vec.{{.ExecType}}()[:fromLength]...)
-		{{end}}
-		default:
-			panic(fmt.Sprintf("unhandled type %d", colType))
-	}
-}
-
-func (m *memColumn) AppendWithSel(
-	vec ColVec, sel []uint16, batchSize uint16, colType types.T, toLength uint64,
-) {
-	switch colType {
-	{{range .}}
-	case types.{{.ExecType}}:
-		toCol := append(m.{{.ExecType}}()[:toLength], make([]{{.GoType}}, batchSize)...)
-		fromCol := vec.{{.ExecType}}()
-
-		for i := uint16(0); i < batchSize; i++ {
-      toCol[uint64(i) + toLength] = fromCol[sel[i]]
-		}
-
-		m.col = toCol
-	{{end}}
-	default:
-		panic(fmt.Sprintf("unhandled type %d", colType))
-	}
-}
-
-func (m *memColumn) Copy(src ColVec, srcStartIdx, srcEndIdx uint64, typ types.T) {
-	switch typ {
-	{{range .}}
-	case types.{{.ExecType}}:
-		copy(m.{{.ExecType}}(), src.{{.ExecType}}()[srcStartIdx:srcEndIdx])
-	{{end}}
-	default:
-		panic(fmt.Sprintf("unhandled type %d", typ))
-	}
-}
-
-func (m *memColumn) CopyWithSelInt64(
-	vec ColVec, sel []uint64, nSel uint16, colType types.T,
-) {
-	// todo (changangela): handle the case when nSel > ColBatchSize
-	switch colType {
-	{{range .}}
-	case types.{{.ExecType}}:
-		toCol := m.{{.ExecType}}()
-		fromCol := vec.{{.ExecType}}()
-		for i := uint16(0); i < nSel; i++ {
-			toCol[i] = fromCol[sel[i]]
-		}
-	{{end}}
-	default:
-		panic(fmt.Sprintf("unhandled type %d", colType))
-	}
-}
-
-func (m *memColumn) CopyWithSelInt16(vec ColVec, sel []uint16, nSel uint16, colType types.T) {
-	switch colType {
-	{{range .}}
-	case types.{{.ExecType}}:
-		toCol := m.{{.ExecType}}()
-		fromCol := vec.{{.ExecType}}()
-		for i := uint16(0); i < nSel; i++ {
-			toCol[i] = fromCol[sel[i]]
-		}
-	{{end}}
-	default:
-		panic(fmt.Sprintf("unhandled type %d", colType))
-	}
-}
-`
-
-type colVecGen struct {
-	ExecType string
-	GoType   string
-}
-
-func genColVec(wr io.Writer) error {
-	// Build list of all exec types.
-	var gens []colVecGen
-	for _, t := range types.AllTypes {
-		gen := colVecGen{
-			ExecType: t.String(),
-			GoType:   t.GoTypeName(),
-		}
-		gens = append(gens, gen)
-	}
-
-	tmpl, err := template.New("colVecTemplate").Parse(colVecTemplate)
+func genColvec(wr io.Writer) error {
+	d, err := ioutil.ReadFile("pkg/sql/exec/colvec_tmpl.go")
 	if err != nil {
 		return err
 	}
 
-	return tmpl.Execute(wr, gens)
-}
+	s := string(d)
 
+	// Replace the template variables.
+	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
+	s = strings.Replace(s, "_TYPES_T", "types.{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+
+	// Now, generate the op, from the template.
+	tmpl, err := template.New("colvec_op").Parse(s)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, comparisonOpToOverloads[tree.NE])
+}
 func init() {
-	registerGenerator(genColVec, "colvec.eg.go")
+	registerGenerator(genColvec, "colvec.eg.go")
 }


### PR DESCRIPTION
This commit extracts the execgen template string from `colvec_gen.go` into its
own template file at `colvec_tmpl.go`. This makes it easier to make templating
changes.

Release note: None