### PR TITLE
sql: report the table writer in EXPLAIN

### DIFF
--- a/pkg/sql/logictest/testdata/planner_test/check_constraints
+++ b/pkg/sql/logictest/testdata/planner_test/check_constraints
@@ -25,6 +25,7 @@ count                ·         ·                          ()                  
  └── update          ·         ·                          ()                                 ·
       │              table     t9                         ·                                  ·
       │              set       b                          ·                                  ·
+      │              strategy  updater                    ·                                  ·
       │              check 0   t9.a > t9.b                ·                                  ·
       │              check 1   t9.d IS NULL               ·                                  ·
       └── render     ·         ·                          (a, b, d, "?column?")              a=CONST; "?column?"=CONST; key()
@@ -45,6 +46,7 @@ count                ·         ·                 ()                           
  └── update          ·         ·                 ()                           ·
       │              table     t9                ·                            ·
       │              set       a                 ·                            ·
+      │              strategy  updater           ·                            ·
       │              check 0   t9.a > t9.b       ·                            ·
       │              check 1   t9.d IS NULL      ·                            ·
       └── render     ·         ·                 (a, b, c, d, e, "?column?")  a=CONST; "?column?"=CONST; key()

--- a/pkg/sql/logictest/testdata/planner_test/custom_mutation_indexes
+++ b/pkg/sql/logictest/testdata/planner_test/custom_mutation_indexes
@@ -23,52 +23,56 @@ CREATE TABLE a (
 query TTT
 EXPLAIN DELETE FROM a WHERE a=10 AND b='10' AND c=1 AND d=3;
 ----
-count                ·       ·
- └── delete          ·       ·
-      │              from    a
-      └── render     ·       ·
-           └── scan  ·       ·
-·                    table   a@a_a_e_k_l_idx
-·                    spans   /10-/11
-·                    filter  ((b = '10') AND (c = 1)) AND (d = 3)
+count                ·         ·
+ └── delete          ·         ·
+      │              from      a
+      │              strategy  deleter
+      └── render     ·         ·
+           └── scan  ·         ·
+·                    table     a@a_a_e_k_l_idx
+·                    spans     /10-/11
+·                    filter    ((b = '10') AND (c = 1)) AND (d = 3)
 
 query TTT
 EXPLAIN UPDATE a SET a = 3 WHERE a=10 AND b='10' AND c=1 AND d=3;
 ----
-count                ·      ·
- └── update          ·      ·
-      │              table  a
-      │              set    a
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  a@primary
-·                    spans  /10/"10"/1/3-/10/"10"/1/4
+count                ·         ·
+ └── update          ·         ·
+      │              table     a
+      │              set       a
+      │              strategy  updater
+      └── render     ·         ·
+           └── scan  ·         ·
+·                    table     a@primary
+·                    spans     /10/"10"/1/3-/10/"10"/1/4
 
 # Check that the default index selection can be overridden.
 
 query TTT
 EXPLAIN DELETE FROM a@primary WHERE a=10 AND b='10' AND c=1 AND d=3;
 ----
-count                ·      ·
- └── delete          ·      ·
-      │              from   a
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  a@primary
-·                    spans  /10/"10"/1/3-/10/"10"/1/4
+count                ·         ·
+ └── delete          ·         ·
+      │              from      a
+      │              strategy  deleter
+      └── render     ·         ·
+           └── scan  ·         ·
+·                    table     a@primary
+·                    spans     /10/"10"/1/3-/10/"10"/1/4
 
 query TTT
 EXPLAIN UPDATE a@a_a_e_k_l_idx SET a = 3 WHERE a=10 AND b='10' AND c=1 AND d=3;
 ----
-count                      ·       ·
- └── update                ·       ·
-      │                    table   a
-      │                    set     a
-      └── render           ·       ·
-           └── index-join  ·       ·
-                ├── scan   ·       ·
-                │          table   a@a_a_e_k_l_idx
-                │          spans   /10-/11
-                │          filter  ((b = '10') AND (c = 1)) AND (d = 3)
-                └── scan   ·       ·
-·                          table   a@primary
+count                      ·         ·
+ └── update                ·         ·
+      │                    table     a
+      │                    set       a
+      │                    strategy  updater
+      └── render           ·         ·
+           └── index-join  ·         ·
+                ├── scan   ·         ·
+                │          table     a@a_a_e_k_l_idx
+                │          spans     /10-/11
+                │          filter    ((b = '10') AND (c = 1)) AND (d = 3)
+                └── scan   ·         ·
+·                          table     a@primary

--- a/pkg/sql/logictest/testdata/planner_test/ddl
+++ b/pkg/sql/logictest/testdata/planner_test/ddl
@@ -245,6 +245,7 @@ render                    ·         ·                 (k)                    �
       └── update          ·         ·                 (k, v, z)              ·
            │              table     kv                ·                      ·
            │              set       v                 ·                      ·
+           │              strategy  updater           ·                      ·
            └── render     ·         ·                 (k, v, z, "?column?")  "?column?"=CONST; k!=NULL; key(k)
                 │         render 0  test.public.kv.k  ·                      ·
                 │         render 1  test.public.kv.v  ·                      ·

--- a/pkg/sql/logictest/testdata/planner_test/delete
+++ b/pkg/sql/logictest/testdata/planner_test/delete
@@ -57,87 +57,93 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 query TTT colnames
 EXPLAIN DELETE FROM unindexed
 ----
-tree                 field  description
-count                ·      ·
- └── delete          ·      ·
-      │              from   unindexed
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  unindexed@primary
-·                    spans  ALL
+tree                 field     description
+count                ·         ·
+ └── delete          ·         ·
+      │              from      unindexed
+      │              strategy  fast deleter
+      └── render     ·         ·
+           └── scan  ·         ·
+·                    table     unindexed@primary
+·                    spans     ALL
 
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v
 ----
-count                ·       ·
- └── delete          ·       ·
-      │              from    unindexed
-      └── nosort     ·       ·
-           │         order   +v
-           └── scan  ·       ·
-·                    table   unindexed@primary
-·                    spans   ALL
-·                    filter  v = 7
+count                ·         ·
+ └── delete          ·         ·
+      │              from      unindexed
+      │              strategy  deleter
+      └── nosort     ·         ·
+           │         order     +v
+           └── scan  ·         ·
+·                    table     unindexed@primary
+·                    spans     ALL
+·                    filter    v = 7
 
 # Check DELETE with LIMIT clause (MySQL extension)
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 5 LIMIT 10
 ----
-count                     ·       ·
- └── delete               ·       ·
-      │                   from    unindexed
-      └── limit           ·       ·
-           │              count   10
-           └── render     ·       ·
-                └── scan  ·       ·
-·                         table   unindexed@primary
-·                         spans   ALL
-·                         filter  v = 5
+count                     ·         ·
+ └── delete               ·         ·
+      │                   from      unindexed
+      │                   strategy  deleter
+      └── limit           ·         ·
+           │              count     10
+           └── render     ·         ·
+                └── scan  ·         ·
+·                         table     unindexed@primary
+·                         spans     ALL
+·                         filter    v = 5
 
 query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10
 ----
-count                     ·      ·
- └── delete               ·      ·
-      │                   from   indexed
-      └── limit           ·      ·
-           │              count  10
-           └── render     ·      ·
-                └── scan  ·      ·
-·                         table  indexed@indexed_value_idx
-·                         spans  /5-/6
-·                         limit  10
+count                     ·         ·
+ └── delete               ·         ·
+      │                   from      indexed
+      │                   strategy  deleter
+      └── limit           ·         ·
+           │              count     10
+           └── render     ·         ·
+                └── scan  ·         ·
+·                         table     indexed@indexed_value_idx
+·                         spans     /5-/6
+·                         limit     10
 
 query TTT
 EXPLAIN DELETE FROM indexed LIMIT 10
 ----
-count                     ·      ·
- └── delete               ·      ·
-      │                   from   indexed
-      └── limit           ·      ·
-           │              count  10
-           └── render     ·      ·
-                └── scan  ·      ·
-·                         table  indexed@primary
-·                         spans  ALL
-·                         limit  10
+count                     ·         ·
+ └── delete               ·         ·
+      │                   from      indexed
+      │                   strategy  deleter
+      └── limit           ·         ·
+           │              count     10
+           └── render     ·         ·
+                └── scan  ·         ·
+·                         table     indexed@primary
+·                         spans     ALL
+·                         limit     10
 
 query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10 RETURNING id
 ----
-render                          ·      ·
- └── run                        ·      ·
-      └── delete                ·      ·
-           │                    from   indexed
-           └── limit            ·      ·
-                │               count  10
-                └── index-join  ·      ·
-                     ├── scan   ·      ·
-                     │          table  indexed@indexed_value_idx
-                     │          spans  /5-/6
-                     │          limit  10
-                     └── scan   ·      ·
-·                               table  indexed@primary
+render                          ·         ·
+ └── run                        ·         ·
+      └── delete                ·         ·
+           │                    from      indexed
+           │                    strategy  deleter
+           └── limit            ·         ·
+                │               count     10
+                └── index-join  ·         ·
+                     ├── scan   ·         ·
+                     │          table     indexed@indexed_value_idx
+                     │          spans     /5-/6
+                     │          limit     10
+                     └── scan   ·         ·
+·                               table     indexed@primary
 
 # Ensure that the scan for cross-range point deletes are parallelized.
 statement ok
@@ -149,6 +155,7 @@ EXPLAIN DELETE FROM a WHERE a IN (10, 20)
 count           ·         ·
  └── delete     ·         ·
       │         from      a
+      │         strategy  deleter
       └── scan  ·         ·
 ·               table     a@primary
 ·               spans     /10-/10/# /20-/20/#

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -334,11 +334,12 @@ CREATE TABLE t (
 query TTT
 EXPLAIN INSERT INTO t VALUES (1, 2)
 ----
-count             ·     ·
- └── insert       ·     ·
-      │           into  t(k, v)
-      └── values  ·     ·
-·                 size  2 columns, 1 row
+count             ·         ·
+ └── insert       ·         ·
+      │           into      t(k, v)
+      │           strategy  inserter
+      └── values  ·         ·
+·                 size      2 columns, 1 row
 
 query I
 SELECT max(level) FROM [EXPLAIN (VERBOSE) INSERT INTO t VALUES (1, 2)]
@@ -449,6 +450,7 @@ tree              field          description       columns                     o
 count             ·              ·                 ()                          ·
  └── insert       ·              ·                 ()                          ·
       │           into           t(k, v)           ·                           ·
+      │           strategy       inserter          ·                           ·
       └── values  ·              ·                 (column1 int, column2 int)  ·
 ·                 size           2 columns, 1 row  ·                           ·
 ·                 row 0, expr 0  (1)[int]          ·                           ·
@@ -562,6 +564,7 @@ EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1
 count                ·         ·                            ()              ·
  └── delete          ·         ·                            ()              ·
       │              from      t                            ·               ·
+      │              strategy  deleter                      ·               ·
       └── render     ·         ·                            (k int)         ·
            │         render 0  (k)[int]                     ·               ·
            └── scan  ·         ·                            (k int, v int)  ·
@@ -574,6 +577,7 @@ EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 count                ·         ·                            ()              ·
  └── delete          ·         ·                            ()              ·
       │              from      t                            ·               ·
+      │              strategy  deleter                      ·               ·
       └── render     ·         ·                            (k int)         k!=NULL; key(k)
            │         render 0  (k)[int]                     ·               ·
            └── scan  ·         ·                            (k int, v int)  k!=NULL; v!=NULL; key(k)
@@ -588,6 +592,7 @@ count                ·         ·                              ()              
  └── update          ·         ·                              ()                              ·
       │              table     t                              ·                               ·
       │              set       v                              ·                               ·
+      │              strategy  updater                        ·                               ·
       └── render     ·         ·                              (k int, v int, "?column?" int)  k!=NULL; v!=NULL; key(k)
            │         render 0  (k)[int]                       ·                               ·
            │         render 1  (v)[int]                       ·                               ·
@@ -604,6 +609,7 @@ count                ·         ·                              ()              
  └── update          ·         ·                              ()                              ·
       │              table     t                              ·                               ·
       │              set       v                              ·                               ·
+      │              strategy  updater                        ·                               ·
       └── render     ·         ·                              (k int, v int, "?column?" int)  ·
            │         render 0  (k)[int]                       ·                               ·
            │         render 1  (v)[int]                       ·                               ·

--- a/pkg/sql/logictest/testdata/planner_test/insert
+++ b/pkg/sql/logictest/testdata/planner_test/insert
@@ -301,6 +301,7 @@ EXPLAIN (VERBOSE) INSERT INTO insert_t TABLE select_t ORDER BY v DESC
 count                     ·          ·
  └── insert               ·          ·
       │                   into       insert_t(x, v, rowid)
+      │                   strategy   inserter
       │                   default 0  NULL
       │                   default 1  NULL
       │                   default 2  unique_rowid()
@@ -322,6 +323,7 @@ EXPLAIN (VERBOSE) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 count                     ·          ·
  └── insert               ·          ·
       │                   into       insert_t(x, v, rowid)
+      │                   strategy   inserter
       │                   default 0  NULL
       │                   default 1  NULL
       │                   default 2  unique_rowid()
@@ -339,13 +341,14 @@ count                     ·          ·
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) LIMIT 1
 ----
-count                  ·      ·
- └── insert            ·      ·
-      │                into   insert_t(x, v, rowid)
-      └── limit        ·      ·
-           │           count  1
-           └── values  ·      ·
-·                      size   2 columns, 2 rows
+count                  ·         ·
+ └── insert            ·         ·
+      │                into      insert_t(x, v, rowid)
+      │                strategy  inserter
+      └── limit        ·         ·
+           │           count     1
+           └── values  ·         ·
+·                      size      2 columns, 2 rows
 
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1
@@ -353,6 +356,7 @@ EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1
 count                       ·         ·
  └── insert                 ·         ·
       │                     into      insert_t(x, v, rowid)
+      │                     strategy  inserter
       └── limit             ·         ·
            │                count     1
            └── sort         ·         ·
@@ -367,6 +371,7 @@ EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2) LIMIT 1
 count                       ·         ·
  └── insert                 ·         ·
       │                     into      insert_t(x, v, rowid)
+      │                     strategy  inserter
       └── limit             ·         ·
            │                count     1
            └── sort         ·         ·
@@ -381,6 +386,7 @@ EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1)
 count                       ·         ·
  └── insert                 ·         ·
       │                     into      insert_t(x, v, rowid)
+      │                     strategy  inserter
       └── limit             ·         ·
            │                count     1
            └── sort         ·         ·

--- a/pkg/sql/logictest/testdata/planner_test/insert
+++ b/pkg/sql/logictest/testdata/planner_test/insert
@@ -394,3 +394,4 @@ count                       ·         ·
                 │           strategy  top 1
                 └── values  ·         ·
 ·                           size      2 columns, 2 rows
+

--- a/pkg/sql/logictest/testdata/planner_test/insert_plans
+++ b/pkg/sql/logictest/testdata/planner_test/insert_plans
@@ -1,0 +1,90 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE kv (
+  k INT PRIMARY KEY,
+  v INT
+)
+
+query TTT
+SELECT tree, field, description FROM [
+EXPLAIN (VERBOSE) INSERT INTO kv TABLE kv
+]
+----
+count           ·         ·
+ └── insert     ·         ·
+      │         into      kv(k, v)
+      │         strategy  inserter
+      └── scan  ·         ·
+·               table     kv@primary
+·               spans     ALL
+
+query TTT
+SELECT tree, field, description FROM [
+EXPLAIN (VERBOSE) INSERT INTO kv TABLE kv ON CONFLICT DO NOTHING
+]
+----
+count           ·         ·
+ └── upsert     ·         ·
+      │         into      kv(k, v)
+      │         strategy  strict upserter
+      └── scan  ·         ·
+·               table     kv@primary
+·               spans     ALL
+
+query TTT
+SELECT tree, field, description FROM [
+EXPLAIN (VERBOSE) INSERT INTO kv TABLE kv ON CONFLICT(k) DO NOTHING
+]
+----
+count           ·         ·
+ └── upsert     ·         ·
+      │         into      kv(k, v)
+      │         strategy  upserter
+      └── scan  ·         ·
+·               table     kv@primary
+·               spans     ALL
+
+query TTT
+SELECT tree, field, description FROM [
+EXPLAIN (VERBOSE) INSERT INTO kv TABLE kv ON CONFLICT(k) DO UPDATE SET v = excluded.v + 1
+]
+----
+count           ·         ·
+ └── upsert     ·         ·
+      │         into      kv(k, v)
+      │         strategy  upserter
+      │         eval 0    excluded.v + 1
+      └── scan  ·         ·
+·               table     kv@primary
+·               spans     ALL
+
+query TTT
+SELECT tree, field, description FROM [
+EXPLAIN (VERBOSE) UPSERT INTO kv TABLE kv
+]
+----
+count           ·         ·
+ └── upsert     ·         ·
+      │         into      kv(k, v)
+      │         strategy  fast upserter
+      └── scan  ·         ·
+·               table     kv@primary
+·               spans     ALL
+
+statement ok
+CREATE UNIQUE INDEX ON kv(v)
+
+query TTT
+SELECT tree, field, description FROM [
+EXPLAIN (VERBOSE) UPSERT INTO kv TABLE kv
+]
+----
+count           ·         ·
+ └── upsert     ·         ·
+      │         into      kv(k, v)
+      │         strategy  upserter
+      │         eval 0    excluded.v
+      └── scan  ·         ·
+·               table     kv@primary
+·               spans     ALL

--- a/pkg/sql/logictest/testdata/planner_test/needed_columns
+++ b/pkg/sql/logictest/testdata/planner_test/needed_columns
@@ -169,6 +169,7 @@ EXPLAIN (VERBOSE) INSERT INTO kv(k, v) SELECT 1 AS a, 2 AS b FROM (SELECT 3 AS x
 count                         ·         ·         ()                        ·
  └── insert                   ·         ·         ()                        ·
       │                       into      kv(k, v)  ·                         ·
+      │                       strategy  inserter  ·                         ·
       └── render              ·         ·         (a, b)                    a=CONST; b=CONST
            │                  render 0  1         ·                         ·
            │                  render 1  2         ·                         ·
@@ -184,6 +185,7 @@ EXPLAIN (VERBOSE) DELETE FROM kv WHERE k = 3
 count                ·         ·                 ()               ·
  └── delete          ·         ·                 ()               ·
       │              from      kv                ·                ·
+      │              strategy  fast deleter      ·                ·
       └── render     ·         ·                 (k)              k=CONST; key()
            │         render 0  test.public.kv.k  ·                ·
            └── scan  ·         ·                 (k, v[omitted])  k=CONST; key()

--- a/pkg/sql/logictest/testdata/planner_test/order_by
+++ b/pkg/sql/logictest/testdata/planner_test/order_by
@@ -505,6 +505,7 @@ render                        ·         ·                (b)        ·
  └── run                      ·         ·                (a, b, c)  ·
       └── insert              ·         ·                (a, b, c)  ·
            │                  into      t(a, b)          ·          ·
+           │                  strategy  inserter         ·          ·
            └── render         ·         ·                (x, y)     x=CONST; y=CONST
                 │             render 0  1                ·          ·
                 │             render 1  2                ·          ·
@@ -518,6 +519,7 @@ render               ·         ·                (b)        key()
  └── run             ·         ·                (a, b, c)  a=CONST; key()
       └── delete     ·         ·                (a, b, c)  a=CONST; key()
            │         from      t                ·          ·
+           │         strategy  deleter          ·          ·
            └── scan  ·         ·                (a, b, c)  a=CONST; key()
 ·                    table     t@primary        ·          ·
 ·                    spans     /3-/3/#          ·          ·
@@ -531,6 +533,7 @@ render                    ·         ·                (b)              ·
       └── update          ·         ·                (a, b, c)        ·
            │              table     t                ·                ·
            │              set       c                ·                ·
+           │              strategy  updater          ·                ·
            └── render     ·         ·                (a, b, c, bool)  bool=CONST; a!=NULL; key(a)
                 │         render 0  test.public.t.a  ·                ·
                 │         render 1  test.public.t.b  ·                ·

--- a/pkg/sql/logictest/testdata/planner_test/spool
+++ b/pkg/sql/logictest/testdata/planner_test/spool
@@ -8,147 +8,157 @@ query TTT
 EXPLAIN WITH a AS (INSERT INTO t VALUES (2) RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-limit                       ·      ·
- │                          count  1
- └── spool                  ·      ·
-      │                     limit  1
-      └── run               ·      ·
-           └── insert       ·      ·
-                │           into   t(x)
-                └── values  ·      ·
-·                           size   1 column, 1 row
+limit                       ·         ·
+ │                          count     1
+ └── spool                  ·         ·
+      │                     limit     1
+      └── run               ·         ·
+           └── insert       ·         ·
+                │           into      t(x)
+                │           strategy  inserter
+                └── values  ·         ·
+·                           size      1 column, 1 row
 
 query TTT
 EXPLAIN WITH a AS (DELETE FROM t RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-limit                     ·      ·
- │                        count  1
- └── spool                ·      ·
-      │                   limit  1
-      └── run             ·      ·
-           └── delete     ·      ·
-                │         from   t
-                └── scan  ·      ·
-·                         table  t@primary
-·                         spans  ALL
+limit                     ·         ·
+ │                        count     1
+ └── spool                ·         ·
+      │                   limit     1
+      └── run             ·         ·
+           └── delete     ·         ·
+                │         from      t
+                │         strategy  deleter
+                └── scan  ·         ·
+·                         table     t@primary
+·                         spans     ALL
 
 
 query TTT
 EXPLAIN WITH a AS (UPDATE t SET x = x + 1 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-limit                          ·      ·
- │                             count  1
- └── spool                     ·      ·
-      │                        limit  1
-      └── run                  ·      ·
-           └── update          ·      ·
-                │              table  t
-                │              set    x
-                └── render     ·      ·
-                     └── scan  ·      ·
-·                              table  t@primary
-·                              spans  ALL
+limit                          ·         ·
+ │                             count     1
+ └── spool                     ·         ·
+      │                        limit     1
+      └── run                  ·         ·
+           └── update          ·         ·
+                │              table     t
+                │              set       x
+                │              strategy  updater
+                └── render     ·         ·
+                     └── scan  ·         ·
+·                              table     t@primary
+·                              spans     ALL
 
 query TTT
 EXPLAIN WITH a AS (UPSERT INTO t VALUES (2) RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-limit                       ·      ·
- │                          count  1
- └── spool                  ·      ·
-      │                     limit  1
-      └── run               ·      ·
-           └── upsert       ·      ·
-                │           into   t(x)
-                └── values  ·      ·
-·                           size   1 column, 1 row
+limit                       ·         ·
+ │                          count     1
+ └── spool                  ·         ·
+      │                     limit     1
+      └── run               ·         ·
+           └── upsert       ·         ·
+                │           into      t(x)
+                │           strategy  upserter
+                └── values  ·         ·
+·                           size      1 column, 1 row
 
 # Ditto all mutations, with the statement source syntax.
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t VALUES (2) RETURNING x] LIMIT 1
 ----
-limit                       ·      ·
- │                          count  1
- └── spool                  ·      ·
-      │                     limit  1
-      └── run               ·      ·
-           └── insert       ·      ·
-                │           into   t(x)
-                └── values  ·      ·
-·                           size   1 column, 1 row
+limit                       ·         ·
+ │                          count     1
+ └── spool                  ·         ·
+      │                     limit     1
+      └── run               ·         ·
+           └── insert       ·         ·
+                │           into      t(x)
+                │           strategy  inserter
+                └── values  ·         ·
+·                           size      1 column, 1 row
 
 query TTT
 EXPLAIN SELECT * FROM [DELETE FROM t RETURNING x] LIMIT 1
 ----
-limit                     ·      ·
- │                        count  1
- └── spool                ·      ·
-      │                   limit  1
-      └── run             ·      ·
-           └── delete     ·      ·
-                │         from   t
-                └── scan  ·      ·
-·                         table  t@primary
-·                         spans  ALL
+limit                     ·         ·
+ │                        count     1
+ └── spool                ·         ·
+      │                   limit     1
+      └── run             ·         ·
+           └── delete     ·         ·
+                │         from      t
+                │         strategy  deleter
+                └── scan  ·         ·
+·                         table     t@primary
+·                         spans     ALL
 
 query TTT
 EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
 ----
-limit                          ·      ·
- │                             count  1
- └── spool                     ·      ·
-      │                        limit  1
-      └── run                  ·      ·
-           └── update          ·      ·
-                │              table  t
-                │              set    x
-                └── render     ·      ·
-                     └── scan  ·      ·
-·                              table  t@primary
-·                              spans  ALL
+limit                          ·         ·
+ │                             count     1
+ └── spool                     ·         ·
+      │                        limit     1
+      └── run                  ·         ·
+           └── update          ·         ·
+                │              table     t
+                │              set       x
+                │              strategy  updater
+                └── render     ·         ·
+                     └── scan  ·         ·
+·                              table     t@primary
+·                              spans     ALL
 
 query TTT
 EXPLAIN SELECT * FROM [UPSERT INTO t VALUES (2) RETURNING x] LIMIT 1
 ----
-limit                       ·      ·
- │                          count  1
- └── spool                  ·      ·
-      │                     limit  1
-      └── run               ·      ·
-           └── upsert       ·      ·
-                │           into   t(x)
-                └── values  ·      ·
-·                           size   1 column, 1 row
+limit                       ·         ·
+ │                          count     1
+ └── spool                  ·         ·
+      │                     limit     1
+      └── run               ·         ·
+           └── upsert       ·         ·
+                │           into      t(x)
+                │           strategy  upserter
+                └── values  ·         ·
+·                           size      1 column, 1 row
 
 # Check that a spool is also inserted for other processings than LIMIT.
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t VALUES (2) RETURNING x] ORDER BY x
 ----
-sort                        ·      ·
- │                          order  +x
- └── spool                  ·      ·
-      └── run               ·      ·
-           └── insert       ·      ·
-                │           into   t(x)
-                └── values  ·      ·
-·                           size   1 column, 1 row
+sort                        ·         ·
+ │                          order     +x
+ └── spool                  ·         ·
+      └── run               ·         ·
+           └── insert       ·         ·
+                │           into      t(x)
+                │           strategy  inserter
+                └── values  ·         ·
+·                           size      1 column, 1 row
 
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t VALUES (2) RETURNING x], t
 ----
-join                        ·      ·
- │                          type   cross
- ├── spool                  ·      ·
- │    └── run               ·      ·
- │         └── insert       ·      ·
- │              │           into   t(x)
- │              └── values  ·      ·
- │                          size   1 column, 1 row
- └── scan                   ·      ·
-·                           table  t@primary
-·                           spans  ALL
+join                        ·         ·
+ │                          type      cross
+ ├── spool                  ·         ·
+ │    └── run               ·         ·
+ │         └── insert       ·         ·
+ │              │           into      t(x)
+ │              │           strategy  inserter
+ │              └── values  ·         ·
+ │                          size      1 column, 1 row
+ └── scan                   ·         ·
+·                           table     t@primary
+·                           spans     ALL
 
 # Check that if a spool is already added at some level, then it is not added
 # again at levels below.
@@ -157,72 +167,79 @@ EXPLAIN WITH a AS (INSERT INTO t VALUES(2) RETURNING x),
              b AS (INSERT INTO t SELECT x+1 FROM a RETURNING x)
         SELECT * FROM b LIMIT 1
 ----
-limit                                      ·      ·
- │                                         count  1
- └── spool                                 ·      ·
-      │                                    limit  1
-      └── run                              ·      ·
-           └── insert                      ·      ·
-                │                          into   t(x)
-                └── render                 ·      ·
-                     └── run               ·      ·
-                          └── insert       ·      ·
-                               │           into   t(x)
-                               └── values  ·      ·
-·                                          size   1 column, 1 row
+limit                                      ·         ·
+ │                                         count     1
+ └── spool                                 ·         ·
+      │                                    limit     1
+      └── run                              ·         ·
+           └── insert                      ·         ·
+                │                          into      t(x)
+                │                          strategy  inserter
+                └── render                 ·         ·
+                     └── run               ·         ·
+                          └── insert       ·         ·
+                               │           into      t(x)
+                               │           strategy  inserter
+                               └── values  ·         ·
+·                                          size      1 column, 1 row
 
 # Check that no spool is inserted if a top-level render is elided.
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t VALUES (2) RETURNING x]
 ----
-run               ·     ·
- └── insert       ·     ·
-      │           into  t(x)
-      └── values  ·     ·
-·                 size  1 column, 1 row
+run               ·         ·
+ └── insert       ·         ·
+      │           into      t(x)
+      │           strategy  inserter
+      └── values  ·         ·
+·                 size      1 column, 1 row
 
 # Check that no spool is used for a top-level INSERT, but
 # sub-INSERTs still get a spool.
 query TTT
 EXPLAIN INSERT INTO t SELECT x+1 FROM [INSERT INTO t VALUES(2) RETURNING x]
 ----
-count                                 ·     ·
- └── insert                           ·     ·
-      │                               into  t(x)
-      └── spool                       ·     ·
-           └── render                 ·     ·
-                └── run               ·     ·
-                     └── insert       ·     ·
-                          │           into  t(x)
-                          └── values  ·     ·
-·                                     size  1 column, 1 row
+count                                 ·         ·
+ └── insert                           ·         ·
+      │                               into      t(x)
+      │                               strategy  inserter
+      └── spool                       ·         ·
+           └── render                 ·         ·
+                └── run               ·         ·
+                     └── insert       ·         ·
+                          │           into      t(x)
+                          │           strategy  inserter
+                          └── values  ·         ·
+·                                     size      1 column, 1 row
 
 # Check that simple computations using RETURNING get their spool pulled up.
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t VALUES (1) RETURNING x+10] WHERE @1 < 3 LIMIT 10
 ----
-limit                                 ·       ·
- │                                    count   10
- └── spool                            ·       ·
-      │                               limit   10
-      └── filter                      ·       ·
-           │                          filter  "?column?" < 3
-           └── render                 ·       ·
-                └── run               ·       ·
-                     └── insert       ·       ·
-                          │           into    t(x)
-                          └── values  ·       ·
-·                                     size    1 column, 1 row
+limit                                 ·         ·
+ │                                    count     10
+ └── spool                            ·         ·
+      │                               limit     10
+      └── filter                      ·         ·
+           │                          filter    "?column?" < 3
+           └── render                 ·         ·
+                └── run               ·         ·
+                     └── insert       ·         ·
+                          │           into      t(x)
+                          │           strategy  inserter
+                          └── values  ·         ·
+·                                     size      1 column, 1 row
 
 # Check that a pulled up spool gets elided at the top level.
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t VALUES (1) RETURNING x+10] WHERE @1 < 3
 ----
-filter                      ·       ·
- │                          filter  "?column?" < 3
- └── render                 ·       ·
-      └── run               ·       ·
-           └── insert       ·       ·
-                │           into    t(x)
-                └── values  ·       ·
-·                           size    1 column, 1 row
+filter                      ·         ·
+ │                          filter    "?column?" < 3
+ └── render                 ·         ·
+      └── run               ·         ·
+           └── insert       ·         ·
+                │           into      t(x)
+                │           strategy  inserter
+                └── values  ·         ·
+·                           size      1 column, 1 row

--- a/pkg/sql/logictest/testdata/planner_test/update
+++ b/pkg/sql/logictest/testdata/planner_test/update
@@ -97,13 +97,14 @@ CREATE TABLE xyz (
 query TTT
 EXPLAIN UPDATE xyz SET y = x
 ----
-count           ·      ·
- └── update     ·      ·
-      │         table  xyz
-      │         set    y
-      └── scan  ·      ·
-·               table  xyz@primary
-·               spans  ALL
+count           ·         ·
+ └── update     ·         ·
+      │         table     xyz
+      │         set       y
+      │         strategy  updater
+      └── scan  ·         ·
+·               table     xyz@primary
+·               spans     ALL
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
@@ -112,6 +113,7 @@ count                ·         ·                  ()                          
  └── update          ·         ·                  ()                                 ·
       │              table     xyz                ·                                  ·
       │              set       x, y               ·                                  ·
+      │              strategy  updater            ·                                  ·
       └── render     ·         ·                  (x, y, z, "?column?", "?column?")  "?column?"=CONST; "?column?"=CONST; x!=NULL; key(x)
            │         render 0  test.public.xyz.x  ·                                  ·
            │         render 1  test.public.xyz.y  ·                                  ·
@@ -125,13 +127,14 @@ count                ·         ·                  ()                          
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (y, x)
 ----
-count           ·      ·            ()         ·
- └── update     ·      ·            ()         ·
-      │         table  xyz          ·          ·
-      │         set    x, y         ·          ·
-      └── scan  ·      ·            (x, y, z)  x!=NULL; key(x)
-·               table  xyz@primary  ·          ·
-·               spans  ALL          ·          ·
+count           ·         ·            ()         ·
+ └── update     ·         ·            ()         ·
+      │         table     xyz          ·          ·
+      │         set       x, y         ·          ·
+      │         strategy  updater      ·          ·
+      └── scan  ·         ·            (x, y, z)  x!=NULL; key(x)
+·               table     xyz@primary  ·          ·
+·               spans     ALL          ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (2, 2)
@@ -140,6 +143,7 @@ count                ·         ·                  ()                     ·
  └── update          ·         ·                  ()                     ·
       │              table     xyz                ·                      ·
       │              set       x, y               ·                      ·
+      │              strategy  updater            ·                      ·
       └── render     ·         ·                  (x, y, z, "?column?")  "?column?"=CONST; x!=NULL; key(x)
            │         render 0  test.public.xyz.x  ·                      ·
            │         render 1  test.public.xyz.y  ·                      ·
@@ -193,32 +197,34 @@ CREATE TABLE kv (
 query TTT
 EXPLAIN UPDATE kv SET v = v + 1 ORDER BY v DESC
 ----
-count                     ·      ·
- └── update               ·      ·
-      │                   table  kv
-      │                   set    v
-      └── render          ·      ·
-           └── sort       ·      ·
-                │         order  -v
-                └── scan  ·      ·
-·                         table  kv@primary
-·                         spans  ALL
+count                     ·         ·
+ └── update               ·         ·
+      │                   table     kv
+      │                   set       v
+      │                   strategy  updater
+      └── render          ·         ·
+           └── sort       ·         ·
+                │         order     -v
+                └── scan  ·         ·
+·                         table     kv@primary
+·                         spans     ALL
 
 # Use case for UPDATE ... ORDER BY: renumbering a PK without unique violation.
 query TTT
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
-count                     ·      ·
- └── update               ·      ·
-      │                   table  kv
-      │                   set    v
-      └── render          ·      ·
-           └── limit      ·      ·
-                │         count  1
-                └── scan  ·      ·
-·                         table  kv@primary
-·                         spans  -/2/#
-·                         limit  1
+count                     ·         ·
+ └── update               ·         ·
+      │                   table     kv
+      │                   set       v
+      │                   strategy  updater
+      └── render          ·         ·
+           └── limit      ·         ·
+                │         count     1
+                └── scan  ·         ·
+·                         table     kv@primary
+·                         spans     -/2/#
+·                         limit     1
 
 # Check that updates on tables with multiple column families behave as
 # they should.
@@ -257,6 +263,7 @@ count                ·         ·
  └── update          ·         ·
       │              table     a
       │              set       b
+      │              strategy  updater
       └── render     ·         ·
            └── scan  ·         ·
 ·                    table     a@primary

--- a/pkg/sql/logictest/testdata/planner_test/upsert
+++ b/pkg/sql/logictest/testdata/planner_test/upsert
@@ -11,14 +11,15 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO kv TABLE kv ORDER BY v DESC
 ]
 ----
-count                ·      ·
- └── upsert          ·      ·
-      │              into   kv(k, v)
-      └── sort       ·      ·
-           │         order  -v
-           └── scan  ·      ·
-·                    table  kv@primary
-·                    spans  ALL
+count                ·         ·
+ └── upsert          ·         ·
+      │              into      kv(k, v)
+      │              strategy  fast upserter
+      └── sort       ·         ·
+           │         order     -v
+           └── scan  ·         ·
+·                    table     kv@primary
+·                    spans     ALL
 
 # Regression test for #25726.
 # UPSERT over tables with column families, on the fast path, use the

--- a/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
@@ -26,6 +26,7 @@ count                ·         ·             ()                         ·
  └── update          ·         ·             ()                         ·
       │              table     t9            ·                          ·
       │              set       b             ·                          ·
+      │              strategy  updater       ·                          ·
       │              check 0   t9.a > t9.b   ·                          ·
       │              check 1   t9.d IS NULL  ·                          ·
       └── render     ·         ·             (a, b, c, d, e, column11)  ·
@@ -46,6 +47,7 @@ count                ·         ·             ()                         ·
  └── update          ·         ·             ()                         ·
       │              table     t9            ·                          ·
       │              set       a             ·                          ·
+      │              strategy  updater       ·                          ·
       │              check 0   t9.a > t9.b   ·                          ·
       │              check 1   t9.d IS NULL  ·                          ·
       └── render     ·         ·             (a, b, c, d, e, column11)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -245,6 +245,7 @@ render                    ·         ·            (k)                 ·
       └── update          ·         ·            (k, v, z)           ·
            │              table     kv           ·                   ·
            │              set       v            ·                   ·
+           │              strategy  updater      ·                   ·
            └── render     ·         ·            (k, v, z, column7)  ·
                 │         render 0  k            ·                   ·
                 │         render 1  v            ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -57,84 +57,90 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 query TTT colnames
 EXPLAIN DELETE FROM unindexed
 ----
-tree                 field  description
-count                ·      ·
- └── delete          ·      ·
-      │              from   unindexed
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  unindexed@primary
-·                    spans  ALL
+tree                 field     description
+count                ·         ·
+ └── delete          ·         ·
+      │              from      unindexed
+      │              strategy  fast deleter
+      └── render     ·         ·
+           └── scan  ·         ·
+·                    table     unindexed@primary
+·                    spans     ALL
 
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v
 ----
-count                ·       ·
- └── delete          ·       ·
-      │              from    unindexed
-      └── nosort     ·       ·
-           │         order   +v
-           └── scan  ·       ·
-·                    table   unindexed@primary
-·                    spans   ALL
-·                    filter  v = 7
+count                ·         ·
+ └── delete          ·         ·
+      │              from      unindexed
+      │              strategy  deleter
+      └── nosort     ·         ·
+           │         order     +v
+           └── scan  ·         ·
+·                    table     unindexed@primary
+·                    spans     ALL
+·                    filter    v = 7
 
 # Check DELETE with LIMIT clause (MySQL extension)
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 5 LIMIT 10
 ----
-count                     ·       ·
- └── delete               ·       ·
-      │                   from    unindexed
-      └── limit           ·       ·
-           │              count   10
-           └── render     ·       ·
-                └── scan  ·       ·
-·                         table   unindexed@primary
-·                         spans   ALL
-·                         filter  v = 5
+count                     ·         ·
+ └── delete               ·         ·
+      │                   from      unindexed
+      │                   strategy  deleter
+      └── limit           ·         ·
+           │              count     10
+           └── render     ·         ·
+                └── scan  ·         ·
+·                         table     unindexed@primary
+·                         spans     ALL
+·                         filter    v = 5
 
 query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10
 ----
-count                     ·      ·
- └── delete               ·      ·
-      │                   from   indexed
-      └── limit           ·      ·
-           │              count  10
-           └── render     ·      ·
-                └── scan  ·      ·
-·                         table  indexed@indexed_value_idx
-·                         spans  /5-/6
-·                         limit  10
+count                     ·         ·
+ └── delete               ·         ·
+      │                   from      indexed
+      │                   strategy  deleter
+      └── limit           ·         ·
+           │              count     10
+           └── render     ·         ·
+                └── scan  ·         ·
+·                         table     indexed@indexed_value_idx
+·                         spans     /5-/6
+·                         limit     10
 
 query TTT
 EXPLAIN DELETE FROM indexed LIMIT 10
 ----
-count                     ·      ·
- └── delete               ·      ·
-      │                   from   indexed
-      └── limit           ·      ·
-           │              count  10
-           └── render     ·      ·
-                └── scan  ·      ·
-·                         table  indexed@primary
-·                         spans  ALL
-·                         limit  10
+count                     ·         ·
+ └── delete               ·         ·
+      │                   from      indexed
+      │                   strategy  deleter
+      └── limit           ·         ·
+           │              count     10
+           └── render     ·         ·
+                └── scan  ·         ·
+·                         table     indexed@primary
+·                         spans     ALL
+·                         limit     10
 
 query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10 RETURNING id
 ----
-render                          ·      ·
- └── run                        ·      ·
-      └── delete                ·      ·
-           │                    from   indexed
-           └── limit            ·      ·
-                │               count  10
-                └── index-join  ·      ·
-                     ├── scan   ·      ·
-                     │          table  indexed@indexed_value_idx
-                     │          spans  /5-/6
-                     │          limit  10
-                     └── scan   ·      ·
-·                               table  indexed@primary
+render                          ·         ·
+ └── run                        ·         ·
+      └── delete                ·         ·
+           │                    from      indexed
+           │                    strategy  deleter
+           └── limit            ·         ·
+                │               count     10
+                └── index-join  ·         ·
+                     ├── scan   ·         ·
+                     │          table     indexed@indexed_value_idx
+                     │          spans     /5-/6
+                     │          limit     10
+                     └── scan   ·         ·
+·                               table     indexed@primary

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -326,11 +326,12 @@ CREATE TABLE t (
 query TTT
 EXPLAIN INSERT INTO t VALUES (1, 2)
 ----
-count             ·     ·
- └── insert       ·     ·
-      │           into  t(k, v)
-      └── values  ·     ·
-·                 size  2 columns, 1 row
+count             ·         ·
+ └── insert       ·         ·
+      │           into      t(k, v)
+      │           strategy  inserter
+      └── values  ·         ·
+·                 size      2 columns, 1 row
 
 query I
 SELECT max(level) FROM [EXPLAIN (VERBOSE) INSERT INTO t VALUES (1, 2)]
@@ -436,6 +437,7 @@ tree              field          description       columns                     o
 count             ·              ·                 ()                          ·
  └── insert       ·              ·                 ()                          ·
       │           into           t(k, v)           ·                           ·
+      │           strategy       inserter          ·                           ·
       └── values  ·              ·                 (column1 int, column2 int)  ·
 ·                 size           2 columns, 1 row  ·                           ·
 ·                 row 0, expr 0  (1)[int]          ·                           ·
@@ -513,6 +515,7 @@ EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 count                ·         ·                            ()              ·
  └── delete          ·         ·                            ()              ·
       │              from      t                            ·               ·
+      │              strategy  deleter                      ·               ·
       └── render     ·         ·                            (k int)         k!=NULL; key(k)
            │         render 0  (k)[int]                     ·               ·
            └── scan  ·         ·                            (k int, v int)  k!=NULL; v!=NULL; key(k)
@@ -527,6 +530,7 @@ count                ·         ·                              ()              
  └── update          ·         ·                              ()                           ·
       │              table     t                              ·                            ·
       │              set       v                              ·                            ·
+      │              strategy  updater                        ·                            ·
       └── render     ·         ·                              (k int, v int, column5 int)  ·
            │         render 0  (k)[int]                       ·                            ·
            │         render 1  (v)[int]                       ·                            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -301,6 +301,7 @@ EXPLAIN (VERBOSE) INSERT INTO insert_t TABLE select_t ORDER BY v DESC LIMIT 10
 count                          ·         ·
  └── insert                    ·         ·
       │                        into      insert_t(x, v, rowid)
+      │                        strategy  inserter
       └── render               ·         ·
            │                   render 0  x
            │                   render 1  v
@@ -322,6 +323,7 @@ EXPLAIN (VERBOSE) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 count                ·         ·
  └── insert          ·         ·
       │              into      insert_t(x, v, rowid)
+      │              strategy  inserter
       └── render     ·         ·
            │         render 0  x
            │         render 1  v
@@ -335,56 +337,60 @@ count                ·         ·
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) LIMIT 1
 ----
-count                       ·      ·
- └── insert                 ·      ·
-      │                     into   insert_t(x, v, rowid)
-      └── render            ·      ·
-           └── limit        ·      ·
-                │           count  1
-                └── values  ·      ·
-·                           size   2 columns, 2 rows
+count                       ·         ·
+ └── insert                 ·         ·
+      │                     into      insert_t(x, v, rowid)
+      │                     strategy  inserter
+      └── render            ·         ·
+           └── limit        ·         ·
+                │           count     1
+                └── values  ·         ·
+·                           size      2 columns, 2 rows
 
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1
 ----
-count                            ·      ·
- └── insert                      ·      ·
-      │                          into   insert_t(x, v, rowid)
-      └── render                 ·      ·
-           └── limit             ·      ·
-                │                count  1
-                └── sort         ·      ·
-                     │           order  +column2
-                     └── values  ·      ·
-·                                size   2 columns, 2 rows
+count                            ·         ·
+ └── insert                      ·         ·
+      │                          into      insert_t(x, v, rowid)
+      │                          strategy  inserter
+      └── render                 ·         ·
+           └── limit             ·         ·
+                │                count     1
+                └── sort         ·         ·
+                     │           order     +column2
+                     └── values  ·         ·
+·                                size      2 columns, 2 rows
 
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2) LIMIT 1
 ----
-count                            ·      ·
- └── insert                      ·      ·
-      │                          into   insert_t(x, v, rowid)
-      └── render                 ·      ·
-           └── limit             ·      ·
-                │                count  1
-                └── sort         ·      ·
-                     │           order  +column2
-                     └── values  ·      ·
-·                                size   2 columns, 2 rows
+count                            ·         ·
+ └── insert                      ·         ·
+      │                          into      insert_t(x, v, rowid)
+      │                          strategy  inserter
+      └── render                 ·         ·
+           └── limit             ·         ·
+                │                count     1
+                └── sort         ·         ·
+                     │           order     +column2
+                     └── values  ·         ·
+·                                size      2 columns, 2 rows
 
 query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1)
 ----
-count                            ·      ·
- └── insert                      ·      ·
-      │                          into   insert_t(x, v, rowid)
-      └── render                 ·      ·
-           └── limit             ·      ·
-                │                count  1
-                └── sort         ·      ·
-                     │           order  +column2
-                     └── values  ·      ·
-·                                size   2 columns, 2 rows
+count                            ·         ·
+ └── insert                      ·         ·
+      │                          into      insert_t(x, v, rowid)
+      │                          strategy  inserter
+      └── render                 ·         ·
+           └── limit             ·         ·
+                │                count     1
+                └── sort         ·         ·
+                     │           order     +column2
+                     └── values  ·         ·
+·                                size      2 columns, 2 rows
 
 # ORDER BY expression that's not inserted into table.
 query TTTTT
@@ -396,6 +402,7 @@ render                                   ·         ·                      ("?c
  └── run                                 ·         ·                      (x, v, rowid[hidden])          ·
       └── insert                         ·         ·                      (x, v, rowid[hidden])          ·
            │                             into      insert_t(x, v, rowid)  ·                              ·
+           │                             strategy  inserter               ·                              ·
            └── render                    ·         ·                      (length, "?column?", column9)  ·
                 │                        render 0  length                 ·                              ·
                 │                        render 1  "?column?"             ·                              ·
@@ -431,6 +438,7 @@ render                 ·              ·                      (x)              
  └── run               ·              ·                      (x, rowid[hidden])           ·
       └── insert       ·              ·                      (x, rowid[hidden])           ·
            │           into           mutation(x, rowid, y)  ·                            ·
+           │           strategy       inserter               ·                            ·
            └── values  ·              ·                      (column1, column5, column6)  ·
 ·                      size           3 columns, 1 row       ·                            ·
 ·                      row 0, expr 0  2                      ·                            ·
@@ -450,6 +458,7 @@ EXPLAIN (VERBOSE) INSERT INTO mutation(x, y) VALUES (2, 2)
 count             ·              ·                      ()                           ·
  └── insert       ·              ·                      ()                           ·
       │           into           mutation(x, y, rowid)  ·                            ·
+      │           strategy       inserter               ·                            ·
       └── values  ·              ·                      (column1, column2, column7)  ·
 ·                 size           3 columns, 1 row       ·                            ·
 ·                 row 0, expr 0  2                      ·                            ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -487,6 +487,7 @@ render                 ·              ·                 (b)              ·
  └── run               ·              ·                 (a, b, c)        ·
       └── insert       ·              ·                 (a, b, c)        ·
            │           into           t(a, b, c)        ·                ·
+           │           strategy       inserter          ·                ·
            └── values  ·              ·                 (x, y, column6)  ·
 ·                      size           3 columns, 1 row  ·                ·
 ·                      row 0, expr 0  1                 ·                ·
@@ -501,6 +502,7 @@ render               ·         ·                (b)        key()
  └── run             ·         ·                (a, b, c)  a=CONST; key()
       └── delete     ·         ·                (a, b, c)  a=CONST; key()
            │         from      t                ·          ·
+           │         strategy  deleter          ·          ·
            └── scan  ·         ·                (a, b, c)  a=CONST; key()
 ·                    table     t@primary        ·          ·
 ·                    spans     /3-/3/#          ·          ·
@@ -514,6 +516,7 @@ render                    ·         ·          (b)                 ·
       └── update          ·         ·          (a, b, c)           ·
            │              table     t          ·                   ·
            │              set       c          ·                   ·
+           │              strategy  updater    ·                   ·
            └── render     ·         ·          (a, b, c, column7)  ·
                 │         render 0  a          ·                   ·
                 │         render 1  b          ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1417,26 +1417,28 @@ render     ·         ·
 query TTT
 EXPLAIN UPDATE t4 SET c = 30 WHERE a = 10 and b = 20
 ----
-count                ·      ·
- └── update          ·      ·
-      │              table  t4
-      │              set    c
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  t4@primary
-·                    spans  /10/20-/10/20/#
+count                ·         ·
+ └── update          ·         ·
+      │              table     t4
+      │              set       c
+      │              strategy  updater
+      └── render     ·         ·
+           └── scan  ·         ·
+·                    table     t4@primary
+·                    spans     /10/20-/10/20/#
 
 # Optimization should not be applied for deletes.
 query TTT
 EXPLAIN DELETE FROM t4 WHERE a = 10 and b = 20
 ----
-count                ·      ·
- └── delete          ·      ·
-      │              from   t4
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  t4@primary
-·                    spans  /10/20-/10/20/#
+count                ·         ·
+ └── delete          ·         ·
+      │              from      t4
+      │              strategy  fast deleter
+      └── render     ·         ·
+           └── scan  ·         ·
+·                    table     t4@primary
+·                    spans     /10/20-/10/20/#
 
 # Optimization should not be applied for non point lookups.
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -11,121 +11,129 @@ query TTT
 EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-limit                     ·      ·
- │                        count  1
- └── spool                ·      ·
-      │                   limit  1
-      └── run             ·      ·
-           └── insert     ·      ·
-                │         into   t(x)
-                └── scan  ·      ·
-·                         table  t2@primary
-·                         spans  ALL
+limit                     ·         ·
+ │                        count     1
+ └── spool                ·         ·
+      │                   limit     1
+      └── run             ·         ·
+           └── insert     ·         ·
+                │         into      t(x)
+                │         strategy  inserter
+                └── scan  ·         ·
+·                         table     t2@primary
+·                         spans     ALL
 
 query TTT
 EXPLAIN WITH a AS (DELETE FROM t RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-limit                     ·      ·
- │                        count  1
- └── spool                ·      ·
-      │                   limit  1
-      └── run             ·      ·
-           └── delete     ·      ·
-                │         from   t
-                └── scan  ·      ·
-·                         table  t@primary
-·                         spans  ALL
+limit                     ·         ·
+ │                        count     1
+ └── spool                ·         ·
+      │                   limit     1
+      └── run             ·         ·
+           └── delete     ·         ·
+                │         from      t
+                │         strategy  deleter
+                └── scan  ·         ·
+·                         table     t@primary
+·                         spans     ALL
 
 
 query TTT
 EXPLAIN WITH a AS (UPDATE t SET x = x + 1 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-limit                          ·      ·
- │                             count  1
- └── spool                     ·      ·
-      │                        limit  1
-      └── run                  ·      ·
-           └── update          ·      ·
-                │              table  t
-                │              set    x
-                └── render     ·      ·
-                     └── scan  ·      ·
-·                              table  t@primary
-·                              spans  ALL
+limit                          ·         ·
+ │                             count     1
+ └── spool                     ·         ·
+      │                        limit     1
+      └── run                  ·         ·
+           └── update          ·         ·
+                │              table     t
+                │              set       x
+                │              strategy  updater
+                └── render     ·         ·
+                     └── scan  ·         ·
+·                              table     t@primary
+·                              spans     ALL
 
 query TTT
 EXPLAIN WITH a AS (UPSERT INTO t VALUES (2) RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-limit                       ·      ·
- │                          count  1
- └── spool                  ·      ·
-      │                     limit  1
-      └── run               ·      ·
-           └── upsert       ·      ·
-                │           into   t(x)
-                └── values  ·      ·
-·                           size   1 column, 1 row
+limit                       ·         ·
+ │                          count     1
+ └── spool                  ·         ·
+      │                     limit     1
+      └── run               ·         ·
+           └── upsert       ·         ·
+                │           into      t(x)
+                │           strategy  upserter
+                └── values  ·         ·
+·                           size      1 column, 1 row
 
 # Ditto all mutations, with the statement source syntax.
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x] LIMIT 1
 ----
-limit                     ·      ·
- │                        count  1
- └── spool                ·      ·
-      │                   limit  1
-      └── run             ·      ·
-           └── insert     ·      ·
-                │         into   t(x)
-                └── scan  ·      ·
-·                         table  t2@primary
-·                         spans  ALL
+limit                     ·         ·
+ │                        count     1
+ └── spool                ·         ·
+      │                   limit     1
+      └── run             ·         ·
+           └── insert     ·         ·
+                │         into      t(x)
+                │         strategy  inserter
+                └── scan  ·         ·
+·                         table     t2@primary
+·                         spans     ALL
 
 query TTT
 EXPLAIN SELECT * FROM [DELETE FROM t RETURNING x] LIMIT 1
 ----
-limit                     ·      ·
- │                        count  1
- └── spool                ·      ·
-      │                   limit  1
-      └── run             ·      ·
-           └── delete     ·      ·
-                │         from   t
-                └── scan  ·      ·
-·                         table  t@primary
-·                         spans  ALL
+limit                     ·         ·
+ │                        count     1
+ └── spool                ·         ·
+      │                   limit     1
+      └── run             ·         ·
+           └── delete     ·         ·
+                │         from      t
+                │         strategy  deleter
+                └── scan  ·         ·
+·                         table     t@primary
+·                         spans     ALL
 
 query TTT
 EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
 ----
-limit                          ·      ·
- │                             count  1
- └── spool                     ·      ·
-      │                        limit  1
-      └── run                  ·      ·
-           └── update          ·      ·
-                │              table  t
-                │              set    x
-                └── render     ·      ·
-                     └── scan  ·      ·
-·                              table  t@primary
-·                              spans  ALL
+limit                          ·         ·
+ │                             count     1
+ └── spool                     ·         ·
+      │                        limit     1
+      └── run                  ·         ·
+           └── update          ·         ·
+                │              table     t
+                │              set       x
+                │              strategy  updater
+                └── render     ·         ·
+                     └── scan  ·         ·
+·                              table     t@primary
+·                              spans     ALL
 
 query TTT
 EXPLAIN SELECT * FROM [UPSERT INTO t VALUES (2) RETURNING x] LIMIT 1
 ----
-limit                       ·      ·
- │                          count  1
- └── spool                  ·      ·
-      │                     limit  1
-      └── run               ·      ·
-           └── upsert       ·      ·
-                │           into   t(x)
-                └── values  ·      ·
-·                           size   1 column, 1 row
+limit                       ·         ·
+ │                          count     1
+ └── spool                  ·         ·
+      │                     limit     1
+      └── run               ·         ·
+           └── upsert       ·         ·
+                │           into      t(x)
+                │           strategy  upserter
+                └── values  ·         ·
+·                           size      1 column, 1 row
 
 # Check that a spool is also inserted for other processings than LIMIT.
 query TTT
@@ -139,6 +147,7 @@ group                          ·            ·
            └── run             ·            ·
                 └── insert     ·            ·
                      │         into         t(x)
+                     │         strategy     inserter
                      └── scan  ·            ·
 ·                              table        t2@primary
 ·                              spans        ALL
@@ -146,18 +155,19 @@ group                          ·            ·
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x], t
 ----
-join                      ·      ·
- │                        type   cross
- ├── spool                ·      ·
- │    └── run             ·      ·
- │         └── insert     ·      ·
- │              │         into   t(x)
- │              └── scan  ·      ·
- │                        table  t2@primary
- │                        spans  ALL
- └── scan                 ·      ·
-·                         table  t@primary
-·                         spans  ALL
+join                      ·         ·
+ │                        type      cross
+ ├── spool                ·         ·
+ │    └── run             ·         ·
+ │         └── insert     ·         ·
+ │              │         into      t(x)
+ │              │         strategy  inserter
+ │              └── scan  ·         ·
+ │                        table     t2@primary
+ │                        spans     ALL
+ └── scan                 ·         ·
+·                         table     t@primary
+·                         spans     ALL
 
 # Check that if a spool is already added at some level, then it is not added
 # again at levels below.
@@ -167,78 +177,85 @@ EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x),
              b AS (INSERT INTO t SELECT x+1 FROM a RETURNING x)
         SELECT * FROM b LIMIT 1
 ----
-limit                                         ·      ·
- │                                            count  1
- └── spool                                    ·      ·
-      │                                       limit  1
-      └── run                                 ·      ·
-           └── insert                         ·      ·
-                │                             into   t(x)
-                └── spool                     ·      ·
-                     └── render               ·      ·
-                          └── run             ·      ·
-                               └── insert     ·      ·
-                                    │         into   t(x)
-                                    └── scan  ·      ·
-·                                             table  t2@primary
-·                                             spans  ALL
+limit                                         ·         ·
+ │                                            count     1
+ └── spool                                    ·         ·
+      │                                       limit     1
+      └── run                                 ·         ·
+           └── insert                         ·         ·
+                │                             into      t(x)
+                │                             strategy  inserter
+                └── spool                     ·         ·
+                     └── render               ·         ·
+                          └── run             ·         ·
+                               └── insert     ·         ·
+                                    │         into      t(x)
+                                    │         strategy  inserter
+                                    └── scan  ·         ·
+·                                             table     t2@primary
+·                                             spans     ALL
 
 # Check that no spool is inserted if a top-level render is elided.
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
-run             ·      ·
- └── insert     ·      ·
-      │         into   t(x)
-      └── scan  ·      ·
-·               table  t2@primary
-·               spans  ALL
+run             ·         ·
+ └── insert     ·         ·
+      │         into      t(x)
+      │         strategy  inserter
+      └── scan  ·         ·
+·               table     t2@primary
+·               spans     ALL
 
 # Check that no spool is used for a top-level INSERT, but
 # sub-INSERTs still get a spool.
 query TTT
 EXPLAIN INSERT INTO t SELECT x+1 FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
-count                               ·      ·
- └── insert                         ·      ·
-      │                             into   t(x)
-      └── spool                     ·      ·
-           └── render               ·      ·
-                └── run             ·      ·
-                     └── insert     ·      ·
-                          │         into   t(x)
-                          └── scan  ·      ·
-·                                   table  t2@primary
-·                                   spans  ALL
+count                               ·         ·
+ └── insert                         ·         ·
+      │                             into      t(x)
+      │                             strategy  inserter
+      └── spool                     ·         ·
+           └── render               ·         ·
+                └── run             ·         ·
+                     └── insert     ·         ·
+                          │         into      t(x)
+                          │         strategy  inserter
+                          └── scan  ·         ·
+·                                   table     t2@primary
+·                                   spans     ALL
 
 # Check that simple computations using RETURNING get their spool pulled up.
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10] WHERE @1 < 3 LIMIT 10
 ----
-render                              ·       ·
- └── limit                          ·       ·
-      │                             count   10
-      └── spool                     ·       ·
-           │                        limit   10
-           └── filter               ·       ·
-                │                   filter  x < -7
-                └── run             ·       ·
-                     └── insert     ·       ·
-                          │         into    t(x)
-                          └── scan  ·       ·
-·                                   table   t2@primary
-·                                   spans   ALL
+render                              ·         ·
+ └── limit                          ·         ·
+      │                             count     10
+      └── spool                     ·         ·
+           │                        limit     10
+           └── filter               ·         ·
+                │                   filter    x < -7
+                └── run             ·         ·
+                     └── insert     ·         ·
+                          │         into      t(x)
+                          │         strategy  inserter
+                          └── scan  ·         ·
+·                                   table     t2@primary
+·                                   spans     ALL
 
 # Check that a pulled up spool gets elided at the top level.
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10] WHERE @1 < 3
 ----
-render                    ·       ·
- └── filter               ·       ·
-      │                   filter  x < -7
-      └── run             ·       ·
-           └── insert     ·       ·
-                │         into    t(x)
-                └── scan  ·       ·
-·                         table   t2@primary
-·                         spans   ALL
+render                    ·         ·
+ └── filter               ·         ·
+      │                   filter    x < -7
+      └── run             ·         ·
+           └── insert     ·         ·
+                │         into      t(x)
+                │         strategy  inserter
+                └── scan  ·         ·
+·                         table     t2@primary
+·                         spans     ALL

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -97,14 +97,15 @@ CREATE TABLE xyz (
 query TTT
 EXPLAIN UPDATE xyz SET y = x
 ----
-count                ·      ·
- └── update          ·      ·
-      │              table  xyz
-      │              set    y
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  xyz@primary
-·                    spans  ALL
+count                ·         ·
+ └── update          ·         ·
+      │              table     xyz
+      │              set       y
+      │              strategy  updater
+      └── render     ·         ·
+           └── scan  ·         ·
+·                    table     xyz@primary
+·                    spans     ALL
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
@@ -113,6 +114,7 @@ count                ·         ·            ()                           ·
  └── update          ·         ·            ()                           ·
       │              table     xyz          ·                            ·
       │              set       x, y         ·                            ·
+      │              strategy  updater      ·                            ·
       └── render     ·         ·            (x, y, z, column7, column8)  ·
            │         render 0  x            ·                            ·
            │         render 1  y            ·                            ·
@@ -130,6 +132,7 @@ count                ·         ·            ()               ·
  └── update          ·         ·            ()               ·
       │              table     xyz          ·                ·
       │              set       x, y         ·                ·
+      │              strategy  updater      ·                ·
       └── render     ·         ·            (x, y, z, y, x)  ·
            │         render 0  x            ·                ·
            │         render 1  y            ·                ·
@@ -147,6 +150,7 @@ count                     ·         ·            ()                           
  └── update               ·         ·            ()                           ·
       │                   table     xyz          ·                            ·
       │                   set       x, y         ·                            ·
+      │                   strategy  updater      ·                            ·
       └── render          ·         ·            (x, y, z, column7, column7)  ·
            │              render 0  x            ·                            ·
            │              render 1  y            ·                            ·
@@ -206,32 +210,34 @@ CREATE TABLE kv (
 query TTT
 EXPLAIN UPDATE kv SET v = v + 1 ORDER BY v DESC LIMIT 10
 ----
-count                          ·      ·
- └── update                    ·      ·
-      │                        table  kv
-      │                        set    v
-      └── render               ·      ·
-           └── limit           ·      ·
-                │              count  10
-                └── sort       ·      ·
-                     │         order  -v
-                     └── scan  ·      ·
-·                              table  kv@primary
-·                              spans  ALL
+count                          ·         ·
+ └── update                    ·         ·
+      │                        table     kv
+      │                        set       v
+      │                        strategy  updater
+      └── render               ·         ·
+           └── limit           ·         ·
+                │              count     10
+                └── sort       ·         ·
+                     │         order     -v
+                     └── scan  ·         ·
+·                              table     kv@primary
+·                              spans     ALL
 
 # Use case for UPDATE ... ORDER BY: renumbering a PK without unique violation.
 query TTT
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
-count                ·      ·
- └── update          ·      ·
-      │              table  kv
-      │              set    v
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  kv@primary
-·                    spans  -/2/#
-·                    limit  1
+count                ·         ·
+ └── update          ·         ·
+      │              table     kv
+      │              set       v
+      │              strategy  updater
+      └── render     ·         ·
+           └── scan  ·         ·
+·                    table     kv@primary
+·                    spans     -/2/#
+·                    limit     1
 
 # Check that updates on tables with multiple column families behave as
 # they should.

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -11,14 +11,15 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO kv TABLE kv ORDER BY v DESC
 ]
 ----
-count                ·      ·
- └── upsert          ·      ·
-      │              into   kv(k, v)
-      └── sort       ·      ·
-           │         order  -v
-           └── scan  ·      ·
-·                    table  kv@primary
-·                    spans  ALL
+count                ·         ·
+ └── upsert          ·         ·
+      │              into      kv(k, v)
+      │              strategy  fast upserter
+      └── sort       ·         ·
+           │         order     -v
+           └── scan  ·         ·
+·                    table     kv@primary
+·                    spans     ALL
 
 # Regression test for #25726.
 # UPSERT over tables with column families, on the fast path, use the

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -81,6 +81,10 @@ type tableWriter interface {
 
 	// close frees all resources held by the tableWriter.
 	close(context.Context)
+
+	// desc returns a name suitable for describing the table writer in
+	// the output of EXPLAIN.
+	desc() string
 }
 
 type autoCommitOpt int

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -38,6 +38,9 @@ type tableDeleter struct {
 	alloc *sqlbase.DatumAlloc
 }
 
+// desc is part of the tableWriter interface.
+func (*tableDeleter) desc() string { return "deleter" }
+
 // walkExprs is part of the tableWriter interface.
 func (td *tableDeleter) walkExprs(_ func(desc string, index int, expr tree.TypedExpr)) {}
 

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -29,6 +29,9 @@ type tableInserter struct {
 	ri row.Inserter
 }
 
+// desc is part of the tableWriter interface.
+func (*tableInserter) desc() string { return "inserter" }
+
 // init is part of the tableWriter interface.
 func (ti *tableInserter) init(txn *client.Txn, _ *tree.EvalContext) error {
 	ti.tableWriterBase.init(txn)

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -29,6 +29,9 @@ type tableUpdater struct {
 	ru row.Updater
 }
 
+// desc is part of the tableWriter interface.
+func (*tableUpdater) desc() string { return "updater" }
+
 // init is part of the tableWriter interface.
 func (tu *tableUpdater) init(txn *client.Txn, _ *tree.EvalContext) error {
 	tu.tableWriterBase.init(txn)

--- a/pkg/sql/tablewriter_upsert.go
+++ b/pkg/sql/tablewriter_upsert.go
@@ -272,6 +272,9 @@ type tableUpserter struct {
 	fetcher               row.Fetcher
 }
 
+// desc is part of the tableWriter interface.
+func (*tableUpserter) desc() string { return "upserter" }
+
 // init is part of the tableWriter interface.
 func (tu *tableUpserter) init(txn *client.Txn, evalCtx *tree.EvalContext) error {
 	tu.tableWriterBase.init(txn)

--- a/pkg/sql/tablewriter_upsert_fast.go
+++ b/pkg/sql/tablewriter_upsert_fast.go
@@ -36,6 +36,9 @@ type fastTableUpserter struct {
 	tableUpserterBase
 }
 
+// desc is part of the tableWriter interface.
+func (*fastTableUpserter) desc() string { return "fast upserter" }
+
 // init is part of the tableWriter interface.
 func (tu *fastTableUpserter) init(txn *client.Txn, _ *tree.EvalContext) error {
 	tu.tableWriterBase.init(txn)

--- a/pkg/sql/tablewriter_upsert_strict.go
+++ b/pkg/sql/tablewriter_upsert_strict.go
@@ -38,6 +38,10 @@ type strictTableUpserter struct {
 	conflictIndexes []sqlbase.IndexDescriptor
 }
 
+// desc is part of the tableWriter interface.
+func (*strictTableUpserter) desc() string { return "strict upserter" }
+
+// init is part of the tableWriter interface.
 func (tu *strictTableUpserter) init(txn *client.Txn, evalCtx *tree.EvalContext) error {
 	tu.tableWriterBase.init(txn)
 

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -424,6 +424,7 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			}
 			buf.WriteByte(')')
 			v.observer.attr(name, "into", buf.String())
+			v.observer.attr(name, "strategy", n.run.ti.desc())
 		}
 
 		if v.observer.expr != nil {
@@ -449,6 +450,7 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			}
 			buf.WriteByte(')')
 			v.observer.attr(name, "into", buf.String())
+			v.observer.attr(name, "strategy", n.run.tw.desc())
 		}
 
 		if v.observer.expr != nil {
@@ -477,6 +479,7 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 				}
 				v.observer.attr(name, "set", buf.String())
 			}
+			v.observer.attr(name, "strategy", n.run.tu.desc())
 		}
 		if v.observer.expr != nil {
 			for i, cexpr := range n.run.computeExprs {
@@ -492,6 +495,11 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 	case *deleteNode:
 		if v.observer.attr != nil {
 			v.observer.attr(name, "from", n.run.td.tableDesc().Name)
+			ext := ""
+			if _, fast := canDeleteFast(v.ctx, n.source, &n.run); fast {
+				ext = "fast "
+			}
+			v.observer.attr(name, "strategy", ext+n.run.td.desc())
 		}
 		// A deleter has no sub-expressions, so nothing special to do here.
 		n.source = v.visit(n.source)


### PR DESCRIPTION
This patch changes EXPLAIN to report the internal algorithm used to
perform a mutation statement (INSERT etc). This can be used for
performance troubleshooting.

We are not documenting this since this is likely to change.

Release note: None