### PR TITLE
sql/parser: update the contextual help for EXPORT.

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1789,7 +1789,7 @@ import_stmt:
 // %Help: EXPORT - export data to file in a distributed manner
 // %Category: CCL
 // %Text:
-// EXPORT INTO <format> (<datafile> [WITH <option> [= value] [,...]]) FROM <query>
+// EXPORT INTO <format> <datafile> [WITH <option> [= value] [,...]] FROM <query>
 //
 // Formats:
 //    CSV


### PR DESCRIPTION
Release note (bug fix): the contextual help displayed for EXPORT upon
`\h EXPORT` in `cockroach sql` has been updated to reflect the actual
syntax of the statement.