### PR TITLE
roachtest: load build version for bench

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -97,14 +97,7 @@ Examples:
    roachtest list tag:weekly
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
-			r := newRegistry()
-			if buildTag != "" {
-				if err := r.setBuildVersion(buildTag); err != nil {
-					return err
-				}
-			} else {
-				r.loadBuildVersion()
-			}
+			r := newRegistry(setBuildVersion)
 			if !listBench {
 				registerTests(r)
 			} else {
@@ -134,15 +127,7 @@ the test tags.
 			if count <= 0 {
 				return fmt.Errorf("--count (%d) must by greater than 0", count)
 			}
-
-			r := newRegistry()
-			if buildTag != "" {
-				if err := r.setBuildVersion(buildTag); err != nil {
-					return err
-				}
-			} else {
-				r.loadBuildVersion()
-			}
+			r := newRegistry(setBuildVersion)
 			registerTests(r)
 			os.Exit(r.Run(args, parallelism, artifacts, getUser(username)))
 			return nil
@@ -164,7 +149,7 @@ the test tags.
 			if count <= 0 {
 				return fmt.Errorf("--count (%d) must by greater than 0", count)
 			}
-			r := newRegistry()
+			r := newRegistry(setBuildVersion)
 			registerBenchmarks(r)
 			os.Exit(r.Run(args, parallelism, artifacts, getUser(username)))
 			return nil


### PR DESCRIPTION
Before the PR we would not load the build version on the bench command
which could lead to a nil pointer panic when trying to compare against
MinVersion. This was exposed recently when we enforce that tpcc on AWS
requires version >= v2.2.0. Also refactors the version loading into a
helper.

Release note: None