### PR TITLE
roachtest: create new kv/contention/nodes=4 test

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -28,8 +27,6 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
-	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
@@ -884,75 +881,4 @@ func (c *topicConsumer) Close() {
 		}
 	}
 	_ = c.Consumer.Close()
-}
-
-func verifyTxnPerSecond(
-	ctx context.Context,
-	c *cluster,
-	t *test,
-	adminNode nodeListOption,
-	start, end time.Time,
-	txnTarget, maxPercentTimeUnderTarget float64,
-) {
-	// Query needed information over the timespan of the query.
-	adminURLs := c.ExternalAdminUIAddr(ctx, adminNode)
-	url := "http://" + adminURLs[0] + "/ts/query"
-	request := tspb.TimeSeriesQueryRequest{
-		StartNanos: start.UnixNano(),
-		EndNanos:   end.UnixNano(),
-		// Ask for one minute intervals. We can't just ask for the whole hour
-		// because the time series query system does not support downsampling
-		// offsets.
-		SampleNanos: (1 * time.Minute).Nanoseconds(),
-		Queries: []tspb.Query{
-			{
-				Name:             "cr.node.sql.txn.commit.count",
-				Downsampler:      tspb.TimeSeriesQueryAggregator_AVG.Enum(),
-				SourceAggregator: tspb.TimeSeriesQueryAggregator_SUM.Enum(),
-				Derivative:       tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE.Enum(),
-			},
-			// Query *without* the derivative applied so we can get a total count of
-			// txns over the time period.
-			{
-				Name:             "cr.node.sql.txn.commit.count",
-				Downsampler:      tspb.TimeSeriesQueryAggregator_AVG.Enum(),
-				SourceAggregator: tspb.TimeSeriesQueryAggregator_SUM.Enum(),
-			},
-		},
-	}
-	var response tspb.TimeSeriesQueryResponse
-	if err := httputil.PostJSON(http.Client{}, url, &request, &response); err != nil {
-		t.Fatal(err)
-	}
-
-	// Drop the first two minutes of datapoints as a "ramp-up" period.
-	perMinute := response.Results[0].Datapoints[2:]
-	cumulative := response.Results[1].Datapoints[2:]
-
-	// Check average txns per second over the entire test was above the target.
-	totalTxns := cumulative[len(cumulative)-1].Value - cumulative[0].Value
-	avgTxnPerSec := totalTxns / float64(end.Sub(start)/time.Second)
-
-	if avgTxnPerSec < txnTarget {
-		t.Fatalf("average txns per second %f was under target %f", avgTxnPerSec, txnTarget)
-	} else {
-		t.l.Printf("average txns per second: %f", avgTxnPerSec)
-	}
-
-	// Verify that less than 5% of individual one minute periods were underneath
-	// the target.
-	minutesBelowTarget := 0.0
-	for _, dp := range perMinute {
-		if dp.Value < txnTarget {
-			minutesBelowTarget++
-		}
-	}
-	if perc := minutesBelowTarget / float64(len(perMinute)); perc > maxPercentTimeUnderTarget {
-		t.Fatalf(
-			"spent %f%% of time below target of %f txn/s, wanted no more than %f%%",
-			perc*100, txnTarget, maxPercentTimeUnderTarget*100,
-		)
-	} else {
-		t.l.Printf("spent %f%% of time below target of %f txn/s", perc*100, txnTarget)
-	}
 }

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -81,6 +81,57 @@ func registerKV(r *registry) {
 	}
 }
 
+func registerKVContention(r *registry) {
+	const nodes = 4
+	r.Add(testSpec{
+		Name:    fmt.Sprintf("kv/contention/nodes=%d", nodes),
+		Cluster: makeClusterSpec(nodes + 1),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+			c.Start(ctx, t, c.Range(1, nodes))
+
+			// Enable request tracing, which is a good tool for understanding
+			// how different transactions are interacting.
+			c.Run(ctx, c.Node(1),
+				`./cockroach sql --insecure -e "SET CLUSTER SETTING trace.debug.enable = true"`)
+
+			t.Status("running workload")
+			m := newMonitor(ctx, c, c.Range(1, nodes))
+			m.Go(func(ctx context.Context) error {
+				// Write to a small number of keys to generate a large amount of
+				// contention. Use a relatively high amount of concurrency and
+				// aim to average one concurrent write for each key in the keyspace.
+				const cycleLength = 512
+				const concurrency = 128
+				const avgConcPerKey = 1
+				const batchSize = avgConcPerKey * (cycleLength / concurrency)
+
+				// Split the table so that each node can have a single leaseholder.
+				splits := nodes
+
+				// Run the workload for an hour. Add a secondary index to avoid
+				// UPSERTs performing blind writes.
+				const duration = 1 * time.Hour
+				cmd := fmt.Sprintf("./workload run kv --init --secondary-index --duration=%s "+
+					"--cycle-length=%d --concurrency=%d --batch=%d --splits=%d {pgurl:1-%d}",
+					duration, cycleLength, concurrency, batchSize, splits, nodes)
+				start := timeutil.Now()
+				c.Run(ctx, c.Node(nodes+1), cmd)
+				end := timeutil.Now()
+
+				// Assert that the average throughput stayed above a certain
+				// threshold. In this case, assert that max throughput only
+				// dipped below 10 qps for 5% of the time.
+				const minQPS = 10
+				verifyTxnPerSecond(ctx, c, t, c.Node(1), start, end, minQPS, 0.05)
+				return nil
+			})
+			m.Wait()
+		},
+	})
+}
+
 func registerKVQuiescenceDead(r *registry) {
 	r.Add(testSpec{
 		Name:       "kv/quiescence/nodes=3",

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -46,6 +46,7 @@ func registerTests(r *registry) {
 	registerInterleaved(r)
 	registerJepsen(r)
 	registerKV(r)
+	registerKVContention(r)
 	registerKVQuiescenceDead(r)
 	registerKVGracefulDraining(r)
 	registerKVScalability(r)

--- a/pkg/cmd/roachtest/ts_util.go
+++ b/pkg/cmd/roachtest/ts_util.go
@@ -1,0 +1,96 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+)
+
+func verifyTxnPerSecond(
+	ctx context.Context,
+	c *cluster,
+	t *test,
+	adminNode nodeListOption,
+	start, end time.Time,
+	txnTarget, maxPercentTimeUnderTarget float64,
+) {
+	// Query needed information over the timespan of the query.
+	adminURLs := c.ExternalAdminUIAddr(ctx, adminNode)
+	url := "http://" + adminURLs[0] + "/ts/query"
+	request := tspb.TimeSeriesQueryRequest{
+		StartNanos: start.UnixNano(),
+		EndNanos:   end.UnixNano(),
+		// Ask for one minute intervals. We can't just ask for the whole hour
+		// because the time series query system does not support downsampling
+		// offsets.
+		SampleNanos: (1 * time.Minute).Nanoseconds(),
+		Queries: []tspb.Query{
+			{
+				Name:             "cr.node.txn.commits",
+				Downsampler:      tspb.TimeSeriesQueryAggregator_AVG.Enum(),
+				SourceAggregator: tspb.TimeSeriesQueryAggregator_SUM.Enum(),
+				Derivative:       tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE.Enum(),
+			},
+			// Query *without* the derivative applied so we can get a total count of
+			// txns over the time period.
+			{
+				Name:             "cr.node.txn.commits",
+				Downsampler:      tspb.TimeSeriesQueryAggregator_AVG.Enum(),
+				SourceAggregator: tspb.TimeSeriesQueryAggregator_SUM.Enum(),
+			},
+		},
+	}
+	var response tspb.TimeSeriesQueryResponse
+	if err := httputil.PostJSON(http.Client{}, url, &request, &response); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drop the first two minutes of datapoints as a "ramp-up" period.
+	perMinute := response.Results[0].Datapoints[2:]
+	cumulative := response.Results[1].Datapoints[2:]
+
+	// Check average txns per second over the entire test was above the target.
+	totalTxns := cumulative[len(cumulative)-1].Value - cumulative[0].Value
+	avgTxnPerSec := totalTxns / float64(end.Sub(start)/time.Second)
+
+	if avgTxnPerSec < txnTarget {
+		t.Fatalf("average txns per second %f was under target %f", avgTxnPerSec, txnTarget)
+	} else {
+		t.l.Printf("average txns per second: %f", avgTxnPerSec)
+	}
+
+	// Verify that less than the specified limit of each individual one minute
+	// period was underneath the target.
+	minutesBelowTarget := 0.0
+	for _, dp := range perMinute {
+		if dp.Value < txnTarget {
+			minutesBelowTarget++
+		}
+	}
+	if perc := minutesBelowTarget / float64(len(perMinute)); perc > maxPercentTimeUnderTarget {
+		t.Fatalf(
+			"spent %f%% of time below target of %f txn/s, wanted no more than %f%%",
+			perc*100, txnTarget, maxPercentTimeUnderTarget*100,
+		)
+	} else {
+		t.l.Printf("spent %f%% of time below target of %f txn/s", perc*100, txnTarget)
+	}
+}

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -154,7 +154,7 @@ func (w *kv) Tables() []workload.Table {
 		Splits: workload.Tuples(
 			w.splits,
 			func(splitIdx int) []interface{} {
-				stride := (float64(math.MaxInt64) - float64(math.MinInt64)) / float64(w.splits+1)
+				stride := (float64(w.cycleLength) - float64(math.MinInt64)) / float64(w.splits+1)
 				splitPoint := int(math.MinInt64 + float64(splitIdx+1)*stride)
 				return []interface{}{splitPoint}
 			},


### PR DESCRIPTION
Closes #32814.

This commit adds a roachtest that stresses the kinds of scenarios that we saw bring down adriatic in #32582. It runs `kv` with a cycle length of 512, a concurrency of 128, and a batch size of 4. The test runs this on a 4 node cluster. It then verifies that QPS stayed above a certain threshold for the entire duration of the test.