### PR TITLE
storage: reduce log spam from MaybeGossipSystemConfig

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -6553,8 +6553,8 @@ func (r *Replica) shouldGossip() bool {
 }
 
 // MaybeGossipSystemConfig scans the entire SystemConfig span and gossips it.
-// The first call is on NewReplica. Further calls come from the trigger on
-// EndTransaction or range lease acquisition.
+// Further calls come from the trigger on EndTransaction or range lease
+// acquisition.
 //
 // Note that MaybeGossipSystemConfig gossips information only when the
 // lease is actually held. The method does not request a range lease
@@ -6576,7 +6576,7 @@ func (r *Replica) MaybeGossipSystemConfig(ctx context.Context) error {
 		return nil
 	}
 	if !r.ContainsKey(keys.SystemConfigSpan.Key) {
-		log.VEventf(ctx, 2,
+		log.VEventf(ctx, 3,
 			"not gossiping system config because the replica doesn't contain the system config's start key")
 		return nil
 	}


### PR DESCRIPTION
All replicas were logging at level 2 the fact that they're not the ones
who should be gossipping the system config. I've increased it to 3 to
separate it since it's a way more common message than others around at
level 2 (most replias are not in charge of the system config).

Also remove a stale comment.

Release note: None