### PR TITLE
vendor: update thrift and zipkin-go-opentracing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -142,12 +142,11 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:e64acfe8cda1955db545ede8e863c54d69f1ac6cd058df4349be4040320840fd"
+  digest = "1:b39cf81d5f440b9c0757a25058432d33af867e5201109bf53621356d9dab4b73"
   name = "github.com/apache/thrift"
   packages = ["lib/go/thrift"]
   pruneopts = "UT"
-  revision = "327ebb6c2b6df8bf075da02ef45a2a034e9b79ba"
-  version = "0.11.0"
+  revision = "2b7365c54f823013cc6a4760798051b22743c103"
 
 [[projects]]
   branch = "master"
@@ -1147,8 +1146,8 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:ef06a435177b3b245740de74ea6e7116a3d43e5f21d5e84f3def995297a991a9"
-  name = "github.com/openzipkin/zipkin-go-opentracing"
+  digest = "1:c28cdeafaa5fc255ce6f51b1ee800505dfe231431f9a036f6cca9382987e64ec"
+  name = "github.com/openzipkin-contrib/zipkin-go-opentracing"
   packages = [
     ".",
     "flag",
@@ -1158,8 +1157,8 @@
     "wire",
   ]
   pruneopts = "UT"
-  revision = "4c9fbcbd6d73a644fd17214fe475296780c68fb5"
-  version = "v0.3.3"
+  revision = "f0f479ad013a498e4cbfb369414e5d3880903779"
+  version = "v0.3.5"
 
 [[projects]]
   digest = "1:95741de3af260a92cc5c7f3f3061e85273f5a81b5db20d4bd68da74bd521675e"
@@ -1776,7 +1775,7 @@
     "github.com/olekukonko/tablewriter",
     "github.com/opentracing/opentracing-go",
     "github.com/opentracing/opentracing-go/log",
-    "github.com/openzipkin/zipkin-go-opentracing",
+    "github.com/openzipkin-contrib/zipkin-go-opentracing",
     "github.com/petermattis/goid",
     "github.com/pkg/errors",
     "github.com/pmezard/go-difflib/difflib",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -82,6 +82,10 @@ ignored = [
   name = "github.com/golang/dep"
   branch = "master"
 
+[[constraint]]
+  name = "golang.org/x/crypto"
+  branch = "master"
+
 # github.com/docker/docker depends on a few functions not included in the
 # latest release: reference.{FamiliarName,ParseNormalizedNamed,TagNameOnly}.
 #
@@ -90,6 +94,12 @@ ignored = [
 [[override]]
   name = "github.com/docker/distribution"
   branch = "master"
+
+# github.com/openzipkin-contrib/zipkin-go-opentracing requires a newer
+# version of thrift than is currently present in a release.
+[[override]]
+  name = "github.com/apache/thrift"
+  revision = "2b7365c54f823013cc6a4760798051b22743c103"
 
 [prune]
   go-tests = true
@@ -113,13 +123,3 @@ ignored = [
   [[prune.project]]
     name = "github.com/knz/go-libedit"
     unused-packages = false
-
-[[constraint]]
-  branch = "master"
-  name = "golang.org/x/crypto"
-
-# Newer releases of zipkin depend on unreleased bits from
-# github.com/apache/thrift.
-[[constraint]]
-  name = "github.com/openzipkin/zipkin-go-opentracing"
-  version = "=0.3.3"

--- a/pkg/util/tracing/shadow.go
+++ b/pkg/util/tracing/shadow.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	lightstep "github.com/lightstep/lightstep-tracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
-	zipkin "github.com/openzipkin/zipkin-go-opentracing"
+	zipkin "github.com/openzipkin-contrib/zipkin-go-opentracing"
 )
 
 type shadowTracerManager interface {


### PR DESCRIPTION
Fixes #30576.
Informs #30774.

https://github.com/openzipkin-contrib/zipkin-go-opentracing/compare/4c9fbcb...f0f479a
https://github.com/apache/thrift/compare/327ebb6...2b7365c

I audited every commit in the zipkin-go-opentracing diff and every
commit to the `lib/go` package of the thrift diff.

Release note (bug fix): Updated Zipkin library to avoid deadlock when
stopping Zipkin tracing.