### PR TITLE
opt: add more EXPLAIN (OPT) flavors

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Cockroach Authors.
+// Copyright 2019 The Cockroach Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,12 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package testutils
+package execbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
@@ -55,7 +53,7 @@ func fmtInterceptor(f *memo.ExprFmtCtx, tp treeprinter.Node, nd opt.Expr) bool {
 	}
 
 	// Build the scalar expression and format it as a single tree node.
-	bld := execbuilder.New(nil /* factory */, f.Memo, nd, nil /* evalCtx */)
+	bld := New(nil /* factory */, f.Memo, nd, nil /* evalCtx */)
 	md := f.Memo.Metadata()
 	ivh := tree.MakeIndexedVarHelper(nil /* container */, md.NumColumns())
 	expr, err := bld.BuildScalar(&ivh)
@@ -86,36 +84,4 @@ func onlyScalars(nd opt.Expr) bool {
 		}
 	}
 	return true
-}
-
-type indexedVarContainer struct {
-	md *opt.Metadata
-}
-
-var _ tree.IndexedVarContainer = &indexedVarContainer{}
-
-// IndexedVarEval is part of the tree.IndexedVarContainer interface.
-func (c *indexedVarContainer) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum, error) {
-	panic("not implemented")
-}
-
-// IndexedVarResolvedType is part of the tree.IndexedVarContainer interface.
-func (c *indexedVarContainer) IndexedVarResolvedType(idx int) types.T {
-	return c.md.ColumnMeta(opt.ColumnID(idx)).Type
-}
-
-// IndexedVarEval is part of the tree.IndexedVarContainer interface.
-func (c *indexedVarContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return &varFormatter{alias: c.md.ColumnMeta(opt.ColumnID(idx)).Alias}
-}
-
-type varFormatter struct {
-	alias string
-}
-
-var _ tree.NodeFormatter = &varFormatter{}
-
-// Format is part of the tree.NodeFormatter interface.
-func (v *varFormatter) Format(ctx *tree.FmtCtx) {
-	ctx.WriteString(v.alias)
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -610,6 +610,25 @@ query T
 EXPLAIN (OPT) SELECT 1 AS r
 ----
 values
+ └── (1,)
+
+query T
+EXPLAIN (OPT,VERBOSE) SELECT 1 AS r
+----
+values
+ ├── columns: r:1
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 0.02
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── prune: (1)
+ └── (1,)
+
+query T
+EXPLAIN (OPT,TYPES) SELECT 1 AS r
+----
+values
  ├── columns: r:1(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
@@ -619,6 +638,142 @@ values
  ├── prune: (1)
  └── tuple [type=tuple{int}]
       └── const: 1 [type=int]
+
+query T
+EXPLAIN (OPT) SELECT * FROM tc WHERE a = 10 ORDER BY b
+----
+sort
+ └── index-join tc
+      └── scan tc@c
+           └── constraint: /1/3: [/10 - /10]
+
+query T
+EXPLAIN (OPT,VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
+----
+sort
+ ├── columns: a:1 b:2
+ ├── stats: [rows=9.9, distinct(1)=1, null(1)=0]
+ ├── cost: 51.3728708
+ ├── fd: ()-->(1)
+ ├── ordering: +2 opt(1) [provided: +2]
+ ├── prune: (2)
+ └── index-join tc
+      ├── columns: a:1 b:2
+      ├── stats: [rows=9.9, distinct(1)=1, null(1)=0]
+      ├── cost: 50.51
+      ├── fd: ()-->(1)
+      ├── prune: (2)
+      └── scan tc@c
+           ├── columns: a:1 rowid:3
+           ├── constraint: /1/3: [/10 - /10]
+           ├── stats: [rows=9.9, distinct(1)=1, null(1)=0, distinct(3)=9.9, null(3)=0]
+           ├── cost: 10.306
+           ├── key: (3)
+           └── fd: ()-->(1)
+
+query T
+EXPLAIN (OPT,TYPES) SELECT * FROM tc WHERE a = 10 ORDER BY b
+----
+sort
+ ├── columns: a:1(int!null) b:2(int)
+ ├── stats: [rows=9.9, distinct(1)=1, null(1)=0]
+ ├── cost: 51.3728708
+ ├── fd: ()-->(1)
+ ├── ordering: +2 opt(1) [provided: +2]
+ ├── prune: (2)
+ └── index-join tc
+      ├── columns: a:1(int!null) b:2(int)
+      ├── stats: [rows=9.9, distinct(1)=1, null(1)=0]
+      ├── cost: 50.51
+      ├── fd: ()-->(1)
+      ├── prune: (2)
+      └── scan tc@c
+           ├── columns: a:1(int!null) rowid:3(int!null)
+           ├── constraint: /1/3: [/10 - /10]
+           ├── stats: [rows=9.9, distinct(1)=1, null(1)=0, distinct(3)=9.9, null(3)=0]
+           ├── cost: 10.306
+           ├── key: (3)
+           └── fd: ()-->(1)
+
+query T
+EXPLAIN (OPT) SELECT * FROM tc WHERE a + 2 * b > 1 ORDER BY a*b
+----
+sort
+ └── project
+      ├── select
+      │    ├── scan tc
+      │    └── filters
+      │         └── (a + (b * 2)) > 1
+      └── projections
+           └── a * b
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT * FROM tc WHERE a + 2 * b > 1 ORDER BY a*b
+----
+sort
+ ├── columns: a:1 b:2  [hidden: column4:4]
+ ├── stats: [rows=333.333333]
+ ├── cost: 1129.24548
+ ├── fd: (1,2)-->(4)
+ ├── ordering: +4
+ ├── prune: (1,2,4)
+ └── project
+      ├── columns: column4:4 a:1 b:2
+      ├── stats: [rows=333.333333]
+      ├── cost: 1066.69667
+      ├── fd: (1,2)-->(4)
+      ├── prune: (1,2,4)
+      ├── select
+      │    ├── columns: a:1 b:2
+      │    ├── stats: [rows=333.333333]
+      │    ├── cost: 1060.02
+      │    ├── scan tc
+      │    │    ├── columns: a:1 b:2
+      │    │    ├── stats: [rows=1000]
+      │    │    ├── cost: 1050.01
+      │    │    └── prune: (1,2)
+      │    └── filters
+      │         └── (a + (b * 2)) > 1 [outer=(1,2)]
+      └── projections
+           └── a * b [outer=(1,2)]
+
+query T
+EXPLAIN (OPT, TYPES) SELECT * FROM tc WHERE a + 2 * b > 1 ORDER BY a*b
+----
+sort
+ ├── columns: a:1(int) b:2(int)  [hidden: column4:4(int)]
+ ├── stats: [rows=333.333333]
+ ├── cost: 1129.24548
+ ├── fd: (1,2)-->(4)
+ ├── ordering: +4
+ ├── prune: (1,2,4)
+ └── project
+      ├── columns: column4:4(int) a:1(int) b:2(int)
+      ├── stats: [rows=333.333333]
+      ├── cost: 1066.69667
+      ├── fd: (1,2)-->(4)
+      ├── prune: (1,2,4)
+      ├── select
+      │    ├── columns: a:1(int) b:2(int)
+      │    ├── stats: [rows=333.333333]
+      │    ├── cost: 1060.02
+      │    ├── scan tc
+      │    │    ├── columns: a:1(int) b:2(int)
+      │    │    ├── stats: [rows=1000]
+      │    │    ├── cost: 1050.01
+      │    │    └── prune: (1,2)
+      │    └── filters
+      │         └── gt [type=bool, outer=(1,2)]
+      │              ├── plus [type=int]
+      │              │    ├── variable: a [type=int]
+      │              │    └── mult [type=int]
+      │              │         ├── variable: b [type=int]
+      │              │         └── const: 2 [type=int]
+      │              └── const: 1 [type=int]
+      └── projections
+           └── mult [type=int, outer=(1,2)]
+                ├── variable: a [type=int]
+                └── variable: b [type=int]
 
 # Test with an unsupported statement.
 statement error window functions are not supported

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -39,6 +39,10 @@ func TestMemo(t *testing.T) {
 	runDataDrivenTest(t, "testdata/memo", flags)
 }
 
+func TestFormat(t *testing.T) {
+	runDataDrivenTest(t, "testdata/format", memo.ExprFmtShowAll)
+}
+
 func TestLogicalProps(t *testing.T) {
 	flags := memo.ExprFmtHideCost | memo.ExprFmtHideQualifications | memo.ExprFmtHideStats
 	runDataDrivenTest(t, "testdata/logprops/", flags)

--- a/pkg/sql/opt/memo/testdata/format
+++ b/pkg/sql/opt/memo/testdata/format
@@ -1,0 +1,245 @@
+exec-ddl
+CREATE TABLE t (a INT, b INT, k INT PRIMARY KEY)
+----
+TABLE t
+ ├── a int
+ ├── b int
+ ├── k int not null
+ └── INDEX primary
+      └── k int not null
+
+opt format=show-all
+SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
+----
+sort
+ ├── columns: "?column?":5(int) min:4(int)  [hidden: t.public.t.a:1(int)]
+ ├── stats: [rows=98.1771622]
+ ├── cost: 1097.85224
+ ├── key: (1)
+ ├── fd: (1)-->(4,5)
+ ├── ordering: +1
+ ├── prune: (1,4,5)
+ └── project
+      ├── columns: "?column?":5(int) t.public.t.a:1(int) min:4(int)
+      ├── stats: [rows=98.1771622]
+      ├── cost: 1082.88531
+      ├── key: (1)
+      ├── fd: (1)-->(4,5)
+      ├── prune: (1,4,5)
+      ├── group-by
+      │    ├── columns: t.public.t.a:1(int) min:4(int)
+      │    ├── grouping columns: t.public.t.a:1(int)
+      │    ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=3.3]
+      │    ├── cost: 1080.91177
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(4)
+      │    ├── prune: (4)
+      │    ├── select
+      │    │    ├── columns: t.public.t.a:1(int) t.public.t.b:2(int!null) t.public.t.k:3(int!null)
+      │    │    ├── stats: [rows=330, distinct(1)=98.1771622, null(1)=3.3, distinct(2)=98.265847, null(2)=0, distinct(3)=330, null(3)=0]
+      │    │    ├── cost: 1070.02
+      │    │    ├── key: (3)
+      │    │    ├── fd: (3)-->(1,2)
+      │    │    ├── interesting orderings: (+3)
+      │    │    ├── scan t.public.t
+      │    │    │    ├── columns: t.public.t.a:1(int) t.public.t.b:2(int) t.public.t.k:3(int!null)
+      │    │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10, distinct(3)=1000, null(3)=0]
+      │    │    │    ├── cost: 1060.01
+      │    │    │    ├── key: (3)
+      │    │    │    ├── fd: (3)-->(1,2)
+      │    │    │    ├── prune: (1-3)
+      │    │    │    └── interesting orderings: (+3)
+      │    │    └── filters
+      │    │         └── lt [type=bool, outer=(1-3), constraints=(/2: (/NULL - ])]
+      │    │              ├── variable: t.public.t.b [type=int]
+      │    │              └── plus [type=int]
+      │    │                   ├── variable: t.public.t.k [type=int]
+      │    │                   └── variable: t.public.t.a [type=int]
+      │    └── aggregations
+      │         └── min [type=int, outer=(2)]
+      │              └── variable: t.public.t.b [type=int]
+      └── projections
+           └── plus [type=int, outer=(1)]
+                ├── variable: t.public.t.a [type=int]
+                └── const: 1 [type=int]
+
+opt format=(hide-miscprops,hide-constraints,hide-funcdeps,hide-ruleprops)
+SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
+----
+sort
+ ├── columns: "?column?":5(int) min:4(int)  [hidden: t.public.t.a:1(int)]
+ ├── stats: [rows=98.1771622]
+ ├── cost: 1097.85224
+ ├── ordering: +1
+ └── project
+      ├── columns: "?column?":5(int) t.public.t.a:1(int) min:4(int)
+      ├── stats: [rows=98.1771622]
+      ├── cost: 1082.88531
+      ├── group-by
+      │    ├── columns: t.public.t.a:1(int) min:4(int)
+      │    ├── grouping columns: t.public.t.a:1(int)
+      │    ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=3.3]
+      │    ├── cost: 1080.91177
+      │    ├── select
+      │    │    ├── columns: t.public.t.a:1(int) t.public.t.b:2(int!null) t.public.t.k:3(int!null)
+      │    │    ├── stats: [rows=330, distinct(1)=98.1771622, null(1)=3.3, distinct(2)=98.265847, null(2)=0, distinct(3)=330, null(3)=0]
+      │    │    ├── cost: 1070.02
+      │    │    ├── scan t.public.t
+      │    │    │    ├── columns: t.public.t.a:1(int) t.public.t.b:2(int) t.public.t.k:3(int!null)
+      │    │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10, distinct(3)=1000, null(3)=0]
+      │    │    │    └── cost: 1060.01
+      │    │    └── filters
+      │    │         └── lt [type=bool]
+      │    │              ├── variable: t.public.t.b [type=int]
+      │    │              └── plus [type=int]
+      │    │                   ├── variable: t.public.t.k [type=int]
+      │    │                   └── variable: t.public.t.a [type=int]
+      │    └── aggregations
+      │         └── min [type=int]
+      │              └── variable: t.public.t.b [type=int]
+      └── projections
+           └── plus [type=int]
+                ├── variable: t.public.t.a [type=int]
+                └── const: 1 [type=int]
+
+opt format=(hide-stats,hide-cost,hide-qual,hide-scalars)
+SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
+----
+sort
+ ├── columns: "?column?":5(int) min:4(int)  [hidden: a:1(int)]
+ ├── key: (1)
+ ├── fd: (1)-->(4,5)
+ ├── ordering: +1
+ ├── prune: (1,4,5)
+ └── project
+      ├── columns: "?column?":5(int) a:1(int) min:4(int)
+      ├── key: (1)
+      ├── fd: (1)-->(4,5)
+      ├── prune: (1,4,5)
+      ├── group-by
+      │    ├── columns: a:1(int) min:4(int)
+      │    ├── grouping columns: a:1(int)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(4)
+      │    ├── prune: (4)
+      │    ├── select
+      │    │    ├── columns: a:1(int) b:2(int!null) k:3(int!null)
+      │    │    ├── key: (3)
+      │    │    ├── fd: (3)-->(1,2)
+      │    │    ├── interesting orderings: (+3)
+      │    │    ├── scan t
+      │    │    │    ├── columns: a:1(int) b:2(int) k:3(int!null)
+      │    │    │    ├── key: (3)
+      │    │    │    ├── fd: (3)-->(1,2)
+      │    │    │    ├── prune: (1-3)
+      │    │    │    └── interesting orderings: (+3)
+      │    │    └── filters
+      │    │         └── b < (k + a) [type=bool, outer=(1-3), constraints=(/2: (/NULL - ])]
+      │    └── aggregations
+      │         └── min [type=int, outer=(2)]
+      │              └── variable: b [type=int]
+      └── projections
+           └── a + 1 [type=int, outer=(1)]
+
+opt format=(hide-stats,hide-cost,hide-qual,hide-scalars,hide-types)
+SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
+----
+sort
+ ├── columns: "?column?":5 min:4  [hidden: a:1]
+ ├── key: (1)
+ ├── fd: (1)-->(4,5)
+ ├── ordering: +1
+ ├── prune: (1,4,5)
+ └── project
+      ├── columns: "?column?":5 a:1 min:4
+      ├── key: (1)
+      ├── fd: (1)-->(4,5)
+      ├── prune: (1,4,5)
+      ├── group-by
+      │    ├── columns: a:1 min:4
+      │    ├── grouping columns: a:1
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(4)
+      │    ├── prune: (4)
+      │    ├── select
+      │    │    ├── columns: a:1 b:2 k:3
+      │    │    ├── key: (3)
+      │    │    ├── fd: (3)-->(1,2)
+      │    │    ├── interesting orderings: (+3)
+      │    │    ├── scan t
+      │    │    │    ├── columns: a:1 b:2 k:3
+      │    │    │    ├── key: (3)
+      │    │    │    ├── fd: (3)-->(1,2)
+      │    │    │    ├── prune: (1-3)
+      │    │    │    └── interesting orderings: (+3)
+      │    │    └── filters
+      │    │         └── b < (k + a) [outer=(1-3), constraints=(/2: (/NULL - ])]
+      │    └── aggregations
+      │         └── min [outer=(2)]
+      │              └── variable: b
+      └── projections
+           └── a + 1 [outer=(1)]
+
+opt format=(hide-miscprops,hide-orderings,hide-columns)
+SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
+----
+sort
+ ├── stats: [rows=98.1771622]
+ ├── cost: 1097.85224
+ ├── key: (1)
+ ├── fd: (1)-->(4,5)
+ ├── prune: (1,4,5)
+ └── project
+      ├── stats: [rows=98.1771622]
+      ├── cost: 1082.88531
+      ├── key: (1)
+      ├── fd: (1)-->(4,5)
+      ├── prune: (1,4,5)
+      ├── group-by
+      │    ├── stats: [rows=98.1771622, distinct(1)=98.1771622, null(1)=3.3]
+      │    ├── cost: 1080.91177
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(4)
+      │    ├── prune: (4)
+      │    ├── select
+      │    │    ├── stats: [rows=330, distinct(1)=98.1771622, null(1)=3.3, distinct(2)=98.265847, null(2)=0, distinct(3)=330, null(3)=0]
+      │    │    ├── cost: 1070.02
+      │    │    ├── key: (3)
+      │    │    ├── fd: (3)-->(1,2)
+      │    │    ├── interesting orderings: (+3)
+      │    │    ├── scan t.public.t
+      │    │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10, distinct(3)=1000, null(3)=0]
+      │    │    │    ├── cost: 1060.01
+      │    │    │    ├── key: (3)
+      │    │    │    ├── fd: (3)-->(1,2)
+      │    │    │    ├── prune: (1-3)
+      │    │    │    └── interesting orderings: (+3)
+      │    │    └── filters
+      │    │         └── lt [type=bool, constraints=(/2: (/NULL - ])]
+      │    │              ├── variable: t.public.t.b [type=int]
+      │    │              └── plus [type=int]
+      │    │                   ├── variable: t.public.t.k [type=int]
+      │    │                   └── variable: t.public.t.a [type=int]
+      │    └── aggregations
+      │         └── min [type=int]
+      │              └── variable: t.public.t.b [type=int]
+      └── projections
+           └── plus [type=int]
+                ├── variable: t.public.t.a [type=int]
+                └── const: 1 [type=int]
+
+opt format=hide-all
+SELECT a + 1, min(b) FROM t WHERE k + a > b GROUP BY a ORDER BY a
+----
+sort
+ └── project
+      ├── group-by
+      │    ├── select
+      │    │    ├── scan t
+      │    │    └── filters
+      │    │         └── b < (k + a)
+      │    └── aggregations
+      │         └── min
+      │              └── variable: b
+      └── projections
+           └── a + 1

--- a/pkg/sql/opt/memo/typing_test.go
+++ b/pkg/sql/opt/memo/typing_test.go
@@ -25,7 +25,16 @@ import (
 )
 
 func TestTyping(t *testing.T) {
-	runDataDrivenTest(t, "testdata/typing", memo.ExprFmtHideAll)
+	runDataDrivenTest(t, "testdata/typing",
+		memo.ExprFmtHideMiscProps|
+			memo.ExprFmtHideConstraints|
+			memo.ExprFmtHideFuncDeps|
+			memo.ExprFmtHideRuleProps|
+			memo.ExprFmtHideStats|
+			memo.ExprFmtHideCost|
+			memo.ExprFmtHideQualifications|
+			memo.ExprFmtHideScalars,
+	)
 }
 
 func TestBinaryOverloadExists(t *testing.T) {

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -65,7 +65,13 @@ func TestBuilder(t *testing.T) {
 			var err error
 
 			tester := testutils.NewOptTester(catalog, d.Input)
-			tester.Flags.ExprFormat = memo.ExprFmtHideAll ^ memo.ExprFmtHideScalars
+			tester.Flags.ExprFormat = memo.ExprFmtHideMiscProps |
+				memo.ExprFmtHideConstraints |
+				memo.ExprFmtHideFuncDeps |
+				memo.ExprFmtHideRuleProps |
+				memo.ExprFmtHideStats |
+				memo.ExprFmtHideCost |
+				memo.ExprFmtHideQualifications
 
 			for _, arg := range d.CmdArgs {
 				key, vals := arg.Key, arg.Vals

--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	_ "github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder" // for ExprFmtHideScalars.
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
@@ -382,13 +383,18 @@ func (f *OptTesterFlags) Set(arg datadriven.CmdArg) error {
 		for _, v := range arg.Vals {
 			m := map[string]memo.ExprFmtFlags{
 				"show-all":         memo.ExprFmtShowAll,
-				"hide-all":         memo.ExprFmtHideAll,
+				"hide-miscprops":   memo.ExprFmtHideMiscProps,
+				"hide-constraints": memo.ExprFmtHideConstraints,
+				"hide-funcdeps":    memo.ExprFmtHideFuncDeps,
+				"hide-ruleprops":   memo.ExprFmtHideRuleProps,
 				"hide-stats":       memo.ExprFmtHideStats,
 				"hide-cost":        memo.ExprFmtHideCost,
-				"hide-constraints": memo.ExprFmtHideConstraints,
-				"hide-ruleprops":   memo.ExprFmtHideRuleProps,
-				"hide-scalars":     memo.ExprFmtHideScalars,
 				"hide-qual":        memo.ExprFmtHideQualifications,
+				"hide-scalars":     memo.ExprFmtHideScalars,
+				"hide-orderings":   memo.ExprFmtHideOrderings,
+				"hide-types":       memo.ExprFmtHideTypes,
+				"hide-columns":     memo.ExprFmtHideColumns,
+				"hide-all":         memo.ExprFmtHideAll,
 			}
 			if val, ok := m[v]; ok {
 				f.ExprFormat |= val

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -121,7 +121,17 @@ func TestCoster(t *testing.T) {
 //   ...
 func TestPhysicalProps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	runDataDrivenTest(t, "testdata/physprops/", memo.ExprFmtHideAll)
+	runDataDrivenTest(
+		t, "testdata/physprops/",
+		memo.ExprFmtHideMiscProps|
+			memo.ExprFmtHideConstraints|
+			memo.ExprFmtHideFuncDeps|
+			memo.ExprFmtHideRuleProps|
+			memo.ExprFmtHideStats|
+			memo.ExprFmtHideCost|
+			memo.ExprFmtHideQualifications|
+			memo.ExprFmtHideScalars,
+	)
 }
 
 // TestRuleProps files can be run separately like this:


### PR DESCRIPTION
We add a few more expression formatting flags:
 - hide orderings
 - hide all column information
 - hide type information

We now have three flavours of `EXPLAIN (OPT)`:
 - `EXPLAIN (OPT)`: shows the very basic plan, similar amount of
    detail to the regular `EXPLAIN`
 - `EXPLAIN (OPT,VERBOSE)`: shows almost all information, excluding
   type information.
 - `EXPLAIN (OPT,TYPES)`: shows the most information, including
   information about types.

Release note (sql change): EXPLAIN (OPT) now has a much more brief
output, and EXPLAIN (OPT,VERBOSE) and EXPLAIN (OPT,TYPES) can be used
for more verbose output.

CC @jordanlewis, @knz - you can look just at `sql/opt/exec/execbuilder/testdata/explain` - I think this will make EXPLAIN (OPT) a lot more useful (it can contain an overwhelming amount of text, especially when large tables are involved).