### PR TITLE
roachtest: fix tag:default if no filters are specified

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -54,13 +54,6 @@ type testFilter struct {
 }
 
 func newFilter(filter []string) *testFilter {
-	if len(filter) == 0 {
-		return &testFilter{
-			name: regexp.MustCompile(`.`),
-			tag:  regexp.MustCompile(`.`),
-		}
-	}
-
 	var name []string
 	var tag []string
 	var rawTag []string

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -43,7 +43,7 @@ func TestMatchOrSkip(t *testing.T) {
 		expectedSkip string
 	}{
 		{nil, "foo", nil, true, ""},
-		{nil, "foo", []string{"bar"}, true, ""},
+		{nil, "foo", []string{"bar"}, true, "[tag:default] does not match [bar]"},
 		{[]string{"tag:b"}, "foo", []string{"bar"}, true, ""},
 		{[]string{"tag:b"}, "foo", nil, true, "[tag:b] does not match [default]"},
 		{[]string{"tag:default"}, "foo", nil, true, ""},


### PR DESCRIPTION
If no filters or tags are specified, roachtest is intended to use
`tag:default`. But a bit of spurious code was causing it to use `.` for
the default tag. This was causing a discrepancy between `list weekly`
and `list`. The former would report `weekly/tpcc-max` as skipped while
the latter would not.

Release note: None