### PR TITLE
sql: pass around parser.Statement

### DIFF
--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -177,7 +177,7 @@ func rewriteViewQueryDBNames(table *sqlbase.TableDescriptor, newDB string) error
 			ctxCopy.WithReformatTableNames(nil)
 			ctxCopy.FormatNode(tn)
 		})
-	f.FormatNode(stmt)
+	f.FormatNode(stmt.AST)
 	table.ViewQuery = f.CloseAndGetString()
 	return nil
 }

--- a/pkg/ccl/backupccl/targets_test.go
+++ b/pkg/ccl/backupccl/targets_test.go
@@ -107,7 +107,7 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			targets := stmt.(*tree.Grant).Targets
+			targets := stmt.AST.(*tree.Grant).Targets
 
 			matched, err := descriptorsMatchingTargets(context.TODO(),
 				test.sessionDatabase, searchPath, descriptors, targets)

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -37,7 +37,7 @@ func parseTableDesc(createTableStmt string) (*sqlbase.TableDescriptor, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, `parsing %s`, createTableStmt)
 	}
-	createTable, ok := stmt.(*tree.CreateTable)
+	createTable, ok := stmt.AST.(*tree.CreateTable)
 	if !ok {
 		return nil, errors.Errorf("expected *tree.CreateTable got %T", stmt)
 	}
@@ -60,7 +60,7 @@ func parseValues(tableDesc *sqlbase.TableDescriptor, values string) ([]sqlbase.E
 	if err != nil {
 		return nil, err
 	}
-	selectStmt, ok := valuesStmt.(*tree.Select)
+	selectStmt, ok := valuesStmt.AST.(*tree.Select)
 	if !ok {
 		return nil, errors.Errorf("expected *tree.Select got %T", valuesStmt)
 	}

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -398,7 +398,7 @@ func (f *tableFeedFactory) Feed(t testing.TB, create string, args ...interface{}
 	if err != nil {
 		t.Fatal(err)
 	}
-	createStmt := parsed.(*tree.CreateChangefeed)
+	createStmt := parsed.AST.(*tree.CreateChangefeed)
 	if createStmt.SinkURI != nil {
 		t.Fatalf(`unexpected sink provided: "INTO %s"`, tree.AsString(createStmt.SinkURI))
 	}

--- a/pkg/ccl/importccl/csv_internal_test.go
+++ b/pkg/ccl/importccl/csv_internal_test.go
@@ -67,7 +67,7 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			create, ok := stmt.(*tree.CreateTable)
+			create, ok := stmt.AST.(*tree.CreateTable)
 			if !ok {
 				t.Fatal("expected CREATE TABLE statement in table file")
 			}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -121,7 +121,7 @@ func readCreateTableFromStore(
 	if err != nil {
 		return nil, err
 	}
-	create, ok := stmt.(*tree.CreateTable)
+	create, ok := stmt.AST.(*tree.CreateTable)
 	if !ok {
 		return nil, errors.New("expected CREATE TABLE statement in table file")
 	}

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1442,7 +1442,7 @@ func BenchmarkConvertRecord(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	create := stmt.(*tree.CreateTable)
+	create := stmt.AST.(*tree.CreateTable)
 	st := cluster.MakeTestingClusterSettings()
 
 	tableDesc, err := MakeSimpleTableDescriptor(ctx, st, create, sqlbase.ID(100), sqlbase.ID(100), NoFKs, 1)

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -129,7 +129,7 @@ func Load(
 		if err != nil {
 			return backupccl.BackupDescriptor{}, errors.Wrapf(err, "parsing: %q", cmd)
 		}
-		switch s := stmt.(type) {
+		switch s := stmt.AST.(type) {
 		case *tree.CreateTable:
 			if tableDesc != nil {
 				if err := writeSST(ctx, &backup, dir, tempPrefix, kvs, ts); err != nil {

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -120,7 +120,7 @@ func (t *partitioningTest) parse() error {
 		if err != nil {
 			return errors.Wrapf(err, `parsing %s`, t.parsed.createStmt)
 		}
-		createTable, ok := stmt.(*tree.CreateTable)
+		createTable, ok := stmt.AST.(*tree.CreateTable)
 		if !ok {
 			return errors.Errorf("expected *tree.CreateTable got %T", stmt)
 		}

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -450,7 +450,7 @@ func getMetadataForTable(conn *sqlConn, md basicMetadata, ts string) (tableMetad
 		if err != nil {
 			return tableMetadata{}, fmt.Errorf("type %s is not a valid CockroachDB type", typ)
 		}
-		coltyp := stmt.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAlterColumnType).ToType
+		coltyp := stmt.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAlterColumnType).ToType
 
 		coltypes[name] = coltyp
 		if colnames.Len() > 0 {

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -302,7 +302,7 @@ func scrubStmtStatKey(vt VirtualTabler, key string) (string, bool) {
 			keepNameCtx.WithReformatTableNames(nil)
 			keepNameCtx.FormatNode(&newTn)
 		})
-	f.FormatNode(stmt)
+	f.FormatNode(stmt.AST)
 	return f.CloseAndGetString(), true
 }
 

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -54,7 +54,7 @@ func (ex *connExecutor) execPrepare(
 	}
 
 	ps, err := ex.addPreparedStmt(
-		ctx, parseCmd.Name, Statement{SQL: parseCmd.SQL, AST: parseCmd.Stmt}, parseCmd.TypeHints,
+		ctx, parseCmd.Name, Statement{Statement: parseCmd.Statement}, parseCmd.TypeHints,
 	)
 	if err != nil {
 		return retErr(err)
@@ -160,9 +160,7 @@ func (ex *connExecutor) prepare(
 	if stmt.AST == nil {
 		return prepared, nil
 	}
-	prepared.Str = stmt.String()
-
-	prepared.Statement = stmt.AST
+	prepared.Statement = stmt.Statement
 	prepared.AnonymizedStr = anonymizeStmt(stmt)
 
 	// Point to the prepared state, which can be further populated during query
@@ -510,7 +508,7 @@ func (ex *connExecutor) execDescribe(
 
 		res.SetInTypes(ps.InTypes)
 
-		if stmtHasNoData(ps.Statement) {
+		if stmtHasNoData(ps.AST) {
 			res.SetNoDataRowDescription()
 		} else {
 			res.SetPrepStmtOutput(ctx, ps.Columns)
@@ -522,7 +520,7 @@ func (ex *connExecutor) execDescribe(
 				pgerror.CodeInvalidCursorNameError, "unknown portal %q", descCmd.Name))
 		}
 
-		if stmtHasNoData(portal.Stmt.Statement) {
+		if stmtHasNoData(portal.Stmt.AST) {
 			res.SetNoDataRowDescription()
 		} else {
 			res.SetPortalOutput(ctx, portal.Stmt.Columns, portal.OutFormats)

--- a/pkg/sql/conn_io_test.go
+++ b/pkg/sql/conn_io_test.go
@@ -72,10 +72,10 @@ func TestStmtBuf(t *testing.T) {
 		t.Fatal(err)
 	}
 	buf := NewStmtBuf()
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1})
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s2})
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s3})
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s4})
+	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
+	mustPush(ctx, t, buf, ExecStmt{Stmt: s2.AST})
+	mustPush(ctx, t, buf, ExecStmt{Stmt: s3.AST})
+	mustPush(ctx, t, buf, ExecStmt{Stmt: s4.AST})
 
 	// Check that, while we don't manually advance the cursor, we keep getting the
 	// same statement.
@@ -149,7 +149,7 @@ func TestStmtBufSignal(t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		_ = buf.Push(ctx, ExecStmt{Stmt: s1})
+		_ = buf.Push(ctx, ExecStmt{Stmt: s1.AST})
 	}()
 
 	expPos := CmdPos(0)
@@ -174,7 +174,7 @@ func TestStmtBufLtrim(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		mustPush(ctx, t, buf, ExecStmt{Stmt: stmt})
+		mustPush(ctx, t, buf, ExecStmt{Stmt: stmt.AST})
 	}
 	// Advance the cursor so that we can trim.
 	buf.advanceOne()
@@ -200,7 +200,7 @@ func TestStmtBufClose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustPush(ctx, t, buf, ExecStmt{Stmt: stmt})
+	mustPush(ctx, t, buf, ExecStmt{Stmt: stmt.AST})
 	buf.Close()
 
 	_, _, err = buf.curCmd()
@@ -237,7 +237,7 @@ func TestStmtBufPreparedStmt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1})
+	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
 	mustPush(ctx, t, buf, PrepareStmt{Name: "p1"})
 	mustPush(ctx, t, buf, PrepareStmt{Name: "p2"})
 
@@ -284,20 +284,20 @@ func TestStmtBufBatching(t *testing.T) {
 	// Start a new batch.
 	mustPush(ctx, t, buf, Sync{})
 
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1})
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1})
+	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
+	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
 
 	// Start a new batch.
 	mustPush(ctx, t, buf, Sync{})
 
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1})
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1})
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1})
+	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
+	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
+	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
 
 	// Start a new batch.
 	mustPush(ctx, t, buf, Sync{})
 
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1})
+	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
 
 	// Go to 2nd batch.
 	if err := buf.seekToNextBatch(); err != nil {
@@ -326,7 +326,7 @@ func TestStmtBufBatching(t *testing.T) {
 	// Async start a 4th batch; that will unblock the seek below.
 	go func() {
 		mustPush(ctx, t, buf, Sync{})
-		_ = buf.Push(ctx, ExecStmt{Stmt: s1})
+		_ = buf.Push(ctx, ExecStmt{Stmt: s1.AST})
 	}()
 
 	// Go to 4th batch.

--- a/pkg/sql/conn_io_test.go
+++ b/pkg/sql/conn_io_test.go
@@ -30,7 +30,7 @@ func assertStmt(t *testing.T, cmd Command, exp string) {
 	if !ok {
 		t.Fatalf("%s: expected ExecStmt, got %T", testutils.Caller(1), cmd)
 	}
-	if stmt.Stmt.String() != exp {
+	if stmt.AST.String() != exp {
 		t.Fatalf("%s: expected statement %s, got %s", testutils.Caller(1), exp, stmt)
 	}
 }
@@ -72,10 +72,10 @@ func TestStmtBuf(t *testing.T) {
 		t.Fatal(err)
 	}
 	buf := NewStmtBuf()
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s2.AST})
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s3.AST})
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s4.AST})
+	mustPush(ctx, t, buf, ExecStmt{Statement: s1})
+	mustPush(ctx, t, buf, ExecStmt{Statement: s2})
+	mustPush(ctx, t, buf, ExecStmt{Statement: s3})
+	mustPush(ctx, t, buf, ExecStmt{Statement: s4})
 
 	// Check that, while we don't manually advance the cursor, we keep getting the
 	// same statement.
@@ -149,7 +149,7 @@ func TestStmtBufSignal(t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		_ = buf.Push(ctx, ExecStmt{Stmt: s1.AST})
+		_ = buf.Push(ctx, ExecStmt{Statement: s1})
 	}()
 
 	expPos := CmdPos(0)
@@ -174,7 +174,7 @@ func TestStmtBufLtrim(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		mustPush(ctx, t, buf, ExecStmt{Stmt: stmt.AST})
+		mustPush(ctx, t, buf, ExecStmt{Statement: stmt})
 	}
 	// Advance the cursor so that we can trim.
 	buf.advanceOne()
@@ -200,7 +200,7 @@ func TestStmtBufClose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustPush(ctx, t, buf, ExecStmt{Stmt: stmt.AST})
+	mustPush(ctx, t, buf, ExecStmt{Statement: stmt})
 	buf.Close()
 
 	_, _, err = buf.curCmd()
@@ -237,7 +237,7 @@ func TestStmtBufPreparedStmt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
+	mustPush(ctx, t, buf, ExecStmt{Statement: s1})
 	mustPush(ctx, t, buf, PrepareStmt{Name: "p1"})
 	mustPush(ctx, t, buf, PrepareStmt{Name: "p2"})
 
@@ -284,20 +284,20 @@ func TestStmtBufBatching(t *testing.T) {
 	// Start a new batch.
 	mustPush(ctx, t, buf, Sync{})
 
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
+	mustPush(ctx, t, buf, ExecStmt{Statement: s1})
+	mustPush(ctx, t, buf, ExecStmt{Statement: s1})
 
 	// Start a new batch.
 	mustPush(ctx, t, buf, Sync{})
 
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
+	mustPush(ctx, t, buf, ExecStmt{Statement: s1})
+	mustPush(ctx, t, buf, ExecStmt{Statement: s1})
+	mustPush(ctx, t, buf, ExecStmt{Statement: s1})
 
 	// Start a new batch.
 	mustPush(ctx, t, buf, Sync{})
 
-	mustPush(ctx, t, buf, ExecStmt{Stmt: s1.AST})
+	mustPush(ctx, t, buf, ExecStmt{Statement: s1})
 
 	// Go to 2nd batch.
 	if err := buf.seekToNextBatch(); err != nil {
@@ -326,7 +326,7 @@ func TestStmtBufBatching(t *testing.T) {
 	// Async start a 4th batch; that will unblock the seek below.
 	go func() {
 		mustPush(ctx, t, buf, Sync{})
-		_ = buf.Push(ctx, ExecStmt{Stmt: s1.AST})
+		_ = buf.Push(ctx, ExecStmt{Statement: s1})
 	}()
 
 	// Go to 4th batch.

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -346,7 +346,7 @@ func (p *planner) getViewPlan(
 	if err != nil {
 		return planDataSource{}, errors.Wrapf(err, "failed to parse underlying query from view %q", tn)
 	}
-	sel, ok := stmt.(*tree.Select)
+	sel, ok := stmt.AST.(*tree.Select)
 	if !ok {
 		return planDataSource{},
 			errors.Errorf("failed to parse underlying query from view %q as a select", tn)

--- a/pkg/sql/database_test.go
+++ b/pkg/sql/database_test.go
@@ -35,7 +35,7 @@ func TestMakeDatabaseDesc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	desc := makeDatabaseDesc(stmt.(*tree.CreateDatabase))
+	desc := makeDatabaseDesc(stmt.AST.(*tree.CreateDatabase))
 	if desc.Name != "test" {
 		t.Fatalf("expected Name == test, got %s", desc.Name)
 	}

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -75,7 +75,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.makePlan(ctx, Statement{SQL: query, AST: stmt}); err != nil {
+	if err := p.makePlan(ctx, Statement{SQL: query, AST: stmt.AST}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -142,7 +142,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		recv := MakeDistSQLReceiver(
 			ctx,
 			rw,
-			stmt.StatementType(),
+			stmt.AST.StatementType(),
 			execCfg.RangeDescriptorCache,
 			execCfg.LeaseHolderCache,
 			txn,

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -75,7 +75,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.makePlan(ctx, Statement{SQL: query, AST: stmt.AST}); err != nil {
+	if err := p.makePlan(ctx, Statement{Statement: stmt}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -375,7 +375,7 @@ func assertExpectedPlansForTests(t *testing.T, sqlSetup string, plansToTest []*T
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := p.makePlan(ctx, Statement{SQL: test.SQL, AST: stmt}); err != nil {
+		if err := p.makePlan(ctx, Statement{SQL: test.SQL, AST: stmt.AST}); err != nil {
 			t.Fatal(err)
 		}
 		actualPlanTree := planToTree(ctx, p.curPlan)

--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -375,7 +375,7 @@ func assertExpectedPlansForTests(t *testing.T, sqlSetup string, plansToTest []*T
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := p.makePlan(ctx, Statement{SQL: test.SQL, AST: stmt.AST}); err != nil {
+		if err := p.makePlan(ctx, Statement{Statement: stmt}); err != nil {
 			t.Fatal(err)
 		}
 		actualPlanTree := planToTree(ctx, p.curPlan)

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -506,7 +506,7 @@ func (ie *internalExecutorImpl) execInternal(
 			ctx,
 			ExecStmt{
 				SQL:          stmt,
-				Stmt:         s,
+				Stmt:         s.AST,
 				TimeReceived: timeReceived,
 				ParseStart:   parseStart,
 				ParseEnd:     parseEnd,
@@ -519,7 +519,7 @@ func (ie *internalExecutorImpl) execInternal(
 			ctx,
 			PrepareStmt{
 				SQL:        stmt,
-				Stmt:       s,
+				Stmt:       s.AST,
 				ParseStart: parseStart,
 				ParseEnd:   parseEnd,
 				TypeHints:  typeHints,

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -453,7 +453,7 @@ func (ie *internalExecutorImpl) execInternal(
 
 	timeReceived := timeutil.Now()
 	parseStart := timeReceived
-	s, err := parser.ParseOne(stmt)
+	parsed, err := parser.ParseOne(stmt)
 	if err != nil {
 		return result{}, err
 	}
@@ -505,8 +505,7 @@ func (ie *internalExecutorImpl) execInternal(
 		if err := stmtBuf.Push(
 			ctx,
 			ExecStmt{
-				SQL:          stmt,
-				Stmt:         s.AST,
+				Statement:    parsed,
 				TimeReceived: timeReceived,
 				ParseStart:   parseStart,
 				ParseEnd:     parseEnd,
@@ -518,8 +517,7 @@ func (ie *internalExecutorImpl) execInternal(
 		if err := stmtBuf.Push(
 			ctx,
 			PrepareStmt{
-				SQL:        stmt,
-				Stmt:       s.AST,
+				Statement:  parsed,
 				ParseStart: parseStart,
 				ParseEnd:   parseEnd,
 				TypeHints:  typeHints,

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -529,7 +529,7 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 }
 
 func (h *harness) runUsingAPI(tb testing.TB, bmType BenchmarkType, usePrepared bool) {
-	var stmt tree.Statement
+	var stmt parser.Statement
 	var err error
 	if !usePrepared {
 		stmt, err = parser.ParseOne(h.query.query)
@@ -548,7 +548,7 @@ func (h *harness) runUsingAPI(tb testing.TB, bmType BenchmarkType, usePrepared b
 	}
 
 	if !usePrepared {
-		bld := optbuilder.New(h.ctx, &h.semaCtx, &h.evalCtx, h.cat, h.optimizer.Factory(), stmt)
+		bld := optbuilder.New(h.ctx, &h.semaCtx, &h.evalCtx, h.cat, h.optimizer.Factory(), stmt.AST)
 		if err = bld.Build(); err != nil {
 			tb.Fatalf("%v", err)
 		}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -68,7 +68,7 @@ func TestMemoInit(t *testing.T) {
 
 	var o xform.Optimizer
 	o.Init(&evalCtx)
-	err = optbuilder.New(ctx, &semaCtx, &evalCtx, catalog, o.Factory(), stmt).Build()
+	err = optbuilder.New(ctx, &semaCtx, &evalCtx, catalog, o.Factory(), stmt.AST).Build()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestMemoIsStale(t *testing.T) {
 
 	var o xform.Optimizer
 	o.Init(&evalCtx)
-	err = optbuilder.New(ctx, &semaCtx, &evalCtx, catalog, o.Factory(), stmt).Build()
+	err = optbuilder.New(ctx, &semaCtx, &evalCtx, catalog, o.Factory(), stmt.AST).Build()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -153,7 +153,7 @@ func (b *Builder) buildView(view cat.View, inScope *scope) (outScope *scope) {
 			panic(builderError{wrapped})
 		}
 
-		sel, ok = stmt.(*tree.Select)
+		sel, ok = stmt.AST.(*tree.Select)
 		if !ok {
 			panic("expected SELECT statement")
 		}

--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -807,7 +807,7 @@ func (ot *OptTester) buildExpr(factory *norm.Factory) error {
 		return err
 	}
 
-	b := optbuilder.New(ot.ctx, &ot.semaCtx, &ot.evalCtx, ot.catalog, factory, stmt)
+	b := optbuilder.New(ot.ctx, &ot.semaCtx, &ot.evalCtx, ot.catalog, factory, stmt.AST)
 	b.AllowUnsupportedExpr = ot.Flags.AllowUnsupportedExpr
 	if ot.Flags.FullyQualifyNames {
 		b.FmtFlags = tree.FmtAlwaysQualifyTableNames

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -264,11 +264,11 @@ func (tc *Catalog) ExecuteDDL(sql string) (string, error) {
 		return "", err
 	}
 
-	if stmt.StatementType() != tree.DDL {
-		return "", fmt.Errorf("statement type is not DDL: %v", stmt.StatementType())
+	if stmt.AST.StatementType() != tree.DDL {
+		return "", fmt.Errorf("statement type is not DDL: %v", stmt.AST.StatementType())
 	}
 
-	switch stmt := stmt.(type) {
+	switch stmt := stmt.AST.(type) {
 	case *tree.CreateTable:
 		tab := tc.CreateTable(stmt)
 		return tab.String(), nil

--- a/pkg/sql/opt/testutils/testcat/vtable.go
+++ b/pkg/sql/opt/testutils/testcat/vtable.go
@@ -42,7 +42,7 @@ func init() {
 			panic(fmt.Sprintf("error initializing virtual table map: %s", err))
 		}
 
-		ct, ok := parsed.(*tree.CreateTable)
+		ct, ok := parsed.AST.(*tree.CreateTable)
 		if !ok {
 			panic("virtual table schemas must be CREATE TABLE statements")
 		}

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -51,7 +51,7 @@ func TestDetachMemo(t *testing.T) {
 
 	var o xform.Optimizer
 	o.Init(&evalCtx)
-	err = optbuilder.New(ctx, &semaCtx, &evalCtx, catalog, o.Factory(), stmt).Build()
+	err = optbuilder.New(ctx, &semaCtx, &evalCtx, catalog, o.Factory(), stmt.AST).Build()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestDetachMemo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = optbuilder.New(ctx, &semaCtx, &evalCtx, catalog, o.Factory(), stmt2).Build()
+	err = optbuilder.New(ctx, &semaCtx, &evalCtx, catalog, o.Factory(), stmt2.AST).Build()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -329,7 +329,7 @@ func planQuery(t *testing.T, s serverutils.TestServerInterface, sql string) (*pl
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.makePlan(context.TODO(), Statement{SQL: sql, AST: stmt.AST}); err != nil {
+	if err := p.makePlan(context.TODO(), Statement{Statement: stmt}); err != nil {
 		t.Fatal(err)
 	}
 	return p, func() {

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -329,7 +329,7 @@ func planQuery(t *testing.T, s serverutils.TestServerInterface, sql string) (*pl
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.makePlan(context.TODO(), Statement{SQL: sql, AST: stmt}); err != nil {
+	if err := p.makePlan(context.TODO(), Statement{SQL: sql, AST: stmt.AST}); err != nil {
 		t.Fatal(err)
 	}
 	return p, func() {

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -106,15 +106,15 @@ func (p *Parser) ParseWithInt(sql string, nakedIntType *coltypes.TInt) (Statemen
 	return p.parseWithDepth(1, sql, nakedIntType, nakedSerialType)
 }
 
-func (p *Parser) parseOneWithDepth(depth int, sql string) (tree.Statement, error) {
+func (p *Parser) parseOneWithDepth(depth int, sql string) (Statement, error) {
 	stmts, err := p.parseWithDepth(1, sql, defaultNakedIntType, defaultNakedSerialType)
 	if err != nil {
-		return nil, err
+		return Statement{}, err
 	}
 	if len(stmts) != 1 {
-		return nil, pgerror.NewAssertionErrorf("expected 1 statement, but found %d", len(stmts))
+		return Statement{}, pgerror.NewAssertionErrorf("expected 1 statement, but found %d", len(stmts))
 	}
-	return stmts[0].AST, nil
+	return stmts[0], nil
 }
 
 func (p *Parser) scanOneStmt() (sql string, tokens []sqlSymType, done bool) {
@@ -235,7 +235,7 @@ func Parse(sql string) (Statements, error) {
 // used in various internal-execution paths where we might receive
 // bits of SQL from other nodes. In general, we expect that all
 // user-generated SQL has been run through the ParseWithInt() function.
-func ParseOne(sql string) (tree.Statement, error) {
+func ParseOne(sql string) (Statement, error) {
 	var p Parser
 	return p.parseOneWithDepth(1, sql)
 }
@@ -248,7 +248,7 @@ func ParseTableNameWithIndex(sql string) (tree.TableNameWithIndex, error) {
 	if err != nil {
 		return tree.TableNameWithIndex{}, err
 	}
-	rename, ok := stmt.(*tree.RenameIndex)
+	rename, ok := stmt.AST.(*tree.RenameIndex)
 	if !ok {
 		return tree.TableNameWithIndex{}, pgerror.NewAssertionErrorf("expected an ALTER INDEX statement, but found %T", stmt)
 	}
@@ -263,7 +263,7 @@ func ParseTableName(sql string) (*tree.TableName, error) {
 	if err != nil {
 		return nil, err
 	}
-	rename, ok := stmt.(*tree.RenameTable)
+	rename, ok := stmt.AST.(*tree.RenameTable)
 	if !ok {
 		return nil, pgerror.NewAssertionErrorf("expected an ALTER TABLE statement, but found %T", stmt)
 	}
@@ -276,7 +276,7 @@ func parseExprs(exprs []string) (tree.Exprs, error) {
 	if err != nil {
 		return nil, err
 	}
-	set, ok := stmt.(*tree.SetVar)
+	set, ok := stmt.AST.(*tree.SetVar)
 	if !ok {
 		return nil, pgerror.NewAssertionErrorf("expected a SET statement, but found %T", stmt)
 	}

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -204,7 +204,7 @@ func processPgxStartup(ctx context.Context, s serverutils.TestServerInterface, c
 			log.Infof(ctx, "stop wait at: %v", cmd)
 			return nil
 		}
-		query := exec.Stmt.String()
+		query := exec.AST.String()
 		if !strings.HasPrefix(query, "SELECT t.oid") {
 			log.Infof(ctx, "stop wait at query: %s", query)
 			return nil
@@ -391,8 +391,8 @@ func expectExecStmt(
 		t.Fatalf("%s: expected command ExecStmt, got: %T (%+v)", testutils.Caller(1), cmd, cmd)
 	}
 
-	if es.Stmt.String() != expSQL {
-		t.Fatalf("%s: expected %s, got %s", testutils.Caller(1), expSQL, es.Stmt.String())
+	if es.AST.String() != expSQL {
+		t.Fatalf("%s: expected %s, got %s", testutils.Caller(1), expSQL, es.AST.String())
 	}
 
 	if es.ParseStart == (time.Time{}) {
@@ -430,8 +430,8 @@ func expectPrepareStmt(
 		t.Fatalf("%s: expected name %s, got %s", testutils.Caller(1), expName, pr.Name)
 	}
 
-	if pr.Stmt.String() != expSQL {
-		t.Fatalf("%s: expected %s, got %s", testutils.Caller(1), expSQL, pr.Stmt.String())
+	if pr.AST.String() != expSQL {
+		t.Fatalf("%s: expected %s, got %s", testutils.Caller(1), expSQL, pr.AST.String())
 	}
 
 	if err := finishQuery(prepare, c); err != nil {

--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -64,7 +64,7 @@ func readEncodingTests(t testing.TB) []*encodingTest {
 		if err != nil {
 			t.Fatal(err)
 		}
-		selectStmt, ok := stmt.(*tree.Select)
+		selectStmt, ok := stmt.AST.(*tree.Select)
 		if !ok {
 			t.Fatal("not select")
 		}

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -544,7 +544,7 @@ func (p *planner) delegateQuery(
 	if err != nil {
 		return nil, err
 	}
-	plan, err := p.newPlan(ctx, stmt, desiredTypes)
+	plan, err := p.newPlan(ctx, stmt.AST, desiredTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -28,17 +28,12 @@ import (
 // PreparedStatement is a SQL statement that has been parsed and the types
 // of arguments and results have been determined.
 type PreparedStatement struct {
-	// Str is the statement string prior to parsing, used to generate
-	// error messages. This may be used in
-	// the future to present a contextual error message based on location
-	// information.
-	Str string
+	sqlbase.PrepareMetadata
+
 	// Memo is the memoized data structure constructed by the cost-based optimizer
 	// during prepare of a SQL statement. It can significantly speed up execution
 	// if it is used by the optimizer as a starting point.
 	Memo *memo.Memo
-
-	sqlbase.PrepareMetadata
 
 	memAcc mon.BoundAccount
 }
@@ -47,13 +42,12 @@ type PreparedStatement struct {
 // usage, in bytes.
 func (p *PreparedStatement) MemoryEstimate() int64 {
 	// Account for the memory used by this prepared statement:
-	//   1. Size of the query string and prepared struct.
+	//   1. Size of the prepare metadata.
 	//   2. Size of the prepared memo, if using the cost-based optimizer.
-	size := int64(len(p.Str) + int(unsafe.Sizeof(*p)))
+	size := p.PrepareMetadata.MemoryEstimate()
 	if p.Memo != nil {
 		size += p.Memo.MemoryEstimate()
 	}
-	size += p.PrepareMetadata.MemoryEstimate()
 	return size
 }
 

--- a/pkg/sql/sem/tree/col_types_test.go
+++ b/pkg/sql/sem/tree/col_types_test.go
@@ -70,10 +70,10 @@ func TestParseColumnType(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%d: %s", i, err)
 			}
-			if sql != stmt.String() {
-				t.Errorf("%d: expected %s, but got %s", i, sql, stmt)
+			if sql != stmt.AST.String() {
+				t.Errorf("%d: expected %s, but got %s", i, sql, stmt.AST)
 			}
-			createTable, ok := stmt.(*tree.CreateTable)
+			createTable, ok := stmt.AST.(*tree.CreateTable)
 			if !ok {
 				t.Fatalf("%d: expected tree.CreateTable, but got %T", i, stmt)
 			}
@@ -107,12 +107,12 @@ func TestParseColumnTypeAliases(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%d: %s", i, err)
 			}
-			if d.expectedStr != stmt.String() {
-				t.Errorf("%d: expected %s, but got %s", i, d.expectedStr, stmt)
+			if d.expectedStr != stmt.AST.String() {
+				t.Errorf("%d: expected %s, but got %s", i, d.expectedStr, stmt.AST)
 			}
-			createTable, ok := stmt.(*tree.CreateTable)
+			createTable, ok := stmt.AST.(*tree.CreateTable)
 			if !ok {
-				t.Fatalf("%d: expected tree.CreateTable, but got %T", i, stmt)
+				t.Fatalf("%d: expected tree.CreateTable, but got %T", i, stmt.AST)
 			}
 			columnDef, ok2 := createTable.Defs[0].(*tree.ColumnTableDef)
 			if !ok2 {

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -107,7 +107,7 @@ func TestFormatStatement(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			stmtStr := tree.AsStringWithFlags(stmt, test.f)
+			stmtStr := tree.AsStringWithFlags(stmt.AST, test.f)
 			if stmtStr != test.expected {
 				t.Fatalf("expected %q, got %q", test.expected, stmtStr)
 			}
@@ -156,7 +156,7 @@ func TestFormatTableName(t *testing.T) {
 				t.Fatal(err)
 			}
 			f.Reset()
-			f.FormatNode(stmt)
+			f.FormatNode(stmt.AST)
 			stmtStr := f.String()
 			if stmtStr != test.expected {
 				t.Fatalf("expected %q, got %q", test.expected, stmtStr)
@@ -422,7 +422,7 @@ func BenchmarkFormatRandomStatements(b *testing.B) {
 			continue
 		}
 		strs[i] = rdm
-		stmts[i] = stmt
+		stmts[i] = stmt.AST
 		i++
 	}
 

--- a/pkg/sql/sem/tree/function_name_test.go
+++ b/pkg/sql/sem/tree/function_name_test.go
@@ -42,7 +42,7 @@ func TestResolveFunction(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", tc.in, err)
 		}
-		f, ok := stmt.(*tree.Select).Select.(*tree.SelectClause).Exprs[0].Expr.(*tree.FuncExpr)
+		f, ok := stmt.AST.(*tree.Select).Select.(*tree.SelectClause).Exprs[0].Expr.(*tree.FuncExpr)
 		if !ok {
 			t.Fatalf("%s does not parse to a tree.FuncExpr", tc.in)
 		}

--- a/pkg/sql/sem/tree/name_resolution_test.go
+++ b/pkg/sql/sem/tree/name_resolution_test.go
@@ -127,7 +127,7 @@ func TestClassifyTablePattern(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				tp, err := stmt.(*tree.Grant).Targets.Tables[0].NormalizeTablePattern()
+				tp, err := stmt.AST.(*tree.Grant).Targets.Tables[0].NormalizeTablePattern()
 				if err != nil {
 					return nil, err
 				}
@@ -223,7 +223,7 @@ func TestClassifyColumnName(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				v := stmt.(*tree.Select).Select.(*tree.SelectClause).Exprs[0].Expr.(tree.VarName)
+				v := stmt.AST.(*tree.Select).Select.(*tree.SelectClause).Exprs[0].Expr.(tree.VarName)
 				return v.NormalizeVarName()
 			}()
 			if !testutils.IsError(err, tc.err) {
@@ -751,7 +751,7 @@ func TestResolveTablePatternOrName(t *testing.T) {
 				if err != nil {
 					return nil, "", err
 				}
-				tp, err := stmt.(*tree.Grant).Targets.Tables[0].NormalizeTablePattern()
+				tp, err := stmt.AST.(*tree.Grant).Targets.Tables[0].NormalizeTablePattern()
 				if err != nil {
 					return nil, "", err
 				}

--- a/pkg/sql/sem/tree/pretty_test.go
+++ b/pkg/sql/sem/tree/pretty_test.go
@@ -90,7 +90,7 @@ func runTestPrettyData(t *testing.T, prefix string, cfg tree.PrettyCfg, matches 
 				for i := range work {
 					thisCfg := cfg
 					thisCfg.LineWidth = i
-					res[i-1] = thisCfg.Pretty(stmt)
+					res[i-1] = thisCfg.Pretty(stmt.AST)
 				}
 				return nil
 			}
@@ -151,7 +151,7 @@ func TestPrettyVerify(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got := tree.Pretty(stmt)
+			got := tree.Pretty(stmt.AST)
 			if pretty != got {
 				t.Fatalf("got: %s\nexpected: %s", got, pretty)
 			}
@@ -175,7 +175,7 @@ func BenchmarkPrettyData(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		docs = append(docs, cfg.Doc(stmt))
+		docs = append(docs, cfg.Doc(stmt.AST))
 	}
 
 	b.ResetTimer()

--- a/pkg/sql/statement.go
+++ b/pkg/sql/statement.go
@@ -15,14 +15,14 @@
 package sql
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 // Statement contains a statement with optional expected result columns and metadata.
 type Statement struct {
-	SQL           string
-	AST           tree.Statement
+	parser.Statement
+
 	ExpectedTypes sqlbase.ResultColumns
 	AnonymizedStr string
 	queryID       ClusterWideID

--- a/pkg/sql/subquery_test.go
+++ b/pkg/sql/subquery_test.go
@@ -33,7 +33,7 @@ func TestStartSubqueriesReturnsError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.makePlan(context.TODO(), Statement{SQL: sql, AST: stmt}); err != nil {
+	if err := p.makePlan(context.TODO(), Statement{SQL: sql, AST: stmt.AST}); err != nil {
 		t.Fatal(err)
 	}
 	params := runParams{ctx: context.TODO(), p: p, extendedEvalCtx: &p.extendedEvalCtx}

--- a/pkg/sql/subquery_test.go
+++ b/pkg/sql/subquery_test.go
@@ -33,7 +33,7 @@ func TestStartSubqueriesReturnsError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.makePlan(context.TODO(), Statement{SQL: sql, AST: stmt.AST}); err != nil {
+	if err := p.makePlan(context.TODO(), Statement{Statement: stmt}); err != nil {
 		t.Fatal(err)
 	}
 	params := runParams{ctx: context.TODO(), p: p, extendedEvalCtx: &p.extendedEvalCtx}

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -45,7 +45,7 @@ func CreateTestTableDescriptor(
 		nil, /* txn */
 		nil, /* vt */
 		st,
-		stmt.(*tree.CreateTable),
+		stmt.AST.(*tree.CreateTable),
 		parentID, id,
 		hlc.Timestamp{}, /* creationTime */
 		privileges,
@@ -102,7 +102,7 @@ func (dsp *DistSQLPlanner) Exec(
 		return err
 	}
 	p := localPlanner.(*planner)
-	if err := p.makePlan(ctx, Statement{SQL: sql, AST: stmt}); err != nil {
+	if err := p.makePlan(ctx, Statement{SQL: sql, AST: stmt.AST}); err != nil {
 		return err
 	}
 	rw := newCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {
@@ -112,7 +112,7 @@ func (dsp *DistSQLPlanner) Exec(
 	recv := MakeDistSQLReceiver(
 		ctx,
 		rw,
-		stmt.StatementType(),
+		stmt.AST.StatementType(),
 		execCfg.RangeDescriptorCache,
 		execCfg.LeaseHolderCache,
 		p.txn,

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -102,7 +102,7 @@ func (dsp *DistSQLPlanner) Exec(
 		return err
 	}
 	p := localPlanner.(*planner)
-	if err := p.makePlan(ctx, Statement{SQL: sql, AST: stmt.AST}); err != nil {
+	if err := p.makePlan(ctx, Statement{Statement: stmt}); err != nil {
 		return err
 	}
 	rw := newCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -99,7 +99,7 @@ func (t virtualSchemaTable) initVirtualTableDesc(
 		return sqlbase.TableDescriptor{}, err
 	}
 
-	create := stmt.(*tree.CreateTable)
+	create := stmt.AST.(*tree.CreateTable)
 	for _, def := range create.Defs {
 		if d, ok := def.(*tree.ColumnTableDef); ok && d.HasDefaultExpr() {
 			return sqlbase.TableDescriptor{},
@@ -141,7 +141,7 @@ func (v virtualSchemaView) initVirtualTableDesc(
 		return sqlbase.TableDescriptor{}, err
 	}
 
-	create := stmt.(*tree.CreateView)
+	create := stmt.AST.(*tree.CreateView)
 
 	mutDesc, err := MakeViewTableDesc(
 		create,

--- a/pkg/testutils/sqlutils/name_resolution_testutils.go
+++ b/pkg/testutils/sqlutils/name_resolution_testutils.go
@@ -82,7 +82,7 @@ func RunResolveQualifiedStarTest(t *testing.T, ct ColumnItemResolverTester) {
 				if err != nil {
 					return "", "", err
 				}
-				v := stmt.(*tree.Select).Select.(*tree.SelectClause).Exprs[0].Expr.(tree.VarName)
+				v := stmt.AST.(*tree.Select).Select.(*tree.SelectClause).Exprs[0].Expr.(tree.VarName)
 				c, err := v.NormalizeVarName()
 				if err != nil {
 					return "", "", err
@@ -161,7 +161,7 @@ func RunResolveColumnItemTest(t *testing.T, ct ColumnItemResolverTester) {
 				if err != nil {
 					return "", err
 				}
-				v := stmt.(*tree.Select).Select.(*tree.SelectClause).Exprs[0].Expr.(tree.VarName)
+				v := stmt.AST.(*tree.Select).Select.(*tree.SelectClause).Exprs[0].Expr.(tree.VarName)
 				c, err := v.NormalizeVarName()
 				if err != nil {
 					return "", err

--- a/pkg/testutils/sqlutils/pretty.go
+++ b/pkg/testutils/sqlutils/pretty.go
@@ -41,7 +41,7 @@ func VerifyStatementPrettyRoundtrip(t *testing.T, sql string) {
 		if err != nil {
 			t.Fatalf("%s: %s", err, prettyStmt)
 		}
-		prettyFormatted := tree.AsStringWithFlags(parsedPretty, tree.FmtSimple)
+		prettyFormatted := tree.AsStringWithFlags(parsedPretty.AST, tree.FmtSimple)
 		origFormatted := tree.AsStringWithFlags(origStmt, tree.FmtParsable)
 		if prettyFormatted != origFormatted {
 			// Type annotations and unicode strings don't round trip well. Sometimes we
@@ -51,7 +51,7 @@ func VerifyStatementPrettyRoundtrip(t *testing.T, sql string) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			origFormatted = tree.AsStringWithFlags(reparsedStmt, tree.FmtParsable)
+			origFormatted = tree.AsStringWithFlags(reparsedStmt.AST, tree.FmtParsable)
 			if prettyFormatted != origFormatted {
 				t.Fatalf("orig formatted != pretty formatted\norig SQL: %q\norig formatted: %q\npretty printed: %s\npretty formatted: %q",
 					sql,


### PR DESCRIPTION
#### parser: change ParseOne to return parser.Statement

Release note: None

#### sql: pass around parser.Statement

This change cleans up the `Statement/Stmt` and `SQL/Str` fields
throughout sql. All relevant structs now embed parser.Statement. This
automatically plumbs through the extra information from the parser,
like `NumPlaceholders`.

Release note: None
