### PR TITLE
sql: stub ssl_renegotiation_limit

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -692,7 +692,8 @@ var crdbInternalSessionVariablesTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.session_variables (
   variable STRING NOT NULL,
-  value    STRING NOT NULL
+  value    STRING NOT NULL,
+  hidden   BOOL   NOT NULL
 )`,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for _, vName := range varNames {
@@ -701,6 +702,7 @@ CREATE TABLE crdb_internal.session_variables (
 			if err := addRow(
 				tree.NewDString(vName),
 				tree.NewDString(value),
+				tree.MakeDBool(tree.DBool(gen.Hidden)),
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -141,10 +141,10 @@ SELECT * FROM crdb_internal.feature_usage WHERE feature_name = ''
 ----
 feature_name  usage_count
 
-query TT colnames
+query TTB colnames
 SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
-variable                       value
+variable  value  hidden
 
 query TITTTTTBT colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -283,3 +283,6 @@ SET blah.blah = 123
 
 statement error unrecognized configuration parameter "tracing.blah"
 SET tracing.blah = 123
+
+statement error invalid value for parameter "ssl_renegotiation_limit"
+SET ssl_renegotiation_limit = 123

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -195,7 +195,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'database'
       └── values  ·       ·
-·                 size    2 columns, 38 rows
+·                 size    3 columns, 39 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -204,7 +204,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'timezone'
       └── values  ·       ·
-·                 size    2 columns, 38 rows
+·                 size    3 columns, 39 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -213,7 +213,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'default_transaction_isolation'
       └── values  ·       ·
-·                 size    2 columns, 38 rows
+·                 size    3 columns, 39 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -222,7 +222,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_isolation'
       └── values  ·       ·
-·                 size    2 columns, 38 rows
+·                 size    3 columns, 39 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -231,7 +231,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_priority'
       └── values  ·       ·
-·                 size    2 columns, 38 rows
+·                 size    3 columns, 39 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo
@@ -257,7 +257,7 @@ sort                                       ·            ·
                      │    └── filter       ·            ·
                      │         │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
                      │         └── values  ·            ·
-                     │                     size         23 columns, 961 rows
+                     │                     size         23 columns, 962 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -186,7 +186,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'database'
       └── values  ·       ·
-·                 size    2 columns, 38 rows
+·                 size    3 columns, 39 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -195,7 +195,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'timezone'
       └── values  ·       ·
-·                 size    2 columns, 38 rows
+·                 size    3 columns, 39 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -204,7 +204,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'default_transaction_isolation'
       └── values  ·       ·
-·                 size    2 columns, 38 rows
+·                 size    3 columns, 39 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -213,7 +213,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_isolation'
       └── values  ·       ·
-·                 size    2 columns, 38 rows
+·                 size    3 columns, 39 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -222,7 +222,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_priority'
       └── values  ·       ·
-·                 size    2 columns, 38 rows
+·                 size    3 columns, 39 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo
@@ -248,7 +248,7 @@ sort                                       ·            ·
                      │    └── filter       ·            ·
                      │         │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
                      │         └── values  ·            ·
-                     │                     size         23 columns, 961 rows
+                     │                     size         23 columns, 962 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1825,6 +1825,9 @@ CREATE TABLE pg_catalog.pg_settings (
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
+			if gen.Hidden {
+				continue
+			}
 			value := gen.Get(&p.extendedEvalCtx)
 			valueDatum := tree.NewDString(value)
 			var bootDatum tree.Datum = tree.DNull

--- a/pkg/sql/show_var.go
+++ b/pkg/sql/show_var.go
@@ -31,7 +31,7 @@ func (p *planner) ShowVar(ctx context.Context, n *tree.ShowVar) (planNode, error
 
 	if name == "all" {
 		return p.delegateQuery(ctx, "SHOW SESSION ALL",
-			"SELECT variable, value FROM crdb_internal.session_variables",
+			"SELECT variable, value FROM crdb_internal.session_variables WHERE hidden = FALSE",
 			nil, nil)
 	}
 


### PR DESCRIPTION
Fixes #33074.

The `ssl_renegotiation_limit` session var and client status parameter
is used to force renegotiation of the session keys after some traffic
has flowed through the connection. Some clients use this and this
spams the logs. This patch avoids the log spam by providing support
for the session var with a suitable error for unsupported values.

Release note: None