### PR TITLE
storage: log reasons for splits and merges

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1008,7 +1008,7 @@ func TestReplicateAfterRemoveAndSplit(t *testing.T) {
 	// Split the range.
 	splitKey := roachpb.Key("m")
 	splitArgs := adminSplitArgs(splitKey)
-	if _, err := rep1.AdminSplit(context.Background(), *splitArgs); err != nil {
+	if _, err := rep1.AdminSplit(context.Background(), *splitArgs, "test"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -2411,6 +2411,7 @@ func TestStoreRangeGossipOnSplits(t *testing.T) {
 				},
 				SplitKey: splitKey,
 			},
+			"test",
 		)
 		return pErr
 	}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1213,12 +1213,12 @@ func (r *Replica) executeAdminBatch(
 	switch tArgs := args.(type) {
 	case *roachpb.AdminSplitRequest:
 		var reply roachpb.AdminSplitResponse
-		reply, pErr = r.AdminSplit(ctx, *tArgs)
+		reply, pErr = r.AdminSplit(ctx, *tArgs, "manual")
 		resp = &reply
 
 	case *roachpb.AdminMergeRequest:
 		var reply roachpb.AdminMergeResponse
-		reply, pErr = r.AdminMerge(ctx, *tArgs)
+		reply, pErr = r.AdminMerge(ctx, *tArgs, "manual")
 		resp = &reply
 
 	case *roachpb.AdminTransferLeaseRequest:

--- a/pkg/storage/replica_metrics.go
+++ b/pkg/storage/replica_metrics.go
@@ -212,12 +212,22 @@ func calcBehindCount(
 // QueriesPerSecond returns the range's average QPS if it is the current
 // leaseholder. If it isn't, this will return 0 because the replica does not
 // know about the reads that the leaseholder is serving.
+//
+// A "Query" is a BatchRequest (regardless of its contents) arriving at the
+// leaseholder with a gateway node set in the header (i.e. excluding requests
+// that weren't sent through a DistSender, which in practice should be
+// practically none).
 func (r *Replica) QueriesPerSecond() float64 {
 	qps, _ := r.leaseholderStats.avgQPS()
 	return qps
 }
 
-// WritesPerSecond returns the range's average keys written per second.
+// WritesPerSecond returns the range's average keys written per second. A
+// "Write" is a mutation applied by Raft as measured by
+// engine.RocksDBBatchCount(writeBatch). This corresponds roughly to the number
+// of keys mutated by a write. For example, writing 12 intents would count as 24
+// writes (12 for the metadata, 12 for the versions). A DeleteRange that
+// ultimately only removes one key counts as one (or two if it's transactional).
 func (r *Replica) WritesPerSecond() float64 {
 	wps, _ := r.writeStats.avgQPS()
 	return wps


### PR DESCRIPTION
This will make it easier to reason about clashes between the merge and
split queues, which we're supposedly seeing.

My confidence in load-based splitting is rather low because there
doesn't seem to be any testing outside of basic unit tests. I added a
check to the split queue that seems reasonable but was omitted: before
going through with a load-based split, verify that the load is still
high enough to support it. Previously, it seems that the split would've
been carried out even if there hadn't been a write to the replica for a
long time. (This would only have manifested itself in production with
very bursty workloads plus a busy split queue).

This new logging will allow us to identify questionable splits as well
as thrashing between the split and merge queues (along with the reasons
for which these splits and merges occur).

Release note: None