### PR TITLE
exec: left outer join

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1336,6 +1336,7 @@ pkg/sql/exec/any_not_null_agg.eg.go: pkg/sql/exec/any_not_null_agg_tmpl.go
 pkg/sql/exec/avg_agg.eg.go: pkg/sql/exec/avg_agg_tmpl.go
 pkg/sql/exec/colvec.eg.go: pkg/sql/exec/colvec_tmpl.go
 pkg/sql/exec/distinct.eg.go: pkg/sql/exec/distinct_tmpl.go
+pkg/sql/exec/hashjoiner.eg.go: pkg/sql/exec/hashjoiner_tmpl.go
 pkg/sql/exec/quicksort.eg.go: pkg/sql/exec/quicksort_tmpl.go
 pkg/sql/exec/sort.eg.go: pkg/sql/exec/sort_tmpl.go
 pkg/sql/exec/sum_agg.eg.go: pkg/sql/exec/sum_agg_tmpl.go

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -66,11 +66,11 @@ func DecodeIndexKeyToCols(
 			}
 
 			length := int(ancestor.SharedPrefixLen)
-			key, err = DecodeKeyValsToCols(vecs[:length], idx, indexColIdx, types[:length], colDirs[:length], key)
+			key, err = DecodeKeyValsToCols(vecs, idx, indexColIdx[:length], types[:length], colDirs[:length], key)
 			if err != nil {
 				return nil, false, err
 			}
-			vecs, types, colDirs = vecs[length:], types[length:], colDirs[length:]
+			indexColIdx, types, colDirs = indexColIdx[length:], types[length:], colDirs[length:]
 
 			// Consume the interleaved sentinel.
 			var ok bool

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -76,6 +76,13 @@ type ColVec interface {
 	// the contents of this ColVec.
 	CopyWithSelInt16(vec ColVec, sel []uint16, nSel uint16, colType types.T)
 
+	// CopyWithSelAndNilsInt64 copies vec, filtered by sel, unless nils is set,
+	// into ColVec. It replaces the contents of this ColVec.
+	CopyWithSelAndNilsInt64(vec ColVec, sel []uint64, nSel uint16, nils []bool, colType types.T)
+	// CopyWithSelAndNilsInt64 copies vec, filtered by sel, unless nils is set,
+	// into ColVec. It replaces the contents of this ColVec.
+	CopyWithSelAndNilsInt16(vec ColVec, sel []uint16, nSel uint16, nils []bool, colType types.T)
+
 	PrettyValueAt(idx uint16) string
 }
 

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -102,6 +102,8 @@ type Nulls interface {
 
 	// UnsetNulls sets the column to have 0 null values.
 	UnsetNulls()
+	// SetNulls sets the column to have only null values.
+	SetNulls()
 }
 
 var _ ColVec = &memColumn{}
@@ -168,6 +170,13 @@ func (m *memColumn) UnsetNulls() {
 	m.hasNulls = false
 	for i := range m.nulls {
 		m.nulls[i] = 0
+	}
+}
+
+func (m *memColumn) SetNulls() {
+	m.hasNulls = true
+	for i := range m.nulls {
+		m.nulls[i] = ^0
 	}
 }
 

--- a/pkg/sql/exec/colvec_tmpl.go
+++ b/pkg/sql/exec/colvec_tmpl.go
@@ -156,3 +156,79 @@ func (m *memColumn) CopyWithSelInt16(vec ColVec, sel []uint16, nSel uint16, colT
 		panic(fmt.Sprintf("unhandled type %d", colType))
 	}
 }
+
+func (m *memColumn) CopyWithSelAndNilsInt64(
+	vec ColVec, sel []uint64, nSel uint16, nils []bool, colType types.T,
+) {
+	m.UnsetNulls()
+
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		toCol := m._TemplateType()
+		fromCol := vec._TemplateType()
+
+		if vec.HasNulls() {
+			for i := uint16(0); i < nSel; i++ {
+				if nils[i] {
+					m.SetNull(i)
+				} else {
+					if vec.NullAt64(sel[i]) {
+						m.SetNull(i)
+					} else {
+						toCol[i] = fromCol[sel[i]]
+					}
+				}
+			}
+		} else {
+			for i := uint16(0); i < nSel; i++ {
+				if nils[i] {
+					m.SetNull(i)
+				} else {
+					toCol[i] = fromCol[sel[i]]
+				}
+			}
+		}
+	// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
+
+func (m *memColumn) CopyWithSelAndNilsInt16(
+	vec ColVec, sel []uint16, nSel uint16, nils []bool, colType types.T,
+) {
+	m.UnsetNulls()
+
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		toCol := m._TemplateType()
+		fromCol := vec._TemplateType()
+
+		if vec.HasNulls() {
+			for i := uint16(0); i < nSel; i++ {
+				if nils[i] {
+					m.SetNull(i)
+				} else {
+					if vec.NullAt(sel[i]) {
+						m.SetNull(i)
+					} else {
+						toCol[i] = fromCol[sel[i]]
+					}
+				}
+			}
+		} else {
+			for i := uint16(0); i < nSel; i++ {
+				if nils[i] {
+					m.SetNull(i)
+				} else {
+					toCol[i] = fromCol[sel[i]]
+				}
+			}
+		}
+		// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}

--- a/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
@@ -47,6 +47,18 @@ func genHashJoiner(wr io.Writer) error {
 	rehash := regexp.MustCompile(`_REHASH_BODY\((.*)\)`)
 	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "SelInd" "$1"}}`)
 
+	distinctCollectRightOuter := regexp.MustCompile(`_DISTINCT_COLLECT_RIGHT_OUTER\((.*)\)`)
+	s = distinctCollectRightOuter.ReplaceAllString(s, `{{template "distinctCollectRightOuter" buildDict "Global" . "SelInd" "$1"}}`)
+
+	distinctCollectNoOuter := regexp.MustCompile(`_DISTINCT_COLLECT_NO_OUTER\((.*)\)`)
+	s = distinctCollectNoOuter.ReplaceAllString(s, `{{template "distinctCollectNoOuter" buildDict "Global" . "SelInd" "$1"}}`)
+
+	collectRightOuter := regexp.MustCompile(`_COLLECT_RIGHT_OUTER\((.*)\)`)
+	s = collectRightOuter.ReplaceAllString(s, `{{template "collectRightOuter" buildDict "Global" . "SelInd" "$1"}}`)
+
+	collectNoOuter := regexp.MustCompile(`_COLLECT_NO_OUTER\((.*)\)`)
+	s = collectNoOuter.ReplaceAllString(s, `{{template "collectNoOuter" buildDict "Global" . "SelInd" "$1"}}`)
+
 	checkCol := regexp.MustCompile(`_CHECK_COL_WITH_NULLS\((.*)\)`)
 	s = checkCol.ReplaceAllString(s, `{{template "checkColWithNulls" buildDict "Global" . "SelInd" "$1"}}`)
 

--- a/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
@@ -16,195 +16,76 @@ package main
 
 import (
 	"io"
+	"io/ioutil"
+	"regexp"
+	"strings"
 	"text/template"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/pkg/errors"
 )
 
-const hashJoinerTemplate = `
-package exec
-
-import (
-  "fmt"
-	"bytes"
-	"math"
-	
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
-)
-
-// rehash takes a element of a key (tuple representing a row of equality
-// column values) at a given column and computes a new hash by applying a
-// transformation to the existing hash.
-func (ht *hashTable) rehash(
-	buckets []uint64, keyIdx int, t types.T, col ColVec, nKeys uint64, sel []uint16,
-) {
-	switch t {
-	{{range .}}
-		case types.{{.ExecType}}:
-			keys := col.{{.ExecType}}()
-			if sel != nil {
-		  	for i := uint64(0); i < nKeys; i++ {
-					{{if eq .ExecType "Bool"}}
-						if keys[sel[i]] {
-							buckets[i] = buckets[i]*31 + 1
-						}
-					{{else if eq .ExecType "Bytes"}}
-					  hash := 1
-					  for b := range keys[sel[i]] {
-					  	hash = hash*31 + b
-					  }
-					  buckets[i] = buckets[i]*31 + uint64(hash)
-					{{else if (eq .ExecType "Float32")}}
-						buckets[i] = buckets[i]*31 + uint64(math.Float32bits(keys[sel[i]]))
-					{{else if (eq .ExecType "Float64")}}
-						buckets[i] = buckets[i]*31 + math.Float64bits(keys[sel[i]])
-					{{else if (eq .ExecType "Decimal")}}
-						d, err := keys[sel[i]].Float64()
-						if err != nil {
-							panic(fmt.Sprintf("%v", err))
-						}
-						buckets[i] = buckets[i]*31 + math.Float64bits(d)
-					{{else}}
-					  buckets[i] = buckets[i]*31 + uint64(keys[sel[i]])
-					{{end}}
-				}
-			} else {
-		  	for i := uint64(0); i < nKeys; i++ {
-					{{if eq .ExecType "Bool"}}
-						if keys[i] {
-							buckets[i] = buckets[i]*31 + 1
-						}
-					{{else if eq .ExecType "Bytes"}}
-						hash := 1
-						for b := range keys[i] {
-							hash = hash*31 + b
-						}
-						buckets[i] = buckets[i]*31 + uint64(hash)
-					{{else if (eq .ExecType "Float32")}}
-						buckets[i] = buckets[i]*31 + uint64(math.Float32bits(keys[i]))
-					{{else if (eq .ExecType "Float64")}}
-						buckets[i] = buckets[i]*31 + math.Float64bits(keys[i])
-					{{else if (eq .ExecType "Decimal")}}
-						d, err := keys[i].Float64()
-						if err != nil {
-							panic(fmt.Sprintf("%v", err))
-						}
-						buckets[i] = buckets[i]*31 + math.Float64bits(d)
-					{{else}}
-						buckets[i] = buckets[i]*31 + uint64(keys[i])
-					{{end}}
-				}
-			}
-	{{end}}
-	default:
-		panic(fmt.Sprintf("unhandled type %d", t))
-	}
-}
-
-// checkCol determines if the current key column in the groupID buckets matches
-// the specified equality column key. If there is a match, then the key is added
-// to differs. If the bucket has reached the end, the key is rejected. If any
-// element in the key is null, then there is no match.
-func (prober *hashJoinProber) checkCol(t types.T, keyColIdx int, nToCheck uint16, sel []uint16) {
-	switch t {
-	{{range .}}
-		case types.{{.ExecType}}:
-			buildVec := prober.ht.vals[prober.ht.keyCols[keyColIdx]]
-			probeVec := prober.keys[keyColIdx]
-
-			buildKeys := buildVec.{{.ExecType}}()
-			probeKeys := probeVec.{{.ExecType}}()
-
-			if sel != nil {
-				for i := uint16(0); i < nToCheck; i++ {
-					// keyID of 0 is reserved to represent the end of the next chain.
-					if keyID := prober.groupID[prober.toCheck[i]]; keyID != 0 {
-						// the build table key (calculated using keys[keyID - 1] = key) is
-						// compared to the corresponding probe table to determine if a match is
-						// found.
-
-						if probeVec.NullAt(sel[prober.toCheck[i]]) {
-							prober.groupID[prober.toCheck[i]] = 0
-						} else if buildVec.NullAt64(keyID-1) {
-							prober.differs[prober.toCheck[i]] = true
-						} else {
-						{{if eq .ExecType "Bytes"}}
-							if !bytes.Equal(buildKeys[keyID-1], probeKeys[sel[prober.toCheck[i]]]) {
-								prober.differs[prober.toCheck[i]] = true
-							}
-						{{else if (eq .ExecType "Decimal")}}
-							if buildKeys[keyID-1].Cmp(&probeKeys[sel[prober.toCheck[i]]]) != 0 {
-								prober.differs[prober.toCheck[i]] = true
-							}
-						{{else}}
-							if buildKeys[keyID-1] != probeKeys[sel[prober.toCheck[i]]] {
-								prober.differs[prober.toCheck[i]] = true
-							}
-						{{end}}
-						}
-					}
-				}
-			} else {
-				for i := uint16(0); i < nToCheck; i++ {
-					// keyID of 0 is reserved to represent the end of the next chain.
-					if keyID := prober.groupID[prober.toCheck[i]]; keyID != 0 {
-						// the build table key (calculated using keys[keyID - 1] = key) is
-						// compared to the corresponding probe table to determine if a match is
-						// found.
-
-						if probeVec.NullAt(prober.toCheck[i]) {
-							prober.groupID[prober.toCheck[i]] = 0
-						} else if buildVec.NullAt64(keyID-1) {
-							prober.differs[prober.toCheck[i]] = true
-						} else {
-						{{if eq .ExecType "Bytes"}}
-							if !bytes.Equal(buildKeys[keyID-1], probeKeys[prober.toCheck[i]]) {
-								prober.differs[prober.toCheck[i]] = true
-							}
-						{{else if (eq .ExecType "Decimal")}}
-							if buildKeys[keyID-1].Cmp(&probeKeys[prober.toCheck[i]]) != 0 {
-								prober.differs[prober.toCheck[i]] = true
-							}
-						{{else}}
-							if buildKeys[keyID-1] != probeKeys[prober.toCheck[i]] {
-								prober.differs[prober.toCheck[i]] = true
-							}
-						{{end}}
-						}
-					}
-				}
-			}
-	{{end}}
-	default:
-		panic(fmt.Sprintf("unhandled type %d", t))
-	}
-}
-`
-
-type hashJoinerGen struct {
-	ExecType string
-	GoType   string
-}
-
-func genHashJoinerDistinct(wr io.Writer) error {
-	// Build list of all exec types.
-	var gens []hashJoinerGen
-	for _, t := range types.AllTypes {
-		gen := hashJoinerGen{
-			ExecType: t.String(),
-			GoType:   t.GoTypeName(),
-		}
-		gens = append(gens, gen)
-	}
-
-	tmpl, err := template.New("hashJoinerTemplate").Parse(hashJoinerTemplate)
+func genHashJoiner(wr io.Writer) error {
+	t, err := ioutil.ReadFile("pkg/sql/exec/hashjoiner_tmpl.go")
 	if err != nil {
 		return err
 	}
 
-	return tmpl.Execute(wr, gens)
+	s := string(t)
+
+	s = strings.Replace(s, "_TYPES_T", "types.{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "_SEL_IND", "{{.SelInd}}", -1)
+
+	assignNeRe := regexp.MustCompile(`_ASSIGN_NE\((.*),(.*),(.*)\)`)
+	s = assignNeRe.ReplaceAllString(s, "{{.Global.Assign $1 $2 $3}}")
+
+	assignHash := regexp.MustCompile(`_ASSIGN_HASH\((.*),(.*)\)`)
+	s = assignHash.ReplaceAllString(s, "{{.Global.UnaryAssign $1 $2}}")
+
+	rehash := regexp.MustCompile(`_REHASH_BODY\((.*)\)`)
+	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "SelInd" "$1"}}`)
+
+	checkCol := regexp.MustCompile(`_CHECK_COL_WITH_NULLS\((.*)\)`)
+	s = checkCol.ReplaceAllString(s, `{{template "checkColWithNulls" buildDict "Global" . "SelInd" "$1"}}`)
+
+	checkColMain := regexp.MustCompile(`_CHECK_COL_MAIN\((.*\))`)
+	s = checkColMain.ReplaceAllString(s, `{{template "checkColMain" .}}`)
+
+	checkColBody := regexp.MustCompile(`_CHECK_COL_BODY\((.*),(.*),(.*)\)`)
+	s = checkColBody.ReplaceAllString(s, `{{template "checkColBody" buildDict "Global" .Global "SelInd" .SelInd "ProbeHasNulls" $2 "BuildHasNulls" $3}}`)
+
+	tmpl, err := template.New("hashjoiner_op").Funcs(template.FuncMap{
+		"buildDict": func(values ...interface{}) (map[string]interface{}, error) {
+			if len(values)%2 != 0 {
+				return nil, errors.New("invalid call to buildDict")
+			}
+			dict := make(map[string]interface{}, len(values)/2)
+			for i := 0; i < len(values); i += 2 {
+				key, ok := values[i].(string)
+				if !ok {
+					return nil, errors.New("buildDict keys must be strings")
+				}
+				dict[key] = values[i+1]
+			}
+			return dict, nil
+		},
+	}).Parse(s)
+
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, struct {
+		NETemplate   interface{}
+		HashTemplate interface{}
+	}{
+		NETemplate:   comparisonOpToOverloads[tree.NE],
+		HashTemplate: hashOverloads,
+	})
 }
 
 func init() {
-	registerGenerator(genHashJoinerDistinct, "hashjoiner.eg.go")
+	registerGenerator(genHashJoiner, "hashjoiner.eg.go")
 }

--- a/pkg/sql/exec/execgen/cmd/execgen/overloads.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/overloads.go
@@ -78,8 +78,9 @@ type overload struct {
 
 	// TODO(solon): These would not be necessary if we changed the zero values of
 	// ComparisonOperator and BinaryOperator to be invalid.
-	IsCmpOp bool
-	IsBinOp bool
+	IsCmpOp  bool
+	IsBinOp  bool
+	IsHashOp bool
 }
 
 type assignFunc func(op overload, target, l, r string) string
@@ -95,6 +96,10 @@ var binaryOpToOverloads map[tree.BinaryOperator][]*overload
 // that implement it.
 var comparisonOpToOverloads map[tree.ComparisonOperator][]*overload
 
+// hashOverloads is a list of all of the overloads that implement the hash
+// operation.
+var hashOverloads []*overload
+
 // Assign produces a Go source string that assigns the "target" variable to the
 // result of applying the overload to the two inputs, l and r.
 //
@@ -108,6 +113,16 @@ func (o overload) Assign(target, l, r string) string {
 	}
 	// Default assign form assumes an infix operator.
 	return fmt.Sprintf("%s = %s %s %s", target, l, o.OpStr, r)
+}
+
+func (o overload) UnaryAssign(target, v string) string {
+	if o.AssignFunc != nil {
+		if ret := o.AssignFunc(o, target, v, ""); ret != "" {
+			return ret
+		}
+	}
+	// Default assign form assumes a function operator.
+	return fmt.Sprintf("%s = %s(%s)", target, o.OpStr, v)
 }
 
 func init() {
@@ -167,6 +182,18 @@ func init() {
 			comparisonOpOverloads = append(comparisonOpOverloads, ov)
 			comparisonOpToOverloads[op] = append(comparisonOpToOverloads[op], ov)
 		}
+
+		ov := &overload{
+			IsHashOp: true,
+			LTyp:     t,
+			OpStr:    "uint64",
+		}
+		if customizer != nil {
+			if b, ok := customizer.(hashTypeCustomizer); ok {
+				ov.AssignFunc = b.getHashAssignFunc()
+			}
+		}
+		hashOverloads = append(hashOverloads, ov)
 	}
 }
 
@@ -198,6 +225,12 @@ type cmpOpTypeCustomizer interface {
 	getCmpOpAssignFunc() assignFunc
 }
 
+// hashTypeCustomizer is a type customizer that changes how the templater
+// produces hash output for a particular type.
+type hashTypeCustomizer interface {
+	getHashAssignFunc() assignFunc
+}
+
 // boolCustomizer is necessary since bools don't support < <= > >= in Go.
 type boolCustomizer struct{}
 
@@ -210,6 +243,11 @@ type bytesCustomizer struct{}
 // variable-set semantics.
 type decimalCustomizer struct{}
 
+// float32Customizer and float64Customizer are necessary since float32 and
+// float64 require additional logic for hashing.
+type float32Customizer struct{}
+type float64Customizer struct{}
+
 func (boolCustomizer) getCmpOpAssignFunc() assignFunc {
 	return func(op overload, target, l, r string) string {
 		switch op.CmpOp {
@@ -218,6 +256,18 @@ func (boolCustomizer) getCmpOpAssignFunc() assignFunc {
 		}
 		return fmt.Sprintf("%s = tree.CompareBools(%s, %s) %s 0",
 			target, l, r, op.OpStr)
+	}
+}
+
+func (boolCustomizer) getHashAssignFunc() assignFunc {
+	return func(op overload, target, v, _ string) string {
+		return fmt.Sprintf(`
+			x := uint64(0)
+			if %[2]s {
+    		x = 1
+			}
+			%[1]s = x
+		`, target, v)
 	}
 }
 
@@ -231,6 +281,18 @@ func (bytesCustomizer) getCmpOpAssignFunc() assignFunc {
 		}
 		return fmt.Sprintf("%s = bytes.Compare(%s, %s) %s 0",
 			target, l, r, op.OpStr)
+	}
+}
+
+func (bytesCustomizer) getHashAssignFunc() assignFunc {
+	return func(op overload, target, v, _ string) string {
+		return fmt.Sprintf(`
+			_temp := 1
+			for b := range %s {
+				_temp = _temp*31 + b
+			}
+			%s = uint64(hash)
+		`, v, target)
 	}
 }
 
@@ -248,12 +310,39 @@ func (decimalCustomizer) getBinOpAssignFunc() assignFunc {
 	}
 }
 
+func (decimalCustomizer) getHashAssignFunc() assignFunc {
+	return func(op overload, target, v, _ string) string {
+		return fmt.Sprintf(`
+			d, err := %[2]s.Float64()
+			if err != nil {
+				panic(fmt.Sprintf("%%v", err))
+			}
+			%[1]s = math.Float64bits(d)
+		`, target, v)
+	}
+}
+
+func (float32Customizer) getHashAssignFunc() assignFunc {
+	return func(op overload, target, v, _ string) string {
+		return fmt.Sprintf("%s = uint64(math.Float32bits(%s))", target, v)
+	}
+}
+
+func (float64Customizer) getHashAssignFunc() assignFunc {
+	return func(op overload, target, v, _ string) string {
+		return fmt.Sprintf("%s = math.Float64bits(%s)", target, v)
+	}
+}
+
 func registerTypeCustomizers() {
 	typeCustomizers = make(map[types.T]typeCustomizer)
 	registerTypeCustomizer(types.Bool, boolCustomizer{})
 	registerTypeCustomizer(types.Bytes, bytesCustomizer{})
 	registerTypeCustomizer(types.Decimal, decimalCustomizer{})
+	registerTypeCustomizer(types.Float32, float32Customizer{})
+	registerTypeCustomizer(types.Float64, float64Customizer{})
 }
 
 // Avoid unused warning for Assign, which is only used in templates.
 var _ = overload{}.Assign
+var _ = overload{}.UnaryAssign

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -55,6 +55,54 @@ func TestHashJoinerInt64(t *testing.T) {
 		expectedTuples tuples
 	}{
 		{
+			leftTypes:  []types.T{types.Int64},
+			rightTypes: []types.T{types.Int64},
+
+			// Test null handling only on probe column.
+			leftTuples: tuples{
+				{0},
+			},
+			rightTuples: tuples{
+				{nil},
+				{0},
+			},
+
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			leftOutCols:  []uint32{0},
+			rightOutCols: []uint32{},
+
+			expectedTuples: tuples{
+				{0},
+			},
+		},
+		{
+			leftTypes:  []types.T{types.Int64},
+			rightTypes: []types.T{types.Int64},
+
+			// Test null handling only on build column.
+			leftTuples: tuples{
+				{nil},
+				{nil},
+				{1},
+				{0},
+			},
+			rightTuples: tuples{
+				{1},
+				{0},
+			},
+
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			leftOutCols:  []uint32{0},
+			rightOutCols: []uint32{},
+
+			expectedTuples: tuples{
+				{1},
+				{0},
+			},
+		},
+		{
 			leftTypes:  []types.T{types.Int64, types.Int64},
 			rightTypes: []types.T{types.Int64, types.Int64},
 

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -61,6 +61,39 @@ func TestHashJoinerInt64(t *testing.T) {
 			leftTypes:  []types.T{types.Int64},
 			rightTypes: []types.T{types.Int64},
 
+			leftTuples: tuples{
+				{0},
+				{1},
+				{2},
+				{3},
+				{4},
+			},
+			rightTuples: tuples{
+				{1},
+				{3},
+				{5},
+			},
+
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			leftOutCols:  []uint32{0},
+			rightOutCols: []uint32{0},
+
+			leftOuter:     true,
+			buildDistinct: true,
+
+			expectedTuples: tuples{
+				{1, 1},
+				{3, 3},
+				{0, nil},
+				{2, nil},
+				{4, nil},
+			},
+		},
+		{
+			leftTypes:  []types.T{types.Int64},
+			rightTypes: []types.T{types.Int64},
+
 			// Test right outer join.
 			leftTuples: tuples{
 				{0},

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -52,8 +52,38 @@ func TestHashJoinerInt64(t *testing.T) {
 		buildRightSide bool
 		buildDistinct  bool
 
+		leftOuter  bool
+		rightOuter bool
+
 		expectedTuples tuples
 	}{
+		{
+			leftTypes:  []types.T{types.Int64},
+			rightTypes: []types.T{types.Int64},
+
+			// Test right outer join.
+			leftTuples: tuples{
+				{0},
+				{1},
+			},
+			rightTuples: tuples{
+				{1},
+				{2},
+			},
+
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
+			leftOutCols:  []uint32{0},
+			rightOutCols: []uint32{0},
+
+			rightOuter:    true,
+			buildDistinct: true,
+
+			expectedTuples: tuples{
+				{1, 1},
+				{nil, 2},
+			},
+		},
 		{
 			leftTypes:  []types.T{types.Int64},
 			rightTypes: []types.T{types.Int64},
@@ -591,6 +621,7 @@ func TestHashJoinerInt64(t *testing.T) {
 							outCols:     tc.leftOutCols,
 							sourceTypes: tc.leftTypes,
 							source:      leftSource,
+							outer:       tc.leftOuter,
 						},
 
 						right: hashJoinerSourceSpec{
@@ -598,6 +629,7 @@ func TestHashJoinerInt64(t *testing.T) {
 							outCols:     tc.rightOutCols,
 							sourceTypes: tc.rightTypes,
 							source:      rightSource,
+							outer:       tc.rightOuter,
 						},
 
 						buildRightSide: tc.buildRightSide,
@@ -667,47 +699,52 @@ func BenchmarkHashJoiner(b *testing.B) {
 				}
 			}
 
-			for _, buildDistinct := range []bool{true, false} {
-				b.Run(fmt.Sprintf("distinct=%v", buildDistinct), func(b *testing.B) {
-					for _, nBatches := range []int{1 << 1, 1 << 8, 1 << 12, 1 << 16} {
-						b.Run(fmt.Sprintf("rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
-							// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
-							// batch) * nCols (number of columns / row) * 2 (number of sources).
-							b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols * 2))
-							b.ResetTimer()
-							for i := 0; i < b.N; i++ {
-								leftSource := newFiniteBatchSource(batch, nBatches)
-								rightSource := newRepeatableBatchSource(batch)
+			for _, rightOuter := range []bool{true, false} {
+				b.Run(fmt.Sprintf("rightOuter=%v", rightOuter), func(b *testing.B) {
+					for _, buildDistinct := range []bool{true, false} {
+						b.Run(fmt.Sprintf("distinct=%v", buildDistinct), func(b *testing.B) {
+							for _, nBatches := range []int{1 << 1, 1 << 8, 1 << 12} {
+								b.Run(fmt.Sprintf("rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
+									// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+									// batch) * nCols (number of columns / row) * 2 (number of sources).
+									b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols * 2))
+									b.ResetTimer()
+									for i := 0; i < b.N; i++ {
+										leftSource := newFiniteBatchSource(batch, nBatches)
+										rightSource := newRepeatableBatchSource(batch)
 
-								spec := hashJoinerSpec{
-									left: hashJoinerSourceSpec{
-										eqCols:      []uint32{0, 2},
-										outCols:     []uint32{0, 1},
-										sourceTypes: sourceTypes,
-										source:      leftSource,
-									},
+										spec := hashJoinerSpec{
+											left: hashJoinerSourceSpec{
+												eqCols:      []uint32{0, 2},
+												outCols:     []uint32{0, 1},
+												sourceTypes: sourceTypes,
+												source:      leftSource,
+											},
 
-									right: hashJoinerSourceSpec{
-										eqCols:      []uint32{1, 3},
-										outCols:     []uint32{2, 3},
-										sourceTypes: sourceTypes,
-										source:      rightSource,
-									},
+											right: hashJoinerSourceSpec{
+												eqCols:      []uint32{1, 3},
+												outCols:     []uint32{2, 3},
+												sourceTypes: sourceTypes,
+												source:      rightSource,
+												outer:       rightOuter,
+											},
 
-									buildDistinct: buildDistinct,
-								}
+											buildDistinct: buildDistinct,
+										}
 
-								hj := &hashJoinEqInnerOp{
-									spec: spec,
-								}
+										hj := &hashJoinEqInnerOp{
+											spec: spec,
+										}
 
-								hj.Init()
+										hj.Init()
 
-								for i := 0; i < nBatches; i++ {
-									// Technically, the non-distinct hash join will produce much more
-									// than nBatches of output.
-									hj.Next()
-								}
+										for i := 0; i < nBatches; i++ {
+											// Technically, the non-distinct hash join will produce much more
+											// than nBatches of output.
+											hj.Next()
+										}
+									}
+								})
 							}
 						})
 					}

--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -1,0 +1,170 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for hashjoiner.eg.go. It's formatted in a
+// special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package exec
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// {{/*
+
+// Dummy import to pull in "tree" package.
+var _ tree.Datum
+
+// Dummy import to pull in "math" package
+var _ = math.Pi
+
+// Dummy import to pull in "bytes" package.
+var _ bytes.Buffer
+
+// _ASSIGN_HASH is the template equality function for assigning the first input
+// to the result of the hash value of the second input.
+func _ASSIGN_HASH(_, _ string) uint64 {
+	panic("")
+}
+
+func _CHECK_COL_MAIN(_SEL_IND uin64) { // */}}
+	// {{define "checkColMain"}}
+	buildVal := buildKeys[keyID-1]
+	probeVal := probeKeys[_SEL_IND]
+	var unique bool
+	_ASSIGN_NE("unique", "buildVal", "probeVal")
+
+	if unique {
+		prober.differs[prober.toCheck[i]] = true
+	}
+	// {{end}}
+
+	// {{/*
+}
+
+func _CHECK_COL_BODY(_SEL_IND uint64, _PROBE_HAS_NULLS bool, BUILD_HAS_NULLS bool) { // */}}
+	// {{define "checkColBody"}}
+	for i := uint16(0); i < nToCheck; i++ {
+		// keyID of 0 is reserved to represent the end of the next chain.
+
+		if keyID := prober.groupID[prober.toCheck[i]]; keyID != 0 {
+			// the build table key (calculated using keys[keyID - 1] = key) is
+			// compared to the corresponding probe table to determine if a match is
+			// found.
+
+			/* {{if .ProbeHasNulls }} */
+			if probeVec.NullAt(_SEL_IND) {
+				prober.groupID[prober.toCheck[i]] = 0
+			} else /*{{end}} {{if .BuildHasNulls}} */ if buildVec.NullAt64(keyID - 1) {
+				prober.differs[prober.toCheck[i]] = true
+			} else /*{{end}} */ {
+				_CHECK_COL_MAIN(_SEL_IND)
+			}
+		}
+	}
+	// {{end}}
+	// {{/*
+}
+
+func _CHECK_COL_WITH_NULLS(_SEL_IND uint64) { // */}}
+	// {{define "checkColWithNulls"}}
+	if probeVec.HasNulls() {
+		if buildVec.HasNulls() {
+			_CHECK_COL_BODY(_SEL_IND, true, true)
+		} else {
+			_CHECK_COL_BODY(_SEL_IND, true, false)
+		}
+	} else {
+		if buildVec.HasNulls() {
+			_CHECK_COL_BODY(_SEL_IND, false, true)
+		} else {
+			_CHECK_COL_BODY(_SEL_IND, false, false)
+		}
+	}
+	// {{end}}
+	// {{/*
+}
+
+func _REHASH_BODY(_ string) { // */}}
+	// {{define "rehashBody"}}
+	for i := uint64(0); i < nKeys; i++ {
+		v := keys[_SEL_IND]
+		var hash uint64
+		_ASSIGN_HASH("hash", "v")
+		buckets[i] = buckets[i]*31 + hash
+	}
+	// {{end}}
+
+	// {{/*
+}
+
+// */}}
+
+// rehash takes a element of a key (tuple representing a row of equality
+// column values) at a given column and computes a new hash by applying a
+// transformation to the existing hash.
+func (ht *hashTable) rehash(
+	buckets []uint64, keyIdx int, t types.T, col ColVec, nKeys uint64, sel []uint16,
+) {
+	switch t {
+	// {{range $hashType := .HashTemplate}}
+	case _TYPES_T:
+		keys := col._TemplateType()
+		if sel != nil {
+			_REHASH_BODY(sel[i])
+		} else {
+			_REHASH_BODY(i)
+		}
+
+	// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", t))
+	}
+}
+
+// checkCol determines if the current key column in the groupID buckets matches
+// the specified equality column key. If there is a match, then the key is added
+// to differs. If the bucket has reached the end, the key is rejected. If any
+// element in the key is null, then there is no match.
+func (prober *hashJoinProber) checkCol(t types.T, keyColIdx int, nToCheck uint16, sel []uint16) {
+	switch t {
+	// {{range $neType := .NETemplate}}
+	case _TYPES_T:
+		buildVec := prober.ht.vals[prober.ht.keyCols[keyColIdx]]
+		probeVec := prober.keys[keyColIdx]
+
+		buildKeys := buildVec._TemplateType()
+		probeKeys := probeVec._TemplateType()
+
+		if sel != nil {
+			_CHECK_COL_WITH_NULLS(sel[prober.toCheck[i]])
+		} else {
+			_CHECK_COL_WITH_NULLS(prober.toCheck[i])
+		}
+		// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", t))
+	}
+}

--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -49,7 +49,7 @@ func _ASSIGN_HASH(_, _ string) uint64 {
 	panic("")
 }
 
-func _CHECK_COL_MAIN(_SEL_IND uin64) { // */}}
+func _CHECK_COL_MAIN(_SEL_IND uint64) { // */}}
 	// {{define "checkColMain"}}
 	buildVal := buildKeys[keyID-1]
 	probeVal := probeKeys[_SEL_IND]
@@ -120,6 +120,84 @@ func _REHASH_BODY(_ string) { // */}}
 	// {{/*
 }
 
+func _COLLECT_RIGHT_OUTER(_SEL_IND uint64) { // */}}
+	// {{define "collectRightOuter"}}
+	for i := uint16(0); i < batchSize; i++ {
+		currentID := prober.head[i]
+
+		if currentID == 0 {
+			prober.buildNil[nResults] = true
+		}
+
+		for {
+			if nResults >= ColBatchSize {
+				prober.prevBatch = batch
+				return nResults
+			}
+
+			prober.buildIdx[nResults] = currentID - 1
+			prober.probeIdx[nResults] = _SEL_IND
+			currentID = prober.ht.same[currentID]
+			prober.head[i] = currentID
+			nResults++
+
+			if currentID == 0 {
+				break
+			}
+		}
+	}
+	// {{end}}
+	// {{/*
+}
+
+func _COLLECT_NO_OUTER(_SEL_IND uint64) { // */}}
+	// {{define "collectNoOuter"}}
+	for i := uint16(0); i < batchSize; i++ {
+		currentID := prober.head[i]
+		for currentID != 0 {
+			if nResults >= ColBatchSize {
+				prober.prevBatch = batch
+				return nResults
+			}
+
+			prober.buildIdx[nResults] = currentID - 1
+			prober.probeIdx[nResults] = _SEL_IND
+			currentID = prober.ht.same[currentID]
+			prober.head[i] = currentID
+			nResults++
+		}
+	}
+	// {{end}}
+	// {{/*
+}
+
+func _DISTINCT_COLLECT_RIGHT_OUTER(_SEL_IND uint64) { // */}}
+	// {{define "distinctCollectRightOuter"}}
+	for i := uint16(0); i < batchSize; i++ {
+		// Index of keys and outputs in the hash table is calculated as ID - 1.
+		prober.buildIdx[i] = prober.groupID[i] - 1
+		prober.probeIdx[i] = _SEL_IND
+
+		prober.buildNil[i] = prober.groupID[i] == 0
+	}
+	// {{end}}
+	// {{/*
+}
+
+func _DISTINCT_COLLECT_NO_OUTER(_SEL_IND uint16) { // */}}
+	// {{define "distinctCollectNoOuter"}}
+	for i := uint16(0); i < batchSize; i++ {
+		if prober.groupID[i] != 0 {
+			// Index of keys and outputs in the hash table is calculated as ID - 1.
+			prober.buildIdx[nResults] = prober.groupID[i] - 1
+			prober.probeIdx[nResults] = _SEL_IND
+			nResults++
+		}
+	}
+	// {{end}}
+	// {{/*
+}
+
 // */}}
 
 // rehash takes a element of a key (tuple representing a row of equality
@@ -167,4 +245,62 @@ func (prober *hashJoinProber) checkCol(t types.T, keyColIdx int, nToCheck uint16
 	default:
 		panic(fmt.Sprintf("unhandled type %d", t))
 	}
+}
+
+// collect prepares the buildIdx and probeIdx arrays where the buildIdx and
+// probeIdx at each index are joined to make an output row. The total number of
+// resulting rows is returned.
+func (prober *hashJoinProber) collect(batch ColBatch, batchSize uint16, sel []uint16) uint16 {
+	nResults := uint16(0)
+
+	if prober.spec.outer {
+		if sel != nil {
+			_COLLECT_RIGHT_OUTER(sel[i])
+		} else {
+			_COLLECT_RIGHT_OUTER(i)
+		}
+	} else {
+		if sel != nil {
+			_COLLECT_NO_OUTER(sel[i])
+		} else {
+			_COLLECT_NO_OUTER(i)
+		}
+	}
+
+	return nResults
+}
+
+// distinctCollect prepares the batch with the joined output columns where the build
+// row index for each probe row is given in the groupID slice. This function
+// requires assumes a N-1 hash join.
+func (prober *hashJoinProber) distinctCollect(
+	batch ColBatch, batchSize uint16, sel []uint16,
+) uint16 {
+	nResults := uint16(0)
+
+	if prober.spec.outer {
+		nResults = batchSize
+
+		if sel != nil {
+			_DISTINCT_COLLECT_RIGHT_OUTER(sel[i])
+		} else {
+			_DISTINCT_COLLECT_RIGHT_OUTER(i)
+		}
+	} else {
+		if sel != nil {
+			_DISTINCT_COLLECT_NO_OUTER(sel[i])
+		} else {
+			_DISTINCT_COLLECT_NO_OUTER(i)
+		}
+	}
+
+	if prober.buildOuter {
+		// if buildOuter is set, we need to mark all of the build table rows
+		// that have been probed.
+		for _, ID := range prober.groupID {
+			prober.ht.visited[ID] = true
+		}
+	}
+
+	return nResults
 }

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -1,4 +1,4 @@
-# LogicTest: local local-opt local-parallel-stmts fakedist fakedist-opt fakedist-metadata
+# LogicTest: local local-opt local-vec local-parallel-stmts fakedist fakedist-opt fakedist-metadata
 
 # Grandparent table
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -1,4 +1,4 @@
-# LogicTest: local local-opt local-parallel-stmts fakedist fakedist-opt fakedist-metadata
+# LogicTest: local local-opt local-vec local-parallel-stmts fakedist fakedist-opt fakedist-metadata
 
 # SELECT with no table.
 

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -60,11 +61,6 @@ type cTableInfo struct {
 	// The set of indexes into the cols array that are required for columns
 	// in the value part.
 	neededValueColsByIdx util.FastIntSet
-
-	// The number of needed columns from the value part of the row. Once we've
-	// seen this number of value columns for a particular row, we can stop
-	// decoding values in that row.
-	neededValueCols int
 
 	// Map used to get the index for columns in cols.
 	colIdxMap map[sqlbase.ColumnID]int
@@ -153,9 +149,13 @@ type CFetcher struct {
 		// curSpan is the current span that the kv fetcher just returned data from.
 		curSpan roachpb.Span
 		// nextKV is the kv to process next.
-		nextKV roachpb.KeyValue
+		nextKV *roachpb.KeyValue
 		// seekPrefix is the prefix to seek to in stateSeekPrefix.
 		seekPrefix roachpb.Key
+		// how many needed cols we've found so far in the value
+		valueColsFound int
+
+		remainingValueColsByIdx util.FastIntSet
 		// lastRowPrefix is the row prefix for the last row we saw a key for. New
 		// keys are compared against this prefix to determine whether they're part
 		// of a new row or not.
@@ -232,6 +232,11 @@ func (rf *CFetcher) Init(
 	var indexColumnIDs []sqlbase.ColumnID
 	indexColumnIDs, table.indexColumnDirs = table.index.FullColumnIDs()
 
+	compositeColumnIDs := util.MakeFastIntSet()
+	for _, id := range table.index.CompositeColumnIDs {
+		compositeColumnIDs.Add(int(id))
+	}
+
 	table.neededValueColsByIdx = tableArgs.ValNeededForCol.Copy()
 	neededIndexCols := 0
 	nIndexCols := len(indexColumnIDs)
@@ -246,7 +251,11 @@ func (rf *CFetcher) Init(
 			table.indexColOrdinals[i] = colIdx
 			if table.neededCols.Contains(int(id)) {
 				neededIndexCols++
-				table.neededValueColsByIdx.Remove(colIdx)
+				if !compositeColumnIDs.Contains(int(id)) {
+					// A composite column lives both in the index and in the value; if
+					// its needed, it must also be decoded from the value.
+					table.neededValueColsByIdx.Remove(colIdx)
+				}
 			}
 		} else {
 			table.indexColOrdinals[i] = -1
@@ -263,11 +272,6 @@ func (rf *CFetcher) Init(
 		if neededIndexCols > 0 || len(table.index.InterleavedBy) > 0 || len(table.index.Interleave.Ancestors) > 0 {
 			rf.mustDecodeIndexKey = true
 		}
-
-		// The number of columns we need to read from the value part of the key.
-		// It's the total number of needed columns minus the ones we read from the
-		// index key, except for composite columns.
-		table.neededValueCols = table.neededCols.Len() - neededIndexCols + len(table.index.CompositeColumnIDs)
 
 		if table.isSecondaryIndex {
 			for i := range table.cols {
@@ -382,6 +386,10 @@ const (
 	//     -> decodeFirstKVOfRow
 	stateInitFetch
 
+	// stateResetBatch resets the batch of a fetcher, removing nulls and the
+	// selection vector.
+	stateResetBatch
+
 	// stateDecodeFirstKVOfRow is the state of looking at a key that is part of
 	// a row that the fetcher hasn't processed before. s.machine.nextKV must be
 	// set.
@@ -492,9 +500,15 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (exec.ColBatch, error) {
 				*/
 			}
 
-			rf.machine.nextKV = kv
+			rf.machine.nextKV = &kv
 			rf.machine.state[0] = stateDecodeFirstKVOfRow
 
+		case stateResetBatch:
+			for i := range rf.machine.colvecs {
+				rf.machine.colvecs[i].UnsetNulls()
+			}
+			rf.machine.batch.SetSelection(false)
+			rf.shiftState()
 		case stateDecodeFirstKVOfRow:
 			if rf.mustDecodeIndexKey {
 				if debugState {
@@ -527,6 +541,7 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (exec.ColBatch, error) {
 				prefix := rf.machine.nextKV.Key[:len(rf.machine.nextKV.Key)-len(key)]
 				rf.machine.lastRowPrefix = prefix
 			}
+			rf.machine.remainingValueColsByIdx.CopyFrom(rf.table.neededValueColsByIdx)
 			// Process the current KV's value component.
 			if _, _, err := rf.processValue(ctx, sqlbase.FamilyID(0)); err != nil {
 				return nil, err
@@ -555,7 +570,7 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (exec.ColBatch, error) {
 				// TODO(jordan): if nextKV returns newSpan = true, set the new span
 				// prefix and indicate that it needs decoding.
 				if bytes.Compare(kv.Key, rf.machine.seekPrefix) >= 0 {
-					rf.machine.nextKV = kv
+					rf.machine.nextKV = &kv
 					break
 				}
 			}
@@ -574,7 +589,7 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (exec.ColBatch, error) {
 			}
 			// TODO(jordan): if nextKV returns newSpan = true, set the new span
 			// prefix and indicate that it needs decoding.
-			rf.machine.nextKV = kv
+			rf.machine.nextKV = &kv
 
 			// TODO(jordan): optimize this prefix check by skipping span prefix.
 			if !bytes.HasPrefix(kv.Key, rf.machine.lastRowPrefix) {
@@ -621,9 +636,13 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (exec.ColBatch, error) {
 			// We're finished with a row. Bump the row index, fill the row in with
 			// nulls if necessary, emit the batch if necessary, and move to the next
 			// state.
+			if err := rf.fillNulls(); err != nil {
+				return nil, err
+			}
 			rf.machine.rowIdx++
 			rf.shiftState()
 			if rf.machine.rowIdx >= exec.ColBatchSize {
+				rf.pushState(stateResetBatch)
 				rf.machine.batch.SetLength(rf.machine.rowIdx)
 				rf.machine.rowIdx = 0
 				return rf.machine.batch, nil
@@ -649,6 +668,11 @@ func (rf *CFetcher) shiftState() {
 	rf.machine.state[2] = stateInvalid
 }
 
+func (rf *CFetcher) pushState(state fetcherState) {
+	copy(rf.machine.state[1:], rf.machine.state[:2])
+	rf.machine.state[0] = state
+}
+
 // processValue processes the state machine's current value component, setting
 // columns in the rowIdx'th tuple in the current batch depending on what data
 // is found in the current value component.
@@ -670,7 +694,7 @@ func (rf *CFetcher) processValue(
 		)
 	}
 
-	if table.neededCols.Empty() {
+	if table.neededValueColsByIdx.Empty() {
 		// We don't need to decode any values.
 		if rf.traceKV {
 			prettyValue = tree.DNull.String()
@@ -792,6 +816,8 @@ func (rf *CFetcher) processValueSingle(
 			if err != nil {
 				return "", "", err
 			}
+			rf.machine.remainingValueColsByIdx.Remove(idx)
+
 			if rf.traceKV {
 				// TODO(jordan): handle this case by reaching into the colvecs array and
 				// pulling out a pretty value.
@@ -827,8 +853,7 @@ func (rf *CFetcher) processValueBytes(
 	var lastColID sqlbase.ColumnID
 	var typeOffset, dataOffset int
 	var typ encoding.Type
-	valueColsFound := 0
-	for len(valueBytes) > 0 && valueColsFound < table.neededValueCols {
+	for len(valueBytes) > 0 && rf.machine.remainingValueColsByIdx.Len() > 0 {
 		typeOffset, dataOffset, colIDDiff, typ, err = encoding.DecodeValueTag(valueBytes)
 		if err != nil {
 			return "", "", err
@@ -861,10 +886,10 @@ func (rf *CFetcher) processValueBytes(
 		if err != nil {
 			return "", "", err
 		}
+		rf.machine.remainingValueColsByIdx.Remove(idx)
 		if rf.traceKV {
 			fmt.Fprintf(rf.machine.prettyValueBuf, "/?")
 		}
-		valueColsFound++
 	}
 	if rf.traceKV {
 		prettyValue = rf.machine.prettyValueBuf.String()
@@ -878,4 +903,28 @@ func (rf *CFetcher) processValueTuple(
 	ctx context.Context, table *cTableInfo, tupleBytes []byte, prettyKeyPrefix string,
 ) (prettyKey string, prettyValue string, err error) {
 	return rf.processValueBytes(ctx, table, tupleBytes, prettyKeyPrefix)
+}
+func (rf *CFetcher) fillNulls() error {
+	table := &rf.table
+	if rf.machine.remainingValueColsByIdx.Empty() {
+		return nil
+	}
+	for i, ok := rf.machine.remainingValueColsByIdx.Next(0); ok; i, ok = rf.machine.remainingValueColsByIdx.Next(i + 1) {
+		if !table.cols[i].Nullable {
+			var indexColValues []string
+			for _, idx := range table.indexColOrdinals {
+				if idx != -1 {
+					indexColValues = append(indexColValues, rf.machine.colvecs[idx].PrettyValueAt(rf.machine.rowIdx))
+				} else {
+					indexColValues = append(indexColValues, "?")
+				}
+				return scrub.WrapError(scrub.UnexpectedNullValueError, errors.Errorf(
+					"Non-nullable column \"%s:%s\" with no value! Index scanned was %q with the index key columns (%s) and the values (%s)",
+					table.desc.Name, table.cols[i].Name, table.index.Name,
+					strings.Join(table.index.ColumnNames, ","), strings.Join(indexColValues, ",")))
+			}
+		}
+		rf.machine.colvecs[i].SetNull(rf.machine.rowIdx)
+	}
+	return nil
 }

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -152,8 +152,6 @@ type CFetcher struct {
 		nextKV *roachpb.KeyValue
 		// seekPrefix is the prefix to seek to in stateSeekPrefix.
 		seekPrefix roachpb.Key
-		// how many needed cols we've found so far in the value
-		valueColsFound int
 
 		remainingValueColsByIdx util.FastIntSet
 		// lastRowPrefix is the row prefix for the last row we saw a key for. New

--- a/pkg/sql/row/fetcherstate_string.go
+++ b/pkg/sql/row/fetcherstate_string.go
@@ -4,9 +4,9 @@ package row
 
 import "strconv"
 
-const _fetcherState_name = "stateInvalidstateInitFetchstateDecodeFirstKVOfRowstateSeekPrefixstateFetchNextKVWithUnfinishedRowstateFinalizeRowstateEmitLastBatchstateFinished"
+const _fetcherState_name = "stateInvalidstateInitFetchstateResetBatchstateDecodeFirstKVOfRowstateSeekPrefixstateFetchNextKVWithUnfinishedRowstateFinalizeRowstateEmitLastBatchstateFinished"
 
-var _fetcherState_index = [...]uint8{0, 12, 26, 49, 64, 97, 113, 131, 144}
+var _fetcherState_index = [...]uint8{0, 12, 26, 41, 64, 79, 112, 128, 146, 159}
 
 func (i fetcherState) String() string {
 	if i < 0 || i >= fetcherState(len(_fetcherState_index)-1) {

--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -200,6 +200,22 @@ func (s FastIntSet) Copy() FastIntSet {
 	return c
 }
 
+// CopyFrom sets the receiver to a copy of c, which can then be modified
+// independently.
+func (s *FastIntSet) CopyFrom(c FastIntSet) {
+	if c.large != nil {
+		if s.large == nil {
+			s.large = new(intsets.Sparse)
+		}
+		s.large.Copy(s.large)
+	} else {
+		s.small = c.small
+		if s.large != nil {
+			s.large.Clear()
+		}
+	}
+}
+
 // UnionWith adds all the elements from rhs to this set.
 func (s *FastIntSet) UnionWith(rhs FastIntSet) {
 	if s.large == nil && rhs.large == nil {


### PR DESCRIPTION
This commit adds left outer join support to the columnarized hash joiner. The hash joiner now has left, right and full outer join support. This PR builds off of #33206.