### PR TITLE
sql: wait for node statuses in TestShowQueries

### DIFF
--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1135,10 +1135,6 @@ func setupPartitioningTestCluster(
 	sqlDB.Exec(t, `SET CLUSTER SETTING server.declined_reservation_timeout = '0s'`)
 	sqlDB.Exec(t, `SET CLUSTER SETTING server.failed_reservation_timeout = '0s'`)
 
-	// Make sure all stores are present in the NodeStatus endpoint or else zone
-	// config changes may flake (#25488).
-	tc.WaitForNodeStatuses(t)
-
 	return tc.Conns[0], sqlDB, func() {
 		tc.Stopper().Stop(context.Background())
 		resetZoneConfig()

--- a/pkg/sql/show_trace_replica_test.go
+++ b/pkg/sql/show_trace_replica_test.go
@@ -55,10 +55,6 @@ func TestShowTraceReplica(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, numNodes, tcArgs)
 	defer tc.Stopper().Stop(ctx)
 
-	// Make sure all stores are present in the NodeStatus endpoint or else zone
-	// config changes may flake (#25488).
-	tc.WaitForNodeStatuses(t)
-
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 	sqlDB.Exec(t, `ALTER RANGE "default" CONFIGURE ZONE USING constraints = '[+n4]'`)
 	sqlDB.Exec(t, `ALTER DATABASE system CONFIGURE ZONE USING constraints = '[+n4]'`)


### PR DESCRIPTION
A few tests use `WaitForNodeStatuses`; it turns out `TestShowQueries` also
needs it. Given that this seems to be a recurring problem
(see #25488, #25649, #31574), this change makes `StartTestCluster`
always wait for statuses.

Fixes #31574.

Release note: None