### PR TITLE
build: test enterprise features in the every-pr teamcity build

### DIFF
--- a/build/teamcity-local-roachtest.sh
+++ b/build/teamcity-local-roachtest.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 source "$(dirname "${0}")/teamcity-support.sh"
 
 tc_start_block "Prepare environment"
+# Grab a testing license good for one hour.
+COCKROACH_DEV_LICENSE=$(curl -f "https://register.cockroachdb.com/api/prodtest")
 run mkdir -p artifacts
 maybe_ccache
 tc_end_block "Prepare environment"
@@ -19,9 +21,10 @@ tc_end_block "Compile roachprod/workload/roachtest"
 
 tc_start_block "Run local roachtests"
 # TODO(peter,dan): curate a suite of the tests that works locally.
-run build/builder.sh \
+run build/builder.sh env \
+  COCKROACH_DEV_LICENSE="$COCKROACH_DEV_LICENSE" \
 	stdbuf -oL -eL \
-	./bin/roachtest run '(acceptance|kv/splits)' \
+	./bin/roachtest run '(acceptance|kv/splits|cdc/bank)' \
   --local \
   --cockroach "cockroach" \
   --roachprod "bin/roachprod" \

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -234,7 +234,7 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 	m := newMonitor(workloadCtx, c, crdbNodes)
 	var doneAtomic int64
 	m.Go(func(ctx context.Context) error {
-		err := c.RunE(ctx, workloadNode, `./workload run bank {pgurl:1}`)
+		err := c.RunE(ctx, workloadNode, `./workload run bank {pgurl:1} --max-rate=10`)
 		if atomic.LoadInt64(&doneAtomic) > 0 {
 			return nil
 		}
@@ -263,7 +263,10 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 		//  return errors.New("test requires at least 2 partitions to be interesting")
 		// }
 
-		const requestedResolved = 100
+		var requestedResolved = 100
+		if local {
+			requestedResolved = 10
+		}
 		var numResolved, rowsSinceResolved int
 		v := changefeedccl.Validators{
 			changefeedccl.NewOrderValidator(`bank`),


### PR DESCRIPTION
This is done by grabbing a one hour testing license from the
registration server.

Release note: None