### PR TITLE
opt: Project merged Upsert columns

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -438,7 +438,7 @@ func (sc *SchemaChanger) distBackfill(
 			if backfillType == columnBackfill {
 				fkTables, err := row.TablesNeededForFKs(
 					ctx,
-					*tableDesc,
+					tableDesc,
 					row.CheckUpdates,
 					row.NoLookup,
 					row.NoCheckPrivilege,
@@ -665,7 +665,7 @@ func columnBackfillInTxn(
 	var otherTableDescs []*sqlbase.ImmutableTableDescriptor
 	fkTables, err := row.TablesNeededForFKs(
 		ctx,
-		*tableDesc,
+		tableDesc,
 		row.CheckUpdates,
 		row.NoLookup,
 		row.NoCheckPrivilege,

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -283,7 +283,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 ) (roachpb.Key, error) {
 	fkTables, _ := row.TablesNeededForFKs(
 		ctx,
-		*tableDesc,
+		tableDesc,
 		row.CheckUpdates,
 		row.NoLookup,
 		row.NoCheckPrivilege,

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -100,7 +100,7 @@ func (p *planner) Delete(
 	// Determine what are the foreign key tables that are involved in the deletion.
 	fkTables, err := row.TablesNeededForFKs(
 		ctx,
-		*desc,
+		desc,
 		row.CheckDeletes,
 		p.LookupTableByID,
 		p.CheckPrivilege,

--- a/pkg/sql/delete_test.go
+++ b/pkg/sql/delete_test.go
@@ -129,7 +129,7 @@ CREATE TABLE IF NOT EXISTS child_with_index(
 
 			fkTables, err := row.TablesNeededForFKs(
 				context.TODO(),
-				*pd,
+				pd,
 				row.CheckDeletes,
 				lookup,
 				row.NoCheckPrivilege,

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -120,7 +120,7 @@ func (p *planner) Insert(
 	}
 	fkTables, err := row.TablesNeededForFKs(
 		ctx,
-		*desc,
+		desc,
 		fkCheckType,
 		p.LookupTableByID,
 		p.CheckPrivilege,

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -1217,10 +1217,11 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 	//
 	// TODO(andyk): Using ensureColumns here can result in an extra Render.
 	// Upgrade execution engine to not require this.
-	colList := make(opt.ColList, 0, len(ups.InsertCols)+len(ups.FetchCols)+len(ups.UpdateCols))
+	colList := make(opt.ColList, 0, len(ups.InsertCols)+len(ups.FetchCols)+len(ups.UpdateCols)+1)
 	colList = appendColsWhenPresent(colList, ups.InsertCols)
 	colList = appendColsWhenPresent(colList, ups.FetchCols)
 	colList = appendColsWhenPresent(colList, ups.UpdateCols)
+	colList = append(colList, ups.CanaryCol)
 	input, err = b.ensureColumns(input, colList, nil, ups.ProvidedPhysical().Ordering)
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -482,17 +482,17 @@ ordinality        ·              ·                 (x, "ordinality")  ·
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
 ----
-render                 ·              ·                 (b)              ·
- │                     render 0       b                 ·                ·
- └── run               ·              ·                 (a, b, c)        ·
-      └── insert       ·              ·                 (a, b, c)        ·
-           │           into           t(a, b, c)        ·                ·
-           │           strategy       inserter          ·                ·
-           └── values  ·              ·                 (x, y, column6)  ·
-·                      size           3 columns, 1 row  ·                ·
-·                      row 0, expr 0  1                 ·                ·
-·                      row 0, expr 1  2                 ·                ·
-·                      row 0, expr 2  NULL              ·                ·
+render                 ·              ·                   (b)              ·
+ │                     render 0       b                   ·                ·
+ └── run               ·              ·                   (a, b, c)        ·
+      └── insert       ·              ·                   (a, b, c)        ·
+           │           into           t(a, b, c)          ·                ·
+           │           strategy       inserter            ·                ·
+           └── values  ·              ·                   (x, y, column6)  ·
+·                      size           3 columns, 1 row    ·                ·
+·                      row 0, expr 0  1                   ·                ·
+·                      row 0, expr 1  2                   ·                ·
+·                      row 0, expr 2  CAST(NULL AS BOOL)  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) DELETE FROM t WHERE a = 3 RETURNING b

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -62,20 +62,22 @@ query TTT
 EXPLAIN WITH a AS (UPSERT INTO t VALUES (2), (3) RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-limit                            ·         ·
- │                               count     1
- └── spool                       ·         ·
-      │                          limit     1
-      └── run                    ·         ·
-           └── upsert            ·         ·
-                │                into      t(x)
-                │                strategy  opt upserter
-                └── lookup-join  ·         ·
-                     │           type      left outer
-                     ├── values  ·         ·
-                     │           size      1 column, 2 rows
-                     └── scan    ·         ·
-·                                table     t@primary
+limit                                      ·         ·
+ │                                         count     1
+ └── spool                                 ·         ·
+      │                                    limit     1
+      └── run                              ·         ·
+           └── upsert                      ·         ·
+                │                          into      t(x)
+                │                          strategy  opt upserter
+                └── render                 ·         ·
+                     └── render            ·         ·
+                          └── lookup-join  ·         ·
+                               │           type      left outer
+                               ├── values  ·         ·
+                               │           size      1 column, 2 rows
+                               └── scan    ·         ·
+·                                          table     t@primary
 
 # Ditto all mutations, with the statement source syntax.
 query TTT
@@ -128,20 +130,22 @@ limit                          ·         ·
 query TTT
 EXPLAIN SELECT * FROM [UPSERT INTO t VALUES (2), (3) RETURNING x] LIMIT 1
 ----
-limit                            ·         ·
- │                               count     1
- └── spool                       ·         ·
-      │                          limit     1
-      └── run                    ·         ·
-           └── upsert            ·         ·
-                │                into      t(x)
-                │                strategy  opt upserter
-                └── lookup-join  ·         ·
-                     │           type      left outer
-                     ├── values  ·         ·
-                     │           size      1 column, 2 rows
-                     └── scan    ·         ·
-·                                table     t@primary
+limit                                      ·         ·
+ │                                         count     1
+ └── spool                                 ·         ·
+      │                                    limit     1
+      └── run                              ·         ·
+           └── upsert                      ·         ·
+                │                          into      t(x)
+                │                          strategy  opt upserter
+                └── render                 ·         ·
+                     └── render            ·         ·
+                          └── lookup-join  ·         ·
+                               │           type      left outer
+                               ├── values  ·         ·
+                               │           size      1 column, 2 rows
+                               └── scan    ·         ·
+·                                          table     t@primary
 
 # Check that a spool is also inserted for other processings than LIMIT.
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -11,27 +11,33 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) UPSERT INTO kv TABLE kv ORDER BY v DESC LIMIT 2
 ]
 ----
-count                               ·         ·
- └── upsert                         ·         ·
-      │                             into      kv(k, v)
-      │                             strategy  opt upserter
-      └── render                    ·         ·
-           │                        render 0  k
-           │                        render 1  v
-           │                        render 2  k
-           │                        render 3  v
-           │                        render 4  v
-           └── lookup-join          ·         ·
-                │                   type      inner
-                ├── limit           ·         ·
-                │    │              count     2
-                │    └── sort       ·         ·
-                │         │         order     -v
-                │         └── scan  ·         ·
-                │                   table     kv@primary
-                │                   spans     ALL
-                └── scan            ·         ·
-·                                   table     kv@primary
+count                                    ·         ·
+ └── upsert                              ·         ·
+      │                                  into      kv(k, v)
+      │                                  strategy  opt upserter
+      └── render                         ·         ·
+           │                             render 0  upsert_k
+           │                             render 1  upsert_v
+           │                             render 2  upsert_k
+           │                             render 3  v
+           │                             render 4  upsert_v
+           │                             render 5  k
+           └── render                    ·         ·
+                │                        render 0  CASE WHEN k IS NULL THEN k ELSE k END
+                │                        render 1  CASE WHEN k IS NULL THEN v ELSE v END
+                │                        render 2  k
+                │                        render 3  v
+                └── lookup-join          ·         ·
+                     │                   type      inner
+                     ├── limit           ·         ·
+                     │    │              count     2
+                     │    └── sort       ·         ·
+                     │         │         order     -v
+                     │         └── scan  ·         ·
+                     │                   table     kv@primary
+                     │                   spans     ALL
+                     └── scan            ·         ·
+·                                        table     kv@primary
 
 # Regression test for #25726.
 # UPSERT over tables with column families, on the fast path, use the

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -275,63 +275,69 @@ func (sf *ScanFlags) Empty() bool {
 	return !sf.NoIndexJoin && !sf.ForceIndex
 }
 
-// MapToInputIDs maps from the ID of a target table column to the ID(s) of the
-// corresponding input column(s) that provides the value for it:
+// MapToInputID maps from the ID of a target table column to the ID of the
+// corresponding input column that provides the value for it:
 //
-//   Insert: a = InsertCols
-//   Update: a = UpdateCols/FetchCols
-//   Upsert: a = UpdateCols/FetchCols, b = InsertCols
-//   Delete: a = FetchCols
+//   Insert: InsertCols
+//   Update: UpdateCols/FetchCols
+//   Upsert: InsertCols/UpdateCols/FetchCols
+//   Delete: FetchCols
 //
-// For the UpdateCols/FetchCols case, use the corresponding UpdateCol if it is
-// non-zero (meaning that column will be updated), else use the FetchCol (which
-// holds the existing value of the column).
-func (m *MutationPrivate) MapToInputIDs(tabColID opt.ColumnID) (a, b opt.ColumnID) {
+// When choosing from UpdateCols/FetchCols, use the corresponding UpdateCol if
+// it is non-zero (meaning that column will be updated), else use the FetchCol
+// (which holds the existing value of the column). And for the Upsert case, use
+// either the UpdateCols/FetchCols or the InsertCols value, as long as it is
+// non-zero. If both are non-zero, then they must be the same, since they are
+// set to the same CASE expression column.
+//
+// If there is no matching input column ID, MapToInputID returns 0.
+func (m *MutationPrivate) MapToInputID(tabColID opt.ColumnID) opt.ColumnID {
 	ord := m.Table.ColumnOrdinal(tabColID)
-	if m.FetchCols != nil {
-		if m.UpdateCols != nil && m.UpdateCols[ord] != 0 {
-			a = m.UpdateCols[ord]
-		} else {
-			a = m.FetchCols[ord]
-		}
-	}
+
+	var ins opt.ColumnID
 	if m.InsertCols != nil {
-		if a == 0 {
-			a = m.InsertCols[ord]
-		} else {
-			b = m.InsertCols[ord]
-		}
+		ins = m.InsertCols[ord]
 	}
-	return a, b
+
+	var upd opt.ColumnID
+	if m.UpdateCols != nil {
+		upd = m.UpdateCols[ord]
+	}
+	if upd == 0 && m.FetchCols != nil {
+		upd = m.FetchCols[ord]
+	}
+
+	if ins != 0 {
+		if upd != 0 && ins != upd {
+			panic("insert and update columns should be the same")
+		}
+		return ins
+	}
+	return upd
 }
 
 // MapToInputCols maps the given set of table columns to a corresponding set of
-// input columns using the MapToInputID function. This method should not be
-// called for Upsert ops, since the mapping is ambiguous.
+// input columns using the MapToInputID function.
 func (m *MutationPrivate) MapToInputCols(tabCols opt.ColSet) opt.ColSet {
 	var inCols opt.ColSet
 	tabCols.ForEach(func(t int) {
-		a, b := m.MapToInputIDs(opt.ColumnID(t))
-		if b != 0 {
-			panic("MapToInputCols cannot be called for Upsert case")
+		id := m.MapToInputID(opt.ColumnID(t))
+		if id == 0 {
+			panic(fmt.Sprintf("could not find input column for %d", t))
 		}
-		inCols.Add(int(a))
+		inCols.Add(int(id))
 	})
 	return inCols
 }
 
 // AddEquivTableCols adds an FD to the given set that declares an equivalence
-// between each table column and its corresponding input column. This method
-// should not be called for Upsert ops, since the mapping is ambiguous.
+// between each table column and its corresponding input column.
 func (m *MutationPrivate) AddEquivTableCols(md *opt.Metadata, fdset *props.FuncDepSet) {
 	for i, n := 0, md.Table(m.Table).ColumnCount(); i < n; i++ {
 		t := m.Table.ColumnID(i)
-		a, b := m.MapToInputIDs(t)
-		if b != 0 {
-			panic("AddEquivTableCols cannot be called for Upsert case")
-		}
-		if a != 0 {
-			fdset.AddEquivalency(t, a)
+		id := m.MapToInputID(t)
+		if id != 0 {
+			fdset.AddEquivalency(t, id)
 		}
 	}
 }

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -1902,17 +1902,7 @@ func (sb *statisticsBuilder) colStatMutation(
 
 	// Get colstat from child by mapping requested columns to corresponding
 	// input columns.
-	var inColSet opt.ColSet
-	if mutation.Op() == opt.UpsertOp {
-		// Treat the Upsert operator as if it was an Insert. This is not precise,
-		// as some percentage of rows will come from the fetch/update columns.
-		temp := *private
-		temp.FetchCols = nil
-		temp.UpdateCols = nil
-		inColSet = temp.MapToInputCols(colSet)
-	} else {
-		inColSet = private.MapToInputCols(colSet)
-	}
+	inColSet := private.MapToInputCols(colSet)
 	inColStat := sb.colStatFromChild(inColSet, mutation, 0 /* childIdx */)
 
 	// Construct mutation colstat using the corresponding input stats.

--- a/pkg/sql/opt/memo/testdata/logprops/insert
+++ b/pkg/sql/opt/memo/testdata/logprops/insert
@@ -47,14 +47,14 @@ insert abcde
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── project
-      ├── columns: column13:13(int) y:8(int!null) column10:10(int!null) column11:11(int) column12:12(unknown)
+      ├── columns: column13:13(int) y:8(int!null) column10:10(int!null) column11:11(int) column12:12(int)
       ├── cardinality: [0 - 10]
       ├── side-effects
       ├── fd: ()-->(10,12), (8)-->(13)
       ├── prune: (8,10-13)
       ├── interesting orderings: (+8)
       ├── project
-      │    ├── columns: column10:10(int!null) column11:11(int) column12:12(unknown) y:8(int!null)
+      │    ├── columns: column10:10(int!null) column11:11(int) column12:12(int) y:8(int!null)
       │    ├── cardinality: [0 - 10]
       │    ├── side-effects
       │    ├── fd: ()-->(10,12)
@@ -82,7 +82,8 @@ insert abcde
       │    └── projections
       │         ├── const: 10 [type=int]
       │         ├── function: unique_rowid [type=int, side-effects]
-      │         └── null [type=unknown]
+      │         └── cast: INT8 [type=int]
+      │              └── null [type=unknown]
       └── projections
            └── plus [type=int, outer=(8,10)]
                 ├── plus [type=int]
@@ -113,14 +114,14 @@ project
       ├── side-effects, mutations
       ├── fd: ()-->(3), (1)==(2), (2)==(1), (1)-->(4)
       └── project
-           ├── columns: column13:13(int) y:8(int!null) column10:10(int!null) column11:11(int) column12:12(unknown)
+           ├── columns: column13:13(int) y:8(int!null) column10:10(int!null) column11:11(int) column12:12(int)
            ├── cardinality: [0 - 10]
            ├── side-effects
            ├── fd: ()-->(10,12), (8)-->(13)
            ├── prune: (8,10-13)
            ├── interesting orderings: (+8)
            ├── project
-           │    ├── columns: column10:10(int!null) column11:11(int) column12:12(unknown) y:8(int!null)
+           │    ├── columns: column10:10(int!null) column11:11(int) column12:12(int) y:8(int!null)
            │    ├── cardinality: [0 - 10]
            │    ├── side-effects
            │    ├── fd: ()-->(10,12)
@@ -148,7 +149,8 @@ project
            │    └── projections
            │         ├── const: 10 [type=int]
            │         ├── function: unique_rowid [type=int, side-effects]
-           │         └── null [type=unknown]
+           │         └── cast: INT8 [type=int]
+           │              └── null [type=unknown]
            └── projections
                 └── plus [type=int, outer=(8,10)]
                      ├── plus [type=int]
@@ -177,12 +179,12 @@ project
       ├── side-effects, mutations
       ├── fd: ()-->(3), (1)==(2), (2)==(1), (1)-->(4)
       └── project
-           ├── columns: column13:13(int) y:8(int!null) column10:10(int!null) column11:11(int) column12:12(unknown)
+           ├── columns: column13:13(int) y:8(int!null) column10:10(int!null) column11:11(int) column12:12(int)
            ├── side-effects
            ├── fd: ()-->(10,12), (8)-->(13)
            ├── prune: (8,10-13)
            ├── project
-           │    ├── columns: column10:10(int!null) column11:11(int) column12:12(unknown) y:8(int!null)
+           │    ├── columns: column10:10(int!null) column11:11(int) column12:12(int) y:8(int!null)
            │    ├── side-effects
            │    ├── fd: ()-->(10,12)
            │    ├── prune: (8,10-12)
@@ -198,7 +200,8 @@ project
            │    └── projections
            │         ├── const: 10 [type=int]
            │         ├── function: unique_rowid [type=int, side-effects]
-           │         └── null [type=unknown]
+           │         └── cast: INT8 [type=int]
+           │              └── null [type=unknown]
            └── projections
                 └── plus [type=int, outer=(8,10)]
                      ├── plus [type=int]
@@ -224,14 +227,14 @@ insert abcde
  ├── key: ()
  ├── fd: ()-->(1-5)
  └── project
-      ├── columns: column12:12(int) column1:7(int) column2:8(int) column9:9(int!null) column10:10(int) column11:11(unknown)
+      ├── columns: column12:12(int) column1:7(int) column2:8(int) column9:9(int!null) column10:10(int) column11:11(int)
       ├── cardinality: [1 - 1]
       ├── side-effects
       ├── key: ()
       ├── fd: ()-->(7-12)
       ├── prune: (7-12)
       ├── project
-      │    ├── columns: column9:9(int!null) column10:10(int) column11:11(unknown) column1:7(int) column2:8(int)
+      │    ├── columns: column9:9(int!null) column10:10(int) column11:11(int) column1:7(int) column2:8(int)
       │    ├── cardinality: [1 - 1]
       │    ├── side-effects
       │    ├── key: ()
@@ -249,7 +252,8 @@ insert abcde
       │    └── projections
       │         ├── const: 10 [type=int]
       │         ├── function: unique_rowid [type=int, side-effects]
-      │         └── null [type=unknown]
+      │         └── cast: INT8 [type=int]
+      │              └── null [type=unknown]
       └── projections
            └── plus [type=int, outer=(8,9)]
                 ├── plus [type=int]
@@ -278,12 +282,12 @@ project
       ├── side-effects, mutations
       ├── fd: ()-->(1,3), (2)-->(4)
       └── project
-           ├── columns: column14:14(int) y:8(int!null) int8:10(int) column11:11(int!null) column12:12(int) column13:13(unknown)
+           ├── columns: column14:14(int) y:8(int!null) int8:10(int) column11:11(int!null) column12:12(int) column13:13(int)
            ├── side-effects
            ├── fd: ()-->(8,11,13), (10)-->(14)
            ├── prune: (8,10-14)
            ├── project
-           │    ├── columns: column11:11(int!null) column12:12(int) column13:13(unknown) y:8(int!null) int8:10(int)
+           │    ├── columns: column11:11(int!null) column12:12(int) column13:13(int) y:8(int!null) int8:10(int)
            │    ├── side-effects
            │    ├── fd: ()-->(8,11,13)
            │    ├── prune: (8,10-13)
@@ -315,7 +319,8 @@ project
            │    └── projections
            │         ├── const: 10 [type=int]
            │         ├── function: unique_rowid [type=int, side-effects]
-           │         └── null [type=unknown]
+           │         └── cast: INT8 [type=int]
+           │              └── null [type=unknown]
            └── projections
                 └── plus [type=int, outer=(10,11)]
                      ├── plus [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1057,7 +1057,8 @@ full-join
  │    └── tuple [type=tuple{unknown}]
  │         └── null [type=unknown]
  └── filters
-      └── null [type=bool, constraints=(contradiction; tight)]
+      └── cast: BOOL [type=bool]
+           └── null [type=unknown]
 
 # Calculate full-join cardinality of one input with unknown cardinality.
 build

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -61,103 +61,142 @@ project
  └── upsert abc
       ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
       ├── canary column: 13
-      ├── fetch columns: a:10(int) b:11(int) c:12(int) rowid:13(int)
+      ├── fetch columns: a:10(int) b:11(int) c:12(int) upsert_rowid:20(int)
       ├── insert-mapping:
-      │    ├──  x:5 => a:1
-      │    ├──  y:6 => b:2
-      │    ├──  column9:9 => c:3
-      │    └──  column8:8 => rowid:4
+      │    ├──  upsert_a:17 => a:1
+      │    ├──  upsert_b:18 => b:2
+      │    ├──  upsert_c:19 => c:3
+      │    └──  upsert_rowid:20 => rowid:4
       ├── update-mapping:
-      │    ├──  column14:14 => a:1
-      │    ├──  column15:15 => b:2
-      │    └──  column16:16 => c:3
+      │    ├──  upsert_a:17 => a:1
+      │    ├──  upsert_b:18 => b:2
+      │    └──  upsert_c:19 => c:3
       ├── side-effects, mutations
       └── project
-           ├── columns: column16:16(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null) column15:15(int)
+           ├── columns: upsert_a:17(int) upsert_b:18(int) upsert_c:19(int) upsert_rowid:20(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
            ├── side-effects
-           ├── key: (5,13)
-           ├── fd: ()-->(6,9,14), (5)-->(8), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15), (15)-->(16)
-           ├── prune: (5,6,8-16)
-           ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
+           ├── fd: (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
+           ├── prune: (10-13,17-20)
+           ├── interesting orderings: (+13) (+10) (+11,+12,+13)
            ├── project
-           │    ├── columns: column14:14(int!null) column15:15(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+           │    ├── columns: column16:16(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null) column15:15(int)
            │    ├── side-effects
            │    ├── key: (5,13)
-           │    ├── fd: ()-->(6,9,14), (5)-->(8), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15)
-           │    ├── prune: (5,6,8-15)
+           │    ├── fd: ()-->(6,9,14), (5)-->(8), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15), (15)-->(16)
+           │    ├── prune: (5,6,8-16)
            │    ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
-           │    ├── left-join
-           │    │    ├── columns: x:5(int!null) y:6(int!null) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+           │    ├── project
+           │    │    ├── columns: column14:14(int!null) column15:15(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
            │    │    ├── side-effects
            │    │    ├── key: (5,13)
-           │    │    ├── fd: ()-->(6,9), (5)-->(8), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
-           │    │    ├── prune: (5,8,10,13)
-           │    │    ├── reject-nulls: (10-13)
+           │    │    ├── fd: ()-->(6,9,14), (5)-->(8), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15)
+           │    │    ├── prune: (5,6,8-15)
            │    │    ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
-           │    │    ├── project
-           │    │    │    ├── columns: column9:9(int) x:5(int!null) y:6(int!null) column8:8(int)
+           │    │    ├── left-join
+           │    │    │    ├── columns: x:5(int!null) y:6(int!null) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
            │    │    │    ├── side-effects
-           │    │    │    ├── key: (5)
-           │    │    │    ├── fd: ()-->(6,9), (5)-->(8)
-           │    │    │    ├── prune: (5,6,8,9)
-           │    │    │    ├── interesting orderings: (+5) (+6)
+           │    │    │    ├── key: (5,13)
+           │    │    │    ├── fd: ()-->(6,9), (5)-->(8), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
+           │    │    │    ├── prune: (5,8,10,13)
+           │    │    │    ├── reject-nulls: (10-13)
+           │    │    │    ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
            │    │    │    ├── project
-           │    │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int!null)
+           │    │    │    │    ├── columns: column9:9(int) x:5(int!null) y:6(int!null) column8:8(int)
            │    │    │    │    ├── side-effects
            │    │    │    │    ├── key: (5)
-           │    │    │    │    ├── fd: ()-->(6), (5)-->(8)
-           │    │    │    │    ├── prune: (5,6,8)
+           │    │    │    │    ├── fd: ()-->(6,9), (5)-->(8)
+           │    │    │    │    ├── prune: (5,6,8,9)
            │    │    │    │    ├── interesting orderings: (+5) (+6)
            │    │    │    │    ├── project
-           │    │    │    │    │    ├── columns: x:5(int!null) y:6(int!null)
+           │    │    │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int!null)
+           │    │    │    │    │    ├── side-effects
            │    │    │    │    │    ├── key: (5)
-           │    │    │    │    │    ├── fd: ()-->(6)
-           │    │    │    │    │    ├── prune: (5,6)
+           │    │    │    │    │    ├── fd: ()-->(6), (5)-->(8)
+           │    │    │    │    │    ├── prune: (5,6,8)
            │    │    │    │    │    ├── interesting orderings: (+5) (+6)
-           │    │    │    │    │    └── select
-           │    │    │    │    │         ├── columns: x:5(int!null) y:6(int!null) z:7(int)
-           │    │    │    │    │         ├── key: (5)
-           │    │    │    │    │         ├── fd: ()-->(6), (5)-->(7), (6,7)~~>(5)
-           │    │    │    │    │         ├── prune: (5,7)
-           │    │    │    │    │         ├── interesting orderings: (+5) (+6,+7,+5) (+7,+6,+5)
-           │    │    │    │    │         ├── scan xyz
-           │    │    │    │    │         │    ├── columns: x:5(int!null) y:6(int) z:7(int)
-           │    │    │    │    │         │    ├── key: (5)
-           │    │    │    │    │         │    ├── fd: (5)-->(6,7), (6,7)~~>(5)
-           │    │    │    │    │         │    ├── prune: (5-7)
-           │    │    │    │    │         │    └── interesting orderings: (+5) (+6,+7,+5) (+7,+6,+5)
-           │    │    │    │    │         └── filters
-           │    │    │    │    │              └── eq [type=bool, outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
-           │    │    │    │    │                   ├── variable: y [type=int]
-           │    │    │    │    │                   └── const: 1 [type=int]
+           │    │    │    │    │    ├── project
+           │    │    │    │    │    │    ├── columns: x:5(int!null) y:6(int!null)
+           │    │    │    │    │    │    ├── key: (5)
+           │    │    │    │    │    │    ├── fd: ()-->(6)
+           │    │    │    │    │    │    ├── prune: (5,6)
+           │    │    │    │    │    │    ├── interesting orderings: (+5) (+6)
+           │    │    │    │    │    │    └── select
+           │    │    │    │    │    │         ├── columns: x:5(int!null) y:6(int!null) z:7(int)
+           │    │    │    │    │    │         ├── key: (5)
+           │    │    │    │    │    │         ├── fd: ()-->(6), (5)-->(7), (6,7)~~>(5)
+           │    │    │    │    │    │         ├── prune: (5,7)
+           │    │    │    │    │    │         ├── interesting orderings: (+5) (+6,+7,+5) (+7,+6,+5)
+           │    │    │    │    │    │         ├── scan xyz
+           │    │    │    │    │    │         │    ├── columns: x:5(int!null) y:6(int) z:7(int)
+           │    │    │    │    │    │         │    ├── key: (5)
+           │    │    │    │    │    │         │    ├── fd: (5)-->(6,7), (6,7)~~>(5)
+           │    │    │    │    │    │         │    ├── prune: (5-7)
+           │    │    │    │    │    │         │    └── interesting orderings: (+5) (+6,+7,+5) (+7,+6,+5)
+           │    │    │    │    │    │         └── filters
+           │    │    │    │    │    │              └── eq [type=bool, outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+           │    │    │    │    │    │                   ├── variable: y [type=int]
+           │    │    │    │    │    │                   └── const: 1 [type=int]
+           │    │    │    │    │    └── projections
+           │    │    │    │    │         └── function: unique_rowid [type=int, side-effects]
            │    │    │    │    └── projections
-           │    │    │    │         └── function: unique_rowid [type=int, side-effects]
-           │    │    │    └── projections
-           │    │    │         └── plus [type=int, outer=(6)]
-           │    │    │              ├── variable: y [type=int]
-           │    │    │              └── const: 1 [type=int]
-           │    │    ├── scan abc
-           │    │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
-           │    │    │    ├── key: (13)
-           │    │    │    ├── fd: (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
-           │    │    │    ├── prune: (10-13)
-           │    │    │    └── interesting orderings: (+13) (+10) (+11,+12,+13)
-           │    │    └── filters
-           │    │         ├── eq [type=bool, outer=(6,11), constraints=(/6: (/NULL - ]; /11: (/NULL - ]), fd=(6)==(11), (11)==(6)]
-           │    │         │    ├── variable: y [type=int]
-           │    │         │    └── variable: b [type=int]
-           │    │         └── eq [type=bool, outer=(9,12), constraints=(/9: (/NULL - ]; /12: (/NULL - ]), fd=(9)==(12), (12)==(9)]
-           │    │              ├── variable: column9 [type=int]
+           │    │    │    │         └── plus [type=int, outer=(6)]
+           │    │    │    │              ├── variable: y [type=int]
+           │    │    │    │              └── const: 1 [type=int]
+           │    │    │    ├── scan abc
+           │    │    │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
+           │    │    │    │    ├── key: (13)
+           │    │    │    │    ├── fd: (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13)
+           │    │    │    │    ├── prune: (10-13)
+           │    │    │    │    └── interesting orderings: (+13) (+10) (+11,+12,+13)
+           │    │    │    └── filters
+           │    │    │         ├── eq [type=bool, outer=(6,11), constraints=(/6: (/NULL - ]; /11: (/NULL - ]), fd=(6)==(11), (11)==(6)]
+           │    │    │         │    ├── variable: y [type=int]
+           │    │    │         │    └── variable: b [type=int]
+           │    │    │         └── eq [type=bool, outer=(9,12), constraints=(/9: (/NULL - ]; /12: (/NULL - ]), fd=(9)==(12), (12)==(9)]
+           │    │    │              ├── variable: column9 [type=int]
+           │    │    │              └── variable: c [type=int]
+           │    │    └── projections
+           │    │         ├── const: 1 [type=int]
+           │    │         └── plus [type=int, outer=(6,12)]
+           │    │              ├── variable: y [type=int]
            │    │              └── variable: c [type=int]
            │    └── projections
-           │         ├── const: 1 [type=int]
-           │         └── plus [type=int, outer=(6,12)]
-           │              ├── variable: y [type=int]
-           │              └── variable: c [type=int]
+           │         └── plus [type=int, outer=(15)]
+           │              ├── variable: column15 [type=int]
+           │              └── const: 1 [type=int]
            └── projections
-                └── plus [type=int, outer=(15)]
-                     ├── variable: column15 [type=int]
-                     └── const: 1 [type=int]
+                ├── case [type=int, outer=(5,13,14)]
+                │    ├── true [type=bool]
+                │    ├── when [type=int]
+                │    │    ├── is [type=bool]
+                │    │    │    ├── variable: rowid [type=int]
+                │    │    │    └── null [type=unknown]
+                │    │    └── variable: x [type=int]
+                │    └── variable: column14 [type=int]
+                ├── case [type=int, outer=(6,13,15)]
+                │    ├── true [type=bool]
+                │    ├── when [type=int]
+                │    │    ├── is [type=bool]
+                │    │    │    ├── variable: rowid [type=int]
+                │    │    │    └── null [type=unknown]
+                │    │    └── variable: y [type=int]
+                │    └── variable: column15 [type=int]
+                ├── case [type=int, outer=(9,13,16)]
+                │    ├── true [type=bool]
+                │    ├── when [type=int]
+                │    │    ├── is [type=bool]
+                │    │    │    ├── variable: rowid [type=int]
+                │    │    │    └── null [type=unknown]
+                │    │    └── variable: column9 [type=int]
+                │    └── variable: column16 [type=int]
+                └── case [type=int, outer=(8,13)]
+                     ├── true [type=bool]
+                     ├── when [type=int]
+                     │    ├── is [type=bool]
+                     │    │    ├── variable: rowid [type=int]
+                     │    │    └── null [type=unknown]
+                     │    └── variable: column8 [type=int]
+                     └── variable: rowid [type=int]
 
 # DO NOTHING case.
 build
@@ -331,80 +370,120 @@ build
 UPSERT INTO abc (a) VALUES (1), (2) RETURNING b+c
 ----
 project
- ├── columns: "?column?":14(int)
+ ├── columns: "?column?":18(int)
  ├── cardinality: [2 - ]
  ├── side-effects, mutations
- ├── prune: (14)
+ ├── prune: (18)
  ├── upsert abc
  │    ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
  │    ├── canary column: 12
- │    ├── fetch columns: a:9(int) b:10(int) c:11(int) rowid:12(int)
+ │    ├── fetch columns: a:9(int) upsert_b:15(int) c:11(int) upsert_rowid:17(int)
  │    ├── insert-mapping:
- │    │    ├──  column1:5 => a:1
- │    │    ├──  column6:6 => b:2
- │    │    ├──  column8:8 => c:3
- │    │    └──  column7:7 => rowid:4
+ │    │    ├──  upsert_a:14 => a:1
+ │    │    ├──  upsert_b:15 => b:2
+ │    │    ├──  upsert_c:16 => c:3
+ │    │    └──  upsert_rowid:17 => rowid:4
  │    ├── update-mapping:
- │    │    ├──  column1:5 => a:1
- │    │    └──  column13:13 => c:3
+ │    │    ├──  upsert_a:14 => a:1
+ │    │    └──  upsert_c:16 => c:3
  │    ├── cardinality: [2 - ]
  │    ├── side-effects, mutations
  │    └── project
- │         ├── columns: column13:13(int) column1:5(int) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+ │         ├── columns: upsert_a:14(int) upsert_b:15(int) upsert_c:16(int) upsert_rowid:17(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
  │         ├── cardinality: [2 - ]
  │         ├── side-effects
- │         ├── fd: ()-->(6,8), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12), (10)-->(13)
- │         ├── prune: (5-13)
+ │         ├── fd: (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12), (10,12)-->(15)
+ │         ├── prune: (9-12,14-17)
  │         ├── interesting orderings: (+12) (+9) (+10,+11,+12)
- │         ├── left-join
- │         │    ├── columns: column1:5(int) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+ │         ├── project
+ │         │    ├── columns: column13:13(int) column1:5(int) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
  │         │    ├── cardinality: [2 - ]
  │         │    ├── side-effects
- │         │    ├── fd: ()-->(6,8), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12)
- │         │    ├── prune: (5,6,8-11)
- │         │    ├── reject-nulls: (9-12)
+ │         │    ├── fd: ()-->(6,8), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12), (10)-->(13)
+ │         │    ├── prune: (5-13)
  │         │    ├── interesting orderings: (+12) (+9) (+10,+11,+12)
- │         │    ├── project
- │         │    │    ├── columns: column8:8(int) column1:5(int) column6:6(int!null) column7:7(int)
- │         │    │    ├── cardinality: [2 - 2]
+ │         │    ├── left-join
+ │         │    │    ├── columns: column1:5(int) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+ │         │    │    ├── cardinality: [2 - ]
  │         │    │    ├── side-effects
- │         │    │    ├── fd: ()-->(6,8)
- │         │    │    ├── prune: (5-8)
+ │         │    │    ├── fd: ()-->(6,8), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12)
+ │         │    │    ├── prune: (5,6,8-11)
+ │         │    │    ├── reject-nulls: (9-12)
+ │         │    │    ├── interesting orderings: (+12) (+9) (+10,+11,+12)
  │         │    │    ├── project
- │         │    │    │    ├── columns: column6:6(int!null) column7:7(int) column1:5(int)
+ │         │    │    │    ├── columns: column8:8(int) column1:5(int) column6:6(int!null) column7:7(int)
  │         │    │    │    ├── cardinality: [2 - 2]
  │         │    │    │    ├── side-effects
- │         │    │    │    ├── fd: ()-->(6)
- │         │    │    │    ├── prune: (5-7)
- │         │    │    │    ├── values
- │         │    │    │    │    ├── columns: column1:5(int)
+ │         │    │    │    ├── fd: ()-->(6,8)
+ │         │    │    │    ├── prune: (5-8)
+ │         │    │    │    ├── project
+ │         │    │    │    │    ├── columns: column6:6(int!null) column7:7(int) column1:5(int)
  │         │    │    │    │    ├── cardinality: [2 - 2]
- │         │    │    │    │    ├── prune: (5)
- │         │    │    │    │    ├── tuple [type=tuple{int}]
- │         │    │    │    │    │    └── const: 1 [type=int]
- │         │    │    │    │    └── tuple [type=tuple{int}]
- │         │    │    │    │         └── const: 2 [type=int]
+ │         │    │    │    │    ├── side-effects
+ │         │    │    │    │    ├── fd: ()-->(6)
+ │         │    │    │    │    ├── prune: (5-7)
+ │         │    │    │    │    ├── values
+ │         │    │    │    │    │    ├── columns: column1:5(int)
+ │         │    │    │    │    │    ├── cardinality: [2 - 2]
+ │         │    │    │    │    │    ├── prune: (5)
+ │         │    │    │    │    │    ├── tuple [type=tuple{int}]
+ │         │    │    │    │    │    │    └── const: 1 [type=int]
+ │         │    │    │    │    │    └── tuple [type=tuple{int}]
+ │         │    │    │    │    │         └── const: 2 [type=int]
+ │         │    │    │    │    └── projections
+ │         │    │    │    │         ├── const: 10 [type=int]
+ │         │    │    │    │         └── function: unique_rowid [type=int, side-effects]
  │         │    │    │    └── projections
- │         │    │    │         ├── const: 10 [type=int]
- │         │    │    │         └── function: unique_rowid [type=int, side-effects]
- │         │    │    └── projections
- │         │    │         └── plus [type=int, outer=(6)]
- │         │    │              ├── variable: column6 [type=int]
- │         │    │              └── const: 1 [type=int]
- │         │    ├── scan abc
- │         │    │    ├── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
- │         │    │    ├── key: (12)
- │         │    │    ├── fd: (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12)
- │         │    │    ├── prune: (9-12)
- │         │    │    └── interesting orderings: (+12) (+9) (+10,+11,+12)
- │         │    └── filters
- │         │         └── eq [type=bool, outer=(7,12), constraints=(/7: (/NULL - ]; /12: (/NULL - ]), fd=(7)==(12), (12)==(7)]
- │         │              ├── variable: column7 [type=int]
- │         │              └── variable: rowid [type=int]
+ │         │    │    │         └── plus [type=int, outer=(6)]
+ │         │    │    │              ├── variable: column6 [type=int]
+ │         │    │    │              └── const: 1 [type=int]
+ │         │    │    ├── scan abc
+ │         │    │    │    ├── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+ │         │    │    │    ├── key: (12)
+ │         │    │    │    ├── fd: (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12)
+ │         │    │    │    ├── prune: (9-12)
+ │         │    │    │    └── interesting orderings: (+12) (+9) (+10,+11,+12)
+ │         │    │    └── filters
+ │         │    │         └── eq [type=bool, outer=(7,12), constraints=(/7: (/NULL - ]; /12: (/NULL - ]), fd=(7)==(12), (12)==(7)]
+ │         │    │              ├── variable: column7 [type=int]
+ │         │    │              └── variable: rowid [type=int]
+ │         │    └── projections
+ │         │         └── plus [type=int, outer=(10)]
+ │         │              ├── variable: b [type=int]
+ │         │              └── const: 1 [type=int]
  │         └── projections
- │              └── plus [type=int, outer=(10)]
- │                   ├── variable: b [type=int]
- │                   └── const: 1 [type=int]
+ │              ├── case [type=int, outer=(5,12)]
+ │              │    ├── true [type=bool]
+ │              │    ├── when [type=int]
+ │              │    │    ├── is [type=bool]
+ │              │    │    │    ├── variable: rowid [type=int]
+ │              │    │    │    └── null [type=unknown]
+ │              │    │    └── variable: column1 [type=int]
+ │              │    └── variable: column1 [type=int]
+ │              ├── case [type=int, outer=(6,10,12)]
+ │              │    ├── true [type=bool]
+ │              │    ├── when [type=int]
+ │              │    │    ├── is [type=bool]
+ │              │    │    │    ├── variable: rowid [type=int]
+ │              │    │    │    └── null [type=unknown]
+ │              │    │    └── variable: column6 [type=int]
+ │              │    └── variable: b [type=int]
+ │              ├── case [type=int, outer=(8,12,13)]
+ │              │    ├── true [type=bool]
+ │              │    ├── when [type=int]
+ │              │    │    ├── is [type=bool]
+ │              │    │    │    ├── variable: rowid [type=int]
+ │              │    │    │    └── null [type=unknown]
+ │              │    │    └── variable: column8 [type=int]
+ │              │    └── variable: column13 [type=int]
+ │              └── case [type=int, outer=(7,12)]
+ │                   ├── true [type=bool]
+ │                   ├── when [type=int]
+ │                   │    ├── is [type=bool]
+ │                   │    │    ├── variable: rowid [type=int]
+ │                   │    │    └── null [type=unknown]
+ │                   │    └── variable: column7 [type=int]
+ │                   └── variable: rowid [type=int]
  └── projections
       └── plus [type=int, outer=(2,3)]
            ├── variable: b [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -75,15 +75,15 @@ select
  │    ├── side-effects, mutations
  │    ├── stats: [rows=200, distinct(1)=1, null(1)=0, distinct(2)=200, null(2)=0]
  │    └── project
- │         ├── columns: column12:12(int!null) a:4(int!null) b:5(string!null) column8:8(unknown) x:9(string) y:10(int) z:11(float)
+ │         ├── columns: column12:12(int!null) a:4(int!null) b:5(string!null) column8:8(float) x:9(string) y:10(int) z:11(float)
  │         ├── stats: [rows=200, distinct(4)=200, null(4)=0, distinct(5)=1, null(5)=0]
  │         ├── fd: ()-->(5,8,12), (9)-->(10,11)
  │         ├── left-join
- │         │    ├── columns: a:4(int!null) b:5(string!null) column8:8(unknown) x:9(string) y:10(int) z:11(float)
+ │         │    ├── columns: a:4(int!null) b:5(string!null) column8:8(float) x:9(string) y:10(int) z:11(float)
  │         │    ├── stats: [rows=200, distinct(4)=200, null(4)=0, distinct(5)=1, null(5)=0, distinct(9)=1, null(9)=0]
  │         │    ├── fd: ()-->(5,8), (9)-->(10,11)
  │         │    ├── project
- │         │    │    ├── columns: column8:8(unknown) a:4(int!null) b:5(string!null)
+ │         │    │    ├── columns: column8:8(float) a:4(int!null) b:5(string!null)
  │         │    │    ├── stats: [rows=200, distinct(4)=200, null(4)=0, distinct(5)=1, null(5)=0]
  │         │    │    ├── fd: ()-->(5,8)
  │         │    │    ├── project
@@ -103,7 +103,7 @@ select
  │         │    │    │         └── filters
  │         │    │    │              └── b = 'foo' [type=bool, outer=(5), constraints=(/5: [/'foo' - /'foo']; tight), fd=()-->(5)]
  │         │    │    └── projections
- │         │    │         └── null [type=unknown]
+ │         │    │         └── NULL::FLOAT8 [type=float]
  │         │    ├── scan xyz
  │         │    │    ├── columns: x:9(string!null) y:10(int!null) z:11(float)
  │         │    │    ├── stats: [rows=1000, distinct(9)=1000, null(9)=0]
@@ -135,12 +135,12 @@ upsert xyz
  ├── side-effects, mutations
  ├── stats: [rows=0]
  └── left-join
-      ├── columns: a:4(int!null) b:5(string) column8:8(unknown) x:9(string) y:10(int) z:11(float)
+      ├── columns: a:4(int!null) b:5(string) column8:8(float) x:9(string) y:10(int) z:11(float)
       ├── cardinality: [0 - 0]
       ├── stats: [rows=0]
       ├── fd: ()-->(8), (9)-->(10,11)
       ├── project
-      │    ├── columns: column8:8(unknown) a:4(int!null) b:5(string)
+      │    ├── columns: column8:8(float) a:4(int!null) b:5(string)
       │    ├── cardinality: [0 - 0]
       │    ├── stats: [rows=0]
       │    ├── fd: ()-->(8)
@@ -162,7 +162,7 @@ upsert xyz
       │    │         └── filters
       │    │              └── false [type=bool]
       │    └── projections
-      │         └── null [type=unknown]
+      │         └── NULL::FLOAT8 [type=float]
       ├── scan xyz
       │    ├── columns: x:9(string!null) y:10(int!null) z:11(float)
       │    ├── stats: [rows=1000]

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -60,59 +60,67 @@ WHERE y=10
 select
  ├── columns: x:1(string!null) y:2(int!null) z:3(float)
  ├── side-effects, mutations
- ├── stats: [rows=1, distinct(1)=0.633042178, null(1)=0, distinct(2)=1, null(2)=0]
+ ├── stats: [rows=1, distinct(1)=0.999742533, null(1)=0, distinct(2)=1, null(2)=0]
  ├── fd: ()-->(2)
  ├── upsert xyz
  │    ├── columns: x:1(string!null) y:2(int!null) z:3(float)
  │    ├── canary column: 9
- │    ├── fetch columns: x:9(string) y:10(int) z:11(float)
+ │    ├── fetch columns: upsert_x:13(string) y:10(int) upsert_z:15(float)
  │    ├── insert-mapping:
- │    │    ├──  b:5 => x:1
- │    │    ├──  a:4 => y:2
- │    │    └──  column8:8 => z:3
+ │    │    ├──  upsert_x:13 => x:1
+ │    │    ├──  upsert_y:14 => y:2
+ │    │    └──  upsert_z:15 => z:3
  │    ├── update-mapping:
- │    │    └──  column12:12 => y:2
+ │    │    └──  upsert_y:14 => y:2
  │    ├── side-effects, mutations
- │    ├── stats: [rows=200, distinct(1)=1, null(1)=0, distinct(2)=200, null(2)=0]
+ │    ├── stats: [rows=200, distinct(1)=181.351171, null(1)=0, distinct(2)=200, null(2)=0]
  │    └── project
- │         ├── columns: column12:12(int!null) a:4(int!null) b:5(string!null) column8:8(float) x:9(string) y:10(int) z:11(float)
- │         ├── stats: [rows=200, distinct(4)=200, null(4)=0, distinct(5)=1, null(5)=0]
- │         ├── fd: ()-->(5,8,12), (9)-->(10,11)
- │         ├── left-join
- │         │    ├── columns: a:4(int!null) b:5(string!null) column8:8(float) x:9(string) y:10(int) z:11(float)
- │         │    ├── stats: [rows=200, distinct(4)=200, null(4)=0, distinct(5)=1, null(5)=0, distinct(9)=1, null(9)=0]
- │         │    ├── fd: ()-->(5,8), (9)-->(10,11)
- │         │    ├── project
- │         │    │    ├── columns: column8:8(float) a:4(int!null) b:5(string!null)
- │         │    │    ├── stats: [rows=200, distinct(4)=200, null(4)=0, distinct(5)=1, null(5)=0]
- │         │    │    ├── fd: ()-->(5,8)
+ │         ├── columns: upsert_x:13(string) upsert_y:14(int) upsert_z:15(float) x:9(string) y:10(int) z:11(float)
+ │         ├── stats: [rows=200, distinct(13)=181.351171, null(13)=0, distinct(14)=200, null(14)=0]
+ │         ├── fd: (9)-->(10,11), (9)-->(13)
+ │         ├── project
+ │         │    ├── columns: column12:12(int!null) a:4(int!null) b:5(string!null) column8:8(float) x:9(string) y:10(int) z:11(float)
+ │         │    ├── stats: [rows=200, distinct(5,9)=181.351171, null(5,9)=0, distinct(4,9,12)=200, null(4,9,12)=0]
+ │         │    ├── fd: ()-->(5,8,12), (9)-->(10,11)
+ │         │    ├── left-join
+ │         │    │    ├── columns: a:4(int!null) b:5(string!null) column8:8(float) x:9(string) y:10(int) z:11(float)
+ │         │    │    ├── stats: [rows=200, distinct(9)=1, null(9)=0, distinct(4,9)=200, null(4,9)=0, distinct(5,9)=181.351171, null(5,9)=0]
+ │         │    │    ├── fd: ()-->(5,8), (9)-->(10,11)
  │         │    │    ├── project
- │         │    │    │    ├── columns: a:4(int!null) b:5(string!null)
+ │         │    │    │    ├── columns: column8:8(float) a:4(int!null) b:5(string!null)
  │         │    │    │    ├── stats: [rows=200, distinct(4)=200, null(4)=0, distinct(5)=1, null(5)=0]
- │         │    │    │    ├── fd: ()-->(5)
- │         │    │    │    └── select
- │         │    │    │         ├── columns: a:4(int!null) b:5(string!null) c:6(float) rowid:7(int!null)
- │         │    │    │         ├── stats: [rows=200, distinct(4)=200, null(4)=0, distinct(5)=1, null(5)=0, distinct(7)=200, null(7)=0]
- │         │    │    │         ├── key: (7)
- │         │    │    │         ├── fd: ()-->(5), (7)-->(4,6)
- │         │    │    │         ├── scan abc
- │         │    │    │         │    ├── columns: a:4(int!null) b:5(string) c:6(float) rowid:7(int!null)
- │         │    │    │         │    ├── stats: [rows=2000, distinct(4)=2000, null(4)=0, distinct(5)=10, null(5)=0, distinct(7)=2000, null(7)=0]
- │         │    │    │         │    ├── key: (7)
- │         │    │    │         │    └── fd: (7)-->(4-6)
- │         │    │    │         └── filters
- │         │    │    │              └── b = 'foo' [type=bool, outer=(5), constraints=(/5: [/'foo' - /'foo']; tight), fd=()-->(5)]
- │         │    │    └── projections
- │         │    │         └── NULL::FLOAT8 [type=float]
- │         │    ├── scan xyz
- │         │    │    ├── columns: x:9(string!null) y:10(int!null) z:11(float)
- │         │    │    ├── stats: [rows=1000, distinct(9)=1000, null(9)=0]
- │         │    │    ├── key: (9)
- │         │    │    └── fd: (9)-->(10,11)
- │         │    └── filters
- │         │         └── b = x [type=bool, outer=(5,9), constraints=(/5: (/NULL - ]; /9: (/NULL - ]), fd=(5)==(9), (9)==(5)]
+ │         │    │    │    ├── fd: ()-->(5,8)
+ │         │    │    │    ├── project
+ │         │    │    │    │    ├── columns: a:4(int!null) b:5(string!null)
+ │         │    │    │    │    ├── stats: [rows=200, distinct(4)=200, null(4)=0, distinct(5)=1, null(5)=0]
+ │         │    │    │    │    ├── fd: ()-->(5)
+ │         │    │    │    │    └── select
+ │         │    │    │    │         ├── columns: a:4(int!null) b:5(string!null) c:6(float) rowid:7(int!null)
+ │         │    │    │    │         ├── stats: [rows=200, distinct(4)=200, null(4)=0, distinct(5)=1, null(5)=0, distinct(7)=200, null(7)=0]
+ │         │    │    │    │         ├── key: (7)
+ │         │    │    │    │         ├── fd: ()-->(5), (7)-->(4,6)
+ │         │    │    │    │         ├── scan abc
+ │         │    │    │    │         │    ├── columns: a:4(int!null) b:5(string) c:6(float) rowid:7(int!null)
+ │         │    │    │    │         │    ├── stats: [rows=2000, distinct(4)=2000, null(4)=0, distinct(5)=10, null(5)=0, distinct(7)=2000, null(7)=0]
+ │         │    │    │    │         │    ├── key: (7)
+ │         │    │    │    │         │    └── fd: (7)-->(4-6)
+ │         │    │    │    │         └── filters
+ │         │    │    │    │              └── b = 'foo' [type=bool, outer=(5), constraints=(/5: [/'foo' - /'foo']; tight), fd=()-->(5)]
+ │         │    │    │    └── projections
+ │         │    │    │         └── NULL::FLOAT8 [type=float]
+ │         │    │    ├── scan xyz
+ │         │    │    │    ├── columns: x:9(string!null) y:10(int!null) z:11(float)
+ │         │    │    │    ├── stats: [rows=1000, distinct(9)=1000, null(9)=0]
+ │         │    │    │    ├── key: (9)
+ │         │    │    │    └── fd: (9)-->(10,11)
+ │         │    │    └── filters
+ │         │    │         └── b = x [type=bool, outer=(5,9), constraints=(/5: (/NULL - ]; /9: (/NULL - ]), fd=(5)==(9), (9)==(5)]
+ │         │    └── projections
+ │         │         └── const: 5 [type=int]
  │         └── projections
- │              └── const: 5 [type=int]
+ │              ├── CASE WHEN x IS NULL THEN b ELSE x END [type=string, outer=(5,9)]
+ │              ├── CASE WHEN x IS NULL THEN a ELSE column12 END [type=int, outer=(4,9,12)]
+ │              └── CASE WHEN x IS NULL THEN column8 ELSE z END [type=float, outer=(8,9,11)]
  └── filters
       └── y = 10 [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
 
@@ -123,50 +131,59 @@ UPSERT INTO xyz SELECT b, a FROM abc WHERE False RETURNING *
 upsert xyz
  ├── columns: x:1(string!null) y:2(int!null) z:3(float)
  ├── canary column: 9
- ├── fetch columns: x:9(string) y:10(int) z:11(float)
+ ├── fetch columns: upsert_x:12(string) y:10(int) z:11(float)
  ├── insert-mapping:
- │    ├──  b:5 => x:1
- │    ├──  a:4 => y:2
- │    └──  column8:8 => z:3
+ │    ├──  upsert_x:12 => x:1
+ │    ├──  upsert_y:13 => y:2
+ │    └──  upsert_z:14 => z:3
  ├── update-mapping:
- │    ├──  a:4 => y:2
- │    └──  column8:8 => z:3
+ │    ├──  upsert_y:13 => y:2
+ │    └──  upsert_z:14 => z:3
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  ├── stats: [rows=0]
- └── left-join
-      ├── columns: a:4(int!null) b:5(string) column8:8(float) x:9(string) y:10(int) z:11(float)
+ └── project
+      ├── columns: upsert_x:12(string) upsert_y:13(int) upsert_z:14(float) x:9(string) y:10(int) z:11(float)
       ├── cardinality: [0 - 0]
       ├── stats: [rows=0]
-      ├── fd: ()-->(8), (9)-->(10,11)
-      ├── project
-      │    ├── columns: column8:8(float) a:4(int!null) b:5(string)
+      ├── fd: (9)-->(10,11)
+      ├── left-join
+      │    ├── columns: a:4(int!null) b:5(string) column8:8(float) x:9(string) y:10(int) z:11(float)
       │    ├── cardinality: [0 - 0]
       │    ├── stats: [rows=0]
-      │    ├── fd: ()-->(8)
+      │    ├── fd: ()-->(8), (9)-->(10,11)
       │    ├── project
-      │    │    ├── columns: a:4(int!null) b:5(string)
+      │    │    ├── columns: column8:8(float) a:4(int!null) b:5(string)
       │    │    ├── cardinality: [0 - 0]
       │    │    ├── stats: [rows=0]
-      │    │    └── select
-      │    │         ├── columns: a:4(int!null) b:5(string) c:6(float) rowid:7(int!null)
-      │    │         ├── cardinality: [0 - 0]
-      │    │         ├── stats: [rows=0]
-      │    │         ├── key: (7)
-      │    │         ├── fd: (7)-->(4-6)
-      │    │         ├── scan abc
-      │    │         │    ├── columns: a:4(int!null) b:5(string) c:6(float) rowid:7(int!null)
-      │    │         │    ├── stats: [rows=2000]
-      │    │         │    ├── key: (7)
-      │    │         │    └── fd: (7)-->(4-6)
-      │    │         └── filters
-      │    │              └── false [type=bool]
-      │    └── projections
-      │         └── NULL::FLOAT8 [type=float]
-      ├── scan xyz
-      │    ├── columns: x:9(string!null) y:10(int!null) z:11(float)
-      │    ├── stats: [rows=1000]
-      │    ├── key: (9)
-      │    └── fd: (9)-->(10,11)
-      └── filters
-           └── b = x [type=bool, outer=(5,9), constraints=(/5: (/NULL - ]; /9: (/NULL - ]), fd=(5)==(9), (9)==(5)]
+      │    │    ├── fd: ()-->(8)
+      │    │    ├── project
+      │    │    │    ├── columns: a:4(int!null) b:5(string)
+      │    │    │    ├── cardinality: [0 - 0]
+      │    │    │    ├── stats: [rows=0]
+      │    │    │    └── select
+      │    │    │         ├── columns: a:4(int!null) b:5(string) c:6(float) rowid:7(int!null)
+      │    │    │         ├── cardinality: [0 - 0]
+      │    │    │         ├── stats: [rows=0]
+      │    │    │         ├── key: (7)
+      │    │    │         ├── fd: (7)-->(4-6)
+      │    │    │         ├── scan abc
+      │    │    │         │    ├── columns: a:4(int!null) b:5(string) c:6(float) rowid:7(int!null)
+      │    │    │         │    ├── stats: [rows=2000]
+      │    │    │         │    ├── key: (7)
+      │    │    │         │    └── fd: (7)-->(4-6)
+      │    │    │         └── filters
+      │    │    │              └── false [type=bool]
+      │    │    └── projections
+      │    │         └── NULL::FLOAT8 [type=float]
+      │    ├── scan xyz
+      │    │    ├── columns: x:9(string!null) y:10(int!null) z:11(float)
+      │    │    ├── stats: [rows=1000]
+      │    │    ├── key: (9)
+      │    │    └── fd: (9)-->(10,11)
+      │    └── filters
+      │         └── b = x [type=bool, outer=(5,9), constraints=(/5: (/NULL - ]; /9: (/NULL - ]), fd=(5)==(9), (9)==(5)]
+      └── projections
+           ├── CASE WHEN x IS NULL THEN b ELSE x END [type=string, outer=(5,9)]
+           ├── CASE WHEN x IS NULL THEN a ELSE a END [type=int, outer=(4,9)]
+           └── CASE WHEN x IS NULL THEN column8 ELSE column8 END [type=float, outer=(8,9)]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -123,30 +123,37 @@ upsert xy
  ├── canary column: 5
  ├── fetch columns: x:5(int) y:6(int)
  ├── insert-mapping:
- │    ├──  column1:3 => x:1
- │    └──  column2:4 => y:2
+ │    ├──  upsert_x:9 => x:1
+ │    └──  upsert_y:10 => y:2
  ├── update-mapping:
- │    ├──  u:7 => x:1
- │    └──  v:8 => y:2
+ │    ├──  upsert_x:9 => x:1
+ │    └──  upsert_y:10 => y:2
  ├── cardinality: [2 - ]
  ├── side-effects, mutations
- └── left-join (lookup uv)
-      ├── columns: column1:3(int) column2:4(int) x:5(int) y:6(int) u:7(int) v:8(int)
-      ├── key columns: [3] = [7]
+ └── project
+      ├── columns: upsert_x:9(int) upsert_y:10(int) x:5(int) y:6(int)
       ├── cardinality: [2 - ]
-      ├── fd: (5)-->(6), (7)-->(8)
-      ├── left-join (lookup xy)
-      │    ├── columns: column1:3(int) column2:4(int) x:5(int) y:6(int)
-      │    ├── key columns: [3] = [5]
+      ├── fd: (5)-->(6)
+      ├── left-join (lookup uv)
+      │    ├── columns: column1:3(int) column2:4(int) x:5(int) y:6(int) u:7(int) v:8(int)
+      │    ├── key columns: [3] = [7]
       │    ├── cardinality: [2 - ]
-      │    ├── fd: (5)-->(6)
-      │    ├── values
-      │    │    ├── columns: column1:3(int) column2:4(int)
-      │    │    ├── cardinality: [2 - 2]
-      │    │    ├── (1, 2) [type=tuple{int, int}]
-      │    │    └── (3, 4) [type=tuple{int, int}]
+      │    ├── fd: (5)-->(6), (7)-->(8)
+      │    ├── left-join (lookup xy)
+      │    │    ├── columns: column1:3(int) column2:4(int) x:5(int) y:6(int)
+      │    │    ├── key columns: [3] = [5]
+      │    │    ├── cardinality: [2 - ]
+      │    │    ├── fd: (5)-->(6)
+      │    │    ├── values
+      │    │    │    ├── columns: column1:3(int) column2:4(int)
+      │    │    │    ├── cardinality: [2 - 2]
+      │    │    │    ├── (1, 2) [type=tuple{int, int}]
+      │    │    │    └── (3, 4) [type=tuple{int, int}]
+      │    │    └── filters (true)
       │    └── filters (true)
-      └── filters (true)
+      └── projections
+           ├── CASE WHEN x IS NULL THEN column1 ELSE u END [type=int, outer=(3,5,7)]
+           └── CASE WHEN x IS NULL THEN column2 ELSE v END [type=int, outer=(4,5,8)]
 
 # Decorrelate DELETE statement.
 opt expect=DecorrelateJoin

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -90,6 +90,10 @@ func init() {
 //   3. Computed columns which will be updated when a conflict is detected and
 //      that are dependent on one or more updated columns.
 //
+// In addition, the insert and update column expressions are merged into a
+// single set of upsert column expressions that toggle between the insert and
+// update values depending on whether the canary column is null.
+//
 // For example, if this is the schema and INSERT..ON CONFLICT statement:
 //
 //   CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
@@ -97,15 +101,21 @@ func init() {
 //
 // Then an input expression equivalent to this would be built:
 //
-//   SELECT ins_a, ins_b, ins_c, fetch_a, fetch_b, fetch_c, 10 AS upd_b
+//   SELECT
+//     fetch_a,
+//     fetch_b,
+//     fetch_c,
+//     CASE WHEN fetch_a IS NULL ins_a ELSE fetch_a END AS ups_a,
+//     CASE WHEN fetch_a IS NULL ins_b ELSE 10 END AS ups_b,
+//     CASE WHEN fetch_a IS NULL ins_c ELSE fetch_c END AS ups_c,
 //   FROM (VALUES (1, 2, NULL)) AS ins(ins_a, ins_b, ins_c)
 //   LEFT OUTER JOIN abc AS fetch(fetch_a, fetch_b, fetch_c)
 //   ON ins_a = fetch_a
 //
-// At runtime, the Upsert execution operator will test the fetch_a column. If
-// it is null, then there is no existing row, so the operator inserts a new row
-// using the (ins_a, ins_b, ins_c) columns. Otherwise, the operator formulates
-// an update using the (upd_b) column, along with any needed fetch columns.
+// The CASE expressions will often prevent the unnecessary evaluation of the
+// update expression in the case where an insertion needs to occur. In addition,
+// it simplifies logical property calculation, since a 1:1 mapping to each
+// target table column from a corresponding input column is maintained.
 //
 // If the ON CONFLICT clause contains a DO NOTHING clause, then each UNIQUE
 // index on the target table requires its own LEFT OUTER JOIN to check whether a
@@ -604,6 +614,8 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, onConflict *tr
 		}
 
 		// Construct the left join + filter.
+		// TODO(andyk): Convert this to use anti-join once we have support for
+		// lookup anti-joins.
 		mb.outScope.expr = mb.b.factory.ConstructProject(
 			mb.b.factory.ConstructSelect(
 				mb.b.factory.ConstructLeftJoin(
@@ -759,6 +771,8 @@ func (mb *mutationBuilder) setUpsertCols(insertCols tree.NameList) {
 // buildUpsert constructs an Upsert operator, possibly wrapped by a Project
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
+	mb.projectUpsertColumns()
+
 	private := memo.MutationPrivate{
 		Table:       mb.tabID,
 		InsertCols:  mb.insertColList,
@@ -770,6 +784,114 @@ func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
 	mb.outScope.expr = mb.b.factory.ConstructUpsert(mb.outScope.expr, &private)
 
 	mb.buildReturning(returning)
+}
+
+// projectUpsertColumns projects a set of merged columns that will be either
+// inserted into the target table, or else used to update an existing row,
+// depending on whether the canary column is null. For example:
+//
+//   UPSERT INTO ab VALUES (ins_a, ins_b) ON CONFLICT (a) DO UPDATE SET b=upd_b
+//
+// will cause the columns to be projected:
+//
+//   SELECT
+//     fetch_a,
+//     fetch_b,
+//     CASE WHEN fetch_a IS NULL ins_a ELSE fetch_a END AS ups_a,
+//     CASE WHEN fetch_b IS NULL ins_b ELSE upd_b END AS ups_b,
+//   FROM (SELECT ins_a, ins_b, upd_b, fetch_a, fetch_b FROM ...)
+//
+// For each column, a CASE expression is created that toggles between the insert
+// and update values depending on whether the canary column is null. These
+// columns can then feed into any constraint checking expressions, which operate
+// on the final result values.
+func (mb *mutationBuilder) projectUpsertColumns() {
+	projectionsScope := mb.outScope.replace()
+	projectionsScope.cols = make([]scopeColumn, 0, len(mb.outScope.cols))
+
+	addAnonymousColumn := func(id opt.ColumnID) *scopeColumn {
+		projectionsScope.cols = append(projectionsScope.cols, scopeColumn{
+			typ: mb.md.ColumnMeta(id).Type,
+			id:  id,
+		})
+		return &projectionsScope.cols[len(projectionsScope.cols)-1]
+	}
+
+	// Pass through all fetch columns. This always includes the canary column.
+	fetchColSet := mb.fetchColList.ToSet()
+	for i := range mb.outScope.cols {
+		col := &mb.outScope.cols[i]
+		if fetchColSet.Contains(int(col.id)) {
+			// Don't copy the column's name, since fetch columns can no longer be
+			// referenced by expressions, such as any check constraints.
+			addAnonymousColumn(col.id)
+		}
+	}
+
+	// Project a column for each target table column that needs to be either
+	// inserted or updated.
+	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
+		insertColID := mb.insertColList[i]
+		updateColID := mb.updateColList[i]
+		if updateColID == 0 {
+			updateColID = mb.fetchColList[i]
+		}
+
+		var scopeCol *scopeColumn
+		switch {
+		case insertColID == 0 && updateColID == 0:
+			// Neither insert nor update required for this column, so skip.
+			continue
+
+		case insertColID == 0:
+			// No insert is required, so just pass through update column.
+			scopeCol = addAnonymousColumn(updateColID)
+
+		case updateColID == 0:
+			// No update is required, so just pass through insert column.
+			scopeCol = addAnonymousColumn(insertColID)
+
+		default:
+			// Generate CASE that toggles between insert and update column.
+			caseExpr := mb.b.factory.ConstructCase(
+				memo.TrueSingleton,
+				memo.ScalarListExpr{
+					mb.b.factory.ConstructWhen(
+						mb.b.factory.ConstructIs(
+							mb.b.factory.ConstructVariable(mb.canaryColID),
+							memo.NullSingleton,
+						),
+						mb.b.factory.ConstructVariable(insertColID),
+					),
+				},
+				mb.b.factory.ConstructVariable(updateColID),
+			)
+
+			alias := fmt.Sprintf("upsert_%s", mb.tab.Column(i).ColName())
+			typ := mb.md.ColumnMeta(insertColID).Type
+			scopeCol = mb.b.synthesizeColumn(projectionsScope, alias, typ, nil /* expr */, caseExpr)
+		}
+
+		// Assign name to synthesized column. Check constraint columns may refer
+		// to columns in the table by name.
+		scopeCol.table = *mb.tab.Name()
+		scopeCol.name = mb.tab.Column(i).ColName()
+
+		// Update the ids for the insert and update columns that are involved in
+		// the Upsert. The new column ids will be used by the Upsert operator in
+		// place of the original column ids.
+		if mb.insertColList[i] != 0 {
+			mb.insertColList[i] = scopeCol.id
+		}
+		if mb.updateColList[i] != 0 {
+			mb.updateColList[i] = scopeCol.id
+		} else if mb.fetchColList[i] != 0 {
+			mb.fetchColList[i] = scopeCol.id
+		}
+	}
+
+	mb.b.constructProjectForScope(mb.outScope, projectionsScope)
+	mb.outScope = projectionsScope
 }
 
 // ensureUniqueConflictCols tries to prove that the given list of column names

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -334,7 +334,7 @@ func (mb *mutationBuilder) addSynthesizedCols(
 		}
 		tabColID := mb.tabID.ColumnID(i)
 		expr := mb.parseDefaultOrComputedExpr(tabColID)
-		texpr := mb.outScope.resolveType(expr, tabCol.DatumType())
+		texpr := mb.outScope.resolveAndRequireType(expr, tabCol.DatumType())
 		scopeCol := mb.b.addColumn(projectionsScope, "" /* alias */, texpr)
 		mb.b.buildScalar(texpr, mb.outScope, projectionsScope, scopeCol, nil)
 
@@ -449,7 +449,7 @@ func (mb *mutationBuilder) parseDefaultOrComputedExpr(colID opt.ColumnID) tree.E
 	}
 
 	mb.parsedExprs[ord] = expr
-	return mb.parsedExprs[ord]
+	return expr
 }
 
 // findNotNullIndexCol finds the first not-null column in the given index and
@@ -516,7 +516,7 @@ func getAliasedTableName(n tree.TableExpr) (*tree.TableName, *tree.TableName) {
 //
 // This is used by the UPDATE, INSERT and UPSERT code.
 func checkDatumTypeFitsColumnType(col cat.Column, typ types.T) {
-	if typ == types.Unknown || typ.Equivalent(col.DatumType()) {
+	if typ.Equivalent(col.DatumType()) {
 		return
 	}
 

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -114,19 +114,28 @@ insert abcde
  │    ├──  column1:7 => a:1
  │    ├──  column8:8 => b:2
  │    ├──  column9:9 => c:3
- │    ├──  column8:8 => d:4
+ │    ├──  column11:11 => d:4
  │    ├──  column1:7 => e:5
  │    └──  column10:10 => rowid:6
  └── project
-      ├── columns: column8:8(unknown) column9:9(int!null) column10:10(int) column1:7(int)
-      ├── values
-      │    ├── columns: column1:7(int)
-      │    └── tuple [type=tuple{int}]
-      │         └── const: 1 [type=int]
+      ├── columns: column11:11(int) column1:7(int) column8:8(int) column9:9(int!null) column10:10(int)
+      ├── project
+      │    ├── columns: column8:8(int) column9:9(int!null) column10:10(int) column1:7(int)
+      │    ├── values
+      │    │    ├── columns: column1:7(int)
+      │    │    └── tuple [type=tuple{int}]
+      │    │         └── const: 1 [type=int]
+      │    └── projections
+      │         ├── cast: INT8 [type=int]
+      │         │    └── null [type=unknown]
+      │         ├── const: 10 [type=int]
+      │         └── function: unique_rowid [type=int]
       └── projections
-           ├── null [type=unknown]
-           ├── const: 10 [type=int]
-           └── function: unique_rowid [type=int]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── variable: column8 [type=int]
+                │    └── variable: column9 [type=int]
+                └── const: 1 [type=int]
 
 # Ordered input.
 build
@@ -138,26 +147,35 @@ insert abcde
  │    ├──  y:8 => a:1
  │    ├──  column10:10 => b:2
  │    ├──  column11:11 => c:3
- │    ├──  column10:10 => d:4
+ │    ├──  column13:13 => d:4
  │    ├──  y:8 => e:5
  │    └──  column12:12 => rowid:6
  └── project
-      ├── columns: column10:10(unknown) column11:11(int!null) column12:12(int) y:8(int)
-      ├── limit
-      │    ├── columns: y:8(int) z:9(float)
-      │    ├── internal-ordering: +8,+9
-      │    ├── sort
+      ├── columns: column13:13(int) y:8(int) column10:10(int) column11:11(int!null) column12:12(int)
+      ├── project
+      │    ├── columns: column10:10(int) column11:11(int!null) column12:12(int) y:8(int)
+      │    ├── limit
       │    │    ├── columns: y:8(int) z:9(float)
-      │    │    ├── ordering: +8,+9
-      │    │    └── project
-      │    │         ├── columns: y:8(int) z:9(float)
-      │    │         └── scan xyz
-      │    │              └── columns: x:7(string!null) y:8(int) z:9(float)
-      │    └── const: 10 [type=int]
+      │    │    ├── internal-ordering: +8,+9
+      │    │    ├── sort
+      │    │    │    ├── columns: y:8(int) z:9(float)
+      │    │    │    ├── ordering: +8,+9
+      │    │    │    └── project
+      │    │    │         ├── columns: y:8(int) z:9(float)
+      │    │    │         └── scan xyz
+      │    │    │              └── columns: x:7(string!null) y:8(int) z:9(float)
+      │    │    └── const: 10 [type=int]
+      │    └── projections
+      │         ├── cast: INT8 [type=int]
+      │         │    └── null [type=unknown]
+      │         ├── const: 10 [type=int]
+      │         └── function: unique_rowid [type=int]
       └── projections
-           ├── null [type=unknown]
-           ├── const: 10 [type=int]
-           └── function: unique_rowid [type=int]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── variable: column10 [type=int]
+                │    └── variable: column11 [type=int]
+                └── const: 1 [type=int]
 
 # Ignore ORDER BY without LIMIT.
 build
@@ -169,19 +187,28 @@ insert abcde
  │    ├──  y:8 => a:1
  │    ├──  column10:10 => b:2
  │    ├──  column11:11 => c:3
- │    ├──  column10:10 => d:4
+ │    ├──  column13:13 => d:4
  │    ├──  y:8 => e:5
  │    └──  column12:12 => rowid:6
  └── project
-      ├── columns: column10:10(unknown) column11:11(int!null) column12:12(int) y:8(int)
+      ├── columns: column13:13(int) y:8(int) column10:10(int) column11:11(int!null) column12:12(int)
       ├── project
-      │    ├── columns: y:8(int) z:9(float)
-      │    └── scan xyz
-      │         └── columns: x:7(string!null) y:8(int) z:9(float)
+      │    ├── columns: column10:10(int) column11:11(int!null) column12:12(int) y:8(int)
+      │    ├── project
+      │    │    ├── columns: y:8(int) z:9(float)
+      │    │    └── scan xyz
+      │    │         └── columns: x:7(string!null) y:8(int) z:9(float)
+      │    └── projections
+      │         ├── cast: INT8 [type=int]
+      │         │    └── null [type=unknown]
+      │         ├── const: 10 [type=int]
+      │         └── function: unique_rowid [type=int]
       └── projections
-           ├── null [type=unknown]
-           ├── const: 10 [type=int]
-           └── function: unique_rowid [type=int]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── variable: column10 [type=int]
+                │    └── variable: column11 [type=int]
+                └── const: 1 [type=int]
 
 # Use placeholders.
 build
@@ -214,19 +241,25 @@ insert abcde
  │    ├──  column1:7 => e:5
  │    └──  column10:10 => rowid:6
  └── project
-      ├── columns: column11:11(unknown) column1:7(int) column2:8(unknown) column3:9(unknown) column10:10(int)
+      ├── columns: column11:11(int) column1:7(int) column2:8(int) column3:9(int) column10:10(int)
       ├── project
-      │    ├── columns: column10:10(int) column1:7(int) column2:8(unknown) column3:9(unknown)
+      │    ├── columns: column10:10(int) column1:7(int) column2:8(int) column3:9(int)
       │    ├── values
-      │    │    ├── columns: column1:7(int) column2:8(unknown) column3:9(unknown)
-      │    │    └── tuple [type=tuple{int, unknown, unknown}]
+      │    │    ├── columns: column1:7(int) column2:8(int) column3:9(int)
+      │    │    └── tuple [type=tuple{int, int, int}]
       │    │         ├── const: 2 [type=int]
-      │    │         ├── null [type=unknown]
-      │    │         └── null [type=unknown]
+      │    │         ├── cast: INT8 [type=int]
+      │    │         │    └── null [type=unknown]
+      │    │         └── cast: INT8 [type=int]
+      │    │              └── null [type=unknown]
       │    └── projections
       │         └── function: unique_rowid [type=int]
       └── projections
-           └── null [type=unknown]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── variable: column2 [type=int]
+                │    └── variable: column3 [type=int]
+                └── const: 1 [type=int]
 
 # Duplicate expressions.
 build
@@ -271,14 +304,17 @@ insert uv
  ├── columns: <none>
  ├── insert-mapping:
  │    ├──  column4:4 => u:1
- │    ├──  column4:4 => v:2
- │    └──  column5:5 => rowid:3
+ │    ├──  column5:5 => v:2
+ │    └──  column6:6 => rowid:3
  └── project
-      ├── columns: column4:4(unknown) column5:5(int)
+      ├── columns: column4:4(decimal) column5:5(bytes) column6:6(int)
       ├── values
       │    └── tuple [type=tuple]
       └── projections
-           ├── null [type=unknown]
+           ├── cast: DECIMAL [type=decimal]
+           │    └── null [type=unknown]
+           ├── cast: BYTES [type=bytes]
+           │    └── null [type=unknown]
            └── function: unique_rowid [type=int]
 
 # Use DEFAULT expressions in VALUES expression.
@@ -302,7 +338,8 @@ insert abcde
       │    │    ├── columns: column1:7(int) column2:8(int) column3:9(int)
       │    │    ├── tuple [type=tuple{int, int, int}]
       │    │    │    ├── const: 1 [type=int]
-      │    │    │    ├── null [type=unknown]
+      │    │    │    ├── cast: INT8 [type=int]
+      │    │    │    │    └── null [type=unknown]
       │    │    │    └── const: 2 [type=int]
       │    │    ├── tuple [type=tuple{int, int, int}]
       │    │    │    ├── const: 2 [type=int]
@@ -314,7 +351,8 @@ insert abcde
       │    │    │    └── const: 10 [type=int]
       │    │    └── tuple [type=tuple{int, int, int}]
       │    │         ├── const: 4 [type=int]
-      │    │         ├── null [type=unknown]
+      │    │         ├── cast: INT8 [type=int]
+      │    │         │    └── null [type=unknown]
       │    │         └── const: 10 [type=int]
       │    └── projections
       │         └── function: unique_rowid [type=int]
@@ -349,49 +387,67 @@ project
       │    ├──  "?column?":7 => a:1
       │    ├──  column8:8 => b:2
       │    ├──  column9:9 => c:3
-      │    ├──  column8:8 => d:4
+      │    ├──  column11:11 => d:4
       │    ├──  "?column?":7 => e:5
       │    └──  column10:10 => rowid:6
       └── project
-           ├── columns: column8:8(unknown) column9:9(int!null) column10:10(int) "?column?":7(int!null)
+           ├── columns: column11:11(int) "?column?":7(int!null) column8:8(int) column9:9(int!null) column10:10(int)
            ├── project
-           │    ├── columns: "?column?":7(int!null)
-           │    ├── values
-           │    │    └── tuple [type=tuple]
+           │    ├── columns: column8:8(int) column9:9(int!null) column10:10(int) "?column?":7(int!null)
+           │    ├── project
+           │    │    ├── columns: "?column?":7(int!null)
+           │    │    ├── values
+           │    │    │    └── tuple [type=tuple]
+           │    │    └── projections
+           │    │         └── const: 1 [type=int]
            │    └── projections
-           │         └── const: 1 [type=int]
+           │         ├── cast: INT8 [type=int]
+           │         │    └── null [type=unknown]
+           │         ├── const: 10 [type=int]
+           │         └── function: unique_rowid [type=int]
            └── projections
-                ├── null [type=unknown]
-                ├── const: 10 [type=int]
-                └── function: unique_rowid [type=int]
+                └── plus [type=int]
+                     ├── plus [type=int]
+                     │    ├── variable: column8 [type=int]
+                     │    └── variable: column9 [type=int]
+                     └── const: 1 [type=int]
 
 # Return values from aliased table.
 build
 INSERT INTO abcde AS foo SELECT 1 RETURNING foo.a + 1, foo.b * foo.c
 ----
 project
- ├── columns: "?column?":11(int) "?column?":12(int)
+ ├── columns: "?column?":12(int) "?column?":13(int)
  ├── insert foo
  │    ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) e:5(int!null) rowid:6(int!null)
  │    ├── insert-mapping:
  │    │    ├──  "?column?":7 => a:1
  │    │    ├──  column8:8 => b:2
  │    │    ├──  column9:9 => c:3
- │    │    ├──  column8:8 => d:4
+ │    │    ├──  column11:11 => d:4
  │    │    ├──  "?column?":7 => e:5
  │    │    └──  column10:10 => rowid:6
  │    └── project
- │         ├── columns: column8:8(unknown) column9:9(int!null) column10:10(int) "?column?":7(int!null)
+ │         ├── columns: column11:11(int) "?column?":7(int!null) column8:8(int) column9:9(int!null) column10:10(int)
  │         ├── project
- │         │    ├── columns: "?column?":7(int!null)
- │         │    ├── values
- │         │    │    └── tuple [type=tuple]
+ │         │    ├── columns: column8:8(int) column9:9(int!null) column10:10(int) "?column?":7(int!null)
+ │         │    ├── project
+ │         │    │    ├── columns: "?column?":7(int!null)
+ │         │    │    ├── values
+ │         │    │    │    └── tuple [type=tuple]
+ │         │    │    └── projections
+ │         │    │         └── const: 1 [type=int]
  │         │    └── projections
- │         │         └── const: 1 [type=int]
+ │         │         ├── cast: INT8 [type=int]
+ │         │         │    └── null [type=unknown]
+ │         │         ├── const: 10 [type=int]
+ │         │         └── function: unique_rowid [type=int]
  │         └── projections
- │              ├── null [type=unknown]
- │              ├── const: 10 [type=int]
- │              └── function: unique_rowid [type=int]
+ │              └── plus [type=int]
+ │                   ├── plus [type=int]
+ │                   │    ├── variable: column8 [type=int]
+ │                   │    └── variable: column9 [type=int]
+ │                   └── const: 1 [type=int]
  └── projections
       ├── plus [type=int]
       │    ├── variable: a [type=int]
@@ -412,19 +468,28 @@ project
       │    ├──  column1:7 => a:1
       │    ├──  column8:8 => b:2
       │    ├──  column9:9 => c:3
-      │    ├──  column8:8 => d:4
+      │    ├──  column11:11 => d:4
       │    ├──  column1:7 => e:5
       │    └──  column10:10 => rowid:6
       └── project
-           ├── columns: column8:8(unknown) column9:9(int!null) column10:10(int) column1:7(int)
-           ├── values
-           │    ├── columns: column1:7(int)
-           │    └── tuple [type=tuple{int}]
-           │         └── const: 1 [type=int]
+           ├── columns: column11:11(int) column1:7(int) column8:8(int) column9:9(int!null) column10:10(int)
+           ├── project
+           │    ├── columns: column8:8(int) column9:9(int!null) column10:10(int) column1:7(int)
+           │    ├── values
+           │    │    ├── columns: column1:7(int)
+           │    │    └── tuple [type=tuple{int}]
+           │    │         └── const: 1 [type=int]
+           │    └── projections
+           │         ├── cast: INT8 [type=int]
+           │         │    └── null [type=unknown]
+           │         ├── const: 10 [type=int]
+           │         └── function: unique_rowid [type=int]
            └── projections
-                ├── null [type=unknown]
-                ├── const: 10 [type=int]
-                └── function: unique_rowid [type=int]
+                └── plus [type=int]
+                     ├── plus [type=int]
+                     │    ├── variable: column8 [type=int]
+                     │    └── variable: column9 [type=int]
+                     └── const: 1 [type=int]
 
 # Try to use aggregate function in RETURNING clause.
 build
@@ -633,19 +698,28 @@ insert abcde
  │    ├──  column1:7 => a:1
  │    ├──  column8:8 => b:2
  │    ├──  column9:9 => c:3
- │    ├──  column8:8 => d:4
+ │    ├──  column11:11 => d:4
  │    ├──  column1:7 => e:5
  │    └──  column10:10 => rowid:6
  └── project
-      ├── columns: column8:8(unknown) column9:9(int!null) column10:10(int) column1:7(int)
-      ├── values
-      │    ├── columns: column1:7(int)
-      │    └── tuple [type=tuple{int}]
-      │         └── const: 1 [type=int]
+      ├── columns: column11:11(int) column1:7(int) column8:8(int) column9:9(int!null) column10:10(int)
+      ├── project
+      │    ├── columns: column8:8(int) column9:9(int!null) column10:10(int) column1:7(int)
+      │    ├── values
+      │    │    ├── columns: column1:7(int)
+      │    │    └── tuple [type=tuple{int}]
+      │    │         └── const: 1 [type=int]
+      │    └── projections
+      │         ├── cast: INT8 [type=int]
+      │         │    └── null [type=unknown]
+      │         ├── const: 10 [type=int]
+      │         └── function: unique_rowid [type=int]
       └── projections
-           ├── null [type=unknown]
-           ├── const: 10 [type=int]
-           └── function: unique_rowid [type=int]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── variable: column8 [type=int]
+                │    └── variable: column9 [type=int]
+                └── const: 1 [type=int]
 
 # Insert value into hidden rowid column.
 build
@@ -659,19 +733,28 @@ project
       │    ├──  column1:7 => a:1
       │    ├──  column9:9 => b:2
       │    ├──  column10:10 => c:3
-      │    ├──  column9:9 => d:4
+      │    ├──  column11:11 => d:4
       │    ├──  column1:7 => e:5
       │    └──  column2:8 => rowid:6
       └── project
-           ├── columns: column9:9(unknown) column10:10(int!null) column1:7(int) column2:8(int)
-           ├── values
-           │    ├── columns: column1:7(int) column2:8(int)
-           │    └── tuple [type=tuple{int, int}]
-           │         ├── const: 1 [type=int]
-           │         └── const: 2 [type=int]
+           ├── columns: column11:11(int) column1:7(int) column2:8(int) column9:9(int) column10:10(int!null)
+           ├── project
+           │    ├── columns: column9:9(int) column10:10(int!null) column1:7(int) column2:8(int)
+           │    ├── values
+           │    │    ├── columns: column1:7(int) column2:8(int)
+           │    │    └── tuple [type=tuple{int, int}]
+           │    │         ├── const: 1 [type=int]
+           │    │         └── const: 2 [type=int]
+           │    └── projections
+           │         ├── cast: INT8 [type=int]
+           │         │    └── null [type=unknown]
+           │         └── const: 10 [type=int]
            └── projections
-                ├── null [type=unknown]
-                └── const: 10 [type=int]
+                └── plus [type=int]
+                     ├── plus [type=int]
+                     │    ├── variable: column9 [type=int]
+                     │    └── variable: column10 [type=int]
+                     └── const: 1 [type=int]
 
 # Use DEFAULT expressions in VALUES expression.
 build
@@ -694,7 +777,8 @@ insert abcde
       │    ├── columns: column1:7(int) column2:8(int) column3:9(int) column4:10(int)
       │    ├── tuple [type=tuple{int, int, int, int}]
       │    │    ├── const: 10 [type=int]
-      │    │    ├── null [type=unknown]
+      │    │    ├── cast: INT8 [type=int]
+      │    │    │    └── null [type=unknown]
       │    │    ├── const: 1 [type=int]
       │    │    └── function: unique_rowid [type=int]
       │    ├── tuple [type=tuple{int, int, int, int}]
@@ -704,7 +788,8 @@ insert abcde
       │    │    └── function: unique_rowid [type=int]
       │    └── tuple [type=tuple{int, int, int, int}]
       │         ├── const: 10 [type=int]
-      │         ├── null [type=unknown]
+      │         ├── cast: INT8 [type=int]
+      │         │    └── null [type=unknown]
       │         ├── const: 2 [type=int]
       │         └── const: 100 [type=int]
       └── projections
@@ -725,19 +810,29 @@ insert abcde
  │    ├──  column1:7 => a:1
  │    ├──  column8:8 => b:2
  │    ├──  column9:9 => c:3
- │    ├──  column8:8 => d:4
+ │    ├──  column11:11 => d:4
  │    ├──  column1:7 => e:5
  │    └──  column10:10 => rowid:6
  └── project
-      ├── columns: column8:8(unknown) column9:9(int!null) column10:10(int) column1:7(unknown)
-      ├── values
-      │    ├── columns: column1:7(unknown)
-      │    └── tuple [type=tuple{unknown}]
-      │         └── null [type=unknown]
+      ├── columns: column11:11(int) column1:7(int) column8:8(int) column9:9(int!null) column10:10(int)
+      ├── project
+      │    ├── columns: column8:8(int) column9:9(int!null) column10:10(int) column1:7(int)
+      │    ├── values
+      │    │    ├── columns: column1:7(int)
+      │    │    └── tuple [type=tuple{int}]
+      │    │         └── cast: INT8 [type=int]
+      │    │              └── null [type=unknown]
+      │    └── projections
+      │         ├── cast: INT8 [type=int]
+      │         │    └── null [type=unknown]
+      │         ├── const: 10 [type=int]
+      │         └── function: unique_rowid [type=int]
       └── projections
-           ├── null [type=unknown]
-           ├── const: 10 [type=int]
-           └── function: unique_rowid [type=int]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── variable: column8 [type=int]
+                │    └── variable: column9 [type=int]
+                └── const: 1 [type=int]
 
 # Mismatched type.
 build
@@ -827,19 +922,28 @@ insert abcde
  │    ├──  column2:8 => a:1
  │    ├──  column9:9 => b:2
  │    ├──  column10:10 => c:3
- │    ├──  column9:9 => d:4
+ │    ├──  column11:11 => d:4
  │    ├──  column2:8 => e:5
  │    └──  column1:7 => rowid:6
  └── project
-      ├── columns: column9:9(unknown) column10:10(int!null) column1:7(int) column2:8(int)
-      ├── values
-      │    ├── columns: column1:7(int) column2:8(int)
-      │    └── tuple [type=tuple{int, int}]
-      │         ├── const: 1 [type=int]
-      │         └── const: 2 [type=int]
+      ├── columns: column11:11(int) column1:7(int) column2:8(int) column9:9(int) column10:10(int!null)
+      ├── project
+      │    ├── columns: column9:9(int) column10:10(int!null) column1:7(int) column2:8(int)
+      │    ├── values
+      │    │    ├── columns: column1:7(int) column2:8(int)
+      │    │    └── tuple [type=tuple{int, int}]
+      │    │         ├── const: 1 [type=int]
+      │    │         └── const: 2 [type=int]
+      │    └── projections
+      │         ├── cast: INT8 [type=int]
+      │         │    └── null [type=unknown]
+      │         └── const: 10 [type=int]
       └── projections
-           ├── null [type=unknown]
-           └── const: 10 [type=int]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── variable: column9 [type=int]
+                │    └── variable: column10 [type=int]
+                └── const: 1 [type=int]
 
 # Use returning INSERT as a FROM expression.
 build

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -109,7 +109,8 @@ select
  ├── scan abc
  │    └── columns: a:1(int!null) b:2(int) c:3(int)
  └── filters
-      └── null [type=bool]
+      └── cast: BOOL [type=bool]
+           └── null [type=unknown]
 
 build
 SELECT * FROM abc WHERE a = NULL
@@ -119,7 +120,8 @@ select
  ├── scan abc
  │    └── columns: a:1(int!null) b:2(int) c:3(int)
  └── filters
-      └── null [type=bool]
+      └── cast: BOOL [type=bool]
+           └── null [type=unknown]
 
 build
 SELECT *,* FROM abc

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -171,15 +171,24 @@ update abcde
  │    ├──  column13:13 => a:1
  │    ├──  column13:13 => b:2
  │    ├──  column13:13 => c:3
- │    ├──  column13:13 => d:4
+ │    ├──  column14:14 => d:4
  │    ├──  column13:13 => e:5
  │    └──  column13:13 => rowid:6
  └── project
-      ├── columns: column13:13(unknown) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
-      ├── scan abcde
-      │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int)
+      ├── project
+      │    ├── columns: column13:13(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    ├── scan abcde
+      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    └── projections
+      │         └── cast: INT8 [type=int]
+      │              └── null [type=unknown]
       └── projections
-           └── null [type=unknown]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── variable: column13 [type=int]
+                │    └── variable: column13 [type=int]
+                └── const: 1 [type=int]
 
 # Set columns using variable expressions.
 build
@@ -613,15 +622,24 @@ update abcde
  ├── update-mapping:
  │    ├──  column13:13 => b:2
  │    ├──  column14:14 => c:3
- │    ├──  column13:13 => d:4
+ │    ├──  column15:15 => d:4
  │    └──  a:7 => e:5
  └── project
-      ├── columns: column13:13(unknown) column14:14(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
-      ├── scan abcde
-      │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      ├── columns: column15:15(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int) column14:14(int!null)
+      ├── project
+      │    ├── columns: column13:13(int) column14:14(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    ├── scan abcde
+      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    └── projections
+      │         ├── cast: INT8 [type=int]
+      │         │    └── null [type=unknown]
+      │         └── const: 10 [type=int]
       └── projections
-           ├── null [type=unknown]
-           └── const: 10 [type=int]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── variable: column13 [type=int]
+                │    └── variable: column14 [type=int]
+                └── const: 1 [type=int]
 
 # Allow not-null column to be updated with NULL DEFAULT value (would fail at
 # runtime if there are any rows to update).
@@ -636,13 +654,14 @@ update abcde
  │    ├──  column14:14 => d:4
  │    └──  column13:13 => e:5
  └── project
-      ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(unknown)
+      ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int)
       ├── project
-      │    ├── columns: column13:13(unknown) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    ├── columns: column13:13(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    ├── scan abcde
       │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
       │    └── projections
-      │         └── null [type=unknown]
+      │         └── cast: INT8 [type=int]
+      │              └── null [type=unknown]
       └── projections
            └── plus [type=int]
                 ├── plus [type=int]
@@ -698,16 +717,25 @@ update abcde
  │    ├──  column15:15 => a:1
  │    ├──  column14:14 => b:2
  │    ├──  column13:13 => c:3
- │    ├──  column13:13 => d:4
+ │    ├──  column16:16 => d:4
  │    └──  column15:15 => e:5
  └── project
-      ├── columns: column13:13(unknown) column14:14(int!null) column15:15(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
-      ├── scan abcde
-      │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      ├── columns: column16:16(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int) column14:14(int!null) column15:15(int!null)
+      ├── project
+      │    ├── columns: column13:13(int) column14:14(int!null) column15:15(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    ├── scan abcde
+      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    └── projections
+      │         ├── cast: INT8 [type=int]
+      │         │    └── null [type=unknown]
+      │         ├── const: 1 [type=int]
+      │         └── const: 2 [type=int]
       └── projections
-           ├── null [type=unknown]
-           ├── const: 1 [type=int]
-           └── const: 2 [type=int]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── variable: column14 [type=int]
+                │    └── variable: column13 [type=int]
+                └── const: 1 [type=int]
 
 # Tuples + DEFAULT.
 build
@@ -719,15 +747,24 @@ update abcde
  ├── update-mapping:
  │    ├──  column13:13 => b:2
  │    ├──  column14:14 => c:3
- │    ├──  column13:13 => d:4
+ │    ├──  column15:15 => d:4
  │    └──  a:7 => e:5
  └── project
-      ├── columns: column13:13(unknown) column14:14(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
-      ├── scan abcde
-      │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      ├── columns: column15:15(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int) column14:14(int!null)
+      ├── project
+      │    ├── columns: column13:13(int) column14:14(int!null) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    ├── scan abcde
+      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    └── projections
+      │         ├── cast: INT8 [type=int]
+      │         │    └── null [type=unknown]
+      │         └── const: 10 [type=int]
       └── projections
-           ├── null [type=unknown]
-           └── const: 10 [type=int]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── variable: column13 [type=int]
+                │    └── variable: column14 [type=int]
+                └── const: 1 [type=int]
 
 # Tuples + non-null DEFAULT.
 build
@@ -739,14 +776,23 @@ update abcde
  ├── update-mapping:
  │    ├──  column13:13 => a:1
  │    ├──  column13:13 => b:2
- │    ├──  column13:13 => d:4
+ │    ├──  column14:14 => d:4
  │    └──  column13:13 => e:5
  └── project
-      ├── columns: column13:13(unknown) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
-      ├── scan abcde
-      │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      ├── columns: column14:14(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null) column13:13(int)
+      ├── project
+      │    ├── columns: column13:13(int) a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    ├── scan abcde
+      │    │    └── columns: a:7(int!null) b:8(int) c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    └── projections
+      │         └── cast: INT8 [type=int]
+      │              └── null [type=unknown]
       └── projections
-           └── null [type=unknown]
+           └── plus [type=int]
+                ├── plus [type=int]
+                │    ├── variable: column13 [type=int]
+                │    └── variable: c [type=int]
+                └── const: 1 [type=int]
 
 build
 UPDATE abcde SET (a, b)=(1, 2, 3)

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -710,9 +710,9 @@ upsert abc
  │    ├──  column14:14 => b:2
  │    └──  column15:15 => c:3
  └── project
-      ├── columns: column15:15(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(unknown) column14:14(int!null)
+      ├── columns: column15:15(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int!null)
       ├── project
-      │    ├── columns: column13:13(unknown) column14:14(int!null) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+      │    ├── columns: column13:13(int) column14:14(int!null) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    ├── left-join
       │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    │    ├── project
@@ -737,7 +737,8 @@ upsert abc
       │    │              ├── variable: column1 [type=int]
       │    │              └── variable: a [type=int]
       │    └── projections
-      │         ├── null [type=unknown]
+      │         ├── cast: INT8 [type=int]
+      │         │    └── null [type=unknown]
       │         └── const: 10 [type=int]
       └── projections
            └── plus [type=int]
@@ -822,15 +823,16 @@ upsert xyz
  │    ├──  column5:5 => y:2
  │    └──  column5:5 => z:3
  └── left-join
-      ├── columns: column1:4(int) column5:5(unknown) x:6(int) y:7(int) z:8(int)
+      ├── columns: column1:4(int) column5:5(int) x:6(int) y:7(int) z:8(int)
       ├── project
-      │    ├── columns: column5:5(unknown) column1:4(int)
+      │    ├── columns: column5:5(int) column1:4(int)
       │    ├── values
       │    │    ├── columns: column1:4(int)
       │    │    └── tuple [type=tuple{int}]
       │    │         └── const: 1 [type=int]
       │    └── projections
-      │         └── null [type=unknown]
+      │         └── cast: INT8 [type=int]
+      │              └── null [type=unknown]
       ├── scan xyz
       │    └── columns: x:6(int!null) y:7(int) z:8(int)
       └── filters

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -69,7 +69,8 @@ CREATE TABLE mutation (
     m INT PRIMARY KEY,
     n INT,
     "o:write-only" INT DEFAULT(10),
-    "p:write-only" INT AS (o + n) STORED
+    "p:write-only" INT AS (o + n) STORED,
+    "q:delete-only" INT
 )
 ----
 TABLE mutation
@@ -77,6 +78,7 @@ TABLE mutation
  ├── n int
  ├── o int
  ├── p int
+ ├── q int
  └── INDEX primary
       └── m int not null
 
@@ -94,130 +96,21 @@ UPDATE SET a=5
 upsert abc
  ├── columns: <none>
  ├── canary column: 13
- ├── fetch columns: a:10(int) b:11(int) c:12(int) rowid:13(int)
+ ├── fetch columns: a:10(int) upsert_b:17(int) c:12(int) upsert_rowid:19(int)
  ├── insert-mapping:
- │    ├──  x:5 => a:1
- │    ├──  y:6 => b:2
- │    ├──  column9:9 => c:3
- │    └──  column8:8 => rowid:4
+ │    ├──  upsert_a:16 => a:1
+ │    ├──  upsert_b:17 => b:2
+ │    ├──  upsert_c:18 => c:3
+ │    └──  upsert_rowid:19 => rowid:4
  ├── update-mapping:
- │    ├──  column14:14 => a:1
- │    └──  column15:15 => c:3
+ │    ├──  upsert_a:16 => a:1
+ │    └──  upsert_c:18 => c:3
  └── project
-      ├── columns: column15:15(int) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null)
+      ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_rowid:19(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
       ├── project
-      │    ├── columns: column14:14(int!null) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
-      │    ├── left-join
-      │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
-      │    │    ├── project
-      │    │    │    ├── columns: column9:9(int) x:5(int!null) y:6(int) column8:8(int)
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: x:5(int!null) y:6(int)
-      │    │    │    │    │    └── scan xyz
-      │    │    │    │    │         └── columns: x:5(int!null) y:6(int) z:7(int)
-      │    │    │    │    └── projections
-      │    │    │    │         └── function: unique_rowid [type=int]
-      │    │    │    └── projections
-      │    │    │         └── plus [type=int]
-      │    │    │              ├── variable: y [type=int]
-      │    │    │              └── const: 1 [type=int]
-      │    │    ├── scan abc
-      │    │    │    └── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
-      │    │    └── filters
-      │    │         └── eq [type=bool]
-      │    │              ├── variable: x [type=int]
-      │    │              └── variable: a [type=int]
-      │    └── projections
-      │         └── const: 5 [type=int]
-      └── projections
-           └── plus [type=int]
-                ├── variable: b [type=int]
-                └── const: 1 [type=int]
-
-# Set all columns, multi-column conflict.
-build
-INSERT INTO abc (a, b, rowid)
-SELECT x, y, z FROM xyz
-ON CONFLICT (b, c) DO
-UPDATE SET a=1, b=2, rowid=3
-RETURNING *
-----
-project
- ├── columns: a:1(int!null) b:2(int) c:3(int)
- └── upsert abc
-      ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
-      ├── canary column: 12
-      ├── fetch columns: a:9(int) b:10(int) c:11(int) rowid:12(int)
-      ├── insert-mapping:
-      │    ├──  x:5 => a:1
-      │    ├──  y:6 => b:2
-      │    ├──  column8:8 => c:3
-      │    └──  z:7 => rowid:4
-      ├── update-mapping:
-      │    ├──  column13:13 => a:1
-      │    ├──  column14:14 => b:2
-      │    ├──  column16:16 => c:3
-      │    └──  column15:15 => rowid:4
-      └── project
-           ├── columns: column16:16(int) x:5(int!null) y:6(int) z:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null) column14:14(int!null) column15:15(int!null)
-           ├── project
-           │    ├── columns: column13:13(int!null) column14:14(int!null) column15:15(int!null) x:5(int!null) y:6(int) z:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-           │    ├── left-join
-           │    │    ├── columns: x:5(int!null) y:6(int) z:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-           │    │    ├── project
-           │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int) z:7(int)
-           │    │    │    ├── scan xyz
-           │    │    │    │    └── columns: x:5(int!null) y:6(int) z:7(int)
-           │    │    │    └── projections
-           │    │    │         └── plus [type=int]
-           │    │    │              ├── variable: y [type=int]
-           │    │    │              └── const: 1 [type=int]
-           │    │    ├── scan abc
-           │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
-           │    │    └── filters
-           │    │         ├── eq [type=bool]
-           │    │         │    ├── variable: y [type=int]
-           │    │         │    └── variable: b [type=int]
-           │    │         └── eq [type=bool]
-           │    │              ├── variable: column8 [type=int]
-           │    │              └── variable: c [type=int]
-           │    └── projections
-           │         ├── const: 1 [type=int]
-           │         ├── const: 2 [type=int]
-           │         └── const: 3 [type=int]
-           └── projections
-                └── plus [type=int]
-                     ├── variable: column14 [type=int]
-                     └── const: 1 [type=int]
-
-# UPDATE + WHERE clause.
-build
-INSERT INTO abc
-SELECT x, y FROM xyz
-ON CONFLICT (a) DO
-UPDATE SET b=10
-WHERE abc.a>0
-----
-upsert abc
- ├── columns: <none>
- ├── canary column: 13
- ├── fetch columns: a:10(int) b:11(int) c:12(int) rowid:13(int)
- ├── insert-mapping:
- │    ├──  x:5 => a:1
- │    ├──  y:6 => b:2
- │    ├──  column9:9 => c:3
- │    └──  column8:8 => rowid:4
- ├── update-mapping:
- │    ├──  column14:14 => b:2
- │    └──  column15:15 => c:3
- └── project
-      ├── columns: column15:15(int) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null)
-      ├── project
-      │    ├── columns: column14:14(int!null) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
-      │    ├── select
-      │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+      │    ├── columns: column15:15(int) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null)
+      │    ├── project
+      │    │    ├── columns: column14:14(int!null) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
       │    │    ├── left-join
       │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
       │    │    │    ├── project
@@ -240,20 +133,234 @@ upsert abc
       │    │    │         └── eq [type=bool]
       │    │    │              ├── variable: x [type=int]
       │    │    │              └── variable: a [type=int]
-      │    │    └── filters
-      │    │         └── or [type=bool]
-      │    │              ├── is [type=bool]
-      │    │              │    ├── variable: rowid [type=int]
-      │    │              │    └── null [type=unknown]
-      │    │              └── gt [type=bool]
-      │    │                   ├── variable: a [type=int]
-      │    │                   └── const: 0 [type=int]
+      │    │    └── projections
+      │    │         └── const: 5 [type=int]
       │    └── projections
-      │         └── const: 10 [type=int]
+      │         └── plus [type=int]
+      │              ├── variable: b [type=int]
+      │              └── const: 1 [type=int]
       └── projections
-           └── plus [type=int]
-                ├── variable: column14 [type=int]
-                └── const: 1 [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: x [type=int]
+           │    └── variable: column14 [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: y [type=int]
+           │    └── variable: b [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column9 [type=int]
+           │    └── variable: column15 [type=int]
+           └── case [type=int]
+                ├── true [type=bool]
+                ├── when [type=int]
+                │    ├── is [type=bool]
+                │    │    ├── variable: rowid [type=int]
+                │    │    └── null [type=unknown]
+                │    └── variable: column8 [type=int]
+                └── variable: rowid [type=int]
+
+# Set all columns, multi-column conflict.
+build
+INSERT INTO abc (a, b, rowid)
+SELECT x, y, z FROM xyz
+ON CONFLICT (b, c) DO
+UPDATE SET a=1, b=2, rowid=3
+RETURNING *
+----
+project
+ ├── columns: a:1(int!null) b:2(int) c:3(int)
+ └── upsert abc
+      ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
+      ├── canary column: 12
+      ├── fetch columns: a:9(int) b:10(int) c:11(int) rowid:12(int)
+      ├── insert-mapping:
+      │    ├──  upsert_a:17 => a:1
+      │    ├──  upsert_b:18 => b:2
+      │    ├──  upsert_c:19 => c:3
+      │    └──  upsert_rowid:20 => rowid:4
+      ├── update-mapping:
+      │    ├──  upsert_a:17 => a:1
+      │    ├──  upsert_b:18 => b:2
+      │    ├──  upsert_c:19 => c:3
+      │    └──  upsert_rowid:20 => rowid:4
+      └── project
+           ├── columns: upsert_a:17(int) upsert_b:18(int) upsert_c:19(int) upsert_rowid:20(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+           ├── project
+           │    ├── columns: column16:16(int) x:5(int!null) y:6(int) z:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null) column14:14(int!null) column15:15(int!null)
+           │    ├── project
+           │    │    ├── columns: column13:13(int!null) column14:14(int!null) column15:15(int!null) x:5(int!null) y:6(int) z:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+           │    │    ├── left-join
+           │    │    │    ├── columns: x:5(int!null) y:6(int) z:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+           │    │    │    ├── project
+           │    │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int) z:7(int)
+           │    │    │    │    ├── scan xyz
+           │    │    │    │    │    └── columns: x:5(int!null) y:6(int) z:7(int)
+           │    │    │    │    └── projections
+           │    │    │    │         └── plus [type=int]
+           │    │    │    │              ├── variable: y [type=int]
+           │    │    │    │              └── const: 1 [type=int]
+           │    │    │    ├── scan abc
+           │    │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+           │    │    │    └── filters
+           │    │    │         ├── eq [type=bool]
+           │    │    │         │    ├── variable: y [type=int]
+           │    │    │         │    └── variable: b [type=int]
+           │    │    │         └── eq [type=bool]
+           │    │    │              ├── variable: column8 [type=int]
+           │    │    │              └── variable: c [type=int]
+           │    │    └── projections
+           │    │         ├── const: 1 [type=int]
+           │    │         ├── const: 2 [type=int]
+           │    │         └── const: 3 [type=int]
+           │    └── projections
+           │         └── plus [type=int]
+           │              ├── variable: column14 [type=int]
+           │              └── const: 1 [type=int]
+           └── projections
+                ├── case [type=int]
+                │    ├── true [type=bool]
+                │    ├── when [type=int]
+                │    │    ├── is [type=bool]
+                │    │    │    ├── variable: rowid [type=int]
+                │    │    │    └── null [type=unknown]
+                │    │    └── variable: x [type=int]
+                │    └── variable: column13 [type=int]
+                ├── case [type=int]
+                │    ├── true [type=bool]
+                │    ├── when [type=int]
+                │    │    ├── is [type=bool]
+                │    │    │    ├── variable: rowid [type=int]
+                │    │    │    └── null [type=unknown]
+                │    │    └── variable: y [type=int]
+                │    └── variable: column14 [type=int]
+                ├── case [type=int]
+                │    ├── true [type=bool]
+                │    ├── when [type=int]
+                │    │    ├── is [type=bool]
+                │    │    │    ├── variable: rowid [type=int]
+                │    │    │    └── null [type=unknown]
+                │    │    └── variable: column8 [type=int]
+                │    └── variable: column16 [type=int]
+                └── case [type=int]
+                     ├── true [type=bool]
+                     ├── when [type=int]
+                     │    ├── is [type=bool]
+                     │    │    ├── variable: rowid [type=int]
+                     │    │    └── null [type=unknown]
+                     │    └── variable: z [type=int]
+                     └── variable: column15 [type=int]
+
+# UPDATE + WHERE clause.
+build
+INSERT INTO abc
+SELECT x, y FROM xyz
+ON CONFLICT (a) DO
+UPDATE SET b=10
+WHERE abc.a>0
+----
+upsert abc
+ ├── columns: <none>
+ ├── canary column: 13
+ ├── fetch columns: upsert_a:16(int) b:11(int) c:12(int) upsert_rowid:19(int)
+ ├── insert-mapping:
+ │    ├──  upsert_a:16 => a:1
+ │    ├──  upsert_b:17 => b:2
+ │    ├──  upsert_c:18 => c:3
+ │    └──  upsert_rowid:19 => rowid:4
+ ├── update-mapping:
+ │    ├──  upsert_b:17 => b:2
+ │    └──  upsert_c:18 => c:3
+ └── project
+      ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_rowid:19(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+      ├── project
+      │    ├── columns: column15:15(int) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null)
+      │    ├── project
+      │    │    ├── columns: column14:14(int!null) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+      │    │    ├── select
+      │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+      │    │    │    ├── left-join
+      │    │    │    │    ├── columns: x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: column9:9(int) x:5(int!null) y:6(int) column8:8(int)
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: column8:8(int) x:5(int!null) y:6(int)
+      │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    ├── columns: x:5(int!null) y:6(int)
+      │    │    │    │    │    │    │    └── scan xyz
+      │    │    │    │    │    │    │         └── columns: x:5(int!null) y:6(int) z:7(int)
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── function: unique_rowid [type=int]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── plus [type=int]
+      │    │    │    │    │              ├── variable: y [type=int]
+      │    │    │    │    │              └── const: 1 [type=int]
+      │    │    │    │    ├── scan abc
+      │    │    │    │    │    └── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null)
+      │    │    │    │    └── filters
+      │    │    │    │         └── eq [type=bool]
+      │    │    │    │              ├── variable: x [type=int]
+      │    │    │    │              └── variable: a [type=int]
+      │    │    │    └── filters
+      │    │    │         └── or [type=bool]
+      │    │    │              ├── is [type=bool]
+      │    │    │              │    ├── variable: rowid [type=int]
+      │    │    │              │    └── null [type=unknown]
+      │    │    │              └── gt [type=bool]
+      │    │    │                   ├── variable: a [type=int]
+      │    │    │                   └── const: 0 [type=int]
+      │    │    └── projections
+      │    │         └── const: 10 [type=int]
+      │    └── projections
+      │         └── plus [type=int]
+      │              ├── variable: column14 [type=int]
+      │              └── const: 1 [type=int]
+      └── projections
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: x [type=int]
+           │    └── variable: a [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: y [type=int]
+           │    └── variable: column14 [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column9 [type=int]
+           │    └── variable: column15 [type=int]
+           └── case [type=int]
+                ├── true [type=bool]
+                ├── when [type=int]
+                │    ├── is [type=bool]
+                │    │    ├── variable: rowid [type=int]
+                │    │    └── null [type=unknown]
+                │    └── variable: column8 [type=int]
+                └── variable: rowid [type=int]
 
 # Use RETURNING INSERT..ON CONFLICT as a FROM clause.
 build
@@ -269,51 +376,86 @@ sort
       └── upsert abc
            ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
            ├── canary column: 12
-           ├── fetch columns: a:9(int) b:10(int) c:11(int) rowid:12(int)
+           ├── fetch columns: upsert_a:15(int) b:10(int) c:11(int) upsert_rowid:18(int)
            ├── insert-mapping:
-           │    ├──  column1:5 => a:1
-           │    ├──  column2:6 => b:2
-           │    ├──  column8:8 => c:3
-           │    └──  column7:7 => rowid:4
+           │    ├──  upsert_a:15 => a:1
+           │    ├──  upsert_b:16 => b:2
+           │    ├──  upsert_c:17 => c:3
+           │    └──  upsert_rowid:18 => rowid:4
            ├── update-mapping:
-           │    ├──  column13:13 => b:2
-           │    └──  column14:14 => c:3
+           │    ├──  upsert_b:16 => b:2
+           │    └──  upsert_c:17 => c:3
            └── project
-                ├── columns: column14:14(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null)
+                ├── columns: upsert_a:15(int) upsert_b:16(int) upsert_c:17(int) upsert_rowid:18(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
                 ├── project
-                │    ├── columns: column13:13(int!null) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-                │    ├── left-join
-                │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-                │    │    ├── project
-                │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+                │    ├── columns: column14:14(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null)
+                │    ├── project
+                │    │    ├── columns: column13:13(int!null) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+                │    │    ├── left-join
+                │    │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
                 │    │    │    ├── project
-                │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
-                │    │    │    │    ├── values
-                │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
-                │    │    │    │    │    ├── tuple [type=tuple{int, int}]
-                │    │    │    │    │    │    ├── const: 1 [type=int]
-                │    │    │    │    │    │    └── const: 2 [type=int]
-                │    │    │    │    │    └── tuple [type=tuple{int, int}]
-                │    │    │    │    │         ├── const: 3 [type=int]
-                │    │    │    │    │         └── const: 4 [type=int]
+                │    │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+                │    │    │    │    ├── project
+                │    │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+                │    │    │    │    │    ├── values
+                │    │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+                │    │    │    │    │    │    ├── tuple [type=tuple{int, int}]
+                │    │    │    │    │    │    │    ├── const: 1 [type=int]
+                │    │    │    │    │    │    │    └── const: 2 [type=int]
+                │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
+                │    │    │    │    │    │         ├── const: 3 [type=int]
+                │    │    │    │    │    │         └── const: 4 [type=int]
+                │    │    │    │    │    └── projections
+                │    │    │    │    │         └── function: unique_rowid [type=int]
                 │    │    │    │    └── projections
-                │    │    │    │         └── function: unique_rowid [type=int]
-                │    │    │    └── projections
-                │    │    │         └── plus [type=int]
-                │    │    │              ├── variable: column2 [type=int]
-                │    │    │              └── const: 1 [type=int]
-                │    │    ├── scan abc
-                │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
-                │    │    └── filters
-                │    │         └── eq [type=bool]
-                │    │              ├── variable: column1 [type=int]
-                │    │              └── variable: a [type=int]
+                │    │    │    │         └── plus [type=int]
+                │    │    │    │              ├── variable: column2 [type=int]
+                │    │    │    │              └── const: 1 [type=int]
+                │    │    │    ├── scan abc
+                │    │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+                │    │    │    └── filters
+                │    │    │         └── eq [type=bool]
+                │    │    │              ├── variable: column1 [type=int]
+                │    │    │              └── variable: a [type=int]
+                │    │    └── projections
+                │    │         └── const: 1 [type=int]
                 │    └── projections
-                │         └── const: 1 [type=int]
+                │         └── plus [type=int]
+                │              ├── variable: column13 [type=int]
+                │              └── const: 1 [type=int]
                 └── projections
-                     └── plus [type=int]
-                          ├── variable: column13 [type=int]
-                          └── const: 1 [type=int]
+                     ├── case [type=int]
+                     │    ├── true [type=bool]
+                     │    ├── when [type=int]
+                     │    │    ├── is [type=bool]
+                     │    │    │    ├── variable: rowid [type=int]
+                     │    │    │    └── null [type=unknown]
+                     │    │    └── variable: column1 [type=int]
+                     │    └── variable: a [type=int]
+                     ├── case [type=int]
+                     │    ├── true [type=bool]
+                     │    ├── when [type=int]
+                     │    │    ├── is [type=bool]
+                     │    │    │    ├── variable: rowid [type=int]
+                     │    │    │    └── null [type=unknown]
+                     │    │    └── variable: column2 [type=int]
+                     │    └── variable: column13 [type=int]
+                     ├── case [type=int]
+                     │    ├── true [type=bool]
+                     │    ├── when [type=int]
+                     │    │    ├── is [type=bool]
+                     │    │    │    ├── variable: rowid [type=int]
+                     │    │    │    └── null [type=unknown]
+                     │    │    └── variable: column8 [type=int]
+                     │    └── variable: column14 [type=int]
+                     └── case [type=int]
+                          ├── true [type=bool]
+                          ├── when [type=int]
+                          │    ├── is [type=bool]
+                          │    │    ├── variable: rowid [type=int]
+                          │    │    └── null [type=unknown]
+                          │    └── variable: column7 [type=int]
+                          └── variable: rowid [type=int]
 
 # Use table alias.
 build
@@ -325,50 +467,85 @@ UPDATE SET a=tab.a*excluded.a
 upsert tab
  ├── columns: <none>
  ├── canary column: 12
- ├── fetch columns: a:9(int) b:10(int) c:11(int) rowid:12(int)
+ ├── fetch columns: a:9(int) upsert_b:16(int) c:11(int) upsert_rowid:18(int)
  ├── insert-mapping:
- │    ├──  column1:5 => a:1
- │    ├──  column2:6 => b:2
- │    ├──  column8:8 => c:3
- │    └──  column7:7 => rowid:4
+ │    ├──  upsert_a:15 => a:1
+ │    ├──  upsert_b:16 => b:2
+ │    ├──  upsert_c:17 => c:3
+ │    └──  upsert_rowid:18 => rowid:4
  ├── update-mapping:
- │    ├──  column13:13 => a:1
- │    └──  column14:14 => c:3
+ │    ├──  upsert_a:15 => a:1
+ │    └──  upsert_c:17 => c:3
  └── project
-      ├── columns: column14:14(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int)
+      ├── columns: upsert_a:15(int) upsert_b:16(int) upsert_c:17(int) upsert_rowid:18(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       ├── project
-      │    ├── columns: column13:13(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-      │    ├── left-join
-      │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-      │    │    ├── project
-      │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      │    ├── columns: column14:14(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int)
+      │    ├── project
+      │    │    ├── columns: column13:13(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+      │    │    ├── left-join
+      │    │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
-      │    │    │    │    ├── values
-      │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
-      │    │    │    │    │    └── tuple [type=tuple{int, int}]
-      │    │    │    │    │         ├── const: 1 [type=int]
-      │    │    │    │    │         └── const: 2 [type=int]
+      │    │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+      │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
+      │    │    │    │    │    │         ├── const: 1 [type=int]
+      │    │    │    │    │    │         └── const: 2 [type=int]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── function: unique_rowid [type=int]
       │    │    │    │    └── projections
-      │    │    │    │         └── function: unique_rowid [type=int]
-      │    │    │    └── projections
-      │    │    │         └── plus [type=int]
-      │    │    │              ├── variable: column2 [type=int]
-      │    │    │              └── const: 1 [type=int]
-      │    │    ├── scan tab
-      │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
-      │    │    └── filters
-      │    │         └── eq [type=bool]
-      │    │              ├── variable: column1 [type=int]
-      │    │              └── variable: a [type=int]
+      │    │    │    │         └── plus [type=int]
+      │    │    │    │              ├── variable: column2 [type=int]
+      │    │    │    │              └── const: 1 [type=int]
+      │    │    │    ├── scan tab
+      │    │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+      │    │    │    └── filters
+      │    │    │         └── eq [type=bool]
+      │    │    │              ├── variable: column1 [type=int]
+      │    │    │              └── variable: a [type=int]
+      │    │    └── projections
+      │    │         └── mult [type=int]
+      │    │              ├── variable: a [type=int]
+      │    │              └── variable: column1 [type=int]
       │    └── projections
-      │         └── mult [type=int]
-      │              ├── variable: a [type=int]
-      │              └── variable: column1 [type=int]
+      │         └── plus [type=int]
+      │              ├── variable: b [type=int]
+      │              └── const: 1 [type=int]
       └── projections
-           └── plus [type=int]
-                ├── variable: b [type=int]
-                └── const: 1 [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column1 [type=int]
+           │    └── variable: column13 [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column2 [type=int]
+           │    └── variable: b [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column8 [type=int]
+           │    └── variable: column14 [type=int]
+           └── case [type=int]
+                ├── true [type=bool]
+                ├── when [type=int]
+                │    ├── is [type=bool]
+                │    │    ├── variable: rowid [type=int]
+                │    │    └── null [type=unknown]
+                │    └── variable: column7 [type=int]
+                └── variable: rowid [type=int]
 
 # Conflict columns don't match unique index (too few columns).
 build
@@ -533,62 +710,89 @@ WHERE excluded.y>xyz.y
 RETURNING xyz.x*2, y+z
 ----
 project
- ├── columns: "?column?":13(int) "?column?":14(int)
+ ├── columns: "?column?":16(int) "?column?":17(int)
  ├── upsert xyz
  │    ├── columns: x:1(int!null) y:2(int) z:3(int)
  │    ├── canary column: 7
  │    ├── fetch columns: x:7(int) y:8(int) z:9(int)
  │    ├── insert-mapping:
- │    │    ├──  column1:4 => x:1
- │    │    ├──  column2:5 => y:2
- │    │    └──  column3:6 => z:3
+ │    │    ├──  upsert_x:13 => x:1
+ │    │    ├──  upsert_y:14 => y:2
+ │    │    └──  upsert_z:15 => z:3
  │    ├── update-mapping:
- │    │    ├──  column10:10 => x:1
- │    │    ├──  column11:11 => y:2
- │    │    └──  column12:12 => z:3
+ │    │    ├──  upsert_x:13 => x:1
+ │    │    ├──  upsert_y:14 => y:2
+ │    │    └──  upsert_z:15 => z:3
  │    └── project
- │         ├── columns: column10:10(int) column11:11(int) column12:12(int) column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
- │         ├── select
- │         │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
- │         │    ├── left-join
+ │         ├── columns: upsert_x:13(int) upsert_y:14(int) upsert_z:15(int) x:7(int) y:8(int) z:9(int)
+ │         ├── project
+ │         │    ├── columns: column10:10(int) column11:11(int) column12:12(int) column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+ │         │    ├── select
  │         │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
- │         │    │    ├── values
- │         │    │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
- │         │    │    │    ├── tuple [type=tuple{int, int, int}]
- │         │    │    │    │    ├── const: 1 [type=int]
- │         │    │    │    │    ├── const: 2 [type=int]
- │         │    │    │    │    └── const: 3 [type=int]
- │         │    │    │    └── tuple [type=tuple{int, int, int}]
- │         │    │    │         ├── const: -1 [type=int]
- │         │    │    │         ├── const: -1 [type=int]
- │         │    │    │         └── const: -1 [type=int]
- │         │    │    ├── scan xyz
- │         │    │    │    └── columns: x:7(int!null) y:8(int) z:9(int)
+ │         │    │    ├── left-join
+ │         │    │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+ │         │    │    │    ├── values
+ │         │    │    │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
+ │         │    │    │    │    ├── tuple [type=tuple{int, int, int}]
+ │         │    │    │    │    │    ├── const: 1 [type=int]
+ │         │    │    │    │    │    ├── const: 2 [type=int]
+ │         │    │    │    │    │    └── const: 3 [type=int]
+ │         │    │    │    │    └── tuple [type=tuple{int, int, int}]
+ │         │    │    │    │         ├── const: -1 [type=int]
+ │         │    │    │    │         ├── const: -1 [type=int]
+ │         │    │    │    │         └── const: -1 [type=int]
+ │         │    │    │    ├── scan xyz
+ │         │    │    │    │    └── columns: x:7(int!null) y:8(int) z:9(int)
+ │         │    │    │    └── filters
+ │         │    │    │         ├── eq [type=bool]
+ │         │    │    │         │    ├── variable: column3 [type=int]
+ │         │    │    │         │    └── variable: z [type=int]
+ │         │    │    │         └── eq [type=bool]
+ │         │    │    │              ├── variable: column2 [type=int]
+ │         │    │    │              └── variable: y [type=int]
  │         │    │    └── filters
- │         │    │         ├── eq [type=bool]
- │         │    │         │    ├── variable: column3 [type=int]
- │         │    │         │    └── variable: z [type=int]
- │         │    │         └── eq [type=bool]
- │         │    │              ├── variable: column2 [type=int]
- │         │    │              └── variable: y [type=int]
- │         │    └── filters
- │         │         └── or [type=bool]
- │         │              ├── is [type=bool]
- │         │              │    ├── variable: x [type=int]
- │         │              │    └── null [type=unknown]
- │         │              └── gt [type=bool]
- │         │                   ├── variable: column2 [type=int]
- │         │                   └── variable: y [type=int]
+ │         │    │         └── or [type=bool]
+ │         │    │              ├── is [type=bool]
+ │         │    │              │    ├── variable: x [type=int]
+ │         │    │              │    └── null [type=unknown]
+ │         │    │              └── gt [type=bool]
+ │         │    │                   ├── variable: column2 [type=int]
+ │         │    │                   └── variable: y [type=int]
+ │         │    └── projections
+ │         │         ├── plus [type=int]
+ │         │         │    ├── variable: column1 [type=int]
+ │         │         │    └── const: 1 [type=int]
+ │         │         ├── mult [type=int]
+ │         │         │    ├── variable: column2 [type=int]
+ │         │         │    └── variable: y [type=int]
+ │         │         └── minus [type=int]
+ │         │              ├── variable: column1 [type=int]
+ │         │              └── variable: column3 [type=int]
  │         └── projections
- │              ├── plus [type=int]
- │              │    ├── variable: column1 [type=int]
- │              │    └── const: 1 [type=int]
- │              ├── mult [type=int]
- │              │    ├── variable: column2 [type=int]
- │              │    └── variable: y [type=int]
- │              └── minus [type=int]
- │                   ├── variable: column1 [type=int]
- │                   └── variable: column3 [type=int]
+ │              ├── case [type=int]
+ │              │    ├── true [type=bool]
+ │              │    ├── when [type=int]
+ │              │    │    ├── is [type=bool]
+ │              │    │    │    ├── variable: x [type=int]
+ │              │    │    │    └── null [type=unknown]
+ │              │    │    └── variable: column1 [type=int]
+ │              │    └── variable: column10 [type=int]
+ │              ├── case [type=int]
+ │              │    ├── true [type=bool]
+ │              │    ├── when [type=int]
+ │              │    │    ├── is [type=bool]
+ │              │    │    │    ├── variable: x [type=int]
+ │              │    │    │    └── null [type=unknown]
+ │              │    │    └── variable: column2 [type=int]
+ │              │    └── variable: column11 [type=int]
+ │              └── case [type=int]
+ │                   ├── true [type=bool]
+ │                   ├── when [type=int]
+ │                   │    ├── is [type=bool]
+ │                   │    │    ├── variable: x [type=int]
+ │                   │    │    └── null [type=unknown]
+ │                   │    └── variable: column3 [type=int]
+ │                   └── variable: column12 [type=int]
  └── projections
       ├── mult [type=int]
       │    ├── variable: x [type=int]
@@ -630,64 +834,99 @@ UPDATE SET (b, a)=(SELECT x, y+excluded.b FROM xyz WHERE x=excluded.a)
 upsert abc
  ├── columns: <none>
  ├── canary column: 12
- ├── fetch columns: a:9(int) b:10(int) c:11(int) rowid:12(int)
+ ├── fetch columns: a:9(int) b:10(int) c:11(int) upsert_rowid:21(int)
  ├── insert-mapping:
- │    ├──  column1:5 => a:1
- │    ├──  column2:6 => b:2
- │    ├──  column8:8 => c:3
- │    └──  column7:7 => rowid:4
+ │    ├──  upsert_a:18 => a:1
+ │    ├──  upsert_b:19 => b:2
+ │    ├──  upsert_c:20 => c:3
+ │    └──  upsert_rowid:21 => rowid:4
  ├── update-mapping:
- │    ├──  "?column?":16 => a:1
- │    ├──  x:13 => b:2
- │    └──  column17:17 => c:3
+ │    ├──  upsert_a:18 => a:1
+ │    ├──  upsert_b:19 => b:2
+ │    └──  upsert_c:20 => c:3
  └── project
-      ├── columns: column17:17(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int)
-      ├── left-join-apply
-      │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int)
-      │    ├── left-join
-      │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-      │    │    ├── project
-      │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      ├── columns: upsert_a:18(int) upsert_b:19(int) upsert_c:20(int) upsert_rowid:21(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+      ├── project
+      │    ├── columns: column17:17(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int)
+      │    ├── left-join-apply
+      │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int)
+      │    │    ├── left-join
+      │    │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
-      │    │    │    │    ├── values
-      │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
-      │    │    │    │    │    └── tuple [type=tuple{int, int}]
-      │    │    │    │    │         ├── const: 1 [type=int]
-      │    │    │    │    │         └── const: 2 [type=int]
+      │    │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+      │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
+      │    │    │    │    │    │         ├── const: 1 [type=int]
+      │    │    │    │    │    │         └── const: 2 [type=int]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── function: unique_rowid [type=int]
       │    │    │    │    └── projections
-      │    │    │    │         └── function: unique_rowid [type=int]
-      │    │    │    └── projections
-      │    │    │         └── plus [type=int]
-      │    │    │              ├── variable: column2 [type=int]
-      │    │    │              └── const: 1 [type=int]
-      │    │    ├── scan abc
-      │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
-      │    │    └── filters
-      │    │         └── eq [type=bool]
-      │    │              ├── variable: column1 [type=int]
-      │    │              └── variable: a [type=int]
-      │    ├── max1-row
-      │    │    ├── columns: x:13(int!null) "?column?":16(int)
-      │    │    └── project
-      │    │         ├── columns: "?column?":16(int) x:13(int!null)
-      │    │         ├── select
-      │    │         │    ├── columns: x:13(int!null) y:14(int) z:15(int)
-      │    │         │    ├── scan xyz
-      │    │         │    │    └── columns: x:13(int!null) y:14(int) z:15(int)
-      │    │         │    └── filters
-      │    │         │         └── eq [type=bool]
-      │    │         │              ├── variable: x [type=int]
-      │    │         │              └── variable: column1 [type=int]
-      │    │         └── projections
-      │    │              └── plus [type=int]
-      │    │                   ├── variable: y [type=int]
-      │    │                   └── variable: column2 [type=int]
-      │    └── filters (true)
+      │    │    │    │         └── plus [type=int]
+      │    │    │    │              ├── variable: column2 [type=int]
+      │    │    │    │              └── const: 1 [type=int]
+      │    │    │    ├── scan abc
+      │    │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+      │    │    │    └── filters
+      │    │    │         └── eq [type=bool]
+      │    │    │              ├── variable: column1 [type=int]
+      │    │    │              └── variable: a [type=int]
+      │    │    ├── max1-row
+      │    │    │    ├── columns: x:13(int!null) "?column?":16(int)
+      │    │    │    └── project
+      │    │    │         ├── columns: "?column?":16(int) x:13(int!null)
+      │    │    │         ├── select
+      │    │    │         │    ├── columns: x:13(int!null) y:14(int) z:15(int)
+      │    │    │         │    ├── scan xyz
+      │    │    │         │    │    └── columns: x:13(int!null) y:14(int) z:15(int)
+      │    │    │         │    └── filters
+      │    │    │         │         └── eq [type=bool]
+      │    │    │         │              ├── variable: x [type=int]
+      │    │    │         │              └── variable: column1 [type=int]
+      │    │    │         └── projections
+      │    │    │              └── plus [type=int]
+      │    │    │                   ├── variable: y [type=int]
+      │    │    │                   └── variable: column2 [type=int]
+      │    │    └── filters (true)
+      │    └── projections
+      │         └── plus [type=int]
+      │              ├── variable: x [type=int]
+      │              └── const: 1 [type=int]
       └── projections
-           └── plus [type=int]
-                ├── variable: x [type=int]
-                └── const: 1 [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column1 [type=int]
+           │    └── variable: ?column? [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column2 [type=int]
+           │    └── variable: x [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column8 [type=int]
+           │    └── variable: column17 [type=int]
+           └── case [type=int]
+                ├── true [type=bool]
+                ├── when [type=int]
+                │    ├── is [type=bool]
+                │    │    ├── variable: rowid [type=int]
+                │    │    └── null [type=unknown]
+                │    └── variable: column7 [type=int]
+                └── variable: rowid [type=int]
 
 # Default expressions.
 build
@@ -699,51 +938,86 @@ UPDATE SET a=DEFAULT, b=DEFAULT
 upsert abc
  ├── columns: <none>
  ├── canary column: 12
- ├── fetch columns: a:9(int) b:10(int) c:11(int) rowid:12(int)
+ ├── fetch columns: a:9(int) b:10(int) c:11(int) upsert_rowid:19(int)
  ├── insert-mapping:
- │    ├──  column1:5 => a:1
- │    ├──  column2:6 => b:2
- │    ├──  column8:8 => c:3
- │    └──  column7:7 => rowid:4
+ │    ├──  upsert_a:16 => a:1
+ │    ├──  upsert_b:17 => b:2
+ │    ├──  upsert_c:18 => c:3
+ │    └──  upsert_rowid:19 => rowid:4
  ├── update-mapping:
- │    ├──  column13:13 => a:1
- │    ├──  column14:14 => b:2
- │    └──  column15:15 => c:3
+ │    ├──  upsert_a:16 => a:1
+ │    ├──  upsert_b:17 => b:2
+ │    └──  upsert_c:18 => c:3
  └── project
-      ├── columns: column15:15(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int!null)
+      ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_rowid:19(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       ├── project
-      │    ├── columns: column13:13(int) column14:14(int!null) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-      │    ├── left-join
-      │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-      │    │    ├── project
-      │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      │    ├── columns: column15:15(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int!null)
+      │    ├── project
+      │    │    ├── columns: column13:13(int) column14:14(int!null) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+      │    │    ├── left-join
+      │    │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
-      │    │    │    │    ├── values
-      │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
-      │    │    │    │    │    └── tuple [type=tuple{int, int}]
-      │    │    │    │    │         ├── const: 1 [type=int]
-      │    │    │    │    │         └── const: 2 [type=int]
+      │    │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+      │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
+      │    │    │    │    │    │         ├── const: 1 [type=int]
+      │    │    │    │    │    │         └── const: 2 [type=int]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── function: unique_rowid [type=int]
       │    │    │    │    └── projections
-      │    │    │    │         └── function: unique_rowid [type=int]
-      │    │    │    └── projections
-      │    │    │         └── plus [type=int]
-      │    │    │              ├── variable: column2 [type=int]
-      │    │    │              └── const: 1 [type=int]
-      │    │    ├── scan abc
-      │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
-      │    │    └── filters
-      │    │         └── eq [type=bool]
-      │    │              ├── variable: column1 [type=int]
-      │    │              └── variable: a [type=int]
+      │    │    │    │         └── plus [type=int]
+      │    │    │    │              ├── variable: column2 [type=int]
+      │    │    │    │              └── const: 1 [type=int]
+      │    │    │    ├── scan abc
+      │    │    │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+      │    │    │    └── filters
+      │    │    │         └── eq [type=bool]
+      │    │    │              ├── variable: column1 [type=int]
+      │    │    │              └── variable: a [type=int]
+      │    │    └── projections
+      │    │         ├── cast: INT8 [type=int]
+      │    │         │    └── null [type=unknown]
+      │    │         └── const: 10 [type=int]
       │    └── projections
-      │         ├── cast: INT8 [type=int]
-      │         │    └── null [type=unknown]
-      │         └── const: 10 [type=int]
+      │         └── plus [type=int]
+      │              ├── variable: column14 [type=int]
+      │              └── const: 1 [type=int]
       └── projections
-           └── plus [type=int]
-                ├── variable: column14 [type=int]
-                └── const: 1 [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column1 [type=int]
+           │    └── variable: column13 [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column2 [type=int]
+           │    └── variable: column14 [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: rowid [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column8 [type=int]
+           │    └── variable: column15 [type=int]
+           └── case [type=int]
+                ├── true [type=bool]
+                ├── when [type=int]
+                │    ├── is [type=bool]
+                │    │    ├── variable: rowid [type=int]
+                │    │    └── null [type=unknown]
+                │    └── variable: column7 [type=int]
+                └── variable: rowid [type=int]
 
 # ------------------------------------------------------------------------------
 # Test mutation columns.
@@ -757,51 +1031,86 @@ UPDATE SET m=mutation.m+1
 ----
 upsert mutation
  ├── columns: <none>
- ├── canary column: 9
- ├── fetch columns: m:9(int) n:10(int) o:11(int) p:12(int)
+ ├── canary column: 10
+ ├── fetch columns: m:10(int) upsert_n:18(int) upsert_o:19(int) p:13(int) q:14(int)
  ├── insert-mapping:
- │    ├──  column1:5 => m:1
- │    ├──  column2:6 => n:2
- │    ├──  column7:7 => o:3
- │    └──  column8:8 => p:4
+ │    ├──  upsert_m:17 => m:1
+ │    ├──  upsert_n:18 => n:2
+ │    ├──  upsert_o:19 => o:3
+ │    └──  upsert_p:20 => p:4
  ├── update-mapping:
- │    ├──  column13:13 => m:1
- │    └──  column14:14 => p:4
+ │    ├──  upsert_m:17 => m:1
+ │    └──  upsert_p:20 => p:4
  └── project
-      ├── columns: column14:14(int) column1:5(int) column2:6(int) column7:7(int!null) column8:8(int) m:9(int) n:10(int) o:11(int) p:12(int) column13:13(int)
+      ├── columns: upsert_m:17(int) upsert_n:18(int) upsert_o:19(int) upsert_p:20(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       ├── project
-      │    ├── columns: column13:13(int) column1:5(int) column2:6(int) column7:7(int!null) column8:8(int) m:9(int) n:10(int) o:11(int) p:12(int)
-      │    ├── left-join
-      │    │    ├── columns: column1:5(int) column2:6(int) column7:7(int!null) column8:8(int) m:9(int) n:10(int) o:11(int) p:12(int)
-      │    │    ├── project
-      │    │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int!null)
+      │    ├── columns: column16:16(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
+      │    ├── project
+      │    │    ├── columns: column15:15(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    ├── left-join
+      │    │    │    ├── columns: column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column7:7(int!null) column1:5(int) column2:6(int)
-      │    │    │    │    ├── values
-      │    │    │    │    │    ├── columns: column1:5(int) column2:6(int)
-      │    │    │    │    │    └── tuple [type=tuple{int, int}]
-      │    │    │    │    │         ├── const: 1 [type=int]
-      │    │    │    │    │         └── const: 2 [type=int]
+      │    │    │    │    ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: column8:8(int!null) column1:6(int) column2:7(int)
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:6(int) column2:7(int)
+      │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
+      │    │    │    │    │    │         ├── const: 1 [type=int]
+      │    │    │    │    │    │         └── const: 2 [type=int]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── const: 10 [type=int]
       │    │    │    │    └── projections
-      │    │    │    │         └── const: 10 [type=int]
-      │    │    │    └── projections
-      │    │    │         └── plus [type=int]
-      │    │    │              ├── variable: column7 [type=int]
-      │    │    │              └── variable: column2 [type=int]
-      │    │    ├── scan mutation
-      │    │    │    └── columns: m:9(int!null) n:10(int) o:11(int) p:12(int)
-      │    │    └── filters
-      │    │         └── eq [type=bool]
-      │    │              ├── variable: column1 [type=int]
-      │    │              └── variable: m [type=int]
+      │    │    │    │         └── plus [type=int]
+      │    │    │    │              ├── variable: column8 [type=int]
+      │    │    │    │              └── variable: column2 [type=int]
+      │    │    │    ├── scan mutation
+      │    │    │    │    └── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    └── filters
+      │    │    │         └── eq [type=bool]
+      │    │    │              ├── variable: column1 [type=int]
+      │    │    │              └── variable: m [type=int]
+      │    │    └── projections
+      │    │         └── plus [type=int]
+      │    │              ├── variable: m [type=int]
+      │    │              └── const: 1 [type=int]
       │    └── projections
       │         └── plus [type=int]
-      │              ├── variable: m [type=int]
-      │              └── const: 1 [type=int]
+      │              ├── variable: o [type=int]
+      │              └── variable: n [type=int]
       └── projections
-           └── plus [type=int]
-                ├── variable: o [type=int]
-                └── variable: n [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: m [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column1 [type=int]
+           │    └── variable: column15 [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: m [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column2 [type=int]
+           │    └── variable: n [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: m [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column8 [type=int]
+           │    └── variable: o [type=int]
+           └── case [type=int]
+                ├── true [type=bool]
+                ├── when [type=int]
+                │    ├── is [type=bool]
+                │    │    ├── variable: m [type=int]
+                │    │    └── null [type=unknown]
+                │    └── variable: column9 [type=int]
+                └── variable: column16 [type=int]
 
 # ------------------------------------------------------------------------------
 # Test UPSERT.
@@ -814,31 +1123,58 @@ UPSERT INTO xyz VALUES (1)
 upsert xyz
  ├── columns: <none>
  ├── canary column: 6
- ├── fetch columns: x:6(int) y:7(int) z:8(int)
+ ├── fetch columns: upsert_x:9(int) y:7(int) z:8(int)
  ├── insert-mapping:
- │    ├──  column1:4 => x:1
- │    ├──  column5:5 => y:2
- │    └──  column5:5 => z:3
+ │    ├──  upsert_x:9 => x:1
+ │    ├──  upsert_y:10 => y:2
+ │    └──  upsert_z:11 => z:3
  ├── update-mapping:
- │    ├──  column5:5 => y:2
- │    └──  column5:5 => z:3
- └── left-join
-      ├── columns: column1:4(int) column5:5(int) x:6(int) y:7(int) z:8(int)
-      ├── project
-      │    ├── columns: column5:5(int) column1:4(int)
-      │    ├── values
-      │    │    ├── columns: column1:4(int)
-      │    │    └── tuple [type=tuple{int}]
-      │    │         └── const: 1 [type=int]
-      │    └── projections
-      │         └── cast: INT8 [type=int]
-      │              └── null [type=unknown]
-      ├── scan xyz
-      │    └── columns: x:6(int!null) y:7(int) z:8(int)
-      └── filters
-           └── eq [type=bool]
-                ├── variable: column1 [type=int]
-                └── variable: x [type=int]
+ │    ├──  upsert_y:10 => y:2
+ │    └──  upsert_z:11 => z:3
+ └── project
+      ├── columns: upsert_x:9(int) upsert_y:10(int) upsert_z:11(int) x:6(int) y:7(int) z:8(int)
+      ├── left-join
+      │    ├── columns: column1:4(int) column5:5(int) x:6(int) y:7(int) z:8(int)
+      │    ├── project
+      │    │    ├── columns: column5:5(int) column1:4(int)
+      │    │    ├── values
+      │    │    │    ├── columns: column1:4(int)
+      │    │    │    └── tuple [type=tuple{int}]
+      │    │    │         └── const: 1 [type=int]
+      │    │    └── projections
+      │    │         └── cast: INT8 [type=int]
+      │    │              └── null [type=unknown]
+      │    ├── scan xyz
+      │    │    └── columns: x:6(int!null) y:7(int) z:8(int)
+      │    └── filters
+      │         └── eq [type=bool]
+      │              ├── variable: column1 [type=int]
+      │              └── variable: x [type=int]
+      └── projections
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: x [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column1 [type=int]
+           │    └── variable: x [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: x [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column5 [type=int]
+           │    └── variable: column5 [type=int]
+           └── case [type=int]
+                ├── true [type=bool]
+                ├── when [type=int]
+                │    ├── is [type=bool]
+                │    │    ├── variable: x [type=int]
+                │    │    └── null [type=unknown]
+                │    └── variable: column5 [type=int]
+                └── variable: column5 [type=int]
 
 # Test multi-column primary key that contains all columns in table.
 build
@@ -847,26 +1183,45 @@ UPSERT INTO uv VALUES (1, 2) RETURNING *
 upsert uv
  ├── columns: u:1(int!null) v:2(int!null)
  ├── canary column: 5
- ├── fetch columns: u:5(int) v:6(int)
+ ├── fetch columns: upsert_u:7(int) upsert_v:8(int)
  ├── insert-mapping:
- │    ├──  column1:3 => u:1
- │    └──  column2:4 => v:2
+ │    ├──  upsert_u:7 => u:1
+ │    └──  upsert_v:8 => v:2
  ├── update-mapping:
- └── left-join
-      ├── columns: column1:3(int) column2:4(int) u:5(int) v:6(int)
-      ├── values
-      │    ├── columns: column1:3(int) column2:4(int)
-      │    └── tuple [type=tuple{int, int}]
-      │         ├── const: 1 [type=int]
-      │         └── const: 2 [type=int]
-      ├── scan uv
-      │    └── columns: u:5(int!null) v:6(int!null)
-      └── filters
-           ├── eq [type=bool]
-           │    ├── variable: column1 [type=int]
+ └── project
+      ├── columns: upsert_u:7(int) upsert_v:8(int) u:5(int) v:6(int)
+      ├── left-join
+      │    ├── columns: column1:3(int) column2:4(int) u:5(int) v:6(int)
+      │    ├── values
+      │    │    ├── columns: column1:3(int) column2:4(int)
+      │    │    └── tuple [type=tuple{int, int}]
+      │    │         ├── const: 1 [type=int]
+      │    │         └── const: 2 [type=int]
+      │    ├── scan uv
+      │    │    └── columns: u:5(int!null) v:6(int!null)
+      │    └── filters
+      │         ├── eq [type=bool]
+      │         │    ├── variable: column1 [type=int]
+      │         │    └── variable: u [type=int]
+      │         └── eq [type=bool]
+      │              ├── variable: column2 [type=int]
+      │              └── variable: v [type=int]
+      └── projections
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: u [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column1 [type=int]
            │    └── variable: u [type=int]
-           └── eq [type=bool]
-                ├── variable: column2 [type=int]
+           └── case [type=int]
+                ├── true [type=bool]
+                ├── when [type=int]
+                │    ├── is [type=bool]
+                │    │    ├── variable: u [type=int]
+                │    │    └── null [type=unknown]
+                │    └── variable: column2 [type=int]
                 └── variable: v [type=int]
 
 # Use returning UPSERT as a FROM expression.
@@ -878,38 +1233,73 @@ project
  └── upsert abc
       ├── columns: a:1(int!null) b:2(int) c:3(int) rowid:4(int!null)
       ├── canary column: 12
-      ├── fetch columns: a:9(int) b:10(int) c:11(int) rowid:12(int)
+      ├── fetch columns: a:9(int) b:10(int) c:11(int) upsert_rowid:16(int)
       ├── insert-mapping:
-      │    ├──  column1:5 => a:1
-      │    ├──  column2:6 => b:2
-      │    ├──  column8:8 => c:3
-      │    └──  column7:7 => rowid:4
+      │    ├──  upsert_a:13 => a:1
+      │    ├──  upsert_b:14 => b:2
+      │    ├──  upsert_c:15 => c:3
+      │    └──  upsert_rowid:16 => rowid:4
       ├── update-mapping:
-      │    ├──  column1:5 => a:1
-      │    ├──  column2:6 => b:2
-      │    └──  column8:8 => c:3
-      └── left-join
-           ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
-           ├── project
-           │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+      │    ├──  upsert_a:13 => a:1
+      │    ├──  upsert_b:14 => b:2
+      │    └──  upsert_c:15 => c:3
+      └── project
+           ├── columns: upsert_a:13(int) upsert_b:14(int) upsert_c:15(int) upsert_rowid:16(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+           ├── left-join
+           │    ├── columns: column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
            │    ├── project
-           │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
-           │    │    ├── values
-           │    │    │    ├── columns: column1:5(int) column2:6(int)
-           │    │    │    └── tuple [type=tuple{int, int}]
-           │    │    │         ├── const: 1 [type=int]
-           │    │    │         └── const: 2 [type=int]
+           │    │    ├── columns: column8:8(int) column1:5(int) column2:6(int) column7:7(int)
+           │    │    ├── project
+           │    │    │    ├── columns: column7:7(int) column1:5(int) column2:6(int)
+           │    │    │    ├── values
+           │    │    │    │    ├── columns: column1:5(int) column2:6(int)
+           │    │    │    │    └── tuple [type=tuple{int, int}]
+           │    │    │    │         ├── const: 1 [type=int]
+           │    │    │    │         └── const: 2 [type=int]
+           │    │    │    └── projections
+           │    │    │         └── function: unique_rowid [type=int]
            │    │    └── projections
-           │    │         └── function: unique_rowid [type=int]
-           │    └── projections
-           │         └── plus [type=int]
-           │              ├── variable: column2 [type=int]
-           │              └── const: 1 [type=int]
-           ├── scan abc
-           │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
-           └── filters
-                └── eq [type=bool]
-                     ├── variable: column7 [type=int]
+           │    │         └── plus [type=int]
+           │    │              ├── variable: column2 [type=int]
+           │    │              └── const: 1 [type=int]
+           │    ├── scan abc
+           │    │    └── columns: a:9(int!null) b:10(int) c:11(int) rowid:12(int!null)
+           │    └── filters
+           │         └── eq [type=bool]
+           │              ├── variable: column7 [type=int]
+           │              └── variable: rowid [type=int]
+           └── projections
+                ├── case [type=int]
+                │    ├── true [type=bool]
+                │    ├── when [type=int]
+                │    │    ├── is [type=bool]
+                │    │    │    ├── variable: rowid [type=int]
+                │    │    │    └── null [type=unknown]
+                │    │    └── variable: column1 [type=int]
+                │    └── variable: column1 [type=int]
+                ├── case [type=int]
+                │    ├── true [type=bool]
+                │    ├── when [type=int]
+                │    │    ├── is [type=bool]
+                │    │    │    ├── variable: rowid [type=int]
+                │    │    │    └── null [type=unknown]
+                │    │    └── variable: column2 [type=int]
+                │    └── variable: column2 [type=int]
+                ├── case [type=int]
+                │    ├── true [type=bool]
+                │    ├── when [type=int]
+                │    │    ├── is [type=bool]
+                │    │    │    ├── variable: rowid [type=int]
+                │    │    │    └── null [type=unknown]
+                │    │    └── variable: column8 [type=int]
+                │    └── variable: column8 [type=int]
+                └── case [type=int]
+                     ├── true [type=bool]
+                     ├── when [type=int]
+                     │    ├── is [type=bool]
+                     │    │    ├── variable: rowid [type=int]
+                     │    │    └── null [type=unknown]
+                     │    └── variable: column7 [type=int]
                      └── variable: rowid [type=int]
 
 # Use explicitly specified column names.
@@ -919,28 +1309,55 @@ UPSERT INTO xyz (z, x, y) VALUES (1, 2, 3)
 upsert xyz
  ├── columns: <none>
  ├── canary column: 7
- ├── fetch columns: x:7(int) y:8(int) z:9(int)
+ ├── fetch columns: upsert_x:10(int) y:8(int) z:9(int)
  ├── insert-mapping:
- │    ├──  column2:5 => x:1
- │    ├──  column3:6 => y:2
- │    └──  column1:4 => z:3
+ │    ├──  upsert_x:10 => x:1
+ │    ├──  upsert_y:11 => y:2
+ │    └──  upsert_z:12 => z:3
  ├── update-mapping:
- │    ├──  column3:6 => y:2
- │    └──  column1:4 => z:3
- └── left-join
-      ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
-      ├── values
-      │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
-      │    └── tuple [type=tuple{int, int, int}]
-      │         ├── const: 1 [type=int]
-      │         ├── const: 2 [type=int]
-      │         └── const: 3 [type=int]
-      ├── scan xyz
-      │    └── columns: x:7(int!null) y:8(int) z:9(int)
-      └── filters
-           └── eq [type=bool]
-                ├── variable: column2 [type=int]
-                └── variable: x [type=int]
+ │    ├──  upsert_y:11 => y:2
+ │    └──  upsert_z:12 => z:3
+ └── project
+      ├── columns: upsert_x:10(int) upsert_y:11(int) upsert_z:12(int) x:7(int) y:8(int) z:9(int)
+      ├── left-join
+      │    ├── columns: column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+      │    ├── values
+      │    │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
+      │    │    └── tuple [type=tuple{int, int, int}]
+      │    │         ├── const: 1 [type=int]
+      │    │         ├── const: 2 [type=int]
+      │    │         └── const: 3 [type=int]
+      │    ├── scan xyz
+      │    │    └── columns: x:7(int!null) y:8(int) z:9(int)
+      │    └── filters
+      │         └── eq [type=bool]
+      │              ├── variable: column2 [type=int]
+      │              └── variable: x [type=int]
+      └── projections
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: x [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column2 [type=int]
+           │    └── variable: x [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: x [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column3 [type=int]
+           │    └── variable: column3 [type=int]
+           └── case [type=int]
+                ├── true [type=bool]
+                ├── when [type=int]
+                │    ├── is [type=bool]
+                │    │    ├── variable: x [type=int]
+                │    │    └── null [type=unknown]
+                │    └── variable: column1 [type=int]
+                └── variable: column1 [type=int]
 
 # Use unknown name in upsert column list.
 build

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1429,15 +1429,15 @@ sort
  └── upsert abc
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       ├── canary column: 7
-      ├── fetch columns: a:7(int) b:8(int) c:9(int)
+      ├── fetch columns: a:7(int) upsert_b:12(int) upsert_c:13(int)
       ├── insert-mapping:
-      │    ├──  x:4 => a:1
-      │    ├──  y:5 => b:2
-      │    └──  z:6 => c:3
+      │    ├──  upsert_a:11 => a:1
+      │    ├──  upsert_b:12 => b:2
+      │    └──  upsert_c:13 => c:3
       ├── update-mapping:
-      │    └──  column10:10 => a:1
+      │    └──  upsert_a:11 => a:1
       └── project
-           ├── columns: column10:10(int!null) x:4(int!null) y:5(int!null) z:6(int!null) a:7(int) b:8(int) c:9(int)
+           ├── columns: upsert_a:11(int) upsert_b:12(int) upsert_c:13(int) a:7(int) b:8(int) c:9(int)
            ├── left-join (lookup abc)
            │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null) a:7(int) b:8(int) c:9(int)
            │    ├── key columns: [4 5 6] = [7 8 9]
@@ -1452,7 +1452,9 @@ sort
            │    │    └── const: 2 [type=int]
            │    └── filters (true)
            └── projections
-                └── const: 10 [type=int]
+                ├── CASE WHEN a IS NULL THEN x ELSE 10 END [type=int]
+                ├── CASE WHEN a IS NULL THEN y ELSE b END [type=int]
+                └── CASE WHEN a IS NULL THEN z ELSE c END [type=int]
 
 # --------------------------------------------------
 # Delete operator.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -876,7 +876,7 @@ func (ef *execFactory) ConstructInsert(
 	// Determine the foreign key tables involved in the update.
 	fkTables, err := row.TablesNeededForFKs(
 		ef.planner.extendedEvalCtx.Context,
-		*tabDesc,
+		tabDesc,
 		row.CheckInserts,
 		ef.planner.LookupTableByID,
 		ef.planner.CheckPrivilege,
@@ -950,7 +950,7 @@ func (ef *execFactory) ConstructUpdate(
 	// Determine the foreign key tables involved in the update.
 	fkTables, err := row.TablesNeededForFKs(
 		ef.planner.extendedEvalCtx.Context,
-		*tabDesc,
+		tabDesc,
 		row.CheckUpdates,
 		ef.planner.LookupTableByID,
 		ef.planner.CheckPrivilege,
@@ -1051,7 +1051,7 @@ func (ef *execFactory) ConstructUpsert(
 	// Determine the foreign key tables involved in the upsert.
 	fkTables, err := row.TablesNeededForFKs(
 		ef.planner.extendedEvalCtx.Context,
-		*tabDesc,
+		tabDesc,
 		fkCheckType,
 		ef.planner.LookupTableByID,
 		ef.planner.CheckPrivilege,
@@ -1152,7 +1152,7 @@ func (ef *execFactory) ConstructDelete(
 	// Determine the foreign key tables involved in the update.
 	fkTables, err := row.TablesNeededForFKs(
 		ef.planner.extendedEvalCtx.Context,
-		*tabDesc,
+		tabDesc,
 		row.CheckDeletes,
 		ef.planner.LookupTableByID,
 		ef.planner.CheckPrivilege,

--- a/pkg/sql/row/fk.go
+++ b/pkg/sql/row/fk.go
@@ -180,7 +180,7 @@ func (q *tableLookupQueue) dequeue() (TableLookup, FKCheck, bool) {
 // CheckHelpers are required.
 func TablesNeededForFKs(
 	ctx context.Context,
-	table sqlbase.ImmutableTableDescriptor,
+	table *sqlbase.ImmutableTableDescriptor,
 	usage FKCheck,
 	lookup TableLookupFunction,
 	checkPrivilege CheckPrivilegeFunction,
@@ -194,7 +194,7 @@ func TablesNeededForFKs(
 		analyzeExpr:    analyzeExpr,
 	}
 	// Add the passed in table descriptor to the table lookup.
-	baseTableLookup := TableLookup{Table: &table}
+	baseTableLookup := TableLookup{Table: table}
 	if err := baseTableLookup.addCheckHelper(ctx, analyzeExpr); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/row/fk_test.go
+++ b/pkg/sql/row/fk_test.go
@@ -186,7 +186,7 @@ func TestTablesNeededForFKs(t *testing.T) {
 	test := func(t *testing.T, usage FKCheck, expectedIDs []ID) {
 		tableLookups, err := TablesNeededForFKs(
 			context.TODO(),
-			*xDesc,
+			xDesc,
 			usage,
 			lookup,
 			NoCheckPrivilege,

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -124,8 +124,9 @@ func (tu *optTableUpserter) row(ctx context.Context, row tree.Datums, traceKV bo
 	}
 
 	// Update the row.
+	updateEnd := fetchEnd + len(tu.updateCols)
 	return tu.updateConflictingRow(
-		ctx, tu.b, row[insertEnd:fetchEnd], row[fetchEnd:], tu.tableDesc(), traceKV)
+		ctx, tu.b, row[insertEnd:fetchEnd], row[fetchEnd:updateEnd], tu.tableDesc(), traceKV)
 }
 
 // atBatchEnd is part of the extendedTableWriter interface.

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -101,7 +101,7 @@ func (p *planner) Update(
 	// Determine what are the foreign key tables that are involved in the update.
 	fkTables, err := row.TablesNeededForFKs(
 		ctx,
-		*desc,
+		desc,
 		row.CheckUpdates,
 		p.LookupTableByID,
 		p.CheckPrivilege,


### PR DESCRIPTION
Currently, the Upsert operator's insert and update columns are
separately created and maintained. For example:

  CREATE TABLE abc (a INT PRIMARY KEY, b INT)
  INSERT INTO abc VALUES (1) ON CONFLICT (a) DO UPDATE SET b=5

Here are the projected columns:

  SELECT
    a AS fetch_a, b AS fetch_b,
    1 AS ins_a, NULL AS ins_b,
    5 AS upd_b
  FROM ...

This commit constructs CASE statements that merge the insert and
update columns, like this:

  SELECT
    a AS fetch_a, b AS fetch_b,
    CASE WHEN fetch_a IS NULL THEN 1 ELSE fetch_a END AS ups_a,
    CASE WHEN fetch_a IS NULL THEN NULL::INT ELSE 5 END AS ups_b
  FROM ...

The advantages to making this change are:

1. This sets us up to implement check constraints, since they will now
   be able to operate on the combined columns.
2. This often avoids evaluating the update expression when an insert
   needs to occur for a given row.
3. This simplifies the property derivation, making Upsert act just like
   Update, Insert, and Delete. It's now possible to cleanly map each
   mutation output column to a single input column.
