### PR TITLE
exec: add OFFSET columnar operator

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -268,7 +268,7 @@ func newColOperator(
 		op = exec.NewSimpleProjectOp(op, renderedCols)
 	}
 	if post.Offset != 0 {
-		return nil, errors.New("offset unsupported")
+		op = exec.NewOffsetOp(op, post.Offset)
 	}
 	if post.Limit != 0 {
 		op = exec.NewLimitOp(op, post.Limit)

--- a/pkg/sql/exec/offset.go
+++ b/pkg/sql/exec/offset.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+// offsetOp is an operator that implements offset, returning everything
+// after the first n tuples in its input.
+type offsetOp struct {
+	input Operator
+
+	internalBatch ColBatch
+	offset        uint64
+
+	// seen is the number of tuples seen so far.
+	seen uint64
+}
+
+// NewOffsetOp returns a new offset operator with the given offset.
+func NewOffsetOp(input Operator, offset uint64) Operator {
+	c := &offsetOp{
+		input:  input,
+		offset: offset,
+	}
+	return c
+}
+
+func (c *offsetOp) Init() {
+	c.internalBatch = NewMemBatch(nil)
+	c.input.Init()
+}
+
+func (c *offsetOp) Next() ColBatch {
+	for {
+		bat := c.input.Next()
+		length := bat.Length()
+		if length == 0 {
+			return bat
+		}
+
+		c.seen += uint64(length)
+
+		delta := c.seen - c.offset
+		// If the current batch encompasses the offset "boundary",
+		// add the elements after the boundary to the selection vector.
+		if delta > 0 && delta < uint64(length) {
+			sel := bat.Selection()
+			outputStartIdx := length - uint16(delta)
+			if sel != nil {
+				copy(sel, sel[outputStartIdx:length])
+			} else {
+				bat.SetSelection(true)
+				sel = bat.Selection()[:delta] // slice for bounds check elimination
+				for i := range sel {
+					sel[i] = outputStartIdx + uint16(i)
+				}
+			}
+			bat.SetLength(uint16(delta))
+		}
+
+		if c.seen > c.offset {
+			return bat
+		}
+	}
+}
+
+// Reset resets the offsetOp for another run. Primarily used for
+// benchmarks.
+func (c *offsetOp) Reset() {
+	c.seen = 0
+}

--- a/pkg/sql/exec/offset_test.go
+++ b/pkg/sql/exec/offset_test.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func TestOffset(t *testing.T) {
+	tcs := []struct {
+		offset   uint64
+		tuples   []tuple
+		expected []tuple
+	}{
+		{
+			offset:   0,
+			tuples:   tuples{{1}, {2}, {3}, {4}},
+			expected: tuples{{1}, {2}, {3}, {4}},
+		},
+		{
+			offset:   1,
+			tuples:   tuples{{1}, {2}, {3}, {4}},
+			expected: tuples{{2}, {3}, {4}},
+		},
+		{
+			offset:   2,
+			tuples:   tuples{{1}, {2}, {3}, {4}},
+			expected: tuples{{3}, {4}},
+		},
+		{
+			offset:   4,
+			tuples:   tuples{{1}, {2}, {3}, {4}},
+			expected: tuples{},
+		},
+		{
+			offset:   100000,
+			tuples:   tuples{{1}, {2}, {3}, {4}},
+			expected: tuples{},
+		},
+	}
+
+	for _, tc := range tcs {
+		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+			s := NewOffsetOp(input[0], tc.offset)
+			out := newOpTestOutput(s, []int{0}, tc.expected)
+
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func BenchmarkOffset(b *testing.B) {
+	batch := NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
+	batch.SetLength(ColBatchSize)
+	source := newRepeatableBatchSource(batch)
+	source.Init()
+
+	o := NewOffsetOp(source, 1)
+	// Set throughput proportional to size of the selection vector.
+	b.SetBytes(2 * ColBatchSize)
+	for i := 0; i < b.N; i++ {
+		o.(*offsetOp).Reset()
+		o.Next()
+	}
+}


### PR DESCRIPTION
Implements the OFFSET columnar operator. The OFFSET operator is
like the opposite of the limit operator: it returns the input
without the first n rows.

The primary motivation behind all columnar operators is to
speedup performance. Adding the OFFSET operator helps make the
set of columnar operators more complete.

Closes #33710

Benchmark results:

```
goos: darwin
goarch: amd64
pkg: github.com/cockroachdb/cockroach/pkg/sql/exec
BenchmarkOffset-8   	 3000000	       490 ns/op	4176.98 MB/s	       0 B/op	       0 allocs/op
PASS
```

Release note: None