### PR TITLE
release-2.1: gossip: require node descriptors have non-empty addresses

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -393,6 +393,9 @@ func (g *Gossip) GetNodeMetrics() *Metrics {
 func (g *Gossip) SetNodeDescriptor(desc *roachpb.NodeDescriptor) error {
 	ctx := g.AnnotateCtx(context.TODO())
 	log.Infof(ctx, "NodeDescriptor set to %+v", desc)
+	if desc.Address.IsEmpty() {
+		log.Fatalf(ctx, "n%d address is empty", desc.NodeID)
+	}
 	if err := g.AddInfoProto(MakeNodeIDKey(desc.NodeID), desc, NodeDescriptorTTL); err != nil {
 		return errors.Errorf("n%d: couldn't gossip descriptor: %v", desc.NodeID, err)
 	}
@@ -799,7 +802,7 @@ func (g *Gossip) updateNodeAddress(key string, content roachpb.Value) {
 	// nodes to prevent other parts of the system from trying to talk to it.
 	// We can't directly compare the node against the empty descriptor because
 	// the proto has a repeated field and thus isn't comparable.
-	if desc.NodeID == 0 && desc.Address.IsEmpty() {
+	if desc.NodeID == 0 || desc.Address.IsEmpty() {
 		nodeID, err := NodeIDFromKey(key, KeyNodeIDPrefix)
 		if err != nil {
 			log.Errorf(ctx, "unable to update node address for removed node: %s", err)
@@ -830,12 +833,6 @@ func (g *Gossip) updateNodeAddress(key string, content roachpb.Value) {
 	// of resolvers so we can keep connecting to gossip if the original
 	// resolvers go offline.
 	g.maybeAddResolverLocked(desc.Address)
-
-	// We ignore empty addresses for the sake of not breaking the many tests
-	// that don't bother specifying addresses.
-	if desc.Address.IsEmpty() {
-		return
-	}
 
 	// If the new node's address conflicts with another node's address, then it
 	// must be the case that the new node has replaced the previous one. Remove
@@ -946,6 +943,9 @@ func (g *Gossip) recomputeMaxPeersLocked() {
 // GetNodeDescriptor and internally by getNodeIDAddressLocked.
 func (g *Gossip) getNodeDescriptorLocked(nodeID roachpb.NodeID) (*roachpb.NodeDescriptor, error) {
 	if desc, ok := g.nodeDescs[nodeID]; ok {
+		if desc.Address.IsEmpty() {
+			log.Fatalf(g.AnnotateCtx(context.Background()), "n%d has an empty address", nodeID)
+		}
 		return desc, nil
 	}
 

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -172,6 +172,13 @@ func (l *simpleTransportAdapter) NextReplica() roachpb.ReplicaDescriptor {
 func (*simpleTransportAdapter) MoveToFront(roachpb.ReplicaDescriptor) {
 }
 
+func newNodeDesc(nodeID roachpb.NodeID) *roachpb.NodeDescriptor {
+	return &roachpb.NodeDescriptor{
+		NodeID:  nodeID,
+		Address: util.MakeUnresolvedAddr("tcp", fmt.Sprintf("invalid.invalid:%d", nodeID)),
+	}
+}
+
 // TestSendRPCOrder verifies that sendRPC correctly takes into account the
 // lease holder, attributes and required consistency to determine where to send
 // remote requests.
@@ -340,7 +347,8 @@ func TestSendRPCOrder(t *testing.T) {
 		{
 			// The local node needs to get its attributes during sendRPC.
 			nd := &roachpb.NodeDescriptor{
-				NodeID: 6,
+				NodeID:  6,
+				Address: util.MakeUnresolvedAddr("tcp", fmt.Sprintf("invalid.invalid:6")),
 				Locality: roachpb.Locality{
 					Tiers: tc.tiers,
 				},
@@ -590,10 +598,7 @@ func TestDistSenderDownNodeEvictLeaseholder(t *testing.T) {
 	g, clock := makeGossip(t, stopper)
 	if err := g.AddInfoProto(
 		gossip.MakeNodeIDKey(roachpb.NodeID(2)),
-		&roachpb.NodeDescriptor{
-			NodeID:  2,
-			Address: util.MakeUnresolvedAddr("tcp", "neverused:12345"),
-		},
+		newNodeDesc(2),
 		gossip.NodeDescriptorTTL,
 	); err != nil {
 		t.Fatal(err)
@@ -723,10 +728,7 @@ func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock
 
 	const nodeID = 1
 	g := gossip.NewTest(nodeID, rpcContext, server, stopper, metric.NewRegistry())
-	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{
-		NodeID:  nodeID,
-		Address: util.MakeUnresolvedAddr("tcp", "neverused:9999"),
-	}); err != nil {
+	if err := g.SetNodeDescriptor(newNodeDesc(nodeID)); err != nil {
 		t.Fatal(err)
 	}
 	if err := g.AddInfo(gossip.KeySentinel, nil, time.Hour); err != nil {
@@ -930,11 +932,7 @@ func TestEvictCacheOnUnknownLeaseHolder(t *testing.T) {
 
 	// Gossip the two nodes referred to in testUserRangeDescriptor3Replicas.
 	for i := 2; i <= 3; i++ {
-		addr := util.MakeUnresolvedAddr("tcp", fmt.Sprintf("node%d", i))
-		nd := &roachpb.NodeDescriptor{
-			NodeID:  roachpb.NodeID(i),
-			Address: util.MakeUnresolvedAddr(addr.Network(), addr.String()),
-		}
+		nd := newNodeDesc(roachpb.NodeID(i))
 		if err := g.AddInfoProto(gossip.MakeNodeIDKey(roachpb.NodeID(i)), nd, time.Hour); err != nil {
 			t.Fatal(err)
 		}
@@ -1218,7 +1216,7 @@ func TestSendRPCRetry(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
-	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
+	if err := g.SetNodeDescriptor(newNodeDesc(1)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1289,7 +1287,7 @@ func TestSendRPCRangeNotFoundError(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
-	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
+	if err := g.SetNodeDescriptor(newNodeDesc(1)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1380,7 +1378,7 @@ func TestGetNodeDescriptor(t *testing.T) {
 		Clock:      clock,
 	}, g)
 	g.NodeID.Reset(5)
-	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 5}); err != nil {
+	if err := g.SetNodeDescriptor(newNodeDesc(5)); err != nil {
 		t.Fatal(err)
 	}
 	testutils.SucceedsSoon(t, func() error {
@@ -1671,7 +1669,7 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
-	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
+	if err := g.SetNodeDescriptor(newNodeDesc(1)); err != nil {
 		t.Fatal(err)
 	}
 	nd := &roachpb.NodeDescriptor{
@@ -1793,7 +1791,7 @@ func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
-	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
+	if err := g.SetNodeDescriptor(newNodeDesc(1)); err != nil {
 		t.Fatal(err)
 	}
 	nd := &roachpb.NodeDescriptor{
@@ -1953,7 +1951,7 @@ func TestMultiRangeSplitEndTransaction(t *testing.T) {
 		},
 	}
 
-	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
+	if err := g.SetNodeDescriptor(newNodeDesc(1)); err != nil {
 		t.Fatal(err)
 	}
 	nd := &roachpb.NodeDescriptor{
@@ -2148,10 +2146,7 @@ func TestGatewayNodeID(t *testing.T) {
 
 	g, clock := makeGossip(t, stopper)
 	const expNodeID = 42
-	nd := &roachpb.NodeDescriptor{
-		NodeID:  expNodeID,
-		Address: util.MakeUnresolvedAddr("tcp", "foobar:1234"),
-	}
+	nd := newNodeDesc(expNodeID)
 	g.NodeID.Reset(nd.NodeID)
 	if err := g.SetNodeDescriptor(nd); err != nil {
 		t.Fatal(err)
@@ -2201,7 +2196,7 @@ func TestErrorIndexAlignment(t *testing.T) {
 
 	g, clock := makeGossip(t, stopper)
 
-	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
+	if err := g.SetNodeDescriptor(newNodeDesc(1)); err != nil {
 		t.Fatal(err)
 	}
 	nd := &roachpb.NodeDescriptor{

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -107,7 +107,10 @@ func createTestStoreWithEngine(
 
 	rpcContext := rpc.NewContext(
 		ac, &base.Config{Insecure: true}, storeCfg.Clock, stopper, &storeCfg.Settings.Version)
-	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
+	nodeDesc := &roachpb.NodeDescriptor{
+		NodeID:  1,
+		Address: util.MakeUnresolvedAddr("tcp", "invalid.invalid:26257"),
+	}
 	server := rpc.NewServer(rpcContext) // never started
 	storeCfg.Gossip = gossip.NewTest(
 		nodeDesc.NodeID, rpcContext, server, stopper, metric.NewRegistry(),

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/tscache"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -93,7 +94,10 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	ambient.AddLogTag("n", nc)
 
 	nodeID := roachpb.NodeID(1)
-	nodeDesc := &roachpb.NodeDescriptor{NodeID: nodeID}
+	nodeDesc := &roachpb.NodeDescriptor{
+		NodeID:  nodeID,
+		Address: util.MakeUnresolvedAddr("tcp", "invalid.invalid:26257"),
+	}
 
 	ltc.tester = t
 	ltc.Stopper = stop.NewStopper()


### PR DESCRIPTION
Backport 1/1 commits from #33171.

/cc @cockroachdb/release

---

This brings a slight bit of sanity to gossip, which previously had to
assume that a node descriptor could have an empty address for testing
purposes. We now ensure that node descriptors set via
`Gossip.SetNodeDescriptor` always have a non-empty address.

Unify the logic for detecting empty node descriptors to check for either
the zero node-id or an empty address.

See #29035

Release note: None
