### PR TITLE
publish-provisional-artifacts: don't build the archive during -bless

### DIFF
--- a/pkg/cmd/publish-provisional-artifacts/main.go
+++ b/pkg/cmd/publish-provisional-artifacts/main.go
@@ -20,13 +20,13 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"flag"
 	"fmt"
 	"go/build"
 	"io"
 	"log"
 	"mime"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -48,12 +48,14 @@ const (
 
 var provisionalReleasePrefixRE = regexp.MustCompile(`^provisional_[0-9]{12}_`)
 
-type s3putter interface {
+type s3I interface {
+	GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error)
 	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
 }
 
-// Overridden in testing.
-var testableS3 = func() (s3putter, error) {
+type execRunner func(*exec.Cmd) ([]byte, error)
+
+func makeS3() (s3I, error) {
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String("us-east-1"),
 	})
@@ -78,10 +80,10 @@ var libsRe = func() *regexp.Regexp {
 
 var osVersionRe = regexp.MustCompile(`\d+(\.\d+)*-`)
 
-var isRelease = flag.Bool("release", false, "build in release mode instead of bleeding-edge mode")
+var isReleaseF = flag.Bool("release", false, "build in release mode instead of bleeding-edge mode")
 var destBucket = flag.String("bucket", "", "override default bucket")
-var doProvisional = flag.Bool("provisional", false, "publish provisional binaries")
-var doBless = flag.Bool("bless", false, "bless provisional binaries")
+var doProvisionalF = flag.Bool("provisional", false, "publish provisional binaries")
+var doBlessF = flag.Bool("bless", false, "bless provisional binaries")
 
 var (
 	noCache = "no-cache"
@@ -97,18 +99,24 @@ func main() {
 	flag.Parse()
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
-	// TODO(dan): non-release builds currently aren't broken into the two
-	// phases. Instead, the provisional phase does them both.
-	if !*isRelease {
-		*doProvisional = true
-		*doBless = false
-	}
-
 	if _, ok := os.LookupEnv(awsAccessKeyIDKey); !ok {
 		log.Fatalf("AWS access key ID environment variable %s is not set", awsAccessKeyIDKey)
 	}
 	if _, ok := os.LookupEnv(awsSecretAccessKeyKey); !ok {
 		log.Fatalf("AWS secret access key environment variable %s is not set", awsSecretAccessKeyKey)
+	}
+	s3, err := makeS3()
+	if err != nil {
+		log.Fatalf("Creating AWS S3 session: %s", err)
+	}
+	execFn := func(c *exec.Cmd) ([]byte, error) {
+		if c.Stdout != nil {
+			return nil, errors.New("exec: Stdout already set")
+		}
+		var stdout bytes.Buffer
+		c.Stdout = io.MultiWriter(&stdout, os.Stdout)
+		err := c.Run()
+		return stdout.Bytes(), err
 	}
 
 	branch, ok := os.LookupEnv(teamcityBuildBranchKey)
@@ -119,16 +127,48 @@ func main() {
 	if err != nil {
 		log.Fatalf("unable to locate CRDB directory: %s", err)
 	}
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = pkg.Dir
+	log.Printf("%s %s", cmd.Env, cmd.Args)
+	shaOut, err := cmd.Output()
+	if err != nil {
+		log.Fatalf("%s: out=%q err=%s", cmd.Args, shaOut, err)
+	}
+
+	run(s3, execFn, runFlags{
+		doProvisional: *doProvisionalF,
+		doBless:       *doBlessF,
+		isRelease:     *isReleaseF,
+		branch:        branch,
+		pkgDir:        pkg.Dir,
+		sha:           string(bytes.TrimSpace(shaOut)),
+	})
+}
+
+type runFlags struct {
+	doProvisional, doBless bool
+	isRelease              bool
+	branch, sha            string
+	pkgDir                 string
+}
+
+func run(svc s3I, execFn execRunner, flags runFlags) {
+	// TODO(dan): non-release builds currently aren't broken into the two
+	// phases. Instead, the provisional phase does them both.
+	if !flags.isRelease {
+		flags.doProvisional = true
+		flags.doBless = false
+	}
 
 	var versionStr string
 	var updateLatest bool
-	if *isRelease {
+	if flags.isRelease {
 		// If the tag starts with "provisional_", then we're building a binary
 		// that we hope will be some final release and the tag will be of the
 		// form `provisional_<yyyymmddhhss>_<semver>`. If all goes well with the
 		// long running tests, these bits will be released exactly as-is, so the
 		// version is set to <semver> by stripping the prefix.
-		versionStr = provisionalReleasePrefixRE.ReplaceAllLiteralString(branch, "")
+		versionStr = provisionalReleasePrefixRE.ReplaceAllLiteralString(flags.branch, "")
 
 		ver, err := version.Parse(versionStr)
 		if err != nil {
@@ -146,26 +186,14 @@ func main() {
 			updateLatest = true
 		}
 	} else {
-		cmd := exec.Command("git", "rev-parse", "HEAD")
-		cmd.Dir = pkg.Dir
-		log.Printf("%s %s", cmd.Env, cmd.Args)
-		out, err := cmd.Output()
-		if err != nil {
-			log.Fatalf("%s: out=%q err=%s", cmd.Args, out, err)
-		}
-		versionStr = string(bytes.TrimSpace(out))
+		versionStr = flags.sha
 		updateLatest = true
-	}
-
-	svc, err := testableS3()
-	if err != nil {
-		log.Fatalf("Creating AWS S3 session: %s", err)
 	}
 
 	var bucketName string
 	if len(*destBucket) > 0 {
 		bucketName = *destBucket
-	} else if *isRelease {
+	} else if flags.isRelease {
 		bucketName = "binaries.cockroachdb.com"
 	} else {
 		bucketName = "cockroach"
@@ -201,8 +229,8 @@ func main() {
 			// {suffix: ".race", goflags: "-race"},
 		} {
 			var o opts
-			o.PkgDir = pkg.Dir
-			o.Branch = branch
+			o.PkgDir = flags.pkgDir
+			o.Branch = flags.branch
 			o.VersionStr = versionStr
 			o.BucketName = bucketName
 			o.BuildType = target.buildType
@@ -212,7 +240,7 @@ func main() {
 			o.Base = "cockroach" + o.Suffix
 
 			// TODO(tamird): build deadlock,race binaries for all targets?
-			if i > 0 && (*isRelease || !strings.HasSuffix(o.BuildType, "linux-gnu")) {
+			if i > 0 && (flags.isRelease || !strings.HasSuffix(o.BuildType, "linux-gnu")) {
 				log.Printf("skipping auxiliary build: %s", pretty.Sprint(o))
 				continue
 			}
@@ -227,21 +255,21 @@ func main() {
 		}
 	}
 	archiveBuildOpts := opts{
-		PkgDir:     pkg.Dir,
+		PkgDir:     flags.pkgDir,
 		BucketName: bucketName,
 		VersionStr: versionStr,
 	}
 
-	if *doProvisional {
+	if flags.doProvisional {
 		for _, o := range cockroachBuildOpts {
-			buildCockroach(svc, o)
+			buildCockroach(svc, execFn, flags, o)
 
 			absolutePath := filepath.Join(o.PkgDir, o.Base)
 			binary, err := os.Open(absolutePath)
 			if err != nil {
 				log.Fatalf("os.Open(%s): %s", absolutePath, err)
 			}
-			if !*isRelease {
+			if !flags.isRelease {
 				putNonRelease(svc, o, binary)
 			} else {
 				putRelease(svc, o, binary)
@@ -250,12 +278,12 @@ func main() {
 				log.Fatal(err)
 			}
 		}
-		if *isRelease {
-			buildAndPutArchive(svc, archiveBuildOpts)
+		if flags.isRelease {
+			buildAndPutArchive(svc, execFn, archiveBuildOpts)
 		}
 	}
-	if *doBless {
-		if !*isRelease {
+	if flags.doBless {
+		if !flags.isRelease {
 			log.Fatal("cannot bless non-release versions")
 		}
 		if updateLatest {
@@ -267,7 +295,7 @@ func main() {
 	}
 }
 
-func buildAndPutArchive(svc s3putter, o opts) {
+func buildAndPutArchive(svc s3I, execFn execRunner, o opts) {
 	log.Printf("building archive %s", pretty.Sprint(o))
 	defer func() {
 		log.Printf("done building archive: %s", pretty.Sprint(o))
@@ -282,11 +310,10 @@ func buildAndPutArchive(svc s3putter, o opts) {
 		fmt.Sprintf("BUILDINFO_TAG=%s", o.VersionStr),
 	)
 	cmd.Dir = o.PkgDir
-	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	log.Printf("%s %s", cmd.Env, cmd.Args)
-	if err := cmd.Run(); err != nil {
-		log.Fatalf("%s: %s", cmd.Args, err)
+	if out, err := execFn(cmd); err != nil {
+		log.Fatalf("%s %s: %s\n\n%s", cmd.Env, cmd.Args, err, out)
 	}
 
 	absoluteSrcArchivePath := filepath.Join(o.PkgDir, srcArchive)
@@ -308,7 +335,7 @@ func buildAndPutArchive(svc s3putter, o opts) {
 	}
 }
 
-func buildCockroach(svc s3putter, o opts) {
+func buildCockroach(svc s3I, execFn execRunner, flags runFlags, o opts) {
 	log.Printf("building cockroach %s", pretty.Sprint(o))
 	defer func() {
 		log.Printf("done building cockroach: %s", pretty.Sprint(o))
@@ -320,17 +347,16 @@ func buildCockroach(svc s3putter, o opts) {
 		args = append(args, fmt.Sprintf("%s=%s", "SUFFIX", o.Suffix))
 		args = append(args, fmt.Sprintf("%s=%s", "TAGS", o.Tags))
 		args = append(args, fmt.Sprintf("%s=%s", "BUILDCHANNEL", "official-binary"))
-		if *isRelease {
+		if flags.isRelease {
 			args = append(args, fmt.Sprintf("%s=%s", "BUILDINFO_TAG", o.VersionStr))
 			args = append(args, fmt.Sprintf("%s=%s", "BUILD_TAGGED_RELEASE", "true"))
 		}
 		cmd := exec.Command("mkrelease", args...)
 		cmd.Dir = o.PkgDir
-		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		log.Printf("%s %s", cmd.Env, cmd.Args)
-		if err := cmd.Run(); err != nil {
-			log.Fatalf("%s: %s", cmd.Args, err)
+		if out, err := execFn(cmd); err != nil {
+			log.Fatalf("%s %s: %s\n\n%s", cmd.Env, cmd.Args, err, out)
 		}
 	}
 
@@ -340,11 +366,10 @@ func buildCockroach(svc s3putter, o opts) {
 		cmd := exec.Command(binaryName, "version")
 		cmd.Dir = o.PkgDir
 		cmd.Env = append(cmd.Env, "MALLOC_CONF=prof:true")
-		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		log.Printf("%s %s", cmd.Env, cmd.Args)
-		if err := cmd.Run(); err != nil {
-			log.Fatalf("%s %s: %s", cmd.Env, cmd.Args, err)
+		if out, err := execFn(cmd); err != nil {
+			log.Fatalf("%s %s: %s\n\n%s", cmd.Env, cmd.Args, err, out)
 		}
 
 		// ldd only works on binaries built for the host. "linux-musl"
@@ -356,7 +381,7 @@ func buildCockroach(svc s3putter, o opts) {
 			cmd := exec.Command("ldd", binaryName)
 			cmd.Dir = o.PkgDir
 			log.Printf("%s %s", cmd.Env, cmd.Args)
-			out, err := cmd.Output()
+			out, err := execFn(cmd)
 			if err != nil {
 				log.Fatalf("%s: out=%q err=%s", cmd.Args, out, err)
 			}
@@ -393,7 +418,7 @@ func TrimDotExe(name string) (string, bool) {
 	return strings.TrimSuffix(name, dotExe), strings.HasSuffix(name, dotExe)
 }
 
-func putNonRelease(svc s3putter, o opts, binary io.ReadSeeker) {
+func putNonRelease(svc s3I, o opts, binary io.ReadSeeker) {
 	const repoName = "cockroach"
 	remoteName, hasExe := TrimDotExe(o.Base)
 	// TODO(tamird): do we want to keep doing this? No longer
@@ -458,7 +483,7 @@ func s3KeyArchive(o opts) (string, string) {
 	return archiveBase, srcArchive
 }
 
-func putRelease(svc s3putter, o opts, binary *os.File) {
+func putRelease(svc s3I, o opts, binary *os.File) {
 	// Stat the binary. Info is needed for archive headers.
 	binaryInfo, err := binary.Stat()
 	if err != nil {
@@ -522,18 +547,20 @@ func putRelease(svc s3putter, o opts, binary *os.File) {
 	}
 }
 
-func markLatestRelease(svc s3putter, o opts) {
+func markLatestRelease(svc s3I, o opts) {
 	_, keyRelease := s3KeyRelease(o)
-	binaryURL := fmt.Sprintf("https://s3.amazonaws.com/%s/%s", o.BucketName, keyRelease)
-	log.Printf("Downloading from %s", binaryURL)
-	binary, err := http.DefaultClient.Get(binaryURL)
+	log.Printf("Downloading from %s/%s", o.BucketName, keyRelease)
+	binary, err := svc.GetObject(&s3.GetObjectInput{
+		Bucket: &o.BucketName,
+		Key:    &keyRelease,
+	})
 	if err != nil {
-		log.Fatalf("downloading %s: %s", binaryURL, err)
+		log.Fatal(err)
 	}
 	defer binary.Body.Close()
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, binary.Body); err != nil {
-		log.Fatalf("downloading %s: %s", binaryURL, err)
+		log.Fatalf("downloading %s/%s: %s", o.BucketName, keyRelease, err)
 	}
 
 	oLatest := o
@@ -551,18 +578,21 @@ func markLatestRelease(svc s3putter, o opts) {
 	}
 }
 
-func markLatestArchive(svc s3putter, o opts) {
+func markLatestArchive(svc s3I, o opts) {
 	_, keyRelease := s3KeyArchive(o)
-	binaryURL := fmt.Sprintf("https://s3.amazonaws.com/%s/%s", o.BucketName, keyRelease)
-	log.Printf("Downloading from %s", binaryURL)
-	binary, err := http.DefaultClient.Get(binaryURL)
+
+	log.Printf("Downloading from %s/%s", o.BucketName, keyRelease)
+	binary, err := svc.GetObject(&s3.GetObjectInput{
+		Bucket: &o.BucketName,
+		Key:    &keyRelease,
+	})
 	if err != nil {
-		log.Fatalf("downloading %s: %s", binaryURL, err)
+		log.Fatal(err)
 	}
 	defer binary.Body.Close()
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, binary.Body); err != nil {
-		log.Fatalf("downloading %s: %s", binaryURL, err)
+		log.Fatalf("downloading %s/%s: %s", o.BucketName, keyRelease, err)
 	}
 
 	oLatest := o

--- a/pkg/cmd/publish-provisional-artifacts/main_test.go
+++ b/pkg/cmd/publish-provisional-artifacts/main_test.go
@@ -1,0 +1,251 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type mockS3 struct {
+	gets []string
+	puts []string
+}
+
+var _ s3I = (*mockS3)(nil)
+
+func (s *mockS3) GetObject(i *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	url := fmt.Sprintf(`s3://%s/%s`, *i.Bucket, *i.Key)
+	s.gets = append(s.gets, url)
+	o := &s3.GetObjectOutput{
+		Body: ioutil.NopCloser(bytes.NewBufferString(url)),
+	}
+	return o, nil
+}
+
+func (s *mockS3) PutObject(i *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	url := fmt.Sprintf(`s3://%s/%s`, *i.Bucket, *i.Key)
+	if i.CacheControl != nil {
+		url += `/` + *i.CacheControl
+	}
+	if i.Body != nil {
+		bytes, err := ioutil.ReadAll(i.Body)
+		if err != nil {
+			return nil, err
+		}
+		if utf8.Valid(bytes) {
+			s.puts = append(s.puts, fmt.Sprintf("%s CONTENTS %s", url, bytes))
+		} else {
+			s.puts = append(s.puts, fmt.Sprintf("%s CONTENTS <binary stuff>", url))
+		}
+	} else if i.WebsiteRedirectLocation != nil {
+		s.puts = append(s.puts, fmt.Sprintf("%s REDIRECT %s", url, *i.WebsiteRedirectLocation))
+	}
+	return &s3.PutObjectOutput{}, nil
+}
+
+type mockExecRunner struct {
+	cmds []string
+}
+
+func (r *mockExecRunner) run(c *exec.Cmd) ([]byte, error) {
+	if c.Dir == `` {
+		return nil, errors.Errorf(`Dir must be specified`)
+	}
+	cmd := fmt.Sprintf("env=%s args=%s", c.Env, c.Args)
+
+	var path string
+	if c.Args[0] == `mkrelease` {
+		path = filepath.Join(c.Dir, `cockroach`)
+		for _, arg := range c.Args {
+			if strings.HasPrefix(arg, `SUFFIX=`) {
+				path += strings.TrimPrefix(arg, `SUFFIX=`)
+			}
+		}
+	} else if c.Args[0] == `make` && c.Args[1] == `archive` {
+		for _, arg := range c.Args {
+			if strings.HasPrefix(arg, `ARCHIVE=`) {
+				path = filepath.Join(c.Dir, strings.TrimPrefix(arg, `ARCHIVE=`))
+				break
+			}
+		}
+	}
+
+	if path != `` {
+		if err := ioutil.WriteFile(path, []byte(cmd), 0666); err != nil {
+			return nil, err
+		}
+		r.cmds = append(r.cmds, cmd)
+	}
+
+	var output []byte
+	return output, nil
+}
+
+func TestProvisional(t *testing.T) {
+	tests := []struct {
+		name         string
+		flags        runFlags
+		expectedCmds []string
+		expectedGets []string
+		expectedPuts []string
+	}{
+		{
+			name: `release`,
+			flags: runFlags{
+				doProvisional: true,
+				isRelease:     true,
+				branch:        `provisional_201901010101_v0.0.1-alpha`,
+			},
+			expectedCmds: []string{
+				"env=[] args=[mkrelease darwin GOFLAGS= SUFFIX=.darwin-10.9-amd64 TAGS= BUILDCHANNEL=official-binary BUILDINFO_TAG=v0.0.1-alpha BUILD_TAGGED_RELEASE=true]",
+				"env=[] args=[mkrelease linux-gnu GOFLAGS= SUFFIX=.linux-2.6.32-gnu-amd64 TAGS= BUILDCHANNEL=official-binary BUILDINFO_TAG=v0.0.1-alpha BUILD_TAGGED_RELEASE=true]",
+				"env=[] args=[mkrelease linux-musl GOFLAGS= SUFFIX=.linux-2.6.32-musl-amd64 TAGS= BUILDCHANNEL=official-binary BUILDINFO_TAG=v0.0.1-alpha BUILD_TAGGED_RELEASE=true]",
+				"env=[] args=[mkrelease windows GOFLAGS= SUFFIX=.windows-6.2-amd64.exe TAGS= BUILDCHANNEL=official-binary BUILDINFO_TAG=v0.0.1-alpha BUILD_TAGGED_RELEASE=true]",
+				"env=[] args=[make archive ARCHIVE_BASE=cockroach-v0.0.1-alpha ARCHIVE=cockroach-v0.0.1-alpha.src.tgz BUILDINFO_TAG=v0.0.1-alpha]",
+			},
+			expectedGets: nil,
+			expectedPuts: []string{
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-10.9-amd64.tgz " +
+					"CONTENTS <binary stuff>",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.linux-amd64.tgz " +
+					"CONTENTS <binary stuff>",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.linux-musl-amd64.tgz " +
+					"CONTENTS <binary stuff>",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.windows-6.2-amd64.zip " +
+					"CONTENTS <binary stuff>",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.src.tgz " +
+					"CONTENTS env=[] args=[make archive ARCHIVE_BASE=cockroach-v0.0.1-alpha ARCHIVE=cockroach-v0.0.1-alpha.src.tgz BUILDINFO_TAG=v0.0.1-alpha]",
+			},
+		},
+		{
+			name: `edge`,
+			flags: runFlags{
+				doProvisional: true,
+				isRelease:     false,
+				branch:        `master`,
+				sha:           `00SHA00`,
+			},
+			expectedCmds: []string{
+				"env=[] args=[mkrelease darwin GOFLAGS= SUFFIX=.darwin-10.9-amd64 TAGS= BUILDCHANNEL=official-binary]",
+				"env=[] args=[mkrelease linux-gnu GOFLAGS= SUFFIX=.linux-2.6.32-gnu-amd64 TAGS= BUILDCHANNEL=official-binary]",
+				"env=[] args=[mkrelease linux-musl GOFLAGS= SUFFIX=.linux-2.6.32-musl-amd64 TAGS= BUILDCHANNEL=official-binary]",
+				"env=[] args=[mkrelease windows GOFLAGS= SUFFIX=.windows-6.2-amd64.exe TAGS= BUILDCHANNEL=official-binary]",
+			},
+			expectedGets: nil,
+			expectedPuts: []string{
+				"s3://cockroach//cockroach/cockroach.darwin-amd64.00SHA00 " +
+					"CONTENTS env=[] args=[mkrelease darwin GOFLAGS= SUFFIX=.darwin-10.9-amd64 TAGS= BUILDCHANNEL=official-binary]",
+				"s3://cockroach/cockroach/cockroach.darwin-amd64.LATEST/no-cache " +
+					"REDIRECT /cockroach/cockroach.darwin-amd64.00SHA00",
+				"s3://cockroach//cockroach/cockroach.linux-gnu-amd64.00SHA00 " +
+					"CONTENTS env=[] args=[mkrelease linux-gnu GOFLAGS= SUFFIX=.linux-2.6.32-gnu-amd64 TAGS= BUILDCHANNEL=official-binary]",
+				"s3://cockroach/cockroach/cockroach.linux-gnu-amd64.LATEST/no-cache " +
+					"REDIRECT /cockroach/cockroach.linux-gnu-amd64.00SHA00",
+				"s3://cockroach//cockroach/cockroach.linux-musl-amd64.00SHA00 " +
+					"CONTENTS env=[] args=[mkrelease linux-musl GOFLAGS= SUFFIX=.linux-2.6.32-musl-amd64 TAGS= BUILDCHANNEL=official-binary]",
+				"s3://cockroach/cockroach/cockroach.linux-musl-amd64.LATEST/no-cache " +
+					"REDIRECT /cockroach/cockroach.linux-musl-amd64.00SHA00",
+				"s3://cockroach//cockroach/cockroach.windows-amd64.00SHA00.exe " +
+					"CONTENTS env=[] args=[mkrelease windows GOFLAGS= SUFFIX=.windows-6.2-amd64.exe TAGS= BUILDCHANNEL=official-binary]",
+				"s3://cockroach/cockroach/cockroach.windows-amd64.LATEST/no-cache " +
+					"REDIRECT /cockroach/cockroach.windows-amd64.00SHA00.exe",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir, cleanup := testutils.TempDir(t)
+			defer cleanup()
+
+			var s3 mockS3
+			var exec mockExecRunner
+			flags := test.flags
+			flags.pkgDir = dir
+			run(&s3, exec.run, flags)
+			require.Equal(t, test.expectedCmds, exec.cmds)
+			require.Equal(t, test.expectedGets, s3.gets)
+			require.Equal(t, test.expectedPuts, s3.puts)
+		})
+	}
+}
+
+func TestBless(t *testing.T) {
+	tests := []struct {
+		name         string
+		flags        runFlags
+		expectedGets []string
+		expectedPuts []string
+	}{
+		{
+			name: "testing",
+			flags: runFlags{
+				doBless:   true,
+				isRelease: true,
+				branch:    `provisional_201901010101_v0.0.1-alpha`,
+			},
+			expectedGets: nil,
+			expectedPuts: nil,
+		},
+		{
+			name: "stable",
+			flags: runFlags{
+				doBless:   true,
+				isRelease: true,
+				branch:    `provisional_201901010101_v0.0.1`,
+			},
+			expectedGets: []string{
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1.darwin-10.9-amd64.tgz",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1.linux-amd64.tgz",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1.linux-musl-amd64.tgz",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1.windows-6.2-amd64.zip",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1.src.tgz",
+			},
+			expectedPuts: []string{
+				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.tgz/no-cache " +
+					"CONTENTS s3://binaries.cockroachdb.com/cockroach-v0.0.1.darwin-10.9-amd64.tgz",
+				"s3://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz/no-cache " +
+					"CONTENTS s3://binaries.cockroachdb.com/cockroach-v0.0.1.linux-amd64.tgz",
+				"s3://binaries.cockroachdb.com/cockroach-latest.linux-musl-amd64.tgz/no-cache " +
+					"CONTENTS s3://binaries.cockroachdb.com/cockroach-v0.0.1.linux-musl-amd64.tgz",
+				"s3://binaries.cockroachdb.com/cockroach-latest.windows-6.2-amd64.zip/no-cache " +
+					"CONTENTS s3://binaries.cockroachdb.com/cockroach-v0.0.1.windows-6.2-amd64.zip",
+				"s3://binaries.cockroachdb.com/cockroach-latest.src.tgz/no-cache " +
+					"CONTENTS s3://binaries.cockroachdb.com/cockroach-v0.0.1.src.tgz",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var s3 mockS3
+			var execFn execRunner // bless shouldn't exec anything
+			run(&s3, execFn, test.flags)
+			require.Equal(t, test.expectedGets, s3.gets)
+			require.Equal(t, test.expectedPuts, s3.puts)
+		})
+	}
+}


### PR DESCRIPTION
Instead, build it during -provisional like everything else. Copy it
unchanged into latest during -bless to match they way binaries work.
This changes the name of the folder inside the .tgz from
`cockroach-latest` to `cockroach-v<semver>` but 1) we don't really
advertise the "latest" artifacts so no-one should be depending on this
detail and 2) this is a better name anyway.

Release note: None