### PR TITLE
opt: Convert mutation operators to use set of return columns

### DIFF
--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -194,13 +194,20 @@ func (f *stubFactory) ConstructShowTrace(typ tree.ShowTraceType, compact bool) (
 }
 
 func (f *stubFactory) ConstructInsert(
-	input exec.Node, table cat.Table, insertCols exec.ColumnOrdinalSet, rowsNeeded bool,
+	input exec.Node,
+	table cat.Table,
+	insertCols exec.ColumnOrdinalSet,
+	returnCols exec.ColumnOrdinalSet,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
 
 func (f *stubFactory) ConstructUpdate(
-	input exec.Node, table cat.Table, fetchCols, updateCols exec.ColumnOrdinalSet, rowsNeeded bool,
+	input exec.Node,
+	table cat.Table,
+	fetchCols exec.ColumnOrdinalSet,
+	updateCols exec.ColumnOrdinalSet,
+	returnCols exec.ColumnOrdinalSet,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
@@ -218,13 +225,16 @@ func (f *stubFactory) ConstructUpsert(
 	insertCols exec.ColumnOrdinalSet,
 	fetchCols exec.ColumnOrdinalSet,
 	updateCols exec.ColumnOrdinalSet,
-	rowsNeeded bool,
+	returnCols exec.ColumnOrdinalSet,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
 
 func (f *stubFactory) ConstructDelete(
-	input exec.Node, table cat.Table, fetchCols exec.ColumnOrdinalSet, rowsNeeded bool,
+	input exec.Node,
+	table cat.Table,
+	fetchCols exec.ColumnOrdinalSet,
+	returnCols exec.ColumnOrdinalSet,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -241,11 +241,14 @@ type Factory interface {
 	// same order they're defined. The insertCols set contains the ordinal
 	// positions of columns in the table into which values are inserted. All
 	// columns are expected to be present except delete-only mutation columns,
-	// since those do not need to participate in an insert operation. The
-	// rowsNeeded parameter is true if a RETURNING clause needs the inserted
-	// row(s) as output.
+	// since those do not need to participate in an insert operation. If a
+	// RETURNING clause needs the inserted row(s) as output, then returnCols
+	// specifies the columns which need to be projected by the operator.
 	ConstructInsert(
-		input Node, table cat.Table, insertCols ColumnOrdinalSet, rowsNeeded bool,
+		input Node,
+		table cat.Table,
+		insertCols ColumnOrdinalSet,
+		returnCols ColumnOrdinalSet,
 	) (Node, error)
 
 	// ConstructUpdate creates a node that implements an UPDATE statement. The
@@ -258,10 +261,15 @@ type Factory interface {
 	// The fetchCols and updateCols sets contain the ordinal positions of the
 	// fetch and update columns in the target table. The input must contain those
 	// columns in the same order as they appear in the table schema, with the
-	// fetch columns first and the update columns second. The rowsNeeded parameter
-	// is true if a RETURNING clause needs the updated row(s) as output.
+	// fetch columns first and the update columns second. If a RETURNING clause
+	// needs the updated row(s) as output, then returnCols specifies the columns
+	// which need to be projected by the operator.
 	ConstructUpdate(
-		input Node, table cat.Table, fetchCols, updateCols ColumnOrdinalSet, rowsNeeded bool,
+		input Node,
+		table cat.Table,
+		fetchCols ColumnOrdinalSet,
+		updateCols ColumnOrdinalSet,
+		returnCols ColumnOrdinalSet,
 	) (Node, error)
 
 	// ConstructUpsert creates a node that implements an INSERT..ON CONFLICT or
@@ -287,6 +295,9 @@ type Factory interface {
 	// columns {0, 1, 2} of the table. The next 3 columns contain the existing
 	// values of columns {0, 1, 2} of the table. The last column contains the
 	// new value for column {1} of the table.
+	//
+	// If a RETURNING clause needs the upserted row(s) as output, then returnCols
+	// specifies the columns which need to be projected by the operator.
 	ConstructUpsert(
 		input Node,
 		table cat.Table,
@@ -294,7 +305,7 @@ type Factory interface {
 		insertCols ColumnOrdinalSet,
 		fetchCols ColumnOrdinalSet,
 		updateCols ColumnOrdinalSet,
-		rowsNeeded bool,
+		returnCols ColumnOrdinalSet,
 	) (Node, error)
 
 	// ConstructDelete creates a node that implements a DELETE statement. The
@@ -303,10 +314,11 @@ type Factory interface {
 	//
 	// The fetchCols set contains the ordinal positions of the fetch columns in
 	// the target table. The input must contain those columns in the same order
-	// as they appear in the table schema. The rowsNeeded parameter is true if a
-	// RETURNING clause needs the deleted row(s) as output.
+	// as they appear in the table schema. If a RETURNING clause needs the deleted
+	// row(s) as output, then returnCols specifies the columns which need to be
+	// projected by the operator.
 	ConstructDelete(
-		input Node, table cat.Table, fetchCols ColumnOrdinalSet, rowsNeeded bool,
+		input Node, table cat.Table, fetchCols ColumnOrdinalSet, returnCols ColumnOrdinalSet,
 	) (Node, error)
 
 	// ConstructCreateTable returns a node that implements a CREATE TABLE

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -973,7 +973,7 @@ func (b *logicalPropsBuilder) buildMutationProps(mutation RelExpr, rel *props.Re
 
 	// If no columns are output by the operator, then all other properties retain
 	// default values.
-	if !private.NeedResults {
+	if private.ReturnCols.Empty() {
 		return
 	}
 
@@ -983,15 +983,7 @@ func (b *logicalPropsBuilder) buildMutationProps(mutation RelExpr, rel *props.Re
 
 	// Output Columns
 	// --------------
-	// Only non-mutation columns are output columns.
-	for i, n := 0, tab.ColumnCount(); i < n; i++ {
-		if cat.IsMutationColumn(tab, i) {
-			continue
-		}
-
-		colID := int(private.Table.ColumnID(i))
-		rel.OutputCols.Add(colID)
-	}
+	rel.OutputCols = private.ReturnCols
 
 	// Not Null Columns
 	// ----------------

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -33,6 +33,13 @@ define MutationPrivate {
     # passed to the Metadata.Table method in order to fetch cat.Table metadata.
     Table TableID
 
+    # ReturnCols are the set of columns returned by the mutation operator when
+    # the RETURNING clause has been specified. By default, the return columns
+    # include all columns in the table, including hidden columns, but not
+    # including any columns that are undergoing mutation (being added or dropped
+    # as part of online schema change).
+    ReturnCols ColSet
+
     # InsertCols are columns from the Input expression that will be inserted into
     # the target table. They must be a subset of the Input expression's output
     # columns. The count and order of columns corresponds to the count and order
@@ -94,13 +101,6 @@ define MutationPrivate {
     # If the canary column value is null for a particular input row, then a new
     # row is inserted into the table. Otherwise, the existing row is updated.
     CanaryCol ColumnID
-
-    # NeedResults is true if the Insert operator returns output rows. One output
-    # row will be returned for each input row. The output row contains all
-    # columns in the table, including hidden columns, but not including any
-    # columns that are undergoing mutation (being added or dropped as part of
-    # online schema change).
-    NeedResults bool
 }
 
 # Update evaluates a relational input expression that fetches existing rows from

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -89,9 +89,9 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildDelete(returning tree.ReturningExprs) {
 	private := memo.MutationPrivate{
-		Table:       mb.tabID,
-		FetchCols:   mb.fetchColList,
-		NeedResults: returning != nil,
+		Table:      mb.tabID,
+		FetchCols:  mb.fetchColList,
+		ReturnCols: mb.makeReturnCols(returning),
 	}
 	mb.outScope.expr = mb.b.factory.ConstructDelete(mb.outScope.expr, &private)
 

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -522,9 +522,9 @@ func (mb *mutationBuilder) addDefaultAndComputedColsForInsert() {
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildInsert(returning tree.ReturningExprs) {
 	private := memo.MutationPrivate{
-		Table:       mb.tabID,
-		InsertCols:  mb.insertColList,
-		NeedResults: returning != nil,
+		Table:      mb.tabID,
+		InsertCols: mb.insertColList,
+		ReturnCols: mb.makeReturnCols(returning),
 	}
 	mb.outScope.expr = mb.b.factory.ConstructInsert(mb.outScope.expr, &private)
 
@@ -760,12 +760,12 @@ func (mb *mutationBuilder) setUpsertCols(insertCols tree.NameList) {
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
 	private := memo.MutationPrivate{
-		Table:       mb.tabID,
-		InsertCols:  mb.insertColList,
-		FetchCols:   mb.fetchColList,
-		UpdateCols:  mb.updateColList,
-		CanaryCol:   mb.canaryColID,
-		NeedResults: returning != nil,
+		Table:      mb.tabID,
+		InsertCols: mb.insertColList,
+		FetchCols:  mb.fetchColList,
+		UpdateCols: mb.updateColList,
+		CanaryCol:  mb.canaryColID,
+		ReturnCols: mb.makeReturnCols(returning),
 	}
 	mb.outScope.expr = mb.b.factory.ConstructUpsert(mb.outScope.expr, &private)
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -357,6 +357,26 @@ func (mb *mutationBuilder) addSynthesizedCols(
 	}
 }
 
+// makeReturnCols returns the set of column ids that will be returned by the
+// mutation operator, based on the RETURNING clause. It is empty if there was
+// no RETURNING clause.
+func (mb *mutationBuilder) makeReturnCols(returning tree.ReturningExprs) opt.ColSet {
+	// Only need output columns if the RETURNING clause is specified.
+	if returning == nil {
+		return opt.ColSet{}
+	}
+
+	// Only non-mutation columns are output columns.
+	var cols opt.ColSet
+	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
+		if cat.IsMutationColumn(mb.tab, i) {
+			continue
+		}
+		cols.Add(int(mb.tabID.ColumnID(i)))
+	}
+	return cols
+}
+
 // buildReturning wraps the input expression with a Project operator that
 // projects the given RETURNING expressions.
 func (mb *mutationBuilder) buildReturning(returning tree.ReturningExprs) {

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -332,10 +332,10 @@ func (mb *mutationBuilder) addComputedColsForUpdate() {
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildUpdate(returning tree.ReturningExprs) {
 	private := memo.MutationPrivate{
-		Table:       mb.tabID,
-		FetchCols:   mb.fetchColList,
-		UpdateCols:  mb.updateColList,
-		NeedResults: returning != nil,
+		Table:      mb.tabID,
+		FetchCols:  mb.fetchColList,
+		UpdateCols: mb.updateColList,
+		ReturnCols: mb.makeReturnCols(returning),
 	}
 	mb.outScope.expr = mb.b.factory.ConstructUpdate(mb.outScope.expr, &private)
 

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -867,7 +867,10 @@ func (ef *execFactory) ConstructShowTrace(typ tree.ShowTraceType, compact bool) 
 }
 
 func (ef *execFactory) ConstructInsert(
-	input exec.Node, table cat.Table, insertCols exec.ColumnOrdinalSet, rowsNeeded bool,
+	input exec.Node,
+	table cat.Table,
+	insertCols exec.ColumnOrdinalSet,
+	returnCols exec.ColumnOrdinalSet,
 ) (exec.Node, error) {
 	// Derive insert table and column descriptors.
 	tabDesc := table.(*optTable).desc
@@ -895,22 +898,17 @@ func (ef *execFactory) ConstructInsert(
 
 	// Determine the relational type of the generated insert node.
 	// If rows are not needed, no columns are returned.
-	var returnCols sqlbase.ResultColumns
-	if rowsNeeded {
-		// Insert always returns all non-mutation columns, in the same order they
-		// are defined in the table.
-		returnCols = sqlbase.ResultColumnsFromColDescs(tabDesc.Columns)
-	}
+	resultCols := makeResultColumnList(table, returnCols)
 
 	// Regular path for INSERT.
 	ins := insertNodePool.Get().(*insertNode)
 	*ins = insertNode{
 		source:  input.(planNode),
-		columns: returnCols,
+		columns: resultCols,
 		run: insertRun{
 			ti:          tableInserter{ri: ri},
 			checkHelper: fkTables[tabDesc.ID].CheckHelper,
-			rowsNeeded:  rowsNeeded,
+			rowsNeeded:  resultCols != nil,
 			iVarContainerForComputedCols: sqlbase.RowIndexedVarContainer{
 				Cols:    tabDesc.Columns,
 				Mapping: ri.InsertColIDtoRowIndex,
@@ -922,7 +920,7 @@ func (ef *execFactory) ConstructInsert(
 	// serialize the data-modifying plan to ensure that no data is
 	// observed that hasn't been validated first. See the comments
 	// on BatchedNext() in plan_batch.go.
-	if rowsNeeded {
+	if resultCols != nil {
 		return &spoolNode{source: &serializeNode{source: ins}}, nil
 	}
 
@@ -932,7 +930,11 @@ func (ef *execFactory) ConstructInsert(
 }
 
 func (ef *execFactory) ConstructUpdate(
-	input exec.Node, table cat.Table, fetchCols, updateCols exec.ColumnOrdinalSet, rowsNeeded bool,
+	input exec.Node,
+	table cat.Table,
+	fetchCols exec.ColumnOrdinalSet,
+	updateCols exec.ColumnOrdinalSet,
+	returnCols exec.ColumnOrdinalSet,
 ) (exec.Node, error) {
 	// Derive table and column descriptors.
 	tabDesc := table.(*optTable).desc
@@ -980,12 +982,7 @@ func (ef *execFactory) ConstructUpdate(
 
 	// Determine the relational type of the generated update node.
 	// If rows are not needed, no columns are returned.
-	var returnCols sqlbase.ResultColumns
-	if rowsNeeded {
-		// Update always returns all non-mutation columns, in the same order they
-		// are defined in the table.
-		returnCols = sqlbase.ResultColumnsFromColDescs(tabDesc.Columns)
-	}
+	resultCols := makeResultColumnList(table, returnCols)
 
 	// updateColsIdx inverts the mapping of UpdateCols to FetchCols. See
 	// the explanatory comments in updateRun.
@@ -997,11 +994,11 @@ func (ef *execFactory) ConstructUpdate(
 	upd := updateNodePool.Get().(*updateNode)
 	*upd = updateNode{
 		source:  input.(planNode),
-		columns: returnCols,
+		columns: resultCols,
 		run: updateRun{
 			tu:          tableUpdater{ru: ru},
 			checkHelper: fkTables[tabDesc.ID].CheckHelper,
-			rowsNeeded:  rowsNeeded,
+			rowsNeeded:  resultCols != nil,
 			iVarContainerForComputedCols: sqlbase.RowIndexedVarContainer{
 				CurSourceRow: make(tree.Datums, len(ru.FetchCols)),
 				Cols:         ru.FetchCols,
@@ -1016,7 +1013,7 @@ func (ef *execFactory) ConstructUpdate(
 	// Serialize the data-modifying plan to ensure that no data is observed that
 	// hasn't been validated first. See the comments on BatchedNext() in
 	// plan_batch.go.
-	if rowsNeeded {
+	if resultCols != nil {
 		return &spoolNode{source: &serializeNode{source: upd}}, nil
 	}
 
@@ -1032,7 +1029,7 @@ func (ef *execFactory) ConstructUpsert(
 	insertCols exec.ColumnOrdinalSet,
 	fetchCols exec.ColumnOrdinalSet,
 	updateCols exec.ColumnOrdinalSet,
-	rowsNeeded bool,
+	returnCols exec.ColumnOrdinalSet,
 ) (exec.Node, error) {
 	// Derive table and column descriptors.
 	tabDesc := table.(*optTable).desc
@@ -1089,12 +1086,7 @@ func (ef *execFactory) ConstructUpsert(
 
 	// Determine the relational type of the generated upsert node.
 	// If rows are not needed, no columns are returned.
-	var returnCols sqlbase.ResultColumns
-	if rowsNeeded {
-		// Upsert always returns all non-mutation columns, in the same order they
-		// are defined in the table.
-		returnCols = sqlbase.ResultColumnsFromColDescs(tabDesc.Columns)
-	}
+	resultCols := makeResultColumnList(table, returnCols)
 
 	// updateColsIdx inverts the mapping of UpdateCols to FetchCols. See
 	// the explanatory comments in updateRun.
@@ -1107,7 +1099,7 @@ func (ef *execFactory) ConstructUpsert(
 	ups := upsertNodePool.Get().(*upsertNode)
 	*ups = upsertNode{
 		source:  input.(planNode),
-		columns: returnCols,
+		columns: resultCols,
 		run: upsertRun{
 			checkHelper: fkTables[tabDesc.ID].CheckHelper,
 			insertCols:  insertColDescs,
@@ -1119,7 +1111,7 @@ func (ef *execFactory) ConstructUpsert(
 				tableUpserterBase: tableUpserterBase{
 					ri:          ri,
 					alloc:       &ef.planner.alloc,
-					collectRows: rowsNeeded,
+					collectRows: resultCols != nil,
 				},
 				canaryOrdinal: int(canaryCol),
 				fkTables:      fkTables,
@@ -1133,7 +1125,7 @@ func (ef *execFactory) ConstructUpsert(
 	// Serialize the data-modifying plan to ensure that no data is observed that
 	// hasn't been validated first. See the comments on BatchedNext() in
 	// plan_batch.go.
-	if rowsNeeded {
+	if resultCols != nil {
 		return &spoolNode{source: &serializeNode{source: ups}}, nil
 	}
 
@@ -1143,7 +1135,10 @@ func (ef *execFactory) ConstructUpsert(
 }
 
 func (ef *execFactory) ConstructDelete(
-	input exec.Node, table cat.Table, fetchCols exec.ColumnOrdinalSet, rowsNeeded bool,
+	input exec.Node,
+	table cat.Table,
+	fetchCols exec.ColumnOrdinalSet,
+	returnCols exec.ColumnOrdinalSet,
 ) (exec.Node, error) {
 	// Derive table and column descriptors.
 	tabDesc := table.(*optTable).desc
@@ -1181,28 +1176,23 @@ func (ef *execFactory) ConstructDelete(
 
 	// Determine the relational type of the generated delete node.
 	// If rows are not needed, no columns are returned.
-	var returnCols sqlbase.ResultColumns
-	if rowsNeeded {
-		// Delete always returns all non-mutation columns, in the same order they
-		// are defined in the table.
-		returnCols = sqlbase.ResultColumnsFromColDescs(tabDesc.Columns)
-	}
+	resultCols := makeResultColumnList(table, returnCols)
 
 	// Now make a delete node. We use a pool.
 	del := deleteNodePool.Get().(*deleteNode)
 	*del = deleteNode{
 		source:  input.(planNode),
-		columns: returnCols,
+		columns: resultCols,
 		run: deleteRun{
 			td:         tableDeleter{rd: rd, alloc: &ef.planner.alloc},
-			rowsNeeded: rowsNeeded,
+			rowsNeeded: resultCols != nil,
 		},
 	}
 
 	// Serialize the data-modifying plan to ensure that no data is observed that
 	// hasn't been validated first. See the comments on BatchedNext() in
 	// plan_batch.go.
-	if rowsNeeded {
+	if resultCols != nil {
 		return &spoolNode{source: &serializeNode{source: del}}, nil
 	}
 
@@ -1266,6 +1256,26 @@ func makeColDescList(table cat.Table, cols exec.ColumnOrdinalSet) []sqlbase.Colu
 		colDescs = append(colDescs, *extractColumnDescriptor(table.Column(i)))
 	}
 	return colDescs
+}
+
+// makeResultColumnList returns a list of ResultColumns. Columns are included if
+// their ordinal position in the given table is in the cols set.
+func makeResultColumnList(table cat.Table, cols exec.ColumnOrdinalSet) sqlbase.ResultColumns {
+	if cols.Empty() {
+		return nil
+	}
+
+	resultCols := make(sqlbase.ResultColumns, 0, cols.Len())
+	for i, n := 0, table.ColumnCount(); i < n; i++ {
+		if !cols.Contains(i) {
+			continue
+		}
+		col := table.Column(i)
+		resultCols = append(resultCols, sqlbase.ResultColumn{
+			Name: string(col.ColName()), Typ: col.DatumType(), Hidden: col.IsHidden(),
+		})
+	}
+	return resultCols
 }
 
 // makeScanColumnsConfig builds a scanColumnsConfig struct by constructing a


### PR DESCRIPTION
In preparation for doing needed column analysis, keep the set of columns
returned by a mutation operator rather than simply a boolean NeedResults
field. This will later enable a subset of columns to be projected.

Release note: None