### PR TITLE
cli: Deflake TestRemoveDeadReplicas

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -885,7 +885,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 		s.setReplicaGCQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableReplicateQueue {
-		s.setReplicateQueueActive(false)
+		s.SetReplicateQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableSplitQueue {
 		s.setSplitQueueActive(false)
@@ -4514,7 +4514,10 @@ func (s *Store) setRaftLogQueueActive(active bool) {
 func (s *Store) setReplicaGCQueueActive(active bool) {
 	s.replicaGCQueue.SetDisabled(!active)
 }
-func (s *Store) setReplicateQueueActive(active bool) {
+
+// SetReplicateQueueActive controls the replication queue. Only
+// intended for tests.
+func (s *Store) SetReplicateQueueActive(active bool) {
 	s.replicateQueue.SetDisabled(!active)
 }
 func (s *Store) setSplitQueueActive(active bool) {


### PR DESCRIPTION
The move to create all ranges at bootstrap time means it is no longer
the case that n1 has all the leases. This means that we may need to
wait for leases to expire while waiting for full replication.

Fixes #33495

Release note: None