### PR TITLE
sql,sqlbase: fix the introspection for pre-2.1 BIT columns

### DIFF
--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -310,10 +310,10 @@ func UnmarshalColumnValueToCol(
 			vec.Int16()[idx] = int16(v)
 		case 32:
 			vec.Int32()[idx] = int32(v)
-		case 0, 64:
-			vec.Int64()[idx] = v
 		default:
-			return errors.Errorf("invalid int width: %d", typ.Width)
+			// Pre-2.1 BIT was using INT encoding with arbitrary sizes.
+			// We map these to 64-bit INT now. See #34161.
+			vec.Int64()[idx] = v
 		}
 	case sqlbase.ColumnType_FLOAT:
 		var v float64

--- a/pkg/sql/colencoding/value_encoding.go
+++ b/pkg/sql/colencoding/value_encoding.go
@@ -89,10 +89,10 @@ func decodeUntaggedDatumToCol(
 			vec.Int16()[idx] = int16(i)
 		case 32:
 			vec.Int32()[idx] = int32(i)
-		case 0, 64:
-			vec.Int64()[idx] = i
 		default:
-			return buf, errors.Errorf("unknown integer width %d", t.Width)
+			// Pre-2.1 BIT was using INT encoding with arbitrary sizes.
+			// We map these to 64-bit INT now. See #34161.
+			vec.Int64()[idx] = i
 		}
 	default:
 		return buf, errors.Errorf("couldn't decode type %s", t)

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -21,11 +21,16 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/jackc/pgx/pgtype"
 )
 
 func TestGossipAlertsTable(t *testing.T) {
@@ -60,4 +65,143 @@ func TestGossipAlertsTable(t *testing.T) {
 	if a != e {
 		t.Fatalf("got:\n%s\nexpected:\n%s", a, e)
 	}
+}
+
+// TestOldBitColumnMetadata checks that a pre-2.1 BIT columns
+// shows up properly in metadata post-2.1.
+func TestOldBitColumnMetadata(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// The descriptor changes made must have an immediate effect
+	// so disable leases on tables.
+	defer sql.TestDisableTableLeases()()
+
+	params, _ := tests.CreateTestServerParams()
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// We now want to create a pre-2.1 table descriptor with an
+	// old-style bit column. We're going to edit the table descriptor
+	// manually, without going through SQL.
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	for i := range tableDesc.Columns {
+		if tableDesc.Columns[i].Name == "k" {
+			tableDesc.Columns[i].Type.VisibleType = 4 // Pre-2.1 BIT.
+			tableDesc.Columns[i].Type.Width = 12      // Arbitrary non-std INT size.
+			break
+		}
+	}
+	// To make this test future-proof we must ensure that there isn't
+	// any logic in an unrelated place which will prevent the table from
+	// being committed. To verify this, we add another column and check
+	// it appears in introspection afterwards.
+	//
+	// We also avoid the regular schema change logic entirely, because
+	// this may be equipped with code to "fix" the old-style BIT column
+	// we defined above.
+	alterCmd, err := parser.ParseOne("ALTER TABLE t ADD COLUMN z INT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	colDef := alterCmd.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAddColumn).ColumnDef
+	col, _, _, err := sqlbase.MakeColumnDefDescs(colDef, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	col.ID = tableDesc.NextColumnID
+	tableDesc.NextColumnID++
+	tableDesc.Families[0].ColumnNames = append(tableDesc.Families[0].ColumnNames, col.Name)
+	tableDesc.Families[0].ColumnIDs = append(tableDesc.Families[0].ColumnIDs, col.ID)
+	tableDesc.Columns = append(tableDesc.Columns, *col)
+
+	// Write the modified descriptor.
+	if err := kvDB.Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
+		return txn.Put(ctx, sqlbase.MakeDescMetadataKey(tableDesc.ID), sqlbase.WrapDescriptor(tableDesc))
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the column metadata from information_schema.
+	rows, err := sqlDB.Query(`
+SELECT column_name, character_maximum_length, numeric_precision, numeric_precision_radix, crdb_sql_type
+  FROM t.information_schema.columns
+ WHERE table_catalog = 't' AND table_schema = 'public' AND table_name = 'test'
+   AND column_name != 'rowid'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	expected := 0
+	for rows.Next() {
+		var colName string
+		var charMaxLength, numPrec, numPrecRadix pgtype.Int8
+		var sqlType string
+		if err := rows.Scan(&colName, &charMaxLength, &numPrec, &numPrecRadix, &sqlType); err != nil {
+			t.Fatal(err)
+		}
+		switch colName {
+		case "k":
+			if charMaxLength.Status != pgtype.Null {
+				t.Fatalf("x character_maximum_length: expected null, got %d", charMaxLength.Int)
+			}
+			if numPrec.Int != 64 {
+				t.Fatalf("x numeric_precision: expected 64, got %v", numPrec.Get())
+			}
+			if numPrecRadix.Int != 2 {
+				t.Fatalf("x numeric_precision_radix: expected 64, got %v", numPrecRadix.Get())
+			}
+			if sqlType != "INT8" {
+				t.Fatalf("x crdb_sql_type: expected INT8, got %q", sqlType)
+			}
+			expected |= 2
+		case "z":
+			// This is just a canary to verify that the manually-modified
+			// table descriptor is visible to introspection.
+			expected |= 1
+		default:
+			t.Fatalf("unexpected col: %q", colName)
+		}
+	}
+	if expected != 3 {
+		t.Fatal("did not find both expected rows")
+	}
+
+	// Now test the workaround: using ALTER to "upgrade" the type fully to INT.
+	if _, err := sqlDB.Exec(`ALTER TABLE t.test ALTER COLUMN k SET DATA TYPE INT8`); err != nil {
+		t.Fatal(err)
+	}
+
+	// And verify that this has re-set the fields.
+	tableDesc = sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	found := false
+	for i := range tableDesc.Columns {
+		col := tableDesc.Columns[i]
+		if col.Name == "k" {
+			// TODO(knz): post-2.2, we're removing the visible types for
+			// integer types so the expectation will be just 0 here.
+			if col.Type.VisibleType != 0 && col.Type.VisibleType != sqlbase.ColumnType_BIGINT {
+				t.Errorf("unexpected visible type: got %s, expected NONE or BIGINT", col.Type.VisibleType.String())
+			}
+			if col.Type.Width != 64 {
+				t.Errorf("unexpected width: got %d, expected 64", col.Type.Width)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("column disappeared")
+	}
+
 }

--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -155,7 +155,7 @@ func (m *materializer) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 					m.row[outIdx].Datum = m.da.NewDInt(tree.DInt(col.Int16()[rowIdx]))
 				case 32:
 					m.row[outIdx].Datum = m.da.NewDInt(tree.DInt(col.Int32()[rowIdx]))
-				case 0, 64:
+				default:
 					m.row[outIdx].Datum = m.da.NewDInt(tree.DInt(col.Int64()[rowIdx]))
 				}
 			case sqlbase.ColumnType_FLOAT:

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -907,9 +907,9 @@ FROM information_schema.columns
 WHERE table_schema = 'public' AND table_name = 'char_len'
 ----
 table_name  column_name  character_maximum_length  character_octet_length
-char_len    a            64                        NULL
-char_len    b            16                        NULL
-char_len    c            32                        NULL
+char_len    a            NULL                      NULL
+char_len    b            NULL                      NULL
+char_len    c            NULL                      NULL
 char_len    d            NULL                      NULL
 char_len    e            12                        48
 char_len    dc           1                         4

--- a/pkg/sql/sqlbase/structured.pb.go
+++ b/pkg/sql/sqlbase/structured.pb.go
@@ -56,7 +56,7 @@ func (x *ConstraintValidity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ConstraintValidity) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{0}
+	return fileDescriptor_structured_096aadf1685143bc, []int{0}
 }
 
 // These mirror the types supported by sql/coltypes.
@@ -164,7 +164,7 @@ func (x *ColumnType_SemanticType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ColumnType_SemanticType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{0, 0}
+	return fileDescriptor_structured_096aadf1685143bc, []int{0, 0}
 }
 
 type ColumnType_VisibleType int32
@@ -224,7 +224,7 @@ func (x *ColumnType_VisibleType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ColumnType_VisibleType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{0, 1}
+	return fileDescriptor_structured_096aadf1685143bc, []int{0, 1}
 }
 
 type ForeignKeyReference_Action int32
@@ -269,7 +269,7 @@ func (x *ForeignKeyReference_Action) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Action) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{1, 0}
+	return fileDescriptor_structured_096aadf1685143bc, []int{1, 0}
 }
 
 // Match is the algorithm used to compare composite keys.
@@ -306,7 +306,7 @@ func (x *ForeignKeyReference_Match) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ForeignKeyReference_Match) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{1, 1}
+	return fileDescriptor_structured_096aadf1685143bc, []int{1, 1}
 }
 
 // The direction of a column in the index.
@@ -343,7 +343,7 @@ func (x *IndexDescriptor_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{6, 0}
+	return fileDescriptor_structured_096aadf1685143bc, []int{6, 0}
 }
 
 // The direction of a column in the index.
@@ -380,7 +380,7 @@ func (x *IndexDescriptor_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (IndexDescriptor_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{6, 1}
+	return fileDescriptor_structured_096aadf1685143bc, []int{6, 1}
 }
 
 // A descriptor within a mutation is unavailable for reads, writes
@@ -445,7 +445,7 @@ func (x *DescriptorMutation_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{7, 0}
+	return fileDescriptor_structured_096aadf1685143bc, []int{7, 0}
 }
 
 // Direction of mutation.
@@ -488,7 +488,7 @@ func (x *DescriptorMutation_Direction) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DescriptorMutation_Direction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{7, 1}
+	return fileDescriptor_structured_096aadf1685143bc, []int{7, 1}
 }
 
 // State is set if this TableDescriptor is in the process of being added or deleted.
@@ -535,7 +535,7 @@ func (x *TableDescriptor_State) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_State) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{8, 0}
+	return fileDescriptor_structured_096aadf1685143bc, []int{8, 0}
 }
 
 // AuditMode indicates which auditing actions to take when this table is used.
@@ -572,7 +572,7 @@ func (x *TableDescriptor_AuditMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TableDescriptor_AuditMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{8, 1}
+	return fileDescriptor_structured_096aadf1685143bc, []int{8, 1}
 }
 
 type ColumnType struct {
@@ -604,7 +604,7 @@ func (m *ColumnType) Reset()         { *m = ColumnType{} }
 func (m *ColumnType) String() string { return proto.CompactTextString(m) }
 func (*ColumnType) ProtoMessage()    {}
 func (*ColumnType) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{0}
+	return fileDescriptor_structured_096aadf1685143bc, []int{0}
 }
 func (m *ColumnType) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -650,7 +650,7 @@ func (m *ForeignKeyReference) Reset()         { *m = ForeignKeyReference{} }
 func (m *ForeignKeyReference) String() string { return proto.CompactTextString(m) }
 func (*ForeignKeyReference) ProtoMessage()    {}
 func (*ForeignKeyReference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{1}
+	return fileDescriptor_structured_096aadf1685143bc, []int{1}
 }
 func (m *ForeignKeyReference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -697,7 +697,7 @@ func (m *ColumnDescriptor) Reset()         { *m = ColumnDescriptor{} }
 func (m *ColumnDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnDescriptor) ProtoMessage()    {}
 func (*ColumnDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{2}
+	return fileDescriptor_structured_096aadf1685143bc, []int{2}
 }
 func (m *ColumnDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -750,7 +750,7 @@ func (m *ColumnFamilyDescriptor) Reset()         { *m = ColumnFamilyDescriptor{}
 func (m *ColumnFamilyDescriptor) String() string { return proto.CompactTextString(m) }
 func (*ColumnFamilyDescriptor) ProtoMessage()    {}
 func (*ColumnFamilyDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{3}
+	return fileDescriptor_structured_096aadf1685143bc, []int{3}
 }
 func (m *ColumnFamilyDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -798,7 +798,7 @@ func (m *InterleaveDescriptor) Reset()         { *m = InterleaveDescriptor{} }
 func (m *InterleaveDescriptor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor) ProtoMessage()    {}
 func (*InterleaveDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{4}
+	return fileDescriptor_structured_096aadf1685143bc, []int{4}
 }
 func (m *InterleaveDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -844,7 +844,7 @@ func (m *InterleaveDescriptor_Ancestor) Reset()         { *m = InterleaveDescrip
 func (m *InterleaveDescriptor_Ancestor) String() string { return proto.CompactTextString(m) }
 func (*InterleaveDescriptor_Ancestor) ProtoMessage()    {}
 func (*InterleaveDescriptor_Ancestor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{4, 0}
+	return fileDescriptor_structured_096aadf1685143bc, []int{4, 0}
 }
 func (m *InterleaveDescriptor_Ancestor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -891,7 +891,7 @@ func (m *PartitioningDescriptor) Reset()         { *m = PartitioningDescriptor{}
 func (m *PartitioningDescriptor) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor) ProtoMessage()    {}
 func (*PartitioningDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{5}
+	return fileDescriptor_structured_096aadf1685143bc, []int{5}
 }
 func (m *PartitioningDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -936,7 +936,7 @@ func (m *PartitioningDescriptor_List) Reset()         { *m = PartitioningDescrip
 func (m *PartitioningDescriptor_List) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_List) ProtoMessage()    {}
 func (*PartitioningDescriptor_List) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{5, 0}
+	return fileDescriptor_structured_096aadf1685143bc, []int{5, 0}
 }
 func (m *PartitioningDescriptor_List) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -983,7 +983,7 @@ func (m *PartitioningDescriptor_Range) Reset()         { *m = PartitioningDescri
 func (m *PartitioningDescriptor_Range) String() string { return proto.CompactTextString(m) }
 func (*PartitioningDescriptor_Range) ProtoMessage()    {}
 func (*PartitioningDescriptor_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{5, 1}
+	return fileDescriptor_structured_096aadf1685143bc, []int{5, 1}
 }
 func (m *PartitioningDescriptor_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1117,7 +1117,7 @@ func (m *IndexDescriptor) Reset()         { *m = IndexDescriptor{} }
 func (m *IndexDescriptor) String() string { return proto.CompactTextString(m) }
 func (*IndexDescriptor) ProtoMessage()    {}
 func (*IndexDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{6}
+	return fileDescriptor_structured_096aadf1685143bc, []int{6}
 }
 func (m *IndexDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1170,7 +1170,7 @@ func (m *DescriptorMutation) Reset()         { *m = DescriptorMutation{} }
 func (m *DescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*DescriptorMutation) ProtoMessage()    {}
 func (*DescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{7}
+	return fileDescriptor_structured_096aadf1685143bc, []int{7}
 }
 func (m *DescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1424,7 +1424,7 @@ func (m *TableDescriptor) Reset()         { *m = TableDescriptor{} }
 func (m *TableDescriptor) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor) ProtoMessage()    {}
 func (*TableDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{8}
+	return fileDescriptor_structured_096aadf1685143bc, []int{8}
 }
 func (m *TableDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1676,7 +1676,7 @@ func (m *TableDescriptor_SchemaChangeLease) Reset()         { *m = TableDescript
 func (m *TableDescriptor_SchemaChangeLease) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SchemaChangeLease) ProtoMessage()    {}
 func (*TableDescriptor_SchemaChangeLease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{8, 0}
+	return fileDescriptor_structured_096aadf1685143bc, []int{8, 0}
 }
 func (m *TableDescriptor_SchemaChangeLease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1715,7 +1715,7 @@ func (m *TableDescriptor_CheckConstraint) Reset()         { *m = TableDescriptor
 func (m *TableDescriptor_CheckConstraint) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_CheckConstraint) ProtoMessage()    {}
 func (*TableDescriptor_CheckConstraint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{8, 1}
+	return fileDescriptor_structured_096aadf1685143bc, []int{8, 1}
 }
 func (m *TableDescriptor_CheckConstraint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1820,7 +1820,7 @@ func (m *TableDescriptor_NameInfo) Reset()         { *m = TableDescriptor_NameIn
 func (m *TableDescriptor_NameInfo) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_NameInfo) ProtoMessage()    {}
 func (*TableDescriptor_NameInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{8, 2}
+	return fileDescriptor_structured_096aadf1685143bc, []int{8, 2}
 }
 func (m *TableDescriptor_NameInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1862,7 +1862,7 @@ func (m *TableDescriptor_Reference) Reset()         { *m = TableDescriptor_Refer
 func (m *TableDescriptor_Reference) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Reference) ProtoMessage()    {}
 func (*TableDescriptor_Reference) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{8, 3}
+	return fileDescriptor_structured_096aadf1685143bc, []int{8, 3}
 }
 func (m *TableDescriptor_Reference) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1901,7 +1901,7 @@ func (m *TableDescriptor_MutationJob) Reset()         { *m = TableDescriptor_Mut
 func (m *TableDescriptor_MutationJob) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_MutationJob) ProtoMessage()    {}
 func (*TableDescriptor_MutationJob) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{8, 4}
+	return fileDescriptor_structured_096aadf1685143bc, []int{8, 4}
 }
 func (m *TableDescriptor_MutationJob) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1945,7 +1945,7 @@ func (m *TableDescriptor_SequenceOpts) Reset()         { *m = TableDescriptor_Se
 func (m *TableDescriptor_SequenceOpts) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_SequenceOpts) ProtoMessage()    {}
 func (*TableDescriptor_SequenceOpts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{8, 5}
+	return fileDescriptor_structured_096aadf1685143bc, []int{8, 5}
 }
 func (m *TableDescriptor_SequenceOpts) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1981,7 +1981,7 @@ func (m *TableDescriptor_Replacement) Reset()         { *m = TableDescriptor_Rep
 func (m *TableDescriptor_Replacement) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_Replacement) ProtoMessage()    {}
 func (*TableDescriptor_Replacement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{8, 6}
+	return fileDescriptor_structured_096aadf1685143bc, []int{8, 6}
 }
 func (m *TableDescriptor_Replacement) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2020,7 +2020,7 @@ func (m *TableDescriptor_GCDescriptorMutation) Reset()         { *m = TableDescr
 func (m *TableDescriptor_GCDescriptorMutation) String() string { return proto.CompactTextString(m) }
 func (*TableDescriptor_GCDescriptorMutation) ProtoMessage()    {}
 func (*TableDescriptor_GCDescriptorMutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{8, 7}
+	return fileDescriptor_structured_096aadf1685143bc, []int{8, 7}
 }
 func (m *TableDescriptor_GCDescriptorMutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2061,7 +2061,7 @@ func (m *DatabaseDescriptor) Reset()         { *m = DatabaseDescriptor{} }
 func (m *DatabaseDescriptor) String() string { return proto.CompactTextString(m) }
 func (*DatabaseDescriptor) ProtoMessage()    {}
 func (*DatabaseDescriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{9}
+	return fileDescriptor_structured_096aadf1685143bc, []int{9}
 }
 func (m *DatabaseDescriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2121,7 +2121,7 @@ func (m *Descriptor) Reset()         { *m = Descriptor{} }
 func (m *Descriptor) String() string { return proto.CompactTextString(m) }
 func (*Descriptor) ProtoMessage()    {}
 func (*Descriptor) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structured_5d7c10ae22dcc34f, []int{10}
+	return fileDescriptor_structured_096aadf1685143bc, []int{10}
 }
 func (m *Descriptor) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8923,10 +8923,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/sqlbase/structured.proto", fileDescriptor_structured_5d7c10ae22dcc34f)
+	proto.RegisterFile("sql/sqlbase/structured.proto", fileDescriptor_structured_096aadf1685143bc)
 }
 
-var fileDescriptor_structured_5d7c10ae22dcc34f = []byte{
+var fileDescriptor_structured_096aadf1685143bc = []byte{
 	// 3170 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x59, 0xcd, 0x6f, 0x1b, 0x47,
 	0x96, 0x57, 0x93, 0x4d, 0xb2, 0xf9, 0xf8, 0xd5, 0x2a, 0xcb, 0x0e, 0xcd, 0x38, 0x92, 0xcc, 0xc4,

--- a/pkg/sql/sqlbase/structured.proto
+++ b/pkg/sql/sqlbase/structured.proto
@@ -159,7 +159,7 @@ message ColumnType {
     INTEGER = 1;   // Deprecated, remove post-2.2.
     SMALLINT = 2;  // Deprecated, remove post-2.2.
     BIGINT = 3;    // Deprecated, remove post-2.2.
-    reserved 4;
+    reserved 4;    // Pre-2.1 BIT. Not used any more.
     REAL = 5;
     DOUBLE_PRECISION = 6; // Deprecated, remove post-2.2.
     VARCHAR = 7;


### PR DESCRIPTION
Fixes  #34161.

Prior to CockroachDB 2.1, a BIT column was defined in column
descriptors using column type INT and a non-canonical type width.

When such a pre-2.1 column descriptor is loaded in a post-2.1
cockroachdb cluster (eg during an upgrade) the BIT column is
"upgraded" to INT, which is value-wise compatible.

However the introspection logic was not updated accordingly, and these
pre-2.1 BIT columns would show up in `information_schema.columns`
using mangled values.

Release note (bug fix): The value of
`information_schema.columns.character_maximum_column` is set to NULL
for all integer types, for compatibility with PostgreSQL.

Release note (bug fix): The values reported in
`information_schema.columns` for integer columns created prior to
CockroachDB v2.1 as BIT (back when CockroachDB mis-defined BIT as a
special-case integer) are now fixed and consistent with other integer
types.