### PR TITLE
sql: remove execStartable interface

### DIFF
--- a/pkg/sql/cancel_queries.go
+++ b/pkg/sql/cancel_queries.go
@@ -49,6 +49,10 @@ func (p *planner) CancelQueries(ctx context.Context, n *tree.CancelQueries) (pla
 	}, nil
 }
 
+func (n *cancelQueriesNode) startExec(runParams) error {
+	return nil
+}
+
 func (n *cancelQueriesNode) Next(params runParams) (bool, error) {
 	// TODO(knz): instead of performing the cancels sequentially,
 	// accumulate all the query IDs and then send batches to each of the

--- a/pkg/sql/cancel_sessions.go
+++ b/pkg/sql/cancel_sessions.go
@@ -49,6 +49,10 @@ func (p *planner) CancelSessions(ctx context.Context, n *tree.CancelSessions) (p
 	}, nil
 }
 
+func (n *cancelSessionsNode) startExec(runParams) error {
+	return nil
+}
+
 func (n *cancelSessionsNode) Next(params runParams) (bool, error) {
 	// TODO(knz): instead of performing the cancels sequentially,
 	// accumulate all the query IDs and then send batches to each of the

--- a/pkg/sql/control_jobs.go
+++ b/pkg/sql/control_jobs.go
@@ -62,7 +62,6 @@ func (n *controlJobsNode) FastPathResults() (int, bool) {
 	return n.numRows, true
 }
 
-// startExec implements the execStartable interface.
 func (n *controlJobsNode) startExec(params runParams) error {
 	reg := params.p.ExecCfg().JobRegistry
 	for {

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -149,6 +149,10 @@ func isHidden(desc *ImmutableTableDescriptor, columnID sqlbase.ColumnID) bool {
 	panic("column not found in table")
 }
 
+func (*createStatsNode) startExec(runParams) error {
+	return pgerror.NewAssertionErrorf("createStatsNode cannot be executed locally")
+}
+
 func (*createStatsNode) Next(runParams) (bool, error) {
 	return false, pgerror.NewAssertionErrorf("createStatsNode cannot be executed locally")
 }

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -50,6 +50,10 @@ func (f *filterNode) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 	return f.source.info.NodeFormatter(idx)
 }
 
+func (f *filterNode) startExec(runParams) error {
+	return nil
+}
+
 // Next implements the planNode interface.
 func (f *filterNode) Next(params runParams) (bool, error) {
 	for {

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -242,6 +242,10 @@ type indexJoinRun struct {
 
 const indexJoinBatchSize = 100
 
+func (n *indexJoinNode) startExec(runParams) error {
+	return nil
+}
+
 func (n *indexJoinNode) Next(params runParams) (bool, error) {
 	// Loop looking up the next row. We either are going to pull a row from the
 	// table or a batch of rows from the index. If we pull a batch of rows from

--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -60,7 +60,6 @@ type lookupJoinRun struct {
 	n *joinNode
 }
 
-// startExec is part of the execStartable interface.
 func (lj *lookupJoinNode) startExec(params runParams) error {
 	// Make sure the table node has a span (full scan).
 	var err error

--- a/pkg/sql/max_one_row.go
+++ b/pkg/sql/max_one_row.go
@@ -36,6 +36,10 @@ type max1RowNode struct {
 	values tree.Datums
 }
 
+func (m *max1RowNode) startExec(runParams) error {
+	return nil
+}
+
 func (m *max1RowNode) Next(params runParams) (bool, error) {
 	if m.nexted {
 		return false, nil

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -93,6 +93,10 @@ type ordinalityRun struct {
 	curCnt int64
 }
 
+func (o *ordinalityNode) startExec(runParams) error {
+	return nil
+}
+
 func (o *ordinalityNode) Next(params runParams) (bool, error) {
 	hasNext, err := o.source.Next(params)
 	if !hasNext || err != nil {

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -115,7 +115,6 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *dropViewNode:
 	case *explainDistSQLNode:
 	case *hookFnNode:
-	case *iterativeSortStrategy:
 	case *relocateNode:
 	case *renameColumnNode:
 	case *renameDatabaseNode:
@@ -133,9 +132,6 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *showTraceNode:
 	case *showTraceReplicaNode:
 	case *showZoneConfigNode:
-	case *sortAllStrategy:
-	case *sortTopKStrategy:
-	case *sortValues:
 	case *splitNode:
 	case *truncateNode:
 	case *unaryNode:

--- a/pkg/sql/project_set.go
+++ b/pkg/sql/project_set.go
@@ -243,6 +243,10 @@ type projectSetRun struct {
 	done []bool
 }
 
+func (n *projectSetNode) startExec(runParams) error {
+	return nil
+}
+
 func (n *projectSetNode) Next(params runParams) (bool, error) {
 	for {
 		// If there's a cancellation request or a timeout, process it here.

--- a/pkg/sql/relocate.go
+++ b/pkg/sql/relocate.go
@@ -133,6 +133,10 @@ type relocateRun struct {
 	storeMap map[roachpb.StoreID]roachpb.NodeID
 }
 
+func (n *relocateNode) startExec(runParams) error {
+	return nil
+}
+
 func (n *relocateNode) Next(params runParams) (bool, error) {
 	// Each Next call relocates one range (corresponding to one row from n.rows).
 	// TODO(radu): perform multiple relocations in parallel.

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -368,6 +368,10 @@ type renderRun struct {
 	row tree.Datums
 }
 
+func (r *renderNode) startExec(runParams) error {
+	return nil
+}
+
 func (r *renderNode) Next(params runParams) (bool, error) {
 	if next, err := r.source.plan.Next(params); !next {
 		return false, err

--- a/pkg/sql/sequence_select.go
+++ b/pkg/sql/sequence_select.go
@@ -43,6 +43,10 @@ func (p *planner) SequenceSelectNode(desc *sqlbase.ImmutableTableDescriptor) (pl
 	}, nil
 }
 
+func (ss *sequenceSelectNode) startExec(runParams) error {
+	return nil
+}
+
 func (ss *sequenceSelectNode) Next(params runParams) (bool, error) {
 	if ss.done {
 		return false, nil

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -221,6 +221,10 @@ type sortRun struct {
 	valueIter    valueIterator
 }
 
+func (n *sortNode) startExec(runParams) error {
+	return nil
+}
+
 func (n *sortNode) Next(params runParams) (bool, error) {
 	cancelChecker := params.p.cancelChecker
 

--- a/pkg/sql/spool.go
+++ b/pkg/sql/spool.go
@@ -37,7 +37,6 @@ func (p *planner) makeSpool(source planNode) planNode {
 	return &spoolNode{source: source}
 }
 
-// startExec implements the execStartable interface.
 func (s *spoolNode) startExec(params runParams) error {
 	// If FastPathResults() on the source indicates that the results are
 	// already available (2nd value true), then the computation is

--- a/pkg/sql/unary.go
+++ b/pkg/sql/unary.go
@@ -32,6 +32,10 @@ type unaryRun struct {
 	consumed bool
 }
 
+func (*unaryNode) startExec(runParams) error {
+	return nil
+}
+
 func (*unaryNode) Values() tree.Datums { return nil }
 
 func (u *unaryNode) Next(runParams) (bool, error) {

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -45,6 +45,10 @@ func (p *planner) newContainerVirtualTableNode(
 	}
 }
 
+func (n *virtualTableNode) startExec(runParams) error {
+	return nil
+}
+
 func (n *virtualTableNode) Next(params runParams) (bool, error) {
 	row, err := n.next()
 	if err != nil {

--- a/pkg/sql/zero.go
+++ b/pkg/sql/zero.go
@@ -37,6 +37,7 @@ func NewZeroNode(columns sqlbase.ResultColumns) PlanNode {
 	return newZeroNode(columns)
 }
 
-func (z *zeroNode) Next(runParams) (bool, error) { return false, nil }
-func (*zeroNode) Values() tree.Datums            { return nil }
-func (*zeroNode) Close(context.Context)          {}
+func (*zeroNode) startExec(runParams) error    { return nil }
+func (*zeroNode) Next(runParams) (bool, error) { return false, nil }
+func (*zeroNode) Values() tree.Datums          { return nil }
+func (*zeroNode) Close(context.Context)        {}

--- a/pkg/sql/zigzag_join.go
+++ b/pkg/sql/zigzag_join.go
@@ -65,7 +65,6 @@ type zigzagJoinSide struct {
 	fixedVals *valuesNode
 }
 
-// startExec is part of the execStartable interface.
 func (zj *zigzagJoinNode) startExec(params runParams) error {
 	panic("zigzag joins cannot be executed outside of distsql")
 }


### PR DESCRIPTION
The execStartable interface adds some unnecessary complication. It is
more straightforward if all planNodes have this method, even if it
does nothing. In fact, IMO it's a good thing™ to have a method that
explicitly does nothing, it forces whomever writes it to think if it
should be doing something.

Release note: None