### PR TITLE
roachprod: make wipe remove logs on cloud clusters

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -211,7 +211,7 @@ func (c *SyncedCluster) Wipe() {
 		} else {
 			cmd = `find /mnt/data* -maxdepth 1 -type f -exec rm -f {} \; ;
 rm -fr /mnt/data*/{auxiliary,local,tmp,cassandra,cockroach,cockroach-temp*,mongo-data} \; ;
-rm -fr certs* ;
+rm -fr {certs*,logs} ;
 `
 		}
 		return sess.CombinedOutput(cmd)


### PR DESCRIPTION
Change `wipe` to remove the logs directory on cloud clusters. This
unifies the behavior of `wipe` for local and cloud clusters.

Fixes #33602

Release note: None