### PR TITLE
roachtest: add MinVersion to scrub tests

### DIFF
--- a/pkg/cmd/roachtest/scrub.go
+++ b/pkg/cmd/roachtest/scrub.go
@@ -88,5 +88,6 @@ func makeScrubTPCCTest(
 				Duration: length,
 			})
 		},
+		MinVersion: "v2.2.0",
 	}
 }


### PR DESCRIPTION
The `scrub` tests have been passing on master, but failing on 2.1 because there
was a bug (fixed in #32908).

Release note: None