### PR TITLE
rangefeed: Proper ordering for catchup scan

### DIFF
--- a/pkg/storage/rangefeed/registry_test.go
+++ b/pkg/storage/rangefeed/registry_test.go
@@ -245,11 +245,11 @@ func TestRegistrationCatchUpScan(t *testing.T) {
 	expEvents := []*roachpb.RangeFeedEvent{
 		rangeFeedValue(
 			roachpb.Key("d"),
-			roachpb.Value{RawBytes: []byte("val5"), Timestamp: hlc.Timestamp{WallTime: 20}},
+			roachpb.Value{RawBytes: []byte("val6"), Timestamp: hlc.Timestamp{WallTime: 19}},
 		),
 		rangeFeedValue(
 			roachpb.Key("d"),
-			roachpb.Value{RawBytes: []byte("val6"), Timestamp: hlc.Timestamp{WallTime: 19}},
+			roachpb.Value{RawBytes: []byte("val5"), Timestamp: hlc.Timestamp{WallTime: 20}},
 		),
 		rangeFeedValue(
 			roachpb.Key("g"),


### PR DESCRIPTION
Modifies the catch-up scan of the rangefeed to output results in the
needed order to meet guarantees for the Changefeed. Specifically, MVCC
entries for each key are now output in ascending timestamp order,
whereas on disk they are stored in descending timestamp order.

Adjusts a small number of tests to match the new guarantees, and adds a
new validator-based test to explicitly test the ordering.

Fixes #32946

Release note: None