### PR TITLE
sql: return number of placeholders from parser

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -46,7 +46,7 @@ func descForTable(
 	t *testing.T, create string, parent, id sqlbase.ID, fks fkHandler,
 ) *sqlbase.TableDescriptor {
 	t.Helper()
-	parsed, _, err := parser.Parse(create)
+	parsed, err := parser.Parse(create)
 	if err != nil {
 		t.Fatalf("could not parse %q: %v", create, err)
 	}
@@ -55,8 +55,8 @@ func descForTable(
 	var stmt *tree.CreateTable
 
 	if len(parsed) == 2 {
-		stmt = parsed[1].(*tree.CreateTable)
-		name := parsed[0].(*tree.CreateSequence).Name.String()
+		stmt = parsed[1].AST.(*tree.CreateTable)
+		name := parsed[0].AST.(*tree.CreateSequence).Name.String()
 
 		ts := hlc.Timestamp{WallTime: nanos}
 		priv := sqlbase.NewDefaultPrivilegeDescriptor()
@@ -68,7 +68,7 @@ func descForTable(
 		}
 		fks.resolver[name] = &desc
 	} else {
-		stmt = parsed[0].(*tree.CreateTable)
+		stmt = parsed[0].AST.(*tree.CreateTable)
 	}
 	table, err := MakeSimpleTableDescriptor(context.TODO(), nil, stmt, parent, id, fks, nanos)
 	if err != nil {

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -84,7 +84,7 @@ func (p *postgreStream) Next() (interface{}, error) {
 
 	for p.s.Scan() {
 		t := p.s.Text()
-		stmts, _, err := parser.Parse(t)
+		stmts, err := parser.Parse(t)
 		if err != nil {
 			// Something non-parseable may be something we don't yet parse but still
 			// want to ignore.
@@ -100,7 +100,7 @@ func (p *postgreStream) Next() (interface{}, error) {
 			// If the statement is COPY ... FROM STDIN, set p.copy so the next call to
 			// this function will read copy data. We still return this COPY statement
 			// for this invocation.
-			if cf, ok := stmts[0].(*tree.CopyFrom); ok && cf.Stdin {
+			if cf, ok := stmts[0].AST.(*tree.CopyFrom); ok && cf.Stdin {
 				// Set p.copy which reconfigures the scanner's split func.
 				p.copy = newPostgreStreamCopy(p.s, copyDefaultDelimiter, copyDefaultNull)
 
@@ -116,7 +116,7 @@ func (p *postgreStream) Next() (interface{}, error) {
 					return nil, errors.Errorf("expected empty line")
 				}
 			}
-			return stmts[0], nil
+			return stmts[0].AST, nil
 		default:
 			return nil, errors.Errorf("unexpected: got %d statements", len(stmts))
 		}

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -491,7 +491,7 @@ func (c *cliState) handleFunctionHelp(cmd []string, nextState, errState cliState
 		}
 		fmt.Println()
 	} else {
-		_, _, err := parser.Parse(fmt.Sprintf("select %s(??", funcName))
+		_, err := parser.Parse(fmt.Sprintf("select %s(??", funcName))
 		pgerr, ok := pgerror.GetPGCause(err)
 		if !ok || !strings.HasPrefix(pgerr.Hint, "help:") {
 			fmt.Fprintf(stderr,

--- a/pkg/cli/sqlfmt.go
+++ b/pkg/cli/sqlfmt.go
@@ -47,10 +47,10 @@ func runSQLFmt(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("tab width must be > 0: %d", sqlfmtCtx.tabWidth)
 	}
 
-	var sl tree.StatementList
+	var sl parser.Statements
 	if len(sqlfmtCtx.execStmts) != 0 {
 		for _, exec := range sqlfmtCtx.execStmts {
-			stmts, _, err := parser.Parse(exec)
+			stmts, err := parser.Parse(exec)
 			if err != nil {
 				return err
 			}
@@ -61,7 +61,7 @@ func runSQLFmt(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		sl, _, err = parser.Parse(string(in))
+		sl, err = parser.Parse(string(in))
 		if err != nil {
 			return err
 		}
@@ -77,8 +77,8 @@ func runSQLFmt(cmd *cobra.Command, args []string) error {
 		cfg.Align = tree.PrettyAlignAndDeindent
 	}
 
-	for _, s := range sl {
-		fmt.Print(cfg.Pretty(s))
+	for i := range sl {
+		fmt.Print(cfg.Pretty(sl[i].AST))
 		if len(sl) > 1 {
 			fmt.Print(";")
 		}

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1284,7 +1284,7 @@ func (s *adminServer) QueryPlan(
 
 	// As long as there's only one query provided it's safe to construct the
 	// explain query.
-	stmts, _, err := parser.Parse(req.Query)
+	stmts, err := parser.Parse(req.Query)
 	if err != nil {
 		return nil, s.serverError(err)
 	}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1027,10 +1027,10 @@ func anonymizeStmtAndConstants(stmt tree.Statement) string {
 func AnonymizeStatementsForReporting(action, sqlStmts string, r interface{}) error {
 	var anonymized []string
 	{
-		stmts, _, err := parser.Parse(sqlStmts)
+		stmts, err := parser.Parse(sqlStmts)
 		if err == nil {
-			for _, stmt := range stmts {
-				anonymized = append(anonymized, anonymizeStmtAndConstants(stmt))
+			for i := range stmts {
+				anonymized = append(anonymized, anonymizeStmtAndConstants(stmts[i].AST))
 			}
 		}
 	}

--- a/pkg/sql/lex/encode_test.go
+++ b/pkg/sql/lex/encode_test.go
@@ -73,7 +73,7 @@ func testEncodeString(t *testing.T, input []byte, encode func(*bytes.Buffer, str
 			t.Fatalf("unprintable character: %v (%v): %s %v", ch, input, sql, []byte(sql))
 		}
 	}
-	stmts, _, err := parser.Parse(sql)
+	stmts, err := parser.Parse(sql)
 	if err != nil {
 		t.Fatalf("%s: expected success, but found %s", sql, err)
 	}

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -529,7 +529,7 @@ func (ls *logicStatement) readSQL(
 		if !hasVars {
 			newSyntax, err := func(inSql string) (string, error) {
 				// Can't rewrite the SQL otherwise because the vars make it invalid.
-				stmtList, _, err := parser.Parse(inSql)
+				stmtList, err := parser.Parse(inSql)
 				if err != nil {
 					if ls.expectErr != "" {
 						// Maybe a parse error was expected. Simply do not rewrite.
@@ -542,11 +542,11 @@ func (ls *logicStatement) readSQL(
 				pcfg.LineWidth = *sqlfmtLen
 				pcfg.Simplify = false
 				pcfg.UseTabs = false
-				for i, s := range stmtList {
+				for i := range stmtList {
 					if i > 0 {
 						fmt.Fprintln(&newSyntax, ";")
 					}
-					fmt.Fprint(&newSyntax, pcfg.Pretty(s))
+					fmt.Fprint(&newSyntax, pcfg.Pretty(stmtList[i].AST))
 				}
 				return newSyntax.String(), nil
 			}(ls.sql)

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -393,7 +393,7 @@ func TestContextualHelp(t *testing.T) {
 	// The following checks that the grammar rules properly report help.
 	for _, test := range testData {
 		t.Run(test.input, func(t *testing.T) {
-			_, _, err := Parse(test.input)
+			_, err := Parse(test.input)
 			if err == nil {
 				t.Fatalf("parser didn't trigger error")
 			}
@@ -421,7 +421,7 @@ func TestHelpKeys(t *testing.T) {
 	// checks that the parser renders the correct help message.
 	for key, body := range HelpMessages {
 		t.Run(key, func(t *testing.T) {
-			_, _, err := Parse(key + " ??")
+			_, err := Parse(key + " ??")
 			if err == nil {
 				t.Errorf("parser didn't trigger error")
 				return

--- a/pkg/sql/parser/lexer.go
+++ b/pkg/sql/parser/lexer.go
@@ -37,8 +37,10 @@ type lexer struct {
 	// token returned by Lex().
 	lastPos int
 
-	stmt      tree.Statement
-	lastError *parseErr
+	stmt tree.Statement
+	// numPlaceholders is 1 + the highest placeholder index encountered.
+	numPlaceholders int
+	lastError       *parseErr
 }
 
 func (l *lexer) init(
@@ -48,6 +50,7 @@ func (l *lexer) init(
 	l.tokens = tokens
 	l.lastPos = -1
 	l.stmt = nil
+	l.numPlaceholders = 0
 	l.lastError = nil
 
 	l.nakedIntType = nakedIntType
@@ -122,6 +125,18 @@ func (l *lexer) lastToken() sqlSymType {
 		}
 	}
 	return l.tokens[l.lastPos]
+}
+
+// SetStmt is called from the parser when the statement is constructed.
+func (l *lexer) SetStmt(stmt tree.Statement) {
+	l.stmt = stmt
+}
+
+// UpdateNumPlaceholders is called from the parser when a placeholder is constructed.
+func (l *lexer) UpdateNumPlaceholders(p *tree.Placeholder) {
+	if n := int(p.Idx) + 1; l.numPlaceholders < n {
+		l.numPlaceholders = n
+	}
 }
 
 // parseErr holds parsing error state.

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -42,6 +42,16 @@ type Statement struct {
 	// is not appropriate for use in logging, as it may contain passwords and
 	// other sensitive data.
 	SQL string
+
+	// NumPlaceholders indicates the number of arguments to the statement (which
+	// are referenced through placeholders). This corresponds to the highest
+	// argument position (i.e. the x in "$x") that appears in the query.
+	//
+	// Note: where there are "gaps" in the placeholder positions, this number is
+	// based on the highest position encountered. For example, for `SELECT $3`,
+	// NumPlaceholders is 3. These cases are malformed and will result in a
+	// type-check error.
+	NumPlaceholders int
 }
 
 // Statements is a list of parsed statements.
@@ -152,11 +162,8 @@ func (p *Parser) parseWithDepth(
 		if err != nil {
 			return nil, err
 		}
-		if stmt != nil {
-			stmts = append(stmts, Statement{
-				AST: stmt,
-				SQL: sql,
-			})
+		if stmt.AST != nil {
+			stmts = append(stmts, stmt)
 		}
 		if done {
 			break
@@ -172,7 +179,7 @@ func (p *Parser) parse(
 	tokens []sqlSymType,
 	nakedIntType *coltypes.TInt,
 	nakedSerialType *coltypes.TSerial,
-) (tree.Statement, error) {
+) (Statement, error) {
 	p.lexer.init(sql, tokens, nakedIntType, nakedSerialType)
 	defer p.lexer.cleanup()
 	if p.parserImpl.Parse(&p.lexer) != 0 {
@@ -192,9 +199,13 @@ func (p *Parser) parse(
 			err.Hint = lastError.hint
 		}
 		err.Detail = lastError.detail
-		return nil, err
+		return Statement{}, err
 	}
-	return p.lexer.stmt, nil
+	return Statement{
+		AST:             p.lexer.stmt,
+		SQL:             sql,
+		NumPlaceholders: p.lexer.numPlaceholders,
+	}, nil
 }
 
 // unaryNegation constructs an AST node for a negation. This attempts

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1246,12 +1246,9 @@ func TestParse(t *testing.T) {
 	var p parser.Parser // Verify that the same parser can be reused.
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {
-			stmts, strs, err := p.Parse(d.sql)
+			stmts, err := p.Parse(d.sql)
 			if err != nil {
 				t.Fatalf("%s: expected success, but found %s", d.sql, err)
-			}
-			if len(strs) == 1 && strs[0] != d.sql {
-				t.Errorf("expected string %s, got %s", d.sql, strs[0])
 			}
 			s := stmts.String()
 			if d.sql != s {
@@ -1259,18 +1256,6 @@ func TestParse(t *testing.T) {
 			}
 			sqlutils.VerifyStatementPrettyRoundtrip(t, d.sql)
 		})
-		stmts, strs, err := p.Parse(d.sql)
-		if err != nil {
-			t.Fatalf("%s: expected success, but found %s", d.sql, err)
-		}
-		if len(strs) == 1 && strs[0] != d.sql {
-			t.Errorf("expected string %s, got %s", d.sql, strs[0])
-		}
-		s := stmts.String()
-		if d.sql != s {
-			t.Errorf("expected \n%q\n, but found \n%q", d.sql, s)
-		}
-		sqlutils.VerifyStatementPrettyRoundtrip(t, d.sql)
 	}
 }
 
@@ -1987,16 +1972,16 @@ func TestParse2(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {
-			stmts, _, err := parser.Parse(d.sql)
+			stmts, err := parser.Parse(d.sql)
 			if err != nil {
 				t.Errorf("%s: expected success, but found %s", d.sql, err)
 				return
 			}
-			s := tree.AsStringWithFlags(&stmts, tree.FmtShowPasswords)
+			s := stmts.StringWithFlags(tree.FmtShowPasswords)
 			if d.expected != s {
 				t.Errorf("%s: expected %s, but found (%d statements): %s", d.sql, d.expected, len(stmts), s)
 			}
-			if _, _, err := parser.Parse(s); err != nil {
+			if _, err := parser.Parse(s); err != nil {
 				t.Errorf("expected string found, but not parsable: %s:\n%s", err, s)
 			}
 			sqlutils.VerifyStatementPrettyRoundtrip(t, d.expected)
@@ -2021,16 +2006,16 @@ func TestParseTree(t *testing.T) {
 
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {
-			stmts, _, err := parser.Parse(d.sql)
+			stmts, err := parser.Parse(d.sql)
 			if err != nil {
 				t.Errorf("%s: expected success, but found %s", d.sql, err)
 				return
 			}
-			s := tree.AsStringWithFlags(&stmts, tree.FmtAlwaysGroupExprs)
+			s := stmts.StringWithFlags(tree.FmtAlwaysGroupExprs)
 			if d.expected != s {
 				t.Errorf("%s: expected %s, but found (%d statements): %s", d.sql, d.expected, len(stmts), s)
 			}
-			if _, _, err := parser.Parse(s); err != nil {
+			if _, err := parser.Parse(s); err != nil {
 				t.Errorf("expected string found, but not parsable: %s:\n%s", err, s)
 			}
 			sqlutils.VerifyStatementPrettyRoundtrip(t, d.expected)
@@ -2052,7 +2037,7 @@ func TestParseSyntax(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {
-			if _, _, err := parser.Parse(d.sql); err != nil {
+			if _, err := parser.Parse(d.sql); err != nil {
 				t.Fatalf("%s: expected success, but not parsable %s", d.sql, err)
 			}
 			sqlutils.VerifyStatementPrettyRoundtrip(t, d.sql)
@@ -2479,7 +2464,7 @@ HINT: try \h SELECT`,
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {
-			_, _, err := parser.Parse(d.sql)
+			_, err := parser.Parse(d.sql)
 			if err == nil {
 				t.Errorf("expected error, got nil for:\n%s", d.sql)
 				return
@@ -2516,7 +2501,7 @@ func TestParsePanic(t *testing.T) {
 		"(F(F(F(F(F(F(F(F(F(F" +
 		"(F(F(F(F(F(F(F(F(F((" +
 		"F(0"
-	_, _, err := parser.Parse(s)
+	_, err := parser.Parse(s)
 	expected := `syntax error at or near "EOF"`
 	if !testutils.IsError(err, expected) {
 		t.Fatalf("expected %s, but found %v", expected, err)
@@ -2894,7 +2879,7 @@ func TestUnimplementedSyntax(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.sql, func(t *testing.T) {
-			_, _, err := parser.Parse(d.sql)
+			_, err := parser.Parse(d.sql)
 			if err == nil {
 				t.Errorf("%s: expected error, got nil", d.sql)
 				return
@@ -2926,6 +2911,38 @@ func TestUnimplementedSyntax(t *testing.T) {
 				if !strings.HasSuffix(pgerr.Hint, exp2) {
 					t.Errorf("%s: expected %q at end of hint, got %q", d.sql, exp2, pgerr.Hint)
 				}
+			}
+		})
+	}
+}
+
+// TestParseSQL verifies that Statement.SQL is set correctly.
+func TestParseSQL(t *testing.T) {
+	testData := []struct {
+		in  string
+		exp []string
+	}{
+		{in: ``, exp: nil},
+		{in: `SELECT 1`, exp: []string{`SELECT 1`}},
+		{in: `SELECT 1;`, exp: []string{`SELECT 1`}},
+		{in: `SELECT 1 /* comment */`, exp: []string{`SELECT 1`}},
+		{in: `SELECT 1;SELECT 2`, exp: []string{`SELECT 1`, `SELECT 2`}},
+		{in: `SELECT 1 /* comment */ ;SELECT 2`, exp: []string{`SELECT 1`, `SELECT 2`}},
+		{in: `SELECT 1 /* comment */ ; /* comment */ SELECT 2`, exp: []string{`SELECT 1`, `SELECT 2`}},
+	}
+	var p parser.Parser // Verify that the same parser can be reused.
+	for _, d := range testData {
+		t.Run(d.in, func(t *testing.T) {
+			stmts, err := p.Parse(d.in)
+			if err != nil {
+				t.Fatalf("expected success, but found %s", err)
+			}
+			var res []string
+			for i := range stmts {
+				res = append(res, stmts[i].SQL)
+			}
+			if !reflect.DeepEqual(res, d.exp) {
+				t.Errorf("expected \n%v\n, but found %v", res, d.exp)
 			}
 		})
 	}
@@ -2966,8 +2983,7 @@ func BenchmarkParse(b *testing.B) {
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, _, err := parser.Parse(tc.query)
-				if err != nil {
+				if _, err := parser.Parse(tc.query); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1031,7 +1031,7 @@ func newNameFromStr(s string) *tree.Name {
 stmt_block:
   stmt
   {
-    sqllex.(*lexer).stmt = $1.stmt()
+    sqllex.(*lexer).SetStmt($1.stmt())
   }
 
 stmt:
@@ -1815,7 +1815,9 @@ string_or_placeholder:
   }
 | PLACEHOLDER
   {
-    $$.val = $1.placeholder()
+    p := $1.placeholder()
+    sqllex.(*lexer).UpdateNumPlaceholders(p)
+    $$.val = p
   }
 
 string_or_placeholder_list:
@@ -7560,7 +7562,9 @@ d_expr:
   }
 | PLACEHOLDER
   {
-    $$.val = $1.placeholder()
+    p := $1.placeholder()
+    sqllex.(*lexer).UpdateNumPlaceholders(p)
+    $$.val = p
   }
 // TODO(knz/jordan): extend this for compound types. See explanation above.
 | '(' a_expr ')' '.' '*'

--- a/pkg/sql/sem/builtins/help_test.go
+++ b/pkg/sql/sem/builtins/help_test.go
@@ -31,7 +31,7 @@ func TestHelpFunctions(t *testing.T) {
 			continue
 		}
 		t.Run(f, func(t *testing.T) {
-			_, _, err := parser.Parse("select " + f + "(??")
+			_, err := parser.Parse("select " + f + "(??")
 			if err == nil {
 				t.Errorf("parser didn't trigger error")
 				return

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -411,7 +411,7 @@ func BenchmarkFormatRandomStatements(b *testing.B) {
 		b.Fatalf("error instantiating RSG: %v", err)
 	}
 	strs := make([]string, 1000)
-	stmts := make(tree.StatementList, 1000)
+	stmts := make([]tree.Statement, 1000)
 	for i := 0; i < 1000; {
 		rdm := r.Generate("stmt", 20)
 		stmt, err := parser.ParseOne(rdm)

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -153,19 +153,6 @@ type IndependentFromParallelizedPriors interface {
 	independentFromParallelizedPriors()
 }
 
-// StatementList is a list of statements.
-type StatementList []Statement
-
-// Format implements the NodeFormatter interface.
-func (l *StatementList) Format(ctx *FmtCtx) {
-	for i, s := range *l {
-		if i > 0 {
-			ctx.WriteString("; ")
-		}
-		ctx.FormatNode(s)
-	}
-}
-
 // ObserverStatement is a marker interface for statements which are allowed to
 // run regardless of the current transaction state: statements other than
 // rollback are generally rejected if the session is in a failed transaction
@@ -920,7 +907,6 @@ func (n *ShowVar) String() string                   { return AsString(n) }
 func (n *ShowZoneConfig) String() string            { return AsString(n) }
 func (n *ShowFingerprints) String() string          { return AsString(n) }
 func (n *Split) String() string                     { return AsString(n) }
-func (l *StatementList) String() string             { return AsString(l) }
 func (n *Truncate) String() string                  { return AsString(n) }
 func (n *UnionClause) String() string               { return AsString(n) }
 func (n *Update) String() string                    { return AsString(n) }

--- a/pkg/sql/show_syntax.go
+++ b/pkg/sql/show_syntax.go
@@ -81,7 +81,7 @@ func runShowSyntax(
 	report func(ctx context.Context, field, msg string) error,
 	reportErr func(err error),
 ) error {
-	stmts, _, err := parser.Parse(stmt)
+	stmts, err := parser.Parse(stmt)
 	if err != nil {
 		if reportErr != nil {
 			reportErr(err)
@@ -125,8 +125,9 @@ func runShowSyntax(
 			}
 		}
 	} else {
-		for _, stmt := range stmts {
-			if err := report(ctx, "sql", tree.AsStringWithFlags(stmt, tree.FmtParsable)); err != nil {
+		for i := range stmts {
+			str := tree.AsStringWithFlags(stmts[i].AST, tree.FmtParsable)
+			if err := report(ctx, "sql", str); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -48,17 +48,17 @@ var (
 )
 
 func verifyFormat(sql string) error {
-	stmts, _, err := parser.Parse(sql)
+	stmts, err := parser.Parse(sql)
 	if err != nil {
 		// Cannot serialize a statement list without parsing it.
 		return nil
 	}
-	formattedSQL := tree.AsStringWithFlags(&stmts, tree.FmtShowPasswords)
-	formattedStmts, _, err := parser.Parse(formattedSQL)
+	formattedSQL := stmts.StringWithFlags(tree.FmtShowPasswords)
+	formattedStmts, err := parser.Parse(formattedSQL)
 	if err != nil {
 		return errors.Wrapf(err, "cannot parse output of Format: sql=%q, formattedSQL=%q", sql, formattedSQL)
 	}
-	formattedFormattedSQL := tree.AsStringWithFlags(&formattedStmts, tree.FmtShowPasswords)
+	formattedFormattedSQL := formattedStmts.StringWithFlags(tree.FmtShowPasswords)
 	if formattedSQL != formattedFormattedSQL {
 		return errors.Errorf("Parse followed by Format is not idempotent: %q -> %q != %q", sql, formattedSQL, formattedFormattedSQL)
 	}

--- a/pkg/testutils/sqlutils/pretty.go
+++ b/pkg/testutils/sqlutils/pretty.go
@@ -26,14 +26,15 @@ import (
 func VerifyStatementPrettyRoundtrip(t *testing.T, sql string) {
 	t.Helper()
 
-	stmts, _, err := parser.Parse(sql)
+	stmts, err := parser.Parse(sql)
 	if err != nil {
 		t.Fatalf("%s: %s", err, sql)
 	}
 	cfg := tree.DefaultPrettyCfg()
 	// Be careful to not simplify otherwise the tests won't round trip.
 	cfg.Simplify = false
-	for _, origStmt := range stmts {
+	for i := range stmts {
+		origStmt := stmts[i].AST
 		// Be careful to not simplify otherwise the tests won't round trip.
 		prettyStmt := cfg.Pretty(origStmt)
 		parsedPretty, err := parser.ParseOne(prettyStmt)


### PR DESCRIPTION
#### sql: replace StatementList with parser.Statements

This change consolidates the AST and the SQL string (both returned by
the parser) in a `tree.Statement` structure. This makes the API
cleaner, and allows adding more information about the statement in the
future.

Release note: None

#### sql: return number of placeholders from parser

The parser now returns the number of placeholders in the statement.
This is calculated during parsing, as 1 plus the highest placeholder
index encountered.

This is to be used in a later change to replace placeholder maps with
slices.

Release note: None
