### PR TITLE
sql: benchmark for the query cache

### DIFF
--- a/pkg/sql/querycache/query_cache_test.go
+++ b/pkg/sql/querycache/query_cache_test.go
@@ -216,11 +216,12 @@ func TestSynchronization(t *testing.T) {
 	wg.Wait()
 }
 
-// BenchmarkQueryCache is a worst case benchmark where every session misses the
-// cache. The result of the benchmark is the time to do a pair of Find, Add
-// operations.
-func BenchmarkQueryCache(b *testing.B) {
-	// Run a worst case benchmark where every worker misses the cache.
+// BenchmarkWorstCase is a worst case benchmark where every session
+// misses the cache. The result of the benchmark is the time to do a pair of
+// Find, Add operations.
+//
+// For server-level benchmarks, see BenchmarkQueryCache in pkg/sql.
+func BenchmarkWorstCase(b *testing.B) {
 	for _, numWorkers := range []int{1, 10, 100} {
 		b.Run(fmt.Sprintf("%d", numWorkers), func(b *testing.B) {
 			const cacheSize = 10


### PR DESCRIPTION
Adding a set of benchmarks which run queries against a server with and
without the query cache.

Sample results (on a gceworker):
```
name                                          time/op
QueryCache/GoodWorkload/Clients1/CacheOn-24   378µs ± 2%
QueryCache/GoodWorkload/Clients1/CacheOff-24  458µs ± 4%
QueryCache/GoodWorkload/Clients4/CacheOn-24   378µs ± 3%
QueryCache/GoodWorkload/Clients4/CacheOff-24  452µs ± 3%
QueryCache/GoodWorkload/Clients8/CacheOn-24   377µs ± 2%
QueryCache/GoodWorkload/Clients8/CacheOff-24  451µs ± 1%
QueryCache/BadWorkload/Clients1/CacheOn-24    464µs ± 3%
QueryCache/BadWorkload/Clients1/CacheOff-24   465µs ± 3%
QueryCache/BadWorkload/Clients4/CacheOn-24    466µs ± 2%
QueryCache/BadWorkload/Clients4/CacheOff-24   463µs ± 2%
QueryCache/BadWorkload/Clients8/CacheOn-24    464µs ± 1%
QueryCache/BadWorkload/Clients8/CacheOff-24   463µs ± 3%
```

Release note: None