### PR TITLE
backport-2.1: roachtest: add and fix acceptance/replicagc-changed-peers

### DIFF
--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -98,6 +98,7 @@ func newReplicaGCQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *repl
 		queueConfig{
 			maxSize:                  defaultQueueMaxSize,
 			needsLease:               false,
+			needsRaftInitialized:     true,
 			needsSystemConfig:        false,
 			acceptsUnsplitRanges:     true,
 			processDestroyedReplicas: true,


### PR DESCRIPTION
@petermattis this should bring release-2.1 into parity with master in https://github.com/cockroachdb/cockroach/issues/33153#issuecomment-450509602. (`master` apparently also fails sometimes, but shouldn't usually).

----

Backport 1/2 commits from #32845.

/cc @cockroachdb/release

---

This fixes the failure of the acceptance test (see below)
since it will wake up dormant replicas, at which point they'll
become candidates and are checked for replicaGC aggressively.

This change also means that as a node restarts, all replicas are woken
up (once) over an interval of 10 minutes (default scan interval) when a
node restarts. This is a kind of "slow unquiescence storm" that should
not impact cluster performance significantly. For example, at 50k
ranges, we'd wake up ~83 ranges per second over the first ten minutes
after restarting a node (virtually all of these ranges are expected to
immediately quiesce again).

It's still unfortunate that this is sort of a side effect in the base
queue and driven by the scanner. Perhaps we could add a goroutine at
node start time that explicitly performs this task, and generates
appropriate output to indicate what's happening.

For the test:

Shut down a node, move all of its replicas to a completely disjoint set
of stores, and restart the node. Ensure that it replicaGCs the remaining
replicas reasonably fast (i.e. within minutes).

Note that #32843 would cause failures in this test as well, but this
problem has not been observed so far and are unlikely to occur in this
test since it leaves no freedom for replica placement at any time.

Fixes #25131.
Fixes #24067.

[1]: https://github.com/cockroachdb/cockroach/blob/cf617ba86cae5e6a8b7f977ebb49ea6f0afe6a95/pkg/storage/replica_gc_queue.go#L144-L155

Release note (bug fix): CockroachDB will no longer report erroneous under-replicated ranges corresponding to replicas that were waiting to be deleted.
