### PR TITLE
server, logictest: minor cleanups around cluster version

### DIFF
--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -32,5 +32,5 @@ type TestingKnobs struct {
 	DistSQL             ModuleTestingKnobs
 	SQLEvalContext      ModuleTestingKnobs
 	RegistryLiveness    ModuleTestingKnobs
-	Upgrade             ModuleTestingKnobs
+	Server              ModuleTestingKnobs
 }

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -163,8 +163,8 @@ func TestClusterVersionPersistedOnJoin(t *testing.T) {
 		Store: &storage.StoreTestingKnobs{
 			BootstrapVersion: &bootstrapVersion,
 		},
-		Upgrade: &server.UpgradeTestingKnobs{
-			DisableUpgrade: 1,
+		Server: &server.TestingKnobs{
+			DisableAutomaticVersionUpgrade: 1,
 		},
 	}
 
@@ -211,8 +211,8 @@ func TestClusterVersionUpgrade(t *testing.T) {
 		Store: &storage.StoreTestingKnobs{
 			BootstrapVersion: &bootstrapVersion,
 		},
-		Upgrade: &server.UpgradeTestingKnobs{
-			DisableUpgrade: 1,
+		Server: &server.TestingKnobs{
+			DisableAutomaticVersionUpgrade: 1,
 		},
 	}
 	tc := setupMixedCluster(t, knobs, versions, dir)
@@ -222,7 +222,7 @@ func TestClusterVersionUpgrade(t *testing.T) {
 	if err := tc.setDowngrade(0, oldVersion.String()); err != nil {
 		t.Fatalf("error setting CLUSTER SETTING cluster.preserve_downgrade_option: %s", err)
 	}
-	atomic.StoreInt32(&knobs.Upgrade.(*server.UpgradeTestingKnobs).DisableUpgrade, 0)
+	atomic.StoreInt32(&knobs.Server.(*server.TestingKnobs).DisableAutomaticVersionUpgrade, 0)
 
 	// Check the cluster version is still oldVersion.
 	curVersion := tc.getVersionFromSelect(0)


### PR DESCRIPTION
Mainly turning some fields in the test logic spec from pointers to
versions to values. When they were pointers I was affraid to assign
the addresses of global versions to them.

Release note: None