### PR TITLE
changefeed: add experimental support for cloud storage sinks

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -172,6 +172,7 @@ func kvsToRows(
 func emitEntries(
 	settings *cluster.Settings,
 	details jobspb.ChangefeedDetails,
+	watchedSpans []roachpb.Span,
 	encoder Encoder,
 	sink Sink,
 	inputFn func(context.Context) ([]emitEntry, error),
@@ -182,15 +183,16 @@ func emitEntries(
 	emitRowFn := func(ctx context.Context, row emitRow) error {
 		var keyCopy, valueCopy []byte
 
-		encodedKey, err := encoder.EncodeKey(row.tableDesc, row.datums)
-		if err != nil {
-			return err
+		if envelopeType(details.Opts[optEnvelope]) != optEnvelopeValueOnly {
+			encodedKey, err := encoder.EncodeKey(row.tableDesc, row.datums)
+			if err != nil {
+				return err
+			}
+			scratch, keyCopy = scratch.Copy(encodedKey, 0 /* extraCap */)
 		}
-		scratch, keyCopy = scratch.Copy(encodedKey, 0 /* extraCap */)
 
-		if !row.deleted && envelopeType(details.Opts[optEnvelope]) == optEnvelopeRow {
-			var encodedValue []byte
-			encodedValue, err = encoder.EncodeValue(row.tableDesc, row.datums, row.timestamp)
+		if !row.deleted && envelopeType(details.Opts[optEnvelope]) != optEnvelopeKeyOnly {
+			encodedValue, err := encoder.EncodeValue(row.tableDesc, row.datums, row.timestamp)
 			if err != nil {
 				return err
 			}
@@ -202,7 +204,9 @@ func emitEntries(
 				return err
 			}
 		}
-		if err := sink.EmitRow(ctx, row.tableDesc.Name, keyCopy, valueCopy); err != nil {
+		if err := sink.EmitRow(
+			ctx, row.tableDesc, keyCopy, valueCopy, row.timestamp,
+		); err != nil {
 			return err
 		}
 		if log.V(3) {
@@ -211,8 +215,12 @@ func emitEntries(
 		return nil
 	}
 
+	// This SpanFrontier only tracks the spans being watched on this node.
+	// (There is a different SpanFrontier elsewhere for the entire changefeed.)
+	watchedSF := makeSpanFrontier(watchedSpans...)
+
 	var lastFlush time.Time
-	// TODO(dan): We could keep these in a spanFrontier to eliminate dups.
+	// TODO(dan): We could keep these in `watchedSF` to eliminate dups.
 	var resolvedSpans []jobspb.ResolvedSpan
 
 	return func(ctx context.Context) ([]jobspb.ResolvedSpan, error) {
@@ -238,6 +246,7 @@ func emitEntries(
 				}
 			}
 			if input.resolved != nil {
+				_ = watchedSF.Forward(input.resolved.Span, input.resolved.Timestamp)
 				resolvedSpans = append(resolvedSpans, *input.resolved)
 			}
 		}
@@ -264,7 +273,7 @@ func emitEntries(
 		// otherwise, we could lose buffered messages and violate the
 		// at-least-once guarantee. This is also true for checkpointing the
 		// resolved spans in the job progress.
-		if err := sink.Flush(ctx); err != nil {
+		if err := sink.Flush(ctx, watchedSF.Frontier()); err != nil {
 			return nil, err
 		}
 		lastFlush = timeutil.Now()
@@ -329,7 +338,7 @@ func emitResolvedTimestamp(
 	payload = append([]byte(nil), payload...)
 	// TODO(dan): Emit more fine-grained (table level) resolved
 	// timestamps.
-	if err := sink.EmitResolvedTimestamp(ctx, payload); err != nil {
+	if err := sink.EmitResolvedTimestamp(ctx, payload, resolved); err != nil {
 		return err
 	}
 	if log.V(2) {

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -119,7 +119,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 
 	var err error
 	if ca.sink, err = getSink(
-		ca.spec.Feed.SinkURI, ca.spec.Feed.Opts, ca.spec.Feed.Targets,
+		ca.spec.Feed.SinkURI, ca.spec.Feed.Opts, ca.spec.Feed.Targets, ca.flowCtx.Settings,
 	); err != nil {
 		// Early abort in the case that there is an error creating the sink.
 		ca.MoveToDraining(err)
@@ -160,7 +160,8 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 	if cfKnobs, ok := ca.flowCtx.TestingKnobs().Changefeed.(*TestingKnobs); ok {
 		knobs = *cfKnobs
 	}
-	ca.tickFn = emitEntries(ca.flowCtx.Settings, ca.spec.Feed, ca.encoder, ca.sink, rowsFn, knobs, metrics)
+	ca.tickFn = emitEntries(
+		ca.flowCtx.Settings, ca.spec.Feed, spans, ca.encoder, ca.sink, rowsFn, knobs, metrics)
 
 	// Give errCh enough buffer both possible errors from supporting goroutines,
 	// but only the first one is ever used.
@@ -393,7 +394,7 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 
 	var err error
 	if cf.sink, err = getSink(
-		cf.spec.Feed.SinkURI, cf.spec.Feed.Opts, cf.spec.Feed.Targets,
+		cf.spec.Feed.SinkURI, cf.spec.Feed.Opts, cf.spec.Feed.Targets, cf.flowCtx.Settings,
 	); err != nil {
 		cf.MoveToDraining(err)
 		return ctx

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -180,7 +180,7 @@ func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, err
 	// TODO(dan): Figure out what updated and resolved timestamps should
 	// look like with avro.
 	for _, opt := range []string{optUpdatedTimestamps, optResolvedTimestamps} {
-		if _, ok := opts[optUpdatedTimestamps]; ok {
+		if _, ok := opts[opt]; ok {
 			return nil, errors.Errorf(
 				`%s=%s is not yet compatible with %s`, optFormat, optFormatAvro, opt)
 		}

--- a/pkg/ccl/changefeedccl/table_history.go
+++ b/pkg/ccl/changefeedccl/table_history.go
@@ -268,9 +268,6 @@ func fetchTableDescriptorVersions(
 				if err != nil {
 					return err
 				}
-				// WIP: I think targets currently doesn't contain interleaved
-				// parents if they are not watched by the changefeed, but this
-				// seems wrong.
 				origName, ok := targets[sqlbase.ID(tableID)]
 				if !ok {
 					// Uninteresting table.


### PR DESCRIPTION
The data files are named `<timestamp>_<topic>_<schema_id>_<uniquer>.<ext>`.

`<timestamp>` is truncated to some bucket size, specified by the required
sink param `bucket_size`. Bucket size is a tradeoff between number of files
and the end-to-end latency of data being resolved.

`<topic>` corresponds to one SQL table.

`<schema_id>` changes whenever the SQL table schema changes, which allows us
to guarantee to users that _all entries in a given file have the same
schema_.

`<uniquer>` is used to keep nodes in a cluster from overwriting each other's
data and should be ignored by external users.

`<ext>` implies the format of the file: currently the only option is
`ndjson`, which means a text file conforming to the "Newline Delimited JSON"
spec.

Each record in the data files is a value, keys are not included, so the
`envelope` option must be set to `row`, which is the default. Within a file,
records are not guaranteed to be sorted by timestamp. A duplicate of some
record might exist in a different file or even in the same file.

The resolved timestamp files are named `<timestamp>.RESOLVED`. This is
carefully done so that we can offer the following external guarantee: At any
given time, if the the files are iterated in lexicographic filename order,
then encountering any filename containing `RESOLVED` means that everything
before it is finalized (and thus can be ingested into some other system and
deleted, included in hive queries, etc). A typical user of cloudStorageSink
would periodically do exactly this.

Still TODO is writing out data schemas, Avro support, bounding memory usage.
Eliminating duplicates would be great, but may not be immediately practical.

Partially completes #28675

Release note (enterprise change): `CHANGEFEED`s now experimentally
support writing to cloud storage, for easy use with analytics databases