### PR TITLE
roachtest: don't run `upgrade` on release-2.1

### DIFF
--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -257,7 +257,7 @@ func registerUpgrade(r *registry) {
 	for _, n := range []int{5} {
 		r.Add(testSpec{
 			Name:       fmt.Sprintf("upgrade/oldVersion=%s/nodes=%d", oldVersion, n),
-			MinVersion: "v2.1.0",
+			MinVersion: "v2.2.0",
 			Nodes:      nodes(n),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runUpgrade(ctx, t, c, oldVersion)


### PR DESCRIPTION
Upgrading from 2.1.3 to the same or a higher 2.1.x patch release
is a no-op, but the test expects something to happen.

Fixes #34088.

Release note: None