### PR TITLE
sql: clarify and document formatting flags

### DIFF
--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -228,7 +228,7 @@ func (sp *csvWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
 		if sp.spec.Options.NullEncoding != nil {
 			nullsAs = *sp.spec.Options.NullEncoding
 		}
-		f := tree.NewFmtCtxWithBuf(tree.FmtParseDatums)
+		f := tree.NewFmtCtxWithBuf(tree.FmtExport)
 		defer f.Close()
 
 		csvRow := make([]string, len(types))

--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -72,7 +72,7 @@ func TestExportImportBank(t *testing.T) {
 	db, dir, cleanup := setupExportableBank(t, 3, 100)
 	defer cleanup()
 
-	// Add some unicode to prove FmtParseDatums works as advertised.
+	// Add some unicode to prove FmtExport works as advertised.
 	db.Exec(t, "UPDATE bank SET payload = payload || '✅' WHERE id = 5")
 	db.Exec(t, "UPDATE bank SET payload = NULL WHERE id % 2 = 0")
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4194,7 +4194,7 @@ func stringToArray(str string, delimPtr *string, nullStr *string) (tree.Datum, e
 // delim. If nullStr is non-nil, NULL values in the array will be replaced by
 // it.
 func arrayToString(arr *tree.DArray, delim string, nullStr *string) (tree.Datum, error) {
-	f := tree.NewFmtCtxWithBuf(tree.FmtParseDatums)
+	f := tree.NewFmtCtxWithBuf(tree.FmtArrayToString)
 
 	for i := range arr.Array {
 		if arr.Array[i] == tree.DNull {

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1123,7 +1123,7 @@ func (*DString) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DString) Format(ctx *FmtCtx) {
 	buf, f := ctx.Buffer, ctx.flags
-	if f.HasFlags(fmtUnicodeStrings) {
+	if f.HasFlags(fmtRawStrings) {
 		buf.WriteString(string(*d))
 	} else {
 		lex.EncodeSQLStringWithFlags(buf, string(*d), f.EncodeFlags())
@@ -2529,11 +2529,11 @@ func (d *DJSON) Format(ctx *FmtCtx) {
 	// TODO(justin): ideally the JSON string encoder should know it needs to
 	// escape things to be inside SQL strings in order to avoid this allocation.
 	s := d.JSON.String()
-	if ctx.flags.HasFlags(fmtUnicodeStrings) {
+	if ctx.flags.HasFlags(fmtRawStrings) {
 		ctx.Buffer.WriteString(s)
-		return
+	} else {
+		lex.EncodeSQLStringWithFlags(ctx.Buffer, s, ctx.flags.EncodeFlags())
 	}
-	lex.EncodeSQLStringWithFlags(ctx.Buffer, s, ctx.flags.EncodeFlags())
 }
 
 // Size implements the Datum interface.

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -54,7 +54,7 @@ func ParseStringAs(t types.T, s string, evalCtx *EvalContext) (Datum, error) {
 }
 
 // ParseDatumStringAs parses s as type t. This function is guaranteed to
-// round-trip when printing a Datum with FmtParseDatums.
+// round-trip when printing a Datum with FmtExport.
 func ParseDatumStringAs(t types.T, s string, evalCtx *EvalContext) (Datum, error) {
 	switch t {
 	case types.Bytes:

--- a/pkg/sql/sem/tree/parse_string_test.go
+++ b/pkg/sql/sem/tree/parse_string_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 // TestParseDatumStringAs tests that datums are roundtrippable between
-// printing with FmtParseDatums and ParseDatumStringAs.
+// printing with FmtExport and ParseDatumStringAs.
 func TestParseDatumStringAs(t *testing.T) {
 	tests := map[types.T][]string{
 		types.Bool: {
@@ -125,7 +125,7 @@ func TestParseDatumStringAs(t *testing.T) {
 					if d.ResolvedType() != typ {
 						t.Fatalf("unexpected type: %s", d.ResolvedType())
 					}
-					ds := AsStringWithFlags(d, FmtParseDatums)
+					ds := AsStringWithFlags(d, FmtExport)
 					if s != ds {
 						t.Fatalf("unexpected string: %q, expected: %q", ds, s)
 					}

--- a/pkg/sql/sem/tree/parse_string_test.go
+++ b/pkg/sql/sem/tree/parse_string_test.go
@@ -91,11 +91,16 @@ func TestParseDatumStringAs(t *testing.T) {
 			"1",
 			"1.0",
 			`""`,
+			`"abc"`,
+			`"ab\u0000c"`,
+			`"ab\u0001c"`,
+			`"ab⚣ cd"`,
 		},
 		types.String: {
 			"",
 			"abc",
 			"abc\x00",
+			"ab⚣ cd",
 		},
 		types.Time: {
 			"01:02:03",


### PR DESCRIPTION
Informs  #33429.

- `fmtUnicodeStrings` -> `fmtRawStrings` (nothing unicode about them)
- `FmtParseDatums` -> `FmtExport` (to clarify away from FmtParsable)
- separate `FmtExport` and `FmtArrayToString` - these are two
  independent concepts, even if they currently happen to share an
  implementation. Chances are FmtExport will evolve away.

Release note: None