### PR TITLE
cli/start,server: clarify init vs join

### DIFF
--- a/pkg/cli/interactive_tests/test_init_command.tcl
+++ b/pkg/cli/interactive_tests/test_init_command.tcl
@@ -9,7 +9,8 @@ source [file join [file dirnam $argv0] common.tcl]
 system "$argv start --insecure --pid-file=server_pid -s=path=logs/db --listen-addr=localhost --background --join=localhost:26258 >>logs/expect-cmd.log 2>&1"
 
 start_test "Check that the server has informed us and the log file that it was ready before forking off in the background"
-system "grep -q 'initial startup completed, will now wait' logs/db/logs/cockroach.log"
+system "grep -q 'initial startup completed' logs/db/logs/cockroach.log"
+system "grep -q 'will now attempt to join a running cluster, or wait' logs/db/logs/cockroach.log"
 end_test
 
 start_test "Check that the SQL shell successfully times out upon connecting to an uninitialized node"

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -504,9 +504,10 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 		if waitForInit {
 			log.Shout(ctx, log.Severity_INFO,
-				"initial startup completed, will now wait for `cockroach init`\n"+
-					"or a join to a running cluster to start accepting clients.\n"+
-					"Check the log file(s) for progress.")
+				"initial startup completed.\n"+
+					"Node will now attempt to join a running cluster, or wait for `cockroach init`.\n"+
+					"Client connections will be accepted after this completes successfully.\n"+
+					"Check the log file(s) for progress. ")
 		}
 
 		// Ensure the configuration logging is written to disk in case a

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -243,10 +243,11 @@ type Config struct {
 	EventLogEnabled bool
 
 	// ReadyFn is called when the server has started listening on its
-	// sockets. The boolean argument indicates (iff true) that the
+	// sockets.
+	// The argument waitForInit indicates (iff true) that the
 	// server is not bootstrapped yet, will not bootstrap itself and
-	// will be waiting for an `init` command. This can be used to inform
-	// the user.
+	// will be waiting for an `init` command or accept bootstrapping
+	// from a joined node.
 	ReadyFn func(waitForInit bool)
 
 	// DelayedBootstrapFn is called if the boostrap process does not complete


### PR DESCRIPTION
Fixes #33302.

Regarding the behavior of `cockroach start --join` upon first
start (before bootstrap).

Prior to this patch:

```
*
* INFO: initial startup completed, will now wait for `cockroach init`
* or a join to a running cluster to start accepting clients.
* Check the log file(s) for progress.
*
```

The emphasis was incorrectly put on the waiting ("will now wait") and
on init vs join. In practice, waiting is uncommon and a join is more
frequent than init.

After this patch:

```
*
* INFO: initial startup completed.
* Node will now attempt to join a running cluster, or wait for `cockroach init`.
* Client connections will be accepted after this completes successfully.
* Check the log file(s) for progress.
*
```

Release note (cli change): The informational message printed upon
`cockroach start --join` when a node is started the first time has
been reworded, to emphasize that joining a running cluster is the
preferred course of action.