### PR TITLE
sql: use query cache for prepare

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -181,7 +181,8 @@ func (ex *connExecutor) prepare(
 
 	p := &ex.planner
 	ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTimestamp */)
-	if err := ex.populatePrepared(ctx, txn, stmt, placeholderHints, p); err != nil {
+	flags, err := ex.populatePrepared(ctx, txn, stmt, placeholderHints, p)
+	if err != nil {
 		txn.CleanupOnError(ctx, err)
 		return nil, err
 	}
@@ -193,6 +194,7 @@ func (ex *connExecutor) prepare(
 	if err := prepared.memAcc.Grow(ctx, prepared.MemoryEstimate()); err != nil {
 		return nil, err
 	}
+	ex.updateOptCounters(flags)
 	return prepared, nil
 }
 
@@ -204,7 +206,7 @@ func (ex *connExecutor) populatePrepared(
 	stmt Statement,
 	placeholderHints tree.PlaceholderTypes,
 	p *planner,
-) error {
+) (planFlags, error) {
 	prepared := stmt.Prepared
 	p.semaCtx.Placeholders.Reset(placeholderHints)
 	p.extendedEvalCtx.PrepareOnly = true
@@ -217,7 +219,7 @@ func (ex *connExecutor) populatePrepared(
 
 	protoTS, err := p.isAsOf(stmt.AST, ex.server.cfg.Clock.Now() /* max */)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if protoTS != nil {
 		p.semaCtx.AsOfTimestamp = protoTS
@@ -232,20 +234,22 @@ func (ex *connExecutor) populatePrepared(
 	// As of right now, the optimizer only works on SELECT statements and will
 	// fallback for all others, so this should be safe for the foreseeable
 	// future.
+	var flags planFlags
 	var isCorrelated bool
 	if optMode := ex.sessionData.OptimizerMode; optMode != sessiondata.OptimizerOff {
 		log.VEvent(ctx, 2, "preparing using optimizer")
 		var err error
-		isCorrelated, err = p.prepareUsingOptimizer(ctx, stmt)
+		flags, isCorrelated, err = p.prepareUsingOptimizer(ctx, stmt)
 		if err == nil {
 			log.VEvent(ctx, 2, "optimizer prepare succeeded")
 			// stmt.Prepared fields have been populated.
-			return nil
+			return flags, nil
 		}
 		log.VEventf(ctx, 1, "optimizer prepare failed: %v", err)
 		if !canFallbackFromOpt(err, optMode, stmt) {
-			return err
+			return 0, err
 		}
+		flags = planFlagOptFallback
 		log.VEvent(ctx, 1, "prepare falls back on heuristic planner")
 	} else {
 		log.VEvent(ctx, 2, "optimizer disabled (prepare)")
@@ -256,23 +260,23 @@ func (ex *connExecutor) populatePrepared(
 	// plan.
 	if err := p.prepare(ctx, stmt.AST); err != nil {
 		enhanceErrWithCorrelation(err, isCorrelated)
-		return err
+		return 0, err
 	}
 
 	if p.curPlan.plan == nil {
 		// Statement with no result columns and no support for placeholders.
-		return nil
+		return flags, nil
 	}
 	defer p.curPlan.close(ctx)
 
 	prepared.Columns = p.curPlan.columns()
 	for _, c := range prepared.Columns {
 		if err := checkResultType(c.Typ); err != nil {
-			return err
+			return 0, err
 		}
 	}
 	prepared.Types = p.semaCtx.Placeholders.Types
-	return nil
+	return flags, nil
 }
 
 func (ex *connExecutor) execBind(

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/lib/pq/oid"
@@ -145,8 +146,10 @@ func (ex *connExecutor) prepare(
 	}
 
 	prepared := &PreparedStatement{
-		PlaceholderTypesInfo: tree.PlaceholderTypesInfo{
-			TypeHints: placeholderHints,
+		PrepareMetadata: sqlbase.PrepareMetadata{
+			PlaceholderTypesInfo: tree.PlaceholderTypesInfo{
+				TypeHints: placeholderHints,
+			},
 		},
 		memAcc: ex.sessionMon.MakeBoundAccount(),
 	}

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -53,7 +53,7 @@ func (p *PreparedStatement) MemoryEstimate() int64 {
 	if p.Memo != nil {
 		size += p.Memo.MemoryEstimate()
 	}
-	// TODO(radu): account for more fields.
+	size += p.PrepareMetadata.MemoryEstimate()
 	return size
 }
 

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/lib/pq/oid"
 )
 
 // PreparedStatement is a SQL statement that has been parsed and the types
@@ -34,24 +33,12 @@ type PreparedStatement struct {
 	// the future to present a contextual error message based on location
 	// information.
 	Str string
-	// AnonymizedStr is the anonymized statement string suitable for recording
-	// in statement statistics.
-	AnonymizedStr string
-	// Statement is the parsed, prepared SQL statement. It may be nil if the
-	// prepared statement is empty.
-	Statement tree.Statement
 	// Memo is the memoized data structure constructed by the cost-based optimizer
 	// during prepare of a SQL statement. It can significantly speed up execution
 	// if it is used by the optimizer as a starting point.
 	Memo *memo.Memo
 
-	tree.PlaceholderTypesInfo
-
-	Columns sqlbase.ResultColumns
-
-	// InTypes represents the inferred types for placeholder, using protocol
-	// identifiers. Used for reporting on Describe.
-	InTypes []oid.Oid
+	sqlbase.PrepareMetadata
 
 	memAcc mon.BoundAccount
 }

--- a/pkg/sql/sem/tree/placeholders.go
+++ b/pkg/sql/sem/tree/placeholders.go
@@ -28,6 +28,20 @@ import (
 // PlaceholderTypes relates placeholder names to their resolved type.
 type PlaceholderTypes map[types.PlaceholderIdx]types.T
 
+// Equals returns true if two PlaceholderTypes contain the same types.
+func (pt PlaceholderTypes) Equals(other PlaceholderTypes) bool {
+	if len(pt) != len(other) {
+		return false
+	}
+	for i, t := range pt {
+		otherT, ok := other[i]
+		if !ok || !t.Equivalent(otherT) {
+			return false
+		}
+	}
+	return true
+}
+
 // QueryArguments relates placeholder names to their provided query argument.
 //
 // A nil value represents a NULL argument.

--- a/pkg/sql/sqlbase/prepared_statement.go
+++ b/pkg/sql/sqlbase/prepared_statement.go
@@ -1,0 +1,42 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlbase
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/lib/pq/oid"
+)
+
+// PrepareMetadata encapsulates information about a statement that is gathered
+// during Prepare and is later used during Describe or Execute.
+type PrepareMetadata struct {
+	// AnonymizedStr is the anonymized statement string suitable for recording
+	// in statement statistics.
+	AnonymizedStr string
+	// Statement is the parsed, prepared SQL statement. It may be nil if the
+	// prepared statement is empty.
+	Statement tree.Statement
+
+	// Provides TypeHints and Types fields which contain placeholder typing
+	// information.
+	tree.PlaceholderTypesInfo
+
+	// Columns are the types and names of the query output columns.
+	Columns ResultColumns
+
+	// InTypes represents the inferred types for placeholder, using protocol
+	// identifiers. Used for reporting on Describe.
+	InTypes []oid.Oid
+}


### PR DESCRIPTION
Note: the "refactor usage of placeholder TypeHints" commit is from a separate PR, ignore that one.

#### sql: separate prepared statement metadata

Separating the metadata for prepared statements in a sqlbase struct,
which will also be used by the plan cache.

Release note: None

#### sql: use query cache for prepare

This change enables the use of the query cache for Prepare. The cache
optionally stores a `*PrepareMetadata` for each query which can later
be reused.

Release note: None