### PR TITLE
rpc: adopt logging in circuitbreaker

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -302,11 +302,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:220d60c10e7c67f52168c496bf778fb00ec88e12956a933b7ce53d286fb438fe"
+  digest = "1:5502cef94063585c627f3bc3ffc80ad7f0f1e0f1b5dccf8aeff9a822526806da"
   name = "github.com/cockroachdb/circuitbreaker"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3e861b2e1d31642be9e447dc6f8aa599813e98b4"
+  revision = "a614b14ccf63dd2311d4ff646c30c61b8ed34aa8"
 
 [[projects]]
   branch = "master"

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -168,7 +168,7 @@ func gossipSucceedsSoon(
 			// If the client wasn't able to connect, restart it.
 			g := gossip[client]
 			g.mu.Lock()
-			client.startLocked(g, disconnected, rpcContext, stopper, rpcContext.NewBreaker())
+			client.startLocked(g, disconnected, rpcContext, stopper, rpcContext.NewBreaker(""))
 			g.mu.Unlock()
 		default:
 		}
@@ -306,7 +306,7 @@ func TestClientNodeID(t *testing.T) {
 		case <-disconnected:
 			// The client hasn't been started or failed to start, loop and try again.
 			local.mu.Lock()
-			c.startLocked(local, disconnected, rpcContext, stopper, rpcContext.NewBreaker())
+			c.startLocked(local, disconnected, rpcContext, stopper, rpcContext.NewBreaker(""))
 			local.mu.Unlock()
 		}
 	}

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1572,7 +1572,8 @@ func (g *Gossip) startClientLocked(addr net.Addr) {
 	defer g.clientsMu.Unlock()
 	breaker, ok := g.clientsMu.breakers[addr.String()]
 	if !ok {
-		breaker = g.rpcContext.NewBreaker()
+		name := fmt.Sprintf("gossip %v->%v", g.rpcContext.Addr, addr)
+		breaker = g.rpcContext.NewBreaker(name)
 		g.clientsMu.breakers[addr.String()] = breaker
 	}
 	ctx := g.AnnotateCtx(context.TODO())

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -552,7 +552,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 			localAddr := local.GetNodeAddr()
 			c := newClient(log.AmbientContext{Tracer: tracing.NewTracer()}, localAddr, makeMetrics())
 			peer.mu.Lock()
-			c.startLocked(peer, disconnectedCh, peer.rpcContext, stopper, peer.rpcContext.NewBreaker())
+			c.startLocked(peer, disconnectedCh, peer.rpcContext, stopper, peer.rpcContext.NewBreaker(""))
 			peer.mu.Unlock()
 
 			disconnectedClient := <-disconnectedCh

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -681,12 +681,13 @@ func (ctx *Context) GRPCDial(target string) *Connection {
 }
 
 // NewBreaker creates a new circuit breaker properly configured for RPC
-// connections.
-func (ctx *Context) NewBreaker() *circuit.Breaker {
+// connections. name is used internally for logging state changes of the
+// returned breaker.
+func (ctx *Context) NewBreaker(name string) *circuit.Breaker {
 	if ctx.BreakerFactory != nil {
 		return ctx.BreakerFactory()
 	}
-	return newBreaker(&ctx.breakerClock)
+	return newBreaker(ctx.masterCtx, name, &ctx.breakerClock)
 }
 
 // ErrNotHeartbeated is returned by ConnHealth when we have not yet performed

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -3894,7 +3894,7 @@ func TestFailedPreemptiveSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const expErr = "snapshot failed: unknown peer 3"
+	const expErr = "snapshot failed: failed to resolve n3: unknown peer 3"
 	if err := rep.ChangeReplicas(
 		context.Background(),
 		roachpb.ADD_REPLICA,


### PR DESCRIPTION
Adopts changes to the circuitbreaker package to enable logging. 
Fixes #33657

Release note: None