### PR TITLE
opt: Tweak calculation of unapplied conjuncts for inv indexes

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -947,7 +947,7 @@ SELECT * FROM tjson WHERE b @> '{"a":"b"}'
 ----
 index-join tjson
  ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
- ├── stats: [rows=1666.66667, distinct(1)=1666.66667, null(1)=0]
+ ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  └── scan tjson@b_idx
@@ -964,7 +964,7 @@ SELECT * FROM tjson WHERE b @> '{"a":"b", "c":"d"}'
 inner-join (lookup tjson)
  ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
  ├── key columns: [1] = [1]
- ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0]
+ ├── stats: [rows=61.7283951, distinct(1)=61.7283951, null(1)=0]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── inner-join (zigzag tjson@b_idx tjson@b_idx)
@@ -984,7 +984,7 @@ SELECT * FROM tjson WHERE c @> '{"a":"b"}'
 ----
 select
  ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
- ├── stats: [rows=1666.66667, distinct(1)=1666.66667, null(1)=0]
+ ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── scan tjson
@@ -1002,7 +1002,7 @@ SELECT * FROM tjson WHERE c @> '{"a":"b", "c":"d"}'
 ----
 select
  ├── columns: a:1(int!null) b:2(jsonb) c:3(jsonb)
- ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0]
+ ├── stats: [rows=61.7283951, distinct(1)=61.7283951, null(1)=0]
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  ├── scan tjson

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1761,11 +1761,11 @@ memo (optimized, ~10KB, required=[presentation: a:1])
  ├── G1: (project G2 G3 a)
  │    └── [presentation: a:1]
  │         ├── best: (project G2 G3 a)
- │         └── cost: 191.63
+ │         └── cost: 87.93
  ├── G2: (select G4 G5) (lookup-join G6 G5 t5,keyCols=[1],outCols=(1,2)) (select G7 G5)
  │    └── []
  │         ├── best: (lookup-join G6 G5 t5,keyCols=[1],outCols=(1,2))
- │         └── cost: 190.51
+ │         └── cost: 87.80
  ├── G3: (projections)
  ├── G4: (scan t5,cols=(1,2))
  │    └── []

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -658,7 +658,7 @@ memo (optimized, ~6KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
- │         └── cost: 570.03
+ │         └── cost: 567.81
  ├── G2: (select G4 G5) (index-join G6 b,cols=(1,4))
  │    └── []
  │         ├── best: (index-join G6 b,cols=(1,4))


### PR DESCRIPTION
This change updates the logic around counting unapplied conjuncts in
JSON contain filters (@>) to make it more consistent with the
calculation for number of conjuncts in constrained scans. This has the
advantage of making stats easier to read and understand in opt tester
output. Previously, index joins with constrained scans often had higher
row count than their child nodes.

Release note: None