### PR TITLE
sql: fix the lifetime of portals

### DIFF
--- a/pkg/internal/client/sender.go
+++ b/pkg/internal/client/sender.go
@@ -296,7 +296,13 @@ func (m *MockTransactionalSender) AugmentMeta(context.Context, roachpb.TxnCoordM
 }
 
 // OnFinish is part of the TxnSender interface.
-func (m *MockTransactionalSender) OnFinish(_ func(error)) { panic("unimplemented") }
+func (m *MockTransactionalSender) OnFinish(f func(error)) {
+	// We accept the nil, as that's commonly used to reset a previously-set
+	// closure.
+	if f != nil {
+		panic("unimplemented")
+	}
+}
 
 // SetSystemConfigTrigger is part of the TxnSender interface.
 func (m *MockTransactionalSender) SetSystemConfigTrigger() error { panic("unimplemented") }
@@ -346,7 +352,7 @@ func (m *MockTransactionalSender) ManualRestart(
 
 // IsSerializablePushAndRefreshNotPossible is part of the TxnSender interface.
 func (m *MockTransactionalSender) IsSerializablePushAndRefreshNotPossible() bool {
-	panic("unimplemented")
+	return false
 }
 
 // Epoch is part of the TxnSender interface.

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -1,0 +1,318 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package sql
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+// Test portal implicit destruction. Unless destroying a portal is explicitly
+// requested, portals live until the end of the transaction in which
+// they'recreated. If they're created outside of a transaction, they live until
+// the next transaction completes (so until the next statement is executed,
+// which statement is expected to be the execution of the portal that was just
+// created).
+// For the non-transactional case, our behavior is different than Postgres',
+// which states that, outside of transactions, portals live until the next Sync
+// protocol command.
+func TestPortalsDestroyedOnTxnFinish(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	buf, syncResults, finished, stopper, err := startConnExecutor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopper.Stop(ctx)
+	defer func() {
+		buf.Close()
+	}()
+
+	// First we test the non-transactional case. We'll send a
+	// Parse/Bind/Describe/Execute/Describe. We expect the first Describe to
+	// succeed and the 2nd one to fail (since the portal is destroyed after the
+	// Execute).
+	cmdPos := 0
+	stmt := mustParseOne("SELECT 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = buf.Push(ctx, PrepareStmt{Name: "ps_nontxn", Statement: stmt}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPos++
+	if err = buf.Push(ctx, BindStmt{
+		PreparedStatementName: "ps_nontxn",
+		PortalName:            "portal1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPos++
+	successfulDescribePos := cmdPos
+	if err = buf.Push(ctx, DescribeStmt{
+		Name: "portal1",
+		Type: pgwirebase.PreparePortal,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPos++
+	successfulDescribePos = cmdPos
+	if err = buf.Push(ctx, ExecPortal{
+		Name: "portal1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPos++
+	failedDescribePos := cmdPos
+	if err = buf.Push(ctx, DescribeStmt{
+		Name: "portal1",
+		Type: pgwirebase.PreparePortal,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPos++
+	if err = buf.Push(ctx, Sync{}); err != nil {
+		t.Fatal(err)
+	}
+
+	results := <-syncResults
+	numResults := len(results)
+	if numResults != cmdPos+1 {
+		t.Fatalf("expected %d results, got: %d", cmdPos+1, len(results))
+	}
+	if err := results[successfulDescribePos].err; err != nil {
+		t.Fatalf("expected first Describe to succeed, got err: %s", err)
+	}
+	if !testutils.IsError(results[failedDescribePos].err, "unknown portal") {
+		t.Fatalf("expected error \"unknown portal\", got: %v", results[failedDescribePos].err)
+	}
+
+	// Now we test the transactional case. We'll send a
+	// BEGIN/Parse/Bind/SELECT/Describe/COMMIT/Describe. We expect the first
+	// Describe to succeed and the 2nd one to fail (since the portal is destroyed
+	// after the COMMIT). The point of the SELECT is to show that the portal
+	// survives execution of a statement.
+	cmdPos++
+	stmt = mustParseOne("BEGIN")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := buf.Push(ctx, ExecStmt{Statement: stmt}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPos++
+	stmt = mustParseOne("SELECT 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = buf.Push(ctx, PrepareStmt{Name: "ps1", Statement: stmt}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPos++
+	if err = buf.Push(ctx, BindStmt{
+		PreparedStatementName: "ps1",
+		PortalName:            "portal1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPos++
+	stmt = mustParseOne("SELECT 2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := buf.Push(ctx, ExecStmt{Statement: stmt}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPos++
+	successfulDescribePos = cmdPos
+	if err = buf.Push(ctx, DescribeStmt{
+		Name: "portal1",
+		Type: pgwirebase.PreparePortal,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPos++
+	stmt = mustParseOne("COMMIT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := buf.Push(ctx, ExecStmt{Statement: stmt}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPos++
+	failedDescribePos = cmdPos
+	if err = buf.Push(ctx, DescribeStmt{
+		Name: "portal1",
+		Type: pgwirebase.PreparePortal,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdPos++
+	if err = buf.Push(ctx, Sync{}); err != nil {
+		t.Fatal(err)
+	}
+
+	results = <-syncResults
+
+	exp := cmdPos + 1 - numResults
+	if len(results) != exp {
+		t.Fatalf("expected %d results, got: %d", exp, len(results))
+	}
+	succDescIdx := successfulDescribePos - numResults
+	if err := results[succDescIdx].err; err != nil {
+		t.Fatalf("expected first Describe to succeed, got err: %s", err)
+	}
+	failDescIdx := failedDescribePos - numResults
+	if !testutils.IsError(results[failDescIdx].err, "unknown portal") {
+		t.Fatalf("expected error \"unknown portal\", got: %v", results[failDescIdx].err)
+	}
+
+	buf.Close()
+	if err := <-finished; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustParseOne(s string) parser.Statement {
+	stmts, err := parser.Parse(s)
+	if err != nil {
+		log.Fatal(context.TODO(), err)
+	}
+	return stmts[0]
+}
+
+type dummyLivenessProvider struct {
+}
+
+// IsLive implements the livenessProvider interface.
+func (l dummyLivenessProvider) IsLive(roachpb.NodeID) (bool, error) {
+	return true, nil
+}
+
+// startConnExecutor start a goroutine running a connExecutor. This connExecutor
+// is using a mocked KV that can't really do anything, so it can't run
+// statements that need to "access the database". It can only execute things
+// like `SELECT 1`. It's intended for testing interactions with the network
+// protocol.
+//
+// It returns a StmtBuf which is to be used to providing input to the executor,
+// a channel for getting results after sending Sync commands, a channel that
+// gets the error from closing down the executor once the StmtBuf is closed, a
+// stopper that must be stopped when the test completes (this does not stop the
+// executor but stops other background work).
+func startConnExecutor(
+	ctx context.Context,
+) (*StmtBuf, <-chan []resWithPos, <-chan error, *stop.Stopper, error) {
+	// A lot of boilerplate for creating a connExecutor.
+	stopper := stop.NewStopper()
+	clock := hlc.NewClock(hlc.UnixNano, 0 /* maxOffset */)
+	factory := client.MakeMockTxnSenderFactory(
+		func(context.Context, *roachpb.Transaction, roachpb.BatchRequest,
+		) (*roachpb.BatchResponse, *roachpb.Error) {
+			return nil, nil
+		})
+	db := client.NewDB(testutils.MakeAmbientCtx(), factory, clock)
+	st := cluster.MakeTestingClusterSettings()
+	nodeID := &base.NodeIDContainer{}
+	nodeID.Set(ctx, 1)
+	distSQLMetrics := distsqlrun.MakeDistSQLMetrics(time.Hour /* histogramWindow */)
+	cfg := &ExecutorConfig{
+		AmbientCtx:      testutils.MakeAmbientCtx(),
+		Settings:        st,
+		Clock:           clock,
+		DB:              db,
+		SessionRegistry: NewSessionRegistry(),
+		NodeInfo: NodeInfo{
+			NodeID:    nodeID,
+			ClusterID: func() uuid.UUID { return uuid.UUID{} },
+		},
+		DistSQLPlanner: NewDistSQLPlanner(
+			ctx, distsqlrun.Version, st, roachpb.NodeDescriptor{},
+			nil, /* rpcCtx */
+			distsqlrun.NewServer(ctx, distsqlrun.ServerConfig{
+				AmbientContext: testutils.MakeAmbientCtx(),
+				Settings:       st,
+				Stopper:        stopper,
+				Metrics:        &distSQLMetrics,
+				NodeID:         nodeID,
+			}),
+			nil, /* distSender */
+			nil, /* gossip */
+			stopper,
+			dummyLivenessProvider{}, /* liveness */
+			nil, /* nodeDialer */
+		),
+		TestingKnobs: &ExecutorTestingKnobs{},
+	}
+	pool := mon.MakeUnlimitedMonitor(
+		context.Background(), "test", mon.MemoryResource,
+		nil /* curCount */, nil /* maxHist */, math.MaxInt64, st,
+	)
+	// This pool should never be Stop()ed because, if the test is failing, memory
+	// is not properly released.
+
+	s := NewServer(cfg, &pool)
+	buf := NewStmtBuf()
+	syncResults := make(chan []resWithPos, 1)
+	var cc ClientComm = &internalClientComm{
+		sync: func(res []resWithPos) {
+			syncResults <- res
+		},
+	}
+	sqlMetrics := MakeMemMetrics("test" /* endpoint */, time.Second /* histogramWindow */)
+
+	conn, err := s.SetupConn(ctx, SessionArgs{}, buf, cc, sqlMetrics)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	finished := make(chan error)
+
+	// We're going to run the connExecutor in the background. On the main test
+	// routine, we're going to push commands into the StmtBuf and, from time to
+	// time, collect and check their results.
+	go func() {
+		finished <- s.ServeConn(ctx, conn, mon.BoundAccount{}, nil /* cancel */)
+	}()
+	return buf, syncResults, finished, stopper, nil
+}

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -932,3 +932,18 @@ func (r *bufferedCommandResult) Discard() {
 		r.closeCallback(r, discarded, nil /* err */)
 	}
 }
+
+// SetInTypes is part of the DescribeResult interface.
+func (r *bufferedCommandResult) SetInTypes([]oid.Oid) {}
+
+// SetNoDataRowDescription is part of the DescribeResult interface.
+func (r *bufferedCommandResult) SetNoDataRowDescription() {}
+
+// SetPrepStmtOutput is part of the DescribeResult interface.
+func (r *bufferedCommandResult) SetPrepStmtOutput(context.Context, sqlbase.ResultColumns) {}
+
+// SetPortalOutput is part of the DescribeResult interface.
+func (r *bufferedCommandResult) SetPortalOutput(
+	context.Context, sqlbase.ResultColumns, []pgwirebase.FormatCode,
+) {
+}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -628,7 +628,7 @@ func (icc *internalClientComm) Flush(pos CmdPos) error {
 
 // CreateDescribeResult is part of the ClientComm interface.
 func (icc *internalClientComm) CreateDescribeResult(pos CmdPos) DescribeResult {
-	panic("unimplemented")
+	return icc.createRes(pos, nil /* onClose */)
 }
 
 // CreateDeleteResult is part of the ClientComm interface.

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -329,7 +329,7 @@ const (
 // txnEvent is part of advanceInfo, informing the connExecutor about some
 // transaction events. It is used by the connExecutor to clear state associated
 // with a SQL transaction (other than the state encapsulated in TxnState; e.g.
-// as schema changes).
+// schema changes and portals).
 //
 //go:generate stringer -type=txnEvent
 type txnEvent int


### PR DESCRIPTION
Before this patch, the lifetime of portals was completely broken (wrt
Postgres). A portal used to live until the prepared statement from which
it was created was destroyed.
What Postgres wants is the following:
- for portals created in transactions, they live until the transaction is
done
- for portals created outside of transactions, they live until the
following Sync command
Notice that the life times of portals has nothing to do with the
lifetime of prepared statements.

This patch implements something kinda analogous:
- transactional portals live until the transaction is done, like in
Postgres
- non-transactional portals live until the next transaction is done, so
they'll be destroyed as soon as a non-transactional statement is
executed, or when they themselves are executed (which is the common
case), or until some other transaction runs. This is close enough.

This patch also comes with other points:
- I've reworked how portals and prepared statements are kept alive by
references from two sources: the prepStmtsNamespace and
prepStmtsNamespaceAtTxnRewindPos. Entries need to live while they're
referenced from either of those. The code used to implement a pretty
unscrutable scheme for ensuring this, now I've switched it to a
reference counting scheme which is simpler.
- I've removed the references from prepared statements to portals and
I've reworked the way in which prepStmtsNamespace is cleared, and so
hopefully I've eliminated a bunch of map allocations happening in
between transactions that Nathan was complaining about.
- I've written a test which is the first ever unit test for the
connExecutor. It took an ungodly amount of boiler plate to create a
connExecutor that's not running in the context of a full node, but now
it can be nicely reused. Having this testing facility was long overdue.

Release note: None