### PR TITLE
libroach/engine: plumb support for SingleDelete operation

### DIFF
--- a/c-deps/libroach/batch.h
+++ b/c-deps/libroach/batch.h
@@ -32,6 +32,7 @@ struct DBBatch : public DBEngine {
   virtual DBStatus Put(DBKey key, DBSlice value);
   virtual DBStatus Merge(DBKey key, DBSlice value);
   virtual DBStatus Delete(DBKey key);
+  virtual DBStatus SingleDelete(DBKey key);
   virtual DBStatus DeleteRange(DBKey start, DBKey end);
   virtual DBStatus CommitBatch(bool sync);
   virtual DBStatus ApplyBatchRepr(DBSlice repr, bool sync);
@@ -63,6 +64,7 @@ struct DBWriteOnlyBatch : public DBEngine {
   virtual DBStatus Put(DBKey key, DBSlice value);
   virtual DBStatus Merge(DBKey key, DBSlice value);
   virtual DBStatus Delete(DBKey key);
+  virtual DBStatus SingleDelete(DBKey key);
   virtual DBStatus DeleteRange(DBKey start, DBKey end);
   virtual DBStatus CommitBatch(bool sync);
   virtual DBStatus ApplyBatchRepr(DBSlice repr, bool sync);

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -411,12 +411,12 @@ DBStatus DBCompactRange(DBEngine* db, DBSlice start, DBSlice end, bool force_bot
   return kSuccess;
 }
 
-DBStatus DBDisableAutoCompaction(DBEngine *db) {
+DBStatus DBDisableAutoCompaction(DBEngine* db) {
   auto status = db->rep->SetOptions({{"disable_auto_compactions", "true"}});
   return ToDBStatus(status);
 }
 
-DBStatus DBEnableAutoCompaction(DBEngine *db) {
+DBStatus DBEnableAutoCompaction(DBEngine* db) {
   auto status = db->rep->EnableAutoCompaction({db->rep->DefaultColumnFamily()});
   return ToDBStatus(status);
 }
@@ -438,6 +438,8 @@ DBStatus DBMerge(DBEngine* db, DBKey key, DBSlice value) { return db->Merge(key,
 DBStatus DBGet(DBEngine* db, DBKey key, DBString* value) { return db->Get(key, value); }
 
 DBStatus DBDelete(DBEngine* db, DBKey key) { return db->Delete(key); }
+
+DBStatus DBSingleDelete(DBEngine* db, DBKey key) { return db->SingleDelete(key); }
 
 DBStatus DBDeleteRange(DBEngine* db, DBKey start, DBKey end) { return db->DeleteRange(start, end); }
 

--- a/c-deps/libroach/engine.cc
+++ b/c-deps/libroach/engine.cc
@@ -159,6 +159,11 @@ DBStatus DBImpl::Delete(DBKey key) {
   return ToDBStatus(rep->Delete(options, EncodeKey(key)));
 }
 
+DBStatus DBImpl::SingleDelete(DBKey key) {
+  rocksdb::WriteOptions options;
+  return ToDBStatus(rep->SingleDelete(options, EncodeKey(key)));
+}
+
 DBStatus DBImpl::DeleteRange(DBKey start, DBKey end) {
   rocksdb::WriteOptions options;
   return ToDBStatus(

--- a/c-deps/libroach/engine.h
+++ b/c-deps/libroach/engine.h
@@ -33,6 +33,7 @@ struct DBEngine {
   virtual DBStatus Put(DBKey key, DBSlice value) = 0;
   virtual DBStatus Merge(DBKey key, DBSlice value) = 0;
   virtual DBStatus Delete(DBKey key) = 0;
+  virtual DBStatus SingleDelete(DBKey key) = 0;
   virtual DBStatus DeleteRange(DBKey start, DBKey end) = 0;
   virtual DBStatus CommitBatch(bool sync) = 0;
   virtual DBStatus ApplyBatchRepr(DBSlice repr, bool sync) = 0;
@@ -80,6 +81,7 @@ struct DBImpl : public DBEngine {
   virtual DBStatus Put(DBKey key, DBSlice value);
   virtual DBStatus Merge(DBKey key, DBSlice value);
   virtual DBStatus Delete(DBKey key);
+  virtual DBStatus SingleDelete(DBKey key);
   virtual DBStatus DeleteRange(DBKey start, DBKey end);
   virtual DBStatus CommitBatch(bool sync);
   virtual DBStatus ApplyBatchRepr(DBSlice repr, bool sync);

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -134,8 +134,8 @@ DBStatus DBCompactRange(DBEngine* db, DBSlice start, DBSlice end, bool force_bot
 // Disable/enable automatic compactions. Automatic compactions are
 // enabled by default. Disabling is provided for testing purposes so
 // that automatic compactions do not interfere with test expectations.
-DBStatus DBDisableAutoCompaction(DBEngine *db);
-DBStatus DBEnableAutoCompaction(DBEngine *db);
+DBStatus DBDisableAutoCompaction(DBEngine* db);
+DBStatus DBEnableAutoCompaction(DBEngine* db);
 
 // Stores the approximate on-disk size of the given key range into the
 // supplied uint64.
@@ -152,6 +152,11 @@ DBStatus DBGet(DBEngine* db, DBKey key, DBString* value);
 
 // Deletes the database entry for "key".
 DBStatus DBDelete(DBEngine* db, DBKey key);
+
+// Deletes the most recent database entry for "key". See the following
+// documentation for details on the subtleties of this operation:
+// https://github.com/facebook/rocksdb/wiki/Single-Delete.
+DBStatus DBSingleDelete(DBEngine* db, DBKey key);
 
 // Deletes a range of keys from start (inclusive) to end (exclusive).
 DBStatus DBDeleteRange(DBEngine* db, DBKey start, DBKey end);
@@ -326,7 +331,8 @@ typedef struct {
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
                       bool inconsistent, bool tombstones);
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
-                       int64_t max_keys, DBTxn txn, bool inconsistent, bool reverse, bool tombstones);
+                       int64_t max_keys, DBTxn txn, bool inconsistent, bool reverse,
+                       bool tombstones);
 
 // DBStatsResult contains various runtime stats for RocksDB.
 typedef struct {

--- a/c-deps/libroach/snapshot.cc
+++ b/c-deps/libroach/snapshot.cc
@@ -35,6 +35,8 @@ DBStatus DBSnapshot::Get(DBKey key, DBString* value) {
 
 DBStatus DBSnapshot::Delete(DBKey key) { return FmtStatus("unsupported"); }
 
+DBStatus DBSnapshot::SingleDelete(DBKey key) { return FmtStatus("unsupported"); }
+
 DBStatus DBSnapshot::DeleteRange(DBKey start, DBKey end) { return FmtStatus("unsupported"); }
 
 DBStatus DBSnapshot::CommitBatch(bool sync) { return FmtStatus("unsupported"); }

--- a/c-deps/libroach/snapshot.h
+++ b/c-deps/libroach/snapshot.h
@@ -29,6 +29,7 @@ struct DBSnapshot : public DBEngine {
   virtual DBStatus Put(DBKey key, DBSlice value);
   virtual DBStatus Merge(DBKey key, DBSlice value);
   virtual DBStatus Delete(DBKey key);
+  virtual DBStatus SingleDelete(DBKey key);
   virtual DBStatus DeleteRange(DBKey start, DBKey end);
   virtual DBStatus CommitBatch(bool sync);
   virtual DBStatus ApplyBatchRepr(DBSlice repr, bool sync);

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -207,6 +207,14 @@ type Writer interface {
 	// Note that clear actually removes entries from the storage
 	// engine, rather than inserting tombstones.
 	Clear(key MVCCKey) error
+	// SingleClear removes the most recent write to the item from the db with
+	// the given key. Whether older version of the item will come back to life
+	// if not also removed with SingleClear is undefined. See the following:
+	//   https://github.com/facebook/rocksdb/wiki/Single-Delete
+	// for details on the SingleDelete operation that this method invokes. Note
+	// that clear actually removes entries from the storage engine, rather than
+	// inserting tombstones.
+	SingleClear(key MVCCKey) error
 	// ClearRange removes a set of entries, from start (inclusive) to end
 	// (exclusive). Similar to Clear, this method actually removes entries from
 	// the storage engine.

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -259,6 +259,13 @@ func (s spanSetWriter) Clear(key engine.MVCCKey) error {
 	return s.w.Clear(key)
 }
 
+func (s spanSetWriter) SingleClear(key engine.MVCCKey) error {
+	if err := s.spans.CheckAllowed(SpanReadWrite, roachpb.Span{Key: key.Key}); err != nil {
+		return err
+	}
+	return s.w.SingleClear(key)
+}
+
 func (s spanSetWriter) ClearRange(start, end engine.MVCCKey) error {
 	if err := s.spans.CheckAllowed(SpanReadWrite, roachpb.Span{Key: start.Key, EndKey: end.Key}); err != nil {
 		return err


### PR DESCRIPTION
Informs #8979.

This commit doesn't actually use the operation yet, but any experiments
will require this plumbing, so it made sense to pull it out and properly
test it.

Release note: None