### PR TITLE
storage: enhance slow handle Raft ready log messages

### DIFF
--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -467,10 +467,12 @@ var noSnap IncomingSnapshot
 //
 // The returned string is nonzero whenever an error is returned to give a
 // non-sensitive cue as to what happened.
-func (r *Replica) handleRaftReady(inSnap IncomingSnapshot) (handleRaftReadyStats, string, error) {
+func (r *Replica) handleRaftReady(
+	ctx context.Context, inSnap IncomingSnapshot,
+) (handleRaftReadyStats, string, error) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
-	return r.handleRaftReadyRaftMuLocked(inSnap)
+	return r.handleRaftReadyRaftMuLocked(ctx, inSnap)
 }
 
 // handleRaftReadyLocked is the same as handleRaftReady but requires that the
@@ -479,11 +481,10 @@ func (r *Replica) handleRaftReady(inSnap IncomingSnapshot) (handleRaftReadyStats
 // The returned string is nonzero whenever an error is returned to give a
 // non-sensitive cue as to what happened.
 func (r *Replica) handleRaftReadyRaftMuLocked(
-	inSnap IncomingSnapshot,
+	ctx context.Context, inSnap IncomingSnapshot,
 ) (handleRaftReadyStats, string, error) {
 	var stats handleRaftReadyStats
 
-	ctx := r.AnnotateCtx(context.TODO())
 	var hasReady bool
 	var rd raft.Ready
 	r.mu.Lock()

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6508,17 +6508,18 @@ func TestQuotaPoolAccessOnDestroyedReplica(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tc.store.removeReplicaImpl(context.TODO(), repl, repl.Desc().NextReplicaID, RemoveOptions{
+	ctx := repl.AnnotateCtx(context.Background())
+	if err := tc.store.removeReplicaImpl(ctx, repl, repl.Desc().NextReplicaID, RemoveOptions{
 		DestroyData: true,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, _, err := repl.handleRaftReady(noSnap); err != nil {
+	if _, _, err := repl.handleRaftReady(ctx, noSnap); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, _, err := repl.handleRaftReady(noSnap); err != nil {
+	if _, _, err := repl.handleRaftReady(ctx, noSnap); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Use a context annotated with the replica. Take the opportunity to plumb
context through a few more code paths in order to avoid unnecessary
annotating.

Release note: None