### PR TITLE
sql: make pg_catalog OIDs stable and refer to the descriptor IDs directly

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -290,9 +290,6 @@ const (
 	// clusters (default databases).
 	MinNonPredefinedUserDescID = MinUserDescID + 2
 
-	// VirtualDescriptorID is the ID used by all virtual descriptors.
-	VirtualDescriptorID = math.MaxUint32
-
 	// RootNamespaceID is the ID of the root namespace.
 	RootNamespaceID = 0
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -52,40 +52,40 @@ const crdbInternalName = "crdb_internal"
 
 var crdbInternal = virtualSchema{
 	name: crdbInternalName,
-	tableDefs: []virtualSchemaDef{
-		crdbInternalBackwardDependenciesTable,
-		crdbInternalBuildInfoTable,
-		crdbInternalBuiltinFunctionsTable,
-		crdbInternalClusterQueriesTable,
-		crdbInternalClusterSessionsTable,
-		crdbInternalClusterSettingsTable,
-		crdbInternalCreateStmtsTable,
-		crdbInternalFeatureUsage,
-		crdbInternalForwardDependenciesTable,
-		crdbInternalGossipNodesTable,
-		crdbInternalGossipAlertsTable,
-		crdbInternalGossipLivenessTable,
-		crdbInternalGossipNetworkTable,
-		crdbInternalIndexColumnsTable,
-		crdbInternalJobsTable,
-		crdbInternalKVNodeStatusTable,
-		crdbInternalKVStoreStatusTable,
-		crdbInternalLeasesTable,
-		crdbInternalLocalQueriesTable,
-		crdbInternalLocalSessionsTable,
-		crdbInternalLocalMetricsTable,
-		crdbInternalPartitionsTable,
-		crdbInternalRangesNoLeasesTable,
-		crdbInternalRangesView,
-		crdbInternalRuntimeInfoTable,
-		crdbInternalSchemaChangesTable,
-		crdbInternalSessionTraceTable,
-		crdbInternalSessionVariablesTable,
-		crdbInternalStmtStatsTable,
-		crdbInternalTableColumnsTable,
-		crdbInternalTableIndexesTable,
-		crdbInternalTablesTable,
-		crdbInternalZonesTable,
+	tableDefs: map[sqlbase.ID]virtualSchemaDef{
+		sqlbase.CrdbInternalBackwardDependenciesTableID: crdbInternalBackwardDependenciesTable,
+		sqlbase.CrdbInternalBuildInfoTableID:            crdbInternalBuildInfoTable,
+		sqlbase.CrdbInternalBuiltinFunctionsTableID:     crdbInternalBuiltinFunctionsTable,
+		sqlbase.CrdbInternalClusterQueriesTableID:       crdbInternalClusterQueriesTable,
+		sqlbase.CrdbInternalClusterSessionsTableID:      crdbInternalClusterSessionsTable,
+		sqlbase.CrdbInternalClusterSettingsTableID:      crdbInternalClusterSettingsTable,
+		sqlbase.CrdbInternalCreateStmtsTableID:          crdbInternalCreateStmtsTable,
+		sqlbase.CrdbInternalFeatureUsageID:              crdbInternalFeatureUsage,
+		sqlbase.CrdbInternalForwardDependenciesTableID:  crdbInternalForwardDependenciesTable,
+		sqlbase.CrdbInternalGossipNodesTableID:          crdbInternalGossipNodesTable,
+		sqlbase.CrdbInternalGossipAlertsTableID:         crdbInternalGossipAlertsTable,
+		sqlbase.CrdbInternalGossipLivenessTableID:       crdbInternalGossipLivenessTable,
+		sqlbase.CrdbInternalGossipNetworkTableID:        crdbInternalGossipNetworkTable,
+		sqlbase.CrdbInternalIndexColumnsTableID:         crdbInternalIndexColumnsTable,
+		sqlbase.CrdbInternalJobsTableID:                 crdbInternalJobsTable,
+		sqlbase.CrdbInternalKVNodeStatusTableID:         crdbInternalKVNodeStatusTable,
+		sqlbase.CrdbInternalKVStoreStatusTableID:        crdbInternalKVStoreStatusTable,
+		sqlbase.CrdbInternalLeasesTableID:               crdbInternalLeasesTable,
+		sqlbase.CrdbInternalLocalQueriesTableID:         crdbInternalLocalQueriesTable,
+		sqlbase.CrdbInternalLocalSessionsTableID:        crdbInternalLocalSessionsTable,
+		sqlbase.CrdbInternalLocalMetricsTableID:         crdbInternalLocalMetricsTable,
+		sqlbase.CrdbInternalPartitionsTableID:           crdbInternalPartitionsTable,
+		sqlbase.CrdbInternalRangesNoLeasesTableID:       crdbInternalRangesNoLeasesTable,
+		sqlbase.CrdbInternalRangesViewID:                crdbInternalRangesView,
+		sqlbase.CrdbInternalRuntimeInfoTableID:          crdbInternalRuntimeInfoTable,
+		sqlbase.CrdbInternalSchemaChangesTableID:        crdbInternalSchemaChangesTable,
+		sqlbase.CrdbInternalSessionTraceTableID:         crdbInternalSessionTraceTable,
+		sqlbase.CrdbInternalSessionVariablesTableID:     crdbInternalSessionVariablesTable,
+		sqlbase.CrdbInternalStmtStatsTableID:            crdbInternalStmtStatsTable,
+		sqlbase.CrdbInternalTableColumnsTableID:         crdbInternalTableColumnsTable,
+		sqlbase.CrdbInternalTableIndexesTableID:         crdbInternalTableIndexesTable,
+		sqlbase.CrdbInternalTablesTableID:               crdbInternalTablesTable,
+		sqlbase.CrdbInternalZonesTableID:                crdbInternalZonesTable,
 	},
 	validWithNoDatabaseContext: true,
 }
@@ -1109,14 +1109,8 @@ CREATE TABLE crdb_internal.create_statements (
 					return err
 				}
 
-				descID := tree.DNull
-				if table.ID != keys.VirtualDescriptorID {
-					descID = tree.NewDInt(tree.DInt(table.ID))
-				}
-				dbDescID := tree.DNull
-				if table.GetParentID() != keys.VirtualDescriptorID {
-					dbDescID = tree.NewDInt(tree.DInt(table.GetParentID()))
-				}
+				descID := tree.NewDInt(tree.DInt(table.ID))
+				dbDescID := tree.NewDInt(tree.DInt(table.GetParentID()))
 				if createNofk == "" {
 					createNofk = stmt
 				}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -109,27 +109,27 @@ var informationSchema = virtualSchema{
 		"view_table_usage",
 		"views",
 	),
-	tableDefs: []virtualSchemaDef{
-		informationSchemaAdministrableRoleAuthorizations,
-		informationSchemaApplicableRoles,
-		informationSchemaColumnPrivileges,
-		informationSchemaColumnsTable,
-		informationSchemaConstraintColumnUsageTable,
-		informationSchemaEnabledRoles,
-		informationSchemaKeyColumnUsageTable,
-		informationSchemaParametersTable,
-		informationSchemaReferentialConstraintsTable,
-		informationSchemaRoleTableGrants,
-		informationSchemaRoutineTable,
-		informationSchemaSchemataTable,
-		informationSchemaSchemataTablePrivileges,
-		informationSchemaSequences,
-		informationSchemaStatisticsTable,
-		informationSchemaTableConstraintTable,
-		informationSchemaTablePrivileges,
-		informationSchemaTablesTable,
-		informationSchemaViewsTable,
-		informationSchemaUserPrivileges,
+	tableDefs: map[sqlbase.ID]virtualSchemaDef{
+		sqlbase.InformationSchemaAdministrableRoleAuthorizationsID: informationSchemaAdministrableRoleAuthorizations,
+		sqlbase.InformationSchemaApplicableRolesID:                 informationSchemaApplicableRoles,
+		sqlbase.InformationSchemaColumnPrivilegesID:                informationSchemaColumnPrivileges,
+		sqlbase.InformationSchemaColumnsTableID:                    informationSchemaColumnsTable,
+		sqlbase.InformationSchemaConstraintColumnUsageTableID:      informationSchemaConstraintColumnUsageTable,
+		sqlbase.InformationSchemaEnabledRolesID:                    informationSchemaEnabledRoles,
+		sqlbase.InformationSchemaKeyColumnUsageTableID:             informationSchemaKeyColumnUsageTable,
+		sqlbase.InformationSchemaParametersTableID:                 informationSchemaParametersTable,
+		sqlbase.InformationSchemaReferentialConstraintsTableID:     informationSchemaReferentialConstraintsTable,
+		sqlbase.InformationSchemaRoleTableGrantsID:                 informationSchemaRoleTableGrants,
+		sqlbase.InformationSchemaRoutineTableID:                    informationSchemaRoutineTable,
+		sqlbase.InformationSchemaSchemataTableID:                   informationSchemaSchemataTable,
+		sqlbase.InformationSchemaSchemataTablePrivilegesID:         informationSchemaSchemataTablePrivileges,
+		sqlbase.InformationSchemaSequencesID:                       informationSchemaSequences,
+		sqlbase.InformationSchemaStatisticsTableID:                 informationSchemaStatisticsTable,
+		sqlbase.InformationSchemaTableConstraintTableID:            informationSchemaTableConstraintTable,
+		sqlbase.InformationSchemaTablePrivilegesID:                 informationSchemaTablePrivileges,
+		sqlbase.InformationSchemaTablesTableID:                     informationSchemaTablesTable,
+		sqlbase.InformationSchemaViewsTableID:                      informationSchemaViewsTable,
+		sqlbase.InformationSchemaUserPrivilegesID:                  informationSchemaUserPrivileges,
 	},
 	tableValidator:             validateInformationSchemaTable,
 	validWithNoDatabaseContext: true,
@@ -1115,7 +1115,7 @@ var informationSchemaTablesTable = virtualSchemaTable{
 				}
 				tableType := tableTypeBaseTable
 				insertable := yesString
-				if isVirtualDescriptor(table) {
+				if table.IsVirtualTable() {
 					tableType = tableTypeSystemView
 					insertable = noString
 				} else if table.IsView() {

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -205,24 +205,24 @@ SELECT oid, datname, datdba, encoding, datcollate, datctype, datistemplate, data
 FROM pg_catalog.pg_database
 ORDER BY oid
 ----
-oid         datname        datdba  encoding  datcollate  datctype    datistemplate  datallowconn
-381876367   system         NULL    6         en_US.utf8  en_US.utf8  false          true
-2069902775  constraint_db  NULL    6         en_US.utf8  en_US.utf8  false          true
-2326011399  postgres       NULL    6         en_US.utf8  en_US.utf8  false          true
-2754439556  defaultdb      NULL    6         en_US.utf8  en_US.utf8  false          true
-3819194709  test           NULL    6         en_US.utf8  en_US.utf8  false          true
+oid  datname        datdba  encoding  datcollate  datctype    datistemplate  datallowconn
+1    system         NULL    6         en_US.utf8  en_US.utf8  false          true
+50   defaultdb      NULL    6         en_US.utf8  en_US.utf8  false          true
+51   postgres       NULL    6         en_US.utf8  en_US.utf8  false          true
+52   test           NULL    6         en_US.utf8  en_US.utf8  false          true
+54   constraint_db  NULL    6         en_US.utf8  en_US.utf8  false          true
 
 query OTIOIIOT colnames
 SELECT oid, datname, datconnlimit, datlastsysoid, datfrozenxid, datminmxid, dattablespace, datacl
 FROM pg_catalog.pg_database
 ORDER BY oid
 ----
-oid         datname        datconnlimit  datlastsysoid  datfrozenxid  datminmxid  dattablespace  datacl
-381876367   system         -1            NULL           NULL          NULL        0              NULL
-2069902775  constraint_db  -1            NULL           NULL          NULL        0              NULL
-2326011399  postgres       -1            NULL           NULL          NULL        0              NULL
-2754439556  defaultdb      -1            NULL           NULL          NULL        0              NULL
-3819194709  test           -1            NULL           NULL          NULL        0              NULL
+oid  datname        datconnlimit  datlastsysoid  datfrozenxid  datminmxid  dattablespace  datacl
+1    system         -1            NULL           NULL          NULL        0              NULL
+50   defaultdb      -1            NULL           NULL          NULL        0              NULL
+51   postgres       -1            NULL           NULL          NULL        0              NULL
+52   test           -1            NULL           NULL          NULL        0              NULL
+54   constraint_db  -1            NULL           NULL          NULL        0              NULL
 
 ## pg_catalog.pg_tables
 
@@ -271,17 +271,17 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
 oid         relname       relnamespace  reltype  relowner  relam  relfilenode  reltablespace
-4183203597  t1            393119649     0        NULL      NULL   0            0
-586319997   primary       393119649     0        NULL      NULL   0            0
-586319998   t1_a_key      393119649     0        NULL      NULL   0            0
-586319999   index_key     393119649     0        NULL      NULL   0            0
-192646233   t2            393119649     0        NULL      NULL   0            0
-2761941313  primary       393119649     0        NULL      NULL   0            0
-2761941314  t2_t1_id_idx  393119649     0        NULL      NULL   0            0
-226054345   t3            393119649     0        NULL      NULL   0            0
-4084598993  primary       393119649     0        NULL      NULL   0            0
-4084598994  t3_a_b_idx    393119649     0        NULL      NULL   0            0
-4252432642  v1            393119649     0        NULL      NULL   0            0
+55          t1            393119649     0        NULL      NULL   0            0
+1724255603  primary       393119649     0        NULL      NULL   0            0
+1724255600  t1_a_key      393119649     0        NULL      NULL   0            0
+1724255601  index_key     393119649     0        NULL      NULL   0            0
+56          t2            393119649     0        NULL      NULL   0            0
+3204566167  primary       393119649     0        NULL      NULL   0            0
+3204566164  t2_t1_id_idx  393119649     0        NULL      NULL   0            0
+57          t3            393119649     0        NULL      NULL   0            0
+2520943903  primary       393119649     0        NULL      NULL   0            0
+2520943900  t3_a_b_idx    393119649     0        NULL      NULL   0            0
+58          v1            393119649     0        NULL      NULL   0            0
 
 query TIRIOBBT colnames
 SELECT relname, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared, relpersistence
@@ -350,29 +350,29 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
 attrelid    relname       attname  atttypid  attstattarget  attlen  attnum  attndims  attcacheoff
-4183203597  t1            p        701       0              8       1       0         -1
-4183203597  t1            a        20        0              8       2       0         -1
-4183203597  t1            b        20        0              8       3       0         -1
-4183203597  t1            c        20        0              8       4       0         -1
-586319997   primary       p        701       0              8       1       0         -1
-586319998   t1_a_key      a        20        0              8       2       0         -1
-586319999   index_key     b        20        0              8       3       0         -1
-586319999   index_key     c        20        0              8       4       0         -1
-192646233   t2            t1_id    20        0              8       1       0         -1
-192646233   t2            rowid    20        0              8       2       0         -1
-2761941313  primary       rowid    20        0              8       2       0         -1
-2761941314  t2_t1_id_idx  t1_id    20        0              8       1       0         -1
-226054345   t3            a        20        0              8       1       0         -1
-226054345   t3            b        20        0              8       2       0         -1
-226054345   t3            c        25        0              -1      3       0         -1
-226054345   t3            rowid    20        0              8       4       0         -1
-4084598993  primary       rowid    20        0              8       4       0         -1
-4084598994  t3_a_b_idx    a        20        0              8       1       0         -1
-4084598994  t3_a_b_idx    b        20        0              8       2       0         -1
-4252432642  v1            p        701       0              8       1       0         -1
-4252432642  v1            a        20        0              8       2       0         -1
-4252432642  v1            b        20        0              8       3       0         -1
-4252432642  v1            c        20        0              8       4       0         -1
+55          t1            p        701       0              8       1       0         -1
+55          t1            a        20        0              8       2       0         -1
+55          t1            b        20        0              8       3       0         -1
+55          t1            c        20        0              8       4       0         -1
+1724255603  primary       p        701       0              8       1       0         -1
+1724255600  t1_a_key      a        20        0              8       2       0         -1
+1724255601  index_key     b        20        0              8       3       0         -1
+1724255601  index_key     c        20        0              8       4       0         -1
+56          t2            t1_id    20        0              8       1       0         -1
+56          t2            rowid    20        0              8       2       0         -1
+3204566167  primary       rowid    20        0              8       2       0         -1
+3204566164  t2_t1_id_idx  t1_id    20        0              8       1       0         -1
+57          t3            a        20        0              8       1       0         -1
+57          t3            b        20        0              8       2       0         -1
+57          t3            c        25        0              -1      3       0         -1
+57          t3            rowid    20        0              8       4       0         -1
+2520943903  primary       rowid    20        0              8       4       0         -1
+2520943900  t3_a_b_idx    a        20        0              8       1       0         -1
+2520943900  t3_a_b_idx    b        20        0              8       2       0         -1
+58          v1            p        701       0              8       1       0         -1
+58          v1            a        20        0              8       2       0         -1
+58          v1            b        20        0              8       3       0         -1
+58          v1            c        20        0              8       4       0         -1
 
 query TTIBTTBB colnames
 SELECT c.relname, attname, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef
@@ -487,7 +487,7 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
 relname  attname  typname  attcollation  collname
-t3       c        text     1661428263    en-US
+t3       c        text     3903121477    en-US
 
 
 ## pg_catalog.pg_am
@@ -508,11 +508,11 @@ JOIN pg_catalog.pg_class c ON ad.adrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-oid         relname  adrelid     adnum  adbin           adsrc
-1371742922  t1       4183203597  4      12:::INT8       12:::INT8
-3294137148  t2       192646233   2      unique_rowid()  unique_rowid()
-1821466931  t3       226054345   3      'FOO':::STRING  'FOO':::STRING
-437430594   t3       226054345   4      unique_rowid()  unique_rowid()
+oid         relname  adrelid  adnum  adbin           adsrc
+1049803768  t1       55       4      12:::INT8       12:::INT8
+2755687926  t2       56       2      unique_rowid()  unique_rowid()
+2465155533  t3       57       3      'FOO':::STRING  'FOO':::STRING
+2369639920  t3       57       4      unique_rowid()  unique_rowid()
 
 ## pg_catalog.pg_indexes
 
@@ -522,13 +522,13 @@ FROM pg_catalog.pg_indexes
 WHERE schemaname = 'public'
 ----
 crdb_oid    schemaname  tablename  indexname     tablespace
-586319997   public      t1         primary       NULL
-586319998   public      t1         t1_a_key      NULL
-586319999   public      t1         index_key     NULL
-2761941313  public      t2         primary       NULL
-2761941314  public      t2         t2_t1_id_idx  NULL
-4084598993  public      t3         primary       NULL
-4084598994  public      t3         t3_a_b_idx    NULL
+1724255603  public      t1         primary       NULL
+1724255600  public      t1         t1_a_key      NULL
+1724255601  public      t1         index_key     NULL
+3204566167  public      t2         primary       NULL
+3204566164  public      t2         t2_t1_id_idx  NULL
+2520943903  public      t3         primary       NULL
+2520943900  public      t3         t3_a_b_idx    NULL
 
 query OTTT colnames
 SELECT crdb_oid, tablename, indexname, indexdef
@@ -536,13 +536,13 @@ FROM pg_catalog.pg_indexes
 WHERE schemaname = 'public'
 ----
 crdb_oid    tablename  indexname     indexdef
-586319997   t1         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t1 (p ASC)
-586319998   t1         t1_a_key      CREATE UNIQUE INDEX t1_a_key ON constraint_db.public.t1 (a ASC)
-586319999   t1         index_key     CREATE UNIQUE INDEX index_key ON constraint_db.public.t1 (b ASC, c ASC)
-2761941313  t2         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t2 (rowid ASC)
-2761941314  t2         t2_t1_id_idx  CREATE INDEX t2_t1_id_idx ON constraint_db.public.t2 (t1_id ASC)
-4084598993  t3         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t3 (rowid ASC)
-4084598994  t3         t3_a_b_idx    CREATE INDEX t3_a_b_idx ON constraint_db.public.t3 (a ASC, b DESC) STORING (c)
+1724255603  t1         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t1 (p ASC)
+1724255600  t1         t1_a_key      CREATE UNIQUE INDEX t1_a_key ON constraint_db.public.t1 (a ASC)
+1724255601  t1         index_key     CREATE UNIQUE INDEX index_key ON constraint_db.public.t1 (b ASC, c ASC)
+3204566167  t2         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t2 (rowid ASC)
+3204566164  t2         t2_t1_id_idx  CREATE INDEX t2_t1_id_idx ON constraint_db.public.t2 (t1_id ASC)
+2520943903  t3         primary       CREATE UNIQUE INDEX "primary" ON constraint_db.public.t3 (rowid ASC)
+2520943900  t3         t3_a_b_idx    CREATE INDEX t3_a_b_idx ON constraint_db.public.t3 (a ASC, b DESC) STORING (c)
 
 ## pg_catalog.pg_index
 
@@ -551,9 +551,9 @@ SELECT indexrelid, indrelid, indnatts, indisunique, indisprimary, indisexclusion
 FROM pg_catalog.pg_index
 WHERE indnatts = 2
 ----
-indexrelid  indrelid    indnatts  indisunique  indisprimary  indisexclusion
-586319999   4183203597  2         true         false         false
-4084598994  226054345   2         false        false         false
+indexrelid  indrelid  indnatts  indisunique  indisprimary  indisexclusion
+1724255601  55        2         true         false         false
+2520943900  57        2         false        false         false
 
 query OBBBBB colnames
 SELECT indexrelid, indimmediate, indisclustered, indisvalid, indcheckxmin, indisready
@@ -561,17 +561,17 @@ FROM pg_catalog.pg_index
 WHERE indnatts = 2
 ----
 indexrelid  indimmediate  indisclustered  indisvalid  indcheckxmin  indisready
-586319999   true          false           true        false         false
-4084598994  false         false           true        false         false
+1724255601  true          false           true        false         false
+2520943900  false         false           true        false         false
 
 query OOBBTTTTTT colnames
 SELECT indexrelid, indrelid, indislive, indisreplident, indkey, indcollation, indclass, indoption, indexprs, indpred
 FROM pg_catalog.pg_index
 WHERE indnatts = 2
 ----
-indexrelid  indrelid    indislive  indisreplident  indkey  indcollation  indclass  indoption  indexprs  indpred
-586319999   4183203597  true       false           3 4     0 0           0 0       0 0        NULL      NULL
-4084598994  226054345   true       false           1 2     0 0           0 0       0 0        NULL      NULL
+indexrelid  indrelid  indislive  indisreplident  indkey  indcollation  indclass  indoption  indexprs  indpred
+1724255601  55        true       false           3 4     0 0           0 0       0 0        NULL      NULL
+2520943900  57        true       false           1 2     0 0           0 0       0 0        NULL      NULL
 
 statement ok
 SET DATABASE = system
@@ -581,27 +581,27 @@ SELECT *
 FROM pg_catalog.pg_index
 ORDER BY indexrelid
 ----
-indexrelid  indrelid    indnatts  indisunique  indisprimary  indisexclusion  indimmediate  indisclustered  indisvalid  indcheckxmin  indisready  indislive  indisreplident  indkey   indcollation           indclass  indoption  indexprs  indpred
-27122201    2904033927  2         true         true          false           true          false           true        false         false       true       false           1 6      0 0                    0 0       0 0        NULL      NULL
-235043584   971623778   2         true         true          false           true          false           true        false         false       true       false           1 2      1661428263 1661428263  0 0       0 0        NULL      NULL
-235043586   971623778   1         false        false         false           false         false           true        false         false       true       false           2        1661428263             0         0          NULL      NULL
-235043587   971623778   1         false        false         false           false         false           true        false         false       true       false           1        1661428263             0         0          NULL      NULL
-553144061   2568924675  2         true         true          false           true          false           true        false         false       true       false           1 2      0 0                    0 0       0 0        NULL      NULL
-633004884   1455563232  1         false        false         false           false         false           true        false         false       true       false           4        0                      0         0          NULL      NULL
-633004885   1455563232  1         false        false         false           false         false           true        false         false       true       false           5        0                      0         0          NULL      NULL
-633004886   1455563232  1         true         true          false           true          false           true        false         false       true       false           1        0                      0         0          NULL      NULL
-961325075   2492394317  1         true         true          false           true          false           true        false         false       true       false           1        0                      0         0          NULL      NULL
-1112802205  3710069875  3         true         true          false           true          false           true        false         false       true       false           1 2 3    0 0 0                  0 0 0     0 0 0      NULL      NULL
-1168848597  1038690067  2         true         true          false           true          false           true        false         false       true       false           1 7      0 0                    0 0       0 0        NULL      NULL
-1849259112  3649853378  1         true         true          false           true          false           true        false         false       true       false           1        0                      0         0          NULL      NULL
-1849259115  3649853378  2         false        false         false           false         false           true        false         false       true       false           2 3      1661428263 0           0 0       0 0        NULL      NULL
-2151986803  504491171   1         true         true          false           true          false           true        false         false       true       false           1        1661428263             0         0          NULL      NULL
-2490277766  936526412   1         true         true          false           true          false           true        false         false       true       false           1        1661428263             0         0          NULL      NULL
-2516644345  13912245    1         true         true          false           true          false           true        false         false       true       false           1        0                      0         0          NULL      NULL
-2795406519  4084372773  1         true         true          false           true          false           true        false         false       true       false           1        1661428263             0         0          NULL      NULL
-2916809960  3412769920  2         true         true          false           true          false           true        false         false       true       false           1 2      0 1661428263           0 0       0 0        NULL      NULL
-3042779560  1692823172  2         true         true          false           true          false           true        false         false       true       false           1 2      1661428263 1661428263  0 0       0 0        NULL      NULL
-4083294912  4199044472  4         true         true          false           true          false           true        false         false       true       false           1 2 4 3  0 0 0 0                0 0 0 0   0 0 0 0    NULL      NULL
+indexrelid  indrelid  indnatts  indisunique  indisprimary  indisexclusion  indimmediate  indisclustered  indisvalid  indcheckxmin  indisready  indislive  indisreplident  indkey   indcollation           indclass  indoption  indexprs  indpred
+79207949    14        1         true         true          false           true          false           true        false         false       true       false           1        3903121477             0         0          NULL      NULL
+497494183   5         1         true         true          false           true          false           true        false         false       true       false           1        0                      0         0          NULL      NULL
+715847935   20        2         true         true          false           true          false           true        false         false       true       false           1 2      0 0                    0 0       0 0        NULL      NULL
+1040377038  2         2         true         true          false           true          false           true        false         false       true       false           1 2      0 3903121477           0 0       0 0        NULL      NULL
+1449281139  12        2         true         true          false           true          false           true        false         false       true       false           1 6      0 0                    0 0       0 0        NULL      NULL
+2001460420  6         1         true         true          false           true          false           true        false         false       true       false           1        3903121477             0         0          NULL      NULL
+2081594414  11        4         true         true          false           true          false           true        false         false       true       false           1 2 4 3  0 0 0 0                0 0 0 0   0 0 0 0    NULL      NULL
+2161296387  13        2         true         true          false           true          false           true        false         false       true       false           1 7      0 0                    0 0       0 0        NULL      NULL
+2487895828  23        1         false        false         false           false         false           true        false         false       true       false           2        3903121477             0         0          NULL      NULL
+2487895829  23        1         false        false         false           false         false           true        false         false       true       false           1        3903121477             0         0          NULL      NULL
+2487895830  23        2         true         true          false           true          false           true        false         false       true       false           1 2      3903121477 3903121477  0 0       0 0        NULL      NULL
+2601023541  4         1         true         true          false           true          false           true        false         false       true       false           1        3903121477             0         0          NULL      NULL
+2610088885  3         1         true         true          false           true          false           true        false         false       true       false           1        0                      0         0          NULL      NULL
+3414183968  19        1         true         true          false           true          false           true        false         false       true       false           1        0                      0         0          NULL      NULL
+3414183970  19        1         false        false         false           false         false           true        false         false       true       false           4        0                      0         0          NULL      NULL
+3414183971  19        1         false        false         false           false         false           true        false         false       true       false           5        0                      0         0          NULL      NULL
+3854428722  21        2         true         true          false           true          false           true        false         false       true       false           1 2      3903121477 3903121477  0 0       0 0        NULL      NULL
+3917935933  15        2         false        false         false           false         false           true        false         false       true       false           2 3      3903121477 0           0 0       0 0        NULL      NULL
+3917935934  15        1         true         true          false           true          false           true        false         false       true       false           1        0                      0         0          NULL      NULL
+3993652359  24        3         true         true          false           true          false           true        false         false       true       false           1 2 3    0 0 0                  0 0 0     0 0 0      NULL      NULL
 
 # From #26504
 query OOI colnames
@@ -612,38 +612,38 @@ FROM pg_index
 ORDER BY indexrelid, operator_argument_position
 ----
 indexrelid  operator_argument_type_oid  operator_argument_position
-27122201    0                           1
-27122201    0                           2
-235043584   0                           1
-235043584   0                           2
-235043586   0                           1
-235043587   0                           1
-553144061   0                           1
-553144061   0                           2
-633004884   0                           1
-633004885   0                           1
-633004886   0                           1
-961325075   0                           1
-1112802205  0                           1
-1112802205  0                           2
-1112802205  0                           3
-1168848597  0                           1
-1168848597  0                           2
-1849259112  0                           1
-1849259115  0                           1
-1849259115  0                           2
-2151986803  0                           1
-2490277766  0                           1
-2516644345  0                           1
-2795406519  0                           1
-2916809960  0                           1
-2916809960  0                           2
-3042779560  0                           1
-3042779560  0                           2
-4083294912  0                           1
-4083294912  0                           2
-4083294912  0                           3
-4083294912  0                           4
+79207949    0                           1
+497494183   0                           1
+715847935   0                           1
+715847935   0                           2
+1040377038  0                           1
+1040377038  0                           2
+1449281139  0                           1
+1449281139  0                           2
+2001460420  0                           1
+2081594414  0                           1
+2081594414  0                           2
+2081594414  0                           3
+2081594414  0                           4
+2161296387  0                           1
+2161296387  0                           2
+2487895828  0                           1
+2487895829  0                           1
+2487895830  0                           1
+2487895830  0                           2
+2601023541  0                           1
+2610088885  0                           1
+3414183968  0                           1
+3414183970  0                           1
+3414183971  0                           1
+3854428722  0                           1
+3854428722  0                           2
+3917935933  0                           1
+3917935933  0                           2
+3917935934  0                           1
+3993652359  0                           1
+3993652359  0                           2
+3993652359  0                           3
 
 ## pg_catalog.pg_collation
 
@@ -655,7 +655,7 @@ SELECT * FROM pg_collation
 WHERE collname='en-US'
 ----
 oid         collname  collnamespace  collowner  collencoding  collcollate  collctype
-1661428263  en-US     393119649      NULL       6             NULL         NULL
+3903121477  en-US     393119649      NULL       6             NULL         NULL
 
 ## pg_catalog.pg_constraint
 ##
@@ -670,12 +670,12 @@ WHERE n.nspname = 'public'
 ORDER BY con.oid
 ----
 oid         conname    connamespace  contype
-706565544   index_key  393119649     u
-706565545   t1_a_key   393119649     u
-1705475931  check_b    393119649     c
-1968296057  fk         393119649     f
-2304211364  fk         393119649     f
-2922443201  primary    393119649     p
+76027687    primary    393119649     p
+171215401   check_b    393119649     c
+1196424466  index_key  393119649     u
+1196424467  t1_a_key   393119649     u
+1410317551  fk         393119649     f
+3509302322  fk         393119649     f
 
 query TTBBBOOO colnames
 SELECT conname, contype, condeferrable, condeferred, convalidated, conrelid, contypid, conindid
@@ -684,13 +684,13 @@ JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public'
 ORDER BY con.oid
 ----
-conname    contype  condeferrable  condeferred  convalidated  conrelid    contypid  conindid
-index_key  u        false          false        true          4183203597  0         586319999
-t1_a_key   u        false          false        true          4183203597  0         586319998
-check_b    c        false          false        true          226054345   0         0
-fk         f        false          false        true          192646233   0         586319998
-fk         f        false          false        true          226054345   0         586319999
-primary    p        false          false        true          4183203597  0         586319997
+conname    contype  condeferrable  condeferred  convalidated  conrelid  contypid  conindid
+primary    p        false          false        true          55        0         1724255603
+check_b    c        false          false        true          57        0         0
+index_key  u        false          false        true          55        0         1724255601
+t1_a_key   u        false          false        true          55        0         1724255600
+fk         f        false          false        true          56        0         1724255600
+fk         f        false          false        true          57        0         1724255601
 
 query T
 SELECT conname
@@ -708,10 +708,10 @@ WHERE n.nspname = 'public' AND contype IN ('c', 'p', 'u')
 ORDER BY con.oid
 ----
 conname    confrelid  confupdtype  confdeltype  confmatchtype
+primary    0          NULL         NULL         NULL
+check_b    0          NULL         NULL         NULL
 index_key  0          NULL         NULL         NULL
 t1_a_key   0          NULL         NULL         NULL
-check_b    0          NULL         NULL         NULL
-primary    0          NULL         NULL         NULL
 
 query TOTTT colnames
 SELECT conname, confrelid, confupdtype, confdeltype, confmatchtype
@@ -720,9 +720,9 @@ JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public' AND contype = 'f'
 ORDER BY con.oid
 ----
-conname  confrelid   confupdtype  confdeltype  confmatchtype
-fk       4183203597  a            a            s
-fk       4183203597  a            a            s
+conname  confrelid  confupdtype  confdeltype  confmatchtype
+fk       55         a            a            s
+fk       55         a            a            s
 
 query TBIBT colnames
 SELECT conname, conislocal, coninhcount, connoinherit, conkey
@@ -732,12 +732,12 @@ WHERE n.nspname = 'public'
 ORDER BY con.oid
 ----
 conname    conislocal  coninhcount  connoinherit  conkey
+primary    true        0            true          {1}
+check_b    true        0            true          {2}
 index_key  true        0            true          {3,4}
 t1_a_key   true        0            true          {2}
-check_b    true        0            true          {2}
 fk         true        0            true          {1}
 fk         true        0            true          {1,2}
-primary    true        0            true          {1}
 
 query TTTTTTTT colnames
 SELECT conname, confkey, conpfeqop, conppeqop, conffeqop, conexclop, conbin, consrc
@@ -747,10 +747,10 @@ WHERE n.nspname = 'public' AND contype IN ('c', 'p', 'u')
 ORDER BY con.oid
 ----
 conname    confkey  conpfeqop  conppeqop  conffeqop  conexclop  conbin  consrc
+primary    NULL     NULL       NULL       NULL       NULL       NULL    NULL
+check_b    NULL     NULL       NULL       NULL       NULL       b > 11  b > 11
 index_key  NULL     NULL       NULL       NULL       NULL       NULL    NULL
 t1_a_key   NULL     NULL       NULL       NULL       NULL       NULL    NULL
-check_b    NULL     NULL       NULL       NULL       NULL       b > 11  b > 11
-primary    NULL     NULL       NULL       NULL       NULL       NULL    NULL
 
 query TTTTTTTT colnames
 SELECT conname, confkey, conpfeqop, conppeqop, conffeqop, conexclop, conbin, consrc
@@ -770,9 +770,9 @@ SELECT classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype
 FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
-classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-2416812286  1968296057  0         2990889189  586319998  0            n
-2416812286  2304211364  0         2990889189  586319999  0            n
+classid     objid       objsubid  refclassid  refobjid    refobjsubid  deptype
+4294967233  1410317551  0         4294967235  1724255600  0            n
+4294967233  3509302322  0         4294967235  1724255601  0            n
 
 # All entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table.
@@ -784,7 +784,7 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-2416812286  2990889189  pg_constraint  pg_class
+4294967233  4294967235  pg_constraint  pg_class
 
 # All entries in pg_depend are foreign key constraints that reference an index
 # in pg_class.
@@ -1077,14 +1077,14 @@ ORDER BY oid
 oid   typname       typndims  typcollation  typdefaultbin  typdefault  typacl
 16    bool          0         0             NULL           NULL        NULL
 17    bytea         0         0             NULL           NULL        NULL
-18    char          0         1661428263    NULL           NULL        NULL
-19    name          0         1661428263    NULL           NULL        NULL
+18    char          0         3903121477    NULL           NULL        NULL
+19    name          0         3903121477    NULL           NULL        NULL
 20    int8          0         0             NULL           NULL        NULL
 21    int2          0         0             NULL           NULL        NULL
 22    int2vector    0         0             NULL           NULL        NULL
 23    int4          0         0             NULL           NULL        NULL
 24    regproc       0         0             NULL           NULL        NULL
-25    text          0         1661428263    NULL           NULL        NULL
+25    text          0         3903121477    NULL           NULL        NULL
 26    oid           0         0             NULL           NULL        NULL
 30    oidvector     0         0             NULL           NULL        NULL
 700   float4        0         0             NULL           NULL        NULL
@@ -1092,20 +1092,20 @@ oid   typname       typndims  typcollation  typdefaultbin  typdefault  typacl
 869   inet          0         0             NULL           NULL        NULL
 1000  _bool         0         0             NULL           NULL        NULL
 1001  _bytea        0         0             NULL           NULL        NULL
-1002  _char         0         1661428263    NULL           NULL        NULL
-1003  _name         0         1661428263    NULL           NULL        NULL
+1002  _char         0         3903121477    NULL           NULL        NULL
+1003  _name         0         3903121477    NULL           NULL        NULL
 1005  _int2         0         0             NULL           NULL        NULL
 1007  _int4         0         0             NULL           NULL        NULL
-1009  _text         0         1661428263    NULL           NULL        NULL
-1014  _bpchar       0         1661428263    NULL           NULL        NULL
-1015  _varchar      0         1661428263    NULL           NULL        NULL
+1009  _text         0         3903121477    NULL           NULL        NULL
+1014  _bpchar       0         3903121477    NULL           NULL        NULL
+1015  _varchar      0         3903121477    NULL           NULL        NULL
 1016  _int8         0         0             NULL           NULL        NULL
 1021  _float4       0         0             NULL           NULL        NULL
 1022  _float8       0         0             NULL           NULL        NULL
 1028  _oid          0         0             NULL           NULL        NULL
 1041  _inet         0         0             NULL           NULL        NULL
-1042  bpchar        0         1661428263    NULL           NULL        NULL
-1043  varchar       0         1661428263    NULL           NULL        NULL
+1042  bpchar        0         3903121477    NULL           NULL        NULL
+1043  varchar       0         3903121477    NULL           NULL        NULL
 1082  date          0         0             NULL           NULL        NULL
 1083  time          0         0             NULL           NULL        NULL
 1114  timestamp     0         0             NULL           NULL        NULL
@@ -1126,7 +1126,7 @@ oid   typname       typndims  typcollation  typdefaultbin  typdefault  typacl
 2205  regclass      0         0             NULL           NULL        NULL
 2206  regtype       0         0             NULL           NULL        NULL
 2249  record        0         0             NULL           NULL        NULL
-2277  anyarray      0         1661428263    NULL           NULL        NULL
+2277  anyarray      0         3903121477    NULL           NULL        NULL
 2283  anyelement    0         0             NULL           NULL        NULL
 2950  uuid          0         0             NULL           NULL        NULL
 2951  _uuid         0         0             NULL           NULL        NULL
@@ -1220,9 +1220,9 @@ FROM pg_catalog.pg_roles
 ORDER BY rolname
 ----
 oid         rolname   rolsuper  rolinherit  rolcreaterole  rolcreatedb  rolcatupdate  rolcanlogin  rolreplication
-823966177   admin     true      true        true           true         false         false        false
-2901009604  root      true      false       true           true         false         true         false
-2499926009  testuser  false     false       false          false        false         true         false
+2310524507  admin     true      true        true           true         false         false        false
+1546506610  root      true      false       true           true         false         true         false
+2264919399  testuser  false     false       false          false        false         true         false
 
 query OTITTBT colnames
 SELECT oid, rolname, rolconnlimit, rolpassword, rolvaliduntil, rolbypassrls, rolconfig
@@ -1230,9 +1230,9 @@ FROM pg_catalog.pg_roles
 ORDER BY rolname
 ----
 oid         rolname   rolconnlimit  rolpassword  rolvaliduntil  rolbypassrls  rolconfig
-823966177   admin     -1            ********     NULL           false         NULL
-2901009604  root      -1            ********     NULL           false         NULL
-2499926009  testuser  -1            ********     NULL           false         NULL
+2310524507  admin     -1            ********     NULL           false         NULL
+1546506610  root      -1            ********     NULL           false         NULL
+2264919399  testuser  -1            ********     NULL           false         NULL
 
 ## pg_catalog.pg_auth_members
 
@@ -1240,8 +1240,8 @@ query OOOB colnames
 SELECT roleid, member, grantor, admin_option
 FROM pg_catalog.pg_auth_members
 ----
-roleid     member      grantor  admin_option
-823966177  2901009604  NULL     true
+roleid      member      grantor  admin_option
+2310524507  1546506610  NULL     true
 
 ## pg_catalog.pg_user
 
@@ -1251,8 +1251,8 @@ FROM pg_catalog.pg_user
 ORDER BY usename
 ----
 usename   usesysid    usecreatedb  usesuper  userepl  usebypassrls  passwd    valuntil  useconfig
-root      2901009604  true         true      false    false         ********  NULL      NULL
-testuser  2499926009  false        false     false    false         ********  NULL      NULL
+root      1546506610  true         true      false    false         ********  NULL      NULL
+testuser  2264919399  false        false     false    false         ********  NULL      NULL
 
 ## pg_catalog.pg_description
 
@@ -1471,9 +1471,9 @@ CREATE SEQUENCE bar MAXVALUE 10 MINVALUE 5 START 6 INCREMENT 2
 query OOIIIIIB colnames
 SELECT * FROM pg_catalog.pg_sequence
 ----
-seqrelid    seqtypid  seqstart  seqincrement  seqmax               seqmin  seqcache  seqcycle
-1978455413  20        1         1             9223372036854775807  1       1         false
-3953462681  20        6         2             10                   5       1         false
+seqrelid  seqtypid  seqstart  seqincrement  seqmax               seqmin  seqcache  seqcycle
+64        20        1         1             9223372036854775807  1       1         false
+65        20        6         2             10                   5       1         false
 
 statement ok
 DROP DATABASE seq
@@ -1491,8 +1491,8 @@ SELECT * FROM pg_catalog.pg_sequence
 query OTOOTBBOOOOOOOO colnames
 SELECT * FROM pg_catalog.pg_operator where oprname='+' and oprleft='float8'::regtype
 ----
-oid         oprname  oprnamespace  oprowner  oprkind  oprcanmerge  oprcanhash  oprleft  oprright  oprresult  oprcom  oprnegate  oprcode  oprrest  oprjoin
-3695865198  +        2980797153    NULL      b        false        false       701      701       701        NULL    NULL       NULL     NULL     NULL
+oid       oprname  oprnamespace  oprowner  oprkind  oprcanmerge  oprcanhash  oprleft  oprright  oprresult  oprcom  oprnegate  oprcode  oprrest  oprjoin
+74817020  +        2980797153    NULL      b        false        false       701      701       701        NULL    NULL       NULL     NULL     NULL
 
 # Verify proper functionality of system information functions.
 
@@ -1516,10 +1516,10 @@ JOIN pg_catalog.pg_class c ON def.adrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-1371742922  t1  12:::INT8
-3294137148  t2  unique_rowid()
-1821466931  t3  'FOO':::STRING
-437430594   t3  unique_rowid()
+1049803768  t1  12:::INT8
+2755687926  t2  unique_rowid()
+2465155533  t3  'FOO':::STRING
+2369639920  t3  unique_rowid()
 
 # Verify that a set database shows tables from that database for a non-root
 # user, when that user has permissions.
@@ -1582,7 +1582,7 @@ FROM pg_proc p
 JOIN pg_type t ON t.typinput = p.oid
 WHERE t.typname = '_int4'
 ----
-639449980  array_in  array_in
+780513238  array_in  array_in
 
 ## #16285
 ## int2vectors should be 0-indexed

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -61,7 +61,7 @@ pg_constraint  pg_constraint
 query OO
 SELECT 'pg_constraint '::REGCLASS, '"pg_constraint"'::REGCLASS::OID
 ----
-pg_constraint  139623798
+pg_constraint  4294967233
 
 query O
 SELECT 4061301040::REGCLASS
@@ -73,12 +73,12 @@ SELECT oid, oid::regclass, oid::regclass::int, oid::regclass::int::regclass, oid
 FROM pg_class
 WHERE relname = 'pg_constraint'
 ----
-139623798  pg_constraint  139623798  pg_constraint  pg_constraint
+4294967233  pg_constraint  4294967233  pg_constraint  pg_constraint
 
 query OOOO
 SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE, 'pg_catalog.upper'::REGPROCEDURE, 'upper'::REGPROC::OID
 ----
-upper  upper  upper  2896429946
+upper  upper  upper  3615042040
 
 query error invalid function name
 SELECT 'invalid.more.pg_catalog.upper'::REGPROCEDURE
@@ -86,7 +86,7 @@ SELECT 'invalid.more.pg_catalog.upper'::REGPROCEDURE
 query OOO
 SELECT 'upper(int)'::REGPROC, 'upper(int)'::REGPROCEDURE, 'upper(int)'::REGPROC::OID
 ----
-upper  upper  2896429946
+upper  upper  3615042040
 
 query error unknown function: blah\(\)
 SELECT 'blah(ignored, ignored)'::REGPROC, 'blah(ignored, ignored)'::REGPROCEDURE
@@ -160,7 +160,7 @@ pg_constraint
 query OO
 SELECT ('pg_constraint')::REGCLASS, ('pg_constraint')::REGCLASS::OID
 ----
-pg_constraint  139623798
+pg_constraint  4294967233
 
 ## Test visibility of pg_* via oid casts.
 

--- a/pkg/sql/logictest/testdata/planner_test/join
+++ b/pkg/sql/logictest/testdata/planner_test/join
@@ -388,7 +388,7 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 10  ·            type       inner
 10  ·            equality   (refobjid) = (oid)
 11  filter       ·          ·
-11  ·            filter     (dep.classid = 139623798) AND (dep.refclassid = 1411792157)
+11  ·            filter     (dep.classid = 4294967233) AND (dep.refclassid = 4294967235)
 11  filter       ·          ·
 11  ·            filter     pkic.relkind = 'i'
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -393,7 +393,7 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 13  ·              type       inner
 13  ·              equality   (refobjid) = (oid)
 14  filter         ·          ·
-14  ·              filter     (classid = 139623798) AND (refclassid = 1411792157)
+14  ·              filter     (classid = 4294967233) AND (refclassid = 4294967235)
 15  virtual table  ·          ·
 15  ·              source     ·
 14  filter         ·          ·

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -180,45 +180,45 @@ var pgCatalog = virtualSchema{
 		"pg_user_mappings",
 		"pg_views",
 	),
-	tableDefs: []virtualSchemaDef{
-		pgCatalogAmTable,
-		pgCatalogAttrDefTable,
-		pgCatalogAttributeTable,
-		pgCatalogAuthMembersTable,
-		pgCatalogClassTable,
-		pgCatalogCollationTable,
-		pgCatalogConstraintTable,
-		pgCatalogDatabaseTable,
-		pgCatalogDependTable,
-		pgCatalogDescriptionTable,
-		pgCatalogSharedDescriptionTable,
-		pgCatalogEnumTable,
-		pgCatalogExtensionTable,
-		pgCatalogForeignDataWrapperTable,
-		pgCatalogForeignServerTable,
-		pgCatalogForeignTableTable,
-		pgCatalogIndexTable,
-		pgCatalogIndexesTable,
-		pgCatalogInheritsTable,
-		pgCatalogLanguageTable,
-		pgCatalogNamespaceTable,
-		pgCatalogOperatorTable,
-		pgCatalogProcTable,
-		pgCatalogRangeTable,
-		pgCatalogRewriteTable,
-		pgCatalogRolesTable,
-		pgCatalogSequencesTable,
-		pgCatalogSettingsTable,
-		pgCatalogUserTable,
-		pgCatalogUserMappingTable,
-		pgCatalogTablesTable,
-		pgCatalogTablespaceTable,
-		pgCatalogTriggerTable,
-		pgCatalogTypeTable,
-		pgCatalogViewsTable,
-		pgCatalogStatActivityTable,
-		pgCatalogSecurityLabelTable,
-		pgCatalogSharedSecurityLabelTable,
+	tableDefs: map[sqlbase.ID]virtualSchemaDef{
+		sqlbase.PgCatalogAmTableID:                  pgCatalogAmTable,
+		sqlbase.PgCatalogAttrDefTableID:             pgCatalogAttrDefTable,
+		sqlbase.PgCatalogAttributeTableID:           pgCatalogAttributeTable,
+		sqlbase.PgCatalogAuthMembersTableID:         pgCatalogAuthMembersTable,
+		sqlbase.PgCatalogClassTableID:               pgCatalogClassTable,
+		sqlbase.PgCatalogCollationTableID:           pgCatalogCollationTable,
+		sqlbase.PgCatalogConstraintTableID:          pgCatalogConstraintTable,
+		sqlbase.PgCatalogDatabaseTableID:            pgCatalogDatabaseTable,
+		sqlbase.PgCatalogDependTableID:              pgCatalogDependTable,
+		sqlbase.PgCatalogDescriptionTableID:         pgCatalogDescriptionTable,
+		sqlbase.PgCatalogSharedDescriptionTableID:   pgCatalogSharedDescriptionTable,
+		sqlbase.PgCatalogEnumTableID:                pgCatalogEnumTable,
+		sqlbase.PgCatalogExtensionTableID:           pgCatalogExtensionTable,
+		sqlbase.PgCatalogForeignDataWrapperTableID:  pgCatalogForeignDataWrapperTable,
+		sqlbase.PgCatalogForeignServerTableID:       pgCatalogForeignServerTable,
+		sqlbase.PgCatalogForeignTableTableID:        pgCatalogForeignTableTable,
+		sqlbase.PgCatalogIndexTableID:               pgCatalogIndexTable,
+		sqlbase.PgCatalogIndexesTableID:             pgCatalogIndexesTable,
+		sqlbase.PgCatalogInheritsTableID:            pgCatalogInheritsTable,
+		sqlbase.PgCatalogLanguageTableID:            pgCatalogLanguageTable,
+		sqlbase.PgCatalogNamespaceTableID:           pgCatalogNamespaceTable,
+		sqlbase.PgCatalogOperatorTableID:            pgCatalogOperatorTable,
+		sqlbase.PgCatalogProcTableID:                pgCatalogProcTable,
+		sqlbase.PgCatalogRangeTableID:               pgCatalogRangeTable,
+		sqlbase.PgCatalogRewriteTableID:             pgCatalogRewriteTable,
+		sqlbase.PgCatalogRolesTableID:               pgCatalogRolesTable,
+		sqlbase.PgCatalogSequencesTableID:           pgCatalogSequencesTable,
+		sqlbase.PgCatalogSettingsTableID:            pgCatalogSettingsTable,
+		sqlbase.PgCatalogUserTableID:                pgCatalogUserTable,
+		sqlbase.PgCatalogUserMappingTableID:         pgCatalogUserMappingTable,
+		sqlbase.PgCatalogTablesTableID:              pgCatalogTablesTable,
+		sqlbase.PgCatalogTablespaceTableID:          pgCatalogTablespaceTable,
+		sqlbase.PgCatalogTriggerTableID:             pgCatalogTriggerTable,
+		sqlbase.PgCatalogTypeTableID:                pgCatalogTypeTable,
+		sqlbase.PgCatalogViewsTableID:               pgCatalogViewsTable,
+		sqlbase.PgCatalogStatActivityTableID:        pgCatalogStatActivityTable,
+		sqlbase.PgCatalogSecurityLabelTableID:       pgCatalogSecurityLabelTable,
+		sqlbase.PgCatalogSharedSecurityLabelTableID: pgCatalogSharedSecurityLabelTable,
 	},
 	// Postgres's catalogs are ill-defined when there is no current
 	// database set. Simply reject any attempts to use them in that
@@ -333,7 +333,7 @@ CREATE TABLE pg_catalog.pg_attrdef (
 					defSrc := tree.NewDString(*column.DefaultExpr)
 					return addRow(
 						h.ColumnOid(db, scName, table, column), // oid
-						h.TableOid(db, scName, table),          // adrelid
+						h.TableOid(table.ID),                   // adrelid
 						tree.NewDInt(tree.DInt(colNum)),        // adnum
 						defSrc, // adbin
 						defSrc, // adsrc
@@ -402,7 +402,7 @@ CREATE TABLE pg_catalog.pg_attribute (
 
 			// Columns for table.
 			if err := forEachColumnInTable(table, func(column *sqlbase.ColumnDescriptor) error {
-				tableID := h.TableOid(db, scName, table)
+				tableID := h.TableOid(table.ID)
 				return addColumn(column, tableID, column.ID)
 			}); err != nil {
 				return err
@@ -498,18 +498,18 @@ CREATE TABLE pg_catalog.pg_class (
 				}
 				namespaceOid := h.NamespaceOid(db, scName)
 				if err := addRow(
-					h.TableOid(db, scName, table), // oid
-					tree.NewDName(table.Name),     // relname
-					namespaceOid,                  // relnamespace
-					oidZero,                       // reltype (PG creates a composite type in pg_type for each table)
-					tree.DNull,                    // relowner
-					tree.DNull,                    // relam
-					oidZero,                       // relfilenode
-					oidZero,                       // reltablespace
-					tree.DNull,                    // relpages
-					tree.DNull,                    // reltuples
-					zeroVal,                       // relallvisible
-					oidZero,                       // reltoastrelid
+					h.TableOid(table.ID),      // oid
+					tree.NewDName(table.Name), // relname
+					namespaceOid,              // relnamespace
+					oidZero,                   // reltype (PG creates a composite type in pg_type for each table)
+					tree.DNull,                // relowner
+					tree.DNull,                // relam
+					oidZero,                   // relfilenode
+					oidZero,                   // reltablespace
+					tree.DNull,                // relpages
+					tree.DNull,                // reltuples
+					zeroVal,                   // relallvisible
+					oidZero,                   // reltoastrelid
 					tree.MakeDBool(tree.DBool(table.IsPhysicalTable())), // relhasindex
 					tree.DBoolFalse,                                     // relisshared
 					relPersistencePermanent,                             // relPersistence
@@ -688,7 +688,7 @@ CREATE TABLE pg_catalog.pg_constraint (
 				return err
 			}
 			namespaceOid := h.NamespaceOid(db, scName)
-			tblOid := h.TableOid(db, scName, table)
+			tblOid := h.TableOid(table.ID)
 			for conName, con := range conInfo {
 				oid := tree.DNull
 				contype := tree.DNull
@@ -726,7 +726,7 @@ CREATE TABLE pg_catalog.pg_constraint (
 					oid = h.ForeignKeyConstraintOid(db, tree.PublicSchema, table, con.FK)
 					contype = conTypeFK
 					conindid = h.IndexOid(referencedDB, tree.PublicSchema, con.ReferencedTable, con.ReferencedIndex)
-					confrelid = h.TableOid(referencedDB, tree.PublicSchema, con.ReferencedTable)
+					confrelid = h.TableOid(con.ReferencedTable.ID)
 					confupdtype = fkActionNone
 					confdeltype = fkActionNone
 					confmatchtype = fkMatchTypeSimple
@@ -867,7 +867,7 @@ CREATE TABLE pg_catalog.pg_database (
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, nil /*all databases*/, func(db *sqlbase.DatabaseDescriptor) error {
 			return addRow(
-				h.DBOid(db),                // oid
+				h.DBOid(db.ID),             // oid
 				tree.NewDName(db.Name),     // datname
 				tree.DNull,                 // datdba
 				builtins.DatEncodingUTFId,  // encoding
@@ -947,8 +947,8 @@ CREATE TABLE pg_catalog.pg_depend (
 			if err != nil {
 				return err
 			}
-			pgConstraintTableOid := h.TableOid(db, pgCatalogName, pgConstraintsDesc)
-			pgClassTableOid := h.TableOid(db, pgCatalogName, pgClassDesc)
+			pgConstraintTableOid := h.TableOid(pgConstraintsDesc.ID)
+			pgClassTableOid := h.TableOid(pgClassDesc.ID)
 			for _, con := range conInfo {
 				if con.Kind != sqlbase.ConstraintTypeFK {
 					continue
@@ -1020,7 +1020,7 @@ CREATE TABLE pg_catalog.pg_description (
 				tableLookup tableLookupFn) error {
 				if comment, ok := commentMap[tree.DInt(table.ID)]; ok {
 					return addRow(
-						h.TableOid(db, scName, table),
+						h.TableOid(table.ID),
 						oidZero,
 						comment[1],
 						comment[2])
@@ -1035,7 +1035,7 @@ CREATE TABLE pg_catalog.pg_description (
 		return forEachDatabaseDesc(ctx, p, nil /*all databases*/, func(db *sqlbase.DatabaseDescriptor) error {
 			if comment, ok := commentMap[tree.DInt(db.ID)]; ok {
 				return addRow(
-					h.DBOid(db),
+					h.DBOid(db.ID),
 					oidZero,
 					comment[1],
 					comment[2])
@@ -1192,7 +1192,7 @@ CREATE TABLE pg_catalog.pg_index (
 		h := makeOidHasher()
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual tables do not have indexes */
 			func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {
-				tableOid := h.TableOid(db, scName, table)
+				tableOid := h.TableOid(table.ID)
 				return forEachIndexInTable(table, func(index *sqlbase.IndexDescriptor) error {
 					isMutation, isWriteOnly :=
 						table.GetIndexMutationCapabilities(index.ID)
@@ -1793,7 +1793,7 @@ CREATE TABLE pg_catalog.pg_sequence (
 				}
 				opts := table.SequenceOpts
 				return addRow(
-					h.TableOid(db, scName, table),           // seqrelid
+					h.TableOid(table.ID),                    // seqrelid
 					tree.NewDOid(tree.DInt(oid.T_int8)),     // seqtypid
 					tree.NewDInt(tree.DInt(opts.Start)),     // seqstart
 					tree.NewDInt(tree.DInt(opts.Increment)), // seqincrement
@@ -2407,8 +2407,6 @@ type oidTypeTag uint8
 const (
 	_ oidTypeTag = iota
 	namespaceTypeTag
-	databaseTypeTag
-	tableTypeTag
 	indexTypeTag
 	columnTypeTag
 	checkConstraintTypeTag
@@ -2472,20 +2470,12 @@ func (h oidHasher) NamespaceOid(db *sqlbase.DatabaseDescriptor, scName string) *
 	return h.getOid()
 }
 
-func (h oidHasher) DBOid(db *sqlbase.DatabaseDescriptor) *tree.DOid {
-	h.writeTypeTag(databaseTypeTag)
-	h.writeDB(db)
-	return h.getOid()
+func (h oidHasher) DBOid(dbID sqlbase.ID) *tree.DOid {
+	return tree.NewDOid(tree.DInt(dbID))
 }
 
-func (h oidHasher) TableOid(
-	db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor,
-) *tree.DOid {
-	h.writeTypeTag(tableTypeTag)
-	h.writeDB(db)
-	h.writeSchema(scName)
-	h.writeTable(table)
-	return h.getOid()
+func (h oidHasher) TableOid(tableID sqlbase.ID) *tree.DOid {
+	return tree.NewDOid(tree.DInt(tableID))
 }
 
 func (h oidHasher) IndexOid(

--- a/pkg/sql/sqlbase/constants.go
+++ b/pkg/sql/sqlbase/constants.go
@@ -14,7 +14,11 @@
 
 package sqlbase
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+import (
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+)
 
 // DefaultSearchPath is the search path used by virgin sessions.
 var DefaultSearchPath = sessiondata.MakeSearchPath([]string{"public"})
@@ -27,3 +31,102 @@ var AdminRole = "admin"
 // dropped, assigned to another role, and is generally not listed.
 // It can be granted privileges, implicitly granting them to all users (current and future).
 var PublicRole = "public"
+
+// TableID for virtual tables.
+const (
+	CrdbInternalID ID = math.MaxUint32 - iota
+	CrdbInternalBackwardDependenciesTableID
+	CrdbInternalBuildInfoTableID
+	CrdbInternalBuiltinFunctionsTableID
+	CrdbInternalClusterQueriesTableID
+	CrdbInternalClusterSessionsTableID
+	CrdbInternalClusterSettingsTableID
+	CrdbInternalCreateStmtsTableID
+	CrdbInternalFeatureUsageID
+	CrdbInternalForwardDependenciesTableID
+	CrdbInternalGossipNodesTableID
+	CrdbInternalGossipAlertsTableID
+	CrdbInternalGossipLivenessTableID
+	CrdbInternalGossipNetworkTableID
+	CrdbInternalIndexColumnsTableID
+	CrdbInternalJobsTableID
+	CrdbInternalKVNodeStatusTableID
+	CrdbInternalKVStoreStatusTableID
+	CrdbInternalLeasesTableID
+	CrdbInternalLocalQueriesTableID
+	CrdbInternalLocalSessionsTableID
+	CrdbInternalLocalMetricsTableID
+	CrdbInternalPartitionsTableID
+	CrdbInternalRangesNoLeasesTableID
+	CrdbInternalRangesViewID
+	CrdbInternalRuntimeInfoTableID
+	CrdbInternalSchemaChangesTableID
+	CrdbInternalSessionTraceTableID
+	CrdbInternalSessionVariablesTableID
+	CrdbInternalStmtStatsTableID
+	CrdbInternalTableColumnsTableID
+	CrdbInternalTableIndexesTableID
+	CrdbInternalTablesTableID
+	CrdbInternalZonesTableID
+	InformationSchemaID
+	InformationSchemaAdministrableRoleAuthorizationsID
+	InformationSchemaApplicableRolesID
+	InformationSchemaColumnPrivilegesID
+	InformationSchemaColumnsTableID
+	InformationSchemaConstraintColumnUsageTableID
+	InformationSchemaEnabledRolesID
+	InformationSchemaKeyColumnUsageTableID
+	InformationSchemaParametersTableID
+	InformationSchemaReferentialConstraintsTableID
+	InformationSchemaRoleTableGrantsID
+	InformationSchemaRoutineTableID
+	InformationSchemaSchemataTableID
+	InformationSchemaSchemataTablePrivilegesID
+	InformationSchemaSequencesID
+	InformationSchemaStatisticsTableID
+	InformationSchemaTableConstraintTableID
+	InformationSchemaTablePrivilegesID
+	InformationSchemaTablesTableID
+	InformationSchemaViewsTableID
+	InformationSchemaUserPrivilegesID
+	PgCatalogID
+	PgCatalogAmTableID
+	PgCatalogAttrDefTableID
+	PgCatalogAttributeTableID
+	PgCatalogAuthMembersTableID
+	PgCatalogClassTableID
+	PgCatalogCollationTableID
+	PgCatalogConstraintTableID
+	PgCatalogDatabaseTableID
+	PgCatalogDependTableID
+	PgCatalogDescriptionTableID
+	PgCatalogSharedDescriptionTableID
+	PgCatalogEnumTableID
+	PgCatalogExtensionTableID
+	PgCatalogForeignDataWrapperTableID
+	PgCatalogForeignServerTableID
+	PgCatalogForeignTableTableID
+	PgCatalogIndexTableID
+	PgCatalogIndexesTableID
+	PgCatalogInheritsTableID
+	PgCatalogLanguageTableID
+	PgCatalogNamespaceTableID
+	PgCatalogOperatorTableID
+	PgCatalogProcTableID
+	PgCatalogRangeTableID
+	PgCatalogRewriteTableID
+	PgCatalogRolesTableID
+	PgCatalogSequencesTableID
+	PgCatalogSettingsTableID
+	PgCatalogUserTableID
+	PgCatalogUserMappingTableID
+	PgCatalogTablesTableID
+	PgCatalogTablespaceTableID
+	PgCatalogTriggerTableID
+	PgCatalogTypeTableID
+	PgCatalogViewsTableID
+	PgCatalogStatActivityTableID
+	PgCatalogSecurityLabelTableID
+	PgCatalogSharedSecurityLabelTableID
+	MinVirtualID = PgCatalogSharedSecurityLabelTableID
+)

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -511,7 +511,7 @@ func (desc *TableDescriptor) IsSequence() bool {
 // virtual Table (like the information_schema tables) and thus doesn't
 // need to be physically stored.
 func (desc *TableDescriptor) IsVirtualTable() bool {
-	return desc.ID == keys.VirtualDescriptorID
+	return MinVirtualID <= desc.ID
 }
 
 // IsPhysicalTable returns true if the TableDescriptor actually describes a

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -178,7 +177,7 @@ func (sc *TableStatisticsCache) GetTableStats(
 		// for table_statistics itself).
 		return nil, nil
 	}
-	if tableID == keys.VirtualDescriptorID {
+	if sqlbase.MinVirtualID <= tableID {
 		// Don't try to get statistics for virtual tables.
 		return nil, nil
 	}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -858,7 +858,7 @@ func (p *planner) writeTableDescToBatch(
 	mutationID sqlbase.MutationID,
 	b *client.Batch,
 ) error {
-	if isVirtualDescriptor(tableDesc) {
+	if tableDesc.IsVirtualTable() {
 		return pgerror.NewAssertionErrorf("virtual descriptors cannot be stored, found: %v", tableDesc)
 	}
 


### PR DESCRIPTION
Feature for #32940

Can handle in future #32963, #32964

Databases and tables OID use descriptor id directly. It's fine because we create the id with sql.GenerateUniqueDescID.

Virtual tables use static negative ID. Do not use the same math.MaxUint32 anymore.

Release note(sql change): Databases and tables pg_catalog OID values are changed.