### PR TITLE
roachtest: only publish artifacts for failed tests

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -947,7 +947,10 @@ func (r *registry) runAsync(
 			if teamCity {
 				fmt.Fprintf(r.out, "##teamcity[testFinished name='%s' flowId='%s']\n", t.Name(), t.Name())
 
-				if artifactsDir != "" {
+				// Only publish artifacts for failed tests. At the time of writing, a full roachtest
+				// suite results in ~6gb of artifacts which we can't retain for more than a few days
+				// (and this in turn delays the resolution of failures).
+				if t.Failed() && artifactsDir != "" {
 					escapedTestName := teamCityNameEscape(t.Name())
 					artifactsGlobPath := filepath.Join(artifactsDir, "**")
 					artifactsSpec := fmt.Sprintf("%s => %s", artifactsGlobPath, escapedTestName)


### PR DESCRIPTION
A full run of roachtest has 6+ gbs of artifacts and we delete them
after four days. If we only retain the artifacts for failed tests,
we'll be able to retain logs for much longer, which will be helpful.

Besides, to download the artifacts for one test, TeamCity forces you
to download the artifacts for all tests, and this can take a while.

Release note: None