### PR TITLE
sql: fix a crash when an INSERT ON CONFLICT SET UPDATE uses the resul…

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -753,3 +753,4 @@ SELECT * FROM ex33313 ORDER BY foo
 foo  bar  baz
 1    1    1
 3    2    2
+

--- a/pkg/sql/logictest/testdata/planner_test/upsert
+++ b/pkg/sql/logictest/testdata/planner_test/upsert
@@ -141,3 +141,23 @@ id   a
 
 statement ok
 DROP TABLE test_table;
+
+subtest regression_32473
+
+statement ok
+CREATE TABLE customers (
+  customer_id serial PRIMARY KEY,
+  name VARCHAR UNIQUE,
+  email VARCHAR NOT NULL
+);
+
+# The heuristic planner does not support non-tuple expressions on the RHS, throwing
+# a planning error immediately.
+statement error unimplemented: cannot use this type of expression on the right of UPDATE SET
+INSERT INTO customers (name, email) VALUES ('bob', 'bob@email.com') ON CONFLICT (name)
+  DO UPDATE SET (name, email) = (
+    SELECT 'bob', 'otherbob@email.com'
+  )
+
+statement ok
+DROP TABLE customers

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -64,3 +64,38 @@ querying next range at /Table/54/1/1/1/1
 r20: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 1
+
+subtest regression_32473
+
+statement ok
+CREATE TABLE customers (
+  customer_id serial PRIMARY KEY,
+  name VARCHAR UNIQUE,
+  email VARCHAR NOT NULL
+);
+
+statement ok
+INSERT INTO customers (name, email) VALUES ('bob', 'bob@email.com') ON CONFLICT (name)
+  DO UPDATE SET (name, email) = (
+    SELECT 'bob', 'otherbob@email.com'
+  )
+
+query TT
+SELECT name, email FROM customers
+----
+bob  bob@email.com
+
+# This statement only works with the optimizer enabled.
+statement ok
+INSERT INTO customers (name, email) VALUES ('bob', 'bob@email.com') ON CONFLICT (name)
+  DO UPDATE SET (name, email) = (
+    SELECT 'bob2', 'otherbob@email.com'
+  )
+
+query TT
+SELECT name, email FROM customers
+----
+bob2  otherbob@email.com
+
+statement ok
+DROP TABLE customers


### PR DESCRIPTION
…ts of a subquery

The upsert path did not perform the subquery analysis so there was no typing
available for the subquery.

Note that only with the optimizer enabled does this correctly perform the
SET UPDATE path.

Fixes #32473.

Release note(bug fix): Fixed a crash that occurred when performing an INSERT ON
CONFLICT with a SET UPDATE that uses values from a subquery.