### PR TITLE
storage: evaluate limited scans optimistically without latching

### DIFF
--- a/pkg/storage/replica_write.go
+++ b/pkg/storage/replica_write.go
@@ -74,7 +74,7 @@ func (r *Replica) executeWriteBatch(
 		return nil, roachpb.NewError(err)
 	}
 
-	spans, err := r.collectSpans(&ba)
+	spans, _, err := r.collectSpans(&ba)
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}
@@ -87,7 +87,7 @@ func (r *Replica) executeWriteBatch(
 		// after preceding commands have been run to successful completion.
 		log.Event(ctx, "acquire latches")
 		var err error
-		endCmds, err = r.beginCmds(ctx, &ba, spans)
+		endCmds, err = r.beginCmds(ctx, &ba, spans, false /* optimistic */)
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}

--- a/pkg/storage/spanlatch/manager.go
+++ b/pkg/storage/spanlatch/manager.go
@@ -204,7 +204,7 @@ func (m *Manager) Acquire(
 	lg, snap := m.sequence(spans, ts)
 	defer snap.close()
 
-	err := m.wait(ctx, lg, snap)
+	err := m.wait(ctx, lg, &snap)
 	if err != nil {
 		m.Release(lg)
 		return nil, err
@@ -331,7 +331,7 @@ func ifGlobal(ts hlc.Timestamp, s spanset.SpanScope) hlc.Timestamp {
 
 // wait waits for all interfering latches in the provided snapshot to complete
 // before returning.
-func (m *Manager) wait(ctx context.Context, lg *Guard, snap snapshot) error {
+func (m *Manager) wait(ctx context.Context, lg *Guard, snap *snapshot) error {
 	timer := timeutil.NewTimer()
 	timer.Reset(base.SlowRequestThreshold)
 	defer timer.Stop()

--- a/pkg/storage/spanlatch/manager_test.go
+++ b/pkg/storage/spanlatch/manager_test.go
@@ -104,7 +104,7 @@ func (m *Manager) MustAcquireChCtx(
 	ch := make(chan *Guard)
 	lg, snap := m.sequence(spans, ts)
 	go func() {
-		err := m.wait(ctx, lg, snap)
+		err := m.wait(ctx, lg, &snap)
 		if err != nil {
 			m.Release(lg)
 			lg = nil


### PR DESCRIPTION
Fixes #9521.
Supersedes #31904.

SQL has a tendency to create scans which cover a range's entire key span, though looking only to return a finite number of results. These requests end up blocking on writes that are holding latches over keys that the scan will not actually touch. In reality, when there is a scan with a limit, the actual affected key span ends up being a small subset of the range's key span.

This change creates a new "optimistic evaluation" path for read-only requests. When evaluating optimistically, the batch will sequence itself with the latch manager, but will not wait to acquire all of its latches. Instead, it begins evaluating immediately and verifies that it would not have needed to wait on any latch acquisitions after-the-fact. When performing this verification, it uses knowledge about the limited set of keys that the scan actually looked at. If there are no conflicts, the scan succeeds. If there are conflicts, the request waits for all of its latch acquisition attempts to finish and re-evaluates.

This PR replaces #31904. The major difference between the two is that this PR exploits the structure of the latch manager to efficiently perform optimistic latch acquisition and after-the-fact verification of conflicts. Doing this requires keeping no extra state because it uses the immutable snapshots that the latch manager now captures during sequencing. The other major difference is that this PR does not release latches after a failed optimistic evaluation.

NOTE: a prevalent theory about the pathological case addressed in this PR was that overestimated read latches would serialize with write latches and write latches would serialize with overestimated read latches, causing all requests on a range to serialize. I wasn't seeing this "chaining" occur in practice. It turns out that the "timestamp awareness" in the latch manager should avoid this behavior in most cases because later writes will have higher timestamps than earlier reads, so they won't wait on them to execute. An argument could be made that because the hypothesized serialization of requests doesn't actually exist, the added complexity of this change isn't justified. I'm curious what reviewers think.

### Benchmark Results

```
name                                   old ops/sec  new ops/sec  delta
kv95/cores=16/nodes=3/splits=3          51.9k ± 0%   51.7k ± 1%     ~     (p=0.400 n=3+3)
kvS70-L1/cores=16/nodes=3/splits=3      24.1k ± 4%   27.7k ± 1%  +14.75%  (p=0.100 n=3+3)
kvS70-L5/cores=16/nodes=3/splits=3      24.5k ± 1%   27.5k ± 1%  +12.08%  (p=0.100 n=3+3)
kvS70-L1000/cores=16/nodes=3/splits=3   16.0k ± 1%   16.6k ± 2%   +3.79%  (p=0.100 n=3+3)

name                                   old p50(ms)  new p50(ms)  delta
kv95/cores=16/nodes=3/splits=3           0.70 ± 0%    0.70 ± 0%     ~     (all equal)
kvS70-L1/cores=16/nodes=3/splits=3       1.07 ± 6%    0.90 ± 0%  -15.62%  (p=0.100 n=3+3)
kvS70-L5/cores=16/nodes=3/splits=3       1.10 ± 0%    0.90 ± 0%  -18.18%  (p=0.100 n=3+3)
kvS70-L1000/cores=16/nodes=3/splits=3    1.80 ± 0%    1.67 ± 4%   -7.41%  (p=0.100 n=3+3)

name                                   old p99(ms)  new p99(ms)  delta
kv95/cores=16/nodes=3/splits=3           1.80 ± 0%    1.80 ± 0%     ~     (all equal)
kvS70-L1/cores=16/nodes=3/splits=3       5.77 ±32%    4.70 ± 0%     ~     (p=0.400 n=3+3)
kvS70-L5/cores=16/nodes=3/splits=3       5.00 ± 0%    4.70 ± 0%   -6.00%  (p=0.100 n=3+3)
kvS70-L1000/cores=16/nodes=3/splits=3    6.90 ± 3%    7.33 ± 8%     ~     (p=0.400 n=3+3)
```

_S\<num\> = --span-percent=\<num\>, L\<num\> = --span-limit=\<num\>_

Release note (performance improvement): improved performance on workloads which mix OLAP queries with inserts and updates.