### PR TITLE
storage: remove the old VersionRaftLastIndex migration

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -606,7 +606,7 @@ func runDebugCheckStoreDescriptors(ctx context.Context, db *engine.RocksDB) erro
 	var failed bool
 	if err := storage.IterateRangeDescriptors(ctx, db,
 		func(desc roachpb.RangeDescriptor) (bool, error) {
-			claimedMS, err := stateloader.Make(serverCfg.Settings, desc.RangeID).LoadMVCCStats(ctx, db)
+			claimedMS, err := stateloader.Make(desc.RangeID).LoadMVCCStats(ctx, db)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -39,7 +39,6 @@ const (
 	VersionSplitHardStateBelowRaft
 	VersionStatsBasedRebalancing
 	Version1_1
-	VersionRaftLastIndex
 	VersionMVCCNetworkStats
 	VersionMeta2Splits // unused
 	VersionRPCNetworkStats
@@ -124,11 +123,12 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		Key:     Version1_1,
 		Version: roachpb.Version{Major: 1, Minor: 1},
 	},
-	{
-		// VersionRaftLastIndex is https://github.com/cockroachdb/cockroach/pull/18717.
-		Key:     VersionRaftLastIndex,
-		Version: roachpb.Version{Major: 1, Minor: 1, Unstable: 1},
-	},
+	// Removed.
+	// {
+	//   // VersionRaftLastIndex is https://github.com/cockroachdb/cockroach/pull/18717.
+	//   Key:     VersionRaftLastIndex,
+	//   Version: roachpb.Version{Major: 1, Minor: 1, Unstable: 1},
+	// },
 	{
 		// VersionMVCCNetworkStats is https://github.com/cockroachdb/cockroach/pull/18828.
 		Key:     VersionMVCCNetworkStats,

--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -953,7 +953,7 @@ func splitTrigger(
 			// clobber downstream simply because that's what 1.0 does and if we
 			// don't write it here, then a 1.0 version applying it as a follower
 			// won't write a HardState at all and is guaranteed to crash.
-			rsl := stateloader.Make(rec.ClusterSettings(), split.RightDesc.RangeID)
+			rsl := stateloader.Make(split.RightDesc.RangeID)
 			if err := rsl.SynthesizeRaftState(ctx, batch); err != nil {
 				return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to synthesize initial Raft state")
 			}

--- a/pkg/storage/batcheval/stateloader.go
+++ b/pkg/storage/batcheval/stateloader.go
@@ -18,5 +18,5 @@ import "github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 
 // MakeStateLoader creates a StateLoader for the EvalContext.
 func MakeStateLoader(rec EvalContext) stateloader.StateLoader {
-	return stateloader.Make(rec.ClusterSettings(), rec.GetRangeID())
+	return stateloader.Make(rec.GetRangeID())
 }

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -788,11 +788,11 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	// Get the range stats for both ranges now that we have data.
 	snap := store.Engine().NewSnapshot()
 	defer snap.Close()
-	msA, err := stateloader.Make(nil /* st */, lhsDesc.RangeID).LoadMVCCStats(ctx, snap)
+	msA, err := stateloader.Make(lhsDesc.RangeID).LoadMVCCStats(ctx, snap)
 	if err != nil {
 		t.Fatal(err)
 	}
-	msB, err := stateloader.Make(nil /* st */, rhsDesc.RangeID).LoadMVCCStats(ctx, snap)
+	msB, err := stateloader.Make(rhsDesc.RangeID).LoadMVCCStats(ctx, snap)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -817,7 +817,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	// Get the range stats for the merged range and verify.
 	snap = store.Engine().NewSnapshot()
 	defer snap.Close()
-	msMerged, err := stateloader.Make(nil /* st */, replMerged.RangeID).LoadMVCCStats(ctx, snap)
+	msMerged, err := stateloader.Make(replMerged.RangeID).LoadMVCCStats(ctx, snap)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -574,7 +574,7 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 	}
 
 	// Get the original stats for key and value bytes.
-	ms, err := stateloader.Make(nil /* st */, rangeID).LoadMVCCStats(context.Background(), store.Engine())
+	ms, err := stateloader.Make(rangeID).LoadMVCCStats(context.Background(), store.Engine())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -651,12 +651,12 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 
 	// Compare stats of split ranges to ensure they are non zero and
 	// exceed the original range when summed.
-	left, err := stateloader.Make(nil /* st */, rangeID).LoadMVCCStats(context.Background(), store.Engine())
+	left, err := stateloader.Make(rangeID).LoadMVCCStats(context.Background(), store.Engine())
 	if err != nil {
 		t.Fatal(err)
 	}
 	lKeyBytes, lValBytes := left.KeyBytes, left.ValBytes
-	right, err := stateloader.Make(nil /* st */, newRng.RangeID).LoadMVCCStats(context.Background(), store.Engine())
+	right, err := stateloader.Make(newRng.RangeID).LoadMVCCStats(context.Background(), store.Engine())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -713,7 +713,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	// Get the range stats now that we have data.
 	snap := store.Engine().NewSnapshot()
 	defer snap.Close()
-	ms, err := stateloader.Make(nil /* st */, repl.RangeID).LoadMVCCStats(ctx, snap)
+	ms, err := stateloader.Make(repl.RangeID).LoadMVCCStats(ctx, snap)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -736,12 +736,12 @@ func TestStoreRangeSplitStats(t *testing.T) {
 
 	snap = store.Engine().NewSnapshot()
 	defer snap.Close()
-	msLeft, err := stateloader.Make(nil /* st */, repl.RangeID).LoadMVCCStats(ctx, snap)
+	msLeft, err := stateloader.Make(repl.RangeID).LoadMVCCStats(ctx, snap)
 	if err != nil {
 		t.Fatal(err)
 	}
 	replRight := store.LookupReplica(midKey)
-	msRight, err := stateloader.Make(nil /* st */, replRight.RangeID).LoadMVCCStats(ctx, snap)
+	msRight, err := stateloader.Make(replRight.RangeID).LoadMVCCStats(ctx, snap)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -921,12 +921,12 @@ func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 
 	snap := store.Engine().NewSnapshot()
 	defer snap.Close()
-	msLeft, err := stateloader.Make(nil /* st */, repl.RangeID).LoadMVCCStats(ctx, snap)
+	msLeft, err := stateloader.Make(repl.RangeID).LoadMVCCStats(ctx, snap)
 	if err != nil {
 		t.Fatal(err)
 	}
 	replRight := store.LookupReplica(midKey)
-	msRight, err := stateloader.Make(nil /* st */, replRight.RangeID).LoadMVCCStats(ctx, snap)
+	msRight, err := stateloader.Make(replRight.RangeID).LoadMVCCStats(ctx, snap)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -962,7 +962,7 @@ func fillRange(
 	src := rand.New(rand.NewSource(0))
 	var key []byte
 	for {
-		ms, err := stateloader.Make(nil /* st */, rangeID).LoadMVCCStats(context.Background(), store.Engine())
+		ms, err := stateloader.Make(rangeID).LoadMVCCStats(context.Background(), store.Engine())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1455,7 +1455,7 @@ func TestSortRangeDescByAge(t *testing.T) {
 }
 
 func verifyRangeStats(eng engine.Reader, rangeID roachpb.RangeID, expMS enginepb.MVCCStats) error {
-	ms, err := stateloader.Make(nil /* st */, rangeID).LoadMVCCStats(context.Background(), eng)
+	ms, err := stateloader.Make(rangeID).LoadMVCCStats(context.Background(), eng)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -375,7 +375,7 @@ func TestConsistencyQueueRecomputeStats(t *testing.T) {
 		}
 		defer eng.Close()
 
-		rsl := stateloader.Make(nil /* st */, rangeID)
+		rsl := stateloader.Make(rangeID)
 		ms, err := rsl.LoadMVCCStats(ctx, eng)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -428,7 +428,7 @@ func (r *Replica) sha512(
 	result.RecomputedMS = ms
 	hasher.Sum(result.SHA512[:0])
 
-	curMS, err := stateloader.Make(r.store.cfg.Settings, desc.RangeID).LoadMVCCStats(ctx, snap)
+	curMS, err := stateloader.Make(desc.RangeID).LoadMVCCStats(ctx, snap)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -433,7 +433,7 @@ func (r *Replica) GetSnapshot(
 	// to use Replica.mu.stateLoader. This call is not performance sensitive, so
 	// create a new state loader.
 	snapData, err := snapshot(
-		ctx, snapUUID, stateloader.Make(r.store.cfg.Settings, rangeID), snapType,
+		ctx, snapUUID, stateloader.Make(rangeID), snapType,
 		snap, rangeID, r.store.raftEntryCache, withSideloaded, startKey,
 	)
 	if err != nil {
@@ -620,10 +620,6 @@ func (r *Replica) append(
 		if err != nil {
 			return 0, 0, 0, err
 		}
-	}
-
-	if err := r.raftMu.stateLoader.SetLastIndex(ctx, batch, lastIndex); err != nil {
-		return 0, 0, 0, err
 	}
 
 	raftLogSize := prevRaftLogSize + diff.SysBytes

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -941,7 +941,7 @@ func TestRaftSSTableSideloadingSnapshot(t *testing.T) {
 			if withSS {
 				ss = tc.repl.raftMu.sideloaded
 			}
-			rsl := stateloader.Make(tc.store.ClusterSettings(), tc.repl.RangeID)
+			rsl := stateloader.Make(tc.repl.RangeID)
 			entries, err := entries(
 				ctx, rsl, tc.store.Engine(), tc.repl.RangeID, tc.store.raftEntryCache,
 				ss, sideloadedIndex, sideloadedIndex+1, 1<<20,

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -5472,7 +5472,7 @@ func TestReplicaResolveIntentRange(t *testing.T) {
 }
 
 func verifyRangeStats(eng engine.Reader, rangeID roachpb.RangeID, expMS enginepb.MVCCStats) error {
-	ms, err := stateloader.Make(nil /* st */, rangeID).LoadMVCCStats(context.Background(), eng)
+	ms, err := stateloader.Make(rangeID).LoadMVCCStats(context.Background(), eng)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/stateloader/initial.go
+++ b/pkg/storage/stateloader/initial.go
@@ -53,7 +53,7 @@ func WriteInitialReplicaState(
 	gcThreshold hlc.Timestamp,
 	txnSpanGCThreshold hlc.Timestamp,
 ) (enginepb.MVCCStats, error) {
-	rsl := Make(st, desc.RangeID)
+	rsl := Make(desc.RangeID)
 
 	var s storagepb.ReplicaState
 	s.TruncatedState = &roachpb.RaftTruncatedState{
@@ -124,7 +124,7 @@ func WriteInitialState(
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}
-	if err := Make(st, desc.RangeID).SynthesizeRaftState(ctx, eng); err != nil {
+	if err := Make(desc.RangeID).SynthesizeRaftState(ctx, eng); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
 	return newMS, nil

--- a/pkg/storage/stateloader/initial_test.go
+++ b/pkg/storage/stateloader/initial_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -57,7 +56,7 @@ func TestSynthesizeHardState(t *testing.T) {
 		func() {
 			batch := eng.NewBatch()
 			defer batch.Close()
-			rsl := Make(cluster.MakeTestingClusterSettings(), 1)
+			rsl := Make(roachpb.RangeID(1))
 
 			if test.OldHS != nil {
 				if err := rsl.SetHardState(context.Background(), batch, *test.OldHS); err != nil {

--- a/pkg/storage/stats_test.go
+++ b/pkg/storage/stats_test.go
@@ -69,7 +69,7 @@ func TestRangeStatsInit(t *testing.T) {
 		GCBytesAge:      10,
 		LastUpdateNanos: 11,
 	}
-	rsl := stateloader.Make(nil /* st */, tc.repl.RangeID)
+	rsl := stateloader.Make(tc.repl.RangeID)
 	if err := rsl.SetMVCCStats(context.Background(), tc.engine, &ms); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2165,7 +2165,7 @@ func (s *Store) WriteInitialData(
 			return err
 		}
 
-		sl := stateloader.Make(s.ClusterSettings(), rangeID)
+		sl := stateloader.Make(rangeID)
 		if err := sl.SetMVCCStats(ctx, batch, &computedStats); err != nil {
 			return err
 		}
@@ -2237,13 +2237,11 @@ func (s *Store) NewRangeDescriptor(
 // splitPreApply is called when the raft command is applied. Any
 // changes to the given ReadWriter will be written atomically with the
 // split commit.
-func splitPreApply(
-	ctx context.Context, st *cluster.Settings, eng engine.ReadWriter, split roachpb.SplitTrigger,
-) {
+func splitPreApply(ctx context.Context, eng engine.ReadWriter, split roachpb.SplitTrigger) {
 	// Update the raft HardState with the new Commit value now that the
 	// replica is initialized (combining it with existing or default
 	// Term and Vote).
-	rsl := stateloader.Make(st, split.RightDesc.RangeID)
+	rsl := stateloader.Make(split.RightDesc.RangeID)
 	if err := rsl.SynthesizeRaftState(ctx, eng); err != nil {
 		log.Fatal(ctx, err)
 	}


### PR DESCRIPTION
... which allows us to remove StateLoader.SetLastIndex()

Release note: None