### PR TITLE
sql: delete distsql modes 2.0-off and 2.0-auto

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -60,7 +60,7 @@
 <tr><td><code>server.time_until_store_dead</code></td><td>duration</td><td><code>5m0s</code></td><td>the time after which if there is no new gossiped information about a store, it is considered dead</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
 <tr><td><code>sql.defaults.default_int_size</code></td><td>integer</td><td><code>8</code></td><td>the size, in bytes, of an INT type</td></tr>
-<tr><td><code>sql.defaults.distsql</code></td><td>enumeration</td><td><code>1</code></td><td>default distributed SQL execution mode [off = 0, auto = 1, on = 2, 2.0-off = 3, 2.0-auto = 4]</td></tr>
+<tr><td><code>sql.defaults.distsql</code></td><td>enumeration</td><td><code>1</code></td><td>default distributed SQL execution mode [off = 0, auto = 1, on = 2]</td></tr>
 <tr><td><code>sql.defaults.experimental_optimizer_mutations</code></td><td>boolean</td><td><code>false</code></td><td>default experimental_optimizer_mutations mode</td></tr>
 <tr><td><code>sql.defaults.experimental_vectorize</code></td><td>enumeration</td><td><code>0</code></td><td>default experimental_vectorize mode [off = 0, on = 1, always = 2]</td></tr>
 <tr><td><code>sql.defaults.optimizer</code></td><td>enumeration</td><td><code>1</code></td><td>default cost-based optimizer mode [off = 0, on = 1, local = 2]</td></tr>

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -712,23 +712,17 @@ func (ex *connExecutor) execStmtInParallel(
 
 		planner.statsCollector.PhaseTimes()[plannerStartExecStmt] = timeutil.Now()
 
-		shouldUseDistSQL := shouldUseDistSQL(distributePlan, ex.sessionData.DistSQLMode)
 		samplePlanDescription := ex.sampleLogicalPlanDescription(
-			stmt, shouldUseDistSQL, false /* optimizerUsed */, planner)
+			stmt, false /* optimizerUsed */, planner)
 
 		var flags planFlags
-		if shouldUseDistSQL {
-			if distributePlan {
-				flags.Set(planFlagDistributed)
-			} else {
-				flags.Set(planFlagDistSQLLocal)
-			}
-			ex.sessionTracing.TraceExecStart(ctx, "distributed-parallel")
-			err = ex.execWithDistSQLEngine(ctx, planner, stmt.AST.StatementType(), res, distributePlan)
+		if distributePlan {
+			flags.Set(planFlagDistributed)
 		} else {
-			ex.sessionTracing.TraceExecStart(ctx, "local-parallel")
-			err = ex.execWithLocalEngine(ctx, planner, stmt.AST.StatementType(), res)
+			flags.Set(planFlagDistSQLLocal)
 		}
+		ex.sessionTracing.TraceExecStart(ctx, "parallel")
+		err = ex.execWithDistSQLEngine(ctx, planner, stmt.AST.StatementType(), res, distributePlan)
 		ex.sessionTracing.TraceExecEnd(ctx, res.Err(), res.RowsAffected())
 		planner.statsCollector.PhaseTimes()[plannerEndExecStmt] = timeutil.Now()
 
@@ -849,21 +843,15 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	queryMeta.isDistributed = distributePlan
 	ex.mu.Unlock()
 
-	shouldUseDistSQL := shouldUseDistSQL(distributePlan, ex.sessionData.DistSQLMode)
-	samplePlanDescription := ex.sampleLogicalPlanDescription(stmt, shouldUseDistSQL, flags.IsSet(planFlagOptUsed), planner)
+	samplePlanDescription := ex.sampleLogicalPlanDescription(stmt, flags.IsSet(planFlagOptUsed), planner)
 
-	if shouldUseDistSQL {
-		if distributePlan {
-			flags.Set(planFlagDistributed)
-		} else {
-			flags.Set(planFlagDistSQLLocal)
-		}
-		ex.sessionTracing.TraceExecStart(ctx, "distributed")
-		err = ex.execWithDistSQLEngine(ctx, planner, stmt.AST.StatementType(), res, distributePlan)
+	if distributePlan {
+		flags.Set(planFlagDistributed)
 	} else {
-		ex.sessionTracing.TraceExecStart(ctx, "local")
-		err = ex.execWithLocalEngine(ctx, planner, stmt.AST.StatementType(), res)
+		flags.Set(planFlagDistSQLLocal)
 	}
+	ex.sessionTracing.TraceExecStart(ctx, "distributed")
+	err = ex.execWithDistSQLEngine(ctx, planner, stmt.AST.StatementType(), res, distributePlan)
 	ex.sessionTracing.TraceExecEnd(ctx, res.Err(), res.RowsAffected())
 	planner.statsCollector.PhaseTimes()[plannerEndExecStmt] = timeutil.Now()
 	if err != nil {
@@ -918,13 +906,13 @@ func (ex *connExecutor) makeExecPlan(
 // sampleLogicalPlanDescription returns a serialized representation of a statement's logical plan.
 // The returned ExplainTreePlanNode will be nil if plan should not be sampled.
 func (ex *connExecutor) sampleLogicalPlanDescription(
-	stmt Statement, useDistSQL bool, optimizerUsed bool, planner *planner,
+	stmt Statement, optimizerUsed bool, planner *planner,
 ) *roachpb.ExplainTreePlanNode {
 	if !sampleLogicalPlans.Get(&ex.appStats.st.SV) {
 		return nil
 	}
 
-	if ex.saveLogicalPlanDescription(stmt, useDistSQL, optimizerUsed) {
+	if ex.saveLogicalPlanDescription(stmt, optimizerUsed) {
 		return planToTree(context.Background(), planner.curPlan)
 	}
 	return nil
@@ -933,10 +921,8 @@ func (ex *connExecutor) sampleLogicalPlanDescription(
 // saveLogicalPlanDescription returns if we should save this as a sample logical plan
 // for its corresponding fingerprint. We use `saveFingerprintPlanOnceEvery`
 // to assess how frequently to sample logical plans.
-func (ex *connExecutor) saveLogicalPlanDescription(
-	stmt Statement, useDistSQL bool, optimizerUsed bool,
-) bool {
-	stats := ex.appStats.getStatsForStmt(stmt, useDistSQL, optimizerUsed, nil, false /* createIfNonexistent */)
+func (ex *connExecutor) saveLogicalPlanDescription(stmt Statement, optimizerUsed bool) bool {
+	stats := ex.appStats.getStatsForStmt(stmt, true /* distSQLUsed */, optimizerUsed, nil, false /* createIfNonexistent */)
 	if stats == nil {
 		// Save logical plan the first time we see new statement fingerprint.
 		return true
@@ -973,68 +959,6 @@ func canFallbackFromOpt(err error, optMode sessiondata.OptimizerMode, stmt State
 		}
 	}
 	return true
-}
-
-// execWithLocalEngine runs a plan using the local (non-distributed) SQL
-// engine.
-// If an error is returned, the connection needs to stop processing queries.
-// Such errors are also written to res.
-// Query execution errors are written to res; they are not returned.
-func (ex *connExecutor) execWithLocalEngine(
-	ctx context.Context, planner *planner, stmtType tree.StatementType, res RestrictedCommandResult,
-) error {
-	// Create a BoundAccount to track the memory usage of each row.
-	rowAcc := planner.extendedEvalCtx.Mon.MakeBoundAccount()
-	planner.extendedEvalCtx.ActiveMemAcc = &rowAcc
-	defer rowAcc.Close(ctx)
-
-	params := runParams{
-		ctx:             ctx,
-		extendedEvalCtx: &planner.extendedEvalCtx,
-		p:               planner,
-	}
-
-	if err := planner.curPlan.start(params); err != nil {
-		res.SetError(err)
-		return nil
-	}
-
-	switch stmtType {
-	case tree.RowsAffected:
-		count, err := countRowsAffected(params, planner.curPlan.plan)
-		if err != nil {
-			res.SetError(err)
-			return nil
-		}
-		res.IncrementRowsAffected(count)
-		return nil
-	case tree.Rows:
-		consumeCtx, cleanup := ex.sessionTracing.TraceExecConsume(ctx)
-		defer cleanup()
-
-		var commErr error
-		queryErr := ex.forEachRow(params, planner.curPlan.plan, func(values tree.Datums) error {
-			for _, val := range values {
-				if err := checkResultType(val.ResolvedType()); err != nil {
-					return err
-				}
-			}
-			ex.sessionTracing.TraceExecRowsResult(consumeCtx, values)
-			commErr = res.AddRow(consumeCtx, values)
-			return commErr
-		})
-		if commErr != nil {
-			res.SetError(commErr)
-			return commErr
-		}
-		if queryErr != nil {
-			res.SetError(queryErr)
-		}
-		return nil
-	default:
-		// Calling StartPlan is sufficient for other statement types.
-		return nil
-	}
 }
 
 // execWithDistSQLEngine converts a plan to a distributed SQL physical plan and
@@ -1086,31 +1010,6 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	ex.server.cfg.DistSQLPlanner.PlanAndRun(
 		ctx, evalCtx, planCtx, planner.txn, planner.curPlan.plan, recv)
 	return recv.commErr
-}
-
-// forEachRow calls the provided closure for each successful call to
-// planNode.Next with planNode.Values, making sure to properly track memory
-// usage.
-//
-// f is not allowed to hold on to the row slice. It needs to make a copy if it
-// want to use the memory later.
-//
-// Errors returned by this method are to be considered query errors. If the
-// caller wants to handle some errors within the callback differently, it has to
-// capture those itself.
-func (ex *connExecutor) forEachRow(params runParams, p planNode, f func(tree.Datums) error) error {
-	next, err := p.Next(params)
-	for ; next; next, err = p.Next(params) {
-		// If we're tracking memory, clear the previous row's memory account.
-		if params.extendedEvalCtx.ActiveMemAcc != nil {
-			params.extendedEvalCtx.ActiveMemAcc.Clear(params.ctx)
-		}
-
-		if err := f(p.Values()); err != nil {
-			return err
-		}
-	}
-	return err
 }
 
 // execStmtInNoTxnState "executes" a statement when no transaction is in scope.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -154,11 +154,9 @@ var DistSQLClusterExecMode = settings.RegisterEnumSetting(
 	"default distributed SQL execution mode",
 	"auto",
 	map[int64]string{
-		int64(sessiondata.DistSQLOff):       "off",
-		int64(sessiondata.DistSQLAuto):      "auto",
-		int64(sessiondata.DistSQLOn):        "on",
-		int64(sessiondata.DistSQL2Dot0Auto): "2.0-auto",
-		int64(sessiondata.DistSQL2Dot0Off):  "2.0-off",
+		int64(sessiondata.DistSQLOff):  "off",
+		int64(sessiondata.DistSQLAuto): "auto",
+		int64(sessiondata.DistSQLOn):   "on",
 	},
 )
 
@@ -526,29 +524,13 @@ func countRowsAffected(params runParams, p planNode) (int, error) {
 	return count, err
 }
 
-// shouldUseDistSQL returns true if the combination of mode and distribution
-// requirement given by shouldDistributeGivenRecAndMode requires that the
-// distSQL engine should be used.
-// This is always true unless the mode is set to 2.0-auto or 2.0-off.
-// 2.0-auto causes the distribution recommendation to control whether distsql is
-// used at all, and 2.0-off causes distsql to never be used regardless of the
-// recommendation.
-func shouldUseDistSQL(distributePlan bool, mode sessiondata.DistSQLExecMode) bool {
-	if mode == sessiondata.DistSQL2Dot0Off {
-		return false
-	} else if mode == sessiondata.DistSQL2Dot0Auto {
-		return distributePlan
-	}
-	return true
-}
-
 func shouldDistributeGivenRecAndMode(
 	rec distRecommendation, mode sessiondata.DistSQLExecMode,
 ) bool {
 	switch mode {
-	case sessiondata.DistSQLOff, sessiondata.DistSQL2Dot0Off:
+	case sessiondata.DistSQLOff:
 		return false
-	case sessiondata.DistSQLAuto, sessiondata.DistSQL2Dot0Auto:
+	case sessiondata.DistSQLAuto:
 		return rec == shouldDistribute
 	case sessiondata.DistSQLOn, sessiondata.DistSQLAlways:
 		return rec != cannotDistribute

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -62,9 +62,7 @@ type explainDistSQLRun struct {
 }
 
 func (n *explainDistSQLNode) startExec(params runParams) error {
-	if n.analyze &&
-		(params.SessionData().DistSQLMode == sessiondata.DistSQLOff ||
-			params.SessionData().DistSQLMode == sessiondata.DistSQL2Dot0Off) {
+	if n.analyze && params.SessionData().DistSQLMode == sessiondata.DistSQLOff {
 		return pgerror.NewErrorf(
 			pgerror.CodeObjectNotInPrerequisiteStateError,
 			"cannot run EXPLAIN ANALYZE while distsql is disabled",

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -418,17 +418,17 @@ type testClusterConfig struct {
 // If no configs are indicated, the default one is used (unless overridden
 // via -config).
 var logicTestConfigs = []testClusterConfig{
-	{name: "local", numNodes: 1, overrideDistSQLMode: "2.0-off", overrideOptimizerMode: "off"},
+	{name: "local", numNodes: 1, overrideDistSQLMode: "off", overrideOptimizerMode: "off"},
 	{name: "local-v1.1@v1.0-noupgrade", numNodes: 1,
-		overrideDistSQLMode: "2.0-off", overrideOptimizerMode: "off",
+		overrideDistSQLMode: "off", overrideOptimizerMode: "off",
 		bootstrapVersion: cluster.ClusterVersion{
 			Version: cluster.VersionByKey(cluster.VersionBase),
 		},
 		serverVersion:  roachpb.Version{Major: 1, Minor: 1},
 		disableUpgrade: true,
 	},
-	{name: "local-opt", numNodes: 1, overrideDistSQLMode: "2.0-off", overrideOptimizerMode: "on"},
-	{name: "local-parallel-stmts", numNodes: 1, parallelStmts: true, overrideDistSQLMode: "2.0-off", overrideOptimizerMode: "off"},
+	{name: "local-opt", numNodes: 1, overrideDistSQLMode: "off", overrideOptimizerMode: "on"},
+	{name: "local-parallel-stmts", numNodes: 1, parallelStmts: true, overrideDistSQLMode: "off", overrideOptimizerMode: "off"},
 	{name: "local-vec", numNodes: 1, overrideOptimizerMode: "off", overrideExpVectorize: "on"},
 	{name: "fakedist", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "off"},
 	{name: "fakedist-opt", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "on"},
@@ -436,7 +436,7 @@ var logicTestConfigs = []testClusterConfig{
 		distSQLMetadataTestEnabled: true, skipShort: true},
 	{name: "fakedist-disk", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "off",
 		distSQLUseDisk: true, skipShort: true},
-	{name: "5node-local", numNodes: 5, overrideDistSQLMode: "2.0-off", overrideOptimizerMode: "off"},
+	{name: "5node-local", numNodes: 5, overrideDistSQLMode: "off", overrideOptimizerMode: "off"},
 	{name: "5node-dist", numNodes: 5, overrideDistSQLMode: "on", overrideOptimizerMode: "off"},
 	{name: "5node-dist-opt", numNodes: 5, overrideDistSQLMode: "on", overrideOptimizerMode: "on"},
 	{name: "5node-dist-metadata", numNodes: 5, overrideDistSQLMode: "on", distSQLMetadataTestEnabled: true,

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1338,7 +1338,7 @@ datestyle                          ISO, MDY      NULL      NULL        NULL     
 default_int_size                   8             NULL      NULL        NULL        string
 default_transaction_isolation      serializable  NULL      NULL        NULL        string
 default_transaction_read_only      off           NULL      NULL        NULL        string
-distsql                            2.0-off       NULL      NULL        NULL        string
+distsql                            off           NULL      NULL        NULL        string
 experimental_enable_zigzag_join    off           NULL      NULL        NULL        string
 experimental_force_lookup_join     off           NULL      NULL        NULL        string
 experimental_force_split_at        off           NULL      NULL        NULL        string
@@ -1383,7 +1383,7 @@ datestyle                          ISO, MDY      NULL  user     NULL      ISO, M
 default_int_size                   8             NULL  user     NULL      8             8
 default_transaction_isolation      serializable  NULL  user     NULL      default       default
 default_transaction_read_only      off           NULL  user     NULL      off           off
-distsql                            2.0-off       NULL  user     NULL      2.0-off       2.0-off
+distsql                            off           NULL  user     NULL      off           off
 experimental_enable_zigzag_join    off           NULL  user     NULL      off           off
 experimental_force_lookup_join     off           NULL  user     NULL      off           off
 experimental_force_split_at        off           NULL  user     NULL      off           off

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -181,7 +181,7 @@ DEALLOCATE ALL
 statement
 PREPARE x AS SELECT avg(column1) OVER (PARTITION BY column2) FROM (VALUES (1, 2), (3, 4))
 
-query R
+query R rowsort
 EXECUTE x
 ----
 1
@@ -190,7 +190,7 @@ EXECUTE x
 statement
 PREPARE y AS SELECT avg(a.column1) OVER (PARTITION BY a.column2) FROM (VALUES (1, 2), (3, 4)) a
 
-query R
+query R rowsort
 EXECUTE y
 ----
 1

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -101,7 +101,7 @@ query T colnames
 SHOW distsql
 ----
 distsql
-2.0-off
+off
 
 ## Test that our no-op compatibility vars work
 
@@ -165,12 +165,6 @@ SET distsql = on
 statement ok
 SET distsql = off
 
-statement ok
-SET distsql = '2.0-off'
-
-statement ok
-SET distsql = '2.0-auto'
-
 statement error invalid value for parameter "distsql": "bogus"
 SET distsql = bogus
 
@@ -178,10 +172,10 @@ statement ok
 SET experimental_vectorize = on
 
 statement ok
-SET experimental_vectorize = off
+SET experimental_vectorize = always
 
 statement ok
-SET experimental_vectorize = always
+SET experimental_vectorize = off
 
 statement error invalid value for parameter "experimental_vectorize": "bogus"
 SET experimental_vectorize = bogus

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -35,7 +35,7 @@ datestyle                          ISO, MDY
 default_int_size                   8
 default_transaction_isolation      serializable
 default_transaction_read_only      off
-distsql                            2.0-off
+distsql                            off
 experimental_enable_zigzag_join    off
 experimental_force_lookup_join     off
 experimental_force_split_at        off
@@ -66,7 +66,7 @@ query I colnames
 SELECT * FROM [SHOW CLUSTER SETTING sql.defaults.distsql]
 ----
 sql.defaults.distsql
-3
+0
 
 query TTTT colnames
 SELECT * FROM [SHOW ALL CLUSTER SETTINGS] WHERE variable LIKE '%organization'

--- a/pkg/sql/logictest/testdata/planner_test/select
+++ b/pkg/sql/logictest/testdata/planner_test/select
@@ -1,5 +1,40 @@
 # LogicTest: local
 
+# Prepare a trace to be inspected below.
+
+statement ok
+SET tracing = on; BEGIN; SELECT 1; COMMIT; SELECT 2; SET tracing = off
+
+# Inspect the trace: we exclude messages containing newlines as these
+# may contain non-deterministic txn object descriptions.
+# This also checks that the span column properly reports separate
+# SQL transactions.
+# We replace the command position because the values depend on exactly
+# how many commands we ran in the session.
+query ITT
+SELECT
+  span, regexp_replace(message, 'pos:[0-9]*', 'pos:?'), operation
+FROM [SHOW TRACE FOR SESSION]
+WHERE message LIKE '%SPAN START%' OR message LIKE '%pos%executing%';
+----
+0                         === SPAN START: session recording ===                session recording
+0                         [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  session recording
+1                         === SPAN START: sql txn ===                          sql txn
+1                         [Open pos:?] executing ExecStmt: SELECT 1            sql txn
+2                         === SPAN START: consuming rows ===                   consuming rows
+3                         === SPAN START: flow ===                             flow
+7                         === SPAN START: values ===
+cockroach.processorid: 0  values
+1                         [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  sql txn
+0                         [NoTxn pos:?] executing ExecStmt: SELECT 2           session recording
+4                         === SPAN START: sql txn ===                          sql txn
+4                         [Open pos:?] executing ExecStmt: SELECT 2            sql txn
+5                         === SPAN START: consuming rows ===                   consuming rows
+6                         === SPAN START: flow ===                             flow
+8                         === SPAN START: values ===
+cockroach.processorid: 0  values
+0                         [NoTxn pos:?] executing ExecStmt: SET TRACING = off  session recording
+
 # ------------------------------------------------------------------------------
 # Test with storing columns.
 # ------------------------------------------------------------------------------

--- a/pkg/sql/logictest/testdata/planner_test/show_trace
+++ b/pkg/sql/logictest/testdata/planner_test/show_trace
@@ -1,0 +1,418 @@
+# LogicTest: local
+
+# Check SHOW KV TRACE FOR SESSION.
+
+statement ok
+SET tracing = on,kv,results; CREATE DATABASE t; SET tracing = off
+
+# Check the KV trace; we need to remove the eventlog entry and
+# internal queries since the timestamp is non-deterministic.
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message NOT LIKE '%Z/%'
+  AND operation NOT LIKE 'kv.DistSender: sending partial batch%'  -- order of partial batches is not deterministic
+  AND tag NOT LIKE '%intExec=%'
+  AND tag NOT LIKE '%scExec%'
+  AND tag NOT LIKE '%IndexBackfiller%'
+----
+dist sender send  querying next range at /Table/2/1/0/"t"/3/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /System/"desc-idgen"
+dist sender send  r3: sending batch 1 Inc to (n1,s1):1
+flow              CPut /Table/2/1/0/"t"/3/1 -> 53
+flow              CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
+dist sender send  querying next range at /Table/2/1/0/"t"/3/1
+dist sender send  r6: sending batch 2 CPut to (n1,s1):1
+sql txn           rows affected: 0
+dist sender send  querying next range at /Table/SystemConfigSpan/Start
+dist sender send  querying next range at /Table/2/1/0/"t"/3/1
+dist sender send  r8: sending batch 5 QueryIntent to (n1,s1):1
+dist sender send  querying next range at /Table/SystemConfigSpan/Start
+dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+
+
+# More KV operations.
+statement ok
+SET tracing = on,kv,results; CREATE TABLE t.kv(k INT PRIMARY KEY, v INT); SET tracing = off
+
+query TT
+SELECT operation, regexp_replace(message, 'wall_time:\d+', 'wall_time:...') as message
+  FROM [SHOW KV TRACE FOR SESSION]
+WHERE message NOT LIKE '%Z/%'
+  AND operation NOT LIKE 'kv.DistSender: sending partial batch%'  -- order of partial batches is not deterministic
+  AND tag NOT LIKE '%intExec=%'
+  AND tag NOT LIKE '%scExec%'
+  AND tag NOT LIKE '%IndexBackfiller%'
+----
+dist sender send  querying next range at /Table/2/1/0/"test"/3/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/52/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/2/1/0/"t"/3/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/53/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /System/"desc-idgen"
+dist sender send  r3: sending batch 1 Inc to (n1,s1):1
+flow              CPut /Table/2/1/53/"kv"/3/1 -> 54
+flow              CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
+dist sender send  r6: sending batch 2 CPut to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/53/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+sql txn           rows affected: 0
+dist sender send  querying next range at /Table/SystemConfigSpan/Start
+dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
+dist sender send  r8: sending batch 5 QueryIntent to (n1,s1):1
+dist sender send  querying next range at /Table/SystemConfigSpan/Start
+dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+
+# We avoid using the full trace output, because that would make the
+# ensuing trace especially chatty, as it traces the index backfill at
+# the end of the implicit transaction. A chatty trace could be OK in
+# tests, however the backfill also incur job table traffic which has a
+# timestamp index, and we can't use (non-deterministic) timestamp
+# values in expected values.
+statement ok
+SET tracing = on,kv,results; CREATE UNIQUE INDEX woo ON t.kv(v); SET tracing = off
+
+query TT
+SELECT operation,
+       regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message
+  FROM [SHOW KV TRACE FOR SESSION]
+WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
+  AND operation NOT LIKE 'kv.DistSender: sending partial batch%'  -- order of partial batches is not deterministic
+  /* since the transactions involved are multi-range, intent resolving is async and
+  sometimes there's still intents around */
+  AND message NOT SIMILAR TO '%(PushTxn|ResolveIntent)%'
+  AND tag NOT LIKE '%intExec=%'
+  AND tag NOT LIKE '%scExec%'
+  AND tag NOT LIKE '%IndexBackfiller%'
+----
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+flow              Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+dist sender send  r6: sending batch 1 Put to (n1,s1):1
+sql txn           rows affected: 0
+dist sender send  r11: sending batch 3 QueryIntent to (n1,s1):1
+dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+
+statement ok
+SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+----
+flow              CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
+flow              InitPut /Table/54/2/2/0 -> /BYTES/0x89
+dist sender send  querying next range at /Table/54/1/1/0
+dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
+flow              fast path completed
+sql txn           rows affected: 1
+
+
+statement error duplicate key value
+SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
+
+query TT
+set tracing=off;
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+----
+flow              CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
+flow              InitPut /Table/54/2/2/0 -> /BYTES/0x89
+dist sender send  querying next range at /Table/54/1/1/0
+dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
+sql txn           execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
+dist sender send  querying next range at /Table/54/1/1/0
+dist sender send  r20: sending batch 1 EndTxn to (n1,s1):1
+
+statement error duplicate key value
+SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
+
+query TT
+set tracing=off;
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+----
+flow              CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
+flow              InitPut /Table/54/2/2/0 -> /BYTES/0x8a
+dist sender send  querying next range at /Table/54/1/2/0
+dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
+sql txn           execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
+dist sender send  querying next range at /Table/54/1/2/0
+dist sender send  r20: sending batch 1 EndTxn to (n1,s1):1
+
+statement ok
+SET tracing = on,kv,results; CREATE TABLE t.kv2 AS TABLE t.kv; SET tracing = off
+
+query TT
+SELECT operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 'wall_time:...'), '\d\d\d\d\d+', '...PK...') as message
+  FROM [SHOW KV TRACE FOR SESSION]
+WHERE message NOT LIKE '%Z/%'
+  AND operation NOT LIKE 'kv.DistSender: sending partial batch%'  -- order of partial batches is not deterministic
+  AND tag NOT LIKE '%intExec=%'
+  AND tag NOT LIKE '%scExec%'
+  AND tag NOT LIKE '%IndexBackfiller%'
+----
+dist sender send  querying next range at /Table/2/1/0/"test"/3/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/52/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/2/1/0/"t"/3/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/53/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+table reader      Scan /Table/54/{1-2}
+dist sender send  querying next range at /Table/54/1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
+dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /System/"desc-idgen"
+dist sender send  r3: sending batch 1 Inc to (n1,s1):1
+flow              CPut /Table/2/1/53/"kv2"/3/1 -> 55
+flow              CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
+dist sender send  r6: sending batch 2 CPut to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/53/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+table reader      fetched: /kv/primary/1/v -> /2
+flow              CPut /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
+dist sender send  querying next range at /Table/SystemConfigSpan/Start
+dist sender send  querying next range at /Table/55/1/...PK.../0
+dist sender send  r20: sending batch 1 CPut to (n1,s1):1
+dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
+dist sender send  r8: sending batch 5 QueryIntent to (n1,s1):1
+dist sender send  querying next range at /Table/SystemConfigSpan/Start
+dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+flow              fast path completed
+sql txn           rows affected: 1
+
+statement ok
+SET tracing = on,kv,results; UPDATE t.kv2 SET v = v + 2; SET tracing = off
+
+query TT
+SELECT operation, regexp_replace(message, '(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.)?\d\d\d\d\d+', '...PK...') as message
+  FROM [SHOW KV TRACE FOR SESSION]
+WHERE message NOT LIKE '%Z/%'
+  AND tag NOT LIKE '%intExec=%'
+  AND tag NOT LIKE '%scExec%'
+  AND tag NOT LIKE '%IndexBackfiller%'
+----
+dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/55/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r7: sending batch 1 EndTxn, 1 QueryIntent to (n1,s1):1
+table reader      Scan /Table/55/{1-2}
+dist sender send  querying next range at /Table/55/1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
+table reader      fetched: /kv2/primary/...PK.../k/v -> /1/2
+flow              Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
+dist sender send  querying next range at /Table/55/1/...PK.../0
+dist sender send  r20: sending batch 1 Put, 1 EndTxn to (n1,s1):1
+flow              fast path completed
+sql txn           rows affected: 1
+
+statement ok
+SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+----
+flow              Scan /Table/55/{1-2}
+dist sender send  querying next range at /Table/55/1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
+flow              DelRange /Table/55/1 - /Table/55/2
+dist sender send  querying next range at /Table/55/1
+dist sender send  r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+flow              fast path completed
+sql txn           rows affected: 1
+
+statement ok
+SET tracing = on,kv,results; DROP TABLE t.kv2; SET tracing = off
+
+query TT
+SELECT operation,
+       regexp_replace(regexp_replace(regexp_replace(message, 'drop_job_id:[1-9]\d*', 'drop_job_id:...'), 'wall_time:\d+', 'wall_time:...'), 'drop_time:\d+', 'drop_time:...') as message
+  FROM [SHOW KV TRACE FOR SESSION]
+WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
+  AND operation NOT LIKE 'kv.DistSender: sending partial batch%'  -- order of partial batches is not deterministic
+  AND tag NOT LIKE '%intExec=%'
+  AND tag NOT LIKE '%scExec%'
+  AND tag NOT LIKE '%IndexBackfiller%'
+----
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+flow              Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... >
+dist sender send  r6: sending batch 1 Put to (n1,s1):1
+sql txn           rows affected: 0
+dist sender send  r11: sending batch 4 QueryIntent to (n1,s1):1
+dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+
+statement ok
+SET tracing = on,kv,results; DELETE FROM t.kv; SET tracing = off
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+----
+flow              Scan /Table/54/{1-2}
+dist sender send  querying next range at /Table/54/1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
+flow              fetched: /kv/primary/1/v -> /2
+flow              Del /Table/54/2/2/0
+flow              Del /Table/54/1/1/0
+dist sender send  querying next range at /Table/54/1/1/0
+dist sender send  r20: sending batch 2 Del, 1 EndTxn to (n1,s1):1
+flow              fast path completed
+sql txn           rows affected: 1
+
+statement ok
+SET tracing = on,kv,results; DROP INDEX t.kv@woo CASCADE; SET tracing = off
+
+query TT
+SELECT operation,
+       regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message
+  FROM [SHOW KV TRACE FOR SESSION]
+WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
+  AND operation NOT LIKE 'kv.DistSender: sending partial batch%'  -- order of partial batches is not deterministic
+  /* since the transactions involved are multi-range, intent resolving is async and
+  sometimes there's still intents around */
+  AND message NOT SIMILAR TO '%(PushTxn|ResolveIntent)%'
+  AND tag NOT LIKE '%intExec=%'
+  AND tag NOT LIKE '%scExec%'
+  AND tag NOT LIKE '%IndexBackfiller%'
+----
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+flow              Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+dist sender send  r6: sending batch 1 Put to (n1,s1):1
+sql txn           rows affected: 0
+dist sender send  r11: sending batch 3 QueryIntent to (n1,s1):1
+dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+
+statement ok
+SET tracing = on,kv,results; DROP TABLE t.kv; SET tracing = off
+
+query TT
+SELECT operation, regexp_replace(regexp_replace(regexp_replace(message, 'job_id:[1-9]\d*', 'job_id:...', 'g'), 'wall_time:\d+', 'wall_time:...'), 'drop_time:\d+', 'drop_time:...', 'g') as message
+  FROM [SHOW KV TRACE FOR SESSION]
+WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
+  AND operation NOT LIKE 'kv.DistSender: sending partial batch%'  -- order of partial batches is not deterministic
+  AND tag NOT LIKE '%intExec=%'
+  AND tag NOT LIKE '%scExec%'
+  AND tag NOT LIKE '%IndexBackfiller%'
+----
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+flow              Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > >
+dist sender send  r6: sending batch 1 Put to (n1,s1):1
+sql txn           rows affected: 0
+dist sender send  r11: sending batch 8 QueryIntent to (n1,s1):1
+dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+
+# Check that session tracing does not inhibit the fast path for inserts &
+# friends (the path resulting in 1PC transactions).
+
+subtest autocommit
+
+statement ok
+CREATE TABLE t.kv3(k INT PRIMARY KEY, v INT)
+
+statement ok
+SET tracing = on; INSERT INTO t.kv3 (k, v) VALUES (1,1); SET tracing = off
+
+# We look for rows containing an EndTxn as proof that the
+# insertNode is committing the txn.
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE e'%1 CPut, 1 EndTxn%' AND message NOT LIKE e'%proposing command%'
+----
+r20: sending batch 1 CPut, 1 EndTxn to (n1,s1):1
+1 CPut, 1 EndTxn
+
+## TODO(tschottdorf): re-enable
+# statement ok
+# CREATE TABLE t.enginestats(k INT PRIMARY KEY, v INT)
+#
+# statement ok
+# SHOW TRACE FOR SELECT * FROM t.enginestats
+#
+# query T
+# SELECT message FROM [ SHOW TRACE FOR SESSION ] WHERE message LIKE '%InternalDelete%'
+# ----
+# engine stats: {InternalDeleteSkippedCount:0 TimeBoundNumSSTs:0}
+
+# Check that we can run set tracing regardless of the current tracing state.
+# This is convenient; sometimes it's unclear, for example, if you previously
+# stopped tracing or not, so issuing a set tracing=off should just work.
+subtest idempotent
+
+statement ok
+SET tracing = on; SET tracing = on;
+
+statement ok
+SET tracing = off; SET tracing = off;
+
+# Check that we can run set tracing in the aborted state (this is implemented by
+# making set tracing an ObserverStmt). This is very convenient for clients that
+# start tracing, then might get an error, then want to stop tracing.
+subtest aborted_txn
+
+query error pq: foo
+BEGIN; SELECT crdb_internal.force_error('', 'foo')
+
+statement ok
+SET tracing = off
+
+statement ok
+ROLLBACK
+
+subtest replica
+
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY)
+
+statement ok
+SET tracing = on; SELECT * FROM t; SET tracing = off
+
+query III colnames
+SELECT DISTINCT node_id, store_id, replica_id
+  FROM [SHOW EXPERIMENTAL_REPLICA TRACE FOR SESSION]
+----
+node_id  store_id  replica_id
+1        1         6
+1        1         7
+1        1         20

--- a/pkg/sql/logictest/testdata/planner_test/upsert
+++ b/pkg/sql/logictest/testdata/planner_test/upsert
@@ -46,6 +46,65 @@ r20: sending batch 1 Put, 2 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 1
 
+# KV operations.
+statement ok
+CREATE DATABASE t; CREATE TABLE t.kv(k INT PRIMARY KEY, v INT)
+
+statement ok
+CREATE UNIQUE INDEX woo ON t.kv(v)
+
+statement ok
+SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,3); SET tracing = off
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+----
+flow              Scan /Table/56/1/2{-/#}
+dist sender send  querying next range at /Table/56/1/2
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
+flow              CPut /Table/56/1/2/0 -> /TUPLE/2:2:Int/3
+flow              InitPut /Table/56/2/3/0 -> /BYTES/0x8a
+dist sender send  querying next range at /Table/56/1/2/0
+dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
+flow              fast path completed
+sql txn           rows affected: 1
+
+statement ok
+SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+----
+flow              Scan /Table/56/1/1{-/#}
+dist sender send  querying next range at /Table/56/1/1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
+flow              CPut /Table/56/1/1/0 -> /TUPLE/2:2:Int/2
+flow              InitPut /Table/56/2/2/0 -> /BYTES/0x89
+dist sender send  querying next range at /Table/56/1/1/0
+dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
+flow              fast path completed
+sql txn           rows affected: 1
+
+statement error duplicate key value
+SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
+
+query TT
+set tracing=off;
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+----
+flow              Scan /Table/56/1/2{-/#}
+dist sender send  querying next range at /Table/56/1/2
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
+flow              fetched: /kv/primary/2/v -> /3
+flow              Put /Table/56/1/2/0 -> /TUPLE/2:2:Int/2
+flow              Del /Table/56/2/3/0
+flow              CPut /Table/56/2/2/0 -> /BYTES/0x8a
+dist sender send  querying next range at /Table/56/1/2/0
+dist sender send  r20: sending batch 1 Put, 1 CPut, 1 Del, 1 EndTxn to (n1,s1):1
+sql txn           execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
+dist sender send  querying next range at /Table/56/1/2/0
+dist sender send  r20: sending batch 1 EndTxn to (n1,s1):1
+
 subtest regression_32834
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -333,10 +333,10 @@ query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
 ----
-fetched: /abc/primary/4/5/6 -> NULL
+fetched: /abc/primary/4/5/6/d -> 'Two'
 fetched: /abc/primary/4/5/6 -> NULL
 output row: [4]
-fetched: /abc/primary/1/2/3 -> NULL
+fetched: /abc/primary/1/2/3/d -> 'one'
 fetched: /abc/primary/1/2/3 -> NULL
 output row: [1]
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1,5 +1,35 @@
 # LogicTest: local-opt
 
+# Prepare a trace to be inspected below.
+
+statement ok
+SET tracing = on; BEGIN; SELECT 1; COMMIT; SELECT 2; SET tracing = off
+
+# Inspect the trace: we exclude messages containing newlines as these
+# may contain non-deterministic txn object descriptions.
+# This also checks that the span column properly reports separate
+# SQL transactions.
+# We replace the command position because the values depend on exactly
+# how many commands we ran in the session.
+query ITT
+SELECT
+  span, regexp_replace(message, 'pos:[0-9]*', 'pos:?'), operation
+FROM [SHOW TRACE FOR SESSION]
+WHERE message LIKE '%SPAN START%' OR message LIKE '%pos%executing%';
+----
+0  === SPAN START: session recording ===                session recording
+0  [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  session recording
+1  === SPAN START: sql txn ===                          sql txn
+1  [Open pos:?] executing ExecStmt: SELECT 1            sql txn
+2  === SPAN START: consuming rows ===                   consuming rows
+3  === SPAN START: flow ===                             flow
+1  [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  sql txn
+0  [NoTxn pos:?] executing ExecStmt: SELECT 2           session recording
+4  === SPAN START: sql txn ===                          sql txn
+4  [Open pos:?] executing ExecStmt: SELECT 2            sql txn
+5  === SPAN START: consuming rows ===                   consuming rows
+6  === SPAN START: flow ===                             flow
+0  [NoTxn pos:?] executing ExecStmt: SET TRACING = off  session recording
 
 # ------------------------------------------------------------------------------
 # Numeric References Tests.

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1385,7 +1385,7 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
 ----
 fetched: /t4/primary/10/20 -> NULL
-fetched: /t4/primary/10/20/c -> 40
+fetched: /t4/primary/10/20/d -> 40
 output row: [40]
 
 # Point lookup on both d and e uses a single span for the two adjacent column

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -1,33 +1,4 @@
-# LogicTest: local local-opt
-
-# Prepare a trace to be inspected below.
-
-statement ok
-SET tracing = on; BEGIN; SELECT 1; COMMIT; SELECT 2; SET tracing = off
-
-# Inspect the trace: we exclude messages containing newlines as these
-# may contain non-deterministic txn object descriptions.
-# This also checks that the span column properly reports separate
-# SQL transactions.
-# We replace the command position because the values depend on exactly
-# how many commands we ran in the session.
-query ITT
-SELECT
-  span, regexp_replace(message, 'pos:[0-9]*', 'pos:?'), operation
-FROM [SHOW TRACE FOR SESSION]
-WHERE message LIKE '%SPAN START%' OR message LIKE '%pos%executing%';
-----
-0  === SPAN START: session recording ===                session recording
-0  [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  session recording
-1  === SPAN START: sql txn ===                          sql txn
-1  [Open pos:?] executing ExecStmt: SELECT 1            sql txn
-2  === SPAN START: consuming rows ===                   consuming rows
-1  [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  sql txn
-0  [NoTxn pos:?] executing ExecStmt: SELECT 2           session recording
-3  === SPAN START: sql txn ===                          sql txn
-3  [Open pos:?] executing ExecStmt: SELECT 2            sql txn
-4  === SPAN START: consuming rows ===                   consuming rows
-0  [NoTxn pos:?] executing ExecStmt: SET TRACING = off  session recording
+# LogicTest: local-opt
 
 # Check SHOW KV TRACE FOR SESSION.
 
@@ -48,8 +19,8 @@ dist sender send  querying next range at /Table/2/1/0/"t"/3/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /System/"desc-idgen"
 dist sender send  r3: sending batch 1 Inc to (n1,s1):1
-sql txn           CPut /Table/2/1/0/"t"/3/1 -> 53
-sql txn           CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
+flow              CPut /Table/2/1/0/"t"/3/1 -> 53
+flow              CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
 dist sender send  querying next range at /Table/2/1/0/"t"/3/1
 dist sender send  r6: sending batch 2 CPut to (n1,s1):1
 sql txn           rows affected: 0
@@ -85,8 +56,8 @@ dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /System/"desc-idgen"
 dist sender send  r3: sending batch 1 Inc to (n1,s1):1
-sql txn           CPut /Table/2/1/53/"kv"/3/1 -> 54
-sql txn           CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+flow              CPut /Table/2/1/53/"kv"/3/1 -> 54
+flow              CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
 dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
 dist sender send  r6: sending batch 2 CPut to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/53/2/1
@@ -125,7 +96,7 @@ dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
-sql txn           Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+flow              Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
 dist sender send  r6: sending batch 1 Put to (n1,s1):1
 sql txn           rows affected: 0
 dist sender send  r11: sending batch 3 QueryIntent to (n1,s1):1
@@ -137,11 +108,11 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
-sql txn           CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
-sql txn           InitPut /Table/54/2/2/0 -> /BYTES/0x89
+flow              CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
+flow              InitPut /Table/54/2/2/0 -> /BYTES/0x89
 dist sender send  querying next range at /Table/54/1/1/0
 dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
-sql txn           fast path completed
+flow              fast path completed
 sql txn           rows affected: 1
 
 
@@ -152,8 +123,8 @@ query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
-sql txn           CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
-sql txn           InitPut /Table/54/2/2/0 -> /BYTES/0x89
+flow              CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
+flow              InitPut /Table/54/2/2/0 -> /BYTES/0x89
 dist sender send  querying next range at /Table/54/1/1/0
 dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
 sql txn           execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
@@ -167,62 +138,10 @@ query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
-sql txn           CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
-sql txn           InitPut /Table/54/2/2/0 -> /BYTES/0x8a
+flow              CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
+flow              InitPut /Table/54/2/2/0 -> /BYTES/0x8a
 dist sender send  querying next range at /Table/54/1/2/0
 dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
-sql txn           execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
-dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r20: sending batch 1 EndTxn to (n1,s1):1
-
-statement ok
-SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,3); SET tracing = off
-
-query TT
-SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-----
-sql txn           Scan /Table/54/1/2{-/#}
-dist sender send  querying next range at /Table/54/1/2
-dist sender send  r20: sending batch 1 Scan to (n1,s1):1
-sql txn           CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/3
-sql txn           InitPut /Table/54/2/3/0 -> /BYTES/0x8a
-dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
-sql txn           fast path completed
-sql txn           rows affected: 1
-
-statement ok
-SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
-
-query TT
-SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-----
-sql txn           Scan /Table/54/1/1{-/#}
-dist sender send  querying next range at /Table/54/1/1
-dist sender send  r20: sending batch 1 Scan to (n1,s1):1
-sql txn           fetched: /kv/primary/1/v -> /2
-sql txn           Put /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
-dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r20: sending batch 1 Put, 1 EndTxn to (n1,s1):1
-sql txn           fast path completed
-sql txn           rows affected: 1
-
-statement error duplicate key value
-SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
-
-query TT
-set tracing=off;
-SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
-----
-sql txn           Scan /Table/54/1/2{-/#}
-dist sender send  querying next range at /Table/54/1/2
-dist sender send  r20: sending batch 1 Scan to (n1,s1):1
-sql txn           fetched: /kv/primary/2/v -> /3
-sql txn           Put /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
-sql txn           Del /Table/54/2/3/0
-sql txn           CPut /Table/54/2/2/0 -> /BYTES/0x8a
-dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r20: sending batch 1 Put, 1 CPut, 1 Del, 1 EndTxn to (n1,s1):1
 sql txn           execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 dist sender send  querying next range at /Table/54/1/2/0
 dist sender send  r20: sending batch 1 EndTxn to (n1,s1):1
@@ -247,32 +166,30 @@ dist sender send  querying next range at /Table/2/1/0/"t"/3/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
+table reader      Scan /Table/54/{1-2}
+dist sender send  querying next range at /Table/54/1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
 dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /System/"desc-idgen"
 dist sender send  r3: sending batch 1 Inc to (n1,s1):1
-sql txn           CPut /Table/2/1/53/"kv2"/3/1 -> 55
-sql txn           CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+flow              CPut /Table/2/1/53/"kv2"/3/1 -> 55
+flow              CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
 dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
 dist sender send  r6: sending batch 2 CPut to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/53/2/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
-sql txn           Scan /Table/54/{1-2}
-dist sender send  querying next range at /Table/54/1
-dist sender send  r20: sending batch 1 Scan to (n1,s1):1
-sql txn           fetched: /kv/primary/1/v -> /2
-sql txn           CPut /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
-sql txn           fetched: /kv/primary/2/v -> /3
-sql txn           CPut /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/3
+table reader      fetched: /kv/primary/1/v -> /2
+flow              CPut /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
 dist sender send  querying next range at /Table/SystemConfigSpan/Start
 dist sender send  querying next range at /Table/55/1/...PK.../0
-dist sender send  r20: sending batch 2 CPut to (n1,s1):1
+dist sender send  r20: sending batch 1 CPut to (n1,s1):1
 dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
 dist sender send  r8: sending batch 5 QueryIntent to (n1,s1):1
 dist sender send  querying next range at /Table/SystemConfigSpan/Start
 dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
-sql txn           fast path completed
-sql txn           rows affected: 2
+flow              fast path completed
+sql txn           rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; UPDATE t.kv2 SET v = v + 2; SET tracing = off
@@ -290,17 +207,15 @@ dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/55/2/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r7: sending batch 1 EndTxn, 1 QueryIntent to (n1,s1):1
-sql txn           Scan /Table/55/{1-2}
+table reader      Scan /Table/55/{1-2}
 dist sender send  querying next range at /Table/55/1
 dist sender send  r20: sending batch 1 Scan to (n1,s1):1
-sql txn           fetched: /kv2/primary/...PK.../k/v -> /1/2
-sql txn           Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
-sql txn           fetched: /kv2/primary/...PK.../k/v -> /2/3
-sql txn           Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/5
+table reader      fetched: /kv2/primary/...PK.../k/v -> /1/2
+flow              Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
 dist sender send  querying next range at /Table/55/1/...PK.../0
-dist sender send  r20: sending batch 2 Put, 1 EndTxn to (n1,s1):1
-sql txn           fast path completed
-sql txn           rows affected: 2
+dist sender send  r20: sending batch 1 Put, 1 EndTxn to (n1,s1):1
+flow              fast path completed
+sql txn           rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off
@@ -308,14 +223,14 @@ SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
-sql txn           Scan /Table/55/{1-2}
+flow              Scan /Table/55/{1-2}
 dist sender send  querying next range at /Table/55/1
 dist sender send  r20: sending batch 1 Scan to (n1,s1):1
-sql txn           DelRange /Table/55/1 - /Table/55/2
+flow              DelRange /Table/55/1 - /Table/55/2
 dist sender send  querying next range at /Table/55/1
 dist sender send  r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
-sql txn           fast path completed
-sql txn           rows affected: 2
+flow              fast path completed
+sql txn           rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv2; SET tracing = off
@@ -340,7 +255,7 @@ dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
-sql txn           Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... >
+flow              Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... >
 dist sender send  r6: sending batch 1 Put to (n1,s1):1
 sql txn           rows affected: 0
 dist sender send  r11: sending batch 4 QueryIntent to (n1,s1):1
@@ -352,19 +267,16 @@ SET tracing = on,kv,results; DELETE FROM t.kv; SET tracing = off
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
-sql txn           Scan /Table/54/{1-2}
+flow              Scan /Table/54/{1-2}
 dist sender send  querying next range at /Table/54/1
 dist sender send  r20: sending batch 1 Scan to (n1,s1):1
-sql txn           fetched: /kv/primary/1/v -> /2
-sql txn           Del /Table/54/2/2/0
-sql txn           Del /Table/54/1/1/0
-sql txn           fetched: /kv/primary/2/v -> /3
-sql txn           Del /Table/54/2/3/0
-sql txn           Del /Table/54/1/2/0
+flow              fetched: /kv/primary/1/v -> /2
+flow              Del /Table/54/2/2/0
+flow              Del /Table/54/1/1/0
 dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r20: sending batch 4 Del, 1 EndTxn to (n1,s1):1
-sql txn           fast path completed
-sql txn           rows affected: 2
+dist sender send  r20: sending batch 2 Del, 1 EndTxn to (n1,s1):1
+flow              fast path completed
+sql txn           rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP INDEX t.kv@woo CASCADE; SET tracing = off
@@ -398,7 +310,7 @@ dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
-sql txn           Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+flow              Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
 dist sender send  r6: sending batch 1 Put to (n1,s1):1
 sql txn           rows affected: 0
 dist sender send  r11: sending batch 3 QueryIntent to (n1,s1):1
@@ -426,7 +338,7 @@ dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
-sql txn           Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > >
+flow              Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > >
 dist sender send  r6: sending batch 1 Put to (n1,s1):1
 sql txn           rows affected: 0
 dist sender send  r11: sending batch 8 QueryIntent to (n1,s1):1

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -70,6 +70,66 @@ r20: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 1
 
+# KV operations.
+statement ok
+CREATE DATABASE t; CREATE TABLE t.kv(k INT PRIMARY KEY, v INT)
+
+statement ok
+CREATE UNIQUE INDEX woo ON t.kv(v)
+
+statement ok
+SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,3); SET tracing = off
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+----
+table reader      Scan /Table/56/1/2{-/#}
+dist sender send  querying next range at /Table/56/1/2
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
+flow              CPut /Table/56/1/2/0 -> /TUPLE/2:2:Int/3
+flow              InitPut /Table/56/2/3/0 -> /BYTES/0x8a
+dist sender send  querying next range at /Table/56/1/2/0
+dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
+flow              fast path completed
+sql txn           rows affected: 1
+
+statement ok
+SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
+
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+----
+table reader      Scan /Table/56/1/1{-/#}
+dist sender send  querying next range at /Table/56/1/1
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
+flow              CPut /Table/56/1/1/0 -> /TUPLE/2:2:Int/2
+flow              InitPut /Table/56/2/2/0 -> /BYTES/0x89
+dist sender send  querying next range at /Table/56/1/1/0
+dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
+flow              fast path completed
+sql txn           rows affected: 1
+
+statement error duplicate key value
+SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
+
+query TT
+set tracing=off;
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+----
+table reader      Scan /Table/56/1/2{-/#}
+dist sender send  querying next range at /Table/56/1/2
+dist sender send  r20: sending batch 1 Scan to (n1,s1):1
+table reader      fetched: /kv/primary/2/v -> /3
+flow              Put /Table/56/1/2/0 -> /TUPLE/2:2:Int/2
+flow              Del /Table/56/2/3/0
+flow              CPut /Table/56/2/2/0 -> /BYTES/0x8a
+dist sender send  querying next range at /Table/56/1/2/0
+dist sender send  r20: sending batch 1 Put, 1 CPut, 1 Del, 1 EndTxn to (n1,s1):1
+sql txn           execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
+dist sender send  querying next range at /Table/56/1/2/0
+dist sender send  r20: sending batch 1 EndTxn to (n1,s1):1
+
+
 subtest regression_32473
 
 statement ok

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -188,16 +188,10 @@ func BytesEncodeFormatFromString(val string) (_ BytesEncodeFormat, ok bool) {
 	}
 }
 
-// DistSQLExecMode controls if and when the Executor uses DistSQL and
-// distributes queries.
-// In 2.0, these settings controlled whether we use DistSQL or we use the
-// local path.
-//
-// Since 2.1, we normally run everything through the DistSQL infrastructure,
+// DistSQLExecMode controls if and when the Executor distributes queries.
+// Since 2.1, we run everything through the DistSQL infrastructure,
 // and these settings control whether to use a distributed plan, or use a plan
-// that only involves local DistSQL processors. We still support 2.0-style
-// "off" and "auto" settings for now (for benchmarks, or in case of
-// regressions).
+// that only involves local DistSQL processors.
 type DistSQLExecMode int64
 
 const (
@@ -208,12 +202,6 @@ const (
 	DistSQLAuto
 	// DistSQLOn means that we distribute queries that are supported.
 	DistSQLOn
-	// DistSQL2Dot0Off means that we use the "off" setting from 2.0 - never use
-	// the DistSQL engine.
-	DistSQL2Dot0Off
-	// DistSQL2Dot0Auto means that we use the "auto" setting from 2.0 - fall back
-	// to local unless distribution is recommended.
-	DistSQL2Dot0Auto
 	// DistSQLAlways means that we only distribute; unsupported queries fail.
 	DistSQLAlways
 )
@@ -226,10 +214,6 @@ func (m DistSQLExecMode) String() string {
 		return "auto"
 	case DistSQLOn:
 		return "on"
-	case DistSQL2Dot0Auto:
-		return "2.0-auto"
-	case DistSQL2Dot0Off:
-		return "2.0-off"
 	case DistSQLAlways:
 		return "always"
 	default:
@@ -246,10 +230,6 @@ func DistSQLExecModeFromString(val string) (_ DistSQLExecMode, ok bool) {
 		return DistSQLAuto, true
 	case "ON":
 		return DistSQLOn, true
-	case "2.0-AUTO":
-		return DistSQL2Dot0Auto, true
-	case "2.0-OFF":
-		return DistSQL2Dot0Off, true
 	case "ALWAYS":
 		return DistSQLAlways, true
 	default:


### PR DESCRIPTION
This removes user ability to query using the local engine.

Closes #34162.

Release note (sql change): remove the 2.0-off and 2.0-auto distsql
modes. All queries are now run via the newer, distsql engine; queries
are still only distributed if appropriate.