### PR TITLE
release-2.1: distsqlrun: fix lookup join order preservation

### DIFF
--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -45,9 +45,9 @@ const (
 	// jrPerformingLookup means we are performing an index lookup for the current
 	// input row batch.
 	jrPerformingLookup
-	// jrCollectingOutputRows is used for left outer joins. It means we are
-	// collecting the result of the index lookup to be emitted, while preserving
-	// the order of the input and rendering rows for unmatched inputs.
+	// jrCollectingOutputRows means we are collecting the result of the index
+	// lookup to be emitted, while preserving the order of the input, and
+	// optionally rendering rows for unmatched inputs for left outer joins.
 	jrCollectingOutputRows
 	// jrEmittingRows means we are emitting the results of the index lookup.
 	jrEmittingRows
@@ -400,11 +400,16 @@ func (jr *joinReader) readInput() (joinReaderState, *ProducerMetadata) {
 		return jrStateUnknown, jr.DrainHelper()
 	}
 
-	// If this is an outer join, maintain a map from input row index to the
-	// corresponding output rows. This will allow us to emit unmatched rows while
-	// preserving the order of the input. For inner joins, we can skip this step
-	// and add output rows directly to jr.toEmit.
-	if jr.joinType == sqlbase.LeftOuterJoin {
+	// Maintain a map from input row index to the corresponding output rows. This
+	// will allow us to preserve the order of the input in the face of multiple
+	// input rows having the same lookup keyspan, or if we're doing an outer join
+	// and we need to emit unmatched rows.
+	if len(jr.inputRowIdxToOutputRows) >= len(jr.inputRows) {
+		jr.inputRowIdxToOutputRows = jr.inputRowIdxToOutputRows[:len(jr.inputRows)]
+		for i := range jr.inputRowIdxToOutputRows {
+			jr.inputRowIdxToOutputRows[i] = nil
+		}
+	} else {
 		jr.inputRowIdxToOutputRows = make([]sqlbase.EncDatumRows, len(jr.inputRows))
 	}
 
@@ -518,12 +523,8 @@ func (jr *joinReader) performLookup() (joinReaderState, *ProducerMetadata) {
 			}
 			if renderedRow != nil {
 				rowCopy := jr.out.rowAlloc.CopyRow(renderedRow)
-				if jr.inputRowIdxToOutputRows == nil {
-					jr.toEmit = append(jr.toEmit, rowCopy)
-				} else {
-					jr.inputRowIdxToOutputRows[inputRowIdx] = append(
-						jr.inputRowIdxToOutputRows[inputRowIdx], rowCopy)
-				}
+				jr.inputRowIdxToOutputRows[inputRowIdx] = append(
+					jr.inputRowIdxToOutputRows[inputRowIdx], rowCopy)
 			}
 		}
 	}
@@ -535,20 +536,19 @@ func (jr *joinReader) performLookup() (joinReaderState, *ProducerMetadata) {
 	return jrEmittingRows, nil
 }
 
-// collectOutputRows is used for left joins only. It iterates over
-// jr.inputRowIdxToOutputRows and adds output rows to jr.Emit, rendering rows
-// for unmatched inputs while preserving the input order. For inner joins it is
-// a no-op.
+// collectOutputRows iterates over jr.inputRowIdxToOutputRows and adds output
+// rows to jr.Emit, rendering rows for unmatched inputs if the join is a left
+// outer join, while preserving the input order.
 func (jr *joinReader) collectOutputRows() joinReaderState {
-	if jr.joinType == sqlbase.LeftOuterJoin {
-		for i, outputRows := range jr.inputRowIdxToOutputRows {
-			if len(outputRows) == 0 {
+	for i, outputRows := range jr.inputRowIdxToOutputRows {
+		if len(outputRows) == 0 {
+			if jr.joinType == sqlbase.LeftOuterJoin {
 				if row := jr.renderUnmatchedRow(jr.inputRows[i], leftSide); row != nil {
 					jr.toEmit = append(jr.toEmit, jr.out.rowAlloc.CopyRow(row))
 				}
-			} else {
-				jr.toEmit = append(jr.toEmit, outputRows...)
 			}
+		} else {
+			jr.toEmit = append(jr.toEmit, outputRows...)
 		}
 	}
 	return jrEmittingRows

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -135,6 +135,24 @@ func TestJoinReader(t *testing.T) {
 			expected:    "[[0 2 2] [0 2 2] [0 5 5] [1 0 0] [1 5 5]]",
 		},
 		{
+			description: "Test lookup joins preserve order of left input",
+			post: PostProcessSpec{
+				Projection:    true,
+				OutputColumns: []uint32{0, 1, 3},
+			},
+			input: [][]tree.Datum{
+				{aFn(2), bFn(2)},
+				{aFn(5), bFn(5)},
+				{aFn(2), bFn(2)},
+				{aFn(10), bFn(10)},
+				{aFn(15), bFn(15)},
+			},
+			lookupCols:  []uint32{0, 1},
+			inputTypes:  twoIntCols,
+			outputTypes: threeIntCols,
+			expected:    "[[0 2 2] [0 5 5] [0 2 2] [1 0 0] [1 5 5]]",
+		},
+		{
 			description: "Test lookup join with onExpr",
 			post: PostProcessSpec{
 				Projection:    true,
@@ -326,7 +344,7 @@ func TestJoinReader(t *testing.T) {
 				}
 
 				// Set a lower batch size to force multiple batches.
-				jr.batchSize = 2
+				jr.batchSize = 3
 
 				jr.Run(ctx, nil /* wg */)
 

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -21,8 +21,8 @@ ALTER TABLE abc INJECT STATISTICS '[
   {
     "columns": ["a"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1,
-    "distinct_count": 1
+    "row_count": 100,
+    "distinct_count": 100
   }
 ]'
 
@@ -31,8 +31,8 @@ ALTER TABLE def INJECT STATISTICS '[
   {
     "columns": ["f"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10,
-    "distinct_count": 10
+    "row_count": 10000,
+    "distinct_count": 10000
   }
 ]'
 
@@ -41,8 +41,8 @@ ALTER TABLE gh INJECT STATISTICS '[
   {
     "columns": ["g"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10,
-    "distinct_count": 10
+    "row_count": 10000,
+    "distinct_count": 10000
   }
 ]'
 
@@ -155,8 +155,8 @@ ALTER TABLE books INJECT STATISTICS '[
   {
     "columns": ["title"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1,
-    "distinct_count": 1
+    "row_count": 100,
+    "distinct_count": 100
   }
 ]'
 
@@ -165,8 +165,8 @@ ALTER TABLE books2 INJECT STATISTICS '[
   {
     "columns": ["title"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10,
-    "distinct_count": 10
+    "row_count": 10000,
+    "distinct_count": 1000
   }
 ]'
 
@@ -186,8 +186,8 @@ ALTER TABLE authors INJECT STATISTICS '[
   {
     "columns": ["name"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1,
-    "distinct_count": 1
+    "row_count": 100,
+    "distinct_count": 100
   }
 ]'
 
@@ -250,8 +250,8 @@ ALTER TABLE small INJECT STATISTICS '[
   {
     "columns": ["a"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1,
-    "distinct_count": 1
+    "row_count": 100,
+    "distinct_count": 100
   }
 ]'
 
@@ -260,8 +260,8 @@ ALTER TABLE large INJECT STATISTICS '[
   {
     "columns": ["a"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10,
-    "distinct_count": 10
+    "row_count": 10000,
+    "distinct_count": 10000
   }
 ]'
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -153,7 +153,7 @@ ALTER TABLE books2 INJECT STATISTICS '[
     "columns": ["title"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
     "row_count": 10000,
-    "distinct_count": 10000
+    "distinct_count": 1000
   }
 ]'
 
@@ -176,7 +176,7 @@ distinct               ·            ·               (title)                   
 ·                      table        books2@primary  ·                             ·
 
 statement ok
-CREATE TABLE authors (name STRING PRIMARY KEY, book STRING)
+CREATE TABLE authors (name STRING, book STRING)
 
 statement ok
 ALTER TABLE authors INJECT STATISTICS '[
@@ -219,24 +219,28 @@ SHOW EXPERIMENTAL_RANGES FROM TABLE books
 start_key  end_key  range_id  replicas  lease_holder
 NULL       NULL     10        {5}       5
 
+# TODO(radu): this doesn't seem to be a lookup join, but it should be.
+
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT authors.name FROM books AS b1, books2 AS b2, authors WHERE b1.title = b2.title AND authors.book = b1.title AND b1.shelf <> b2.shelf]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJzEk09r4zAQxe_7Kbxz2oAWW_4XMAR02MNmD8kSeis5KNY0EXUsI8nQEvLdi21oYjdW_lx61Hh-857eWAcolcAF36OB7BkoEEhgTaDSKkdjlG7KXdNcvEEWEJBlVdumvCaQK42QHcBKWyBksFC_VeWnQECg5bJo244EVG1PkLF8i5BNj-RsMHUPfuKbAlfIBWo_6I2HSss91-9so9SrCYHAsraZxyhhEYxp00e16WVtXttdk9WYXjiqd5KpS6UFahTD9K63XDD9l5vdPyVL1H7Y9_wZT0hYRFg8ajp6NKTIsaDb9hN_Z15x336BL_ZXYzeezLTc7roDnTQ3WXgs9X7OPHb678YvldyT5x9prCxz6yd9N4yOzk9786-81BWaSpUGb3qqQZMYii12GzCq1jn-1ypvZbrjsuXagkBju6_T7jAvu0-NwXOYOuGoB9MhHN4Bh0M4csKJWzm-A_6inDjh1B1Y6oSDAbw-_vgIAAD__0987gU=
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzEkz-PozAQxfv7FNxUF8knMP8iIUVyccXliuQUXXdK4eDZxFqCkW2kXUX57iugILDB-dNsaTO_eW_e4BOUSuCKH9FA9h8oEEhgS6DSKkdjlG6uu6KleIMsICDLqrbN9ZZArjRCdgIrbYGQwUr9VJWfAgGBlsuiLTsTULXtIWP5HiGbn8lFY-pu_I_vCtwgF6j9YNAeKi2PXL-znVKvJgQC69pmHqOERTClTZ_Vpte1eW0PTVYX4uGkeDgp3mvWpdICNYpxlLdLrkzwm5vDHyVL1H44HKC3S1hEWDxpOno2scixrfuWFX9lXvHQfoEv9kdjN54ttNwfugOdNZOsPJZ63xce63_C6aGSR_L8JY2VZW79ZOiG0cn-6aD_jWe7QVOp0uBd7zZoEkOxx24DRtU6x79a5a1Md1y3XHsh0Nju67w7LMvuU2PwEqZOOBrAdAyHD8DhGI6ccOJWjh-APyknTjh1B5Y64WAEb8_fPgIAAP__9WvxFg==
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT a.name FROM authors AS a JOIN books2 AS b2 ON a.book = b2.title ORDER BY a.name
 ----
-tree              field     description      columns              ordering
-render            ·         ·                (name)               +name
- │                render 0  name             ·                    ·
- └── lookup-join  ·         ·                (name, book, title)  +name
-      │           type      inner            ·                    ·
-      ├── scan    ·         ·                (name, book)         +name
-      │           table     authors@primary  ·                    ·
-      │           spans     ALL              ·                    ·
-      └── scan    ·         ·                (title)              ·
-·                 table     books2@primary   ·                    ·
+tree                 field     description      columns              ordering
+render               ·         ·                (name)               +name
+ │                   render 0  name             ·                    ·
+ └── lookup-join     ·         ·                (name, book, title)  +name
+      │              type      inner            ·                    ·
+      ├── sort       ·         ·                (name, book)         +name
+      │    │         order     +name            ·                    ·
+      │    └── scan  ·         ·                (name, book)         ·
+      │              table     authors@primary  ·                    ·
+      │              spans     ALL              ·                    ·
+      └── scan       ·         ·                (title)              ·
+·                    table     books2@primary   ·                    ·
 
 # Cross joins should not be planned as lookup joins.
 query TTTTT colnames
@@ -263,7 +267,7 @@ render          ·         ·               (title, edition, shelf, title, editi
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM authors INNER JOIN books2 ON books2.edition = 1 WHERE books2.title = authors.book]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkU9r8zAMxu_vpzA666Vx2l4MA187RjpKbyMHNxFd1tYK_gMbJd99OB6sHWu2HfVIPz2P5TNYbqkyJ_KgnkACwhJqhN5xQ96zS3IeWrWvoAqEzvYxJLlGaNgRqDOELhwJFFT8n_tZCQgtBdMdx7EBgWP4hHwwewI1H_BisZxevDW7I23ItORmxdV66F13Mu5NmxieU95bfvIvfvfc2Q87-b3djvng00sfmA-xFy_cWcFWCZ3EdSX0QtwJqZRaVdukxKCElqhL1HPUC9TLm1HLq6g_3HxDvmfr6VdHL4Yagdo95X_1HF1Dj46b0SaX65EbhZZ8yN15LlY2t1LAS1hOwuU0XE7CxRe4Hv69BwAA___eYeIR
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkc9q8zAQxO_fU4g970csJ7kICrqmFKeE3IoPir2kbhKt0R9oCX73IqvQpDRue9Ts_nZGzBkst1SZE3lQTyABYQk1Qu-4Ie_ZJTkvrdpXUAVCZ_sYklwjNOwI1BlCF44ECir-z_2sBISWgumO49qAwDF8Qj6YPYGaD3hxWE4f3prdkTZkWnKz4uo89K47GfemTQzPKS_COgYltERdwi1z-Rfze-7sh7f83nvHfPDp2w_Mh9iLF-6sYKuETuK6Enoh7oRUSq2q7VVC1HPUC9TLm1HLq6g_FLAh37P19KsGiqFGoHZPuWTP0TX06LgZbfJzPXKj0JIPeTrPj5XNoxTwEpaTcDkNl5Nw8QWuh3_vAQAA__9Cz-Ui
 
 ####################################
 #  LOOKUP JOIN ON SECONDARY INDEX  #


### PR DESCRIPTION
Backport 1/1 commits from #33536.

/cc @cockroachdb/release

---

Fixes #33354.

Previously, a lookup join with a left side that doesn't have an
injective mapping into the right side would fail to preserve its input
order, in violation of its contract.

Now, the code is modified to use the order-preserving pathway that was
designed for outer joins all the time, to prevent the issue.

Release note (bug fix): lookup joins preserve their input order even if
more than one row of the input corresponds to the same row of the lookup
table.
