### PR TITLE
roachtest: switch tests to use the no-barrier ext4 option by default

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1367,7 +1367,7 @@ func main() {
 	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.UseLocalSSD,
 		"local-ssd", true, "Use local SSD")
 	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.NoExt4Barrier,
-		"local-ssd-no-ext4-barrier", false,
+		"local-ssd-no-ext4-barrier", true,
 		`Mount the local SSD with the "-o nobarrier" flag. `+
 			`Ignored if --local-ssd=false is specified.`)
 	createCmd.Flags().IntVarP(&numNodes,

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -58,8 +58,6 @@ type cdcTestArgs struct {
 }
 
 func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
-	c.RemountNoBarrier(ctx)
-
 	crdbNodes := c.Range(1, c.nodes-1)
 	workloadNode := c.Node(c.nodes)
 	kafkaNode := c.Node(c.nodes)

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -658,6 +658,7 @@ type clusterConfig struct {
 	localCluster bool
 	teeOpt       teeOptType
 	user         string
+	useIOBarrier bool
 }
 
 // newCluster creates a new roachprod cluster.
@@ -714,6 +715,9 @@ func newCluster(ctx context.Context, l *logger, cfg clusterConfig) (*cluster, er
 	sargs = append(sargs, cfg.nodes[0].args()...)
 	if !local && zonesF != "" && cfg.nodes[0].Zones == "" {
 		sargs = append(sargs, "--gce-zones="+zonesF)
+	}
+	if !cfg.useIOBarrier {
+		sargs = append(sargs, "--local-ssd-no-ext4-barrier")
 	}
 
 	c.status("creating cluster")
@@ -1220,14 +1224,6 @@ func (c *cluster) RunWithBuffer(
 	}
 	return execCmdWithBuffer(ctx, l,
 		append([]string{roachprod, "run", c.makeNodes(node), "--"}, args...)...)
-}
-
-// RemountNoBarrier remounts the cluster's local SSDs with the nobarrier option.
-func (c *cluster) RemountNoBarrier(ctx context.Context) {
-	c.Run(ctx, c.All(),
-		"sudo", "umount", "/mnt/data1", ";",
-		"sudo", "mount", "-o", "discard,defaults,nobarrier",
-		"$(awk '/\\/mnt\\/data1/ {print $1}' /etc/mtab)", "/mnt/data1")
 }
 
 // pgURL returns the Postgres endpoint for the specified node. It accepts a flag

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -30,10 +30,6 @@ import (
 
 func registerKV(r *registry) {
 	runKV := func(ctx context.Context, t *test, c *cluster, percent int, encryption option) {
-		if !c.isLocal() {
-			c.RemountNoBarrier(ctx)
-		}
-
 		nodes := c.nodes - 1
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -83,10 +79,6 @@ func registerKVQuiescenceDead(r *registry) {
 		Nodes:      nodes(4),
 		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			if !c.isLocal() {
-				c.RemountNoBarrier(ctx)
-			}
-
 			nodes := c.nodes - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -166,10 +158,6 @@ func registerKVGracefulDraining(r *registry) {
 		Name:  "kv/gracefuldraining/nodes=3",
 		Nodes: nodes(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			if !c.isLocal() {
-				c.RemountNoBarrier(ctx)
-			}
-
 			nodes := c.nodes - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -329,10 +317,6 @@ func registerKVSplits(r *registry) {
 func registerKVScalability(r *registry) {
 	runScalability := func(ctx context.Context, t *test, c *cluster, percent int) {
 		nodes := c.nodes - 1
-
-		if !c.isLocal() {
-			c.RemountNoBarrier(ctx)
-		}
 
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))

--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -83,10 +83,6 @@ func (o *sysbenchOptions) cmd() string {
 }
 
 func runSysbench(ctx context.Context, t *test, c *cluster, opts sysbenchOptions) {
-	if !c.isLocal() {
-		c.RemountNoBarrier(ctx)
-	}
-
 	allNodes := c.Range(1, c.nodes)
 	roachNodes := c.Range(1, c.nodes-1)
 	loadNode := c.Node(c.nodes)

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -64,8 +64,6 @@ func runTPCC(ctx context.Context, t *test, c *cluster, opts tpccOptions) {
 		opts.Warehouses = 1
 		opts.Duration = 1 * time.Minute
 		rampDuration = 30 * time.Second
-	} else if !opts.ZFS {
-		c.RemountNoBarrier(ctx)
 	}
 
 	c.Put(ctx, cockroach, "./cockroach", crdbNodes)
@@ -525,11 +523,6 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 	for _, g := range loadGroup {
 		roachNodes = roachNodes.merge(g.roachNodes)
 		loadNodes = loadNodes.merge(g.loadNodes)
-	}
-
-	// Disable write barrier on mounted SSDs.
-	if !c.isLocal() {
-		c.RemountNoBarrier(ctx)
 	}
 
 	c.Put(ctx, cockroach, "./cockroach", roachNodes)

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -22,10 +22,6 @@ import (
 
 func registerYCSB(r *registry) {
 	runYCSB := func(ctx context.Context, t *test, c *cluster, wl string) {
-		if !c.isLocal() {
-			c.RemountNoBarrier(ctx)
-		}
-
 		nodes := c.nodes - 1
 
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))


### PR DESCRIPTION
Before this patch, some tests were awkwardly reformatting a file system
to get the no-barrier option since they needed it for running faster.
The vast majority of other tests don't care - nobody cares about
durability across machine crashes for these tests.
So, this patch switches the default to be no-barrier. Tests that want it
don't need to do anything any more - and they no longer need to do
reformatting (they now take advantage of a recent capability added to
roachtest for mounting things right in the first place). Tests that
don't care remain unchanged. Tests that need it switch to declaring that
in the test spec.

The only test that cares is the synctest, as far as I know. Please let
me know if you can think of any other.

Release note: None