### PR TITLE
sql: prevent crash with invalid placeholders in DEFAULT

### DIFF
--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -75,7 +75,7 @@ func parseValues(tableDesc *sqlbase.TableDescriptor, values string) ([]sqlbase.E
 		for colIdx, expr := range rowTuple {
 			col := tableDesc.Columns[colIdx]
 			typedExpr, err := sqlbase.SanitizeVarFreeExpr(
-				expr, col.Type.ToDatumType(), "avro", semaCtx, evalCtx, false /* allowImpure */)
+				expr, col.Type.ToDatumType(), "avro", semaCtx, false /* allowImpure */)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -92,7 +92,7 @@ func valueEncodePartitionTuple(
 
 		var semaCtx tree.SemaContext
 		typedExpr, err := sqlbase.SanitizeVarFreeExpr(expr, cols[i].Type.ToDatumType(), "partition",
-			&semaCtx, evalCtx, false /* allowImpure */)
+			&semaCtx, false /* allowImpure */)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -398,7 +398,9 @@ func (ex *connExecutor) execStmtInOpenState(
 		}
 	}
 
-	p.semaCtx.Placeholders.Assign(pinfo, stmt.NumPlaceholders)
+	if err := p.semaCtx.Placeholders.Assign(pinfo, stmt.NumPlaceholders); err != nil {
+		return makeErrEvent(err)
+	}
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
 	ex.phaseTimes[plannerStartExecStmt] = timeutil.Now()
 	p.stmt = &stmt

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -186,8 +186,11 @@ func (ex *connExecutor) populatePrepared(
 	placeholderHints tree.PlaceholderTypes,
 	p *planner,
 ) (planFlags, error) {
+	if err := p.semaCtx.Placeholders.Init(stmt.NumPlaceholders, placeholderHints); err != nil {
+		return 0, err
+	}
 	prepared := stmt.Prepared
-	p.semaCtx.Placeholders.Init(stmt.NumPlaceholders, placeholderHints)
+
 	p.extendedEvalCtx.PrepareOnly = true
 	p.extendedEvalCtx.ActiveMemAcc = &prepared.memAcc
 	// constantMemAcc accounts for all constant folded values that are computed

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -226,8 +226,7 @@ func (n *createViewNode) makeViewTableDesc(
 		}
 		// The new types in the CREATE VIEW column specs never use
 		// SERIAL so we need not process SERIAL types here.
-		col, _, _, err := sqlbase.MakeColumnDefDescs(
-			&columnTableDef, &params.p.semaCtx, params.EvalContext())
+		col, _, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, &params.p.semaCtx)
 		if err != nil {
 			return desc, err
 		}
@@ -266,7 +265,7 @@ func MakeViewTableDesc(
 		}
 		// The new types in the CREATE VIEW column specs never use
 		// SERIAL so we need not process SERIAL types here.
-		col, _, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, semaCtx, evalCtx)
+		col, _, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, semaCtx)
 		if err != nil {
 			return desc, err
 		}

--- a/pkg/sql/execute.go
+++ b/pkg/sql/execute.go
@@ -46,7 +46,7 @@ func fillInPlaceholders(
 		}
 		typedExpr, err := sqlbase.SanitizeVarFreeExpr(
 			e, typ, "EXECUTE parameter", /* context */
-			&semaCtx, nil /* evalCtx */, true /* allowImpure */)
+			&semaCtx, true /* allowImpure */)
 		if err != nil {
 			return nil, pgerror.NewError(pgerror.CodeWrongObjectTypeError, err.Error())
 		}

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -486,7 +486,9 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 		}
 	}
 
-	h.semaCtx.Placeholders.Init(len(h.query.args), nil /* typeHints */)
+	if err := h.semaCtx.Placeholders.Init(len(h.query.args), nil /* typeHints */); err != nil {
+		tb.Fatal(err)
+	}
 	if h.query.prepare {
 		// Prepare the query by normalizing it (if it has placeholders) or exploring
 		// it (if it doesn't have placeholders), and cache the resulting memo so that

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -518,7 +518,6 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 			typ,
 			"", /* context */
 			&h.semaCtx,
-			&h.evalCtx,
 			true, /* allowImpure */
 		)
 		if err != nil {

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -64,7 +64,9 @@ func TestMemoInit(t *testing.T) {
 
 	ctx := context.Background()
 	semaCtx := tree.MakeSemaContext(false /* privileged */)
-	semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */)
+	if err := semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */); err != nil {
+		t.Fatal(err)
+	}
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 	var o xform.Optimizer

--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -806,7 +806,9 @@ func (ot *OptTester) buildExpr(factory *norm.Factory) error {
 	if err != nil {
 		return err
 	}
-	ot.semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */)
+	if err := ot.semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */); err != nil {
+		return err
+	}
 	b := optbuilder.New(ot.ctx, &ot.semaCtx, &ot.evalCtx, ot.catalog, factory, stmt.AST)
 	b.AllowUnsupportedExpr = ot.Flags.AllowUnsupportedExpr
 	if ot.Flags.FullyQualifyNames {

--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -201,7 +201,9 @@ func ClassifyConversion(
 
 	// See if there's existing cast logic.  If so, return general.
 	ctx := tree.MakeSemaContext(false)
-	ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
+	if err := ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
+		return ColumnConversionImpossible, err
+	}
 
 	// Use a placeholder just to sub in the original type.
 	fromPlaceholder, err := (&tree.Placeholder{Idx: 0}).TypeCheck(&ctx, oldType.ToDatumType())

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -25,6 +25,33 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
+func TestContainsVars(t *testing.T) {
+	testData := []struct {
+		expr     string
+		expected bool
+	}{
+		{`123`, false},
+		{`123+123`, false},
+		{`$1`, true},
+		{`123+$1`, true},
+		{`@1`, true},
+		{`123+@1`, true},
+	}
+
+	for _, d := range testData {
+		t.Run(d.expr, func(t *testing.T) {
+			expr, err := parser.ParseExpr(d.expr)
+			if err != nil {
+				t.Fatalf("%s: %v", d.expr, err)
+			}
+			res := tree.ContainsVars(expr)
+			if res != d.expected {
+				t.Fatalf("%s: expected %v, got %v", d.expr, d.expected, res)
+			}
+		})
+	}
+}
+
 func TestNormalizeExpr(t *testing.T) {
 	defer tree.MockNameTypes(map[string]types.T{
 		"a":  types.Int,

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -245,7 +245,9 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 	for i, d := range testData {
 		t.Run(fmt.Sprintf("%v/%v", d.exprs, d.overloads), func(t *testing.T) {
 			ctx := MakeSemaContext(false)
-			ctx.Placeholders.Init(2 /* numPlaceholders */, nil /* typeHints */)
+			if err := ctx.Placeholders.Init(2 /* numPlaceholders */, nil /* typeHints */); err != nil {
+				t.Fatal(err)
+			}
 			desired := types.Any
 			if d.desired != nil {
 				desired = d.desired

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -38,7 +38,9 @@ func BenchmarkTypeCheck(b *testing.B) {
 		b.Fatalf("%s: %v", expr, err)
 	}
 	ctx := tree.MakeSemaContext(false)
-	ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
+	if err := ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
+		b.Fatal(err)
+	}
 	for i := 0; i < b.N; i++ {
 		_, err := tree.TypeCheck(expr, &ctx, types.Int)
 		if err != nil {
@@ -180,7 +182,9 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 	}
 	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
 		ctx := tree.MakeSemaContext(false)
-		ctx.Placeholders.Init(len(test.ptypes), clonePlaceholderTypes(test.ptypes))
+		if err := ctx.Placeholders.Init(len(test.ptypes), clonePlaceholderTypes(test.ptypes)); err != nil {
+			t.Fatal(err)
+		}
 		desired := types.Any
 		if test.desired != nil {
 			desired = test.desired
@@ -321,7 +325,10 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 	}
 	for i, d := range testData {
 		ctx := tree.MakeSemaContext(false)
-		ctx.Placeholders.Init(len(d.ptypes), d.ptypes)
+		if err := ctx.Placeholders.Init(len(d.ptypes), d.ptypes); err != nil {
+			t.Error(err)
+			continue
+		}
 		desired := types.Any
 		if d.desired != nil {
 			desired = d.desired

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -174,7 +174,9 @@ func TestTypeCheck(t *testing.T) {
 				t.Fatalf("%s: %v", d.expr, err)
 			}
 			ctx := tree.MakeSemaContext(false)
-			ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
+			if err := ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
+				t.Fatal(err)
+			}
 			typeChecked, err := tree.TypeCheck(expr, &ctx, types.Any)
 			if err != nil {
 				t.Fatalf("%s: unexpected error %s", d.expr, err)

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -30,14 +30,9 @@ import (
 // type and contains no variable expressions. It returns the type-checked and
 // constant-folded expression.
 func SanitizeVarFreeExpr(
-	expr tree.Expr,
-	expectedType types.T,
-	context string,
-	semaCtx *tree.SemaContext,
-	evalCtx *tree.EvalContext,
-	allowImpure bool,
+	expr tree.Expr, expectedType types.T, context string, semaCtx *tree.SemaContext, allowImpure bool,
 ) (tree.TypedExpr, error) {
-	if tree.ContainsVars(evalCtx, expr) {
+	if tree.ContainsVars(expr) {
 		return nil, pgerror.NewErrorf(pgerror.CodeSyntaxError,
 			"variable sub-expressions are not allowed in %s", context)
 	}
@@ -78,13 +73,13 @@ func SanitizeVarFreeExpr(
 // SERIAL type and replace it with a suitable integer type and default
 // expression.
 //
-// semaCtx and evalCtx can be nil if no default expression is used for the
+// semaCtx can be nil if no default expression is used for the
 // column.
 //
 // The DEFAULT expression is returned in TypedExpr form for analysis (e.g. recording
 // sequence dependencies).
 func MakeColumnDefDescs(
-	d *tree.ColumnTableDef, semaCtx *tree.SemaContext, evalCtx *tree.EvalContext,
+	d *tree.ColumnTableDef, semaCtx *tree.SemaContext,
 ) (*ColumnDescriptor, *IndexDescriptor, tree.TypedExpr, error) {
 	if _, ok := d.Type.(*coltypes.TSerial); ok {
 		// To the reader of this code: if control arrives here, this means
@@ -127,7 +122,7 @@ func MakeColumnDefDescs(
 		// Verify the default expression type is compatible with the column type
 		// and does not contain invalid functions.
 		if typedExpr, err = SanitizeVarFreeExpr(
-			d.DefaultExpr.Expr, colDatumType, "DEFAULT", semaCtx, evalCtx, true, /* allowImpure */
+			d.DefaultExpr.Expr, colDatumType, "DEFAULT", semaCtx, true, /* allowImpure */
 		); err != nil {
 			return nil, nil, nil, err
 		}


### PR DESCRIPTION
Informs #34127.
Informs #33724.

There are two commits in here. Both in combination are needed to avoid the reported crash.

This PR prevents the crash but does not fully address the issue: after this PR the error reported to the client will be about a mismatch in the number of placeholders vs types, but really we expect something about placeholders not supported in DEFAULT. That's why the other issue remains open (and we'll look at it later).