### PR TITLE
release-2.1: sql: fix panic in insert on conflict do update

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -727,3 +727,51 @@ x
 
 statement ok
 COMMIT
+
+subtest regression_32834
+
+statement ok
+CREATE TABLE test_table (
+  id BIGINT PRIMARY KEY,
+  a BIGINT,
+  b BIGINT
+);
+
+statement ok
+INSERT INTO test_table (id, a) VALUES
+  (123, 456), (123, 456)
+  ON CONFLICT (id) DO UPDATE SET a = EXCLUDED.a;
+
+query II colnames
+SELECT id, a
+FROM test_table
+----
+id   a
+123  456
+
+statement ok
+INSERT INTO test_table (id, a) VALUES
+  (123, 1), (123, 2), (123, 1)
+  ON CONFLICT (id) DO UPDATE SET a = EXCLUDED.a;
+
+query II colnames
+SELECT id, a
+FROM test_table
+----
+id   a
+123  1
+
+statement ok
+INSERT INTO test_table (id, a) VALUES
+  (123, 1), (123, 2), (123, 3)
+  ON CONFLICT (id) DO UPDATE SET a = EXCLUDED.a;
+
+query II colnames
+SELECT id, a
+FROM test_table
+----
+id   a
+123  3
+
+statement ok
+DROP TABLE test_table;


### PR DESCRIPTION
Backport 1/2 commits from #33245.

/cc @cockroachdb/release

---

There was an assumption that the row inserter and row updater had the same
columns in the same order and if that wasn't the case row inserter's columns
would be larger.

This assumption is incorrect, so to fix it, when storing the existing rows
(which are used to see if they conflicts with other rows further on in the
statement) instead of storing the row used for inputs, convert the rows
directly to those required by the row updater.

Fixes #32834.

Release note (bug fix): Fixed an issue in which if a nullable column wasn't
supplied in an INSERT ON CONFLICT DO UPDATE statement, it may cause a panic.
