### PR TITLE
sql: use integer placeholder IDs

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -17,7 +17,6 @@ package sql
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -296,7 +295,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		}
 		typeHints := make(tree.PlaceholderTypes, len(s.Types))
 		for i, t := range s.Types {
-			typeHints[strconv.Itoa(i+1)] = coltypes.CastTargetToDatumType(t)
+			typeHints[types.PlaceholderIdx(i)] = coltypes.CastTargetToDatumType(t)
 		}
 		if _, err := ex.addPreparedStmt(
 			ctx, name, Statement{SQL: s.Statement.String(), AST: s.Statement}, typeHints,

--- a/pkg/sql/execute.go
+++ b/pkg/sql/execute.go
@@ -15,10 +15,9 @@
 package sql
 
 import (
-	"strconv"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -39,7 +38,7 @@ func fillInPlaceholders(
 	qArgs := make(tree.QueryArguments, len(params))
 	var semaCtx tree.SemaContext
 	for i, e := range params {
-		idx := strconv.Itoa(i + 1)
+		idx := types.PlaceholderIdx(i)
 
 		typedExpr, err := sqlbase.SanitizeVarFreeExpr(
 			e, ps.TypeHints[idx], "EXECUTE parameter", /* context */

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"runtime/pprof"
-	"strconv"
 	"testing"
 	"time"
 
@@ -37,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -510,10 +510,10 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 		}
 
 		var texpr tree.TypedExpr
-		name := strconv.Itoa(i + 1)
+		id := types.PlaceholderIdx(i)
 		texpr, err = sqlbase.SanitizeVarFreeExpr(
 			parg,
-			h.semaCtx.Placeholders.TypeHints[name],
+			h.semaCtx.Placeholders.TypeHints[id],
 			"", /* context */
 			&h.semaCtx,
 			&h.evalCtx,
@@ -523,7 +523,7 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 			tb.Fatalf("%v", err)
 		}
 
-		h.semaCtx.Placeholders.Values[name] = texpr
+		h.semaCtx.Placeholders.Values[id] = texpr
 	}
 	h.evalCtx.Placeholders = &h.semaCtx.Placeholders
 }

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -2455,6 +2455,27 @@ EXPLAIN EXECUTE a
         ^
 HINT: try \h EXPLAIN`,
 		},
+		{
+			`SELECT $0`,
+			`placeholder index must be between 1 and 65536
+SELECT $0
+       ^
+HINT: try \h SELECT`,
+		},
+		{
+			`SELECT $-1`,
+			`syntax error at or near "$"
+SELECT $-1
+       ^
+HINT: try \h SELECT`,
+		},
+		{
+			`SELECT $123456789`,
+			`placeholder index must be between 1 and 65536
+SELECT $123456789
+       ^
+HINT: try \h SELECT`,
+		},
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {

--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -23,7 +23,6 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -656,17 +655,14 @@ func (s *scanner) scanPlaceholder(lval *sqlSymType) {
 	}
 	lval.str = s.in[start:s.pos]
 
-	uval, err := strconv.ParseUint(lval.str, 10, 64)
-	if err == nil && uval > 1<<63 {
-		err = pgerror.NewErrorf(pgerror.CodeNumericValueOutOfRangeError, "integer value out of range: %d", uval)
-	}
+	placeholder, err := tree.NewPlaceholder(lval.str)
 	if err != nil {
 		lval.id = ERROR
 		lval.str = err.Error()
 		return
 	}
-
 	lval.id = PLACEHOLDER
+	lval.union.val = placeholder
 }
 
 // scanHexString scans the content inside x'....'.

--- a/pkg/sql/parser/scan_test.go
+++ b/pkg/sql/parser/scan_test.go
@@ -322,7 +322,8 @@ func TestScanError(t *testing.T) {
 		{`x'beef\x41'`, "invalid hexadecimal bytes literal"},
 		{`X'beef\x41\x41'`, "invalid hexadecimal bytes literal"},
 		{`x'a'`, "invalid hexadecimal bytes literal"},
-		{`$9223372036854775809`, "integer value out of range"},
+		{`$0`, "placeholder index must be between 1 and 65536"},
+		{`$9223372036854775809`, "placeholder index must be between 1 and 65536"},
 		{`B'123'`, `"2" is not a valid binary digit`},
 	}
 	for _, d := range testData {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -111,6 +111,9 @@ func (u *sqlSymUnion) strVal() *tree.StrVal {
     }
     return nil
 }
+func (u *sqlSymUnion) placeholder() *tree.Placeholder {
+    return u.val.(*tree.Placeholder)
+}
 func (u *sqlSymUnion) auditMode() tree.AuditMode {
     return u.val.(tree.AuditMode)
 }
@@ -451,7 +454,7 @@ func newNameFromStr(s string) *tree.Name {
 // Non-keyword token types.
 %token <str> IDENT SCONST BCONST BITCONST
 %token <*tree.NumVal> ICONST FCONST
-%token <str> PLACEHOLDER
+%token <*tree.Placeholder> PLACEHOLDER
 %token <str> TYPECAST TYPEANNOTATE DOT_DOT
 %token <str> LESS_EQUALS GREATER_EQUALS NOT_EQUALS
 %token <str> NOT_REGMATCH REGIMATCH NOT_REGIMATCH
@@ -1812,7 +1815,7 @@ string_or_placeholder:
   }
 | PLACEHOLDER
   {
-    $$.val = tree.NewPlaceholder($1)
+    $$.val = $1.placeholder()
   }
 
 string_or_placeholder_list:
@@ -7557,7 +7560,7 @@ d_expr:
   }
 | PLACEHOLDER
   {
-    $$.val = tree.NewPlaceholder($1)
+    $$.val = $1.placeholder()
   }
 // TODO(knz/jordan): extend this for compound types. See explanation above.
 | '(' a_expr ')' '.' '*'

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -554,7 +554,7 @@ func (c *conn) handleParse(
 			err := pgwirebase.NewProtocolViolationErrorf("unknown oid type: %v", t)
 			return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
 		}
-		sqlTypeHints[strconv.Itoa(i+1)] = v
+		sqlTypeHints[types.PlaceholderIdx(i)] = v
 	}
 
 	startParse := timeutil.Now()

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3411,7 +3411,7 @@ func (d *Placeholder) AmbiguousFormat() bool {
 }
 
 func (d *Placeholder) mustGetValue(ctx *EvalContext) Datum {
-	e, ok := ctx.Placeholders.Value(d.Name)
+	e, ok := ctx.Placeholders.Value(d.Idx)
 	if !ok {
 		panic("fail")
 	}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3981,17 +3981,17 @@ func (t *Placeholder) Eval(ctx *EvalContext) (Datum, error) {
 		// placeholder evaluates to itself at this point.
 		return t, nil
 	}
-	e, ok := ctx.Placeholders.Value(t.Name)
+	e, ok := ctx.Placeholders.Value(t.Idx)
 	if !ok {
 		return nil, pgerror.NewErrorf(pgerror.CodeUndefinedParameterError,
-			"no value provided for placeholder: $%s", t.Name)
+			"no value provided for placeholder: %s", t)
 	}
 	// Placeholder expressions cannot contain other placeholders, so we do
 	// not need to recurse.
-	typ, typed := ctx.Placeholders.Type(t.Name, false)
+	typ, typed := ctx.Placeholders.Type(t.Idx, false)
 	if !typed {
 		// All placeholders should be typed at this point.
-		return nil, pgerror.NewAssertionErrorf("missing type for placeholder %s", t.Name)
+		return nil, pgerror.NewAssertionErrorf("missing type for placeholder %s", t)
 	}
 	if !e.ResolvedType().Equivalent(typ) {
 		// This happens when we overrode the placeholder's type during type

--- a/pkg/sql/sem/tree/placeholders.go
+++ b/pkg/sql/sem/tree/placeholders.go
@@ -26,12 +26,12 @@ import (
 )
 
 // PlaceholderTypes relates placeholder names to their resolved type.
-type PlaceholderTypes map[string]types.T
+type PlaceholderTypes map[types.PlaceholderIdx]types.T
 
 // QueryArguments relates placeholder names to their provided query argument.
 //
 // A nil value represents a NULL argument.
-type QueryArguments map[string]TypedExpr
+type QueryArguments map[types.PlaceholderIdx]TypedExpr
 
 var emptyQueryArgumentStr = "{}"
 
@@ -43,7 +43,7 @@ func (qa *QueryArguments) String() string {
 	buf.WriteByte('{')
 	sep := ""
 	for k, v := range *qa {
-		fmt.Fprintf(&buf, "%s$%s:%q", sep, k, v)
+		fmt.Fprintf(&buf, "%s%s:%q", sep, k, v)
 		sep = ", "
 	}
 	buf.WriteByte('}')
@@ -107,7 +107,7 @@ func (p *PlaceholderInfo) AssertAllAssigned() error {
 	var missing []string
 	for pn := range p.Types {
 		if _, ok := p.Values[pn]; !ok {
-			missing = append(missing, "$"+pn)
+			missing = append(missing, pn.String())
 		}
 	}
 	if len(missing) > 0 {
@@ -124,10 +124,10 @@ func (p *PlaceholderInfo) AssertAllAssigned() error {
 // Type returns the known type of a placeholder. If allowHints is true, will
 // return a type hint if there's no known type yet but there is a type hint.
 // Returns false in the 2nd value if the placeholder is not typed.
-func (p *PlaceholderInfo) Type(name string, allowHints bool) (types.T, bool) {
-	if t, ok := p.Types[name]; ok {
+func (p *PlaceholderInfo) Type(idx types.PlaceholderIdx, allowHints bool) (types.T, bool) {
+	if t, ok := p.Types[idx]; ok {
 		return t, true
-	} else if t, ok := p.TypeHints[name]; ok {
+	} else if t, ok := p.TypeHints[idx]; ok {
 		return t, true
 	}
 	return nil, false
@@ -135,8 +135,8 @@ func (p *PlaceholderInfo) Type(name string, allowHints bool) (types.T, bool) {
 
 // Value returns the known value of a placeholder.  Returns false in
 // the 2nd value if the placeholder does not have a value.
-func (p *PlaceholderInfo) Value(name string) (TypedExpr, bool) {
-	if v, ok := p.Values[name]; ok {
+func (p *PlaceholderInfo) Value(idx types.PlaceholderIdx) (TypedExpr, bool) {
+	if v, ok := p.Values[idx]; ok {
 		return v, true
 	}
 	return nil, false
@@ -144,20 +144,20 @@ func (p *PlaceholderInfo) Value(name string) (TypedExpr, bool) {
 
 // SetType assigns a known type to a placeholder.
 // Reports an error if another type was previously assigned.
-func (p *PlaceholderInfo) SetType(name string, typ types.T) error {
-	if t, ok := p.Types[name]; ok {
+func (p *PlaceholderInfo) SetType(idx types.PlaceholderIdx, typ types.T) error {
+	if t, ok := p.Types[idx]; ok {
 		if !typ.Equivalent(t) {
 			return pgerror.NewErrorf(
 				pgerror.CodeDatatypeMismatchError,
-				"placeholder %s already has type %s, cannot assign %s", name, t, typ)
+				"placeholder %s already has type %s, cannot assign %s", idx, t, typ)
 		}
 		return nil
 	}
-	p.Types[name] = typ
-	if _, ok := p.TypeHints[name]; !ok {
+	p.Types[idx] = typ
+	if _, ok := p.TypeHints[idx]; !ok {
 		// If the client didn't give us a type hint, we must communicate our
 		// inferred type to pgwire so it can know how to parse incoming data.
-		p.TypeHints[name] = typ
+		p.TypeHints[idx] = typ
 	}
 	return nil
 }
@@ -183,7 +183,7 @@ func (p *PlaceholderInfo) SetTypeHints(src PlaceholderTypes) {
 // whether the placeholder's type remains unset in the PlaceholderInfo.
 func (p *PlaceholderInfo) IsUnresolvedPlaceholder(expr Expr) bool {
 	if t, ok := StripParens(expr).(*Placeholder); ok {
-		_, res := p.TypeHints[t.Name]
+		_, res := p.TypeHints[t.Idx]
 		return !res
 	}
 	return false

--- a/pkg/sql/sqlbase/column_type_properties.go
+++ b/pkg/sql/sqlbase/column_type_properties.go
@@ -787,10 +787,10 @@ func CheckDatumTypeFitsColumnType(
 	// populated 'colTyp' with a type to assign to it.
 	colTyp := col.Type.ToDatumType()
 	if p, pok := typ.(types.TPlaceholder); pok {
-		if err := pmap.SetType(p.Name, colTyp); err != nil {
+		if err := pmap.SetType(p.Idx, colTyp); err != nil {
 			return pgerror.NewErrorf(pgerror.CodeIndeterminateDatatypeError,
 				"cannot infer type for placeholder %s from column %q: %s",
-				p.Name, tree.ErrNameString(&col.Name), err)
+				p.Idx, tree.ErrNameString(&col.Name), err)
 		}
 	} else if !typ.Equivalent(colTyp) {
 		// Not a placeholder; check that the value cast has succeeded.


### PR DESCRIPTION
This change modifies `tree.Placeholder` to store an integer ID
(between 1 and 65535) instead of a string. This saves silly
allocations in pgwire, and in a future change we can switch the
PlaceholderInfo maps to slices.

Informs #30086.

Release note: None