### PR TITLE
release-2.1: sql: prevent crash with invalid placeholders in DEFAULT

### DIFF
--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -78,7 +78,7 @@ func parseValues(tableDesc *sqlbase.TableDescriptor, values string) ([]sqlbase.E
 		for colIdx, expr := range rowTuple {
 			col := tableDesc.Columns[colIdx]
 			typedExpr, err := sqlbase.SanitizeVarFreeExpr(
-				expr, col.Type.ToDatumType(), "avro", semaCtx, evalCtx, false /* allowImpure */)
+				expr, col.Type.ToDatumType(), "avro", semaCtx, false /* allowImpure */)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -85,7 +85,7 @@ func valueEncodePartitionTuple(
 
 		var semaCtx tree.SemaContext
 		typedExpr, err := sqlbase.SanitizeVarFreeExpr(expr, cols[i].Type.ToDatumType(), "partition",
-			&semaCtx, evalCtx, false /* allowImpure */)
+			&semaCtx, false /* allowImpure */)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -237,8 +237,7 @@ func (n *createViewNode) makeViewTableDesc(
 		}
 		// The new types in the CREATE VIEW column specs never use
 		// SERIAL so we need not process SERIAL types here.
-		col, _, _, err := sqlbase.MakeColumnDefDescs(
-			&columnTableDef, &params.p.semaCtx, params.EvalContext())
+		col, _, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, &params.p.semaCtx)
 		if err != nil {
 			return desc, err
 		}

--- a/pkg/sql/execute.go
+++ b/pkg/sql/execute.go
@@ -43,7 +43,7 @@ func fillInPlaceholders(
 
 		typedExpr, err := sqlbase.SanitizeVarFreeExpr(
 			e, ps.TypeHints[idx], "EXECUTE parameter", /* context */
-			&semaCtx, nil /* evalCtx */, true /* allowImpure */)
+			&semaCtx, true /* allowImpure */)
 		if err != nil {
 			return nil, pgerror.NewError(pgerror.CodeWrongObjectTypeError, err.Error())
 		}

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -517,7 +517,6 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 			h.semaCtx.Placeholders.TypeHints[name],
 			"", /* context */
 			&h.semaCtx,
-			&h.evalCtx,
 			true, /* allowImpure */
 		)
 		if err != nil {

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -353,7 +353,7 @@ func (expr *ComparisonExpr) normalize(v *NormalizeVisitor) TypedExpr {
 				expr.Left = left.Left
 				expr.Right = newRightExpr
 				expr.memoizeFn()
-				if !isVar(v.ctx, expr.Left) {
+				if !isVar(v.ctx, expr.Left, true /*allowConstPlaceholders*/) {
 					// Continue as long as the left side of the comparison is not a
 					// variable.
 					continue
@@ -407,7 +407,7 @@ func (expr *ComparisonExpr) normalize(v *NormalizeVisitor) TypedExpr {
 				expr.Left = left.Right
 				expr.Right = newRightExpr
 				expr.memoizeFn()
-				if !isVar(v.ctx, expr.Left) {
+				if !isVar(v.ctx, expr.Left, true /*allowConstPlaceholders*/) {
 					// Continue as long as the left side of the comparison is not a
 					// variable.
 					continue
@@ -806,7 +806,7 @@ var _ Visitor = &isConstVisitor{}
 
 func (v *isConstVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	if v.isConst {
-		if isVar(v.ctx, expr) {
+		if isVar(v.ctx, expr, true /*allowConstPlaceholders*/) {
 			v.isConst = false
 			return false, expr
 		}
@@ -865,7 +865,7 @@ func (v *fastIsConstVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 			// NormalizeVisitor may have wrapped a NULL.
 			return true, expr
 		}
-		if _, ok := expr.(Datum); !ok || isVar(v.ctx, expr) {
+		if _, ok := expr.(Datum); !ok || isVar(v.ctx, expr, true /*allowConstPlaceholders*/) {
 			// If the child expression is not a const Datum, the parent expression is
 			// not constant. Note that all constant literals have already been
 			// normalized to Datum in TypeCheck.
@@ -878,7 +878,7 @@ func (v *fastIsConstVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	// If the parent expression is a variable or impure function, we know that it
 	// is not constant.
 
-	if isVar(v.ctx, expr) {
+	if isVar(v.ctx, expr, true /*allowConstPlaceholders*/) {
 		v.isConst = false
 		return false, expr
 	}
@@ -904,26 +904,38 @@ func (v *fastIsConstVisitor) run(expr Expr) bool {
 }
 
 // isVar returns true if the expression's value can vary during plan
-// execution.
-func isVar(evalCtx *EvalContext, expr Expr) bool {
+// execution. The parameter allowConstPlaceholders should be true
+// in the common case of scalar expressions that will be evaluated
+// in the context of the execution of a prepared query, where the
+// placeholder will have the same value for every row processed.
+// It is set to false for scalar expressions that are not
+// evaluated as part of query execution, eg. DEFAULT expressions.
+func isVar(evalCtx *EvalContext, expr Expr, allowConstPlaceholders bool) bool {
 	switch expr.(type) {
 	case VariableExpr:
 		return true
 	case *Placeholder:
-		return evalCtx != nil && (!evalCtx.HasPlaceholders() || evalCtx.Placeholders.IsUnresolvedPlaceholder(expr))
+		if allowConstPlaceholders {
+			if evalCtx == nil || !evalCtx.HasPlaceholders() {
+				// The placeholder cannot be resolved -- it is variable.
+				return true
+			}
+			return evalCtx.Placeholders.IsUnresolvedPlaceholder(expr)
+		}
+		// Placeholders considered always variable.
+		return true
 	}
 	return false
 }
 
 type containsVarsVisitor struct {
-	evalCtx      *EvalContext
 	containsVars bool
 }
 
 var _ Visitor = &containsVarsVisitor{}
 
 func (v *containsVarsVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
-	if !v.containsVars && isVar(v.evalCtx, expr) {
+	if !v.containsVars && isVar(nil, expr, false /*allowConstPlaceholders*/) {
 		v.containsVars = true
 	}
 	if v.containsVars {
@@ -936,8 +948,8 @@ func (*containsVarsVisitor) VisitPost(expr Expr) Expr { return expr }
 
 // ContainsVars returns true if the expression contains any variables.
 // (variables = sub-expressions, placeholders, indexed vars, etc.)
-func ContainsVars(evalCtx *EvalContext, expr Expr) bool {
-	v := containsVarsVisitor{evalCtx: evalCtx, containsVars: false}
+func ContainsVars(expr Expr) bool {
+	v := containsVarsVisitor{containsVars: false}
 	WalkExprConst(&v, expr)
 	return v.containsVars
 }

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -25,6 +25,33 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
+func TestContainsVars(t *testing.T) {
+	testData := []struct {
+		expr     string
+		expected bool
+	}{
+		{`123`, false},
+		{`123+123`, false},
+		{`$1`, true},
+		{`123+$1`, true},
+		{`@1`, true},
+		{`123+@1`, true},
+	}
+
+	for _, d := range testData {
+		t.Run(d.expr, func(t *testing.T) {
+			expr, err := parser.ParseExpr(d.expr)
+			if err != nil {
+				t.Fatalf("%s: %v", d.expr, err)
+			}
+			res := tree.ContainsVars(expr)
+			if res != d.expected {
+				t.Fatalf("%s: expected %v, got %v", d.expr, d.expected, res)
+			}
+		})
+	}
+}
+
 func TestNormalizeExpr(t *testing.T) {
 	defer tree.MockNameTypes(map[string]types.T{
 		"a":  types.Int,

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
@@ -293,20 +294,19 @@ func assignSequenceOptions(
 // e.g. `DEFAULT nextval('my_sequence')`.
 // The passed-in column descriptor is mutated, and the modified sequence descriptors are returned.
 func maybeAddSequenceDependencies(
+	ctx context.Context,
 	sc SchemaResolver,
 	tableDesc *sqlbase.TableDescriptor,
 	col *sqlbase.ColumnDescriptor,
 	expr tree.TypedExpr,
-	evalCtx *tree.EvalContext,
 ) ([]*MutableTableDescriptor, error) {
-	ctx := evalCtx.Ctx()
 	seqNames, err := getUsedSequenceNames(expr)
 	if err != nil {
 		return nil, err
 	}
 	var seqDescs []*sqlbase.TableDescriptor
 	for _, seqName := range seqNames {
-		parsedSeqName, err := evalCtx.Sequence.ParseQualifiedTableName(ctx, seqName)
+		parsedSeqName, err := parser.ParseTableName(seqName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -31,14 +31,9 @@ import (
 // type and contains no variable expressions. It returns the type-checked and
 // constant-folded expression.
 func SanitizeVarFreeExpr(
-	expr tree.Expr,
-	expectedType types.T,
-	context string,
-	semaCtx *tree.SemaContext,
-	evalCtx *tree.EvalContext,
-	allowImpure bool,
+	expr tree.Expr, expectedType types.T, context string, semaCtx *tree.SemaContext, allowImpure bool,
 ) (tree.TypedExpr, error) {
-	if tree.ContainsVars(evalCtx, expr) {
+	if tree.ContainsVars(expr) {
 		return nil, pgerror.NewErrorf(pgerror.CodeSyntaxError,
 			"variable sub-expressions are not allowed in %s", context)
 	}
@@ -79,13 +74,13 @@ func SanitizeVarFreeExpr(
 // SERIAL type and replace it with a suitable integer type and default
 // expression.
 //
-// semaCtx and evalCtx can be nil if no default expression is used for the
+// semaCtx can be nil if no default expression is used for the
 // column.
 //
 // The DEFAULT expression is returned in TypedExpr form for analysis (e.g. recording
 // sequence dependencies).
 func MakeColumnDefDescs(
-	d *tree.ColumnTableDef, semaCtx *tree.SemaContext, evalCtx *tree.EvalContext,
+	d *tree.ColumnTableDef, semaCtx *tree.SemaContext,
 ) (*ColumnDescriptor, *IndexDescriptor, tree.TypedExpr, error) {
 	if _, ok := d.Type.(*coltypes.TSerial); ok {
 		// To the reader of this code: if control arrives here, this means
@@ -128,7 +123,7 @@ func MakeColumnDefDescs(
 		// Verify the default expression type is compatible with the column type
 		// and does not contain invalid functions.
 		if typedExpr, err = SanitizeVarFreeExpr(
-			d.DefaultExpr.Expr, colDatumType, "DEFAULT", semaCtx, evalCtx, true, /* allowImpure */
+			d.DefaultExpr.Expr, colDatumType, "DEFAULT", semaCtx, true, /* allowImpure */
 		); err != nil {
 			return nil, nil, nil, err
 		}


### PR DESCRIPTION
Backport 1/2 commits from #34134.

/cc @cockroachdb/release

---

Informs #34127. (and fixes the user-facing crash)
Informs #33724.

