### PR TITLE
storage/rangefeed: per registration buffer

### DIFF
--- a/pkg/storage/replica_rangefeed.go
+++ b/pkg/storage/replica_rangefeed.go
@@ -198,7 +198,7 @@ func (r *Replica) maybeInitRangefeedRaftMuLocked() *rangefeed.Processor {
 		Clock:            r.Clock(),
 		Span:             desc.RSpan(),
 		TxnPusher:        &tp,
-		EventChanCap:     4096,
+		EventChanCap:     256,
 		EventChanTimeout: 50 * time.Millisecond,
 	}
 	r.raftMu.rangefeed = rangefeed.NewProcessor(cfg)


### PR DESCRIPTION
Modifies the rangefeed package so that each individual registration
maintains an output buffer which is processed by a dedicated goroutine.
This eliminates the possibility of a slow consumer blocking the
processor from making progress.

Previously, writing events to registrations was synchronous, meaning
that a single slow consumer could cause the publishing process to block.
If publishing was blocked for too long, the processor along with all
registrations were immediately torn down. With this change, a slow
consumer will no longer block its siblings; if a single consumer blocks
for too long, it will enter an "overflow" state and will be torn down as
  soon as its existing buffer is fully processed.

The registry/registration interface has been modified fairly
significantly to accomodate this; the processor itself has seen modest
modification (mostly moving functionality to the registry level and
removing no-longer-needed support for the previous functionality). Some
of the processor tests have been modified to account for the now
asynchronous nature of publishing events to individual streams.

Fixes #32945

Release note: None