### PR TITLE
opt: change catalog interface to not mutate table names in-place

### DIFF
--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -50,17 +50,29 @@ type SchemaName = tree.TableNamePrefix
 // Catalog is an interface to a database catalog, exposing only the information
 // needed by the query optimizer.
 type Catalog interface {
-	// ResolveSchema locates a schema with the given name. If no such schema
-	// exists, then ResolveSchema returns an error. As a side effect, the name
-	// parameter is updated to be fully qualified if it was not before (i.e. to
-	// include catalog and schema names).
-	ResolveSchema(ctx context.Context, name *SchemaName) (Schema, error)
+	// ResolveSchema locates a schema with the given name and returns it along
+	// with the resolved SchemaName (which has all components filled in).
+	//
+	// The resolved SchemaName is the same with the resulting Schema.Name() except
+	// that it has the ExplicitCatalog/ExplicitSchema flags set to correspond to
+	// the input name. Its use is mainly for cosmetic purposes.
+	//
+	// If no such schema exists, then ResolveSchema returns an error.
+	ResolveSchema(ctx context.Context, name *SchemaName) (Schema, SchemaName, error)
 
-	// ResolveDataSource locates a data source with the given name and returns it.
-	// If no such data source exists, then ResolveDataSource returns an error. As
-	// a side effect, the name parameter is updated to be fully qualified if it
-	// was not before (i.e. to include catalog and schema names).
-	ResolveDataSource(ctx context.Context, name *DataSourceName) (DataSource, error)
+	// ResolveDataSource locates a data source with the given name and returns it
+	// along with the resolved DataSourceName.
+	//
+	// The resolved DataSourceName is the same with the resulting
+	// DataSource.Name() except that it has the ExplicitCatalog/ExplicitSchema
+	// flags set to correspond to the input name. Its use is mainly for cosmetic
+	// purposes. For example: the input name might be "t". The fully qualified
+	// DataSource.Name() would be "currentdb.public.t"; the returned
+	// DataSourceName would have the same fields but would still be formatted as
+	// "t".
+	//
+	// If no such data source exists, then ResolveDataSource returns an error.
+	ResolveDataSource(ctx context.Context, name *DataSourceName) (DataSource, DataSourceName, error)
 
 	// ResolveDataSourceByID is similar to ResolveDataSource, except that it
 	// locates a data source by its StableID. See the comment for StableID for

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -149,7 +149,7 @@ func (md *Metadata) CheckDependencies(
 		var toCheck cat.Object
 		if old, ok := dep.(cat.DataSource); ok {
 			// Resolve data source object.
-			new, err := catalog.ResolveDataSource(ctx, old.Name())
+			new, _, err := catalog.ResolveDataSource(ctx, old.Name())
 			if err != nil {
 				return false, err
 			}
@@ -159,7 +159,7 @@ func (md *Metadata) CheckDependencies(
 			toCheck = new
 		} else if old, ok := dep.(cat.Schema); ok {
 			// Resolve schema object.
-			new, err := catalog.ResolveSchema(ctx, old.Name())
+			new, _, err := catalog.ResolveSchema(ctx, old.Name())
 			if err != nil {
 				return false, err
 			}

--- a/pkg/sql/opt/optbuilder/create_table.go
+++ b/pkg/sql/opt/optbuilder/create_table.go
@@ -29,7 +29,10 @@ import (
 // buildCreateTable constructs a CreateTable operator based on the CREATE TABLE
 // statement.
 func (b *Builder) buildCreateTable(ct *tree.CreateTable, inScope *scope) (outScope *scope) {
-	sch := b.resolveSchemaForCreate(&ct.Table)
+	sch, resName := b.resolveSchemaForCreate(&ct.Table)
+	// TODO(radu): we are modifying the AST in-place here. We should be storing
+	// the resolved name separately.
+	ct.Table.TableNamePrefix = resName
 	schID := b.factory.Metadata().AddSchema(sch)
 
 	// HoistConstraints normalizes any column constraints in the CreateTable AST

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -58,7 +58,10 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 	tn, alias := getAliasedTableName(del.Table)
 
 	// Find which table we're working on, check the permissions.
-	tab := b.resolveTable(tn, privilege.DELETE)
+	tab, resName := b.resolveTable(tn, privilege.DELETE)
+	if alias == nil {
+		alias = &resName
+	}
 
 	// Check Select permission as well, since existing values must be read.
 	b.checkPrivilege(tab, privilege.SELECT)

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -155,7 +155,10 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 	tn, alias := getAliasedTableName(ins.Table)
 
 	// Find which table we're working on, check the permissions.
-	tab := b.resolveTable(tn, privilege.INSERT)
+	tab, resName := b.resolveTable(tn, privilege.INSERT)
+	if alias == nil {
+		alias = &resName
+	}
 
 	if ins.OnConflict != nil {
 		// UPSERT and INDEX ON CONFLICT will read from the table to check for

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -512,9 +512,8 @@ func resultsNeeded(r tree.ReturningClause) bool {
 }
 
 // getAliasedTableName returns the underlying table name for a TableExpr that
-// could be either an alias or a normal table name. It also returns the original
-// table name, which will be equal to the alias name if the input is an alias,
-// or identical to the table name if the input is a normal table name.
+// could be either an alias or a normal table name. It also returns the alias,
+// if there is one.
 //
 // This is not meant to perform name resolution, but rather simply to extract
 // the name indicated after FROM in DELETE/INSERT/UPDATE/UPSERT.
@@ -534,9 +533,6 @@ func getAliasedTableName(n tree.TableExpr) (*tree.TableName, *tree.TableName) {
 		panic(builderError{pgerror.Unimplemented(
 			"complex table expression in UPDATE/DELETE",
 			"cannot use a complex table name with DELETE/UPDATE")})
-	}
-	if alias == nil {
-		alias = tn
 	}
 	return tn, alias
 }

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -116,7 +116,7 @@ func (b *Builder) addExtraColumn(
 func (b *Builder) analyzeOrderByIndex(
 	order *tree.Order, inScope, projectionsScope, orderByScope *scope,
 ) {
-	tab := b.resolveTable(&order.Table, privilege.SELECT)
+	tab, _ := b.resolveTable(&order.Table, privilege.SELECT)
 	index, err := b.findIndexByName(tab, order.Index)
 	if err != nil {
 		panic(builderError{err})

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -86,10 +86,10 @@ func (b *Builder) buildDataSource(
 			return outScope
 		}
 
-		ds := b.resolveDataSource(tn, privilege.SELECT)
+		ds, resName := b.resolveDataSource(tn, privilege.SELECT)
 		switch t := ds.(type) {
 		case cat.Table:
-			return b.buildScan(t, tn, nil /* ordinals */, indexFlags, excludeMutations, inScope)
+			return b.buildScan(t, &resName, nil /* ordinals */, indexFlags, excludeMutations, inScope)
 		case cat.View:
 			return b.buildView(t, inScope)
 		case cat.Sequence:

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -91,7 +91,10 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 	tn, alias := getAliasedTableName(upd.Table)
 
 	// Find which table we're working on, check the permissions.
-	tab := b.resolveTable(tn, privilege.UPDATE)
+	tab, resName := b.resolveTable(tn, privilege.UPDATE)
+	if alias == nil {
+		alias = &resName
+	}
 
 	// Check Select permission as well, since existing values must be read.
 	b.checkPrivilege(tab, privilege.SELECT)


### PR DESCRIPTION
The catalog interface modifies the input `TableName` by rearranging or
filling in parts. This implicit modification leads to many subtleties
in the code; in particular, it's not clear to what extent the new name
is important in each code path.

This change modifies the catalog interface to return the new name
separately. This makes it explicit how the new name is used in
optbuilder code.

It also makes more sense conceptually because the input name is
unresolved and shouldn't even be of the type `TableName` (for one,
`TableName` has specific parts for schema/catalog and before resolving
we don't know which part of the name is which). I plan to work on a
bigger change in sql land to change the input to an `UnresolvedName`.

Release note: None