### PR TITLE
roachtest: record json stats for tpccbench runs

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -572,11 +572,11 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 					}
 
 					t.Status(fmt.Sprintf("running benchmark, warehouses=%d", warehouses))
-
 					cmd := fmt.Sprintf("./workload run tpcc --warehouses=%d --active-warehouses=%d "+
-						"--tolerate-errors --ramp=%s --duration=%s%s {pgurl%s}",
+						"--tolerate-errors --ramp=%s --duration=%s%s {pgurl%s} "+
+						"--histograms=logs/warehouses=%d/stats.json",
 						b.LoadWarehouses, activeWarehouses, rampDur,
-						loadDur, extraFlags, sqlGateways)
+						loadDur, extraFlags, sqlGateways, activeWarehouses)
 					out, err := c.RunWithBuffer(ctx, t.l, group.loadNodes, cmd)
 					loadDone <- timeutil.Now()
 					if err != nil {


### PR DESCRIPTION
This PR is part of collecting and presenting nightly max warehouse data from
the tpccbench roachtest. In the current teamcity configuration we upload all
files called stats.json to cloud storage. This data is used to drive roachperf.
Collecting the incremental histograms from each tpcc run will generate more data
but should enable roachperf to compute tpmC and the max warehouses number as
well as reusing existing logic to allow users to drill down into the performance
of individual tpcc runs within a run of tpccbench. The changes to roachperf to
make use of this data will come in a future PR.

Release note: None