### PR TITLE
release-2.1: sql: fix crash in distsql planning for lookup joins

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1915,7 +1915,7 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 		distsqlrun.ProcessorCoreUnion{JoinReader: &joinReaderSpec},
 		post,
 		types,
-		dsp.convertOrdering(planPhysicalProps(n), plan.PlanToStreamColMap),
+		dsp.convertOrdering(planPhysicalProps(n), planToStreamColMap),
 	)
 	plan.PlanToStreamColMap = planToStreamColMap
 	return plan, nil

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -498,3 +498,15 @@ query I
 SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.d = u.d WHERE t.e = 5
 ----
 1
+
+# Regression test for #33342. We want the ordering in the lookup join node to
+# be +f not +a; this is achieved by making def show up in the query first (and
+# thus get smaller opt.ColumnIDs).
+query IIIIII colnames,partialsort(4)
+SELECT * FROM def JOIN abc ON a=f ORDER BY a
+----
+d     e  f  a  b     c
+2     1  1  1  1     2
+NULL  2  1  1  1     2
+1     1  2  2  NULL  2
+1     1  2  2  1     1

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -560,3 +560,24 @@ render            ·         ·          (a)              ·
       │           filter    e = 5      ·                ·
       └── scan    ·         ·          (a, d)           ·
 ·                 table     u@idx      ·                ·
+
+# Plan for #33342 regression test. We want the ordering in the lookup join node
+# to be `+f` not `+a`; this is achieved by making def show up in the query
+# first (and thus get smaller opt.ColumnIDs).
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM def JOIN abc ON a=f ORDER BY a
+----
+render            ·         ·            (d, e, f, a, b, c)  ·
+ │                render 0  d            ·                   ·
+ │                render 1  e            ·                   ·
+ │                render 2  f            ·                   ·
+ │                render 3  a            ·                   ·
+ │                render 4  b            ·                   ·
+ │                render 5  c            ·                   ·
+ └── lookup-join  ·         ·            (a, b, c, d, e, f)  +f
+      │           type      inner        ·                   ·
+      ├── scan    ·         ·            (a, b, c)           +a
+      │           table     abc@primary  ·                   ·
+      │           spans     ALL          ·                   ·
+      └── scan    ·         ·            (d, e, f)           ·
+·                 table     def@primary  ·                   ·


### PR DESCRIPTION
Fixes a crash caused when we have a required ordering on a lookup join
and the chosen column is on the lookup side.

Fixes #33342.

Release note (bug fix): Fixed a crash caused by some queries that
involve lookup joins where an input ordering must be preserved.

I'm making this fix directly on release-2.1 because it's no longer reproducible on master. I will make the same change to the distsql code there in a separate PR.

CC @cockroachdb/release 