### PR TITLE
sql: clean up EXPLAIN for index-join and lookup-join

### DIFF
--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -242,8 +242,8 @@ type indexJoinRun struct {
 
 const indexJoinBatchSize = 100
 
-func (n *indexJoinNode) startExec(runParams) error {
-	return nil
+func (n *indexJoinNode) startExec(params runParams) error {
+	return n.table.startExec(params)
 }
 
 func (n *indexJoinNode) Next(params runParams) (bool, error) {

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -753,4 +753,3 @@ SELECT * FROM ex33313 ORDER BY foo
 foo  bar  baz
 1    1    1
 3    2    2
-

--- a/pkg/sql/logictest/testdata/planner_test/aggregate
+++ b/pkg/sql/logictest/testdata/planner_test/aggregate
@@ -842,11 +842,10 @@ group                 ·            ·                        (z, max)          
       │               render 0     test.public.group_ord.z  ·                            ·
       │               render 1     test.public.group_ord.y  ·                            ·
       └── index-join  ·            ·                        (x[omitted], y, z)           x!=NULL; weak-key(x,z); +z
-           ├── scan   ·            ·                        (x, y[omitted], z[omitted])  x!=NULL; weak-key(x,z); +z
-           │          table        group_ord@foo            ·                            ·
-           │          spans        ALL                      ·                            ·
-           └── scan   ·            ·                        (x[omitted], y, z)           ·
-·                     table        group_ord@primary        ·                            ·
+           │          table        group_ord@primary        ·                            ·
+           └── scan   ·            ·                        (x, y[omitted], z[omitted])  x!=NULL; weak-key(x,z); +z
+·                     table        group_ord@foo            ·                            ·
+·                     spans        ALL                      ·                            ·
 
 # Test that a merge join is used on two aggregate subqueries with orderings on
 # the GROUP BY columns. Note that an ORDER BY is not necessary on the
@@ -878,11 +877,10 @@ join                       ·               ·                        (x, max, z
            │               render 0        test.public.group_ord.z  ·                            ·
            │               render 1        test.public.group_ord.y  ·                            ·
            └── index-join  ·               ·                        (x[omitted], y, z)           x!=NULL; weak-key(x,z); +z
-                ├── scan   ·               ·                        (x, y[omitted], z[omitted])  x!=NULL; weak-key(x,z); +z
-                │          table           group_ord@foo            ·                            ·
-                │          spans           ALL                      ·                            ·
-                └── scan   ·               ·                        (x[omitted], y, z)           ·
-·                          table           group_ord@primary        ·                            ·
+                │          table           group_ord@primary        ·                            ·
+                └── scan   ·               ·                        (x, y[omitted], z[omitted])  x!=NULL; weak-key(x,z); +z
+·                          table           group_ord@foo            ·                            ·
+·                          spans           ALL                      ·                            ·
 
 # Regression test for #25533 (crash when propagating filter through GROUP BY).
 query TTTTT

--- a/pkg/sql/logictest/testdata/planner_test/custom_mutation_indexes
+++ b/pkg/sql/logictest/testdata/planner_test/custom_mutation_indexes
@@ -70,9 +70,8 @@ count                      ·         ·
       │                    strategy  updater
       └── render           ·         ·
            └── index-join  ·         ·
-                ├── scan   ·         ·
-                │          table     a@a_a_e_k_l_idx
-                │          spans     /10-/11
-                │          filter    ((b = '10') AND (c = 1)) AND (d = 3)
+                │          table     a@primary
                 └── scan   ·         ·
-·                          table     a@primary
+·                          table     a@a_a_e_k_l_idx
+·                          spans     /10-/11
+·                          filter    ((b = '10') AND (c = 1)) AND (d = 3)

--- a/pkg/sql/logictest/testdata/planner_test/delete
+++ b/pkg/sql/logictest/testdata/planner_test/delete
@@ -138,12 +138,11 @@ render                          ·         ·
            └── limit            ·         ·
                 │               count     10
                 └── index-join  ·         ·
-                     ├── scan   ·         ·
-                     │          table     indexed@indexed_value_idx
-                     │          spans     /5-/6
-                     │          limit     10
+                     │          table     indexed@primary
                      └── scan   ·         ·
-·                               table     indexed@primary
+·                               table     indexed@indexed_value_idx
+·                               spans     /5-/6
+·                               limit     10
 
 # Ensure that the scan for cross-range point deletes are parallelized.
 statement ok

--- a/pkg/sql/logictest/testdata/planner_test/distsql_lookup_join
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_lookup_join
@@ -232,11 +232,10 @@ render                ·               ·
       │               table           multiples@primary
       │               spans           ALL
       └── index-join  ·               ·
-           ├── scan   ·               ·
-           │          table           multiples@bc
-           │          spans           ALL
+           │          table           multiples@primary
            └── scan   ·               ·
-·                     table           multiples@primary
+·                     table           multiples@bc
+·                     spans           ALL
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.a, t2.d FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b]

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -437,11 +437,10 @@ sort                  ·         ·                 (a, b)                      
       │               render 0  test.public.tc.a  ·                                        ·
       │               render 1  test.public.tc.b  ·                                        ·
       └── index-join  ·         ·                 (a, b, rowid[hidden,omitted])            a=CONST; rowid!=NULL; key(rowid)
-           ├── scan   ·         ·                 (a[omitted], b[omitted], rowid[hidden])  a=CONST; rowid!=NULL; key(rowid)
-           │          table     tc@c              ·                                        ·
-           │          spans     /10-/11           ·                                        ·
-           └── scan   ·         ·                 (a, b, rowid[hidden,omitted])            ·
-·                     table     tc@primary        ·                                        ·
+           │          table     tc@primary        ·                                        ·
+           └── scan   ·         ·                 (a[omitted], b[omitted], rowid[hidden])  a=CONST; rowid!=NULL; key(rowid)
+·                     table     tc@c              ·                                        ·
+·                     spans     /10-/11           ·                                        ·
 
 query TTTTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
@@ -696,16 +695,14 @@ CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-render           ·         ·                             (x int, y int)                                       x!=NULL; y!=NULL
- │               render 0  (x)[int]                      ·                                                    ·
- │               render 1  (y)[int]                      ·                                                    ·
- └── index-join  ·         ·                             (x int, y int, rowid[hidden,omitted] int)            x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
-      ├── scan   ·         ·                             (x[omitted] int, y[omitted] int, rowid[hidden] int)  x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
-      │          table     tt@a                          ·                                                    ·
-      │          spans     /!NULL-/10                    ·                                                    ·
-      └── scan   ·         ·                             (x int, y int, rowid[hidden,omitted] int)            ·
-·                table     tt@primary                    ·                                                    ·
-·                filter    ((y)[int] > (10)[int])[bool]  ·                                                    ·
+render           ·         ·           (x int, y int)                                       x!=NULL; y!=NULL
+ │               render 0  (x)[int]    ·                                                    ·
+ │               render 1  (y)[int]    ·                                                    ·
+ └── index-join  ·         ·           (x int, y int, rowid[hidden,omitted] int)            x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
+      │          table     tt@primary  ·                                                    ·
+      └── scan   ·         ·           (x[omitted] int, y[omitted] int, rowid[hidden] int)  x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
+·                table     tt@a        ·                                                    ·
+·                spans     /!NULL-/10  ·                                                    ·
 
 query TTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM tt WHERE x < 10 AND y > 10

--- a/pkg/sql/logictest/testdata/planner_test/inverted_index
+++ b/pkg/sql/logictest/testdata/planner_test/inverted_index
@@ -13,61 +13,55 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
 index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                    ·                ·
- │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
- └── scan   ·      ·                            (a, b)           ·
-·           table  d@primary                    ·                ·
+ │          table  d@primary                    ·                ·
+ └── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                    ·                ·
+·           spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
 ----
 index-join  ·      ·                                        (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                                ·                ·
- │          spans  /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·                ·
- └── scan   ·      ·                                        (a, b)           ·
-·           table  d@primary                                ·                ·
+ │          table  d@primary                                ·                ·
+ └── scan   ·      ·                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                                ·                ·
+·           spans  /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
 ----
 index-join  ·      ·                                                (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                                        ·                ·
- │          spans  /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
- └── scan   ·      ·                                                (a, b)           ·
-·           table  d@primary                                        ·                ·
+ │          table  d@primary                                        ·                ·
+ └── scan   ·      ·                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                                        ·                ·
+·           spans  /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
 ----
 index-join  ·      ·                             (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                     ·                ·
- │          spans  /"a"/"b"/True-/"a"/"b"/False  ·                ·
- └── scan   ·      ·                             (a, b)           ·
-·           table  d@primary                     ·                ·
+ │          table  d@primary                     ·                ·
+ └── scan   ·      ·                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                     ·                ·
+·           spans  /"a"/"b"/True-/"a"/"b"/False  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[1]'
 ----
 index-join  ·      ·                        (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                ·                ·
- │          spans  /Arr/1-/Arr/1/PrefixEnd  ·                ·
- └── scan   ·      ·                        (a, b)           ·
-·           table  d@primary                ·                ·
+ │          table  d@primary                ·                ·
+ └── scan   ·      ·                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                ·                ·
+·           spans  /Arr/1-/Arr/1/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
 ----
 index-join  ·      ·                                                (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                                        ·                ·
- │          spans  /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·                ·
- └── scan   ·      ·                                                (a, b)           ·
-·           table  d@primary                                        ·                ·
+ │          table  d@primary                                        ·                ·
+ └── scan   ·      ·                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                                        ·                ·
+·           spans  /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
@@ -90,21 +84,19 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
 ----
 index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                    ·                ·
- │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
- └── scan   ·      ·                            (a, b)           ·
-·           table  d@primary                    ·                ·
+ │          table  d@primary                    ·                ·
+ └── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                    ·                ·
+·           spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
 ----
 index-join  ·      ·                                    (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                            ·                ·
- │          spans  /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd  ·                ·
- └── scan   ·      ·                                    (a, b)           ·
-·           table  d@primary                            ·                ·
+ │          table  d@primary                            ·                ·
+ └── scan   ·      ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                            ·                ·
+·           spans  /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd  ·                ·
 
 # Regression test for #29399. Do not panic when NULL::STRING is on the right
 # hand side of ->.
@@ -117,11 +109,10 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 ----
 index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                    ·                ·
- │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
- └── scan   ·      ·                            (a, b)           ·
-·           table  d@primary                    ·                ·
+ │          table  d@primary                    ·                ·
+ └── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                    ·                ·
+·           spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
@@ -152,46 +143,38 @@ scan  ·       ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
-index-join  ·       ·                                    (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·       ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table   d@foo_inv                            ·                ·
- │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·                ·
- └── scan   ·       ·                                    (a, b)           ·
-·           table   d@primary                            ·                ·
-·           filter  b @> '{"a": {"b": "c"}, "f": "g"}'   ·                ·
+index-join  ·      ·                                    (a, b)           b=CONST; a!=NULL; key(a)
+ │          table  d@primary                            ·                ·
+ └── scan   ·      ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                            ·                ·
+·           spans  /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
-index-join  ·       ·                                             (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·       ·                                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table   d@foo_inv                                     ·                ·
- │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd           ·                ·
- └── scan   ·       ·                                             (a, b)           ·
-·           table   d@primary                                     ·                ·
-·           filter  b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·                ·
+index-join  ·      ·                                    (a, b)           b=CONST; a!=NULL; key(a)
+ │          table  d@primary                            ·                ·
+ └── scan   ·      ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                            ·                ·
+·           spans  /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
-index-join  ·       ·                                                        (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·       ·                                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table   d@foo_inv                                                ·                ·
- │          spans   /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
- └── scan   ·       ·                                                        (a, b)           ·
-·           table   d@primary                                                ·                ·
-·           filter  b @> '[{"a": {"b": [[2]]}}, "d"]'                        ·                ·
+index-join  ·      ·                                                        (a, b)           b=CONST; a!=NULL; key(a)
+ │          table  d@primary                                                ·                ·
+ └── scan   ·      ·                                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                                                ·                ·
+·           spans  /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
 ----
-index-join  ·       ·                         (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·       ·                         (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table   d@foo_inv                 ·                ·
- │          spans   /"b"/2-/"b"/2/PrefixEnd   ·                ·
- └── scan   ·       ·                         (a, b)           ·
-·           table   d@primary                 ·                ·
-·           filter  b @> '{"a": {}, "b": 2}'  ·                ·
+index-join  ·      ·                        (a, b)           b=CONST; a!=NULL; key(a)
+ │          table  d@primary                ·                ·
+ └── scan   ·      ·                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table  d@foo_inv                ·                ·
+·           spans  /"b"/2-/"b"/2/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": {}}'

--- a/pkg/sql/logictest/testdata/planner_test/limit
+++ b/pkg/sql/logictest/testdata/planner_test/limit
@@ -7,16 +7,14 @@ CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX(v))
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE v > 4 AND w > 30 ORDER BY v LIMIT 2
 ----
-tree             field   description  columns                      ordering
-limit            ·       ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
- │               count   2            ·                            ·
- └── index-join  ·       ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
-      ├── scan   ·       ·            (k, v[omitted], w[omitted])  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
-      │          table   t@t_v_idx    ·                            ·
-      │          spans   /5-          ·                            ·
-      └── scan   ·       ·            (k, v, w)                    ·
-·                table   t@primary    ·                            ·
-·                filter  w > 30       ·                            ·
+tree             field  description  columns                      ordering
+limit            ·      ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+ │               count  2            ·                            ·
+ └── index-join  ·      ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+      │          table  t@primary    ·                            ·
+      └── scan   ·      ·            (k, v[omitted], w[omitted])  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+·                table  t@t_v_idx    ·                            ·
+·                spans  /5-          ·                            ·
 
 # This kind of query can be used to work around memory usage limits. We need to
 # choose the "hard" limit of 100 over the "soft" limit of 25 (with the hard

--- a/pkg/sql/logictest/testdata/planner_test/order_by
+++ b/pkg/sql/logictest/testdata/planner_test/order_by
@@ -248,11 +248,10 @@ EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 sort             ·      ·
  │               order  +b,+a,+d
  └── index-join  ·      ·
-      ├── scan   ·      ·
-      │          table  abc@bc
-      │          spans  /11-
+      │          table  abc@primary
       └── scan   ·      ·
-·                table  abc@primary
+·                table  abc@bc
+·                spans  /11-
 
 # We cannot have rows with identical values for a,b,c so we don't need to
 # sort for d.
@@ -260,11 +259,10 @@ query TTT
 EXPLAIN SELECT a, b, c, d FROM abc WHERE b > 10 ORDER BY b, a, c, d
 ----
 index-join  ·      ·
- ├── scan   ·      ·
- │          table  abc@ba
- │          spans  /11-
+ │          table  abc@primary
  └── scan   ·      ·
-·           table  abc@primary
+·           table  abc@ba
+·           spans  /11-
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c

--- a/pkg/sql/logictest/testdata/planner_test/select
+++ b/pkg/sql/logictest/testdata/planner_test/select
@@ -453,26 +453,24 @@ EXPLAIN SELECT price FROM a WHERE item IN ('sock', 'ball')
 ----
 render           ·         ·
  └── index-join  ·         ·
-      ├── scan   ·         ·
-      │          table     a@item
-      │          spans     /"ball"-/"ball"/PrefixEnd /"sock"-/"sock"/PrefixEnd
-      │          parallel  ·
+      │          table     a@primary
       └── scan   ·         ·
-·                table     a@primary
+·                table     a@item
+·                spans     /"ball"-/"ball"/PrefixEnd /"sock"-/"sock"/PrefixEnd
+·                parallel  ·
 
 # Range queries on non-int types are not parallel due to unbounded number of
 # results.
 query TTT
 EXPLAIN SELECT item FROM a WHERE price > 5 AND price < 10 OR price > 20 AND price < 40
 ----
-render           ·         ·
- └── index-join  ·         ·
-      ├── scan   ·         ·
-      │          table     a@p
-      │          spans     /5.000000000000001-/9.999999999999998/PrefixEnd /20.000000000000004-/39.99999999999999/PrefixEnd
-      │          filter    (price < 10.0) OR (price > 20.0)
-      └── scan   ·         ·
-·                table     a@primary
+render           ·       ·
+ └── index-join  ·       ·
+      │          table   a@primary
+      └── scan   ·       ·
+·                table   a@p
+·                spans   /5.000000000000001-/9.999999999999998/PrefixEnd /20.000000000000004-/39.99999999999999/PrefixEnd
+·                filter  (price < 10.0) OR (price > 20.0)
 
 # TODO(radu): fix this testcase after #31614 is resolved. There should be no filter left.
 query TTT

--- a/pkg/sql/logictest/testdata/planner_test/select_index
+++ b/pkg/sql/logictest/testdata/planner_test/select_index
@@ -188,17 +188,15 @@ render                     ·               ·
            │               equality        (b) = (b)
            │               mergeJoinOrder  +"(b=b)"
            ├── index-join  ·               ·
-           │    ├── scan   ·               ·
-           │    │          table           t@bc
-           │    │          spans           -/"3"
+           │    │          table           t@primary
            │    └── scan   ·               ·
-           │               table           t@primary
+           │               table           t@bc
+           │               spans           -/"3"
            └── index-join  ·               ·
-                ├── scan   ·               ·
-                │          table           t@bc
-                │          spans           -/"3"
+                │          table           t@primary
                 └── scan   ·               ·
-·                          table           t@primary
+·                          table           t@bc
+·                          spans           -/"3"
 
 statement ok
 TRUNCATE TABLE t
@@ -638,12 +636,11 @@ EXPLAIN SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20
 limit              ·      ·
  │                 count  20
  └── index-join    ·      ·
-      ├── revscan  ·      ·
-      │            table  test2@test2_k_key
-      │            spans  /!NULL-/"100"/PrefixEnd
-      │            limit  20
-      └── scan     ·      ·
-·                  table  test2@primary
+      │            table  test2@primary
+      └── revscan  ·      ·
+·                  table  test2@test2_k_key
+·                  spans  /!NULL-/"100"/PrefixEnd
+·                  limit  20
 
 # Result check: The following query must not issue more than the
 # requested LIMIT K/V reads, even though an index join batches 100
@@ -873,11 +870,10 @@ render           ·         ·                 (x, y)                           
  │               render 0  test.public.xy.x  ·                                        ·
  │               render 1  test.public.xy.y  ·                                        ·
  └── index-join  ·         ·                 (x, y, rowid[hidden,omitted])            y=CONST; rowid!=NULL; key(rowid)
-      ├── scan   ·         ·                 (x[omitted], y[omitted], rowid[hidden])  y=CONST; rowid!=NULL; key(rowid)
-      │          table     xy@xy_y_idx       ·                                        ·
-      │          spans     /NULL-/!NULL      ·                                        ·
-      └── scan   ·         ·                 (x, y, rowid[hidden,omitted])            ·
-·                table     xy@primary        ·                                        ·
+      │          table     xy@primary        ·                                        ·
+      └── scan   ·         ·                 (x[omitted], y[omitted], rowid[hidden])  y=CONST; rowid!=NULL; key(rowid)
+·                table     xy@xy_y_idx       ·                                        ·
+·                spans     /NULL-/!NULL      ·                                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM 4
@@ -886,11 +882,10 @@ render           ·         ·                 (x, y)                           
  │               render 0  test.public.xy.x  ·                                        ·
  │               render 1  test.public.xy.y  ·                                        ·
  └── index-join  ·         ·                 (x, y, rowid[hidden,omitted])            y=CONST; rowid!=NULL; key(rowid)
-      ├── scan   ·         ·                 (x[omitted], y[omitted], rowid[hidden])  y=CONST; rowid!=NULL; key(rowid)
-      │          table     xy@xy_y_idx       ·                                        ·
-      │          spans     /4-/5             ·                                        ·
-      └── scan   ·         ·                 (x, y, rowid[hidden,omitted])            ·
-·                table     xy@primary        ·                                        ·
+      │          table     xy@primary        ·                                        ·
+      └── scan   ·         ·                 (x[omitted], y[omitted], rowid[hidden])  y=CONST; rowid!=NULL; key(rowid)
+·                table     xy@xy_y_idx       ·                                        ·
+·                spans     /4-/5             ·                                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL
@@ -899,11 +894,10 @@ render           ·         ·                 (x, y)                           
  │               render 0  test.public.xy.x  ·                                        ·
  │               render 1  test.public.xy.y  ·                                        ·
  └── index-join  ·         ·                 (x, y, rowid[hidden,omitted])            y!=NULL; rowid!=NULL; key(y,rowid)
-      ├── scan   ·         ·                 (x[omitted], y[omitted], rowid[hidden])  y!=NULL; rowid!=NULL; key(y,rowid)
-      │          table     xy@xy_y_idx       ·                                        ·
-      │          spans     /!NULL-           ·                                        ·
-      └── scan   ·         ·                 (x, y, rowid[hidden,omitted])            ·
-·                table     xy@primary        ·                                        ·
+      │          table     xy@primary        ·                                        ·
+      └── scan   ·         ·                 (x[omitted], y[omitted], rowid[hidden])  y!=NULL; rowid!=NULL; key(y,rowid)
+·                table     xy@xy_y_idx       ·                                        ·
+·                spans     /!NULL-           ·                                        ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM 4
@@ -912,11 +906,10 @@ render           ·         ·                 (x, y)                           
  │               render 0  test.public.xy.x  ·                                        ·
  │               render 1  test.public.xy.y  ·                                        ·
  └── index-join  ·         ·                 (x, y, rowid[hidden,omitted])            y!=NULL; rowid!=NULL; key(y,rowid)
-      ├── scan   ·         ·                 (x[omitted], y[omitted], rowid[hidden])  y!=NULL; rowid!=NULL; key(y,rowid)
-      │          table     xy@xy_y_idx       ·                                        ·
-      │          spans     -/4 /5-           ·                                        ·
-      └── scan   ·         ·                 (x, y, rowid[hidden,omitted])            ·
-·                table     xy@primary        ·                                        ·
+      │          table     xy@primary        ·                                        ·
+      └── scan   ·         ·                 (x[omitted], y[omitted], rowid[hidden])  y!=NULL; rowid!=NULL; key(y,rowid)
+·                table     xy@xy_y_idx       ·                                        ·
+·                spans     -/4 /5-           ·                                        ·
 
 # Regression tests for #22670.
 statement ok
@@ -966,11 +959,10 @@ query TTT
 EXPLAIN SELECT * FROM noncover WHERE b = 2
 ----
 index-join  ·      ·
- ├── scan   ·      ·
- │          table  noncover@b
- │          spans  /2-/3
+ │          table  noncover@primary
  └── scan   ·      ·
-·           table  noncover@primary
+·           table  noncover@b
+·           spans  /2-/3
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE b = 2; SET tracing = off
@@ -990,11 +982,10 @@ query TTT
 EXPLAIN SELECT * FROM noncover WHERE c = 6
 ----
 index-join  ·      ·
- ├── scan   ·      ·
- │          table  noncover@c
- │          spans  /6-/7
+ │          table  noncover@primary
  └── scan   ·      ·
-·           table  noncover@primary
+·           table  noncover@c
+·           spans  /6-/7
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE c = 7; SET tracing = off
@@ -1014,32 +1005,28 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 ORDER BY c DESC
 ----
 index-join    ·      ·                 (a, b, c, d)                             c!=NULL; key(c); -c
- ├── revscan  ·      ·                 (a, b[omitted], c[omitted], d[omitted])  c!=NULL; key(c); -c
- │            table  noncover@c        ·                                        ·
- │            spans  /1-               ·                                        ·
- └── scan     ·      ·                 (a, b, c, d)                             ·
-·             table  noncover@primary  ·                                        ·
+ │            table  noncover@primary  ·                                        ·
+ └── revscan  ·      ·                 (a, b[omitted], c[omitted], d[omitted])  c!=NULL; key(c); -c
+·             table  noncover@c        ·                                        ·
+·             spans  /1-               ·                                        ·
 
 query TTT
 EXPLAIN SELECT * FROM noncover WHERE c > 0 ORDER BY c
 ----
 index-join  ·      ·
- ├── scan   ·      ·
- │          table  noncover@c
- │          spans  /1-
+ │          table  noncover@primary
  └── scan   ·      ·
-·           table  noncover@primary
+·           table  noncover@c
+·           spans  /1-
 
 query TTT
 EXPLAIN SELECT * FROM noncover WHERE c > 0 AND d = 8
 ----
-index-join  ·       ·
- ├── scan   ·       ·
- │          table   noncover@c
- │          spans   /1-
- └── scan   ·       ·
-·           table   noncover@primary
-·           filter  d = 8
+index-join  ·      ·
+ │          table  noncover@primary
+ └── scan   ·      ·
+·           table  noncover@c
+·           spans  /1-
 
 # The following testcases verify that when we have a small limit, we prefer an
 # order-matching index.
@@ -1059,12 +1046,11 @@ EXPLAIN SELECT * FROM noncover ORDER BY c LIMIT 5
 limit            ·      ·
  │               count  5
  └── index-join  ·      ·
-      ├── scan   ·      ·
-      │          table  noncover@c
-      │          spans  ALL
-      │          limit  5
+      │          table  noncover@primary
       └── scan   ·      ·
-·                table  noncover@primary
+·                table  noncover@c
+·                spans  ALL
+·                limit  5
 
 query TTT
 SELECT tree, field, description FROM [
@@ -1088,12 +1074,11 @@ limit            ·       ·
  │               count   5
  │               offset  5
  └── index-join  ·       ·
-      ├── scan   ·       ·
-      │          table   noncover@c
-      │          spans   ALL
-      │          limit   10
+      │          table   noncover@primary
       └── scan   ·       ·
-·                table   noncover@primary
+·                table   noncover@c
+·                spans   ALL
+·                limit   10
 
 query TTT
 SELECT tree, field, description FROM [
@@ -1145,12 +1130,11 @@ EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0
 ]
 ----
 index-join  ·       ·
- ├── scan   ·       ·
- │          table   t2@bc
- │          spans   /2-/3
- │          filter  (c % 2) = 0
+ │          table   t2@primary
  └── scan   ·       ·
-·           table   t2@primary
+·           table   t2@bc
+·           spans   /2-/3
+·           filter  (c % 2) = 0
 
 # We do NOT look up the table row for '21' and '23'.
 statement ok
@@ -1175,12 +1159,11 @@ EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c != b
 ]
 ----
 index-join  ·       ·
- ├── scan   ·       ·
- │          table   t2@bc
- │          spans   /2/!NULL-/3
- │          filter  c != b
+ │          table   t2@primary
  └── scan   ·       ·
-·           table   t2@primary
+·           table   t2@bc
+·           spans   /2/!NULL-/3
+·           filter  c != b
 
 # We do NOT look up the table row for '22'.
 statement ok
@@ -1263,8 +1246,7 @@ EXPLAIN (VERBOSE) SELECT a FROM t2 WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s !
 render           ·         ·                 (a)                                      a!=NULL
  │               render 0  test.public.t2.a  ·                                        ·
  └── index-join  ·         ·                 (a, b[omitted], c[omitted], s[omitted])  b=CONST; a!=NULL; weak-key(a,c)
-      ├── scan   ·         ·                 (a, b[omitted], c[omitted], s[omitted])  b=CONST; a!=NULL; weak-key(a,c)
-      │          table     t2@bc             ·                                        ·
-      │          spans     /2-/3             ·                                        ·
-      └── scan   ·         ·                 (a, b[omitted], c[omitted], s[omitted])  ·
-·                table     t2@primary        ·                                        ·
+      │          table     t2@primary        ·                                        ·
+      └── scan   ·         ·                 (a, b[omitted], c[omitted], s[omitted])  b=CONST; a!=NULL; weak-key(a,c)
+·                table     t2@bc             ·                                        ·
+·                spans     /2-/3             ·                                        ·

--- a/pkg/sql/logictest/testdata/planner_test/select_index_flags
+++ b/pkg/sql/logictest/testdata/planner_test/select_index_flags
@@ -43,36 +43,33 @@ query TTT
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
 index-join  ·       ·
- ├── scan   ·       ·
- │          table   abcd@b
- │          spans   ALL
- │          filter  (a >= 20) AND (a <= 30)
+ │          table   abcd@primary
  └── scan   ·       ·
-·           table   abcd@primary
+·           table   abcd@b
+·           spans   ALL
+·           filter  (a >= 20) AND (a <= 30)
 
 # Force index b, reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} WHERE a >= 20 AND a <= 30
 ----
 index-join    ·       ·
- ├── revscan  ·       ·
- │            table   abcd@b
- │            spans   ALL
- │            filter  (a >= 20) AND (a <= 30)
- └── scan     ·       ·
-·             table   abcd@primary
+ │            table   abcd@primary
+ └── revscan  ·       ·
+·             table   abcd@b
+·             spans   ALL
+·             filter  (a >= 20) AND (a <= 30)
 
 # Force index cd
 query TTT
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
 index-join  ·       ·
- ├── scan   ·       ·
- │          table   abcd@cd
- │          spans   ALL
- │          filter  (a >= 20) AND (a <= 30)
+ │          table   abcd@primary
  └── scan   ·       ·
-·           table   abcd@primary
+·           table   abcd@cd
+·           spans   ALL
+·           filter  (a >= 20) AND (a <= 30)
 
 # Force index bcd
 query TTT
@@ -97,14 +94,12 @@ render     ·       ·
 query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
-render           ·       ·
- └── index-join  ·       ·
-      ├── scan   ·       ·
-      │          table   abcd@b
-      │          spans   ALL
-      └── scan   ·       ·
-·                table   abcd@primary
-·                filter  (c >= 20) AND (c <= 30)
+render           ·      ·
+ └── index-join  ·      ·
+      │          table  abcd@primary
+      └── scan   ·      ·
+·                table  abcd@b
+·                spans  ALL
 
 # No hint, should be using index cd
 query TTT
@@ -129,36 +124,32 @@ render     ·       ·
 query TTT
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----
-render           ·       ·
- └── index-join  ·       ·
-      ├── scan   ·       ·
-      │          table   abcd@b
-      │          spans   ALL
-      └── scan   ·       ·
-·                table   abcd@primary
-·                filter  (c >= 20) AND (c < 40)
+render           ·      ·
+ └── index-join  ·      ·
+      │          table  abcd@primary
+      └── scan   ·      ·
+·                table  abcd@b
+·                spans  ALL
 
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 ----
 index-join  ·       ·
- ├── scan   ·       ·
- │          table   abcd@b
- │          spans   ALL
- │          filter  (a >= 20) AND (a <= 30)
+ │          table   abcd@primary
  └── scan   ·       ·
-·           table   abcd@primary
+·           table   abcd@b
+·           spans   ALL
+·           filter  (a >= 20) AND (a <= 30)
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
 render           ·      ·
  └── index-join  ·      ·
-      ├── scan   ·      ·
-      │          table  abcd@cd
-      │          spans  /10-/11
+      │          table  abcd@primary
       └── scan   ·      ·
-·                table  abcd@primary
+·                table  abcd@cd
+·                spans  /10-/11
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10

--- a/pkg/sql/logictest/testdata/planner_test/tuple
+++ b/pkg/sql/logictest/testdata/planner_test/tuple
@@ -100,18 +100,16 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3) AND (a, b, c) < (8, 9, 10)
 ----
-render           ·         ·                                                     (a, b, c)                          ·
- │               render 0  test.public.abc.a                                     ·                                  ·
- │               render 1  test.public.abc.b                                     ·                                  ·
- │               render 2  test.public.abc.c                                     ·                                  ·
- └── index-join  ·         ·                                                     (a, b, c, rowid[hidden,omitted])   rowid!=NULL; weak-key(a,b,rowid)
-      ├── scan   ·         ·                                                     (a, b, c[omitted], rowid[hidden])  rowid!=NULL; weak-key(a,b,rowid)
-      │          table     abc@abc_a_b_idx                                       ·                                  ·
-      │          spans     /1/2-/8/10                                            ·                                  ·
-      │          filter    ((a, b) >= (1, 2)) AND ((a, b) <= (8, 9))             ·                                  ·
-      └── scan   ·         ·                                                     (a, b, c, rowid[hidden,omitted])   ·
-·                table     abc@primary                                           ·                                  ·
-·                filter    ((a, b, c) > (1, 2, 3)) AND ((a, b, c) < (8, 9, 10))  ·                                  ·
+render           ·         ·                                          (a, b, c)                          ·
+ │               render 0  test.public.abc.a                          ·                                  ·
+ │               render 1  test.public.abc.b                          ·                                  ·
+ │               render 2  test.public.abc.c                          ·                                  ·
+ └── index-join  ·         ·                                          (a, b, c, rowid[hidden,omitted])   rowid!=NULL; weak-key(a,b,rowid)
+      │          table     abc@primary                                ·                                  ·
+      └── scan   ·         ·                                          (a, b, c[omitted], rowid[hidden])  rowid!=NULL; weak-key(a,b,rowid)
+·                table     abc@abc_a_b_idx                            ·                                  ·
+·                spans     /1/2-/8/10                                 ·                                  ·
+·                filter    ((a, b) >= (1, 2)) AND ((a, b) <= (8, 9))  ·                                  ·
 
 statement ok
 DROP TABLE abc

--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -118,6 +118,10 @@ func (lj *lookupJoinNode) startExec(params runParams) error {
 		}
 	}
 
+	if err := lj.table.startExec(params); err != nil {
+		return err
+	}
+
 	rightSrc := planDataSource{
 		info: &sqlbase.DataSourceInfo{SourceColumns: planColumns(lj.table)},
 		plan: lj.table,
@@ -143,7 +147,10 @@ func (lj *lookupJoinNode) startExec(params runParams) error {
 		}
 	}
 	lj.run.n = params.p.makeJoinNode(leftSrc, rightSrc, pred)
-	return lj.run.n.startExec(params)
+	if err := lj.run.n.startExec(params); err != nil {
+		return err
+	}
+	return lj.table.startExec(params)
 }
 
 func (lj *lookupJoinNode) Next(params runParams) (bool, error) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -104,12 +104,11 @@ count                 ·         ·
       │               from      indexed
       │               strategy  deleter
       └── index-join  ·         ·
-           ├── scan   ·         ·
-           │          table     indexed@indexed_value_idx
-           │          spans     /5-/6
-           │          limit     10
+           │          table     indexed@primary
            └── scan   ·         ·
-·                     table     indexed@primary
+·                     table     indexed@indexed_value_idx
+·                     spans     /5-/6
+·                     limit     10
 
 query TTT
 EXPLAIN DELETE FROM indexed LIMIT 10
@@ -133,9 +132,8 @@ render                     ·         ·
            │               from      indexed
            │               strategy  deleter
            └── index-join  ·         ·
-                ├── scan   ·         ·
-                │          table     indexed@indexed_value_idx
-                │          spans     /5-/6
-                │          limit     10
+                │          table     indexed@primary
                 └── scan   ·         ·
-·                          table     indexed@primary
+·                          table     indexed@indexed_value_idx
+·                          spans     /5-/6
+·                          limit     10

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -424,11 +424,10 @@ EXPLAIN (VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
 sort             ·      ·           (a, b)              +b
  │               order  +b          ·                   ·
  └── index-join  ·      ·           (a, b)              ·
-      ├── scan   ·      ·           (a, rowid[hidden])  ·
-      │          table  tc@c        ·                   ·
-      │          spans  /10-/11     ·                   ·
-      └── scan   ·      ·           (a, b)              ·
-·                table  tc@primary  ·                   ·
+      │          table  tc@primary  ·                   ·
+      └── scan   ·      ·           (a, rowid[hidden])  ·
+·                table  tc@c        ·                   ·
+·                spans  /10-/11     ·                   ·
 
 query TTTTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -13,61 +13,55 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
 index-join  ·      ·                            (a, b)  ·
- ├── scan   ·      ·                            (a)     ·
- │          table  d@foo_inv                    ·       ·
- │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
- └── scan   ·      ·                            (a, b)  ·
-·           table  d@primary                    ·       ·
+ │          table  d@primary                    ·       ·
+ └── scan   ·      ·                            (a)     ·
+·           table  d@foo_inv                    ·       ·
+·           spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
 ----
 index-join  ·      ·                                        (a, b)  ·
- ├── scan   ·      ·                                        (a)     ·
- │          table  d@foo_inv                                ·       ·
- │          spans  /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·       ·
- └── scan   ·      ·                                        (a, b)  ·
-·           table  d@primary                                ·       ·
+ │          table  d@primary                                ·       ·
+ └── scan   ·      ·                                        (a)     ·
+·           table  d@foo_inv                                ·       ·
+·           spans  /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
 ----
 index-join  ·      ·                                                (a, b)  ·
- ├── scan   ·      ·                                                (a)     ·
- │          table  d@foo_inv                                        ·       ·
- │          spans  /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
- └── scan   ·      ·                                                (a, b)  ·
-·           table  d@primary                                        ·       ·
+ │          table  d@primary                                        ·       ·
+ └── scan   ·      ·                                                (a)     ·
+·           table  d@foo_inv                                        ·       ·
+·           spans  /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
 ----
 index-join  ·      ·                             (a, b)  ·
- ├── scan   ·      ·                             (a)     ·
- │          table  d@foo_inv                     ·       ·
- │          spans  /"a"/"b"/True-/"a"/"b"/False  ·       ·
- └── scan   ·      ·                             (a, b)  ·
-·           table  d@primary                     ·       ·
+ │          table  d@primary                     ·       ·
+ └── scan   ·      ·                             (a)     ·
+·           table  d@foo_inv                     ·       ·
+·           spans  /"a"/"b"/True-/"a"/"b"/False  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[1]'
 ----
 index-join  ·      ·                        (a, b)  ·
- ├── scan   ·      ·                        (a)     ·
- │          table  d@foo_inv                ·       ·
- │          spans  /Arr/1-/Arr/1/PrefixEnd  ·       ·
- └── scan   ·      ·                        (a, b)  ·
-·           table  d@primary                ·       ·
+ │          table  d@primary                ·       ·
+ └── scan   ·      ·                        (a)     ·
+·           table  d@foo_inv                ·       ·
+·           spans  /Arr/1-/Arr/1/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
 ----
 index-join  ·      ·                                                (a, b)  ·
- ├── scan   ·      ·                                                (a)     ·
- │          table  d@foo_inv                                        ·       ·
- │          spans  /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·       ·
- └── scan   ·      ·                                                (a, b)  ·
-·           table  d@primary                                        ·       ·
+ │          table  d@primary                                        ·       ·
+ └── scan   ·      ·                                                (a)     ·
+·           table  d@foo_inv                                        ·       ·
+·           spans  /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
@@ -91,21 +85,19 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
 ----
 index-join  ·      ·                            (a, b)  ·
- ├── scan   ·      ·                            (a)     ·
- │          table  d@foo_inv                    ·       ·
- │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
- └── scan   ·      ·                            (a, b)  ·
-·           table  d@primary                    ·       ·
+ │          table  d@primary                    ·       ·
+ └── scan   ·      ·                            (a)     ·
+·           table  d@foo_inv                    ·       ·
+·           spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->'a'->'c' = '"b"'
 ----
 index-join  ·      ·                                    (a, b)  ·
- ├── scan   ·      ·                                    (a)     ·
- │          table  d@foo_inv                            ·       ·
- │          spans  /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd  ·       ·
- └── scan   ·      ·                                    (a, b)  ·
-·           table  d@primary                            ·       ·
+ │          table  d@primary                            ·       ·
+ └── scan   ·      ·                                    (a)     ·
+·           table  d@foo_inv                            ·       ·
+·           spans  /"a"/"c"/"b"-/"a"/"c"/"b"/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b->(NULL::STRING) = '"b"'
@@ -116,11 +108,10 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 ----
 index-join  ·      ·                            (a, b)  ·
- ├── scan   ·      ·                            (a)     ·
- │          table  d@foo_inv                    ·       ·
- │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
- └── scan   ·      ·                            (a, b)  ·
-·           table  d@primary                    ·       ·
+ │          table  d@primary                    ·       ·
+ └── scan   ·      ·                            (a)     ·
+·           table  d@foo_inv                    ·       ·
+·           spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
@@ -155,11 +146,10 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 filter           ·       ·                                    (a, b)  ·
  │               filter  b @> '{"a": {"b": "c"}, "f": "g"}'   ·       ·
  └── index-join  ·       ·                                    (a, b)  ·
-      ├── scan   ·       ·                                    (a)     ·
-      │          table   d@foo_inv                            ·       ·
-      │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·       ·
-      └── scan   ·       ·                                    (a, b)  ·
-·                table   d@primary                            ·       ·
+      │          table   d@primary                            ·       ·
+      └── scan   ·       ·                                    (a)     ·
+·                table   d@foo_inv                            ·       ·
+·                spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
@@ -167,11 +157,10 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "
 filter           ·       ·                                             (a, b)  ·
  │               filter  b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
  └── index-join  ·       ·                                             (a, b)  ·
-      ├── scan   ·       ·                                             (a)     ·
-      │          table   d@foo_inv                                     ·       ·
-      │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd           ·       ·
-      └── scan   ·       ·                                             (a, b)  ·
-·                table   d@primary                                     ·       ·
+      │          table   d@primary                                     ·       ·
+      └── scan   ·       ·                                             (a)     ·
+·                table   d@foo_inv                                     ·       ·
+·                spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd           ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
@@ -179,11 +168,10 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 filter           ·       ·                                                        (a, b)  ·
  │               filter  b @> '[{"a": {"b": [[2]]}}, "d"]'                        ·       ·
  └── index-join  ·       ·                                                        (a, b)  ·
-      ├── scan   ·       ·                                                        (a)     ·
-      │          table   d@foo_inv                                                ·       ·
-      │          spans   /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
-      └── scan   ·       ·                                                        (a, b)  ·
-·                table   d@primary                                                ·       ·
+      │          table   d@primary                                                ·       ·
+      └── scan   ·       ·                                                        (a)     ·
+·                table   d@foo_inv                                                ·       ·
+·                spans   /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
 
 statement ok
 SET experimental_enable_zigzag_join = true
@@ -192,52 +180,49 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
 lookup-join       ·          ·                                    (a, b)  ·
+ │                table      d@primary                            ·       ·
  │                type       inner                                ·       ·
  │                pred       @2 @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
- ├── zigzag-join  ·          ·                                    (a)     ·
- │    │           type       inner                                ·       ·
- │    ├── scan    ·          ·                                    (a)     ·
- │    │           table      d@foo_inv                            ·       ·
- │    │           fixedvals  1 column                             ·       ·
- │    └── scan    ·          ·                                    ()      ·
- │                table      d@foo_inv                            ·       ·
- │                fixedvals  1 column                             ·       ·
- └── scan         ·          ·                                    (b)     ·
-·                 table      d@primary                            ·       ·
+ └── zigzag-join  ·          ·                                    (a)     ·
+      │           type       inner                                ·       ·
+      ├── scan    ·          ·                                    (a)     ·
+      │           table      d@foo_inv                            ·       ·
+      │           fixedvals  1 column                             ·       ·
+      └── scan    ·          ·                                    ()      ·
+·                 table      d@foo_inv                            ·       ·
+·                 fixedvals  1 column                             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
 lookup-join       ·          ·                                              (a, b)  ·
+ │                table      d@primary                                      ·       ·
  │                type       inner                                          ·       ·
  │                pred       @2 @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
- ├── zigzag-join  ·          ·                                              (a)     ·
- │    │           type       inner                                          ·       ·
- │    ├── scan    ·          ·                                              (a)     ·
- │    │           table      d@foo_inv                                      ·       ·
- │    │           fixedvals  1 column                                       ·       ·
- │    └── scan    ·          ·                                              ()      ·
- │                table      d@foo_inv                                      ·       ·
- │                fixedvals  1 column                                       ·       ·
- └── scan         ·          ·                                              (b)     ·
-·                 table      d@primary                                      ·       ·
+ └── zigzag-join  ·          ·                                              (a)     ·
+      │           type       inner                                          ·       ·
+      ├── scan    ·          ·                                              (a)     ·
+      │           table      d@foo_inv                                      ·       ·
+      │           fixedvals  1 column                                       ·       ·
+      └── scan    ·          ·                                              ()      ·
+·                 table      d@foo_inv                                      ·       ·
+·                 fixedvals  1 column                                       ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
 lookup-join       ·          ·                                   (a, b)  ·
+ │                table      d@primary                           ·       ·
  │                type       inner                               ·       ·
  │                pred       @2 @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
- ├── zigzag-join  ·          ·                                   (a)     ·
- │    │           type       inner                               ·       ·
- │    ├── scan    ·          ·                                   (a)     ·
- │    │           table      d@foo_inv                           ·       ·
- │    │           fixedvals  1 column                            ·       ·
- │    └── scan    ·          ·                                   ()      ·
- │                table      d@foo_inv                           ·       ·
- │                fixedvals  1 column                            ·       ·
- └── scan         ·          ·                                   (b)     ·
-·                 table      d@primary                           ·       ·
+ └── zigzag-join  ·          ·                                   (a)     ·
+      │           type       inner                               ·       ·
+      ├── scan    ·          ·                                   (a)     ·
+      │           table      d@foo_inv                           ·       ·
+      │           fixedvals  1 column                            ·       ·
+      └── scan    ·          ·                                   ()      ·
+·                 table      d@foo_inv                           ·       ·
+·                 fixedvals  1 column                            ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
@@ -245,11 +230,10 @@ EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
 filter           ·       ·                         (a, b)  ·
  │               filter  b @> '{"a": {}, "b": 2}'  ·       ·
  └── index-join  ·       ·                         (a, b)  ·
-      ├── scan   ·       ·                         (a)     ·
-      │          table   d@foo_inv                 ·       ·
-      │          spans   /"b"/2-/"b"/2/PrefixEnd   ·       ·
-      └── scan   ·       ·                         (a, b)  ·
-·                table   d@primary                 ·       ·
+      │          table   d@primary                 ·       ·
+      └── scan   ·       ·                         (a)     ·
+·                table   d@foo_inv                 ·       ·
+·                spans   /"b"/2-/"b"/2/PrefixEnd   ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": {}}'

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -1413,11 +1413,10 @@ EXPLAIN (VERBOSE) SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 filter           ·       ·
  │               filter  c = 6.0
  └── index-join  ·       ·
-      ├── scan   ·       ·
-      │          table   zigzag@b_idx
-      │          spans   /5-/6
+      │          table   zigzag@primary
       └── scan   ·       ·
-·                table   zigzag@primary
+·                table   zigzag@b_idx
+·                spans   /5-/6
 
 # Enable zigzag joins.
 statement ok
@@ -1447,18 +1446,17 @@ EXPLAIN (VERBOSE) SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0
 ]
 ----
 lookup-join       ·          ·
+ │                table      zigzag@primary
  │                type       inner
- ├── zigzag-join  ·          ·
- │    │           type       inner
- │    │           pred       (@2 = 5) AND (@3 = 6.0)
- │    ├── scan    ·          ·
- │    │           table      zigzag@b_idx
- │    │           fixedvals  1 column
- │    └── scan    ·          ·
- │                table      zigzag@c_idx
- │                fixedvals  1 column
- └── scan         ·          ·
-·                 table      zigzag@primary
+ └── zigzag-join  ·          ·
+      │           type       inner
+      │           pred       (@2 = 5) AND (@3 = 6.0)
+      ├── scan    ·          ·
+      │           table      zigzag@b_idx
+      │           fixedvals  1 column
+      └── scan    ·          ·
+·                 table      zigzag@c_idx
+·                 fixedvals  1 column
 
 # Zigzag join nested inside a lookup, with an on condition on lookup join.
 query TTT
@@ -1467,16 +1465,15 @@ EXPLAIN (VERBOSE) SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0 AND d > 4
 ]
 ----
 lookup-join       ·          ·
+ │                table      zigzag@primary
  │                type       inner
  │                pred       @4 > 4.0
- ├── zigzag-join  ·          ·
- │    │           type       inner
- │    │           pred       (@2 = 5) AND (@3 = 6.0)
- │    ├── scan    ·          ·
- │    │           table      zigzag@b_idx
- │    │           fixedvals  1 column
- │    └── scan    ·          ·
- │                table      zigzag@c_idx
- │                fixedvals  1 column
- └── scan         ·          ·
-·                 table      zigzag@primary
+ └── zigzag-join  ·          ·
+      │           type       inner
+      │           pred       (@2 = 5) AND (@3 = 6.0)
+      ├── scan    ·          ·
+      │           table      zigzag@b_idx
+      │           fixedvals  1 column
+      └── scan    ·          ·
+·                 table      zigzag@c_idx
+·                 fixedvals  1 column

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -13,11 +13,10 @@ limit                 ·       ·            (k, v, w)  +v
  └── filter           ·       ·            (k, v, w)  +v
       │               filter  w > 30       ·          ·
       └── index-join  ·       ·            (k, v, w)  +v
-           ├── scan   ·       ·            (k, v)     +v
-           │          table   t@t_v_idx    ·          ·
-           │          spans   /5-/8        ·          ·
-           └── scan   ·       ·            (k, v, w)  ·
-·                     table   t@primary    ·          ·
+           │          table   t@primary    ·          ·
+           └── scan   ·       ·            (k, v)     +v
+·                     table   t@t_v_idx    ·          ·
+·                     spans   /5-/8        ·          ·
 
 # This kind of query can be used to work around memory usage limits. We need to
 # choose the "hard" limit of 100 over the "soft" limit of 25 (with the hard
@@ -132,12 +131,11 @@ render           ·         ·          (k, w)     ·
  │               render 0  k          ·          ·
  │               render 1  w          ·          ·
  └── index-join  ·         ·          (k, v, w)  ·
-      ├── scan   ·         ·          (k, v)     ·
-      │          table     t@t_v_idx  ·          ·
-      │          spans     /1-/101    ·          ·
-      │          limit     10         ·          ·
-      └── scan   ·         ·          (k, v, w)  ·
-·                table     t@primary  ·          ·
+      │          table     t@primary  ·          ·
+      └── scan   ·         ·          (k, v)     ·
+·                table     t@t_v_idx  ·          ·
+·                spans     /1-/101    ·          ·
+·                limit     10         ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 ORDER BY v LIMIT 10
@@ -146,12 +144,11 @@ render           ·         ·          (k, w)     ·
  │               render 0  k          ·          ·
  │               render 1  w          ·          ·
  └── index-join  ·         ·          (k, v, w)  +v
-      ├── scan   ·         ·          (k, v)     +v
-      │          table     t@t_v_idx  ·          ·
-      │          spans     /1-/101    ·          ·
-      │          limit     10         ·          ·
-      └── scan   ·         ·          (k, v, w)  ·
-·                table     t@primary  ·          ·
+      │          table     t@primary  ·          ·
+      └── scan   ·         ·          (k, v)     +v
+·                table     t@t_v_idx  ·          ·
+·                spans     /1-/101    ·          ·
+·                limit     10         ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k, w FROM (SELECT * FROM t WHERE v >= 1 AND v <= 100 ORDER BY k LIMIT 10) ORDER BY v

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -33,64 +33,59 @@ EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b
 ----
 tree         field  description  columns             ordering
 lookup-join  ·      ·            (a, b, c, d, e, f)  ·
+ │           table  def@primary  ·                   ·
  │           type   inner        ·                   ·
- ├── scan    ·      ·            (a, b, c)           ·
- │           table  abc@primary  ·                   ·
- │           spans  ALL          ·                   ·
- └── scan    ·      ·            (d, e, f)           ·
-·            table  def@primary  ·                   ·
+ └── scan    ·      ·            (a, b, c)           ·
+·            table  abc@primary  ·                   ·
+·            spans  ALL          ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a > 1 AND e > 1
 ----
 tree         field  description  columns             ordering
 lookup-join  ·      ·            (a, b, c, d, e, f)  ·
+ │           table  def@primary  ·                   ·
  │           type   inner        ·                   ·
  │           pred   @5 > 1       ·                   ·
- ├── scan    ·      ·            (a, b, c)           ·
- │           table  abc@primary  ·                   ·
- │           spans  /2-          ·                   ·
- └── scan    ·      ·            (d, e, f)           ·
-·            table  def@primary  ·                   ·
+ └── scan    ·      ·            (a, b, c)           ·
+·            table  abc@primary  ·                   ·
+·            spans  /2-          ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = a WHERE f > 1
 ----
 tree         field  description  columns             ordering
 lookup-join  ·      ·            (a, b, c, d, e, f)  ·
+ │           table  def@primary  ·                   ·
  │           type   inner        ·                   ·
  │           pred   @6 > 1       ·                   ·
- ├── scan    ·      ·            (a, b, c)           ·
- │           table  abc@primary  ·                   ·
- │           spans  /2-          ·                   ·
- └── scan    ·      ·            (d, e, f)           ·
-·            table  def@primary  ·                   ·
+ └── scan    ·      ·            (a, b, c)           ·
+·            table  abc@primary  ·                   ·
+·            spans  /2-          ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b WHERE a >= e
 ----
 tree         field  description  columns             ordering
 lookup-join  ·      ·            (a, b, c, d, e, f)  ·
+ │           table  def@primary  ·                   ·
  │           type   inner        ·                   ·
  │           pred   @1 >= @5     ·                   ·
- ├── scan    ·      ·            (a, b, c)           ·
- │           table  abc@primary  ·                   ·
- │           spans  ALL          ·                   ·
- └── scan    ·      ·            (d, e, f)           ·
-·            table  def@primary  ·                   ·
+ └── scan    ·      ·            (a, b, c)           ·
+·            table  abc@primary  ·                   ·
+·            spans  ALL          ·                   ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND a >= e
 ----
 tree         field  description  columns             ordering
 lookup-join  ·      ·            (a, b, c, d, e, f)  ·
+ │           table  def@primary  ·                   ·
  │           type   inner        ·                   ·
  │           pred   @1 >= @5     ·                   ·
- ├── scan    ·      ·            (a, b, c)           ·
- │           table  abc@primary  ·                   ·
- │           spans  ALL          ·                   ·
- └── scan    ·      ·            (d, e, f)           ·
-·            table  def@primary  ·                   ·
+ └── scan    ·      ·            (a, b, c)           ·
+·            table  abc@primary  ·                   ·
+·            spans  ALL          ·                   ·
 
 # Verify a distsql plan.
 statement ok
@@ -134,13 +129,12 @@ render            ·         ·             (a, b, c, d)              ·
  │                render 2  c             ·                         ·
  │                render 3  d             ·                         ·
  └── lookup-join  ·         ·             (a, b, c, d, a, b, c, d)  ·
-      │           type      inner         ·                         ·
-      ├── scan    ·         ·             (a, b, c, d)              ·
       │           table     data@primary  ·                         ·
-      │           spans     ALL           ·                         ·
-      │           filter    c = 1         ·                         ·
+      │           type      inner         ·                         ·
       └── scan    ·         ·             (a, b, c, d)              ·
 ·                 table     data@primary  ·                         ·
+·                 spans     ALL           ·                         ·
+·                 filter    c = 1         ·                         ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM (SELECT * FROM data WHERE c = 1) AS l NATURAL JOIN data AS r]
@@ -183,13 +177,12 @@ distinct               ·            ·               (title)                   
  └── render            ·            ·               (title)                       ·
       │                render 0     title           ·                             ·
       └── lookup-join  ·            ·               (title, shelf, title, shelf)  +title
+           │           table        books2@primary  ·                             ·
            │           type         inner           ·                             ·
            │           pred         @2 != @4        ·                             ·
-           ├── scan    ·            ·               (title, shelf)                +title
-           │           table        books@primary   ·                             ·
-           │           spans        ALL             ·                             ·
-           └── scan    ·            ·               (title, shelf)                ·
-·                      table        books2@primary  ·                             ·
+           └── scan    ·            ·               (title, shelf)                +title
+·                      table        books@primary   ·                             ·
+·                      spans        ALL             ·                             ·
 
 statement ok
 CREATE TABLE authors (name STRING, book STRING)
@@ -249,14 +242,13 @@ tree                 field     description      columns              ordering
 render               ·         ·                (name)               +name
  │                   render 0  name             ·                    ·
  └── lookup-join     ·         ·                (name, book, title)  +name
+      │              table     books2@primary   ·                    ·
       │              type      inner            ·                    ·
-      ├── sort       ·         ·                (name, book)         +name
-      │    │         order     +name            ·                    ·
-      │    └── scan  ·         ·                (name, book)         ·
-      │              table     authors@primary  ·                    ·
-      │              spans     ALL              ·                    ·
-      └── scan       ·         ·                (title)              ·
-·                    table     books2@primary   ·                    ·
+      └── sort       ·         ·                (name, book)         +name
+           │         order     +name            ·                    ·
+           └── scan  ·         ·                (name, book)         ·
+·                    table     authors@primary  ·                    ·
+·                    spans     ALL              ·                    ·
 
 # Cross joins should not be planned as lookup joins.
 query TTTTT colnames
@@ -334,12 +326,11 @@ render            ·         ·              (a, c)     ·
  │                render 0  a              ·          ·
  │                render 1  c              ·          ·
  └── lookup-join  ·         ·              (a, b, c)  ·
+      │           table     large@bc       ·          ·
       │           type      inner          ·          ·
-      ├── scan    ·         ·              (a)        ·
-      │           table     small@primary  ·          ·
-      │           spans     ALL            ·          ·
-      └── scan    ·         ·              (b, c)     ·
-·                 table     large@bc       ·          ·
+      └── scan    ·         ·              (a)        ·
+·                 table     small@primary  ·          ·
+·                 spans     ALL            ·          ·
 
 # Lookup join on non-covering secondary index
 query TTTTT
@@ -349,16 +340,14 @@ render                 ·         ·              (a, d)        ·
  │                     render 0  a              ·             ·
  │                     render 1  d              ·             ·
  └── lookup-join       ·         ·              (a, a, b, d)  ·
+      │                table     large@primary  ·             ·
       │                type      inner          ·             ·
-      ├── lookup-join  ·         ·              (a, a, b)     ·
-      │    │           type      inner          ·             ·
-      │    ├── scan    ·         ·              (a)           ·
-      │    │           table     small@primary  ·             ·
-      │    │           spans     ALL            ·             ·
-      │    └── scan    ·         ·              (a, b)        ·
-      │                table     large@bc       ·             ·
-      └── scan         ·         ·              (d)           ·
-·                      table     large@primary  ·             ·
+      └── lookup-join  ·         ·              (a, a, b)     ·
+           │           table     large@bc       ·             ·
+           │           type      inner          ·             ·
+           └── scan    ·         ·              (a)           ·
+·                      table     small@primary  ·             ·
+·                      spans     ALL            ·             ·
 
 ############################
 #  LEFT OUTER LOOKUP JOIN  #
@@ -369,12 +358,11 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT small.b, large.a FROM small LEFT JOIN large ON small.b = large.a
 ----
 lookup-join  ·      ·              (b, a)  ·
+ │           table  large@primary  ·       ·
  │           type   left outer     ·       ·
- ├── scan    ·      ·              (b)     ·
- │           table  small@primary  ·       ·
- │           spans  ALL            ·       ·
- └── scan    ·      ·              (a)     ·
-·            table  large@primary  ·       ·
+ └── scan    ·      ·              (b)     ·
+·            table  small@primary  ·       ·
+·            spans  ALL            ·       ·
 
 # Left join should preserve input order.
 query TTTTT
@@ -384,13 +372,12 @@ render            ·         ·              (a, b)     +a
  │                render 0  a              ·          ·
  │                render 1  b              ·          ·
  └── lookup-join  ·         ·              (a, a, b)  +a
+      │           table     large@primary  ·          ·
       │           type      left outer     ·          ·
       │           pred      (@3 % 6) = 0   ·          ·
-      ├── scan    ·         ·              (a)        +a
-      │           table     small@primary  ·          ·
-      │           spans     ALL            ·          ·
-      └── scan    ·         ·              (a, b)     ·
-·                 table     large@primary  ·          ·
+      └── scan    ·         ·              (a)        +a
+·                 table     small@primary  ·          ·
+·                 spans     ALL            ·          ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT t1.a, t2.b FROM small t1 LEFT JOIN large t2 ON t1.a = t2.a AND t2.b % 6 = 0 ORDER BY t1.a]
@@ -405,12 +392,11 @@ render            ·         ·              (c, c)     ·
  │                render 0  c              ·          ·
  │                render 1  c              ·          ·
  └── lookup-join  ·         ·              (c, b, c)  ·
+      │           table     large@bc       ·          ·
       │           type      left outer     ·          ·
-      ├── scan    ·         ·              (c)        ·
-      │           table     small@primary  ·          ·
-      │           spans     ALL            ·          ·
-      └── scan    ·         ·              (b, c)     ·
-·                 table     large@bc       ·          ·
+      └── scan    ·         ·              (c)        ·
+·                 table     small@primary  ·          ·
+·                 spans     ALL            ·          ·
 
 # Left join against non-covering secondary index
 query TTTTT
@@ -420,16 +406,14 @@ render                 ·         ·              (c, d)        ·
  │                     render 0  c              ·             ·
  │                     render 1  d              ·             ·
  └── lookup-join       ·         ·              (c, a, b, d)  ·
+      │                table     large@primary  ·             ·
       │                type      left outer     ·             ·
-      ├── lookup-join  ·         ·              (c, a, b)     ·
-      │    │           type      left outer     ·             ·
-      │    ├── scan    ·         ·              (c)           ·
-      │    │           table     small@primary  ·             ·
-      │    │           spans     ALL            ·             ·
-      │    └── scan    ·         ·              (a, b)        ·
-      │                table     large@bc       ·             ·
-      └── scan         ·         ·              (d)           ·
-·                      table     large@primary  ·             ·
+      └── lookup-join  ·         ·              (c, a, b)     ·
+           │           table     large@bc       ·             ·
+           │           type      left outer     ·             ·
+           └── scan    ·         ·              (c)           ·
+·                      table     small@primary  ·             ·
+·                      spans     ALL            ·             ·
 
 # Left join with ON filter on covering index
 query TTTTT
@@ -439,13 +423,12 @@ render            ·         ·              (c, c)     ·
  │                render 0  c              ·          ·
  │                render 1  c              ·          ·
  └── lookup-join  ·         ·              (c, b, c)  ·
+      │           table     large@bc       ·          ·
       │           type      left outer     ·          ·
       │           pred      @3 < 20        ·          ·
-      ├── scan    ·         ·              (c)        ·
-      │           table     small@primary  ·          ·
-      │           spans     ALL            ·          ·
-      └── scan    ·         ·              (b, c)     ·
-·                 table     large@bc       ·          ·
+      └── scan    ·         ·              (c)        ·
+·                 table     small@primary  ·          ·
+·                 spans     ALL            ·          ·
 
 # Left join with ON filter on non-covering index
 # TODO(radu): this doesn't use lookup join yet, the current rules don't cover
@@ -487,13 +470,12 @@ EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e 
 render            ·         ·          (a)              ·
  │                render 0  a          ·                ·
  └── lookup-join  ·         ·          (a, d, e, a, d)  ·
+      │           table     u@idx      ·                ·
       │           type      inner      ·                ·
-      ├── scan    ·         ·          (a, d, e)        ·
-      │           table     t@primary  ·                ·
-      │           spans     ALL        ·                ·
-      │           filter    e = 5      ·                ·
-      └── scan    ·         ·          (a, d)           ·
-·                 table     u@idx      ·                ·
+      └── scan    ·         ·          (a, d, e)        ·
+·                 table     t@primary  ·                ·
+·                 spans     ALL        ·                ·
+·                 filter    e = 5      ·                ·
 
 # Test unique version of same index. (Lookup join should not use column a.)
 statement ok
@@ -508,14 +490,13 @@ EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a WHERE t.e 
 render            ·         ·          (a)              ·
  │                render 0  a          ·                ·
  └── lookup-join  ·         ·          (a, d, e, a, d)  ·
+      │           table     u@idx      ·                ·
       │           type      inner      ·                ·
       │           pred      @1 = @4    ·                ·
-      ├── scan    ·         ·          (a, d, e)        ·
-      │           table     t@primary  ·                ·
-      │           spans     ALL        ·                ·
-      │           filter    e = 5      ·                ·
-      └── scan    ·         ·          (a, d)           ·
-·                 table     u@idx      ·                ·
+      └── scan    ·         ·          (a, d, e)        ·
+·                 table     t@primary  ·                ·
+·                 spans     ALL        ·                ·
+·                 filter    e = 5      ·                ·
 
 # Test index with first primary key column explicit and the rest implicit.
 statement ok
@@ -530,13 +511,12 @@ EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = 
 render            ·         ·          (a)                    ·
  │                render 0  a          ·                      ·
  └── lookup-join  ·         ·          (a, b, d, e, a, b, d)  ·
+      │           table     u@idx      ·                      ·
       │           type      inner      ·                      ·
-      ├── scan    ·         ·          (a, b, d, e)           ·
-      │           table     t@primary  ·                      ·
-      │           spans     ALL        ·                      ·
-      │           filter    e = 5      ·                      ·
-      └── scan    ·         ·          (a, b, d)              ·
-·                 table     u@idx      ·                      ·
+      └── scan    ·         ·          (a, b, d, e)           ·
+·                 table     t@primary  ·                      ·
+·                 spans     ALL        ·                      ·
+·                 filter    e = 5      ·                      ·
 
 # Test index with middle primary key column explicit and the rest implicit.
 statement ok
@@ -551,13 +531,12 @@ EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.b = 
 render            ·         ·          (a)                    ·
  │                render 0  a          ·                      ·
  └── lookup-join  ·         ·          (a, b, d, e, a, b, d)  ·
+      │           table     u@idx      ·                      ·
       │           type      inner      ·                      ·
-      ├── scan    ·         ·          (a, b, d, e)           ·
-      │           table     t@primary  ·                      ·
-      │           spans     ALL        ·                      ·
-      │           filter    e = 5      ·                      ·
-      └── scan    ·         ·          (a, b, d)              ·
-·                 table     u@idx      ·                      ·
+      └── scan    ·         ·          (a, b, d, e)           ·
+·                 table     t@primary  ·                      ·
+·                 spans     ALL        ·                      ·
+·                 filter    e = 5      ·                      ·
 
 # Test index with last primary key column explicit and the rest implicit.
 statement ok
@@ -572,14 +551,13 @@ EXPLAIN (VERBOSE) SELECT u.a FROM t JOIN u ON t.d = u.d AND t.a = u.a AND t.d = 
 render            ·         ·          (a)              ·
  │                render 0  a          ·                ·
  └── lookup-join  ·         ·          (a, d, e, a, d)  ·
+      │           table     u@idx      ·                ·
       │           type      inner      ·                ·
       │           pred      @1 = @4    ·                ·
-      ├── scan    ·         ·          (a, d, e)        ·
-      │           table     t@primary  ·                ·
-      │           spans     ALL        ·                ·
-      │           filter    e = 5      ·                ·
-      └── scan    ·         ·          (a, d)           ·
-·                 table     u@idx      ·                ·
+      └── scan    ·         ·          (a, d, e)        ·
+·                 table     t@primary  ·                ·
+·                 spans     ALL        ·                ·
+·                 filter    e = 5      ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def JOIN abc ON a=f ORDER BY a
@@ -592,9 +570,8 @@ render            ·         ·            (d, e, f, a, b, c)  ·
  │                render 4  b            ·                   ·
  │                render 5  c            ·                   ·
  └── lookup-join  ·         ·            (a, b, c, d, e, f)  +a
+      │           table     def@primary  ·                   ·
       │           type      inner        ·                   ·
-      ├── scan    ·         ·            (a, b, c)           +a
-      │           table     abc@primary  ·                   ·
-      │           spans     ALL          ·                   ·
-      └── scan    ·         ·            (d, e, f)           ·
-·                 table     def@primary  ·                   ·
+      └── scan    ·         ·            (a, b, c)           +a
+·                 table     abc@primary  ·                   ·
+·                 spans     ALL          ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -229,11 +229,10 @@ render                ·      ·
  └── sort             ·      ·
       │               order  +b,+a,+d
       └── index-join  ·      ·
-           ├── scan   ·      ·
-           │          table  abc@bc
-           │          spans  /11-/30
+           │          table  abc@primary
            └── scan   ·      ·
-·                     table  abc@primary
+·                     table  abc@bc
+·                     spans  /11-/30
 
 # An inequality should not be enough to force the use of the index.
 query TTT
@@ -744,13 +743,12 @@ render                      ·              ·                 (k)              
            │                render 0       k                 ·                ·
            │                render 1       v                 ·                ·
            └── lookup-join  ·              ·                 (column1, k, v)  ·
+                │           table          kv@primary        ·                ·
                 │           type           inner             ·                ·
-                ├── values  ·              ·                 (column1)        ·
-                │           size           1 column, 2 rows  ·                ·
-                │           row 0, expr 0  1                 ·                ·
-                │           row 1, expr 0  3                 ·                ·
-                └── scan    ·              ·                 (k, v)           ·
-·                           table          kv@primary        ·                ·
+                └── values  ·              ·                 (column1)        ·
+·                           size           1 column, 2 rows  ·                ·
+·                           row 0, expr 0  1                 ·                ·
+·                           row 1, expr 0  3                 ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
@@ -780,8 +778,7 @@ sort                  ·       ·                (x, y, z)              +x
  └── filter           ·       ·                (x, y, z)              ·
       │               filter  x = y            ·                      ·
       └── index-join  ·       ·                (x, y, z)              ·
-           ├── scan   ·       ·                (y, z, rowid[hidden])  ·
-           │          table   xyz@xyz_z_y_idx  ·                      ·
-           │          spans   /1/!NULL-/2      ·                      ·
-           └── scan   ·       ·                (x, y, z)              ·
-·                     table   xyz@primary      ·                      ·
+           │          table   xyz@primary      ·                      ·
+           └── scan   ·       ·                (y, z, rowid[hidden])  ·
+·                     table   xyz@xyz_z_y_idx  ·                      ·
+·                     spans   /1/!NULL-/2      ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -68,9 +68,8 @@ query TTT retry
 EXECUTE change_stats
 ----
 lookup-join  ·      ·
+ │           table  cd@primary
  │           type   inner
- ├── scan    ·      ·
- │           table  ab@primary
- │           spans  ALL
  └── scan    ·      ·
-·            table  cd@primary
+·            table  ab@primary
+·            spans  ALL

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1137,26 +1137,24 @@ EXPLAIN SELECT price FROM a WHERE item IN ('sock', 'ball')
 ----
 render           ·         ·
  └── index-join  ·         ·
-      ├── scan   ·         ·
-      │          table     a@item
-      │          spans     /"ball"-/"ball"/PrefixEnd /"sock"-/"sock"/PrefixEnd
-      │          parallel  ·
+      │          table     a@primary
       └── scan   ·         ·
-·                table     a@primary
+·                table     a@item
+·                spans     /"ball"-/"ball"/PrefixEnd /"sock"-/"sock"/PrefixEnd
+·                parallel  ·
 
 # Range queries on non-int types are not parallel due to unbounded number of
 # results.
 query TTT
 EXPLAIN SELECT item FROM a WHERE price > 5 AND price < 10 OR price > 20 AND price < 40
 ----
-render           ·         ·
- └── index-join  ·         ·
-      ├── scan   ·         ·
-      │          table     a@p
-      │          spans     /5.000000000000001-/9.999999999999998/PrefixEnd /20.000000000000004-/39.99999999999999/PrefixEnd
-      │          filter    (price < 10.0) OR (price > 20.0)
-      └── scan   ·         ·
-·                table     a@primary
+render           ·       ·
+ └── index-join  ·       ·
+      │          table   a@primary
+      └── scan   ·       ·
+·                table   a@p
+·                spans   /5.000000000000001-/9.999999999999998/PrefixEnd /20.000000000000004-/39.99999999999999/PrefixEnd
+·                filter  (price < 10.0) OR (price > 20.0)
 
 statement ok
 SET CLUSTER SETTING sql.parallel_scans.enabled = false

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -196,17 +196,15 @@ render                ·               ·                    (b, a, c, d, a, c, 
       │               equality        (b) = (b)            ·                         ·
       │               mergeJoinOrder  +"(b=b)"             ·                         ·
       ├── index-join  ·               ·                    (a, b, c, d)              ·
-      │    ├── scan   ·               ·                    (a, b, c)                 ·
-      │    │          table           t@bc                 ·                         ·
-      │    │          spans           /"3"-/"3"/PrefixEnd  ·                         ·
-      │    └── scan   ·               ·                    (a, b, c, d)              ·
-      │               table           t@primary            ·                         ·
+      │    │          table           t@primary            ·                         ·
+      │    └── scan   ·               ·                    (a, b, c)                 ·
+      │               table           t@bc                 ·                         ·
+      │               spans           /"3"-/"3"/PrefixEnd  ·                         ·
       └── index-join  ·               ·                    (a, b, c, d)              ·
-           ├── scan   ·               ·                    (a, b, c)                 ·
-           │          table           t@bc                 ·                         ·
-           │          spans           /"3"-/"3"/PrefixEnd  ·                         ·
-           └── scan   ·               ·                    (a, b, c, d)              ·
-·                     table           t@primary            ·                         ·
+           │          table           t@primary            ·                         ·
+           └── scan   ·               ·                    (a, b, c)                 ·
+·                     table           t@bc                 ·                         ·
+·                     spans           /"3"-/"3"/PrefixEnd  ·                         ·
 
 statement ok
 TRUNCATE TABLE t
@@ -654,12 +652,11 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20
 ----
 index-join    ·      ·                        (id, k, v)  -k
- ├── revscan  ·      ·                        (id, k)     -k
- │            table  test2@test2_k_key        ·           ·
- │            spans  /!NULL-/"100"/PrefixEnd  ·           ·
- │            limit  20                       ·           ·
- └── scan     ·      ·                        (id, k, v)  ·
-·             table  test2@primary            ·           ·
+ │            table  test2@primary            ·           ·
+ └── revscan  ·      ·                        (id, k)     -k
+·             table  test2@test2_k_key        ·           ·
+·             spans  /!NULL-/"100"/PrefixEnd  ·           ·
+·             limit  20                       ·           ·
 
 # Result check: The following query must not issue more than the
 # requested LIMIT K/V reads, even though an index join batches 100
@@ -907,21 +904,19 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM NULL
 ----
 index-join  ·      ·             (x, y)              ·
- ├── scan   ·      ·             (y, rowid[hidden])  ·
- │          table  xy@xy_y_idx   ·                   ·
- │          spans  /NULL-/!NULL  ·                   ·
- └── scan   ·      ·             (x, y)              ·
-·           table  xy@primary    ·                   ·
+ │          table  xy@primary    ·                   ·
+ └── scan   ·      ·             (y, rowid[hidden])  ·
+·           table  xy@xy_y_idx   ·                   ·
+·           spans  /NULL-/!NULL  ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM 4
 ----
 index-join  ·      ·            (x, y)              ·
- ├── scan   ·      ·            (y, rowid[hidden])  ·
- │          table  xy@xy_y_idx  ·                   ·
- │          spans  /4-/5        ·                   ·
- └── scan   ·      ·            (x, y)              ·
-·           table  xy@primary   ·                   ·
+ │          table  xy@primary   ·                   ·
+ └── scan   ·      ·            (y, rowid[hidden])  ·
+·           table  xy@xy_y_idx  ·                   ·
+·           spans  /4-/5        ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x FROM xy WHERE y > 0 AND y < 2 ORDER BY y
@@ -929,11 +924,10 @@ EXPLAIN (VERBOSE) SELECT x FROM xy WHERE y > 0 AND y < 2 ORDER BY y
 render           ·         ·            (x)                 ·
  │               render 0  x            ·                   ·
  └── index-join  ·         ·            (x, y)              ·
-      ├── scan   ·         ·            (y, rowid[hidden])  ·
-      │          table     xy@xy_y_idx  ·                   ·
-      │          spans     /1-/2        ·                   ·
-      └── scan   ·         ·            (x, y)              ·
-·                table     xy@primary   ·                   ·
+      │          table     xy@primary   ·                   ·
+      └── scan   ·         ·            (y, rowid[hidden])  ·
+·                table     xy@xy_y_idx  ·                   ·
+·                spans     /1-/2        ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL
@@ -996,11 +990,10 @@ query TTT
 EXPLAIN SELECT * FROM noncover WHERE b = 2
 ----
 index-join  ·      ·
- ├── scan   ·      ·
- │          table  noncover@b
- │          spans  /2-/3
+ │          table  noncover@primary
  └── scan   ·      ·
-·           table  noncover@primary
+·           table  noncover@b
+·           spans  /2-/3
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE b = 2; SET tracing = off
@@ -1020,11 +1013,10 @@ query TTT
 EXPLAIN SELECT * FROM noncover WHERE c = 6
 ----
 index-join  ·      ·
- ├── scan   ·      ·
- │          table  noncover@c
- │          spans  /6-/7
+ │          table  noncover@primary
  └── scan   ·      ·
-·           table  noncover@primary
+·           table  noncover@c
+·           spans  /6-/7
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM noncover WHERE c = 7; SET tracing = off
@@ -1084,12 +1076,11 @@ query TTT
 EXPLAIN SELECT * FROM noncover ORDER BY c LIMIT 5
 ----
 index-join  ·      ·
- ├── scan   ·      ·
- │          table  noncover@c
- │          spans  ALL
- │          limit  5
+ │          table  noncover@primary
  └── scan   ·      ·
-·           table  noncover@primary
+·           table  noncover@c
+·           spans  ALL
+·           limit  5
 
 query TTT
 SELECT tree, field, description FROM [
@@ -1179,12 +1170,11 @@ EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0
 ]
 ----
 index-join  ·       ·
- ├── scan   ·       ·
- │          table   t2@bc
- │          spans   /2-/3
- │          filter  (c % 2) = 0
+ │          table   t2@primary
  └── scan   ·       ·
-·           table   t2@primary
+·           table   t2@bc
+·           spans   /2-/3
+·           filter  (c % 2) = 0
 
 # We do NOT look up the table row for '21' and '23'.
 statement ok
@@ -1209,12 +1199,11 @@ EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c != b
 ]
 ----
 index-join  ·       ·
- ├── scan   ·       ·
- │          table   t2@bc
- │          spans   /2/!NULL-/3
- │          filter  c != b
+ │          table   t2@primary
  └── scan   ·       ·
-·           table   t2@primary
+·           table   t2@bc
+·           spans   /2/!NULL-/3
+·           filter  c != b
 
 # We do NOT look up the table row for '22'.
 statement ok
@@ -1316,11 +1305,10 @@ EXPLAIN (VERBOSE) SELECT a FROM t2 WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s !
 render           ·         ·           (a)        ·
  │               render 0  a           ·          ·
  └── index-join  ·         ·           (a, b, s)  ·
-      ├── scan   ·         ·           (a, b)     ·
-      │          table     t2@bc       ·          ·
-      │          spans     /2-/3       ·          ·
-      └── scan   ·         ·           (a, b, s)  ·
-·                table     t2@primary  ·          ·
+      │          table     t2@primary  ·          ·
+      └── scan   ·         ·           (a, b)     ·
+·                table     t2@bc       ·          ·
+·                spans     /2-/3       ·          ·
 
 statement ok
 CREATE TABLE t3 (k INT PRIMARY KEY, v INT, w INT, INDEX v(v))
@@ -1331,11 +1319,10 @@ EXPLAIN (VERBOSE) SELECT w FROM t3 WHERE v > 0 AND v < 10 ORDER BY v
 render           ·         ·           (w)     ·
  │               render 0  w           ·       ·
  └── index-join  ·         ·           (v, w)  +v
-      ├── scan   ·         ·           (k, v)  +v
-      │          table     t3@v        ·       ·
-      │          spans     /1-/10      ·       ·
-      └── scan   ·         ·           (v, w)  ·
-·                table     t3@primary  ·       ·
+      │          table     t3@primary  ·       ·
+      └── scan   ·         ·           (k, v)  +v
+·                table     t3@v        ·       ·
+·                spans     /1-/10      ·       ·
 
 # ------------------------------------------------------------------------------
 # These tests are for the point lookup optimization: for single row lookups on

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -75,11 +75,10 @@ EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 filter           ·       ·
  │               filter  (a >= 20) AND (a <= 30)
  └── index-join  ·       ·
-      ├── scan   ·       ·
-      │          table   abcd@b
-      │          spans   ALL
+      │          table   abcd@primary
       └── scan   ·       ·
-·                table   abcd@primary
+·                table   abcd@b
+·                spans   ALL
 
 # Force index b, reverse scan.
 query TTT
@@ -88,35 +87,32 @@ EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} WHERE a >= 20 AND a <= 30
 filter             ·       ·
  │                 filter  (a >= 20) AND (a <= 30)
  └── index-join    ·       ·
-      ├── revscan  ·       ·
-      │            table   abcd@b
-      │            spans   ALL
-      └── scan     ·       ·
-·                  table   abcd@primary
+      │            table   abcd@primary
+      └── revscan  ·       ·
+·                  table   abcd@b
+·                  spans   ALL
 
 # Force index b, allowing reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@b ORDER BY b DESC LIMIT 5
 ----
 index-join    ·      ·
- ├── revscan  ·      ·
- │            table  abcd@b
- │            spans  ALL
- │            limit  5
- └── scan     ·      ·
-·             table  abcd@primary
+ │            table  abcd@primary
+ └── revscan  ·      ·
+·             table  abcd@b
+·             spans  ALL
+·             limit  5
 
 # Force index b, reverse scan.
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} ORDER BY b DESC LIMIT 5
 ----
 index-join    ·      ·
- ├── revscan  ·      ·
- │            table  abcd@b
- │            spans  ALL
- │            limit  5
- └── scan     ·      ·
-·             table  abcd@primary
+ │            table  abcd@primary
+ └── revscan  ·      ·
+·             table  abcd@b
+·             spans  ALL
+·             limit  5
 
 
 # Force index b, forward scan.
@@ -128,11 +124,10 @@ limit                 ·      ·
  └── sort             ·      ·
       │               order  -b
       └── index-join  ·      ·
-           ├── scan   ·      ·
-           │          table  abcd@b
-           │          spans  ALL
+           │          table  abcd@primary
            └── scan   ·      ·
-·                     table  abcd@primary
+·                     table  abcd@b
+·                     spans  ALL
 
 # Force index cd
 query TTT
@@ -141,11 +136,10 @@ EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 filter           ·       ·
  │               filter  (a >= 20) AND (a <= 30)
  └── index-join  ·       ·
-      ├── scan   ·       ·
-      │          table   abcd@cd
-      │          spans   ALL
+      │          table   abcd@primary
       └── scan   ·       ·
-·                table   abcd@primary
+·                table   abcd@cd
+·                spans   ALL
 
 # Force index bcd
 query TTT
@@ -174,11 +168,10 @@ render                ·       ·
  └── filter           ·       ·
       │               filter  (c >= 20) AND (c <= 30)
       └── index-join  ·       ·
-           ├── scan   ·       ·
-           │          table   abcd@b
-           │          spans   ALL
+           │          table   abcd@primary
            └── scan   ·       ·
-·                     table   abcd@primary
+·                     table   abcd@b
+·                     spans   ALL
 
 # No hint, should be using index cd
 query TTT
@@ -204,11 +197,10 @@ EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 filter           ·       ·
  │               filter  (c >= 20) AND (c < 40)
  └── index-join  ·       ·
-      ├── scan   ·       ·
-      │          table   abcd@b
-      │          spans   ALL
+      │          table   abcd@primary
       └── scan   ·       ·
-·                table   abcd@primary
+·                table   abcd@b
+·                spans   ALL
 
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
@@ -216,21 +208,19 @@ EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 filter           ·       ·
  │               filter  (a >= 20) AND (a <= 30)
  └── index-join  ·       ·
-      ├── scan   ·       ·
-      │          table   abcd@b
-      │          spans   ALL
+      │          table   abcd@primary
       └── scan   ·       ·
-·                table   abcd@primary
+·                table   abcd@b
+·                spans   ALL
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
 index-join  ·      ·
- ├── scan   ·      ·
- │          table  abcd@cd
- │          spans  /10-/11
+ │          table  abcd@primary
  └── scan   ·      ·
-·           table  abcd@primary
+·           table  abcd@cd
+·           spans  /10-/11
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -73,11 +73,10 @@ limit                                      ·         ·
                 └── render                 ·         ·
                      └── render            ·         ·
                           └── lookup-join  ·         ·
+                               │           table     t@primary
                                │           type      left outer
-                               ├── values  ·         ·
-                               │           size      1 column, 2 rows
-                               └── scan    ·         ·
-·                                          table     t@primary
+                               └── values  ·         ·
+·                                          size      1 column, 2 rows
 
 # Ditto all mutations, with the statement source syntax.
 query TTT
@@ -141,11 +140,10 @@ limit                                      ·         ·
                 └── render                 ·         ·
                      └── render            ·         ·
                           └── lookup-join  ·         ·
+                               │           table     t@primary
                                │           type      left outer
-                               ├── values  ·         ·
-                               │           size      1 column, 2 rows
-                               └── scan    ·         ·
-·                                          table     t@primary
+                               └── values  ·         ·
+·                                          size      1 column, 2 rows
 
 # Check that a spool is also inserted for other processings than LIMIT.
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -73,11 +73,10 @@ EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3) AND (a,b,c) < (8
 filter           ·       ·                                                     (a, b, c)              ·
  │               filter  ((a, b, c) > (1, 2, 3)) AND ((a, b, c) < (8, 9, 10))  ·                      ·
  └── index-join  ·       ·                                                     (a, b, c)              ·
-      ├── scan   ·       ·                                                     (a, b, rowid[hidden])  ·
-      │          table   abc@abc_a_b_idx                                       ·                      ·
-      │          spans   /1/2-/8/10                                            ·                      ·
-      └── scan   ·       ·                                                     (a, b, c)              ·
-·                table   abc@primary                                           ·                      ·
+      │          table   abc@primary                                           ·                      ·
+      └── scan   ·       ·                                                     (a, b, rowid[hidden])  ·
+·                table   abc@abc_a_b_idx                                       ·                      ·
+·                spans   /1/2-/8/10                                            ·                      ·
 
 statement ok
 DROP TABLE abc

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -28,16 +28,15 @@ count                                    ·         ·
                 │                        render 2  k
                 │                        render 3  v
                 └── lookup-join          ·         ·
-                     │                   type      inner
-                     ├── limit           ·         ·
-                     │    │              count     2
-                     │    └── sort       ·         ·
-                     │         │         order     -v
-                     │         └── scan  ·         ·
                      │                   table     kv@primary
-                     │                   spans     ALL
-                     └── scan            ·         ·
+                     │                   type      inner
+                     └── limit           ·         ·
+                          │              count     2
+                          └── sort       ·         ·
+                               │         order     -v
+                               └── scan  ·         ·
 ·                                        table     kv@primary
+·                                        spans     ALL
 
 # Regression test for #25726.
 # UPSERT over tables with column families, on the fast path, use the

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -216,18 +216,20 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 		n.source.plan = v.visit(n.source.plan)
 
 	case *indexJoinNode:
+		if v.observer.attr != nil {
+			v.observer.attr(name, "table", fmt.Sprintf("%s@%s", n.table.desc.Name, n.table.index.Name))
+		}
 		v.visitConcrete(n.index)
-		v.visitConcrete(n.table)
 
 	case *lookupJoinNode:
 		if v.observer.attr != nil {
+			v.observer.attr(name, "table", fmt.Sprintf("%s@%s", n.table.desc.Name, n.table.index.Name))
 			v.observer.attr(name, "type", joinTypeStr(n.joinType))
 		}
 		if v.observer.expr != nil && n.onCond != nil && n.onCond != tree.DBoolTrue {
 			v.expr(name, "pred", -1, n.onCond)
 		}
 		n.input = v.visit(n.input)
-		v.visitConcrete(n.table)
 
 	case *zigzagJoinNode:
 		if v.observer.attr != nil {


### PR DESCRIPTION
The index join and lookup join nodes show the table as a separate
`scan` child. This is confusing because we're not actually scanning
that table, and when reading the output it's not obvious which input
is which.

This change removes the scan child and adds the table and index as a
property of the index-join/lookup-join.

Release note (sql change): Improved output of EXPLAIN for index-join
and lookup-join.