### PR TITLE
sql: fix the privilege checking for UPSERT

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -27,7 +27,7 @@ statement ok
 REVOKE ALL ON t FROM bar
 
 statement ok
-INSERT INTO t VALUES(1, 1),(2, 2)
+INSERT INTO t VALUES (1, 1), (2, 2)
 
 statement ok
 SELECT * from t
@@ -79,7 +79,7 @@ statement error user testuser does not have GRANT privilege on relation t
 REVOKE ALL ON t FROM bar
 
 statement error user testuser does not have INSERT privilege on relation t
-INSERT INTO t VALUES(1, 1),(2, 2)
+INSERT INTO t VALUES (1, 1), (2, 2)
 
 statement error user testuser does not have SELECT privilege on relation t
 SELECT * FROM t
@@ -126,7 +126,10 @@ statement error user testuser does not have GRANT privilege on relation t
 REVOKE ALL ON t FROM bar
 
 statement error user testuser does not have INSERT privilege on relation t
-INSERT INTO t VALUES(1, 1),(2, 2)
+INSERT INTO t VALUES (1, 1), (2, 2)
+
+statement error user testuser does not have INSERT privilege on relation t
+UPSERT INTO t VALUES (1, 1), (2, 2)
 
 statement ok
 SELECT * FROM t
@@ -170,7 +173,7 @@ statement ok
 REVOKE ALL ON t FROM bar
 
 statement ok
-INSERT INTO t VALUES(1, 1),(2, 2)
+INSERT INTO t VALUES (1, 1), (2, 2)
 
 statement error user testuser does not have SELECT privilege on relation t
 SELECT * FROM t
@@ -214,7 +217,7 @@ statement ok
 REVOKE ALL ON t FROM bar
 
 statement ok
-INSERT INTO t VALUES(1, 1),(2, 2)
+INSERT INTO t VALUES (1, 1), (2, 2)
 
 statement ok
 SELECT * FROM t
@@ -252,7 +255,29 @@ GRANT INSERT ON t TO testuser
 user testuser
 
 statement ok
+INSERT INTO t VALUES (1, 2)
+
+statement error user testuser does not have SELECT privilege on relation t
 INSERT INTO t VALUES (1, 2) ON CONFLICT (k) DO NOTHING
+
+statement error user testuser does not have SELECT privilege on relation t
+INSERT INTO t VALUES (1, 2) ON CONFLICT (k) DO UPDATE SET v = excluded.v
+
+statement error user testuser does not have SELECT privilege on relation t
+UPSERT INTO t VALUES (1, 2)
+
+user root
+
+statement ok
+GRANT SELECT ON t TO testuser
+
+user testuser
+
+statement ok
+INSERT INTO t VALUES (1, 2) ON CONFLICT (k) DO NOTHING
+
+statement error user testuser does not have UPDATE privilege on relation t
+UPSERT INTO t VALUES (1, 2)
 
 statement error user testuser does not have UPDATE privilege on relation t
 INSERT INTO t VALUES (1, 2) ON CONFLICT (k) DO UPDATE SET v = excluded.v
@@ -266,7 +291,7 @@ GRANT UPDATE ON t TO testuser
 user testuser
 
 statement ok
-INSERT INTO t VALUES (1, 2) ON CONFLICT (k) DO NOTHING
+UPSERT INTO t VALUES (1, 2)
 
 statement ok
 INSERT INTO t VALUES (1, 2) ON CONFLICT (k) DO UPDATE SET v = excluded.v

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -775,3 +775,4 @@ id   a
 
 statement ok
 DROP TABLE test_table;
+


### PR DESCRIPTION
Fixes  #33346.

Release note (bug fix): the UPSERT and INSERT ON CONFLICT statements
were not properly checking that the user had SELECT privilege on the
target table, even though they need to read from the table to
determine whether there are duplicates. They do now.