### PR TITLE
backport-2.1: sql: ensure orphaned lease deletion uses a post bootstrap timestamp

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1441,6 +1441,11 @@ func (s *Server) Start(ctx context.Context) error {
 		return errors.Wrap(err, "inspecting engines")
 	}
 
+	// Record a walltime that is lower than the lowest hlc timestamp this current
+	// instance of the node can use. We do not use startTime because it is lower
+	// than the timestamp used to create the bootstrap schema.
+	timeThreshold := s.clock.Now().WallTime
+
 	// Now that we have a monotonic HLC wrt previous incarnations of the process,
 	// init all the replicas. At this point *some* store has been bootstrapped or
 	// we're joining an existing cluster for the first time.
@@ -1688,7 +1693,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Delete all orphaned table leases created by a prior instance of this
 	// node.
-	s.leaseMgr.DeleteOrphanedLeases(startTime)
+	s.leaseMgr.DeleteOrphanedLeases(timeThreshold)
 
 	log.Event(ctx, "server ready")
 

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -1756,8 +1756,9 @@ func (m *LeaseManager) refreshSomeLeases(ctx context.Context) {
 }
 
 // DeleteOrphanedLeases releases all orphaned leases created by a prior
-// instance of this node.
-func (m *LeaseManager) DeleteOrphanedLeases(startTime time.Time) {
+// instance of this node. timeThreshold is a walltime lower than the
+// lowest hlc timestamp that the current instance of the node can use.
+func (m *LeaseManager) DeleteOrphanedLeases(timeThreshold int64) {
 	if m.testingKnobs.DisableDeleteOrphanedLeases {
 		return
 	}
@@ -1775,10 +1776,17 @@ func (m *LeaseManager) DeleteOrphanedLeases(startTime time.Time) {
 		// Read orphaned leases.
 		sqlQuery := fmt.Sprintf(`
 SELECT "descID", version, expiration FROM system.lease AS OF SYSTEM TIME %d WHERE "nodeID" = %d
-`, startTime.UnixNano(), nodeID)
-		rows, _, err := m.LeaseStore.execCfg.InternalExecutor.Query(
-			ctx, "read orphaned table leases", nil /*txn*/, sqlQuery)
-		if err != nil {
+`, timeThreshold, nodeID)
+		var rows []tree.Datums
+		retryOptions := base.DefaultRetryOptions()
+		retryOptions.Closer = m.stopper.ShouldQuiesce()
+		// The retry is required because of errors caused by node restarts. Retry 30 times.
+		if err := retry.WithMaxAttempts(ctx, retryOptions, 30, func() error {
+			var err error
+			rows, _, err = m.LeaseStore.execCfg.InternalExecutor.Query(
+				ctx, "read orphaned table leases", nil /*txn*/, sqlQuery)
+			return err
+		}); err != nil {
 			log.Warningf(ctx, "unable to read orphaned leases: %+v", err)
 			return
 		}

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -1763,7 +1763,7 @@ CREATE TABLE t.after (k CHAR PRIMARY KEY, v CHAR);
 
 	// Assume server shuts down here and a new instance of the server starts up.
 	// All leases created prior to this time are declared orphaned.
-	now := timeutil.Now()
+	now := timeutil.Now().UnixNano()
 
 	// Acquire a lease on "after" by name after server startup.
 	afterTable, _, err := t.node(1).AcquireByName(ctx, t.server.Clock().Now(), dbID, "after")


### PR DESCRIPTION
Backport 1/1 commits from #33168.

/cc @cockroachdb/release

---

This is to ensure that it doesn't see a system.lease table doesn't
exist error. Also retry orphaned lease request upto 30 times when
the request sees an error.

fixes #33121

Release note: None
