### PR TITLE
roachtest: eliminate the concept of subtests

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -21,10 +21,6 @@ import (
 )
 
 func registerAcceptance(r *registry) {
-	// The acceptance tests all share a cluster and run sequentially. In
-	// local mode the acceptance tests should be configured to run within a
-	// minute or so as these tests are run on every merge to master.
-
 	testCases := []struct {
 		name string
 		fn   func(ctx context.Context, t *test, c *cluster)
@@ -54,7 +50,7 @@ func registerAcceptance(r *registry) {
 	}
 	tags := []string{"default", "quick"}
 	const numNodes = 4
-	spec := testSpec{
+	specTemplate := testSpec{
 		// NB: teamcity-post-failures.py relies on the acceptance tests
 		// being named acceptance/<testname> and will avoid posting a
 		// blank issue for the "acceptance" parent test. Make sure to
@@ -62,22 +58,20 @@ func registerAcceptance(r *registry) {
 		// this naming scheme ever change (or issues such as #33519)
 		// will be posted.
 		Name:    "acceptance",
+		Timeout: 10 * time.Minute,
 		Tags:    tags,
 		Cluster: makeClusterSpec(numNodes),
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-		spec.SubTests = append(spec.SubTests, testSpec{
-			Skip:    tc.skip,
-			Name:    tc.name,
-			Timeout: 10 * time.Minute,
-			Tags:    tags,
-			Run: func(ctx context.Context, t *test, c *cluster) {
-				c.Wipe(ctx)
-				tc.fn(ctx, t, c)
-			},
-		})
+		tc := tc // copy for closure
+		spec := specTemplate
+		spec.Name = specTemplate.Name + "/" + tc.name
+		spec.Run = func(ctx context.Context, t *test, c *cluster) {
+			// TODO(andrei): !!! remove this wipe once the test runner starts doing it.
+			c.Wipe(ctx)
+			tc.fn(ctx, t, c)
+		}
+		r.Add(spec)
 	}
-	r.Add(spec)
 }

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -32,7 +32,10 @@ func registerClearRange(r *registry) {
 			// to <3:30h but it varies.
 			Timeout:    5*time.Hour + 90*time.Minute,
 			MinVersion: `v2.2.0`,
-			Cluster:    makeClusterSpec(10),
+			// This test reformats a drive to ZFS, so we don't want it reused.
+			// TODO(andrei): Can the test itself reuse the cluster (under --count=2)?
+			// In other words, would a OnlyTagged("clearrange") policy be good?
+			Cluster: makeClusterSpec(10, NoReuse),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runClearRange(ctx, t, c, checks)
 			},

--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -74,7 +74,7 @@ type clockJumpTestCase struct {
 	aliveAfterOffset bool
 }
 
-func makeClockJumpTests() testSpec {
+func registerClockJumpTests(r *registry) {
 	testCases := []clockJumpTestCase{
 		{
 			name:             "large_forward_enabled",
@@ -111,30 +111,20 @@ func makeClockJumpTests() testSpec {
 		},
 	}
 
-	spec := testSpec{
-		Name: "jump",
-	}
-
 	for i := range testCases {
 		tc := testCases[i]
-		spec.SubTests = append(spec.SubTests, testSpec{
-			Name: tc.name,
+		spec := testSpec{
+			Name:    "clock/jump/" + tc.name,
+			Cluster: makeClusterSpec(1),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runClockJump(ctx, t, c, tc)
 			},
-		})
+		}
+		r.Add(spec)
 	}
-
-	return spec
 }
 
 func registerClock(r *registry) {
-	r.Add(testSpec{
-		Name:    "clock",
-		Cluster: makeClusterSpec(1),
-		SubTests: []testSpec{
-			makeClockJumpTests(),
-			makeClockMonotonicTests(),
-		},
-	})
+	registerClockJumpTests(r)
+	registerClockMonotonicTests(r)
 }

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -103,7 +103,7 @@ type clockMonotonicityTestCase struct {
 	expectIncreasingWallTime bool
 }
 
-func makeClockMonotonicTests() testSpec {
+func registerClockMonotonicTests(r *registry) {
 	testCases := []clockMonotonicityTestCase{
 		{
 			name:                     "persistent",
@@ -113,19 +113,17 @@ func makeClockMonotonicTests() testSpec {
 		},
 	}
 
-	spec := testSpec{
-		Name: "monotonic",
-	}
-
 	for i := range testCases {
 		tc := testCases[i]
-		spec.SubTests = append(spec.SubTests, testSpec{
-			Name: tc.name,
+		spec := testSpec{
+			Name: "clock/monotonic/" + tc.name,
+			// These tests muck with NTP, therefor we don't want the cluster reused by
+			// others.
+			Cluster: makeClusterSpec(1, OnlyTagged("ClockMonotonicTests")),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runClockMonotonicity(ctx, t, c, tc)
 			},
-		})
+		}
+		r.Add(spec)
 	}
-
-	return spec
 }

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -28,7 +28,8 @@ func registerDiskFull(r *registry) {
 	r.Add(testSpec{
 		Name:       "disk-full",
 		MinVersion: `v2.1.0`,
-		Cluster:    makeClusterSpec(5),
+		// !!! check that the cluster wipe removes the balast
+		Cluster: makeClusterSpec(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if c.isLocal() {
 				t.spec.Skip = "you probably don't want to fill your local disk"

--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -278,42 +278,28 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 }
 
 func registerJepsen(r *registry) {
-	// We're splitting the tests arbitrarily into a number of "batches" - top
-	// level tests. We do this so that we can different groups can run in parallel
-	// (as subtests don't run concurrently with each other). We put more than one
-	// test in a group so that Jepsen's lengthy cluster initialization step can be
-	// amortized (the individual tests are smart enough to not do it if it has
-	// been done already).
-	//
 	// NB: the "comments" test is not included because it requires
 	// linearizability.
-	groups := [][]string{
-		{"bank", "bank-multitable"},
-		{"g2", "monotonic"},
-		{"register", "sequential", "sets"},
-	}
-
-	for i := range groups {
-		spec := testSpec{
-			Name:    fmt.Sprintf("jepsen-batch%d", i+1),
-			Cluster: makeClusterSpec(6),
-		}
-
-		for _, testName := range groups[i] {
-			testName := testName
-			sub := testSpec{Name: testName}
-			for _, nemesis := range jepsenNemeses {
-				nemesis := nemesis
-				sub.SubTests = append(sub.SubTests, testSpec{
-					Name: nemesis.name,
-					Run: func(ctx context.Context, t *test, c *cluster) {
-						runJepsen(ctx, t, c, testName, nemesis.config)
-					},
-				})
+	tests := []string{"bank", "bank-multitable", "g2", "monotonic", "register", "sequential", "sets"}
+	for _, testName := range tests {
+		testName := testName
+		for _, nemesis := range jepsenNemeses {
+			nemesis := nemesis // copy for closure
+			spec := testSpec{
+				Name: fmt.Sprintf("jepsen/%s/%s", testName, nemesis.name),
+				// The Jepsen tests do funky things to machines, like muck with the
+				// system clock; therefor, their clusters cannot be reused other tests
+				// except the Jepsen ones themselves which reset all this state when
+				// they start. It is important, however, that the Jepsen tests reuses
+				// clusters because they have a lengthy setup step, but avoid doing it
+				// if they detect that the machines have already been properly
+				// initialized.
+				Cluster: makeClusterSpec(6, OnlyTagged("jepsen")),
+				Run: func(ctx context.Context, t *test, c *cluster) {
+					runJepsen(ctx, t, c, testName, nemesis.config)
+				},
 			}
-			spec.SubTests = append(spec.SubTests, sub)
+			r.Add(spec)
 		}
-
-		r.Add(spec)
 	}
 }

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -104,7 +104,7 @@ Examples:
 				registerBenchmarks(r)
 			}
 
-			names := r.ListAll(args)
+			names := r.List(args)
 			for _, name := range names {
 				fmt.Println(name)
 			}

--- a/pkg/cmd/roachtest/synctest.go
+++ b/pkg/cmd/roachtest/synctest.go
@@ -35,7 +35,8 @@ fi
 	r.Add(testSpec{
 		Name:       "synctest",
 		MinVersion: `v2.2.0`,
-		Cluster:    makeClusterSpec(1),
+		// This test sets up a custom file system; we don't want the cluster reused.
+		Cluster:     makeClusterSpec(1, NoReuse),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			n := c.Node(1)
 			tmpDir, err := ioutil.TempDir("", "synctest")

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/internal/issues"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
@@ -48,8 +49,9 @@ var (
 
 // testFilter holds the name and tag filters for filtering tests.
 type testFilter struct {
-	name   *regexp.Regexp
-	tag    *regexp.Regexp
+	name *regexp.Regexp
+	tag  *regexp.Regexp
+	// rawTag is the string representation of the regexps in tag
 	rawTag []string
 }
 
@@ -92,17 +94,23 @@ func newFilter(filter []string) *testFilter {
 	}
 }
 
+type reusePolicy int
+
+const (
+	// A sentinel so that we can validate that all the tests set a policy.
+	_ reusePolicy = iota
+	noReuse
+	onlyTagged
+	any
+)
+
 type testSpec struct {
 	Skip string // if non-empty, test will be skipped
 	// When Skip is set, this can contain more text to be printed in the logs
 	// after the "--- SKIP" line.
 	SkipDetails string
-	// For subtests, Name is supposed to originally be assigned to the name of the
-	// subtest when constructing the spec and then, once added to the registry, it
-	// will automatically be expanded to contain all the parents' names. At that
-	// point, subtestName will be populated to the original value of Name.
-	Name        string
-	subtestName string
+
+	Name string
 	// The maximum duration the test is allowed to run before it is considered
 	// failed. If not specified, the default timeout is 10m before the test's
 	// associated cluster expires. The timeout is always truncated to 10m before
@@ -118,9 +126,7 @@ type testSpec struct {
 	// tests. If no tags are specified, the set ["default"] is automatically
 	// given.
 	Tags []string
-	// Cluster provides the specification for the cluster to use for the test. Only
-	// a top-level testSpec may contain a nodes specification. The cluster is
-	// shared by all subtests.
+	// Cluster provides the specification for the cluster to use for the test.
 	Cluster clusterSpec
 
 	// UseIOBarrier controls the local-ssd-no-ext4-barrier flag passed to
@@ -135,12 +141,8 @@ type testSpec struct {
 	// care about.
 	UseIOBarrier bool
 
-	// A testSpec must specify only one of Run or SubTests. All subtests run in
-	// the same cluster, without concurrency between them. Subtest should not
-	// assume any particular state for the cluster as the SubTest may be run in
-	// isolation.
-	Run      func(ctx context.Context, t *test, c *cluster)
-	SubTests []testSpec
+	// Run is the test function.
+	Run func(ctx context.Context, t *test, c *cluster)
 }
 
 // matchOrSkip returns true if the filter matches the test. If the filter does
@@ -163,31 +165,6 @@ func (t *testSpec) matchOrSkip(filter *testFilter) bool {
 	}
 	t.Skip = fmt.Sprintf("%s does not match %s", filter.rawTag, t.Tags)
 	return true
-}
-
-// matchRegex returns true if the regex matches the test's name or any of the
-// subtest names.
-func (t *testSpec) matchRegex(filter *testFilter) bool {
-	if t.matchOrSkip(filter) {
-		return true
-	}
-	for i := range t.SubTests {
-		if t.SubTests[i].matchRegex(filter) {
-			return true
-		}
-	}
-	return false
-}
-
-func (t *testSpec) matchRegexRecursive(filter *testFilter) []testSpec {
-	var res []testSpec
-	if t.matchOrSkip(filter) {
-		res = append(res, *t)
-	}
-	for i := range t.SubTests {
-		res = append(res, t.SubTests[i].matchRegexRecursive(filter)...)
-	}
-	return res
 }
 
 type registry struct {
@@ -340,34 +317,17 @@ func (r *registry) verifyValidClusterName(testName string) error {
 	return nil
 }
 
-func (r *registry) prepareSpec(spec *testSpec, depth int) error {
-	if depth == 0 {
-		spec.subtestName = spec.Name
-		// Only top-level tests can create clusters, so those are the only ones for
-		// which we need to verify the cluster name.
-		if err := r.verifyValidClusterName(spec.Name); err != nil {
-			return err
-		}
+func (r *registry) prepareSpec(spec *testSpec) error {
+	if err := r.verifyValidClusterName(spec.Name); err != nil {
+		return err
 	}
 
-	if (spec.Run != nil) == (len(spec.SubTests) > 0) {
-		return fmt.Errorf("%s: must specify only one of Run or SubTests", spec.Name)
+	if spec.Run == nil {
+		return fmt.Errorf("%s: must specify Run", spec.Name)
 	}
 
-	if spec.Run == nil && spec.Timeout > 0 {
-		return fmt.Errorf("%s: timeouts only apply to tests specifying Run", spec.Name)
-	}
-
-	if depth > 0 && spec.Cluster.NodeCount > 0 {
-		return fmt.Errorf("%s: subtest may not provide cluster specification", spec.Name)
-	}
-
-	for i := range spec.SubTests {
-		spec.SubTests[i].subtestName = spec.SubTests[i].Name
-		spec.SubTests[i].Name = spec.Name + "/" + spec.SubTests[i].Name
-		if err := r.prepareSpec(&spec.SubTests[i], depth+1); err != nil {
-			return err
-		}
+	if spec.Cluster.ReusePolicy == (clusterReusePolicy{}) {
+		return fmt.Errorf("%s: must specify a ClusterReusePolicy", spec.Name)
 	}
 
 	if spec.MinVersion != "" {
@@ -393,46 +353,43 @@ func (r *registry) Add(spec testSpec) {
 		fmt.Fprintf(os.Stderr, "test %s already registered\n", spec.Name)
 		os.Exit(1)
 	}
-	if err := r.prepareSpec(&spec, 0); err != nil {
+	if err := r.prepareSpec(&spec); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
 	r.m[spec.Name] = &spec
 }
 
-// ListTopLevel lists the top level tests that match re, or that have a subtests
-// that matches re.
-func (r *registry) ListTopLevel(filter *testFilter) []*testSpec {
-	var results []*testSpec
-	for _, t := range r.m {
-		if t.matchRegex(filter) {
-			results = append(results, t)
-		}
-	}
-
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Name < results[j].Name
-	})
-	return results
-}
-
-// ListAll lists all tests that match one of the filters. If a subtest matches
-// but a parent doesn't, only the subtest is returned. If a parent matches, all
-// subtests are returned.
-func (r *registry) ListAll(filters []string) []string {
-	filter := newFilter(filters)
+// GetTests returns all the tests that match the given regexp.
+// Skipped tests are included, and tests that don't match their minVersion spec
+// are also included but also marked as skipped.
+func (r *registry) GetTests(filter *testFilter) []testSpec {
 	var tests []testSpec
 	for _, t := range r.m {
-		tests = append(tests, t.matchRegexRecursive(filter)...)
-	}
-	var names []string
-	for _, t := range tests {
+		if !t.matchOrSkip(filter) {
+			continue
+		}
 		if t.Skip == "" && t.minVersion != nil {
+			log.Infof(context.TODO(), "%s at least %s", r.buildVersion, t.minVersion)
 			if !r.buildVersion.AtLeast(t.minVersion) {
 				t.Skip = fmt.Sprintf("build-version (%s) < min-version (%s)",
 					r.buildVersion, t.minVersion)
 			}
 		}
+		tests = append(tests, *t)
+	}
+	sort.Slice(tests, func(i, j int) bool {
+		return tests[i].Name < tests[j].Name
+	})
+	return tests
+}
+
+// List lists tests that match one of the filters.
+func (r *registry) List(filters []string) []string {
+	filter := newFilter(filters)
+	tests := r.GetTests(filter)
+	var names []string
+	for _, t := range tests {
 		name := t.Name
 		if t.Skip != "" {
 			name += " (skipped: " + t.Skip + ")"
@@ -452,21 +409,11 @@ func (r *registry) ListAll(filters []string) []string {
 func (r *registry) Run(filters []string, parallelism int, artifactsDir string, user string) int {
 	filter := newFilter(filters)
 	// Find the top-level tests to run.
-	tests := r.ListTopLevel(filter)
+	tests := r.GetTests(filter)
 	if len(tests) == 0 {
 		fmt.Fprintf(r.out, "warning: no tests to run %s\n", filters)
 		fmt.Fprintf(r.out, "FAIL\n")
 		return 1
-	}
-
-	// Skip any tests for which the min-version is less than the build-version.
-	for _, t := range tests {
-		if t.Skip == "" && t.minVersion != nil {
-			if !r.buildVersion.AtLeast(t.minVersion) {
-				t.Skip = fmt.Sprintf("build-version (%s) < min-version (%s)",
-					r.buildVersion, t.minVersion)
-			}
-		}
 	}
 
 	wg := &sync.WaitGroup{}
@@ -513,12 +460,11 @@ func (r *registry) Run(filters []string, parallelism int, artifactsDir string, u
 				var runDir string
 				if artifactsDir != "" {
 					runDir = filepath.Join(
-						artifactsDir, teamCityNameEscape(tests[i].subtestName), artifactsSuffix)
+						artifactsDir, teamCityNameEscape(tests[i].Name), artifactsSuffix)
 				}
 
 				r.runAsync(
-					ctx, tests[i], filter, nil /* parent */, nil, /* cluster */
-					runNum, teeOpt, runDir, user, func(failed bool) {
+					ctx, &tests[i], filter, runNum, teeOpt, runDir, user, func(failed bool) {
 						wg.Done()
 						<-sem
 					})
@@ -568,11 +514,6 @@ func (r *registry) Run(filters []string, parallelism int, artifactsDir string, u
 			})
 			var buf bytes.Buffer
 			for _, t := range runningTests {
-				if t.spec.Run == nil {
-					// Ignore tests with subtests.
-					continue
-				}
-
 				t.mu.Lock()
 				done := t.mu.done
 				var status map[int64]testStatus
@@ -661,8 +602,7 @@ type test struct {
 	debugEnabled bool
 
 	// artifactsDir is the path to the directory holding all the artifacts for
-	// this test. It will contain a test.log file, cluster logs, and
-	// subdirectories for subtests.
+	// this test. It will contain a test.log file and cluster logs.
 	artifactsDir string
 	mu           struct {
 		syncutil.RWMutex
@@ -902,21 +842,15 @@ func (t *test) IsBuildVersion(minVersion string) bool {
 	return t.registry.buildVersion.AtLeast(vers)
 }
 
-// runAsync starts a goroutine that runs a test. If the test has subtests,
-// runAsync will be invoked recursively, but in a blocking manner.
+// runAsync starts a goroutine that runs a test.
 //
 // Args:
-// parent: The test's parent. Nil if the test is not a subtest.
-// c: The cluster on which the test (and all subtests) will run. If nil, a new
-//    cluster will be created.
 // runNum: The 1-based index of this test run, if --count > 1. Otherwise (if
 // 		   there's a single run), runNum is 0.
 func (r *registry) runAsync(
 	ctx context.Context,
 	spec *testSpec,
 	filter *testFilter,
-	parent *test,
-	c *cluster,
 	runNum int,
 	teeOpt teeOptType,
 	artifactsDir string,
@@ -1066,92 +1000,50 @@ func (r *registry) runAsync(
 			return
 		}
 
-		if c == nil {
-			if clusterName == "" {
-				var name string
-				if !local {
-					name = clusterID
-					if name == "" {
-						name = fmt.Sprintf("%d", timeutil.Now().Unix())
-					}
-					name += "-" + t.Name()
+		var c *cluster
+		if clusterName == "" {
+			var name string
+			if !local {
+				name = clusterID
+				if name == "" {
+					name = fmt.Sprintf("%d", timeutil.Now().Unix())
 				}
-				cfg := clusterConfig{
-					name:         name,
-					nodes:        t.spec.Cluster,
-					useIOBarrier: t.spec.UseIOBarrier,
-					artifactsDir: t.ArtifactsDir(),
-					localCluster: local,
-					teeOpt:       teeOpt,
-					user:         user,
-				}
-				var err error
-				c, err = newCluster(ctx, t.l, cfg)
-				if err != nil {
-					t.Skip("failed to created cluster", err.Error())
-				}
-			} else {
-				opt := attachOpt{
-					skipValidation: r.config.skipClusterValidationOnAttach,
-					skipStop:       r.config.skipClusterStopOnAttach,
-					skipWipe:       r.config.skipClusterWipeOnAttach,
-				}
-				var err error
-				c, err = attachToExistingCluster(ctx, clusterName, t.l, t.spec.Cluster, opt)
-				FatalIfErr(t, err)
+				name += "-" + t.Name()
 			}
-			if c != nil {
-				defer func() {
-					if (!debugEnabled && !t.debugEnabled) || !t.Failed() {
-						c.Destroy(ctx)
-					} else {
-						c.l.Printf("not destroying cluster to allow debugging\n")
-					}
-				}()
+			cfg := clusterConfig{
+				name:         name,
+				nodes:        t.spec.Cluster,
+				artifactsDir: t.ArtifactsDir(),
+				localCluster: local,
+				teeOpt:       teeOpt,
+				user:         user,
+				useIOBarrier: t.spec.UseIOBarrier,
+			}
+			var err error
+			c, err = newCluster(ctx, t.l, cfg)
+			// !!! is this the right thing to do here?
+			if err != nil {
+				t.Skip("failed to created cluster", err.Error())
 			}
 		} else {
-			c = c.clone()
+			opt := attachOpt{
+				skipValidation: r.config.skipClusterValidationOnAttach,
+				skipStop:       r.config.skipClusterStopOnAttach,
+				skipWipe:       r.config.skipClusterWipeOnAttach,
+			}
+			var err error
+			c, err = attachToExistingCluster(ctx, clusterName, t.l, t.spec.Cluster, opt)
+			FatalIfErr(t, err)
 		}
 		c.setTest(t)
 
-		// If we have subtests, handle them here and return.
-		if t.spec.Run == nil {
-			for i := range t.spec.SubTests {
-				childSpec := t.spec.SubTests[i]
-				if childSpec.matchRegex(filter) {
-					var wg sync.WaitGroup
-					wg.Add(1)
-
-					// Each subtest gets its own subdir in the parent's artifacts dir.
-					var childDir string
-					if t.ArtifactsDir() != "" {
-						childDir = filepath.Join(t.ArtifactsDir(), teamCityNameEscape(childSpec.subtestName))
-					}
-
-					r.runAsync(ctx, &childSpec, filter, t, c,
-						runNum, teeOpt, childDir, user, func(failed bool) {
-							if failed {
-								// Mark the parent test as failed since one of the subtests
-								// failed.
-								t.mu.Lock()
-								t.mu.failed = true
-								t.mu.Unlock()
-							}
-							if failed && debugEnabled {
-								// The test failed and debugging is enabled. Don't try to stumble
-								// forward running another test or subtest, just exit
-								// immediately.
-								os.Exit(1)
-							}
-							wg.Done()
-						})
-					wg.Wait()
-				}
+		defer func() {
+			if (!debugEnabled && !t.debugEnabled) || !t.Failed() {
+				c.Destroy(ctx)
+			} else {
+				c.l.Printf("not destroying cluster to allow debugging\n")
 			}
-			return
-		}
-
-		// No subtests, so this is a leaf test.
+		}()
 
 		timeout := time.Hour
 		defer func() {
@@ -1203,8 +1095,7 @@ func (r *registry) runAsync(
 				if err := c.FetchDebugZip(ctx); err != nil {
 					c.l.Printf("failed to download logs: %s", err)
 				}
-				// NB: c.destroyed is nil for cloned clusters (i.e. in subtests).
-				if !debugEnabled && c.destroyed != nil {
+				if !debugEnabled {
 					c.Destroy(ctx)
 				}
 			case <-done:

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -70,15 +70,16 @@ func TestRegistryRun(t *testing.T) {
 	r := newRegistry()
 	r.out = ioutil.Discard
 	r.Add(testSpec{
-		Name: "pass",
-		Run: func(ctx context.Context, t *test, c *cluster) {
-		},
+		Name:    "pass",
+		Run:     func(ctx context.Context, t *test, c *cluster) {},
+		Cluster: makeClusterSpec(0),
 	})
 	r.Add(testSpec{
 		Name: "fail",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			t.Fatal("failed")
 		},
+		Cluster: makeClusterSpec(0),
 	})
 
 	testCases := []struct {
@@ -128,7 +129,8 @@ func TestRegistryStatus(t *testing.T) {
 	r.out = &buf
 	r.statusInterval = 20 * time.Millisecond
 	r.Add(testSpec{
-		Name: `status`,
+		Name:    `status`,
+		Cluster: makeClusterSpec(0),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			t.Status("waiting")
 			var wg sync.WaitGroup
@@ -181,7 +183,8 @@ func TestRegistryStatusUnknown(t *testing.T) {
 	r.statusInterval = 20 * time.Millisecond
 
 	r.Add(testSpec{
-		Name: `status`,
+		Name:    `status`,
+		Cluster: makeClusterSpec(0),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			for i := 0; i < 100; i++ {
 				time.Sleep(r.statusInterval)
@@ -212,6 +215,7 @@ func TestRegistryRunTimeout(t *testing.T) {
 	r.Add(testSpec{
 		Name:    `timeout`,
 		Timeout: 10 * time.Millisecond,
+		Cluster: makeClusterSpec(0),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			<-ctx.Done()
 		},
@@ -221,49 +225,6 @@ func TestRegistryRunTimeout(t *testing.T) {
 	out := buf.String()
 	if !timeoutRE.MatchString(out) {
 		t.Fatalf("unable to find \"timed out\" message:\n%s", out)
-	}
-}
-
-func TestRegistryRunSubTestFailed(t *testing.T) {
-	var buf syncedBuffer
-	failedRE := regexp.MustCompile(`(?m)^.*--- FAIL: parent \(.*$`)
-
-	r := newRegistry()
-	r.out = &buf
-	r.Add(testSpec{
-		Name: "parent",
-		SubTests: []testSpec{{
-			Name: "child",
-			Run: func(ctx context.Context, t *test, c *cluster) {
-				t.Fatal("failed")
-			},
-		}},
-	})
-
-	r.Run([]string{"."}, defaultParallelism, "" /* artifactsDir */, "myuser")
-	out := buf.String()
-	if !failedRE.MatchString(out) {
-		t.Fatalf("unable to find \"FAIL: parent\" message:\n%s", out)
-	}
-}
-
-func TestRegistryRunNoTests(t *testing.T) {
-	var buf syncedBuffer
-	failedRE := regexp.MustCompile(`(?m)^warning: no tests to run \[notest\]\nFAIL$`)
-
-	r := newRegistry()
-	r.out = &buf
-	r.Add(testSpec{
-		Name: "some-test",
-		Run: func(ctx context.Context, t *test, c *cluster) {
-			t.Fatal("failed")
-		},
-	})
-
-	r.Run([]string{"notest"}, defaultParallelism, "" /* artifactsDir */, "myuser")
-	out := buf.String()
-	if !failedRE.MatchString(out) {
-		t.Fatalf("unable to find \"warning: no tests to run\" message:\n%s", out)
 	}
 }
 
@@ -325,13 +286,8 @@ func TestRegistryVerifyValidClusterName(t *testing.T) {
 func TestRegistryPrepareSpec(t *testing.T) {
 	dummyRun := func(context.Context, *test, *cluster) {}
 
-	var listTests func(t *testSpec) []string
-	listTests = func(t *testSpec) []string {
-		r := []string{t.Name}
-		for i := range t.SubTests {
-			r = append(r, listTests(&t.SubTests[i])...)
-		}
-		return r
+	var listTests = func(t *testSpec) []string {
+		return []string{t.Name}
 	}
 
 	testCases := []struct {
@@ -341,77 +297,19 @@ func TestRegistryPrepareSpec(t *testing.T) {
 	}{
 		{
 			testSpec{
-				Name: "a",
-				Run:  dummyRun,
+				Name:    "a",
+				Run:     dummyRun,
+				Cluster: makeClusterSpec(0),
 			},
 			"",
 			[]string{"a"},
-		},
-		{
-			testSpec{
-				Name: "a",
-				SubTests: []testSpec{{
-					Name: "b",
-					Run:  dummyRun,
-				}},
-			},
-			"",
-			[]string{"a", "a/b"},
-		},
-		{
-			testSpec{
-				Name: "a",
-				Run:  dummyRun,
-				SubTests: []testSpec{{
-					Name: "b",
-					Run:  dummyRun,
-				}},
-			},
-			"a: must specify only one of Run or SubTests",
-			nil,
-		},
-		{
-			testSpec{
-				Name: "a",
-				SubTests: []testSpec{{
-					Name: "b",
-				}},
-			},
-			"a/b: must specify only one of Run or SubTests",
-			nil,
-		},
-		{
-			testSpec{
-				Name: "a",
-				SubTests: []testSpec{{
-					Name: "b",
-					Run:  dummyRun,
-					SubTests: []testSpec{{
-						Name: "c",
-						Run:  dummyRun,
-					}},
-				}},
-			},
-			"b: must specify only one of Run or SubTests",
-			nil,
-		},
-		{
-			testSpec{
-				Name: "a",
-				SubTests: []testSpec{{
-					Name:    "b",
-					Cluster: makeClusterSpec(1),
-					Run:     dummyRun,
-				}},
-			},
-			"a/b: subtest may not provide cluster specification",
-			nil,
 		},
 		{
 			testSpec{
 				Name:       "a",
 				MinVersion: "v2.1.0",
 				Run:        dummyRun,
+				Cluster:    makeClusterSpec(0),
 			},
 			"",
 			[]string{"a"},
@@ -419,38 +317,18 @@ func TestRegistryPrepareSpec(t *testing.T) {
 		{
 			testSpec{
 				Name:       "a",
-				MinVersion: "v2.1.0-foo",
-				Run:        dummyRun,
-			},
-			regexp.QuoteMeta(`invalid version v2.1.0-foo, cannot specify a prerelease (-xxx)`),
-			nil,
-		},
-		{
-			testSpec{
-				Name:       "a",
 				MinVersion: "foo",
 				Run:        dummyRun,
+				Cluster:    makeClusterSpec(0),
 			},
 			"a: unable to parse min-version: invalid version string 'foo'",
-			nil,
-		},
-		{
-			testSpec{
-				Name:    "a",
-				Timeout: time.Second,
-				SubTests: []testSpec{{
-					Name: "b",
-					Run:  dummyRun,
-				}},
-			},
-			"a: timeouts only apply to tests specifying Run",
 			nil,
 		},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			r := newRegistry()
-			err := r.prepareSpec(&c.spec, 0)
+			err := r.prepareSpec(&c.spec)
 			if !testutils.IsError(err, c.expectedErr) {
 				t.Fatalf("expected %q, but found %q", c.expectedErr, err.Error())
 			}
@@ -484,6 +362,7 @@ func TestRegistryMinVersion(t *testing.T) {
 			r.Add(testSpec{
 				Name:       "a",
 				MinVersion: "v2.0.0",
+				Cluster:    makeClusterSpec(0),
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runA = true
 				},
@@ -491,6 +370,7 @@ func TestRegistryMinVersion(t *testing.T) {
 			r.Add(testSpec{
 				Name:       "b",
 				MinVersion: "v2.1.0",
+				Cluster:    makeClusterSpec(0),
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runB = true
 				},

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -45,7 +45,11 @@ type tpccOptions struct {
 	Chaos      func() Chaos                // for late binding of stopper
 	During     func(context.Context) error // for running a function during the test
 	Duration   time.Duration
-	ZFS        bool
+	// ZFS, if set, will make the cluster use a ZFS volume.
+	// Be careful with ClusterReusePolicy when using this.
+	//
+	// TODO(andrei): move this to the test's cluster spec.
+	ZFS bool
 }
 
 // tpccFixturesCmd generates the command string to load tpcc data for the


### PR DESCRIPTION
The point of subtests was that all the subtests under a root share a
cluster. This patch introduces more flexible policies for sharing
clusters across tests (only the declaration of these policies is here;
the implementation is in future commits). The policies replace the need
for subtests, so they go away, simplifying the code considerably.

Release note: None