### PR TITLE
sql: stop returning dropped unique columns in DELETE RETURNING

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -219,3 +219,25 @@ DELETE FROM t29494 RETURNING *
 
 statement ok
 COMMIT
+
+subtest regression_33361
+
+statement ok
+CREATE TABLE t33361(x INT PRIMARY KEY, y INT UNIQUE, z INT); INSERT INTO t33361 VALUES (1, 2, 3)
+
+statement ok
+BEGIN; ALTER TABLE t33361 DROP COLUMN y
+
+statement error column "y" does not exist
+DELETE FROM t33361 RETURNING y
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN; ALTER TABLE t33361 DROP COLUMN y
+
+query II
+DELETE FROM t33361 RETURNING *; COMMIT
+----
+1 3


### PR DESCRIPTION
this change is a followup to fix #32188

unique columns have an index on them. When such a column is dropped,
a DELETE statement will read a dropped column to correctly drop
the index on it, but this dropped column is exposed through the
RETURNING clause. This change stops exposing the column via RETURNING.

fixes #33361

Release note (sql change): fixed problem with returning dropped
unique columns in DELETE RETURNING statement.