### PR TITLE
roachtest: update hibernate blacklist

### DIFF
--- a/pkg/cmd/roachtest/hibernate_blacklist.go
+++ b/pkg/cmd/roachtest/hibernate_blacklist.go
@@ -326,7 +326,6 @@ var hibernateBlackList2_2 = blacklist{
 	"org.hibernate.test.proxy.ProxyTest.testRefreshLockInitializedProxy":                                                                                                             "6583",
 	"org.hibernate.test.quote.QuoteTest.testUnionSubclassEntityQuoting":                                                                                                              "5807",
 	"org.hibernate.test.quote.TableGeneratorQuotingTest.testTableGeneratorQuoting":                                                                                                   "16769",
-	"org.hibernate.test.schemaupdate.MigrationTest.testIndexCreationViaSchemaUpdate":                                                                                                 "31761",
 	"org.hibernate.test.schemaupdate.PostgreSQLMultipleSchemaSequenceTest.test":                                                                                                      "26443",
 	"org.hibernate.test.schemaupdate.SchemaUpdateTest.testSchemaUpdateAndValidation[0]":                                                                                              "24062",
 	"org.hibernate.test.schemaupdate.SchemaUpdateTest.testSchemaUpdateAndValidation[1]":                                                                                              "24062",


### PR DESCRIPTION
Thanks to the closing of #31761 this test now passes.

Closes #33163.

Release note: None