### PR TITLE
sql/stats: rename sql.defaults.experimental_automatic_statistics

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -61,7 +61,6 @@
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
 <tr><td><code>sql.defaults.default_int_size</code></td><td>integer</td><td><code>8</code></td><td>the size, in bytes, of an INT type</td></tr>
 <tr><td><code>sql.defaults.distsql</code></td><td>enumeration</td><td><code>1</code></td><td>default distributed SQL execution mode [off = 0, auto = 1, on = 2, 2.0-off = 3, 2.0-auto = 4]</td></tr>
-<tr><td><code>sql.defaults.experimental_automatic_statistics</code></td><td>boolean</td><td><code>false</code></td><td>default experimental automatic statistics mode</td></tr>
 <tr><td><code>sql.defaults.experimental_optimizer_mutations</code></td><td>boolean</td><td><code>false</code></td><td>default experimental_optimizer_mutations mode</td></tr>
 <tr><td><code>sql.defaults.experimental_vectorize</code></td><td>enumeration</td><td><code>0</code></td><td>default experimental_vectorize mode [off = 0, on = 1, always = 2]</td></tr>
 <tr><td><code>sql.defaults.optimizer</code></td><td>enumeration</td><td><code>1</code></td><td>default cost-based optimizer mode [off = 0, on = 1, local = 2]</td></tr>
@@ -81,6 +80,7 @@
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statistics to be collected</td></tr>
 <tr><td><code>sql.parallel_scans.enabled</code></td><td>boolean</td><td><code>true</code></td><td>parallelizes scanning different ranges when the maximum result size can be deduced</td></tr>
 <tr><td><code>sql.query_cache.enabled</code></td><td>boolean</td><td><code>false</code></td><td>enable the query cache</td></tr>
+<tr><td><code>sql.stats.experimental_automatic</code></td><td>boolean</td><td><code>false</code></td><td>experimental automatic statistics mode</td></tr>
 <tr><td><code>sql.tablecache.lease.refresh_limit</code></td><td>integer</td><td><code>50</code></td><td>maximum number of tables to periodically refresh leases for</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>
 <tr><td><code>sql.trace.session_eventlog.enabled</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable session tracing</td></tr>

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2791,7 +2791,7 @@ func TestCreateStatsAfterRestore(t *testing.T) {
 	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
 	defer cleanupFn()
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING sql.defaults.experimental_automatic_statistics=true`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.experimental_automatic=true`)
 
 	sqlDB.Exec(t, `BACKUP DATABASE data TO $1 WITH revision_history`, localFoo)
 	sqlDB.Exec(t, `CREATE DATABASE "data 2"`)

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -2431,7 +2431,7 @@ func TestCreateStatsAfterImport(t *testing.T) {
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING sql.defaults.experimental_automatic_statistics=true`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.experimental_automatic=true`)
 
 	sqlDB.Exec(t, "IMPORT PGDUMP ($1)", "nodelocal:///cockroachdump/dump.sql")
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -5,7 +5,7 @@ CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c), INDE
 
 # Enable automatic stats
 statement ok
-SET CLUSTER SETTING sql.defaults.experimental_automatic_statistics = true
+SET CLUSTER SETTING sql.stats.experimental_automatic = true
 
 # Generate all combinations of values 1 to 10.
 statement ok
@@ -24,7 +24,7 @@ __auto__         {d}           1000       0               1000
 
 # Disable automatic stats
 statement ok
-SET CLUSTER SETTING sql.defaults.experimental_automatic_statistics = false
+SET CLUSTER SETTING sql.stats.experimental_automatic = false
 
 # Update more than 5% of the table.
 statement ok
@@ -41,7 +41,7 @@ __auto__         {d}           1000       0               1000
 
 # Enable automatic stats
 statement ok
-SET CLUSTER SETTING sql.defaults.experimental_automatic_statistics = true
+SET CLUSTER SETTING sql.stats.experimental_automatic = true
 
 # Update more than 5% of the table.
 statement ok

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -32,11 +32,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// AutomaticStatisticsClusterMode controls the cluster default for when
-// automatic table statistics collection is enabled.
+// AutomaticStatisticsClusterMode controls the cluster setting for enabling
+// automatic table statistics collection.
 var AutomaticStatisticsClusterMode = settings.RegisterBoolSetting(
-	"sql.defaults.experimental_automatic_statistics",
-	"default experimental automatic statistics mode",
+	"sql.stats.experimental_automatic",
+	"experimental automatic statistics mode",
 	false,
 )
 


### PR DESCRIPTION
This commit renames `sql.defaults.experimental_automatic_statistics` to
`sql.stats.experimental_automatic`. The `sql.defaults.*` settings typically
are default values for session vars, which is not the case for
`experimental_automatic_statistics`.

Fixes #34016

Release note: None