### PR TITLE
storage/engine: fix sstIterator error propagation

### DIFF
--- a/pkg/storage/engine/sst_iterator.go
+++ b/pkg/storage/engine/sst_iterator.go
@@ -118,6 +118,8 @@ func (r *sstIterator) Valid() (bool, error) {
 // Next implements the SimpleIterator interface.
 func (r *sstIterator) Next() {
 	if r.valid = r.iter.Next(); !r.valid {
+		r.err = errors.Wrap(r.iter.Close(), "closing sstable iterator")
+		r.iter = nil
 		return
 	}
 


### PR DESCRIPTION
If the LevelDB iterator inside `sstIterator` returns not valid, we have
to close the iterator in order to retrieve any error.

Release note: None