### PR TITLE
release-2.1: sql: report unsupported built-in functions in telemetry

### DIFF
--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -309,6 +309,12 @@ func TestReportUsage(t *testing.T) {
 		) {
 			t.Fatal(err)
 		}
+		// If the function ever gets supported, change to pick one that is not supported yet.
+		if _, err := db.Exec(`SELECT json_object_agg()`); !testutils.IsError(
+			err, "this function is not supported",
+		) {
+			t.Fatal(err)
+		}
 		// If the vtable ever gets supported, change to pick one that is not supported yet.
 		if _, err := db.Exec(`SELECT * FROM pg_catalog.pg_stat_wal_receiver`); !testutils.IsError(
 			err, "virtual schema table not implemented",
@@ -535,6 +541,7 @@ func TestReportUsage(t *testing.T) {
 		"test.b": 2,
 		"test.c": 3,
 
+		"unimplemented.#33285.json_object_agg":          10,
 		"unimplemented.pg_catalog.pg_stat_wal_receiver": 10,
 		"unimplemented.syntax.#32555":                   10,
 		"unimplemented.syntax.#32564":                   10,

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -287,6 +287,9 @@ var aggregates = map[string]builtinDefinition{
 			"Aggregates values as a JSON or JSONB array."),
 	),
 
+	"json_object_agg":  makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 33285, Class: tree.AggregateClass, Impure: true}),
+	"jsonb_object_agg": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 33285, Class: tree.AggregateClass, Impure: true}),
+
 	AnyNotNull: makePrivate(makeBuiltin(aggProps(),
 		makeAggOverloadWithReturnType(
 			[]types.T{types.Any},

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2540,6 +2540,11 @@ may increase either contention or retry errors, or both.`,
 
 	// JSON functions.
 
+	"json_to_recordset":        makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 33285, Category: categoryJSON}),
+	"jsonb_to_recordset":       makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 33285, Category: categoryJSON}),
+	"json_populate_recordset":  makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 33285, Category: categoryJSON}),
+	"jsonb_populate_recordset": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 33285, Category: categoryJSON}),
+
 	"json_remove_path": makeBuiltin(jsonProps(),
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.JSON}, {"path", types.TArray{Typ: types.String}}},

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -33,6 +33,12 @@ type FunctionDefinition struct {
 // FunctionProperties defines the properties of the built-in
 // functions that are common across all overloads.
 type FunctionProperties struct {
+	// UnsupportedWithIssue, if non-zero indicates the built-in is not
+	// really supported; the name is a placeholder. Value -1 just says
+	// "not supported" without an issue to link; values > 0 provide an
+	// issue number to link.
+	UnsupportedWithIssue int
+
 	// NullableArgs is set to true when a function's definition can
 	// handle NULL arguments. When set, the function will be given the
 	// chance to see NULL arguments. When not, the function will

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -688,6 +688,15 @@ func NewInvalidFunctionUsageError(class FunctionClass, context string) error {
 // checkFunctionUsage checks whether a given built-in function is
 // allowed in the current context.
 func (sc *SemaContext) checkFunctionUsage(expr *FuncExpr, def *FunctionDefinition) error {
+	if def.UnsupportedWithIssue != 0 {
+		// Note: no need to embed the function name in the message; the
+		// caller will add the function name as prefix.
+		const msg = "this function is not supported"
+		if def.UnsupportedWithIssue < 0 {
+			return pgerror.Unimplemented(def.Name+"()", msg)
+		}
+		return pgerror.UnimplementedWithIssueDetailError(def.UnsupportedWithIssue, def.Name, msg)
+	}
 	if def.Private {
 		return errors.Wrapf(errPrivateFunction, "%s()", def.Name)
 	}


### PR DESCRIPTION
Backport 1/1 commits from #33390.

/cc @cockroachdb/release

