### PR TITLE
sql: add kv tracing to foreign key lookups

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -149,6 +149,16 @@ CREATE TABLE "user content"."customer reviews" (
 statement ok
 INSERT INTO orders VALUES (1, 1, '780', 2)
 
+statement error foreign key violation: value \['fake'\] not found in products@primary
+SET tracing = on,kv,results; INSERT INTO orders VALUES (2, 2, 'fake', 2); SET tracing = off
+
+query T rowsort
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE 'FKScan%'
+----
+FKScan /Table/53/1/{2-3}
+FKScan /Table/54/1/"fake"{-/PrefixEnd}
+
 statement error pgcode 23503 foreign key violation: values \['780'\] in columns \[sku\] referenced in table "orders"
 DELETE FROM products
 

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -587,8 +587,10 @@ r1: sending batch 1 Del, 1 BeginTxn to (n1,s1):1
 cascading delete into table: 81 using index: 1
 querying next range at /Table/79/1/1/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/1/#/80/1/1/#/81/{1-2}
 querying next range at /Table/79/1/1/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/1/#/80/{1-2}
 querying next range at /Table/79/1/1/#/80/1
 r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/2 -> NULL
@@ -604,8 +606,10 @@ r1: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 81 using index: 1
 querying next range at /Table/79/1/2/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/2/#/80/1/1/#/81/{1-2}
 querying next range at /Table/79/1/2/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/2/#/80/{1-2}
 querying next range at /Table/79/1/2/#/80/1
 r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/3 -> NULL
@@ -621,8 +625,10 @@ r1: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 81 using index: 1
 querying next range at /Table/79/1/3/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/3/#/80/1/1/#/81/{1-2}
 querying next range at /Table/79/1/3/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/3/#/80/{1-2}
 querying next range at /Table/79/1/3/#/80/1
 r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/4 -> NULL
@@ -638,8 +644,10 @@ r1: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 81 using index: 1
 querying next range at /Table/79/1/4/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/4/#/80/1/1/#/81/{1-2}
 querying next range at /Table/79/1/4/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/4/#/80/{1-2}
 querying next range at /Table/79/1/4/#/80/1
 r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/5 -> NULL
@@ -655,8 +663,10 @@ r1: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 81 using index: 1
 querying next range at /Table/79/1/5/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/5/#/80/1/1/#/81/{1-2}
 querying next range at /Table/79/1/5/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/5/#/80/{1-2}
 querying next range at /Table/79/1/5/#/80/1
 r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/6 -> NULL
@@ -672,8 +682,10 @@ r1: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 81 using index: 1
 querying next range at /Table/79/1/6/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/6/#/80/1/1/#/81/{1-2}
 querying next range at /Table/79/1/6/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/6/#/80/{1-2}
 querying next range at /Table/79/1/6/#/80/1
 r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/7 -> NULL
@@ -689,8 +701,10 @@ r1: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 81 using index: 1
 querying next range at /Table/79/1/7/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/7/#/80/1/1/#/81/{1-2}
 querying next range at /Table/79/1/7/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/7/#/80/{1-2}
 querying next range at /Table/79/1/7/#/80/1
 r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/8 -> NULL
@@ -706,8 +720,10 @@ r1: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 81 using index: 1
 querying next range at /Table/79/1/8/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/8/#/80/1/1/#/81/{1-2}
 querying next range at /Table/79/1/8/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/8/#/80/{1-2}
 querying next range at /Table/79/1/8/#/80/1
 r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/9 -> NULL
@@ -723,8 +739,10 @@ r1: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 81 using index: 1
 querying next range at /Table/79/1/9/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/9/#/80/1/1/#/81/{1-2}
 querying next range at /Table/79/1/9/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/9/#/80/{1-2}
 querying next range at /Table/79/1/9/#/80/1
 r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/10 -> NULL
@@ -740,8 +758,10 @@ r1: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 81 using index: 1
 querying next range at /Table/79/1/10/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/10/#/80/1/1/#/81/{1-2}
 querying next range at /Table/79/1/10/#/80/1/1/#/81/1
 r1: sending batch 1 Scan to (n1,s1):1
+FKScan /Table/79/1/10/#/80/{1-2}
 querying next range at /Table/79/1/10/#/80/1
 r1: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 querying next range at /Table/79/1/1/0

--- a/pkg/sql/row/cascader.go
+++ b/pkg/sql/row/cascader.go
@@ -1145,7 +1145,7 @@ func (c *cascader) cascadeAll(
 			return pgerror.NewAssertionErrorf("could not find row deleter for table %d", tableID)
 		}
 		for deletedRows.Len() > 0 {
-			if err := rowDeleter.Fks.addAllIdxChecks(ctx, deletedRows.At(0)); err != nil {
+			if err := rowDeleter.Fks.addAllIdxChecks(ctx, deletedRows.At(0), traceKV); err != nil {
 				return err
 			}
 			if err := rowDeleter.Fks.checker.runCheck(ctx, deletedRows.At(0), nil); err != nil {
@@ -1187,7 +1187,7 @@ func (c *cascader) cascadeAll(
 			// If there's only a single change, which is quite often the case, there
 			// is no need to worry about intermediate states.  Just run the check and
 			// avoid a bunch of allocations.
-			if err := rowUpdater.Fks.addIndexChecks(ctx, originalRows.At(0), updatedRows.At(0)); err != nil {
+			if err := rowUpdater.Fks.addIndexChecks(ctx, originalRows.At(0), updatedRows.At(0), traceKV); err != nil {
 				return err
 			}
 			if !rowUpdater.Fks.hasFKs() {
@@ -1228,7 +1228,7 @@ func (c *cascader) cascadeAll(
 				}
 			}
 
-			if err := rowUpdater.Fks.addIndexChecks(ctx, originalRows.At(i), finalRow); err != nil {
+			if err := rowUpdater.Fks.addIndexChecks(ctx, originalRows.At(i), finalRow, traceKV); err != nil {
 				return err
 			}
 			if !rowUpdater.Fks.hasFKs() {

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -165,7 +165,7 @@ func (ri *Inserter) InsertRow(
 	}
 
 	if ri.Fks.checker != nil && checkFKs == CheckFKs {
-		if err := ri.Fks.addAllIdxChecks(ctx, values); err != nil {
+		if err := ri.Fks.addAllIdxChecks(ctx, values, traceKV); err != nil {
 			return err
 		}
 		if err := ri.Fks.checker.runCheck(ctx, nil, values); err != nil {
@@ -696,7 +696,7 @@ func (ru *Updater) UpdateRow(
 		}
 
 		if checkFKs == CheckFKs {
-			if err := ru.Fks.addIndexChecks(ctx, oldValues, ru.newValues); err != nil {
+			if err := ru.Fks.addIndexChecks(ctx, oldValues, ru.newValues, traceKV); err != nil {
 				return nil, err
 			}
 			if !ru.Fks.hasFKs() {
@@ -799,7 +799,7 @@ func (ru *Updater) UpdateRow(
 	}
 
 	if checkFKs == CheckFKs {
-		if err := ru.Fks.addIndexChecks(ctx, oldValues, ru.newValues); err != nil {
+		if err := ru.Fks.addIndexChecks(ctx, oldValues, ru.newValues, traceKV); err != nil {
 			return nil, err
 		}
 		if !ru.Fks.hasFKs() {
@@ -980,7 +980,7 @@ func (rd *Deleter) DeleteRow(
 		}
 	}
 	if rd.Fks.checker != nil && checkFKs == CheckFKs {
-		if err := rd.Fks.addAllIdxChecks(ctx, values); err != nil {
+		if err := rd.Fks.addAllIdxChecks(ctx, values, traceKV); err != nil {
 			return err
 		}
 		return rd.Fks.checker.runCheck(ctx, values, nil)
@@ -998,7 +998,7 @@ func (rd *Deleter) DeleteIndexRow(
 	traceKV bool,
 ) error {
 	if rd.Fks.checker != nil {
-		if err := rd.Fks.addAllIdxChecks(ctx, values); err != nil {
+		if err := rd.Fks.addAllIdxChecks(ctx, values, traceKV); err != nil {
 			return err
 		}
 		if err := rd.Fks.checker.runCheck(ctx, values, nil); err != nil {

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -170,6 +170,7 @@ var kvMsgRegexp = regexp.MustCompile(
 		"^Del ",
 		"^Get ",
 		"^Scan ",
+		"^FKScan ",
 		"^querying next range at ",
 		"^output row: ",
 		"^rows affected: ",


### PR DESCRIPTION
Previously, foreign key lookups had no kv tracing facility. Now, the
scans emitted by the lookups are added to the trace when kv tracing is
enabled.

Updates #33326.

Release note (sql change): foreign key checks are now added to kv
traces.