### PR TITLE
roachtest: always get the logs

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -1064,7 +1064,10 @@ func (r *registry) runAsync(
 				if err := c.FetchDebugZip(ctx); err != nil {
 					c.l.Printf("failed to download debug zip: %s", err)
 				}
-			} else {
+				// NB: fetch the logs even when we have a debug zip because
+				// debug zip can't ever get the logs for down nodes.
+				// We only save artifacts for failed tests in CI, so this
+				// duplication is acceptable.
 				if err := c.FetchLogs(ctx); err != nil {
 					c.l.Printf("failed to download logs: %s", err)
 				}


### PR DESCRIPTION
`debug zip` can't download the logs reliably, for example when the
target node is dead.

Touches #33485.

Release note: None