### PR TITLE
server: rework the initServer

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -291,15 +291,6 @@ func bootstrapCluster(
 	return clusterID, nil
 }
 
-// duplicateBootstrapError is returned by Node.bootstrap when the node is already initialized.
-type duplicateBootstrapError struct {
-	ClusterID uuid.UUID
-}
-
-func (e *duplicateBootstrapError) Error() string {
-	return fmt.Sprintf("cluster has already been initialized with ID %s", e.ClusterID)
-}
-
 // NewNode returns a new instance of Node.
 //
 // execCfg can be nil to help bootstrapping of a Server (the Node is created
@@ -358,7 +349,7 @@ func (n *Node) bootstrap(
 	ctx context.Context, engines []engine.Engine, bootstrapVersion cluster.ClusterVersion,
 ) error {
 	if n.initialBoot || n.clusterID.Get() != uuid.Nil {
-		return &duplicateBootstrapError{ClusterID: n.clusterID.Get()}
+		return fmt.Errorf("cluster has already been initialized with ID %s", n.clusterID.Get())
 	}
 	n.initialBoot = true
 	clusterID, err := bootstrapCluster(ctx, n.storeCfg, engines, bootstrapVersion, n.txnMetrics)


### PR DESCRIPTION
Before this patch, the initServer was complicated - it had some sort of
a semaphore exposed with an unclear API. It was also performing
bootstrapping of the cluster, duplicating code with the Server which
performs bootstrap in cases where an initServer is not used.
No more. This patch reduces the scope of the initServer to be a
glorified channel signaled when bootstrap is requested. Bootstrapping is
left to the calling Server, and so code is unified.

This patch is part of a somewhat chaotic assault on the cluster
bootstrap and generally node startup code, which I find inscrutable.
Other patches flying by stem from this unravelling sweater. One of the
goals is to rework bootstrapping such that the nodeIDContainer hack goes
away.

Release note: None