### PR TITLE
cli/interactive_tests: unskip test_url_db_override

### DIFF
--- a/pkg/cli/interactive_tests/test_url_db_override.tcl
+++ b/pkg/cli/interactive_tests/test_url_db_override.tcl
@@ -85,7 +85,7 @@ eexpect eof
 end_test
 
 start_test "Check that the host flag overrides the host if URL is already set."
-spawn $argv sql --url "postgresql://root@localhost:26257?sslmode=disable" --host nonexistent -e "select 1"
+spawn $argv sql --url "postgresql://root@localhost:26257?sslmode=disable" --host nonexistent.invalid -e "select 1"
 eexpect "cannot dial server"
 eexpect "nonexistent"
 eexpect eof


### PR DESCRIPTION
Fixes #30796.

... and use a more clearly guaranteed-bad DNS name for the expected
failure. Suggested by @petermattis.

Release note: None