### PR TITLE
distsql: refactor flow.StartSync()

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -258,7 +258,7 @@ func (dsp *DistSQLPlanner) Run(
 	}
 
 	// TODO(radu): this should go through the flow scheduler.
-	if err := flow.StartSync(ctx, func() {}); err != nil {
+	if err := flow.Run(ctx, func() {}); err != nil {
 		log.Fatalf(ctx, "unexpected error from syncFlow.Start(): %s "+
 			"The error should have gone to the consumer.", err)
 	}
@@ -267,8 +267,6 @@ func (dsp *DistSQLPlanner) Run(
 	if planCtx.planner != nil && !planCtx.ignoreClose {
 		planCtx.planner.curPlan.close(ctx)
 	}
-
-	flow.Wait()
 	flow.Cleanup(ctx)
 }
 

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -75,7 +75,7 @@ func runTestFlow(
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := flow.StartAsync(ctx, func() {}); err != nil {
+	if err := flow.Start(ctx, func() {}); err != nil {
 		t.Fatal(err)
 	}
 	flow.Wait()

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -563,7 +563,7 @@ func TestSyncFlowAfterDrain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := flow.StartAsync(ctx, func() {}); err != nil {
+	if err := flow.Start(ctx, func() {}); err != nil {
 		t.Fatal(err)
 	}
 	flow.Wait()

--- a/pkg/sql/distsqlrun/flow_scheduler.go
+++ b/pkg/sql/distsqlrun/flow_scheduler.go
@@ -96,7 +96,7 @@ func (fs *flowScheduler) runFlowNow(ctx context.Context, f *Flow) error {
 	)
 	fs.mu.numRunning++
 	fs.metrics.FlowStart()
-	if err := f.StartAsync(ctx, func() { fs.flowDoneCh <- f }); err != nil {
+	if err := f.Start(ctx, func() { fs.flowDoneCh <- f }); err != nil {
 		return err
 	}
 	// TODO(radu): we could replace the WaitGroup with a structure that keeps a

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -537,11 +537,10 @@ func (ds *ServerImpl) RunSyncFlow(stream distsqlpb.DistSQL_RunSyncFlowServer) er
 		defer ctxCancel()
 		f.startables = append(f.startables, mbox)
 		ds.Metrics.FlowStart()
-		if err := f.StartSync(ctx, func() {}); err != nil {
+		if err := f.Run(ctx, func() {}); err != nil {
 			log.Fatalf(ctx, "unexpected error from syncFlow.Start(): %s "+
 				"The error should have gone to the consumer.", err)
 		}
-		f.Wait()
 		f.Cleanup(ctx)
 		ds.Metrics.FlowStop()
 	}); err != nil {


### PR DESCRIPTION
It was burdening the caller with also calling Flow.Wait(), although
that's bizarre for a sync method. No longer.
Also rename some Flow methods.

Release note: None