### PR TITLE
rangefeed: Fix flaky TestProcessorConcurrentStop

### DIFF
--- a/pkg/storage/rangefeed/processor.go
+++ b/pkg/storage/rangefeed/processor.go
@@ -166,6 +166,8 @@ func (p *Processor) Start(stopper *stop.Stopper, rtsIter engine.SimpleIterator) 
 	ctx := p.AnnotateCtx(context.Background())
 	stopper.RunWorker(ctx, func(ctx context.Context) {
 		defer close(p.stoppedC)
+		ctx, cancelOutputLoops := context.WithCancel(ctx)
+		defer cancelOutputLoops()
 
 		// Launch an async task to scan over the resolved timestamp iterator and
 		// initialize the unresolvedIntentQueue. Ignore error if quiescing.


### PR DESCRIPTION
This test was flaky because the context used to start output loops was
based on the background context, and thus wasn't being cancelled when
the processor was stopped.

This was caught by bors in #33557, but it retried and merged anyway.

Release note: None