### PR TITLE
sql,kv,followerreadsccl: enable follower reads for historical queries

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -314,6 +314,15 @@ significant than <code>element</code> to zero (or one, for day and month)</p>
 <p>Compatible elements: year, quarter, month, week, hour, minute, second,
 millisecond, microsecond.</p>
 </span></td></tr>
+<tr><td><code>experimental_follower_read_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns a timestamp which is very likely to be safe to perform
+against a follower replica.</p>
+<p>This function is intended to be used with an AS OF SYSTEM TIME clause to perform
+historical reads against a time which is recent but sufficiently old for reads
+to be performed against the closest replica as opposed to the currently
+leaseholder for a given range.</p>
+<p>Note that this function requires an enterprise license on a CCL distribution to
+return without an error.</p>
+</span></td></tr>
 <tr><td><code>experimental_strftime(input: <a href="date.html">date</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>From <code>input</code>, extracts and formats the time as identified in <code>extract_format</code> using standard <code>strftime</code> notation (though not all formatting is supported).</p>
 </span></td></tr>
 <tr><td><code>experimental_strftime(input: <a href="timestamp.html">timestamp</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>From <code>input</code>, extracts and formats the time as identified in <code>extract_format</code> using standard <code>strftime</code> notation (though not all formatting is supported).</p>

--- a/pkg/ccl/ccl_init.go
+++ b/pkg/ccl/ccl_init.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/buildccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/followerreadsccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/importccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/roleccl"

--- a/pkg/ccl/followerreadsccl/followerreads_test.go
+++ b/pkg/ccl/followerreadsccl/followerreads_test.go
@@ -1,0 +1,158 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package followerreadsccl
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlplan/replicaoracle"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+const expectedFollowerReadOffset = -1 * (30 * (1 + .2*3)) * time.Second
+
+func TestEvalFollowerReadOffset(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	disableEnterprise := utilccl.TestingEnableEnterprise()
+	defer disableEnterprise()
+	st := cluster.MakeTestingClusterSettings()
+	if offset, err := evalFollowerReadOffset(uuid.MakeV4(), st); err != nil {
+		t.Fatal(err)
+	} else if offset != expectedFollowerReadOffset {
+		t.Fatalf("expected %v, got %v", expectedFollowerReadOffset, offset)
+	}
+	disableEnterprise()
+	_, err := evalFollowerReadOffset(uuid.MakeV4(), st)
+	if !testutils.IsError(err, "requires an enterprise license") {
+		t.Fatalf("failed to get error when evaluating follower read offset without " +
+			"an enterprise license")
+	}
+}
+
+func TestCanSendToFollower(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	disableEnterprise := utilccl.TestingEnableEnterprise()
+	defer disableEnterprise()
+	st := cluster.MakeTestingClusterSettings()
+	storage.FollowerReadsEnabled.Override(&st.SV, true)
+	old := hlc.Timestamp{
+		WallTime: timeutil.Now().Add(2 * expectedFollowerReadOffset).UnixNano(),
+	}
+	oldHeader := roachpb.Header{Txn: &roachpb.Transaction{
+		OrigTimestamp: old,
+	}}
+	rw := roachpb.BatchRequest{Header: oldHeader}
+	rw.Add(&roachpb.PutRequest{})
+	if canSendToFollower(uuid.MakeV4(), st, rw) {
+		t.Fatalf("should not be able to send a rw request to a follower")
+	}
+	roNoTxn := roachpb.BatchRequest{}
+	roNoTxn.Add(&roachpb.GetRequest{})
+	if canSendToFollower(uuid.MakeV4(), st, roNoTxn) {
+		t.Fatalf("should not be able to send a batch with no txn to a follower")
+	}
+	roOld := roachpb.BatchRequest{Header: oldHeader}
+	roOld.Add(&roachpb.GetRequest{})
+	if !canSendToFollower(uuid.MakeV4(), st, roOld) {
+		t.Fatalf("should be able to send an old ro batch to a follower")
+	}
+	storage.FollowerReadsEnabled.Override(&st.SV, false)
+	if canSendToFollower(uuid.MakeV4(), st, roOld) {
+		t.Fatalf("should not be able to send an old ro batch to a follower when follower reads are disabled")
+	}
+	storage.FollowerReadsEnabled.Override(&st.SV, true)
+	roNew := roachpb.BatchRequest{Header: roachpb.Header{
+		Txn: &roachpb.Transaction{
+			OrigTimestamp: hlc.Timestamp{WallTime: timeutil.Now().UnixNano()},
+		},
+	}}
+	if canSendToFollower(uuid.MakeV4(), st, roNew) {
+		t.Fatalf("should not be able to send a new ro batch to a follower")
+	}
+	disableEnterprise()
+	if canSendToFollower(uuid.MakeV4(), st, roOld) {
+		t.Fatalf("should not be able to send an old ro batch to a follower without enterprise enabled")
+	}
+}
+
+func TestFollowerReadMultipleValidation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic from setting followerReadMultiple to .1")
+		}
+	}()
+	st := cluster.MakeTestingClusterSettings()
+	followerReadMultiple.Override(&st.SV, .1)
+}
+
+// TestOracle tests the OracleFactory exposed by this package.
+// This test ends up being rather indirect but works by checking if the type
+// of the oracle returned from the factory differs between requests we'd
+// expect to support follower reads and that which we'd expect not to.
+func TestOracleFactory(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	disableEnterprise := utilccl.TestingEnableEnterprise()
+	defer disableEnterprise()
+	st := cluster.MakeTestingClusterSettings()
+	storage.FollowerReadsEnabled.Override(&st.SV, true)
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+	aCtx := log.AmbientContext{Tracer: tracing.NewTracer()}
+	rpcContext := rpc.NewContext(
+		aCtx,
+		&base.Config{Insecure: true},
+		clock,
+		stopper,
+		&st.Version,
+	)
+	c := client.NewDB(log.AmbientContext{
+		Tracer: tracing.NewTracer(),
+	}, client.MockTxnSenderFactory{},
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond))
+	txn := client.NewTxn(context.TODO(), c, 0, client.RootTxn)
+	of := replicaoracle.NewOracleFactory(followerReadAwareChoice, replicaoracle.Config{
+		Settings:   st,
+		RPCContext: rpcContext,
+	})
+	noFollowerReadOracle := of.Oracle(txn)
+	old := hlc.Timestamp{
+		WallTime: timeutil.Now().Add(2 * expectedFollowerReadOffset).UnixNano(),
+	}
+	txn.SetFixedTimestamp(context.TODO(), old)
+	followerReadOracle := of.Oracle(txn)
+	if reflect.TypeOf(followerReadOracle) == reflect.TypeOf(noFollowerReadOracle) {
+		t.Fatalf("expected types of %T and %T to differ", followerReadOracle,
+			noFollowerReadOracle)
+	}
+	disableEnterprise()
+	disabledFollowerReadOracle := of.Oracle(txn)
+	if reflect.TypeOf(disabledFollowerReadOracle) != reflect.TypeOf(noFollowerReadOracle) {
+		t.Fatalf("expected types of %T and %T not to differ", disabledFollowerReadOracle,
+			noFollowerReadOracle)
+	}
+}

--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -1,0 +1,353 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"bufio"
+	"context"
+	gosql "database/sql"
+	"math/rand"
+	"net/http"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+func registerFollowerReads(r *registry) {
+	r.Add(testSpec{
+		Name: "follower-reads/nodes=3",
+		Cluster: clusterSpec{
+			NodeCount: 3,
+			CPUs:      2,
+			Geo:       true,
+		},
+		Run: runFollowerReadsTest,
+	})
+}
+
+// runFollowerReadsTest is a basic litmus test that follower reads work.
+// The test does the following:
+//
+//  * Creates a database and table.
+//  * Installs a number of rows into that table.
+//  * Queries the data initially with a recent timestamp and expecting an
+//    error because the table does not exist in the past immediately following
+//    creation.
+//  * Waits until the required duration has elapsed such that the installed
+//    data can be read with a follower read issued using `follower_timestamp()`.
+//  * Performs a single `follower_timestamp()` select query against a single
+//    row on all of the nodes and then observes the counter metric for
+//    store-level follower reads ensuring that they occurred on at least
+//    two of the nodes.
+//  * Performs reads against the written data on all of the nodes at a steady
+//    rate for 20 seconds, ensure that the 90-%ile SQL latencies during that
+//    time are under 10ms which implies that no WAN RPCs occurred.
+//
+func runFollowerReadsTest(ctx context.Context, t *test, c *cluster) {
+	crdbNodes := c.Range(1, c.nodes)
+	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
+	c.Wipe(ctx, crdbNodes)
+	c.Start(ctx, t, crdbNodes)
+
+	var conns []*gosql.DB
+	for i := 0; i < c.nodes; i++ {
+		conns = append(conns, c.Conn(ctx, i+1))
+		defer conns[i].Close()
+	}
+	db := conns[0]
+
+	if _, err := db.ExecContext(ctx, "SET CLUSTER SETTING kv.closed_timestamp.follower_reads_enabled = 'true'"); err != nil {
+		t.Fatalf("failed to enable follower reads: %v", err)
+	}
+	if r, err := db.ExecContext(ctx, "CREATE DATABASE test;"); err != nil {
+		t.Fatalf("failed to create database: %v %v", err, r)
+	}
+	if r, err := db.ExecContext(ctx, "CREATE TABLE test.test ( k INT8, v INT8, PRIMARY KEY (k) )"); err != nil {
+		t.Fatalf("failed to create table: %v %v", err, r)
+	}
+
+	const rows = 100
+	const concurrency = 32
+	sem := make(chan struct{}, concurrency)
+	data := make(map[int]int64)
+	insert := func(ctx context.Context, k int) func() error {
+		v := rand.Int63()
+		data[k] = v
+		return func() error {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			_, err := db.ExecContext(ctx, "INSERT INTO test.test VALUES ( $1, $2 )", k, v)
+			return err
+		}
+	}
+	// chooseKV picks a random key-value pair by exploiting the pseudo-random
+	// ordering of keys when traversing a map with in a range statement.
+	chooseKV := func() (k int, v int64) {
+		for k, v = range data {
+			return k, v
+		}
+		panic("data is empty")
+	}
+	verifySelect := func(ctx context.Context, node, k int, expectError bool, expectedVal int64) func() error {
+		return func() error {
+			nodeDB := conns[node-1]
+			r := nodeDB.QueryRowContext(ctx, "SELECT v FROM test.test AS OF SYSTEM "+
+				"TIME experimental_follower_read_timestamp() WHERE k = $1", k)
+			var got int64
+			if err := r.Scan(&got); err != nil {
+				// Ignore errors due to cancellation.
+				if ctx.Err() != nil {
+					return nil
+				}
+				if expectError {
+					return nil
+				}
+				return err
+			}
+
+			if expectError {
+				return errors.Errorf("failed to get expected error on node %d", node)
+			}
+			if got != expectedVal {
+				return errors.Errorf("Didn't get expected val on node %d: %v != %v",
+					node, got, expectedVal)
+			}
+			return nil
+		}
+	}
+	doSelects := func(ctx context.Context, node int) func() error {
+		return func() error {
+			for ctx.Err() == nil {
+				k, v := chooseKV()
+				err := verifySelect(ctx, node, k, false, v)()
+				if err != nil && ctx.Err() == nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
+	// Insert the data.
+	g, gCtx := errgroup.WithContext(ctx)
+	for i := 0; i < rows; i++ {
+		g.Go(insert(gCtx, i))
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("failed to insert data: %v", err)
+	}
+	// Verify error on immediate read.
+	g, gCtx = errgroup.WithContext(ctx)
+	for i := 1; i <= c.nodes; i++ {
+		// Expect an error performing a historical read at first because the table
+		// won't have been created yet.
+		g.Go(verifySelect(gCtx, i, 0, true, 0))
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("unexpected error performing historical reads: %v", err)
+	}
+	// Wait for follower_timestamp() historical reads to have data.
+	followerReadDuration, err := computeFollowerReadDuration(ctx, db)
+	if err != nil {
+		t.Fatalf("failed to compute follower read duration: %v", err)
+	}
+	select {
+	case <-time.After(followerReadDuration):
+	case <-ctx.Done():
+		t.Fatalf("context canceled: %v", ctx.Err())
+	}
+	// Read the follower read counts before issuing the follower reads to observe
+	// the delta and protect from follower reads which might have happened due to
+	// system queries.
+	followerReadsBefore, err := getFollowerReadCounts(ctx, c)
+	if err != nil {
+		t.Fatalf("failed to get follower read counts: %v", err)
+	}
+	// Perform reads at follower_timestamp() and ensure we get the expected value.
+	g, gCtx = errgroup.WithContext(ctx)
+	k, v := chooseKV()
+	for i := 1; i <= c.nodes; i++ {
+		g.Go(verifySelect(gCtx, i, k, false, v))
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("error verifying node values: %v", err)
+	}
+	// Verify that the follower read count increments on at least two nodes.
+	followerReadsAfter, err := getFollowerReadCounts(ctx, c)
+	if err != nil {
+		t.Fatalf("failed to get follower read counts: %v", err)
+	}
+	nodesWhichSawFollowerReads := 0
+	for i := 0; i < len(followerReadsAfter); i++ {
+		if followerReadsAfter[i] > followerReadsBefore[i] {
+			nodesWhichSawFollowerReads++
+		}
+	}
+	if nodesWhichSawFollowerReads < 2 {
+		t.Fatalf("fewer than 2 follower reads occurred: saw %v before and %v after",
+			followerReadsBefore, followerReadsAfter)
+	}
+	// Run reads for 60s which given the metrics window of 10s should guarantee
+	// that the most recent SQL latency time series data should relate to at least
+	// some of these reads.
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	g, gCtx = errgroup.WithContext(timeoutCtx)
+	for i := 0; i < concurrency; i++ {
+		g.Go(doSelects(gCtx, rand.Intn(c.nodes)+1))
+	}
+	start := timeutil.Now()
+	if err := g.Wait(); err != nil && timeoutCtx.Err() == nil {
+		t.Fatalf("error reading data: %v", err)
+	}
+	// Perform a ts query to verify that the SQL latencies were well below the
+	// WAN latencies which should be at least 50ms.
+	verifySQLLatency(ctx, c, t, c.Node(1), start, timeutil.Now(), 20*time.Millisecond)
+}
+
+func computeFollowerReadDuration(ctx context.Context, db *gosql.DB) (time.Duration, error) {
+	var targetDurationStr string
+	err := db.QueryRowContext(ctx, "SELECT value FROM crdb_internal.cluster_settings WHERE variable = 'kv.closed_timestamp.target_duration'").Scan(&targetDurationStr)
+	if err != nil {
+		return 0, err
+	}
+	targetDuration, err := time.ParseDuration(targetDurationStr)
+	if err != nil {
+		return 0, err
+	}
+	var closeFraction float64
+	err = db.QueryRowContext(ctx, "SELECT value FROM crdb_internal.cluster_settings WHERE variable = 'kv.closed_timestamp.close_fraction'").Scan(&closeFraction)
+	if err != nil {
+		return 0, err
+	}
+	// target_multiple is a hidden setting which cannot be read from crdb_internal
+	// so for now hard code to the default value.
+	const targetMultiple = 3
+	return time.Duration(float64(targetDuration) * (1 + targetMultiple*closeFraction)), nil
+}
+
+// verifySQLLatency verifies that the client-facing SQL latencies in the 90th
+// percentile remain below target latency between start and end ignoring the
+// first 20s.
+func verifySQLLatency(
+	ctx context.Context,
+	c *cluster,
+	t *test,
+	adminNode nodeListOption,
+	start, end time.Time,
+	targetLatency time.Duration,
+) {
+	// Query needed information over the timespan of the query.
+	adminURLs := c.ExternalAdminUIAddr(ctx, adminNode)
+	url := "http://" + adminURLs[0] + "/ts/query"
+	request := tspb.TimeSeriesQueryRequest{
+		StartNanos: start.UnixNano(),
+		EndNanos:   end.UnixNano(),
+		// Ask for 10s intervals.
+		SampleNanos: (10 * time.Second).Nanoseconds(),
+		Queries: []tspb.Query{
+			{
+				Name: "cr.node.sql.service.latency-p90",
+			},
+		},
+	}
+	var response tspb.TimeSeriesQueryResponse
+	if err := httputil.PostJSON(http.Client{}, url, &request, &response); err != nil {
+		t.Fatal(err)
+	}
+	perTenSeconds := response.Results[0].Datapoints
+	// Drop the first 20 seconds of datapoints as a "ramp-up" period.
+	if len(perTenSeconds) < 3 {
+		t.Fatalf("not enough ts data to verify latency")
+	}
+	perTenSeconds = perTenSeconds[2:]
+	for _, dp := range perTenSeconds {
+		if time.Duration(dp.Value) > targetLatency {
+			t.Fatalf("latency value %v for ts data point %v is above target latency %v",
+				time.Duration(dp.Value), dp, targetLatency)
+		}
+	}
+}
+
+const followerReadsMetric = "follower_reads_success_count"
+
+// getFollowerReadCounts returns a slice from node to follower read count
+// according to the metric.
+func getFollowerReadCounts(ctx context.Context, c *cluster) ([]int, error) {
+	followerReadCounts := make([]int, c.nodes)
+	getFollowerReadCount := func(ctx context.Context, node int) func() error {
+		return func() error {
+			url := "http://" + c.ExternalAdminUIAddr(ctx, c.Node(node))[0] + "/_status/vars"
+			resp, err := http.Get(url)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 200 {
+				return errors.Errorf("invalid non-200 status code %v", resp.StatusCode)
+			}
+			scanner := bufio.NewScanner(resp.Body)
+			for scanner.Scan() {
+				m, ok := parsePrometheusMetric(scanner.Text())
+				if ok {
+					if m.metric == followerReadsMetric {
+						v, err := strconv.ParseFloat(m.value, 64)
+						if err != nil {
+							return err
+						}
+						followerReadCounts[node-1] = int(v)
+					}
+				}
+			}
+			return nil
+		}
+	}
+	g, gCtx := errgroup.WithContext(ctx)
+	for i := 1; i <= c.nodes; i++ {
+		g.Go(getFollowerReadCount(gCtx, i))
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return followerReadCounts, nil
+}
+
+var prometheusMetricStringPattern = "(?P<metric>\\w+)\\{" +
+	"(?P<labelvalues>(\\w+=\".*\",)*(\\w+=\".*\")?)\\}\\s+(?P<value>.*)"
+var promethusMetricStringRE = regexp.MustCompile(prometheusMetricStringPattern)
+
+type prometheusMetric struct {
+	metric      string
+	labelValues string
+	value       string
+}
+
+func parsePrometheusMetric(s string) (*prometheusMetric, bool) {
+	matches := promethusMetricStringRE.FindStringSubmatch(s)
+	if matches == nil {
+		return nil, false
+	}
+	return &prometheusMetric{
+		metric:      matches[1],
+		labelValues: matches[2],
+		value:       matches[5],
+	}, true
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -37,6 +37,7 @@ func registerTests(r *registry) {
 	registerDrop(r)
 	registerElectionAfterRestart(r)
 	registerEncryption(r)
+	registerFollowerReads(r)
 	registerGossip(r)
 	registerHibernate(r)
 	registerHotSpotSplits(r)

--- a/pkg/kv/range_iter.go
+++ b/pkg/kv/range_iter.go
@@ -72,21 +72,6 @@ func (ri *RangeIterator) Desc() *roachpb.RangeDescriptor {
 	return ri.desc
 }
 
-// LeaseHolderStoreID returns the lease holder's StoreID of the iterator's current range, if that
-// information is present in the DistSender's LeaseHolderCache. The second
-// return val is true if the descriptor has been found.
-// The iterator must be valid.
-func (ri *RangeIterator) LeaseHolderStoreID(ctx context.Context) (roachpb.StoreID, bool) {
-	if !ri.Valid() {
-		panic(ri.Error())
-	}
-	// TODO(andrei): The leaseHolderCache might have a replica that's not part of
-	// the RangeDescriptor that the iterator is currently positioned on. IOW, the
-	// leaseHolderCache can be inconsistent with the RangeDescriptorCache, and
-	// with reality. We should attempt to fix-up caches when this is encountered.
-	return ri.ds.leaseHolderCache.Lookup(ctx, ri.Desc().RangeID)
-}
-
 // Token returns the eviction token corresponding to the range
 // descriptor for the current iteration. The iterator must be valid.
 func (ri *RangeIterator) Token() *EvictionToken {

--- a/pkg/sql/distsqlplan/replicaoracle/oracle.go
+++ b/pkg/sql/distsqlplan/replicaoracle/oracle.go
@@ -1,0 +1,295 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package replicaoracle provides functionality for distsqlplan to choose a
+// replica for a range.
+package replicaoracle
+
+import (
+	"context"
+	"math"
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
+)
+
+// Policy determines how an Oracle should select a replica.
+type Policy byte
+
+var (
+	// RandomChoice chooses lease replicas randomly.
+	RandomChoice = RegisterPolicy(newRandomOracleFactory)
+	// BinPackingChoice bin-packs the choices.
+	BinPackingChoice = RegisterPolicy(newBinPackingOracleFactory)
+	// ClosestChoice chooses the node closest to the current node.
+	ClosestChoice = RegisterPolicy(newClosestOracleFactory)
+)
+
+// Config is used to construct an OracleFactory.
+type Config struct {
+	NodeDesc         roachpb.NodeDescriptor
+	Settings         *cluster.Settings
+	Gossip           *gossip.Gossip
+	RPCContext       *rpc.Context
+	LeaseHolderCache *kv.LeaseHolderCache
+}
+
+// Oracle is used to choose the lease holder for ranges. This
+// interface was extracted so we can experiment with different choosing
+// policies.
+// Note that choices that start out random can act as self-fulfilling prophecies
+// - if there's no active lease, the node that will be asked to execute part of
+// the query (the chosen node) will acquire a new lease.
+type Oracle interface {
+	// ChoosePreferredReplica returns a choice for one range. Implementors are
+	// free to use the queryState param, which has info about the number of	ranges
+	// already handled by each node for the current SQL query. The state is not
+	// updated with the result of this method; the caller is in charge of  that.
+	//
+	// A RangeUnavailableError can be returned if there's no information in gossip
+	// about any of the nodes that might be tried.
+	ChoosePreferredReplica(
+		context.Context, roachpb.RangeDescriptor, QueryState,
+	) (kv.ReplicaInfo, error)
+}
+
+// OracleFactory creates an oracle for a Txn.
+type OracleFactory interface {
+	Oracle(*client.Txn) Oracle
+}
+
+// OracleFactoryFunc creates an OracleFactory from a Config.
+type OracleFactoryFunc func(Config) OracleFactory
+
+// NewOracleFactory creates an oracle with the given policy.
+func NewOracleFactory(policy Policy, cfg Config) OracleFactory {
+	ff, ok := oracleFactoryFuncs[policy]
+	if !ok {
+		panic(errors.Errorf("unknown Policy %v", policy))
+	}
+	return ff(cfg)
+}
+
+// RegisterPolicy creates a new policy given a function which constructs an
+// OracleFactory. RegisterPolicy is intended to be called only during init and
+// is not safe for concurrent use.
+func RegisterPolicy(f OracleFactoryFunc) Policy {
+	if len(oracleFactoryFuncs) == 255 {
+		panic("Can only register 255 Policy instances")
+	}
+	r := Policy(len(oracleFactoryFuncs))
+	oracleFactoryFuncs[r] = f
+	return r
+}
+
+var oracleFactoryFuncs = map[Policy]OracleFactoryFunc{}
+
+// QueryState encapsulates the history of assignments of ranges to nodes
+// done by an oracle on behalf of one particular query.
+type QueryState struct {
+	RangesPerNode  map[roachpb.NodeID]int
+	AssignedRanges map[roachpb.RangeID]kv.ReplicaInfo
+}
+
+// MakeQueryState creates an initialized QueryState.
+func MakeQueryState() QueryState {
+	return QueryState{
+		RangesPerNode:  make(map[roachpb.NodeID]int),
+		AssignedRanges: make(map[roachpb.RangeID]kv.ReplicaInfo),
+	}
+}
+
+// randomOracle is a Oracle that chooses the lease holder randomly
+// among the replicas in a range descriptor.
+type randomOracle struct {
+	gossip *gossip.Gossip
+}
+
+var _ OracleFactory = &randomOracle{}
+
+func newRandomOracleFactory(cfg Config) OracleFactory {
+	return &randomOracle{gossip: cfg.Gossip}
+}
+
+func (o *randomOracle) Oracle(_ *client.Txn) Oracle {
+	return o
+}
+
+func (o *randomOracle) ChoosePreferredReplica(
+	ctx context.Context, desc roachpb.RangeDescriptor, _ QueryState,
+) (kv.ReplicaInfo, error) {
+	replicas, err := replicaSliceOrErr(desc, o.gossip)
+	if err != nil {
+		return kv.ReplicaInfo{}, err
+	}
+	return replicas[rand.Intn(len(replicas))], nil
+}
+
+type closestOracle struct {
+	gossip      *gossip.Gossip
+	latencyFunc kv.LatencyFunc
+	// nodeDesc is the descriptor of the current node. It will be used to give
+	// preference to the current node and others "close" to it.
+	nodeDesc roachpb.NodeDescriptor
+}
+
+func newClosestOracleFactory(cfg Config) OracleFactory {
+	return &closestOracle{
+		latencyFunc: latencyFunc(cfg.RPCContext),
+		gossip:      cfg.Gossip,
+		nodeDesc:    cfg.NodeDesc,
+	}
+}
+
+func (o *closestOracle) Oracle(_ *client.Txn) Oracle {
+	return o
+}
+
+func (o *closestOracle) ChoosePreferredReplica(
+	ctx context.Context, desc roachpb.RangeDescriptor, queryState QueryState,
+) (kv.ReplicaInfo, error) {
+	replicas, err := replicaSliceOrErr(desc, o.gossip)
+	if err != nil {
+		return kv.ReplicaInfo{}, err
+	}
+	replicas.OptimizeReplicaOrder(&o.nodeDesc, o.latencyFunc)
+	return replicas[0], nil
+}
+
+// maxPreferredRangesPerLeaseHolder applies to the binPackingOracle.
+// When choosing lease holders, we try to choose the same node for all the
+// ranges applicable, until we hit this limit. The rationale is that maybe a
+// bunch of those ranges don't have an active lease, so our choice is going to
+// be self-fulfilling. If so, we want to collocate the lease holders. But above
+// some limit, we prefer to take the parallelism and distribute to multiple
+// nodes. The actual number used is based on nothing.
+const maxPreferredRangesPerLeaseHolder = 10
+
+// binPackingOracle coalesces choices together, so it gives preference to
+// replicas on nodes that are already assumed to be lease holders for some other
+// ranges that are going to be part of a single query.
+// Secondarily, it gives preference to replicas that are "close" to the current
+// node.
+// Finally, it tries not to overload any node.
+type binPackingOracle struct {
+	leaseHolderCache                 *kv.LeaseHolderCache
+	maxPreferredRangesPerLeaseHolder int
+	gossip                           *gossip.Gossip
+	latencyFunc                      kv.LatencyFunc
+	// nodeDesc is the descriptor of the current node. It will be used to give
+	// preference to the current node and others "close" to it.
+	nodeDesc roachpb.NodeDescriptor
+}
+
+func newBinPackingOracleFactory(cfg Config) OracleFactory {
+	return &binPackingOracle{
+		maxPreferredRangesPerLeaseHolder: maxPreferredRangesPerLeaseHolder,
+		gossip:                           cfg.Gossip,
+		nodeDesc:                         cfg.NodeDesc,
+		leaseHolderCache:                 cfg.LeaseHolderCache,
+		latencyFunc:                      latencyFunc(cfg.RPCContext),
+	}
+}
+
+var _ OracleFactory = &binPackingOracle{}
+
+func (o *binPackingOracle) Oracle(_ *client.Txn) Oracle {
+	return o
+}
+
+func (o *binPackingOracle) ChoosePreferredReplica(
+	ctx context.Context, desc roachpb.RangeDescriptor, queryState QueryState,
+) (kv.ReplicaInfo, error) {
+	// Attempt to find a cached lease holder and use it if found.
+	// If an error occurs, ignore it and proceed to choose a replica below.
+	if storeID, ok := o.leaseHolderCache.Lookup(ctx, desc.RangeID); ok {
+		var repl kv.ReplicaInfo
+		repl.ReplicaDescriptor = roachpb.ReplicaDescriptor{StoreID: storeID}
+		// Fill in the node descriptor.
+		nodeID, err := o.gossip.GetNodeIDForStoreID(storeID)
+		if err != nil {
+			log.VEventf(ctx, 2, "failed to lookup store %d: %s", storeID, err)
+		} else if nd, err := o.gossip.GetNodeDescriptor(nodeID); err != nil {
+			log.VEventf(ctx, 2, "failed to resolve node %d: %s", nodeID, err)
+		} else {
+			repl.ReplicaDescriptor.NodeID = nodeID
+			repl.NodeDesc = nd
+			return repl, nil
+		}
+	}
+
+	// If we've assigned the range before, return that assignment.
+	if repl, ok := queryState.AssignedRanges[desc.RangeID]; ok {
+		return repl, nil
+	}
+
+	replicas, err := replicaSliceOrErr(desc, o.gossip)
+	if err != nil {
+		return kv.ReplicaInfo{}, err
+	}
+	replicas.OptimizeReplicaOrder(&o.nodeDesc, o.latencyFunc)
+
+	// Look for a replica that has been assigned some ranges, but it's not yet full.
+	minLoad := int(math.MaxInt32)
+	var leastLoadedIdx int
+	for i, repl := range replicas {
+		assignedRanges := queryState.RangesPerNode[repl.NodeID]
+		if assignedRanges != 0 && assignedRanges < o.maxPreferredRangesPerLeaseHolder {
+			return repl, nil
+		}
+		if assignedRanges < minLoad {
+			leastLoadedIdx = i
+			minLoad = assignedRanges
+		}
+	}
+	// Either no replica was assigned any previous ranges, or all replicas are
+	// full. Use the least-loaded one (if all the load is 0, then the closest
+	// replica is returned).
+	return replicas[leastLoadedIdx], nil
+}
+
+// replicaSliceOrErr returns a ReplicaSlice for the given range descriptor.
+// ReplicaSlices are restricted to replicas on nodes for which a NodeDescriptor
+// is available in gossip. If no nodes are available, a RangeUnavailableError is
+// returned.
+func replicaSliceOrErr(desc roachpb.RangeDescriptor, gsp *gossip.Gossip) (kv.ReplicaSlice, error) {
+	replicas := kv.NewReplicaSlice(gsp, &desc)
+	if len(replicas) == 0 {
+		// We couldn't get node descriptors for any replicas.
+		var nodeIDs []roachpb.NodeID
+		for _, r := range desc.Replicas {
+			nodeIDs = append(nodeIDs, r.NodeID)
+		}
+		return kv.ReplicaSlice{}, sqlbase.NewRangeUnavailableError(
+			desc.RangeID, errors.Errorf("node info not available in gossip"), nodeIDs...)
+	}
+	return replicas, nil
+}
+
+// latencyFunc returns a kv.LatencyFunc for use with
+// Replicas.OptimizeReplicaOrder.
+func latencyFunc(rpcCtx *rpc.Context) kv.LatencyFunc {
+	if rpcCtx != nil {
+		return rpcCtx.RemoteClocks.Latency
+	}
+	return nil
+}

--- a/pkg/sql/distsqlplan/replicaoracle/oracle_test.go
+++ b/pkg/sql/distsqlplan/replicaoracle/oracle_test.go
@@ -1,0 +1,134 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package replicaoracle
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+)
+
+// TestRandomOracle defeats TestUnused for RandomChoice.
+func TestRandomOracle(t *testing.T) {
+	_ = NewOracleFactory(RandomChoice, Config{})
+}
+
+// Test that the binPackingOracle is consistent in its choices: once a range has
+// been assigned to one node, that choice is reused.
+func TestBinPackingOracleIsConsistent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	rng := roachpb.RangeDescriptor{RangeID: 99}
+	queryState := MakeQueryState()
+	expRepl := kv.ReplicaInfo{
+		ReplicaDescriptor: roachpb.ReplicaDescriptor{
+			NodeID: 99, StoreID: 99, ReplicaID: 99}}
+	queryState.AssignedRanges[rng.RangeID] = expRepl
+	of := NewOracleFactory(BinPackingChoice, Config{
+		LeaseHolderCache: kv.NewLeaseHolderCache(func() int64 { return 1 }),
+	})
+	// For our purposes, an uninitialized binPackingOracle will do.
+	bp := of.Oracle(nil)
+	repl, err := bp.ChoosePreferredReplica(context.TODO(), rng, queryState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repl != expRepl {
+		t.Fatalf("expected replica %+v, got: %+v", expRepl, repl)
+	}
+}
+
+func TestClosest(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+	g, _ := makeGossip(t, stopper)
+	nd, _ := g.GetNodeDescriptor(1)
+	of := NewOracleFactory(ClosestChoice, Config{
+		Gossip:   g,
+		NodeDesc: *nd,
+	})
+	of.(*closestOracle).latencyFunc = func(s string) (time.Duration, bool) {
+		if strings.HasSuffix(s, "2") {
+			return time.Nanosecond, true
+		}
+		return time.Millisecond, true
+	}
+	o := of.Oracle(nil)
+	info, err := o.ChoosePreferredReplica(context.TODO(), roachpb.RangeDescriptor{
+		Replicas: []roachpb.ReplicaDescriptor{
+			{NodeID: 1, StoreID: 1},
+			{NodeID: 2, StoreID: 2},
+			{NodeID: 3, StoreID: 3},
+		},
+	}, QueryState{})
+	if err != nil {
+		t.Fatalf("Failed to choose closest replica: %v", err)
+	}
+	if info.NodeID != 2 {
+		t.Fatalf("Failed to choose node 2, got %v", info.NodeID)
+	}
+}
+
+func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock) {
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	rpcContext := rpc.NewContext(
+		log.AmbientContext{Tracer: tracing.NewTracer()},
+		&base.Config{Insecure: true},
+		clock,
+		stopper,
+		&cluster.MakeTestingClusterSettings().Version,
+	)
+	server := rpc.NewServer(rpcContext)
+
+	const nodeID = 1
+	g := gossip.NewTest(nodeID, rpcContext, server, stopper, metric.NewRegistry())
+	if err := g.SetNodeDescriptor(newNodeDesc(nodeID)); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddInfo(gossip.KeySentinel, nil, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	for i := roachpb.NodeID(2); i <= 3; i++ {
+		err := g.AddInfoProto(gossip.MakeNodeIDKey(i), newNodeDesc(i), gossip.NodeDescriptorTTL)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return g, clock
+}
+
+func newNodeDesc(nodeID roachpb.NodeID) *roachpb.NodeDescriptor {
+	return &roachpb.NodeDescriptor{
+		NodeID:  nodeID,
+		Address: util.MakeUnresolvedAddr("tcp", fmt.Sprintf("invalid.invalid:%d", nodeID)),
+	}
+}

--- a/pkg/sql/distsqlplan/span_resolver_internal_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_internal_test.go
@@ -13,34 +13,3 @@
 // permissions and limitations under the License.
 
 package distsqlplan
-
-import (
-	"testing"
-
-	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-)
-
-// Test that the binPackingOracle is consistent in its choices: once a range has
-// been assigned to one node, that choice is reused.
-func TestBinPackingOracleIsConsistent(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	rng := roachpb.RangeDescriptor{RangeID: 99}
-
-	queryState := makeOracleQueryState()
-	expRepl := kv.ReplicaInfo{
-		ReplicaDescriptor: roachpb.ReplicaDescriptor{
-			NodeID: 99, StoreID: 99, ReplicaID: 99}}
-	queryState.assignedRanges[rng.RangeID] = expRepl
-	// For our purposes, an uninitialized binPackingOracle will do.
-	bp := binPackingOracle{}
-	repl, err := bp.ChoosePreferredLeaseHolder(rng, queryState)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if repl != expRepl {
-		t.Fatalf("expected replica %+v, got: %+v", expRepl, repl)
-	}
-}

--- a/pkg/sql/distsqlplan/span_resolver_test.go
+++ b/pkg/sql/distsqlplan/span_resolver_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlplan"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlplan/replicaoracle"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -89,8 +90,9 @@ func TestSpanResolverUsesCaches(t *testing.T) {
 	s3 := tc.Servers[3]
 
 	lr := distsqlplan.NewSpanResolver(
-		s3.DistSender(), s3.Gossip(), s3.GetNode().Descriptor,
-		distsqlplan.BinPackingLeaseHolderChoice)
+		s3.Cfg.Settings,
+		s3.DistSender(), s3.Gossip(), s3.GetNode().Descriptor, nil,
+		replicaoracle.BinPackingChoice)
 
 	var spans []spanWithDir
 	for i := 0; i < 3; i++ {
@@ -194,9 +196,10 @@ func TestSpanResolver(t *testing.T) {
 
 	rowRanges, tableDesc := setupRanges(db, s.(*server.TestServer), cdb, t)
 	lr := distsqlplan.NewSpanResolver(
+		s.(*server.TestServer).Cfg.Settings,
 		s.DistSender(), s.Gossip(),
-		s.(*server.TestServer).GetNode().Descriptor,
-		distsqlplan.BinPackingLeaseHolderChoice)
+		s.(*server.TestServer).GetNode().Descriptor, nil,
+		replicaoracle.BinPackingChoice)
 
 	ctx := context.Background()
 	it := lr.NewSpanResolverIterator(nil)
@@ -287,9 +290,11 @@ func TestMixedDirections(t *testing.T) {
 
 	rowRanges, tableDesc := setupRanges(db, s.(*server.TestServer), cdb, t)
 	lr := distsqlplan.NewSpanResolver(
+		s.(*server.TestServer).Cfg.Settings,
 		s.DistSender(), s.Gossip(),
 		s.(*server.TestServer).GetNode().Descriptor,
-		distsqlplan.BinPackingLeaseHolderChoice)
+		nil,
+		replicaoracle.BinPackingChoice)
 
 	ctx := context.Background()
 	it := lr.NewSpanResolverIterator(nil)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -729,7 +729,6 @@ func (p *planner) isAsOf(stmt tree.Statement, max hlc.Timestamp) (*hlc.Timestamp
 	default:
 		return nil, nil
 	}
-
 	ts, err := p.EvalAsOfTimestamp(asOf, max)
 	return &ts, err
 }

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -29,7 +29,7 @@ SELECT * FROM t AS OF SYSTEM TIME -( ('1' || 'ns')::INTERVAL )
 ----
 2
 
-statement error pq: AS OF SYSTEM TIME: only constant expressions are allowed
+statement error pq: AS OF SYSTEM TIME: only constant expressions or experimental_follower_read_timestamp are allowed
 SELECT * FROM t AS OF SYSTEM TIME cluster_logical_timestamp()
 
 statement error pq: subqueries are not allowed in AS OF SYSTEM TIME
@@ -37,6 +37,15 @@ SELECT * FROM t AS OF SYSTEM TIME (SELECT '-1h'::INTERVAL)
 
 statement error pq: relation "t" does not exist
 SELECT * FROM t AS OF SYSTEM TIME '-1h'
+
+statement error pq: experimental_follower_read_timestamp\(\): experimental_follower_read_timestamp is only available in ccl distribution
+SELECT * FROM t AS OF SYSTEM TIME experimental_follower_read_timestamp()
+
+statement error pq: unknown signature: experimental_follower_read_timestamp\(string\) \(desired <timestamptz>\)
+SELECT * FROM t AS OF SYSTEM TIME experimental_follower_read_timestamp('boom')
+
+statement error pq: AS OF SYSTEM TIME: only constant expressions or experimental_follower_read_timestamp are allowed
+SELECT * FROM t AS OF SYSTEM TIME now()
 
 statement error cannot specify timestamp in the future
 SELECT * FROM t AS OF SYSTEM TIME '10s'

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -209,7 +209,6 @@ func (ts *txnState) resetForNewSQLTxn(
 	if txn == nil {
 		ts.mu.txn = client.NewTxn(ts.Ctx, tranCtx.db, tranCtx.nodeID, client.RootTxn)
 		ts.mu.txn.SetDebugName(opName)
-
 	} else {
 		ts.mu.txn = txn
 	}

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -279,6 +279,14 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 
+	// Metric for tracking follower reads.
+	metaFollowerReadsCount = metric.Metadata{
+		Name:        "follower_reads.success_count",
+		Help:        "Number of reads successfully processed by any replica",
+		Measurement: "Read Ops",
+		Unit:        metric.Unit_COUNT,
+	}
+
 	// RocksDB metrics.
 	metaRdbBlockCacheHits = metric.Metadata{
 		Name:        "rocksdb.block.cache.hits",
@@ -966,6 +974,9 @@ type StoreMetrics struct {
 	AverageQueriesPerSecond *metric.GaugeFloat64
 	AverageWritesPerSecond  *metric.GaugeFloat64
 
+	// Follower read metrics.
+	FollowerReadsCount *metric.Counter
+
 	// RocksDB metrics.
 	RdbBlockCacheHits           *metric.Gauge
 	RdbBlockCacheMisses         *metric.Gauge
@@ -1162,6 +1173,9 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		// Rebalancing metrics.
 		AverageQueriesPerSecond: metric.NewGaugeFloat64(metaAverageQueriesPerSecond),
 		AverageWritesPerSecond:  metric.NewGaugeFloat64(metaAverageWritesPerSecond),
+
+		// Follower reads metrics.
+		FollowerReadsCount: metric.NewCounter(metaFollowerReadsCount),
 
 		// RocksDB metrics.
 		RdbBlockCacheHits:           metric.NewGauge(metaRdbBlockCacheHits),

--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -41,6 +41,7 @@ func (r *Replica) executeReadOnlyBatch(
 			if nErr := r.canServeFollowerRead(ctx, ba, pErr); nErr != nil {
 				return nil, nErr
 			}
+			r.store.metrics.FollowerReadsCount.Inc(1)
 		}
 	}
 	r.limitTxnMaxTimestamp(ctx, &ba, status)


### PR DESCRIPTION
Follower reads are reads which can be served from any replica as opposed to just
the current lease holder. The foundation for this change was laid with the work
to introduce closed timestamps and to support follower reads at the replica
level. This change adds the required support to the sql and kv layers and
additionally exposes a new syntax to ease client adoption of the functionality.

The change adds the followerreadsccl package with logic to check when follower
reads are safe and to inject the functionality so that it can be packaged as an
enterprise feature.

Modifies `AS OF SYSTEM TIME` semantics to allow for the evaluation of a new
builtin tentatively called `follower_read_timestamp()` in addition to constant
expressions. This new builtin ensures that an enterprise license exists and then
returns a time that can likely be used to read from a follower.

The change abstracts (and renames to the more appropriate replicaoracle) the
existing leaseHolderOracle in the distsqlplan package to allow a follower read
aware policy to be injected.

Lastly the change add to kv a site to inject a function for checking if follower
reads are safe and allowed given a cluster, settings, and batch request.

This change includes a high level roachtest which validates observable behavior
of performing follower reads by examining latencies for reads in a geo-
replicated setting.

Implements #33474 
Fixes #16593

Release note (enterprise change): Add support for performing sufficiently old
historical reads against closest replicas rather than leaseholders. A new
builtin function `follower_read_timestamp()` which can be used with `AS OF
SYSTEM TIME` clauses to generate a timestamp which is likely to be safe for
reads from a follower.