### PR TITLE
roachtest: deflake cdc/initial-scan

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -707,8 +707,7 @@ func createChangefeed(db *gosql.DB, targets, sinkURL string, initialScan bool) (
 	createStmt := fmt.Sprintf(`CREATE CHANGEFEED FOR %s INTO $1 WITH resolved`, targets)
 	extraArgs := []interface{}{sinkURL}
 	if !initialScan {
-		createStmt += `, cursor=$2`
-		extraArgs = append(extraArgs, timeutil.Now().Add(-time.Second).UnixNano())
+		createStmt += `, cursor='-1s'`
 	}
 	if err := db.QueryRow(createStmt, extraArgs...).Scan(&jobID); err != nil {
 		return 0, err


### PR DESCRIPTION
The timestamp for the initial scan was previously generated on the test
runner, which is usually someone's laptop or a teamcity machine. Avoid
this by using the time interval AS OF SYSTEM TIME notation.

This is a better fix for #32813

Release note: None