### PR TITLE
sql: refactor usage of placeholder TypeHints

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1193,9 +1193,11 @@ func (ex *connExecutor) run(
 			ex.curStmt = portal.Stmt.Statement
 
 			*pinfo = tree.PlaceholderInfo{
-				TypeHints: portal.Stmt.TypeHints,
-				Types:     portal.Stmt.Types,
-				Values:    portal.Qargs,
+				PlaceholderTypesInfo: tree.PlaceholderTypesInfo{
+					TypeHints: portal.Stmt.TypeHints,
+					Types:     portal.Stmt.Types,
+				},
+				Values: portal.Qargs,
 			}
 
 			ex.phaseTimes[sessionQueryReceived] = tcmd.TimeReceived

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -509,11 +509,11 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 			tb.Fatalf("%v", err)
 		}
 
-		var texpr tree.TypedExpr
 		id := types.PlaceholderIdx(i)
-		texpr, err = sqlbase.SanitizeVarFreeExpr(
+		typ, _ := h.semaCtx.Placeholders.ValueType(id)
+		texpr, err := sqlbase.SanitizeVarFreeExpr(
 			parg,
-			h.semaCtx.Placeholders.TypeHints[id],
+			typ,
 			"", /* context */
 			&h.semaCtx,
 			&h.evalCtx,

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -44,14 +44,9 @@ type PreparedStatement struct {
 	// during prepare of a SQL statement. It can significantly speed up execution
 	// if it is used by the optimizer as a starting point.
 	Memo *memo.Memo
-	// TypeHints contains the types of the placeholders set by the client. It
-	// dictates how input parameters for those placeholders will be parsed. If a
-	// placeholder has no type hint, it will be populated during type checking.
-	TypeHints tree.PlaceholderTypes
-	// Types contains the final types of the placeholders, after type checking.
-	// These may differ from the types in TypeHints, if a user provides an
-	// imprecise type hint like sending an int for an oid comparison.
-	Types   tree.PlaceholderTypes
+
+	tree.PlaceholderTypesInfo
+
 	Columns sqlbase.ResultColumns
 
 	// InTypes represents the inferred types for placeholder, using protocol

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3988,7 +3988,7 @@ func (t *Placeholder) Eval(ctx *EvalContext) (Datum, error) {
 	}
 	// Placeholder expressions cannot contain other placeholders, so we do
 	// not need to recurse.
-	typ, typed := ctx.Placeholders.Type(t.Idx, false)
+	typ, typed := ctx.Placeholders.Types[t.Idx]
 	if !typed {
 		// All placeholders should be typed at this point.
 		return nil, pgerror.NewAssertionErrorf("missing type for placeholder %s", t)

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1296,7 +1296,7 @@ func (expr *Placeholder) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr
 	// when there are no available values for the placeholders yet, because
 	// during Execute all placeholders are replaced from the AST before type
 	// checking.
-	if typ, ok := ctx.Placeholders.Type(expr.Idx, true); ok {
+	if typ, ok := ctx.Placeholders.Type(expr.Idx); ok {
 		if !desired.Equivalent(typ) {
 			// This indicates there's a conflict between what the type system thinks
 			// the type for this position should be, and the actual type of the

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -16,6 +16,7 @@ package tree_test
 
 import (
 	"context"
+	"fmt"
 	"go/constant"
 	"go/token"
 	"reflect"
@@ -177,7 +178,7 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 	}
 	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
 		ctx := tree.MakeSemaContext(false)
-		ctx.Placeholders.SetTypeHints(clonePlaceholderTypes(test.ptypes))
+		ctx.Placeholders.Reset(clonePlaceholderTypes(test.ptypes))
 		desired := types.Any
 		if test.desired != nil {
 			desired = test.desired
@@ -252,7 +253,9 @@ func TestTypeCheckSameTypedExprs(t *testing.T) {
 		{nil, types.Decimal, exprs(intConst("1"), placeholder(1)), types.Decimal, mapPTypesDecimal},
 		{nil, types.Decimal, exprs(decConst("1.1"), placeholder(1)), types.Decimal, mapPTypesDecimal},
 	} {
-		attemptTypeCheckSameTypedExprs(t, i, d)
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			attemptTypeCheckSameTypedExprs(t, i, d)
+		})
 	}
 }
 
@@ -316,7 +319,7 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 	}
 	for i, d := range testData {
 		ctx := tree.MakeSemaContext(false)
-		ctx.Placeholders.SetTypeHints(d.ptypes)
+		ctx.Placeholders.Reset(d.ptypes)
 		desired := types.Any
 		if d.desired != nil {
 			desired = d.desired


### PR DESCRIPTION
Currently, `TypeHints` starts out with any placeholder type hints
provided and the types of the other placeholders are subsequently
populated (during type-checking). The "final" types of all
placeholders are also in `Types`. The final type can differ from the
type hint: in some cases, the hint is overridden (see the description
of https://github.com/cockroachdb/cockroach/commit/35279d8ec544c4977aec8c296256acf63856c363 for more information about this).

The information that gets added to `TypeHints` is redundant with
`Types`. This change refactors the usage so that the type hints are
never modified. This will help with plan caching, where we want to
check that the same type hints were provided (between the current
statement and the cached information).

Release note: None