### PR TITLE
tests: disable tracing after error in fk logictest

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -150,7 +150,10 @@ statement ok
 INSERT INTO orders VALUES (1, 1, '780', 2)
 
 statement error foreign key violation: value \['fake'\] not found in products@primary
-SET tracing = on,kv,results; INSERT INTO orders VALUES (2, 2, 'fake', 2); SET tracing = off
+SET tracing = on,kv,results; INSERT INTO orders VALUES (2, 2, 'fake', 2)
+
+statement ok
+SET tracing = off
 
 query T rowsort
 SELECT message FROM [SHOW KV TRACE FOR SESSION]


### PR DESCRIPTION
A recent patch introduced a mistake in the fk test where tracing wasn't
disabled after an error, leading to a giant trace that was very slow to
compute on the server side.

Release note: None