### PR TITLE
server: deflake TestAdminAPIEvents

### DIFF
--- a/pkg/server/server_update.go
+++ b/pkg/server/server_update.go
@@ -127,6 +127,10 @@ func (s *Server) upgradeStatus(ctx context.Context) (bool, error) {
 		}
 	}
 
+	if newVersion == "" {
+		return false, errors.Errorf("no live nodes found")
+	}
+
 	// Check if we really need to upgrade cluster version.
 	if newVersion == clusterVersion {
 		return true, nil


### PR DESCRIPTION
The version auto upgrade loop may fail to find any live node early after
startup, in which case it would run a bogus cluster upgrade. That
upgrade is benign (a noop) but it leaves an event which confuses the
test.

It does highlight two concerns:

a) we'd really want to learn all the nodes that exist, not just those
   that are gossiped. As is, we're risking illegaly upgrading a mixed
   version cluster in which nodes have recently restarted.
b) the node itself should really be live at this point. This is one
   of many flakes where a bit more synchonicity could help. And,
   more generally, whenever something comes out of Gossip, ideally
   it would have a fallback to the KV store that could be consulted
   when desired.

Release note: None