### PR TITLE
opt: adjust cache size

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -74,7 +74,8 @@ const (
 
 	defaultSQLTableStatCacheSize = 256
 
-	defaultSQLQueryCacheSize = 1024 * 1024
+	// This comes out to 1024 cache entries.
+	defaultSQLQueryCacheSize = 8 * 1024 * 1024
 )
 
 var productionSettingsWebpage = fmt.Sprintf(


### PR DESCRIPTION
Adjust the cache size to 8MB (so it fits 1024 entries). This memory
won't actually be used when the cache is disabled (the default).

Release note: None