### PR TITLE
ui: change redux.serializeState usage to redux.serialize

### DIFF
--- a/pkg/ui/src/redux/state.ts
+++ b/pkg/ui/src/redux/state.ts
@@ -62,13 +62,15 @@ export function createAdminUIStore() {
       // Support for redux dev tools
       // https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd
       (window as any).devToolsExtension ? (window as any).devToolsExtension({
-        // TODO(maxlang): implement {,de}serializeAction.
-        // TODO(maxlang): implement deserializeState.
-        serializeState: (_key: string, value: any): Object => {
-          if (value && value.toRaw) {
-            return value.toRaw();
-          }
-          return value;
+        serialize: {
+          options: {
+            function: (_key: string, value: any): Object => {
+              if (value && value.toRaw) {
+                return value.toRaw();
+              }
+              return value;
+            },
+          },
         },
       }) : _.identity,
     ) as GenericStoreEnhancer,


### PR DESCRIPTION
Fixes: #19520

Since Redux 2.12.1, the serializeState method has been deprecated in favor of the new serialize method.

See [https://github.com/zalmoxisus/redux-devtools-extension/releases/tag/v2.12.1](https://github.com/zalmoxisus/redux-devtools-extension/releases/tag/v2.12.1)