### PR TITLE
opt: Support check constraints

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -410,6 +410,7 @@ func (sc *SchemaChanger) distBackfill(
 					row.NoLookup,
 					row.NoCheckPrivilege,
 					nil, /* AnalyzeExprFunction */
+					nil, /* CheckHelper */
 				)
 				if err != nil {
 					return err
@@ -602,6 +603,7 @@ func columnBackfillInTxn(
 		row.NoLookup,
 		row.NoCheckPrivilege,
 		nil, /* AnalyzeExprFunction */
+		nil, /* CheckHelper */
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -147,6 +147,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 		row.NoLookup,
 		row.NoCheckPrivilege,
 		nil, /* AnalyzeExprFunction */
+		nil, /* CheckHelper */
 	)
 	for i, fkTableDesc := range otherTables {
 		found, ok := fkTables[fkTableDesc.ID]

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -105,6 +105,7 @@ func (p *planner) Delete(
 		p.LookupTableByID,
 		p.CheckPrivilege,
 		p.analyzeExpr,
+		nil, /* checkHelper */
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/delete_test.go
+++ b/pkg/sql/delete_test.go
@@ -133,7 +133,8 @@ CREATE TABLE IF NOT EXISTS child_with_index(
 				row.CheckDeletes,
 				lookup,
 				row.NoCheckPrivilege,
-				nil, /* AnalyzeExprFunction */
+				nil, /* analyzeExpr */
+				nil, /* checkHelper */
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -151,11 +151,11 @@ INSERT INTO t5 VALUES (1, 10, 20) ON CONFLICT (k) DO NOTHING
 statement ok
 INSERT INTO t5 VALUES (1, 10, 9) ON CONFLICT (k) DO NOTHING
 
-# TODO(andyk): The CBO behaves differently than the HP and PG in this case. It
-# only checks constraints if an insert or update actually occurs. In this case,
-# the DO NOTHING clause skips the update, so there is no need to check the
-# constraint. Once the CBO incorporates check constraints, this difference in
-# behavior should go away.
+# The CBO behaves differently than the HP and PG in this case. It only checks
+# constraints if an insert or update actually occurs. In this case, the DO
+# NOTHING clause skips the update, so there is no need to check the constraint.
+# TODO(andyk): Uncomment this case once the HP is removed. When that occurs,
+# remove the corresponding cases from the CBO/HP-specific upsert test cases.
 #statement error pgcode 23514 failed to satisfy CHECK constraint
 #INSERT INTO t5 VALUES (1, 10, 20) ON CONFLICT (k) DO NOTHING
 

--- a/pkg/sql/logictest/testdata/planner_test/upsert
+++ b/pkg/sql/logictest/testdata/planner_test/upsert
@@ -161,3 +161,14 @@ INSERT INTO customers (name, email) VALUES ('bob', 'bob@email.com') ON CONFLICT 
 
 statement ok
 DROP TABLE customers
+
+# The heuristic planner behaves differently than the CBO in this case. It always
+# checks constraints, even if no insert or update actually occurs.
+statement ok
+CREATE TABLE t5 (k INT PRIMARY KEY, a INT, b int CHECK (a > b))
+
+statement ok
+INSERT INTO t5 VALUES (1, 10, 9) ON CONFLICT (k) DO NOTHING
+
+statement error pgcode 23514 failed to satisfy CHECK constraint
+INSERT INTO t5 VALUES (1, 10, 20) ON CONFLICT (k) DO NOTHING

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -194,13 +194,22 @@ func (f *stubFactory) ConstructShowTrace(typ tree.ShowTraceType, compact bool) (
 }
 
 func (f *stubFactory) ConstructInsert(
-	input exec.Node, table cat.Table, insertCols exec.ColumnOrdinalSet, rowsNeeded bool,
+	input exec.Node,
+	table cat.Table,
+	insertCols exec.ColumnOrdinalSet,
+	checks exec.CheckOrdinalSet,
+	rowsNeeded bool,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
 
 func (f *stubFactory) ConstructUpdate(
-	input exec.Node, table cat.Table, fetchCols, updateCols exec.ColumnOrdinalSet, rowsNeeded bool,
+	input exec.Node,
+	table cat.Table,
+	fetchCols exec.ColumnOrdinalSet,
+	updateCols exec.ColumnOrdinalSet,
+	checks exec.CheckOrdinalSet,
+	rowsNeeded bool,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }
@@ -218,6 +227,7 @@ func (f *stubFactory) ConstructUpsert(
 	insertCols exec.ColumnOrdinalSet,
 	fetchCols exec.ColumnOrdinalSet,
 	updateCols exec.ColumnOrdinalSet,
+	checks exec.CheckOrdinalSet,
 	rowsNeeded bool,
 ) (exec.Node, error) {
 	return struct{}{}, nil

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -164,6 +164,10 @@ func FormatCatalogTable(cat Catalog, tab Table, tp treeprinter.Node) {
 			formatCatalogFKRef(cat, tab, tab.Index(i), fkRef, child)
 		}
 	}
+
+	for i := 0; i < tab.CheckCount(); i++ {
+		child.Childf("CHECK (%s)", tab.Check(i))
+	}
 }
 
 // formatCatalogIndex nicely formats a catalog index using a treeprinter for

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -66,7 +66,22 @@ type Table interface {
 
 	// Statistic returns the ith statistic, where i < StatisticCount.
 	Statistic(i int) TableStatistic
+
+	// CheckCount returns the number of check constraints present on the table.
+	CheckCount() int
+
+	// Check returns the ith check constraint, where i < CheckCount.
+	Check(i int) CheckConstraint
 }
+
+// CheckConstraint is the SQL text for a check constraint on a table. Check
+// constraints are user-defined restrictions on the content of each row in a
+// table. For example, this check constraint ensures that only values greater
+// than zero can be inserted into the table:
+//
+//   CREATE TABLE a (a INT CHECK (a > 0))
+//
+type CheckConstraint string
 
 // TableStatistic is an interface to a table statistic. Each statistic is
 // associated with a set of columns.

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -1130,6 +1130,7 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (execPlan, error) {
 	// inserted (e.g. delete-only mutation columns don't need to be inserted).
 	colList := make(opt.ColList, 0, len(ins.InsertCols))
 	colList = appendColsWhenPresent(colList, ins.InsertCols)
+	colList = appendColsWhenPresent(colList, ins.CheckCols)
 	input, err = b.ensureColumns(input, colList, nil, ins.ProvidedPhysical().Ordering)
 	if err != nil {
 		return execPlan{}, err
@@ -1138,7 +1139,14 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (execPlan, error) {
 	// Construct the Insert node.
 	tab := b.mem.Metadata().Table(ins.Table)
 	insertOrds := ordinalSetFromColList(ins.InsertCols)
-	node, err := b.factory.ConstructInsert(input.root, tab, insertOrds, ins.NeedResults)
+	checkOrds := ordinalSetFromColList(ins.CheckCols)
+	node, err := b.factory.ConstructInsert(
+		input.root,
+		tab,
+		insertOrds,
+		checkOrds,
+		ins.NeedResults,
+	)
 	if err != nil {
 		return execPlan{}, err
 	}
@@ -1173,6 +1181,7 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (execPlan, error) {
 	colList := make(opt.ColList, 0, len(upd.FetchCols)+len(upd.UpdateCols))
 	colList = appendColsWhenPresent(colList, upd.FetchCols)
 	colList = appendColsWhenPresent(colList, upd.UpdateCols)
+	colList = appendColsWhenPresent(colList, upd.CheckCols)
 	input, err = b.ensureColumns(input, colList, nil, upd.ProvidedPhysical().Ordering)
 	if err != nil {
 		return execPlan{}, err
@@ -1183,7 +1192,15 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (execPlan, error) {
 	tab := md.Table(upd.Table)
 	fetchColOrds := ordinalSetFromColList(upd.FetchCols)
 	updateColOrds := ordinalSetFromColList(upd.UpdateCols)
-	node, err := b.factory.ConstructUpdate(input.root, tab, fetchColOrds, updateColOrds, upd.NeedResults)
+	checkOrds := ordinalSetFromColList(upd.CheckCols)
+	node, err := b.factory.ConstructUpdate(
+		input.root,
+		tab,
+		fetchColOrds,
+		updateColOrds,
+		checkOrds,
+		upd.NeedResults,
+	)
 	if err != nil {
 		return execPlan{}, err
 	}
@@ -1222,6 +1239,7 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 	colList = appendColsWhenPresent(colList, ups.FetchCols)
 	colList = appendColsWhenPresent(colList, ups.UpdateCols)
 	colList = append(colList, ups.CanaryCol)
+	colList = appendColsWhenPresent(colList, ups.CheckCols)
 	input, err = b.ensureColumns(input, colList, nil, ups.ProvidedPhysical().Ordering)
 	if err != nil {
 		return execPlan{}, err
@@ -1234,8 +1252,17 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 	insertColOrds := ordinalSetFromColList(ups.InsertCols)
 	fetchColOrds := ordinalSetFromColList(ups.FetchCols)
 	updateColOrds := ordinalSetFromColList(ups.UpdateCols)
+	checkOrds := ordinalSetFromColList(ups.CheckCols)
 	node, err := b.factory.ConstructUpsert(
-		input.root, tab, canaryCol, insertColOrds, fetchColOrds, updateColOrds, ups.NeedResults)
+		input.root,
+		tab,
+		canaryCol,
+		insertColOrds,
+		fetchColOrds,
+		updateColOrds,
+		checkOrds,
+		ups.NeedResults,
+	)
 	if err != nil {
 		return execPlan{}, err
 	}

--- a/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
@@ -22,41 +22,41 @@ CREATE TABLE t9 (
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t9 SET b = 2 WHERE a = 5
 ----
-count                ·         ·             ()                         ·
- └── update          ·         ·             ()                         ·
-      │              table     t9            ·                          ·
-      │              set       b             ·                          ·
-      │              strategy  updater       ·                          ·
-      │              check 0   t9.a > t9.b   ·                          ·
-      │              check 1   t9.d IS NULL  ·                          ·
-      └── render     ·         ·             (a, b, c, d, e, column11)  ·
-           │         render 0  a             ·                          ·
-           │         render 1  b             ·                          ·
-           │         render 2  c             ·                          ·
-           │         render 3  d             ·                          ·
-           │         render 4  e             ·                          ·
-           │         render 5  2             ·                          ·
-           └── scan  ·         ·             (a, b, c, d, e)            ·
-·                    table     t9@primary    ·                          ·
-·                    spans     /5-/5/#       ·                          ·
+count                ·         ·           ()                                         ·
+ └── update          ·         ·           ()                                         ·
+      │              table     t9          ·                                          ·
+      │              set       b           ·                                          ·
+      │              strategy  updater     ·                                          ·
+      └── render     ·         ·           (a, b, c, d, e, column11, check1, check2)  ·
+           │         render 0  a           ·                                          ·
+           │         render 1  b           ·                                          ·
+           │         render 2  c           ·                                          ·
+           │         render 3  d           ·                                          ·
+           │         render 4  e           ·                                          ·
+           │         render 5  2           ·                                          ·
+           │         render 6  a > 2       ·                                          ·
+           │         render 7  d IS NULL   ·                                          ·
+           └── scan  ·         ·           (a, b, c, d, e)                            ·
+·                    table     t9@primary  ·                                          ·
+·                    spans     /5-/5/#     ·                                          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) UPDATE t9 SET a = 2 WHERE a = 5
 ----
-count                ·         ·             ()                         ·
- └── update          ·         ·             ()                         ·
-      │              table     t9            ·                          ·
-      │              set       a             ·                          ·
-      │              strategy  updater       ·                          ·
-      │              check 0   t9.a > t9.b   ·                          ·
-      │              check 1   t9.d IS NULL  ·                          ·
-      └── render     ·         ·             (a, b, c, d, e, column11)  ·
-           │         render 0  a             ·                          ·
-           │         render 1  b             ·                          ·
-           │         render 2  c             ·                          ·
-           │         render 3  d             ·                          ·
-           │         render 4  e             ·                          ·
-           │         render 5  2             ·                          ·
-           └── scan  ·         ·             (a, b, c, d, e)            ·
-·                    table     t9@primary    ·                          ·
-·                    spans     /5-/5/#       ·                          ·
+count                ·         ·           ()                                         ·
+ └── update          ·         ·           ()                                         ·
+      │              table     t9          ·                                          ·
+      │              set       a           ·                                          ·
+      │              strategy  updater     ·                                          ·
+      └── render     ·         ·           (a, b, c, d, e, column11, check1, check2)  ·
+           │         render 0  a           ·                                          ·
+           │         render 1  b           ·                                          ·
+           │         render 2  c           ·                                          ·
+           │         render 3  d           ·                                          ·
+           │         render 4  e           ·                                          ·
+           │         render 5  2           ·                                          ·
+           │         render 6  b < 2       ·                                          ·
+           │         render 7  d IS NULL   ·                                          ·
+           └── scan  ·         ·           (a, b, c, d, e)                            ·
+·                    table     t9@primary  ·                                          ·
+·                    spans     /5-/5/#     ·                                          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -104,3 +104,15 @@ bob2  otherbob@email.com
 
 statement ok
 DROP TABLE customers
+
+# The CBO behaves differently than the HP and PG in this case. It only checks
+# constraints if an insert or update actually occurs. In this case, the DO
+# NOTHING clause skips the update, so there is no need to check the constraint.
+statement ok
+CREATE TABLE t5 (k INT PRIMARY KEY, a INT, b int CHECK (a > b))
+
+statement ok
+INSERT INTO t5 VALUES (1, 10, 9) ON CONFLICT (k) DO NOTHING
+
+statement ok
+INSERT INTO t5 VALUES (1, 10, 20) ON CONFLICT (k) DO NOTHING

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -245,7 +245,11 @@ type Factory interface {
 	// rowsNeeded parameter is true if a RETURNING clause needs the inserted
 	// row(s) as output.
 	ConstructInsert(
-		input Node, table cat.Table, insertCols ColumnOrdinalSet, rowsNeeded bool,
+		input Node,
+		table cat.Table,
+		insertCols ColumnOrdinalSet,
+		checks CheckOrdinalSet,
+		rowsNeeded bool,
 	) (Node, error)
 
 	// ConstructUpdate creates a node that implements an UPDATE statement. The
@@ -261,7 +265,12 @@ type Factory interface {
 	// fetch columns first and the update columns second. The rowsNeeded parameter
 	// is true if a RETURNING clause needs the updated row(s) as output.
 	ConstructUpdate(
-		input Node, table cat.Table, fetchCols, updateCols ColumnOrdinalSet, rowsNeeded bool,
+		input Node,
+		table cat.Table,
+		fetchCols ColumnOrdinalSet,
+		updateCols ColumnOrdinalSet,
+		checks CheckOrdinalSet,
+		rowsNeeded bool,
 	) (Node, error)
 
 	// ConstructUpsert creates a node that implements an INSERT..ON CONFLICT or
@@ -294,6 +303,7 @@ type Factory interface {
 		insertCols ColumnOrdinalSet,
 		fetchCols ColumnOrdinalSet,
 		updateCols ColumnOrdinalSet,
+		checks CheckOrdinalSet,
 		rowsNeeded bool,
 	) (Node, error)
 
@@ -363,6 +373,10 @@ type ColumnOrdinal int32
 
 // ColumnOrdinalSet contains a set of ColumnOrdinal values as ints.
 type ColumnOrdinalSet = util.FastIntSet
+
+// CheckOrdinalSet contains the ordinal positions of a set of check constraints
+// taken from the opt.Table.Check collection.
+type CheckOrdinalSet = util.FastIntSet
 
 // AggInfo represents an aggregation (see ConstructGroupBy).
 type AggInfo struct {

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -294,19 +294,16 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if len(colList) == 0 {
 			tp.Child("columns: <none>")
 		}
-		tpChild := tp.Child("insert-mapping:")
-		f.formatMutation(e, tpChild, t.InsertCols, t.Table)
+		f.formatMutation(e, tp, "insert-mapping:", t.InsertCols, t.Table)
+		f.formatColList(e, tp, "check columns:", t.CheckCols)
 
 	case *UpdateExpr:
 		if len(colList) == 0 {
 			tp.Child("columns: <none>")
 		}
 		f.formatColList(e, tp, "fetch columns:", t.FetchCols)
-		tpChild := tp.Child("update-mapping:")
-		f.formatMutation(e, tpChild, t.UpdateCols, t.Table)
-
-	case *CreateTableExpr:
-		tp.Child(t.Syntax.String())
+		f.formatMutation(e, tp, "update-mapping:", t.UpdateCols, t.Table)
+		f.formatColList(e, tp, "check columns:", t.CheckCols)
 
 	case *UpsertExpr:
 		if len(colList) == 0 {
@@ -314,16 +311,18 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 		tp.Childf("canary column: %d", t.CanaryCol)
 		f.formatColList(e, tp, "fetch columns:", t.FetchCols)
-		tpChild := tp.Child("insert-mapping:")
-		f.formatMutation(e, tpChild, t.InsertCols, t.Table)
-		tpChild = tp.Child("update-mapping:")
-		f.formatMutation(e, tpChild, t.UpdateCols, t.Table)
+		f.formatMutation(e, tp, "insert-mapping:", t.InsertCols, t.Table)
+		f.formatMutation(e, tp, "update-mapping:", t.UpdateCols, t.Table)
+		f.formatColList(e, tp, "check columns:", t.CheckCols)
 
 	case *DeleteExpr:
 		if len(colList) == 0 {
 			tp.Child("columns: <none>")
 		}
 		f.formatColList(e, tp, "fetch columns:", t.FetchCols)
+
+	case *CreateTableExpr:
+		tp.Child(t.Syntax.String())
 	}
 
 	if !f.HasFlags(ExprFmtHideMiscProps) {
@@ -627,15 +626,20 @@ func (f *ExprFmtCtx) formatColList(
 //   a:1 => x:4
 //
 func (f *ExprFmtCtx) formatMutation(
-	nd RelExpr, tp treeprinter.Node, colList opt.ColList, tabID opt.TableID,
+	nd RelExpr, tp treeprinter.Node, heading string, colList opt.ColList, tabID opt.TableID,
 ) {
+	if len(colList) == 0 {
+		return
+	}
+
+	tpChild := tp.Child(heading)
 	for i, col := range colList {
 		if col != 0 {
 			f.Buffer.Reset()
 			formatCol(f, "" /* label */, col, opt.ColSet{}, true /* omitType */)
 			f.Buffer.WriteString(" =>")
 			formatCol(f, "" /* label */, tabID.ColumnID(i), opt.ColSet{}, true /* omitType */)
-			tp.Child(f.Buffer.String())
+			tpChild.Child(f.Buffer.String())
 		}
 	}
 }

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -45,7 +45,7 @@ define MutationPrivate {
     #   INSERT INTO ab VALUES (1, 2)
     #
     # If there is a delete-only mutation column "c", then InsertCols would contain
-    # [id-a, id-b, 0].
+    # [a_colid, b_colid, 0].
     InsertCols ColList
 
     # FetchCols are columns from the Input expression that will be fetched from
@@ -70,7 +70,7 @@ define MutationPrivate {
     # The "c" column is needed because its value is used as part of computing an
     # updated value, and the "d" column is needed because it's in the same family
     # as "c". Taking all this into account, FetchCols would contain this list:
-    # [id-a, 0, id-c, id-d, 0].
+    # [a_colid, 0, c_colid, d_colid, 0].
     FetchCols ColList
 
     # UpdateCols are columns from the Input expression that contain updated values
@@ -86,8 +86,25 @@ define MutationPrivate {
     #   UPDATE abc SET b=1
     #
     # Since column "b" is updated, and "c" is a computed column dependent on "b",
-    # then UpdateCols would contain [0, id-b, id-c].
+    # then UpdateCols would contain [0, b_colid, c_colid].
     UpdateCols ColList
+
+    # CheckCols are columns from the Input expression containing the results of
+    # evaluating the check constraints from the target table. Evaluating a check
+    # check constraint expression produces a boolean value which is projected as
+    # a column and then checked by the mutation operator. Check columns must be
+    # a subset of the Input expression's output columns. The count and order of
+    # columns corresponds to the count and order of the target table's Check
+    # collection (see the opt.Table.CheckCount and opt.Table.Check methods). If
+    # any column ID is zero, then that check will not be performed (i.e. because
+    # it's been statically proved to be true). For example:
+    #
+    #   CREATE TABLE abc (a INT CHECK (a > 0), b INT, c INT CHECK (c <> 0))
+    #   UPDATE abc SET a=1, b=b+1
+    #
+    # Since the check constraint for column "a" can be statically proven to be
+    # true, CheckCols would contain [0, b_colid].
+    CheckCols ColList
 
     # CanaryCol is used only with the Upsert operator. It identifies the column
     # that the execution engine uses to decide whether to insert or to update.

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -531,9 +531,13 @@ func (mb *mutationBuilder) addDefaultAndComputedColsForInsert() {
 // buildInsert constructs an Insert operator, possibly wrapped by a Project
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildInsert(returning tree.ReturningExprs) {
+	// Add any check constraint boolean columns to the input.
+	mb.addCheckConstraintCols()
+
 	private := memo.MutationPrivate{
 		Table:       mb.tabID,
 		InsertCols:  mb.insertColList,
+		CheckCols:   mb.checkColList,
 		NeedResults: returning != nil,
 	}
 	mb.outScope.expr = mb.b.factory.ConstructInsert(mb.outScope.expr, &private)
@@ -584,11 +588,6 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, onConflict *tr
 			excludeMutations,
 			inScope,
 		)
-
-		// Add the scan columns to the current scope. It's OK to modify the current
-		// scope because it contains only INSERT columns that were added by the
-		// mutationBuilder, and which aren't needed for any other purpose.
-		mb.outScope.appendColumnsFromScope(scanScope)
 
 		// Remember the column ID of a scan column that is not null. This will be
 		// used to detect whether a conflict was detected for a row. Such a column
@@ -771,7 +770,11 @@ func (mb *mutationBuilder) setUpsertCols(insertCols tree.NameList) {
 // buildUpsert constructs an Upsert operator, possibly wrapped by a Project
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
+	// Merge input insert and update columns using CASE expressions.
 	mb.projectUpsertColumns()
+
+	// Add any check constraint boolean columns to the input.
+	mb.addCheckConstraintCols()
 
 	private := memo.MutationPrivate{
 		Table:       mb.tabID,
@@ -779,6 +782,7 @@ func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
 		FetchCols:   mb.fetchColList,
 		UpdateCols:  mb.updateColList,
 		CanaryCol:   mb.canaryColID,
+		CheckCols:   mb.checkColList,
 		NeedResults: returning != nil,
 	}
 	mb.outScope.expr = mb.b.factory.ConstructUpsert(mb.outScope.expr, &private)

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -63,6 +63,14 @@ type scopeColumn struct {
 	exprStr string
 }
 
+// clearName sets the empty table and column name. This is used to make the
+// column anonymous so that it cannot be referenced, but will still be
+// projected.
+func (c *scopeColumn) clearName() {
+	c.name = ""
+	c.table = tree.TableName{}
+}
+
 // getExpr returns the the expression that this column refers to, or the column
 // itself if the column does not refer to an expression.
 func (c *scopeColumn) getExpr() tree.TypedExpr {

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -62,6 +62,23 @@ TABLE mutation
  └── INDEX primary
       └── m int not null
 
+exec-ddl
+CREATE TABLE checks (
+    a INT PRIMARY KEY CHECK (a > 0),
+    b INT,
+    c INT,
+    CHECK (checks.b < c)
+)
+----
+TABLE checks
+ ├── a int not null
+ ├── b int
+ ├── c int
+ ├── INDEX primary
+ │    └── a int not null
+ ├── CHECK (checks.b < c)
+ └── CHECK (a > 0)
+
 # Unknown target table.
 build
 INSERT INTO unknown VALUES (1, 2, 3)
@@ -1227,3 +1244,59 @@ build
 INSERT INTO mutation (m, n, q) VALUES (1, 2, 3)
 ----
 error (42P10): column "q" is being backfilled
+
+# ------------------------------------------------------------------------------
+# Test check constraints
+# ------------------------------------------------------------------------------
+
+# Insert constants.
+build
+INSERT INTO checks (a, b, c) VALUES (1, 2, 3)
+----
+insert checks
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:4 => a:1
+ │    ├──  column2:5 => b:2
+ │    └──  column3:6 => c:3
+ ├── check columns: check1:7(bool) check2:8(bool)
+ └── project
+      ├── columns: check1:7(bool) check2:8(bool) column1:4(int) column2:5(int) column3:6(int)
+      ├── values
+      │    ├── columns: column1:4(int) column2:5(int) column3:6(int)
+      │    └── tuple [type=tuple{int, int, int}]
+      │         ├── const: 1 [type=int]
+      │         ├── const: 2 [type=int]
+      │         └── const: 3 [type=int]
+      └── projections
+           ├── lt [type=bool]
+           │    ├── variable: column2 [type=int]
+           │    └── variable: column3 [type=int]
+           └── gt [type=bool]
+                ├── variable: column1 [type=int]
+                └── const: 0 [type=int]
+
+# Insert results of SELECT.
+build
+INSERT INTO checks SELECT a, b, c FROM abcde
+----
+insert checks
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  abcde.a:4 => checks.a:1
+ │    ├──  abcde.b:5 => checks.b:2
+ │    └──  abcde.c:6 => checks.c:3
+ ├── check columns: check1:10(bool) check2:11(bool)
+ └── project
+      ├── columns: check1:10(bool) check2:11(bool) abcde.a:4(int!null) abcde.b:5(int) abcde.c:6(int)
+      ├── project
+      │    ├── columns: abcde.a:4(int!null) abcde.b:5(int) abcde.c:6(int)
+      │    └── scan abcde
+      │         └── columns: abcde.a:4(int!null) abcde.b:5(int) abcde.c:6(int) d:7(int) e:8(int) rowid:9(int!null)
+      └── projections
+           ├── lt [type=bool]
+           │    ├── variable: abcde.b [type=int]
+           │    └── variable: abcde.c [type=int]
+           └── gt [type=bool]
+                ├── variable: abcde.a [type=int]
+                └── const: 0 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -60,6 +60,23 @@ TABLE mutation
  └── INDEX primary
       └── m int not null
 
+exec-ddl
+CREATE TABLE checks (
+	a INT PRIMARY KEY CHECK (a > 0),
+	b INT,
+	c INT,
+	CHECK (checks.b < c)
+)
+----
+TABLE checks
+ ├── a int not null
+ ├── b int
+ ├── c int
+ ├── INDEX primary
+ │    └── a int not null
+ ├── CHECK (checks.b < c)
+ └── CHECK (a > 0)
+
 # ------------------------------------------------------------------------------
 # Basic tests.
 # ------------------------------------------------------------------------------
@@ -1335,3 +1352,127 @@ build
 UPDATE mutation SET m=1 ORDER BY o LIMIT 2
 ----
 error (42P10): column "o" is being backfilled
+
+# ------------------------------------------------------------------------------
+# Test check constraints
+# ------------------------------------------------------------------------------
+
+# Update all columns to be constant.
+build
+UPDATE checks SET a=1, b=2, c=3
+----
+update checks
+ ├── columns: <none>
+ ├── fetch columns: a:4(int) b:5(int) c:6(int)
+ ├── update-mapping:
+ │    ├──  column7:7 => a:1
+ │    ├──  column8:8 => b:2
+ │    └──  column9:9 => c:3
+ ├── check columns: check1:10(bool) check2:11(bool)
+ └── project
+      ├── columns: check1:10(bool) check2:11(bool) a:4(int!null) b:5(int) c:6(int) column7:7(int!null) column8:8(int!null) column9:9(int!null)
+      ├── project
+      │    ├── columns: column7:7(int!null) column8:8(int!null) column9:9(int!null) a:4(int!null) b:5(int) c:6(int)
+      │    ├── scan checks
+      │    │    └── columns: a:4(int!null) b:5(int) c:6(int)
+      │    └── projections
+      │         ├── const: 1 [type=int]
+      │         ├── const: 2 [type=int]
+      │         └── const: 3 [type=int]
+      └── projections
+           ├── lt [type=bool]
+           │    ├── variable: column8 [type=int]
+           │    └── variable: column9 [type=int]
+           └── gt [type=bool]
+                ├── variable: column7 [type=int]
+                └── const: 0 [type=int]
+
+# Do not update columns for one of the constraints.
+build
+UPDATE checks SET a=1
+----
+update checks
+ ├── columns: <none>
+ ├── fetch columns: a:4(int) b:5(int) c:6(int)
+ ├── update-mapping:
+ │    └──  column7:7 => a:1
+ ├── check columns: check1:8(bool) check2:9(bool)
+ └── project
+      ├── columns: check1:8(bool) check2:9(bool) a:4(int!null) b:5(int) c:6(int) column7:7(int!null)
+      ├── project
+      │    ├── columns: column7:7(int!null) a:4(int!null) b:5(int) c:6(int)
+      │    ├── scan checks
+      │    │    └── columns: a:4(int!null) b:5(int) c:6(int)
+      │    └── projections
+      │         └── const: 1 [type=int]
+      └── projections
+           ├── lt [type=bool]
+           │    ├── variable: b [type=int]
+           │    └── variable: c [type=int]
+           └── gt [type=bool]
+                ├── variable: column7 [type=int]
+                └── const: 0 [type=int]
+
+# Update one column in constraint, but not the other.
+build
+UPDATE checks SET b=2
+----
+update checks
+ ├── columns: <none>
+ ├── fetch columns: a:4(int) b:5(int) c:6(int)
+ ├── update-mapping:
+ │    └──  column7:7 => b:2
+ ├── check columns: check1:8(bool) check2:9(bool)
+ └── project
+      ├── columns: check1:8(bool) check2:9(bool) a:4(int!null) b:5(int) c:6(int) column7:7(int!null)
+      ├── project
+      │    ├── columns: column7:7(int!null) a:4(int!null) b:5(int) c:6(int)
+      │    ├── scan checks
+      │    │    └── columns: a:4(int!null) b:5(int) c:6(int)
+      │    └── projections
+      │         └── const: 2 [type=int]
+      └── projections
+           ├── lt [type=bool]
+           │    ├── variable: column7 [type=int]
+           │    └── variable: c [type=int]
+           └── gt [type=bool]
+                ├── variable: a [type=int]
+                └── const: 0 [type=int]
+
+# Update using tuple and subquery.
+build
+UPDATE checks SET (a, b)=(SELECT a, b FROM abcde WHERE abcde.a=checks.a)
+----
+update checks
+ ├── columns: <none>
+ ├── fetch columns: checks.a:4(int) checks.b:5(int) checks.c:6(int)
+ ├── update-mapping:
+ │    ├──  abcde.a:7 => checks.a:1
+ │    └──  abcde.b:8 => checks.b:2
+ ├── check columns: check1:13(bool) check2:14(bool)
+ └── project
+      ├── columns: check1:13(bool) check2:14(bool) checks.a:4(int!null) checks.b:5(int) checks.c:6(int) abcde.a:7(int) abcde.b:8(int)
+      ├── left-join-apply
+      │    ├── columns: checks.a:4(int!null) checks.b:5(int) checks.c:6(int) abcde.a:7(int) abcde.b:8(int)
+      │    ├── scan checks
+      │    │    └── columns: checks.a:4(int!null) checks.b:5(int) checks.c:6(int)
+      │    ├── max1-row
+      │    │    ├── columns: abcde.a:7(int!null) abcde.b:8(int)
+      │    │    └── project
+      │    │         ├── columns: abcde.a:7(int!null) abcde.b:8(int)
+      │    │         └── select
+      │    │              ├── columns: abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │              ├── scan abcde
+      │    │              │    └── columns: abcde.a:7(int!null) abcde.b:8(int) abcde.c:9(int) d:10(int) e:11(int) rowid:12(int!null)
+      │    │              └── filters
+      │    │                   └── eq [type=bool]
+      │    │                        ├── variable: abcde.a [type=int]
+      │    │                        └── variable: checks.a [type=int]
+      │    └── filters (true)
+      └── projections
+           ├── lt [type=bool]
+           │    ├── variable: abcde.b [type=int]
+           │    └── variable: checks.c [type=int]
+           └── gt [type=bool]
+                ├── variable: abcde.a [type=int]
+                └── const: 0 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -82,6 +82,23 @@ TABLE mutation
  └── INDEX primary
       └── m int not null
 
+exec-ddl
+CREATE TABLE checks (
+	a INT PRIMARY KEY CHECK (a > 0),
+	b INT,
+	c INT,
+	CHECK (checks.b < c)
+)
+----
+TABLE checks
+ ├── a int not null
+ ├── b int
+ ├── c int
+ ├── INDEX primary
+ │    └── a int not null
+ ├── CHECK (checks.b < c)
+ └── CHECK (a > 0)
+
 # ------------------------------------------------------------------------------
 # Basic tests.
 # ------------------------------------------------------------------------------
@@ -1364,3 +1381,288 @@ build
 UPSERT INTO xyz (x, unknown) VALUES (1)
 ----
 error (42703): column "unknown" does not exist
+
+# ------------------------------------------------------------------------------
+# Test check constraints
+# ------------------------------------------------------------------------------
+
+# INSERT..ON CONFLICT
+build
+INSERT INTO checks (a, b) VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET b=3, c=4
+----
+upsert checks
+ ├── columns: <none>
+ ├── canary column: 7
+ ├── fetch columns: upsert_a:12(int) b:8(int) c:9(int)
+ ├── insert-mapping:
+ │    ├──  upsert_a:12 => a:1
+ │    ├──  upsert_b:13 => b:2
+ │    └──  upsert_c:14 => c:3
+ ├── update-mapping:
+ │    ├──  upsert_b:13 => b:2
+ │    └──  upsert_c:14 => c:3
+ ├── check columns: check1:15(bool) check2:16(bool)
+ └── project
+      ├── columns: check1:15(bool) check2:16(bool) a:7(int) b:8(int) c:9(int) upsert_a:12(int) upsert_b:13(int) upsert_c:14(int)
+      ├── project
+      │    ├── columns: upsert_a:12(int) upsert_b:13(int) upsert_c:14(int) a:7(int) b:8(int) c:9(int)
+      │    ├── project
+      │    │    ├── columns: column10:10(int!null) column11:11(int!null) column1:4(int) column2:5(int) column6:6(int) a:7(int) b:8(int) c:9(int)
+      │    │    ├── left-join
+      │    │    │    ├── columns: column1:4(int) column2:5(int) column6:6(int) a:7(int) b:8(int) c:9(int)
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: column6:6(int) column1:4(int) column2:5(int)
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:4(int) column2:5(int)
+      │    │    │    │    │    └── tuple [type=tuple{int, int}]
+      │    │    │    │    │         ├── const: 1 [type=int]
+      │    │    │    │    │         └── const: 2 [type=int]
+      │    │    │    │    └── projections
+      │    │    │    │         └── cast: INT8 [type=int]
+      │    │    │    │              └── null [type=unknown]
+      │    │    │    ├── scan checks
+      │    │    │    │    └── columns: a:7(int!null) b:8(int) c:9(int)
+      │    │    │    └── filters
+      │    │    │         └── eq [type=bool]
+      │    │    │              ├── variable: column1 [type=int]
+      │    │    │              └── variable: a [type=int]
+      │    │    └── projections
+      │    │         ├── const: 3 [type=int]
+      │    │         └── const: 4 [type=int]
+      │    └── projections
+      │         ├── case [type=int]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=int]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: a [type=int]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: column1 [type=int]
+      │         │    └── variable: a [type=int]
+      │         ├── case [type=int]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=int]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: a [type=int]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: column2 [type=int]
+      │         │    └── variable: column10 [type=int]
+      │         └── case [type=int]
+      │              ├── true [type=bool]
+      │              ├── when [type=int]
+      │              │    ├── is [type=bool]
+      │              │    │    ├── variable: a [type=int]
+      │              │    │    └── null [type=unknown]
+      │              │    └── variable: column6 [type=int]
+      │              └── variable: column11 [type=int]
+      └── projections
+           ├── lt [type=bool]
+           │    ├── variable: upsert_b [type=int]
+           │    └── variable: upsert_c [type=int]
+           └── gt [type=bool]
+                ├── variable: upsert_a [type=int]
+                └── const: 0 [type=int]
+
+# INSERT..ON CONFLICT DO NOTHING
+build
+INSERT INTO checks (a, b) VALUES (1, 2) ON CONFLICT (a) DO NOTHING
+----
+insert checks
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:4 => checks.a:1
+ │    ├──  column2:5 => checks.b:2
+ │    └──  column6:6 => checks.c:3
+ ├── check columns: check1:10(bool) check2:11(bool)
+ └── project
+      ├── columns: check1:10(bool) check2:11(bool) column1:4(int) column2:5(int) column6:6(int)
+      ├── project
+      │    ├── columns: column1:4(int) column2:5(int) column6:6(int)
+      │    └── select
+      │         ├── columns: column1:4(int) column2:5(int) column6:6(int) checks_1.a:7(int) checks_1.b:8(int) checks_1.c:9(int)
+      │         ├── left-join
+      │         │    ├── columns: column1:4(int) column2:5(int) column6:6(int) checks_1.a:7(int) checks_1.b:8(int) checks_1.c:9(int)
+      │         │    ├── project
+      │         │    │    ├── columns: column6:6(int) column1:4(int) column2:5(int)
+      │         │    │    ├── values
+      │         │    │    │    ├── columns: column1:4(int) column2:5(int)
+      │         │    │    │    └── tuple [type=tuple{int, int}]
+      │         │    │    │         ├── const: 1 [type=int]
+      │         │    │    │         └── const: 2 [type=int]
+      │         │    │    └── projections
+      │         │    │         └── cast: INT8 [type=int]
+      │         │    │              └── null [type=unknown]
+      │         │    ├── scan checks_1
+      │         │    │    └── columns: checks_1.a:7(int!null) checks_1.b:8(int) checks_1.c:9(int)
+      │         │    └── filters
+      │         │         └── eq [type=bool]
+      │         │              ├── variable: column1 [type=int]
+      │         │              └── variable: checks_1.a [type=int]
+      │         └── filters
+      │              └── is [type=bool]
+      │                   ├── variable: checks_1.a [type=int]
+      │                   └── null [type=unknown]
+      └── projections
+           ├── lt [type=bool]
+           │    ├── variable: column2 [type=int]
+           │    └── variable: column6 [type=int]
+           └── gt [type=bool]
+                ├── variable: column1 [type=int]
+                └── const: 0 [type=int]
+
+# UPSERT
+build
+UPSERT INTO checks (a, b) VALUES (1, 2)
+----
+upsert checks
+ ├── columns: <none>
+ ├── canary column: 7
+ ├── fetch columns: upsert_a:10(int) b:8(int) upsert_c:12(int)
+ ├── insert-mapping:
+ │    ├──  upsert_a:10 => a:1
+ │    ├──  upsert_b:11 => b:2
+ │    └──  upsert_c:12 => c:3
+ ├── update-mapping:
+ │    └──  upsert_b:11 => b:2
+ ├── check columns: check1:13(bool) check2:14(bool)
+ └── project
+      ├── columns: check1:13(bool) check2:14(bool) a:7(int) b:8(int) c:9(int) upsert_a:10(int) upsert_b:11(int) upsert_c:12(int)
+      ├── project
+      │    ├── columns: upsert_a:10(int) upsert_b:11(int) upsert_c:12(int) a:7(int) b:8(int) c:9(int)
+      │    ├── left-join
+      │    │    ├── columns: column1:4(int) column2:5(int) column6:6(int) a:7(int) b:8(int) c:9(int)
+      │    │    ├── project
+      │    │    │    ├── columns: column6:6(int) column1:4(int) column2:5(int)
+      │    │    │    ├── values
+      │    │    │    │    ├── columns: column1:4(int) column2:5(int)
+      │    │    │    │    └── tuple [type=tuple{int, int}]
+      │    │    │    │         ├── const: 1 [type=int]
+      │    │    │    │         └── const: 2 [type=int]
+      │    │    │    └── projections
+      │    │    │         └── cast: INT8 [type=int]
+      │    │    │              └── null [type=unknown]
+      │    │    ├── scan checks
+      │    │    │    └── columns: a:7(int!null) b:8(int) c:9(int)
+      │    │    └── filters
+      │    │         └── eq [type=bool]
+      │    │              ├── variable: column1 [type=int]
+      │    │              └── variable: a [type=int]
+      │    └── projections
+      │         ├── case [type=int]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=int]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: a [type=int]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: column1 [type=int]
+      │         │    └── variable: a [type=int]
+      │         ├── case [type=int]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=int]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: a [type=int]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: column2 [type=int]
+      │         │    └── variable: column2 [type=int]
+      │         └── case [type=int]
+      │              ├── true [type=bool]
+      │              ├── when [type=int]
+      │              │    ├── is [type=bool]
+      │              │    │    ├── variable: a [type=int]
+      │              │    │    └── null [type=unknown]
+      │              │    └── variable: column6 [type=int]
+      │              └── variable: c [type=int]
+      └── projections
+           ├── lt [type=bool]
+           │    ├── variable: upsert_b [type=int]
+           │    └── variable: upsert_c [type=int]
+           └── gt [type=bool]
+                ├── variable: upsert_a [type=int]
+                └── const: 0 [type=int]
+
+# Use subqueries and excluded.
+build
+INSERT INTO checks
+SELECT a, b FROM abc
+ON CONFLICT (a) DO UPDATE SET a=excluded.a, b=(SELECT x FROM xyz WHERE x=checks.a)
+----
+upsert checks
+ ├── columns: <none>
+ ├── canary column: 9
+ ├── fetch columns: checks.a:9(int) checks.b:10(int) upsert_c:18(int)
+ ├── insert-mapping:
+ │    ├──  upsert_a:16 => checks.a:1
+ │    ├──  upsert_b:17 => checks.b:2
+ │    └──  upsert_c:18 => checks.c:3
+ ├── update-mapping:
+ │    ├──  upsert_a:16 => checks.a:1
+ │    └──  upsert_b:17 => checks.b:2
+ ├── check columns: check1:19(bool) check2:20(bool)
+ └── project
+      ├── columns: check1:19(bool) check2:20(bool) checks.a:9(int) checks.b:10(int) checks.c:11(int) upsert_a:16(int) upsert_b:17(int) upsert_c:18(int)
+      ├── project
+      │    ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) checks.a:9(int) checks.b:10(int) checks.c:11(int)
+      │    ├── project
+      │    │    ├── columns: column15:15(int) abc.a:4(int!null) abc.b:5(int) column8:8(int) checks.a:9(int) checks.b:10(int) checks.c:11(int)
+      │    │    ├── left-join
+      │    │    │    ├── columns: abc.a:4(int!null) abc.b:5(int) column8:8(int) checks.a:9(int) checks.b:10(int) checks.c:11(int)
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: column8:8(int) abc.a:4(int!null) abc.b:5(int)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: abc.a:4(int!null) abc.b:5(int)
+      │    │    │    │    │    └── scan abc
+      │    │    │    │    │         └── columns: abc.a:4(int!null) abc.b:5(int) abc.c:6(int) rowid:7(int!null)
+      │    │    │    │    └── projections
+      │    │    │    │         └── cast: INT8 [type=int]
+      │    │    │    │              └── null [type=unknown]
+      │    │    │    ├── scan checks
+      │    │    │    │    └── columns: checks.a:9(int!null) checks.b:10(int) checks.c:11(int)
+      │    │    │    └── filters
+      │    │    │         └── eq [type=bool]
+      │    │    │              ├── variable: abc.a [type=int]
+      │    │    │              └── variable: checks.a [type=int]
+      │    │    └── projections
+      │    │         └── subquery [type=int]
+      │    │              └── max1-row
+      │    │                   ├── columns: x:12(int!null)
+      │    │                   └── project
+      │    │                        ├── columns: x:12(int!null)
+      │    │                        └── select
+      │    │                             ├── columns: x:12(int!null) y:13(int) z:14(int)
+      │    │                             ├── scan xyz
+      │    │                             │    └── columns: x:12(int!null) y:13(int) z:14(int)
+      │    │                             └── filters
+      │    │                                  └── eq [type=bool]
+      │    │                                       ├── variable: x [type=int]
+      │    │                                       └── variable: checks.a [type=int]
+      │    └── projections
+      │         ├── case [type=int]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=int]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: checks.a [type=int]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: abc.a [type=int]
+      │         │    └── variable: abc.a [type=int]
+      │         ├── case [type=int]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=int]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: checks.a [type=int]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: abc.b [type=int]
+      │         │    └── variable: column15 [type=int]
+      │         └── case [type=int]
+      │              ├── true [type=bool]
+      │              ├── when [type=int]
+      │              │    ├── is [type=bool]
+      │              │    │    ├── variable: checks.a [type=int]
+      │              │    │    └── null [type=unknown]
+      │              │    └── variable: column8 [type=int]
+      │              └── variable: checks.c [type=int]
+      └── projections
+           ├── lt [type=bool]
+           │    ├── variable: upsert_b [type=int]
+           │    └── variable: upsert_c [type=int]
+           └── gt [type=bool]
+                ├── variable: upsert_a [type=int]
+                └── const: 0 [type=int]

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -315,8 +315,7 @@ func (mb *mutationBuilder) addComputedColsForUpdate() {
 					col.table = *mb.tab.Name()
 				} else {
 					// Clear name so that it will never match.
-					col.table = tree.TableName{}
-					col.name = ""
+					col.clearName()
 				}
 			}
 		}
@@ -331,10 +330,13 @@ func (mb *mutationBuilder) addComputedColsForUpdate() {
 // buildUpdate constructs an Update operator, possibly wrapped by a Project
 // operator that corresponds to the given RETURNING clause.
 func (mb *mutationBuilder) buildUpdate(returning tree.ReturningExprs) {
+	mb.addCheckConstraintCols()
+
 	private := memo.MutationPrivate{
 		Table:       mb.tabID,
 		FetchCols:   mb.fetchColList,
 		UpdateCols:  mb.updateColList,
+		CheckCols:   mb.checkColList,
 		NeedResults: returning != nil,
 	}
 	mb.outScope.expr = mb.b.factory.ConstructUpdate(mb.outScope.expr, &private)

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -84,6 +84,9 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 			if def.PrimaryKey {
 				tab.addIndex(&def.IndexTableDef, primaryIndex)
 			}
+
+		case *tree.CheckConstraintTableDef:
+			tab.Checks = append(tab.Checks, cat.CheckConstraint(tree.Serialize(def.Expr)))
 		}
 	}
 

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -414,6 +414,7 @@ type Table struct {
 	Columns    []*Column
 	Indexes    []*Index
 	Stats      TableStats
+	Checks     []cat.CheckConstraint
 	IsVirtual  bool
 	Catalog    cat.Catalog
 	Mutations  []cat.MutationColumn
@@ -485,6 +486,16 @@ func (tt *Table) StatisticCount() int {
 // Statistic is part of the cat.Table interface.
 func (tt *Table) Statistic(i int) cat.TableStatistic {
 	return tt.Stats[i]
+}
+
+// CheckCount is part of the cat.Table interface.
+func (tt *Table) CheckCount() int {
+	return len(tt.Checks)
+}
+
+// Check is part of the cat.Table interface.
+func (tt *Table) Check(i int) cat.CheckConstraint {
+	return tt.Checks[i]
 }
 
 // FindOrdinal returns the ordinal of the column with the given name.

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -279,13 +279,21 @@ TABLE leaderboard_record
  │    ├── leaderboard_id bytes not null
  │    ├── expires_at int not null
  │    └── owner_id bytes not null
- └── INDEX test_idx
-      ├── leaderboard_id bytes not null
-      ├── expires_at int not null
-      ├── score int not null
-      ├── updated_at_inverse int not null
-      ├── id bytes not null
-      └── owner_id bytes not null
+ ├── INDEX test_idx
+ │    ├── leaderboard_id bytes not null
+ │    ├── expires_at int not null
+ │    ├── score int not null
+ │    ├── updated_at_inverse int not null
+ │    ├── id bytes not null
+ │    └── owner_id bytes not null
+ ├── CHECK (rank_value >= 0)
+ ├── CHECK (num_score >= 0)
+ ├── CHECK (length(metadata) < 16000)
+ ├── CHECK (ranked_at >= 0)
+ ├── CHECK (updated_at > 0)
+ ├── CHECK (updated_at > 0)
+ ├── CHECK (expires_at >= 0)
+ └── CHECK (expires_at >= 0)
 
 opt
 SELECT score, expires_at

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -469,6 +469,17 @@ func (ot *optTable) ensureColMap() {
 	}
 }
 
+// CheckCount is part of the cat.Table interface.
+func (ot *optTable) CheckCount() int {
+	return len(ot.desc.Checks)
+}
+
+// Check is part of the cat.Table interface.
+func (ot *optTable) Check(i int) cat.CheckConstraint {
+	check := ot.desc.Checks[i]
+	return cat.CheckConstraint(check.Expr)
+}
+
 // lookupColumnOrdinal returns the ordinal of the column with the given ID. A
 // cache makes the lookup O(1).
 func (ot *optTable) lookupColumnOrdinal(colID sqlbase.ColumnID) (int, error) {

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -867,11 +867,18 @@ func (ef *execFactory) ConstructShowTrace(typ tree.ShowTraceType, compact bool) 
 }
 
 func (ef *execFactory) ConstructInsert(
-	input exec.Node, table cat.Table, insertCols exec.ColumnOrdinalSet, rowsNeeded bool,
+	input exec.Node,
+	table cat.Table,
+	insertCols exec.ColumnOrdinalSet,
+	checks exec.CheckOrdinalSet,
+	rowsNeeded bool,
 ) (exec.Node, error) {
 	// Derive insert table and column descriptors.
 	tabDesc := table.(*optTable).desc
 	colDescs := makeColDescList(table, insertCols)
+
+	// Construct the check helper if there are any check constraints.
+	checkHelper := sqlbase.NewInputCheckHelper(checks, tabDesc)
 
 	// Determine the foreign key tables involved in the update.
 	fkTables, err := row.MakeFkMetadata(
@@ -881,6 +888,7 @@ func (ef *execFactory) ConstructInsert(
 		ef.planner.LookupTableByID,
 		ef.planner.CheckPrivilege,
 		ef.planner.analyzeExpr,
+		checkHelper,
 	)
 	if err != nil {
 		return nil, err
@@ -909,7 +917,7 @@ func (ef *execFactory) ConstructInsert(
 		columns: returnCols,
 		run: insertRun{
 			ti:          tableInserter{ri: ri},
-			checkHelper: fkTables[tabDesc.ID].CheckHelper,
+			checkHelper: checkHelper,
 			rowsNeeded:  rowsNeeded,
 			iVarContainerForComputedCols: sqlbase.RowIndexedVarContainer{
 				Cols:    tabDesc.Columns,
@@ -932,7 +940,12 @@ func (ef *execFactory) ConstructInsert(
 }
 
 func (ef *execFactory) ConstructUpdate(
-	input exec.Node, table cat.Table, fetchCols, updateCols exec.ColumnOrdinalSet, rowsNeeded bool,
+	input exec.Node,
+	table cat.Table,
+	fetchCols exec.ColumnOrdinalSet,
+	updateCols exec.ColumnOrdinalSet,
+	checks exec.CheckOrdinalSet,
+	rowsNeeded bool,
 ) (exec.Node, error) {
 	// Derive table and column descriptors.
 	tabDesc := table.(*optTable).desc
@@ -947,6 +960,9 @@ func (ef *execFactory) ConstructUpdate(
 		sourceSlots[i] = scalarSlot{column: updateColDescs[i], sourceIndex: len(fetchColDescs) + i}
 	}
 
+	// Construct the check helper if there are any check constraints.
+	checkHelper := sqlbase.NewInputCheckHelper(checks, tabDesc)
+
 	// Determine the foreign key tables involved in the update.
 	fkTables, err := row.MakeFkMetadata(
 		ef.planner.extendedEvalCtx.Context,
@@ -955,6 +971,7 @@ func (ef *execFactory) ConstructUpdate(
 		ef.planner.LookupTableByID,
 		ef.planner.CheckPrivilege,
 		ef.planner.analyzeExpr,
+		checkHelper,
 	)
 	if err != nil {
 		return nil, err
@@ -1000,7 +1017,7 @@ func (ef *execFactory) ConstructUpdate(
 		columns: returnCols,
 		run: updateRun{
 			tu:          tableUpdater{ru: ru},
-			checkHelper: fkTables[tabDesc.ID].CheckHelper,
+			checkHelper: checkHelper,
 			rowsNeeded:  rowsNeeded,
 			iVarContainerForComputedCols: sqlbase.RowIndexedVarContainer{
 				CurSourceRow: make(tree.Datums, len(ru.FetchCols)),
@@ -1032,6 +1049,7 @@ func (ef *execFactory) ConstructUpsert(
 	insertCols exec.ColumnOrdinalSet,
 	fetchCols exec.ColumnOrdinalSet,
 	updateCols exec.ColumnOrdinalSet,
+	checks exec.CheckOrdinalSet,
 	rowsNeeded bool,
 ) (exec.Node, error) {
 	// Derive table and column descriptors.
@@ -1048,6 +1066,9 @@ func (ef *execFactory) ConstructUpsert(
 		fkCheckType = row.CheckUpdates
 	}
 
+	// Construct the check helper if there are any check constraints.
+	checkHelper := sqlbase.NewInputCheckHelper(checks, tabDesc)
+
 	// Determine the foreign key tables involved in the upsert.
 	fkTables, err := row.MakeFkMetadata(
 		ef.planner.extendedEvalCtx.Context,
@@ -1056,6 +1077,7 @@ func (ef *execFactory) ConstructUpsert(
 		ef.planner.LookupTableByID,
 		ef.planner.CheckPrivilege,
 		ef.planner.analyzeExpr,
+		checkHelper,
 	)
 	if err != nil {
 		return nil, err
@@ -1109,7 +1131,7 @@ func (ef *execFactory) ConstructUpsert(
 		source:  input.(planNode),
 		columns: returnCols,
 		run: upsertRun{
-			checkHelper: fkTables[tabDesc.ID].CheckHelper,
+			checkHelper: checkHelper,
 			insertCols:  insertColDescs,
 			iVarContainerForComputedCols: sqlbase.RowIndexedVarContainer{
 				Cols:    tabDesc.Columns,
@@ -1157,6 +1179,7 @@ func (ef *execFactory) ConstructDelete(
 		ef.planner.LookupTableByID,
 		ef.planner.CheckPrivilege,
 		ef.planner.analyzeExpr,
+		nil, /* checkHelper */
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/row/cascader.go
+++ b/pkg/sql/row/cascader.go
@@ -1203,11 +1203,13 @@ func (c *cascader) cascadeAll(
 			}
 			// Now check all check constraints for the table.
 			checkHelper := c.fkTables[tableID].CheckHelper
-			if err := checkHelper.LoadRow(rowUpdater.UpdateColIDtoRowIndex, updatedRows.At(0), false); err != nil {
-				return err
-			}
-			if err := checkHelper.Check(c.evalCtx); err != nil {
-				return err
+			if checkHelper != nil {
+				if err := checkHelper.LoadEvalRow(rowUpdater.UpdateColIDtoRowIndex, updatedRows.At(0), false); err != nil {
+					return err
+				}
+				if err := checkHelper.CheckEval(c.evalCtx); err != nil {
+					return err
+				}
 			}
 			continue
 		}
@@ -1244,11 +1246,13 @@ func (c *cascader) cascadeAll(
 			}
 			// Now check all check constraints for the table.
 			checkHelper := c.fkTables[tableID].CheckHelper
-			if err := checkHelper.LoadRow(rowUpdater.UpdateColIDtoRowIndex, finalRow, false); err != nil {
-				return err
-			}
-			if err := checkHelper.Check(c.evalCtx); err != nil {
-				return err
+			if checkHelper != nil {
+				if err := checkHelper.LoadEvalRow(rowUpdater.UpdateColIDtoRowIndex, finalRow, false); err != nil {
+					return err
+				}
+				if err := checkHelper.CheckEval(c.evalCtx); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/sql/row/fk_test.go
+++ b/pkg/sql/row/fk_test.go
@@ -190,7 +190,8 @@ func TestMakeFkMetadata(t *testing.T) {
 			usage,
 			lookup,
 			NoCheckPrivilege,
-			nil, /* AnalyzeExprFunction */
+			nil, /* analyzeExpr */
+			nil, /* checkHelper */
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/sql/tablewriter_upsert.go
+++ b/pkg/sql/tablewriter_upsert.go
@@ -530,7 +530,7 @@ func (tu *tableUpserter) updateConflictingRow(
 	checkHelper := tu.fkTables[tableDesc.ID].CheckHelper
 
 	// Do we need to (re-)compute computed columns or CHECK expressions?
-	if tu.anyComputed || len(checkHelper.Exprs) > 0 {
+	if tu.anyComputed || checkHelper != nil {
 		// For computed columns, the goal for the following code appends
 		// the computed columns at the end of updateValues.
 		// For CHECK constraints, the goal of the following code
@@ -564,7 +564,7 @@ func (tu *tableUpserter) updateConflictingRow(
 			return nil, err
 		}
 
-		if len(checkHelper.Exprs) > 0 {
+		if checkHelper != nil {
 			// If there are CHECK expressions, we must add the computed
 			// columns to the input row.
 
@@ -574,10 +574,10 @@ func (tu *tableUpserter) updateConflictingRow(
 			}
 
 			// Check CHECK constraints.
-			if err := checkHelper.LoadRow(tu.ru.FetchColIDtoRowIndex, newValues, false); err != nil {
+			if err := checkHelper.LoadEvalRow(tu.ru.FetchColIDtoRowIndex, newValues, false); err != nil {
 				return nil, err
 			}
-			if err := checkHelper.Check(tu.evalCtx); err != nil {
+			if err := checkHelper.CheckEval(tu.evalCtx); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -433,8 +433,10 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			for i, dexpr := range n.run.defaultExprs {
 				v.metadataExpr(name, "default", i, dexpr)
 			}
-			for i, cexpr := range n.run.checkHelper.Exprs {
-				v.metadataExpr(name, "check", i, cexpr)
+			if n.run.checkHelper != nil {
+				for i, cexpr := range n.run.checkHelper.Exprs {
+					v.metadataExpr(name, "check", i, cexpr)
+				}
 			}
 		}
 		n.source = v.visit(n.source)
@@ -459,8 +461,10 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			for i, dexpr := range n.run.defaultExprs {
 				v.metadataExpr(name, "default", i, dexpr)
 			}
-			for i, cexpr := range n.run.checkHelper.Exprs {
-				v.metadataExpr(name, "check", i, cexpr)
+			if n.run.checkHelper != nil {
+				for i, cexpr := range n.run.checkHelper.Exprs {
+					v.metadataExpr(name, "check", i, cexpr)
+				}
 			}
 			n.run.tw.walkExprs(func(d string, i int, e tree.TypedExpr) {
 				v.metadataExpr(name, d, i, e)
@@ -487,8 +491,10 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			for i, cexpr := range n.run.computeExprs {
 				v.metadataExpr(name, "computed", i, cexpr)
 			}
-			for i, cexpr := range n.run.checkHelper.Exprs {
-				v.metadataExpr(name, "check", i, cexpr)
+			if n.run.checkHelper != nil {
+				for i, cexpr := range n.run.checkHelper.Exprs {
+					v.metadataExpr(name, "check", i, cexpr)
+				}
 			}
 		}
 		// An updater has no sub-expressions, so nothing special to do here.


### PR DESCRIPTION
Check constraints are user-defined expressions that restrict the values
in each row of a table. For example:

  CREATE TABLE abc (a INT CHECK (a > 0))

If a row is inserted or updated, this check constraint ensures that the
value of column "a" will always be positive.

This commit adds support for check constraints to the cost-based optimizer
by appending boolean columns to the input expression of each mutation
operator, one for each check constraint defined on the table. The SQL
execution operators will then check these columns at runtime; if any
value is false, it will report a constraint violation error.

Incorporating check constraints into the input expression allows the
constraint expressions to be globally optimized. For example, if an
INSERT expression inserts constant values, then a check constraint
might be validated statically, at compile-time.
