### PR TITLE
exec: improvements to EncDatumRows to ColVec conversion

### DIFF
--- a/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
@@ -16,73 +16,34 @@ package main
 
 import (
 	"io"
+	"io/ioutil"
+	"strings"
 	"text/template"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
-const rowsToVecTemplate = `
-package exec
-
-import (
-  "fmt"
-
-	"github.com/cockroachdb/apd"
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-)
-
-// EncDatumRowsToColVec converts one column from EncDatumRows to a column
-// vector. columnIdx is the 0-based index of the column in the EncDatumRows.
-func EncDatumRowsToColVec(
-	rows sqlbase.EncDatumRows,
-	vec ColVec,
-	columnIdx int,
-	columnType *sqlbase.ColumnType,
-	alloc *sqlbase.DatumAlloc,
-) error {
-	nRows := uint16(len(rows))
-  // TODO(solon): Make this chain of conditionals more efficient: either a
-  // switch statement or even better a lookup table on SemanticType. Also get
-  // rid of the somewhat dubious assumption that Width is unset (0) for column
-  // types where it does not apply.
-	{{range .}}
-	if columnType.SemanticType == sqlbase.{{.SemanticType}} && columnType.Width == {{.Width}} {
-		col := vec.{{.ExecType}}()
-		datumToPhysicalFn := types.GetDatumToPhysicalFn(*columnType)
-		for i := uint16(0); i < nRows; i++ {
-			if rows[i][columnIdx].Datum == nil {
-				if err := rows[i][columnIdx].EnsureDecoded(columnType, alloc); err != nil {
-					return err
-				}
-			}
-			datum := rows[i][columnIdx].Datum
-			if datum == tree.DNull {
-				vec.SetNull(i)
-			} else {
-				v, err := datumToPhysicalFn(datum)
-				if err != nil {
-					return err
-				}
-				col[i] = v.({{.GoType}})
-			}
-		}
-		return nil
-	}
-	{{end}}
-	panic(fmt.Sprintf("Unsupported column type and width: %s, %d", columnType.SQLString(), columnType.Width))
+// Width is used when a SemanticType has a width that has an associated distinct
+// ExecType. One or more of these structs is used as a special case when
+// multiple widths need to be associated to one SemanticType in a
+// columnConversion struct.
+type Width struct {
+	Width    int32
+	ExecType string
+	GoType   string
 }
-`
 
 // columnConversion defines a conversion from a sqlbase.ColumnType to an
 // exec.ColVec.
 type columnConversion struct {
 	// SemanticType is the semantic type of the ColumnType.
 	SemanticType string
-	// Width is the optional width of the ColumnType.
-	Width int32
+
+	// Widths is set if this SemanticType has several widths to special-case. If
+	// set, only the ExecType and GoType in the Widths is used.
+	Widths []Width
+
 	// ExecType is the exec.T to which we're converting. It should correspond to
 	// a method name on exec.ColVec.
 	ExecType string
@@ -90,27 +51,53 @@ type columnConversion struct {
 }
 
 func genRowsToVec(wr io.Writer) error {
+	f, err := ioutil.ReadFile("pkg/sql/exec/rowstovec_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(f)
+
+	// Replace the template variables.
+	s = strings.Replace(s, "_TemplateType", "{{.ExecType}}", -1)
+	s = strings.Replace(s, "_GOTYPE", "{{.GoType}}", -1)
+	s = strings.Replace(s, "_SEMANTIC_TYPE", "sqlbase.{{.SemanticType}}", -1)
+	s = strings.Replace(s, "_WIDTH", "{{.Width}}", -1)
+
+	rowsToVecRe := makeFunctionRegex("_ROWS_TO_COL_VEC", 4)
+	s = rowsToVecRe.ReplaceAllString(s, `{{ template "rowsToColVec" . }}`)
+
 	// Build the list of supported column conversions.
 	var columnConversions []columnConversion
 	for s, name := range sqlbase.ColumnType_SemanticType_name {
 		semanticType := sqlbase.ColumnType_SemanticType(s)
-		for _, width := range getWidths(semanticType) {
-			ct := sqlbase.ColumnType{SemanticType: semanticType, Width: width}
+		ct := sqlbase.ColumnType{SemanticType: semanticType}
+		conversion := columnConversion{
+			SemanticType: "ColumnType_" + name,
+		}
+		widths := getWidths(semanticType)
+		for _, width := range widths {
+			ct.Width = width
 			t := types.FromColumnType(ct)
 			if t == types.Unhandled {
 				continue
 			}
-			conversion := columnConversion{
-				SemanticType: "ColumnType_" + name,
-				Width:        width,
-				ExecType:     t.String(),
-				GoType:       t.GoTypeName(),
-			}
-			columnConversions = append(columnConversions, conversion)
+			conversion.Widths = append(
+				conversion.Widths, Width{Width: width, ExecType: t.String(), GoType: t.GoTypeName()},
+			)
 		}
+		if widths == nil {
+			t := types.FromColumnType(ct)
+			if t == types.Unhandled {
+				continue
+			}
+			conversion.ExecType = t.String()
+			conversion.GoType = t.GoTypeName()
+		}
+		columnConversions = append(columnConversions, conversion)
 	}
 
-	tmpl, err := template.New("rowsToVec").Parse(rowsToVecTemplate)
+	tmpl, err := template.New("rowsToVec").Parse(s)
 	if err != nil {
 		return err
 	}
@@ -122,10 +109,10 @@ func init() {
 }
 
 // getWidths returns allowable ColumnType.Width values for the specified
-// SemanticType.
+// SemanticType. If the returned slice is nil, any width is allowed.
 func getWidths(semanticType sqlbase.ColumnType_SemanticType) []int32 {
 	if semanticType == sqlbase.ColumnType_INT {
 		return []int32{0, 8, 16, 32, 64}
 	}
-	return []int32{0}
+	return nil
 }

--- a/pkg/sql/exec/rowstovec_test.go
+++ b/pkg/sql/exec/rowstovec_test.go
@@ -86,15 +86,17 @@ func TestEncDatumRowsToColVecString(t *testing.T) {
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDString("bar")}},
 	}
 	vec := newMemColumn(types.Bytes, 2)
-	ct := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_STRING}
-	if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, &ct, &alloc); err != nil {
-		t.Fatal(err)
-	}
-	expected := newMemColumn(types.Bytes, 2)
-	expected.Bytes()[0] = []byte("foo")
-	expected.Bytes()[1] = []byte("bar")
-	if !reflect.DeepEqual(vec, expected) {
-		t.Errorf("expected vector %+v, got %+v", expected, vec)
+	for _, width := range []int32{0, 25} {
+		ct := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_STRING, Width: width}
+		if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, &ct, &alloc); err != nil {
+			t.Fatal(err)
+		}
+		expected := newMemColumn(types.Bytes, 2)
+		expected.Bytes()[0] = []byte("foo")
+		expected.Bytes()[1] = []byte("bar")
+		if !reflect.DeepEqual(vec, expected) {
+			t.Errorf("expected vector %+v, got %+v", expected, vec)
+		}
 	}
 }
 

--- a/pkg/sql/exec/rowstovec_tmpl.go
+++ b/pkg/sql/exec/rowstovec_tmpl.go
@@ -1,0 +1,108 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for rowstovec.eg.go. It's formatted in a
+// special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package exec
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// {{/*
+
+// Dummy import to pull in "apd" package.
+var _ apd.Decimal
+
+const (
+	_SEMANTIC_TYPE = sqlbase.ColumnType_SemanticType(0)
+	_WIDTH         = int32(0)
+)
+
+type _GOTYPE interface{}
+
+func _ROWS_TO_COL_VEC(
+	rows sqlbase.EncDatumRows, vec ColVec, columnIdx int, alloc *sqlbase.DatumAlloc,
+) error { // */}}
+	// {{define "rowsToColVec"}}
+	nRows := uint16(len(rows))
+	col := vec._TemplateType()
+	datumToPhysicalFn := types.GetDatumToPhysicalFn(*columnType)
+	for i := uint16(0); i < nRows; i++ {
+		if rows[i][columnIdx].Datum == nil {
+			if err := rows[i][columnIdx].EnsureDecoded(columnType, alloc); err != nil {
+				return err
+			}
+		}
+		datum := rows[i][columnIdx].Datum
+		if datum == tree.DNull {
+			vec.SetNull(i)
+		} else {
+			v, err := datumToPhysicalFn(datum)
+			if err != nil {
+				return err
+			}
+			col[i] = v.(_GOTYPE)
+		}
+	}
+	// {{end}}
+	// {{/*
+	return nil
+}
+
+// */}}
+
+// EncDatumRowsToColVec converts one column from EncDatumRows to a column
+// vector. columnIdx is the 0-based index of the column in the EncDatumRows.
+func EncDatumRowsToColVec(
+	rows sqlbase.EncDatumRows,
+	vec ColVec,
+	columnIdx int,
+	columnType *sqlbase.ColumnType,
+	alloc *sqlbase.DatumAlloc,
+) error {
+
+	switch columnType.SemanticType {
+	// {{range .}}
+	case _SEMANTIC_TYPE:
+		// {{ if .Widths }}
+		switch columnType.Width {
+		// {{range .Widths}}
+		case _WIDTH:
+			_ROWS_TO_COL_VEC(rows, vec, columnIdx, columnType, alloc)
+		// {{end}}
+		default:
+			panic(fmt.Sprintf("unsupported width %d for column type %s", columnType.Width, columnType.SQLString()))
+		}
+		// {{ else }}
+		_ROWS_TO_COL_VEC(rows, vec, columnIdx, columnType, alloc)
+		// {{end}}
+	// {{end}}
+	default:
+		panic(fmt.Sprintf("unsupported column type %s", columnType.SQLString()))
+	}
+	return nil
+}


### PR DESCRIPTION
- Introduces a switch statement instead of an if statement per
SemanticType given that the conditions are mutually exclusive.
- ColumnTypes are now not required to have a 0 width. This avoids
panics in cases where we were attempting to convert a fixed width
column type (e.g. STRING(25)).

Release note: None