### PR TITLE
storage: have sequenced reads use the intent history

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -307,6 +307,7 @@ DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_sp
 typedef struct {
   DBSlice id;
   uint32_t epoch;
+  int32_t sequence;
   DBTimestamp max_timestamp;
 } DBTxn;
 

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -330,10 +330,10 @@ typedef struct {
 } DBScanResults;
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
-                      bool inconsistent, bool tombstones);
+                      bool inconsistent, bool tombstones, bool ignore_sequence);
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
                        int64_t max_keys, DBTxn txn, bool inconsistent, bool reverse,
-                       bool tombstones);
+                       bool tombstones, bool ignore_sequence);
 
 // DBStatsResult contains various runtime stats for RocksDB.
 typedef struct {

--- a/c-deps/libroach/mvcc.cc
+++ b/c-deps/libroach/mvcc.cc
@@ -274,26 +274,26 @@ DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_sp
 }
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
-                      bool inconsistent, bool tombstones) {
+                      bool inconsistent, bool tombstones, bool ignore_sequence) {
   // Get is implemented as a scan where we retrieve a single key. We specify an
   // empty key for the end key which will ensure we don't retrieve a key
   // different than the start key. This is a bit of a hack.
   const DBSlice end = {0, 0};
   ScopedStats scoped_iter(iter);
   mvccForwardScanner scanner(iter, key, end, timestamp, 1 /* max_keys */, txn, inconsistent,
-                             tombstones);
+                             tombstones, ignore_sequence);
   return scanner.get();
 }
 
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
                        int64_t max_keys, DBTxn txn, bool inconsistent, bool reverse,
-                       bool tombstones) {
+                       bool tombstones, bool ignore_sequence) {
   ScopedStats scoped_iter(iter);
   if (reverse) {
-    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, inconsistent, tombstones);
+    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, inconsistent, tombstones, ignore_sequence);
     return scanner.scan();
   } else {
-    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, txn, inconsistent, tombstones);
+    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, txn, inconsistent, tombstones, ignore_sequence);
     return scanner.scan();
   }
 }

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -95,6 +95,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>2.1-4</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>2.1-5</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
 </tbody>
 </table>

--- a/pkg/kv/txn_interceptor_sequence_nums.go
+++ b/pkg/kv/txn_interceptor_sequence_nums.go
@@ -72,11 +72,15 @@ func (s *txnSeqNumAllocator) setWrapped(wrapped lockedSender) { s.wrapped = wrap
 // populateMetaLocked is part of the txnInterceptor interface.
 func (s *txnSeqNumAllocator) populateMetaLocked(meta *roachpb.TxnCoordMeta) {
 	meta.CommandCount = s.commandCount
+	meta.Txn.Sequence = s.seqNumCounter
 }
 
 // augmentMetaLocked is part of the txnInterceptor interface.
 func (s *txnSeqNumAllocator) augmentMetaLocked(meta roachpb.TxnCoordMeta) {
 	s.commandCount += meta.CommandCount
+	if meta.Txn.Sequence > s.seqNumCounter {
+		s.seqNumCounter = meta.Txn.Sequence
+	}
 }
 
 // epochBumpedLocked is part of the txnInterceptor interface.

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -70,6 +70,7 @@ const (
 	VersionLoadSplits
 	VersionExportStorageWorkload
 	VersionLazyTxnRecord
+	VersionSequencedReads
 
 	// Add new versions here (step one of two).
 
@@ -308,6 +309,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionLazyTxnRecord is https://github.com/cockroachdb/cockroach/pull/33566.
 		Key:     VersionLazyTxnRecord,
 		Version: roachpb.Version{Major: 2, Minor: 1, Unstable: 4},
+	},
+	{
+		// VersionExportStorageWorkload is https://github.com/cockroachdb/cockroach/pull/33244.
+		Key:     VersionSequencedReads,
+		Version: roachpb.Version{Major: 2, Minor: 1, Unstable: 5},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -268,7 +268,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-2.1-4
+2.1-5
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -365,7 +365,7 @@ select * from crdb_internal.gossip_alerts
 query T
 select crdb_internal.node_executable_version()
 ----
-2.1-4
+2.1-5
 
 user root
 

--- a/pkg/storage/batcheval/cmd_get.go
+++ b/pkg/storage/batcheval/cmd_get.go
@@ -36,14 +36,9 @@ func Get(
 	h := cArgs.Header
 	reply := resp.(*roachpb.GetResponse)
 
-	var ignoreSeq bool
-	if !cArgs.EvalCtx.ClusterSettings().Version.IsActive(cluster.VersionSequencedReads) {
-		ignoreSeq = true
-	}
-
 	val, intent, err := engine.MVCCGet(ctx, batch, args.Key, h.Timestamp, engine.MVCCGetOptions{
 		Inconsistent:   h.ReadConsistency != roachpb.CONSISTENT,
-		IgnoreSequence: ignoreSeq,
+		IgnoreSequence: shouldIgnoreSequenceNums(cArgs.EvalCtx),
 		Txn:            h.Txn,
 	})
 	if err != nil {
@@ -69,4 +64,20 @@ func Get(
 		}
 	}
 	return result.FromIntents(intents, args), err
+}
+
+func shouldIgnoreSequenceNums(rec EvalContext) bool {
+	// Versions 2.1 and below did not properly propagate sequence numbers to leaf
+	// TxnCoordSenders. This means that we can't rely on sequence numbers being
+	// properly assigned by those nodes. Gate the use of sequence numbers while
+	// scanning on a cluster setting.
+	// NOTE: because we check this during batcheval instead of when sending a
+	// get/scan request with an associated flag on the request itself, 2.2 clients
+	// can't use a similar IsActive check to determine when they can start relying
+	// on the correct sequence number behavior. Instead, they must wait until a
+	// new cluster version introduced in 2.3. Alternatively, we can add a flag to
+	// batch headers that can be set on a client (who would perform the IsActive
+	// check itself) and would override this decision. We haven't added that yet
+	// because it's not clear that it will be needed.
+	return !rec.ClusterSettings().Version.IsActive(cluster.VersionSequencedReads)
 }

--- a/pkg/storage/batcheval/cmd_reverse_scan.go
+++ b/pkg/storage/batcheval/cmd_reverse_scan.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
@@ -46,12 +47,17 @@ func ReverseScan(
 	case roachpb.BATCH_RESPONSE:
 		var kvData []byte
 		var numKvs int64
+		var ignoreSeq bool
+		if !cArgs.EvalCtx.ClusterSettings().Version.IsActive(cluster.VersionSequencedReads) {
+			ignoreSeq = true
+		}
 		kvData, numKvs, resumeSpan, intents, err = engine.MVCCScanToBytes(
 			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp,
 			engine.MVCCScanOptions{
-				Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
-				Txn:          h.Txn,
-				Reverse:      true,
+				Inconsistent:   h.ReadConsistency != roachpb.CONSISTENT,
+				IgnoreSequence: ignoreSeq,
+				Txn:            h.Txn,
+				Reverse:        true,
 			})
 		if err != nil {
 			return result.Result{}, err
@@ -60,11 +66,16 @@ func ReverseScan(
 		reply.BatchResponses = [][]byte{kvData}
 	case roachpb.KEY_VALUES:
 		var rows []roachpb.KeyValue
+		var ignoreSeq bool
+		if !cArgs.EvalCtx.ClusterSettings().Version.IsActive(cluster.VersionSequencedReads) {
+			ignoreSeq = true
+		}
 		rows, resumeSpan, intents, err = engine.MVCCScan(
 			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp, engine.MVCCScanOptions{
-				Inconsistent: h.ReadConsistency != roachpb.CONSISTENT,
-				Txn:          h.Txn,
-				Reverse:      true,
+				Inconsistent:   h.ReadConsistency != roachpb.CONSISTENT,
+				IgnoreSequence: ignoreSeq,
+				Txn:            h.Txn,
+				Reverse:        true,
 			})
 		if err != nil {
 			return result.Result{}, err

--- a/pkg/storage/batcheval/cmd_scan.go
+++ b/pkg/storage/batcheval/cmd_scan.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
@@ -47,15 +46,11 @@ func Scan(
 	case roachpb.BATCH_RESPONSE:
 		var kvData []byte
 		var numKvs int64
-		var ignoreSeq bool
-		if !cArgs.EvalCtx.ClusterSettings().Version.IsActive(cluster.VersionSequencedReads) {
-			ignoreSeq = true
-		}
 		kvData, numKvs, resumeSpan, intents, err = engine.MVCCScanToBytes(
 			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp,
 			engine.MVCCScanOptions{
 				Inconsistent:   h.ReadConsistency != roachpb.CONSISTENT,
-				IgnoreSequence: ignoreSeq,
+				IgnoreSequence: shouldIgnoreSequenceNums(cArgs.EvalCtx),
 				Txn:            h.Txn,
 			})
 		if err != nil {
@@ -65,14 +60,10 @@ func Scan(
 		reply.BatchResponses = [][]byte{kvData}
 	case roachpb.KEY_VALUES:
 		var rows []roachpb.KeyValue
-		var ignoreSeq bool
-		if !cArgs.EvalCtx.ClusterSettings().Version.IsActive(cluster.VersionSequencedReads) {
-			ignoreSeq = true
-		}
 		rows, resumeSpan, intents, err = engine.MVCCScan(
 			ctx, batch, args.Key, args.EndKey, cArgs.MaxKeys, h.Timestamp, engine.MVCCScanOptions{
 				Inconsistent:   h.ReadConsistency != roachpb.CONSISTENT,
-				IgnoreSequence: ignoreSeq,
+				IgnoreSequence: shouldIgnoreSequenceNums(cArgs.EvalCtx),
 				Txn:            h.Txn,
 			})
 		if err != nil {

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -715,7 +715,6 @@ func MVCCGetAsTxn(
 	txnMeta enginepb.TxnMeta,
 ) (*roachpb.Value, *roachpb.Intent, error) {
 	return MVCCGet(ctx, engine, key, timestamp, MVCCGetOptions{
-		IgnoreSequence: true,
 		Txn: &roachpb.Transaction{
 			TxnMeta:       txnMeta,
 			Status:        roachpb.PENDING,

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1830,8 +1830,18 @@ func MVCCDeleteRange(
 	// In order to detect the potential write intent by another concurrent
 	// transaction with a newer timestamp, we need to use the max timestamp for
 	// scan.
+	scanTs := hlc.MaxTimestamp
+	// In order for this operation to be idempotent when run transactionally, we
+	// need to perform the initial scan at the previous sequence number so that
+	// we don't see the result from equal or later sequences.
+	var scanTxn *roachpb.Transaction
+	if txn != nil {
+		prevSeqTxn := txn.Clone()
+		prevSeqTxn.Sequence--
+		scanTxn = &prevSeqTxn
+	}
 	kvs, resumeSpan, _, err := MVCCScan(
-		ctx, engine, key, endKey, max, hlc.MaxTimestamp, MVCCScanOptions{Txn: txn})
+		ctx, engine, key, endKey, max, scanTs, MVCCScanOptions{Txn: scanTxn})
 	if err != nil {
 		return nil, nil, 0, err
 	}

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -671,7 +671,10 @@ type MVCCGetOptions struct {
 	// See the documentation for MVCCGet for information on these parameters.
 	Inconsistent bool
 	Tombstones   bool
-	Txn          *roachpb.Transaction
+	// TODO(nathanvanbenschoten): Remove all references of IgnoreSequence
+	// in 2.3.
+	IgnoreSequence bool
+	Txn            *roachpb.Transaction
 }
 
 // MVCCGet returns the most recent value for the specified key whose timestamp
@@ -712,6 +715,7 @@ func MVCCGetAsTxn(
 	txnMeta enginepb.TxnMeta,
 ) (*roachpb.Value, *roachpb.Intent, error) {
 	return MVCCGet(ctx, engine, key, timestamp, MVCCGetOptions{
+		IgnoreSequence: true,
 		Txn: &roachpb.Transaction{
 			TxnMeta:       txnMeta,
 			Status:        roachpb.PENDING,
@@ -1930,8 +1934,11 @@ type MVCCScanOptions struct {
 	// See the documentation for MVCCScan for information on these parameters.
 	Inconsistent bool
 	Tombstones   bool
-	Reverse      bool
-	Txn          *roachpb.Transaction
+	// TODO(nathanvanbenschoten): Remove all references of IgnoreSequence
+	// in 2.3.
+	IgnoreSequence bool
+	Reverse        bool
+	Txn            *roachpb.Transaction
 }
 
 // MVCCScan scans the key range [key, endKey) in the provided engine up to some

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2266,8 +2266,8 @@ func (r *rocksDBIterator) MVCCGet(
 
 	r.clearState()
 	state := C.MVCCGet(
-		r.iter, goToCSlice(key), goToCTimestamp(timestamp),
-		goToCTxn(opts.Txn), C.bool(opts.Inconsistent), C.bool(opts.Tombstones),
+		r.iter, goToCSlice(key), goToCTimestamp(timestamp), goToCTxn(opts.Txn),
+		C.bool(opts.Inconsistent), C.bool(opts.Tombstones), C.bool(opts.IgnoreSequence),
 	)
 
 	if err := statusToError(state.status); err != nil {
@@ -2334,7 +2334,9 @@ func (r *rocksDBIterator) MVCCScan(
 	state := C.MVCCScan(
 		r.iter, goToCSlice(start), goToCSlice(end),
 		goToCTimestamp(timestamp), C.int64_t(max),
-		goToCTxn(opts.Txn), C.bool(opts.Inconsistent), C.bool(opts.Reverse), C.bool(opts.Tombstones),
+		goToCTxn(opts.Txn), C.bool(opts.Inconsistent),
+		C.bool(opts.Reverse), C.bool(opts.Tombstones),
+		C.bool(opts.IgnoreSequence),
 	)
 
 	if err := statusToError(state.status); err != nil {

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2512,6 +2512,7 @@ func goToCTxn(txn *roachpb.Transaction) C.DBTxn {
 	if txn != nil {
 		r.id = goToCSlice(txn.ID.GetBytes())
 		r.epoch = C.uint32_t(txn.Epoch)
+		r.sequence = C.int32_t(txn.Sequence)
 		r.max_timestamp = goToCTimestamp(txn.MaxTimestamp)
 	}
 	return r

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -4365,6 +4365,7 @@ func TestEndTransactionDirectGC(t *testing.T) {
 				var gr roachpb.GetResponse
 				if _, err := batcheval.Get(
 					ctx, tc.engine, batcheval.CommandArgs{
+						EvalCtx: NewReplicaEvalContext(tc.repl, &allSpans),
 						Args: &roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{
 							Key: keys.TransactionKey(txn.Key, txn.ID),
 						}},


### PR DESCRIPTION
Reads can now use the intent history to serve reads from
values written at a lower sequence. Reads no longer read
all writes in a transaction but instead read all writes
in the transaction with a higher sequence than it. If a key
is written to multiple times within a transaction, the read
can now get the appropriate value using the intent history.

Release note: None