### PR TITLE
roachtest: update hibernate blacklist for 2.1

### DIFF
--- a/pkg/cmd/roachtest/hibernate_blacklist.go
+++ b/pkg/cmd/roachtest/hibernate_blacklist.go
@@ -639,7 +639,6 @@ var hibernateBlackList2_1 = blacklist{
 	"org.hibernate.test.proxy.ProxyTest.testRefreshLockInitializedProxy":                                                                                                             "6583",
 	"org.hibernate.test.quote.QuoteTest.testUnionSubclassEntityQuoting":                                                                                                              "5807",
 	"org.hibernate.test.quote.TableGeneratorQuotingTest.testTableGeneratorQuoting":                                                                                                   "16769",
-	"org.hibernate.test.schemaupdate.MigrationTest.testIndexCreationViaSchemaUpdate":                                                                                                 "31761",
 	"org.hibernate.test.schemaupdate.PostgreSQLMultipleSchemaSequenceTest.test":                                                                                                      "26443",
 	"org.hibernate.test.schemaupdate.SchemaUpdateTest.testSchemaUpdateAndValidation[0]":                                                                                              "26738",
 	"org.hibernate.test.schemaupdate.SchemaUpdateTest.testSchemaUpdateAndValidation[1]":                                                                                              "26738",


### PR DESCRIPTION
Thanks to #33276, this test now passes on the 2.1 branch.

Closes #33402.

Release note: None