### PR TITLE
sql: fix logical plan sampling for non-null stats

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -188,7 +188,10 @@ func distChangefeedFlow(
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, noTxn, &p, recv, &evalCtxCopy, finishedSetupFn)
+	cleanup := dsp.Run(planCtx, noTxn, &p, recv, &evalCtxCopy, finishedSetupFn)
+	if cleanup != nil {
+		cleanup()
+	}
 	return resultRows.Err()
 }
 

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -444,12 +444,15 @@ func (sc *SchemaChanger) distBackfill(
 			if err != nil {
 				return err
 			}
-			sc.distSQLPlanner.Run(
+			cleanup := sc.distSQLPlanner.Run(
 				planCtx,
 				nil, /* txn - the processors manage their own transactions */
 				&plan, recv, evalCtx,
 				nil, /* finishedSetupFn */
 			)
+			if cleanup != nil {
+				cleanup()
+			}
 			return rw.Err()
 		}); err != nil {
 			return err

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -920,6 +920,13 @@ func (ex *connExecutor) saveLogicalPlanDescription(
 		// Save logical plan the first time we see new statement fingerprint.
 		return true
 	}
+	mostRecentPlan := stats.data.SensitiveInfo.MostRecentPlanDescription
+	if len(mostRecentPlan.Name) == 0 || len(mostRecentPlan.Attrs) == 0 {
+		// No plan has been sampled for existing stats, either because
+		// sql.metrics.statement_details.sample_logical_plans was previously
+		// false, or because stats was collected from an older version.
+		return true
+	}
 	stats.Lock()
 	count := stats.data.Count
 	stats.Unlock()

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -500,13 +500,10 @@ type PlanningCtx struct {
 
 	// isLocal is set to true if we're planning this query on a single node.
 	isLocal bool
-	planner *planner
-	// ignoreClose, when set to true, will prevent the closing of the planner's
-	// current plan. The top-level query needs to close it, but everything else
-	// (like subqueries or EXPLAIN ANALYZE) should set this to true to avoid
-	// double closes of the planNode tree.
-	ignoreClose bool
-	stmtType    tree.StatementType
+
+	planner  *planner
+	stmtType tree.StatementType
+
 	// planDepth is set to the current depth of the planNode tree. It's used to
 	// keep track of whether it's valid to run a root node in a special fast path
 	// mode.

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -88,7 +88,10 @@ func PlanAndRunExport(
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, txn, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+	cleanup := dsp.Run(planCtx, txn, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+	if cleanup != nil {
+		cleanup()
+	}
 	return resultRows.Err()
 }
 
@@ -482,7 +485,10 @@ func LoadCSV(
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
 	return db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		dsp.Run(planCtx, txn, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+		cleanup := dsp.Run(planCtx, txn, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+		if cleanup != nil {
+			cleanup()
+		}
 		return resultRows.Err()
 	})
 }
@@ -625,7 +631,10 @@ func (dsp *DistSQLPlanner) loadCSVSamplingPlan(
 	samples = nil
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(planCtx, nil, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+	cleanup := dsp.Run(planCtx, nil, &p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+	if cleanup != nil {
+		cleanup()
+	}
 	if err := rowResultWriter.Err(); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -119,6 +119,8 @@ func (dsp *DistSQLPlanner) initRunners() {
 // mutated.
 // - finishedSetupFn, if non-nil, is called synchronously after all the
 // processors have successfully started up.
+//
+// The returned cleanup callback must be called by the caller to release resources.
 func (dsp *DistSQLPlanner) Run(
 	planCtx *PlanningCtx,
 	txn *client.Txn,
@@ -126,7 +128,7 @@ func (dsp *DistSQLPlanner) Run(
 	recv *DistSQLReceiver,
 	evalCtx *extendedEvalContext,
 	finishedSetupFn func(),
-) {
+) (cleanup func()) {
 	ctx := planCtx.ctx
 
 	var (
@@ -147,7 +149,7 @@ func (dsp *DistSQLPlanner) Run(
 		if err != nil {
 			log.Infof(ctx, "%s: %s", clientRejectedMsg, err)
 			recv.SetError(err)
-			return
+			return nil
 		}
 		meta.StripRootToLeaf()
 		txnCoordMeta = &meta
@@ -155,7 +157,7 @@ func (dsp *DistSQLPlanner) Run(
 
 	if err := planCtx.sanityCheckAddresses(); err != nil {
 		recv.SetError(err)
-		return
+		return nil
 	}
 
 	flows := plan.GenerateFlowSpecs(dsp.nodeDesc.NodeID /* gateway */)
@@ -230,17 +232,17 @@ func (dsp *DistSQLPlanner) Run(
 	}
 	if firstErr != nil {
 		recv.SetError(firstErr)
-		return
+		return nil
 	}
 
 	// Set up the flow on this node.
 	localReq := setupReq
 	localReq.Flow = *flows[thisNodeID]
-	defer distsqlplan.ReleaseSetupFlowRequest(&localReq)
+	cleanupFlowRequest := func() { distsqlplan.ReleaseSetupFlowRequest(&localReq) }
 	ctx, flow, err := dsp.distSQLSrv.SetupLocalSyncFlow(ctx, evalCtx.Mon, &localReq, recv, localState)
 	if err != nil {
 		recv.SetError(err)
-		return
+		return cleanupFlowRequest
 	}
 
 	if finishedSetupFn != nil {
@@ -252,12 +254,11 @@ func (dsp *DistSQLPlanner) Run(
 		log.Fatalf(ctx, "unexpected error from syncFlow.Start(): %s "+
 			"The error should have gone to the consumer.", err)
 	}
-	// We need to close the planNode tree we translated into a DistSQL plan before
-	// flow.Cleanup, which closes memory accounts that expect to be emptied.
-	if planCtx.planner != nil && !planCtx.ignoreClose {
-		planCtx.planner.curPlan.close(ctx)
+	cleanupRun := func() {
+		cleanupFlowRequest()
+		flow.Cleanup(ctx)
 	}
-	flow.Cleanup(ctx)
+	return cleanupRun
 }
 
 // DistSQLReceiver is a RowReceiver that writes results to a rowResultWriter.
@@ -674,9 +675,6 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	subqueryPlanCtx.isLocal = !distributeSubquery
 	subqueryPlanCtx.planner = planner
 	subqueryPlanCtx.stmtType = tree.Rows
-	// Don't close the top-level plan from subqueries - someone else will handle
-	// that.
-	subqueryPlanCtx.ignoreClose = true
 
 	subqueryPhysPlan, err := dsp.createPlanForNode(subqueryPlanCtx, subqueryPlan.plan)
 	if err != nil {
@@ -712,7 +710,10 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	subqueryRowReceiver := NewRowResultWriter(rows)
 	subqueryRecv.resultWriter = subqueryRowReceiver
 	subqueryPlans[planIdx].started = true
-	dsp.Run(subqueryPlanCtx, planner.txn, &subqueryPhysPlan, subqueryRecv, evalCtx, nil /* finishedSetupFn */)
+	cleanup := dsp.Run(subqueryPlanCtx, planner.txn, &subqueryPhysPlan, subqueryRecv, evalCtx, nil /* finishedSetupFn */)
+	if cleanup != nil {
+		cleanup()
+	}
 	if subqueryRecv.commErr != nil {
 		return subqueryRecv.commErr
 	}
@@ -774,6 +775,10 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 // while using that resultWriter), the error is also stored in
 // DistSQLReceiver.commErr. That can be tested to see if a client session needs
 // to be closed.
+//
+// The returned cleanup callback, if non-nil, must be called *after*
+// closing the planNode tree (if there is one), to ensure proper
+// ordering of memory monitoring assertions.
 func (dsp *DistSQLPlanner) PlanAndRun(
 	ctx context.Context,
 	evalCtx *extendedEvalContext,
@@ -781,22 +786,22 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 	txn *client.Txn,
 	plan planNode,
 	recv *DistSQLReceiver,
-) {
+) (cleanup func()) {
 	log.VEventf(ctx, 1, "creating DistSQL plan with isLocal=%v", planCtx.isLocal)
 
 	physPlan, err := dsp.createPlanForNode(planCtx, plan)
 	if err != nil {
 		recv.SetError(err)
-		return
+		return nil
 	}
 	dsp.FinalizePlan(planCtx, &physPlan)
-	dsp.Run(planCtx, txn, &physPlan, recv, evalCtx, nil /* finishedSetupFn */)
+	cleanup = dsp.Run(planCtx, txn, &physPlan, recv, evalCtx, nil /* finishedSetupFn */)
 	if recv.resultWriter.Err() == nil {
 		if err := dsp.logEvents(ctx, evalCtx, plan); err != nil {
 			recv.SetError(err)
-			return
 		}
 	}
+	return cleanup
 }
 
 // logEvents logs events in the system.eventlog table for successful completion

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -161,8 +161,13 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		planCtx.planner = p
 		planCtx.stmtType = recv.stmtType
 
-		execCfg.DistSQLPlanner.PlanAndRun(
+		cleanup := execCfg.DistSQLPlanner.PlanAndRun(
 			ctx, evalCtx, planCtx, txn, p.curPlan.plan, recv)
+		// Closing the plan before calling cleanup() as per the contract on PlanAndRun().
+		p.curPlan.close(ctx)
+		if cleanup != nil {
+			cleanup()
+		}
 		return rw.Err()
 	})
 	if err != nil {

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -563,8 +563,11 @@ func scrubRunDistSQL(
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := p.extendedEvalCtx
-	p.extendedEvalCtx.DistSQLPlanner.Run(
+	cleanup := p.extendedEvalCtx.DistSQLPlanner.Run(
 		planCtx, p.txn, plan, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+	if cleanup != nil {
+		cleanup()
+	}
 	if rowResultWriter.Err() != nil {
 		return rows, rowResultWriter.Err()
 	} else if rows.Len() == 0 {

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -129,6 +129,14 @@ func (dsp *DistSQLPlanner) Exec(
 	planCtx.planner = p
 	planCtx.stmtType = recv.stmtType
 
-	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.plan, recv)
+	//TODO(celia) temporarily removing func() to build
+	//cleanup := dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.plan, recv, func() {})
+	cleanup := dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.plan, recv)
+
+	// Closing the plan before calling cleanup() as per the contract on PlanAndRun().
+	p.curPlan.close(ctx)
+	if cleanup != nil {
+		cleanup()
+	}
 	return rw.Err()
 }


### PR DESCRIPTION
Depends on #33561; first commit is from there.

Previously, the logic to determine if we should save a sample logical plan
didn't account for the case where statementStatistics might exist without a
sample. This can happen if user has set
`sql.metrics.statement_details.sample_logical_plans` to false, or if the
stats were collected before this feature was introduced. This patch fixes it.

Release note: None
