### PR TITLE
changefeedccl: support updated and resolved timestamps in avro

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -17,9 +17,39 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/linkedin/goavro"
 	"github.com/pkg/errors"
 )
+
+// The file contains a very specific marriage between avro and our SQL schemas.
+// It's not intended to be a general purpose avro utility.
+//
+// Avro is a spec for data schemas, a binary format for encoding a record
+// conforming to a given schema, and various container formats for those encoded
+// records. It also has rules for determining backward and forward compatibility
+// of schemas as they evolve.
+//
+// The Confluent ecosystem, Kafka plus other things, has first-class support for
+// Avro, including a server for registering schemas and referencing which
+// registered schema a Kafka record conforms to.
+//
+// We map a SQL table schema to an Avro record with 1:1 mapping between table
+// columns and Avro fields. The type of the column is mapped to a native Avro
+// type as faithfully as possible. This is then used to make an "optional" Avro
+// field for that column by unioning with null and explicitly specifying null as
+// default, regardless of whether the sql column allows NULLs. This may seem an
+// odd choice, but it allows for all adjacent Avro schemas for a given SQL table
+// to be backward and forward compatible with each other. Forward and backward
+// compatibility drastically eases use of the resulting data by downstream
+// systems, especially when working with long histories of archived data across
+// many schema changes (such as a data lake).
+//
+// One downside of the above is that it's not possible to recover the original
+// SQL table schema from an Avro one. (This is also true for other reasons, such
+// as lossy mappings from sql types to avro types.) To partially address this,
+// the SQL column type is embedded as metadata in the Avro field schema in a way
+// that Avro ignores it but passes it along.
 
 // avroSchemaType is one of the set of avro primitive types.
 type avroSchemaType interface{}
@@ -46,6 +76,8 @@ func avroUnionKey(t avroSchemaType) string {
 		return s
 	case avroLogicalType:
 		return avroUnionKey(s.SchemaType) + `.` + s.LogicalType
+	case *avroRecord:
+		return s.Name
 	default:
 		panic(fmt.Sprintf(`unsupported type %T %v`, t, t))
 	}
@@ -56,35 +88,60 @@ func avroUnionKey(t avroSchemaType) string {
 type avroSchemaField struct {
 	SchemaType avroSchemaType `json:"type"`
 	Name       string         `json:"name"`
+	Default    *string        `json:"default"`
+	Metadata   string         `json:"__crdb__,omitempty"`
 
-	// TODO(dan): typ should be derivable from the json `type` and `logicalType`
-	// fields. This would make it possible to roundtrip CockroachDB schemas
-	// through avro.
 	typ sqlbase.ColumnType
 
 	encodeFn func(tree.Datum) (interface{}, error)
 	decodeFn func(interface{}) (tree.Datum, error)
 }
 
-// avroSchemaRecord is our representation of the schema of an avro record.
-// Serializing it to JSON gives the standard schema representation.
-type avroSchemaRecord struct {
+// avroRecord is our representation of the schema of an avro record. Serializing
+// it to JSON gives the standard schema representation.
+type avroRecord struct {
 	SchemaType string             `json:"type"`
 	Name       string             `json:"name"`
 	Fields     []*avroSchemaField `json:"fields"`
+	codec      *goavro.Codec
+}
+
+// avroDataRecord is an `avroRecord` that represents the schema of a SQL table
+// or index.
+type avroDataRecord struct {
+	avroRecord
 
 	colIdxByFieldIdx map[int]int
 	fieldIdxByName   map[string]int
-	codec            *goavro.Codec
 	alloc            sqlbase.DatumAlloc
+}
+
+// avroMetadata is the `avroEnvelopeRecord` metadata.
+type avroMetadata map[string]interface{}
+
+// avroEnvelopeOpts controls which fields in avroEnvelopeRecord are set.
+type avroEnvelopeOpts struct {
+	updatedField, resolvedField bool
+	afterField                  bool
+}
+
+// avroEnvelopeRecord is an `avroRecord` that wraps a changed SQL row and some
+// metadata.
+type avroEnvelopeRecord struct {
+	avroRecord
+
+	opts  avroEnvelopeOpts
+	after *avroDataRecord
 }
 
 // columnDescToAvroSchema converts a column descriptor into its corresponding
 // avro field schema.
 func columnDescToAvroSchema(colDesc *sqlbase.ColumnDescriptor) (*avroSchemaField, error) {
 	schema := &avroSchemaField{
-		Name: SQLNameToAvroName(colDesc.Name),
-		typ:  colDesc.Type,
+		Name:     SQLNameToAvroName(colDesc.Name),
+		Metadata: colDesc.SQLString(),
+		Default:  nil,
+		typ:      colDesc.Type,
 	}
 
 	var avroType avroSchemaType
@@ -175,9 +232,14 @@ func columnDescToAvroSchema(colDesc *sqlbase.ColumnDescriptor) (*avroSchemaField
 	}
 	schema.SchemaType = avroType
 
-	if colDesc.Nullable {
+	// Make every field optional by unioning it with null, so that all schema
+	// evolutions for a table are considered "backward compatible" by avro. This
+	// means that the Avro type doesn't mirror the column's nullability, but it
+	// makes it much easier to work with long histories of table data afterward,
+	// especially for things like loading into analytics databases.
+	{
 		// The default for a union type is the default for the first element of
-		// the union. For nullable fields with no default, we want null.
+		// the union.
 		schema.SchemaType = []avroSchemaType{avroSchemaNull, avroType}
 		encodeFn := schema.encodeFn
 		decodeFn := schema.decodeFn
@@ -200,8 +262,6 @@ func columnDescToAvroSchema(colDesc *sqlbase.ColumnDescriptor) (*avroSchemaField
 		}
 	}
 
-	// TODO(dan): Handle default and computed values.
-
 	return schema, nil
 }
 
@@ -209,10 +269,12 @@ func columnDescToAvroSchema(colDesc *sqlbase.ColumnDescriptor) (*avroSchemaField
 // record schema. The fields are kept in the same order as columns in the index.
 func indexToAvroSchema(
 	tableDesc *sqlbase.TableDescriptor, indexDesc *sqlbase.IndexDescriptor,
-) (*avroSchemaRecord, error) {
-	schema := &avroSchemaRecord{
-		Name:             SQLNameToAvroName(tableDesc.Name),
-		SchemaType:       `record`,
+) (*avroDataRecord, error) {
+	schema := &avroDataRecord{
+		avroRecord: avroRecord{
+			Name:       SQLNameToAvroName(tableDesc.Name),
+			SchemaType: `record`,
+		},
 		fieldIdxByName:   make(map[string]int),
 		colIdxByFieldIdx: make(map[int]int),
 	}
@@ -244,10 +306,12 @@ func indexToAvroSchema(
 
 // tableToAvroSchema converts a column descriptor into its corresponding avro
 // record schema. The fields are kept in the same order as `tableDesc.Columns`.
-func tableToAvroSchema(tableDesc *sqlbase.TableDescriptor) (*avroSchemaRecord, error) {
-	schema := &avroSchemaRecord{
-		Name:             SQLNameToAvroName(tableDesc.Name),
-		SchemaType:       `record`,
+func tableToAvroSchema(tableDesc *sqlbase.TableDescriptor) (*avroDataRecord, error) {
+	schema := &avroDataRecord{
+		avroRecord: avroRecord{
+			Name:       SQLNameToAvroName(tableDesc.Name),
+			SchemaType: `record`,
+		},
 		fieldIdxByName:   make(map[string]int),
 		colIdxByFieldIdx: make(map[int]int),
 	}
@@ -273,7 +337,7 @@ func tableToAvroSchema(tableDesc *sqlbase.TableDescriptor) (*avroSchemaRecord, e
 }
 
 // textualFromRow encodes the given row data into avro's defined JSON format.
-func (r *avroSchemaRecord) textualFromRow(row sqlbase.EncDatumRow) ([]byte, error) {
+func (r *avroDataRecord) textualFromRow(row sqlbase.EncDatumRow) ([]byte, error) {
 	native, err := r.nativeFromRow(row)
 	if err != nil {
 		return nil, err
@@ -282,7 +346,7 @@ func (r *avroSchemaRecord) textualFromRow(row sqlbase.EncDatumRow) ([]byte, erro
 }
 
 // BinaryFromRow encodes the given row data into avro's defined binary format.
-func (r *avroSchemaRecord) BinaryFromRow(buf []byte, row sqlbase.EncDatumRow) ([]byte, error) {
+func (r *avroDataRecord) BinaryFromRow(buf []byte, row sqlbase.EncDatumRow) ([]byte, error) {
 	native, err := r.nativeFromRow(row)
 	if err != nil {
 		return nil, err
@@ -291,7 +355,7 @@ func (r *avroSchemaRecord) BinaryFromRow(buf []byte, row sqlbase.EncDatumRow) ([
 }
 
 // rowFromTextual decodes the given row data from avro's defined JSON format.
-func (r *avroSchemaRecord) rowFromTextual(buf []byte) (sqlbase.EncDatumRow, error) {
+func (r *avroDataRecord) rowFromTextual(buf []byte) (sqlbase.EncDatumRow, error) {
 	native, newBuf, err := r.codec.NativeFromTextual(buf)
 	if err != nil {
 		return nil, err
@@ -303,7 +367,7 @@ func (r *avroSchemaRecord) rowFromTextual(buf []byte) (sqlbase.EncDatumRow, erro
 }
 
 // RowFromBinary decodes the given row data from avro's defined binary format.
-func (r *avroSchemaRecord) RowFromBinary(buf []byte) (sqlbase.EncDatumRow, error) {
+func (r *avroDataRecord) RowFromBinary(buf []byte) (sqlbase.EncDatumRow, error) {
 	native, newBuf, err := r.codec.NativeFromBinary(buf)
 	if err != nil {
 		return nil, err
@@ -314,7 +378,7 @@ func (r *avroSchemaRecord) RowFromBinary(buf []byte) (sqlbase.EncDatumRow, error
 	return r.rowFromNative(native)
 }
 
-func (r *avroSchemaRecord) nativeFromRow(row sqlbase.EncDatumRow) (interface{}, error) {
+func (r *avroDataRecord) nativeFromRow(row sqlbase.EncDatumRow) (interface{}, error) {
 	avroDatums := make(map[string]interface{}, len(row))
 	for fieldIdx, field := range r.Fields {
 		d := row[r.colIdxByFieldIdx[fieldIdx]]
@@ -329,7 +393,7 @@ func (r *avroSchemaRecord) nativeFromRow(row sqlbase.EncDatumRow) (interface{}, 
 	return avroDatums, nil
 }
 
-func (r *avroSchemaRecord) rowFromNative(native interface{}) (sqlbase.EncDatumRow, error) {
+func (r *avroDataRecord) rowFromNative(native interface{}) (sqlbase.EncDatumRow, error) {
 	avroDatums, ok := native.(map[string]interface{})
 	if !ok {
 		return nil, errors.Errorf(`unknown avro native type: %T`, native)
@@ -349,6 +413,97 @@ func (r *avroSchemaRecord) rowFromNative(native interface{}) (sqlbase.EncDatumRo
 		row[r.colIdxByFieldIdx[fieldIdx]] = sqlbase.DatumToEncDatum(field.typ, decoded)
 	}
 	return row, nil
+}
+
+// envelopeToAvroSchema creates an avro record schema for an envelope containing
+// before and after versions of a row change and metadata about that row change.
+func envelopeToAvroSchema(
+	topic string, opts avroEnvelopeOpts, after *avroDataRecord,
+) (*avroEnvelopeRecord, error) {
+	schema := &avroEnvelopeRecord{
+		avroRecord: avroRecord{
+			Name:       SQLNameToAvroName(topic) + `_envelope`,
+			SchemaType: `record`,
+		},
+		opts: opts,
+	}
+
+	if opts.updatedField {
+		updatedField := &avroSchemaField{
+			SchemaType: []avroSchemaType{avroSchemaNull, avroSchemaString},
+			Name:       `updated`,
+			Default:    nil,
+		}
+		schema.Fields = append(schema.Fields, updatedField)
+	}
+	if opts.resolvedField {
+		resolvedField := &avroSchemaField{
+			SchemaType: []avroSchemaType{avroSchemaNull, avroSchemaString},
+			Name:       `resolved`,
+			Default:    nil,
+		}
+		schema.Fields = append(schema.Fields, resolvedField)
+	}
+	if opts.afterField {
+		schema.after = after
+		afterField := &avroSchemaField{
+			Name:       `after`,
+			SchemaType: []avroSchemaType{avroSchemaNull, after},
+			Default:    nil,
+		}
+		schema.Fields = append(schema.Fields, afterField)
+	}
+
+	schemaJSON, err := json.Marshal(schema)
+	if err != nil {
+		return nil, err
+	}
+	schema.codec, err = goavro.NewCodec(string(schemaJSON))
+	if err != nil {
+		return nil, err
+	}
+	return schema, nil
+}
+
+// BinaryFromRow encodes the given metadata and row data into avro's defined
+// binary format.
+func (r *avroEnvelopeRecord) BinaryFromRow(
+	buf []byte, meta avroMetadata, row sqlbase.EncDatumRow,
+) ([]byte, error) {
+	native := map[string]interface{}{
+		`after`: nil,
+	}
+	if r.opts.updatedField {
+		native[`updated`] = nil
+		if u, ok := meta[`updated`]; ok {
+			delete(meta, `updated`)
+			ts, ok := u.(hlc.Timestamp)
+			if !ok {
+				return nil, errors.Errorf(`unknown metadata timestamp type: %T`, u)
+			}
+			native[`updated`] = goavro.Union(avroUnionKey(avroSchemaString), ts.AsOfSystemTime())
+		}
+	}
+	if r.opts.resolvedField {
+		native[`resolved`] = nil
+		if u, ok := meta[`resolved`]; ok {
+			delete(meta, `resolved`)
+			ts, ok := u.(hlc.Timestamp)
+			if !ok {
+				return nil, errors.Errorf(`unknown metadata timestamp type: %T`, u)
+			}
+			native[`resolved`] = goavro.Union(avroUnionKey(avroSchemaString), ts.AsOfSystemTime())
+		}
+	}
+	// WIP verify that meta is now empty
+	if row != nil {
+		afterNative, err := r.after.nativeFromRow(row)
+		if err != nil {
+			return nil, err
+		}
+		native[`after`] = goavro.Union(avroUnionKey(&r.after.avroRecord), afterNative)
+	}
+	return r.codec.BinaryFromNative(buf, native)
 }
 
 // decimalToRat converts one of our apd decimals to the format expected by the

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -197,6 +197,17 @@ func columnDescToAvroSchema(colDesc *sqlbase.ColumnDescriptor) (*avroSchemaField
 		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
 			return tree.MakeDTimestamp(x.(time.Time), time.Microsecond), nil
 		}
+	case sqlbase.ColumnType_TIMESTAMPTZ:
+		avroType = avroLogicalType{
+			SchemaType:  avroSchemaLong,
+			LogicalType: `timestamp-micros`,
+		}
+		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
+			return d.(*tree.DTimestampTZ).Time, nil
+		}
+		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
+			return tree.MakeDTimestampTZ(x.(time.Time), time.Microsecond), nil
+		}
 	case sqlbase.ColumnType_DECIMAL:
 		if colDesc.Type.Precision == 0 {
 			return nil, errors.Errorf(

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -330,15 +330,9 @@ func checkpointResolvedTimestamp(
 func emitResolvedTimestamp(
 	ctx context.Context, encoder Encoder, sink Sink, resolved hlc.Timestamp,
 ) error {
-	payload, err := encoder.EncodeResolvedTimestamp(resolved)
-	if err != nil {
-		return err
-	}
-	// TODO(dan): Plumb a bufalloc.ByteAllocator to use here.
-	payload = append([]byte(nil), payload...)
 	// TODO(dan): Emit more fine-grained (table level) resolved
 	// timestamps.
-	if err := sink.EmitResolvedTimestamp(ctx, payload, resolved); err != nil {
+	if err := sink.EmitResolvedTimestamp(ctx, encoder, resolved); err != nil {
 		return err
 	}
 	if log.V(2) {

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/ledger"
 	"github.com/linkedin/goavro"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -183,6 +185,45 @@ func TestAvroSchemaChange(t *testing.T) {
 		if err := foo.Err(); !testutils.IsError(err, `type UUID not yet supported with avro`) {
 			t.Fatalf(`expected "type UUID not yet supported with avro" error got: %+v`, err)
 		}
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+}
+
+func TestAvroLedger(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		reg := makeTestSchemaRegistry()
+		defer reg.Close()
+
+		ctx := context.Background()
+		gen := ledger.FromFlags(`--customers=1`)
+		_, err := workload.Setup(ctx, db, gen, 0, 0)
+		require.NoError(t, err)
+
+		ledger := f.Feed(t, `CREATE CHANGEFEED FOR
+	                       customer, transaction, entry, session
+	                       WITH format=$1, confluent_schema_registry=$2
+	               `, optFormatAvro, reg.server.URL)
+		defer ledger.Close(t)
+
+		assertPayloadsAvro(t, reg, ledger, []string{
+			`customer: {"id":{"long":0}}->{"after":{"customer":{"balance":{"bytes.decimal":"0"},"created":{"long.timestamp-micros":"2114-03-27T13:14:27.287114Z"},"credit_limit":null,"currency_code":{"string":"XVL"},"id":{"long":0},"identifier":{"string":"0"},"is_active":{"boolean":true},"is_system_customer":{"boolean":true},"name":null,"sequence_number":{"long":-1}}}}`,
+			`entry: {"id":{"long":1543039099823358511}}->{"after":{"entry":{"amount":{"bytes.decimal":"0"},"created_ts":{"long.timestamp-micros":"1990-12-09T23:47:23.811124Z"},"customer_id":{"long":0},"id":{"long":1543039099823358511},"money_type":{"string":"C"},"system_amount":{"bytes.decimal":"44061/500"},"transaction_id":{"string":"payment:a8c7f832-281a-39c5-8820-1fb960ff6465"}}}}`,
+			`entry: {"id":{"long":2244708090865615074}}->{"after":{"entry":{"amount":{"bytes.decimal":"1/50"},"created_ts":{"long.timestamp-micros":"2075-11-08T22:07:12.055686Z"},"customer_id":{"long":0},"id":{"long":2244708090865615074},"money_type":{"string":"C"},"system_amount":{"bytes.decimal":"44061/500"},"transaction_id":{"string":"payment:a8c7f832-281a-39c5-8820-1fb960ff6465"}}}}`,
+			`entry: {"id":{"long":3305628230121721621}}->{"after":{"entry":{"amount":{"bytes.decimal":"1/25"},"created_ts":{"long.timestamp-micros":"2185-01-30T21:38:15.06669Z"},"customer_id":{"long":0},"id":{"long":3305628230121721621},"money_type":{"string":"C"},"system_amount":{"bytes.decimal":"44061/500"},"transaction_id":{"string":"payment:e3757ca7-d646-66ea-2b8d-6116831cbb05"}}}}`,
+			`entry: {"id":{"long":4151935814835861840}}->{"after":{"entry":{"amount":{"bytes.decimal":"3/50"},"created_ts":{"long.timestamp-micros":"1684-10-05T17:51:40.795101Z"},"customer_id":{"long":0},"id":{"long":4151935814835861840},"money_type":{"string":"C"},"system_amount":{"bytes.decimal":"44061/500"},"transaction_id":{"string":"payment:e3757ca7-d646-66ea-2b8d-6116831cbb05"}}}}`,
+			`entry: {"id":{"long":5577006791947779410}}->{"after":{"entry":{"amount":{"bytes.decimal":"0"},"created_ts":{"long.timestamp-micros":"2185-11-07T09:42:42.666146Z"},"customer_id":{"long":0},"id":{"long":5577006791947779410},"money_type":{"string":"C"},"system_amount":{"bytes.decimal":"-88123/1000"},"transaction_id":{"string":"payment:a8c7f832-281a-39c5-8820-1fb960ff6465"}}}}`,
+			`entry: {"id":{"long":6640668014774057861}}->{"after":{"entry":{"amount":{"bytes.decimal":"-1/50"},"created_ts":{"long.timestamp-micros":"1690-05-19T13:29:46.145044Z"},"customer_id":{"long":0},"id":{"long":6640668014774057861},"money_type":{"string":"C"},"system_amount":{"bytes.decimal":"-88123/1000"},"transaction_id":{"string":"payment:a8c7f832-281a-39c5-8820-1fb960ff6465"}}}}`,
+			`entry: {"id":{"long":7414159922357799360}}->{"after":{"entry":{"amount":{"bytes.decimal":"-1/25"},"created_ts":{"long.timestamp-micros":"1706-02-05T02:38:08.15195Z"},"customer_id":{"long":0},"id":{"long":7414159922357799360},"money_type":{"string":"C"},"system_amount":{"bytes.decimal":"-88123/1000"},"transaction_id":{"string":"payment:e3757ca7-d646-66ea-2b8d-6116831cbb05"}}}}`,
+			`entry: {"id":{"long":8475284246537043955}}->{"after":{"entry":{"amount":{"bytes.decimal":"-3/50"},"created_ts":{"long.timestamp-micros":"2048-07-21T10:02:40.114474Z"},"customer_id":{"long":0},"id":{"long":8475284246537043955},"money_type":{"string":"C"},"system_amount":{"bytes.decimal":"-88123/1000"},"transaction_id":{"string":"payment:e3757ca7-d646-66ea-2b8d-6116831cbb05"}}}}`,
+			`session: {"session_id":{"string":"pLnfgDsc3WD9F3qNfHK6a95jjJkwzDkh0h3fhfUVuS0jZ9uVbhV4vC6AWX40IV"}}->{"after":{"session":{"data":{"string":"SP3NcHciWvqZTa3N06RxRTZHWUsaD7HEdz1ThbXfQ7pYSQ4n378l2VQKGNbSuJE0fQbzONJAAwdCxmM9BIabKERsUhPNmMmdf3eSJyYtqwcFiUILzXv3fcNIrWO8sToFgoilA1U2WxNeW2gdgUVDsEWJ88aX8tLF"},"expiry_timestamp":{"long.timestamp-micros":"2052-05-14T04:02:49.264975Z"},"last_update":{"long.timestamp-micros":"2070-03-19T02:10:22.552438Z"},"session_id":{"string":"pLnfgDsc3WD9F3qNfHK6a95jjJkwzDkh0h3fhfUVuS0jZ9uVbhV4vC6AWX40IV"}}}}`,
+			`transaction: {"external_id":{"string":"payment:a8c7f832-281a-39c5-8820-1fb960ff6465"}}->{"after":{"transaction":{"context":{"string":"BpLnfgDsc3WD9F3qNfHK6a95jjJkwzDkh0h3fhfUVuS0jZ9uVbhV4vC6"},"created_ts":{"long.timestamp-micros":"2178-08-01T19:10:30.064819Z"},"external_id":{"string":"payment:a8c7f832-281a-39c5-8820-1fb960ff6465"},"response":{"bytes":"MDZSeFJUWkhXVXNhRDdIRWR6MVRoYlhmUTdwWVNRNG4zNzhsMlZRS0dOYlN1SkUwZlFiek9OSkFBd2RDeG1NOUJJYWJLRVJzVWhQTm1NbWRmM2VTSnlZdHF3Y0ZpVUlMelh2M2ZjTklyV084c1RvRmdvaWxBMVUyV3hOZVcyZ2RnVVZEc0VXSjg4YVg4dExGSjk1cVlVN1VyTjljdGVjd1p0NlM1empoRDF0WFJUbWtZS1FvTjAyRm1XblFTSzN3UkM2VUhLM0txQXR4alAzWm1EMmp0dDR6Z3I2TWVVam9BamNPMGF6TW10VTRZdHYxUDhPUG1tU05hOThkN3RzdGF4eTZuYWNuSkJTdUZwT2h5SVhFN1BKMURoVWtMWHFZWW5FTnVucWRzd3BUdzVVREdEUzM0bVNQWUs4dm11YjNYOXVYSXU3Rk5jSmpBUlFUM1JWaFZydDI0UDdpNnhDckw2RmM0R2N1SEMxNGthdW5BVFVQUkhqR211Vm14SHN5enpCYnlPb25xVlVTREsxVg=="},"reversed_by":null,"systimestamp":{"long.timestamp-micros":"2215-07-28T23:47:01.795499Z"},"tcomment":null,"transaction_type_reference":{"long":400},"username":{"string":"WX40IVUWSP3NcHciWvqZ"}}}}`,
+			`transaction: {"external_id":{"string":"payment:e3757ca7-d646-66ea-2b8d-6116831cbb05"}}->{"after":{"transaction":{"context":{"string":"KSiOW5eQ8sklpgstrQZtAcrsGvPnYSXMOpFIpPzS8iI5N2gN7lD1rYjT"},"created_ts":{"long.timestamp-micros":"2062-07-27T13:21:35.213969Z"},"external_id":{"string":"payment:e3757ca7-d646-66ea-2b8d-6116831cbb05"},"response":{"bytes":"bWdkbHVWOFVvcWpRM1JBTTRTWjNzT0M4ZnlzZXN5NnRYeVZ5WTBnWkE1aVNJUjM4MFVPVWFwQTlPRmpuRWtiaHF6MlRZSlZIWUFtTHI5R0kyMlo3NFVmNjhDMFRRb2RDdWF0NmhmWmZSYmFlV1pJSFExMGJsSjVqQUd2VVRpWWJOWHZPcWowYlRUM24xNmNqQVNEN29qN2RPbVlVbTFua3AybnVvWTZGZlgzcVFHY09SbHZ2UHdHaHNDZWlZTmpvTVRoUXBFc0ZrSVpZVUxxNFFORzc1M25mamJYdENaUm4xSmVZV1hpUW1IWjJZMWIxb1lZbUtBS05aQjF1MGt1TU5ZbEFISW5hY1JoTkFzakd6bnBKSXZZdmZqWXk3MXV4OVI5SkRNQUMxRUtOSGFZVWNlekk4OHRHYmdwbWFGaXdIV09sUFQ5RUJVcHh6MHlCSnZGM1BKcW5jejVwMnpnVVhDcm9kZTV6UG5pNjJQV1dtMk5pSWVkSUxFaExLVVNHVWRNU1R5N1pmcjRyY2RJTw=="},"reversed_by":null,"systimestamp":{"long.timestamp-micros":"2229-01-11T00:56:37.706179Z"},"tcomment":null,"transaction_type_reference":{"long":400},"username":{"string":"XJXORIpfMGxOaIIFFFts"}}}}`,
+		})
 	}
 
 	t.Run(`sinkless`, sinklessTest(testFn))

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -48,13 +48,15 @@ func (s *metricsSink) EmitRow(
 }
 
 func (s *metricsSink) EmitResolvedTimestamp(
-	ctx context.Context, payload []byte, resolved hlc.Timestamp,
+	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
 ) error {
 	start := timeutil.Now()
-	err := s.wrapped.EmitResolvedTimestamp(ctx, payload, resolved)
+	err := s.wrapped.EmitResolvedTimestamp(ctx, encoder, resolved)
 	if err == nil {
 		s.metrics.EmittedMessages.Inc(1)
-		s.metrics.EmittedBytes.Inc(int64(len(payload)))
+		// TODO(dan): This wasn't correct. The wrapped sink may emit the payload
+		// any number of times.
+		// s.metrics.EmittedBytes.Inc(int64(len(payload)))
 		s.metrics.EmitNanos.Inc(timeutil.Since(start).Nanoseconds())
 	}
 	return err

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"encoding/hex"
+	"fmt"
 	"math/rand"
 	"strings"
 
@@ -83,11 +84,11 @@ func FromConfig(rows int, payloadBytes int, ranges int) workload.Generator {
 	if ranges > rows {
 		ranges = rows
 	}
-	b := bankMeta.New().(*bank)
-	b.rows = rows
-	b.payloadBytes = payloadBytes
-	b.ranges = ranges
-	return b
+	return workload.FromFlags(bankMeta,
+		fmt.Sprintf(`--rows=%d`, rows),
+		fmt.Sprintf(`--payload-bytes=%d`, payloadBytes),
+		fmt.Sprintf(`--ranges=%d`, ranges),
+	)
 }
 
 // Meta implements the Generator interface.

--- a/pkg/workload/ledger/generate.go
+++ b/pkg/workload/ledger/generate.go
@@ -39,6 +39,7 @@ const (
 func (w *ledger) ledgerCustomerInitialRow(rowIdx int) []interface{} {
 	rng := w.rngPool.Get().(*rand.Rand)
 	defer w.rngPool.Put(rng)
+	rng.Seed(w.seed + int64(rowIdx))
 
 	return []interface{}{
 		rowIdx,                // id
@@ -63,6 +64,7 @@ func (w *ledger) ledgerCustomerSplitRow(splitIdx int) []interface{} {
 func (w *ledger) ledgerTransactionInitialRow(rowIdx int) []interface{} {
 	rng := w.rngPool.Get().(*rand.Rand)
 	defer w.rngPool.Put(rng)
+	rng.Seed(w.seed + int64(rowIdx))
 
 	h := w.hashPool.Get().(hash.Hash64)
 	defer w.hashPool.Put(h)
@@ -92,6 +94,7 @@ func (w *ledger) ledgerTransactionSplitRow(splitIdx int) []interface{} {
 func (w *ledger) ledgerEntryInitialRow(rowIdx int) []interface{} {
 	rng := w.rngPool.Get().(*rand.Rand)
 	defer w.rngPool.Put(rng)
+	rng.Seed(w.seed + int64(rowIdx))
 
 	// Alternate.
 	debit := rowIdx%2 == 0
@@ -133,6 +136,7 @@ func (w *ledger) ledgerEntrySplitRow(splitIdx int) []interface{} {
 func (w *ledger) ledgerSessionInitialRow(rowIdx int) []interface{} {
 	rng := w.rngPool.Get().(*rand.Rand)
 	defer w.rngPool.Put(rng)
+	rng.Seed(w.seed + int64(rowIdx))
 
 	return []interface{}{
 		randSessionID(rng),   // session_id

--- a/pkg/workload/ledger/ledger.go
+++ b/pkg/workload/ledger/ledger.go
@@ -76,6 +76,11 @@ var ledgerMeta = workload.Meta{
 	},
 }
 
+// FromFlags returns a new ledger Generator configured with the given flags.
+func FromFlags(flags ...string) workload.Generator {
+	return workload.FromFlags(ledgerMeta, flags...)
+}
+
 // Meta implements the Generator interface.
 func (*ledger) Meta() workload.Meta { return ledgerMeta }
 

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -86,9 +86,7 @@ func init() {
 // FromWarehouses returns a tpcc generator pre-configured with the specified
 // number of warehouses.
 func FromWarehouses(warehouses int) workload.Generator {
-	gen := tpccMeta.New().(*tpcc)
-	gen.warehouses = warehouses
-	return gen
+	return workload.FromFlags(tpccMeta, fmt.Sprintf(`--warehouses=%d`, warehouses))
 }
 
 var tpccMeta = workload.Meta{


### PR DESCRIPTION
To do this, the avro format is changed in a backward-incompatible way.
This is unfortunate but okay since we've marked avro as experimental
with exactly this sort of thing in mind.

We map a SQL table schema to an Avro record with 1:1 mapping between
table columns and Avro fields. The type of the column is mapped to a
native Avro type as faithfully as possible. This is then used to make an
"optional" Avro field for that column by unioning with null and
explictly specifying null as default, regardless of whether the sql
column allows NULLs. This may seem an odd choice, but it allows for all
adjacent Avro schemas for a given SQL table to be backward and forward
compatible with each other. Forward and backward compatibility
drastically eases use of the resulting data by downstream systems,
especially when working with long histories of archived data across many
schema changes (such as a data lake).

One downside of the above is that it's not possible to recover the
original SQL table schema from an Avro one. (This is also true for other
reasons, such as lossy mappings from sql types to avro types.) To
partially address this, the SQL column type is embedded as metadata in
the Avro field schema in a way that Avro ignores it but passes it along.

I have a roachest that verifies the compatiblity guarantees using the
Confluent Schema Registry, but it still needs some polish and I wanted
to get this part out now.

Release note (backward-incompatible change): `CHANGEFEED`'s
experimental avro format has changed. The new format is backward and
forward compatible with adjacent schemas for the same table.