### PR TITLE
backport-2.1: storage: fatal on replica corruption

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1375,6 +1375,12 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	var exitStatus int
+	log.SetExitFunc(true /* hideStack */, func(i int) {
+		exitStatus = i
+	})
+	defer log.ResetExitFunc()
+
 	const numReplicas = 5
 	const extraStores = 3
 
@@ -1488,6 +1494,10 @@ func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 			}
 			return nil
 		})
+	}
+
+	if exitStatus != 255 {
+		t.Fatalf("unexpected exit status %d", exitStatus)
 	}
 }
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -6719,6 +6719,8 @@ func (r *Replica) maybeSetCorrupt(ctx context.Context, pErr *roachpb.Error) *roa
 			cErr.Processed = false
 			return roachpb.NewError(cErr)
 		}
+
+		log.Fatalf(ctx, "replica is corrupted: %s", pErr)
 	}
 	return pErr
 }


### PR DESCRIPTION
Backport 1/1 commits from #33391.

/cc @cockroachdb/release

---

This path is seldom taken, but when it does and the node keeps running,
it won't be performing as expected. Besides, individual replicas can
become "corrupt" due to problems that affect a larger scope, as seen
in #33375 (which is caused by a txn anomaly, #32784).

Release note: None
