### PR TITLE
sql, ui: add cluster name setting

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -4,6 +4,7 @@
 <tr><td><code>cloudstorage.gs.default.key</code></td><td>string</td><td><code></code></td><td>if set, JSON key to use during Google Cloud Storage operations</td></tr>
 <tr><td><code>cloudstorage.http.custom_ca</code></td><td>string</td><td><code></code></td><td>custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage</td></tr>
 <tr><td><code>cloudstorage.timeout</code></td><td>duration</td><td><code>10m0s</code></td><td>the timeout for import/export storage operations</td></tr>
+<tr><td><code>cluster.name</code></td><td>string</td><td><code></code></td><td>cluster name</td></tr>
 <tr><td><code>cluster.organization</code></td><td>string</td><td><code></code></td><td>organization name</td></tr>
 <tr><td><code>cluster.preserve_downgrade_option</code></td><td>string</td><td><code></code></td><td>disable (automatic or manual) cluster version upgrade from the specified version until reset</td></tr>
 <tr><td><code>compactor.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when false, the system will reclaim space occupied by deleted data less aggressively</td></tr>

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1632,6 +1632,9 @@ func (s *Server) Start(ctx context.Context) error {
 				}
 				return nil
 			},
+			GetClusterName: func() string {
+				return s.execCfg.Name()
+			},
 		}),
 	)
 	s.mux.Handle("/", authenticatedUIHandler)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -64,6 +64,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ClusterName is the cluster name.
+var ClusterName = settings.RegisterStringSetting(
+	"cluster.name",
+	"cluster name",
+	"",
+)
+
 // ClusterOrganization is the organization name.
 var ClusterOrganization = settings.RegisterStringSetting(
 	"cluster.organization",
@@ -372,6 +379,11 @@ type ExecutorConfig struct {
 	// Caches updated by DistSQL.
 	RangeDescriptorCache *kv.RangeDescriptorCache
 	LeaseHolderCache     *kv.LeaseHolderCache
+}
+
+// Name returns the value of cluster.name.
+func (ec *ExecutorConfig) Name() string {
+	return ClusterName.Get(&ec.Settings.SV)
 }
 
 // Organization returns the value of cluster.organization.

--- a/pkg/ui/src/util/dataFromServer.ts
+++ b/pkg/ui/src/util/dataFromServer.ts
@@ -19,6 +19,7 @@ export interface DataFromServer {
   Tag: string;
   Version: string;
   NodeID: string;
+  ClusterName: string;
 }
 
 // Tell TypeScript about `window.dataFromServer`, which is set in a script

--- a/pkg/ui/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/src/views/app/containers/layout/index.tsx
@@ -16,12 +16,21 @@ import React from "react";
 import { Helmet } from "react-helmet";
 import { RouterState } from "react-router";
 
+import { getDataFromServer } from "src/util/dataFromServer";
 import NavigationBar from "src/views/app/components/layoutSidebar";
 import TimeWindowManager from "src/views/app/containers/timewindow";
 import AlertBanner from "src/views/app/containers/alertBanner";
 import RequireLogin from "src/views/login/requireLogin";
 
 import "./layout.styl";
+
+function getBaseTitle() {
+    const clusterName = getDataFromServer().ClusterName;
+    if (clusterName === "") {
+        return "Cockroach Console";
+    }
+    return `${clusterName} Cluster | Cockroach Console`;
+}
 
 /**
  * Defines the main layout of all admin ui pages. This includes static
@@ -31,9 +40,10 @@ import "./layout.styl";
  */
 export default class extends React.Component<RouterState, {}> {
   render() {
+    const baseTitle = getBaseTitle();
     return (
       <RequireLogin>
-        <Helmet titleTemplate="%s | Cockroach Console" defaultTitle="Cockroach Console" />
+        <Helmet titleTemplate={`%s | ${baseTitle}`} defaultTitle={baseTitle} />
         <TimeWindowManager/>
         <AlertBanner/>
         <NavigationBar/>

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -97,6 +97,7 @@ type indexHTMLArgs struct {
 	Tag                  string
 	Version              string
 	NodeID               string
+	ClusterName          string
 }
 
 // bareIndexHTML is used in place of indexHTMLTemplate when the binary is built
@@ -113,6 +114,7 @@ type Config struct {
 	LoginEnabled         bool
 	NodeID               *base.NodeIDContainer
 	GetUser              func(ctx context.Context) *string
+	GetClusterName       func() string
 }
 
 // Handler returns an http.Handler that serves the UI,
@@ -144,6 +146,7 @@ func Handler(cfg Config) http.Handler {
 			Tag:                  buildInfo.Tag,
 			Version:              build.VersionPrefix(),
 			NodeID:               cfg.NodeID.String(),
+			ClusterName:          cfg.GetClusterName(),
 		}); err != nil {
 			err = errors.Wrap(err, "templating index.html")
 			http.Error(w, err.Error(), 500)


### PR DESCRIPTION
## sql: add a cluster.name setting

Release note (sql change): Add a new cluster setting to store a
user-sepecified name for the cluster.

## ui: show cluster name in window title

Release note (admin ui change): If set, show the cluster name from the
cluster.name setting in the browser's title bar.
Closes: #33365

<img width="419" alt="screen shot 2019-01-15 at 3 12 37 pm" src="https://user-images.githubusercontent.com/793969/51207152-06f17200-18d8-11e9-9f8c-acd07e51cc33.png">
