### PR TITLE
storage: remove unused code

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -348,14 +348,6 @@ func (ts *TestServer) ExpectedInitialRangeCount() (int, error) {
 	return ExpectedInitialRangeCount(ts.DB())
 }
 
-// ExpectedInitialUserRangeCount returns the expected number of ranges that should
-// be on the server after initial (asynchronous) splits have been completed,
-// assuming no additional information is added outside of the normal bootstrap
-// process.
-func (ts *TestServer) ExpectedInitialUserRangeCount() int {
-	return ExpectedInitialUserRangeCount(ts.DB())
-}
-
 // ExpectedInitialRangeCount returns the expected number of ranges that should
 // be on the server after bootstrap.
 func ExpectedInitialRangeCount(db *client.DB) (int, error) {
@@ -378,14 +370,6 @@ func ExpectedInitialRangeCount(db *client.DB) (int, error) {
 
 	// `n` splits create `n+1` ranges.
 	return len(config.StaticSplits()) + systemTableSplits + 1, nil
-}
-
-// ExpectedInitialUserRangeCount returns the expected number of user ranges that should
-// be on the server after initial (asynchronous) splits have been completed,
-// assuming no additional information is added outside of the normal bootstrap
-// process.
-func ExpectedInitialUserRangeCount(db *client.DB) int {
-	return 1
 }
 
 // Stores returns the collection of stores from this TestServer's node.

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1682,7 +1682,7 @@ func TestSystemZoneConfigs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedUserRanges := tc.Servers[0].ExpectedInitialUserRangeCount()
+	expectedUserRanges := 1
 	expectedSystemRanges -= expectedUserRanges
 	systemNumReplicas := int(*config.DefaultSystemZoneConfig().NumReplicas)
 	userNumReplicas := int(*config.DefaultZoneConfig().NumReplicas)


### PR DESCRIPTION
Release note: None

These were detected with a newer version of the linters (I'm working on updating that dependency). Are any of the routines in rocksdb worth keeping around for possible future use? (I can add them back with a `var _ = ...`)