### PR TITLE
storage: fatal on replica corruption

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1377,6 +1377,12 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	var exitStatus int
+	log.SetExitFunc(true /* hideStack */, func(i int) {
+		exitStatus = i
+	})
+	defer log.ResetExitFunc()
+
 	const numReplicas = 5
 	const extraStores = 3
 
@@ -1490,6 +1496,10 @@ func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 			}
 			return nil
 		})
+	}
+
+	if exitStatus != 255 {
+		t.Fatalf("unexpected exit status %d", exitStatus)
 	}
 }
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -6702,6 +6702,8 @@ func (r *Replica) maybeSetCorrupt(ctx context.Context, pErr *roachpb.Error) *roa
 			cErr.Processed = false
 			return roachpb.NewError(cErr)
 		}
+
+		log.Fatalf(ctx, "replica is corrupted: %s", pErr)
 	}
 	return pErr
 }


### PR DESCRIPTION
This path is seldom taken, but when it does and the node keeps running,
it won't be performing as expected. Besides, individual replicas can
become "corrupt" due to problems that affect a larger scope, as seen
in #33375 (which is caused by a txn anomaly, #32784).

Release note: None