### PR TITLE
settings: rename kv.raft_log.synchronize to kv.raft_log.disable_synchronization_unsafe

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -28,7 +28,7 @@
 <tr><td><code>kv.closed_timestamp.follower_reads_enabled</code></td><td>boolean</td><td><code>false</code></td><td>allow (all) replicas to serve consistent historical reads based on closed timestamp information</td></tr>
 <tr><td><code>kv.closed_timestamp.target_duration</code></td><td>duration</td><td><code>30s</code></td><td>if nonzero, attempt to provide closed timestamp notifications for timestamps trailing cluster time by approximately this duration</td></tr>
 <tr><td><code>kv.raft.command.max_size</code></td><td>byte size</td><td><code>64 MiB</code></td><td>maximum size of a raft command</td></tr>
-<tr><td><code>kv.raft_log.synchronize</code></td><td>boolean</td><td><code>true</code></td><td>set to true to synchronize on Raft log writes to persistent storage ('false' risks data loss)</td></tr>
+<tr><td><code>kv.raft_log.disable_synchronization_unsafe</code></td><td>boolean</td><td><code>false</code></td><td>set to true to disable synchronization on Raft log writes to persistent storage. Setting to true risks data loss or data corruption on server crashes. The setting is meant for internal testing only and SHOULD NOT be used in production.</td></tr>
 <tr><td><code>kv.range.backpressure_range_size_multiplier</code></td><td>float</td><td><code>2</code></td><td>multiple of range_max_bytes that a range is allowed to grow to without splitting before writes to that range are blocked, or 0 to disable</td></tr>
 <tr><td><code>kv.range_descriptor_cache.size</code></td><td>integer</td><td><code>1000000</code></td><td>maximum number of entries in the range descriptor and leaseholder caches</td></tr>
 <tr><td><code>kv.range_merge.queue_enabled</code></td><td>boolean</td><td><code>true</code></td><td>whether the automatic merge queue is enabled</td></tr>

--- a/pkg/cmd/allocsim/main.go
+++ b/pkg/cmd/allocsim/main.go
@@ -544,7 +544,7 @@ func main() {
 	c.Start(context.Background())
 	defer c.Close()
 	c.UpdateZoneConfig(1, 1<<20)
-	_, err := c.Nodes[0].DB().Exec("SET CLUSTER SETTING kv.raft_log.synchronize = false;")
+	_, err := c.Nodes[0].DB().Exec("SET CLUSTER SETTING kv.raft_log.disable_synchronization_unsafe = true")
 	if err != nil {
 		log.Fatal(context.Background(), err)
 	}

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -41,6 +41,8 @@ var retiredSettings = map[string]struct{}{
 	// removed as of 2.1.
 	"kv.allocator.stat_based_rebalancing.enabled": {},
 	"kv.allocator.stat_rebalance_threshold":       {},
+	// removed as of 2.2.
+	"kv.raft_log.synchronize": {},
 }
 
 // Register adds a setting to the registry.

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -95,10 +95,12 @@ const (
 
 var testingDisableQuiescence = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_QUIESCENCE", false)
 
-var syncRaftLog = settings.RegisterBoolSetting(
-	"kv.raft_log.synchronize",
-	"set to true to synchronize on Raft log writes to persistent storage ('false' risks data loss)",
-	true,
+var disableSyncRaftLog = settings.RegisterBoolSetting(
+	"kv.raft_log.disable_synchronization_unsafe",
+	"set to true to disable synchronization on Raft log writes to persistent storage. "+
+		"Setting to true risks data loss or data corruption on server crashes. "+
+		"The setting is meant for internal testing only and SHOULD NOT be used in production.",
+	false,
 )
 
 // MaxCommandSizeFloor is the minimum allowed value for the MaxCommandSize
@@ -4199,7 +4201,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// were not persisted to disk, it wouldn't be a problem because raft does not
 	// infer the that entries are persisted on the node that sends a snapshot.
 	start := timeutil.Now()
-	if err := batch.Commit(syncRaftLog.Get(&r.store.cfg.Settings.SV) && rd.MustSync); err != nil {
+	if err := batch.Commit(rd.MustSync && !disableSyncRaftLog.Get(&r.store.cfg.Settings.SV)); err != nil {
 		const expl = "while committing batch"
 		return stats, expl, errors.Wrap(err, expl)
 	}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -915,7 +915,7 @@ func (r *Replica) applySnapshot(
 	}
 
 	// We've written Raft log entries, so we need to sync the WAL.
-	if err := batch.Commit(syncRaftLog.Get(&r.store.cfg.Settings.SV)); err != nil {
+	if err := batch.Commit(!disableSyncRaftLog.Get(&r.store.cfg.Settings.SV)); err != nil {
 		return err
 	}
 	stats.commit = timeutil.Now()


### PR DESCRIPTION
Closes #33132.

Release note: None