### PR TITLE
sql: fix omitted columns bug in wrapped plans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/statement_source
+++ b/pkg/sql/logictest/testdata/logic_test/statement_source
@@ -1,4 +1,4 @@
-# LogicTest: local local-opt local-parallel-stmts
+# LogicTest: local local-opt local-parallel-stmts fakedist fakedist-opt
 
 statement ok
 CREATE TABLE a (a INT PRIMARY KEY, b INT)

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -106,23 +106,7 @@ func (p *planNodeToRowSource) SetInput(ctx context.Context, input distsqlrun.Row
 	return walkPlan(ctx, p.node, planObserver{
 		replaceNode: func(ctx context.Context, nodeName string, plan planNode) (planNode, error) {
 			if plan == p.firstNotWrapped {
-				cols := planColumns(p.firstNotWrapped)
-				nOmitted := 0
-				for i := range cols {
-					if cols[i].Omitted {
-						nOmitted++
-					}
-				}
-				if nOmitted > 0 {
-					newCols := make(sqlbase.ResultColumns, 0, len(cols)-nOmitted)
-					for i := range cols {
-						if !cols[i].Omitted {
-							newCols = append(newCols, cols[i])
-						}
-					}
-					cols = newCols
-				}
-				return makeRowSourceToPlanNode(input, p, cols, p.firstNotWrapped), nil
+				return makeRowSourceToPlanNode(input, p, planColumns(p.firstNotWrapped), p.firstNotWrapped), nil
 			}
 			return nil, nil
 		},

--- a/pkg/sql/row_source_to_plan_node.go
+++ b/pkg/sql/row_source_to_plan_node.go
@@ -54,7 +54,7 @@ func makeRowSourceToPlanNode(
 	planCols sqlbase.ResultColumns,
 	originalPlanNode planNode,
 ) *rowSourceToPlanNode {
-	row := make(tree.Datums, len(s.OutputTypes()))
+	row := make(tree.Datums, len(planCols))
 
 	return &rowSourceToPlanNode{
 		source:           s,
@@ -95,9 +95,22 @@ func (r *rowSourceToPlanNode) Next(params runParams) (bool, error) {
 			return false, nil
 		}
 
-		if err := sqlbase.EncDatumRowToDatums(r.source.OutputTypes(), r.datumRow, r.row, &r.da); err != nil {
-			return false, err
+		idx := 0
+		types := r.source.OutputTypes()
+		for i, col := range r.planCols {
+			if col.Omitted {
+				r.datumRow[i] = tree.DNull
+				continue
+			}
+			encDatum := r.row[idx]
+			err := encDatum.EnsureDecoded(&types[i], &r.da)
+			if err != nil {
+				return false, err
+			}
+			r.datumRow[i] = encDatum.Datum
+			idx++
 		}
+
 		return true, nil
 	}
 }


### PR DESCRIPTION
Previously, the RowSource wrapping planNode incorrectly reported its
columns as not containing any of its potentially omitted columns, the
way DistSQL does. This violates the assumption of the planNode
infrastructure - that omitted columns will always be present in the row,
just marked NULL.

The fix in #30942 was supposed to accomplish this but it was incorrect,
and didn't actually solve the regression cases due to the fact that
the `local` config still means `distsql=2.0-off` rather than
`distsql=off` as it should. This will be corrected very soon - in fact
I discovered this bug while trying to flip the meaning to `=off`.

Release note (bug fix): prevent a crash with certain queries that use
the statement source (square bracket) syntax.