### PR TITLE
settings: make StateMachineSetting.setToDefault a no-op

### DIFF
--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -293,7 +293,8 @@ func (sv *stringedVersion) String() string {
 // versionBump: A string indicating the proposed new value of the setting. Can
 //   be nil, in which case validation is performed and the current value (or the
 //   "default") is returned. Gossip updates pass the incoming gossipped value to
-//   curRawProto and nil for versionBump.
+//   curRawProto and nil for versionBump. SHOW CLUSTE SETTING passes the KV
+//   value as curRawProto and nil as versionBump.
 func versionTransformer(
 	sv *settings.Values, curRawProto []byte, versionBump *string,
 ) (newRawProto []byte, versionStringer interface{}, _ error) {

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -242,7 +242,7 @@ func MakeClusterSettings(minVersion, serverVersion roachpb.Version) *Settings {
 	s.Tracer.Configure(sv)
 
 	version.SetOnChange(sv, func() {
-		_, obj, err := version.Validate(sv, []byte(version.Get(sv)), nil)
+		_, obj, err := version.Validate(sv, []byte(version.Get(sv)), nil /* update */)
 		if err != nil {
 			log.Fatal(context.Background(), err)
 		}
@@ -285,6 +285,15 @@ func (sv *stringedVersion) String() string {
 // It has access to the Settings struct via the opaque member of settings.Values.
 // The returned versionStringer must, when printed, only return strings that are
 // safe to include in diagnostics reporting.
+//
+// Args:
+// curRawProto: The current value of the setting - an encoded ClusterVersion
+//   proto. Can be empty if the setting is not yet set, in which case the
+//   "default" value will be used.
+// versionBump: A string indicating the proposed new value of the setting. Can
+//   be nil, in which case validation is performed and the current value (or the
+//   "default") is returned. Gossip updates pass the incoming gossipped value to
+//   curRawProto and nil for versionBump.
 func versionTransformer(
 	sv *settings.Values, curRawProto []byte, versionBump *string,
 ) (newRawProto []byte, versionStringer interface{}, _ error) {

--- a/pkg/settings/statemachine.go
+++ b/pkg/settings/statemachine.go
@@ -88,7 +88,7 @@ func (*StateMachineSetting) Typ() string {
 func (s *StateMachineSetting) Get(sv *Values) string {
 	encV := sv.getGeneric(s.slotIdx)
 	if encV == nil {
-		defV, _, err := s.transformer(sv, nil, nil)
+		defV, _, err := s.transformer(sv, nil /* old */, nil /* update */)
 		if err != nil {
 			panic(err)
 		}
@@ -116,6 +116,7 @@ func (s *StateMachineSetting) Validate(
 	return s.transformer(sv, old, update)
 }
 
+// set is part of the Setting interface.
 func (s *StateMachineSetting) set(sv *Values, finalEncodedV []byte) error {
 	if _, _, err := s.transformer(sv, finalEncodedV, nil /* update */); err != nil {
 		return err
@@ -127,15 +128,11 @@ func (s *StateMachineSetting) set(sv *Values, finalEncodedV []byte) error {
 	return nil
 }
 
-func (s *StateMachineSetting) setToDefault(sv *Values) {
-	defV, _, err := s.transformer(sv, nil /* old */, nil /* update */)
-	if err != nil {
-		panic(err)
-	}
-	if err := s.set(sv, defV); err != nil {
-		panic(err)
-	}
-}
+// setToDefault is part of the Setting interface.
+//
+// This is a no-op for StateMachineSettings. They don't have defaults that they
+// can go back to at any time.
+func (s *StateMachineSetting) setToDefault(_ *Values) {}
 
 // RegisterStateMachineSetting registers a StateMachineSetting. See the comment
 // for StateMachineSetting for details.

--- a/pkg/settings/statemachine.go
+++ b/pkg/settings/statemachine.go
@@ -117,7 +117,7 @@ func (s *StateMachineSetting) Validate(
 }
 
 func (s *StateMachineSetting) set(sv *Values, finalEncodedV []byte) error {
-	if _, _, err := s.transformer(sv, finalEncodedV, nil); err != nil {
+	if _, _, err := s.transformer(sv, finalEncodedV, nil /* update */); err != nil {
 		return err
 	}
 	if bytes.Equal([]byte(s.Get(sv)), finalEncodedV) {
@@ -128,7 +128,7 @@ func (s *StateMachineSetting) set(sv *Values, finalEncodedV []byte) error {
 }
 
 func (s *StateMachineSetting) setToDefault(sv *Values) {
-	defV, _, err := s.transformer(sv, nil, nil)
+	defV, _, err := s.transformer(sv, nil /* old */, nil /* update */)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -83,7 +83,7 @@ func (p *planner) showStateMachineSetting(
 			// kvRawVal (which is taken from `st.SV` in this case too).
 			gossipRawVal := []byte(s.Get(&st.SV))
 
-			_, gossipObj, err := s.Validate(&st.SV, gossipRawVal, nil)
+			_, gossipObj, err := s.Validate(&st.SV, gossipRawVal, nil /* update */)
 			if err != nil {
 				gossipObj = fmt.Sprintf("<error: %s>", err)
 			}

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -74,7 +74,7 @@ func (p *planner) showStateMachineSetting(
 			// value, and the corresponding sql migration that makes sure
 			// the above select finds something usually runs pretty quickly
 			// when the cluster is bootstrapped.
-			kvRawVal, kvObj, err := s.Validate(&st.SV, prevRawVal, nil)
+			kvRawVal, kvObj, err := s.Validate(&st.SV, prevRawVal, nil /* update */)
 			if err != nil {
 				return errors.Errorf("unable to read existing value: %s", err)
 			}


### PR DESCRIPTION
I think this method didn't make sense: state machine settings (at least
the cluster version, which is currently the only one) don't have
defaults that they can be reset to. We were already refusing SET CLUSTER
SETTING version = DEFAULT.
Also the implementation of that method was hard to parse. I think the
method was only called at startup by the Values.Init() method, at which
point I think it was a no-op / nonsensical (I think it was setting the
cluster version to 0.0).

Release note: None