### PR TITLE
sql: add disk backed indexed row container

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -336,7 +335,7 @@ func (h *hashJoiner) build() (hashJoinerState, sqlbase.EncDatumRow, *ProducerMet
 		if err := h.rows[side].AddRow(h.Ctx, row); err != nil {
 			// If this error is a memory limit error, move to hjConsumingStoredSide.
 			h.storedSide = side
-			if pgErr, ok := pgerror.GetPGCause(err); ok && pgErr.Code == pgerror.CodeOutOfMemoryError {
+			if sqlbase.IsOutOfMemoryError(err) {
 				if !h.useTempStorage {
 					err = errors.Wrap(err, "error while attempting hashJoiner disk spill: temp storage disabled")
 				} else {

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"unsafe"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
@@ -846,7 +845,7 @@ func (h *HashDiskBackedRowContainer) ReserveMarkMemoryMaybe(ctx context.Context)
 // memory error. Returns whether the HashDiskBackedRowContainer spilled to disk
 // and an error if one occurred while doing so.
 func (h *HashDiskBackedRowContainer) spillIfMemErr(ctx context.Context, err error) (bool, error) {
-	if pgErr, ok := pgerror.GetPGCause(err); !(ok && pgErr.Code == pgerror.CodeOutOfMemoryError) {
+	if !sqlbase.IsOutOfMemoryError(err) {
 		return false, nil
 	}
 	if spillErr := h.spillToDisk(ctx); spillErr != nil {

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -17,6 +17,8 @@ package rowcontainer
 import (
 	"container/heap"
 	"context"
+	"fmt"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -24,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/ring"
 	"github.com/pkg/errors"
 )
 
@@ -32,7 +35,9 @@ import (
 type SortableRowContainer interface {
 	Len() int
 	AddRow(context.Context, sqlbase.EncDatumRow) error
-	// Sort sorts the rows according to an ordering specified at initialization.
+	// Sort sorts the rows according to the current ordering (the one set either
+	// at initialization or by the last call of Reorder() - if the container is
+	// ReorderableRowContainer).
 	Sort(context.Context)
 	// NewIterator returns a RowIterator that can be used to iterate over
 	// the rows.
@@ -58,6 +63,17 @@ type SortableRowContainer interface {
 
 	// Close frees up resources held by the SortableRowContainer.
 	Close(context.Context)
+}
+
+// ReorderableRowContainer is a SortableRowContainer that can change the
+// ordering on which the rows are sorted.
+type ReorderableRowContainer interface {
+	SortableRowContainer
+
+	// Reorder changes the ordering on which the rows are sorted. In order for
+	// new ordering to take effect, Sort() must be called. It returns an error if
+	// it occurs.
+	Reorder(context.Context, sqlbase.ColumnOrdering) error
 }
 
 // RowIterator is a simple iterator used to iterate over sqlbase.EncDatumRows.
@@ -94,9 +110,9 @@ type RowIterator interface {
 	Close()
 }
 
-// MemRowContainer is the wrapper around rowcontainer.RowContainer that provides more
-// functionality, especially around converting to/from EncDatumRows and
-// facilitating sorting.
+// MemRowContainer is the wrapper around rowcontainer.RowContainer that
+// provides more functionality, especially around converting to/from
+// EncDatumRows and facilitating sorting.
 type MemRowContainer struct {
 	RowContainer
 	types         []sqlbase.ColumnType
@@ -184,6 +200,13 @@ func (mc *MemRowContainer) Sort(ctx context.Context) {
 	mc.invertSorting = false
 	cancelChecker := sqlbase.NewCancelChecker(ctx)
 	sqlbase.Sort(mc, cancelChecker)
+}
+
+// Reorder implements ReorderableRowContainer. We don't need to create a new
+// MemRowContainer and can just change the ordering on-the-fly.
+func (mc *MemRowContainer) Reorder(_ context.Context, ordering sqlbase.ColumnOrdering) error {
+	mc.ordering = ordering
+	return nil
 }
 
 // Push is part of heap.Interface.
@@ -299,17 +322,17 @@ func (i memRowFinalIterator) Row() (sqlbase.EncDatumRow, error) {
 // Close implements the RowIterator interface.
 func (i memRowFinalIterator) Close() {}
 
-// DiskBackedRowContainer is a SortableRowContainer that uses a MemRowContainer
-// to store rows and spills back to disk automatically if memory usage exceeds a
-// given budget.
+// DiskBackedRowContainer is a ReorderableRowContainer that uses a
+// MemRowContainer to store rows and spills back to disk automatically if
+// memory usage exceeds a given budget.
 type DiskBackedRowContainer struct {
-	// src is the current SortableRowContainer that is being used to store rows.
-	// All the SortableRowContainer methods are redefined rather than delegating
-	// to an embedded struct because of how defer works:
+	// src is the current ReorderableRowContainer that is being used to store
+	// rows. All the ReorderableRowContainer methods are redefined rather than
+	// delegated to an embedded struct because of how defer works:
 	// 	rc.Init(...)
 	//	defer rc.Close(ctx)
 	// The Close will call MemRowContainer.Close(ctx) even after spilling to disk.
-	src SortableRowContainer
+	src ReorderableRowContainer
 
 	mrc *MemRowContainer
 	drc *DiskRowContainer
@@ -379,6 +402,13 @@ func (f *DiskBackedRowContainer) AddRow(ctx context.Context, row sqlbase.EncDatu
 // Sort is part of the SortableRowContainer interface.
 func (f *DiskBackedRowContainer) Sort(ctx context.Context) {
 	f.src.Sort(ctx)
+}
+
+// Reorder implements ReorderableRowContainer.
+func (f *DiskBackedRowContainer) Reorder(
+	ctx context.Context, ordering sqlbase.ColumnOrdering,
+) error {
+	return f.src.Reorder(ctx, ordering)
 }
 
 // InitTopK is part of the SortableRowContainer interface.
@@ -477,3 +507,303 @@ func (f *DiskBackedRowContainer) spillToDisk(ctx context.Context) error {
 	f.spilled = true
 	return nil
 }
+
+// DiskBackedIndexedRowContainer is a wrapper around DiskBackedRowContainer
+// that adds an index to each row added in the order of addition of those rows
+// by storing an extra int column at the end of each row. These indices can be
+// thought of as ordinals of the rows.
+//
+// Note: although DiskRowContainer appends unique rowIDs to the keys that the
+// rows are put at, MemRowContainer doesn't do something like that, so the code
+// that utilizes internal rowIDs of DiskRowContainer ends up being worse than
+// having this specialized container.
+type DiskBackedIndexedRowContainer struct {
+	*DiskBackedRowContainer
+
+	scratchEncRow sqlbase.EncDatumRow
+	storedTypes   []sqlbase.ColumnType
+	datumAlloc    sqlbase.DatumAlloc
+	rowAlloc      sqlbase.EncDatumRowAlloc
+	idx           uint64 // the index of the next row to be added into the container
+
+	// These fields are for optimizations when container spilled to disk.
+	diskRowIter RowIterator
+	idxRowIter  int
+	// nextPosToCache is the index of the row to be cached next. If it is greater
+	// than 0, the cache contains all rows with position in the range
+	// [firstCachedRowPos, nextPosToCache).
+	firstCachedRowPos int
+	nextPosToCache    int
+	indexedRowsCache  ring.Buffer // the cache of up to maxIndexedRowsCacheSize contiguous rows
+	cacheMemAcc       mon.BoundAccount
+}
+
+// MakeDiskBackedIndexedRowContainer creates a DiskBackedIndexedRowContainer
+// with the given engine as the underlying store that rows are stored on when
+// it spills to disk.
+// Arguments:
+//  - ordering is the output ordering; the order in which rows should be sorted.
+//  - types is the schema of rows that will be added to this container.
+//  - evalCtx defines the context in which to evaluate comparisons, only used
+//    when storing rows in memory.
+//  - engine is the underlying store that rows are stored on when the container
+//    spills to disk.
+//  - memoryMonitor is used to monitor this container's memory usage.
+//  - diskMonitor is used to monitor this container's disk usage.
+//  - rowCapacity (if not 0) specifies the number of rows in-memory container
+//    should be preallocated for.
+func MakeDiskBackedIndexedRowContainer(
+	ordering sqlbase.ColumnOrdering,
+	types []sqlbase.ColumnType,
+	evalCtx *tree.EvalContext,
+	engine diskmap.Factory,
+	memoryMonitor *mon.BytesMonitor,
+	diskMonitor *mon.BytesMonitor,
+	rowCapacity int,
+) *DiskBackedIndexedRowContainer {
+	d := DiskBackedIndexedRowContainer{}
+
+	// We will be storing an index of each row as the last INT column.
+	d.storedTypes = make([]sqlbase.ColumnType, len(types)+1)
+	copy(d.storedTypes, types)
+	d.storedTypes[len(d.storedTypes)-1] = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
+	d.scratchEncRow = make(sqlbase.EncDatumRow, len(d.storedTypes))
+	d.DiskBackedRowContainer = &DiskBackedRowContainer{}
+	d.DiskBackedRowContainer.Init(ordering, d.storedTypes, evalCtx, engine, memoryMonitor, diskMonitor, rowCapacity)
+	d.cacheMemAcc = memoryMonitor.MakeBoundAccount()
+	return &d
+}
+
+// AddRow implements SortableRowContainer.
+func (f *DiskBackedIndexedRowContainer) AddRow(ctx context.Context, row sqlbase.EncDatumRow) error {
+	copy(f.scratchEncRow, row)
+	f.scratchEncRow[len(f.scratchEncRow)-1] = sqlbase.DatumToEncDatum(
+		sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT},
+		tree.NewDInt(tree.DInt(f.idx)),
+	)
+	f.idx++
+	return f.DiskBackedRowContainer.AddRow(ctx, f.scratchEncRow)
+}
+
+// Reorder implements ReorderableRowContainer.
+func (f *DiskBackedIndexedRowContainer) Reorder(
+	ctx context.Context, ordering sqlbase.ColumnOrdering,
+) error {
+	if err := f.DiskBackedRowContainer.Reorder(ctx, ordering); err != nil {
+		return err
+	}
+	f.resetCache(ctx)
+	f.resetIterator()
+	return nil
+}
+
+// resetCache resets cache-related fields allowing for reusing the underlying
+// already allocated memory. Since all rows in the cache are flushed, it also
+// clears the corresponding memory account.
+func (f *DiskBackedIndexedRowContainer) resetCache(ctx context.Context) {
+	f.firstCachedRowPos = 0
+	f.nextPosToCache = 0
+	f.indexedRowsCache.Reset()
+	f.cacheMemAcc.Clear(ctx)
+}
+
+func (f *DiskBackedIndexedRowContainer) resetIterator() {
+	if f.diskRowIter != nil {
+		f.diskRowIter.Close()
+		f.diskRowIter = nil
+		f.idxRowIter = 0
+	}
+}
+
+// UnsafeReset resets the underlying container (if it is using disk, it will be
+// reset to using memory).
+func (f *DiskBackedIndexedRowContainer) UnsafeReset(ctx context.Context) error {
+	f.resetCache(ctx)
+	f.resetIterator()
+	f.idx = 0
+	return f.DiskBackedRowContainer.UnsafeReset(ctx)
+}
+
+// Close implements SortableRowContainer.
+func (f *DiskBackedIndexedRowContainer) Close(ctx context.Context) {
+	if f.diskRowIter != nil {
+		f.diskRowIter.Close()
+	}
+	f.cacheMemAcc.Close(ctx)
+	f.DiskBackedRowContainer.Close(ctx)
+}
+
+const maxIndexedRowsCacheSize = 4096
+
+// GetRow implements tree.IndexedRows.
+//
+// Getting a row by index is fast from an in-memory row container but is a lot
+// slower from a disk-backed one. In order to mitigate the impact we add
+// optimizations of maintaining a cache of tree.IndexedRow's and storing a disk
+// iterator along with the index of the row it currently points at.
+func (f *DiskBackedIndexedRowContainer) GetRow(
+	ctx context.Context, pos int,
+) (tree.IndexedRow, error) {
+	var rowWithIdx sqlbase.EncDatumRow
+	var err error
+	if f.UsingDisk() {
+		// The cache contains all contiguous rows up to the biggest pos requested
+		// so far (even if the rows were not requested explicitly). For example,
+		// if the cache is empty and the request comes for a row at pos 3, the
+		// cache will contain 4 rows at positions 0, 1, 2, and 3.
+		if pos >= f.firstCachedRowPos && pos < f.nextPosToCache {
+			requestedRowCachePos := pos - f.firstCachedRowPos
+			return f.indexedRowsCache.Get(requestedRowCachePos).(tree.IndexedRow), nil
+		}
+		if f.diskRowIter == nil {
+			f.diskRowIter = f.DiskBackedRowContainer.drc.NewIterator(ctx)
+			f.diskRowIter.Rewind()
+		}
+		if f.idxRowIter > pos {
+			// The iterator has been advanced further than we need, so we need to
+			// start iterating from the beginning.
+			log.Infof(ctx, "rewinding: cache contains indices [%d, %d) but index %d requested", f.firstCachedRowPos, f.nextPosToCache, pos)
+			f.idxRowIter = 0
+			f.diskRowIter.Rewind()
+			f.resetCache(ctx)
+			if pos-maxIndexedRowsCacheSize > f.nextPosToCache {
+				// The requested pos is further away from the beginning of the
+				// container for the cache to hold all the rows up to pos, so we need
+				// to skip exactly pos-maxIndexedRowsCacheSize of them.
+				f.nextPosToCache = pos - maxIndexedRowsCacheSize
+				f.firstCachedRowPos = f.nextPosToCache
+			}
+		}
+		for ; ; f.diskRowIter.Next() {
+			if ok, err := f.diskRowIter.Valid(); err != nil {
+				return nil, err
+			} else if !ok {
+				return nil, errors.Errorf("row at pos %d not found", pos)
+			}
+			if f.idxRowIter == f.nextPosToCache {
+				rowWithIdx, err = f.diskRowIter.Row()
+				if err != nil {
+					return nil, err
+				}
+				for i := range rowWithIdx {
+					if err := rowWithIdx[i].EnsureDecoded(&f.storedTypes[i], &f.datumAlloc); err != nil {
+						return nil, err
+					}
+				}
+				row, rowIdx := rowWithIdx[:len(rowWithIdx)-1], rowWithIdx[len(rowWithIdx)-1].Datum
+				if idx, ok := rowIdx.(*tree.DInt); ok {
+					if f.indexedRowsCache.Len() == maxIndexedRowsCacheSize {
+						// The cache size is capped at maxIndexedRowsCacheSize, so we first
+						// remove the row with the smallest pos and advance
+						// f.firstCachedRowPos.
+						usage := sizeOfInt + int64(f.indexedRowsCache.GetFirst().(IndexedRow).Row.Size())
+						// TODO(yuzefovich): extend ring.Buffer to allow for reusing the
+						// allocated memory instead of allocating new one for every row.
+						f.indexedRowsCache.RemoveFirst()
+						// TODO(yuzefovich): investigate whether the pattern of growing and
+						// shrinking the memory account can be optimized.
+						f.cacheMemAcc.Shrink(ctx, usage)
+						f.firstCachedRowPos++
+					}
+					// We choose to ignore minor details like IndexedRow overhead and
+					// the cache overhead.
+					usage := sizeOfInt + int64(row.Size())
+					if err := f.cacheMemAcc.Grow(ctx, usage); err != nil {
+						return nil, err
+					}
+					// We actually need to copy the row into memory.
+					ir := IndexedRow{int(*idx), f.rowAlloc.CopyRow(row)}
+					f.indexedRowsCache.AddLast(ir)
+					f.nextPosToCache++
+				} else {
+					return nil, errors.Errorf("unexpected last column type: should be DInt but found %T", idx)
+				}
+				if f.idxRowIter == pos {
+					return f.indexedRowsCache.GetLast().(tree.IndexedRow), nil
+				}
+			}
+			f.idxRowIter++
+		}
+	}
+	rowWithIdx = f.DiskBackedRowContainer.mrc.EncRow(pos)
+	row, rowIdx := rowWithIdx[:len(rowWithIdx)-1], rowWithIdx[len(rowWithIdx)-1].Datum
+	if idx, ok := rowIdx.(*tree.DInt); ok {
+		return IndexedRow{int(*idx), row}, nil
+	}
+	return nil, errors.Errorf("unexpected last column type: should be DInt but found %T", rowIdx)
+}
+
+// getRowWithoutCache returns the row at requested position without using the
+// cache. It utilizes the same disk row iterator along multiple consequent
+// calls and rewinds the iterator only when it has been advanced further than
+// the position requested.
+//
+// NOTE: this method should only be used for testing purposes.
+func (f *DiskBackedIndexedRowContainer) getRowWithoutCache(
+	ctx context.Context, pos int,
+) tree.IndexedRow {
+	if !f.UsingDisk() {
+		panic(errors.Errorf("getRowWithoutCache is called when the container is using memory"))
+	}
+	if f.diskRowIter == nil {
+		f.diskRowIter = f.DiskBackedRowContainer.drc.NewIterator(ctx)
+		f.diskRowIter.Rewind()
+	}
+	if f.idxRowIter > pos {
+		// The iterator has been advanced further than we need, so we need to
+		// start iterating from the beginning.
+		f.idxRowIter = 0
+		f.diskRowIter.Rewind()
+	}
+	for ; ; f.diskRowIter.Next() {
+		if ok, err := f.diskRowIter.Valid(); err != nil {
+			panic(err)
+		} else if !ok {
+			panic(fmt.Sprintf("row at pos %d not found", pos))
+		}
+		if f.idxRowIter == pos {
+			rowWithIdx, err := f.diskRowIter.Row()
+			if err != nil {
+				panic(err)
+			}
+			for i := range rowWithIdx {
+				if err := rowWithIdx[i].EnsureDecoded(&f.storedTypes[i], &f.datumAlloc); err != nil {
+					panic(err)
+				}
+			}
+			row, rowIdx := rowWithIdx[:len(rowWithIdx)-1], rowWithIdx[len(rowWithIdx)-1].Datum
+			if idx, ok := rowIdx.(*tree.DInt); ok {
+				return IndexedRow{int(*idx), f.rowAlloc.CopyRow(row)}
+			}
+			panic(errors.Errorf("unexpected last column type: should be DInt but found %T", rowIdx))
+		}
+		f.idxRowIter++
+	}
+}
+
+// IndexedRow is a row with a corresponding index.
+type IndexedRow struct {
+	Idx int
+	Row sqlbase.EncDatumRow
+}
+
+// GetIdx implements tree.IndexedRow interface.
+func (ir IndexedRow) GetIdx() int {
+	return ir.Idx
+}
+
+// GetDatum implements tree.IndexedRow interface.
+func (ir IndexedRow) GetDatum(colIdx int) (tree.Datum, error) {
+	return ir.Row[colIdx].Datum, nil
+}
+
+// GetDatums implements tree.IndexedRow interface.
+func (ir IndexedRow) GetDatums(startColIdx, endColIdx int) (tree.Datums, error) {
+	datums := make(tree.Datums, 0, endColIdx-startColIdx)
+	for idx := startColIdx; idx < endColIdx; idx++ {
+		datums = append(datums, ir.Row[idx].Datum)
+	}
+	return datums, nil
+}
+
+const sizeOfInt = int64(unsafe.Sizeof(int(0)))

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -214,6 +214,10 @@ func IsQueryCanceledError(err error) bool {
 	return errHasCode(err, pgerror.CodeQueryCanceledError)
 }
 
+// IsOutOfMemoryError checks whether this is an out of memory error.
+func IsOutOfMemoryError(err error) bool {
+	return errHasCode(err, pgerror.CodeOutOfMemoryError)
+}
 func errHasCode(err error, code ...string) bool {
 	if pgErr, ok := pgerror.GetPGCause(err); ok {
 		for _, c := range code {


### PR DESCRIPTION
Adds a wrapper around diskBackedRowContainer that stores an index
of the row as the last column of each row. These indices are needed
when computing window functions since each window function can have
its own ordering, and the indices are the way to "compose" the output
row.

Addresses: #32226.

Having the cache when we spill to disk makes huge difference:
```
BenchmarkDiskBackedIndexedRowContainer/InMemory-12             20000000           101 ns/op      78.71 MB/s
BenchmarkDiskBackedIndexedRowContainer/OnDiskWithCache-12       5000000           361 ns/op      22.12 MB/s
BenchmarkDiskBackedIndexedRowContainer/OnDiskWithoutCache-12               500000         39870 ns/op       0.20 MB/s
```

Release note: None