### PR TITLE
ccl/changefeedccl: deflake TestChangefeedSchemaChangeAllowBackfill

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -142,7 +142,7 @@ func createBenchmarkChangefeed(
 		s.ClusterSettings(), details, encoder, sink, rowsFn, TestingKnobs{}, metrics)
 
 	ctx, cancel := context.WithCancel(ctx)
-	go func() { _ = poller.Run(ctx) }()
+	go func() { _ = poller.Run(ctx, nil) }()
 	go func() { _ = thUpdater.PollTableDescs(ctx) }()
 
 	errCh := make(chan error, 1)


### PR DESCRIPTION
Any goroutine started via `Stopper.RunAsyncTask` needs to watch
`Stopper.ShouldQuiesce()` to determine if it should stop
processing. This wasn't being done properly for the "changefeed-poller"
task causing the test to fail to exit in rare circumstances.

Fixes #33166

Release note: None