### PR TITLE
opt: reorder joins (off by default)

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1660,6 +1660,10 @@ func (m *sessionDataMutator) SetZigzagJoinEnabled(val bool) {
 	m.data.ZigzagJoinEnabled = val
 }
 
+func (m *sessionDataMutator) SetReorderJoins(val bool) {
+	m.data.ZigzagJoinEnabled = val
+}
+
 func (m *sessionDataMutator) SetVectorize(val sessiondata.VectorizeExecMode) {
 	m.data.Vectorize = val
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1661,7 +1661,7 @@ func (m *sessionDataMutator) SetZigzagJoinEnabled(val bool) {
 }
 
 func (m *sessionDataMutator) SetReorderJoins(val bool) {
-	m.data.ZigzagJoinEnabled = val
+	m.data.ReorderJoins = val
 }
 
 func (m *sessionDataMutator) SetVectorize(val sessiondata.VectorizeExecMode) {

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1341,6 +1341,7 @@ default_transaction_read_only      off           NULL      NULL        NULL     
 distsql                            off           NULL      NULL        NULL        string
 experimental_enable_zigzag_join    off           NULL      NULL        NULL        string
 experimental_force_split_at        off           NULL      NULL        NULL        string
+experimental_reorder_joins         off           NULL      NULL        NULL        string
 experimental_serial_normalization  rowid         NULL      NULL        NULL        string
 experimental_vectorize             off           NULL      NULL        NULL        string
 extra_float_digits                 0             NULL      NULL        NULL        string
@@ -1385,6 +1386,7 @@ default_transaction_read_only      off           NULL  user     NULL      off   
 distsql                            off           NULL  user     NULL      off           off
 experimental_enable_zigzag_join    off           NULL  user     NULL      off           off
 experimental_force_split_at        off           NULL  user     NULL      off           off
+experimental_reorder_joins         off           NULL  user     NULL      off           off
 experimental_serial_normalization  rowid         NULL  user     NULL      rowid         rowid
 experimental_vectorize             off           NULL  user     NULL      off           off
 extra_float_digits                 0             NULL  user     NULL      0             2
@@ -1426,6 +1428,7 @@ distsql                            NULL    NULL     NULL     NULL        NULL
 experimental_enable_zigzag_join    NULL    NULL     NULL     NULL        NULL
 experimental_force_split_at        NULL    NULL     NULL     NULL        NULL
 experimental_optimizer_mutations   NULL    NULL     NULL     NULL        NULL
+experimental_reorder_joins         NULL    NULL     NULL     NULL        NULL
 experimental_serial_normalization  NULL    NULL     NULL     NULL        NULL
 experimental_vectorize             NULL    NULL     NULL     NULL        NULL
 extra_float_digits                 NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -38,6 +38,7 @@ default_transaction_read_only      off
 distsql                            off
 experimental_enable_zigzag_join    off
 experimental_force_split_at        off
+experimental_reorder_joins         off
 experimental_serial_normalization  rowid
 experimental_vectorize             off
 extra_float_digits                 0

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -195,7 +195,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'database'
       └── values  ·       ·
-·                 size    3 columns, 39 rows
+·                 size    3 columns, 40 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -204,7 +204,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'timezone'
       └── values  ·       ·
-·                 size    3 columns, 39 rows
+·                 size    3 columns, 40 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -213,7 +213,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'default_transaction_isolation'
       └── values  ·       ·
-·                 size    3 columns, 39 rows
+·                 size    3 columns, 40 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -222,7 +222,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_isolation'
       └── values  ·       ·
-·                 size    3 columns, 39 rows
+·                 size    3 columns, 40 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -231,7 +231,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_priority'
       └── values  ·       ·
-·                 size    3 columns, 39 rows
+·                 size    3 columns, 40 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -186,7 +186,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'database'
       └── values  ·       ·
-·                 size    3 columns, 39 rows
+·                 size    3 columns, 40 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -195,7 +195,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'timezone'
       └── values  ·       ·
-·                 size    3 columns, 39 rows
+·                 size    3 columns, 40 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -204,7 +204,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'default_transaction_isolation'
       └── values  ·       ·
-·                 size    3 columns, 39 rows
+·                 size    3 columns, 40 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -213,7 +213,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_isolation'
       └── values  ·       ·
-·                 size    3 columns, 39 rows
+·                 size    3 columns, 40 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -222,7 +222,7 @@ render            ·       ·
  └── filter       ·       ·
       │           filter  variable = 'transaction_priority'
       └── values  ·       ·
-·                 size    3 columns, 39 rows
+·                 size    3 columns, 40 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -1,0 +1,81 @@
+# LogicTest: local-opt
+
+statement ok
+CREATE TABLE bx (
+  b INT PRIMARY KEY,
+  x INT
+)
+
+statement ok
+CREATE TABLE cy (
+  c INT PRIMARY KEY,
+  y INT
+)
+
+statement ok
+CREATE TABLE dz (
+  d INT PRIMARY KEY,
+  z INT
+)
+
+statement ok
+CREATE TABLE abc (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT
+)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
+----
+render               ·                   ·                (a, b, c, d, b, x, c, y)  ·
+ │                   render 0            a                ·                         ·
+ │                   render 1            b                ·                         ·
+ │                   render 2            c                ·                         ·
+ │                   render 3            d                ·                         ·
+ │                   render 4            b                ·                         ·
+ │                   render 5            x                ·                         ·
+ │                   render 6            c                ·                         ·
+ │                   render 7            y                ·                         ·
+ └── join            ·                   ·                (b, x, c, y, a, b, c, d)  ·
+      │              type                inner            ·                         ·
+      │              equality            (b, c) = (b, c)  ·                         ·
+      │              left cols are key   ·                ·                         ·
+      │              right cols are key  ·                ·                         ·
+      ├── join       ·                   ·                (b, x, c, y)              ·
+      │    │         type                cross            ·                         ·
+      │    ├── scan  ·                   ·                (b, x)                    ·
+      │    │         table               bx@primary       ·                         ·
+      │    │         spans               ALL              ·                         ·
+      │    └── scan  ·                   ·                (c, y)                    ·
+      │              table               cy@primary       ·                         ·
+      │              spans               ALL              ·                         ·
+      └── scan       ·                   ·                (a, b, c, d)              ·
+·                    table               abc@primary      ·                         ·
+·                    spans               /1-/1/#          ·                         ·
+
+statement ok
+SET experimental_reorder_joins = true
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
+----
+render                 ·         ·            (a, b, c, d, b, x, c, y)  ·
+ │                     render 0  a            ·                         ·
+ │                     render 1  b            ·                         ·
+ │                     render 2  c            ·                         ·
+ │                     render 3  d            ·                         ·
+ │                     render 4  b            ·                         ·
+ │                     render 5  x            ·                         ·
+ │                     render 6  c            ·                         ·
+ │                     render 7  y            ·                         ·
+ └── lookup-join       ·         ·            (a, b, c, d, c, y, b, x)  ·
+      │                table     bx@primary   ·                         ·
+      │                type      inner        ·                         ·
+      └── lookup-join  ·         ·            (a, b, c, d, c, y)        ·
+           │           table     cy@primary   ·                         ·
+           │           type      inner        ·                         ·
+           └── scan    ·         ·            (a, b, c, d)              ·
+·                      table     abc@primary  ·                         ·
+·                      spans     /1-/1/#      ·                         ·

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -144,6 +144,9 @@ type Memo struct {
 	// searchPath is the current search path at the time the memo was compiled.
 	// If this changes, then the memo is invalidated.
 	searchPath sessiondata.SearchPath
+
+	// curID is the highest currently in-use scalar expression ID.
+	curID opt.ScalarID
 }
 
 // Init initializes a new empty memo instance, or resets existing state so it
@@ -332,4 +335,10 @@ func (m *Memo) IsOptimized() bool {
 	// assigned.
 	rel, ok := m.rootExpr.(RelExpr)
 	return ok && rel.RequiredPhysical() != nil
+}
+
+// NextID returns a new unique ScalarID to number expressions with.
+func (m *Memo) NextID() opt.ScalarID {
+	m.curID++
+	return m.curID
 }

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -205,7 +205,7 @@ SELECT 1 AS a, 1+z AS b, left(x, 10)::TIMESTAMP AS c, left(x, 10)::TIMESTAMPTZ A
 FROM b
 WHERE z=1 AND concat(x, 'foo', x)=concat(x, 'foo', x)
 ----
-memo (optimized, ~3KB, required=[presentation: a:3,b:4,c:5,d:6])
+memo (optimized, ~4KB, required=[presentation: a:3,b:4,c:5,d:6])
  ├── G1: (project G2 G3)
  │    └── [presentation: a:3,b:4,c:5,d:6]
  │         ├── best: (project G2 G3)
@@ -353,7 +353,7 @@ memo (optimized, ~2KB, required=[presentation: array_agg:3])
 memo
 SELECT DISTINCT field FROM [EXPLAIN SELECT 123 AS k]
 ----
-memo (optimized, ~4KB, required=[presentation: field:3])
+memo (optimized, ~5KB, required=[presentation: field:3])
  ├── G1: (distinct-on G2 G3 cols=(3))
  │    └── [presentation: field:3]
  │         ├── best: (distinct-on G2 G3 cols=(3))

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1460,3 +1460,29 @@ func (c *CustomFuncs) FoldComparison(op opt.Operator, left, right opt.ScalarExpr
 	}
 	return c.f.ConstructConstVal(result)
 }
+
+// AreFiltersSorted determines whether the expressions in a FiltersExpr are
+// ordered by their expression IDs.
+func (c *CustomFuncs) AreFiltersSorted(f memo.FiltersExpr) bool {
+	for i, n := 0, f.ChildCount(); i < n-1; i++ {
+		if f.Child(i).Child(0).(opt.ScalarExpr).ID() > f.Child(i+1).Child(0).(opt.ScalarExpr).ID() {
+			return false
+		}
+	}
+	return true
+}
+
+// SortFilters sorts a filter list by the IDs of the expressions. This has the
+// effect of canonicalizing FiltersExprs which may have the same filters, but
+// in a different order.
+func (c *CustomFuncs) SortFilters(f memo.FiltersExpr) memo.FiltersExpr {
+	result := make(memo.FiltersExpr, len(f))
+	for i, n := 0, f.ChildCount(); i < n; i++ {
+		fi := f.Child(i).(*memo.FiltersItem)
+		result[i] = *fi
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Child(0).(opt.ScalarExpr).ID() < result[j].Child(0).(opt.ScalarExpr).ID()
+	})
+	return result
+}

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1486,3 +1486,9 @@ func (c *CustomFuncs) SortFilters(f memo.FiltersExpr) memo.FiltersExpr {
 	})
 	return result
 }
+
+// ShouldReorderJoins returns whether the optimizer should attempt to find
+// a better ordering of inner joins.
+func (c *CustomFuncs) ShouldReorderJoins() bool {
+	return c.f.evalCtx.SessionData.ReorderJoins
+}

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -447,3 +447,18 @@ $left
 )
 =>
 (ExtractJoinEquality (OpName) $left $right $on $item)
+
+# SortFiltersInJoin ensures that any filters in an inner join are canonicalized
+# by sorting them.
+[SortFiltersInJoin, Normalize]
+(InnerJoin
+    $left:*
+    $right:*
+    $on:* & ^(AreFiltersSorted $on)
+)
+=>
+(InnerJoin
+  $left
+  $right
+  (SortFilters $on)
+)

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -2082,8 +2082,8 @@ inner-join
  │         └── y + 1 [type=int, outer=(7)]
  └── filters
       ├── f >= z::FLOAT8 [type=bool, outer=(3,8), constraints=(/3: (/NULL - ])]
-      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       ├── f >= z::FLOAT8 [type=bool, outer=(3,8), constraints=(/3: (/NULL - ])]
+      ├── k = x [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
       └── i = y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 
 # Don't trigger rule when one of the variables is nullable.
@@ -2322,8 +2322,8 @@ project
       │    ├── key: (3)
       │    └── fd: (3)-->(4)
       └── filters
-           ├── column5 = u [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
-           └── v = (x + u) [type=bool, outer=(1,3,4), constraints=(/4: (/NULL - ])]
+           ├── v = (x + u) [type=bool, outer=(1,3,4), constraints=(/4: (/NULL - ])]
+           └── column5 = u [type=bool, outer=(3,5), constraints=(/3: (/NULL - ]; /5: (/NULL - ]), fd=(3)==(5), (5)==(3)]
 
 # Cases with non-extractable equality.
 opt expect-not=ExtractJoinEqualities

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -84,10 +84,18 @@ type Expr interface {
 	String() string
 }
 
+// ScalarID is the type of the memo-unique identifier given to every scalar
+// expression.
+type ScalarID int
+
 // ScalarExpr is a scalar expression, which is an expression that returns a
 // primitive-typed value like boolean or string rather than rows and columns.
 type ScalarExpr interface {
 	Expr
+
+	// ID is a unique (within the context of a memo) ID that can be
+	// used to define a total order over ScalarExprs.
+	ID() ScalarID
 
 	// DataType is the SQL type of the expression.
 	DataType() types.T

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -200,6 +200,7 @@ func (g *exprsGen) genExprStruct(define *lang.DefineExpr) {
 		if g.needsDataTypeField(define) {
 			fmt.Fprintf(g.w, "  Typ types.T\n")
 		}
+		fmt.Fprintf(g.w, "  id  opt.ScalarID\n")
 	} else if define.Tags.Contains("Enforcer") {
 		fmt.Fprintf(g.w, "  Input RelExpr\n")
 		fmt.Fprintf(g.w, "  best  bestProps\n")
@@ -220,6 +221,11 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 
 	if define.Tags.Contains("Scalar") {
 		fmt.Fprintf(g.w, "var _ opt.ScalarExpr = &%s{}\n\n", opTyp.name)
+
+		// Generate the ID method.
+		fmt.Fprintf(g.w, "func (e *%s) ID() opt.ScalarID {\n", opTyp.name)
+		fmt.Fprintf(g.w, "  return e.id\n")
+		fmt.Fprintf(g.w, "}\n\n")
 	} else {
 		fmt.Fprintf(g.w, "var _ RelExpr = &%s{}\n\n", opTyp.name)
 	}
@@ -498,6 +504,11 @@ func (g *exprsGen) genListExprFuncs(define *lang.DefineExpr) {
 
 	opTyp := g.md.typeOf(define)
 	fmt.Fprintf(g.w, "var _ opt.ScalarExpr = &%s{}\n\n", opTyp.name)
+
+	// Generate the ID method.
+	fmt.Fprintf(g.w, "func (e *%s) ID() opt.ScalarID {\n", opTyp.name)
+	fmt.Fprintf(g.w, "  panic(\"lists have no id\")")
+	fmt.Fprintf(g.w, "}\n\n")
 
 	// Generate the Op method.
 	fmt.Fprintf(g.w, "func (e *%s) Op() opt.Operator {\n", opTyp.name)

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -609,6 +609,7 @@ func (g *exprsGen) genMemoizeFuncs() {
 		}
 
 		if define.Tags.Contains("Scalar") {
+			fmt.Fprintf(g.w, "   id: m.NextID(),\n")
 			fmt.Fprintf(g.w, "  }\n")
 			if g.needsDataTypeField(define) {
 				fmt.Fprintf(g.w, "  e.Typ = InferType(m, e)\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -194,6 +194,10 @@ var EmptyProjectionsExpr = ProjectionsExpr{}
 
 var _ opt.ScalarExpr = &ProjectionsExpr{}
 
+func (e *ProjectionsExpr) ID() opt.ScalarID {
+	panic("lists have no id")
+}
+
 func (e *ProjectionsExpr) Op() opt.Operator {
 	return opt.ProjectionsOp
 }
@@ -229,9 +233,14 @@ type ProjectionsItem struct {
 	ColPrivate
 
 	Typ types.T
+	id  opt.ScalarID
 }
 
 var _ opt.ScalarExpr = &ProjectionsItem{}
+
+func (e *ProjectionsItem) ID() opt.ScalarID {
+	return e.id
+}
 
 func (e *ProjectionsItem) Op() opt.Operator {
 	return opt.ProjectionsItemOp

--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -229,11 +229,10 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	}
 
 	if ot.Flags.ReorderJoins {
-		oldValue := ot.evalCtx.SessionData.ReorderJoins
-		ot.evalCtx.SessionData.ReorderJoins = true
-		defer func() {
+		defer func(oldValue bool) {
 			ot.evalCtx.SessionData.ReorderJoins = oldValue
-		}()
+		}(ot.evalCtx.SessionData.ReorderJoins)
+		ot.evalCtx.SessionData.ReorderJoins = true
 	}
 
 	ot.Flags.Verbose = testing.Verbose()

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -95,3 +95,34 @@
 )
 =>
 (GenerateLookupJoins (OpName) $left $scanPrivate (ConcatFilters $on $filters))
+
+# AssociateJoin applies the rule of join associativity. It converts an
+# expression like:
+#   (A JOIN B ON A.y = B.y) JOIN C ON B.x = C.x
+# to the logically equivalent expression:
+#   A JOIN (B JOIN C ON B.x = C.x) ON A.y = B.y
+[AssociateJoin, Explore]
+(InnerJoin
+    (InnerJoin
+        $innerLeft:* & (ShouldReorderJoins)
+        $innerRight:*
+        $innerOn:*
+    )
+    $right:*
+    $on:*
+)
+=>
+(InnerJoin
+    $innerLeft
+    (InnerJoin
+        $innerRight
+        $right
+        (ExtractBoundConditions $on (OutputCols2 $innerRight $right))
+    )
+    (SortFilters
+        (ConcatFilters
+            (ExtractUnboundConditions $on (OutputCols2 $innerRight $right))
+            $innerOn
+        )
+    )
+)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1222,7 +1222,7 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4,+2])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw ORDER BY w, u DESC, v
 ----
-memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
+memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
@@ -1249,7 +1249,7 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw ORDER BY w DESC, u DESC, v
 ----
-memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: -4])
+memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: -4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=-2,+3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: -4]
  │    │    ├── best: (distinct-on G2="[ordering: -4,-2,+3]" G3 cols=(4),ordering=-2,+3 opt(4))
@@ -1276,7 +1276,7 @@ memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: -4])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw ORDER BY w, u, v DESC
 ----
-memo (optimized, ~3KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
+memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
  ├── G1: (distinct-on G2 G3 cols=(4),ordering=+2,-3 opt(4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4]
  │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(4),ordering=+2,-3 opt(4))

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1373,7 +1373,7 @@ inner-join (lookup pqr)
 memo
 SELECT q,r,s FROM pqr WHERE q = 1 AND r = 2
 ----
-memo (optimized, ~13KB, required=[presentation: q:2,r:3,s:4])
+memo (optimized, ~14KB, required=[presentation: q:2,r:3,s:4])
  ├── G1: (select G2 G3) (lookup-join G4 G5 pqr,keyCols=[1],outCols=(2-4)) (select G6 G7) (select G8 G9) (select G10 G9)
  │    └── [presentation: q:2,r:3,s:4]
  │         ├── best: (lookup-join G4 G5 pqr,keyCols=[1],outCols=(2-4))

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -1,0 +1,336 @@
+exec-ddl
+CREATE TABLE bx (
+  b INT PRIMARY KEY,
+  x INT
+)
+----
+TABLE bx
+ ├── b int not null
+ ├── x int
+ └── INDEX primary
+      └── b int not null
+
+exec-ddl
+CREATE TABLE cy (
+  c INT PRIMARY KEY,
+  y INT
+)
+----
+TABLE cy
+ ├── c int not null
+ ├── y int
+ └── INDEX primary
+      └── c int not null
+
+exec-ddl
+CREATE TABLE dz (
+  d INT PRIMARY KEY,
+  z INT
+)
+----
+TABLE dz
+ ├── d int not null
+ ├── z int
+ └── INDEX primary
+      └── d int not null
+
+exec-ddl
+CREATE TABLE abc (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT
+)
+----
+TABLE abc
+ ├── a int not null
+ ├── b int
+ ├── c int
+ ├── d int
+ └── INDEX primary
+      └── a int not null
+
+opt reorder-joins
+SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
+----
+inner-join (lookup bx)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) b:5(int!null) x:6(int) c:7(int!null) y:8(int)
+ ├── key columns: [2] = [5]
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-8)
+ ├── inner-join (lookup cy)
+ │    ├── columns: a:1(int!null) abc.b:2(int) abc.c:3(int!null) d:4(int) cy.c:7(int!null) y:8(int)
+ │    ├── key columns: [3] = [7]
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-4,7,8)
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) abc.b:2(int) abc.c:3(int) d:4(int)
+ │    │    ├── constraint: /1: [/1 - /1]
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(1-4)
+ │    └── filters (true)
+ └── filters (true)
+
+opt reorder-joins
+SELECT * FROM bx, abc, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
+----
+inner-join (lookup bx)
+ ├── columns: b:1(int!null) x:2(int) a:3(int!null) b:4(int!null) c:5(int!null) d:6(int) c:7(int!null) y:8(int)
+ ├── key columns: [4] = [1]
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-8)
+ ├── inner-join (lookup cy)
+ │    ├── columns: a:3(int!null) abc.b:4(int) abc.c:5(int!null) d:6(int) cy.c:7(int!null) y:8(int)
+ │    ├── key columns: [5] = [7]
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(3-8)
+ │    ├── scan abc
+ │    │    ├── columns: a:3(int!null) abc.b:4(int) abc.c:5(int) d:6(int)
+ │    │    ├── constraint: /3: [/1 - /1]
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(3-6)
+ │    └── filters (true)
+ └── filters (true)
+
+opt reorder-joins
+SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
+----
+inner-join (lookup bx)
+ ├── columns: b:1(int!null) x:2(int) c:3(int!null) y:4(int) a:5(int!null) b:6(int!null) c:7(int!null) d:8(int)
+ ├── key columns: [6] = [1]
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-8)
+ ├── inner-join (lookup cy)
+ │    ├── columns: cy.c:3(int!null) y:4(int) a:5(int!null) abc.b:6(int) abc.c:7(int!null) d:8(int)
+ │    ├── key columns: [7] = [3]
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(3-8)
+ │    ├── scan abc
+ │    │    ├── columns: a:5(int!null) abc.b:6(int) abc.c:7(int) d:8(int)
+ │    │    ├── constraint: /5: [/1 - /1]
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(5-8)
+ │    └── filters (true)
+ └── filters (true)
+
+memo reorder-joins
+SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
+----
+memo (optimized, ~17KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+6) (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8)) (inner-join G6 G7 G8) (inner-join G9 G10 G11) (inner-join G7 G6 G8) (merge-join G6 G7 G5 inner-join,+3,+7) (inner-join G10 G9 G11) (lookup-join G7 G5 cy,keyCols=[7],outCols=(1-8))
+ │    └── [presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8]
+ │         ├── best: (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8))
+ │         └── cost: 11.19
+ ├── G2: (scan bx)
+ │    ├── [ordering: +1]
+ │    │    ├── best: (scan bx)
+ │    │    └── cost: 1040.01
+ │    └── []
+ │         ├── best: (scan bx)
+ │         └── cost: 1040.01
+ ├── G3: (inner-join G6 G9 G8) (inner-join G9 G6 G8) (merge-join G6 G9 G5 inner-join,+3,+7) (lookup-join G9 G5 cy,keyCols=[7],outCols=(3-8))
+ │    └── []
+ │         ├── best: (lookup-join G9 G5 cy,keyCols=[7],outCols=(3-8))
+ │         └── cost: 6.14
+ ├── G4: (filters G12)
+ ├── G5: (filters)
+ ├── G6: (scan cy)
+ │    ├── [ordering: +3]
+ │    │    ├── best: (scan cy)
+ │    │    └── cost: 1040.01
+ │    └── []
+ │         ├── best: (scan cy)
+ │         └── cost: 1040.01
+ ├── G7: (inner-join G9 G2 G4) (inner-join G2 G9 G4) (lookup-join G9 G5 bx,keyCols=[6],outCols=(1,2,5-8)) (merge-join G2 G9 G5 inner-join,+1,+6)
+ │    └── []
+ │         ├── best: (lookup-join G9 G5 bx,keyCols=[6],outCols=(1,2,5-8))
+ │         └── cost: 6.14
+ ├── G8: (filters G13)
+ ├── G9: (select G14 G15) (scan abc,constrained)
+ │    └── []
+ │         ├── best: (scan abc,constrained)
+ │         └── cost: 1.09
+ ├── G10: (inner-join G6 G2 G5) (inner-join G2 G6 G5)
+ │    └── []
+ │         ├── best: (inner-join G6 G2 G5)
+ │         └── cost: 12110.03
+ ├── G11: (filters G12 G13)
+ ├── G12: (eq G16 G17)
+ ├── G13: (eq G18 G19)
+ ├── G14: (scan abc)
+ │    └── []
+ │         ├── best: (scan abc)
+ │         └── cost: 1080.01
+ ├── G15: (filters G20)
+ ├── G16: (variable abc.b)
+ ├── G17: (variable bx.b)
+ ├── G18: (variable abc.c)
+ ├── G19: (variable cy.c)
+ ├── G20: (eq G21 G22)
+ ├── G21: (variable a)
+ └── G22: (const 1)
+
+opt reorder-joins
+SELECT * FROM bx, cy, dz, abc WHERE a = 1
+----
+inner-join
+ ├── columns: b:1(int!null) x:2(int) c:3(int!null) y:4(int) d:5(int!null) z:6(int) a:7(int!null) b:8(int) c:9(int) d:10(int)
+ ├── key: (1,3,5)
+ ├── fd: ()-->(7-10), (1)-->(2), (3)-->(4), (5)-->(6)
+ ├── inner-join
+ │    ├── columns: cy.c:3(int!null) y:4(int) dz.d:5(int!null) z:6(int) a:7(int!null) abc.b:8(int) abc.c:9(int) abc.d:10(int)
+ │    ├── key: (3,5)
+ │    ├── fd: ()-->(7-10), (3)-->(4), (5)-->(6)
+ │    ├── scan cy
+ │    │    ├── columns: cy.c:3(int!null) y:4(int)
+ │    │    ├── key: (3)
+ │    │    └── fd: (3)-->(4)
+ │    ├── inner-join
+ │    │    ├── columns: dz.d:5(int!null) z:6(int) a:7(int!null) abc.b:8(int) abc.c:9(int) abc.d:10(int)
+ │    │    ├── key: (5)
+ │    │    ├── fd: ()-->(7-10), (5)-->(6)
+ │    │    ├── scan dz
+ │    │    │    ├── columns: dz.d:5(int!null) z:6(int)
+ │    │    │    ├── key: (5)
+ │    │    │    └── fd: (5)-->(6)
+ │    │    ├── scan abc
+ │    │    │    ├── columns: a:7(int!null) abc.b:8(int) abc.c:9(int) abc.d:10(int)
+ │    │    │    ├── constraint: /7: [/1 - /1]
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    └── fd: ()-->(7-10)
+ │    │    └── filters (true)
+ │    └── filters (true)
+ ├── scan bx
+ │    ├── columns: bx.b:1(int!null) x:2(int)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── filters (true)
+
+# Note the difference in memo size for with and without reorder-joins, for only four tables.
+# TODO(justin): Find a way to reduce this.
+
+memo
+SELECT * FROM bx, cy, dz, abc WHERE a = 1
+----
+memo (optimized, ~11KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
+ │    └── [presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10]
+ │         ├── best: (inner-join G3 G2 G4)
+ │         └── cost: 10025691.17
+ ├── G2: (scan bx)
+ │    └── []
+ │         ├── best: (scan bx)
+ │         └── cost: 1040.01
+ ├── G3: (inner-join G5 G6 G4) (inner-join G6 G5 G4)
+ │    └── []
+ │         ├── best: (inner-join G5 G6 G4)
+ │         └── cost: 12133.65
+ ├── G4: (filters)
+ ├── G5: (scan cy)
+ │    └── []
+ │         ├── best: (scan cy)
+ │         └── cost: 1040.01
+ ├── G6: (inner-join G7 G8 G4) (inner-join G8 G7 G4)
+ │    └── []
+ │         ├── best: (inner-join G7 G8 G4)
+ │         └── cost: 1063.63
+ ├── G7: (scan dz)
+ │    └── []
+ │         ├── best: (scan dz)
+ │         └── cost: 1040.01
+ ├── G8: (select G9 G10) (scan abc,constrained)
+ │    └── []
+ │         ├── best: (scan abc,constrained)
+ │         └── cost: 1.09
+ ├── G9: (scan abc)
+ │    └── []
+ │         ├── best: (scan abc)
+ │         └── cost: 1080.01
+ ├── G10: (filters G11)
+ ├── G11: (eq G12 G13)
+ ├── G12: (variable a)
+ └── G13: (const 1)
+
+memo reorder-joins
+SELECT * FROM bx, cy, dz, abc WHERE a = 1
+----
+memo (optimized, ~25KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G4) (inner-join G7 G8 G4) (inner-join G9 G10 G4) (inner-join G11 G12 G4) (inner-join G13 G14 G4) (inner-join G15 G16 G4) (inner-join G6 G5 G4) (inner-join G8 G7 G4) (inner-join G10 G9 G4) (inner-join G12 G11 G4) (inner-join G14 G13 G4) (inner-join G16 G15 G4)
+ │    └── [presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10]
+ │         ├── best: (inner-join G3 G2 G4)
+ │         └── cost: 10025691.17
+ ├── G2: (scan bx)
+ │    └── []
+ │         ├── best: (scan bx)
+ │         └── cost: 1040.01
+ ├── G3: (inner-join G5 G7 G4) (inner-join G7 G5 G4) (inner-join G9 G13 G4) (inner-join G11 G15 G4) (inner-join G13 G9 G4) (inner-join G15 G11 G4)
+ │    └── []
+ │         ├── best: (inner-join G5 G7 G4)
+ │         └── cost: 12133.65
+ ├── G4: (filters)
+ ├── G5: (scan cy)
+ │    └── []
+ │         ├── best: (scan cy)
+ │         └── cost: 1040.01
+ ├── G6: (inner-join G7 G2 G4) (inner-join G2 G7 G4) (inner-join G9 G16 G4) (inner-join G11 G14 G4) (inner-join G16 G9 G4) (inner-join G14 G11 G4)
+ │    └── []
+ │         ├── best: (inner-join G7 G2 G4)
+ │         └── cost: 12133.65
+ ├── G7: (inner-join G9 G11 G4) (inner-join G11 G9 G4)
+ │    └── []
+ │         ├── best: (inner-join G9 G11 G4)
+ │         └── cost: 1063.63
+ ├── G8: (inner-join G5 G2 G4) (inner-join G2 G5 G4)
+ │    └── []
+ │         ├── best: (inner-join G5 G2 G4)
+ │         └── cost: 12110.03
+ ├── G9: (scan dz)
+ │    └── []
+ │         ├── best: (scan dz)
+ │         └── cost: 1040.01
+ ├── G10: (inner-join G13 G2 G4) (inner-join G2 G13 G4) (inner-join G11 G8 G4) (inner-join G5 G16 G4) (inner-join G8 G11 G4) (inner-join G16 G5 G4)
+ │    └── []
+ │         ├── best: (inner-join G13 G2 G4)
+ │         └── cost: 12133.65
+ ├── G11: (select G17 G18) (scan abc,constrained)
+ │    └── []
+ │         ├── best: (scan abc,constrained)
+ │         └── cost: 1.09
+ ├── G12: (inner-join G15 G2 G4) (inner-join G2 G15 G4) (inner-join G9 G8 G4) (inner-join G5 G14 G4) (inner-join G8 G9 G4) (inner-join G14 G5 G4)
+ │    └── []
+ │         ├── best: (inner-join G15 G2 G4)
+ │         └── cost: 10025667.55
+ ├── G13: (inner-join G11 G5 G4) (inner-join G5 G11 G4)
+ │    └── []
+ │         ├── best: (inner-join G5 G11 G4)
+ │         └── cost: 1063.63
+ ├── G14: (inner-join G9 G2 G4) (inner-join G2 G9 G4)
+ │    └── []
+ │         ├── best: (inner-join G9 G2 G4)
+ │         └── cost: 12110.03
+ ├── G15: (inner-join G9 G5 G4) (inner-join G5 G9 G4)
+ │    └── []
+ │         ├── best: (inner-join G9 G5 G4)
+ │         └── cost: 12110.03
+ ├── G16: (inner-join G11 G2 G4) (inner-join G2 G11 G4)
+ │    └── []
+ │         ├── best: (inner-join G2 G11 G4)
+ │         └── cost: 1063.63
+ ├── G17: (scan abc)
+ │    └── []
+ │         ├── best: (scan abc)
+ │         └── cost: 1080.01
+ ├── G18: (filters G19)
+ ├── G19: (eq G20 G21)
+ ├── G20: (variable a)
+ └── G21: (const 1)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -530,7 +530,7 @@ select
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
 ----
-memo (optimized, ~6KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~7KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7)
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (select G6 G7)
@@ -595,7 +595,7 @@ select
 memo
 SELECT * FROM b WHERE (u, k, v) > (1, 2, 3) AND (u, k, v) < (8, 9, 10)
 ----
-memo (optimized, ~4KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~5KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G3)
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (select G4 G3)

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -65,6 +65,9 @@ type SessionData struct {
 	// ZigzagJoinEnabled indicates whether the optimizer should try and plan a
 	// zigzag join.
 	ZigzagJoinEnabled bool
+	// ReorderJoins indicates whether the optimizer should try to reorder the
+	// joins in a query.
+	ReorderJoins bool
 	// SequenceState gives access to the SQL sequences that have been manipulated
 	// by the session.
 	SequenceState *SequenceState

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -342,6 +342,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`experimental_reorder_joins`: {
+		GetStringVal: makeBoolGetStringValFn(`experimental_reorder_joins`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := parsePostgresBool(s)
+			if err != nil {
+				return err
+			}
+			m.SetReorderJoins(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.ReorderJoins)
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
 	`experimental_vectorize`: {
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			mode, ok := sessiondata.VectorizeExecModeFromString(s)


### PR DESCRIPTION
This PR introduces the AssociateJoin rule, which, if the appropriate
session variable is set, will explore additional join orderings.

This commit is presented as a first step - it's not remotely
production-ready (i.e., nobody should be turning on the flag).

Release note (sql change): introduced the experimental_reorder_joins
flags which will (slowly) attempt to find better join orderings for a
query. Not practical for real-world usage today.