### PR TITLE
server: de-flake TestServerStartClock

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -153,10 +153,8 @@ func TestServerStartClock(t *testing.T) {
 	}
 
 	now := s.Clock().Now()
-	// We rely on s.Clock() having been initialized from hlc.UnixNano(), which is a
-	// bit fragile.
-	physicalNow := hlc.UnixNano()
-	serverClockWasPushed := (now.Logical > 0) || (now.WallTime > physicalNow)
+	physicalNow := s.Clock().PhysicalNow()
+	serverClockWasPushed := now.WallTime > physicalNow
 	if serverClockWasPushed {
 		t.Fatalf("time: server %s vs actual %d", now, physicalNow)
 	}


### PR DESCRIPTION
When the walltime doesn't move forward (as can happen under stress), the
test was failing due to a logical tick, but those are expected. What's
not expected is the walltime being ahead of the physical one.

Fixes #33719.

Release note: None