### PR TITLE
sql: trim down testing of range mode of window functions

### DIFF
--- a/pkg/sql/sem/tree/window_funcs_test.go
+++ b/pkg/sql/sem/tree/window_funcs_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-const maxCount = 100
 const minOffset = 0
 const maxOffset = 100
 const probabilityOfNewNumber = 0.5
@@ -296,7 +295,8 @@ func partitionToString(partition IndexedRows) string {
 }
 
 func TestRangeMode(t *testing.T) {
-	for count := 1; count <= maxCount; count++ {
+	var counts = [...]int{1, 17, 42, 91}
+	for _, count := range counts {
 		testRangeMode(t, count)
 	}
 }


### PR DESCRIPTION
Previously, testing of range mode of window functions took several
seconds because of running the tests with counts of rows from 1 to
100 which is highly redundant and unnecessary. We reduce the number
of counts to 4 so that time the testing takes is on the order of tens
of milliseconds.

Fixes: #33648.

Release note: None