### PR TITLE
server,sql: introduce optional migrations

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -630,11 +630,12 @@ func TestSpanStatsResponse(t *testing.T) {
 
 func TestSpanStatsGRPCResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 	ts := startServer(t)
-	defer ts.Stopper().Stop(context.TODO())
+	defer ts.Stopper().Stop(ctx)
 
 	rpcStopper := stop.NewStopper()
-	defer rpcStopper.Stop(context.TODO())
+	defer rpcStopper.Stop(ctx)
 	rpcContext := rpc.NewContext(
 		log.AmbientContext{Tracer: ts.ClusterSettings().Tracer}, ts.RPCContext().Config, ts.Clock(),
 		rpcStopper, &ts.ClusterSettings().Version)
@@ -645,13 +646,13 @@ func TestSpanStatsGRPCResponse(t *testing.T) {
 	}
 
 	url := ts.ServingAddr()
-	conn, err := rpcContext.GRPCDial(url).Connect(context.Background())
+	conn, err := rpcContext.GRPCDial(url).Connect(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	client := serverpb.NewStatusClient(conn)
 
-	response, err := client.SpanStats(context.Background(), &request)
+	response, err := client.SpanStats(ctx, &request)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -660,7 +661,7 @@ func TestSpanStatsGRPCResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 	if a, e := int(response.RangeCount), initialRanges; a != e {
-		t.Errorf("expected %d ranges, found %d", e, a)
+		t.Fatalf("expected %d ranges, found %d", e, a)
 	}
 }
 

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -92,7 +92,7 @@ func TestDatabaseDescriptor(t *testing.T) {
 	}
 
 	start := roachpb.Key(keys.MakeTablePrefix(uint32(keys.NamespaceTableID)))
-	if kvs, err := kvDB.Scan(ctx, start, start.PrefixEnd(), 0); err != nil {
+	if kvs, err := kvDB.Scan(ctx, start, start.PrefixEnd(), 0 /* maxRows */); err != nil {
 		t.Fatal(err)
 	} else {
 		descriptorIDs, err := sqlmigrations.ExpectedDescriptorIDs(ctx, kvDB)

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -297,7 +297,8 @@ start_key                          start_pretty                   end_key       
 [156]                              /Table/20                      [157]                              /Table/21                      system         table_statistics  ·           {1}       1
 [157]                              /Table/21                      [158]                              /Table/22                      system         locations         ·           {1}       1
 [158]                              /Table/22                      [159]                              /Table/23                      ·              ·                 ·           {1}       1
-[159]                              /Table/23                      [189 137 137]                      /Table/53/1/1                  system         role_members      ·           {1}       1
+[159]                              /Table/23                      [160]                              /Table/24                      system         role_members      ·           {1}       1
+[160]                              /Table/24                      [189 137 137]                      /Table/53/1/1                  system         comments          ·           {1}       1
 [189 137 137]                      /Table/53/1/1                  [189 137 141 137]                  /Table/53/1/5/1                test           t                 ·           {3,4}     3
 [189 137 141 137]                  /Table/53/1/5/1                [189 137 141 138]                  /Table/53/1/5/2                test           t                 ·           {1,2,3}   1
 [189 137 141 138]                  /Table/53/1/5/2                [189 137 141 139]                  /Table/53/1/5/3                test           t                 ·           {2,3,5}   5
@@ -336,7 +337,8 @@ start_key                          start_pretty                   end_key       
 [156]                              /Table/20                      [157]                              /Table/21                      system         table_statistics  ·           {1}       1
 [157]                              /Table/21                      [158]                              /Table/22                      system         locations         ·           {1}       1
 [158]                              /Table/22                      [159]                              /Table/23                      ·              ·                 ·           {1}       1
-[159]                              /Table/23                      [189 137 137]                      /Table/53/1/1                  system         role_members      ·           {1}       1
+[159]                              /Table/23                      [160]                              /Table/24                      system         role_members      ·           {1}       1
+[160]                              /Table/24                      [189 137 137]                      /Table/53/1/1                  system         comments          ·           {1}       1
 [189 137 137]                      /Table/53/1/1                  [189 137 141 137]                  /Table/53/1/5/1                test           t                 ·           {3,4}     3
 [189 137 141 137]                  /Table/53/1/5/1                [189 137 141 138]                  /Table/53/1/5/2                test           t                 ·           {1,2,3}   1
 [189 137 141 138]                  /Table/53/1/5/2                [189 137 141 139]                  /Table/53/1/5/3                test           t                 ·           {2,3,5}   5

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -140,7 +140,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 sql txn           CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 sql txn           InitPut /Table/54/2/2/0 -> /BYTES/0x89
 dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r19: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
+dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
 sql txn           fast path completed
 sql txn           rows affected: 1
 
@@ -155,10 +155,10 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 sql txn           CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 sql txn           InitPut /Table/54/2/2/0 -> /BYTES/0x89
 dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r19: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
+dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
 sql txn           execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
 dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r19: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r20: sending batch 1 EndTxn to (n1,s1):1
 
 statement error duplicate key value
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -170,10 +170,10 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 sql txn           CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
 sql txn           InitPut /Table/54/2/2/0 -> /BYTES/0x8a
 dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r19: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
+dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
 sql txn           execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r19: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r20: sending batch 1 EndTxn to (n1,s1):1
 
 statement ok
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,3); SET tracing = off
@@ -183,11 +183,11 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 sql txn           Scan /Table/54/1/2{-/#}
 dist sender send  querying next range at /Table/54/1/2
-dist sender send  r19: sending batch 1 Scan to (n1,s1):1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
 sql txn           CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/3
 sql txn           InitPut /Table/54/2/3/0 -> /BYTES/0x8a
 dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r19: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
+dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
 sql txn           fast path completed
 sql txn           rows affected: 1
 
@@ -199,11 +199,11 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 sql txn           Scan /Table/54/1/1{-/#}
 dist sender send  querying next range at /Table/54/1/1
-dist sender send  r19: sending batch 1 Scan to (n1,s1):1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
 sql txn           fetched: /kv/primary/1/v -> /2
 sql txn           Put /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
 dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r19: sending batch 1 Put, 1 EndTxn to (n1,s1):1
+dist sender send  r20: sending batch 1 Put, 1 EndTxn to (n1,s1):1
 sql txn           fast path completed
 sql txn           rows affected: 1
 
@@ -216,16 +216,16 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 sql txn           Scan /Table/54/1/2{-/#}
 dist sender send  querying next range at /Table/54/1/2
-dist sender send  r19: sending batch 1 Scan to (n1,s1):1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
 sql txn           fetched: /kv/primary/2/v -> /3
 sql txn           Put /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
 sql txn           Del /Table/54/2/3/0
 sql txn           CPut /Table/54/2/2/0 -> /BYTES/0x8a
 dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r19: sending batch 1 Put, 1 CPut, 1 Del, 1 EndTxn to (n1,s1):1
+dist sender send  r20: sending batch 1 Put, 1 CPut, 1 Del, 1 EndTxn to (n1,s1):1
 sql txn           execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r19: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r20: sending batch 1 EndTxn to (n1,s1):1
 
 statement ok
 SET tracing = on,kv,results; CREATE TABLE t.kv2 AS TABLE t.kv; SET tracing = off
@@ -259,14 +259,14 @@ dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 sql txn           Scan /Table/54/{1-2}
 dist sender send  querying next range at /Table/54/1
-dist sender send  r19: sending batch 1 Scan to (n1,s1):1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
 sql txn           fetched: /kv/primary/1/v -> /2
 sql txn           CPut /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
 sql txn           fetched: /kv/primary/2/v -> /3
 sql txn           CPut /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/3
 dist sender send  querying next range at /Table/SystemConfigSpan/Start
 dist sender send  querying next range at /Table/55/1/...PK.../0
-dist sender send  r19: sending batch 2 CPut to (n1,s1):1
+dist sender send  r20: sending batch 2 CPut to (n1,s1):1
 dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
 dist sender send  r8: sending batch 5 QueryIntent to (n1,s1):1
 dist sender send  querying next range at /Table/SystemConfigSpan/Start
@@ -292,13 +292,13 @@ dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r7: sending batch 1 EndTxn, 1 QueryIntent to (n1,s1):1
 sql txn           Scan /Table/55/{1-2}
 dist sender send  querying next range at /Table/55/1
-dist sender send  r19: sending batch 1 Scan to (n1,s1):1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
 sql txn           fetched: /kv2/primary/...PK.../k/v -> /1/2
 sql txn           Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
 sql txn           fetched: /kv2/primary/...PK.../k/v -> /2/3
 sql txn           Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/5
 dist sender send  querying next range at /Table/55/1/...PK.../0
-dist sender send  r19: sending batch 2 Put, 1 EndTxn to (n1,s1):1
+dist sender send  r20: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 sql txn           fast path completed
 sql txn           rows affected: 2
 
@@ -310,10 +310,10 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 sql txn           Scan /Table/55/{1-2}
 dist sender send  querying next range at /Table/55/1
-dist sender send  r19: sending batch 1 Scan to (n1,s1):1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
 sql txn           DelRange /Table/55/1 - /Table/55/2
 dist sender send  querying next range at /Table/55/1
-dist sender send  r19: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+dist sender send  r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 sql txn           fast path completed
 sql txn           rows affected: 2
 
@@ -354,7 +354,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 sql txn           Scan /Table/54/{1-2}
 dist sender send  querying next range at /Table/54/1
-dist sender send  r19: sending batch 1 Scan to (n1,s1):1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
 sql txn           fetched: /kv/primary/1/v -> /2
 sql txn           Del /Table/54/2/2/0
 sql txn           Del /Table/54/1/1/0
@@ -362,7 +362,7 @@ sql txn           fetched: /kv/primary/2/v -> /3
 sql txn           Del /Table/54/2/3/0
 sql txn           Del /Table/54/1/2/0
 dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r19: sending batch 4 Del, 1 EndTxn to (n1,s1):1
+dist sender send  r20: sending batch 4 Del, 1 EndTxn to (n1,s1):1
 sql txn           fast path completed
 sql txn           rows affected: 2
 
@@ -448,7 +448,7 @@ SET tracing = on; INSERT INTO t.kv3 (k, v) VALUES (1,1); SET tracing = off
 query T
 SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE e'%1 CPut, 1 EndTxn%' AND message NOT LIKE e'%proposing command%'
 ----
-r19: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
+r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
 1 CPut, 1 EndTxn
 
 ## TODO(tschottdorf): re-enable
@@ -503,4 +503,4 @@ SELECT DISTINCT node_id, store_id, replica_id
 node_id  store_id  replica_id
 1        1         6
 1        1         7
-1        1         19
+1        1         20

--- a/pkg/sql/logictest/testdata/planner_test/insert
+++ b/pkg/sql/logictest/testdata/planner_test/insert
@@ -394,4 +394,3 @@ count                       ·         ·
                 │           strategy  top 1
                 └── values  ·         ·
 ·                           size      2 columns, 2 rows
-

--- a/pkg/sql/logictest/testdata/planner_test/interleaved
+++ b/pkg/sql/logictest/testdata/planner_test/interleaved
@@ -243,10 +243,10 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 ----
 Scan /Table/61/1/{5-7/#}
 querying next range at /Table/61/1/5
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 DelRange /Table/61/1/5 - /Table/61/1/7/NULL
 querying next range at /Table/61/1/5
-r19: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 3
 
@@ -288,10 +288,10 @@ select message FROM [SHOW KV TRACE FOR SESSION]
 ----
 Scan /Table/61/{1-2}
 querying next range at /Table/61/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 DelRange /Table/61/1 - /Table/61/3
 querying next range at /Table/61/1
-r19: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 5
 
@@ -334,229 +334,229 @@ select message FROM [SHOW KV TRACE FOR SESSION];
 ----
 Scan /Table/61/{1-2}
 querying next range at /Table/61/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 fetched: /a/primary/1 -> NULL
 Del /Table/61/1/1/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/1/#/62/{1-2}
 querying next range at /Table/61/1/1/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/1/#/62/1/1{-/#}
 querying next range at /Table/61/1/1/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/1/#/62/1/1/0
 querying next range at /Table/61/1/1/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/1/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/1/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/1/#/62/{1-2}
 querying next range at /Table/61/1/1/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/2 -> NULL
 Del /Table/61/1/2/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/2/#/62/{1-2}
 querying next range at /Table/61/1/2/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/2/#/62/1/1{-/#}
 querying next range at /Table/61/1/2/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/2/#/62/1/1/0
 querying next range at /Table/61/1/2/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/2/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/2/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/2/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/2/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/2/#/62/{1-2}
 querying next range at /Table/61/1/2/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/3 -> NULL
 Del /Table/61/1/3/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/3/#/62/{1-2}
 querying next range at /Table/61/1/3/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/3/#/62/1/1{-/#}
 querying next range at /Table/61/1/3/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/3/#/62/1/1/0
 querying next range at /Table/61/1/3/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/3/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/3/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/3/#/62/{1-2}
 querying next range at /Table/61/1/3/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/4 -> NULL
 Del /Table/61/1/4/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/4/#/62/{1-2}
 querying next range at /Table/61/1/4/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/4/#/62/1/1{-/#}
 querying next range at /Table/61/1/4/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/4/#/62/1/1/0
 querying next range at /Table/61/1/4/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/4/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/4/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/4/#/62/{1-2}
 querying next range at /Table/61/1/4/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/5 -> NULL
 Del /Table/61/1/5/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/5/#/62/{1-2}
 querying next range at /Table/61/1/5/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/5/#/62/1/1{-/#}
 querying next range at /Table/61/1/5/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/5/#/62/1/1/0
 querying next range at /Table/61/1/5/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/5/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/5/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/5/#/62/{1-2}
 querying next range at /Table/61/1/5/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/6 -> NULL
 Del /Table/61/1/6/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/6/#/62/{1-2}
 querying next range at /Table/61/1/6/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/6/#/62/1/1{-/#}
 querying next range at /Table/61/1/6/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/6/#/62/1/1/0
 querying next range at /Table/61/1/6/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/6/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/6/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/6/#/62/{1-2}
 querying next range at /Table/61/1/6/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/7 -> NULL
 Del /Table/61/1/7/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/7/#/62/{1-2}
 querying next range at /Table/61/1/7/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/7/#/62/1/1{-/#}
 querying next range at /Table/61/1/7/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/7/#/62/1/1/0
 querying next range at /Table/61/1/7/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/7/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/7/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/7/#/62/{1-2}
 querying next range at /Table/61/1/7/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/8 -> NULL
 Del /Table/61/1/8/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/8/#/62/{1-2}
 querying next range at /Table/61/1/8/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/8/#/62/1/1{-/#}
 querying next range at /Table/61/1/8/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/8/#/62/1/1/0
 querying next range at /Table/61/1/8/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/8/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/8/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/8/#/62/{1-2}
 querying next range at /Table/61/1/8/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/9 -> NULL
 Del /Table/61/1/9/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/9/#/62/{1-2}
 querying next range at /Table/61/1/9/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/9/#/62/1/1{-/#}
 querying next range at /Table/61/1/9/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/9/#/62/1/1/0
 querying next range at /Table/61/1/9/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/9/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/9/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/9/#/62/{1-2}
 querying next range at /Table/61/1/9/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/10 -> NULL
 Del /Table/61/1/10/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/10/#/62/{1-2}
 querying next range at /Table/61/1/10/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/10/#/62/1/1{-/#}
 querying next range at /Table/61/1/10/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/10/#/62/1/1/0
 querying next range at /Table/61/1/10/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/10/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/10/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/10/#/62/{1-2}
 querying next range at /Table/61/1/10/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 querying next range at /Table/61/1/1/0
-r19: sending batch 10 Del, 1 EndTxn to (n1,s1):1
+r20: sending batch 10 Del, 1 EndTxn to (n1,s1):1
 output row: [1]
 output row: [2]
 output row: [3]

--- a/pkg/sql/logictest/testdata/planner_test/update
+++ b/pkg/sql/logictest/testdata/planner_test/update
@@ -241,14 +241,14 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 ----
 Scan /Table/57/{1-2}
 querying next range at /Table/57/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 fetched: /tu/primary/1 -> NULL
 fetched: /tu/primary/1/b -> 2
 fetched: /tu/primary/1/c/d -> /3/4
 Del /Table/57/1/1/1/1
 Del /Table/57/1/1/2/1
 querying next range at /Table/57/1/1/1/1
-r19: sending batch 2 Del, 1 EndTxn to (n1,s1):1
+r20: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 1
 

--- a/pkg/sql/logictest/testdata/planner_test/upsert
+++ b/pkg/sql/logictest/testdata/planner_test/upsert
@@ -42,9 +42,10 @@ Put /Table/54/1/1/0 -> /TUPLE/
 Del /Table/54/1/1/1/1
 Del /Table/54/1/1/2/1
 querying next range at /Table/54/1/1/0
-r19: sending batch 1 Put, 2 Del, 1 EndTxn to (n1,s1):1
+r20: sending batch 1 Put, 2 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 1
+
 subtest regression_32834
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -245,117 +245,117 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 ----
 Scan /Table/61/1/{5-7/#}
 querying next range at /Table/61/1/5
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 fetched: /a/primary/5 -> NULL
 Del /Table/61/1/5/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/5/#/62/{1-2}
 querying next range at /Table/61/1/5/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/5/#/62/1/1{-/#}
 CascadeScan /Table/61/1/5/#/62/1/2{-/#}
 querying next range at /Table/61/1/5/#/62/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/5/#/62/1/1/0
 Del /Table/61/1/5/#/62/1/2/0
 querying next range at /Table/61/1/5/#/62/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
 CascadeScan /Table/61/1/5/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/5/#/62/1/1/#/63/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 CascadeScan /Table/61/1/5/#/62/1/1/#/63/1/1{-/#}
 CascadeScan /Table/61/1/5/#/62/1/2/#/63/1/1{-/#}
 querying next range at /Table/61/1/5/#/62/1/1/#/63/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/5/#/62/1/1/#/63/1/1/0
 Del /Table/61/1/5/#/62/1/2/#/63/1/1/0
 querying next range at /Table/61/1/5/#/62/1/1/#/63/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 FKScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/5/#/62/1/1/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/5/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/5/#/62/1/2/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/5/#/62/{1-2}
 querying next range at /Table/61/1/5/#/62/1
-r19: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
 fetched: /a/primary/6 -> NULL
 Del /Table/61/1/6/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/6/#/62/{1-2}
 querying next range at /Table/61/1/6/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/6/#/62/1/1{-/#}
 CascadeScan /Table/61/1/6/#/62/1/2{-/#}
 querying next range at /Table/61/1/6/#/62/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/6/#/62/1/1/0
 Del /Table/61/1/6/#/62/1/2/0
 querying next range at /Table/61/1/6/#/62/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
 CascadeScan /Table/61/1/6/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/6/#/62/1/1/#/63/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 CascadeScan /Table/61/1/6/#/62/1/1/#/63/1/1{-/#}
 CascadeScan /Table/61/1/6/#/62/1/2/#/63/1/1{-/#}
 querying next range at /Table/61/1/6/#/62/1/1/#/63/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/6/#/62/1/1/#/63/1/1/0
 Del /Table/61/1/6/#/62/1/2/#/63/1/1/0
 querying next range at /Table/61/1/6/#/62/1/1/#/63/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 FKScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/6/#/62/1/1/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/6/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/6/#/62/1/2/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/6/#/62/{1-2}
 querying next range at /Table/61/1/6/#/62/1
-r19: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
 fetched: /a/primary/7 -> NULL
 Del /Table/61/1/7/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/7/#/62/{1-2}
 querying next range at /Table/61/1/7/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/7/#/62/1/1{-/#}
 CascadeScan /Table/61/1/7/#/62/1/2{-/#}
 querying next range at /Table/61/1/7/#/62/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/7/#/62/1/1/0
 Del /Table/61/1/7/#/62/1/2/0
 querying next range at /Table/61/1/7/#/62/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
 CascadeScan /Table/61/1/7/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/7/#/62/1/1/#/63/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 CascadeScan /Table/61/1/7/#/62/1/1/#/63/1/1{-/#}
 CascadeScan /Table/61/1/7/#/62/1/2/#/63/1/1{-/#}
 querying next range at /Table/61/1/7/#/62/1/1/#/63/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/7/#/62/1/1/#/63/1/1/0
 Del /Table/61/1/7/#/62/1/2/#/63/1/1/0
 querying next range at /Table/61/1/7/#/62/1/1/#/63/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 FKScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/7/#/62/1/1/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/7/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/7/#/62/1/2/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/7/#/62/{1-2}
 querying next range at /Table/61/1/7/#/62/1
-r19: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
 querying next range at /Table/61/1/5/0
-r19: sending batch 3 Del, 1 EndTxn to (n1,s1):1
+r20: sending batch 3 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 3
 
@@ -397,189 +397,189 @@ select message FROM [SHOW KV TRACE FOR SESSION]
 ----
 Scan /Table/61/{1-2}
 querying next range at /Table/61/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 fetched: /a/primary/3 -> NULL
 Del /Table/61/1/3/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/3/#/62/{1-2}
 querying next range at /Table/61/1/3/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/3/#/62/1/1{-/#}
 CascadeScan /Table/61/1/3/#/62/1/2{-/#}
 querying next range at /Table/61/1/3/#/62/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/3/#/62/1/1/0
 Del /Table/61/1/3/#/62/1/2/0
 querying next range at /Table/61/1/3/#/62/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
 CascadeScan /Table/61/1/3/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/3/#/62/1/1/#/63/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 CascadeScan /Table/61/1/3/#/62/1/1/#/63/1/1{-/#}
 CascadeScan /Table/61/1/3/#/62/1/2/#/63/1/1{-/#}
 querying next range at /Table/61/1/3/#/62/1/1/#/63/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/3/#/62/1/1/#/63/1/1/0
 Del /Table/61/1/3/#/62/1/2/#/63/1/1/0
 querying next range at /Table/61/1/3/#/62/1/1/#/63/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 FKScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/3/#/62/1/1/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/3/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/3/#/62/1/2/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/3/#/62/{1-2}
 querying next range at /Table/61/1/3/#/62/1
-r19: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
 fetched: /a/primary/4 -> NULL
 Del /Table/61/1/4/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/4/#/62/{1-2}
 querying next range at /Table/61/1/4/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/4/#/62/1/1{-/#}
 CascadeScan /Table/61/1/4/#/62/1/2{-/#}
 querying next range at /Table/61/1/4/#/62/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/4/#/62/1/1/0
 Del /Table/61/1/4/#/62/1/2/0
 querying next range at /Table/61/1/4/#/62/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
 CascadeScan /Table/61/1/4/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/4/#/62/1/1/#/63/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 CascadeScan /Table/61/1/4/#/62/1/1/#/63/1/1{-/#}
 CascadeScan /Table/61/1/4/#/62/1/2/#/63/1/1{-/#}
 querying next range at /Table/61/1/4/#/62/1/1/#/63/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/4/#/62/1/1/#/63/1/1/0
 Del /Table/61/1/4/#/62/1/2/#/63/1/1/0
 querying next range at /Table/61/1/4/#/62/1/1/#/63/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 FKScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/4/#/62/1/1/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/4/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/4/#/62/1/2/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/4/#/62/{1-2}
 querying next range at /Table/61/1/4/#/62/1
-r19: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
 fetched: /a/primary/8 -> NULL
 Del /Table/61/1/8/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/8/#/62/{1-2}
 querying next range at /Table/61/1/8/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/8/#/62/1/1{-/#}
 CascadeScan /Table/61/1/8/#/62/1/2{-/#}
 querying next range at /Table/61/1/8/#/62/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/8/#/62/1/1/0
 Del /Table/61/1/8/#/62/1/2/0
 querying next range at /Table/61/1/8/#/62/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
 CascadeScan /Table/61/1/8/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/8/#/62/1/1/#/63/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 CascadeScan /Table/61/1/8/#/62/1/1/#/63/1/1{-/#}
 CascadeScan /Table/61/1/8/#/62/1/2/#/63/1/1{-/#}
 querying next range at /Table/61/1/8/#/62/1/1/#/63/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/8/#/62/1/1/#/63/1/1/0
 Del /Table/61/1/8/#/62/1/2/#/63/1/1/0
 querying next range at /Table/61/1/8/#/62/1/1/#/63/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 FKScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/8/#/62/1/1/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/8/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/8/#/62/1/2/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/8/#/62/{1-2}
 querying next range at /Table/61/1/8/#/62/1
-r19: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
 fetched: /a/primary/9 -> NULL
 Del /Table/61/1/9/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/9/#/62/{1-2}
 querying next range at /Table/61/1/9/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/9/#/62/1/1{-/#}
 CascadeScan /Table/61/1/9/#/62/1/2{-/#}
 querying next range at /Table/61/1/9/#/62/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/9/#/62/1/1/0
 Del /Table/61/1/9/#/62/1/2/0
 querying next range at /Table/61/1/9/#/62/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
 CascadeScan /Table/61/1/9/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/9/#/62/1/1/#/63/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 CascadeScan /Table/61/1/9/#/62/1/1/#/63/1/1{-/#}
 CascadeScan /Table/61/1/9/#/62/1/2/#/63/1/1{-/#}
 querying next range at /Table/61/1/9/#/62/1/1/#/63/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/9/#/62/1/1/#/63/1/1/0
 Del /Table/61/1/9/#/62/1/2/#/63/1/1/0
 querying next range at /Table/61/1/9/#/62/1/1/#/63/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 FKScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/9/#/62/1/1/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/9/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/9/#/62/1/2/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/9/#/62/{1-2}
 querying next range at /Table/61/1/9/#/62/1
-r19: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
 fetched: /a/primary/10 -> NULL
 Del /Table/61/1/10/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/10/#/62/{1-2}
 querying next range at /Table/61/1/10/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/10/#/62/1/1{-/#}
 CascadeScan /Table/61/1/10/#/62/1/2{-/#}
 querying next range at /Table/61/1/10/#/62/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/10/#/62/1/1/0
 Del /Table/61/1/10/#/62/1/2/0
 querying next range at /Table/61/1/10/#/62/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
 CascadeScan /Table/61/1/10/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/10/#/62/1/1/#/63/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 CascadeScan /Table/61/1/10/#/62/1/1/#/63/1/1{-/#}
 CascadeScan /Table/61/1/10/#/62/1/2/#/63/1/1{-/#}
 querying next range at /Table/61/1/10/#/62/1/1/#/63/1/1
-r19: sending batch 2 Scan to (n1,s1):1
+r20: sending batch 2 Scan to (n1,s1):1
 Del /Table/61/1/10/#/62/1/1/#/63/1/1/0
 Del /Table/61/1/10/#/62/1/2/#/63/1/1/0
 querying next range at /Table/61/1/10/#/62/1/1/#/63/1/1/0
-r19: sending batch 2 Del to (n1,s1):1
+r20: sending batch 2 Del to (n1,s1):1
 FKScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/10/#/62/1/1/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/10/#/62/1/2/#/63/{1-2}
 querying next range at /Table/61/1/10/#/62/1/2/#/63/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 FKScan /Table/61/1/10/#/62/{1-2}
 querying next range at /Table/61/1/10/#/62/1
-r19: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 2 QueryIntent to (n1,s1):1
 querying next range at /Table/61/1/3/0
-r19: sending batch 5 Del, 1 EndTxn to (n1,s1):1
+r20: sending batch 5 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 5
 
@@ -622,229 +622,229 @@ select message FROM [SHOW KV TRACE FOR SESSION];
 ----
 Scan /Table/61/{1-2}
 querying next range at /Table/61/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 fetched: /a/primary/1 -> NULL
 Del /Table/61/1/1/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/1/#/62/{1-2}
 querying next range at /Table/61/1/1/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/1/#/62/1/1{-/#}
 querying next range at /Table/61/1/1/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/1/#/62/1/1/0
 querying next range at /Table/61/1/1/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/1/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/1/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/1/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/1/#/62/{1-2}
 querying next range at /Table/61/1/1/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/2 -> NULL
 Del /Table/61/1/2/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/2/#/62/{1-2}
 querying next range at /Table/61/1/2/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/2/#/62/1/1{-/#}
 querying next range at /Table/61/1/2/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/2/#/62/1/1/0
 querying next range at /Table/61/1/2/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/2/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/2/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/2/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/2/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/2/#/62/{1-2}
 querying next range at /Table/61/1/2/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/3 -> NULL
 Del /Table/61/1/3/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/3/#/62/{1-2}
 querying next range at /Table/61/1/3/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/3/#/62/1/1{-/#}
 querying next range at /Table/61/1/3/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/3/#/62/1/1/0
 querying next range at /Table/61/1/3/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/3/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/3/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/3/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/3/#/62/{1-2}
 querying next range at /Table/61/1/3/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/4 -> NULL
 Del /Table/61/1/4/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/4/#/62/{1-2}
 querying next range at /Table/61/1/4/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/4/#/62/1/1{-/#}
 querying next range at /Table/61/1/4/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/4/#/62/1/1/0
 querying next range at /Table/61/1/4/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/4/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/4/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/4/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/4/#/62/{1-2}
 querying next range at /Table/61/1/4/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/5 -> NULL
 Del /Table/61/1/5/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/5/#/62/{1-2}
 querying next range at /Table/61/1/5/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/5/#/62/1/1{-/#}
 querying next range at /Table/61/1/5/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/5/#/62/1/1/0
 querying next range at /Table/61/1/5/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/5/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/5/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/5/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/5/#/62/{1-2}
 querying next range at /Table/61/1/5/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/6 -> NULL
 Del /Table/61/1/6/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/6/#/62/{1-2}
 querying next range at /Table/61/1/6/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/6/#/62/1/1{-/#}
 querying next range at /Table/61/1/6/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/6/#/62/1/1/0
 querying next range at /Table/61/1/6/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/6/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/6/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/6/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/6/#/62/{1-2}
 querying next range at /Table/61/1/6/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/7 -> NULL
 Del /Table/61/1/7/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/7/#/62/{1-2}
 querying next range at /Table/61/1/7/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/7/#/62/1/1{-/#}
 querying next range at /Table/61/1/7/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/7/#/62/1/1/0
 querying next range at /Table/61/1/7/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/7/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/7/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/7/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/7/#/62/{1-2}
 querying next range at /Table/61/1/7/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/8 -> NULL
 Del /Table/61/1/8/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/8/#/62/{1-2}
 querying next range at /Table/61/1/8/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/8/#/62/1/1{-/#}
 querying next range at /Table/61/1/8/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/8/#/62/1/1/0
 querying next range at /Table/61/1/8/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/8/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/8/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/8/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/8/#/62/{1-2}
 querying next range at /Table/61/1/8/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/9 -> NULL
 Del /Table/61/1/9/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/9/#/62/{1-2}
 querying next range at /Table/61/1/9/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/9/#/62/1/1{-/#}
 querying next range at /Table/61/1/9/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/9/#/62/1/1/0
 querying next range at /Table/61/1/9/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/9/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/9/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/9/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/9/#/62/{1-2}
 querying next range at /Table/61/1/9/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 fetched: /a/primary/10 -> NULL
 Del /Table/61/1/10/0
 cascading delete into table: 62 using index: 1
 CascadeScan /Table/61/1/10/#/62/{1-2}
 querying next range at /Table/61/1/10/#/62/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 CascadeScan /Table/61/1/10/#/62/1/1{-/#}
 querying next range at /Table/61/1/10/#/62/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 Del /Table/61/1/10/#/62/1/1/0
 querying next range at /Table/61/1/10/#/62/1/1/0
-r19: sending batch 1 Del to (n1,s1):1
+r20: sending batch 1 Del to (n1,s1):1
 cascading delete into table: 63 using index: 1
 CascadeScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/10/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/10/#/62/1/1/#/63/{1-2}
 querying next range at /Table/61/1/10/#/62/1/1/#/63/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 FKScan /Table/61/1/10/#/62/{1-2}
 querying next range at /Table/61/1/10/#/62/1
-r19: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
+r20: sending batch 1 Scan, 1 QueryIntent to (n1,s1):1
 querying next range at /Table/61/1/1/0
-r19: sending batch 10 Del to (n1,s1):1
+r20: sending batch 10 Del to (n1,s1):1
 output row: [1]
 output row: [2]
 output row: [3]
@@ -857,7 +857,7 @@ output row: [9]
 output row: [10]
 rows affected: 10
 querying next range at /Table/61/1/1/0
-r19: sending batch 1 EndTxn, 10 QueryIntent to (n1,s1):1
+r20: sending batch 1 EndTxn, 10 QueryIntent to (n1,s1):1
 
 statement ok
 DROP TABLE c; DROP TABLE b; DROP TABLE a

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -254,13 +254,13 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 ----
 Scan /Table/57/{1-2}
 querying next range at /Table/57/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 fetched: /tu/primary/1 -> NULL
 fetched: /tu/primary/1/b -> 2
 fetched: /tu/primary/1/c/d -> /3/4
 Del /Table/57/1/1/1/1
 Del /Table/57/1/1/2/1
 querying next range at /Table/57/1/1/1/1
-r19: sending batch 2 Del, 1 EndTxn to (n1,s1):1
+r20: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -54,13 +54,13 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 ----
 Scan /Table/54/1/1{-/#}
 querying next range at /Table/54/1/1
-r19: sending batch 1 Scan to (n1,s1):1
+r20: sending batch 1 Scan to (n1,s1):1
 fetched: /tu/primary/1 -> NULL
 fetched: /tu/primary/1/b -> 2
 fetched: /tu/primary/1/c/d -> /3/4
 Del /Table/54/1/1/1/1
 Del /Table/54/1/1/2/1
 querying next range at /Table/54/1/1/1/1
-r19: sending batch 2 Del, 1 EndTxn to (n1,s1):1
+r20: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 1

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -911,15 +911,15 @@ func addSystemDatabaseToSchema(target *MetadataSchema) {
 	target.AddDescriptor(keys.SystemDatabaseID, &LocationsTable)
 	target.AddDescriptor(keys.SystemDatabaseID, &RoleMembersTable)
 
+	// The CommentsTable has been introduced in 2.2. It was added here since it
+	// was introduced, but it's also created as a migration for older clusters.
+	target.AddDescriptor(keys.SystemDatabaseID, &CommentsTable)
+
 	target.AddSplitIDs(keys.PseudoTableIDs...)
 
-	// Adding a new system table? Don't add it to the metadata schema yet!
-	//
-	// The first release to contain the system table must add the system table
-	// via a migration in both fresh clusters and existing clusters. Only in the
-	// next release should you "bake in" the migration by adding the table to
-	// the metadata schema here. This ensures there's only ever one code path
-	// responsible for creating the table.
+	// Adding a new system table? It should be added here to the metadata schema,
+	// and also created as a migration for older cluster. The includedInBootstrap
+	// field should be set on the migration.
 
 	// Default zone config entry.
 	zoneConf := config.DefaultZoneConfig()

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -204,7 +204,7 @@ func TestEnsureMigrations(t *testing.T) {
 			}
 			backwardCompatibleMigrations = tc.migrations
 
-			err := mgr.EnsureMigrations(context.Background())
+			err := mgr.EnsureMigrations(context.Background(), AllMigrations)
 			if !testutils.IsError(err, tc.expectedErr) {
 				t.Errorf("expected error %q, got error %v", tc.expectedErr, err)
 			}
@@ -267,7 +267,7 @@ func TestDBErrors(t *testing.T) {
 			db.scanErr = tc.scanErr
 			db.putErr = tc.putErr
 			db.kvs = make(map[string][]byte)
-			err := mgr.EnsureMigrations(context.Background())
+			err := mgr.EnsureMigrations(context.Background(), AllMigrations)
 			if !testutils.IsError(err, tc.expectedErr) {
 				t.Errorf("expected error %q, got error %v", tc.expectedErr, err)
 			}
@@ -305,7 +305,7 @@ func TestLeaseErrors(t *testing.T) {
 	migration := noopMigration1
 	defer func(prev []migrationDescriptor) { backwardCompatibleMigrations = prev }(backwardCompatibleMigrations)
 	backwardCompatibleMigrations = []migrationDescriptor{migration}
-	if err := mgr.EnsureMigrations(context.Background()); err != nil {
+	if err := mgr.EnsureMigrations(context.Background(), AllMigrations); err != nil {
 		t.Error(err)
 	}
 	if _, ok := db.kvs[string(migrationKey(migration))]; !ok {
@@ -352,7 +352,7 @@ func TestLeaseExpiration(t *testing.T) {
 	}
 	defer func(prev []migrationDescriptor) { backwardCompatibleMigrations = prev }(backwardCompatibleMigrations)
 	backwardCompatibleMigrations = []migrationDescriptor{waitForExitMigration}
-	if err := mgr.EnsureMigrations(context.Background()); err != nil {
+	if err := mgr.EnsureMigrations(context.Background(), AllMigrations); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
This patch introduces the concept of a backwards-compatible migration
that is redundant with the schema created at cluster bootstrap time. If
the cluster is bootstrapped by the cockroach version that is aware of
the migration, then that migration is not run. If the cluster is older,
the migration does run normally.
This is meant to be used (and used already) for migrations that create
new system tables. Here's the deal: we want system tables to be created
at node bootstrap time because we want them to also get their own
dedicated range (as all tables do). Creating the table at bootstrap time
allows us to create a range by hand for it. If the tables in question
are not created at bootstrap time, and are created later by a migration,
then the corresponding range is creating even more later by the split
queue, asynchronously (w.r.t cluster startup). This is a big nuissance
for tests, many of whom like to know in advance the count of ranges that
are to be expected from a new cluster.

This patch uses the new mechanism for the Comments table, which was
recently introduced.

Fixes #33525

Release note: None