### PR TITLE
sql,ccl: refresh table statistics after IMPORT and RESTORE

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -993,8 +994,9 @@ func doDistributedCSVTransform(
 }
 
 type importResumer struct {
-	settings *cluster.Settings
-	res      roachpb.BulkOpSummary
+	settings       *cluster.Settings
+	res            roachpb.BulkOpSummary
+	statsRefresher *stats.Refresher
 }
 
 func (r *importResumer) Resume(
@@ -1057,6 +1059,7 @@ func (r *importResumer) Resume(
 		return err
 	}
 	r.res = res
+	r.statsRefresher = p.ExecCfg().StatsRefresher
 	return nil
 }
 
@@ -1119,6 +1122,17 @@ func (r *importResumer) OnSuccess(ctx context.Context, txn *client.Txn, job *job
 	// imported data.
 	if err := backupccl.WriteTableDescs(ctx, txn, nil, toWrite, job.Payload().Username, r.settings, seqs); err != nil {
 		return errors.Wrapf(err, "creating tables")
+	}
+
+	// Initiate a run of CREATE STATISTICS. We don't know the actual number of
+	// rows affected per table, so we use a large number because we want to make
+	// sure that stats always get created/refreshed here.
+	for i := range toWrite {
+		r.statsRefresher.NotifyMutation(
+			&r.settings.SV,
+			toWrite[i].ID,
+			math.MaxInt32, /* rowsAffected */
+		)
 	}
 
 	return nil

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -303,7 +303,7 @@ func (n *createTableNode) startExec(params runParams) error {
 
 		// Initiate a run of CREATE STATISTICS.
 		params.ExecCfg().StatsRefresher.NotifyMutation(
-			params.EvalContext(),
+			&params.EvalContext().Settings.SV,
 			desc.ID,
 			n.run.rowsAffected,
 		)

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -327,7 +327,7 @@ func (d *deleteNode) BatchedNext(params runParams) (bool, error) {
 
 	// Possibly initiate a run of CREATE STATISTICS.
 	params.ExecCfg().StatsRefresher.NotifyMutation(
-		params.EvalContext(),
+		&params.EvalContext().Settings.SV,
 		d.run.td.tableDesc().ID,
 		d.run.rowCount,
 	)
@@ -534,7 +534,7 @@ func (d *deleteNode) fastDelete(params runParams, scan *scanNode, interleavedFas
 
 	// Possibly initiate a run of CREATE STATISTICS.
 	params.ExecCfg().StatsRefresher.NotifyMutation(
-		params.EvalContext(),
+		&params.EvalContext().Settings.SV,
 		d.run.td.tableDesc().ID,
 		d.run.rowCount,
 	)

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -510,7 +510,7 @@ func (n *insertNode) BatchedNext(params runParams) (bool, error) {
 
 	// Possibly initiate a run of CREATE STATISTICS.
 	params.ExecCfg().StatsRefresher.NotifyMutation(
-		params.EvalContext(),
+		&params.EvalContext().Settings.SV,
 		n.run.ti.tableDesc().ID,
 		n.run.rowCount,
 	)

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -306,7 +306,7 @@ func TestMutationsChannel(t *testing.T) {
 	// Test that the mutations channel doesn't block even when we add 10 more
 	// items than can fit in the buffer.
 	for i := 0; i < refreshChanBufferLen+10; i++ {
-		r.NotifyMutation(evalCtx, sqlbase.ID(53), 5 /* rowsAffected */)
+		r.NotifyMutation(&evalCtx.Settings.SV, sqlbase.ID(53), 5 /* rowsAffected */)
 	}
 
 	if expected, actual := refreshChanBufferLen, len(r.mutations); expected != actual {

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -605,7 +605,7 @@ func (u *updateNode) BatchedNext(params runParams) (bool, error) {
 
 	// Possibly initiate a run of CREATE STATISTICS.
 	params.ExecCfg().StatsRefresher.NotifyMutation(
-		params.EvalContext(),
+		&params.EvalContext().Settings.SV,
 		u.run.tu.tableDesc().ID,
 		u.run.rowCount,
 	)

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -353,7 +353,7 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 
 	// Possibly initiate a run of CREATE STATISTICS.
 	params.ExecCfg().StatsRefresher.NotifyMutation(
-		params.EvalContext(),
+		&params.EvalContext().Settings.SV,
 		n.run.tw.tableDesc().ID,
 		n.run.tw.batchedCount(),
 	)


### PR DESCRIPTION
PR #33131 added logic to automatically refresh table statistics
after approximately 5% of rows in a table have been inserted,
updated, upserted, or deleted. This commit ensures that stats are
also automatically created after a successful `IMPORT` or `RESTORE`.
This will be especially important for collecting stats on read-only
tables that are never updated after import.

As with PR #33131, triggering automatic statistics for `IMPORT` and
`RESTORE` is disabled by default, and can be controlled with the
cluster setting `sql.defaults.experimental_automatic_statistics`.

Release note: None