### PR TITLE
sql: stub domain type info cols in information_schema.columns

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -313,6 +313,9 @@ var informationSchemaColumnsTable = virtualSchemaTable{
 					tree.DNull,                                                  // character_set_catalog
 					tree.DNull,                                                  // character_set_schema
 					tree.DNull,                                                  // character_set_name
+					tree.DNull,                                                  // domain_catalog
+					tree.DNull,                                                  // domain_schema
+					tree.DNull,                                                  // domain_name
 					dStringPtrOrEmpty(column.ComputeExpr),                       // generation_expression
 					yesOrNoDatum(column.Hidden),                                 // is_hidden
 					tree.NewDString(column.Type.SQLString()),                    // crdb_sql_type

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -257,7 +257,7 @@ sort                                       ·            ·
                      │    └── filter       ·            ·
                      │         │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
                      │         └── values  ·            ·
-                     │                     size         20 columns, 958 rows
+                     │                     size         23 columns, 961 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -248,7 +248,7 @@ sort                                       ·            ·
                      │    └── filter       ·            ·
                      │         │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
                      │         └── values  ·            ·
-                     │                     size         20 columns, 958 rows
+                     │                     size         23 columns, 961 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                │           filter       ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')

--- a/pkg/sql/opt/optbuilder/testdata/virtual-scan
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-scan
@@ -7,7 +7,7 @@ build
 SELECT * FROM information_schema.columns
 ----
 virtual-scan t.information_schema.columns
- └── columns: table_catalog:1(string) table_schema:2(string) table_name:3(string) column_name:4(string) ordinal_position:5(int) column_default:6(string) is_nullable:7(string) data_type:8(string) character_maximum_length:9(int) character_octet_length:10(int) numeric_precision:11(int) numeric_precision_radix:12(int) numeric_scale:13(int) datetime_precision:14(int) character_set_catalog:15(string) character_set_schema:16(string) character_set_name:17(string) generation_expression:18(string) is_hidden:19(string) crdb_sql_type:20(string)
+ └── columns: table_catalog:1(string) table_schema:2(string) table_name:3(string) column_name:4(string) ordinal_position:5(int) column_default:6(string) is_nullable:7(string) data_type:8(string) character_maximum_length:9(int) character_octet_length:10(int) numeric_precision:11(int) numeric_precision_radix:12(int) numeric_scale:13(int) datetime_precision:14(int) character_set_catalog:15(string) character_set_schema:16(string) character_set_name:17(string) domain_catalog:18(string) domain_schema:19(string) domain_name:20(string) generation_expression:21(string) is_hidden:22(string) crdb_sql_type:23(string)
 
 # Since we lazily create these, the name resolution codepath is slightly
 # different on the second resolution.
@@ -15,11 +15,11 @@ build
 SELECT * FROM information_schema.columns
 ----
 virtual-scan t.information_schema.columns
- └── columns: table_catalog:1(string) table_schema:2(string) table_name:3(string) column_name:4(string) ordinal_position:5(int) column_default:6(string) is_nullable:7(string) data_type:8(string) character_maximum_length:9(int) character_octet_length:10(int) numeric_precision:11(int) numeric_precision_radix:12(int) numeric_scale:13(int) datetime_precision:14(int) character_set_catalog:15(string) character_set_schema:16(string) character_set_name:17(string) generation_expression:18(string) is_hidden:19(string) crdb_sql_type:20(string)
+ └── columns: table_catalog:1(string) table_schema:2(string) table_name:3(string) column_name:4(string) ordinal_position:5(int) column_default:6(string) is_nullable:7(string) data_type:8(string) character_maximum_length:9(int) character_octet_length:10(int) numeric_precision:11(int) numeric_precision_radix:12(int) numeric_scale:13(int) datetime_precision:14(int) character_set_catalog:15(string) character_set_schema:16(string) character_set_name:17(string) domain_catalog:18(string) domain_schema:19(string) domain_name:20(string) generation_expression:21(string) is_hidden:22(string) crdb_sql_type:23(string)
 
 # Alias the virtual table name.
 build
 SELECT * FROM information_schema.columns c
 ----
 virtual-scan t.information_schema.columns
- └── columns: table_catalog:1(string) table_schema:2(string) table_name:3(string) column_name:4(string) ordinal_position:5(int) column_default:6(string) is_nullable:7(string) data_type:8(string) character_maximum_length:9(int) character_octet_length:10(int) numeric_precision:11(int) numeric_precision_radix:12(int) numeric_scale:13(int) datetime_precision:14(int) character_set_catalog:15(string) character_set_schema:16(string) character_set_name:17(string) generation_expression:18(string) is_hidden:19(string) crdb_sql_type:20(string)
+ └── columns: table_catalog:1(string) table_schema:2(string) table_name:3(string) column_name:4(string) ordinal_position:5(int) column_default:6(string) is_nullable:7(string) data_type:8(string) character_maximum_length:9(int) character_octet_length:10(int) numeric_precision:11(int) numeric_precision_radix:12(int) numeric_scale:13(int) datetime_precision:14(int) character_set_catalog:15(string) character_set_schema:16(string) character_set_name:17(string) domain_catalog:18(string) domain_schema:19(string) domain_name:20(string) generation_expression:21(string) is_hidden:22(string) crdb_sql_type:23(string)

--- a/pkg/sql/vtable/information_schema.go
+++ b/pkg/sql/vtable/information_schema.go
@@ -37,6 +37,9 @@ CREATE TABLE information_schema.columns (
 	CHARACTER_SET_CATALOG    STRING,
 	CHARACTER_SET_SCHEMA     STRING,
 	CHARACTER_SET_NAME       STRING,
+	DOMAIN_CATALOG           STRING,
+	DOMAIN_SCHEMA            STRING,
+	DOMAIN_NAME              STRING,
 	GENERATION_EXPRESSION    STRING,          -- MySQL/CockroachDB extension.
 	IS_HIDDEN                STRING NOT NULL, -- CockroachDB extension for SHOW COLUMNS / dump.
 	CRDB_SQL_TYPE            STRING NOT NULL  -- CockroachDB extension for SHOW COLUMNS / dump.


### PR DESCRIPTION
Requested in https://github.com/cockroachdb/cockroach/issues/27796#issuecomment-435025243.

Release note (sql change): CockroachDB now defines columns
`domain_catalog`, `domain_schema` and `domain_name` in
`information_schema.columns` (using NULL values, since domain types
are not yet supported) for compatibility with PostgreSQL clients that
require them.