### PR TITLE
cli: don't filter on program by default in merge-logs

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1261,7 +1261,7 @@ var debugMergeLogsOpts = struct {
 	file    *regexp.Regexp
 	prefix  string
 }{
-	program: regexp.MustCompile("^cockroach$"),
+	program: regexp.MustCompile("^cockroach.*$"),
 	file:    regexp.MustCompile(log.FilePattern),
 }
 


### PR DESCRIPTION
This behavior can be useful, but more often than not, the glob you're
passing in already matches exactly the right files. If the cockroach
binary wasn't called `cockroach` (this does happen), the previous
default wouldn't match any log files and gave a confusing UX.

Instead, accept any program by default. In cases where a filter is
adequate, one can be specified.

Release note: None