### PR TITLE
opt: mitigation of query cache overhead on bad workloads

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1895,6 +1895,8 @@ func (ex *connExecutor) resetPlanner(
 	p.autoCommit = false
 	p.isPreparing = false
 	p.avoidCachedDescriptors = false
+
+	p.queryCacheSession.Init()
 }
 
 // txnStateTransitionsApplyWrapper is a wrapper on top of Machine built with the

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -161,6 +162,8 @@ type planner struct {
 	// optimizer caches an instance of the cost-based optimizer that can be reused
 	// to plan queries (reused in order to reduce allocations).
 	optimizer xform.Optimizer
+
+	queryCacheSession querycache.Session
 }
 
 // noteworthyInternalMemoryUsageBytes is the minimum size tracked by each
@@ -263,6 +266,8 @@ func newInternalPlanner(
 
 	acc := plannerMon.MakeBoundAccount()
 	p.extendedEvalCtx.ActiveMemAcc = &acc
+
+	p.queryCacheSession.Init()
 
 	return p, func() {
 		// Note that we capture ctx here. This is only valid as long as we create


### PR DESCRIPTION
The query cache logic is modified to "back off" from adding plans when
the workload in a session is not cacheable.

Specifically: we maintain a per-session moving average of the miss
ratio, and when it is over a certain threshold, we ignore most `Add`
operations.

Micro-benchmarks:
```
BenchmarkWorstCase/NoMitigation/1-12       	 5000000	       418 ns/op
BenchmarkWorstCase/NoMitigation/10-12      	 2000000	       646 ns/op
BenchmarkWorstCase/NoMitigation/100-12     	 2000000	       769 ns/op
BenchmarkWorstCase/WithMitigation/1-12     	10000000	       246 ns/op
BenchmarkWorstCase/WithMitigation/10-12    	 5000000	       229 ns/op
BenchmarkWorstCase/WithMitigation/100-12   	 5000000	       311 ns/op
```

Release note: None