### PR TITLE
release-2.1: pgwire: fix binary decoding of decimal NaN and NULL in arrays

### DIFF
--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -26,7 +26,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -46,6 +48,7 @@ func TestEncodings(t *testing.T) {
 		SQL    string
 		Text   string
 		Binary []byte
+		Datum  tree.Datum
 	}
 	f, err := os.Open(filepath.Join("testdata", "encodings.json"))
 	if err != nil {
@@ -99,32 +102,72 @@ func TestEncodings(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			d, err := te.Eval(&evalCtx)
+			tc.Datum, err = te.Eval(&evalCtx)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			t.Run("text", func(t *testing.T) {
-				buf.reset()
-				buf.textFormatter.Buffer.Reset()
-				buf.writeTextDatum(ctx, d, conv)
-				if buf.err != nil {
-					t.Fatal(buf.err)
-				}
-				got := string(verifyLen(t))
-				if got != tc.Text {
-					t.Errorf("unexpected text encoding:\n\t%q found,\n\t%q expected", got, tc.Text)
-				}
+			t.Run("encode", func(t *testing.T) {
+				t.Run("text", func(t *testing.T) {
+					buf.reset()
+					buf.textFormatter.Buffer.Reset()
+					buf.writeTextDatum(ctx, tc.Datum, conv)
+					if buf.err != nil {
+						t.Fatal(buf.err)
+					}
+					got := string(verifyLen(t))
+					if got != tc.Text {
+						t.Errorf("unexpected text encoding:\n\t%q found,\n\t%q expected", got, tc.Text)
+					}
+				})
+				t.Run("binary", func(t *testing.T) {
+					buf.reset()
+					buf.writeBinaryDatum(ctx, tc.Datum, time.UTC)
+					if buf.err != nil {
+						t.Fatal(buf.err)
+					}
+					got := verifyLen(t)
+					if !bytes.Equal(got, tc.Binary) {
+						t.Errorf("unexpected binary encoding:\n\t%v found,\n\t%v expected", got, tc.Binary)
+					}
+				})
 			})
-			t.Run("binary", func(t *testing.T) {
-				buf.reset()
-				buf.writeBinaryDatum(ctx, d, time.UTC)
-				if buf.err != nil {
-					t.Fatal(buf.err)
+
+			t.Run("decode", func(t *testing.T) {
+				switch tc.Datum.(type) {
+				case *tree.DFloat:
+					// Skip floats because postgres rounds them different than Go.
+					t.Skip()
+				case *tree.DTuple:
+					// Unsupported.
+					t.Skip()
 				}
-				got := verifyLen(t)
-				if !bytes.Equal(got, tc.Binary) {
-					t.Errorf("unexpected binary encoding:\n\t%v found,\n\t%v expected", got, tc.Binary)
+				id := tc.Datum.ResolvedType().Oid()
+				var d tree.Datum
+				var err error
+				for code, value := range map[pgwirebase.FormatCode][]byte{
+					pgwirebase.FormatText:   []byte(tc.Text),
+					pgwirebase.FormatBinary: tc.Binary,
+				} {
+					t.Logf("code: %s, value: %q (%[2]s)", code, value)
+					t.Run(code.String(), func(t *testing.T) {
+						if darr, ok := tc.Datum.(*tree.DArray); ok && code == pgwirebase.FormatText {
+							var typ coltypes.T
+							typ, err = coltypes.DatumTypeToColumnType(darr.ParamTyp)
+							if err != nil {
+								t.Fatal(err)
+							}
+							d, err = tree.ParseDArrayFromString(&evalCtx, string(value), typ)
+						} else {
+							d, err = pgwirebase.DecodeOidDatum(id, code, value)
+						}
+						if err != nil {
+							t.Fatal(err)
+						}
+						if d.Compare(&evalCtx, tc.Datum) != 0 {
+							t.Fatalf("%v != %v", d, tc.Datum)
+						}
+					})
 				}
 			})
 		})


### PR DESCRIPTION
Backport 1/1 commits from #33295.

/cc @cockroachdb/release

---

Also enable decoding tests using the same test data from the encoding
tests. Some tests skipped because they are unimplemented or have rounding
issues.

Release note (bug fix): Fixed pgwire binary decoding of decimal NaN and
NULL in arrays.
