### PR TITLE
sql: SHOW RANGES delegates to crdb_internal.ranges

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -945,6 +945,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.node_executable_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the version of CockroachDB this node is running.</p>
 </span></td></tr>
+<tr><td><code>crdb_internal.pretty_key(raw_key: <a href="bytes.html">bytes</a>, skip_fields: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
 <tr><td><code>crdb_internal.set_vmodule(vmodule_string: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used for internal debugging purposes. Incorrect use can severely impact performance.</p>
 </span></td></tr>
 <tr><td><code>current_database() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current database.</p>

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -385,7 +385,6 @@ func doExpandPlan(
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:
 	case *showZoneConfigNode:
-	case *showRangesNode:
 	case *showFingerprintsNode:
 	case *showTraceNode:
 	case *scatterNode:
@@ -892,7 +891,6 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:
 	case *showZoneConfigNode:
-	case *showRangesNode:
 	case *showFingerprintsNode:
 	case *showTraceNode:
 	case *scatterNode:

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -394,7 +394,6 @@ func (p *planner) propagateFilters(
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:
 	case *showZoneConfigNode:
-	case *showRangesNode:
 	case *showFingerprintsNode:
 	case *showTraceNode:
 	case *scatterNode:

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -239,7 +239,6 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:
 	case *showZoneConfigNode:
-	case *showRangesNode:
 	case *showFingerprintsNode:
 	case *showTraceNode:
 	case *scatterNode:

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -287,7 +287,6 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:
 	case *showZoneConfigNode:
-	case *showRangesNode:
 	case *showFingerprintsNode:
 	case *showTraceNode:
 	case *scatterNode:

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -199,7 +199,6 @@ var _ planNode = &scanNode{}
 var _ planNode = &scatterNode{}
 var _ planNode = &serializeNode{}
 var _ planNode = &showFingerprintsNode{}
-var _ planNode = &showRangesNode{}
 var _ planNode = &showTraceNode{}
 var _ planNode = &sortNode{}
 var _ planNode = &splitNode{}

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -107,8 +107,6 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.getColumns(mut, scatterNodeColumns)
 	case *showZoneConfigNode:
 		return n.getColumns(mut, showZoneConfigNodeColumns)
-	case *showRangesNode:
-		return n.getColumns(mut, showRangesColumns)
 	case *showFingerprintsNode:
 		return n.getColumns(mut, showFingerprintsColumns)
 	case *splitNode:

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -130,7 +130,6 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *setVarNode:
 	case *setZoneConfigNode:
 	case *showFingerprintsNode:
-	case *showRangesNode:
 	case *showTraceNode:
 	case *showTraceReplicaNode:
 	case *showZoneConfigNode:

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
@@ -2913,6 +2914,28 @@ may increase either contention or retry errors, or both.`,
 			ReturnType: tree.IdentityReturnType(0),
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				return args[0], nil
+			},
+			Info: "This function is used only by CockroachDB's developers for testing purposes.",
+		},
+	),
+
+	// Return a pretty key for a given raw key, skipping the specified number of
+	// fields.
+	"crdb_internal.pretty_key": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySystemInfo,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"raw_key", types.Bytes},
+				{"skip_fields", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return tree.NewDString(sqlbase.PrettyKey(
+					nil, /* valDirs */
+					roachpb.Key(tree.MustBeDBytes(args[0])),
+					int(tree.MustBeDInt(args[1])))), nil
 			},
 			Info: "This function is used only by CockroachDB's developers for testing purposes.",
 		},

--- a/pkg/sql/show_ranges.go
+++ b/pkg/sql/show_ranges.go
@@ -16,172 +16,45 @@ package sql
 
 import (
 	"context"
-	"sort"
+	"encoding/hex"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/pkg/errors"
 )
 
-// showRangesNode implements the SHOW EXPERIMENTAL_RANGES statement:
+// ShowRanges implements the SHOW EXPERIMENTAL_RANGES statement:
 //   SHOW EXPERIMENTAL_RANGES FROM TABLE t
 //   SHOW EXPERIMENTAL_RANGES FROM INDEX t@idx
 //
 // These statements show the ranges corresponding to the given table or index,
 // along with the list of replicas and the lease holder.
-type showRangesNode struct {
-	optColumnsSlot
-
-	span roachpb.Span
-
-	run showRangesRun
-}
-
 func (p *planner) ShowRanges(ctx context.Context, n *tree.ShowRanges) (planNode, error) {
-	tableDesc, index, err := p.getTableAndIndex(ctx, n.Table, n.Index, privilege.SELECT)
-
+	desc, index, err := p.getTableAndIndex(ctx, n.Table, n.Index, privilege.SELECT)
 	if err != nil {
 		return nil, err
 	}
-	// Note: for interleaved tables, the ranges we report will include rows from
-	// interleaving.
-	return &showRangesNode{
-		span: tableDesc.IndexSpan(index.ID),
-		run: showRangesRun{
-			values: make([]tree.Datum, len(showRangesColumns)),
-		},
-	}, nil
-}
-
-var showRangesColumns = sqlbase.ResultColumns{
-	{
-		Name: "start_key",
-		Typ:  types.String,
-	},
-	{
-		Name: "end_key",
-		Typ:  types.String,
-	},
-	{
-		Name: "range_id",
-		Typ:  types.Int,
-	},
-	{
-		Name: "replicas",
-		// The INTs in the array are Store IDs.
-		Typ: types.TArray{Typ: types.Int},
-	},
-	{
-		Name: "lease_holder",
-		// The store ID for the lease holder.
-		Typ: types.Int,
-	},
-}
-
-// showRangesRun contains the run-time state for showRangesNode during
-// local execution.
-type showRangesRun struct {
-	// descriptorKVs are KeyValues returned from scanning the
-	// relevant meta keys.
-	descriptorKVs []client.KeyValue
-
-	rowIdx int
-	// values stores the current row, updated by Next().
-	values []tree.Datum
-}
-
-func (n *showRangesNode) startExec(params runParams) error {
-	var err error
-	n.run.descriptorKVs, err = ScanMetaKVs(params.ctx, params.p.txn, n.span)
-	return err
-}
-
-func (n *showRangesNode) Next(params runParams) (bool, error) {
-	if n.run.rowIdx >= len(n.run.descriptorKVs) {
-		return false, nil
+	span := desc.IndexSpan(index.ID)
+	if desc.ID < keys.MaxSystemConfigDescID {
+		span = keys.SystemConfigSpan
 	}
-
-	var desc roachpb.RangeDescriptor
-	if err := n.run.descriptorKVs[n.run.rowIdx].ValueProto(&desc); err != nil {
-		return false, err
-	}
-	for i := range n.run.values {
-		n.run.values[i] = tree.DNull
-	}
-
-	// We do not attempt to identify the encoding directions for pretty
-	// printing a split key since it's possible for a key from an arbitrary
-	// table in the same interleaved hierarchy to appear in SHOW
-	// EXPERIMENTAL_RANGES. Consider the interleaved hierarchy
-	//    parent1		      (pid1)
-	//	  child1	      (pid1, cid1)
-	//	      grandchild1     (pid1, cid1, gcid1)
-	//	  child2	      (pid1, cid2, cid3)
-	//	      grandchild2     (pid1, cid2, cid3, gcid2)
-	// and the result of
-	//    SHOW EXPERIMENTAL_RANGES FROM TABLE grandchild1
-	// It is possible for a split key for grandchild2 to show up.
-	// Traversing up the InterleaveDescriptor is futile since we do not
-	// know the SharedPrefixLen in between each interleaved sentinel of a
-	// grandchild2 key.
-	// We thus default the directions (such that '#' pretty prints for
-	// interleaved sentinels).
-	// TODO(richardwu): The one edge case we cannot deal with effectively
-	// are split keys belonging to secondary indexes with descending
-	// column(s).
-	if n.run.rowIdx > 0 {
-		n.run.values[0] = tree.NewDString(sqlbase.PrettyKey(nil /* valDirs */, desc.StartKey.AsRawKey(), 2))
-	}
-
-	if n.run.rowIdx < len(n.run.descriptorKVs)-1 {
-		n.run.values[1] = tree.NewDString(sqlbase.PrettyKey(nil /* valDirs */, desc.EndKey.AsRawKey(), 2))
-	}
-
-	n.run.values[2] = tree.NewDInt(tree.DInt(desc.RangeID))
-
-	var replicas []int
-	for _, rd := range desc.Replicas {
-		replicas = append(replicas, int(rd.StoreID))
-	}
-	sort.Ints(replicas)
-
-	replicaArr := tree.NewDArray(types.Int)
-	replicaArr.Array = make(tree.Datums, len(replicas))
-	for i, r := range replicas {
-		replicaArr.Array[i] = tree.NewDInt(tree.DInt(r))
-	}
-	n.run.values[3] = replicaArr
-
-	// Get the lease holder.
-	// TODO(radu): this will be slow if we have a lot of ranges; find a way to
-	// make this part optional.
-	b := &client.Batch{}
-	b.AddRawRequest(&roachpb.LeaseInfoRequest{
-		RequestHeader: roachpb.RequestHeader{
-			Key: desc.StartKey.AsRawKey(),
-		},
-	})
-	if err := params.p.txn.Run(params.ctx, b); err != nil {
-		return false, errors.Wrap(err, "error getting lease info")
-	}
-	resp := b.RawResponse().Responses[0].GetInner().(*roachpb.LeaseInfoResponse)
-	n.run.values[4] = tree.NewDInt(tree.DInt(resp.Lease.Replica.StoreID))
-
-	n.run.rowIdx++
-	return true, nil
-}
-
-func (n *showRangesNode) Values() tree.Datums {
-	return n.run.values
-}
-
-func (n *showRangesNode) Close(_ context.Context) {
-	n.run.descriptorKVs = nil
+	startKey := hex.EncodeToString([]byte(span.Key))
+	endKey := hex.EncodeToString([]byte(span.EndKey))
+	return p.delegateQuery(ctx, "SHOW RANGES",
+		fmt.Sprintf(`
+SELECT 
+  CASE WHEN r.start_key <= x'%s' THEN NULL ELSE crdb_internal.pretty_key(r.start_key, 2) END AS start_key,
+  CASE WHEN r.end_key >= x'%s' THEN NULL ELSE crdb_internal.pretty_key(r.end_key, 2) END AS end_key,
+  range_id,
+  replicas,
+  lease_holder
+FROM crdb_internal.ranges AS r
+WHERE (r.start_key < x'%s')
+  AND (r.end_key   > x'%s')
+`, startKey, endKey, endKey, startKey), nil, nil)
 }
 
 // ScanMetaKVs returns the meta KVs for the ranges that touch the given span.

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -733,7 +733,6 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&setVarNode{}):               "set",
 	reflect.TypeOf(&setZoneConfigNode{}):        "configure zone",
 	reflect.TypeOf(&showFingerprintsNode{}):     "showFingerprints",
-	reflect.TypeOf(&showRangesNode{}):           "showRanges",
 	reflect.TypeOf(&showTraceNode{}):            "show trace for",
 	reflect.TypeOf(&showTraceReplicaNode{}):     "replica trace",
 	reflect.TypeOf(&showZoneConfigNode{}):       "show zone configuration",


### PR DESCRIPTION
Previously, SHOW RANGES had a near identical implementation to
crdb_internal.ranges, which was also unoptimal as it always needed to
request leaseholder information.

Now, it delegates to crdb_internal.ranges, which deletes duplicate code
and also permits the optimizer to remove the fetching of leaseholder
information unless it's requested.

Release note (sql change): SHOW EXPERIMENTAL_RANGES is faster if no
columns are requested from it, like in SELECT COUNT(*) FROM [SHOW
EXPERIMENTAL_RANGES...].