### PR TITLE
roachtest: fetch logs regardless of whether tests fail

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -1064,13 +1064,13 @@ func (r *registry) runAsync(
 				if err := c.FetchDebugZip(ctx); err != nil {
 					c.l.Printf("failed to download debug zip: %s", err)
 				}
-				// NB: fetch the logs even when we have a debug zip because
-				// debug zip can't ever get the logs for down nodes.
-				// We only save artifacts for failed tests in CI, so this
-				// duplication is acceptable.
-				if err := c.FetchLogs(ctx); err != nil {
-					c.l.Printf("failed to download logs: %s", err)
-				}
+			}
+			// NB: fetch the logs even when we have a debug zip because
+			// debug zip can't ever get the logs for down nodes.
+			// We only save artifacts for failed tests in CI, so this
+			// duplication is acceptable.
+			if err := c.FetchLogs(ctx); err != nil {
+				c.l.Printf("failed to download logs: %s", err)
 			}
 		}()
 


### PR DESCRIPTION
In #33543 we changed the logic to always fetch logs and debug zips on failure
whereas before the change we grabbed logs on success and a debug zip on failure.

This is problematic because the log fetching on success is responsible for
fetching performance statistics data which drive roachperf. This change removes
the failure condition for the retrieval of "logs".

Release note: None