### PR TITLE
backport-2.1: roachtest: use toxiproxy for network testing

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -17,8 +17,7 @@ package client
 import (
 	"context"
 	"fmt"
-
-	"github.com/pkg/errors"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
@@ -28,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/pkg/errors"
 )
 
 // Txn is an in-progress distributed database transaction. A Txn is safe for
@@ -619,17 +619,25 @@ func (txn *Txn) rollback(ctx context.Context) *roachpb.Error {
 		}
 	}
 
+	// We don't have a client whose context we can attach to, but we do want to limit how
+	// long this request is going to be around or it could leak a goroutine (in case of a
+	// long-lived network partition).
 	stopper := txn.db.ctx.Stopper
-	ctx, cancel := stopper.WithCancelOnQuiesce(txn.db.AnnotateCtx(context.Background()))
+	ctx, cancel1 := stopper.WithCancelOnQuiesce(txn.db.AnnotateCtx(context.Background()))
+	// NB: cancel2 makes cancel1 obsolete, but the linters don't know that.
+	ctx, cancel2 := context.WithTimeout(ctx, 3*time.Second)
+
 	if err := stopper.RunAsyncTask(ctx, "async-rollback", func(ctx context.Context) {
-		defer cancel()
+		defer cancel1()
+		defer cancel2()
 		var ba roachpb.BatchRequest
 		ba.Add(endTxnReq(false /* commit */, nil /* deadline */, false /* systemConfigTrigger */))
 		if _, pErr := txn.Send(ctx, ba); pErr != nil {
 			log.Infof(ctx, "async rollback failed: %s", pErr)
 		}
 	}); err != nil {
-		cancel()
+		cancel1()
+		cancel2()
 		return roachpb.NewError(err)
 	}
 	return nil


### PR DESCRIPTION
Backport 1/3 commits from #33282.

Fixes #34136.

/cc @cockroachdb/release

---

Reincarnation of https://github.com/cockroachdb/cockroach/pull/23141.

[toxiproxy] is a TCP proxy which exports an HTTP API that allows
introducing various anomalous network conditions for resilience testing.

Among the interesting things one can simulate are latency and bandwidth
restrictions. This is done programmatically and thus lends itself to the
kind of testing we'd like to do; in particular, it should allow testing
locally a good approximation of geo-replicated clusters and various
network partitions.

The test introduced here isn't really useful yet. We'll need to settle
on something straightforward to test.

Updates #21680.
Updates #14768.

[toxiproxy]: https://github.com/Shopify/toxiproxy

Release note: None
