### PR TITLE
storage: improve TestConsistencyQueueRecomputeStats

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -138,6 +138,12 @@ func (s *Store) ForceRaftSnapshotQueueProcess() {
 	forceScanAndProcess(s, s.raftSnapshotQueue.baseQueue)
 }
 
+// ForceConsistencyQueueProcess runs all the ranges through the consistency
+// queue.
+func (s *Store) ForceConsistencyQueueProcess() {
+	forceScanAndProcess(s, s.consistencyQueue.baseQueue)
+}
+
 // ConsistencyQueueShouldQueue invokes the shouldQueue method on the
 // store's consistency queue.
 func (s *Store) ConsistencyQueueShouldQueue(


### PR DESCRIPTION
This test mucks with the stats of a range and then relies on the
consistency checker queue to repair them. Before this patch, it was
encouraging the consistency queue to run by altering its interval
through a cluster setting. I've found that to not always be sufficient
for guaranteeing a speedy run after #33150 which increases the number of
ranges on the cluster. With that PR, sometimes the range in question
would not be processed soon enough, presumably because other ranges were
enqueued while the queue's interval was still the default of 24h.
I haven't fully investigated what happens; it seems likely to me that
simply changing that cluster setting does not guarantee what we want it
to guarantee. I can investigate more if you think this is surprising.

This patch does away with using the cluster setting and instead forces a
run of the queue. This allowed the code to became more synchronous and
simple too.

Release note: None