### PR TITLE
storage: fix a deadlock in rangefeed teardown

### DIFF
--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -372,7 +372,12 @@ func (p *Processor) Register(
 		if catchUpIter != nil {
 			catchUpIter.Close() // clean up
 		}
-		errC <- roachpb.NewErrorf("rangefeed processor closed")
+		// errC has a capacity of 1. If it is already full, we don't need to send
+		// another error.
+		select {
+		case errC <- roachpb.NewErrorf("rangefeed processor closed"):
+		default:
+		}
 	}
 }
 

--- a/pkg/storage/replica_rangefeed.go
+++ b/pkg/storage/replica_rangefeed.go
@@ -138,7 +138,7 @@ func (r *Replica) RangeFeed(
 	}
 
 	lockedStream := &lockedRangefeedStream{wrapped: stream}
-	errC := make(chan *roachpb.Error)
+	errC := make(chan *roachpb.Error, 1)
 
 	// Lock the raftMu, then register the stream as a new rangefeed registration.
 	// raftMu is held so that the catch-up iterator is captured in the same


### PR DESCRIPTION
Fix two related deadlocks in rangefeed teardown. The error
channel (`errC`) used by `Processor.Register` to indicate a rangefeed
processor is closed needs to be buffered because the caller of
`Processor.Register` is the reader of this channel. Similarly, we need
to consider that processing might have already placed on error on `errC`
and that a reader might never read the "closed" error that
`Processor.Register` is trying to send.

Fixes #33166

Release note: None