### PR TITLE
storage: fix various problems with dynamic replication factor

### DIFF
--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -121,6 +121,7 @@ func createTestNode(
 		st,
 		cfg.Gossip,
 		cfg.Clock,
+		cfg.NodeLiveness.GetNodeCount,
 		storage.MakeStorePoolNodeLivenessFunc(cfg.NodeLiveness),
 		/* deterministic */ false,
 	)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -334,6 +334,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		s.st,
 		s.gossip,
 		s.clock,
+		s.nodeLiveness.GetNodeCount,
 		storage.MakeStorePoolNodeLivenessFunc(s.nodeLiveness),
 		/* deterministic */ false,
 	)

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1230,7 +1230,7 @@ func (s *statusServer) Ranges(
 	}
 
 	isLiveMap := s.nodeLiveness.GetIsLiveMap()
-	availableNodes := s.storePool.AvailableNodeCount()
+	clusterNodes := s.storePool.ClusterNodeCount()
 
 	err = s.stores.VisitStores(func(store *storage.Store) error {
 		timestamp := store.Clock().Now()
@@ -1253,7 +1253,7 @@ func (s *statusServer) Ranges(
 							desc,
 							rep,
 							store.Ident.StoreID,
-							rep.Metrics(ctx, timestamp, isLiveMap, availableNodes),
+							rep.Metrics(ctx, timestamp, isLiveMap, clusterNodes),
 						))
 					return false, nil
 				})
@@ -1273,7 +1273,7 @@ func (s *statusServer) Ranges(
 					*desc,
 					rep,
 					store.Ident.StoreID,
-					rep.Metrics(ctx, timestamp, isLiveMap, availableNodes),
+					rep.Metrics(ctx, timestamp, isLiveMap, clusterNodes),
 				))
 		}
 		return nil

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -1157,12 +1157,9 @@ func computeQuorum(nodes int) int {
 
 // filterBehindReplicas removes any "behind" replicas from the supplied
 // slice. A "behind" replica is one which is not at or past the quorum commit
-// index. We forgive brandNewReplicaID for being behind, since a new range can
-// take a little while to fully catch up.
+// index.
 func filterBehindReplicas(
-	raftStatus *raft.Status,
-	replicas []roachpb.ReplicaDescriptor,
-	brandNewReplicaID roachpb.ReplicaID,
+	raftStatus *raft.Status, replicas []roachpb.ReplicaDescriptor,
 ) []roachpb.ReplicaDescriptor {
 	if raftStatus == nil || len(raftStatus.Progress) == 0 {
 		// raftStatus.Progress is only populated on the Raft leader which means we
@@ -1172,7 +1169,7 @@ func filterBehindReplicas(
 	}
 	candidates := make([]roachpb.ReplicaDescriptor, 0, len(replicas))
 	for _, r := range replicas {
-		if !replicaIsBehind(raftStatus, r.ReplicaID) || r.ReplicaID == brandNewReplicaID {
+		if !replicaIsBehind(raftStatus, r.ReplicaID) {
 			candidates = append(candidates, r)
 		}
 	}
@@ -1198,13 +1195,20 @@ func replicaIsBehind(raftStatus *raft.Status, replicaID roachpb.ReplicaID) bool 
 	return true
 }
 
+// simulateFilterUnremovableReplicas removes any unremovable replicas from the
+// supplied slice. Unlike filterUnremovableReplicas, brandNewReplicaID is
+// considered up-to-date (and thus can participiate in quorum), but is not
+// considered a candidate for removal.
 func simulateFilterUnremovableReplicas(
 	raftStatus *raft.Status,
 	replicas []roachpb.ReplicaDescriptor,
 	brandNewReplicaID roachpb.ReplicaID,
 ) []roachpb.ReplicaDescriptor {
 	status := *raftStatus
-	status.Progress[uint64(brandNewReplicaID)] = raft.Progress{Match: 0}
+	status.Progress[uint64(brandNewReplicaID)] = raft.Progress{
+		State: raft.ProgressStateReplicate,
+		Match: status.Commit,
+	}
 	return filterUnremovableReplicas(&status, replicas, brandNewReplicaID)
 }
 
@@ -1219,20 +1223,34 @@ func filterUnremovableReplicas(
 	replicas []roachpb.ReplicaDescriptor,
 	brandNewReplicaID roachpb.ReplicaID,
 ) []roachpb.ReplicaDescriptor {
-	upToDateReplicas := filterBehindReplicas(raftStatus, replicas, brandNewReplicaID)
+	upToDateReplicas := filterBehindReplicas(raftStatus, replicas)
 	quorum := computeQuorum(len(replicas) - 1)
 	if len(upToDateReplicas) < quorum {
 		// The number of up-to-date replicas is less than quorum. No replicas can
 		// be removed.
 		return nil
 	}
+
 	if len(upToDateReplicas) > quorum {
 		// The number of up-to-date replicas is larger than quorum. Any replica can
-		// be removed.
+		// be removed, though we want to filter out brandNewReplicaID.
+		if brandNewReplicaID != 0 {
+			candidates := make([]roachpb.ReplicaDescriptor, 0, len(replicas)-len(upToDateReplicas))
+			for _, r := range replicas {
+				if r.ReplicaID != brandNewReplicaID {
+					candidates = append(candidates, r)
+				}
+			}
+			return candidates
+		}
 		return replicas
 	}
+
 	candidates := make([]roachpb.ReplicaDescriptor, 0, len(replicas)-len(upToDateReplicas))
 	necessary := func(r roachpb.ReplicaDescriptor) bool {
+		if r.ReplicaID == brandNewReplicaID {
+			return true
+		}
 		for _, t := range upToDateReplicas {
 			if t == r {
 				return true

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -254,15 +254,15 @@ func MakeAllocator(
 // GetNeededReplicas calculates the number of replicas a range should
 // have given its zone config and the number of nodes available for
 // up-replication (i.e. not dead and not decommissioning).
-func GetNeededReplicas(zoneConfigReplicaCount int32, availableNodes int) int {
+func GetNeededReplicas(zoneConfigReplicaCount int32, clusterNodes int) int {
 	numZoneReplicas := int(zoneConfigReplicaCount)
 	need := numZoneReplicas
 
 	// Adjust the replication factor for all ranges if there are fewer
 	// nodes than replicas specified in the zone config, so the cluster
 	// can still function.
-	if availableNodes < need {
-		need = availableNodes
+	if clusterNodes < need {
+		need = clusterNodes
 	}
 
 	// Ensure that we don't up- or down-replicate to an even number of replicas
@@ -302,8 +302,8 @@ func (a *Allocator) ComputeAction(
 
 	have := len(rangeInfo.Desc.Replicas)
 	decommissioningReplicas := a.storePool.decommissioningReplicas(rangeInfo.Desc.RangeID, rangeInfo.Desc.Replicas)
-	availableNodes := a.storePool.AvailableNodeCount()
-	need := GetNeededReplicas(*zone.NumReplicas, availableNodes)
+	clusterNodes := a.storePool.ClusterNodeCount()
+	need := GetNeededReplicas(*zone.NumReplicas, clusterNodes)
 	desiredQuorum := computeQuorum(need)
 	quorum := computeQuorum(have)
 

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -315,10 +315,12 @@ func replicas(storeIDs ...roachpb.StoreID) []roachpb.ReplicaDescriptor {
 // createTestAllocator creates a stopper, gossip, store pool and allocator for
 // use in tests. Stopper must be stopped by the caller.
 func createTestAllocator(
-	deterministic bool,
+	numNodes int, deterministic bool,
 ) (*stop.Stopper, *gossip.Gossip, *StorePool, Allocator, *hlc.ManualClock) {
 	stopper, g, manual, storePool, _ := createTestStorePool(
-		TestTimeUntilStoreDeadOff, deterministic, storagepb.NodeLivenessStatus_LIVE)
+		TestTimeUntilStoreDeadOff, deterministic,
+		func() int { return numNodes },
+		storagepb.NodeLivenessStatus_LIVE)
 	a := MakeAllocator(storePool, func(string) (time.Duration, bool) {
 		return 0, true
 	})
@@ -404,7 +406,7 @@ func mockStorePool(
 func TestAllocatorSimpleRetrieval(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(1, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
 	result, _, err := a.AllocateTarget(
@@ -426,7 +428,7 @@ func TestAllocatorSimpleRetrieval(t *testing.T) {
 func TestAllocatorCorruptReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, g, sp, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, sp, a, _ := createTestAllocator(1, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(sameDCStores, t)
 	const store1ID = roachpb.StoreID(1)
@@ -457,7 +459,7 @@ func TestAllocatorCorruptReplica(t *testing.T) {
 func TestAllocatorNoAvailableDisks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, _, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, _, _, a, _ := createTestAllocator(1, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	result, _, err := a.AllocateTarget(
 		context.Background(),
@@ -476,7 +478,7 @@ func TestAllocatorNoAvailableDisks(t *testing.T) {
 func TestAllocatorTwoDatacenters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(1, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(multiDCStores, t)
 	ctx := context.Background()
@@ -530,7 +532,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 func TestAllocatorExistingReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(1, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(sameDCStores, t)
 	result, _, err := a.AllocateTarget(
@@ -598,7 +600,7 @@ func TestAllocatorMultipleStoresPerNode(t *testing.T) {
 		},
 	}
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(stores, t)
 
@@ -718,7 +720,7 @@ func TestAllocatorRebalance(t *testing.T) {
 		},
 	}
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 
 	gossiputil.NewStoreGossiper(g).GossipStores(stores, t)
@@ -764,7 +766,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	manual := hlc.NewManualClock(123)
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(5, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	// We make 5 stores in this test -- 3 in the same datacenter, and 1 each in
 	// 2 other datacenters. All of our replicas are distributed within these 3
@@ -930,7 +932,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 func TestAllocatorRebalanceDeadNodes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, _, sp, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, _, sp, a, _ := createTestAllocator(8, false /* deterministic */)
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
 
@@ -1090,7 +1092,7 @@ func TestAllocatorRebalanceThrashing(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Deterministic is required when stressing as test case 8 may rebalance
 			// to different configurations.
-			stopper, g, _, a, _ := createTestAllocator( /* deterministic */ true)
+			stopper, g, _, a, _ := createTestAllocator(1, true /* deterministic */)
 			defer stopper.Stop(context.Background())
 
 			st := a.storePool.st
@@ -1173,7 +1175,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 		},
 	}
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 
 	gossiputil.NewStoreGossiper(g).GossipStores(stores, t)
@@ -1209,7 +1211,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 
 func TestAllocatorTransferLeaseTarget(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ true)
+	stopper, g, _, a, _ := createTestAllocator(10, true /* deterministic */)
 	defer stopper.Stop(context.Background())
 
 	// 3 stores where the lease count for each store is equal to 10x the store
@@ -1275,7 +1277,9 @@ func TestAllocatorTransferLeaseTarget(t *testing.T) {
 func TestAllocatorTransferLeaseTargetDraining(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, storePool, nl := createTestStorePool(
-		TestTimeUntilStoreDeadOff, true /* deterministic */, storagepb.NodeLivenessStatus_LIVE)
+		TestTimeUntilStoreDeadOff, true, /* deterministic */
+		func() int { return 10 }, /* nodeCount */
+		storagepb.NodeLivenessStatus_LIVE)
 	a := MakeAllocator(storePool, func(string) (time.Duration, bool) {
 		return 0, true
 	})
@@ -1347,7 +1351,7 @@ func TestAllocatorTransferLeaseTargetDraining(t *testing.T) {
 func TestAllocatorRebalanceDifferentLocalitySizes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
 
@@ -1555,7 +1559,7 @@ func TestAllocatorRebalanceDifferentLocalitySizes(t *testing.T) {
 
 func TestAllocatorTransferLeaseTargetMultiStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ true)
+	stopper, g, _, a, _ := createTestAllocator(10, true /* deterministic */)
 	defer stopper.Stop(context.Background())
 
 	// 3 nodes and 6 stores where the lease count for the first store on each
@@ -1612,7 +1616,7 @@ func TestAllocatorTransferLeaseTargetMultiStore(t *testing.T) {
 
 func TestAllocatorShouldTransferLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ true)
+	stopper, g, _, a, _ := createTestAllocator(10, true /* deterministic */)
 	defer stopper.Stop(context.Background())
 
 	// 4 stores where the lease count for each store is equal to 10x the store
@@ -1667,7 +1671,9 @@ func TestAllocatorShouldTransferLease(t *testing.T) {
 func TestAllocatorShouldTransferLeaseDraining(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, storePool, nl := createTestStorePool(
-		TestTimeUntilStoreDeadOff, true /* deterministic */, storagepb.NodeLivenessStatus_LIVE)
+		TestTimeUntilStoreDeadOff, true, /* deterministic */
+		func() int { return 10 }, /* nodeCount */
+		storagepb.NodeLivenessStatus_LIVE)
 	a := MakeAllocator(storePool, func(string) (time.Duration, bool) {
 		return 0, true
 	})
@@ -1726,7 +1732,7 @@ func TestAllocatorShouldTransferLeaseDraining(t *testing.T) {
 
 func TestAllocatorLeasePreferences(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ true)
+	stopper, g, _, a, _ := createTestAllocator(10, true /* deterministic */)
 	defer stopper.Stop(context.Background())
 
 	// 4 stores with distinct localities, store attributes, and node attributes
@@ -1885,7 +1891,7 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 
 func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ true)
+	stopper, g, _, a, _ := createTestAllocator(10, true /* deterministic */)
 	defer stopper.Stop(context.Background())
 
 	// 6 stores, 2 in each of 3 distinct localities.
@@ -1983,7 +1989,7 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 func TestAllocatorRemoveTargetLocality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(multiDiversityDCStores, t)
@@ -2052,7 +2058,7 @@ func TestAllocatorRemoveTargetLocality(t *testing.T) {
 func TestAllocatorAllocateTargetLocality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(multiDiversityDCStores, t)
@@ -2135,7 +2141,7 @@ func TestAllocatorAllocateTargetLocality(t *testing.T) {
 func TestAllocatorRebalanceTargetLocality(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 
 	stores := []*roachpb.StoreDescriptor{
@@ -2373,7 +2379,7 @@ var (
 func TestAllocateCandidatesNumReplicasConstraints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(multiDiversityDCStores, t)
@@ -2614,7 +2620,7 @@ func TestAllocateCandidatesNumReplicasConstraints(t *testing.T) {
 func TestRemoveCandidatesNumReplicasConstraints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(multiDiversityDCStores, t)
@@ -2838,7 +2844,7 @@ func expectedStoreIDsMatch(expected []roachpb.StoreID, results candidateList) bo
 func TestRebalanceCandidatesNumReplicasConstraints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(multiDiversityDCStores, t)
@@ -3657,7 +3663,9 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	stopper, g, _, storePool, _ := createTestStorePool(
-		TestTimeUntilStoreDeadOff, true /* deterministic */, storagepb.NodeLivenessStatus_LIVE)
+		TestTimeUntilStoreDeadOff, true, /* deterministic */
+		func() int { return 10 }, /* nodeCount */
+		storagepb.NodeLivenessStatus_LIVE)
 	defer stopper.Stop(context.Background())
 
 	// 3 stores where the lease count for each store is equal to 10x the store ID.
@@ -3993,7 +4001,7 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(ctx)
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(stores, t)
@@ -4467,7 +4475,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 		},
 	}
 
-	stopper, _, sp, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, _, sp, a, _ := createTestAllocator(10, false /* deterministic */)
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
 
@@ -4580,7 +4588,7 @@ func TestAllocatorComputeActionRemoveDead(t *testing.T) {
 		},
 	}
 
-	stopper, _, sp, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, _, sp, a, _ := createTestAllocator(10, false /* deterministic */)
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
 
@@ -4801,7 +4809,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 		},
 	}
 
-	stopper, _, sp, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, _, sp, a, _ := createTestAllocator(10, false /* deterministic */)
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
 
@@ -4925,7 +4933,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 		},
 		{
 			storeList:       []roachpb.StoreID{1, 2, 3, 4, 5},
-			expectedAction:  AllocatorRemoveDead,
+			expectedAction:  AllocatorAdd,
 			live:            []roachpb.StoreID{1, 2, 3},
 			unavailable:     []roachpb.StoreID{4},
 			dead:            []roachpb.StoreID{5},
@@ -4941,24 +4949,38 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 		},
 	}
 
-	stopper, _, sp, a, _ := createTestAllocator( /* deterministic */ false)
+	var numNodes int
+	stopper, _, _, sp, _ := createTestStorePool(
+		TestTimeUntilStoreDeadOff, false, /* deterministic */
+		func() int { return numNodes },
+		storagepb.NodeLivenessStatus_LIVE)
+	a := MakeAllocator(sp, func(string) (time.Duration, bool) {
+		return 0, true
+	})
+
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
 	zone := &config.ZoneConfig{
 		NumReplicas: proto.Int32(5),
 	}
 
-	for _, prefixKey := range []roachpb.RKey{roachpb.RKey(keys.NodeLivenessPrefix), roachpb.RKey(keys.SystemPrefix)} {
-		for i, tcase := range testCases {
-			mockStorePool(sp, tcase.live, tcase.unavailable, tcase.dead, tcase.decommissioning, []roachpb.StoreID{}, nil)
-			desc := makeDescriptor(tcase.storeList)
-			desc.EndKey = prefixKey
-			action, _ := a.ComputeAction(ctx, zone, RangeInfo{Desc: &desc})
-			if tcase.expectedAction != action {
-				t.Errorf("test case %d expected action %q, got action %q",
-					i, allocatorActionNames[tcase.expectedAction], allocatorActionNames[action])
-				continue
-			}
+	for _, prefixKey := range []roachpb.RKey{
+		roachpb.RKey(keys.NodeLivenessPrefix),
+		roachpb.RKey(keys.SystemPrefix),
+	} {
+		for _, c := range testCases {
+			t.Run("", func(t *testing.T) {
+				numNodes = len(c.storeList) - len(c.decommissioning)
+				mockStorePool(sp, c.live, c.unavailable, c.dead,
+					c.decommissioning, []roachpb.StoreID{}, nil)
+				desc := makeDescriptor(c.storeList)
+				desc.EndKey = prefixKey
+				action, _ := a.ComputeAction(ctx, zone, RangeInfo{Desc: &desc})
+				if c.expectedAction != action {
+					t.Fatalf("expected action %q, got action %q",
+						allocatorActionNames[c.expectedAction], allocatorActionNames[action])
+				}
+			})
 		}
 	}
 }
@@ -5101,7 +5123,7 @@ func TestAllocatorError(t *testing.T) {
 func TestAllocatorThrottled(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
 
@@ -5441,7 +5463,7 @@ func TestAllocatorRebalanceAway(t *testing.T) {
 		},
 	}
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.TODO())
 	gossiputil.NewStoreGossiper(g).GossipStores(stores, t)
 	ctx := context.Background()
@@ -5537,12 +5559,20 @@ func TestAllocatorFullDisks(t *testing.T) {
 
 	TimeUntilStoreDead.Override(&st.SV, TestTimeUntilStoreDeadOff)
 
+	const generations = 100
+	const nodes = 20
+	const capacity = (1 << 30) + 1
+	const rangeSize = 16 << 20
+
 	mockNodeLiveness := newMockNodeLiveness(storagepb.NodeLivenessStatus_LIVE)
 	sp := NewStorePool(
 		log.AmbientContext{Tracer: st.Tracer},
 		st,
 		g,
 		clock,
+		func() int {
+			return nodes
+		},
 		mockNodeLiveness.nodeLivenessFunc,
 		false, /* deterministic */
 	)
@@ -5556,10 +5586,6 @@ func TestAllocatorFullDisks(t *testing.T) {
 		// Redundant callbacks are required by this test.
 		gossip.Redundant)
 
-	const generations = 100
-	const nodes = 20
-	const capacity = (1 << 30) + 1
-	const rangeSize = 16 << 20
 	rangesPerNode := int(math.Floor(capacity * rebalanceToMaxFractionUsedThreshold / rangeSize))
 	rangesToAdd := rangesPerNode * nodes
 
@@ -5672,6 +5698,11 @@ func Example_rebalancing() {
 	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
 
 	TimeUntilStoreDead.Override(&st.SV, TestTimeUntilStoreDeadOff)
+
+	const generations = 100
+	const nodes = 20
+	const printGenerations = generations / 2
+
 	// Deterministic must be set as this test is comparing the exact output
 	// after each rebalance.
 	sp := NewStorePool(
@@ -5679,6 +5710,9 @@ func Example_rebalancing() {
 		st,
 		g,
 		clock,
+		func() int {
+			return nodes
+		},
 		newMockNodeLiveness(storagepb.NodeLivenessStatus_LIVE).nodeLivenessFunc,
 		/* deterministic */ true,
 	)
@@ -5691,10 +5725,6 @@ func Example_rebalancing() {
 		func(_ string, _ roachpb.Value) { wg.Done() },
 		// Redundant callbacks are required by this test.
 		gossip.Redundant)
-
-	const generations = 100
-	const nodes = 20
-	const printGenerations = generations / 2
 
 	// Initialize testStores.
 	var testStores [nodes]testStore

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -5252,25 +5252,27 @@ func TestFilterUnremovableReplicas(t *testing.T) {
 	}{
 		{0, []uint64{0}, 0, nil},
 		{1, []uint64{1}, 0, nil},
-		{1, []uint64{0, 1}, 0, []uint64{0}},
+		{1, []uint64{0, 1}, 0, nil},
+		{1, []uint64{1, 2}, 0, []uint64{1, 2}},
 		{1, []uint64{1, 2, 3}, 0, []uint64{1, 2, 3}},
 		{2, []uint64{1, 2, 3}, 0, []uint64{1}},
 		{3, []uint64{1, 2, 3}, 0, nil},
 		{1, []uint64{1, 2, 3, 4}, 0, []uint64{1, 2, 3, 4}},
 		{2, []uint64{1, 2, 3, 4}, 0, []uint64{1, 2, 3, 4}},
-		{3, []uint64{1, 2, 3, 4}, 0, []uint64{1, 2}},
+		{3, []uint64{1, 2, 3, 4}, 0, nil},
 		{2, []uint64{1, 2, 3, 4, 5}, 0, []uint64{1, 2, 3, 4, 5}},
 		{3, []uint64{1, 2, 3, 4, 5}, 0, []uint64{1, 2}},
 		{1, []uint64{1, 0}, 2, nil},
-		// TODO(peter): Is this the desired behavior? For a 2-replica range, we
-		// won't be able to process the removal of a replica unless both are
-		// up-to-date.
-		{1, []uint64{1, 0}, 1, []uint64{0}},
+		{1, []uint64{2, 1}, 2, []uint64{2}},
+		{1, []uint64{1, 0}, 1, nil},
+		{1, []uint64{2, 1}, 1, []uint64{1}},
 		{3, []uint64{3, 2, 1}, 3, nil},
 		{3, []uint64{3, 2, 0}, 3, nil},
-		{3, []uint64{4, 3, 2, 1}, 4, []uint64{2}},
-		{3, []uint64{4, 3, 2, 0}, 3, []uint64{0}},
-		{3, []uint64{4, 3, 2, 0}, 4, []uint64{2}},
+		{2, []uint64{4, 3, 2, 1}, 4, []uint64{4, 3, 2}},
+		{2, []uint64{4, 3, 2, 0}, 3, []uint64{4, 3, 0}},
+		{2, []uint64{4, 3, 2, 0}, 4, []uint64{4, 3, 2}},
+		{3, []uint64{4, 3, 2, 1}, 0, nil},
+		{3, []uint64{4, 3, 2, 1}, 4, nil},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
@@ -5320,7 +5322,7 @@ func TestSimulateFilterUnremovableReplicas(t *testing.T) {
 		expected          []uint64
 	}{
 		{1, []uint64{1, 0}, 2, []uint64{1}},
-		{1, []uint64{1, 0}, 1, []uint64{0}},
+		{1, []uint64{1, 0}, 1, nil},
 		{3, []uint64{3, 2, 1}, 3, []uint64{2}},
 		{3, []uint64{3, 2, 0}, 3, []uint64{2}},
 		{3, []uint64{4, 3, 2, 1}, 4, []uint64{4, 3, 2}},

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -747,6 +747,7 @@ func (m *multiTestContext) populateStorePool(
 		cfg.Settings,
 		m.gossips[idx],
 		m.clocks[idx],
+		nodeLiveness.GetNodeCount,
 		storage.MakeStorePoolNodeLivenessFunc(nodeLiveness),
 		/* deterministic */ false,
 	)

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -221,6 +221,10 @@ func NewTestStorePool(cfg StoreConfig) *StorePool {
 		cfg.Settings,
 		cfg.Gossip,
 		cfg.Clock,
+		// NodeCountFunc
+		func() int {
+			return 1
+		},
 		func(roachpb.NodeID, time.Time, time.Duration) storagepb.NodeLivenessStatus {
 			return storagepb.NodeLivenessStatus_LIVE
 		},

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -971,3 +971,17 @@ func (nl *NodeLiveness) AsLiveClock() closedts.LiveClockFn {
 		return now, ctpb.Epoch(liveness.Epoch), nil
 	}
 }
+
+// GetNodeCount returns a count of the number of nodes in the cluster,
+// including dead nodes, but excluding decommissioning or decommissioned nodes.
+func (nl *NodeLiveness) GetNodeCount() int {
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+	var count int
+	for _, l := range nl.mu.nodes {
+		if !l.Decommissioning {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/storage/replica_init_test.go
+++ b/pkg/storage/replica_init_test.go
@@ -1,0 +1,69 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestReplicaUpdateLastReplicaAdded(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	desc := func(replicaIDs ...roachpb.ReplicaID) roachpb.RangeDescriptor {
+		d := roachpb.RangeDescriptor{
+			StartKey: roachpb.RKey("a"),
+			EndKey:   roachpb.RKey("b"),
+			Replicas: make([]roachpb.ReplicaDescriptor, len(replicaIDs)),
+		}
+		for i, id := range replicaIDs {
+			d.Replicas[i].ReplicaID = id
+		}
+		return d
+	}
+
+	testCases := []struct {
+		oldDesc                  roachpb.RangeDescriptor
+		newDesc                  roachpb.RangeDescriptor
+		lastReplicaAdded         roachpb.ReplicaID
+		expectedLastReplicaAdded roachpb.ReplicaID
+	}{
+		// Adding a replica. In normal operation, Replica IDs always increase.
+		{desc(), desc(1), 0, 1},
+		{desc(1), desc(1, 2), 0, 2},
+		{desc(1, 2), desc(1, 2, 3), 0, 3},
+		// Add a replica with an out-of-order ID (this shouldn't happen in practice).
+		{desc(2, 3), desc(1, 2, 3), 0, 0},
+		// Removing a replica has no-effect.
+		{desc(1, 2, 3), desc(2, 3), 3, 3},
+		{desc(1, 2, 3), desc(1, 3), 3, 3},
+		{desc(1, 2, 3), desc(1, 2), 3, 0},
+	}
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			var r Replica
+			r.mu.state.Desc = &c.oldDesc
+			r.mu.lastReplicaAdded = c.lastReplicaAdded
+			r.setDesc(context.Background(), &c.newDesc)
+			if c.expectedLastReplicaAdded != r.mu.lastReplicaAdded {
+				t.Fatalf("expected %d, but found %d",
+					c.expectedLastReplicaAdded, r.mu.lastReplicaAdded)
+			}
+		})
+	}
+}

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -375,8 +375,8 @@ func (rq *replicateQueue) processOneChange(
 			lastReplAdded = 0
 		}
 		candidates := filterUnremovableReplicas(repl.RaftStatus(), desc.Replicas, lastReplAdded)
-		log.VEventf(ctx, 3, "filtered unremovable replicas from %v to get %v as candidates for removal",
-			desc.Replicas, candidates)
+		log.VEventf(ctx, 3, "filtered unremovable replicas from %v to get %v as candidates for removal: %s",
+			desc.Replicas, candidates, rangeRaftProgress(repl.RaftStatus(), desc.Replicas))
 		if len(candidates) == 0 {
 			// After rapid upreplication, the candidates for removal could still be catching up.
 			// Mark this error as benign so it doesn't create confusion in the logs.
@@ -568,7 +568,7 @@ func (rq *replicateQueue) findTargetAndTransferLease(
 	zone *config.ZoneConfig,
 	opts transferLeaseOptions,
 ) (bool, error) {
-	candidates := filterBehindReplicas(repl.RaftStatus(), desc.Replicas, 0 /* brandNewReplicaID */)
+	candidates := filterBehindReplicas(repl.RaftStatus(), desc.Replicas)
 	target := rq.allocator.TransferLeaseTarget(
 		ctx,
 		zone,

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -319,8 +319,8 @@ func (rq *replicateQueue) processOneChange(
 			StoreID: newStore.StoreID,
 		}
 
-		availableNodes := rq.allocator.storePool.AvailableNodeCount()
-		need := GetNeededReplicas(*zone.NumReplicas, availableNodes)
+		clusterNodes := rq.allocator.storePool.ClusterNodeCount()
+		need := GetNeededReplicas(*zone.NumReplicas, clusterNodes)
 		willHave := len(desc.Replicas) + 1
 
 		// Only up-replicate if there are suitable allocation targets such

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4252,10 +4252,10 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	if s.cfg.NodeLiveness != nil {
 		livenessMap = s.cfg.NodeLiveness.GetIsLiveMap()
 	}
-	availableNodes := s.AvailableNodeCount()
+	clusterNodes := s.ClusterNodeCount()
 
 	newStoreReplicaVisitor(s).Visit(func(rep *Replica) bool {
-		metrics := rep.Metrics(ctx, timestamp, livenessMap, availableNodes)
+		metrics := rep.Metrics(ctx, timestamp, livenessMap, clusterNodes)
 		if metrics.Leader {
 			raftLeaderCount++
 			if metrics.LeaseValid && !metrics.Leaseholder {
@@ -4347,15 +4347,14 @@ func (s *Store) ComputeMetrics(ctx context.Context, tick int) error {
 	return nil
 }
 
-// AvailableNodeCount returns this store's view of the number of nodes
-// in the cluster. This is the metric used for adapative zone configs;
-// ranges will not be reported as underreplicated if it is low. Tests
-// that wait for full replication by tracking the underreplicated
-// metric must also check for the expected AvailableNodeCount to avoid
-// catching the cluster while the first node is initialized but the
-// other nodes are not.
-func (s *Store) AvailableNodeCount() int {
-	return s.cfg.StorePool.AvailableNodeCount()
+// ClusterNodeCount returns this store's view of the number of nodes in the
+// cluster. This is the metric used for adapative zone configs; ranges will not
+// be reported as underreplicated if it is low. Tests that wait for full
+// replication by tracking the underreplicated metric must also check for the
+// expected ClusterNodeCount to avoid catching the cluster while the first node
+// is initialized but the other nodes are not.
+func (s *Store) ClusterNodeCount() int {
+	return s.cfg.StorePool.ClusterNodeCount()
 }
 
 // HotReplicaInfo contains a range descriptor and its QPS.

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -84,6 +84,11 @@ var TimeUntilStoreDead = settings.RegisterValidatedDurationSetting(
 	},
 )
 
+// The NodeCountFunc returns a count of the total number of nodes the user
+// intends for their to be in the cluster. The count includes dead nodes, but
+// not decommissioned nodes.
+type NodeCountFunc func() int
+
 // A NodeLivenessFunc accepts a node ID, current time and threshold before
 // a node is considered dead and returns whether or not the node is live.
 type NodeLivenessFunc func(roachpb.NodeID, time.Time, time.Duration) storagepb.NodeLivenessStatus
@@ -200,6 +205,7 @@ type StorePool struct {
 
 	clock          *hlc.Clock
 	gossip         *gossip.Gossip
+	nodeCountFn    NodeCountFunc
 	nodeLivenessFn NodeLivenessFunc
 	startTime      time.Time
 	deterministic  bool
@@ -224,6 +230,7 @@ func NewStorePool(
 	st *cluster.Settings,
 	g *gossip.Gossip,
 	clock *hlc.Clock,
+	nodeCountFn NodeCountFunc,
 	nodeLivenessFn NodeLivenessFunc,
 	deterministic bool,
 ) *StorePool {
@@ -232,6 +239,7 @@ func NewStorePool(
 		st:             st,
 		clock:          clock,
 		gossip:         g,
+		nodeCountFn:    nodeCountFn,
 		nodeLivenessFn: nodeLivenessFn,
 		startTime:      clock.PhysicalTime(),
 		deterministic:  deterministic,
@@ -443,33 +451,11 @@ func (sp *StorePool) decommissioningReplicas(
 	return
 }
 
-// AvailableNodeCount returns the number of nodes which are considered
-// available for use as allocation targets. This includes only nodes which are
-// not dead or decommissioning. It notably does include nodes that are not
-// considered live by node liveness but are also not yet considered dead.
+// AvailableNodeCount returns the number of nodes that are possible allocation
+// targets. This includes dead nodes, but not decommissioning or decommissioned
+// nodes.
 func (sp *StorePool) AvailableNodeCount() int {
-	sp.detailsMu.RLock()
-	defer sp.detailsMu.RUnlock()
-
-	now := sp.clock.PhysicalTime()
-	availableNodes := map[roachpb.NodeID]struct{}{}
-	timeUntilStoreDead := TimeUntilStoreDead.Get(&sp.st.SV)
-
-	for _, detail := range sp.detailsMu.storeDetails {
-		if detail.desc == nil {
-			continue
-		}
-		switch s := detail.status(now, timeUntilStoreDead, 0, sp.nodeLivenessFn); s {
-		case storeStatusThrottled, storeStatusAvailable, storeStatusUnknown, storeStatusReplicaCorrupted:
-			availableNodes[detail.desc.Node.NodeID] = struct{}{}
-		case storeStatusDead, storeStatusDecommissioning:
-			// Do nothing; this node can't/shouldn't have any replicas on it.
-		default:
-			panic(fmt.Sprintf("unknown store status: %d", s))
-		}
-	}
-
-	return len(availableNodes)
+	return sp.nodeCountFn()
 }
 
 // liveAndDeadReplicas divides the provided repls slice into two slices: the

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -279,8 +279,10 @@ func (sp *StorePool) String() string {
 		if status != storeStatusAvailable {
 			fmt.Fprintf(&buf, " (status=%d)", status)
 		}
-		fmt.Fprintf(&buf, ": range-count=%d fraction-used=%.2f",
-			detail.desc.Capacity.RangeCount, detail.desc.Capacity.FractionUsed())
+		if detail.desc != nil {
+			fmt.Fprintf(&buf, ": range-count=%d fraction-used=%.2f",
+				detail.desc.Capacity.RangeCount, detail.desc.Capacity.FractionUsed())
+		}
 		throttled := detail.throttledUntil.Sub(now)
 		if throttled > 0 {
 			fmt.Fprintf(&buf, " [throttled=%.1fs]", throttled.Seconds())

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -451,10 +451,10 @@ func (sp *StorePool) decommissioningReplicas(
 	return
 }
 
-// AvailableNodeCount returns the number of nodes that are possible allocation
+// ClusterNodeCount returns the number of nodes that are possible allocation
 // targets. This includes dead nodes, but not decommissioning or decommissioned
 // nodes.
-func (sp *StorePool) AvailableNodeCount() int {
+func (sp *StorePool) ClusterNodeCount() int {
 	return sp.nodeCountFn()
 }
 

--- a/pkg/storage/store_rebalancer.go
+++ b/pkg/storage/store_rebalancer.go
@@ -503,8 +503,8 @@ func (sr *StoreRebalancer) chooseReplicaToRebalance(
 		log.VEventf(ctx, 3, "considering replica rebalance for r%d with %.2f qps",
 			desc.RangeID, replWithStats.qps)
 
-		availableNodes := sr.rq.allocator.storePool.AvailableNodeCount()
-		desiredReplicas := GetNeededReplicas(*zone.NumReplicas, availableNodes)
+		clusterNodes := sr.rq.allocator.storePool.ClusterNodeCount()
+		desiredReplicas := GetNeededReplicas(*zone.NumReplicas, clusterNodes)
 		targets := make([]roachpb.ReplicationTarget, 0, desiredReplicas)
 		targetReplicas := make([]roachpb.ReplicaDescriptor, 0, desiredReplicas)
 

--- a/pkg/storage/store_rebalancer_test.go
+++ b/pkg/storage/store_rebalancer_test.go
@@ -117,7 +117,7 @@ func TestChooseLeaseToTransfer(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(noLocalityStores, t)
 	storeList, _, _ := a.storePool.getStoreList(firstRange, storeFilterThrottled)
@@ -200,7 +200,7 @@ func TestChooseReplicaToRebalance(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(noLocalityStores, t)
 	storeList, _, _ := a.storePool.getStoreList(firstRange, storeFilterThrottled)
@@ -310,7 +310,7 @@ func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	stopper, g, _, a, _ := createTestAllocator(10, false /* deterministic */)
 	defer stopper.Stop(context.Background())
 	gossiputil.NewStoreGossiper(g).GossipStores(noLocalityStores, t)
 	storeList, _, _ := a.storePool.getStoreList(firstRange, storeFilterThrottled)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -166,6 +166,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		cfg.Settings,
 		cfg.Gossip,
 		cfg.Clock,
+		cfg.NodeLiveness.GetNodeCount,
 		storage.MakeStorePoolNodeLivenessFunc(cfg.NodeLiveness),
 		/* deterministic */ false,
 	)

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -555,7 +555,7 @@ func (tc *TestCluster) WaitForFullReplication() error {
 		notReplicated = false
 		for i, s := range tc.Servers {
 			err := s.Stores().VisitStores(func(s *storage.Store) error {
-				if n := s.AvailableNodeCount(); n != len(tc.Servers) {
+				if n := s.ClusterNodeCount(); n != len(tc.Servers) {
 					log.Infof(context.TODO(), "%s only sees %d/%d available nodes", s, n, len(tc.Servers))
 					notReplicated = true
 					return nil


### PR DESCRIPTION
* roachtest: add replicate/wide roachtest
* storage: reimplement StorePool.AvailableNodeCount
* storage: fix lastReplicaAdded computation
* storage: fix filterUnremovableReplicas badness

Fixes #34122

Release note (bug fix): Avoid down-replicating widely replicated ranges
when nodes in the cluster are temporarily down.