### PR TITLE
sql/stats: rename sql.stats.experimental_automatic

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -80,7 +80,7 @@
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statistics to be collected</td></tr>
 <tr><td><code>sql.parallel_scans.enabled</code></td><td>boolean</td><td><code>true</code></td><td>parallelizes scanning different ranges when the maximum result size can be deduced</td></tr>
 <tr><td><code>sql.query_cache.enabled</code></td><td>boolean</td><td><code>false</code></td><td>enable the query cache</td></tr>
-<tr><td><code>sql.stats.experimental_automatic</code></td><td>boolean</td><td><code>false</code></td><td>experimental automatic statistics mode</td></tr>
+<tr><td><code>sql.stats.experimental_automatic_collection.enabled</code></td><td>boolean</td><td><code>false</code></td><td>experimental automatic statistics collection mode</td></tr>
 <tr><td><code>sql.tablecache.lease.refresh_limit</code></td><td>integer</td><td><code>50</code></td><td>maximum number of tables to periodically refresh leases for</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>
 <tr><td><code>sql.trace.session_eventlog.enabled</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable session tracing</td></tr>

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2791,7 +2791,7 @@ func TestCreateStatsAfterRestore(t *testing.T) {
 	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
 	defer cleanupFn()
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.experimental_automatic=true`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=true`)
 
 	sqlDB.Exec(t, `BACKUP DATABASE data TO $1 WITH revision_history`, localFoo)
 	sqlDB.Exec(t, `CREATE DATABASE "data 2"`)

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -2431,7 +2431,7 @@ func TestCreateStatsAfterImport(t *testing.T) {
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.experimental_automatic=true`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=true`)
 
 	sqlDB.Exec(t, "IMPORT PGDUMP ($1)", "nodelocal:///cockroachdump/dump.sql")
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -5,7 +5,7 @@ CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c), INDE
 
 # Enable automatic stats
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic = true
+SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = true
 
 # Generate all combinations of values 1 to 10.
 statement ok
@@ -24,7 +24,7 @@ __auto__         {d}           1000       0               1000
 
 # Disable automatic stats
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic = false
+SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
 
 # Update more than 5% of the table.
 statement ok
@@ -41,7 +41,7 @@ __auto__         {d}           1000       0               1000
 
 # Enable automatic stats
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic = true
+SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = true
 
 # Update more than 5% of the table.
 statement ok

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -35,8 +35,8 @@ import (
 // AutomaticStatisticsClusterMode controls the cluster setting for enabling
 // automatic table statistics collection.
 var AutomaticStatisticsClusterMode = settings.RegisterBoolSetting(
-	"sql.stats.experimental_automatic",
-	"experimental automatic statistics mode",
+	"sql.stats.experimental_automatic_collection.enabled",
+	"experimental automatic statistics collection mode",
 	false,
 )
 


### PR DESCRIPTION
This commit renames the cluster setting `sql.stats.experimental_automatic` to
`sql.stats.experimental_automatic_collection.enabled`. The previous name
did not match the guidelines set forth in the [naming RFC](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20170317_settings_table.md), which states that
the name should end with a noun. The new name conforms to the requirements.

Informs #34016

Release note: None