### PR TITLE
*: update deps

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,12 +26,12 @@
   version = "v0.1.8"
 
 [[projects]]
-  digest = "1:c4a5edf3b0f38e709a78dcc945997678a364c2b5adfd48842a3dd349c352f833"
+  digest = "1:b8ac7e4464ce21f7487c663aa69b1b3437740bb10ab12d4dc7aa9b02422571a1"
   name = "github.com/Azure/azure-storage-blob-go"
   packages = ["azblob"]
   pruneopts = "UT"
-  revision = "5152f14ace1c6db66bd9cb57840703a8358fa7bc"
-  version = "0.3.0"
+  revision = "45d0c5e3638e2b539942f93c48e419f4f2fc62e4"
+  version = "0.4.0"
 
 [[projects]]
   branch = "master"
@@ -43,6 +43,14 @@
   ]
   pruneopts = "UT"
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
+
+[[projects]]
+  digest = "1:ed77032e4241e3b8329c9304d66452ed196e795876e14be677a546f36b94e67a"
+  name = "github.com/DataDog/zstd"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c7161f8c63c045cbc7ca051dcc969dd0e4054de2"
+  version = "v1.3.5"
 
 [[projects]]
   branch = "2.x"
@@ -93,12 +101,12 @@
   version = "v1.5.0"
 
 [[projects]]
-  digest = "1:18164190243be96ded157ac756efe693bb96370ebdf56a6ed82b9f23c331d1a2"
+  digest = "1:a59a467c541a1bf8b06e4fad6113028c959be6573b78ceca9f8020cd0d2127fc"
   name = "github.com/Shopify/sarama"
   packages = ["."]
   pruneopts = "UT"
-  revision = "bbdbe644099b7fdc8327d5cc69c030945188b2e9"
-  version = "v1.13.0"
+  revision = "879f631812a30a580659e8035e7cda9994bb99ac"
+  version = "v1.20.0"
 
 [[projects]]
   digest = "1:e92f5581902c345eb4ceffdcd4a854fb8f73cf436d47d837d1ec98ef1fe0a214"
@@ -165,7 +173,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:c74cd495c1c67728e8c997748ae2eac7891faf68805669efa6b37a7b65ac179d"
+  digest = "1:48da98794340ba83fedaa183bcd85b435c2c90328b0c380792451db6a4518d2d"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -177,6 +185,7 @@
     "aws/credentials",
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
     "aws/credentials/stscreds",
     "aws/csm",
     "aws/defaults",
@@ -205,16 +214,16 @@
     "service/sts",
   ]
   pruneopts = "UT"
-  revision = "ddc06f9fad886ea5daa5f828f3ca094084f8c2a7"
-  version = "v1.15.90"
+  revision = "1f8a24693bc965514ee0d7aadbabe0ceed184a88"
+  version = "v1.16.16"
 
 [[projects]]
   branch = "master"
-  digest = "1:5e5847e4c115f63c204ec9ea00fce06ac0715fe5ae85a4357acb3b00f1634cbc"
+  digest = "1:e5051373c84dc9e7be61469eafcf5e6ad52d25894cf150fb1e883e1652621bcb"
   name = "github.com/axiomhq/hyperloglog"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e8c19f1749152250b378d1d2e92fdea63b9fa6a9"
+  revision = "4b99d0c2c99ec77eb3a42344d206a88997957495"
 
 [[projects]]
   branch = "master"
@@ -257,12 +266,12 @@
   version = "v1.3.1"
 
 [[projects]]
-  digest = "1:553f73a4171c265045ae4f5d3122429ecf2c9c0c232c91f336127fe45480104a"
+  digest = "1:166438587ed45ac211dab8a3ecebf4fa0c186d0db63430fb9127bbc2e5fcdc67"
   name = "github.com/cenkalti/backoff"
   packages = ["."]
   pruneopts = "UT"
-  revision = "62661b46c4093e2c1f38d943e663db1a29873e80"
-  version = "v2.1.0"
+  revision = "1e4cf3da559842a91afcb6ea6141451e6c30c618"
+  version = "v2.1.1"
 
 [[projects]]
   digest = "1:fed1f537c2f1269fe475a8556c393fe466641682d73ef8fd0491cd3aa1e47bad"
@@ -293,11 +302,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e9b4bf63bdb977f0343e8c1d7a7aa7ff37f4a7126bd7f4a6df0d6b976ee0bf0a"
+  digest = "1:220d60c10e7c67f52168c496bf778fb00ec88e12956a933b7ce53d286fb438fe"
   name = "github.com/cockroachdb/circuitbreaker"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4f5b16865f3ccc4bb8e09413d5c7308e00888b98"
+  revision = "3e861b2e1d31642be9e447dc6f8aa599813e98b4"
 
 [[projects]]
   branch = "master"
@@ -399,7 +408,6 @@
   revision = "280f6062b5bc97ee9b9afe7f2ccb361e59845baa"
 
 [[projects]]
-  branch = "master"
   digest = "1:4ddc17aeaa82cb18c5f0a25d7c253a10682f518f4b2558a82869506eec223d76"
   name = "github.com/docker/distribution"
   packages = [
@@ -408,10 +416,11 @@
   ]
   pruneopts = "UT"
   revision = "40b7b5830a2337bb07627617740c0e39eb92800c"
+  version = "v2.7.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:6f10b9f09d1c735fde0b60f13b1942dbfea3fa8ba34f3081052df54933fccf44"
+  digest = "1:3c9913ecae011df5973403b3522bcc47593b312d32595a376fb361c7408d946b"
   name = "github.com/docker/docker"
   packages = [
     "api",
@@ -438,7 +447,7 @@
     "pkg/term/windows",
   ]
   pruneopts = "UT"
-  revision = "a4a816b6bbed2d1442a1646143662b0f16f0535e"
+  revision = "b4842cfe88b39af42416429396aee10d1fe7c3d6"
 
 [[projects]]
   digest = "1:811c86996b1ca46729bad2724d4499014c4b9effd05ef8c71b852aad90deb0ce"
@@ -542,7 +551,6 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
-  version = "v1.0.0"
 
 [[projects]]
   digest = "1:4062bc6de62d73e2be342243cf138cf499b34d558876db8d9430e2149388a4d8"
@@ -553,23 +561,23 @@
   version = "v0.4.0"
 
 [[projects]]
-  digest = "1:64a5a67c69b70c2420e607a8545d674a23778ed9c3e80607bfd17b77c6c87f6a"
+  digest = "1:c96d16a4451e48e2c44b2c3531fd8ec9248d822637f1911a88959ca0bcae4a64"
   name = "github.com/go-ole/go-ole"
   packages = [
     ".",
     "oleutil",
   ]
   pruneopts = "UT"
-  revision = "a41e3c4b706f6ae8dfbff342b06e40fa4d2d0506"
-  version = "v1.2.1"
+  revision = "39dc8486bd0952279431257138bc428275b86797"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:b57b31665db80eb5a00c672458ab53b1bec0bea386a247368f59ec9b522af120"
+  digest = "1:23dca8a35ce10bf5caf35e92f6a2b5e633f55cbd28259c2207eb31d5b44b0c02"
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
   pruneopts = "UT"
-  revision = "60d456a402782453be397030407e34decaf04d73"
+  revision = "c45f530f8e7fe40f4687eaa50d0c8c5f1b66f9e0"
 
 [[projects]]
   branch = "v1.2.0-with-clone-fix"
@@ -677,7 +685,6 @@
   revision = "22125cfaa6ddc71e145b1535d4b7ee9744fefff2"
 
 [[projects]]
-  branch = "master"
   digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
   name = "github.com/golang/glog"
   packages = ["."]
@@ -745,12 +752,12 @@
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
-  digest = "1:34bd52916ea0a9e4d95d34dab5bc4f125a7ee7b1e11b1a531d2ea43f41b4f4e8"
+  digest = "1:63ede27834b468648817fb80cfb95d40abfc61341f89cb7a0d6779b6aa955425"
   name = "github.com/google/go-github"
   packages = ["github"]
   pruneopts = "UT"
-  revision = "35781f7f4db7b3d7fc3359527472838da65023c6"
-  version = "v19.1.0"
+  revision = "a5cb647b1fac8ba77e1cf25af2f9526658ab63e3"
+  version = "v21.0.0"
 
 [[projects]]
   digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
@@ -762,7 +769,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0e6b2a2f68525514791ba1c45e90689dc740d754faa47c4bccf2edea38cabdd2"
+  digest = "1:7e5c74b1b7c27e6ba7fb0a4417477f6a95dea7cfd00b186ad5a0453e7bde8c84"
   name = "github.com/google/pprof"
   packages = [
     "driver",
@@ -782,15 +789,18 @@
     "third_party/svgpan",
   ]
   pruneopts = "UT"
-  revision = "3ea8567a2e5752420fc544d2e2ad249721768934"
+  revision = "e84dfd68c163c45ea47aa24b3dc7eaa93f6675b1"
 
 [[projects]]
-  digest = "1:e04cc716992a302cacf6d726409a05aa9546241998b24356d6dd0f01bc5a374e"
+  digest = "1:cd9864c6366515827a759931746738ede6079faa08df9c584596370d6add135c"
   name = "github.com/googleapis/gax-go"
-  packages = ["."]
+  packages = [
+    ".",
+    "v2",
+  ]
   pruneopts = "UT"
-  revision = "b001040cd31805261cbd978842099e326dfa857b"
-  version = "v2.0.2"
+  revision = "c8a15bac9b9fe955bd9f900272f9a306465d28cf"
+  version = "v2.0.3"
 
 [[projects]]
   digest = "1:7b5c6e2eeaa9ae5907c391a91c132abfd5c9e8a784a341b5625e750c67e6825d"
@@ -801,7 +811,7 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:69cd81163a00bb8405194d47b8be19283744779b6104f2d6b3735e2a01cdb6fa"
+  digest = "1:c4a0b2286ccdfcb4575e19c2bab20d4972ba7fce2ed7cba0941c168708b96f54"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = [
     "codegenerator",
@@ -815,8 +825,8 @@
     "utilities",
   ]
   pruneopts = "T"
-  revision = "92583770e3f01b09a0d3e9bdf64321d8bebd48f2"
-  version = "v1.4.1"
+  revision = "aeab1d96e0f1368d243e2e5f526aa29d495517bb"
+  version = "v1.5.1"
 
 [[projects]]
   branch = "master"
@@ -874,11 +884,11 @@
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
+  digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   pruneopts = "UT"
-  revision = "0b12d6b5"
+  revision = "c2b33e84"
 
 [[projects]]
   branch = "master"
@@ -995,12 +1005,12 @@
   version = "v0.15.6"
 
 [[projects]]
-  digest = "1:dcc04c4f8d4133c33153289cbf6b329b68518579a5ed9277640eb4b502e5d02b"
+  digest = "1:6ff6c3cb744b42df69cb874c3f19d387ece7ba7998e7d4de811c9bf61a7b1a09"
   name = "github.com/linkedin/goavro"
   packages = ["."]
   pruneopts = "UT"
-  revision = "1beee2a7408830381d63899b90404fccd4d48c58"
-  version = "v2.7.0"
+  revision = "af12b3c46392134a7db8c1a8b6c6a33419fab0ea"
+  version = "v2.7.2"
 
 [[projects]]
   branch = "master"
@@ -1027,12 +1037,12 @@
   version = "v0.0.4"
 
 [[projects]]
-  digest = "1:cdb899c199f907ac9fb50495ec71212c95cb5b0e0a8ee0800da0238036091033"
+  digest = "1:0356f3312c9bd1cbeda81505b7fd437501d8e778ab66998ef69f00d7f9b3a0d7"
   name = "github.com/mattn/go-runewidth"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ce7b0b5c7b45a81508558cd1dba6bb1e4ddb51bb"
-  version = "v0.0.3"
+  revision = "3ee7d812e62a0804a7d0a324e0249ca2db3476d3"
+  version = "v0.0.4"
 
 [[projects]]
   digest = "1:d1f70995feb8132ca8e99b8bba29823c3273f68c239d9ecd93fa5442a56d546f"
@@ -1075,11 +1085,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c6b47becab852021d1a3b474f7228edab8598dbe01994b2be6fad8fe930f9925"
+  digest = "1:edd83fd0e40b6404fc86b177b75f239da01bada08c6d7f3498e2a8fa39aced9e"
   name = "github.com/montanaflynn/stats"
   packages = ["."]
   pruneopts = "UT"
-  revision = "db72e6cae808b936b0c01fd330ff1fcd2c86c95e"
+  revision = "945b007cb92f859e12ca5c7ce32faf23f30a0a85"
 
 [[projects]]
   branch = "master"
@@ -1198,12 +1208,12 @@
   version = "v2.0.7"
 
 [[projects]]
-  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
+  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "UT"
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
@@ -1227,15 +1237,15 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:185cf55b1f44a1bf243558901c3f06efa5c64ba62cfdcbb1bf7bbe8c3fb68561"
+  digest = "1:3fa49ea0332c644e4d4ce3864d8eee2cc6c858cb52bf935e32c28d194a0f2bfa"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = "T"
-  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+  revision = "f287a105a20ec685d797f65cd0ce8fbeaef42da1"
 
 [[projects]]
   branch = "master"
-  digest = "1:db712fde5d12d6cdbdf14b777f0c230f4ff5ab0be8e35b239fc319953ed577a4"
+  digest = "1:ce62b400185bf6b16ef6088011b719e449f5c15c4adb6821589679f752c2788e"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -1243,11 +1253,11 @@
     "model",
   ]
   pruneopts = "UT"
-  revision = "4724e9255275ce38f7179b2478abeae4e28c904f"
+  revision = "2998b132700a7d019ff618c06a234b47c1f3f681"
 
 [[projects]]
   branch = "master"
-  digest = "1:d39e7c7677b161c2dd4c635a2ac196460608c7d8ba5337cc8cae5825a2681f8f"
+  digest = "1:08eb8b60450efe841e37512d66ce366a87d187505d7c67b99307a6c1803483a2"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -1256,7 +1266,7 @@
     "xfs",
   ]
   pruneopts = "UT"
-  revision = "1dc9a6cbc91aacc3e8b2d63db4d2e957a5394ac4"
+  revision = "b1a0a9a36d7453ba0f62578b99712f3a6c5f82d1"
 
 [[projects]]
   branch = "master"
@@ -1294,7 +1304,7 @@
   revision = "836a144573533ea4da4e6929c235fd348aed1c80"
 
 [[projects]]
-  digest = "1:8c4fca372035672ef88720cb0c700f31d78e672eaa98d6a4cb282b39fe63d480"
+  digest = "1:2f3e1ccf496354ee2386400844d37657a7df80be3eeb010fb2e49e0723b62040"
   name = "github.com/shirou/gopsutil"
   packages = [
     "cpu",
@@ -1307,8 +1317,8 @@
     "process",
   ]
   pruneopts = "UT"
-  revision = "0f70a4a06f7a1039305ec9b3ba9c2800f8929fba"
-  version = "v2.18.11"
+  revision = "ccc1c1016bc5d10e803189ee43417c50cdde7f1b"
+  version = "v2.18.12"
 
 [[projects]]
   branch = "master"
@@ -1319,12 +1329,12 @@
   revision = "bb4de0191aa41b5507caa14b0650cdbddcd9280b"
 
 [[projects]]
-  digest = "1:69b1cc331fca23d702bd72f860c6a647afd0aa9fcbc1d0659b1365e26546dd70"
+  digest = "1:87c2e02fb01c27060ccc5ba7c5a407cc91147726f8f40b70cceeedbc52b1f3a8"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "bcd833dfe83d3cebad139e4a29ed79cb2318bf95"
-  version = "v1.2.0"
+  revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:e01b05ba901239c783dfe56450bcde607fc858908529868259c9a8765dc176d0"
@@ -1346,15 +1356,15 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
+  digest = "1:5da8ce674952566deae4dbc23d07c85caafc6cfa815b0b3e03e41979cedb8750"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
     "require",
   ]
   pruneopts = "UT"
-  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
-  version = "v1.2.2"
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
 
 [[projects]]
   branch = "master"
@@ -1366,22 +1376,21 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a489826ac91be264c6d903335fa7d3c9f460b32a973921b72e01208f69144788"
+  digest = "1:71e03c7f9fbead2dd42b87d696a37282dd47ebfb6cdcd7d70ecb8e7bc4f61434"
   name = "go.etcd.io/etcd"
   packages = [
     "raft",
     "raft/raftpb",
   ]
   pruneopts = "UT"
-  revision = "1900a8e26f2c3d46ed9ebdb4c876578efeb9bce4"
+  revision = "fae6e92407e004894f5e0d71baab212732ddd8c2"
 
 [[projects]]
-  digest = "1:39f80d0b170e948e3f1d177ef6252af72f68f395d500a3c01fe4c745bccc7560"
+  digest = "1:3b5a3bc35810830ded5e26ef9516e933083a2380d8e57371fdfde3c70d7c6952"
   name = "go.opencensus.io"
   packages = [
     ".",
     "exemplar",
-    "exporter/stackdriver/propagation",
     "internal",
     "internal/tagencoding",
     "plugin/ochttp",
@@ -1418,11 +1427,11 @@
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
+  revision = "ff983b9c42bc9fbf91556e191cc8efb585c16908"
 
 [[projects]]
   branch = "master"
-  digest = "1:7f11db26ecf61940e5a0bf624bb630b3d89c0f989ae783fdf85c9ed896c0e79b"
+  digest = "1:14ec620555f25e3fbfd7b6f37486696e91600a62680bc4c499b4f783b4687cf1"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -1439,7 +1448,7 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "351d144fa1fc0bd934e2408202be0c29f25e35a0"
+  revision = "1e06a53dbb7e2ed46e91183f219db23c6943c532"
 
 [[projects]]
   branch = "master"
@@ -1478,18 +1487,18 @@
     "syncmap",
   ]
   pruneopts = "UT"
-  revision = "42b317875d0fa942474b76e1b46a6060d720ae6e"
+  revision = "37e7f081c4d4c64e13b10787722085407fe5d15f"
 
 [[projects]]
   branch = "master"
-  digest = "1:b9dceb1408ba5105803d5859193bc7d89ac3199b611cf8681dbaa0aa09c10d9c"
+  digest = "1:5ee4df7ab18e945607ac822de8d10b180baea263b5e8676a1041727543b9c1e4"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "70b957f3b65e069b4930ea94e2721eefa0f8f695"
+  revision = "48ac38b7c8cbedd50b1613c0fccacfc7d88dfcdf"
 
 [[projects]]
   digest = "1:a4427f5b90e0d06b5b19d2891615137a814eb934c5a77397d0d5a753783e5f1e"
@@ -1539,11 +1548,10 @@
     "go/types/typeutil",
   ]
   pruneopts = "UT"
-  revision = "bcd4e47d02889ebbc25c9f4bf3d27e4124b0bf9d"
+  revision = "d30e00c240341e9e2a2d9519c67bd95fde906c7b"
 
 [[projects]]
-  branch = "master"
-  digest = "1:ab94fd374fb8c09f7c04fada3daff1ab4a07e373b81eecf2b4428f191260a969"
+  digest = "1:768c35ec83dd17029060ea581d6ca9fdcaef473ec87e93e4bb750949035f6070"
   name = "google.golang.org/api"
   packages = [
     "gensupport",
@@ -1555,12 +1563,14 @@
     "option",
     "storage/v1",
     "transport/http",
+    "transport/http/internal/propagation",
   ]
   pruneopts = "UT"
-  revision = "9c79deebf7496e355d7e95d82d4af1fe4e769b2f"
+  revision = "19e022d8cf43ce81f046bae8cc18c5397cc7732f"
+  version = "v0.1.0"
 
 [[projects]]
-  digest = "1:8c82ef9b816279a63d490dcdc37218c496923596e8d246c018ded6a0d3f8b59b"
+  digest = "1:7bc25c2efff76b31f146caf630c617be9b666c6164f0632050466fbec0500125"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -1576,8 +1586,8 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
-  version = "v1.0.0"
+  revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
+  version = "v1.4.0"
 
 [[projects]]
   branch = "master"
@@ -1590,7 +1600,7 @@
     "googleapis/rpc/status",
   ]
   pruneopts = "UT"
-  revision = "a1fde740824669f161e97af4237fb80b8734444d"
+  revision = "6909d8a4a91b6d3fd1c4580b6e35816be4706fef"
 
 [[projects]]
   digest = "1:3a98314fd2e43bbd905b33125dad80b10111ba6e5e541db8ed2a953fe01fbb31"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -91,20 +91,21 @@ ignored = [
   source = "https://github.com/cockroachdb/gogoproto"
   branch = "v1.2.0-with-clone-fix"
 
-# github.com/docker/docker depends on a few functions not included in the
-# latest release: reference.{FamiliarName,ParseNormalizedNamed,TagNameOnly}.
-#
-# https://github.com/docker/distribution/commit/429c75f
-# https://github.com/docker/distribution/commit/2caeb61
-[[override]]
-  name = "github.com/docker/distribution"
-  branch = "master"
+# Pin to v1.1.0 because of https://github.com/kisielk/errcheck/issues/162.
+[[constraint]]
+  name = "github.com/kisielk/errcheck"
+  version = "=v1.1.0"
 
 # github.com/openzipkin-contrib/zipkin-go-opentracing requires a newer
 # version of thrift than is currently present in a release.
 [[override]]
   name = "github.com/apache/thrift"
   revision = "2b7365c54f823013cc6a4760798051b22743c103"
+
+# This repository has no releases (as of Jan 2019).
+[[override]]
+  name = "google.golang.org/genproto"
+  branch = "master"
 
 [prune]
   go-tests = true

--- a/pkg/server/serverpb/admin.pb.gw.go
+++ b/pkg/server/serverpb/admin.pb.gw.go
@@ -407,14 +407,14 @@ func RegisterAdminHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()
@@ -428,8 +428,8 @@ func RegisterAdminHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc
 	return RegisterAdminHandlerClient(ctx, mux, NewAdminClient(conn))
 }
 
-// RegisterAdminHandler registers the http handlers for service Admin to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "AdminClient".
+// RegisterAdminHandlerClient registers the http handlers for service Admin
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "AdminClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "AdminClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "AdminClient" to call the correct interceptors.

--- a/pkg/server/serverpb/authentication.pb.gw.go
+++ b/pkg/server/serverpb/authentication.pb.gw.go
@@ -61,14 +61,14 @@ func RegisterLogInHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()
@@ -82,8 +82,8 @@ func RegisterLogInHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc
 	return RegisterLogInHandlerClient(ctx, mux, NewLogInClient(conn))
 }
 
-// RegisterLogInHandler registers the http handlers for service LogIn to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "LogInClient".
+// RegisterLogInHandlerClient registers the http handlers for service LogIn
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "LogInClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "LogInClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "LogInClient" to call the correct interceptors.
@@ -139,14 +139,14 @@ func RegisterLogOutHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMu
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()
@@ -160,8 +160,8 @@ func RegisterLogOutHandler(ctx context.Context, mux *runtime.ServeMux, conn *grp
 	return RegisterLogOutHandlerClient(ctx, mux, NewLogOutClient(conn))
 }
 
-// RegisterLogOutHandler registers the http handlers for service LogOut to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "LogOutClient".
+// RegisterLogOutHandlerClient registers the http handlers for service LogOut
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "LogOutClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "LogOutClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "LogOutClient" to call the correct interceptors.

--- a/pkg/server/serverpb/status.pb.gw.go
+++ b/pkg/server/serverpb/status.pb.gw.go
@@ -751,14 +751,14 @@ func RegisterStatusHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMu
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()
@@ -772,8 +772,8 @@ func RegisterStatusHandler(ctx context.Context, mux *runtime.ServeMux, conn *grp
 	return RegisterStatusHandlerClient(ctx, mux, NewStatusClient(conn))
 }
 
-// RegisterStatusHandler registers the http handlers for service Status to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "StatusClient".
+// RegisterStatusHandlerClient registers the http handlers for service Status
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "StatusClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "StatusClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "StatusClient" to call the correct interceptors.

--- a/pkg/ts/tspb/timeseries.pb.gw.go
+++ b/pkg/ts/tspb/timeseries.pb.gw.go
@@ -52,14 +52,14 @@ func RegisterTimeSeriesHandlerFromEndpoint(ctx context.Context, mux *runtime.Ser
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Infof("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()
@@ -73,8 +73,8 @@ func RegisterTimeSeriesHandler(ctx context.Context, mux *runtime.ServeMux, conn 
 	return RegisterTimeSeriesHandlerClient(ctx, mux, NewTimeSeriesClient(conn))
 }
 
-// RegisterTimeSeriesHandler registers the http handlers for service TimeSeries to "mux".
-// The handlers forward requests to the grpc endpoint over the given implementation of "TimeSeriesClient".
+// RegisterTimeSeriesHandlerClient registers the http handlers for service TimeSeries
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "TimeSeriesClient".
 // Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "TimeSeriesClient"
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "TimeSeriesClient" to call the correct interceptors.


### PR DESCRIPTION
Update all deps except honnef.co/go/tools (will be updated separately) and some `github.com/cockroachdb/` deps which have been updated for go1.11.

Changes:
 - [x] https://github.com/Azure/azure-storage-blob-go/compare/5152f14a...45d0c5e3
 - [x] https://github.com/Shopify/sarama/compare/bbdbe644...879f6318
 - [x] https://github.com/aws/aws-sdk-go/compare/ddc06f9f...1f8a2469
 - [x] https://github.com/axiomhq/hyperloglog/compare/e8c19f17...4b99d0c2
 - [x] https://github.com/cenkalti/backoff/compare/62661b46...1e4cf3da
 - [x] https://github.com/cockroachdb/circuitbreaker/compare/4f5b1686...3e861b2e
 - [x] https://github.com/docker/distribution/compare/40b7b583...91b0f055
 - [x] https://github.com/docker/docker/compare/a4a816b6...b4842cfe
 - [x] https://github.com/go-ole/go-ole/compare/a41e3c4b...39dc8486
 - [x] https://github.com/go-sql-driver/mysql/compare/60d456a4...c45f530f
 - [x] https://github.com/google/go-github/compare/35781f7f...a5cb647b
 - [x] https://github.com/google/pprof/compare/3ea8567a...e84dfd68
 - [x] https://github.com/googleapis/gax-go/compare/b001040c...c8a15bac
 - [x] https://github.com/grpc-ecosystem/grpc-gateway/compare/92583770...aeab1d96
 - [x] https://github.com/jmespath/go-jmespath/compare/0b12d6b5...c2b33e84
 - [x] https://github.com/linkedin/goavro/compare/1beee2a7...af12b3c4
 - [x] https://github.com/mattn/go-runewidth/compare/ce7b0b5c...3ee7d812
 - [x] https://github.com/montanaflynn/stats/compare/db72e6ca...945b007c
 - [x] https://github.com/pkg/errors/compare/645ef004...ba968bfe
 - [x] https://github.com/prometheus/client_model/compare/5c3871d8...f287a105
 - [x] https://github.com/prometheus/common/compare/4724e925...2998b132
 - [x] https://github.com/prometheus/procfs/compare/1dc9a6cb...b1a0a9a3
 - [x] https://github.com/shirou/gopsutil/compare/0f70a4a0...ccc1c101
 - [x] https://github.com/sirupsen/logrus/compare/bcd833df...e1e72e9d
 - [x] https://github.com/stretchr/testify/compare/f35b8ab0...ffdc059b
 - [x] https://github.com/etcd-io/etcd/compare/1900a8e2...fae6e924  (only 23731bf9ba556867089a9cc8db5e492ca6035fe8 touches raft)
 - [x] https://github.com/golang/crypto/compare/505ab145...ff983b9c
 - [x] https://github.com/golang/net/compare/351d144f...1e06a53d
 - [x] https://github.com/golang/sync/compare/42b31787...37e7f081
 - [x] https://github.com/golang/sys/compare/70b957f3...48ac38b7
 - [x] https://github.com/golang/tools/compare/bcd4e47d...d30e00c2
 - [x] https://github.com/google/google-api-go-client/compare/9c79deeb...19e022d8
 - [x] https://github.com/golang/appengine/compare/150dc57a...e9657d88
 - [x] https://github.com/google/go-genproto/compare/a1fde740...6909d8a4

Informs #30774.

Release note: None