### PR TITLE
build: skip TestLint/TestVet

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1024,6 +1024,7 @@ func TestLint(t *testing.T) {
 	})
 
 	t.Run("TestVet", func(t *testing.T) {
+		t.Skip("#34059")
 		t.Parallel()
 		// `go vet` is a special snowflake that emits all its output on
 		// `stderr.


### PR DESCRIPTION
Temporarily skip `TestLint/TestVet` until the upstream warnings can be
silenced.

See #34059

Release note: None