### PR TITLE
roachpb: limit the length of keys in a log message

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -115,6 +115,11 @@ func (rk RKey) String() string {
 	return Key(rk).String()
 }
 
+// StringWithDirs - see Key.String.WithDirs.
+func (rk RKey) StringWithDirs(valDirs []encoding.Direction, maxLen int) string {
+	return Key(rk).StringWithDirs(valDirs, maxLen)
+}
+
 // Key is a custom type for a byte string in proto
 // messages which refer to Cockroach keys.
 type Key []byte
@@ -187,18 +192,28 @@ func (k Key) Compare(b Key) int {
 
 // String returns a string-formatted version of the key.
 func (k Key) String() string {
-	// Leave valDirs unspecified such that values are pretty-printed
-	// with default encoding direction.
-	return k.StringWithDirs(nil /* valDirs */)
+	return k.StringWithDirs(nil /* valDirs */, 0 /* maxLen */)
 }
 
 // StringWithDirs is the value encoding direction-aware version of String.
-func (k Key) StringWithDirs(valDirs []encoding.Direction) string {
+//
+// Args:
+// valDirs: The direction for the key's components, generally needed for correct
+// 	decoding. If nil, the values are pretty-printed with default encoding
+// 	direction.
+// maxLen: If not 0, only the first maxLen chars from the decoded key are
+//   returned, plus a "..." suffix.
+func (k Key) StringWithDirs(valDirs []encoding.Direction, maxLen int) string {
+	var s string
 	if PrettyPrintKey != nil {
-		return PrettyPrintKey(valDirs, k)
+		s = PrettyPrintKey(valDirs, k)
+	} else {
+		s = fmt.Sprintf("%q", []byte(k))
 	}
-
-	return fmt.Sprintf("%q", []byte(k))
+	if maxLen != 0 && len(s) > maxLen {
+		return s[0:maxLen] + "..."
+	}
+	return s
 }
 
 // Format implements the fmt.Formatter interface.

--- a/pkg/sql/sqlbase/keys.go
+++ b/pkg/sql/sqlbase/keys.go
@@ -111,7 +111,7 @@ func IndexKeyValDirs(index *IndexDescriptor) []encoding.Direction {
 // currently true for the fields we care about stripping (the table and index
 // ID).
 func PrettyKey(valDirs []encoding.Direction, key roachpb.Key, skip int) string {
-	p := key.StringWithDirs(valDirs)
+	p := key.StringWithDirs(valDirs, 0 /* maxLen */)
 	for i := 0; i <= skip; i++ {
 		n := strings.IndexByte(p[1:], '/')
 		if n == -1 {

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -347,7 +347,7 @@ func (r *Replica) adminSplitWithDescriptor(
 	extra += splitSnapshotWarningStr(r.RangeID, r.RaftStatus())
 
 	log.Infof(ctx, "initiating a split of this range at key %s [r%d]%s",
-		splitKey, rightDesc.RangeID, extra)
+		splitKey.StringWithDirs(nil /* valDirs */, 50 /* maxLen */), rightDesc.RangeID, extra)
 
 	if err := r.store.DB().Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		log.Event(ctx, "split closure begins")


### PR DESCRIPTION
We had log messages with very long keys in there, also with funky chars
in the decoding, which were an eyesore:
initiating a split of this range at key /Table/54/3/"ॹॹ;,✅\nπ<\...

This patch introduces a String() flavor for keys that limits the length
of the result.

Release note: None