### PR TITLE
client: pool allocations of client.Batch

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -294,7 +294,9 @@ func (txn *Txn) DisablePipelining() error {
 
 // NewBatch creates and returns a new empty batch object for use with the Txn.
 func (txn *Txn) NewBatch() *Batch {
-	return &Batch{txn: txn}
+	b := newBatch()
+	b.txn = txn
+	return b
 }
 
 // Get retrieves the value for a key, returning the retrieved key/value or an
@@ -307,7 +309,9 @@ func (txn *Txn) NewBatch() *Batch {
 func (txn *Txn) Get(ctx context.Context, key interface{}) (KeyValue, error) {
 	b := txn.NewBatch()
 	b.Get(key)
-	return getOneRow(txn.Run(ctx, b), b)
+	kv, err := getOneRow(txn.Run(ctx, b), b)
+	b.Release()
+	return kv, err
 }
 
 // GetProto retrieves the value for a key and decodes the result as a proto
@@ -329,7 +333,9 @@ func (txn *Txn) GetProto(ctx context.Context, key interface{}, msg protoutil.Mes
 func (txn *Txn) Put(ctx context.Context, key, value interface{}) error {
 	b := txn.NewBatch()
 	b.Put(key, value)
-	return getOneErr(txn.Run(ctx, b), b)
+	err := getOneErr(txn.Run(ctx, b), b)
+	b.Release()
+	return err
 }
 
 // CPut conditionally sets the value for a key if the existing value is equal
@@ -344,7 +350,9 @@ func (txn *Txn) Put(ctx context.Context, key, value interface{}) error {
 func (txn *Txn) CPut(ctx context.Context, key, value, expValue interface{}) error {
 	b := txn.NewBatch()
 	b.CPut(key, value, expValue)
-	return getOneErr(txn.Run(ctx, b), b)
+	err := getOneErr(txn.Run(ctx, b), b)
+	b.Release()
+	return err
 }
 
 // InitPut sets the first value for a key to value. An error is reported if a
@@ -358,7 +366,9 @@ func (txn *Txn) CPut(ctx context.Context, key, value, expValue interface{}) erro
 func (txn *Txn) InitPut(ctx context.Context, key, value interface{}, failOnTombstones bool) error {
 	b := txn.NewBatch()
 	b.InitPut(key, value, failOnTombstones)
-	return getOneErr(txn.Run(ctx, b), b)
+	err := getOneErr(txn.Run(ctx, b), b)
+	b.Release()
+	return err
 }
 
 // Inc increments the integer value at key. If the key does not exist it will
@@ -372,7 +382,9 @@ func (txn *Txn) InitPut(ctx context.Context, key, value interface{}, failOnTombs
 func (txn *Txn) Inc(ctx context.Context, key interface{}, value int64) (KeyValue, error) {
 	b := txn.NewBatch()
 	b.Inc(key, value)
-	return getOneRow(txn.Run(ctx, b), b)
+	kv, err := getOneRow(txn.Run(ctx, b), b)
+	b.Release()
+	return kv, err
 }
 
 func (txn *Txn) scan(
@@ -388,6 +400,7 @@ func (txn *Txn) scan(
 		b.ReverseScan(begin, end)
 	}
 	r, err := getOneResult(txn.Run(ctx, b), b)
+	b.Release()
 	return r.Rows, err
 }
 
@@ -448,7 +461,9 @@ func (txn *Txn) Iterate(
 func (txn *Txn) Del(ctx context.Context, keys ...interface{}) error {
 	b := txn.NewBatch()
 	b.Del(keys...)
-	return getOneErr(txn.Run(ctx, b), b)
+	err := getOneErr(txn.Run(ctx, b), b)
+	b.Release()
+	return err
 }
 
 // DelRange deletes the rows between begin (inclusive) and end (exclusive).
@@ -460,7 +475,9 @@ func (txn *Txn) Del(ctx context.Context, keys ...interface{}) error {
 func (txn *Txn) DelRange(ctx context.Context, begin, end interface{}) error {
 	b := txn.NewBatch()
 	b.DelRange(begin, end, false)
-	return getOneErr(txn.Run(ctx, b), b)
+	err := getOneErr(txn.Run(ctx, b), b)
+	b.Release()
+	return err
 }
 
 // Run executes the operations queued up within a batch. Before executing any

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -604,6 +604,7 @@ func (ru *Updater) UpdateRow(
 	batch := b
 	if ru.cascader != nil {
 		batch = ru.cascader.txn.NewBatch()
+		defer batch.Release()
 	}
 
 	if len(oldValues) != len(ru.FetchCols) {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -846,6 +846,7 @@ func (p *planner) writeTableDesc(
 	ctx context.Context, tableDesc *sqlbase.MutableTableDescriptor, mutationID sqlbase.MutationID,
 ) error {
 	b := p.txn.NewBatch()
+	defer b.Release()
 	if err := p.writeTableDescToBatch(ctx, tableDesc, mutationID, b); err != nil {
 		return err
 	}

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -146,6 +146,7 @@ func (tb *tableWriterBase) flushAndStartNewBatch(
 	if err := tb.txn.Run(ctx, tb.b); err != nil {
 		return row.ConvertBatchError(ctx, tableDesc, tb.b)
 	}
+	tb.b.Release()
 	tb.b = tb.txn.NewBatch()
 	tb.batchSize = 0
 	return nil

--- a/pkg/sql/tablewriter_upsert.go
+++ b/pkg/sql/tablewriter_upsert.go
@@ -819,6 +819,7 @@ func (tu *tableUpserter) upsertRowPKSpans(
 	// case, some spots in the slice will be nil (indicating no conflict) and the
 	// others will be conflicting rows.
 	b := tu.txn.NewBatch()
+	defer b.Release()
 	for i := 0; i < tu.insertRows.Len(); i++ {
 		insertRow := tu.insertRows.At(i)
 		entries, err := sqlbase.EncodeSecondaryIndex(

--- a/pkg/sql/tablewriter_upsert_strict.go
+++ b/pkg/sql/tablewriter_upsert_strict.go
@@ -129,6 +129,7 @@ func (tu *strictTableUpserter) getConflictingRows(
 	// The first phase will issue KV requests.
 	// For every row there will be 1 + len(tu.conflictIndexes) requests/responses.
 	b := tu.txn.NewBatch()
+	defer b.Release()
 
 	for i := 0; i < tu.insertRows.Len(); i++ {
 		row := tu.insertRows.At(i)


### PR DESCRIPTION
This object is over 1500 bytes and is frequently allocated just to be
thrown away again right away. Use a sync pool to avoid these
allocations.

Release note: None