### PR TITLE
opt: Fix panic in optCatalog.CheckPrivilege

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/create_table
+++ b/pkg/sql/opt/optbuilder/testdata/create_table
@@ -36,6 +36,12 @@ CREATE TABLE unknown.ab (a INT PRIMARY KEY)
 ----
 error (3F000): cannot create "unknown.ab" because the target database or schema does not exist
 
+# Schema can only be created in public schema.
+build
+CREATE TABLE t.crdb_internal.ab (a INT PRIMARY KEY)
+----
+error (42602): schema cannot be modified: "t.crdb_internal"
+
 # Too few input columns.
 build
 CREATE TABLE ab (a, b) AS SELECT 1

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -407,6 +407,7 @@ func (b *Builder) resolveSchemaForCreate(name *tree.TableName) cat.Schema {
 				tree.ErrString(name)).
 				SetHintf("verify that the current database and search_path are valid and/or the target database exists")})
 		}
+		panic(builderError{err})
 	}
 
 	// Only allow creation of objects in the public schema.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -149,7 +149,7 @@ func (oc *optCatalog) CheckPrivilege(ctx context.Context, o cat.Object, priv pri
 	case *optSequence:
 		return oc.resolver.CheckPrivilege(ctx, t.desc, priv)
 	default:
-		panic("invalid DataSource")
+		return pgerror.NewAssertionErrorf("invalid object type: %T", o)
 	}
 }
 


### PR DESCRIPTION
Fixes #34055

There was a missing panic in resolveSchemaForCreate that
caused the schema object to be nil, which then triggered a panic in
optCatalog.CheckPrivilege. Also changed panic to assertion error.

Release note: None