### PR TITLE
sql/opt: avoid swallowing TransactionAbortedErrors

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -739,7 +739,8 @@ EXECUTE change_view
 statement ok
 ALTER VIEW otherview RENAME TO otherview2
 
-query error pq: relation "otherview" does not exist
+# HP and CBO return slightly different errors, so accept both.
+query error pq: relation "(otherdb.public.)?otherview" does not exist
 EXECUTE change_view
 
 statement ok


### PR DESCRIPTION
An optimizer code path could, in rare cases, fail to propagate a
transaction aborted error. This proved disastrous as, due to a footgun
in our transaction API (#22615), swallowing a transaction aborted error
results in proceeding with a brand new transaction that has no knowledge
of the earlier operations performed on the original transaction.

This presented as a rare and confusing bug in splits, as the split
transaction uses an internal executor. The internal executor would
occasionally silently return a new transaction that only had half of the
necessary operations performed on it, and committing that partial
transaction would result in a "range does not match splits" error.

Fixes #32784.

Release note: None

/cc @tbg