### PR TITLE
kv: stop using BeginTransaction requests

### DIFF
--- a/docs/RFCS/20181209_lazy_txn_record_creation.md
+++ b/docs/RFCS/20181209_lazy_txn_record_creation.md
@@ -1,5 +1,5 @@
 - Feature Name: Lazy Transaction Record Creation (a.k.a Deprecate BeginTransaction)
-- Status: in-progress
+- Status: completed
 - Start Date: 2018-12-09
 - Authors: Nathan VanBenschoten
 - RFC PR: #32971

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -92,6 +92,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>2.1-3</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>2.1-4</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
 </tbody>
 </table>

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -417,6 +417,7 @@ func (tcf *TxnCoordSenderFactory) TransactionalSender(
 	tcs.interceptorAlloc.txnHeartbeat.init(
 		&tcs.mu.Mutex,
 		&tcs.mu.txn,
+		tcf.st,
 		tcs.clock,
 		tcs.heartbeatInterval,
 		&tcs.interceptorAlloc.txnLockGatekeeper,
@@ -581,7 +582,7 @@ func (tc *TxnCoordSender) Send(
 		return nil, pErr
 	}
 
-	if ba.IsSingleEndTransactionRequest() && !tc.interceptorAlloc.txnHeartbeat.mu.everSentBeginTxn {
+	if ba.IsSingleEndTransactionRequest() && !tc.interceptorAlloc.txnHeartbeat.mu.everWroteIntents {
 		return nil, tc.commitReadOnlyTxnLocked(ctx, ba.Requests[0].GetEndTransaction().Deadline)
 	}
 

--- a/pkg/kv/txn_interceptor_metrics.go
+++ b/pkg/kv/txn_interceptor_metrics.go
@@ -47,9 +47,7 @@ func (m *txnMetrics) init(txn *roachpb.Transaction, clock *hlc.Clock, metrics *T
 func (m *txnMetrics) SendLocked(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
-	_, hasBegin := ba.GetArg(roachpb.BeginTransaction)
-	et, hasEnd := ba.GetArg(roachpb.EndTransaction)
-	m.onePCCommit = hasBegin && hasEnd && et.(*roachpb.EndTransactionRequest).Commit
+	m.onePCCommit = ba.IsCompleteTransaction()
 
 	if m.txnStartNanos == 0 {
 		m.txnStartNanos = timeutil.Now().UnixNano()

--- a/pkg/kv/txn_interceptor_pipeliner.go
+++ b/pkg/kv/txn_interceptor_pipeliner.go
@@ -154,9 +154,7 @@ func (tp *txnPipeliner) SendLocked(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	// Fast-path for 1PC transactions.
-	_, hasBT := ba.GetArg(roachpb.BeginTransaction)
-	_, hasET := ba.GetArg(roachpb.EndTransaction)
-	if hasBT && hasET {
+	if ba.IsCompleteTransaction() {
 		return tp.wrapped.SendLocked(ctx, ba)
 	}
 

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -212,6 +212,56 @@ func (ba *BatchRequest) IsSingleComputeChecksumRequest() bool {
 	return false
 }
 
+// IsCompleteTransaction determines whether a batch contains every write in a
+// transactions.
+func (ba *BatchRequest) IsCompleteTransaction() bool {
+	et, hasET := ba.GetArg(EndTransaction)
+	if !hasET || !et.(*EndTransactionRequest).Commit {
+		return false
+	}
+	if _, hasBegin := ba.GetArg(BeginTransaction); hasBegin {
+		// TODO(nvanbenschoten): Remove this condition in 2.3. It can be removed
+		// in 2.3 once we're sure that all nodes will properly set sequence
+		// numbers (i.e. on writes only).
+		return true
+	}
+	maxSeq := et.Header().Sequence
+	switch maxSeq {
+	case 0:
+		// If the batch isn't using sequence numbers,
+		// assume that it is not a complete transaction.
+		return false
+	case 1:
+		// The transaction performed no writes.
+		return true
+	}
+	if int(maxSeq) > len(ba.Requests) {
+		// Fast-path.
+		return false
+	}
+	// Check whether any sequence numbers were skipped between 1 and the
+	// EndTransaction's sequence number. A Batch is only a complete transaction
+	// if it contains every write that the transaction performed.
+	nextSeq := int32(1)
+	for _, args := range ba.Requests {
+		req := args.GetInner()
+		seq := req.Header().Sequence
+		if seq > nextSeq {
+			return false
+		}
+		if seq == nextSeq {
+			if !IsTransactionWrite(req) {
+				return false
+			}
+			nextSeq++
+			if nextSeq == maxSeq {
+				return true
+			}
+		}
+	}
+	panic("unreachable")
+}
+
 // GetPrevLeaseForLeaseRequest returns the previous lease, at the time
 // of proposal, for a request lease or transfer lease request. If the
 // batch does not contain a single lease request, this method will panic.

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -73,6 +73,7 @@ const (
 	VersionCascadingZoneConfigs
 	VersionLoadSplits
 	VersionExportStorageWorkload
+	VersionLazyTxnRecord
 
 	// Add new versions here (step one of two).
 
@@ -304,6 +305,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionExportStorageWorkload is https://github.com/cockroachdb/cockroach/pull/31899.
 		Key:     VersionExportStorageWorkload,
 		Version: roachpb.Version{Major: 2, Minor: 1, Unstable: 3},
+	},
+	{
+		// VersionLazyTxnRecord is https://github.com/cockroachdb/cockroach/pull/33566.
+		Key:     VersionLazyTxnRecord,
+		Version: roachpb.Version{Major: 2, Minor: 1, Unstable: 4},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -268,7 +268,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-2.1-3
+2.1-4
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -365,4 +365,4 @@ select * from crdb_internal.gossip_alerts
 query T
 select crdb_internal.node_executable_version()
 ----
-2.1-3
+2.1-4

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -50,8 +50,8 @@ dist sender send  querying next range at /System/"desc-idgen"
 dist sender send  r3: sending batch 1 Inc to (n1,s1):1
 sql txn           CPut /Table/2/1/0/"t"/3/1 -> 53
 sql txn           CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
-dist sender send  querying next range at /Table/SystemConfigSpan/Start
-dist sender send  r6: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+dist sender send  querying next range at /Table/2/1/0/"t"/3/1
+dist sender send  r6: sending batch 2 CPut to (n1,s1):1
 sql txn           rows affected: 0
 dist sender send  querying next range at /Table/SystemConfigSpan/Start
 dist sender send  querying next range at /Table/2/1/0/"t"/3/1
@@ -87,8 +87,8 @@ dist sender send  querying next range at /System/"desc-idgen"
 dist sender send  r3: sending batch 1 Inc to (n1,s1):1
 sql txn           CPut /Table/2/1/53/"kv"/3/1 -> 54
 sql txn           CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-dist sender send  querying next range at /Table/SystemConfigSpan/Start
-dist sender send  r6: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
+dist sender send  r6: sending batch 2 CPut to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 sql txn           rows affected: 0
@@ -140,7 +140,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 sql txn           CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 sql txn           InitPut /Table/54/2/2/0 -> /BYTES/0x89
 dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r19: sending batch 1 CPut, 1 BeginTxn, 1 EndTxn, 1 InitPut to (n1,s1):1
+dist sender send  r19: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
 sql txn           fast path completed
 sql txn           rows affected: 1
 
@@ -155,7 +155,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 sql txn           CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 sql txn           InitPut /Table/54/2/2/0 -> /BYTES/0x89
 dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r19: sending batch 1 CPut, 1 BeginTxn, 1 EndTxn, 1 InitPut to (n1,s1):1
+dist sender send  r19: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
 sql txn           execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
 dist sender send  querying next range at /Table/54/1/1/0
 dist sender send  r19: sending batch 1 EndTxn to (n1,s1):1
@@ -170,7 +170,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 sql txn           CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
 sql txn           InitPut /Table/54/2/2/0 -> /BYTES/0x8a
 dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r19: sending batch 1 CPut, 1 BeginTxn, 1 EndTxn, 1 InitPut to (n1,s1):1
+dist sender send  r19: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
 sql txn           execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 dist sender send  querying next range at /Table/54/1/2/0
 dist sender send  r19: sending batch 1 EndTxn to (n1,s1):1
@@ -187,7 +187,7 @@ dist sender send  r19: sending batch 1 Scan to (n1,s1):1
 sql txn           CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/3
 sql txn           InitPut /Table/54/2/3/0 -> /BYTES/0x8a
 dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r19: sending batch 1 CPut, 1 BeginTxn, 1 EndTxn, 1 InitPut to (n1,s1):1
+dist sender send  r19: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
 sql txn           fast path completed
 sql txn           rows affected: 1
 
@@ -203,7 +203,7 @@ dist sender send  r19: sending batch 1 Scan to (n1,s1):1
 sql txn           fetched: /kv/primary/1/v -> /2
 sql txn           Put /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r19: sending batch 1 Put, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+dist sender send  r19: sending batch 1 Put, 1 EndTxn to (n1,s1):1
 sql txn           fast path completed
 sql txn           rows affected: 1
 
@@ -222,7 +222,7 @@ sql txn           Put /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
 sql txn           Del /Table/54/2/3/0
 sql txn           CPut /Table/54/2/2/0 -> /BYTES/0x8a
 dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r19: sending batch 1 Put, 1 CPut, 1 Del, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+dist sender send  r19: sending batch 1 Put, 1 CPut, 1 Del, 1 EndTxn to (n1,s1):1
 sql txn           execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 dist sender send  querying next range at /Table/54/1/2/0
 dist sender send  r19: sending batch 1 EndTxn to (n1,s1):1
@@ -253,8 +253,8 @@ dist sender send  querying next range at /System/"desc-idgen"
 dist sender send  r3: sending batch 1 Inc to (n1,s1):1
 sql txn           CPut /Table/2/1/53/"kv2"/3/1 -> 55
 sql txn           CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-dist sender send  querying next range at /Table/SystemConfigSpan/Start
-dist sender send  r6: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
+dist sender send  r6: sending batch 2 CPut to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 sql txn           Scan /Table/54/{1-2}
@@ -298,7 +298,7 @@ sql txn           Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
 sql txn           fetched: /kv2/primary/...PK.../k/v -> /2/3
 sql txn           Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/5
 dist sender send  querying next range at /Table/55/1/...PK.../0
-dist sender send  r19: sending batch 2 Put, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+dist sender send  r19: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 sql txn           fast path completed
 sql txn           rows affected: 2
 
@@ -313,7 +313,7 @@ dist sender send  querying next range at /Table/55/1
 dist sender send  r19: sending batch 1 Scan to (n1,s1):1
 sql txn           DelRange /Table/55/1 - /Table/55/2
 dist sender send  querying next range at /Table/55/1
-dist sender send  r19: sending batch 1 DelRng, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+dist sender send  r19: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 sql txn           fast path completed
 sql txn           rows affected: 2
 
@@ -362,7 +362,7 @@ sql txn           fetched: /kv/primary/2/v -> /3
 sql txn           Del /Table/54/2/3/0
 sql txn           Del /Table/54/1/2/0
 dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r19: sending batch 4 Del, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+dist sender send  r19: sending batch 4 Del, 1 EndTxn to (n1,s1):1
 sql txn           fast path completed
 sql txn           rows affected: 2
 
@@ -443,13 +443,13 @@ CREATE TABLE t.kv3(k INT PRIMARY KEY, v INT)
 statement ok
 SET tracing = on; INSERT INTO t.kv3 (k, v) VALUES (1,1); SET tracing = off
 
-# We look for rows containing a BeginTxn and an EndTxn, as proof that the
+# We look for rows containing an EndTxn as proof that the
 # insertNode is committing the txn.
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE e'%1 CPut, 1 BeginTxn, 1 EndTxn%' AND message NOT LIKE e'%proposing command%'
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE e'%1 CPut, 1 EndTxn%' AND message NOT LIKE e'%proposing command%'
 ----
-r19: sending batch 1 CPut, 1 BeginTxn, 1 EndTxn to (n1,s1):1
-1 CPut, 1 BeginTxn, 1 EndTxn
+r19: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
+1 CPut, 1 EndTxn
 
 ## TODO(tschottdorf): re-enable
 # statement ok

--- a/pkg/sql/logictest/testdata/planner_test/interleaved
+++ b/pkg/sql/logictest/testdata/planner_test/interleaved
@@ -246,7 +246,7 @@ querying next range at /Table/61/1/5
 r19: sending batch 1 Scan to (n1,s1):1
 DelRange /Table/61/1/5 - /Table/61/1/7/NULL
 querying next range at /Table/61/1/5
-r19: sending batch 1 DelRng, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+r19: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 3
 
@@ -291,7 +291,7 @@ querying next range at /Table/61/1
 r19: sending batch 1 Scan to (n1,s1):1
 DelRange /Table/61/1 - /Table/61/3
 querying next range at /Table/61/1
-r19: sending batch 1 DelRng, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+r19: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 5
 
@@ -346,7 +346,7 @@ querying next range at /Table/61/1/1/#/62/1/1
 r19: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/1/#/62/1/1/0
 querying next range at /Table/61/1/1/#/62/1/1/0
-r19: sending batch 1 Del, 1 BeginTxn to (n1,s1):1
+r19: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/1/#/62/1/1/#/63/1

--- a/pkg/sql/logictest/testdata/planner_test/update
+++ b/pkg/sql/logictest/testdata/planner_test/update
@@ -248,7 +248,7 @@ fetched: /tu/primary/1/c/d -> /3/4
 Del /Table/57/1/1/1/1
 Del /Table/57/1/1/2/1
 querying next range at /Table/57/1/1/1/1
-r19: sending batch 2 Del, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+r19: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 1
 

--- a/pkg/sql/logictest/testdata/planner_test/upsert
+++ b/pkg/sql/logictest/testdata/planner_test/upsert
@@ -42,7 +42,7 @@ Put /Table/54/1/1/0 -> /TUPLE/
 Del /Table/54/1/1/1/1
 Del /Table/54/1/1/2/1
 querying next range at /Table/54/1/1/0
-r19: sending batch 1 Put, 2 Del, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+r19: sending batch 1 Put, 2 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 1
 subtest regression_32834

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -259,7 +259,7 @@ r19: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/5/#/62/1/1/0
 Del /Table/61/1/5/#/62/1/2/0
 querying next range at /Table/61/1/5/#/62/1/1/0
-r19: sending batch 2 Del, 1 BeginTxn to (n1,s1):1
+r19: sending batch 2 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
 CascadeScan /Table/61/1/5/#/62/1/2/#/63/{1-2}
@@ -411,7 +411,7 @@ r19: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/3/#/62/1/1/0
 Del /Table/61/1/3/#/62/1/2/0
 querying next range at /Table/61/1/3/#/62/1/1/0
-r19: sending batch 2 Del, 1 BeginTxn to (n1,s1):1
+r19: sending batch 2 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
 CascadeScan /Table/61/1/3/#/62/1/2/#/63/{1-2}
@@ -634,7 +634,7 @@ querying next range at /Table/61/1/1/#/62/1/1
 r19: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/1/#/62/1/1/0
 querying next range at /Table/61/1/1/#/62/1/1/0
-r19: sending batch 1 Del, 1 BeginTxn to (n1,s1):1
+r19: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/1/#/62/1/1/#/63/1

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -261,6 +261,6 @@ fetched: /tu/primary/1/c/d -> /3/4
 Del /Table/57/1/1/1/1
 Del /Table/57/1/1/2/1
 querying next range at /Table/57/1/1/1/1
-r19: sending batch 2 Del, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+r19: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -61,6 +61,6 @@ fetched: /tu/primary/1/c/d -> /3/4
 Del /Table/54/1/1/1/1
 Del /Table/54/1/1/2/1
 querying next range at /Table/54/1/1/1/1
-r19: sending batch 2 Del, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+r19: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 1

--- a/pkg/storage/batcheval/cmd_query_intent.go
+++ b/pkg/storage/batcheval/cmd_query_intent.go
@@ -61,6 +61,9 @@ func QueryIntent(
 	if intent != nil {
 		// See comment on QueryIntentRequest.Txn for an explanation of this
 		// comparison.
+		// TODO(nvanbenschoten): Now that we have a full intent history,
+		// we can look at the exact sequence! That won't serve as much more
+		// than an assertion that QueryIntent is being used correctly.
 		reply.FoundIntent = (args.Txn.ID == intent.Txn.ID) &&
 			(args.Txn.Epoch == intent.Txn.Epoch) &&
 			(args.Txn.Sequence <= intent.Txn.Sequence)


### PR DESCRIPTION
Based on #33523.
Closes #25437.

This is the final part of addressing #32971.

The change gates the use of BeginTransaction on a cluster version. When a cluster's version is sufficiently high, it will stop sending them.

To make this work, a small change was needed for the detection of 1PC transactions. We now use sequence numbers to determine that a batch includes all of the writes in a transaction. This is in line with the proposal from the RFC's `1PC Transactions` section and will work correctly with parallel commits.

Release note (performance improvement): Reduce the network and storage
overhead of multi-Range transactions.