### PR TITLE
sql: skip TestInternalExecAppNameInitialization

### DIFF
--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -147,6 +147,8 @@ func TestSessionBoundInternalExecutor(t *testing.T) {
 func TestInternalExecAppNameInitialization(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	t.Skip("#33268")
+
 	params, _ := tests.CreateTestServerParams()
 	params.Insecure = true
 	s, _, _ := serverutils.StartServer(t, params)


### PR DESCRIPTION
until #33268 is addressed.

(I don't understand the error yet but I wanted to unbreak master)