### PR TITLE
roachtest: use toxiproxy for network testing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -109,6 +109,14 @@
   version = "v1.20.1"
 
 [[projects]]
+  digest = "1:34f7a5e65430906c3eeeebb52f4ff50fdc0ed06e86063c5e13dd3236109de787"
+  name = "github.com/Shopify/toxiproxy"
+  packages = ["client"]
+  pruneopts = "UT"
+  revision = "49b4ea27da29ae83ad3bfe7f7f090d18cbee1dc3"
+  version = "v2.1.4"
+
+[[projects]]
   digest = "1:e92f5581902c345eb4ceffdcd4a854fb8f73cf436d47d837d1ec98ef1fe0a214"
   name = "github.com/StackExchange/wmi"
   packages = ["."]
@@ -716,7 +724,7 @@
   revision = "883fe33ffc4344bad1ecd881f61afd5ec5d80e0a"
 
 [[projects]]
-  digest = "1:5eae7496bdb74a6c7592bc74ea3da8a6a61a361fd52682820900d755bb144194"
+  digest = "1:6ce94e52c5f56dfbea4e3cb99ccf4b44d701d91b16167486e9842b2fe45e717a"
   name = "github.com/golang/protobuf"
   packages = [
     "jsonpb",
@@ -730,7 +738,6 @@
     "ptypes/duration",
     "ptypes/struct",
     "ptypes/timestamp",
-    "ptypes/wrappers",
   ]
   pruneopts = "UT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
@@ -1592,14 +1599,13 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c687169ea4f1554252009306cc8305fc86b9c5a68fbd0e61e7cadd8ed6504767"
+  digest = "1:a7d48ca460ca1b4f6ccd8c95502443afa05df88aee84de7dbeb667a8754e8fa6"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
     "googleapis/iam/v1",
     "googleapis/rpc/code",
     "googleapis/rpc/status",
-    "protobuf/field_mask",
   ]
   pruneopts = "UT"
   revision = "db91494dd46c1fdcbbde05e5ff5eb56df8f7d79a"
@@ -1697,6 +1703,7 @@
     "github.com/MichaelTJones/walk",
     "github.com/PuerkitoBio/goquery",
     "github.com/Shopify/sarama",
+    "github.com/Shopify/toxiproxy/client",
     "github.com/VividCortex/ewma",
     "github.com/abourget/teamcity",
     "github.com/andy-kimball/arenaskl",

--- a/pkg/cmd/roachtest/network.go
+++ b/pkg/cmd/roachtest/network.go
@@ -1,0 +1,251 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	toxiproxy "github.com/Shopify/toxiproxy/client"
+	_ "github.com/lib/pq"
+)
+
+// runNetworkSanity is just a sanity check to make sure we're setting up toxiproxy
+// correctly.
+func runNetworkSanity(ctx context.Context, t *test, origC *cluster, nodes int) {
+	origC.Put(ctx, cockroach, "./cockroach", origC.All())
+	c := Toxify(ctx, origC, origC.All())
+
+	c.Start(ctx, t, c.All())
+
+	db := c.Conn(ctx, 1) // unaffected by toxiproxy
+	defer db.Close()
+	waitForFullReplication(t, db)
+
+	// NB: we're generous with latency in this test because we're checking that
+	// the upstream connections aren't affected by latency below, but the fixed
+	// cost of starting the binary and processing the query is already close to
+	// 100ms.
+	//
+	// NB: last node gets no latency injected, but first node gets cut off below.
+	const latency = 300 * time.Millisecond
+	for i := 1; i <= nodes; i++ {
+		// NB: note that these latencies only apply to connections *to* the node
+		// on which the toxic is active. That is, if n1 has a (down or upstream)
+		// latency toxic of 100ms, then none of its outbound connections are
+		// affected but any connections made to it by other nodes will.
+		// In particular, it's difficult to simulate intricate network partitions
+		// as there's no way to activate toxics only for certain peers.
+		proxy := c.Proxy(i)
+		if _, err := proxy.AddToxic("", "latency", "downstream", 1, toxiproxy.Attributes{
+			"latency": latency / (2 * time.Millisecond), // ms
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := proxy.AddToxic("", "latency", "upstream", 1, toxiproxy.Attributes{
+			"latency": latency / (2 * time.Millisecond), // ms
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	m := newMonitor(ctx, c.cluster, c.All())
+	m.Go(func(ctx context.Context) error {
+		c.Measure(ctx, 1, `SET CLUSTER SETTING trace.debug.enable = true`)
+		c.Measure(ctx, 1, "CREATE DATABASE test")
+		c.Measure(ctx, 1, `CREATE TABLE test.commit (a INT, b INT, v INT, PRIMARY KEY (a, b))`)
+
+		for i := 0; i < 10; i++ {
+			duration := c.Measure(ctx, 1, fmt.Sprintf(
+				"BEGIN; INSERT INTO test.commit VALUES (2, %[1]d), (1, %[1]d), (3, %[1]d); COMMIT",
+				i,
+			))
+			c.l.Printf("%s\n", duration)
+		}
+
+		c.Measure(ctx, 1, `
+set tracing=on;
+insert into test.commit values(3,1000), (1,1000), (2,1000);
+select age, message from [ show trace for session ];
+`)
+
+		for i := 1; i < origC.nodes; i++ {
+			if dur := c.Measure(ctx, i, `SELECT 1`); dur > latency {
+				t.Fatalf("node %d unexpectedly affected by latency: select 1 took %.2fs", i, dur.Seconds())
+			}
+		}
+
+		return nil
+	})
+
+	m.Wait()
+}
+
+func runNetworkTPCC(ctx context.Context, t *test, origC *cluster, nodes int) {
+	serverNodes, workerNode := origC.Range(1, origC.nodes-1), origC.Node(origC.nodes)
+	origC.Put(ctx, cockroach, "./cockroach", origC.All())
+	origC.Put(ctx, workload, "./workload", origC.All())
+
+	c := Toxify(ctx, origC, serverNodes)
+
+	const warehouses = 1
+	c.Start(ctx, t, serverNodes)
+	c.Run(ctx, workerNode, fmt.Sprintf(
+		`./workload fixtures load tpcc --warehouses=%d {pgurl:1}`, warehouses,
+	))
+
+	db := c.Conn(ctx, 1)
+	defer db.Close()
+	waitForFullReplication(t, db)
+
+	duration := time.Hour
+	if local {
+		// NB: this is really just testing the test with this duration, it won't
+		// be able to detect slow goroutine leaks.
+		duration = 5 * time.Minute
+	}
+
+	// Run TPCC, but don't give it the first node (or it basically won't do anything).
+	m := newMonitor(ctx, c.cluster, serverNodes)
+
+	m.Go(func(ctx context.Context) error {
+		t.WorkerStatus("running tpcc")
+
+		tpccL, err := c.l.ChildLogger("tpcc", quietStdout, quietStderr)
+		if err != nil {
+			return err
+		}
+
+		cmd := fmt.Sprintf(
+			"./workload run tpcc --warehouses=%d --wait=false --histograms=logs/stats.json --duration=%s {pgurl:2-%d}",
+			warehouses, duration, c.nodes-1)
+		return c.RunL(ctx, tpccL, workerNode, cmd)
+	})
+
+	checkGoroutines := func(ctx context.Context) int {
+		// NB: at the time of writing, the goroutine count would quickly
+		// stabilize near 230 when the network is partitioned, and around 270
+		// when it isn't. Experimentally a past "slow" goroutine leak leaked ~3
+		// goroutines every minute (though it would likely be more with the tpcc
+		// workload above), which over the duration of an hour would easily push
+		// us over the threshold.
+		const thresh = 350
+
+		uiAddrs := c.ExternalAdminUIAddr(ctx, serverNodes)
+		var maxSeen int
+		for _, addr := range uiAddrs {
+			url := "http://" + addr + "/debug/pprof/goroutine?debug=2"
+			resp, err := http.Get(url)
+			if err != nil {
+				t.Fatal(err)
+			}
+			content, err := ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			numGoroutines := bytes.Count(content, []byte("goroutine "))
+			if numGoroutines >= thresh {
+				t.Fatalf("%s shows %d goroutines (expected <%d)", url, numGoroutines, thresh)
+			}
+			if maxSeen < numGoroutines {
+				maxSeen = numGoroutines
+			}
+		}
+		return maxSeen
+	}
+
+	m.Go(func(ctx context.Context) error {
+		time.Sleep(10 * time.Second) // give tpcc a head start
+		// Give n1 a network partition from the remainder of the cluster. Note that even though it affects
+		// both the "upstream" and "downstream" directions, this is in fact an asymmetric partition since
+		// it only affects connections *to* the node. n1 itself can connect to the cluster just fine.
+		proxy := c.Proxy(1)
+		c.l.Printf("letting inbound traffic to first node time out")
+		for _, direction := range []string{"upstream", "downstream"} {
+			if _, err := proxy.AddToxic("", "timeout", direction, 1, toxiproxy.Attributes{
+				"timeout": 0, // forever
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		t.WorkerStatus("checking goroutines")
+		done := time.After(duration)
+		var maxSeen int
+		for {
+			cur := checkGoroutines(ctx)
+			if maxSeen < cur {
+				c.l.Printf("new goroutine peak: %d", cur)
+				maxSeen = cur
+			}
+
+			select {
+			case <-done:
+				c.l.Printf("done checking goroutines, repairing network")
+				// Repair the network. Note that the TPCC workload would never
+				// finish (despite the duration) without this. In particular,
+				// we don't want to m.Wait() before we do this.
+				toxics, err := proxy.Toxics()
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, toxic := range toxics {
+					if err := proxy.RemoveToxic(toxic.Name); err != nil {
+						t.Fatal(err)
+					}
+				}
+				c.l.Printf("network is repaired")
+
+				// Verify that goroutine count doesn't spike.
+				for i := 0; i < 20; i++ {
+					nowGoroutines := checkGoroutines(ctx)
+					c.l.Printf("currently at most %d goroutines per node", nowGoroutines)
+					time.Sleep(time.Second)
+				}
+
+				return nil
+			default:
+				time.Sleep(3 * time.Second)
+			}
+		}
+	})
+
+	m.Wait()
+}
+
+func registerNetwork(r *registry) {
+	const numNodes = 4
+
+	r.Add(testSpec{
+		Name:  fmt.Sprintf("network/sanity/nodes=%d", numNodes),
+		Nodes: nodes(numNodes),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runNetworkSanity(ctx, t, c, numNodes)
+		},
+	})
+	r.Add(testSpec{
+		Name:  fmt.Sprintf("network/tpcc/nodes=%d", numNodes),
+		Nodes: nodes(numNodes),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runNetworkTPCC(ctx, t, c, numNodes)
+		},
+	})
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -50,6 +50,7 @@ func registerTests(r *registry) {
 	registerKVScalability(r)
 	registerKVSplits(r)
 	registerLargeRange(r)
+	registerNetwork(r)
 	registerQueue(r)
 	registerRebalanceLoad(r)
 	registerReplicaGC(r)

--- a/pkg/cmd/roachtest/toxiproxy.go
+++ b/pkg/cmd/roachtest/toxiproxy.go
@@ -1,0 +1,214 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"net/url"
+	"regexp"
+	"runtime"
+	"strconv"
+	"time"
+
+	toxiproxy "github.com/Shopify/toxiproxy/client"
+)
+
+// cockroachToxiWrapper replaces the cockroach binary. It modifies the listening port so
+// that the nodes in the cluster will communicate through toxiproxy instead of
+// directly.
+const cockroachToxiWrapper = `#!/usr/bin/env bash
+set -eu
+
+cd "$(dirname "${0}")"
+
+orig_port=""
+
+args=()
+
+if [[ "$1" != "start" ]]; then
+	./cockroach.real "$@"
+	exit $?
+fi
+
+for arg in "$@"; do
+	capture=$(echo "${arg}" | sed -E 's/^--port=([0-9]+)$/\1/')
+	if [[ "${capture}" != "${arg}"  ]] && [[ -z "${orig_port}" ]] && [[ -n "${capture}" ]]; then
+		orig_port="${capture}"
+	fi
+	args+=("${arg}")
+done
+
+if [[ -z "${orig_port}" ]]; then
+	orig_port=26257
+fi
+
+args+=("--advertise-port=$((orig_port+10000))")
+
+echo "toxiproxy interception:"
+echo "original args: $@"
+echo "modified args: ${args[@]}"
+./cockroach.real "${args[@]}"
+`
+
+const toxiServerWrapper = `#!/usr/bin/env bash
+set -eu
+
+mkdir -p logs
+./toxiproxy-server -host 0.0.0.0 -port $1 2>&1 > logs/toxiproxy.log & </dev/null
+until nc -z localhost $1; do sleep 0.1; echo "waiting for toxiproxy-server..."; done
+`
+
+// A ToxiCluster wraps a cluster and sets it up for use with toxiproxy.
+// See Toxify() for details.
+type ToxiCluster struct {
+	*cluster
+	toxClients map[int]*toxiproxy.Client
+	toxProxies map[int]*toxiproxy.Proxy
+}
+
+// Toxify takes a cluster and sets it up for use with toxiproxy on the given
+// nodes. On these nodes, the cockroach binary must already have been populated
+// and the cluster must not have been started yet. The returned ToxiCluster
+// wraps the original cluster, whose returned addresses will all go through
+// toxiproxy. The upstream (i.e. non-intercepted) addresses are accessible via
+// getters prefixed with "External".
+func Toxify(ctx context.Context, c *cluster, node nodeListOption) *ToxiCluster {
+	// NB: we can use upstream once they've released 2.1.4; there's a pretty
+	// dramatic perf problem with the "timeout" toxic in 2.1.3.
+	toxiURL := "https://github.com/tbg/toxiproxy/releases/download/v2.1.4rc1/toxiproxy-server-linux-amd64"
+	if local && runtime.GOOS == "darwin" {
+		toxiURL = "https://github.com/tbg/toxiproxy/releases/download/v2.1.4rc1/toxiproxy-server-darwin-amd64"
+	}
+	c.Run(ctx, c.All(), "curl", "-Lo", "toxiproxy-server", toxiURL)
+	c.Run(ctx, c.All(), "chmod", "+x", "toxiproxy-server")
+
+	c.Run(ctx, node, "mv cockroach cockroach.real")
+	c.PutString(ctx, cockroachToxiWrapper, "./cockroach", 0755, node)
+	c.PutString(ctx, toxiServerWrapper, "./toxiproxyd", 0755, node)
+
+	tc := &ToxiCluster{
+		cluster:    c,
+		toxClients: make(map[int]*toxiproxy.Client),
+		toxProxies: make(map[int]*toxiproxy.Proxy),
+	}
+
+	for _, i := range node {
+		n := c.Node(i)
+
+		toxPort := 8474 + i
+		c.Run(ctx, n, fmt.Sprintf("./toxiproxyd %d 2>/dev/null >/dev/null < /dev/null", toxPort))
+
+		externalAddr, port := addrToHostPort(c, c.ExternalAddr(ctx, n)[0])
+		tc.toxClients[i] = toxiproxy.NewClient(fmt.Sprintf("http://%s:%d", externalAddr, toxPort))
+		proxy, err := tc.toxClients[i].CreateProxy("cockroach", fmt.Sprintf(":%d", tc.poisonedPort(port)), fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			c.t.Fatal(err)
+		}
+		tc.toxProxies[i] = proxy
+	}
+
+	return tc
+}
+
+func (tc *ToxiCluster) poisonedPort(port int) int {
+	// NB: to make a change here, you also have to change
+	_ = cockroachToxiWrapper
+	return port + 10000
+}
+
+// Proxy returns the toxiproxy Proxy intercepting the given node's traffic.
+func (tc *ToxiCluster) Proxy(i int) *toxiproxy.Proxy {
+	proxy, found := tc.toxProxies[i]
+	if !found {
+		tc.cluster.t.Fatalf("proxy for node %d not found", i)
+	}
+	return proxy
+}
+
+// ExternalAddr gives the external host:port of the node(s), bypassing the
+// toxiproxy interception.
+func (tc *ToxiCluster) ExternalAddr(ctx context.Context, node nodeListOption) []string {
+	return tc.cluster.ExternalAddr(ctx, node)
+}
+
+// PoisonedExternalAddr gives the external host:port of the toxiproxy process
+// for the given nodes (i.e. the connection will be affected by toxics).
+func (tc *ToxiCluster) PoisonedExternalAddr(ctx context.Context, node nodeListOption) []string {
+	var out []string
+
+	extAddrs := tc.ExternalAddr(ctx, node)
+	for _, addr := range extAddrs {
+		host, port := addrToHostPort(tc.cluster, addr)
+		out = append(out, fmt.Sprintf("%s:%d", host, tc.poisonedPort(port)))
+	}
+	return out
+}
+
+// PoisonedPGAddr gives a connection to the given node that passes through toxiproxy.
+func (tc *ToxiCluster) PoisonedPGAddr(ctx context.Context, node nodeListOption) []string {
+	var out []string
+
+	urls := tc.ExternalPGUrl(ctx, node)
+	exts := tc.PoisonedExternalAddr(ctx, node)
+	for i, s := range urls {
+		u, err := url.Parse(s)
+		if err != nil {
+			tc.cluster.t.Fatal(err)
+		}
+		u.Host = exts[i]
+		out = append(out, u.String())
+	}
+	return out
+}
+
+// PoisonedConn returns an SQL connection to the specified node through toxiproxy.
+func (tc *ToxiCluster) PoisonedConn(ctx context.Context, node int) *gosql.DB {
+	url := tc.PoisonedPGAddr(ctx, tc.cluster.Node(node))[0]
+	db, err := gosql.Open("postgres", url)
+	if err != nil {
+		tc.cluster.t.Fatal(err)
+	}
+	return db
+}
+
+var _ = (*ToxiCluster)(nil).PoisonedConn
+var _ = (*ToxiCluster)(nil).PoisonedPGAddr
+var _ = (*ToxiCluster)(nil).PoisonedExternalAddr
+
+var measureRE = regexp.MustCompile(`real[^0-9]+([0-9.]+)`)
+
+// Measure runs a statement on the given node (bypassing toxiproxy for the
+// client connection) and measures the duration (including the invocation time
+// of `./cockroach sql`. This is simplistic and does not perform proper
+// escaping. It's not useful for anything but simple sanity checks.
+func (tc *ToxiCluster) Measure(ctx context.Context, fromNode int, stmt string) time.Duration {
+	_, port := addrToHostPort(tc.cluster, tc.ExternalAddr(ctx, tc.Node(fromNode))[0])
+	b, err := tc.cluster.RunWithBuffer(ctx, tc.cluster.l, tc.cluster.Node(fromNode), "time", "-p", "./cockroach", "sql", "--insecure", "--port", strconv.Itoa(port), "-e", "'"+stmt+"'")
+	tc.cluster.l.Printf("%s\n", b)
+	if err != nil {
+		tc.cluster.t.Fatal(err)
+	}
+	matches := measureRE.FindSubmatch(b)
+	if len(matches) != 2 {
+		tc.cluster.t.Fatalf("unable to extract duration from output: %s", b)
+	}
+	f, err := strconv.ParseFloat(string(matches[1]), 64)
+	if err != nil {
+		tc.cluster.t.Fatalf("unable to parse %s as float: %s", b, err)
+	}
+	return time.Duration(f * 1E9)
+}

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -606,10 +606,17 @@ func (txn *Txn) rollback(ctx context.Context) *roachpb.Error {
 		}
 	}
 
+	// We don't have a client whose context we can attach to, but we do want to limit how
+	// long this request is going to be around or it could leak a goroutine (in case of a
+	// long-lived network partition).
 	stopper := txn.db.ctx.Stopper
-	ctx, cancel := stopper.WithCancelOnQuiesce(txn.db.AnnotateCtx(context.Background()))
+	ctx, cancel1 := stopper.WithCancelOnQuiesce(txn.db.AnnotateCtx(context.Background()))
+	// NB: cancel2 makes cancel1 obsolete, but the linters don't know that.
+	ctx, cancel2 := context.WithTimeout(ctx, 3*time.Second)
+
 	if err := stopper.RunAsyncTask(ctx, "async-rollback", func(ctx context.Context) {
-		defer cancel()
+		defer cancel1()
+		defer cancel2()
 		var ba roachpb.BatchRequest
 		ba.Add(endTxnReq(false /* commit */, nil /* deadline */, false /* systemConfigTrigger */))
 		if _, pErr := txn.Send(ctx, ba); pErr != nil {
@@ -625,7 +632,8 @@ func (txn *Txn) rollback(ctx context.Context) *roachpb.Error {
 			}
 		}
 	}); err != nil {
-		cancel()
+		cancel1()
+		cancel2()
 		return roachpb.NewError(err)
 	}
 	return nil

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"


### PR DESCRIPTION
Reincarnation of https://github.com/cockroachdb/cockroach/pull/23141.

[toxiproxy] is a TCP proxy which exports an HTTP API that allows
introducing various anomalous network conditions for resilience testing.

Among the interesting things one can simulate are latency and bandwidth
restrictions. This is done programmatically and thus lends itself to the
kind of testing we'd like to do; in particular, it should allow testing
locally a good approximation of geo-replicated clusters and various
network partitions.

The test introduced here isn't really useful yet. We'll need to settle
on something straightforward to test.

Updates #21680.
Updates #14768.

[toxiproxy]: https://github.com/Shopify/toxiproxy

Release note: None