### PR TITLE
Update setup/install instructions for roachprod and roachtest

### DIFF
--- a/pkg/cmd/roachprod/README.md
+++ b/pkg/cmd/roachprod/README.md
@@ -5,15 +5,11 @@ CockroachDB clusters. Use at your own risk! ⚠️
 
 ## Setup
 
-Make sure you have [gcloud installed] and configured (`gcloud auth list` to
+1. Make sure you have [gcloud installed] and configured (`gcloud auth list` to
 check, `gcloud auth login` to authenticate). You may want to update old
 installations (`gcloud components update`).
-
-To build and install into `$GOPATH/bin`:
-
-```
-$ go get -u github.com/cockroachdb/roachprod
-```
+1. Build a local binary of `roachprod`: `make bin/roachprod`
+1. Add `$PWD/bin` to your `PATH` so you can run `roachprod` from the root directory of `cockroach`.
 
 ## Summary
 
@@ -74,6 +70,7 @@ Warning: this reference is incomplete. Be prepared to refer to the CLI help text
 and the source code.
 
 ### Create a cluster
+
 ```
 $ roachprod create foo
 Creating cluster marc-foo with 3 nodes
@@ -86,6 +83,7 @@ Syncing...
 ```
 
 ### Interact using crl-prod tools
+
 `roachprod` populates hosts files in `~/.roachprod/hosts`. These are used by
 `crl-prod` tools to map clusters to node addresses.
 
@@ -118,6 +116,7 @@ marc-foo: status 3/3
 ```
 
 ### SSH into hosts
+
 `roachprod` uses `gcloud` to sync the list of hostnames to `~/.ssh/config` and
 set up keys.
 
@@ -126,6 +125,7 @@ $ ssh marc-foo-0000.us-east1-b.cockroach-ephemeral
 ```
 
 ### List clusters
+
 ```
 $ roachprod list
 marc-foo: 23h58m27s remaining
@@ -136,6 +136,7 @@ Syncing...
 ```
 
 ### Destroy cluster
+
 ```
 $ roachprod destroy marc-foo
 Destroying cluster marc-foo with 3 nodes

--- a/pkg/cmd/roachtest/README.md
+++ b/pkg/cmd/roachtest/README.md
@@ -4,14 +4,12 @@
 automated tests. It relies on the concurrently-developed (but
 separate) tool `roachprod`.
 
-# Prerequisites
+# Setup
 
-- Ensure that `$GOPATH/bin` is on your `PATH`.
-- Install roachprod: `go get -u github.com/cockroachdb/roachprod`
-- Build a linux release binary of `cockroach`: `build/builder.sh mkrelease amd64-linux-gnu`
-- Build a linux binary of the `workload` tool: `build/builder.sh make bin/workload`
-- Build a local binary of `roachtest`: `make bin/roachtest`
-- Set up `gcloud` and `google_compute_engine` ssh key (TODO: more details)
+1. [Set up `roachprod`](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachprod/README.md), if you haven't already. This includes making sure `$PWD/bin` is on your `PATH` and `gcloud` is installed and properly configured.
+1. Build a linux release binary of `cockroach`: `build/builder.sh mkrelease amd64-linux-gnu`
+1. Build a linux binary of the `workload` tool: `build/builder.sh make bin/workload`
+1. Build a local binary of `roachtest`: `make bin/roachtest`
 
 # Usage
 
@@ -22,13 +20,16 @@ your gcloud/`@cockroachlabs.com` username, you'll need to add
 `--user=$CRL_USERNAME` to the `roachtest` command. For non-Cockroach
 Labs employees, set `--gce-project` (and maybe `--user` too).
 
+If `$PWD/bin` isn't on your `PATH`, you'll need to add `--roachprod=<path-to-roachprod>`
+to the `roachtest` command.
+
 ```shell
-bin/roachtest run jepsen/1/bank/split
+roachtest run jepsen/1/bank/split
 ```
 
 While iterating, don't forget to rebuild whichever of the above
-binaries you've touched. For example, the command line that I use
+binaries you've touched. For example, the command line that you might use
 while iterating on jepsen tests is `make bin/roachtest &&
-PATH=~/go/bin:$PATH bin/roachtest run --user=ben jepsen/1/bank/split`
+roachtest run jepsen/1/bank/split`
 
 TODO: document process for creating and reusing a cluster.


### PR DESCRIPTION
The instructions were out-dated, from a time when `roachprod` wasn't a package in the `cockroach` repo, when you had to `go get` it. That's no longer the way. 
  
Release note: None