### PR TITLE
lint: pin honnef.co/go/tools

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -96,6 +96,11 @@ ignored = [
   name = "github.com/kisielk/errcheck"
   version = "=v1.1.0"
 
+# Pin to 2017.2.2 because of https://github.com/cockroachdb/cockroach/issues/33669.
+[[constraint]]
+  name = "honnef.co/go/tools"
+  version = "=2017.2.2"
+
 # github.com/openzipkin-contrib/zipkin-go-opentracing requires a newer
 # version of thrift than is currently present in a release.
 [[override]]


### PR DESCRIPTION
Pin this repository to the previous release that works with our code.
Issue #33669 tracks making things work with the current release.

Release note: None