### PR TITLE
cli/interactive_tests: deflake (more) test_url_db_override

### DIFF
--- a/pkg/cli/interactive_tests/test_url_db_override.tcl
+++ b/pkg/cli/interactive_tests/test_url_db_override.tcl
@@ -87,9 +87,7 @@ end_test
 start_test "Check that the host flag overrides the host if URL is already set."
 spawn $argv sql --url "postgresql://root@localhost:26257?sslmode=disable" --host nonexistent.invalid -e "select 1"
 eexpect "cannot dial server"
-eexpect "nonexistent"
 eexpect eof
 end_test
 
 stop_server $argv
-


### PR DESCRIPTION
Fixes #30796.

The test is merely testing that a `--host` flag will override the
hostname in the URL. Since there is a valid server running for
`localhost` (the host in the URL), and a test immediately before
asserts the server is running and responding, any connection error is
sufficient to demonstrate that `--host` has taken priority. There is
no need to check that the particular hostname is reported in the error
message.

Release note: None