### PR TITLE
opt: fold additional comparison operations with constant inputs

### DIFF
--- a/pkg/sql/opt/memo/typing_test.go
+++ b/pkg/sql/opt/memo/typing_test.go
@@ -139,9 +139,18 @@ func TestTypingBinaryAssumptions(t *testing.T) {
 
 // TestTypingComparisonAssumptions ensures that comparison overloads conform to
 // certain assumptions we're making in the type inference code:
-//   1. The overload can be inferred from the operator type and the data
+//   1. All comparison ops will be present in tree.CmpOps after being mapped
+//      with NormalizeComparison.
+//   2. The overload can be inferred from the operator type and the data
 //      types of its operands.
 func TestTypingComparisonAssumptions(t *testing.T) {
+	for _, op := range opt.ComparisonOperators {
+		newOp, _, _ := memo.NormalizeComparison(op)
+		comp := opt.ComparisonOpReverseMap[newOp]
+		if _, ok := tree.CmpOps[comp]; !ok {
+			t.Errorf("could not find overload for %v", op)
+		}
+	}
 	for name, overloads := range tree.CmpOps {
 		for i, overload := range overloads {
 			op := overload.(*tree.CmpOp)

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -342,7 +342,6 @@ values
 # FoldComparison
 # --------------------------------------------------
 
-# Fold constant.
 opt expect=FoldComparison
 SELECT 1::INT < 2::INT
 ----
@@ -353,7 +352,36 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-# Fold constant.
+opt expect=FoldComparison
+SELECT 1::INT > 2::INT
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,) [type=tuple{bool}]
+
+opt expect=FoldComparison
+SELECT 10.0::FLOAT <= 20.0::FLOAT
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true,) [type=tuple{bool}]
+
+opt expect=FoldComparison
+SELECT 10.0::FLOAT >= 20.0::FLOAT
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,) [type=tuple{bool}]
+
 opt expect=FoldComparison
 SELECT 2.0::DECIMAL = 2::INT
 ----
@@ -364,7 +392,16 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-# Fold constant.
+opt expect=FoldComparison
+SELECT 2.0::DECIMAL != 2::INT
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,) [type=tuple{bool}]
+
 opt expect=FoldComparison
 SELECT 100 IS NOT DISTINCT FROM 200
 ----
@@ -375,7 +412,16 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-# Fold constant.
+opt expect=FoldComparison
+SELECT 100 IS DISTINCT FROM 200
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true,) [type=tuple{bool}]
+
 opt expect=FoldComparison
 SELECT 'foo' IN ('a', 'b', 'c')
 ----
@@ -386,7 +432,116 @@ values
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
 
-# Fold constant.
+opt expect=FoldComparison
+SELECT 'foo' NOT IN ('a', 'b', 'c')
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true,) [type=tuple{bool}]
+
+opt expect=FoldComparison
+SELECT 'foo' LIKE 'foobar'
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,) [type=tuple{bool}]
+
+opt expect=FoldComparison
+SELECT 'foo' NOT LIKE 'foobar'
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true,) [type=tuple{bool}]
+
+opt expect=FoldComparison
+SELECT 'foo' ILIKE 'FOO%'
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true,) [type=tuple{bool}]
+
+opt expect=FoldComparison
+SELECT 'foo' NOT ILIKE 'FOO%'
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,) [type=tuple{bool}]
+
+opt expect=FoldComparison
+SELECT 'monday' SIMILAR TO '_onday'
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true,) [type=tuple{bool}]
+
+opt expect=FoldComparison
+SELECT 'monday' NOT SIMILAR TO '_onday'
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,) [type=tuple{bool}]
+
+opt expect=FoldComparison
+SELECT 'tuEsday' ~ 't[uU][eE]sday'
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true,) [type=tuple{bool}]
+
+opt expect=FoldComparison
+SELECT 'tuEsday' !~ 't[uU][eE]sday'
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,) [type=tuple{bool}]
+
+opt expect=FoldComparison
+SELECT 'wednesday' ~* 'W.*y'
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true,) [type=tuple{bool}]
+
+opt expect=FoldComparison
+SELECT 'wednesday' !~* 'W.*y'
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,) [type=tuple{bool}]
+
 opt expect=FoldComparison
 SELECT '[1, 2]'::JSONB <@ '[1, 2, 3]'::JSONB
 ----
@@ -397,7 +552,6 @@ values
  ├── fd: ()-->(1)
  └── (true,) [type=tuple{bool}]
 
-# Fold constant.
 opt expect=FoldComparison
 SELECT ('a', 'b', 'c') = ('d', 'e', 'f')
 ----

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -148,10 +148,7 @@ SELECT * FROM (SELECT 1 AS one from xy) WHERE one > 0
 project
  ├── columns: one:3(int!null)
  ├── fd: ()-->(3)
- ├── select
- │    ├── scan xy
- │    └── filters
- │         └── 1 > 0 [type=bool]
+ ├── scan xy
  └── projections
       └── const: 1 [type=int]
 


### PR DESCRIPTION
Prior to this commit, some comparison operations with constant inputs
were not getting folded during normalization because the operators do
not have an overload in the `tree.CmpOps` map. The operations need to be
mapped to equivalent expressions before folding. This commit does that
mapping.

For example, greater than (`>`) should be mapped to less than (`<`), with
the operands swapped. Not equal (`!=`) should be mapped to equal (`=`),
with the result inverted.

Fixes #33462

Release note (bug fix): Fixed a bug where some comparison operations
with constant inputs were not getting folded during query optimization,
causing the optimizer to produce less-good plans.