### PR TITLE
backport-2.1: storage: un-starve TestReplicateQueueDownReplicate

### DIFF
--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -191,8 +191,8 @@ func TestReplicateQueueDownReplicate(t *testing.T) {
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationAuto,
 			ServerArgs: base.TestServerArgs{
-				ScanMinIdleTime: time.Millisecond,
-				ScanMaxIdleTime: time.Millisecond,
+				ScanMinIdleTime: 10 * time.Millisecond,
+				ScanMaxIdleTime: 10 * time.Millisecond,
 				Knobs: base.TestingKnobs{
 					Store: &storage.StoreTestingKnobs{
 						// Prevent the merge queue from immediately discarding our splits.


### PR DESCRIPTION
Backport 1/1 commits from #33013.

/cc @cockroachdb/release

---

Before this change,

> make test PKG=./pkg/storage/ TESTS=TestReplicateQueueDownReplicate
> TESTFLAGS='-count 10'

takes ~109s on my laptop. After this change, it takes ~18s.

This is in line with a test failure on CI which looked like the test
had just never managed to schedule the goroutines that matter in time
for things to wrap up.

Fixes #32256.

Release note: None
