### PR TITLE
ui: fix combineStatementStats to coalesce sensitiveInfo

### DIFF
--- a/pkg/ui/src/util/appStats.ts
+++ b/pkg/ui/src/util/appStats.ts
@@ -19,6 +19,7 @@
 import _ from "lodash";
 import * as protos from "src/js/protos";
 import { FixLong } from "src/util/fixLong";
+import ISensitiveInfo = protos.cockroach.sql.ISensitiveInfo;
 
 export type StatementStatistics = protos.cockroach.sql.IStatementStatistics;
 export type CollectedStatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
@@ -63,6 +64,14 @@ export function addStatementStats(a: StatementStatistics, b: StatementStatistics
     run_lat: addNumericStats(a.run_lat, b.run_lat, countA, countB),
     service_lat: addNumericStats(a.service_lat, b.service_lat, countA, countB),
     overhead_lat: addNumericStats(a.overhead_lat, b.overhead_lat, countA, countB),
+    sensitive_info: coalesceSensitiveInfo(a.sensitive_info, b.sensitive_info),
+  };
+}
+
+export function coalesceSensitiveInfo(a: ISensitiveInfo, b: ISensitiveInfo) {
+  return {
+    last_err: a.last_err || b.last_err,
+    most_recent_plan_description: a.most_recent_plan_description || b.most_recent_plan_description,
   };
 }
 

--- a/pkg/ui/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/src/views/statements/statements.spec.tsx
@@ -22,6 +22,7 @@ import { CollectedStatementStatistics } from "src/util/appStats";
 import { appAttr, statementAttr } from "src/util/constants";
 import { selectStatements, selectApps, selectTotalFingerprints, selectLastReset } from "./statementsPage";
 import { selectStatement } from "./statementDetails";
+import ISensitiveInfo = protos.cockroach.sql.ISensitiveInfo;
 
 describe("selectStatements", () => {
   it("returns null if the statements data is invalid", () => {
@@ -391,6 +392,7 @@ function makeStats() {
     run_lat: makeStat(),
     overhead_lat: makeStat(),
     service_lat: makeStat(),
+    sensitive_info: makeEmptySensitiveInfo(),
   };
 }
 
@@ -398,6 +400,13 @@ function makeStat() {
   return {
     mean: 10,
     squared_diffs: 1,
+  };
+}
+
+function makeEmptySensitiveInfo(): ISensitiveInfo {
+  return {
+    last_err: null,
+    most_recent_plan_description: null,
   };
 }
 


### PR DESCRIPTION
Logical plans were previously only displayed if fingerprint
had been executed on exactly one node.

This commit fixes the logic that aggregates statementStats
data to account for data in the sensitiveInfo
property.

Release note: None