### PR TITLE
storage, server: assorted cleanups around server startup and cluster bootstrap

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -199,10 +199,7 @@ func GetBootstrapSchema() sqlbase.MetadataSchema {
 // written, since epoch-based leases cannot be granted until then. All other
 // engines are initialized with their StoreIdent.
 func bootstrapCluster(
-	ctx context.Context,
-	engines []engine.Engine,
-	bootstrapVersion cluster.ClusterVersion,
-	txnMetrics kv.TxnMetrics,
+	ctx context.Context, engines []engine.Engine, bootstrapVersion cluster.ClusterVersion,
 ) (uuid.UUID, error) {
 	clusterID := uuid.MakeV4()
 	// TODO(andrei): It'd be cool if this method wouldn't do anything to engines
@@ -304,7 +301,7 @@ func (n *Node) bootstrap(
 		return fmt.Errorf("cluster has already been initialized with ID %s", n.clusterID.Get())
 	}
 	n.initialBoot = true
-	clusterID, err := bootstrapCluster(ctx, engines, bootstrapVersion, n.txnMetrics)
+	clusterID, err := bootstrapCluster(ctx, engines, bootstrapVersion)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -441,13 +441,9 @@ func (n *Node) start(
 	// Start the closed timestamp subsystem.
 	n.storeCfg.ClosedTimestamp.Start(n.Descriptor.NodeID)
 
-	// Initialize the stores we're going to start.
-	stores, err := n.initStores(ctx, bootstrappedEngines, n.stopper)
-	if err != nil {
-		return err
-	}
-
-	for _, s := range stores {
+	// Create stores from the engines that were already bootstrapped.
+	for _, e := range bootstrappedEngines {
+		s := storage.NewStore(ctx, n.storeCfg, e, &n.Descriptor)
 		if err := s.Start(ctx, n.stopper); err != nil {
 			return errors.Errorf("failed to start store: %s", err)
 		}
@@ -467,7 +463,7 @@ func (n *Node) start(
 	if err := n.validateStores(ctx); err != nil {
 		return err
 	}
-	log.Event(ctx, "validated stores")
+	log.VEventf(ctx, 2, "validated stores")
 
 	// Compute the time this node was last up; this is done by reading the
 	// "last up time" from every store and choosing the most recent timestamp.
@@ -572,25 +568,6 @@ func (n *Node) SetHLCUpperBound(ctx context.Context, hlcUpperBound int64) error 
 	})
 }
 
-// initStores initializes the Stores map from ID to Store. Stores are
-// added to the local sender if already bootstrapped. A bootstrapped
-// Store has a valid ident with cluster, node and Store IDs set. If
-// the Store doesn't yet have a valid ident, it's added to the
-// bootstraps list for initialization once the cluster and node IDs
-// have been determined.
-func (n *Node) initStores(
-	ctx context.Context, engines []engine.Engine, stopper *stop.Stopper,
-) ([]*storage.Store, error) {
-	var stores []*storage.Store
-	for _, e := range engines {
-		s := storage.NewStore(ctx, n.storeCfg, e, &n.Descriptor)
-		log.Eventf(ctx, "created store for engine: %s", e)
-
-		stores = append(stores, s)
-	}
-	return stores, nil
-}
-
 func (n *Node) addStore(store *storage.Store) {
 	cv, err := store.GetClusterVersion(context.TODO())
 	if err != nil {
@@ -664,12 +641,9 @@ func (n *Node) bootstrapStores(
 		}
 	}
 
-	// Start the newly bootstrapped stores.
-	bootstraps, err := n.initStores(ctx, emptyEngines, n.stopper)
-	if err != nil {
-		return err
-	}
-	for _, s := range bootstraps {
+	// Create stores from the newly bootstrapped engines.
+	for _, e := range emptyEngines {
+		s := storage.NewStore(ctx, n.storeCfg, e, &n.Descriptor)
 		if err := s.Start(ctx, stopper); err != nil {
 			return err
 		}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -256,7 +256,7 @@ func bootstrapCluster(
 
 		// The bootstrapping store will not connect to other nodes so its
 		// StoreConfig doesn't really matter.
-		s := storage.NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: FirstNodeID})
+		s := storage.NewStore(ctx, cfg, eng, &roachpb.NodeDescriptor{NodeID: FirstNodeID})
 
 		// Bootstrap store to persist the store ident and cluster version.
 		if err := storage.Bootstrap(ctx, eng, sIdent, bootstrapVersion); err != nil {
@@ -583,7 +583,7 @@ func (n *Node) initStores(
 ) ([]*storage.Store, error) {
 	var stores []*storage.Store
 	for _, e := range engines {
-		s := storage.NewStore(n.storeCfg, e, &n.Descriptor)
+		s := storage.NewStore(ctx, n.storeCfg, e, &n.Descriptor)
 		log.Eventf(ctx, "created store for engine: %s", e)
 
 		stores = append(stores, s)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -294,7 +294,7 @@ func (n *Node) AnnotateCtxWithSpan(
 	return n.storeCfg.AmbientCtx.AnnotateCtxWithSpan(ctx, opName)
 }
 
-func (n *Node) bootstrap(
+func (n *Node) bootstrapCluster(
 	ctx context.Context, engines []engine.Engine, bootstrapVersion cluster.ClusterVersion,
 ) error {
 	if n.initialBoot || n.clusterID.Get() != uuid.Nil {

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -174,16 +174,16 @@ func allocateNodeID(ctx context.Context, db *client.DB) (roachpb.NodeID, error) 
 }
 
 // allocateStoreIDs increments the store id generator key for the
-// specified node to allocate "inc" new, unique store ids. The
+// specified node to allocate count new, unique store ids. The
 // first ID in a contiguous range is returned on success.
 func allocateStoreIDs(
-	ctx context.Context, nodeID roachpb.NodeID, inc int64, db *client.DB,
+	ctx context.Context, nodeID roachpb.NodeID, count int64, db *client.DB,
 ) (roachpb.StoreID, error) {
-	val, err := client.IncrementValRetryable(ctx, db, keys.StoreIDGenerator, inc)
+	val, err := client.IncrementValRetryable(ctx, db, keys.StoreIDGenerator, count)
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to allocate %d store IDs for node %d", inc, nodeID)
+		return 0, errors.Wrapf(err, "unable to allocate %d store IDs for node %d", count, nodeID)
 	}
-	return roachpb.StoreID(val - inc + 1), nil
+	return roachpb.StoreID(val - count + 1), nil
 }
 
 // GetBootstrapSchema returns the schema which will be used to bootstrap a new

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -202,17 +202,17 @@ func (s keySlice) Less(i, j int) bool { return bytes.Compare(s[i], s[j]) < 0 }
 // cluster. Uses an in memory engine.
 func TestBootstrapCluster(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	defer e.Close()
 	if _, err := bootstrapCluster(
-		context.TODO(), []engine.Engine{e}, cluster.TestingClusterVersion,
-		kv.MakeTxnMetrics(metric.TestSampleInterval),
+		ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
 	); err != nil {
 		t.Fatal(err)
 	}
 
 	// Scan the complete contents of the local database directly from the engine.
-	rows, _, _, err := engine.MVCCScan(context.Background(), e, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, engine.MVCCScanOptions{})
+	rows, _, _, err := engine.MVCCScan(ctx, e, keys.LocalMax, roachpb.KeyMax, math.MaxInt64, hlc.MaxTimestamp, engine.MVCCScanOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,7 +262,6 @@ func TestBootstrapNewStore(t *testing.T) {
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	if _, err := bootstrapCluster(
 		ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
-		kv.MakeTxnMetrics(metric.TestSampleInterval),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +317,6 @@ func TestNodeJoin(t *testing.T) {
 
 	if _, err := bootstrapCluster(
 		ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
-		kv.MakeTxnMetrics(metric.TestSampleInterval),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -384,12 +382,12 @@ func TestNodeJoin(t *testing.T) {
 func TestCorruptedClusterID(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	ctx := context.Background()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	defer e.Close()
 
 	if _, err := bootstrapCluster(
-		context.TODO(), []engine.Engine{e},
-		cluster.TestingClusterVersion, kv.MakeTxnMetrics(metric.TestSampleInterval),
+		ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -400,21 +398,23 @@ func TestCorruptedClusterID(t *testing.T) {
 		NodeID:    1,
 		StoreID:   1,
 	}
-	if err := engine.MVCCPutProto(context.Background(), e, nil, keys.StoreIdentKey(), hlc.Timestamp{}, nil, &sIdent); err != nil {
+	if err := engine.MVCCPutProto(
+		ctx, e, nil /* ms */, keys.StoreIdentKey(), hlc.Timestamp{}, nil /* txn */, &sIdent,
+	); err != nil {
 		t.Fatal(err)
 	}
 
 	engines := []engine.Engine{e}
 	_, serverAddr, cfg, node, stopper := createTestNode(util.TestAddr, engines, nil, t)
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 	bootstrappedEngines, newEngines, cv, err := inspectEngines(
-		context.TODO(), engines, cfg.Settings.Version.MinSupportedVersion,
+		ctx, engines, cfg.Settings.Version.MinSupportedVersion,
 		cfg.Settings.Version.ServerVersion, node.clusterID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := node.start(
-		context.Background(), serverAddr, bootstrappedEngines, newEngines,
+		ctx, serverAddr, bootstrappedEngines, newEngines,
 		roachpb.Attributes{}, roachpb.Locality{}, cv,
 		[]roachpb.LocalityAddress{},
 		nil, /* nodeDescriptorCallback */
@@ -736,7 +736,6 @@ func TestStartNodeWithLocality(t *testing.T) {
 		defer e.Close()
 		if _, err := bootstrapCluster(
 			ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
-			kv.MakeTxnMetrics(metric.TestSampleInterval),
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -204,11 +204,9 @@ func TestBootstrapCluster(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	defer e.Close()
-	st := cluster.MakeTestingClusterSettings()
 	if _, err := bootstrapCluster(
-		context.TODO(), storage.StoreConfig{
-			Settings: st,
-		}, []engine.Engine{e}, st.Version.BootstrapVersion(), kv.MakeTxnMetrics(metric.TestSampleInterval),
+		context.TODO(), []engine.Engine{e}, cluster.TestingClusterVersion,
+		kv.MakeTxnMetrics(metric.TestSampleInterval),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -262,9 +260,8 @@ func TestBootstrapNewStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
-	cfg := bootstrapNodeConfig()
 	if _, err := bootstrapCluster(
-		ctx, cfg, []engine.Engine{e}, cfg.Settings.Version.BootstrapVersion(),
+		ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
 		kv.MakeTxnMetrics(metric.TestSampleInterval),
 	); err != nil {
 		t.Fatal(err)
@@ -309,20 +306,6 @@ func TestBootstrapNewStore(t *testing.T) {
 	}
 }
 
-// TODO(tschottdorf): tests calling this previously used an empty store config
-// for bootstrapCluster. When changing it to use TestStoreConfig(nil), the
-// following adjustments were necessary to prevent the test from failing to
-// observe its initial splits in time under stressrace, or timing out (never
-// receiving a response from Replica). Investigate why.
-func bootstrapNodeConfig() storage.StoreConfig {
-	cfg := storage.TestStoreConfig(nil)
-	cfg.CoalescedHeartbeatsInterval = 0
-	cfg.RaftHeartbeatIntervalTicks = 0
-	cfg.RaftTickInterval = 0
-	cfg.RaftElectionTimeoutTicks = 0
-	return cfg
-}
-
 // TestNodeJoin verifies a new node is able to join a bootstrapped
 // cluster consisting of one node.
 func TestNodeJoin(t *testing.T) {
@@ -333,10 +316,8 @@ func TestNodeJoin(t *testing.T) {
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	engineStopper.AddCloser(e)
 
-	cfg := bootstrapNodeConfig()
 	if _, err := bootstrapCluster(
-		ctx, cfg, []engine.Engine{e},
-		cfg.Settings.Version.BootstrapVersion(),
+		ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
 		kv.MakeTxnMetrics(metric.TestSampleInterval),
 	); err != nil {
 		t.Fatal(err)
@@ -406,9 +387,9 @@ func TestCorruptedClusterID(t *testing.T) {
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	defer e.Close()
 
-	cfg := bootstrapNodeConfig()
 	if _, err := bootstrapCluster(
-		context.TODO(), cfg, []engine.Engine{e}, cfg.Settings.Version.BootstrapVersion(), kv.MakeTxnMetrics(metric.TestSampleInterval),
+		context.TODO(), []engine.Engine{e},
+		cluster.TestingClusterVersion, kv.MakeTxnMetrics(metric.TestSampleInterval),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -753,10 +734,8 @@ func TestStartNodeWithLocality(t *testing.T) {
 	testLocalityWithNewNode := func(locality roachpb.Locality) {
 		e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 		defer e.Close()
-		cfg := bootstrapNodeConfig()
 		if _, err := bootstrapCluster(
-			ctx, cfg, []engine.Engine{e},
-			cfg.Settings.Version.BootstrapVersion(),
+			ctx, []engine.Engine{e}, cluster.TestingClusterVersion,
 			kv.MakeTxnMetrics(metric.TestSampleInterval),
 		); err != nil {
 			t.Fatal(err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1773,7 +1773,7 @@ func (s *Server) bootstrapCluster(ctx context.Context) error {
 		}
 	}
 
-	if err := s.node.bootstrap(ctx, s.engines, bootstrapVersion); err != nil {
+	if err := s.node.bootstrapCluster(ctx, s.engines, bootstrapVersion); err != nil {
 		return err
 	}
 	// Force all the system ranges through the replication queue so they

--- a/pkg/settings/cluster/testutils.go
+++ b/pkg/settings/cluster/testutils.go
@@ -1,0 +1,21 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cluster
+
+// TestingClusterVersion is a ClusterVersion that tests can use when they don't
+// want to go through a Settings object.
+var TestingClusterVersion ClusterVersion = ClusterVersion{
+	Version: BinaryServerVersion,
+}

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -169,7 +169,7 @@ func createTestStoreWithOpts(
 	// TODO(bdarnell): arrange to have the transport closed.
 	ctx := context.Background()
 	if !opts.dontBootstrap {
-		if err := storage.Bootstrap(
+		if err := storage.InitEngine(
 			ctx, eng, roachpb.StoreIdent{NodeID: 1, StoreID: 1},
 			storeCfg.Settings.Version.BootstrapVersion(),
 		); err != nil {
@@ -829,7 +829,7 @@ func (m *multiTestContext) addStore(idx int) {
 
 	ctx := context.Background()
 	if needBootstrap {
-		if err := storage.Bootstrap(ctx, eng, roachpb.StoreIdent{
+		if err := storage.InitEngine(ctx, eng, roachpb.StoreIdent{
 			NodeID:  roachpb.NodeID(idx + 1),
 			StoreID: roachpb.StoreID(idx + 1),
 		}, cfg.Settings.Version.BootstrapVersion()); err != nil {

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -176,7 +176,7 @@ func createTestStoreWithOpts(
 			t.Fatal(err)
 		}
 	}
-	store := storage.NewStore(storeCfg, eng, nodeDesc)
+	store := storage.NewStore(ctx, storeCfg, eng, nodeDesc)
 	if !opts.dontBootstrap {
 		var kvs []roachpb.KeyValue
 		var splits []roachpb.RKey
@@ -836,7 +836,7 @@ func (m *multiTestContext) addStore(idx int) {
 			m.t.Fatal(err)
 		}
 	}
-	store := storage.NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: nodeID})
+	store := storage.NewStore(ctx, cfg, eng, &roachpb.NodeDescriptor{NodeID: nodeID})
 	if needBootstrap && idx == 0 {
 		// Bootstrap the initial range on the first store.
 		var splits []roachpb.RKey
@@ -1000,10 +1000,9 @@ func (m *multiTestContext) restartStoreWithoutHeartbeat(i int) {
 	cfg.DB = m.dbs[i]
 	cfg.NodeLiveness = m.nodeLivenesses[i]
 	cfg.StorePool = m.storePools[i]
-	store := storage.NewStore(cfg, m.engines[i], &roachpb.NodeDescriptor{NodeID: roachpb.NodeID(i + 1)})
-	m.stores[i] = store
-
 	ctx := context.Background()
+	store := storage.NewStore(ctx, cfg, m.engines[i], &roachpb.NodeDescriptor{NodeID: roachpb.NodeID(i + 1)})
+	m.stores[i] = store
 
 	// Need to start the store before adding it so that the store ID is initialized.
 	if err := store.Start(ctx, stopper); err != nil {

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -221,7 +221,7 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 		}, bootstrapVersion); err != nil {
 			t.Fatal(err)
 		}
-		tc.store = NewStore(cfg, tc.engine, &roachpb.NodeDescriptor{NodeID: 1})
+		tc.store = NewStore(ctx, cfg, tc.engine, &roachpb.NodeDescriptor{NodeID: 1})
 		// Now that we have our actual store, monkey patch the factory used in cfg.DB.
 		factory.setStore(tc.store)
 		// We created the store without a real KV client, so it can't perform splits

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -214,7 +214,7 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 		factory := &testSenderFactory{}
 		cfg.DB = client.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
 
-		if err := Bootstrap(ctx, tc.engine, roachpb.StoreIdent{
+		if err := InitEngine(ctx, tc.engine, roachpb.StoreIdent{
 			ClusterID: uuid.MakeV4(),
 			NodeID:    1,
 			StoreID:   1,

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -230,9 +230,11 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 		tc.store.mergeQueue.SetDisabled(true)
 
 		if tc.repl == nil && tc.bootstrapMode == bootstrapRangeWithMetadata {
-			if err := tc.store.WriteInitialData(
-				ctx, nil /* initialValues */, bootstrapVersion.Version,
-				1 /* numStores */, nil, /* splits */
+			if err := WriteInitialClusterData(
+				ctx, tc.store.Engine(),
+				nil, /* initialValues */
+				bootstrapVersion.Version,
+				1 /* numStores */, nil /* splits */, cfg.Clock.PhysicalNow(),
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/stateloader/stateloader.go
+++ b/pkg/storage/stateloader/stateloader.go
@@ -48,7 +48,7 @@ type StateLoader struct {
 	keys.RangeIDPrefixBuf
 }
 
-// Make creates an Instance.
+// Make creates a a StateLoader.
 func Make(rangeID roachpb.RangeID) StateLoader {
 	rsl := StateLoader{
 		RangeIDPrefixBuf: keys.MakeRangeIDPrefixBuf(rangeID),

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -752,12 +752,14 @@ func (sc *StoreConfig) LeaseExpiration() int64 {
 }
 
 // NewStore returns a new instance of a store.
-func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescriptor) *Store {
+func NewStore(
+	ctx context.Context, cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescriptor,
+) *Store {
 	// TODO(tschottdorf): find better place to set these defaults.
 	cfg.SetDefaults()
 
 	if !cfg.Valid() {
-		log.Fatalf(context.Background(), "invalid store configuration: %+v", &cfg)
+		log.Fatalf(ctx, "invalid store configuration: %+v", &cfg)
 	}
 	s := &Store{
 		cfg:      cfg,

--- a/pkg/storage/store_bootstrap.go
+++ b/pkg/storage/store_bootstrap.go
@@ -29,12 +29,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Bootstrap writes a new store ident to the underlying engine. To
+// InitEngine writes a new store ident to the underlying engine. To
 // ensure that no crufty data already exists in the engine, it scans
 // the engine contents before writing the new store ident. The engine
 // should be completely empty. It returns an error if called on a
 // non-empty engine.
-func Bootstrap(
+func InitEngine(
 	ctx context.Context, eng engine.Engine, ident roachpb.StoreIdent, cv cluster.ClusterVersion,
 ) error {
 	exIdent, err := ReadStoreIdent(ctx, eng)

--- a/pkg/storage/store_bootstrap.go
+++ b/pkg/storage/store_bootstrap.go
@@ -73,22 +73,26 @@ func InitEngine(
 	return nil
 }
 
-// WriteInitialData writes bootstrapping data to a store. It creates system
-// ranges (filling in meta1 and meta2) and the default zone config.
+// WriteInitialClusterData writes bootstrapping data to an engine. It creates
+// system ranges (filling in meta1 and meta2) and the default zone config.
 //
 // Args:
+// eng: the engine to which data is to be written.
 // initialValues: an optional list of k/v to be written as well after each
 //   value's checksum is initialized.
 // bootstrapVersion: the version at which the cluster is bootstrapped.
 // numStores: the number of stores this node will have.
 // splits: an optional list of split points. Range addressing will be created
 //   for all the splits. The list needs to be sorted.
-func (s *Store) WriteInitialData(
+// nowNanos: the timestamp at which to write the initial engine data.
+func WriteInitialClusterData(
 	ctx context.Context,
+	eng engine.Engine,
 	initialValues []roachpb.KeyValue,
 	bootstrapVersion roachpb.Version,
 	numStores int,
 	splits []roachpb.RKey,
+	nowNanos int64,
 ) error {
 	// Bootstrap version information. We'll add the "bootstrap version" to the
 	// list of initialValues, so that we don't have to handle it specially
@@ -163,11 +167,13 @@ func (s *Store) WriteInitialData(
 		log.VEventf(
 			ctx, 2, "creating range %d [%s, %s). Initial values: %d",
 			desc.RangeID, desc.StartKey, desc.EndKey, len(rangeInitialValues))
-		batch := s.engine.NewBatch()
+		batch := eng.NewBatch()
 		defer batch.Close()
 
-		now := s.cfg.Clock.Now()
-		ctx := context.Background()
+		now := hlc.Timestamp{
+			WallTime: nowNanos,
+			Logical:  0,
+		}
 
 		// NOTE: We don't do stats computations in any of the puts below. Instead,
 		// we write everything and then compute the stats over the whole range.
@@ -231,8 +237,8 @@ func (s *Store) WriteInitialData(
 			enginepb.MVCCStats{},
 			*desc,
 			lease,
-			hlc.Timestamp{},
-			hlc.Timestamp{},
+			hlc.Timestamp{}, /* gcThreshold */
+			hlc.Timestamp{}, /* txnSpanGCThreshold */
 			bootstrapVersion,
 			truncStateType,
 		)
@@ -240,7 +246,7 @@ func (s *Store) WriteInitialData(
 			return err
 		}
 
-		computedStats, err := rditer.ComputeStatsForRange(desc, batch, s.Clock().PhysicalNow())
+		computedStats, err := rditer.ComputeStatsForRange(desc, batch, now.WallTime)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -515,13 +515,14 @@ func TestStorePoolUpdateLocalStore(t *testing.T) {
 // the local copy of store before that store has been gossiped will be a no-op.
 func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 	manual := hlc.NewManualClock(123)
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
 	stopper, _, _, sp, _ := createTestStorePool(
 		TestTimeUntilStoreDead, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		storagepb.NodeLivenessStatus_DEAD)
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 
 	// Create store.
 	node := roachpb.NodeDescriptor{NodeID: roachpb.NodeID(1)}
@@ -529,7 +530,7 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 	stopper.AddCloser(eng)
 	cfg := TestStoreConfig(clock)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
-	store := NewStore(cfg, eng, &node)
+	store := NewStore(ctx, cfg, eng, &node)
 	// Fake an ident because this test doesn't want to start the store
 	// but without an Ident there will be NPEs.
 	store.Ident = &roachpb.StoreIdent{

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -231,9 +231,9 @@ func createTestStoreWithoutStart(
 			return splits[i].Less(splits[j])
 		})
 	}
-	if err := store.WriteInitialData(
-		context.TODO(), kvs /* initialValues */, cfg.Settings.Version.BootstrapVersion().Version,
-		1 /* numStores */, splits,
+	if err := WriteInitialClusterData(
+		context.TODO(), eng, kvs /* initialValues */, cfg.Settings.Version.BootstrapVersion().Version,
+		1 /* numStores */, splits, cfg.Clock.PhysicalNow(),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -442,9 +442,9 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 			return splits[i].Less(splits[j])
 		})
 
-		if err := store.WriteInitialData(
-			ctx, kvs /* initialValues */, cfg.Settings.Version.BootstrapVersion().Version,
-			1 /* numStores */, splits,
+		if err := WriteInitialClusterData(
+			ctx, eng, kvs /* initialValues */, cfg.Settings.Version.BootstrapVersion().Version,
+			1 /* numStores */, splits, cfg.Clock.PhysicalNow(),
 		); err != nil {
 			t.Errorf("failure to create first range: %s", err)
 		}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -217,7 +217,7 @@ func createTestStoreWithoutStart(
 	cfg.DB = client.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
 	store := NewStore(context.TODO(), *cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 	factory.setStore(store)
-	if err := Bootstrap(
+	if err := InitEngine(
 		context.TODO(), eng, roachpb.StoreIdent{NodeID: 1, StoreID: 1}, cfg.Settings.Version.BootstrapVersion(),
 	); err != nil {
 		t.Fatal(err)
@@ -421,7 +421,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 		}
 
 		// Bootstrap with a fake ident.
-		if err := Bootstrap(ctx, eng, testIdent, cfg.Settings.Version.BootstrapVersion()); err != nil {
+		if err := InitEngine(ctx, eng, testIdent, cfg.Settings.Version.BootstrapVersion()); err != nil {
 			t.Errorf("error bootstrapping store: %s", err)
 		}
 
@@ -499,7 +499,7 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	}
 
 	// Bootstrap should fail on non-empty engine.
-	switch err := errors.Cause(Bootstrap(ctx, eng, testIdent, cfg.Settings.Version.BootstrapVersion())); err.(type) {
+	switch err := errors.Cause(InitEngine(ctx, eng, testIdent, cfg.Settings.Version.BootstrapVersion())); err.(type) {
 	case *NotBootstrappedError:
 	default:
 		t.Errorf("unexpected error bootstrapping non-empty store: %v", err)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -215,7 +215,7 @@ func createTestStoreWithoutStart(
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
 	factory := &testSenderFactory{}
 	cfg.DB = client.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
-	store := NewStore(*cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
+	store := NewStore(context.TODO(), *cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 	factory.setStore(store)
 	if err := Bootstrap(
 		context.TODO(), eng, roachpb.StoreIdent{NodeID: 1, StoreID: 1}, cfg.Settings.Version.BootstrapVersion(),
@@ -414,7 +414,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	factory := &testSenderFactory{}
 	cfg.DB = client.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
 	{
-		store := NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
+		store := NewStore(ctx, cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 		// Can't start as haven't bootstrapped.
 		if err := store.Start(ctx, stopper); err == nil {
 			t.Error("expected failure starting un-bootstrapped store")
@@ -451,7 +451,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	}
 
 	// Now, attempt to initialize a store with a now-bootstrapped range.
-	store := NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
+	store := NewStore(ctx, cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 	if err := store.Start(ctx, stopper); err != nil {
 		t.Fatalf("failure initializing bootstrapped store: %s", err)
 	}
@@ -489,7 +489,7 @@ func TestBootstrapOfNonEmptyStore(t *testing.T) {
 	}
 	cfg := TestStoreConfig(nil)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
-	store := NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
+	store := NewStore(ctx, cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 
 	// Can't init as haven't bootstrapped.
 	switch err := errors.Cause(store.Start(ctx, stopper)); err.(type) {

--- a/pkg/storage/stores_test.go
+++ b/pkg/storage/stores_test.go
@@ -114,8 +114,9 @@ func TestStoresVisitStores(t *testing.T) {
 
 func TestStoresGetReplicaForRangeID(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
+	defer stopper.Stop(ctx)
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 
@@ -131,7 +132,7 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 		cfg := TestStoreConfig(clock)
 		cfg.Transport = NewDummyRaftTransport(cfg.Settings)
 
-		store := NewStore(cfg, memEngine, &roachpb.NodeDescriptor{NodeID: 1})
+		store := NewStore(ctx, cfg, memEngine, &roachpb.NodeDescriptor{NodeID: 1})
 		// Fake-set an ident. This is usually read from the engine on store.Start()
 		// which we're not even going to call.
 		store.Ident = &roachpb.StoreIdent{StoreID: storeID}
@@ -216,7 +217,7 @@ func createStores(count int, t *testing.T) (*hlc.ManualClock, []*Store, *Stores,
 		cfg.Transport = NewDummyRaftTransport(cfg.Settings)
 		eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 		stopper.AddCloser(eng)
-		s := NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
+		s := NewStore(context.TODO(), cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 		storeIDAlloc++
 		s.Ident = &roachpb.StoreIdent{StoreID: storeIDAlloc}
 		stores = append(stores, s)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -172,7 +172,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	cfg.TimestampCachePageSize = tscache.TestSklPageSize
 	ctx := context.TODO()
 
-	if err := storage.Bootstrap(ctx, ltc.Eng, roachpb.StoreIdent{NodeID: nodeID, StoreID: 1}, cfg.Settings.Version.BootstrapVersion()); err != nil {
+	if err := storage.InitEngine(ctx, ltc.Eng, roachpb.StoreIdent{NodeID: nodeID, StoreID: 1}, cfg.Settings.Version.BootstrapVersion()); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
 	ltc.Store = storage.NewStore(ctx, cfg, ltc.Eng, nodeDesc)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -175,7 +175,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	if err := storage.Bootstrap(ctx, ltc.Eng, roachpb.StoreIdent{NodeID: nodeID, StoreID: 1}, cfg.Settings.Version.BootstrapVersion()); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
-	ltc.Store = storage.NewStore(cfg, ltc.Eng, nodeDesc)
+	ltc.Store = storage.NewStore(ctx, cfg, ltc.Eng, nodeDesc)
 
 	var initialValues []roachpb.KeyValue
 	var splits []roachpb.RKey

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -189,12 +189,14 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		})
 	}
 
-	if err := ltc.Store.WriteInitialData(
+	if err := storage.WriteInitialClusterData(
 		ctx,
+		ltc.Eng,
 		initialValues,
 		cfg.Settings.Version.ServerVersion,
 		1, /* numStores */
 		splits,
+		ltc.Clock.PhysicalNow(),
 	); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}


### PR DESCRIPTION
See individual commits.

These are all minor. I'm trying to somehow get server creation to only happen after a node id is known, but I'm getting a bit discouraged cause everything is tangled.