### PR TITLE
sql: fix leak of prepared statements

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1596,7 +1596,7 @@ func (ex *connExecutor) commitPrepStmtNamespace(ctx context.Context) {
 		ctx, &ex.prepStmtsNamespace)
 }
 
-// commitPrepStmtNamespace deallocates everything in prepStmtsNamespace that's
+// rewindPrepStmtNamespace deallocates everything in prepStmtsNamespace that's
 // not part of prepStmtsNamespaceAtTxnRewindPos.
 func (ex *connExecutor) rewindPrepStmtNamespace(ctx context.Context) {
 	ex.prepStmtsNamespace.resetTo(
@@ -2210,10 +2210,7 @@ func (ps connExPrepStmtsAccessor) Delete(ctx context.Context, name string) bool 
 
 // DeleteAll is part of the preparedStatementsAccessor interface.
 func (ps connExPrepStmtsAccessor) DeleteAll(ctx context.Context) {
-	ps.ex.prepStmtsNamespace = prepStmtNamespace{
-		prepStmts: make(map[string]prepStmtEntry),
-		portals:   make(map[string]portalEntry),
-	}
+	ps.ex.prepStmtsNamespace.resetTo(ctx, &prepStmtNamespace{})
 }
 
 // contextStatementKey is an empty type for the handle associated with the


### PR DESCRIPTION
The connExPrepStmtsAccessor.DeleteAll() method was not properly implemented and
"leaked" the memory accounting for  prepared statements. This could lead
to crashes, like showed below.

I've looked at the various open issues around memory leak crashes, but
unfortunately I think it's unlikely this fixes those. Anyway, I'll
backport.

root@127.0.0.1:53405/defaultdb> begin; select 1;
root@127.0.0.1:53405/defaultdb  OPEN> prepare x as select 1;
root@127.0.0.1:53405/defaultdb  OPEN> deallocate all;
root@127.0.0.1:53405/defaultdb  OPEN> commit;
root@127.0.0.1:53405/defaultdb> ^D
panic: session: unexpected 10240 leftover bytes

Release note (bug fix): Fix a memory leak around DEALLOCATE and DISCARD
statements that could result in crashes with the "unexpected <amount>
leftover bytes" message.