### PR TITLE
release-2.1: rpc/nodedialer: check context for cancellation before dialing

### DIFF
--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -78,6 +78,10 @@ func (n *Dialer) Dial(ctx context.Context, nodeID roachpb.NodeID) (_ *grpc.Clien
 	if n == nil || n.resolver == nil {
 		return nil, errors.New("no node dialer configured")
 	}
+	// Don't trip the breaker if we're already canceled.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
 	breaker := n.getBreaker(nodeID)
 
 	if !breaker.Ready() {
@@ -117,6 +121,10 @@ func (n *Dialer) DialInternalClient(
 ) (context.Context, roachpb.InternalClient, error) {
 	if n == nil || n.resolver == nil {
 		return nil, nil, errors.New("no node dialer configured")
+	}
+	// Don't trip the breaker if we're already canceled.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, nil, ctxErr
 	}
 	addr, err := n.resolver(nodeID)
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #34026.

/cc @cockroachdb/release

---

Before this PR we would sometimes call in to the nodedialer with a canceled
context and inadvertently end up recording a failure into the circuit breaker.
This behavior led to some amount of noise when debugging #31361.

Release note: None
