### PR TITLE
 storage: get rid of VersionRangeAppliedStateKey

### DIFF
--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -56,7 +56,6 @@ const (
 	Version2_0
 	VersionImportSkipRecords
 	VersionProposedTSLeaseRequest
-	VersionRangeAppliedStateKey
 	VersionImportFormats
 	VersionSecondaryLookupJoins
 	VersionClientSideWritingFlag // unused
@@ -224,11 +223,12 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		Key:     VersionProposedTSLeaseRequest,
 		Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 2},
 	},
-	{
-		// VersionRangeAppliedStateKey is https://github.com/cockroachdb/cockroach/pull/22317.
-		Key:     VersionRangeAppliedStateKey,
-		Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 3},
-	},
+	// Removed
+	// {
+	//   // VersionRangeAppliedStateKey is https://github.com/cockroachdb/cockroach/pull/22317.
+	//   Key:     VersionRangeAppliedStateKey,
+	//   Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 3},
+	// },
 	{
 		// VersionImportFormats is https://github.com/cockroachdb/cockroach/pull/25615.
 		Key:     VersionImportFormats,

--- a/pkg/storage/below_raft_protos_test.go
+++ b/pkg/storage/below_raft_protos_test.go
@@ -72,15 +72,6 @@ var belowRaftGoldenProtos = map[reflect.Type]fixture{
 		emptySum:     615555020845646359,
 		populatedSum: 94706924697857278,
 	},
-	// MVCCStats is still serialized beneath Raft in tests that use old cluster
-	// versions before the RangeAppliedState key.
-	reflect.TypeOf(&enginepb.MVCCStats{}): {
-		populatedConstructor: func(r *rand.Rand) protoutil.Message {
-			return enginepb.NewPopulatedMVCCStats(r, false)
-		},
-		emptySum:     18064891702890239528,
-		populatedSum: 4287370248246326846,
-	},
 	reflect.TypeOf(&raftpb.HardState{}): {
 		populatedConstructor: func(r *rand.Rand) protoutil.Message {
 			type expectedHardState struct {

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -46,25 +46,6 @@ var (
 	NilKey = MVCCKey{}
 )
 
-// AccountForLegacyMVCCStats adjusts ms to account for the predicted impact it
-// will have on the values that it records when the structure is initially stored.
-// Specifically, MVCCStats is stored on the RangeStats legacy key, which means
-// that its creation will have an impact on system-local data size and key count.
-func AccountForLegacyMVCCStats(ms *enginepb.MVCCStats, rangeID roachpb.RangeID) error {
-	key := keys.RangeStatsLegacyKey(rangeID)
-	metaKey := MakeMVCCMetadataKey(key)
-
-	// MVCCStats is stored inline, so compute MVCCMetadata accordingly.
-	value := roachpb.Value{}
-	if err := value.SetProto(ms); err != nil {
-		return err
-	}
-	meta := enginepb.MVCCMetadata{RawBytes: value.RawBytes}
-
-	updateStatsForInline(ms, key, 0, 0, int64(metaKey.EncodedSize()), int64(meta.Size()))
-	return nil
-}
-
 // MakeValue returns the inline value.
 func MakeValue(meta enginepb.MVCCMetadata) roachpb.Value {
 	return roachpb.Value{RawBytes: meta.RawBytes}

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -238,10 +238,6 @@ func (r *Replica) ReplicaIDLocked() roachpb.ReplicaID {
 	return r.mu.replicaID
 }
 
-func (r *Replica) DescLocked() *roachpb.RangeDescriptor {
-	return r.mu.state.Desc
-}
-
 func (r *Replica) AssertState(ctx context.Context, reader engine.Reader) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3173,19 +3173,18 @@ func (r *Replica) evaluateProposal(
 		} else {
 			res.Replicated.DeprecatedDelta = &ms
 		}
-		// If the RangeAppliedState key is not being used and the cluster version is
-		// high enough to guarantee that all current and future binaries will
-		// understand the key, we send the migration flag through Raft. Because
-		// there is a delay between command proposal and application, we may end up
-		// setting this migration flag multiple times. This is ok, because the
-		// migration is idempotent.
-		// TODO(nvanbenschoten): This will be baked in to 2.1, so it can be removed
-		// in the 2.2 release.
+		// If the RangeAppliedState key is not being used yet by the range, we send
+		// the migration flag through Raft. Because there is a delay between command
+		// proposal and application, we may end up setting this migration flag
+		// multiple times. This is ok, because the migration is idempotent.
+		//
+		// NOTE(nvanbenschoten): We can only get rid of this migration code once we
+		// declare it virtually impossible for a proposal created by a cluster at
+		// version 2.0 to still exist (think old unapplied Raft log entries).
 		r.mu.RLock()
 		usingAppliedStateKey := r.mu.state.UsingAppliedStateKey
 		r.mu.RUnlock()
-		if !usingAppliedStateKey &&
-			r.ClusterSettings().Version.IsMinSupported(cluster.VersionRangeAppliedStateKey) {
+		if !usingAppliedStateKey {
 			if res.Replicated.State == nil {
 				res.Replicated.State = &storagepb.ReplicaState{}
 			}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
@@ -9614,157 +9613,18 @@ func assertUsingRangeAppliedState(t *testing.T, repl *Replica, expSet bool) {
 	}
 }
 
-// assertRangeAppliedStateRelatedKeysExist performs a series of assertions
-// that each key related to the RangeAppliedState key migration is either
-// present or missing, depending on the expRASK flag.
-func assertRangeAppliedStateRelatedKeysExist(
-	ctx context.Context, t *testing.T, repl *Replica, expRASK bool,
-) {
-	t.Helper()
-	repl.raftMu.Lock()
-	defer repl.raftMu.Unlock()
-	repl.mu.Lock()
-	defer repl.mu.Unlock()
-
-	assertHasKey := func(key roachpb.Key, expect bool) {
-		t.Helper()
-		val, _, err := engine.MVCCGet(ctx, repl.store.Engine(), key, hlc.Timestamp{},
-			engine.MVCCGetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		exists := val != nil
-		if exists != expect {
-			t.Errorf("expected key %s to exist=%t, found %t", key, expect, exists)
-		}
-	}
-
-	rsl := repl.mu.stateLoader
-	assertHasKey(rsl.RangeAppliedStateKey(), expRASK)
-	assertHasKey(rsl.RaftAppliedIndexLegacyKey(), !expRASK)
-	assertHasKey(rsl.LeaseAppliedIndexLegacyKey(), !expRASK)
-	assertHasKey(rsl.RangeStatsLegacyKey(), !expRASK)
-}
-
-// TestReplicaBootstrapRangeAppliedStateKey verifies that a bootstrapped range
-// is only created with a RangeAppliedStateKey if the cluster version is high
-// enough to permit it.
-func TestReplicaBootstrapRangeAppliedStateKey(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	testCases := []struct {
-		version                 roachpb.Version
-		expRangeAppliedStateKey bool
-	}{
-		{
-			version:                 cluster.VersionByKey(cluster.Version2_0),
-			expRangeAppliedStateKey: false,
-		},
-		{
-			version:                 cluster.VersionByKey(cluster.VersionRangeAppliedStateKey),
-			expRangeAppliedStateKey: true,
-		},
-		{
-			version:                 cluster.BinaryServerVersion,
-			expRangeAppliedStateKey: true,
-		},
-	}
-	for _, c := range testCases {
-		t.Run(fmt.Sprintf("version=%s", c.version), func(t *testing.T) {
-			ctx := context.Background()
-			stopper := stop.NewStopper()
-			defer stopper.Stop(ctx)
-
-			cfg := TestStoreConfig(nil)
-			cfg.Settings = cluster.MakeTestingClusterSettingsWithVersion(
-				c.version /* minVersion */, cluster.BinaryServerVersion /* serverVersion */)
-			tc := testContext{}
-			tc.StartWithStoreConfig(t, stopper, cfg)
-			repl := tc.repl
-
-			// Check that that UsingAppliedStateKey flag in ReplicaState is set
-			// as expected.
-			assertInMemState := func(t *testing.T) {
-				t.Helper()
-				assertUsingRangeAppliedState(t, repl, c.expRangeAppliedStateKey)
-			}
-
-			// Check that persisted keys agree with the UsingAppliedStateKey flag.
-			assertPersistentState := func(t *testing.T) {
-				t.Helper()
-				assertRangeAppliedStateRelatedKeysExist(ctx, t, repl, c.expRangeAppliedStateKey)
-			}
-
-			// Check that in-mem and persistent state agree.
-			assertInMemAndPersistentStateAgree := func(t *testing.T) {
-				t.Helper()
-				repl.AssertState(ctx, tc.engine)
-			}
-
-			// Check that the MVCCStats are correct.
-			computeStatsDelta := func(db *client.DB) (enginepb.MVCCStats, error) {
-				var b client.Batch
-				b.AddRawRequest(&roachpb.RecomputeStatsRequest{
-					RequestHeader: roachpb.RequestHeader{Key: roachpb.KeyMin},
-					DryRun:        true,
-				})
-				if err := db.Run(ctx, &b); err != nil {
-					return enginepb.MVCCStats{}, err
-				}
-				resp := b.RawResponse().Responses[0].GetInner().(*roachpb.RecomputeStatsResponse)
-				delta := enginepb.MVCCStats(resp.AddedDelta)
-				delta.AgeTo(0)
-				return delta, nil
-			}
-			assertEmptyStatsDelta := func(t *testing.T) {
-				t.Helper()
-				delta, err := computeStatsDelta(repl.DB())
-				if err != nil {
-					t.Fatal(err)
-				}
-				if delta != (enginepb.MVCCStats{}) {
-					t.Errorf("unexpected stats adjustment of %+v", delta)
-				}
-			}
-
-			// Perform initial series of assertions.
-			assertInMemState(t)
-			assertPersistentState(t)
-			assertInMemAndPersistentStateAgree(t)
-			assertEmptyStatsDelta(t)
-
-			// Save the ReplicaState and perform persistent assertions again.
-			repl.raftMu.Lock()
-			repl.mu.Lock()
-			if _, err := repl.mu.stateLoader.Save(ctx, tc.engine, repl.mu.state); err != nil {
-				t.Fatalf("could not save ReplicaState: %v", err)
-			}
-			repl.mu.Unlock()
-			repl.raftMu.Unlock()
-			assertPersistentState(t)
-			assertInMemAndPersistentStateAgree(t)
-			assertEmptyStatsDelta(t)
-
-			// Load the ReplicaState and perform in-memory assertions again.
-			repl.raftMu.Lock()
-			repl.mu.Lock()
-			state, err := repl.mu.stateLoader.Load(ctx, tc.engine, repl.DescLocked())
-			if err != nil {
-				t.Fatalf("could not load ReplicaState: %v", err)
-			}
-			repl.mu.state = state
-			repl.mu.Unlock()
-			repl.raftMu.Unlock()
-			assertInMemState(t)
-			assertInMemAndPersistentStateAgree(t)
-		})
-	}
-}
-
 // TestReplicaMigrateRangeAppliedStateKey verifies that a range which is not yet
-// using the RangeAppliedStateKey will eventually trigger a migration to begin
-// using it once the cluster version is high enough to permit its use.
+// using the RangeAppliedStateKey will trigger a migration.
+//
+// NOTE(andrei): This test is... funky. It was written originally to test that
+// the migration was happening once the cluster was upgraded to a certain
+// cluster version. In the meantime, that version has become guaranteed, but the
+// migration code is still kept around because it affects below-Raft command
+// application and we can still theoretically have to apply commands onto
+// replicas that were never migrated (since they haven't been touched since
+// 2.0). So now the test relies on starting with a "migrated" replica and
+// reverting to manually to a non-migrated state, and then checking that the
+// migration happens.
 func TestReplicaMigrateRangeAppliedStateKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -9772,42 +9632,9 @@ func TestReplicaMigrateRangeAppliedStateKey(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	cfg := TestStoreConfig(nil)
-	cfg.Settings = cluster.MakeTestingClusterSettingsWithVersion(
-		cluster.VersionByKey(cluster.Version2_0), /* minVersion */
-		cluster.BinaryServerVersion /* serverVersion */)
 	tc := testContext{}
-	tc.StartWithStoreConfig(t, stopper, cfg)
+	tc.Start(t, stopper)
 	repl := tc.repl
-
-	assertMigrationComplete := func(t *testing.T, exp bool) {
-		t.Helper()
-		assertUsingRangeAppliedState(t, repl, exp)
-		assertRangeAppliedStateRelatedKeysExist(ctx, t, repl, exp)
-	}
-
-	// We should not be using the AppliedStateKey to begin with.
-	assertMigrationComplete(t, false)
-
-	// Begin performing some writes regularly.
-	errCh := make(chan *roachpb.Error, 1)
-	pArgs := putArgs(roachpb.Key("a"), []byte("val"))
-	stopper.RunWorker(ctx, func(ctx context.Context) {
-		ticker := time.NewTicker(2 * time.Millisecond)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				if _, pErr := tc.SendWrapped(&pArgs); pErr != nil {
-					errCh <- pErr
-					return
-				}
-			case <-stopper.ShouldQuiesce():
-				return
-			}
-		}
-	})
 
 	migrateCh := make(chan struct{}, 1)
 	repl.mu.Lock()
@@ -9821,26 +9648,16 @@ func TestReplicaMigrateRangeAppliedStateKey(t *testing.T) {
 			}
 			return nil
 		}
+
+	// Hackily change the in-memory state of the replica so that we can assert
+	// that it flips back.
+	repl.mu.state.UsingAppliedStateKey = false
 	repl.mu.Unlock()
 
-	// No attempt should be made to migrate to the AppliedStateKey
-	select {
-	case <-time.After(20 * time.Millisecond):
-		// Expected. Assert again that we're not yet using the AppliedStateKey.
-		assertMigrationComplete(t, false)
-	case <-migrateCh:
-		t.Fatalf("unexpected migration attempt")
-	case pErr := <-errCh:
-		t.Fatalf("unexpected error %s", pErr)
-	}
-
-	// Bump the cluster version to trigger the ReplicaAppliedState key migration.
-	cv := cluster.ClusterVersion{
-		MinimumVersion: cluster.VersionByKey(cluster.VersionRangeAppliedStateKey),
-		UseVersion:     cluster.BinaryServerVersion,
-	}
-	if err := cfg.Settings.InitializeVersion(cv); err != nil {
-		t.Fatal(err)
+	// Begin performing some writes regularly.
+	pArgs := putArgs(roachpb.Key("a"), []byte("val"))
+	if _, pErr := tc.SendWrapped(&pArgs); pErr != nil {
+		t.Fatal(pErr)
 	}
 
 	// Wait until we see a proposal attempt a migration.
@@ -9849,14 +9666,10 @@ func TestReplicaMigrateRangeAppliedStateKey(t *testing.T) {
 		t.Fatalf("expected to see a migration attempt")
 	case <-migrateCh:
 		// Expected.
-	case pErr := <-errCh:
-		t.Fatalf("unexpected error %s", pErr)
 	}
 
-	// Assert that the replica is now using the ReplicaAppliedState key. The
-	// migration will also trigger assertStateLocked, so we're sure that the
-	// in-memory and on-disk ReplicaStates are not diverging.
-	assertMigrationComplete(t, true)
+	// Assert that the replica is now using the ReplicaAppliedState key.
+	assertUsingRangeAppliedState(t, repl, true /* expSet */)
 }
 
 func TestReplicaShouldCampaignOnWake(t *testing.T) {

--- a/pkg/storage/stateloader/initial.go
+++ b/pkg/storage/stateloader/initial.go
@@ -69,16 +69,9 @@ func WriteInitialReplicaState(
 	s.GCThreshold = &gcThreshold
 	s.TxnSpanGCThreshold = &txnSpanGCThreshold
 
-	// If the MinSupported cluster version is high enough to guarantee that all
-	// nodes will understand the AppliedStateKey then we can just straight to
-	// using it without ever writing the legacy stats and index keys.
-	if st.Version.IsMinSupported(cluster.VersionRangeAppliedStateKey) {
-		s.UsingAppliedStateKey = true
-	} else {
-		if err := engine.AccountForLegacyMVCCStats(s.Stats, desc.RangeID); err != nil {
-			return enginepb.MVCCStats{}, err
-		}
-	}
+	// New ranges use the AppliedStateKey. Old ranges need to deal with a
+	// migration.
+	s.UsingAppliedStateKey = true
 
 	if existingLease, err := rsl.LoadLease(ctx, eng); err != nil {
 		return enginepb.MVCCStats{}, errors.Wrap(err, "error reading lease")


### PR DESCRIPTION
cluster: bump BinaryMinimumSupportedVersion=Version2_1 from 2_0  …
... making 2.2 nodes incompatible with 2.0 nodes.
This lets me assume 2.1 nodes (and do the next commit). The instructions
for when to bump this say to bump this when we introduce 2_2, but I
think that's off (or, rather, we should already have introduced 2.2).
Also see #33578.

Release note: None

storage: get rid of VersionRangeAppliedStateKey  …
This migration is complicated. The patch gets rid of the version guard,
but not otherwise the migration code. Before this patch, the migration
for a range was triggered when a range was not migrated yet and
IsMinSupported(VersionRangeAppliedStateKey). The latter part is always
true: since a previous commit set BinaryMinimumSupportedVersion=2_1,
VersionRangeAppliedStateKey was guaranteed.
After this patch, the migration is triggered when a range was not yet
migrated.
It would seem that we have to live with this migration for an undefined
period of time longer: some ranges might have never been migrated if
they originated in an, say, 1.1 cluster that went through a series of
upgrades but the range was never touched.

One thing that was considered was having the below-Raft command
application always perform the migration if the range wasn't previously
migrated, regardless of what the proposal specifies. This doesn't seem
feasible since we need to guarantee that different replicas apply the
command exactly the same, and so we can't have one ignore the proposal
spec and another one not ignore it. We'll be able to unconditionally
perform the migration once we decree that there can no longer be
proposals "in flight" coming from ancient nodes (think unapplied Raft
lags).

Release note: None