### PR TITLE
engine: refine mvcc logic around moving intent timestamps

### DIFF
--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -1029,7 +1029,7 @@ func (r *Replica) refreshProposalsLocked(refreshAtDelta int, reason refreshRaftR
 			if reason == reasonSnapshotApplied {
 				p.finishApplication(proposalResult{Err: roachpb.NewError(
 					roachpb.NewAmbiguousResultError(
-						fmt.Sprintf("unable to determin whether command was applied via snapshot")))})
+						fmt.Sprintf("unable to determine whether command was applied via snapshot")))})
 			} else {
 				p.finishApplication(proposalResult{ProposalRetry: proposalIllegalLeaseIndex})
 			}

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -528,7 +528,7 @@ func (s *Store) canApplySnapshotLocked(
 				// weren't so difficult).
 				//
 				// A consequence of letting this snapshot through is opening this
-				// replica up to the possiblity of erroneous replicaGC. This is
+				// replica up to the possibility of erroneous replicaGC. This is
 				// because it will retain the replicaID of the current replica,
 				// which is going to be initialized after the snapshot (and thus
 				// gc'able).


### PR DESCRIPTION
This commit cleans up comments and logic in mvccResolveWriteIntent.

Release note: None