### PR TITLE
build: clear GOFLAGS when invoking `go install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ $(info GOPATH set to $(GOPATH))
 
 # We install our vendored tools to a directory within this repository to avoid
 # overwriting any user-installed binaries of the same name in the default GOBIN.
-GO_INSTALL := GOBIN='$(abspath bin)' $(GO) install
+GO_INSTALL := GOBIN='$(abspath bin)' GOFLAGS= $(GO) install
 
 # Prefer tools we've installed with go install and Yarn to those elsewhere on
 # the PATH.

--- a/Makefile
+++ b/Makefile
@@ -868,7 +868,7 @@ stress stressrace:
 roachprod-stress roachprod-stressrace: bin/roachprod-stress
 	# The bootstrap target creates, among other things, ./bin/stress.
 	build/builder.sh make bin/.bootstrap
-	build/builder.sh make test GOFLAGS="$(GOFLAGS) -v -c -o $(notdir $(PKG)).test" PKG=$(PKG)
+	build/builder.sh make test GOFLAGS="$(GOFLAGS) -v -c -o $(notdir $(patsubst %/,%,$(PKG))).test" PKG=$(PKG)
 	@if [ -z "$(CLUSTER)" ]; then \
 	  echo "ERROR: missing or empty CLUSTER"; \
 	else \


### PR DESCRIPTION
Similar to the previous `GOFLAGS` fix, we need to make sure the
`GOFLAGS` env variable is cleared when invoking `go install` as we're
passing those flags on the command line as well. go1.11 added support
for parsing the `GOFLAGS` environment variable, but that support is not
identical to passing those flags on the command line (e.g. there is a
difference between `-o foo` and `-o=foo`).

Fixes #34083

Release note: None