### PR TITLE
sql: update pg_catalog.pg_am to support Postgres v9.5 and v9.6

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -492,12 +492,12 @@ t3       c        text     1661428263    en-US
 
 ## pg_catalog.pg_am
 
-query OTOT colnames
+query OTIIBBBBBBBBBBBOOOOOOOOOOOOOOOOOT colnames
 SELECT *
 FROM pg_catalog.pg_am
 ----
-oid         amname  amhandler  amtype
-2631952481  prefix  NULL       i
+oid         amname  amstrategies  amsupport  amcanorder  amcanorderbyop  amcanbackward  amcanunique  amcanmulticol  amoptionalkey  amsearcharray  amsearchnulls  amstorage  amclusterable  ampredlocks  amkeytype  aminsert  ambeginscan  amgettuple  amgetbitmap  amrescan  amendscan  ammarkpos  amrestrpos  ambuild  ambuildempty  ambulkdelete  amvacuumcleanup  amcanreturn  amcostestimate  amoptions  amhandler  amtype
+2631952481  prefix  0             0          true        false           true           true         true           true           true           true           false      false          false        0          NULL      NULL         0           0            NULL      NULL       NULL       NULL        NULL     NULL          NULL          NULL             NULL         NULL            NULL       NULL       i
 
 ## pg_catalog.pg_attrdef
 

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -257,7 +257,7 @@ sort                                       ·            ·
                      │    └── filter       ·            ·
                      │         │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
                      │         └── values  ·            ·
-                     │                     size         20 columns, 929 rows
+                     │                     size         20 columns, 958 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -248,7 +248,7 @@ sort                                       ·            ·
                      │    └── filter       ·            ·
                      │         │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
                      │         └── values  ·            ·
-                     │                     size         20 columns, 929 rows
+                     │                     size         20 columns, 958 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -226,12 +226,45 @@ var pgCatalog = virtualSchema{
 	validWithNoDatabaseContext: false,
 }
 
-// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-am.html.
+// The catalog pg_am stores information about relation access methods.
+// It's important to note that this table changed drastically between Postgres
+// versions 9.5 and 9.6. We currently support both versions of this table.
+// See: https://www.postgresql.org/docs/9.5/static/catalog-pg-am.html and
+// https://www.postgresql.org/docs/9.6/static/catalog-pg-am.html.
 var pgCatalogAmTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE pg_catalog.pg_am (
 	oid OID,
 	amname NAME,
+	amstrategies INT,
+	amsupport INT,
+	amcanorder BOOL,
+	amcanorderbyop BOOL,
+	amcanbackward BOOL,
+	amcanunique BOOL,
+	amcanmulticol BOOL,
+	amoptionalkey BOOL,
+	amsearcharray BOOL,
+	amsearchnulls BOOL,
+	amstorage BOOL,
+	amclusterable BOOL,
+	ampredlocks BOOL,
+	amkeytype OID,
+	aminsert OID,
+	ambeginscan OID,
+	amgettuple OID,
+	amgetbitmap OID,
+	amrescan OID,
+	amendscan OID,
+	ammarkpos OID,
+	amrestrpos OID,
+	ambuild OID,
+	ambuildempty OID,
+	ambulkdelete OID,
+	amvacuumcleanup OID,
+	amcanreturn OID,
+	amcostestimate OID,
+	amoptions OID,
 	amhandler OID,
 	amtype CHAR
 )`,
@@ -239,10 +272,39 @@ CREATE TABLE pg_catalog.pg_am (
 		h := makeOidHasher()
 		h.writeStr(cockroachIndexEncoding)
 		return addRow(
-			h.getOid(),
-			tree.NewDName(cockroachIndexEncoding),
-			tree.DNull,
-			tree.NewDString("i"),
+			h.getOid(),                            // oid - all versions
+			tree.NewDName(cockroachIndexEncoding), // amname - all versions
+			zeroVal,              // amstrategies - < v9.6
+			zeroVal,              // amsupport - < v9.6
+			tree.DBoolTrue,       // amcanorder - < v9.6
+			tree.DBoolFalse,      // amcanorderbyop - < v9.6
+			tree.DBoolTrue,       // amcanbackward - < v9.6
+			tree.DBoolTrue,       // amcanunique - < v9.6
+			tree.DBoolTrue,       // amcanmulticol - < v9.6
+			tree.DBoolTrue,       // amoptionalkey - < v9.6
+			tree.DBoolTrue,       // amsearcharray - < v9.6
+			tree.DBoolTrue,       // amsearchnulls - < v9.6
+			tree.DBoolFalse,      // amstorage - < v9.6
+			tree.DBoolFalse,      // amclusterable - < v9.6
+			tree.DBoolFalse,      // ampredlocks - < v9.6
+			oidZero,              // amkeytype - < v9.6
+			tree.DNull,           // aminsert - < v9.6
+			tree.DNull,           // ambeginscan - < v9.6
+			oidZero,              // amgettuple - < v9.6
+			oidZero,              // amgetbitmap - < v9.6
+			tree.DNull,           // amrescan - < v9.6
+			tree.DNull,           // amendscan - < v9.6
+			tree.DNull,           // ammarkpos - < v9.6
+			tree.DNull,           // amrestrpos - < v9.6
+			tree.DNull,           // ambuild - < v9.6
+			tree.DNull,           // ambuildempty - < v9.6
+			tree.DNull,           // ambulkdelete - < v9.6
+			tree.DNull,           // amvacuumcleanup - < v9.6
+			tree.DNull,           // amcanreturn - < v9.6
+			tree.DNull,           // amcostestimate - < v9.6
+			tree.DNull,           // amoptions - < v9.6
+			tree.DNull,           // amhandler - > v9.6
+			tree.NewDString("i"), // amtype - > v9.6
 		)
 	},
 }


### PR DESCRIPTION
This table was updated between versions 9.5 and 9.6 and until this point we
only supported version 9.6 onward.

See: https://www.postgresql.org/docs/9.5/static/catalog-pg-am.html and
https://www.postgresql.org/docs/9.6/static/catalog-pg-am.html.

Part of #32624.

Release note (sql change): Support the pg_catalog introspection table pg_am for
both versions 9.5 and 9.6 which changed the table significantly.