### PR TITLE
opt: invalidate cached plans when statistics change

### DIFF
--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -43,14 +43,6 @@ import (
 // For sqlbase objects, the StableID is the 32-bit descriptor ID.
 type StableID uint32
 
-// Version is incremented any time the schema of a catalog data source (table,
-// view, etc.) is changed in any way, including changes to any associated
-// indexes. This enables cached data sources (or other data structures dependent
-// on the data sources) to be invalidated when their schema changes.
-//
-// For sqlbase data sources, the version is the 32-bit descriptor version.
-type Version uint32
-
 // SchemaName is an alias for tree.TableNamePrefix, since it consists of the
 // catalog + schema name.
 type SchemaName = tree.TableNamePrefix

--- a/pkg/sql/opt/cat/data_source.go
+++ b/pkg/sql/opt/cat/data_source.go
@@ -25,15 +25,17 @@ type DataSourceName = tree.TableName
 type DataSource interface {
 	Object
 
-	// Version uniquely identifies a particular iteration of the data source's
-	// schema. Each time the schema changes, the version will be incremented,
-	// which allows changes to be easily detected. See the comment for the Version
-	// type for more detail.
-	Version() Version
-
 	// Name returns the fully normalized, fully qualified, and fully resolved
 	// name of the data source (<db-name>.<schema-name>.<data-source-name>). The
 	// ExplicitCatalog and ExplicitSchema fields will always be true, since all
 	// parts of the name are always specified.
 	Name() *DataSourceName
+
+	// Equals returns true if this DataSource is identical to the given
+	// DataSource.
+	//
+	// This is used for invalidating cached plans and must return false whenever
+	// the schema of a data source changed between the times the two data sources
+	// were resolved.
+	Equals(other DataSource) bool
 }

--- a/pkg/sql/opt/cat/data_source.go
+++ b/pkg/sql/opt/cat/data_source.go
@@ -35,7 +35,7 @@ type DataSource interface {
 	// DataSource.
 	//
 	// This is used for invalidating cached plans and must return false whenever
-	// the schema of a data source changed between the times the two data sources
-	// were resolved.
+	// the schema or statistics of a data source changed between the times the two
+	// data sources were resolved.
 	Equals(other DataSource) bool
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -1,4 +1,4 @@
-# LogicTest: local-opt
+# LogicTest: fakedist-opt
 
 statement ok
 CREATE TABLE ab (a INT PRIMARY KEY, b INT); INSERT INTO ab (a, b) VALUES (1, 10)
@@ -36,3 +36,41 @@ scan  ·       ·
 ·     table   ab@primary
 ·     spans   ALL
 ·     filter  b = 10
+
+## Statistics change: Create statistics and ensure that the plan is recalculated.
+statement ok
+CREATE TABLE cd (c INT PRIMARY KEY, d INT)
+
+statement ok
+PREPARE change_stats AS SELECT * FROM [EXPLAIN SELECT * FROM ab JOIN cd ON a=c]
+
+query TTT
+EXECUTE change_stats
+----
+join       ·               ·
+ │         type            inner
+ │         equality        (a) = (c)
+ │         mergeJoinOrder  +"(a=c)"
+ ├── scan  ·               ·
+ │         table           ab@primary
+ │         spans           ALL
+ └── scan  ·               ·
+·          table           cd@primary
+·          spans           ALL
+
+statement ok
+CREATE STATISTICS s FROM ab
+
+# Now that the optimizer knows table ab has one row (and it assumes a much
+# higher number of rows for cd), it should choose lookup join.
+# We allow retry because stat cache invalidation happens asynchronously.
+query TTT retry
+EXECUTE change_stats
+----
+lookup-join  ·      ·
+ │           type   inner
+ ├── scan    ·      ·
+ │           table  ab@primary
+ │           spans  ALL
+ └── scan    ·      ·
+·            table  cd@primary

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -150,7 +150,7 @@ func (md *Metadata) CheckDependencies(
 			if err != nil {
 				return false, err
 			}
-			if new.Version() != old.Version() {
+			if !new.Equals(old) {
 				return false, nil
 			}
 			toCheck = new

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -355,7 +355,7 @@ func (s *Schema) Name() *cat.SchemaName {
 // View implements the cat.View interface for testing purposes.
 type View struct {
 	ViewID      cat.StableID
-	ViewVersion cat.Version
+	ViewVersion int
 	ViewName    cat.DataSourceName
 	QueryText   string
 	ColumnNames tree.NameList
@@ -377,9 +377,13 @@ func (tv *View) ID() cat.StableID {
 	return tv.ViewID
 }
 
-// Version is part of the cat.DataSource interface.
-func (tv *View) Version() cat.Version {
-	return tv.ViewVersion
+// Equals is part of the cat.DataSource interface.
+func (tv *View) Equals(other cat.DataSource) bool {
+	otherView, ok := other.(*View)
+	if !ok {
+		return false
+	}
+	return tv.ViewID == otherView.ViewID && tv.ViewVersion == otherView.ViewVersion
 }
 
 // Name is part of the cat.DataSource interface.
@@ -405,7 +409,7 @@ func (tv *View) ColumnName(i int) tree.Name {
 // Table implements the cat.Table interface for testing purposes.
 type Table struct {
 	TabID      cat.StableID
-	TabVersion cat.Version
+	TabVersion int
 	TabName    tree.TableName
 	Columns    []*Column
 	Indexes    []*Index
@@ -431,9 +435,13 @@ func (tt *Table) ID() cat.StableID {
 	return tt.TabID
 }
 
-// Version is part of the cat.DataSource interface.
-func (tt *Table) Version() cat.Version {
-	return tt.TabVersion
+// Equals is part of the cat.DataSource interface.
+func (tt *Table) Equals(other cat.DataSource) bool {
+	otherTable, ok := other.(*Table)
+	if !ok {
+		return false
+	}
+	return tt.TabID == otherTable.TabID && tt.TabVersion == otherTable.TabVersion
 }
 
 // Name is part of the cat.DataSource interface.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -305,8 +305,6 @@ type optTable struct {
 	// primary is the inlined wrapper for the table's primary index.
 	primary optIndex
 
-	// stats is nil until StatisticCount is called. After that it will not be nil,
-	// even when there are no statistics.
 	stats []optTableStat
 
 	// colMap is a mapping from unique ColumnID to column ordinal within the
@@ -383,7 +381,19 @@ func (ot *optTable) Equals(other cat.DataSource) bool {
 	if !ok {
 		return false
 	}
-	return ot.desc.ID == otherTable.desc.ID && ot.desc.Version == otherTable.desc.Version
+	if ot.desc.ID != otherTable.desc.ID || ot.desc.Version != otherTable.desc.Version {
+		return false
+	}
+	// Verify the stats are identical.
+	if len(ot.stats) != len(otherTable.stats) {
+		return false
+	}
+	for i := range ot.stats {
+		if !ot.stats[i].equals(&otherTable.stats[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // Name is part of the cat.DataSource interface.
@@ -659,6 +669,20 @@ func (os *optTableStat) init(tab *optTable, stat *stats.TableStatistic) (ok bool
 		if !ok {
 			// Column not in table (this is possible if the column was removed since
 			// the statistic was calculated).
+			return false
+		}
+	}
+	return true
+}
+
+func (os *optTableStat) equals(other *optTableStat) bool {
+	// Two table statistics are considered equal if they have been created at the
+	// same time, on the same set of columns.
+	if os.createdAt != other.createdAt || len(os.columnOrdinals) != len(other.columnOrdinals) {
+		return false
+	}
+	for i, c := range os.columnOrdinals {
+		if c != other.columnOrdinals[i] {
 			return false
 		}
 	}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -221,9 +221,13 @@ func (ov *optView) ID() cat.StableID {
 	return cat.StableID(ov.desc.ID)
 }
 
-// Version is part of the cat.DataSource interface.
-func (ov *optView) Version() cat.Version {
-	return cat.Version(ov.desc.Version)
+// Equals is part of the cat.DataSource interface.
+func (ov *optView) Equals(other cat.DataSource) bool {
+	otherView, ok := other.(*optView)
+	if !ok {
+		return false
+	}
+	return ov.desc.ID == otherView.desc.ID && ov.desc.Version == otherView.desc.Version
 }
 
 // Name is part of the cat.View interface.
@@ -275,9 +279,13 @@ func (os *optSequence) ID() cat.StableID {
 	return cat.StableID(os.desc.ID)
 }
 
-// Version is part of the cat.DataSource interface.
-func (os *optSequence) Version() cat.Version {
-	return cat.Version(os.desc.Version)
+// Equals is part of the cat.DataSource interface.
+func (os *optSequence) Equals(other cat.DataSource) bool {
+	otherSeq, ok := other.(*optSequence)
+	if !ok {
+		return false
+	}
+	return os.desc.ID == otherSeq.desc.ID && os.desc.Version == otherSeq.desc.Version
 }
 
 // Name is part of the cat.DataSource interface.
@@ -369,9 +377,13 @@ func (ot *optTable) ID() cat.StableID {
 	return cat.StableID(ot.desc.ID)
 }
 
-// Version is part of the cat.DataSource interface.
-func (ot *optTable) Version() cat.Version {
-	return cat.Version(ot.desc.Version)
+// Equals is part of the cat.DataSource interface.
+func (ot *optTable) Equals(other cat.DataSource) bool {
+	otherTable, ok := other.(*optTable)
+	if !ok {
+		return false
+	}
+	return ot.desc.ID == otherTable.desc.ID && ot.desc.Version == otherTable.desc.Version
 }
 
 // Name is part of the cat.DataSource interface.


### PR DESCRIPTION
This turned out to be much easier than I expected. I'm open to better suggestions for the method name `Equals`

#### opt/cat: replace Version with Equals

Instead of exposing a `Version`, data sources now expose an `Equals`
method. The version is still used internally, but the optimizer
doesn't need to know about it.

Release note: None

#### opt: invalidate cached plans when statistics change

Release note: None
