### PR TITLE
release-2.1: roachtest: ignore unrelated tags when looking for build version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -984,7 +984,7 @@ $(ARCHIVE).tmp: $(ARCHIVE_EXTRAS)
 # For details, see the "Possible timestamp problems with diff-files?" thread on
 # the Git mailing list (http://marc.info/?l=git&m=131687596307197).
 .buildinfo/tag: | .buildinfo
-	@{ git describe --tags --dirty 2> /dev/null || git rev-parse --short HEAD; } | tr -d \\n > $@
+	@{ git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD; } | tr -d \\n > $@
 
 .buildinfo/rev: | .buildinfo
 	@git rev-parse HEAD > $@

--- a/build/teamcity-post-failures.py
+++ b/build/teamcity-post-failures.py
@@ -63,7 +63,7 @@ def collect_build_results(build_id):
 
 def get_probable_milestone():
     try:
-        tag = subprocess.check_output(['git', 'describe', '--abbrev=0', '--tags'],
+        tag = subprocess.check_output(['git', 'describe', '--abbrev=0', '--tags', '--match=v[0-9]*'],
             universal_newlines=True)
     except subprocess.CalledProcessError as e:
         print('warning: unable to load latest tag: {0}'.format(e))

--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -141,7 +141,7 @@ func getAssignee(
 }
 
 func getLatestTag() (string, error) {
-	cmd := exec.Command("git", "describe", "--abbrev=0", "--tags")
+	cmd := exec.Command("git", "describe", "--abbrev=0", "--tags", "--match=v[0-9]*")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", err

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -132,7 +132,7 @@ func (r *registry) setBuildVersion(buildTag string) error {
 
 func (r *registry) loadBuildVersion() {
 	getLatestTag := func() (string, error) {
-		cmd := exec.Command("git", "describe", "--abbrev=0", "--tags")
+		cmd := exec.Command("git", "describe", "--abbrev=0", "--tags", "--match=v[0-9]*")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return "", err

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -632,8 +632,8 @@ sys.stderr.flush()
 
 # Start with known sections.
 
-current_version = subprocess.check_output(["git", "describe", "--tags", options.until_commit], universal_newlines=True).strip()
-previous_version = subprocess.check_output(["git", "describe", "--tags", options.from_commit], universal_newlines=True).strip()
+current_version = subprocess.check_output(["git", "describe", "--tags", "--match=v[0-9]*", options.until_commit], universal_newlines=True).strip()
+previous_version = subprocess.check_output(["git", "describe", "--tags", "--match=v[0-9]*", options.from_commit], universal_newlines=True).strip()
 
 if not hideheader:
     print("---")


### PR DESCRIPTION
Backport 1/1 commits from #33446.

/cc @cockroachdb/release

---

Release note: None
