### PR TITLE
roachtest: pessimize the weekly/tpcc-max test

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -155,7 +155,7 @@ func registerTPCC(r *registry) {
 		Tags:  []string{`weekly`},
 		Nodes: nodes(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			warehouses := 1500
+			warehouses := 1400
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
 				Duration:   6 * 24 * time.Hour,


### PR DESCRIPTION
Apparently 1500 warehouses really doesn't work. Use 1400 like the
nightly.

Release note: None