### PR TITLE
[wip] storage: move accessors off Replica

### DIFF
--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -273,7 +273,7 @@ func doLookupWithToken(
 	if err != nil {
 		t.Fatal(err)
 	}
-	if (useReverseScan && !r.ContainsKeyInverted(keyAddr)) || (!useReverseScan && !r.ContainsKey(keyAddr)) {
+	if (useReverseScan && !r.ContainsKeyInverted(keyAddr)) || (!useReverseScan && !(*ReplicaEvalContext)(r).ContainsKey(keyAddr)) {
 		t.Fatalf("Returned range did not contain key: %s-%s, %s", r.StartKey, r.EndKey, key)
 	}
 	return r, returnToken

--- a/pkg/server/server_systemlog_gc.go
+++ b/pkg/server/server_systemlog_gc.go
@@ -77,7 +77,7 @@ func (s *Server) gcSystemLog(
 		return timestampLowerBound, 0, nil
 	}
 
-	if !repl.IsFirstRange() || !repl.OwnsValidLease(s.clock.Now()) {
+	if !(*storage.ReplicaEvalContext)(repl).IsFirstRange() || !repl.OwnsValidLease(s.clock.Now()) {
 		return timestampLowerBound, 0, nil
 	}
 

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -212,7 +212,7 @@ type RangeInfo struct {
 func rangeInfoForRepl(repl *Replica, desc *roachpb.RangeDescriptor) RangeInfo {
 	info := RangeInfo{
 		Desc:         desc,
-		LogicalBytes: repl.GetMVCCStats().Total(),
+		LogicalBytes: (*ReplicaEvalContext)(repl).GetMVCCStats().Total(),
 	}
 	if queriesPerSecond, dur := repl.leaseholderStats.avgQPS(); dur >= MinStatsDuration {
 		info.QueriesPerSecond = queriesPerSecond

--- a/pkg/storage/client_lease_test.go
+++ b/pkg/storage/client_lease_test.go
@@ -60,7 +60,7 @@ func TestStoreRangeLease(t *testing.T) {
 		}
 
 		rLeft := mtc.stores[0].LookupReplica(roachpb.RKeyMin)
-		lease, _ := rLeft.GetLease()
+		lease, _ := (*storage.ReplicaEvalContext)(rLeft).GetLease()
 		if lt := lease.Type(); lt != roachpb.LeaseExpiration {
 			t.Fatalf("expected lease type expiration; got %d", lt)
 		}
@@ -69,7 +69,7 @@ func TestStoreRangeLease(t *testing.T) {
 		// we've enabled epoch based range leases.
 		for _, key := range splitKeys {
 			repl := mtc.stores[0].LookupReplica(roachpb.RKey(key))
-			lease, _ = repl.GetLease()
+			lease, _ = (*storage.ReplicaEvalContext)(repl).GetLease()
 			if enableEpoch {
 				if lt := lease.Type(); lt != roachpb.LeaseEpoch {
 					t.Fatalf("expected lease type epoch; got %d", lt)
@@ -109,7 +109,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 
 	// We started with epoch ranges enabled, so verify we have an epoch lease.
 	repl := mtc.stores[0].LookupReplica(roachpb.RKey(splitKey))
-	lease, _ := repl.GetLease()
+	lease, _ := (*storage.ReplicaEvalContext)(repl).GetLease()
 	if lt := lease.Type(); lt != roachpb.LeaseEpoch {
 		t.Fatalf("expected lease type epoch; got %d", lt)
 	}
@@ -126,7 +126,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 
 	// Verify we end up with an expiration lease on restart.
 	repl = mtc.stores[0].LookupReplica(roachpb.RKey(splitKey))
-	lease, _ = repl.GetLease()
+	lease, _ = (*storage.ReplicaEvalContext)(repl).GetLease()
 	if lt := lease.Type(); lt != roachpb.LeaseExpiration {
 		t.Fatalf("expected lease type expiration; got %d", lt)
 	}
@@ -143,7 +143,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 
 	// Verify we end up with an epoch lease on restart.
 	repl = mtc.stores[0].LookupReplica(roachpb.RKey(splitKey))
-	lease, _ = repl.GetLease()
+	lease, _ = (*storage.ReplicaEvalContext)(repl).GetLease()
 	if lt := lease.Type(); lt != roachpb.LeaseEpoch {
 		t.Fatalf("expected lease type epoch; got %d", lt)
 	}

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -966,7 +966,7 @@ func TestStoreRangeMergeInFlightTxns(t *testing.T) {
 				t.Fatal(err)
 			}
 			for {
-				if _, ok := repl.GetTxnWaitQueue().TrackedTxns()[txn1.ID()]; ok {
+				if _, ok := (*storage.ReplicaEvalContext)(repl).GetTxnWaitQueue().TrackedTxns()[txn1.ID()]; ok {
 					break
 				}
 				select {
@@ -3176,12 +3176,13 @@ func TestMergeQueue(t *testing.T) {
 
 	t.Run("combined-threshold", func(t *testing.T) {
 		reset(t)
+		eval := (*storage.ReplicaEvalContext)(lhs())
 
 		// The ranges are individually beneath the minimum size threshold, but
 		// together they'll exceed the maximum size threshold.
 		zone := config.DefaultZoneConfig()
-		zone.RangeMinBytes = proto.Int64(lhs().GetMVCCStats().Total() + 1)
-		zone.RangeMaxBytes = proto.Int64(lhs().GetMVCCStats().Total()*2 - 1)
+		zone.RangeMinBytes = proto.Int64(eval.GetMVCCStats().Total() + 1)
+		zone.RangeMaxBytes = proto.Int64(eval.GetMVCCStats().Total()*2 - 1)
 		setZones(zone)
 		store.MustForceMergeScanAndProcess()
 		verifyUnmerged(t)

--- a/pkg/storage/client_metrics_test.go
+++ b/pkg/storage/client_metrics_test.go
@@ -187,7 +187,7 @@ func TestStoreResolveMetrics(t *testing.T) {
 	{
 		repl := mtc.stores[0].LookupReplica(keys.MustAddr(span.Key))
 		var err error
-		if ba.Replica, err = repl.GetReplicaDescriptor(); err != nil {
+		if ba.Replica, err = (*storage.ReplicaEvalContext)(repl).GetReplicaDescriptor(); err != nil {
 			t.Fatal(err)
 		}
 		ba.RangeID = repl.RangeID

--- a/pkg/storage/client_raft_log_queue_test.go
+++ b/pkg/storage/client_raft_log_queue_test.go
@@ -64,7 +64,7 @@ func TestRaftLogQueue(t *testing.T) {
 	if raftLeaderRepl == nil {
 		t.Fatalf("could not find raft leader replica for range %d", rangeID)
 	}
-	originalIndex, err := raftLeaderRepl.GetFirstIndex()
+	originalIndex, err := (*storage.ReplicaEvalContext)(raftLeaderRepl).GetFirstIndex()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestRaftLogQueue(t *testing.T) {
 
 	// Ensure that firstIndex has increased indicating that the log
 	// truncation has occurred.
-	afterTruncationIndex, err := raftLeaderRepl.GetFirstIndex()
+	afterTruncationIndex, err := (*storage.ReplicaEvalContext)(raftLeaderRepl).GetFirstIndex()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestRaftLogQueue(t *testing.T) {
 		store.MustForceRaftLogScanAndProcess()
 	}
 
-	after2ndTruncationIndex, err := raftLeaderRepl.GetFirstIndex()
+	after2ndTruncationIndex, err := (*storage.ReplicaEvalContext)(raftLeaderRepl).GetFirstIndex()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -606,7 +606,7 @@ func TestReplicateAfterTruncation(t *testing.T) {
 	}
 
 	testutils.SucceedsSoon(t, func() error {
-		if mvcc, mvcc2 := repl.GetMVCCStats(), repl2.GetMVCCStats(); mvcc2 != mvcc {
+		if mvcc, mvcc2 := (*storage.ReplicaEvalContext)(repl).GetMVCCStats(), (*storage.ReplicaEvalContext)(repl2).GetMVCCStats(); mvcc2 != mvcc {
 			return errors.Errorf("expected stats on new range:\n%+v\not equal old:\n%+v", mvcc2, mvcc)
 		}
 		return nil
@@ -1289,11 +1289,11 @@ func TestLogGrowthWhenRefreshingPendingCommands(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			repDesc, err := repl.GetReplicaDescriptor()
+			repDesc, err := (*storage.ReplicaEvalContext)(repl).GetReplicaDescriptor()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if lease, _ := repl.GetLease(); lease.Replica != repDesc {
+			if lease, _ := (*storage.ReplicaEvalContext)(repl).GetLease(); lease.Replica != repDesc {
 				return errors.Errorf("lease not transferred yet; found %v", lease)
 			}
 			return nil
@@ -1533,7 +1533,7 @@ func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 				return errors.New("replica is not available yet")
 			}
 			var err error
-			corruptRep, err = r.GetReplicaDescriptor()
+			corruptRep, err = (*storage.ReplicaEvalContext)(r).GetReplicaDescriptor()
 			return err
 		})
 
@@ -2415,11 +2415,11 @@ outer:
 					if toStore == store {
 						continue
 					}
-					repDesc, err := repl.GetReplicaDescriptor()
+					repDesc, err := (*storage.ReplicaEvalContext)(repl).GetReplicaDescriptor()
 					if err != nil {
 						t.Fatal(err)
 					}
-					if lease, _ := repl.GetLease(); lease.Replica == repDesc {
+					if lease, _ := (*storage.ReplicaEvalContext)(repl).GetLease(); lease.Replica == repDesc {
 						mtc.transferLease(context.TODO(), rangeID, leaderIdx, replicaIdx)
 					}
 					mtc.unreplicateRange(rangeID, leaderIdx)
@@ -3816,7 +3816,7 @@ func TestTransferRaftLeadership(t *testing.T) {
 	if repl0 == nil {
 		t.Fatalf("no replica found for key '%s'", key)
 	}
-	rd0, err := repl0.GetReplicaDescriptor()
+	rd0, err := (*storage.ReplicaEvalContext)(repl0).GetReplicaDescriptor()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3826,7 +3826,7 @@ func TestTransferRaftLeadership(t *testing.T) {
 	if repl1 == nil {
 		t.Fatalf("no replica found for key '%s'", key)
 	}
-	rd1, err := repl1.GetReplicaDescriptor()
+	rd1, err := (*storage.ReplicaEvalContext)(repl1).GetReplicaDescriptor()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4080,7 +4080,7 @@ func TestInitRaftGroupOnRequest(t *testing.T) {
 	mtc.replicateRange(repl.RangeID, 1)
 
 	// Find the leaseholder and then restart the test context.
-	lease, _ := repl.GetLease()
+	lease, _ := (*storage.ReplicaEvalContext)(repl).GetLease()
 	mtc.restart()
 
 	// Get replica from the store which isn't the leaseholder.

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -212,8 +212,8 @@ func TestStoreSplitAbortSpan(t *testing.T) {
 		return results
 	}
 
-	l := collect(store.LookupReplica(keys.MustAddr(left)).AbortSpan())
-	r := collect(store.LookupReplica(keys.MustAddr(right)).AbortSpan())
+	l := collect((*storage.ReplicaEvalContext)(store.LookupReplica(keys.MustAddr(left))).AbortSpan())
+	r := collect((*storage.ReplicaEvalContext)(store.LookupReplica(keys.MustAddr(right))).AbortSpan())
 
 	if !reflect.DeepEqual(expL, l) {
 		t.Fatalf("left hand side: expected %+v, got %+v", expL, l)
@@ -720,7 +720,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	if err := verifyRecomputedStats(snap, repl.Desc(), ms, manual.UnixNano()); err != nil {
 		t.Fatalf("failed to verify range's stats before split: %v", err)
 	}
-	if inMemMS := repl.GetMVCCStats(); inMemMS != ms {
+	if inMemMS := (*storage.ReplicaEvalContext)(repl).GetMVCCStats(); inMemMS != ms {
 		t.Fatalf("in-memory and on-disk diverged:\n%+v\n!=\n%+v", inMemMS, ms)
 	}
 
@@ -1961,8 +1961,8 @@ func TestStoreSplitGCThreshold(t *testing.T) {
 	}
 
 	repl := store.LookupReplica(roachpb.RKey(splitKey))
-	gcThreshold := repl.GetGCThreshold()
-	txnSpanGCThreshold := repl.GetTxnSpanGCThreshold()
+	gcThreshold := (*storage.ReplicaEvalContext)(repl).GetGCThreshold()
+	txnSpanGCThreshold := (*storage.ReplicaEvalContext)(repl).GetTxnSpanGCThreshold()
 
 	if !reflect.DeepEqual(gcThreshold, specifiedGCThreshold) {
 		t.Fatalf("expected RHS's GCThreshold is equal to %v, but got %v", specifiedGCThreshold, gcThreshold)

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1167,7 +1167,7 @@ func (m *multiTestContext) replicateRangeNonFatal(rangeID roachpb.RangeID, dests
 			if err != nil {
 				return err
 			}
-			repDesc, err := repl.GetReplicaDescriptor()
+			repDesc, err := (*storage.ReplicaEvalContext)(repl).GetReplicaDescriptor()
 			if err != nil {
 				return err
 			}

--- a/pkg/storage/closed_timestamp_test.go
+++ b/pkg/storage/closed_timestamp_test.go
@@ -131,7 +131,7 @@ CREATE TABLE cttest.kv (id INT PRIMARY KEY, value STRING);
 	// the transfer basically always works.
 	for ok := false; !ok; time.Sleep(10 * time.Millisecond) {
 		for _, repl := range repls {
-			lease, _ := repl.GetLease()
+			lease, _ := (*storage.ReplicaEvalContext)(repl).GetLease()
 			if lease.Epoch != 0 {
 				ok = true
 				break

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -453,7 +453,7 @@ func TestConsistencyQueueRecomputeStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ms := repl.GetMVCCStats()
+	ms := (*storage.ReplicaEvalContext)(repl).GetMVCCStats()
 	if ms.SysCount >= sysCountGarbage {
 		t.Fatalf("still have a SysCount of %d", ms.SysCount)
 	}

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -535,7 +535,7 @@ func (r *replicaGCer) send(ctx context.Context, req roachpb.GCRequest) error {
 
 	// Technically not needed since we're talking directly to the Replica.
 	ba.RangeID = r.repl.Desc().RangeID
-	ba.Timestamp = r.repl.Clock().Now()
+	ba.Timestamp = r.repl.store.Clock().Now()
 	ba.Add(&req)
 
 	if _, pErr := r.repl.Send(ctx, ba); pErr != nil {
@@ -590,7 +590,7 @@ func (gcq *gcQueue) processImpl(
 		return err
 	}
 
-	log.Eventf(ctx, "MVCC stats after GC: %+v", repl.GetMVCCStats())
+	log.Eventf(ctx, "MVCC stats after GC: %+v", (*ReplicaEvalContext)(repl).GetMVCCStats())
 	log.Eventf(ctx, "GC score after GC: %s", makeGCQueueScore(ctx, repl, repl.store.Clock().Now(), sysCfg))
 	info.updateMetrics(gcq.store.metrics)
 

--- a/pkg/storage/merge_queue.go
+++ b/pkg/storage/merge_queue.go
@@ -169,7 +169,7 @@ func (mq *mergeQueue) shouldQueue(
 		return false, 0
 	}
 
-	sizeRatio := float64(repl.GetMVCCStats().Total()) / float64(repl.GetMinBytes())
+	sizeRatio := float64((*ReplicaEvalContext)(repl).GetMVCCStats().Total()) / float64(repl.GetMinBytes())
 	if math.IsNaN(sizeRatio) || sizeRatio >= 1 {
 		// This range is above the minimum size threshold. It does not need to be
 		// merged.
@@ -225,7 +225,7 @@ func (mq *mergeQueue) process(
 		return nil
 	}
 
-	lhsStats := lhsRepl.GetMVCCStats()
+	lhsStats := (*ReplicaEvalContext)(lhsRepl).GetMVCCStats()
 	minBytes := lhsRepl.GetMinBytes()
 	if lhsStats.Total() >= minBytes {
 		log.VEventf(ctx, 2, "skipping merge: LHS meets minimum size threshold %d with %d bytes",
@@ -233,7 +233,7 @@ func (mq *mergeQueue) process(
 		return nil
 	}
 
-	lhsQPS := lhsRepl.GetSplitQPS()
+	lhsQPS := (*ReplicaEvalContext)(lhsRepl).GetSplitQPS()
 	timeSinceLastReq := lhsRepl.store.Clock().PhysicalTime().Sub(lhsRepl.GetLastRequestTime())
 	rhsDesc, rhsStats, rhsQPS, err := mq.requestRangeStats(ctx, lhsDesc.EndKey.AsRawKey())
 	if err != nil {
@@ -276,7 +276,7 @@ func (mq *mergeQueue) process(
 				NodeID: lhsReplDesc.NodeID, StoreID: lhsReplDesc.StoreID,
 			})
 		}
-		lease, _ := lhsRepl.GetLease()
+		lease, _ := (*ReplicaEvalContext)(lhsRepl).GetLease()
 		for i := range targets {
 			if targets[i].NodeID == lease.Replica.NodeID && targets[i].StoreID == lease.Replica.StoreID {
 				if i > 0 {

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -450,7 +450,7 @@ func (bq *baseQueue) maybeAddLocked(ctx context.Context, repl *Replica, now hlc.
 	if bq.needsLease {
 		// Check to see if either we own the lease or do not know who the lease
 		// holder is.
-		if lease, _ := repl.GetLease(); repl.IsLeaseValid(lease, now) &&
+		if lease, _ := (*ReplicaEvalContext)(repl).GetLease(); repl.IsLeaseValid(lease, now) &&
 			!lease.OwnedBy(repl.store.StoreID()) {
 			if log.V(1) {
 				log.Infof(ctx, "needs lease; not adding: %+v", lease)

--- a/pkg/storage/raft_log_queue_test.go
+++ b/pkg/storage/raft_log_queue_test.go
@@ -529,7 +529,7 @@ func TestProactiveRaftLogTruncate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			oldFirstIndex, err := r.GetFirstIndex()
+			oldFirstIndex, err := (*ReplicaEvalContext)(r).GetFirstIndex()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -546,7 +546,7 @@ func TestProactiveRaftLogTruncate(t *testing.T) {
 			// fairly quickly, there is a slight race between this check and the
 			// truncation, especially when under stress.
 			testutils.SucceedsSoon(t, func() error {
-				newFirstIndex, err := r.GetFirstIndex()
+				newFirstIndex, err := (*ReplicaEvalContext)(r).GetFirstIndex()
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -120,7 +120,7 @@ func (r *Replica) CheckConsistency(
 		// If there's no delta (or some nodes in the cluster may not know
 		// RecomputeStats, in which case sending it to them could crash them),
 		// there's nothing else to do.
-		if delta == (enginepb.MVCCStats{}) || !r.ClusterSettings().Version.IsMinSupported(cluster.VersionRecomputeStats) {
+		if delta == (enginepb.MVCCStats{}) || !r.store.ClusterSettings().Version.IsMinSupported(cluster.VersionRecomputeStats) {
 			return roachpb.CheckConsistencyResponse{}, nil
 		}
 
@@ -225,7 +225,7 @@ func (r *Replica) RunConsistencyCheck(
 	var orderedReplicas []roachpb.ReplicaDescriptor
 	{
 		desc := r.Desc()
-		localReplica, err := r.GetReplicaDescriptor()
+		localReplica, err := (*ReplicaEvalContext)(r).GetReplicaDescriptor()
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get replica descriptor")
 		}

--- a/pkg/storage/replica_destroy.go
+++ b/pkg/storage/replica_destroy.go
@@ -125,12 +125,12 @@ func (r *Replica) postDestroyRaftMuLocked(ctx context.Context, ms enginepb.MVCCS
 func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb.ReplicaID) error {
 	startTime := timeutil.Now()
 
-	ms := r.GetMVCCStats()
+	ms := (*ReplicaEvalContext)(r).GetMVCCStats()
 
 	const destroyData = true
-	batch := r.Engine().NewWriteOnlyBatch()
+	batch := r.store.Engine().NewWriteOnlyBatch()
 	defer batch.Close()
-	if err := r.preDestroyRaftMuLocked(ctx, r.Engine(), batch, nextReplicaID, destroyData); err != nil {
+	if err := r.preDestroyRaftMuLocked(ctx, r.store.Engine(), batch, nextReplicaID, destroyData); err != nil {
 		return err
 	}
 	preTime := timeutil.Now()

--- a/pkg/storage/replica_eval_context.go
+++ b/pkg/storage/replica_eval_context.go
@@ -17,10 +17,21 @@ package storage
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 // todoSpanSet is a placeholder value for callsites that need to pass a properly
@@ -42,9 +53,190 @@ func NewReplicaEvalContext(r *Replica, ss *spanset.SpanSet) batcheval.EvalContex
 	}
 	if util.RaceEnabled {
 		return &SpanSetReplicaEvalContext{
-			i:  r,
+			i:  (*ReplicaEvalContext)(r),
 			ss: *ss,
 		}
 	}
-	return r
+	return (*ReplicaEvalContext)(r)
+}
+
+type ReplicaEvalContext Replica
+
+func (r *ReplicaEvalContext) String() string {
+	return (*Replica)(r).String()
+}
+
+// ClusterSettings returns the node's ClusterSettings.
+func (r *ReplicaEvalContext) ClusterSettings() *cluster.Settings {
+	return r.store.cfg.Settings
+}
+
+// EvalKnobs returns the EvalContext's Knobs.
+func (r *ReplicaEvalContext) EvalKnobs() storagebase.BatchEvalTestingKnobs {
+	return r.store.cfg.TestingKnobs.EvalKnobs
+}
+
+// Engine returns the Replica's underlying Engine. In most cases the
+// evaluation Batch should be used instead.
+func (r *ReplicaEvalContext) Engine() engine.Engine {
+	return r.store.Engine()
+}
+
+// Clock returns the hlc clock shared by this replica.
+func (r *ReplicaEvalContext) Clock() *hlc.Clock {
+	return r.store.Clock()
+}
+
+// DB returns the Replica's client DB.
+func (r *ReplicaEvalContext) DB() *client.DB {
+	return r.store.DB()
+}
+
+// AbortSpan returns the Replica's AbortSpan.
+func (r *ReplicaEvalContext) AbortSpan() *abortspan.AbortSpan {
+	// Despite its name, the AbortSpan doesn't hold on-disk data in
+	// memory. It just provides methods that take a Batch, so SpanSet
+	// declarations are enforced there.
+	return r.abortSpan
+}
+
+// GetTxnWaitQueue returns the Replica's txnwait.Queue.
+func (r *ReplicaEvalContext) GetTxnWaitQueue() *txnwait.Queue {
+	return r.txnWaitQueue
+}
+
+// GetLimiters returns the Replica's limiters.
+func (r *ReplicaEvalContext) GetLimiters() *batcheval.Limiters {
+	return &r.store.limiters
+}
+
+// NodeID returns the ID of the node this replica belongs to.
+func (r *ReplicaEvalContext) NodeID() roachpb.NodeID {
+	return r.store.nodeDesc.NodeID
+}
+
+// StoreID returns the Replica's StoreID.
+func (r *ReplicaEvalContext) StoreID() roachpb.StoreID {
+	return r.store.StoreID()
+}
+
+// GetRangeID returns the Range ID.
+func (r *ReplicaEvalContext) GetRangeID() roachpb.RangeID {
+	return r.RangeID
+}
+
+// IsFirstRange returns true if this is the first range.
+func (r *ReplicaEvalContext) IsFirstRange() bool {
+	return r.RangeID == 1
+}
+
+// GetFirstIndex is the same function as (*Replica).raftFirstIndexLocked without
+// the lock.
+func (r *ReplicaEvalContext) GetFirstIndex() (uint64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// NB: I think this is only called from log truncation decision making
+	// otherwise, so there's an opportunity for further refactoring.
+	return (*Replica)(r).raftFirstIndexLocked()
+}
+
+// GetMVCCStats returns a copy of the MVCC stats object for this range.
+// This accessor is thread-safe, but provides no guarantees about its
+// synchronization with any concurrent writes.
+func (r *ReplicaEvalContext) GetMVCCStats() enginepb.MVCCStats {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return *r.mu.state.Stats
+}
+
+// GetSplitQPS returns the Replica's queries/s request rate.
+// The value returned represents the QPS recorded at the time of the
+// last request which can be found using GetLastRequestTime().
+// NOTE: This should only be used for load based splitting, only
+// works when the load based splitting cluster setting is enabled.
+//
+// Use QueriesPerSecond() for current QPS stats for all other purposes.
+func (r *ReplicaEvalContext) GetSplitQPS() float64 {
+	r.splitMu.Lock()
+	defer r.splitMu.Unlock()
+	return r.splitMu.qps
+}
+
+// GetLastReplicaGCTimestamp reads the timestamp at which the replica was
+// last checked for removal by the replica gc queue.
+func (r *ReplicaEvalContext) GetLastReplicaGCTimestamp(ctx context.Context) (hlc.Timestamp, error) {
+	key := keys.RangeLastReplicaGCTimestampKey(r.RangeID)
+	var timestamp hlc.Timestamp
+	_, err := engine.MVCCGetProto(ctx, r.store.Engine(), key, hlc.Timestamp{}, &timestamp,
+		engine.MVCCGetOptions{})
+	if err != nil {
+		return hlc.Timestamp{}, err
+	}
+	return timestamp, nil
+}
+
+// GetTerm returns the term of the given index in the raft log.
+func (r *ReplicaEvalContext) GetTerm(i uint64) (uint64, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return (*Replica)(r).raftTermRLocked(i)
+}
+
+// GetLeaseAppliedIndex returns the lease index of the last applied command.
+func (r *ReplicaEvalContext) GetLeaseAppliedIndex() uint64 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.mu.state.LeaseAppliedIndex
+}
+
+// GetReplicaDescriptor returns the replica for this range from the range
+// descriptor. Returns a *RangeNotFoundError if the replica is not found.
+// No other errors are returned.
+func (r *ReplicaEvalContext) GetReplicaDescriptor() (roachpb.ReplicaDescriptor, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return (*Replica)(r).getReplicaDescriptorRLocked()
+}
+
+// Desc returns the authoritative range descriptor, acquiring a replica lock in
+// the process.
+func (r *ReplicaEvalContext) Desc() *roachpb.RangeDescriptor {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.mu.state.Desc
+}
+
+// ContainsKey returns whether this range contains the specified key.
+//
+// TODO(bdarnell): This is not the same as RangeDescriptor.ContainsKey.
+func (r *ReplicaEvalContext) ContainsKey(key roachpb.Key) bool {
+	return storagebase.ContainsKey(*r.Desc(), key)
+}
+
+func (r *ReplicaEvalContext) CanCreateTxnRecord(
+	txnID uuid.UUID, txnKey []byte, txnMinTSUpperBound hlc.Timestamp,
+) (ok bool, minCommitTS hlc.Timestamp, reason roachpb.TransactionAbortedReason) {
+	return CanCreateTxnRecord(r.store.tsCache, r.GetTxnSpanGCThreshold(), txnID, txnKey, txnMinTSUpperBound)
+}
+
+// GetGCThreshold returns the GC threshold.
+func (r *ReplicaEvalContext) GetGCThreshold() hlc.Timestamp {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return *r.mu.state.GCThreshold
+}
+
+// GetTxnSpanGCThreshold returns the time of the replica's last transaction span
+// GC.
+func (r *ReplicaEvalContext) GetTxnSpanGCThreshold() hlc.Timestamp {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return *r.mu.state.TxnSpanGCThreshold
+}
+
+// GetLease returns the lease and, if available, the proposed next lease.
+func (r *ReplicaEvalContext) GetLease() (roachpb.Lease, roachpb.Lease) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return (*Replica)(r).getLeaseRLocked()
 }

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -119,7 +119,7 @@ func newReplicaGCQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *repl
 func (rgcq *replicaGCQueue) shouldQueue(
 	ctx context.Context, now hlc.Timestamp, repl *Replica, _ *config.SystemConfig,
 ) (bool, float64) {
-	lastCheck, err := repl.GetLastReplicaGCTimestamp(ctx)
+	lastCheck, err := (*ReplicaEvalContext)(repl).GetLastReplicaGCTimestamp(ctx)
 	if err != nil {
 		log.Errorf(ctx, "could not read last replica GC timestamp: %s", err)
 		return false, 0
@@ -133,7 +133,7 @@ func (rgcq *replicaGCQueue) shouldQueue(
 		WallTime: repl.store.startedAt,
 	}
 
-	if lease, _ := repl.GetLease(); lease.ProposedTS != nil {
+	if lease, _ := (*ReplicaEvalContext)(repl).GetLease(); lease.ProposedTS != nil {
 		lastActivity.Forward(*lease.ProposedTS)
 	}
 

--- a/pkg/storage/replica_gossip.go
+++ b/pkg/storage/replica_gossip.go
@@ -85,7 +85,7 @@ func (r *Replica) MaybeGossipSystemConfig(ctx context.Context) error {
 		log.VEventf(ctx, 2, "not gossiping system config because the replica isn't initialized")
 		return nil
 	}
-	if !r.ContainsKey(keys.SystemConfigSpan.Key) {
+	if !(*ReplicaEvalContext)(r).ContainsKey(keys.SystemConfigSpan.Key) {
 		log.VEventf(ctx, 3,
 			"not gossiping system config because the replica doesn't contain the system config's start key")
 		return nil
@@ -240,7 +240,7 @@ func (r *Replica) getLeaseForGossip(ctx context.Context) (bool, *roachpb.Error) 
 // if this is the first range and a range lease can be obtained. The Store
 // calls this periodically on first range replicas.
 func (r *Replica) maybeGossipFirstRange(ctx context.Context) *roachpb.Error {
-	if !r.IsFirstRange() {
+	if !(*ReplicaEvalContext)(r).IsFirstRange() {
 		return nil
 	}
 

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -288,7 +288,11 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease) {
 	// Gossip the first range whenever its lease is acquired. We check to make
 	// sure the lease is active so that a trailing replica won't process an old
 	// lease request and attempt to gossip the first range.
-	if leaseChangingHands && iAmTheLeaseHolder && r.IsFirstRange() && r.IsLeaseValid(newLease, r.store.Clock().Now()) {
+	if leaseChangingHands &&
+		iAmTheLeaseHolder &&
+		(*ReplicaEvalContext)(r).IsFirstRange() &&
+		r.IsLeaseValid(newLease, r.store.Clock().Now()) {
+
 		r.gossipFirstRange(ctx)
 	}
 
@@ -903,7 +907,7 @@ func (r *Replica) evaluateProposal(
 		usingAppliedStateKey := r.mu.state.UsingAppliedStateKey
 		r.mu.RUnlock()
 		if !usingAppliedStateKey &&
-			r.ClusterSettings().Version.IsMinSupported(cluster.VersionRangeAppliedStateKey) {
+			r.store.ClusterSettings().Version.IsMinSupported(cluster.VersionRangeAppliedStateKey) {
 			if res.Replicated.State == nil {
 				res.Replicated.State = &storagepb.ReplicaState{}
 			}

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -1964,7 +1964,7 @@ func (r *Replica) processRaftCommand(
 
 	if expensiveSplitAssertion && raftCmd.ReplicatedEvalResult.Split != nil {
 		split := raftCmd.ReplicatedEvalResult.Split
-		lhsStatsMS := r.GetMVCCStats()
+		lhsStatsMS := (*ReplicaEvalContext)(r).GetMVCCStats()
 		lhsComputedMS, err := rditer.ComputeStatsForRange(&split.LeftDesc, r.store.Engine(), lhsStatsMS.LastUpdateNanos)
 		if err != nil {
 			log.Fatal(ctx, err)
@@ -1975,7 +1975,7 @@ func (r *Replica) processRaftCommand(
 			log.Fatal(ctx, err)
 		}
 
-		rhsStatsMS := rightReplica.GetMVCCStats()
+		rhsStatsMS := (*ReplicaEvalContext)(rightReplica).GetMVCCStats()
 		rhsComputedMS, err := rditer.ComputeStatsForRange(&split.RightDesc, r.store.Engine(), rhsStatsMS.LastUpdateNanos)
 		if err != nil {
 			log.Fatal(ctx, err)

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -227,7 +227,7 @@ func (rq *replicateQueue) shouldQueue(
 	}
 
 	// If the lease is valid, check to see if we should transfer it.
-	if lease, _ := repl.GetLease(); repl.IsLeaseValid(lease, now) {
+	if lease, _ := (*ReplicaEvalContext)(repl).GetLease(); repl.IsLeaseValid(lease, now) {
 		if rq.canTransferLease() &&
 			rq.allocator.ShouldTransferLease(
 				ctx, zone, desc.Replicas, lease.Replica.StoreID, desc.RangeID, repl.leaseholderStats) {

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -123,7 +123,7 @@ func shouldSplitRange(
 func (sq *splitQueue) shouldQueue(
 	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg *config.SystemConfig,
 ) (shouldQ bool, priority float64) {
-	shouldQ, priority = shouldSplitRange(repl.Desc(), repl.GetMVCCStats(),
+	shouldQ, priority = shouldSplitRange(repl.Desc(), (*ReplicaEvalContext)(repl).GetMVCCStats(),
 		0, /* Don't check for load based splitting yet. */
 		repl.SplitByLoadQPSThreshold(), repl.GetMaxBytes(), sysCfg)
 
@@ -192,7 +192,7 @@ func (sq *splitQueue) processAttempt(
 	// Next handle case of splitting due to size. Note that we don't perform
 	// size-based splitting if maxBytes is 0 (happens in certain test
 	// situations).
-	size := r.GetMVCCStats().Total()
+	size := (*ReplicaEvalContext)(r).GetMVCCStats().Total()
 	maxBytes := r.GetMaxBytes()
 	if maxBytes > 0 && float64(size)/float64(maxBytes) > 1 {
 		_, err := r.adminSplitWithDescriptor(

--- a/pkg/storage/split_queue_test.go
+++ b/pkg/storage/split_queue_test.go
@@ -103,8 +103,9 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		// Testing using shouldSplitRange instead of shouldQueue to avoid using the splitFinder
 		// This tests the merge queue behavior too as a result. For splitFinder tests,
 		// see split/split_test.go.
-		shouldQ, priority := shouldSplitRange(repl.Desc(), repl.GetMVCCStats(),
-			repl.GetSplitQPS(), repl.SplitByLoadQPSThreshold(), repl.GetMaxBytes(), cfg)
+		eval := (*ReplicaEvalContext)(repl)
+		shouldQ, priority := shouldSplitRange(repl.Desc(), eval.GetMVCCStats(),
+			eval.GetSplitQPS(), repl.SplitByLoadQPSThreshold(), repl.GetMaxBytes(), cfg)
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
 		}

--- a/pkg/storage/stats_test.go
+++ b/pkg/storage/stats_test.go
@@ -44,7 +44,7 @@ func TestRangeStatsEmpty(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
-	ms := tc.repl.GetMVCCStats()
+	ms := (*ReplicaEvalContext)(tc.repl).GetMVCCStats()
 	if exp := initialStats(); !reflect.DeepEqual(ms, exp) {
 		t.Errorf("unexpected stats diff(exp, actual):\n%s", pretty.Diff(exp, ms))
 	}

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -569,7 +569,7 @@ func (s *Store) canApplySnapshotLocked(
 				// the leader of the range has cut off communication with this replica.
 				// Expiration based leases, by contrast, will expire quickly if the
 				// leader of the range stops sending this replica heartbeats.
-				lease, pendingLease := r.GetLease()
+				lease, pendingLease := (*ReplicaEvalContext)(r).GetLease()
 				now := s.Clock().Now()
 				return !r.IsLeaseValid(lease, now) &&
 					(pendingLease == (roachpb.Lease{}) || !r.IsLeaseValid(pendingLease, now))

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -159,7 +159,7 @@ func (db *testSender) Send(
 		return nil, roachpb.NewError(roachpb.NewRangeKeyMismatchError(rs.Key.AsRawKey(), rs.EndKey.AsRawKey(), nil))
 	}
 	ba.RangeID = repl.RangeID
-	repDesc, err := repl.GetReplicaDescriptor()
+	repDesc, err := (*ReplicaEvalContext)(repl).GetReplicaDescriptor()
 	if err != nil {
 		return nil, roachpb.NewError(err)
 	}
@@ -460,7 +460,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failure fetching range %d: %s", i, err)
 		}
-		rs := r.GetMVCCStats()
+		rs := (*ReplicaEvalContext)(r).GetMVCCStats()
 
 		// Stats should agree with a recomputation.
 		now := r.store.Clock().Now()

--- a/pkg/storage/txnwait/txnqueue.go
+++ b/pkg/storage/txnwait/txnqueue.go
@@ -144,6 +144,12 @@ type ReplicaInterface interface {
 	ContainsKey(roachpb.Key) bool
 }
 
+type ContainsKeyFunc func(roachpb.Key) bool
+
+var _ ReplicaInterface = ContainsKeyFunc(nil)
+
+func (f ContainsKeyFunc) ContainsKey(k roachpb.Key) bool { return f(k) }
+
 // TestingKnobs represents testing knobs for a Queue.
 type TestingKnobs struct {
 	// OnTxnWaitEnqueue is called when a would-be pusher joins a wait queue.

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -511,7 +511,7 @@ func (tc *TestCluster) WaitForSplitAndReplication(startKey roachpb.Key) error {
 			if err != nil {
 				return err
 			}
-			actualReplicaDesc, err := repl.GetReplicaDescriptor()
+			actualReplicaDesc, err := (*storage.ReplicaEvalContext)(repl).GetReplicaDescriptor()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
I need to move a few more accessors, perhaps introduce some sugar around the cast to `*ReplicaEvalContext`, document the eval contexts and their uses as well as fix the lints, but none of that will change the rationale of this change, 

----


Fundamentally, a Replica is a decorated state machine, and so its
surface area should be small: We should be able to ask for a new
command to be applied, we should be able to query the state, and
there should be machinery that moves the state forward along the
replication log.

The reality is that Replica has over time accumulated all sorts of
accessors, several hundred of them all in all. In particular, the
in-memory state of the Replica is exposed in a mostly ad-hoc fashion.

This commit moves a fair amount of these accessors onto a newly created
ReplicaEvalContext (which implements EvalContext) which is structurally,
but not semantically, identical to Replica.

EvalContext is used when evaluating a command, in which case access to
the state is (with exceptions) serialized through the spanlatch manager
(that is, when reading the descriptor from the eval context, the result
won't change out from under the command since mutations to the
descriptor would have to wait). We extend this concept by allowing use
of the ReplicaEvalContext outside of command evaluation, where the
results of access to the state are subject to change at any time (as
was the case when these accessors sat on Replica itself).

ReplicaEvalContext thus becomes the interface through which one queries
the state machine (for both replicated and auxiliary data). As such,
it absorbs a lot of the straightforward-but-boring functionality that
would previously clutter Replica.

Release note: None