### PR TITLE
release-2.1: sql,sqlbase: fix the introspection for pre-2.1 BIT columns

### DIFF
--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -16,18 +16,21 @@ package sql_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
-
 	"time"
 
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/jackc/pgx/pgtype"
 )
 
 func TestGossipAlertsTable(t *testing.T) {
@@ -62,4 +65,116 @@ func TestGossipAlertsTable(t *testing.T) {
 	if a != e {
 		t.Fatalf("got:\n%s\nexpected:\n%s", a, e)
 	}
+}
+
+// TestOldBitColumnMetadata checks that a pre-2.1 BIT columns
+// shows up properly in metadata post-2.1.
+func TestOldBitColumnMetadata(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// The descriptor changes made must have an immediate effect
+	// so disable leases on tables.
+	defer sql.TestDisableTableLeases()()
+
+	params, _ := tests.CreateTestServerParams()
+	s, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// We now want to create a pre-2.1 table descriptor with an
+	// old-style bit column. We're going to edit the table descriptor
+	// manually, without going through SQL.
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	for i := range tableDesc.Columns {
+		if tableDesc.Columns[i].Name == "k" {
+			tableDesc.Columns[i].Type.VisibleType = 4 // Pre-2.1 BIT.
+			tableDesc.Columns[i].Type.Width = 12      // Arbitrary non-std INT size.
+			break
+		}
+	}
+	// To make this test future-proof we must ensure that there isn't
+	// any logic in an unrelated place which will prevent the table from
+	// being committed. To verify this, we add another column and check
+	// it appears in introspection afterwards.
+	//
+	// We also avoid the regular schema change logic entirely, because
+	// this may be equipped with code to "fix" the old-style BIT column
+	// we defined above.
+	alterCmd, err := parser.ParseOne("ALTER TABLE t ADD COLUMN z INT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	colDef := alterCmd.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAddColumn).ColumnDef
+	col, _, _, err := sqlbase.MakeColumnDefDescs(colDef, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	col.ID = tableDesc.NextColumnID
+	tableDesc.NextColumnID++
+	tableDesc.Families[0].ColumnNames = append(tableDesc.Families[0].ColumnNames, col.Name)
+	tableDesc.Families[0].ColumnIDs = append(tableDesc.Families[0].ColumnIDs, col.ID)
+	tableDesc.Columns = append(tableDesc.Columns, *col)
+
+	// Write the modified descriptor.
+	if err := kvDB.Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
+		return txn.Put(ctx, sqlbase.MakeDescMetadataKey(tableDesc.ID), sqlbase.WrapDescriptor(tableDesc))
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the column metadata from information_schema.
+	rows, err := sqlDB.Query(`
+SELECT column_name, character_maximum_length, numeric_precision, numeric_precision_radix, crdb_sql_type
+  FROM t.information_schema.columns
+ WHERE table_catalog = 't' AND table_schema = 'public' AND table_name = 'test'
+   AND column_name != 'rowid'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	expected := 0
+	for rows.Next() {
+		var colName string
+		var charMaxLength, numPrec, numPrecRadix pgtype.Int8
+		var sqlType string
+		if err := rows.Scan(&colName, &charMaxLength, &numPrec, &numPrecRadix, &sqlType); err != nil {
+			t.Fatal(err)
+		}
+		switch colName {
+		case "k":
+			if charMaxLength.Status != pgtype.Null {
+				t.Fatalf("x character_maximum_length: expected null, got %d", charMaxLength.Int)
+			}
+			if numPrec.Int != 64 {
+				t.Fatalf("x numeric_precision: expected 64, got %v", numPrec.Get())
+			}
+			if numPrecRadix.Int != 2 {
+				t.Fatalf("x numeric_precision_radix: expected 64, got %v", numPrecRadix.Get())
+			}
+			if sqlType != "INT8" {
+				t.Fatalf("x crdb_sql_type: expected INT8, got %q", sqlType)
+			}
+			expected |= 2
+		case "z":
+			// This is just a canary to verify that the manually-modified
+			// table descriptor is visible to introspection.
+			expected |= 1
+		default:
+			t.Fatalf("unexpected col: %q", colName)
+		}
+	}
+	if expected != 3 {
+		t.Fatal("did not find both expected rows")
+	}
+
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -892,8 +892,8 @@ WHERE table_schema = 'public' AND table_name = 'char_len'
 ----
 table_name  column_name  character_maximum_length  character_octet_length
 char_len    a            NULL                      NULL
-char_len    b            16                        NULL
-char_len    c            32                        NULL
+char_len    b            NULL                      NULL
+char_len    c            NULL                      NULL
 char_len    d            NULL                      NULL
 char_len    e            12                        48
 char_len    dc           1                         4

--- a/pkg/sql/sqlbase/column_type_properties.go
+++ b/pkg/sql/sqlbase/column_type_properties.go
@@ -19,12 +19,11 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/pkg/errors"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/pkg/errors"
 )
 
 // This file provides facilities to support the correspondence
@@ -226,7 +225,13 @@ func (c *ColumnType) stringTypeName() string {
 func (c *ColumnType) SQLString() string {
 	switch c.SemanticType {
 	case ColumnType_INT:
-		if name, ok := coltypes.IntegerTypeNames[int(c.Width)]; ok {
+		// Pre-2.1 BIT was using column type INT with arbitrary width We
+		// map this to INT now. See #34161.
+		width := c.Width
+		if width != 0 && width != 64 && width != 32 && width != 16 {
+			width = 64
+		}
+		if name, ok := coltypes.IntegerTypeNames[int(width)]; ok {
 			return name
 		}
 	case ColumnType_STRING, ColumnType_COLLATEDSTRING:
@@ -357,7 +362,7 @@ func (c *ColumnType) InformationSchemaVisibleType() string {
 // expectations.
 func (c *ColumnType) MaxCharacterLength() (int32, bool) {
 	switch c.SemanticType {
-	case ColumnType_INT, ColumnType_STRING, ColumnType_COLLATEDSTRING:
+	case ColumnType_STRING, ColumnType_COLLATEDSTRING:
 		if c.Width > 0 {
 			return c.Width, true
 		}
@@ -396,7 +401,9 @@ func (c *ColumnType) NumericPrecision() (int32, bool) {
 	switch c.SemanticType {
 	case ColumnType_INT:
 		width := c.Width
-		if width == 0 {
+		// Pre-2.1 BIT was using column type INT with arbitrary
+		// widths. Clamp them to fixed/known widths. See #34161.
+		if width != 64 && width != 32 && width != 16 {
 			width = 64
 		}
 		return width, true

--- a/pkg/sql/sqlbase/structured.proto
+++ b/pkg/sql/sqlbase/structured.proto
@@ -153,7 +153,7 @@ message ColumnType {
     INTEGER = 1;   // Deprecated, remove post-2.2.
     SMALLINT = 2;  // Deprecated, remove post-2.2.
     BIGINT = 3;    // Deprecated, remove post-2.2.
-    reserved 4;
+    reserved 4;    // Pre-2.1 BIT. Not used any more.
     REAL = 5;
     DOUBLE_PRECISION = 6; // Deprecated, remove post-2.2.
     VARCHAR = 7;


### PR DESCRIPTION
Backport 1/1 commits from #34182.

/cc @cockroachdb/release

---
