### PR TITLE
release-2.1: gossip: avoid removing nodes that get a new address

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -834,30 +834,6 @@ func (g *Gossip) updateNodeAddress(key string, content roachpb.Value) {
 	// resolvers go offline.
 	g.maybeAddResolverLocked(desc.Address)
 
-	// If the new node's address conflicts with another node's address, then it
-	// must be the case that the new node has replaced the previous one. Remove
-	// it from our set of tracked descriptors to ensure we don't attempt to
-	// connect to its previous identity (as came up in issue #10266).
-	oldNodeID, ok := g.bootstrapAddrs[desc.Address]
-	if ok && oldNodeID != unknownNodeID && oldNodeID != desc.NodeID {
-		log.Infof(ctx, "removing n%d which was at same address (%s) as new node %v",
-			oldNodeID, desc.Address, desc)
-		g.removeNodeDescriptorLocked(oldNodeID)
-
-		// Deleting the local copy isn't enough to remove the node from the gossip
-		// network. We also have to clear it out in the infoStore by overwriting
-		// it with an empty descriptor, which can be represented as just an empty
-		// byte array due to how protocol buffers are serialized.
-		// Calling addInfoLocked here is somewhat recursive since
-		// updateNodeAddress is typically called in response to the infoStore
-		// being updated but won't lead to deadlock because it's called
-		// asynchronously.
-		key := MakeNodeIDKey(oldNodeID)
-		var emptyProto []byte
-		if err := g.addInfoLocked(key, emptyProto, NodeDescriptorTTL); err != nil {
-			log.Errorf(ctx, "failed to empty node descriptor for n%d: %s", oldNodeID, err)
-		}
-	}
 	// Add new address (if it's not already there) to bootstrap info and
 	// persist if possible.
 	added := g.maybeAddBootstrapAddressLocked(desc.Address, desc.NodeID)

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -61,55 +61,6 @@ func TestGossipInfoStore(t *testing.T) {
 	}
 }
 
-// TestGossipOverwriteNode verifies that if a new node is added with the same
-// address as an old node, that old node is removed from the cluster.
-func TestGossipOverwriteNode(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	rpcContext := newInsecureRPCContext(stopper)
-	g := NewTest(1, rpcContext, rpc.NewServer(rpcContext), stopper, metric.NewRegistry())
-	node1 := &roachpb.NodeDescriptor{NodeID: 1, Address: util.MakeUnresolvedAddr("tcp", "1.1.1.1:1")}
-	node2 := &roachpb.NodeDescriptor{NodeID: 2, Address: util.MakeUnresolvedAddr("tcp", "2.2.2.2:2")}
-	if err := g.SetNodeDescriptor(node1); err != nil {
-		t.Fatal(err)
-	}
-	if err := g.SetNodeDescriptor(node2); err != nil {
-		t.Fatal(err)
-	}
-	if val, err := g.GetNodeDescriptor(node1.NodeID); err != nil {
-		t.Error(err)
-	} else if val.NodeID != node1.NodeID {
-		t.Errorf("expected n%d, got %+v", node1.NodeID, val)
-	}
-	if val, err := g.GetNodeDescriptor(node2.NodeID); err != nil {
-		t.Error(err)
-	} else if val.NodeID != node2.NodeID {
-		t.Errorf("expected n%d, got %+v", node2.NodeID, val)
-	}
-
-	// Give node3 the same address as node1, which should cause node1 to be
-	// removed from the cluster.
-	node3 := &roachpb.NodeDescriptor{NodeID: 3, Address: node1.Address}
-	if err := g.SetNodeDescriptor(node3); err != nil {
-		t.Fatal(err)
-	}
-	if val, err := g.GetNodeDescriptor(node3.NodeID); err != nil {
-		t.Error(err)
-	} else if val.NodeID != node3.NodeID {
-		t.Errorf("expected n%d, got %+v", node3.NodeID, val)
-	}
-
-	testutils.SucceedsSoon(t, func() error {
-		expectedErr := `n\d+ has been removed from the cluster`
-		if val, err := g.GetNodeDescriptor(node1.NodeID); !testutils.IsError(err, expectedErr) {
-			return fmt.Errorf("expected error %q fetching n%d; got error %v and node %+v",
-				expectedErr, node1.NodeID, err, val)
-		}
-		return nil
-	})
-}
-
 // TestGossipMoveNode verifies that if a node is moved to a new address, it
 // gets properly updated in gossip (including that any other node that was
 // previously at that address gets removed from the cluster).
@@ -138,8 +89,7 @@ func TestGossipMoveNode(t *testing.T) {
 		}
 	}
 
-	// Move node 2 to the address of node 3, which should cause node 3 to be
-	// removed from the cluster.
+	// Move node 2 to the address of node 3.
 	movedNode := nodes[1]
 	replacedNode := nodes[2]
 	movedNode.Address = replacedNode.Address
@@ -152,11 +102,6 @@ func TestGossipMoveNode(t *testing.T) {
 			return err
 		} else if !proto.Equal(movedNode, val) {
 			return fmt.Errorf("expected node %+v, got %+v", movedNode, val)
-		}
-		expectedErr := `n\d+ has been removed from the cluster`
-		if val, err := g.GetNodeDescriptor(replacedNode.NodeID); !testutils.IsError(err, expectedErr) {
-			return fmt.Errorf("expected error %q fetching n%d; got error %v and node %+v",
-				expectedErr, replacedNode.NodeID, err, val)
 		}
 		return nil
 	})


### PR DESCRIPTION
Backport 1/1 commits from #34155.

/cc @cockroachdb/release

---

Fixes #34120.

K8s deployments make it possible for a node to get restarted using an
address previously attributed to another node, *while the other node
is still alive* (for example, a re-shuffling of node addresses during
a rolling restart).

Prior to this patch, the gossip code was assuming that if a node
starts with an address previously attributed to another node, that
other node must be dead, and thus was (incorrectly) *erasing* that
node's entry, thereby removing it from the cluster.

This scenario can be reproduced like this:

- start 4 nodes n1-n4
- stop n3 and n4
- restart n3 with n4's address

Prior to this patch, this scenario would yield "n4 removed from the
cluster" in other nodes, and n3 was not restarting properly. With the
patch, there is a period of time (until
`server.time_until_store_dead`) during which Raft is confused to not
find n4 at n3's address, but where the cluster otherwise operates
normally. After the store time outs, n4 is properly marked as down and
the log spam stops.

Release note (bug fix): CockroachDB now enables re-starting a node at
an address previously allocated for another node.
