### PR TITLE
[DNM] ccl/gssapiccl: add GSS authentication support on Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 [submodule "pkg/ui/yarn-vendor"]
 	path = pkg/ui/yarn-vendor
 	url = https://github.com/cockroachdb/yarn-vendored
+[submodule "c-deps/krb5"]
+	path = c-deps/krb5
+	url = https://github.com/cockroachdb/krb5.git

--- a/Makefile
+++ b/Makefile
@@ -404,6 +404,7 @@ PROTOBUF_SRC_DIR := $(C_DEPS_DIR)/protobuf
 ROCKSDB_SRC_DIR  := $(C_DEPS_DIR)/rocksdb
 SNAPPY_SRC_DIR   := $(C_DEPS_DIR)/snappy
 LIBROACH_SRC_DIR := $(C_DEPS_DIR)/libroach
+KRB5_SRC_DIR     := $(C_DEPS_DIR)/krb5/src
 
 # Derived build variants.
 use-stdmalloc          := $(findstring stdmalloc,$(TAGS))
@@ -429,6 +430,7 @@ PROTOBUF_DIR := $(BUILD_DIR)/protobuf$(if $(use-msan),_msan)
 ROCKSDB_DIR  := $(BUILD_DIR)/rocksdb$(if $(use-msan),_msan)$(if $(use-stdmalloc),_stdmalloc)$(if $(USE_ROCKSDB_ASSERTIONS),_assert)
 SNAPPY_DIR   := $(BUILD_DIR)/snappy$(if $(use-msan),_msan)
 LIBROACH_DIR := $(BUILD_DIR)/libroach$(if $(use-msan),_msan)
+KRB5_DIR     := $(BUILD_DIR)/krb5$(if $(use-msan),_msan)
 # Can't share with protobuf because protoc is always built for the host.
 PROTOC_DIR := $(GOPATH)/native/$(HOST_TRIPLE)/protobuf
 
@@ -439,11 +441,17 @@ LIBROCKSDB  := $(ROCKSDB_DIR)/librocksdb.a
 LIBSNAPPY   := $(SNAPPY_DIR)/libsnappy.a
 LIBROACH    := $(LIBROACH_DIR)/libroach.a
 LIBROACHCCL := $(LIBROACH_DIR)/libroachccl.a
+LIBKRB5     := $(KRB5_DIR)/lib/libgssapi_krb5.a
 PROTOC 		 := $(PROTOC_DIR)/protoc
 
 C_LIBS_COMMON = $(if $(use-stdmalloc),,$(LIBJEMALLOC)) $(LIBPROTOBUF) $(LIBSNAPPY) $(LIBROCKSDB)
 C_LIBS_OSS = $(C_LIBS_COMMON) $(LIBROACH)
 C_LIBS_CCL = $(C_LIBS_COMMON) $(LIBCRYPTOPP) $(LIBROACHCCL)
+
+# We only include krb5 on linux.
+ifeq "$(findstring linux,$(TARGET_TRIPLE))" "linux"
+C_LIBS_CCL += $(LIBKRB5)
+endif
 
 # Go does not permit dashes in build tags. This is undocumented.
 native-tag := $(subst -,_,$(TARGET_TRIPLE))$(if $(use-stdmalloc),_stdmalloc)$(if $(use-msan),_msan)
@@ -466,7 +474,7 @@ native-tag := $(subst -,_,$(TARGET_TRIPLE))$(if $(use-stdmalloc),_stdmalloc)$(if
 # constraint `{native-tag}` and are built the first time a Make-driven build
 # encounters a given native tag. These tags are unset when building with the Go
 # toolchain directly, so these files are only compiled when building with Make.
-CGO_PKGS := cli server/status storage/engine ccl/storageccl/engineccl
+CGO_PKGS := cli server/status storage/engine ccl/storageccl/engineccl ccl/gssapiccl
 CGO_UNSUFFIXED_FLAGS_FILES := $(addprefix ./pkg/,$(addsuffix /zcgo_flags.go,$(CGO_PKGS)))
 CGO_SUFFIXED_FLAGS_FILES   := $(addprefix ./pkg/,$(addsuffix /zcgo_flags_$(native-tag).go,$(CGO_PKGS)))
 CGO_FLAGS_FILES := $(CGO_UNSUFFIXED_FLAGS_FILES) $(CGO_SUFFIXED_FLAGS_FILES)
@@ -480,8 +488,8 @@ $(CGO_FLAGS_FILES): Makefile
 	@echo >> $@
 	@echo 'package $(notdir $(@D))' >> $@
 	@echo >> $@
-	@echo '// #cgo CPPFLAGS: -I$(JEMALLOC_DIR)/include' >> $@
-	@echo '// #cgo LDFLAGS: $(addprefix -L,$(CRYPTOPP_DIR) $(PROTOBUF_DIR) $(JEMALLOC_DIR)/lib $(SNAPPY_DIR) $(ROCKSDB_DIR) $(LIBROACH_DIR))' >> $@
+	@echo '// #cgo CPPFLAGS: -I$(JEMALLOC_DIR)/include $(if $(findstring linux,$(TARGET_TRIPLE)),-I$(KRB5_DIR)/include)' >> $@
+	@echo '// #cgo LDFLAGS: $(addprefix -L,$(CRYPTOPP_DIR) $(PROTOBUF_DIR) $(JEMALLOC_DIR)/lib $(SNAPPY_DIR) $(ROCKSDB_DIR) $(LIBROACH_DIR) $(if $(findstring linux,$(TARGET_TRIPLE)),$(KRB5_DIR)/lib))' >> $@
 	@echo 'import "C"' >> $@
 
 # BUILD ARTIFACT CACHING
@@ -530,6 +538,19 @@ $(JEMALLOC_DIR)/Makefile: $(C_DEPS_DIR)/jemalloc-rebuild $(JEMALLOC_SRC_DIR)/con
 	@# jemalloc profiling deadlocks when built against musl. See
 	@# https://github.com/jemalloc/jemalloc/issues/585.
 	cd $(JEMALLOC_DIR) && $(JEMALLOC_SRC_DIR)/configure $(xconfigure-flags) $(if $(findstring musl,$(TARGET_TRIPLE)),,--enable-prof)
+
+$(KRB5_SRC_DIR)/configure.in: | bin/.submodules-initialized
+
+$(KRB5_SRC_DIR)/configure: $(KRB5_SRC_DIR)/configure.in
+	cd $(KRB5_SRC_DIR) && autoreconf
+
+$(KRB5_DIR)/Makefile: $(C_DEPS_DIR)/krb5-rebuild $(KRB5_SRC_DIR)/configure
+	rm -rf $(KRB5_DIR)
+	mkdir -p $(KRB5_DIR)
+	@# NOTE: If you change the configure flags below, bump the version in
+	@# $(C_DEPS_DIR)/krb5-rebuild. See above for rationale.
+	@# If CFLAGS is set to -g1 then make will fail. Use "env -" to clear the environment.
+	cd $(KRB5_DIR) && env -u CFLAGS -u CXXFLAGS $(KRB5_SRC_DIR)/configure $(xconfigure-flags) --enable-static --disable-shared
 
 $(PROTOBUF_DIR)/Makefile: $(C_DEPS_DIR)/protobuf-rebuild | bin/.submodules-initialized
 	rm -rf $(PROTOBUF_DIR)
@@ -639,8 +660,11 @@ $(LIBROACH): $(LIBROACH_DIR)/Makefile bin/uptodate .ALWAYS_REBUILD
 $(LIBROACHCCL): $(LIBROACH_DIR)/Makefile bin/uptodate .ALWAYS_REBUILD
 	@uptodate $@ $(libroach-inputs) || $(MAKE) --no-print-directory -C $(LIBROACH_DIR) roachccl
 
+$(LIBKRB5): $(KRB5_DIR)/Makefile bin/uptodate .ALWAYS_REBUILD
+	@uptodate $@ $(KRB5_SRC_DIR) || $(MAKE) --no-print-directory -C $(KRB5_DIR)
+
 # Convenient names for maintainers. Not used by other targets in the Makefile.
-.PHONY: protoc libcryptopp libjemalloc libprotobuf libsnappy librocksdb libroach libroachccl
+.PHONY: protoc libcryptopp libjemalloc libprotobuf libsnappy librocksdb libroach libroachccl libkrb5
 protoc:      $(PROTOC)
 libcryptopp: $(LIBCRYPTOPP)
 libjemalloc: $(LIBJEMALLOC)
@@ -649,6 +673,7 @@ libsnappy:   $(LIBSNAPPY)
 librocksdb:  $(LIBROCKSDB)
 libroach:    $(LIBROACH)
 libroachccl: $(LIBROACHCCL)
+libkrb5:     $(LIBKRB5)
 
 PHONY: check-libroach
 check-libroach: ## Run libroach tests.
@@ -1403,6 +1428,7 @@ clean-c-deps:
 	rm -rf $(ROCKSDB_DIR)
 	rm -rf $(SNAPPY_DIR)
 	rm -rf $(LIBROACH_DIR)
+	rm -rf $(KRB5_DIR)
 
 .PHONY: unsafe-clean-c-deps
 unsafe-clean-c-deps:
@@ -1412,6 +1438,7 @@ unsafe-clean-c-deps:
 	git -C $(ROCKSDB_SRC_DIR)  clean -dxf
 	git -C $(SNAPPY_SRC_DIR)   clean -dxf
 	git -C $(LIBROACH_SRC_DIR) clean -dxf
+	git -C $(KRB5_SRC_DIR)     clean -dxf
 
 .PHONY: clean
 clean: ## Remove build artifacts.

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20190115-153202
+version=20190124-062428
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -260,7 +260,6 @@ RUN apt-get purge -y \
     apt-transport-https \
     automake \
     autopoint \
-    bison \
     bzip2 \
     file \
     flex \

--- a/c-deps/krb5-rebuild
+++ b/c-deps/krb5-rebuild
@@ -1,0 +1,4 @@
+Bump the version below when changing krb5 configure flags. Search for "BUILD
+ARTIFACT CACHING" in build/common.mk for rationale.
+
+1

--- a/pkg/acceptance/adapter_test.go
+++ b/pkg/acceptance/adapter_test.go
@@ -112,3 +112,11 @@ func TestDockerRuby(t *testing.T) {
 	testDockerSuccess(ctx, t, "ruby", []string{"sh", "-c", "cd /mnt/data/ruby && ruby test.rb 3"})
 	testDockerFail(ctx, t, "ruby", []string{"sh", "-c", "cd /mnt/data/ruby && ruby test.rb 1"})
 }
+
+func TestDockerGSS(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	ctx := context.Background()
+	testDockerSuccess(ctx, t, "gss", []string{"/mnt/data/psql/test-gss.sh"})
+}

--- a/pkg/acceptance/testdata/Dockerfile
+++ b/pkg/acceptance/testdata/Dockerfile
@@ -51,9 +51,11 @@ RUN curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg > /etc/apt/trusted.gpg.d
  && curl -fsSL https://packages.microsoft.com/keys/microsoft.asc > /etc/apt/trusted.gpg.d/microsoft.asc \
  && echo "deb https://packages.microsoft.com/repos/microsoft-ubuntu-zesty-prod zesty main" > /etc/apt/sources.list.d/microsoft.list \
  && apt-get update \
- && apt-get install --yes --no-install-recommends \
+ && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     dotnet-sdk-2.0.0 \
     expect \
+    krb5-admin-server \
+    krb5-kdc \
     libc6-dev \
     libpq-dev \
     libpqtypes-dev \
@@ -61,7 +63,7 @@ RUN curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg > /etc/apt/trusted.gpg.d
     maven \
     nodejs \
     gcc \
-    golang \
+    git \
     php-cli \
     php-pgsql \
     postgresql-client \
@@ -69,11 +71,21 @@ RUN curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg > /etc/apt/trusted.gpg.d
     python-psycopg2 \
     ruby \
     ruby-pg \
+    sudo \
     xmlstarlet \
     yarn
 
 RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.0.0/autouseradd-1.0.0-amd64.tar.gz \
     | tar xz -C /usr --strip-components 1
+
+COPY krb5.conf /etc/krb5.conf
+
+RUN kdb5_util create -s -P kpass \
+ && kadmin.local -q "addprinc -randkey postgres/admin" \
+ && kadmin.local -q "addprinc -randkey postgres/localhost@MY.EX" \
+ && kadmin.local -q "ktadd -k /etc/keytab postgres/localhost@MY.EX" \
+ && chmod +r /etc/keytab \
+ && echo 'roach ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # When system packages are not available for a language's PostgreSQL driver,
 # fall back to using that language's package manager. The high-level process
@@ -118,7 +130,13 @@ RUN xmlstarlet ed --inplace \
 RUN (cd /testdata/node && yarn install && mv node_modules /usr/lib/node) \
  && apt-get purge --yes yarn
 
-RUN apt-get purge --yes \
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH=/go
+RUN curl https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar xzv -C /usr/local \
+ && cd /testdata/go \
+ && go get -d
+
+RUN apt-get purge --yes --autoremove \
     curl \
     xmlstarlet \
  && rm -rf /tmp/* /var/lib/apt/lists/* /testdata

--- a/pkg/acceptance/testdata/go/gss_test.go
+++ b/pkg/acceptance/testdata/go/gss_test.go
@@ -1,0 +1,74 @@
+package gss
+
+import (
+	"database/sql"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
+func TestGSS(t *testing.T) {
+	connector, err := pq.NewConnector("user=root sslmode=require")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	tests := []struct {
+		// The hba.conf file/setting.
+		conf string
+		user string
+		// Error message of gss login.
+		gssErr string
+	}{
+		{
+			conf: `host all all all gss`,
+			user: "tester@MY.EX",
+		},
+		{
+			conf: `host all tester@MY.EX all gss`,
+			user: "tester@MY.EX",
+		},
+		{
+			conf:   `host all nope@MY.EX all gss`,
+			user:   "tester@MY.EX",
+			gssErr: "no server.host_based_authentication.configuration entry",
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			if _, err := db.Exec(fmt.Sprintf(`CREATE USER IF NOT EXISTS '%s'`, tc.user)); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.Exec(`SET CLUSTER SETTING server.host_based_authentication.configuration = $1`, tc.conf); err != nil {
+				t.Fatal(err)
+			}
+
+			out, err := exec.Command("psql", "-c", "SELECT 1", "-U", tc.user).CombinedOutput()
+			err = errors.Wrap(err, strings.TrimSpace(string(out)))
+			if !IsError(err, tc.gssErr) {
+				t.Errorf("expected err %v, got %v", tc.gssErr, err)
+			}
+		})
+	}
+}
+
+func IsError(err error, re string) bool {
+	if err == nil && re == "" {
+		return true
+	}
+	if err == nil || re == "" {
+		return false
+	}
+	matched, merr := regexp.MatchString(re, err.Error())
+	if merr != nil {
+		return false
+	}
+	return matched
+}

--- a/pkg/acceptance/testdata/krb/start.sh
+++ b/pkg/acceptance/testdata/krb/start.sh
@@ -1,0 +1,3 @@
+kadmin.local -q "addprinc -pw changeme tester@MY.EX"
+echo changeme | kinit tester@MY.EX
+krb5kdc -n

--- a/pkg/acceptance/testdata/krb5.conf
+++ b/pkg/acceptance/testdata/krb5.conf
@@ -1,0 +1,32 @@
+[logging]
+    default = FILE:/var/log/krb5libs.log
+    kdc = FILE:/var/log/krb5kdc.log
+    admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+    default_realm = MY.EX
+    dns_lookup_realm = false
+    dns_lookup_kdc = false
+    ticket_lifetime = 24h
+    renew_lifetime = 7d
+    forwardable = yes
+
+[realms]
+    MY.EX = {
+        kdc = my.ex:88
+        admin_server = my.ex:74
+        default_domain = my.ex
+    }
+
+[domain_realm]
+    .my.ex = MY.EX
+    my.ex = MY.EX
+
+[appdefaults]
+    pam = {
+        debug = false
+        ticket_lifetime = 36000
+        renew_lifetime = 36000
+        forwardable = true
+        krb4_convert = false
+    }

--- a/pkg/acceptance/testdata/psql/test-gss.sh
+++ b/pkg/acceptance/testdata/psql/test-gss.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+sudo sh -c 'echo 127.0.0.1 my.ex >> /etc/hosts'
+sudo krb5kdc
+sudo kadmin.local -q "addprinc -pw changeme tester@MY.EX"
+echo changeme | kinit tester@MY.EX
+
+#sleep 99999999999
+
+cd /mnt/data/go
+go test

--- a/pkg/acceptance/util_docker.go
+++ b/pkg/acceptance/util_docker.go
@@ -62,7 +62,7 @@ func testDockerSuccess(ctx context.Context, t *testing.T, name string, cmd []str
 const (
 	// Iterating against a locally built version of the docker image can be done
 	// by changing acceptanceImage to the hash of the container.
-	acceptanceImage = "docker.io/cockroachdb/acceptance:20180416-090309"
+	acceptanceImage = "docker.io/cockroachdb/acceptance:20190124-024430"
 )
 
 func testDocker(

--- a/pkg/ccl/ccl_init.go
+++ b/pkg/ccl/ccl_init.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/buildccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/followerreadsccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/gssapiccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/importccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/roleccl"

--- a/pkg/ccl/gssapiccl/empty.go
+++ b/pkg/ccl/gssapiccl/empty.go
@@ -1,0 +1,12 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package gssapiccl
+
+// This file is here so on platforms where gssapi.go isn't built there's at
+// least one .go file to build.

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -1,0 +1,136 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+// +build linux
+
+package gssapiccl
+
+import (
+	"crypto/tls"
+	"strings"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
+	"github.com/pkg/errors"
+)
+
+// #cgo LDFLAGS: -lgssapi_krb5 -lcom_err -lkrb5 -lkrb5support -ldl -lk5crypto -lresolv
+//
+// #include <gssapi/gssapi.h>
+// #include <stdlib.h>
+import "C"
+
+// authGSS performs GSS authentication. See:
+// https:github.com/postgres/postgres/blob/0f9cdd7dca694d487ab663d463b308919f591c02/src/backend/libpq/auth.c#L1090
+func authGSS(
+	c pgwire.AuthConn, tlsState tls.ConnectionState, insecure bool, hashedPassword []byte,
+) (security.UserAuthHook, error) {
+	/*
+		cfg := c.ExecCfg()
+		if err := utilccl.CheckEnterpriseEnabled(
+			cfg.Settings, cfg.ClusterID(), cfg.Organization(), "GSS authentication",
+		); err != nil {
+			return nil, err
+		}
+	*/
+
+	return func(requestedUser string, clientConnection bool) error {
+		var (
+			maj_stat, min_stat, lmin_s, gflags C.OM_uint32
+			gbuf                               C.gss_buffer_desc
+			context_handle                     C.gss_ctx_id_t  = C.GSS_C_NO_CONTEXT
+			acceptor_cred_handle               C.gss_cred_id_t = C.GSS_C_NO_CREDENTIAL
+			src_name                           C.gss_name_t
+			output_token                       C.gss_buffer_desc
+
+			token []byte
+			err   error
+		)
+
+		if err = c.SendAuthRequest(pgwire.AuthTypeGSS, nil); err != nil {
+			return err
+		}
+
+		for {
+			token, err = c.ReadGSSResponse()
+			if err != nil {
+				return err
+			}
+
+			gbuf.length = C.ulong(len(token))
+			gbuf.value = C.CBytes([]byte(token))
+
+			maj_stat = C.gss_accept_sec_context(
+				&min_stat,
+				&context_handle,
+				acceptor_cred_handle,
+				&gbuf,
+				C.GSS_C_NO_CHANNEL_BINDINGS,
+				&src_name,
+				nil,
+				&output_token,
+				&gflags,
+				nil,
+				nil,
+			)
+			C.free(unsafe.Pointer(gbuf.value))
+
+			if output_token.length != 0 {
+				output_bytes := C.GoBytes(output_token.value, C.int(output_token.length))
+				C.gss_release_buffer(&lmin_s, &output_token)
+				if err = c.SendAuthRequest(pgwire.AuthTypeGSSContinue, output_bytes); err != nil {
+					return err
+				}
+			}
+			if maj_stat != C.GSS_S_COMPLETE && maj_stat != C.GSS_S_CONTINUE_NEEDED {
+				C.gss_delete_sec_context(&lmin_s, &context_handle, C.GSS_C_NO_BUFFER)
+				return gss_error("accepting GSS security context failed", maj_stat, min_stat)
+			}
+			if maj_stat != C.GSS_S_CONTINUE_NEEDED {
+				break
+			}
+		}
+
+		maj_stat = C.gss_display_name(&min_stat, src_name, &gbuf, nil)
+		if maj_stat != C.GSS_S_COMPLETE {
+			return gss_error("retrieving GSS user name failed", maj_stat, min_stat)
+		}
+		gssUser := string(C.GoBytes(gbuf.value, C.int(gbuf.length)))
+		C.gss_release_buffer(&lmin_s, &gbuf)
+
+		if !strings.EqualFold(gssUser, requestedUser) {
+			return errors.Errorf("requested user is %s, but GSS auth is for %s", requestedUser, gssUser)
+		}
+
+		return nil
+	}, nil
+}
+
+func gss_error(msg string, maj_stat, min_stat C.OM_uint32) error {
+	var (
+		gmsg            C.gss_buffer_desc
+		lmin_s, msg_ctx C.OM_uint32
+	)
+
+	msg_ctx = 0
+	C.gss_display_status(&lmin_s, maj_stat, C.GSS_C_GSS_CODE, C.GSS_C_NO_OID, &msg_ctx, &gmsg)
+	msg_major := C.GoString((*C.char)(gmsg.value))
+	C.gss_release_buffer(&lmin_s, &gmsg)
+
+	msg_ctx = 0
+	C.gss_display_status(&lmin_s, min_stat, C.GSS_C_MECH_CODE, C.GSS_C_NO_OID, &msg_ctx, &gmsg)
+	msg_minor := C.GoString((*C.char)(gmsg.value))
+	C.gss_release_buffer(&lmin_s, &gmsg)
+
+	return errors.Errorf("%s: %s: %s", msg, msg_major, msg_minor)
+}
+
+func init() {
+	pgwire.RegisterAuthMethod("gss", authGSS)
+}

--- a/pkg/ccl/gssapiccl/gssapi_test.go
+++ b/pkg/ccl/gssapiccl/gssapi_test.go
@@ -1,0 +1,91 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package gssapiccl
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/pkg/errors"
+)
+
+func TestGSS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+	db := sqlutils.MakeSQLRunner(conn)
+
+	os.Setenv("KRB5_KTNAME", "/etc/postgres.keytab")
+
+	const (
+		user = "tester@MY.EX"
+	)
+
+	db.Exec(t, fmt.Sprintf(`CREATE USER '%s'`, user))
+
+	tests := []struct {
+		// The hba.conf file/setting.
+		conf string
+		// Error message of gss login.
+		gssErr string
+	}{
+		{
+			conf: `
+				host all all all gss
+			`,
+		},
+		{
+			conf: `
+				host all tester@MY.EX all gss
+			`,
+		},
+		{
+			conf: `
+				host all nope@MY.EX all gss
+			`,
+			gssErr: "no server.host_based_authentication.configuration entry",
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			t.Log(tc.conf)
+			db.Exec(t, `SET CLUSTER SETTING server.host_based_authentication.configuration = $1`, tc.conf)
+
+			testUserPgURL, cleanupFn := sqlutils.PGUrl(
+				t, s.ServingAddr(), t.Name(), url.User(server.TestUser))
+			defer cleanupFn()
+			_, port, err := net.SplitHostPort(testUserPgURL.Host)
+			if err != nil {
+				t.Fatal(err)
+			}
+			testUserPgURL.Host = fmt.Sprintf("localhost:%s", port)
+			testUserPgURL.User = url.User(user)
+			fmt.Println(testUserPgURL.String())
+			//os.Setenv("KRB5_CONFIG", "./krb5.conf")
+			out, err := exec.Command("psql", "-c", "SELECT 1", testUserPgURL.String()).CombinedOutput()
+			err = errors.Wrap(err, strings.TrimSpace(string(out)))
+			if !testutils.IsError(err, tc.gssErr) {
+				t.Errorf("expected err %v, got %v", tc.gssErr, err)
+			}
+		})
+	}
+}

--- a/pkg/ccl/gssapiccl/main_test.go
+++ b/pkg/ccl/gssapiccl/main_test.go
@@ -1,0 +1,34 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package gssapiccl
+
+import (
+	"os"
+	"testing"
+
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	defer utilccl.TestingEnableEnterprise()()
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/sql/create_user.go
+++ b/pkg/sql/create_user.go
@@ -157,9 +157,9 @@ func (*CreateUserNode) Close(context.Context) {}
 func (n *CreateUserNode) FastPathResults() (int, bool) { return n.run.rowsAffected, true }
 
 const usernameHelp = "usernames are case insensitive, must start with a letter " +
-	"or underscore, may contain letters, digits, dashes, or underscores, and must not exceed 63 characters"
+	"or underscore, may contain letters, digits, dashes, periods, ampersands, or underscores, and must not exceed 63 characters"
 
-var usernameRE = regexp.MustCompile(`^[\p{Ll}_][\p{Ll}0-9_-]{0,62}$`)
+var usernameRE = regexp.MustCompile(`^[\p{Ll}_][\p{Ll}0-9_@.-]{0,62}$`)
 
 var blacklistedUsernames = map[string]struct{}{
 	security.NodeUser: {},

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -51,8 +51,10 @@ import (
 )
 
 const (
-	authOK                int32 = 0
-	authCleartextPassword int32 = 3
+	authOK                    int32 = 0
+	AuthTypeCleartextPassword int32 = 3
+	AuthTypeGSS               int32 = 7
+	AuthTypeGSSContinue       int32 = 8
 )
 
 // conn implements a pgwire network connection (version 3 of the protocol,
@@ -1420,7 +1422,9 @@ var connAuthConf = settings.RegisterValidatedStringSetting(
 
 // AuthConn defines exported methods of a conn needed for pgwire authentication.
 type AuthConn interface {
-	SendAuthPasswordRequest() (string, error)
+	SendAuthRequest(authType int32, data []byte) error
+	ReadPasswordMsg() (string, error)
+	ReadGSSResponse() ([]byte, error)
 }
 
 // AuthMethod defines a method for authentication of a connection.
@@ -1436,7 +1440,10 @@ func RegisterAuthMethod(method string, fn AuthMethod) {
 func authPassword(
 	c AuthConn, tlsState tls.ConnectionState, insecure bool, hashedPassword []byte,
 ) (security.UserAuthHook, error) {
-	password, err := c.SendAuthPasswordRequest()
+	if err := c.SendAuthRequest(AuthTypeCleartextPassword, nil); err != nil {
+		return nil, err
+	}
+	password, err := c.ReadPasswordMsg()
 	if err != nil {
 		return nil, err
 	}
@@ -1476,26 +1483,35 @@ func init() {
 	RegisterAuthMethod("cert-password", authCertPassword)
 }
 
-// SendAuthPasswordRequest requests a cleartext password from the client and
-// returns it.
-func (c *conn) SendAuthPasswordRequest() (string, error) {
+func (c *conn) SendAuthRequest(authType int32, data []byte) error {
 	c.msgBuilder.initMsg(pgwirebase.ServerMsgAuth)
-	c.msgBuilder.putInt32(authCleartextPassword)
-	if err := c.msgBuilder.finishMsg(c.conn); err != nil {
-		return "", err
-	}
+	c.msgBuilder.putInt32(authType)
+	c.msgBuilder.write(data)
+	return c.msgBuilder.finishMsg(c.conn)
+}
 
+func (c *conn) ReadPasswordMsg() (string, error) {
 	typ, n, err := c.readBuf.ReadTypedMsg(&c.rd)
 	c.metrics.BytesInCount.Inc(int64(n))
 	if err != nil {
 		return "", err
 	}
-
 	if typ != pgwirebase.ClientMsgPassword {
 		return "", errors.Errorf("invalid response to authentication request: %s", typ)
 	}
-
 	return c.readBuf.GetString()
+}
+
+func (c *conn) ReadGSSResponse() ([]byte, error) {
+	typ, n, err := c.readBuf.ReadTypedMsg(&c.rd)
+	c.metrics.BytesInCount.Inc(int64(n))
+	if err != nil {
+		return nil, err
+	}
+	if typ != pgwirebase.ClientMsgPassword {
+		return nil, errors.Errorf("invalid response to authentication request: %s", typ)
+	}
+	return c.readBuf.GetBytes(n - 4)
 }
 
 // statusReportParams is a list of session variables that are also

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -234,6 +234,14 @@ func MakeServer(
 			log.Warningf(ambientCtx.AnnotateCtx(context.Background()), "invalid %s: %v", serverHBAConfSetting, err)
 			conf = nil
 		}
+		// Usernames are normalized during session init. Normalize the HBA usernames
+		// in the same way.
+		for _, entry := range conf.Entries {
+			for iu := range entry.User {
+				user := &entry.User[iu]
+				user.Value = tree.Name(user.Value).Normalize()
+			}
+		}
 		server.auth.conf = conf
 	})
 


### PR DESCRIPTION
This PR has a build error when running `make libkrb5`. When I run `make -n libkrb5` and run the outputted commands by hand, it works fine. When running in make it fails, so I'm not sure what's going on here. Does make set some ENV variables or something that causes the problem here? Further, the problem appears to be with `configure`. When I run make by hand in the build dir after this it still fails. Conversely, when I run the configure by hand and then `make libkrb5` it succeeds. Can someone else reproduce this failure? cc @petermattis @knz