### PR TITLE
distsqlrun: refactor the ridiculous processor.Run() interface

### DIFF
--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
@@ -199,13 +198,9 @@ func (sp *csvWriter) OutputTypes() []sqlbase.ColumnType {
 	return sql.ExportPlanResultTypes
 }
 
-func (sp *csvWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (sp *csvWriter) Run(ctx context.Context) {
 	ctx, span := tracing.ChildSpan(ctx, "csvWriter")
 	defer tracing.FinishSpan(span)
-
-	if wg != nil {
-		defer wg.Done()
-	}
 
 	err := func() error {
 		pattern := exportFilePatternDefault

--- a/pkg/ccl/importccl/sst_writer_proc.go
+++ b/pkg/ccl/importccl/sst_writer_proc.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -89,11 +88,7 @@ func (sp *sstWriter) OutputTypes() []sqlbase.ColumnType {
 	return sstOutputTypes
 }
 
-func (sp *sstWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
-	if wg != nil {
-		defer wg.Done()
-	}
-
+func (sp *sstWriter) Run(ctx context.Context) {
 	sp.input.Start(ctx)
 
 	ctx, span := tracing.ChildSpan(ctx, "sstWriter")

--- a/pkg/sql/distsqlrun/aggregator_test.go
+++ b/pkg/sql/distsqlrun/aggregator_test.go
@@ -444,7 +444,7 @@ func BenchmarkAggregation(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.TODO(), nil)
+				d.Run(context.TODO())
 				input.Reset()
 			}
 			b.StopTimer()
@@ -483,7 +483,7 @@ func BenchmarkCountRows(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		d.Run(context.TODO(), nil)
+		d.Run(context.TODO())
 		input.Reset()
 	}
 }
@@ -515,7 +515,7 @@ func BenchmarkGrouping(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		d.Run(context.Background(), nil /* wg */)
+		d.Run(context.Background())
 		input.Reset()
 	}
 	b.StopTimer()
@@ -573,7 +573,7 @@ func benchmarkAggregationWithGrouping(b *testing.B, numOrderedCols int) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.Background(), nil /* wg */)
+				d.Run(context.Background())
 				input.Reset()
 			}
 			b.StopTimer()

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -17,7 +17,6 @@ package distsqlrun
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -69,15 +68,11 @@ func (*backfiller) OutputTypes() []sqlbase.ColumnType {
 }
 
 // Run is part of the Processor interface.
-func (b *backfiller) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (b *backfiller) Run(ctx context.Context) {
 	opName := fmt.Sprintf("%sBackfiller", b.name)
 	ctx = logtags.AddTag(ctx, opName, int(b.spec.Table.ID))
 	ctx, span := processorSpan(ctx, opName)
 	defer tracing.FinishSpan(span)
-
-	if wg != nil {
-		defer wg.Done()
-	}
 
 	if err := b.mainLoop(ctx); err != nil {
 		b.output.Push(nil /* row */, &ProducerMetadata{Err: err})

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -162,7 +162,7 @@ type RowSource interface {
 // RowSourcedProcessor is the union of RowSource and Processor.
 type RowSourcedProcessor interface {
 	RowSource
-	Run(_ context.Context, wg *sync.WaitGroup)
+	Run(context.Context)
 }
 
 // Run reads records from the source and outputs them to the receiver, properly

--- a/pkg/sql/distsqlrun/cluster_test.go
+++ b/pkg/sql/distsqlrun/cluster_test.go
@@ -119,7 +119,8 @@ func TestClusterFlow(t *testing.T) {
 		Flow: distsqlpb.FlowSpec{
 			FlowID: fid,
 			Processors: []distsqlpb.ProcessorSpec{{
-				Core: distsqlpb.ProcessorCoreUnion{TableReader: &tr1},
+				ProcessorID: 1,
+				Core:        distsqlpb.ProcessorCoreUnion{TableReader: &tr1},
 				Post: distsqlpb.PostProcessSpec{
 					Projection:    true,
 					OutputColumns: []uint32{0, 1},
@@ -140,7 +141,8 @@ func TestClusterFlow(t *testing.T) {
 		Flow: distsqlpb.FlowSpec{
 			FlowID: fid,
 			Processors: []distsqlpb.ProcessorSpec{{
-				Core: distsqlpb.ProcessorCoreUnion{TableReader: &tr2},
+				ProcessorID: 2,
+				Core:        distsqlpb.ProcessorCoreUnion{TableReader: &tr2},
 				Post: distsqlpb.PostProcessSpec{
 					Projection:    true,
 					OutputColumns: []uint32{0, 1},
@@ -162,7 +164,8 @@ func TestClusterFlow(t *testing.T) {
 			FlowID: fid,
 			Processors: []distsqlpb.ProcessorSpec{
 				{
-					Core: distsqlpb.ProcessorCoreUnion{TableReader: &tr3},
+					ProcessorID: 3,
+					Core:        distsqlpb.ProcessorCoreUnion{TableReader: &tr3},
 					Post: distsqlpb.PostProcessSpec{
 						Projection:    true,
 						OutputColumns: []uint32{0, 1},
@@ -175,6 +178,7 @@ func TestClusterFlow(t *testing.T) {
 					}},
 				},
 				{
+					ProcessorID: 4,
 					Input: []distsqlpb.InputSyncSpec{{
 						Type: distsqlpb.InputSyncSpec_ORDERED,
 						Ordering: distsqlpb.Ordering{Columns: []distsqlpb.Ordering_Column{

--- a/pkg/sql/distsqlrun/countrows.go
+++ b/pkg/sql/distsqlrun/countrows.go
@@ -16,7 +16,6 @@ package distsqlrun
 
 import (
 	"context"
-	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -110,17 +109,6 @@ func (ag *countAggregator) ConsumerDone() {
 
 func (ag *countAggregator) ConsumerClosed() {
 	ag.InternalClose()
-}
-
-func (ag *countAggregator) Run(ctx context.Context, wg *sync.WaitGroup) {
-	if ag.out.output == nil {
-		panic("aggregator output not initialized for emitting rows")
-	}
-	ctx = ag.Start(ctx)
-	Run(ctx, ag, ag.out.output)
-	if wg != nil {
-		wg.Done()
-	}
 }
 
 // outputStatsToTrace outputs the collected distinct stats to the trace. Will

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -17,7 +17,6 @@ package distsqlrun
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -147,18 +146,6 @@ func (d *Distinct) Start(ctx context.Context) context.Context {
 func (d *SortedDistinct) Start(ctx context.Context) context.Context {
 	d.input.Start(ctx)
 	return d.StartInternal(ctx, sortedDistinctProcName)
-}
-
-// Run is part of the processor interface.
-func (d *SortedDistinct) Run(ctx context.Context, wg *sync.WaitGroup) {
-	if d.out.output == nil {
-		panic("distinct output not initialized for emitting rows")
-	}
-	ctx = d.Start(ctx)
-	Run(ctx, d, d.out.output)
-	if wg != nil {
-		wg.Done()
-	}
 }
 
 func (d *Distinct) matchLastGroupKey(row sqlbase.EncDatumRow) (bool, error) {

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -128,7 +128,7 @@ func TestDistinct(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			d.Run(context.Background(), nil /* wg */)
+			d.Run(context.Background())
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
 			}
@@ -177,7 +177,7 @@ func benchmarkDistinct(b *testing.B, orderedColumns []uint32) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.Background(), nil /* wg */)
+				d.Run(context.Background())
 				input.Reset()
 			}
 		})

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -566,7 +566,10 @@ func (f *Flow) startInternal(ctx context.Context, doneFn func()) error {
 	}
 	for i := 0; i < len(f.processors); i++ {
 		f.waitGroup.Add(1)
-		go f.processors[i].Run(ctx, &f.waitGroup)
+		go func(i int) {
+			f.processors[i].Run(ctx)
+			f.waitGroup.Done()
+		}(i)
 	}
 	f.startedGoroutines = len(f.startables) > 0 || len(f.processors) > 0 || !f.isLocal()
 	return nil
@@ -624,7 +627,7 @@ func (f *Flow) Run(ctx context.Context, doneFn func()) error {
 		return err
 	}
 	if headProc != nil {
-		headProc.Run(ctx, nil)
+		headProc.Run(ctx)
 	}
 	return nil
 }

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -112,7 +112,7 @@ func TestHashJoiner(t *testing.T) {
 				if i == 1 {
 					h.forcedStoredSide = &side
 				}
-				h.Run(context.Background(), nil /* wg */)
+				h.Run(context.Background())
 				side = otherSide(h.storedSide)
 
 				if !out.ProducerClosed {
@@ -230,7 +230,7 @@ func TestHashJoinerError(t *testing.T) {
 			}
 			outTypes := h.OutputTypes()
 			setup(h)
-			h.Run(context.Background(), nil /* wg */)
+			h.Run(context.Background())
 
 			if !out.ProducerClosed {
 				return errors.New("output RowReceiver not closed")
@@ -366,7 +366,7 @@ func TestHashJoinerDrain(t *testing.T) {
 	h.initialBufferSize = 0
 
 	out.ConsumerDone()
-	h.Run(context.Background(), nil /* wg */)
+	h.Run(context.Background())
 
 	if !out.ProducerClosed {
 		t.Fatalf("output RowReceiver not closed")
@@ -490,7 +490,7 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 	// Disable initial buffering. We always store the right stream in this case.
 	h.initialBufferSize = 0
 
-	h.Run(context.Background(), nil /* wg */)
+	h.Run(context.Background())
 
 	if !out.ProducerClosed {
 		t.Fatalf("output RowReceiver not closed")
@@ -582,7 +582,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 						if err != nil {
 							b.Fatal(err)
 						}
-						h.Run(context.Background(), nil /* wg */)
+						h.Run(context.Background())
 						leftInput.Reset()
 						rightInput.Reset()
 					}

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
@@ -411,7 +411,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			irj.Run(ctx, nil /* wg */)
+			irj.Run(ctx)
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
 			}
@@ -612,7 +612,7 @@ func TestInterleavedReaderJoinerTrailingMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	irj.Run(ctx, nil /* wg */)
+	irj.Run(ctx)
 	if !out.ProducerClosed {
 		t.Fatalf("output RowReceiver not closed")
 	}

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -329,7 +329,7 @@ func TestJoinReader(t *testing.T) {
 				// Set a lower batch size to force multiple batches.
 				jr.batchSize = 2
 
-				jr.Run(ctx, nil /* wg */)
+				jr.Run(ctx)
 
 				if !in.Done {
 					t.Fatal("joinReader didn't consume all the rows")
@@ -449,7 +449,7 @@ INSERT INTO test.t VALUES
 			// Set a lower batch size to force multiple batches.
 			jr.batchSize = 2
 
-			jr.Run(ctx, nil /* wg */)
+			jr.Run(ctx)
 
 			// Check results.
 			var res sqlbase.EncDatumRows
@@ -524,7 +524,7 @@ func TestJoinReaderDrain(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		jr.Run(ctx, nil /* wg */)
+		jr.Run(ctx)
 	})
 
 	// ConsumerDone verifies that the producer drains properly by checking that
@@ -545,7 +545,7 @@ func TestJoinReaderDrain(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		jr.Run(ctx, nil /* wg */)
+		jr.Run(ctx)
 		row, meta := out.Next()
 		if row != nil {
 			t.Fatalf("row was pushed unexpectedly: %s", row.String(oneIntCol))
@@ -621,7 +621,7 @@ func BenchmarkJoinReader(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				jr.Run(ctx, nil /* wg */)
+				jr.Run(ctx)
 				input.Reset()
 			}
 		})

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -714,7 +714,7 @@ func TestMergeJoiner(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m.Run(context.Background(), nil /* wg */)
+			m.Run(context.Background())
 
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
@@ -820,7 +820,7 @@ func TestConsumerClosed(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m.Run(context.Background(), nil /* wg */)
+			m.Run(context.Background())
 
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
@@ -867,7 +867,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				m.Run(context.Background(), nil /* wg */)
+				m.Run(context.Background())
 				leftInput.Reset()
 				rightInput.Reset()
 			}
@@ -886,7 +886,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				m.Run(context.Background(), nil /* wg */)
+				m.Run(context.Background())
 				leftInput.Reset()
 				rightInput.Reset()
 			}
@@ -906,7 +906,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				m.Run(context.Background(), nil /* wg */)
+				m.Run(context.Background())
 				leftInput.Reset()
 				rightInput.Reset()
 			}

--- a/pkg/sql/distsqlrun/noop_test.go
+++ b/pkg/sql/distsqlrun/noop_test.go
@@ -54,7 +54,7 @@ func BenchmarkNoop(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.Background(), nil /* wg */)
+				d.Run(context.Background())
 				input.Reset()
 			}
 		})

--- a/pkg/sql/distsqlrun/processor_utils_test.go
+++ b/pkg/sql/distsqlrun/processor_utils_test.go
@@ -162,7 +162,7 @@ func (p *ProcessorTest) RunTestCases(
 			p.config.BeforeTestCase(processor, inputs, output)
 		}
 
-		processor.Run(ctx, nil)
+		processor.Run(ctx)
 
 		if p.config.AfterTestCase != nil {
 			p.config.AfterTestCase(processor, inputs, output)

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -17,7 +17,6 @@ package distsqlrun
 import (
 	"context"
 	"math"
-	"sync"
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -40,8 +39,7 @@ type Processor interface {
 	OutputTypes() []sqlbase.ColumnType
 
 	// Run is the main loop of the processor.
-	// If wg is non-nil, wg.Done is called before exiting.
-	Run(_ context.Context, wg *sync.WaitGroup)
+	Run(context.Context)
 }
 
 // ProcOutputHelper is a helper type that performs filtering and projection on
@@ -796,15 +794,12 @@ func (pb *ProcessorBase) OutputTypes() []sqlbase.ColumnType {
 }
 
 // Run is part of the processor interface.
-func (pb *ProcessorBase) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (pb *ProcessorBase) Run(ctx context.Context) {
 	if pb.out.output == nil {
 		panic("processor output not initialized for emitting rows")
 	}
 	ctx = pb.self.Start(ctx)
 	Run(ctx, pb.self, pb.out.output)
-	if wg != nil {
-		wg.Done()
-	}
 }
 
 // ProcStateOpts contains fields used by the ProcessorBase's family of functions

--- a/pkg/sql/distsqlrun/project_set_test.go
+++ b/pkg/sql/distsqlrun/project_set_test.go
@@ -173,7 +173,7 @@ func BenchmarkProjectSet(b *testing.B) {
 					b.Fatal(err)
 				}
 
-				p.Run(context.Background(), nil /* wg */)
+				p.Run(context.Background())
 			}
 		})
 	}

--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -16,7 +16,6 @@ package distsqlrun
 
 import (
 	"context"
-	"sync"
 
 	"github.com/axiomhq/hyperloglog"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -116,11 +115,7 @@ func (s *sampleAggregator) pushTrailingMeta(ctx context.Context) {
 }
 
 // Run is part of the Processor interface.
-func (s *sampleAggregator) Run(ctx context.Context, wg *sync.WaitGroup) {
-	if wg != nil {
-		defer wg.Done()
-	}
-
+func (s *sampleAggregator) Run(ctx context.Context) {
 	s.input.Start(ctx)
 	s.StartInternal(ctx, sampleAggregatorProcName)
 	defer tracing.FinishSpan(s.span)

--- a/pkg/sql/distsqlrun/sample_aggregator_test.go
+++ b/pkg/sql/distsqlrun/sample_aggregator_test.go
@@ -112,7 +112,7 @@ func TestSampleAggregator(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		p.Run(context.Background(), nil /* wg */)
+		p.Run(context.Background())
 	}
 	// Randomly interleave the output rows from the samplers into a single buffer.
 	samplerResults := NewRowBuffer(samplerOutTypes, nil /* rows */, RowBufferArgs{})
@@ -141,7 +141,7 @@ func TestSampleAggregator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	agg.Run(context.Background(), nil /* wg */)
+	agg.Run(context.Background())
 	// Make sure there was no error.
 	finalOut.GetRowsNoMeta(t)
 	r := sqlutils.MakeSQLRunner(sqlDB)

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -16,7 +16,6 @@ package distsqlrun
 
 import (
 	"context"
-	"sync"
 
 	"github.com/axiomhq/hyperloglog"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
@@ -141,11 +140,7 @@ func (s *samplerProcessor) pushTrailingMeta(ctx context.Context) {
 }
 
 // Run is part of the Processor interface.
-func (s *samplerProcessor) Run(ctx context.Context, wg *sync.WaitGroup) {
-	if wg != nil {
-		defer wg.Done()
-	}
-
+func (s *samplerProcessor) Run(ctx context.Context) {
 	s.input.Start(ctx)
 	s.StartInternal(ctx, samplerProcName)
 	defer tracing.FinishSpan(s.span)

--- a/pkg/sql/distsqlrun/sampler_test.go
+++ b/pkg/sql/distsqlrun/sampler_test.go
@@ -58,7 +58,7 @@ func runSampler(t *testing.T, numRows, numSamples int) []int {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.Run(context.Background(), nil /* wg */)
+	p.Run(context.Background())
 
 	// Verify we have numSamples distinct rows.
 	res := make([]int, 0, numSamples)
@@ -187,7 +187,7 @@ func TestSamplerSketch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.Run(context.Background(), nil /* wg */)
+	p.Run(context.Background())
 
 	rows = out.GetRowsNoMeta(t)
 	// We expect one sampled row and two sketch rows.

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -331,7 +331,7 @@ func TestSorter(t *testing.T) {
 								t.Fatal(err)
 							}
 						}
-						s.Run(context.Background(), nil /* wg */)
+						s.Run(context.Background())
 						if !out.ProducerClosed {
 							t.Fatalf("output RowReceiver not closed")
 						}
@@ -408,7 +408,7 @@ func BenchmarkSortAll(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				s.Run(context.Background(), nil /* wg */)
+				s.Run(context.Background())
 				input.Reset()
 			}
 		})
@@ -450,7 +450,7 @@ func BenchmarkSortLimit(b *testing.B) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					s.Run(context.Background(), nil /* wg */)
+					s.Run(context.Background())
 					input.Reset()
 				}
 			})
@@ -498,7 +498,7 @@ func BenchmarkSortChunks(b *testing.B) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					s.Run(context.Background(), nil /* wg */)
+					s.Run(context.Background())
 					input.Reset()
 				}
 			})

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -152,7 +152,7 @@ func TestTableReader(t *testing.T) {
 					tr.Start(ctx)
 					results = tr
 				} else {
-					tr.Run(ctx, nil /* wg */)
+					tr.Run(ctx)
 					if !buf.ProducerClosed {
 						t.Fatalf("output RowReceiver not closed")
 					}
@@ -246,7 +246,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 			tr.Start(ctx)
 			results = tr
 		} else {
-			tr.Run(ctx, nil /* wg */)
+			tr.Run(ctx)
 			if !buf.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
 			}

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -369,7 +369,7 @@ func runProcessorTest(
 		pt.batchSize = 2
 	}
 
-	p.Run(context.Background(), nil /* wg */)
+	p.Run(context.Background())
 	if !out.ProducerClosed {
 		t.Fatalf("output RowReceiver not closed")
 	}

--- a/pkg/sql/distsqlrun/values_test.go
+++ b/pkg/sql/distsqlrun/values_test.go
@@ -83,7 +83,7 @@ func TestValuesProcessor(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					v.Run(context.Background(), nil)
+					v.Run(context.Background())
 					if !out.ProducerClosed {
 						t.Fatalf("output RowReceiver not closed")
 					}
@@ -155,7 +155,7 @@ func BenchmarkValuesProcessor(b *testing.B) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					v.Run(context.Background(), nil /* wg */)
+					v.Run(context.Background())
 				}
 			})
 		}

--- a/pkg/sql/distsqlrun/zigzagjoiner_test.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner_test.go
@@ -509,7 +509,7 @@ func TestZigzagJoiner(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			z.Run(ctx, nil /* wg */)
+			z.Run(ctx)
 
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
@@ -590,7 +590,7 @@ func TestZigzagJoinerDrain(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		zz.Run(ctx, nil /* wg */)
+		zz.Run(ctx)
 	})
 
 	//TODO(pbardea): When RowSource inputs are added, ensure that meta is


### PR DESCRIPTION
The Run() method was optionally taking a WaitGroup, to signal before
returning. The method is synchronous; the caller can signal whatever it
wants after the callee returns.

Release note: None