### PR TITLE
sql: fix type-indexing bug for wrapped planNodes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/ordinality
+++ b/pkg/sql/logictest/testdata/logic_test/ordinality
@@ -80,3 +80,7 @@ SELECT ordinality = row_number() OVER () FROM foo WITH ORDINALITY
 true
 true
 true
+
+# Regression test for #33659
+statement ok
+TABLE [SHOW ZONE CONFIGURATIONS] WITH ORDINALITY

--- a/pkg/sql/row_source_to_plan_node.go
+++ b/pkg/sql/row_source_to_plan_node.go
@@ -103,7 +103,7 @@ func (r *rowSourceToPlanNode) Next(params runParams) (bool, error) {
 				continue
 			}
 			encDatum := r.row[idx]
-			err := encDatum.EnsureDecoded(&types[i], &r.da)
+			err := encDatum.EnsureDecoded(&types[idx], &r.da)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
Corrects a bug in the last fix for this area, #33537.

Fixes #33659.

Release note: None