### PR TITLE
roachtest: specify cluster specs as a single nodeSpec, not an array

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -61,9 +61,9 @@ func registerAcceptance(r *registry) {
 		// teach that script (if it's still used at that point) should
 		// this naming scheme ever change (or issues such as #33519)
 		// will be posted.
-		Name:  "acceptance",
-		Tags:  tags,
-		Nodes: nodes(numNodes),
+		Name:    "acceptance",
+		Tags:    tags,
+		Cluster: makeClusterSpec(numNodes),
 	}
 
 	for _, tc := range testCases {

--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -76,15 +76,15 @@ func registerAllocator(r *registry) {
 	}
 
 	r.Add(testSpec{
-		Name:  `upreplicate/1to3`,
-		Nodes: nodes(3),
+		Name:    `upreplicate/1to3`,
+		Cluster: makeClusterSpec(3),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runAllocator(ctx, t, c, 1, 10.0)
 		},
 	})
 	r.Add(testSpec{
-		Name:  `rebalance/3to5`,
-		Nodes: nodes(5),
+		Name:    `rebalance/3to5`,
+		Cluster: makeClusterSpec(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runAllocator(ctx, t, c, 3, 42.0)
 		},

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -27,8 +27,8 @@ import (
 
 func registerBackup(r *registry) {
 	r.Add(testSpec{
-		Name:  `backup2TB`,
-		Nodes: nodes(10),
+		Name:    `backup2TB`,
+		Cluster: makeClusterSpec(10),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			nodes := c.nodes
 
@@ -60,7 +60,7 @@ func registerBackup(r *registry) {
 	// verifies them with a fingerprint.
 	r.Add(testSpec{
 		Name:    `backupTPCC`,
-		Nodes:   nodes(3),
+		Cluster: makeClusterSpec(3),
 		Timeout: 1 * time.Hour,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			c.Put(ctx, cockroach, "./cockroach")

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -117,16 +117,16 @@ func registerCancel(r *registry) {
 	}
 
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("cancel/tpcc/distsql/w=%d,nodes=%d", warehouses, numNodes),
-		Nodes: nodes(numNodes),
+		Name:    fmt.Sprintf("cancel/tpcc/distsql/w=%d,nodes=%d", warehouses, numNodes),
+		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCancel(ctx, t, c, queries, warehouses, true /* useDistsql */)
 		},
 	})
 
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("cancel/tpcc/local/w=%d,nodes=%d", warehouses, numNodes),
-		Nodes: nodes(numNodes),
+		Name:    fmt.Sprintf("cancel/tpcc/local/w=%d,nodes=%d", warehouses, numNodes),
+		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCancel(ctx, t, c, queries, warehouses, false /* useDistsql */)
 		},

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -316,7 +316,7 @@ func registerCDC(r *registry) {
 	r.Add(testSpec{
 		Name:       "cdc/tpcc-1000",
 		MinVersion: "v2.1.0",
-		Nodes:      nodes(4, cpu(16)),
+		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -332,7 +332,7 @@ func registerCDC(r *registry) {
 	r.Add(testSpec{
 		Name:       "cdc/initial-scan",
 		MinVersion: "v2.1.0",
-		Nodes:      nodes(4, cpu(16)),
+		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -348,7 +348,7 @@ func registerCDC(r *registry) {
 	r.Add(testSpec{
 		Name:       "cdc/rangefeed",
 		MinVersion: "v2.2.0",
-		Nodes:      nodes(4, cpu(16)),
+		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -365,7 +365,7 @@ func registerCDC(r *registry) {
 	r.Add(testSpec{
 		Name:       "cdc/sink-chaos",
 		MinVersion: "v2.1.0",
-		Nodes:      nodes(4, cpu(16)),
+		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -381,7 +381,7 @@ func registerCDC(r *registry) {
 	r.Add(testSpec{
 		Name:       "cdc/crdb-chaos",
 		MinVersion: "v2.1.0",
-		Nodes:      nodes(4, cpu(16)),
+		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -401,7 +401,7 @@ func registerCDC(r *registry) {
 		// TODO(mrtracy): This workload is designed to be running on a 20CPU nodes,
 		// but this cannot be allocated without some sort of configuration outside
 		// of this test. Look into it.
-		Nodes: nodes(4, cpu(16)),
+		Cluster: makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             ledgerWorkloadType,
@@ -424,7 +424,7 @@ func registerCDC(r *registry) {
 	r.Add(testSpec{
 		Name:       "cdc/bank",
 		MinVersion: "v2.1.0",
-		Nodes:      nodes(4),
+		Cluster:    makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCDCBank(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -29,7 +29,7 @@ func registerClearRange(r *registry) {
 			Name:       fmt.Sprintf(`clearrange/checks=%t`, checks),
 			Timeout:    90 * time.Minute,
 			MinVersion: `v2.1.0`,
-			Nodes:      nodes(10),
+			Cluster:    makeClusterSpec(10),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runClearRange(ctx, t, c, checks)
 			},

--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -130,8 +130,8 @@ func makeClockJumpTests() testSpec {
 
 func registerClock(r *registry) {
 	r.Add(testSpec{
-		Name:  "clock",
-		Nodes: nodes(1),
+		Name:    "clock",
+		Cluster: makeClusterSpec(1),
 		SubTests: []testSpec{
 			makeClockJumpTests(),
 			makeClockMonotonicTests(),

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -138,8 +138,8 @@ func registerCopy(r *registry) {
 	for _, inTxn := range []bool{true, false} {
 		inTxn := inTxn
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", rows, numNodes, inTxn),
-			Nodes: nodes(numNodes),
+			Name:    fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", rows, numNodes, inTxn),
+			Cluster: makeClusterSpec(numNodes),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runCopy(ctx, t, c, rows, inTxn)
 			},

--- a/pkg/cmd/roachtest/debug.go
+++ b/pkg/cmd/roachtest/debug.go
@@ -80,8 +80,8 @@ func registerDebug(r *registry) {
 
 	for _, n := range []int{3} {
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("debug/nodes=%d", n),
-			Nodes: nodes(n),
+			Name:    fmt.Sprintf("debug/nodes=%d", n),
+			Cluster: makeClusterSpec(n),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runDebug(ctx, t, c)
 			},
@@ -147,8 +147,8 @@ func registerDebugHeap(r *registry) {
 
 	for _, n := range []int{3} {
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("debug/heap/nodes=%d", n),
-			Nodes: nodes(n),
+			Name:    fmt.Sprintf("debug/heap/nodes=%d", n),
+			Cluster: makeClusterSpec(n),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runDebug(ctx, t, c)
 			},

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -244,8 +244,8 @@ func registerDecommission(r *registry) {
 	duration := time.Hour
 
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("decommission/nodes=%d/duration=%s", numNodes, duration),
-		Nodes: nodes(numNodes),
+		Name:    fmt.Sprintf("decommission/nodes=%d/duration=%s", numNodes, duration),
+		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {
 				duration = 3 * time.Minute

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -28,7 +28,7 @@ func registerDiskFull(r *registry) {
 	r.Add(testSpec{
 		Name:       "disk-full",
 		MinVersion: `v2.1.0`,
-		Nodes:      nodes(5),
+		Cluster:    makeClusterSpec(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if c.isLocal() {
 				t.spec.Skip = "you probably don't want to fill your local disk"

--- a/pkg/cmd/roachtest/disk_space.go
+++ b/pkg/cmd/roachtest/disk_space.go
@@ -77,7 +77,7 @@ func runDiskUsage(t *test, c *cluster, duration time.Duration, tc diskUsageTestC
 		cmd := cmd // Copy is important for goroutine.
 		i := i     // Ditto.
 
-		cmd = fmt.Sprintf(cmd, nodes)
+		cmd = fmt.Sprintf(cmd, makeClusterSpec)
 		m.Go(func() error {
 			quietL, err := c.l.ChildLogger("kv-"+strconv.Itoa(i), quietStdout)
 			if err != nil {
@@ -318,7 +318,7 @@ func registerDiskUsage(r *registry) {
 		r.Add(
 			testSpec{
 				Name:       fmt.Sprintf("disk_space/tc=%s", testCase.name),
-				Nodes:      nodes(numNodes),
+				Cluster:    makeClusterSpec(numNodes),
 				MinVersion: "v2.1.0", // cockroach debug ballast
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					if local {

--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -39,7 +39,7 @@ func registerDiskStalledDetection(r *registry) {
 					affectsLogDir, affectsDataDir,
 				),
 				MinVersion: `v2.2.0`,
-				Nodes:      nodes(1),
+				Cluster:    makeClusterSpec(1),
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runDiskStalledDetection(ctx, t, c, affectsLogDir, affectsDataDir)
 				},

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -172,7 +172,7 @@ func registerDrop(r *registry) {
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
 		MinVersion: `v2.1.0`,
-		Nodes:      nodes(numNodes),
+		Cluster:    makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			// NB: this is likely not going to work out in `-local` mode. Edit the
 			// numbers during iteration.

--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -24,8 +24,8 @@ import (
 
 func registerElectionAfterRestart(r *registry) {
 	r.Add(testSpec{
-		Name:  "election-after-restart",
-		Nodes: nodes(3),
+		Name:    "election-after-restart",
+		Cluster: makeClusterSpec(3),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			t.Status("starting up")
 			c.Put(ctx, cockroach, "./cockroach")

--- a/pkg/cmd/roachtest/encryption.go
+++ b/pkg/cmd/roachtest/encryption.go
@@ -91,7 +91,7 @@ func registerEncryption(r *registry) {
 		r.Add(testSpec{
 			Name:       fmt.Sprintf("encryption/nodes=%d", n),
 			MinVersion: "v2.1.0",
-			Nodes:      nodes(n),
+			Cluster:    makeClusterSpec(n),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runEncryption(ctx, t, c)
 			},

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -119,8 +119,8 @@ SELECT string_agg(source_id::TEXT || ':' || target_id::TEXT, ',')
 	}
 
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("gossip/chaos/nodes=9"),
-		Nodes: nodes(9),
+		Name:    fmt.Sprintf("gossip/chaos/nodes=9"),
+		Cluster: makeClusterSpec(9),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runGossipChaos(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -290,8 +290,8 @@ echo "ext {
 	}
 
 	r.Add(testSpec{
-		Name:  "hibernate",
-		Nodes: nodes(1),
+		Name:    "hibernate",
+		Cluster: makeClusterSpec(1),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runHibernate(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -100,8 +100,8 @@ func registerHotSpotSplits(r *registry) {
 	concurrency := 128
 
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("hotspotsplits/nodes=%d", numNodes),
-		Nodes: nodes(numNodes),
+		Name:    fmt.Sprintf("hotspotsplits/nodes=%d", numNodes),
+		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {
 				concurrency = 32

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -60,7 +60,7 @@ func registerImportTPCC(r *registry) {
 	for _, numNodes := range []int{4, 32} {
 		r.Add(testSpec{
 			Name:    fmt.Sprintf("import/tpcc/warehouses=%d/nodes=%d", warehouses, numNodes),
-			Nodes:   nodes(numNodes),
+			Cluster: makeClusterSpec(numNodes),
 			Timeout: 5 * time.Hour,
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runImportTPCC(ctx, t, c, warehouses)
@@ -81,7 +81,7 @@ func registerImportTPCH(r *registry) {
 		item := item
 		r.Add(testSpec{
 			Name:    fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),
-			Nodes:   nodes(item.nodes),
+			Cluster: makeClusterSpec(item.nodes),
 			Timeout: item.timeout,
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				c.Put(ctx, cockroach, "./cockroach")

--- a/pkg/cmd/roachtest/interleavedpartitioned.go
+++ b/pkg/cmd/roachtest/interleavedpartitioned.go
@@ -127,8 +127,8 @@ func registerInterleaved(r *registry) {
 	}
 
 	r.Add(testSpec{
-		Name:  "interleavedpartitioned",
-		Nodes: nodes(12, geo(), zones("us-west1-b,us-east4-b,us-central1-a")),
+		Name:    "interleavedpartitioned",
+		Cluster: makeClusterSpec(12, geo(), zones("us-west1-b,us-east4-b,us-central1-a")),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runInterleaved(ctx, t, c,
 				config{

--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -293,8 +293,8 @@ func registerJepsen(r *registry) {
 
 	for i := range groups {
 		spec := testSpec{
-			Name:  fmt.Sprintf("jepsen-batch%d", i+1),
-			Nodes: nodes(6),
+			Name:    fmt.Sprintf("jepsen-batch%d", i+1),
+			Cluster: makeClusterSpec(6),
 		}
 
 		for _, testName := range groups[i] {

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -63,7 +63,7 @@ func registerKV(r *registry) {
 				r.Add(testSpec{
 					Name:       fmt.Sprintf("kv%d/encrypt=%t/nodes=%d", p, e, n),
 					MinVersion: minVersion,
-					Nodes:      nodes(n+1, cpu(8)),
+					Cluster:    makeClusterSpec(n+1, cpu(8)),
 					Run: func(ctx context.Context, t *test, c *cluster) {
 						runKV(ctx, t, c, p, startArgs(fmt.Sprintf("--encrypt=%t", e)))
 					},
@@ -76,7 +76,7 @@ func registerKV(r *registry) {
 func registerKVQuiescenceDead(r *registry) {
 	r.Add(testSpec{
 		Name:       "kv/quiescence/nodes=3",
-		Nodes:      nodes(4),
+		Cluster:    makeClusterSpec(4),
 		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			nodes := c.nodes - 1
@@ -155,8 +155,8 @@ func registerKVQuiescenceDead(r *registry) {
 
 func registerKVGracefulDraining(r *registry) {
 	r.Add(testSpec{
-		Name:  "kv/gracefuldraining/nodes=3",
-		Nodes: nodes(4),
+		Name:    "kv/gracefuldraining/nodes=3",
+		Cluster: makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			nodes := c.nodes - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
@@ -283,7 +283,7 @@ func registerKVSplits(r *registry) {
 		r.Add(testSpec{
 			Name:    fmt.Sprintf("kv/splits/nodes=3/quiesce=%t", item.quiesce),
 			Timeout: item.timeout,
-			Nodes:   nodes(4),
+			Cluster: makeClusterSpec(4),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				nodes := c.nodes - 1
 				c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
@@ -351,8 +351,8 @@ func registerKVScalability(r *registry) {
 		for _, p := range []int{0, 95} {
 			p := p
 			r.Add(testSpec{
-				Name:  fmt.Sprintf("kv%d/scale/nodes=6", p),
-				Nodes: nodes(7, cpu(8)),
+				Name:    fmt.Sprintf("kv%d/scale/nodes=6", p),
+				Cluster: makeClusterSpec(7, cpu(8)),
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runScalability(ctx, t, c, p)
 				},

--- a/pkg/cmd/roachtest/network.go
+++ b/pkg/cmd/roachtest/network.go
@@ -235,15 +235,15 @@ func registerNetwork(r *registry) {
 	const numNodes = 4
 
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("network/sanity/nodes=%d", numNodes),
-		Nodes: nodes(numNodes),
+		Name:    fmt.Sprintf("network/sanity/nodes=%d", numNodes),
+		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runNetworkSanity(ctx, t, c, numNodes)
 		},
 	})
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("network/tpcc/nodes=%d", numNodes),
-		Nodes: nodes(numNodes),
+		Name:    fmt.Sprintf("network/tpcc/nodes=%d", numNodes),
+		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runNetworkTPCC(ctx, t, c, numNodes)
 		},

--- a/pkg/cmd/roachtest/queue.go
+++ b/pkg/cmd/roachtest/queue.go
@@ -28,9 +28,9 @@ func registerQueue(r *registry) {
 	// One node runs the workload generator, all other nodes host CockroachDB.
 	const numNodes = 2
 	r.Add(testSpec{
-		Skip:  "https://github.com/cockroachdb/cockroach/issues/17229",
-		Name:  fmt.Sprintf("queue/nodes=%d", numNodes-1),
-		Nodes: nodes(numNodes),
+		Skip:    "https://github.com/cockroachdb/cockroach/issues/17229",
+		Name:    fmt.Sprintf("queue/nodes=%d", numNodes-1),
+		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runQueue(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -137,7 +137,7 @@ func registerRebalanceLoad(r *registry) {
 
 	r.Add(testSpec{
 		Name:       `rebalance-leases-by-load`,
-		Nodes:      nodes(4), // the last node is just used to generate load
+		Cluster:    makeClusterSpec(4), // the last node is just used to generate load
 		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {
@@ -149,7 +149,7 @@ func registerRebalanceLoad(r *registry) {
 	})
 	r.Add(testSpec{
 		Name:       `rebalance-replicas-by-load`,
-		Nodes:      nodes(7), // the last node is just used to generate load
+		Cluster:    makeClusterSpec(7), // the last node is just used to generate load
 		MinVersion: "v2.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -24,15 +24,15 @@ import (
 func registerReplicaGC(r *registry) {
 
 	r.Add(testSpec{
-		Name:  "replicagc-changed-peers/withRestart",
-		Nodes: nodes(6),
+		Name:    "replicagc-changed-peers/withRestart",
+		Cluster: makeClusterSpec(6),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runReplicaGCChangedPeers(ctx, t, c, true /* withRestart */)
 		},
 	})
 	r.Add(testSpec{
-		Name:  "replicagc-changed-peers/noRestart",
-		Nodes: nodes(6),
+		Name:    "replicagc-changed-peers/noRestart",
+		Cluster: makeClusterSpec(6),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runReplicaGCChangedPeers(ctx, t, c, false /* withRestart */)
 		},

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -224,7 +224,7 @@ func registerRestore(r *registry) {
 	} {
 		r.Add(testSpec{
 			Name:    fmt.Sprintf("restore2TB/nodes=%d", item.nodes),
-			Nodes:   nodes(item.nodes),
+			Cluster: makeClusterSpec(item.nodes),
 			Timeout: item.timeout,
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				c.Put(ctx, cockroach, "./cockroach")

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -74,8 +74,8 @@ func registerRoachmart(r *registry) {
 	for _, v := range []bool{true, false} {
 		v := v
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("roachmart/partition=%v", v),
-			Nodes: nodes(9, geo(), zones("us-central1-b,us-west1-b,europe-west2-b")),
+			Name:    fmt.Sprintf("roachmart/partition=%v", v),
+			Cluster: makeClusterSpec(9, geo(), zones("us-central1-b,us-west1-b,europe-west2-b")),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runRoachmart(ctx, t, c, v)
 			},

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -48,7 +48,7 @@ func registerScaleData(r *registry) {
 			r.Add(testSpec{
 				Name:    fmt.Sprintf("scaledata/%s/nodes=%d", app, n),
 				Timeout: 2 * duration,
-				Nodes:   nodes(n + 1),
+				Cluster: makeClusterSpec(n + 1),
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runSqlapp(ctx, t, c, app, flags, duration)
 				},

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -32,8 +32,8 @@ import (
 
 func registerSchemaChangeKV(r *registry) {
 	r.Add(testSpec{
-		Name:  `schemachange/mixed/kv`,
-		Nodes: nodes(5),
+		Name:    `schemachange/mixed/kv`,
+		Cluster: makeClusterSpec(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup`
 
@@ -304,7 +304,7 @@ func registerSchemaChangeIndexTPCC100(r *registry) {
 func makeIndexAddTpccTest(numNodes, warehouses int, length time.Duration) testSpec {
 	return testSpec{
 		Name:    fmt.Sprintf("schemachange/index/tpcc-%d", warehouses),
-		Nodes:   nodes(numNodes),
+		Cluster: makeClusterSpec(numNodes),
 		Timeout: length * 2,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
@@ -369,7 +369,7 @@ func createIndexAddJob(
 func makeIndexAddRollbackTpccTest(numNodes, warehouses int, length time.Duration) testSpec {
 	return testSpec{
 		Name:    fmt.Sprintf("schemachange/indexrollback/tpcc-%d", warehouses),
-		Nodes:   nodes(numNodes),
+		Cluster: makeClusterSpec(numNodes),
 		Timeout: length * 2,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{

--- a/pkg/cmd/roachtest/scrub.go
+++ b/pkg/cmd/roachtest/scrub.go
@@ -52,8 +52,8 @@ func makeScrubTPCCTest(
 	}
 
 	return testSpec{
-		Name:  fmt.Sprintf("scrub/%s/tpcc-%d", optionName, warehouses),
-		Nodes: nodes(numNodes),
+		Name:    fmt.Sprintf("scrub/%s/tpcc-%d", optionName, warehouses),
+		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -48,7 +48,7 @@ func registerLoadSplits(r *registry) {
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("splits/load/uniform/nodes=%d", numNodes),
 		MinVersion: "v2.2.0",
-		Nodes:      nodes(numNodes),
+		Cluster:    makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			// After load based splitting is turned on, from experiments
 			// it's clear that at least 20 splits will happen. We could
@@ -86,7 +86,7 @@ func registerLoadSplits(r *registry) {
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("splits/load/sequential/nodes=%d", numNodes),
 		MinVersion: "v2.2.0",
-		Nodes:      nodes(numNodes),
+		Cluster:    makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:       10 << 30, // 10 GB
@@ -103,7 +103,7 @@ func registerLoadSplits(r *registry) {
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("splits/load/spanning/nodes=%d", numNodes),
 		MinVersion: "v2.2.0",
-		Nodes:      nodes(numNodes),
+		Cluster:    makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:       10 << 30, // 10 GB
@@ -208,7 +208,7 @@ func registerLargeRange(r *registry) {
 
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("splits/largerange/size=%s,nodes=%d", bytesStr(size), numNodes),
-		Nodes:   nodes(numNodes),
+		Cluster: makeClusterSpec(numNodes),
 		Timeout: 5 * time.Hour,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runLargeRangeSplits(ctx, t, c, size)

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -108,7 +108,7 @@ func registerSQLsmith(r *registry) {
 
 	r.Add(testSpec{
 		Name:       "sqlsmith",
-		Nodes:      nodes(1),
+		Cluster:    makeClusterSpec(1),
 		MinVersion: "v2.2.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runSQLsmith(ctx, t, c)

--- a/pkg/cmd/roachtest/store_gen.go
+++ b/pkg/cmd/roachtest/store_gen.go
@@ -60,8 +60,8 @@ func registerStoreGen(r *registry, args []string) {
 	workloadArgs := strings.Join(args, " ")
 
 	r.Add(testSpec{
-		Name:  "store-gen",
-		Nodes: nodes(stores),
+		Name:    "store-gen",
+		Cluster: makeClusterSpec(stores),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Put(ctx, workload, "./workload")

--- a/pkg/cmd/roachtest/synctest.go
+++ b/pkg/cmd/roachtest/synctest.go
@@ -35,7 +35,7 @@ fi
 	r.Add(testSpec{
 		Name:       "synctest",
 		MinVersion: `v2.2.0`,
-		Nodes:      nodes(1),
+		Cluster:    makeClusterSpec(1),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			n := c.Node(1)
 			tmpDir, err := ioutil.TempDir("", "synctest")

--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -125,9 +125,9 @@ func registerSysbench(r *registry) {
 		}
 
 		r.Add(testSpec{
-			Skip:  "https://github.com/cockroachdb/cockroach/issues/32738",
-			Name:  fmt.Sprintf("sysbench/%s/nodes=%d", w, n),
-			Nodes: nodes(n+1, cpu(cpus)),
+			Skip:    "https://github.com/cockroachdb/cockroach/issues/32738",
+			Name:    fmt.Sprintf("sysbench/%s/nodes=%d", w, n),
+			Cluster: makeClusterSpec(n+1, cpu(cpus)),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runSysbench(ctx, t, c, opts)
 			},

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -115,11 +115,10 @@ type testSpec struct {
 	// tests. If no tags are specified, the set ["default"] is automatically
 	// given.
 	Tags []string
-
-	// Nodes provides the specification for the cluster to use for the test. Only
+	// Cluster provides the specification for the cluster to use for the test. Only
 	// a top-level testSpec may contain a nodes specification. The cluster is
 	// shared by all subtests.
-	Nodes []nodeSpec
+	Cluster clusterSpec
 
 	// UseIOBarrier controls the local-ssd-no-ext4-barrier flag passed to
 	// roachprod when creating a cluster. If set, the flag is not passed, and so
@@ -356,7 +355,7 @@ func (r *registry) prepareSpec(spec *testSpec, depth int) error {
 		return fmt.Errorf("%s: timeouts only apply to tests specifying Run", spec.Name)
 	}
 
-	if depth > 0 && len(spec.Nodes) > 0 {
+	if depth > 0 && spec.Cluster.NodeCount > 0 {
 		return fmt.Errorf("%s: subtest may not provide cluster specification", spec.Name)
 	}
 
@@ -1034,7 +1033,7 @@ func (r *registry) runAsync(
 				}
 				cfg := clusterConfig{
 					name:         name,
-					nodes:        t.spec.Nodes,
+					nodes:        t.spec.Cluster,
 					useIOBarrier: t.spec.UseIOBarrier,
 					artifactsDir: t.ArtifactsDir(),
 					localCluster: local,
@@ -1051,7 +1050,7 @@ func (r *registry) runAsync(
 					skipWipe:       r.config.skipClusterWipeOnAttach,
 				}
 				var err error
-				c, err = attachToExistingCluster(ctx, clusterName, t.l, t.spec.Nodes, opt)
+				c, err = attachToExistingCluster(ctx, clusterName, t.l, t.spec.Cluster, opt)
 				FatalIfErr(t, err)
 			}
 			if c != nil {

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -282,8 +282,8 @@ func TestRegistryRunClusterExpired(t *testing.T) {
 	r.out = &buf
 
 	r.Add(testSpec{
-		Name:  `expired`,
-		Nodes: nodes(1, nodeLifetimeOption(time.Second)),
+		Name:    `expired`,
+		Cluster: makeClusterSpec(1, nodeLifetimeOption(time.Second)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			panic("not reached")
 		},
@@ -399,9 +399,9 @@ func TestRegistryPrepareSpec(t *testing.T) {
 			testSpec{
 				Name: "a",
 				SubTests: []testSpec{{
-					Name:  "b",
-					Nodes: nodes(1),
-					Run:   dummyRun,
+					Name:    "b",
+					Cluster: makeClusterSpec(1),
+					Run:     dummyRun,
 				}},
 			},
 			"a/b: subtest may not provide cluster specification",

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -138,7 +138,7 @@ func registerTPCC(r *registry) {
 		// match our expectation for the max tpcc warehouses that previous
 		// releases will support on this hardware.
 		MinVersion: maxVersion("v2.1.0", maybeMinVersionForFixturesImport(cloud)),
-		Nodes:      nodes(4, cpu(16)),
+		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			warehouses := 1400
 			runTPCC(ctx, t, c, tpccOptions{
@@ -150,7 +150,7 @@ func registerTPCC(r *registry) {
 	r.Add(testSpec{
 		Name:       "tpcc-nowait/nodes=3/w=1",
 		MinVersion: maybeMinVersionForFixturesImport(cloud),
-		Nodes:      nodes(4, cpu(16)),
+		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: 1,
@@ -163,7 +163,7 @@ func registerTPCC(r *registry) {
 		Name:       "weekly/tpcc-max",
 		MinVersion: maybeMinVersionForFixturesImport(cloud),
 		Tags:       []string{`weekly`},
-		Nodes:      nodes(4, cpu(16)),
+		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			warehouses := 1400
 			runTPCC(ctx, t, c, tpccOptions{
@@ -175,7 +175,7 @@ func registerTPCC(r *registry) {
 
 	r.Add(testSpec{
 		Name:       "tpcc/w=100/nodes=3/chaos=true",
-		Nodes:      nodes(4),
+		Cluster:    makeClusterSpec(4),
 		MinVersion: maybeMinVersionForFixturesImport(cloud),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			duration := 30 * time.Minute
@@ -381,11 +381,11 @@ func registerTPCCBenchSpec(r *registry, b tpccBenchSpec) {
 	name := strings.Join(nameParts, "/")
 
 	numNodes := b.Nodes + b.LoadConfig.numLoadNodes(b.Distribution)
-	nodes := nodes(numNodes, opts...)
+	nodes := makeClusterSpec(numNodes, opts...)
 
 	r.Add(testSpec{
 		Name:       name,
-		Nodes:      nodes,
+		Cluster:    nodes,
 		MinVersion: maybeMinVersionForFixturesImport(cloud),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCCBench(ctx, t, c, b)

--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -269,7 +269,7 @@ func registerUpgrade(r *registry) {
 		r.Add(testSpec{
 			Name:       fmt.Sprintf("upgrade/mixedWith=%s/nodes=%d", mixedWithVersion, n),
 			MinVersion: "v2.1.0",
-			Nodes:      nodes(n),
+			Cluster:    makeClusterSpec(n),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runUpgrade(ctx, t, c, mixedWithVersion)
 			},

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -235,7 +235,7 @@ func registerVersion(r *registry) {
 		r.Add(testSpec{
 			Name:       fmt.Sprintf("version/mixedWith=%s/nodes=%d", mixedWithVersion, n),
 			MinVersion: "v2.1.0",
-			Nodes:      nodes(n + 1),
+			Cluster:    makeClusterSpec(n + 1),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runVersion(ctx, t, c, mixedWithVersion)
 			},

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -53,8 +53,8 @@ func registerYCSB(r *registry) {
 
 		wl := wl
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("ycsb/%s/nodes=3", wl),
-			Nodes: nodes(4, cpu(8)),
+			Name:    fmt.Sprintf("ycsb/%s/nodes=3", wl),
+			Cluster: makeClusterSpec(4, cpu(8)),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runYCSB(ctx, t, c, wl)
 			},


### PR DESCRIPTION
The fact that multiple nodeSpecs could in theory be used was confusing,
because some of the fields in the nodeSpec can't be reconciled across
multiple copies. This capability was unused.

Release note: None