### PR TITLE
release-2.1: pgwire: detect, log, and immediately close any cancel requests

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -21,6 +21,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -34,6 +35,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx"
+	"github.com/jackc/pgx/pgproto3"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
 
@@ -42,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -2103,3 +2106,35 @@ func (l pgxTestLogger) Log(level pgx.LogLevel, msg string, data map[string]inter
 
 // pgxTestLogger implements pgx.Logger.
 var _ pgx.Logger = pgxTestLogger{}
+
+func TestCancelRequest(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params := base.TestServerArgs{Insecure: true}
+	s, _, _ := serverutils.StartServer(t, params)
+
+	ctx := context.TODO()
+	defer s.Stopper().Stop(ctx)
+
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", s.Addr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	fe, err := pgproto3.NewFrontend(conn, conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const versionCancel = 80877102
+	if err := fe.Send(&pgproto3.StartupMessage{ProtocolVersion: versionCancel}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fe.Receive(); err != io.EOF {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if count := telemetry.GetFeatureCounts()["pgwire.unimplemented.cancel_request"]; count != 1 {
+		t.Fatalf("expected 1 cancel request, got %d", count)
+	}
+}

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -74,8 +75,9 @@ var (
 )
 
 const (
-	version30  = 196608
-	versionSSL = 80877103
+	version30     = 196608
+	versionSSL    = 80877103
+	versionCancel = 80877102
 )
 
 // cancelMaxWait is the amount of time a draining server gives to sessions to
@@ -206,7 +208,7 @@ func Match(rd io.Reader) bool {
 	if err != nil {
 		return false
 	}
-	return version == version30 || version == versionSSL
+	return version == version30 || version == versionSSL || version == versionCancel
 }
 
 // Start makes the Server ready for serving connections.
@@ -428,6 +430,11 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 	}
 
 	if version != version30 {
+		if version == versionCancel {
+			telemetry.Count("pgwire.unimplemented.cancel_request")
+			_ = conn.Close()
+			return nil
+		}
 		return sendErr(fmt.Errorf("unknown protocol version %d", version))
 	}
 	if errSSLRequired {


### PR DESCRIPTION
Backport 1/1 commits from #33202.

/cc @cockroachdb/release

---

Previously the cmuxer would not detect pgwire cancel requests as pgwire
and instead hand them off to GRPC causing them to hang. We still don't
support cancel, but it should be handled better by clients now.

Fixes #32973

Release note (bug fix): Cancel requests (via the pgwire protocol) will
now close quickly with an EOF instead of hang (but still don't cancel
the request).
