### PR TITLE
sql: switch QueryArguments, PlaceholderTypes to slices

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -345,9 +345,11 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, 
     PARTITION p1 VALUES FROM (0, 0) TO (0, (DEFAULT))
 )
 
-statement error unimplemented: placeholders are not supported in PARTITION BY
-CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES IN ($1)
+# TODO(radu): we are not properly walking the expressions when
+# walking CREATE TABLE.
+statement error pq: could not determine data type of placeholder \$1
+PREPARE a AS CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN ($1:::int)
 )
 
 statement error syntax error

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -306,7 +306,7 @@ func (ex *connExecutor) execBind(
 
 	// Decode the arguments, except for internal queries for which we just verify
 	// that the arguments match what's expected.
-	qargs := tree.QueryArguments{}
+	qargs := make(tree.QueryArguments, numQArgs)
 	if bindCmd.internalArgs != nil {
 		if len(bindCmd.internalArgs) != int(numQArgs) {
 			return retErr(
@@ -320,7 +320,7 @@ func (ex *connExecutor) execBind(
 					pgwirebase.NewProtocolViolationErrorf(
 						"for argument %d expected OID %d, got %d", i, t, oid))
 			}
-			qargs[types.PlaceholderIdx(i)] = datum
+			qargs[i] = datum
 		}
 	} else {
 		qArgFormatCodes := bindCmd.ArgFormatCodes

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -39,7 +39,7 @@ func (ex *connExecutor) execPrepare(
 		return eventNonRetriableErr{IsCommit: fsm.False}, eventNonRetriableErrPayload{err: err}
 	}
 
-	// The anonymous statement can be overwritter.
+	// The anonymous statement can be overwritten.
 	if parseCmd.Name != "" {
 		if _, ok := ex.extraTxnState.prepStmtsNamespace.prepStmts[parseCmd.Name]; ok {
 			err := pgerror.NewErrorf(
@@ -61,44 +61,27 @@ func (ex *connExecutor) execPrepare(
 	}
 
 	// Convert the inferred SQL types back to an array of pgwire Oids.
-	inTypes := make([]oid.Oid, 0, len(ps.Types))
 	if len(ps.TypeHints) > pgwirebase.MaxPreparedStatementArgs {
 		return retErr(
 			pgwirebase.NewProtocolViolationErrorf(
 				"more than %d arguments to prepared statement: %d",
 				pgwirebase.MaxPreparedStatementArgs, len(ps.TypeHints)))
 	}
-	for k := range ps.Types {
-		// Placeholder names are 1-indexed; the arrays in the protocol are
-		// 0-indexed.
-		i := int(k)
-		// Grow inTypes to be at least as large as i. Prepopulate all
-		// slots with the hints provided, if any.
-		for j := len(inTypes); j <= i; j++ {
-			inTypes = append(inTypes, 0)
-			if j < len(parseCmd.RawTypeHints) {
-				inTypes[j] = parseCmd.RawTypeHints[j]
-			}
-		}
+	inferredTypes := make([]oid.Oid, len(ps.Types))
+	copy(inferredTypes, parseCmd.RawTypeHints)
+
+	for i := range ps.Types {
 		// OID to Datum is not a 1-1 mapping (for example, int4 and int8
 		// both map to TypeInt), so we need to maintain the types sent by
 		// the client.
-		if inTypes[i] != 0 {
-			continue
-		}
-		t, _ := ps.ValueType(k)
-		inTypes[i] = t.Oid()
-	}
-	for i, t := range inTypes {
-		if t == 0 {
-			return retErr(pgerror.NewErrorf(
-				pgerror.CodeIndeterminateDatatypeError,
-				"could not determine data type of placeholder %s", types.PlaceholderIdx(i)))
+		if inferredTypes[i] == 0 {
+			t, _ := ps.ValueType(types.PlaceholderIdx(i))
+			inferredTypes[i] = t.Oid()
 		}
 	}
 	// Remember the inferred placeholder types so they can be reported on
 	// Describe.
-	ps.InTypes = inTypes
+	ps.InferredTypes = inferredTypes
 	return nil, nil
 }
 
@@ -139,7 +122,7 @@ func (ex *connExecutor) prepare(
 	ctx context.Context, stmt Statement, placeholderHints tree.PlaceholderTypes,
 ) (*PreparedStatement, error) {
 	if placeholderHints == nil {
-		placeholderHints = make(tree.PlaceholderTypes)
+		placeholderHints = make(tree.PlaceholderTypes, stmt.NumPlaceholders)
 	}
 
 	prepared := &PreparedStatement{
@@ -204,7 +187,7 @@ func (ex *connExecutor) populatePrepared(
 	p *planner,
 ) (planFlags, error) {
 	prepared := stmt.Prepared
-	p.semaCtx.Placeholders.Reset(placeholderHints)
+	p.semaCtx.Placeholders.Init(stmt.NumPlaceholders, placeholderHints)
 	p.extendedEvalCtx.PrepareOnly = true
 	p.extendedEvalCtx.ActiveMemAcc = &prepared.memAcc
 	// constantMemAcc accounts for all constant folded values that are computed
@@ -271,6 +254,10 @@ func (ex *connExecutor) populatePrepared(
 			return 0, err
 		}
 	}
+	// Verify that all placeholder types have been set.
+	if err := p.semaCtx.Placeholders.Types.AssertAllSet(); err != nil {
+		return 0, err
+	}
 	prepared.Types = p.semaCtx.Placeholders.Types
 	return flags, nil
 }
@@ -302,7 +289,7 @@ func (ex *connExecutor) execBind(
 			"unknown prepared statement %q", bindCmd.PreparedStatementName))
 	}
 
-	numQArgs := uint16(len(ps.InTypes))
+	numQArgs := uint16(len(ps.InferredTypes))
 
 	// Decode the arguments, except for internal queries for which we just verify
 	// that the arguments match what's expected.
@@ -314,7 +301,7 @@ func (ex *connExecutor) execBind(
 					"expected %d arguments, got %d", numQArgs, len(bindCmd.internalArgs)))
 		}
 		for i, datum := range bindCmd.internalArgs {
-			t := ps.InTypes[i]
+			t := ps.InferredTypes[i]
 			if oid := datum.ResolvedType().Oid(); datum != tree.DNull && oid != t {
 				return retErr(
 					pgwirebase.NewProtocolViolationErrorf(
@@ -351,7 +338,7 @@ func (ex *connExecutor) execBind(
 
 		for i, arg := range bindCmd.Args {
 			k := types.PlaceholderIdx(i)
-			t := ps.InTypes[i]
+			t := ps.InferredTypes[i]
 			if arg == nil {
 				// nil indicates a NULL argument value.
 				qargs[k] = tree.DNull
@@ -487,7 +474,7 @@ func (ex *connExecutor) execDescribe(
 				"unknown prepared statement %q", descCmd.Name))
 		}
 
-		res.SetInTypes(ps.InTypes)
+		res.SetInferredTypes(ps.InferredTypes)
 
 		if stmtHasNoData(ps.AST) {
 			res.SetNoDataRowDescription()

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -718,8 +718,8 @@ type RestrictedCommandResult interface {
 type DescribeResult interface {
 	ResultBase
 
-	// SetInTypes tells the client about the inferred placeholder types.
-	SetInTypes([]oid.Oid)
+	// SetInferredTypes tells the client about the inferred placeholder types.
+	SetInferredTypes([]oid.Oid)
 	// SetNoDataDescription is used to tell the client that the prepared statement
 	// or portal produces no rows.
 	SetNoDataRowDescription()
@@ -933,8 +933,8 @@ func (r *bufferedCommandResult) Discard() {
 	}
 }
 
-// SetInTypes is part of the DescribeResult interface.
-func (r *bufferedCommandResult) SetInTypes([]oid.Oid) {}
+// SetInferredTypes is part of the DescribeResult interface.
+func (r *bufferedCommandResult) SetInferredTypes([]oid.Oid) {}
 
 // SetNoDataRowDescription is part of the DescribeResult interface.
 func (r *bufferedCommandResult) SetNoDataRowDescription() {}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -441,9 +441,6 @@ statement error could not parse "foo" as type int
 ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 'foo'
 
 statement error variable sub-expressions are not allowed in DEFAULT
-ALTER TABLE add_default ALTER COLUMN b SET DEFAULT $1
-
-statement error variable sub-expressions are not allowed in DEFAULT
 ALTER TABLE add_default ALTER COLUMN b SET DEFAULT c
 
 statement error variable sub-expressions are not allowed in DEFAULT

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -201,9 +201,6 @@ SELECT * FROM t5
 2 11  9
 
 statement error variable sub-expressions are not allowed in CHECK
-CREATE TABLE t6 (x INT CHECK (x = $1))
-
-statement error variable sub-expressions are not allowed in CHECK
 CREATE TABLE t6 (x INT CHECK (x = (SELECT 1)))
 
 # Check auto-generated constraint names.

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -4,9 +4,6 @@ statement error expected DEFAULT expression to have type int, but 'false' has ty
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT false)
 
 statement error variable sub-expressions are not allowed in DEFAULT
-CREATE TABLE t (a INT PRIMARY KEY DEFAULT $1)
-
-statement error variable sub-expressions are not allowed in DEFAULT
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT (SELECT 1))
 
 statement error variable sub-expressions are not allowed in DEFAULT

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -69,7 +69,13 @@ PREPARE a as ()
 statement error could not determine data type of placeholder \$1
 PREPARE a AS SELECT $1
 
-statement
+statement error could not determine data type of placeholder \$1
+PREPARE a AS SELECT $2:::int
+
+statement error could not determine data type of placeholder \$2
+PREPARE a AS SELECT $1:::int, $3:::int
+
+statement ok
 PREPARE a AS SELECT $1:::int + $2
 
 query I
@@ -812,3 +818,6 @@ a  d
 
 statement ok
 ROLLBACK TRANSACTION
+
+statement error no value provided for placeholder: \$1
+SELECT $1:::int

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -486,6 +486,7 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 		}
 	}
 
+	h.semaCtx.Placeholders.Init(len(h.query.args), nil /* typeHints */)
 	if h.query.prepare {
 		// Prepare the query by normalizing it (if it has placeholders) or exploring
 		// it (if it doesn't have placeholders), and cache the resulting memo so that
@@ -502,6 +503,7 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 	}
 
 	// Construct placeholder values.
+	h.semaCtx.Placeholders.Values = make(tree.QueryArguments, len(h.query.args))
 	for i, arg := range h.query.args {
 		var parg tree.Expr
 		parg, err := parser.ParseExpr(fmt.Sprintf("%v", arg))
@@ -523,7 +525,7 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 			tb.Fatalf("%v", err)
 		}
 
-		h.semaCtx.Placeholders.Values[id] = texpr
+		h.semaCtx.Placeholders.Values[i] = texpr
 	}
 	h.evalCtx.Placeholders = &h.semaCtx.Placeholders
 }

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -64,6 +64,7 @@ func TestMemoInit(t *testing.T) {
 
 	ctx := context.Background()
 	semaCtx := tree.MakeSemaContext(false /* privileged */)
+	semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */)
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 	var o xform.Optimizer

--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -806,7 +806,7 @@ func (ot *OptTester) buildExpr(factory *norm.Factory) error {
 	if err != nil {
 		return err
 	}
-
+	ot.semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */)
 	b := optbuilder.New(ot.ctx, &ot.semaCtx, &ot.evalCtx, ot.catalog, factory, stmt.AST)
 	b.AllowUnsupportedExpr = ot.Flags.AllowUnsupportedExpr
 	if ot.Flags.FullyQualifyNames {

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -47,6 +47,7 @@ func TestDetachMemo(t *testing.T) {
 
 	ctx := context.Background()
 	semaCtx := tree.MakeSemaContext(false /* privileged */)
+	semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */)
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 	var o xform.Optimizer
@@ -62,7 +63,7 @@ func TestDetachMemo(t *testing.T) {
 		t.Error("memo expression should be reinitialized by DetachMemo")
 	}
 
-	semaCtx.Placeholders.Clear()
+	semaCtx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
 	o.Init(&evalCtx)
 
 	stmt2, err := parser.ParseOne("SELECT a=$1 FROM abc")
@@ -70,6 +71,7 @@ func TestDetachMemo(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	semaCtx.Placeholders.Init(stmt2.NumPlaceholders, nil /* typeHints */)
 	err = optbuilder.New(ctx, &semaCtx, &evalCtx, catalog, o.Factory(), stmt2.AST).Build()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -226,8 +226,8 @@ func (r *commandResult) SetColumns(ctx context.Context, cols sqlbase.ResultColum
 	}
 }
 
-// SetInTypes is part of the DescribeResult interface.
-func (r *commandResult) SetInTypes(types []oid.Oid) {
+// SetInferredTypes is part of the DescribeResult interface.
+func (r *commandResult) SetInferredTypes(types []oid.Oid) {
 	r.conn.writerState.fi.registerCmd(r.pos)
 	r.conn.bufferParamDesc(types)
 }

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -89,6 +89,12 @@ func (p *planner) prepareUsingOptimizer(
 			return 0, false, err
 		}
 	}
+
+	// Verify that all placeholder types have been set.
+	if err := p.semaCtx.Placeholders.Types.AssertAllSet(); err != nil {
+		return 0, false, err
+	}
+
 	stmt.Prepared.Columns = resultCols
 	stmt.Prepared.Types = p.semaCtx.Placeholders.Types
 	if opc.allowMemoReuse {

--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -201,9 +201,10 @@ func ClassifyConversion(
 
 	// See if there's existing cast logic.  If so, return general.
 	ctx := tree.MakeSemaContext(false)
+	ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
 
 	// Use a placeholder just to sub in the original type.
-	fromPlaceholder, err := (&tree.Placeholder{}).TypeCheck(&ctx, oldType.ToDatumType())
+	fromPlaceholder, err := (&tree.Placeholder{Idx: 0}).TypeCheck(&ctx, oldType.ToDatumType())
 	if err != nil {
 		return ColumnConversionImpossible, err
 	}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3988,8 +3988,8 @@ func (t *Placeholder) Eval(ctx *EvalContext) (Datum, error) {
 	}
 	// Placeholder expressions cannot contain other placeholders, so we do
 	// not need to recurse.
-	typ, typed := ctx.Placeholders.Types[t.Idx]
-	if !typed {
+	typ := ctx.Placeholders.Types[t.Idx]
+	if typ == nil {
 		// All placeholders should be typed at this point.
 		return nil, pgerror.NewAssertionErrorf("missing type for placeholder %s", t)
 	}

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -141,7 +141,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		return &BinaryExpr{Operator: Plus, Left: left, Right: right}
 	}
 	placeholder := func(id int) *Placeholder {
-		return &Placeholder{Idx: types.PlaceholderIdx(id - 1)}
+		return &Placeholder{Idx: types.PlaceholderIdx(id)}
 	}
 
 	unaryIntFn := makeTestOverload(types.Int, types.Int)
@@ -186,8 +186,8 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, []Expr{}, []overloadImpl{unaryIntFnPref, unaryIntFnPref}, ambiguous, false},
 		{nil, []Expr{strConst("PT12H2M")}, []overloadImpl{unaryIntervalFn, unaryIntFn}, unaryIntervalFn, false},
 		// Unary unresolved Placeholders.
-		{nil, []Expr{placeholder(1)}, []overloadImpl{unaryStringFn, unaryIntFn}, shouldError, false},
-		{nil, []Expr{placeholder(1)}, []overloadImpl{unaryStringFn, binaryIntFn}, unaryStringFn, false},
+		{nil, []Expr{placeholder(0)}, []overloadImpl{unaryStringFn, unaryIntFn}, shouldError, false},
+		{nil, []Expr{placeholder(0)}, []overloadImpl{unaryStringFn, binaryIntFn}, unaryStringFn, false},
 		// Unary values (not constants).
 		{nil, []Expr{NewDInt(1)}, []overloadImpl{unaryIntFn, unaryFloatFn}, unaryIntFn, false},
 		{nil, []Expr{NewDFloat(1)}, []overloadImpl{unaryIntFn, unaryFloatFn}, unaryFloatFn, false},
@@ -202,11 +202,11 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, []Expr{strConst("2010-09-28"), strConst("2010-09-29")}, []overloadImpl{binaryTimestampFn, binaryStringFn}, binaryStringFn, false},
 		{nil, []Expr{strConst("2010-09-28"), strConst("2010-09-29")}, []overloadImpl{binaryTimestampFn, binaryIntFn}, binaryTimestampFn, false},
 		// Binary unresolved Placeholders.
-		{nil, []Expr{placeholder(1), placeholder(2)}, []overloadImpl{binaryIntFn, binaryFloatFn}, shouldError, false},
-		{nil, []Expr{placeholder(1), placeholder(2)}, []overloadImpl{binaryIntFn, unaryStringFn}, binaryIntFn, false},
-		{nil, []Expr{placeholder(1), NewDString("a")}, []overloadImpl{binaryIntFn, binaryStringFn}, binaryStringFn, false},
-		{nil, []Expr{placeholder(1), intConst("1")}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryIntFn, false},
-		{nil, []Expr{placeholder(1), intConst("1")}, []overloadImpl{binaryStringFn, binaryFloatFn}, binaryFloatFn, false},
+		{nil, []Expr{placeholder(0), placeholder(1)}, []overloadImpl{binaryIntFn, binaryFloatFn}, shouldError, false},
+		{nil, []Expr{placeholder(0), placeholder(1)}, []overloadImpl{binaryIntFn, unaryStringFn}, binaryIntFn, false},
+		{nil, []Expr{placeholder(0), NewDString("a")}, []overloadImpl{binaryIntFn, binaryStringFn}, binaryStringFn, false},
+		{nil, []Expr{placeholder(0), intConst("1")}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryIntFn, false},
+		{nil, []Expr{placeholder(0), intConst("1")}, []overloadImpl{binaryStringFn, binaryFloatFn}, binaryFloatFn, false},
 		// Binary values.
 		{nil, []Expr{NewDString("a"), NewDString("b")}, []overloadImpl{binaryStringFn, binaryFloatFn, unaryFloatFn}, binaryStringFn, false},
 		{nil, []Expr{NewDString("a"), intConst("1")}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1}, binaryStringFloatFn1, false},
@@ -220,7 +220,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{types.Int, []Expr{intConst("1"), NewDFloat(1)}, []overloadImpl{binaryIntFn, binaryFloatFn, unaryFloatFn}, binaryFloatFn, false},
 		{types.Int, []Expr{NewDString("a"), NewDFloat(1)}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1, binaryStringFloatFn2}, binaryStringFloatFn1, false},
 		{types.Float, []Expr{NewDString("a"), NewDFloat(1)}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1, binaryStringFloatFn2}, binaryStringFloatFn2, false},
-		{types.Float, []Expr{placeholder(1), placeholder(2)}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryFloatFn, false},
+		{types.Float, []Expr{placeholder(0), placeholder(1)}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryFloatFn, false},
 		// Sub-expressions.
 		{nil, []Expr{decConst("1.0"), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, binaryIntFn, false},
 		{nil, []Expr{decConst("1.1"), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, shouldError, false},
@@ -230,14 +230,14 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		{nil, []Expr{plus(decConst("1.1"), decConst("2.2")), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, shouldError, false},
 		{nil, []Expr{plus(NewDFloat(1.1), NewDFloat(2.2)), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryFloatFn, false},
 		// Homogenous preference.
-		{nil, []Expr{NewDInt(1), placeholder(2)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn, false},
-		{nil, []Expr{NewDFloat(1), placeholder(2)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, unsupported, false},
-		{nil, []Expr{intConst("1"), placeholder(2)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn, false},
-		{nil, []Expr{decConst("1.0"), placeholder(2)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, unsupported, false}, // Limitation.
-		{types.Date, []Expr{NewDInt(1), placeholder(2)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn, false},
-		{types.Date, []Expr{NewDFloat(1), placeholder(2)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, unsupported, false},
-		{types.Date, []Expr{intConst("1"), placeholder(2)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn, false},
-		{types.Date, []Expr{decConst("1.0"), placeholder(2)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn, false},
+		{nil, []Expr{NewDInt(1), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn, false},
+		{nil, []Expr{NewDFloat(1), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, unsupported, false},
+		{nil, []Expr{intConst("1"), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn, false},
+		{nil, []Expr{decConst("1.0"), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, unsupported, false}, // Limitation.
+		{types.Date, []Expr{NewDInt(1), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn, false},
+		{types.Date, []Expr{NewDFloat(1), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, unsupported, false},
+		{types.Date, []Expr{intConst("1"), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn, false},
+		{types.Date, []Expr{decConst("1.0"), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn, false},
 		// BinOps
 		{nil, []Expr{NewDInt(1), DNull}, []overloadImpl{binaryIntFn, binaryIntDateFn}, ambiguous, false},
 		{nil, []Expr{NewDInt(1), DNull}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn, true},
@@ -245,6 +245,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 	for i, d := range testData {
 		t.Run(fmt.Sprintf("%v/%v", d.exprs, d.overloads), func(t *testing.T) {
 			ctx := MakeSemaContext(false)
+			ctx.Placeholders.Init(2 /* numPlaceholders */, nil /* typeHints */)
 			desired := types.Any
 			if d.desired != nil {
 				desired = d.desired

--- a/pkg/sql/sem/tree/placeholders.go
+++ b/pkg/sql/sem/tree/placeholders.go
@@ -25,8 +25,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
-// PlaceholderTypes relates placeholder names to their resolved type.
-type PlaceholderTypes map[types.PlaceholderIdx]types.T
+// PlaceholderTypes stores placeholder types (or type hints), one per
+// PlaceholderIdx.  The slice is always pre-allocated to the number of
+// placeholders in the statement. Entries that don't yet have a type are nil.
+type PlaceholderTypes []types.T
 
 // Equals returns true if two PlaceholderTypes contain the same types.
 func (pt PlaceholderTypes) Equals(other PlaceholderTypes) bool {
@@ -34,12 +36,26 @@ func (pt PlaceholderTypes) Equals(other PlaceholderTypes) bool {
 		return false
 	}
 	for i, t := range pt {
-		otherT, ok := other[i]
-		if !ok || !t.Equivalent(otherT) {
+		switch {
+		case t == nil && other[i] == nil:
+		case t == nil || other[i] == nil:
+			return false
+		case !t.Equivalent(other[i]):
 			return false
 		}
 	}
 	return true
+}
+
+// AssertAllSet verifies that all types have been set and returns an error
+// otherwise.
+func (pt PlaceholderTypes) AssertAllSet() error {
+	for i := range pt {
+		if pt[i] == nil {
+			return placeholderTypeAmbiguityError{types.PlaceholderIdx(i)}
+		}
+	}
+	return nil
 }
 
 // QueryArguments stores query arguments, one per PlaceholderIdx.
@@ -75,12 +91,11 @@ type PlaceholderTypesInfo struct {
 // Type returns the known type of a placeholder. If there is no known type yet
 // but there is a type hint, returns the type hint.
 func (p *PlaceholderTypesInfo) Type(idx types.PlaceholderIdx) (_ types.T, ok bool) {
-	if t, ok := p.Types[idx]; ok {
-		return t, true
-	} else if t, ok := p.TypeHints[idx]; ok {
-		return t, true
+	t := p.Types[idx]
+	if t == nil && len(p.TypeHints) >= int(idx) {
+		t = p.TypeHints[idx]
 	}
-	return nil, false
+	return t, (t != nil)
 }
 
 // ValueType returns the type of the value that must be supplied for a placeholder.
@@ -88,19 +103,20 @@ func (p *PlaceholderTypesInfo) Type(idx types.PlaceholderIdx) (_ types.T, ok boo
 // type if there isn't one. This can differ from Type(idx) when a client hint is
 // overridden (see Placeholder.Eval).
 func (p *PlaceholderTypesInfo) ValueType(idx types.PlaceholderIdx) (_ types.T, ok bool) {
-	if t, ok := p.TypeHints[idx]; ok {
-		return t, true
-	} else if t, ok := p.Types[idx]; ok {
-		return t, true
+	var t types.T
+	if len(p.TypeHints) >= int(idx) {
+		t = p.TypeHints[idx]
 	}
-	return nil, false
-
+	if t == nil {
+		t = p.Types[idx]
+	}
+	return t, (t != nil)
 }
 
 // SetType assigns a known type to a placeholder.
 // Reports an error if another type was previously assigned.
 func (p *PlaceholderTypesInfo) SetType(idx types.PlaceholderIdx, typ types.T) error {
-	if t, ok := p.Types[idx]; ok {
+	if t := p.Types[idx]; t != nil {
 		if !typ.Equivalent(t) {
 			return pgerror.NewErrorf(
 				pgerror.CodeDatatypeMismatchError,
@@ -123,40 +139,32 @@ type PlaceholderInfo struct {
 	permitUnassigned bool
 }
 
-// MakePlaceholderInfo constructs an empty PlaceholderInfo.
-func MakePlaceholderInfo() PlaceholderInfo {
-	res := PlaceholderInfo{}
-	res.Clear()
-	return res
-}
-
-// Clear resets the placeholder info map.
-func (p *PlaceholderInfo) Clear() {
-	p.TypeHints = PlaceholderTypes{}
-	p.Types = PlaceholderTypes{}
+// Init initializes a PlaceholderInfo structure appropriate for the given number
+// of placeholders, and with the given (optional) type hints.
+func (p *PlaceholderInfo) Init(numPlaceholders int, typeHints PlaceholderTypes) {
+	p.Types = make(PlaceholderTypes, numPlaceholders)
+	if typeHints == nil {
+		p.TypeHints = make(PlaceholderTypes, numPlaceholders)
+	} else {
+		if len(typeHints) != numPlaceholders {
+			panic("typeHints of invalid length")
+		}
+		p.TypeHints = typeHints
+	}
 	p.Values = nil
 	p.permitUnassigned = false
 }
 
-// Reset resets the type and values in the map and replaces the type hints map
-// by an alias to typeHints. If typeHints is nil, the map is cleared.
-func (p *PlaceholderInfo) Reset(typeHints PlaceholderTypes) {
-	if typeHints != nil {
-		p.TypeHints = typeHints
-		p.Types = PlaceholderTypes{}
-		p.Values = nil
-	} else {
-		p.Clear()
-	}
-}
-
 // Assign resets the PlaceholderInfo to the contents of src.
-// If src is nil, the map is cleared.
-func (p *PlaceholderInfo) Assign(src *PlaceholderInfo) {
+// If src is nil, a new structure is initialized.
+func (p *PlaceholderInfo) Assign(src *PlaceholderInfo, numPlaceholders int) {
 	if src != nil {
+		if len(src.Types) != numPlaceholders {
+			panic("inconsistent number of placeholders")
+		}
 		*p = *src
 	} else {
-		p.Clear()
+		p.Init(numPlaceholders, nil /* typeHints */)
 	}
 }
 
@@ -173,9 +181,10 @@ func (p *PlaceholderInfo) AssertAllAssigned() error {
 		return nil
 	}
 	var missing []string
-	for pn := range p.Types {
-		if _, ok := p.Value(pn); !ok {
-			missing = append(missing, pn.String())
+	for i := range p.Types {
+		idx := types.PlaceholderIdx(i)
+		if _, ok := p.Value(idx); !ok {
+			missing = append(missing, idx.String())
 		}
 	}
 	if len(missing) > 0 {

--- a/pkg/sql/sem/tree/placeholders_test.go
+++ b/pkg/sql/sem/tree/placeholders_test.go
@@ -1,0 +1,77 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+func TestPlaceholderTypesEquals(t *testing.T) {
+	testCases := []struct {
+		a, b  PlaceholderTypes
+		equal bool
+	}{
+		{ // 0
+			PlaceholderTypes{},
+			PlaceholderTypes{},
+			true,
+		},
+		{ // 1
+			PlaceholderTypes{types.Int, types.Int},
+			PlaceholderTypes{types.Int, types.Int},
+			true,
+		},
+		{ // 2
+			PlaceholderTypes{types.Int},
+			PlaceholderTypes{types.Int, types.Int},
+			false,
+		},
+		{ // 3
+			PlaceholderTypes{types.Int, nil},
+			PlaceholderTypes{types.Int, types.Int},
+			false,
+		},
+		{ // 4
+			PlaceholderTypes{types.Int, types.Int},
+			PlaceholderTypes{types.Int, nil},
+			false,
+		},
+		{ // 5
+			PlaceholderTypes{types.Int, nil},
+			PlaceholderTypes{types.Int, nil},
+			true,
+		},
+		{ // 6
+			PlaceholderTypes{types.Int},
+			PlaceholderTypes{types.Int, nil},
+			false,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			res := tc.a.Equals(tc.b)
+			if res != tc.equal {
+				t.Errorf("%v vs %v: expected %t, got %t", tc.a, tc.b, tc.equal, res)
+			}
+			res2 := tc.b.Equals(tc.a)
+			if res != res2 {
+				t.Errorf("%v vs %v: not commutative", tc.a, tc.b)
+			}
+		})
+	}
+}

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -174,6 +174,7 @@ func TestTypeCheck(t *testing.T) {
 				t.Fatalf("%s: %v", d.expr, err)
 			}
 			ctx := tree.MakeSemaContext(false)
+			ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
 			typeChecked, err := tree.TypeCheck(expr, &ctx, types.Any)
 			if err != nil {
 				t.Fatalf("%s: unexpected error %s", d.expr, err)

--- a/pkg/sql/sqlbase/prepared_statement.go
+++ b/pkg/sql/sqlbase/prepared_statement.go
@@ -40,9 +40,9 @@ type PrepareMetadata struct {
 	// Columns are the types and names of the query output columns.
 	Columns ResultColumns
 
-	// InTypes represents the inferred types for placeholder, using protocol
+	// InferredTypes represents the inferred types for placeholder, using protocol
 	// identifiers. Used for reporting on Describe.
-	InTypes []oid.Oid
+	InferredTypes []oid.Oid
 }
 
 // MemoryEstimate returns an estimation (in bytes) of how much memory is used by
@@ -60,6 +60,6 @@ func (pm *PrepareMetadata) MemoryEstimate() int64 {
 		int64(unsafe.Sizeof(types.PlaceholderIdx(0))+unsafe.Sizeof(types.T(nil)))
 
 	res += int64(len(pm.Columns)) * int64(unsafe.Sizeof(ResultColumn{}))
-	res += int64(len(pm.InTypes)) * int64(unsafe.Sizeof(oid.Oid(0)))
+	res += int64(len(pm.InferredTypes)) * int64(unsafe.Sizeof(oid.Oid(0)))
 	return res
 }


### PR DESCRIPTION
#### sql: change QueryArguments map to a slice

Release note: None

#### sql: switch PlaceholderTypes to a slice

We switch `PlaceholderTypes` to a slice instead of a map.

We also fix the handling of cases where some placeholders are unused
(e.g. `SELECT $2:::int`) which now error out (before they would crash
during execution). Note that PG also errors out in this case.

Fixes #30086.

Release note (bug fix): Preparing queries with missing placeholders
(e.g. `SELECT $2::int`) now results in an error.
