### PR TITLE
roachtest: TolerateErrors in cdc/crdbChaos test

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -93,6 +93,9 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 			sqlNodes:           crdbNodes,
 			workloadNodes:      workloadNode,
 			tpccWarehouseCount: args.tpccWarehouseCount,
+			// TolerateErrors if crdbChaos is true; otherwise, the workload will fail
+			// if it attempts to use the node which was brought down by chaos.
+			tolerateErrors: args.crdbChaos,
 		}
 		tpcc.install(ctx, c)
 		// TODO(dan,ajwerner): sleeping momentarily before running the workload


### PR DESCRIPTION
cdc/crdbChaos test was unintentionally broken by #33243. The
tolerateErrors setting is no longer necessary in general, but it is
still required for this test which intentionally shuts down cockroach
nodes.

Fixes #33259

Release note: None