### PR TITLE
sql: fix the collection of logical plan samples

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -111,7 +111,7 @@ const saveFingerprintPlanOnceEvery = 1000
 //
 // samplePlanDescription can be nil, as these are only sampled periodically per unique fingerprint.
 func (a *appStats) recordStatement(
-	stmt Statement,
+	stmt *Statement,
 	samplePlanDescription *roachpb.ExplainTreePlanNode,
 	distSQLUsed bool,
 	optUsed bool,
@@ -157,7 +157,7 @@ func (a *appStats) recordStatement(
 
 // getStatsForStmt retrieves the per-stmt stat object.
 func (a *appStats) getStatsForStmt(
-	stmt Statement, distSQLUsed bool, optimizerUsed bool, err error, createIfNonexistent bool,
+	stmt *Statement, distSQLUsed bool, optimizerUsed bool, err error, createIfNonexistent bool,
 ) *stmtStats {
 	// Extend the statement key with various characteristics, so
 	// that we use separate buckets for the different situations.
@@ -185,7 +185,7 @@ func (a *appStats) getStatsForStmtWithKey(key stmtKey, createIfNonexistent bool)
 	return s
 }
 
-func anonymizeStmt(stmt Statement) string {
+func anonymizeStmt(stmt *Statement) string {
 	return tree.AsStringWithFlags(stmt.AST, tree.FmtHideConstants)
 }
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1994,7 +1994,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 //
 // If an error is returned, it is to be considered a query execution error.
 func (ex *connExecutor) initStatementResult(
-	ctx context.Context, res RestrictedCommandResult, stmt Statement, cols sqlbase.ResultColumns,
+	ctx context.Context, res RestrictedCommandResult, stmt *Statement, cols sqlbase.ResultColumns,
 ) error {
 	for _, c := range cols {
 		if err := checkResultType(c.Typ); err != nil {

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -142,7 +142,7 @@ func (ex *connExecutor) prepare(
 		return prepared, nil
 	}
 	prepared.Statement = stmt.Statement
-	prepared.AnonymizedStr = anonymizeStmt(stmt)
+	prepared.AnonymizedStr = anonymizeStmt(&stmt)
 
 	// Point to the prepared state, which can be further populated during query
 	// preparation.
@@ -160,7 +160,8 @@ func (ex *connExecutor) prepare(
 
 	p := &ex.planner
 	ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTimestamp */)
-	flags, err := ex.populatePrepared(ctx, txn, stmt, placeholderHints, p)
+	p.stmt = &stmt
+	flags, err := ex.populatePrepared(ctx, txn, placeholderHints, p)
 	if err != nil {
 		txn.CleanupOnError(ctx, err)
 		return nil, err
@@ -180,12 +181,9 @@ func (ex *connExecutor) prepare(
 // populatePrepared analyzes and type-checks the query and populates
 // stmt.Prepared.
 func (ex *connExecutor) populatePrepared(
-	ctx context.Context,
-	txn *client.Txn,
-	stmt Statement,
-	placeholderHints tree.PlaceholderTypes,
-	p *planner,
+	ctx context.Context, txn *client.Txn, placeholderHints tree.PlaceholderTypes, p *planner,
 ) (planFlags, error) {
+	stmt := p.stmt
 	if err := p.semaCtx.Placeholders.Init(stmt.NumPlaceholders, placeholderHints); err != nil {
 		return 0, err
 	}
@@ -221,7 +219,7 @@ func (ex *connExecutor) populatePrepared(
 	if optMode := ex.sessionData.OptimizerMode; optMode != sessiondata.OptimizerOff {
 		log.VEvent(ctx, 2, "preparing using optimizer")
 		var err error
-		flags, isCorrelated, err = p.prepareUsingOptimizer(ctx, stmt)
+		flags, isCorrelated, err = p.prepareUsingOptimizer(ctx)
 		if err == nil {
 			log.VEvent(ctx, 2, "optimizer prepare succeeded")
 			// stmt.Prepared fields have been populated.
@@ -231,7 +229,7 @@ func (ex *connExecutor) populatePrepared(
 		if !canFallbackFromOpt(err, optMode, stmt) {
 			return 0, err
 		}
-		flags = planFlagOptFallback
+		flags.Set(planFlagOptFallback)
 		log.VEvent(ctx, 1, "prepare falls back on heuristic planner")
 	} else {
 		log.VEvent(ctx, 2, "optimizer disabled (prepare)")
@@ -247,7 +245,12 @@ func (ex *connExecutor) populatePrepared(
 
 	if p.curPlan.plan == nil {
 		// Statement with no result columns and no support for placeholders.
-		return flags, nil
+		//
+		// Note: we're combining `flags` which comes from
+		// `prepareUsingOptimizer`, with `p.curPlan.flags` which ensures
+		// the new flags combine with the existing flags (this is used
+		// e.g. to maintain the count of times the optimizer was used).
+		return flags | p.curPlan.flags, nil
 	}
 	defer p.curPlan.close(ctx)
 
@@ -262,7 +265,8 @@ func (ex *connExecutor) populatePrepared(
 		return 0, err
 	}
 	prepared.Types = p.semaCtx.Placeholders.Types
-	return flags, nil
+	// The flags are combined, see the comment above for why.
+	return flags | p.curPlan.flags, nil
 }
 
 func (ex *connExecutor) execBind(

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -255,6 +255,7 @@ func (dsp *DistSQLPlanner) Run(
 	// We need to close the planNode tree we translated into a DistSQL plan before
 	// flow.Cleanup, which closes memory accounts that expect to be emptied.
 	if planCtx.planner != nil && !planCtx.ignoreClose {
+		planCtx.planner.curPlan.execErr = recv.resultWriter.Err()
 		planCtx.planner.curPlan.close(ctx)
 	}
 	flow.Cleanup(ctx)

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -151,7 +151,8 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 
 		// We need to re-plan every time, since close() below makes
 		// the plan unusable across retries.
-		if err := p.makePlan(ctx, Statement{Statement: stmt}); err != nil {
+		p.stmt = &Statement{Statement: stmt}
+		if err := p.makePlan(ctx); err != nil {
 			t.Fatal(err)
 		}
 		defer p.curPlan.close(ctx)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1739,7 +1739,7 @@ func (s *sqlStatsCollectorImpl) PhaseTimes() *phaseTimes {
 //
 // samplePlanDescription can be nil, as these are only sampled periodically per unique fingerprint.
 func (s *sqlStatsCollectorImpl) RecordStatement(
-	stmt Statement,
+	stmt *Statement,
 	samplePlanDescription *roachpb.ExplainTreePlanNode,
 	distSQLUsed bool,
 	optUsed bool,

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // explainDistSQLNode is a planNode that wraps a plan and returns

--- a/pkg/sql/explain_tree.go
+++ b/pkg/sql/explain_tree.go
@@ -44,7 +44,7 @@ import (
 //   leaveNode              // keep root node on stack (base case because it's the root).
 //
 // and planToTree would return the join node.
-func planToTree(ctx context.Context, top planTop) *roachpb.ExplainTreePlanNode {
+func planToTree(ctx context.Context, top *planTop) *roachpb.ExplainTreePlanNode {
 	nodeStack := &planNodeStack{}
 	observer := planObserver{
 		enterNode: func(ctx context.Context, nodeName string, plan planNode) (bool, error) {

--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -375,10 +375,11 @@ func assertExpectedPlansForTests(t *testing.T, sqlSetup string, plansToTest []*T
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := p.makePlan(ctx, Statement{Statement: stmt}); err != nil {
+		p.stmt = &Statement{Statement: stmt}
+		if err := p.makePlan(ctx); err != nil {
 			t.Fatal(err)
 		}
-		actualPlanTree := planToTree(ctx, p.curPlan)
+		actualPlanTree := planToTree(ctx, &p.curPlan)
 		assert.Equal(t, test.ExpectedPlanTree, actualPlanTree,
 			"planToTree for %s:\nexpected:%s\nactual:%s", test.SQL, test.ExpectedPlanTree, actualPlanTree)
 		actualPlanString := planToString(ctx, p.curPlan.plan, p.curPlan.subqueryPlans)

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -329,7 +329,8 @@ func planQuery(t *testing.T, s serverutils.TestServerInterface, sql string) (*pl
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.makePlan(context.TODO(), Statement{Statement: stmt}); err != nil {
+	p.stmt = &Statement{Statement: stmt}
+	if err := p.makePlan(context.TODO()); err != nil {
 		t.Fatal(err)
 	}
 	return p, func() {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -53,7 +53,7 @@ type planMaker interface {
 	// iterating using curPlan.plan.Next() and curPlan.plan.Values() in
 	// order to retrieve matching rows. Finally, the plan must be closed
 	// with curPlan.close().
-	makePlan(ctx context.Context, stmt Statement) error
+	makePlan(ctx context.Context) error
 
 	// prepare does the same checks as makePlan but skips building some
 	// data structures necessary for execution, based on the assumption
@@ -291,6 +291,20 @@ type planTop struct {
 	// auditEvents becomes non-nil if any of the descriptors used by
 	// current statement is causing an auditing event. See exec_log.go.
 	auditEvents []auditEvent
+
+	// flags is populated during planning and execution.
+	flags planFlags
+
+	// execErr retains the last execution error, if any.
+	execErr error
+
+	// maybeSavePlan, if defined, is called during close() to
+	// conditionally save the logical plan to savedPlanForStats.
+	maybeSavePlan func(context.Context) *roachpb.ExplainTreePlanNode
+
+	// savedPlanForStats is conditionally populated at the end of
+	// statement execution, for registration in statement statistics.
+	savedPlanForStats *roachpb.ExplainTreePlanNode
 }
 
 // makePlan implements the Planner interface. It populates the
@@ -301,8 +315,9 @@ type planTop struct {
 //
 // After makePlan(), the caller should be careful to also call
 // p.curPlan.Close().
-func (p *planner) makePlan(ctx context.Context, stmt Statement) error {
+func (p *planner) makePlan(ctx context.Context) error {
 	// Reinitialize.
+	stmt := p.stmt
 	p.curPlan = planTop{AST: stmt.AST}
 
 	log.VEvent(ctx, 2, "heuristic planner starts")
@@ -393,6 +408,9 @@ func (p *planner) hideHiddenColumns(
 // close ensures that the plan's resources have been deallocated.
 func (p *planTop) close(ctx context.Context) {
 	if p.plan != nil {
+		if p.maybeSavePlan != nil && p.flags.IsSet(planFlagExecDone) {
+			p.savedPlanForStats = p.maybeSavePlan(ctx)
+		}
 		p.plan.Close(ctx)
 		p.plan = nil
 	}
@@ -922,6 +940,9 @@ const (
 	// planFlagDistSQLLocal is set if the plan is for the DistSQL engine,
 	// but in local mode.
 	planFlagDistSQLLocal
+
+	// planFlagExecDone marks that execution has been completed.
+	planFlagExecDone
 )
 
 func (pf planFlags) IsSet(flag planFlags) bool {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -142,6 +142,10 @@ type planNode interface {
 	// This method should be called if the node has been used in any way (any
 	// methods on it have been called) after it was constructed. Note that this
 	// doesn't imply that startPlan() has been necessarily called.
+	//
+	// This method must not be called during execution - the planNode
+	// tree must remain "live" and readable via walk() even after
+	// execution completes.
 	Close(ctx context.Context)
 }
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -551,7 +551,7 @@ type sqlStatsCollector interface {
 	//
 	// samplePlanDescription can be nil, as these are only sampled periodically per unique fingerprint.
 	RecordStatement(
-		stmt Statement,
+		stmt *Statement,
 		samplePlanDescription *roachpb.ExplainTreePlanNode,
 		distSQLUsed bool,
 		optUsed bool,

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -86,9 +86,6 @@ func (p *planTop) evalSubqueries(params runParams) error {
 }
 
 func (s *subquery) doEval(params runParams) (result tree.Datum, err error) {
-	// After evaluation, there is no plan remaining.
-	defer func() { s.plan.Close(params.ctx); s.plan = nil }()
-
 	switch s.execMode {
 	case distsqlrun.SubqueryExecModeExists:
 		// For EXISTS expressions, all we want to know is if there is at least one

--- a/pkg/sql/subquery_test.go
+++ b/pkg/sql/subquery_test.go
@@ -33,7 +33,8 @@ func TestStartSubqueriesReturnsError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.makePlan(context.TODO(), Statement{Statement: stmt}); err != nil {
+	p.stmt = &Statement{Statement: stmt}
+	if err := p.makePlan(context.TODO()); err != nil {
 		t.Fatal(err)
 	}
 	params := runParams{ctx: context.TODO(), p: p, extendedEvalCtx: &p.extendedEvalCtx}

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -102,7 +102,8 @@ func (dsp *DistSQLPlanner) Exec(
 		return err
 	}
 	p := localPlanner.(*planner)
-	if err := p.makePlan(ctx, Statement{Statement: stmt}); err != nil {
+	p.stmt = &Statement{Statement: stmt}
+	if err := p.makePlan(ctx); err != nil {
 		return err
 	}
 	rw := newCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {


### PR DESCRIPTION
As found by @couchand in https://github.com/cockroachdb/cockroach/pull/33020#discussion_r245752090

The logic was in the wrong place and did not properly account for the
optimizer mode and whether an execution error occured. This patch
fixes it.

To achieve this, the patch requires the ability to inspect the
planNode tree after the execution machinery finishes running the
query.

This is a new requirement and had to be careful about resource
deallocation:

1) it becomes important that a planNode does not get closed during
   execution. This was already mostly true, except for
   `unionNode`. This patch modifies `unionNode` to make it compliant
   with the new protocol, and clarifies the constraint in the
   interface documentation for `planNode.Close()`.

2) when a planNode tree is started (`startExec`), it allocates memory
   in memory accounts set up by the exec machinery.  At the end of
   execution, it is thus important to close the planNode tree before
   the exec machinery accounts are closed. In order to achieve this,
   the patch introduces an inversion of control over the deallocation
   of execution resources.

Before (simplified):

```
executor -> execWith() -> planNode.Next()
                       -> planNode.close()
                       -> execMon.close()
```

After (simplified):

```
executor -> cleanup := execWith() -> planNode.Next()
                                  -> return func() { execMon.close() }
         -> log(planNode)
         -> planNode.close()
         -> cleanup()
```

Release note: None