### PR TITLE
roachtest: increase schema change cancel test timeout to 90 minutes

### DIFF
--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -325,7 +325,7 @@ func makeIndexAddTpccTest(numNodes, warehouses int, length time.Duration) testSp
 }
 
 func registerSchemaChangeCancelIndexTPCC1000(r *registry) {
-	r.Add(makeIndexAddRollbackTpccTest(5, 1000, time.Minute*30))
+	r.Add(makeIndexAddRollbackTpccTest(5, 1000, time.Minute*90))
 }
 
 // Creates an index and job, returning the job ID and a notify channel for


### PR DESCRIPTION
This had recently been reduced from 2 hours to 30 minutes. That
turned out to be too aggressive.

fixes #34085

Release note: None