### PR TITLE
release-2.1: sql: allow specifying scan direction in index hint

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index_flags
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_flags
@@ -15,7 +15,6 @@ statement ok
 INSERT INTO abcd VALUES (10, 11, 12, 13), (20, 21, 22, 23), (30, 31, 32, 33), (40, 41, 42, 43)
 
 # No hint
-
 query IIII rowsort
 SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ----
@@ -23,23 +22,34 @@ SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 30 31 32 33
 
 # Force primary
-
 query IIII rowsort
 SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 ----
 20 21 22 23
 30 31 32 33
 
-# Force index b
+# Force primary, reverse scan.
+query IIII rowsort
+SELECT * FROM abcd@{FORCE_INDEX=primary,DESC} WHERE a >= 20 AND a <= 30
+----
+20 21 22 23
+30 31 32 33
 
+# Force index b
 query IIII rowsort
 SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
 20 21 22 23
 30 31 32 33
 
-# Force index cd
+# Force index b, reverse scan.
+query IIII rowsort
+SELECT * FROM abcd@{FORCE_INDEX=b,DESC} WHERE a >= 20 AND a <= 30
+----
+20 21 22 23
+30 31 32 33
 
+# Force index cd
 query IIII rowsort
 SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
@@ -47,7 +57,6 @@ SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 30 31 32 33
 
 # Force index bcd
-
 query IIII rowsort
 SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
@@ -55,7 +64,6 @@ SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 30 31 32 33
 
 # Force index b (covering)
-
 query I rowsort
 SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
@@ -63,22 +71,19 @@ SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 31
 
 # Force index b (non-covering due to WHERE clause)
-
 query I rowsort
 SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
 21
 
 # No hint, should be using index cd
-
 query II rowsort
 SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ----
 22 23
 32 33
 
-# Force no index
-
+# Force primary index
 query II rowsort
 SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
@@ -86,7 +91,6 @@ SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 32 33
 
 # Force index b
-
 query II rowsort
 SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----

--- a/pkg/sql/logictest/testdata/planner_test/select_index_flags
+++ b/pkg/sql/logictest/testdata/planner_test/select_index_flags
@@ -12,7 +12,6 @@ CREATE TABLE abcd (
 )
 
 # No hint
-
 query TTT
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ----
@@ -21,7 +20,6 @@ scan  ·      ·
 ·     spans  /20-/30/#
 
 # Force primary
-
 query TTT
 EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 ----
@@ -29,8 +27,15 @@ scan  ·      ·
 ·     table  abcd@primary
 ·     spans  /20-/30/#
 
-# Force index b
+# Force primary, reverse scan.
+query TTT
+EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=primary,DESC} WHERE a >= 20 AND a <= 30
+----
+revscan  ·      ·
+·        table  abcd@primary
+·        spans  /20-/30/#
 
+# Force index b
 query TTT
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
@@ -42,8 +47,19 @@ index-join  ·       ·
  └── scan   ·       ·
 ·           table   abcd@primary
 
-# Force index cd
+# Force index b, reverse scan.
+query TTT
+EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} WHERE a >= 20 AND a <= 30
+----
+index-join    ·       ·
+ ├── revscan  ·       ·
+ │            table   abcd@b
+ │            spans   ALL
+ │            filter  (a >= 20) AND (a <= 30)
+ └── scan     ·       ·
+·             table   abcd@primary
 
+# Force index cd
 query TTT
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
@@ -56,7 +72,6 @@ index-join  ·       ·
 ·           table   abcd@primary
 
 # Force index bcd
-
 query TTT
 EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
@@ -66,7 +81,6 @@ scan  ·       ·
 ·     filter  (a >= 20) AND (a <= 30)
 
 # Force index b (covering)
-
 query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
@@ -77,7 +91,6 @@ render     ·       ·
 ·          filter  (a >= 20) AND (a <= 30)
 
 # Force index b (non-covering due to WHERE clause)
-
 query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
@@ -91,7 +104,6 @@ render           ·       ·
 ·                filter  (c >= 20) AND (c <= 30)
 
 # No hint, should be using index cd
-
 query TTT
 EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ----
@@ -100,8 +112,7 @@ render     ·      ·
 ·          table  abcd@cd
 ·          spans  /20-/40
 
-# Force no index
-
+# Force primary index
 query TTT
 EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
@@ -112,7 +123,6 @@ render     ·       ·
 ·          filter  (c >= 20) AND (c < 40)
 
 # Force index b
-
 query TTT
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -12,7 +12,6 @@ CREATE TABLE abcd (
 )
 
 # No hint
-
 query TTT
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ----
@@ -20,8 +19,15 @@ scan  ·      ·
 ·     table  abcd@primary
 ·     spans  /20-/30/#
 
-# Force primary
+# No hint, reverse scan.
+query TTT
+EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30 ORDER BY a DESC
+----
+revscan  ·      ·
+·        table  abcd@primary
+·        spans  /20-/30/#
 
+# Force primary
 query TTT
 EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 ----
@@ -29,8 +35,34 @@ scan  ·      ·
 ·     table  abcd@primary
 ·     spans  /20-/30/#
 
-# Force index b
 
+# Force primary, reverse scan.
+query TTT
+EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=primary,DESC} WHERE a >= 20 AND a <= 30
+----
+revscan  ·      ·
+·        table  abcd@primary
+·        spans  /20-/30/#
+
+# Force primary, allow reverse scan.
+query TTT
+EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30 ORDER BY a DESC
+----
+revscan  ·      ·
+·        table  abcd@primary
+·        spans  /20-/30/#
+
+# Force primary, forward scan.
+query TTT
+EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=primary,ASC} WHERE a >= 20 AND a <= 30 ORDER BY a DESC
+----
+sort       ·      ·
+ │         order  -a
+ └── scan  ·      ·
+·          table  abcd@primary
+·          spans  /20-/30/#
+
+# Force index b
 query TTT
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
@@ -43,8 +75,60 @@ filter           ·       ·
       └── scan   ·       ·
 ·                table   abcd@primary
 
-# Force index cd
+# Force index b, reverse scan.
+query TTT
+EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} WHERE a >= 20 AND a <= 30
+----
+filter             ·       ·
+ │                 filter  (a >= 20) AND (a <= 30)
+ └── index-join    ·       ·
+      ├── revscan  ·       ·
+      │            table   abcd@b
+      │            spans   ALL
+      └── scan     ·       ·
+·                  table   abcd@primary
 
+# Force index b, allowing reverse scan.
+query TTT
+EXPLAIN SELECT * FROM abcd@b ORDER BY b DESC LIMIT 5
+----
+index-join    ·      ·
+ ├── revscan  ·      ·
+ │            table  abcd@b
+ │            spans  ALL
+ │            limit  5
+ └── scan     ·      ·
+·             table  abcd@primary
+
+# Force index b, reverse scan.
+query TTT
+EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} ORDER BY b DESC LIMIT 5
+----
+index-join    ·      ·
+ ├── revscan  ·      ·
+ │            table  abcd@b
+ │            spans  ALL
+ │            limit  5
+ └── scan     ·      ·
+·             table  abcd@primary
+
+
+# Force index b, forward scan.
+query TTT
+EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,ASC} ORDER BY b DESC LIMIT 5
+----
+limit                 ·      ·
+ │                    count  5
+ └── sort             ·      ·
+      │               order  -b
+      └── index-join  ·      ·
+           ├── scan   ·      ·
+           │          table  abcd@b
+           │          spans  ALL
+           └── scan   ·      ·
+·                     table  abcd@primary
+
+# Force index cd
 query TTT
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
@@ -58,7 +142,6 @@ filter           ·       ·
 ·                table   abcd@primary
 
 # Force index bcd
-
 query TTT
 EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
@@ -68,7 +151,6 @@ scan  ·       ·
 ·     filter  (a >= 20) AND (a <= 30)
 
 # Force index b (covering)
-
 query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
@@ -79,7 +161,6 @@ render     ·       ·
 ·          filter  (a >= 20) AND (a <= 30)
 
 # Force index b (non-covering due to WHERE clause)
-
 query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
@@ -94,7 +175,6 @@ render                ·       ·
 ·                     table   abcd@primary
 
 # No hint, should be using index cd
-
 query TTT
 EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ----
@@ -102,8 +182,7 @@ scan  ·      ·
 ·     table  abcd@cd
 ·     spans  /20-/40
 
-# Force no index
-
+# Force primary index
 query TTT
 EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
@@ -113,7 +192,6 @@ scan  ·       ·
 ·     filter  (c >= 20) AND (c < 40)
 
 # Force index b
-
 query TTT
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----

--- a/pkg/sql/opt/memo/expr_view_format.go
+++ b/pkg/sql/opt/memo/expr_view_format.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
@@ -217,7 +218,15 @@ func (ev ExprView) formatRelational(f *ExprFmtCtx, tp treeprinter.Node) {
 				tp.Childf("flags: no-index-join")
 			} else if def.Flags.ForceIndex {
 				idx := ev.Metadata().Table(def.Table).Index(def.Flags.Index)
-				tp.Childf("flags: force-index=%s", idx.IdxName())
+				dir := ""
+				switch def.Flags.Direction {
+				case tree.DefaultDirection:
+				case tree.Ascending:
+					dir = ",fwd"
+				case tree.Descending:
+					dir = ",rev"
+				}
+				tp.Childf("flags: force-index=%s%s", idx.IdxName(), dir)
 			}
 		}
 

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -153,6 +153,7 @@ type ScanFlags struct {
 	// ForceIndex forces the use of a specific index (specified in Index).
 	// ForceIndex and NoIndexJoin cannot both be set at the same time.
 	ForceIndex bool
+	Direction  tree.Direction
 	Index      int
 }
 
@@ -205,7 +206,13 @@ func (s *ScanOpDef) CanProvideOrdering(
 		if s.HardLimit.Reverse() {
 			direction = rev
 		}
+	} else if s.Flags.Direction != 0 {
+		direction = fwd
+		if s.Flags.Direction == tree.Descending {
+			direction = rev
+		}
 	}
+
 	index := md.Table(s.Table).Index(s.Index)
 	for left, right := 0, 0; right < len(required.Columns); {
 		if left >= index.KeyColumnCount() {

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -329,6 +329,7 @@ func (b *Builder) buildScan(
 				}
 				def.Flags.ForceIndex = true
 				def.Flags.Index = idx
+				def.Flags.Direction = indexFlags.Direction
 			}
 		}
 

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -352,6 +352,43 @@ TABLE xyzw
       ├── y int
       └── x int not null
 
+# SELECT with index hints.
+
+build
+SELECT * FROM xyzw@primary
+----
+scan xyzw
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ └── flags: force-index=primary
+
+build
+SELECT * FROM xyzw@foo
+----
+scan xyzw
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ └── flags: force-index=foo
+
+build
+SELECT * FROM xyzw@{FORCE_INDEX=foo,ASC}
+----
+scan xyzw
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ └── flags: force-index=foo,fwd
+
+build
+SELECT * FROM xyzw@{FORCE_INDEX=foo,DESC}
+----
+scan xyzw,rev
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ └── flags: force-index=foo,rev
+
+build
+SELECT * FROM xyzw@{NO_INDEX_JOIN}
+----
+scan xyzw
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ └── flags: no-index-join
+
 build
 SELECT * FROM xyzw LIMIT x
 ----

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -197,3 +197,243 @@ limit
  │              ├── key: (1)
  │              └── fd: (1)-->(2)
  └── const: 5 [type=int]
+
+exec-ddl
+CREATE TABLE abcd (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  INDEX b (b),
+  INDEX cd (c,d),
+  UNIQUE INDEX bcd (b,c,d)
+)
+----
+TABLE abcd
+ ├── a int not null
+ ├── b int
+ ├── c int
+ ├── d int
+ ├── INDEX primary
+ │    └── a int not null
+ ├── INDEX b
+ │    ├── b int
+ │    └── a int not null
+ ├── INDEX cd
+ │    ├── c int
+ │    ├── d int
+ │    └── a int not null
+ └── INDEX bcd
+      ├── b int
+      ├── c int
+      ├── d int
+      └── a int not null (storing)
+
+opt
+EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30 ORDER BY b DESC LIMIT 5
+----
+explain
+ ├── columns: tree:5(string) field:6(string) description:7(string)
+ └── limit
+      ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+      ├── internal-ordering: -2
+      ├── cardinality: [0 - 5]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4), (2-4)~~>(1)
+      ├── ordering: -2
+      ├── sort
+      │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+      │    ├── ordering: -2
+      │    └── select
+      │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+      │         ├── key: (1)
+      │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
+      │         ├── index-join abcd
+      │         │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+      │         │    ├── key: (1)
+      │         │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+      │         │    └── scan abcd@b
+      │         │         ├── columns: a:1(int!null) b:2(int)
+      │         │         ├── flags: force-index=b
+      │         │         ├── key: (1)
+      │         │         └── fd: (1)-->(2)
+      │         └── filters [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
+      │              ├── a >= 20 [type=bool, outer=(1), constraints=(/1: [/20 - ]; tight)]
+      │              └── a <= 30 [type=bool, outer=(1), constraints=(/1: (/NULL - /30]; tight)]
+      └── const: 5 [type=int]
+
+optsteps
+EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30 ORDER BY b DESC LIMIT 5
+----
+================================================================================
+Initial expression
+  Cost: 10000000000000000159028911097599180468360808563945281389781327557747838772170381060813469985856815104.00
+================================================================================
+  explain
+   ├── columns: tree:5(string) field:6(string) description:7(string)
+   └── sort
+        ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+        ├── cardinality: [0 - 5]
+        ├── key: (1)
+        ├── fd: (1)-->(2-4), (2-4)~~>(1)
+        ├── ordering: -2
+        └── limit
+             ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+             ├── internal-ordering: -2
+             ├── cardinality: [0 - 5]
+             ├── key: (1)
+             ├── fd: (1)-->(2-4), (2-4)~~>(1)
+             ├── sort
+             │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+             │    ├── key: (1)
+             │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+             │    ├── ordering: -2
+             │    └── select
+             │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+             │         ├── key: (1)
+             │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
+             │         ├── scan abcd
+             │         │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+             │         │    ├── flags: force-index=b
+             │         │    ├── key: (1)
+             │         │    └── fd: (1)-->(2-4), (2-4)~~>(1)
+             │         └── filters [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
+             │              └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
+             └── const: 5 [type=int]
+================================================================================
+SimplifyFilters
+  Cost: 10000000000000000159028911097599180468360808563945281389781327557747838772170381060813469985856815104.00
+================================================================================
+   explain
+    ├── columns: tree:5(string) field:6(string) description:7(string)
+    └── sort
+         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+         ├── cardinality: [0 - 5]
+         ├── key: (1)
+         ├── fd: (1)-->(2-4), (2-4)~~>(1)
+         ├── ordering: -2
+         └── limit
+              ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+              ├── internal-ordering: -2
+              ├── cardinality: [0 - 5]
+              ├── key: (1)
+              ├── fd: (1)-->(2-4), (2-4)~~>(1)
+              ├── sort
+              │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+              │    ├── key: (1)
+              │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+              │    ├── ordering: -2
+              │    └── select
+              │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+              │         ├── key: (1)
+              │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
+              │         ├── scan abcd
+              │         │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+              │         │    ├── flags: force-index=b
+              │         │    ├── key: (1)
+              │         │    └── fd: (1)-->(2-4), (2-4)~~>(1)
+              │         └── filters [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
+  -           │              └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
+  +           │              ├── a >= 20 [type=bool, outer=(1), constraints=(/1: [/20 - ]; tight)]
+  +           │              └── a <= 30 [type=bool, outer=(1), constraints=(/1: (/NULL - /30]; tight)]
+              └── const: 5 [type=int]
+================================================================================
+GenerateIndexScans
+  Cost: 5141.03
+================================================================================
+   explain
+    ├── columns: tree:5(string) field:6(string) description:7(string)
+  - └── sort
+  + └── limit
+         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  +      ├── internal-ordering: -2
+         ├── cardinality: [0 - 5]
+         ├── key: (1)
+         ├── fd: (1)-->(2-4), (2-4)~~>(1)
+         ├── ordering: -2
+  -      └── limit
+  -           ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  -           ├── internal-ordering: -2
+  -           ├── cardinality: [0 - 5]
+  -           ├── key: (1)
+  -           ├── fd: (1)-->(2-4), (2-4)~~>(1)
+  -           ├── sort
+  -           │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  -           │    ├── key: (1)
+  -           │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+  -           │    ├── ordering: -2
+  -           │    └── select
+  -           │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  -           │         ├── key: (1)
+  -           │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
+  -           │         ├── scan abcd
+  -           │         │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  -           │         │    ├── flags: force-index=b
+  -           │         │    ├── key: (1)
+  -           │         │    └── fd: (1)-->(2-4), (2-4)~~>(1)
+  -           │         └── filters [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
+  -           │              ├── a >= 20 [type=bool, outer=(1), constraints=(/1: [/20 - ]; tight)]
+  -           │              └── a <= 30 [type=bool, outer=(1), constraints=(/1: (/NULL - /30]; tight)]
+  -           └── const: 5 [type=int]
+  +      ├── sort
+  +      │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  +      │    ├── key: (1)
+  +      │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+  +      │    ├── ordering: -2
+  +      │    └── select
+  +      │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  +      │         ├── key: (1)
+  +      │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
+  +      │         ├── index-join abcd
+  +      │         │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+  +      │         │    ├── key: (1)
+  +      │         │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+  +      │         │    └── scan abcd@b
+  +      │         │         ├── columns: a:1(int!null) b:2(int)
+  +      │         │         ├── flags: force-index=b
+  +      │         │         ├── key: (1)
+  +      │         │         └── fd: (1)-->(2)
+  +      │         └── filters [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
+  +      │              ├── a >= 20 [type=bool, outer=(1), constraints=(/1: [/20 - ]; tight)]
+  +      │              └── a <= 30 [type=bool, outer=(1), constraints=(/1: (/NULL - /30]; tight)]
+  +      └── const: 5 [type=int]
+--------------------------------------------------------------------------------
+GenerateConstrainedScans (no changes)
+--------------------------------------------------------------------------------
+================================================================================
+Final best expression
+  Cost: 5141.03
+================================================================================
+  explain
+   ├── columns: tree:5(string) field:6(string) description:7(string)
+   └── limit
+        ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+        ├── internal-ordering: -2
+        ├── cardinality: [0 - 5]
+        ├── key: (1)
+        ├── fd: (1)-->(2-4), (2-4)~~>(1)
+        ├── ordering: -2
+        ├── sort
+        │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+        │    ├── key: (1)
+        │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+        │    ├── ordering: -2
+        │    └── select
+        │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+        │         ├── key: (1)
+        │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
+        │         ├── index-join abcd
+        │         │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+        │         │    ├── key: (1)
+        │         │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+        │         │    └── scan abcd@b
+        │         │         ├── columns: a:1(int!null) b:2(int)
+        │         │         ├── flags: force-index=b
+        │         │         ├── key: (1)
+        │         │         └── fd: (1)-->(2)
+        │         └── filters [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
+        │              ├── a >= 20 [type=bool, outer=(1), constraints=(/1: [/20 - ]; tight)]
+        │              └── a <= 30 [type=bool, outer=(1), constraints=(/1: (/NULL - /30]; tight)]
+        └── const: 5 [type=int]

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -111,8 +111,9 @@ func (p *planner) selectIndex(
 		// An explicit secondary index was requested. Only add it to the candidate
 		// indexes list.
 		candidates = append(candidates, &indexInfo{
-			desc:  s.desc,
-			index: s.specifiedIndex,
+			desc:    s.desc,
+			index:   s.specifiedIndex,
+			reverse: s.specifiedIndexReverse,
 		})
 	} else {
 		candidates = append(candidates, &indexInfo{

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -629,6 +629,8 @@ func TestParse(t *testing.T) {
 		{`SELECT 'a' FROM t@primary`},
 		{`SELECT 'a' FROM t@like`},
 		{`SELECT 'a' FROM t@{NO_INDEX_JOIN}`},
+		{`SELECT 'a' FROM t@{FORCE_INDEX=idx,ASC}`},
+		{`SELECT 'a' FROM t@{FORCE_INDEX=idx,DESC}`},
 		{`SELECT * FROM t AS "of" AS OF SYSTEM TIME '2016-01-01'`},
 
 		{`SELECT BOOL 'foo', 'foo'::BOOL`},
@@ -1272,6 +1274,7 @@ func TestParse2(t *testing.T) {
 		{`SELECT CAST(1 AS "_int8")`, `SELECT CAST(1 AS INT[])`},
 
 		{`SELECT 'a' FROM t@{FORCE_INDEX=bar}`, `SELECT 'a' FROM t@bar`},
+		{`SELECT 'a' FROM t@{ASC,FORCE_INDEX=idx}`, `SELECT 'a' FROM t@{FORCE_INDEX=idx,ASC}`},
 
 		{`SELECT 'a' FROM t@{FORCE_INDEX=[123]}`, `SELECT 'a' FROM t@[123]`},
 		{`SELECT 'a' FROM [123 AS t]@{FORCE_INDEX=[456]}`, `SELECT 'a' FROM [123 AS t]@[456]`},
@@ -2075,9 +2078,9 @@ SELECT a FROM foo@{FORCE_INDEX=bar,FORCE_INDEX=baz}
 		},
 		{
 			`SELECT a FROM foo@{FORCE_INDEX=bar,NO_INDEX_JOIN}`,
-			`FORCE_INDEX cannot be specified in conjunction with NO_INDEX_JOIN at or near "no_index_join"
+			`FORCE_INDEX cannot be specified in conjunction with NO_INDEX_JOIN at or near "}"
 SELECT a FROM foo@{FORCE_INDEX=bar,NO_INDEX_JOIN}
-                                   ^
+                                                ^
 `,
 		},
 		{
@@ -2085,6 +2088,20 @@ SELECT a FROM foo@{FORCE_INDEX=bar,NO_INDEX_JOIN}
 			`NO_INDEX_JOIN specified multiple times at or near "no_index_join"
 SELECT a FROM foo@{NO_INDEX_JOIN,NO_INDEX_JOIN}
                                  ^
+`,
+		},
+		{
+			`SELECT a FROM foo@{ASC}`,
+			`ASC/DESC must be specified in conjunction with an index at or near "}"
+SELECT a FROM foo@{ASC}
+                      ^
+`,
+		},
+		{
+			`SELECT a FROM foo@{DESC}`,
+			`ASC/DESC must be specified in conjunction with an index at or near "}"
+SELECT a FROM foo@{DESC}
+                       ^
 `,
 		},
 		{

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5653,6 +5653,16 @@ index_flags_param:
     /* SKIP DOC */
     $$.val = &tree.IndexFlags{IndexID: tree.IndexID($4.int64())}
   }
+| ASC
+  {
+    /* SKIP DOC */
+    $$.val = &tree.IndexFlags{Direction: tree.Ascending}
+  }
+| DESC
+  {
+    /* SKIP DOC */
+    $$.val = &tree.IndexFlags{Direction: tree.Descending}
+  }
 |
   NO_INDEX_JOIN
   {
@@ -5687,7 +5697,12 @@ opt_index_flags:
   }
 | '@' '{' index_flags_param_list '}'
   {
-    $$.val = $3.indexFlags()
+    flags := $3.indexFlags()
+    if err := flags.Check(); err != nil {
+      sqllex.Error(err.Error())
+      return 1
+    }
+    $$.val = flags
   }
 | /* EMPTY */
   {

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -44,7 +44,8 @@ type scanNode struct {
 	index *sqlbase.IndexDescriptor
 
 	// Set if an index was explicitly specified.
-	specifiedIndex *sqlbase.IndexDescriptor
+	specifiedIndex        *sqlbase.IndexDescriptor
+	specifiedIndexReverse bool
 	// Set if the NO_INDEX_JOIN hint was given.
 	noIndexJoin bool
 
@@ -344,6 +345,9 @@ func (n *scanNode) lookupSpecifiedIndex(indexFlags *tree.IndexFlags) error {
 		if n.specifiedIndex == nil {
 			return errors.Errorf("index [%d] not found", indexFlags.IndexID)
 		}
+	}
+	if indexFlags.Direction == tree.Descending {
+		n.specifiedIndexReverse = true
 	}
 	return nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #34075.

/cc @cockroachdb/release

---

We had a customer query where forcing reverse scan would have been helpful. I plan to backport to 2.1.

This change extends the `table@{FORCE_INDEX=idx}` syntax to
`tabel@{FORCE_INDEX=idx,DIRECTION}` where `DIRECTION` is either `ASC`
or `DESC`. When a direction is specified, that scan direction is
forced; otherwise the planner is free to choose either direction.

Release note (sql change): It is now possible to force a reverse scan
of a specific index using `table@{FORCE_INDEX=index,DESC}`.
