### PR TITLE
sql: remove nanoseconds from INTERVAL

### DIFF
--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -238,11 +238,7 @@ func TestDumpRandom(t *testing.T) {
 			d := timeutil.Unix(0, rnd.Int63()).Round(time.Hour * 24)
 			m := timeutil.Unix(0, rnd.Int63()).Round(time.Microsecond)
 			sign := 1 - rnd.Int63n(2)*2
-			dur := duration.Duration{
-				Months: sign * rnd.Int63n(1000),
-				Days:   sign * rnd.Int63n(1000),
-				Nanos:  sign * rnd.Int63(),
-			}
+			dur := duration.MakeDuration(sign*rnd.Int63(), sign*rnd.Int63n(1000), sign*rnd.Int63n(1000))
 			n := dur.String()
 			o := rnd.Intn(2) == 1
 			e := apd.New(rnd.Int63(), rnd.Int31n(20)-10).String()

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestPrettyPrint(t *testing.T) {
 	tm, _ := time.Parse(time.RFC3339Nano, "2016-03-30T13:40:35.053725008Z")
-	duration := duration.Duration{Months: 1, Days: 1, Nanos: 1 * time.Second.Nanoseconds()}
+	duration := duration.MakeDuration(1*time.Second.Nanoseconds(), 1, 1)
 	durationAsc, _ := encoding.EncodeDurationAscending(nil, duration)
 	durationDesc, _ := encoding.EncodeDurationDescending(nil, duration)
 	bitArray := bitarray.MakeBitArrayFromInt64(8, 58, 7)
@@ -166,7 +166,7 @@ func TestPrettyPrint(t *testing.T) {
 			"/Table/42/1 mon 1 day 00:00:01"},
 		{makeKey(MakeTablePrefix(42),
 			roachpb.RKey(durationDesc)),
-			"/Table/42/-2 mons -2 days +743:59:58.999999999"},
+			"/Table/42/-2 mons -2 days +743:59:58.999999+999ns"},
 
 		// sequence
 		{MakeSequenceKey(55), `/Table/55/1/0/0`},

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -721,7 +721,7 @@ func (v Value) PrettyPrint() string {
 	case ValueType_DURATION:
 		var d duration.Duration
 		d, err = v.GetDuration()
-		buf.WriteString(d.String())
+		buf.WriteString(d.StringNanos())
 	default:
 		err = errors.Errorf("unknown tag: %s", t)
 	}

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -1400,7 +1400,7 @@ func TestValuePrettyPrint(t *testing.T) {
 	_ = decimalValue.SetDecimal(apd.New(628, -2))
 
 	var durationValue Value
-	_ = durationValue.SetDuration(duration.Duration{Months: 1, Days: 2, Nanos: 3})
+	_ = durationValue.SetDuration(duration.DecodeDuration(1, 2, 3))
 
 	var tupleValue Value
 	tupleBytes := encoding.EncodeBytesValue(encoding.EncodeIntValue(nil, 1, 8), 2, []byte("foo"))
@@ -1431,7 +1431,7 @@ func TestValuePrettyPrint(t *testing.T) {
 		{floatValue, "/FLOAT/6.28"},
 		{timeValue, "/TIME/2016-06-29T16:02:50.000000005Z"},
 		{decimalValue, "/DECIMAL/6.28"},
-		{durationValue, "/DURATION/1 mon 2 days 00:00:00.000000003"},
+		{durationValue, "/DURATION/1 mon 2 days 00:00:00+3ns"},
 		{MakeValueFromBytes([]byte{0x1, 0x2, 0xF, 0xFF}), "/BYTES/0x01020fff"},
 		{MakeValueFromString("foo"), "/BYTES/foo"},
 		{tupleValue, "/TUPLE/1:1:Int/8/2:3:Bytes/foo"},

--- a/pkg/server/server_systemlog_gc_test.go
+++ b/pkg/server/server_systemlog_gc_test.go
@@ -228,7 +228,7 @@ func TestLogGCTrigger(t *testing.T) {
 				maxTS,
 			)
 
-			_, err = db.Exec(fmt.Sprintf("SET CLUSTER SETTING server.%s.ttl='1ns'", tc.table))
+			_, err = db.Exec(fmt.Sprintf("SET CLUSTER SETTING server.%s.ttl='1us'", tc.table))
 			a.NoError(err)
 
 			<-gcDone

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -586,7 +586,7 @@ func golangFillQueryArguments(args ...interface{}) tree.Datums {
 		case time.Time:
 			d = tree.MakeDTimestamp(t, time.Microsecond)
 		case time.Duration:
-			d = &tree.DInterval{Duration: duration.Duration{Nanos: t.Nanoseconds()}}
+			d = &tree.DInterval{Duration: duration.MakeDuration(t.Nanoseconds(), 0, 0)}
 		case bitarray.BitArray:
 			d = &tree.DBitArray{BitArray: t}
 		case *apd.Decimal:
@@ -1424,9 +1424,7 @@ func generateSessionTraceVTable(spans []tracing.RecordedSpan) ([]traceRow, error
 			opMap[spanIdx] = tree.NewDString(lrr.span.Operation)
 			if lrr.span.Duration != 0 {
 				durMap[spanIdx] = &tree.DInterval{
-					Duration: duration.Duration{
-						Nanos: lrr.span.Duration.Nanoseconds(),
-					},
+					Duration: duration.MakeDuration(lrr.span.Duration.Nanoseconds(), 0, 0),
 				}
 			}
 		}
@@ -1480,7 +1478,7 @@ func generateSessionTraceVTable(spans []tracing.RecordedSpan) ([]traceRow, error
 
 		ts := res[i][traceTimestampCol].(*tree.DTimestampTZ)
 		res[i][traceAgeCol] = &tree.DInterval{
-			Duration: duration.Duration{Nanos: ts.Sub(minTimestamp).Nanoseconds()},
+			Duration: duration.MakeDuration(ts.Sub(minTimestamp).Nanoseconds(), 0, 0),
 		}
 	}
 

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -510,11 +510,7 @@ func DecodeOidDatum(
 			days := int32(binary.BigEndian.Uint32(b[8:]))
 			months := int32(binary.BigEndian.Uint32(b[12:]))
 
-			duration := duration.Duration{
-				Nanos:  nanos,
-				Days:   int64(days),
-				Months: int64(months),
-			}
+			duration := duration.MakeDuration(nanos, int64(days), int64(months))
 			return &tree.DInterval{Duration: duration}, nil
 		case oid.T_uuid:
 			u, err := tree.ParseDUuidFromBytes(b)

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -390,7 +390,7 @@ func (b *writeBuffer) writeBinaryDatum(
 
 	case *tree.DInterval:
 		b.putInt32(16)
-		b.putInt64(v.Nanos / int64(time.Microsecond/time.Nanosecond))
+		b.putInt64(v.Nanos() / int64(time.Microsecond/time.Nanosecond))
 		b.putInt32(int32(v.Days))
 		b.putInt32(int32(v.Months))
 

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -78,7 +78,7 @@ func TestSchemaChangeLease(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	leaseDuration := time.Duration(leaseInterval.Duration.Nanos)
+	leaseDuration := time.Duration(leaseInterval.Duration.Nanos())
 	sqlRun.Exec(t, `
 CREATE DATABASE t;
 CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);

--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -234,10 +234,7 @@ func makeIntervalTestDatum(count int) []tree.Datum {
 
 	vals := make([]tree.Datum, count)
 	for i := range vals {
-		vals[i] = &tree.DInterval{Duration: duration.Duration{Months: rng.Int63n(1000),
-			Days:  rng.Int63n(1000),
-			Nanos: rng.Int63n(1000000),
-		}}
+		vals[i] = &tree.DInterval{Duration: duration.MakeDuration(rng.Int63n(1000000), rng.Int63n(1000), rng.Int63n(1000))}
 	}
 	return vals
 }

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2173,7 +2173,7 @@ const (
 // ParseDInterval parses and returns the *DInterval Datum value represented by the provided
 // string, or an error if parsing is unsuccessful.
 func ParseDInterval(s string) (*DInterval, error) {
-	return parseDInterval(s, Second)
+	return ParseDIntervalWithField(s, Second)
 }
 
 // truncateDInterval truncates the input DInterval downward to the nearest
@@ -2183,16 +2183,16 @@ func truncateDInterval(d *DInterval, field DurationField) {
 	case Year:
 		d.Duration.Months = d.Duration.Months - d.Duration.Months%12
 		d.Duration.Days = 0
-		d.Duration.Nanos = 0
+		d.Duration.SetNanos(0)
 	case Month:
 		d.Duration.Days = 0
-		d.Duration.Nanos = 0
+		d.Duration.SetNanos(0)
 	case Day:
-		d.Duration.Nanos = 0
+		d.Duration.SetNanos(0)
 	case Hour:
-		d.Duration.Nanos = d.Duration.Nanos - d.Duration.Nanos%time.Hour.Nanoseconds()
+		d.Duration.SetNanos(d.Duration.Nanos() - d.Duration.Nanos()%time.Hour.Nanoseconds())
 	case Minute:
-		d.Duration.Nanos = d.Duration.Nanos - d.Duration.Nanos%time.Minute.Nanoseconds()
+		d.Duration.SetNanos(d.Duration.Nanos() - d.Duration.Nanos()%time.Minute.Nanoseconds())
 	case Second:
 		// Postgres doesn't truncate to whole seconds.
 	}
@@ -2244,13 +2244,13 @@ func parseDInterval(s string, field DurationField) (*DInterval, error) {
 		case Day:
 			ret.Days = int64(f)
 		case Hour:
-			ret.Nanos = time.Hour.Nanoseconds() * int64(f)
+			ret.SetNanos(time.Hour.Nanoseconds() * int64(f))
 		case Minute:
-			ret.Nanos = time.Minute.Nanoseconds() * int64(f)
+			ret.SetNanos(time.Minute.Nanoseconds() * int64(f))
 		case Second:
-			ret.Nanos = int64(float64(time.Second.Nanoseconds()) * f)
+			ret.SetNanos(int64(float64(time.Second.Nanoseconds()) * f))
 		case Millisecond:
-			ret.Nanos = int64(float64(time.Millisecond.Nanoseconds()) * f)
+			ret.SetNanos(int64(float64(time.Millisecond.Nanoseconds()) * f))
 		default:
 			panic(fmt.Sprintf("unhandled DurationField constant %d", field))
 		}
@@ -2304,26 +2304,18 @@ func (d *DInterval) Next(_ *EvalContext) (Datum, bool) {
 
 // IsMax implements the Datum interface.
 func (d *DInterval) IsMax(_ *EvalContext) bool {
-	return d.Months == math.MaxInt64 && d.Days == math.MaxInt64 && d.Nanos == math.MaxInt64
+	return d.Duration == dMaxInterval.Duration
 }
 
 // IsMin implements the Datum interface.
 func (d *DInterval) IsMin(_ *EvalContext) bool {
-	return d.Months == math.MinInt64 && d.Days == math.MinInt64 && d.Nanos == math.MinInt64
+	return d.Duration == dMinInterval.Duration
 }
 
-var dMaxInterval = &DInterval{
-	duration.Duration{
-		Months: math.MaxInt64,
-		Days:   math.MaxInt64,
-		Nanos:  math.MaxInt64,
-	}}
-var dMinInterval = &DInterval{
-	duration.Duration{
-		Months: math.MinInt64,
-		Days:   math.MinInt64,
-		Nanos:  math.MinInt64,
-	}}
+var (
+	dMaxInterval = &DInterval{duration.MakeDuration(math.MaxInt64, math.MaxInt64, math.MaxInt64)}
+	dMinInterval = &DInterval{duration.MakeDuration(math.MinInt64, math.MinInt64, math.MinInt64)}
+)
 
 // Max implements the Datum interface.
 func (d *DInterval) Max(_ *EvalContext) (Datum, bool) {

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -110,20 +110,20 @@ func TestDatumOrdering(t *testing.T) {
 
 		// Intervals
 		{`'1 day':::interval`, noPrev, noNext,
-			`'-768614336404564650 years -8 mons -9223372036854775808 days -2562047:47:16.854775808'`,
-			`'768614336404564650 years 7 mons 9223372036854775807 days 2562047:47:16.854775807'`},
+			`'-768614336404564650 years -8 mons -9223372036854775808 days -2562047:47:16.854775'`,
+			`'768614336404564650 years 7 mons 9223372036854775807 days 2562047:47:16.854775'`},
 		// Max interval: we use Postgres syntax, because Go doesn't accept
 		// months/days and ISO8601 doesn't accept nanoseconds.
 		{`'9223372036854775807 months 9223372036854775807 days ` +
-			`2562047 hours 47 minutes 16 seconds 854775807 nanoseconds':::interval`,
+			`2562047 hours 47 minutes 16 seconds 854775 us':::interval`,
 			noPrev, valIsMax,
-			`'-768614336404564650 years -8 mons -9223372036854775808 days -2562047:47:16.854775808'`,
-			`'768614336404564650 years 7 mons 9223372036854775807 days 2562047:47:16.854775807'`},
+			`'-768614336404564650 years -8 mons -9223372036854775808 days -2562047:47:16.854775'`,
+			`'768614336404564650 years 7 mons 9223372036854775807 days 2562047:47:16.854775'`},
 		{`'-9223372036854775808 months -9223372036854775808 days ` +
-			`-2562047 h -47 m -16 s -854775808 ns':::interval`,
+			`-2562047 h -47 m -16 s -854775 us':::interval`,
 			valIsMin, noNext,
-			`'-768614336404564650 years -8 mons -9223372036854775808 days -2562047:47:16.854775808'`,
-			`'768614336404564650 years 7 mons 9223372036854775807 days 2562047:47:16.854775807'`},
+			`'-768614336404564650 years -8 mons -9223372036854775808 days -2562047:47:16.854775'`,
+			`'768614336404564650 years 7 mons 9223372036854775807 days 2562047:47:16.854775'`},
 
 		// UUIDs
 		{`'ffffffff-ffff-ffff-ffff-ffffffffffff'::uuid`, `'ffffffff-ffff-ffff-ffff-fffffffffffe'`, valIsMax,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -138,7 +138,7 @@ var UnaryOps = map[UnaryOperator]unaryOpOverload{
 			ReturnType: types.Interval,
 			Fn: func(_ *EvalContext, d Datum) (Datum, error) {
 				i := d.(*DInterval).Duration
-				i.Nanos = -i.Nanos
+				i.SetNanos(-i.Nanos())
 				i.Days = -i.Days
 				i.Months = -i.Months
 				return &DInterval{Duration: i}, nil
@@ -766,7 +766,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			ReturnType: types.Interval,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				nanos := left.(*DTimestamp).Sub(right.(*DTimestamp).Time).Nanoseconds()
-				return &DInterval{Duration: duration.Duration{Nanos: nanos}}, nil
+				return &DInterval{Duration: duration.MakeDuration(nanos, 0, 0)}, nil
 			},
 		},
 		&BinOp{
@@ -775,7 +775,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			ReturnType: types.Interval,
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				nanos := left.(*DTimestampTZ).Sub(right.(*DTimestampTZ).Time).Nanoseconds()
-				return &DInterval{Duration: duration.Duration{Nanos: nanos}}, nil
+				return &DInterval{Duration: duration.MakeDuration(nanos, 0, 0)}, nil
 			},
 		},
 		&BinOp{
@@ -786,7 +786,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				// These two quantities aren't directly comparable. Convert the
 				// TimestampTZ to a timestamp first.
 				nanos := left.(*DTimestamp).Sub(right.(*DTimestampTZ).stripTimeZone(ctx).Time).Nanoseconds()
-				return &DInterval{Duration: duration.Duration{Nanos: nanos}}, nil
+				return &DInterval{Duration: duration.MakeDuration(nanos, 0, 0)}, nil
 			},
 		},
 		&BinOp{
@@ -797,7 +797,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				// These two quantities aren't directly comparable. Convert the
 				// TimestampTZ to a timestamp first.
 				nanos := left.(*DTimestampTZ).stripTimeZone(ctx).Sub(right.(*DTimestamp).Time).Nanoseconds()
-				return &DInterval{Duration: duration.Duration{Nanos: nanos}}, nil
+				return &DInterval{Duration: duration.MakeDuration(nanos, 0, 0)}, nil
 			},
 		},
 		&BinOp{
@@ -3254,7 +3254,7 @@ func PerformCast(ctx *EvalContext, d Datum, t coltypes.CastTargetType) (Datum, e
 		case *DFloat:
 			return &DInterval{Duration: duration.FromFloat64(float64(*v))}, nil
 		case *DTime:
-			return &DInterval{Duration: duration.Duration{Nanos: int64(*v) * 1000}}, nil
+			return &DInterval{Duration: duration.MakeDuration(int64(*v)*1000, 0, 0)}, nil
 		case *DDecimal:
 			d := ctx.getTmpDec()
 			dnanos := v.Decimal

--- a/pkg/sql/sem/tree/interval_test.go
+++ b/pkg/sql/sem/tree/interval_test.go
@@ -179,36 +179,50 @@ func TestPGIntervalSyntax(t *testing.T) {
 		{`123`, ``, `interval: missing unit at position 3: "123"`},
 		{`123blah`, ``, `interval: unknown unit "blah" in duration "123blah"`},
 
-		{`1.2 nanosecond`, `00:00:00.000000001`, ``},
-		{`1.2 nanoseconds`, `00:00:00.000000001`, ``},
-		{`1.2 ns`, `00:00:00.000000001`, ``},
-		{` 1.2 ns `, `00:00:00.000000001`, ``},
-		{`-1.2ns`, `-00:00:00.000000001`, ``},
-		{`-1.2nsec`, `-00:00:00.000000001`, ``},
-		{`-1.2nsecs`, `-00:00:00.000000001`, ``},
-		{`-1.2nsecond`, `-00:00:00.000000001`, ``},
-		{`-1.2nseconds`, `-00:00:00.000000001`, ``},
-		{`-9223372036854775808ns`, `-2562047:47:16.854775808`, ``},
-		{`9223372036854775807ns`, `2562047:47:16.854775807`, ``},
+		// ns/us boundary
+		{`499ns`, `00:00:00`, ``},
+		{`500ns`, `00:00:00.000001`, ``},
+		{`.499us`, `00:00:00`, ``},
+		{`.5us`, `00:00:00.000001`, ``},
+		{`-499ns`, `00:00:00`, ``},
+		{`-500ns`, `-00:00:00.000001`, ``},
+		{`-0.499us`, `00:00:00`, ``},
+		{`-0.5us`, `-00:00:00.000001`, ``},
+		{`0.000000499s`, `00:00:00`, ``},
+		{`0.0000005s`, `00:00:00.000001`, ``},
+		{`-0.000000499s`, `00:00:00`, ``},
+		{`-0.0000005s`, `-00:00:00.000001`, ``},
 
-		{`1.2 microsecond`, `00:00:00.0000012`, ``},
-		{`1.2microseconds`, `00:00:00.0000012`, ``},
-		{`1.2us`, `00:00:00.0000012`, ``},
+		{`1.2 nanosecond`, `00:00:00`, ``},
+		{`1.2 nanoseconds`, `00:00:00`, ``},
+		{`1.2 ns`, `00:00:00`, ``},
+		{` 1.2 ns `, `00:00:00`, ``},
+		{`-1.2ns`, `00:00:00`, ``},
+		{`-1.2nsec`, `00:00:00`, ``},
+		{`-1.2nsecs`, `00:00:00`, ``},
+		{`-1.2nsecond`, `00:00:00`, ``},
+		{`-1.2nseconds`, `00:00:00`, ``},
+		{`-9223372036854775808ns`, `-2562047:47:16.854775`, ``},
+		{`9223372036854775807ns`, `2562047:47:16.854775`, ``},
+
+		{`1.2 microsecond`, `00:00:00.000001`, ``},
+		{`1.2microseconds`, `00:00:00.000001`, ``},
+		{`1.2us`, `00:00:00.000001`, ``},
 		// µ = U+00B5 = micro symbol
 		// μ = U+03BC = Greek letter mu
-		{`1.2µs`, `00:00:00.0000012`, ``},
-		{`1.2μs`, `00:00:00.0000012`, ``},
-		{`1.2usec`, `00:00:00.0000012`, ``},
-		{`1.2usecs`, `00:00:00.0000012`, ``},
-		{`1.2usecond`, `00:00:00.0000012`, ``},
-		{`1.2useconds`, `00:00:00.0000012`, ``},
-		{`0.23us`, `00:00:00.00000023`, ``},
-		{`-0.23us`, `-00:00:00.00000023`, ``},
-		{`0.2346us`, `00:00:00.000000234`, ``},
-		{`-1.2us`, `-00:00:00.0000012`, ``},
-		{`1.2us 3ns`, `00:00:00.000001203`, ``},
-		{`  1.2us   3ns   `, `00:00:00.000001203`, ``},
-		{`3ns 1.2us`, `00:00:00.000001203`, ``},
+		{`1.2µs`, `00:00:00.000001`, ``},
+		{`1.2μs`, `00:00:00.000001`, ``},
+		{`1.2usec`, `00:00:00.000001`, ``},
+		{`1.2usecs`, `00:00:00.000001`, ``},
+		{`1.2usecond`, `00:00:00.000001`, ``},
+		{`1.2useconds`, `00:00:00.000001`, ``},
+		{`0.23us`, `00:00:00`, ``},
+		{`-0.23us`, `00:00:00`, ``},
+		{`0.2346us`, `00:00:00`, ``},
+		{`-1.2us`, `-00:00:00.000001`, ``},
+		{`1.2us 3ns`, `00:00:00.000001`, ``},
+		{`  1.2us   3ns   `, `00:00:00.000001`, ``},
+		{`3ns 1.2us`, `00:00:00.000001`, ``},
 
 		{`1.2millisecond`, `00:00:00.0012`, ``},
 		{`1.2milliseconds`, `00:00:00.0012`, ``},
@@ -217,44 +231,44 @@ func TestPGIntervalSyntax(t *testing.T) {
 		{`1.2msecs`, `00:00:00.0012`, ``},
 		{`1.2msecond`, `00:00:00.0012`, ``},
 		{`1.2mseconds`, `00:00:00.0012`, ``},
-		{`0.2304506ms`, `00:00:00.00023045`, ``},
-		{`0.0002304506ms`, `00:00:00.00000023`, ``},
-		{`1 ms 1us 1ns`, `00:00:00.001001001`, ``},
+		{`0.2304506ms`, `00:00:00.00023`, ``},
+		{`0.0002304506ms`, `00:00:00`, ``},
+		{`1 ms 1us 1ns`, `00:00:00.001001`, ``},
 
 		{`1.2second`, `00:00:01.2`, ``},
 		{`1.2seconds`, `00:00:01.2`, ``},
 		{`1.2s`, `00:00:01.2`, ``},
 		{`1.2sec`, `00:00:01.2`, ``},
 		{`1.2secs`, `00:00:01.2`, ``},
-		{`0.2304506708s`, `00:00:00.23045067`, ``},
-		{`0.0002304506708s`, `00:00:00.00023045`, ``},
-		{`0.0000002304506s`, `00:00:00.00000023`, ``},
+		{`0.2304506708s`, `00:00:00.230451`, ``},
+		{`0.0002304506708s`, `00:00:00.00023`, ``},
+		{`0.0000002304506s`, `00:00:00`, ``},
 		{`75.5s`, `00:01:15.5`, ``},
 		{`3675.5s`, `01:01:15.5`, ``},
 		{`86475.5s`, `24:01:15.5`, ``},
-		{`86400s -60000ms 100us -1ns`, `23:59:00.000099999`, ``},
+		{`86400s -60000ms 100us -1ns`, `23:59:00.0001`, ``},
 
 		{`1.2minute`, `00:01:12`, ``},
 		{`1.2minutes`, `00:01:12`, ``},
 		{`1.2m`, `00:01:12`, ``},
 		{`1.2min`, `00:01:12`, ``},
 		{`1.2mins`, `00:01:12`, ``},
-		{`1.2m 8s 20ns`, `00:01:20.00000002`, ``},
+		{`1.2m 8s 20ns`, `00:01:20`, ``},
 		{`0.5m`, `00:00:30`, ``},
 		{`120.5m`, `02:00:30`, ``},
-		{`0.23045067089m`, `00:00:13.827040253`, ``},
-		{`-0.23045067089m`, `-00:00:13.827040253`, ``},
+		{`0.23045067089m`, `00:00:13.82704`, ``},
+		{`-0.23045067089m`, `-00:00:13.82704`, ``},
 
 		{`1.2hour`, `01:12:00`, ``},
 		{`1.2hours`, `01:12:00`, ``},
 		{`1.2h`, `01:12:00`, ``},
 		{`1.2hr`, `01:12:00`, ``},
 		{`1.2hrs`, `01:12:00`, ``},
-		{`1.2h 8m 20ns`, `01:20:00.00000002`, ``},
+		{`1.2h 8m 20ns`, `01:20:00`, ``},
 		{`0.5h`, `00:30:00`, ``},
 		{`25.5h`, `25:30:00`, ``},
-		{`0.23045067089h`, `00:13:49.622415204`, ``},
-		{`-0.23045067089h`, `-00:13:49.622415204`, ``},
+		{`0.23045067089h`, `00:13:49.622415`, ``},
+		{`-0.23045067089h`, `-00:13:49.622415`, ``},
 
 		{`1 day`, `1 day`, ``},
 		{`1 days`, `1 day`, ``},
@@ -282,7 +296,7 @@ func TestPGIntervalSyntax(t *testing.T) {
 		{`1 mon 2 week`, `1 mon 14 days`, ``},
 		{`1.1mon`, `1 mon 3 days`, ``},
 		{`1.2mon`, `1 mon 6 days`, ``},
-		{`1.11mon`, `1 mon 3 days 07:11:59.999999999`, ``},
+		{`1.11mon`, `1 mon 3 days 07:12:00`, ``},
 		{`-9223372036854775808mon`, `-768614336404564650 years -8 mons`, ``},
 		{`9223372036854775807mon`, `768614336404564650 years 7 mons`, ``},
 
@@ -309,56 +323,52 @@ func TestPGIntervalSyntax(t *testing.T) {
 		{`1 day 12:30.5`, `1 day 00:12:30.5`, ``},
 		{`1 day 12:30:40`, `1 day 12:30:40`, ``},
 		{`1 day 12:30:40.5`, `1 day 12:30:40.5`, ``},
-		{`1 day 12:30:40.500500001`, `1 day 12:30:40.500500001`, ``},
+		{`1 day 12:30:40.500500001`, `1 day 12:30:40.5005`, ``},
 
 		// Regressions
 
 		// This was 1ns off due to float rounding.
-		{`50 years 6 mons 75 days 1572897:25:58.535696141`, `50 years 6 mons 75 days 1572897:25:58.535696141`, ``},
+		{`50 years 6 mons 75 days 1572897:25:58.535696141`, `50 years 6 mons 75 days 1572897:25:58.535696`, ``},
 	}
-	for i, test := range testData {
-		dur, err := parseDuration(test.input)
-		if err != nil {
-			if test.error != "" {
-				if err.Error() != test.error {
-					t.Errorf(`%d: %q: got error "%v", expected "%s"`, i, test.input, err, test.error)
+	for _, test := range testData {
+		t.Run(test.input, func(t *testing.T) {
+			dur, err := parseDuration(test.input)
+			if err != nil {
+				if test.error != "" {
+					if err.Error() != test.error {
+						t.Fatalf(`%q: got error "%v", expected "%s"`, test.input, err, test.error)
+					}
+				} else {
+					t.Fatalf("%q: %v", test.input, err)
 				}
-			} else {
-				t.Errorf("%d: %q: %v", i, test.input, err)
+				return
 			}
-			continue
-		} else {
 			if test.error != "" {
-				t.Errorf(`%d: %q: expected error "%q"`, i, test.input, test.error)
-				continue
+				t.Fatalf(`%q: expected error "%q"`, test.input, test.error)
 			}
-		}
-		s := dur.String()
-		if s != test.output {
-			t.Errorf(`%d: %q: got "%s", expected "%s"`, i, test.input, s, test.output)
-			continue
-		}
+			s := dur.String()
+			if s != test.output {
+				t.Fatalf(`%q: got "%s", expected "%s"`, test.input, s, test.output)
+			}
 
-		dur2, err := parseDuration(s)
-		if err != nil {
-			t.Errorf(`%d: %q: repr "%s" is not parsable: %v`, i, test.input, s, err)
-			continue
-		}
-		s2 := dur2.String()
-		if s2 != s {
-			t.Errorf(`%d: %q: repr "%s" does not round-trip, got "%s" instead`,
-				i, test.input, s, s2)
-		}
+			dur2, err := parseDuration(s)
+			if err != nil {
+				t.Fatalf(`%q: repr "%s" is not parsable: %v`, test.input, s, err)
+			}
+			s2 := dur2.String()
+			if s2 != s {
+				t.Fatalf(`%q: repr "%s" does not round-trip, got "%s" instead`, test.input, s, s2)
+			}
 
-		// Test that a Datum recognizes the format.
-		di, err := parseDInterval(test.input, Second)
-		if err != nil {
-			t.Errorf(`%d: %q: unrecognized as datum: %v`, i, test.input, err)
-			continue
-		}
-		s3 := di.Duration.String()
-		if s3 != test.output {
-			t.Errorf(`%d: %q: as datum, got "%s", expected "%s"`, i, test.input, s3, test.output)
-		}
+			// Test that a Datum recognizes the format.
+			di, err := parseDInterval(test.input, Second)
+			if err != nil {
+				t.Fatalf(`%q: unrecognized as datum: %v`, test.input, err)
+			}
+			s3 := di.Duration.String()
+			if s3 != test.output {
+				t.Fatalf(`%q: as datum, got "%s", expected "%s"`, test.input, s3, test.output)
+			}
+		})
 	}
 }

--- a/pkg/sql/sem/tree/testdata/eval/cast
+++ b/pkg/sql/sem/tree/testdata/eval/cast
@@ -555,6 +555,26 @@ eval
 '12:02:01.023'
 
 eval
+'12:01:02.123456789'::interval::text
+----
+'12:01:02.123457'
+
+eval
+'12:01:02.1234564'::interval
+----
+'12:01:02.123456'
+
+eval
+'12:01:02.1234565'::interval
+----
+'12:01:02.123457'
+
+eval
+'12:01:02.1234566'::interval
+----
+'12:01:02.123457'
+
+eval
 interval '1'
 ----
 '00:00:01'
@@ -777,66 +797,66 @@ eval
 eval
 '2h3s4us5ns'::interval::decimal
 ----
-7203.000004005
+7203.000004000
 
 eval
 7203.000004005::decimal::interval
 ----
-'02:00:03.000004005'
+'02:00:03.000004'
 
 eval
 '2h3s4us5ns'::interval::decimal::interval
 ----
-'02:00:03.000004005'
+'02:00:03.000004'
 
 eval
 '-2h-3s-4us-5ns'::interval::decimal::interval
 ----
-'-02:00:03.000004005'
+'-02:00:03.000004'
 
 eval
 '1mon2d3h4s5us6ns'::interval::decimal
 ----
-2775604.000005006
+2775604.000005000
 
 eval
 '1mon2d3h4s5us6ns'::interval::decimal::interval
 ----
-'1 mon 2 days 03:00:04.000005006'
+'1 mon 2 days 03:00:04.000005'
 
 eval
 (-2775604.000005006)::decimal::interval
 ----
-'-1 mons -2 days -03:00:04.000005006'
+'-1 mons -2 days -03:00:04.000005'
 
 eval
 '-1mon-2d-3h-4s-5us-6ns'::interval::decimal::interval
 ----
-'-1 mons -2 days -03:00:04.000005006'
+'-1 mons -2 days -03:00:04.000005'
 
 # MaxInt64
 eval
 (decimal '9223372036854775807.000000001')::interval::decimal
 ----
-9223372036854775807.000000001
+9223372036854775807.000000000
 
 # MinInt64
 eval
 (decimal '-9223372036854775808.000000001')::interval::decimal
 ----
--9223372036854775808.000000001
+-9223372036854775808.000000000
 
 # MaxInt64
 eval
 '296533308798y20d15h30m7s1ns'::interval::decimal::interval
 ----
-'296533308798 years 20 days 15:30:07.000000001'
+'296533308798 years 20 days 15:30:07'
 
 # MinInt64
 eval
 '-296533308798y-20d-15h-30m-8s-1ns'::interval::decimal::interval
 ----
-'-296533308798 years -20 days -15:30:08.000000001'
+'-296533308798 years -20 days -15:30:08'
 
 eval
 '1970-01-01 00:01:00.123456-00:00'::timestamp::float
@@ -856,12 +876,12 @@ eval
 eval
 '2h3s4us5ns'::interval::float
 ----
-7203.000004005
+7203.000004
 
 eval
 '2h3s4us5ns'::interval::float::interval
 ----
-'02:00:03.000004005'
+'02:00:03.000004'
 
 eval
 '1mon2d3h4s5us'::interval::float
@@ -871,17 +891,17 @@ eval
 eval
 '1mon2d3h4s5us'::interval::float::interval
 ----
-'1 mon 2 days 03:00:04.000004999'
+'1 mon 2 days 03:00:04.000005'
 
 eval
 (-2775604.000005006)::float::interval
 ----
-'-1 mons -2 days -03:00:04.000005005'
+'-1 mons -2 days -03:00:04.000005'
 
 eval
 '-1mon-2d-3h-4s-5us-6ns'::interval::float::interval
 ----
-'-1 mons -2 days -03:00:04.000005005'
+'-1 mons -2 days -03:00:04.000005'
 
 eval
 10::int::date

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -270,7 +270,7 @@ func toSettingString(
 			if f.Duration.Months > 0 || f.Duration.Days > 0 {
 				return "", errors.Errorf("cannot use day or month specifiers: %s", d.String())
 			}
-			d := time.Duration(f.Duration.Nanos) * time.Nanosecond
+			d := time.Duration(f.Duration.Nanos()) * time.Nanosecond
 			if err := setting.Validate(d); err != nil {
 				return "", err
 			}

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -234,10 +234,11 @@ func timeZoneVarGetStringVal(
 		}
 
 	case *tree.DInterval:
-		offset, _, _, err = v.Duration.Div(time.Second.Nanoseconds()).Encode()
+		offset, _, _, err = v.Duration.Encode()
 		if err != nil {
 			return "", wrapSetVarError("timezone", values[0].String(), "%v", err)
 		}
+		offset /= int64(time.Second)
 
 	case *tree.DInt:
 		offset = int64(*v) * 60 * 60

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -163,7 +163,7 @@ SELECT variable,
 			case *settings.FloatSetting:
 				d = tree.NewDFloat(tree.DFloat(s.Get(&st.SV)))
 			case *settings.DurationSetting:
-				d = &tree.DInterval{Duration: duration.Duration{Nanos: s.Get(&st.SV).Nanoseconds()}}
+				d = &tree.DInterval{Duration: duration.MakeDuration(s.Get(&st.SV).Nanoseconds(), 0, 0)}
 			case *settings.EnumSetting:
 				d = tree.NewDInt(tree.DInt(s.Get(&st.SV)))
 			case *settings.ByteSizeSetting:

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -123,11 +123,11 @@ func RandDatumWithNullChance(rng *rand.Rand, typ ColumnType, nullChance int) tre
 		return &tree.DTimestamp{Time: timeutil.Unix(rng.Int63n(1000000), rng.Int63n(1000000))}
 	case ColumnType_INTERVAL:
 		sign := 1 - rng.Int63n(2)*2
-		return &tree.DInterval{Duration: duration.Duration{
-			Months: sign * rng.Int63n(1000),
-			Days:   sign * rng.Int63n(1000),
-			Nanos:  sign * rng.Int63n(25*3600*int64(1000000000)),
-		}}
+		return &tree.DInterval{Duration: duration.MakeDuration(
+			sign*rng.Int63n(25*3600*int64(1000000000)),
+			sign*rng.Int63n(1000),
+			sign*rng.Int63n(1000),
+		)}
 	case ColumnType_UUID:
 		return tree.NewDUuid(tree.DUuid{UUID: uuid.MakeV4()})
 	case ColumnType_INET:

--- a/pkg/util/duration/duration.go
+++ b/pkg/util/duration/duration.go
@@ -31,6 +31,7 @@ const (
 	nanosInDay    = 24 * int64(time.Hour) // Try as I might, couldn't do this without the cast.
 	nanosInMonth  = daysInMonth * nanosInDay
 	nanosInSecond = 1000 * 1000 * 1000
+	nanosInMicro  = 1000
 
 	// Used in overflow calculations.
 	maxYearsInDuration = math.MaxInt64 / nanosInMonth
@@ -58,12 +59,70 @@ var ErrEncodeOverflow = errors.New("overflow during Encode")
 // For the purposes of Compare and Encode, 1 month is considered equivalent to
 // 30 days and 1 day is equivalent to 24 * 60 * 60 * 1E9 nanoseconds.
 //
+// Although the Nanos field is a number of nanoseconds, all operations
+// round to the nearest microsecond. Any setting of this field should avoid
+// setting with precision below microseconds. The only exceptions are the
+// encode/decode operations.
+//
 // TODO(dan): Until the overflow and underflow handling is fixed, this is only
 // useful for durations of < 292 years.
 type Duration struct {
 	Months int64
 	Days   int64
-	Nanos  int64
+	// nanos is an unexported field so that it cannot be misused by other
+	// packages. It should almost always be rounded to the nearest microsecond.
+	nanos int64
+}
+
+// MakeDuration returns a Duration rounded to the nearest microsecond.
+func MakeDuration(nanos, days, months int64) Duration {
+	return Duration{
+		Months: months,
+		Days:   days,
+		nanos:  rounded(nanos),
+	}
+}
+
+// DecodeDuration returns a Duration without rounding nanos.
+func DecodeDuration(months, days, nanos int64) Duration {
+	return Duration{
+		Months: months,
+		Days:   days,
+		nanos:  nanos,
+	}
+}
+
+// Nanos returns the nanos of d.
+func (d Duration) Nanos() int64 {
+	return d.nanos
+}
+
+// SetNanos rounds and sets nanos.
+func (d *Duration) SetNanos(nanos int64) {
+	d.nanos = rounded(nanos)
+}
+
+// round rounds nanos to the nearest microsecond.
+func (d Duration) round() Duration {
+	d.nanos = rounded(d.nanos)
+	return d
+}
+
+// rounded returns nanos rounded to the nearest microsecond.
+func (d Duration) rounded() int64 {
+	return rounded(d.nanos)
+}
+
+// rounded returns nanos rounded to the nearest microsecond.
+func rounded(nanos int64) int64 {
+	dur := time.Duration(nanos) * time.Nanosecond
+	v := dur.Round(time.Microsecond).Nanoseconds()
+	// Near the boundaries of int64 will return the argument unchanged. Check
+	// for those cases and truncate instead of round so that we never have nanos.
+	if m := v % nanosInMicro; m != 0 {
+		v -= m
+	}
+	return v
 }
 
 // Compare returns an integer representing the relative length of two Durations.
@@ -79,9 +138,9 @@ func (d Duration) Compare(x Duration) int {
 		return -1
 	} else if normD.Days > normX.Days {
 		return 1
-	} else if normD.Nanos < normX.Nanos {
+	} else if normD.nanos < normX.nanos {
 		return -1
-	} else if normD.Nanos > normX.Nanos {
+	} else if normD.nanos > normX.nanos {
 		return 1
 	}
 	return 0
@@ -92,24 +151,23 @@ func (d Duration) Compare(x Duration) int {
 func FromInt64(x int64) Duration {
 	days := x / (nanosInDay / nanosInSecond)
 	seconds := x % (nanosInDay / nanosInSecond)
-	d := Duration{Days: days, Nanos: seconds * nanosInSecond}
+	d := Duration{Days: days, nanos: seconds * nanosInSecond}
 	return d.normalize()
 }
 
-// FromFloat64 converts a float64 number of seconds to a
-// duration. Inverse conversion of AsFloat64.
+// FromFloat64 converts a float64 number of seconds to a duration. Inverse
+// conversion of AsFloat64.
 func FromFloat64(x float64) Duration {
 	months := int64(x / float64(nanosInMonth/nanosInSecond))
 	secDays := math.Mod(x, float64(nanosInMonth/nanosInSecond))
 	days := int64(secDays / float64(nanosInDay/nanosInSecond))
 	secsRem := math.Mod(secDays, float64(nanosInDay/nanosInSecond))
-	d := Duration{Months: months, Days: days, Nanos: int64(secsRem * 1e9)}
-	return d.normalize()
+	d := Duration{Months: months, Days: days, nanos: int64(secsRem * 1e9)}
+	return d.normalize().round()
 }
 
-// FromBigInt converts a big.Int number of nanoseconds to a
-// duration. Inverse conversion of AsBigInt. Boolean false
-// if the result overflows.
+// FromBigInt converts a big.Int number of nanoseconds to a duration. Inverse
+// conversion of AsBigInt. Boolean false if the result overflows.
 func FromBigInt(src *big.Int) (Duration, bool) {
 	var rem big.Int
 	var monthsDec big.Int
@@ -124,8 +182,8 @@ func FromBigInt(src *big.Int) (Duration, bool) {
 	// Note: we do not need to check for overflow of daysDec because any
 	// excess bits were spilled into months above already.
 
-	d := Duration{Months: monthsDec.Int64(), Days: daysDec.Int64(), Nanos: nanosRem.Int64()}
-	return d.normalize(), true
+	d := Duration{Months: monthsDec.Int64(), Days: daysDec.Int64(), nanos: nanosRem.Int64()}
+	return d.normalize().round(), true
 }
 
 // AsInt64 converts a duration to an int64 number of seconds.
@@ -143,24 +201,25 @@ func (d Duration) AsInt64() (int64, bool) {
 	if dSecs, ok = arith.AddWithOverflow(mSecs, dSecs); !ok {
 		return 0, ok
 	}
-	return arith.AddWithOverflow(dSecs, d.Nanos/nanosInSecond)
+	return arith.AddWithOverflow(dSecs, d.nanos/nanosInSecond)
 }
 
 // AsFloat64 converts a duration to a float64 number of seconds.
 func (d Duration) AsFloat64() float64 {
 	mSecs := float64(d.Months) * float64(nanosInMonth/nanosInSecond)
 	dSecs := float64(d.Days) * float64(nanosInDay/nanosInSecond)
-	return float64(d.Nanos)/float64(nanosInSecond) + mSecs + dSecs
+	// Uses rounded instead of nanos here to remove any on-disk nanos.
+	return float64(d.rounded())/float64(nanosInSecond) + mSecs + dSecs
 }
 
-// AsBigInt converts a duration to a big.Int with the number of
-// nanoseconds.
+// AsBigInt converts a duration to a big.Int with the number of nanoseconds.
 func (d Duration) AsBigInt(dst *big.Int) {
 	dst.SetInt64(d.Months)
 	dst.Mul(dst, bigDaysInMonth)
 	dst.Add(dst, big.NewInt(d.Days))
 	dst.Mul(dst, bigNanosInDay)
-	dst.Add(dst, big.NewInt(d.Nanos))
+	// Uses rounded instead of nanos here to remove any on-disk nanos.
+	dst.Add(dst, big.NewInt(d.rounded()))
 }
 
 const (
@@ -169,9 +228,9 @@ const (
 	secondNanos = uint64(time.Second / time.Nanosecond)
 )
 
-// Format emits a string representation of a Duration to a Buffer.
+// Format emits a string representation of a Duration to a Buffer truncated to microseconds.
 func (d Duration) Format(buf *bytes.Buffer) {
-	if d.Nanos == 0 && d.Days == 0 && d.Months == 0 {
+	if d.nanos == 0 && d.Days == 0 && d.Months == 0 {
 		buf.WriteString("00:00:00")
 		return
 	}
@@ -201,25 +260,24 @@ func (d Duration) Format(buf *bytes.Buffer) {
 		fmt.Fprintf(buf, "%d day%s", d.Days, isPlural(d.Days))
 	}
 
-	if d.Nanos == 0 {
+	if d.nanos == 0 {
 		return
 	}
 
 	wrotePrev(wrote, buf)
 
-	if d.Nanos < 0 {
+	if d.nanos/nanosInMicro < 0 {
 		buf.WriteString("-")
 	} else if negDays {
 		buf.WriteString("+")
 	}
 
-	// Extract abs(d.Nanos). See https://play.golang.org/p/U3_gNMpyUew.
+	// Extract abs(d.nanos). See https://play.golang.org/p/U3_gNMpyUew.
 	var nanos uint64
-	if d.Nanos >= 0 {
-		nanos = uint64(d.Nanos)
+	if d.nanos >= 0 {
+		nanos = uint64(d.nanos)
 	} else {
-
-		nanos = uint64(-d.Nanos)
+		nanos = uint64(-d.nanos)
 	}
 
 	hn := nanos / hourNanos
@@ -230,8 +288,9 @@ func (d Duration) Format(buf *bytes.Buffer) {
 	nanos %= secondNanos
 	fmt.Fprintf(buf, "%02d:%02d:%02d", hn, mn, sn)
 
-	if nanos != 0 {
-		s := fmt.Sprintf(".%09d", nanos)
+	micros := nanos / nanosInMicro
+	if micros != 0 {
+		s := fmt.Sprintf(".%06d", micros)
 		buf.WriteString(strings.TrimRight(s, "0"))
 	}
 }
@@ -259,6 +318,19 @@ func (d Duration) String() string {
 	return buf.String()
 }
 
+// StringNanos returns a string representation of a Duration including
+// its hidden nanoseconds value. To be used only by the encoding/decoding
+// packages for pretty printing of on-disk values.
+func (d Duration) StringNanos() string {
+	var buf bytes.Buffer
+	d.Format(&buf)
+	nanos := d.nanos % nanosInMicro
+	if nanos != 0 {
+		fmt.Fprintf(&buf, "%+dns", nanos)
+	}
+	return buf.String()
+}
+
 // Encode returns three integers such that the original Duration is recoverable
 // (using Decode) and the first int will approximately sort a collection of
 // encoded Durations.
@@ -268,12 +340,12 @@ func (d Duration) Encode() (sortNanos int64, months int64, days int64, err error
 	//
 	// TODO(dan): Compute overflow exactly, then document that EncodeBigInt can be
 	// used in overflow cases.
-	years := d.Months/12 + d.Days/daysInMonth/12 + d.Nanos/nanosInMonth/12
+	years := d.Months/12 + d.Days/daysInMonth/12 + d.nanos/nanosInMonth/12
 	if years > maxYearsInDuration || years < minYearsInDuration {
 		return 0, 0, 0, ErrEncodeOverflow
 	}
 
-	totalNanos := d.Months*nanosInMonth + d.Days*nanosInDay + d.Nanos
+	totalNanos := d.Months*nanosInMonth + d.Days*nanosInDay + d.nanos
 	return totalNanos, d.Months, d.Days, nil
 }
 
@@ -284,7 +356,7 @@ func (d Duration) EncodeBigInt() (sortNanos *big.Int, months int64, days int64) 
 	bigMonths.Mul(bigMonths, big.NewInt(nanosInMonth))
 	bigDays := big.NewInt(d.Days)
 	bigDays.Mul(bigDays, big.NewInt(nanosInDay))
-	totalNanos := big.NewInt(d.Nanos)
+	totalNanos := big.NewInt(d.nanos)
 	totalNanos.Add(totalNanos, bigMonths).Add(totalNanos, bigDays)
 	return totalNanos, d.Months, d.Days
 }
@@ -295,7 +367,7 @@ func Decode(sortNanos int64, months int64, days int64) (Duration, error) {
 	nanos := sortNanos - months*nanosInMonth - days*nanosInDay
 	// TODO(dan): Handle underflow, then document that DecodeBigInt can be used
 	// in underflow cases.
-	return Duration{Months: months, Days: days, Nanos: nanos}, nil
+	return Duration{Months: months, Days: days, nanos: nanos}, nil
 }
 
 // TODO(dan): Write DecodeBigInt.
@@ -347,7 +419,7 @@ func Add(ctx Context, t time.Time, d Duration) time.Time {
 	// or if the day number that we're starting from can never result
 	// in normalization.
 	if mode == AdditionModeLegacy || d.Months == 0 || t.Day() <= 28 {
-		return t.AddDate(0, int(d.Months), int(d.Days)).Add(time.Duration(d.Nanos))
+		return t.AddDate(0, int(d.Months), int(d.Days)).Add(time.Duration(d.nanos))
 	}
 
 	// Adjustments for 1-based math.
@@ -388,45 +460,45 @@ func Add(ctx Context, t time.Time, d Duration) time.Time {
 			res.Nanosecond(), res.Location())
 	}
 
-	return res.AddDate(0, 0, int(d.Days)).Add(time.Duration(d.Nanos))
+	return res.AddDate(0, 0, int(d.Days)).Add(time.Duration(d.nanos))
 }
 
 // Add returns a Duration representing a time length of d+x.
 func (d Duration) Add(x Duration) Duration {
-	return Duration{d.Months + x.Months, d.Days + x.Days, d.Nanos + x.Nanos}
+	return MakeDuration(d.nanos+x.nanos, d.Days+x.Days, d.Months+x.Months)
 }
 
 // Sub returns a Duration representing a time length of d-x.
 func (d Duration) Sub(x Duration) Duration {
-	return Duration{d.Months - x.Months, d.Days - x.Days, d.Nanos - x.Nanos}
+	return MakeDuration(d.nanos-x.nanos, d.Days-x.Days, d.Months-x.Months)
 }
 
 // Mul returns a Duration representing a time length of d*x.
 func (d Duration) Mul(x int64) Duration {
-	return Duration{d.Months * x, d.Days * x, d.Nanos * x}
+	return MakeDuration(d.nanos*x, d.Days*x, d.Months*x)
 }
 
 // Div returns a Duration representing a time length of d/x.
 func (d Duration) Div(x int64) Duration {
-	return Duration{d.Months / x, d.Days / x, d.Nanos / x}
+	return MakeDuration(d.nanos/x, d.Days/x, d.Months/x)
 }
 
 // MulFloat returns a Duration representing a time length of d*x.
 func (d Duration) MulFloat(x float64) Duration {
-	return Duration{
-		int64(float64(d.Months) * x),
-		int64(float64(d.Days) * x),
-		int64(float64(d.Nanos) * x),
-	}
+	return MakeDuration(
+		int64(float64(d.nanos)*x),
+		int64(float64(d.Days)*x),
+		int64(float64(d.Months)*x),
+	)
 }
 
 // DivFloat returns a Duration representing a time length of d/x.
 func (d Duration) DivFloat(x float64) Duration {
-	return Duration{
-		int64(float64(d.Months) / x),
-		int64(float64(d.Days) / x),
-		int64(float64(d.Nanos) / x),
-	}
+	return MakeDuration(
+		int64(float64(d.nanos)/x),
+		int64(float64(d.Days)/x),
+		int64(float64(d.Months)/x),
+	)
 }
 
 // normalized returns a new Duration transformed using the equivalence rules.
@@ -444,10 +516,10 @@ func (d Duration) normalize() Duration {
 	//   made a full month.
 	// - Months did hit MaxInt64 or MinInt64, in which case there can be no more
 	//   months. We only need to shift nanos.
-	if d.Nanos > 0 {
+	if d.nanos > 0 {
 		d = d.shiftPosNanosToDays()
 		d = d.shiftPosDaysToMonths()
-	} else if d.Nanos < 0 {
+	} else if d.nanos < 0 {
 		d = d.shiftNegNanosToDays()
 		d = d.shiftNegDaysToMonths()
 	}
@@ -474,9 +546,9 @@ func (d Duration) shiftPosNanosToDays() Duration {
 		// rate, we can never transfer more than math.MaxInt64 anyway.
 		maxDays = math.MaxInt64 - d.Days
 	}
-	daysFromNanos := int64Min(d.Nanos/nanosInDay, maxDays)
+	daysFromNanos := int64Min(d.nanos/nanosInDay, maxDays)
 	d.Days += daysFromNanos
-	d.Nanos -= daysFromNanos * nanosInDay
+	d.nanos -= daysFromNanos * nanosInDay
 	return d
 }
 
@@ -500,9 +572,9 @@ func (d Duration) shiftNegNanosToDays() Duration {
 		// rate, we can never transfer more than math.MaxInt64 anyway.
 		minDays = math.MinInt64 - d.Days
 	}
-	daysFromNanos := int64Max(d.Nanos/nanosInDay, minDays)
+	daysFromNanos := int64Max(d.nanos/nanosInDay, minDays)
 	d.Days += daysFromNanos
-	d.Nanos -= daysFromNanos * nanosInDay
+	d.nanos -= daysFromNanos * nanosInDay
 	return d
 }
 

--- a/pkg/util/duration/duration_test.go
+++ b/pkg/util/duration/duration_test.go
@@ -40,34 +40,34 @@ type durationTest struct {
 // TODO(dan): Write more tests with a mixture of positive and negative
 // components.
 var positiveDurationTests = []durationTest{
-	{1, Duration{Months: 0, Days: 0, Nanos: 0}, false},
-	{1, Duration{Months: 0, Days: 0, Nanos: 1}, false},
-	{1, Duration{Months: 0, Days: 0, Nanos: nanosInDay - 1}, false},
-	{1, Duration{Months: 0, Days: 1, Nanos: 0}, false},
-	{0, Duration{Months: 0, Days: 0, Nanos: nanosInDay}, false},
-	{1, Duration{Months: 0, Days: 0, Nanos: nanosInDay + 1}, false},
-	{1, Duration{Months: 0, Days: daysInMonth - 1, Nanos: 0}, false},
-	{1, Duration{Months: 0, Days: 0, Nanos: nanosInMonth - 1}, false},
-	{1, Duration{Months: 1, Days: 0, Nanos: 0}, false},
-	{0, Duration{Months: 0, Days: daysInMonth, Nanos: 0}, false},
-	{0, Duration{Months: 0, Days: 0, Nanos: nanosInMonth}, false},
-	{1, Duration{Months: 0, Days: 0, Nanos: nanosInMonth + 1}, false},
-	{1, Duration{Months: 0, Days: daysInMonth + 1, Nanos: 0}, false},
-	{1, Duration{Months: 1, Days: 1, Nanos: 1}, false},
-	{1, Duration{Months: 1, Days: 10, Nanos: 0}, false},
-	{0, Duration{Months: 0, Days: 40, Nanos: 0}, false},
-	{1, Duration{Months: 2, Days: 0, Nanos: 0}, false},
-	{1, Duration{Months: math.MaxInt64 - 1, Days: daysInMonth - 1, Nanos: nanosInDay * 2}, true},
-	{1, Duration{Months: math.MaxInt64 - 1, Days: daysInMonth * 2, Nanos: nanosInDay * 2}, true},
-	{1, Duration{Months: math.MaxInt64, Days: math.MaxInt64, Nanos: nanosInMonth + nanosInDay}, true},
-	{1, Duration{Months: math.MaxInt64, Days: math.MaxInt64, Nanos: math.MaxInt64}, true},
+	{1, Duration{Months: 0, Days: 0, nanos: 0}, false},
+	{1, Duration{Months: 0, Days: 0, nanos: 1}, false},
+	{1, Duration{Months: 0, Days: 0, nanos: nanosInDay - 1}, false},
+	{1, Duration{Months: 0, Days: 1, nanos: 0}, false},
+	{0, Duration{Months: 0, Days: 0, nanos: nanosInDay}, false},
+	{1, Duration{Months: 0, Days: 0, nanos: nanosInDay + 1}, false},
+	{1, Duration{Months: 0, Days: daysInMonth - 1, nanos: 0}, false},
+	{1, Duration{Months: 0, Days: 0, nanos: nanosInMonth - 1}, false},
+	{1, Duration{Months: 1, Days: 0, nanos: 0}, false},
+	{0, Duration{Months: 0, Days: daysInMonth, nanos: 0}, false},
+	{0, Duration{Months: 0, Days: 0, nanos: nanosInMonth}, false},
+	{1, Duration{Months: 0, Days: 0, nanos: nanosInMonth + 1}, false},
+	{1, Duration{Months: 0, Days: daysInMonth + 1, nanos: 0}, false},
+	{1, Duration{Months: 1, Days: 1, nanos: 1}, false},
+	{1, Duration{Months: 1, Days: 10, nanos: 0}, false},
+	{0, Duration{Months: 0, Days: 40, nanos: 0}, false},
+	{1, Duration{Months: 2, Days: 0, nanos: 0}, false},
+	{1, Duration{Months: math.MaxInt64 - 1, Days: daysInMonth - 1, nanos: nanosInDay * 2}, true},
+	{1, Duration{Months: math.MaxInt64 - 1, Days: daysInMonth * 2, nanos: nanosInDay * 2}, true},
+	{1, Duration{Months: math.MaxInt64, Days: math.MaxInt64, nanos: nanosInMonth + nanosInDay}, true},
+	{1, Duration{Months: math.MaxInt64, Days: math.MaxInt64, nanos: math.MaxInt64}, true},
 }
 
 func fullDurationTests() []durationTest {
 	var ret []durationTest
 	for _, test := range positiveDurationTests {
 		d := test.duration
-		negDuration := Duration{Months: -d.Months, Days: -d.Days, Nanos: -d.Nanos}
+		negDuration := Duration{Months: -d.Months, Days: -d.Days, nanos: -d.nanos}
 		ret = append(ret, durationTest{cmpToPrev: -test.cmpToPrev, duration: negDuration, err: test.err})
 	}
 	ret = append(ret, positiveDurationTests...)
@@ -100,7 +100,7 @@ func TestEncodeDecode(t *testing.T) {
 }
 
 func TestCompare(t *testing.T) {
-	prev := Duration{Nanos: 1} // It's expected that we start with something greater than 0.
+	prev := Duration{nanos: 1} // It's expected that we start with something greater than 0.
 	for i, test := range fullDurationTests() {
 		cmp := test.duration.Compare(prev)
 		if cmp != test.cmpToPrev {
@@ -122,8 +122,8 @@ func TestNormalize(t *testing.T) {
 			normalized.Days < -daysInMonth && normalized.Months != math.MinInt64 {
 			t.Errorf("%d days were not normalized [%s]", i, normalized)
 		}
-		if normalized.Nanos > nanosInDay && normalized.Days != math.MaxInt64 ||
-			normalized.Nanos < -nanosInDay && normalized.Days != math.MinInt64 {
+		if normalized.nanos > nanosInDay && normalized.Days != math.MaxInt64 ||
+			normalized.nanos < -nanosInDay && normalized.Days != math.MinInt64 {
 			t.Errorf("%d nanos were not normalized [%s]", i, normalized)
 		}
 	}
@@ -362,6 +362,43 @@ func TestTruncate(t *testing.T) {
 		if s := Truncate(tc.d, tc.r).String(); s != tc.s {
 			t.Errorf("%d: (%s,%s) should give %s, but got %s", i, tc.d, tc.r, tc.s, s)
 		}
+	}
+}
+
+// TestNanos verifies that nanoseconds can only be present after Decode and
+// that any operation will remove them.
+func TestNanos(t *testing.T) {
+	d, err := Decode(1, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expect, actual := int64(1), d.nanos; expect != actual {
+		t.Fatalf("expected %d, got %d", expect, actual)
+	}
+	if expect, actual := "00:00:00+1ns", d.StringNanos(); expect != actual {
+		t.Fatalf("expected %s, got %s", expect, actual)
+	}
+	// Add, even of a 0-duration interval, should call round.
+	d = d.Add(Duration{})
+	if expect, actual := int64(0), d.nanos; expect != actual {
+		t.Fatalf("expected %d, got %d", expect, actual)
+	}
+	d, err = Decode(500, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expect, actual := int64(500), d.nanos; expect != actual {
+		t.Fatalf("expected %d, got %d", expect, actual)
+	}
+	if expect, actual := "00:00:00+500ns", d.StringNanos(); expect != actual {
+		t.Fatalf("expected %s, got %s", expect, actual)
+	}
+	d = d.Add(Duration{})
+	if expect, actual := int64(1000), d.nanos; expect != actual {
+		t.Fatalf("expected %d, got %d", expect, actual)
+	}
+	if expect, actual := "00:00:00.000001", d.StringNanos(); expect != actual {
+		t.Fatalf("expected %s, got %s", expect, actual)
 	}
 }
 

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -1543,7 +1543,7 @@ func prettyPrintFirstValue(dir Direction, b []byte) ([]byte, string, error) {
 		if err != nil {
 			return b, "", err
 		}
-		return b, d.String(), nil
+		return b, d.StringNanos(), nil
 	default:
 		if len(b) >= 1 {
 			switch b[0] {
@@ -1859,7 +1859,7 @@ func EncodeDurationValue(appendTo []byte, colID uint32, d duration.Duration) []b
 func EncodeUntaggedDurationValue(appendTo []byte, d duration.Duration) []byte {
 	appendTo = EncodeNonsortingStdlibVarint(appendTo, d.Months)
 	appendTo = EncodeNonsortingStdlibVarint(appendTo, d.Days)
-	return EncodeNonsortingStdlibVarint(appendTo, d.Nanos)
+	return EncodeNonsortingStdlibVarint(appendTo, d.Nanos())
 }
 
 // EncodeBitArrayValue encodes a bit array value with its value tag,
@@ -2113,7 +2113,7 @@ func DecodeUntaggedDurationValue(b []byte) (remaining []byte, d duration.Duratio
 	if err != nil {
 		return b, duration.Duration{}, err
 	}
-	return b, duration.Duration{Months: months, Days: days, Nanos: nanos}, nil
+	return b, duration.DecodeDuration(months, days, nanos), nil
 }
 
 // DecodeBitArrayValue decodes a value encoded by EncodeUntaggedBitArrayValue.
@@ -2358,7 +2358,7 @@ func PrettyPrintValueEncoded(b []byte) ([]byte, string, error) {
 		if err != nil {
 			return b, "", err
 		}
-		return b, d.String(), nil
+		return b, d.StringNanos(), nil
 	case BitArray:
 		var d bitarray.BitArray
 		b, d, err = DecodeBitArrayValue(b)

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -1112,11 +1112,11 @@ func testCustomEncodeDuration(
 
 func TestEncodeDecodeDuration(t *testing.T) {
 	testCases := []testCaseDuration{
-		{duration.Duration{Months: 0, Days: 0, Nanos: 0}, []byte{0x16, 0x88, 0x88, 0x88}},
-		{duration.Duration{Months: 0, Days: 0, Nanos: 1}, []byte{0x16, 0x89, 0x88, 0x88}},
-		{duration.Duration{Months: 0, Days: 1, Nanos: 0}, []byte{0x16, 0xfb, 0x4e, 0x94, 0x91, 0x4f, 0x00, 0x00, 0x88, 0x89}},
-		{duration.Duration{Months: 1, Days: 0, Nanos: 0}, []byte{0x16, 0xfc, 0x09, 0x35, 0x69, 0x07, 0x42, 0x00, 0x00, 0x89, 0x88}},
-		{duration.Duration{Months: 0, Days: 40, Nanos: 0}, []byte{0x16, 0xfc, 0x0c, 0x47, 0x36, 0xb4, 0x58, 0x00, 0x00, 0x88, 0xb0}},
+		{duration.DecodeDuration(0, 0, 0), []byte{0x16, 0x88, 0x88, 0x88}},
+		{duration.DecodeDuration(0, 0, 1), []byte{0x16, 0x89, 0x88, 0x88}},
+		{duration.DecodeDuration(0, 1, 0), []byte{0x16, 0xfb, 0x4e, 0x94, 0x91, 0x4f, 0x00, 0x00, 0x88, 0x89}},
+		{duration.DecodeDuration(1, 0, 0), []byte{0x16, 0xfc, 0x09, 0x35, 0x69, 0x07, 0x42, 0x00, 0x00, 0x89, 0x88}},
+		{duration.DecodeDuration(0, 40, 0), []byte{0x16, 0xfc, 0x0c, 0x47, 0x36, 0xb4, 0x58, 0x00, 0x00, 0x88, 0xb0}},
 	}
 	testBasicEncodeDuration(testCases, EncodeDurationAscending, t)
 	testCustomEncodeDuration(testCases, EncodeDurationAscending, DecodeDurationAscending, t)
@@ -1124,11 +1124,11 @@ func TestEncodeDecodeDuration(t *testing.T) {
 
 func TestEncodeDecodeDescending(t *testing.T) {
 	testCases := []testCaseDuration{
-		{duration.Duration{Months: 0, Days: 40, Nanos: 0}, []byte{0x16, 0x81, 0xf3, 0xb8, 0xc9, 0x4b, 0xa7, 0xff, 0xff, 0x87, 0xff, 0x87, 0xd7}},
-		{duration.Duration{Months: 1, Days: 0, Nanos: 0}, []byte{0x16, 0x81, 0xf6, 0xca, 0x96, 0xf8, 0xbd, 0xff, 0xff, 0x87, 0xfe, 0x87, 0xff}},
-		{duration.Duration{Months: 0, Days: 1, Nanos: 0}, []byte{0x16, 0x82, 0xb1, 0x6b, 0x6e, 0xb0, 0xff, 0xff, 0x87, 0xff, 0x87, 0xfe}},
-		{duration.Duration{Months: 0, Days: 0, Nanos: 1}, []byte{0x16, 0x87, 0xfe, 0x87, 0xff, 0x87, 0xff}},
-		{duration.Duration{Months: 0, Days: 0, Nanos: 0}, []byte{0x16, 0x87, 0xff, 0x87, 0xff, 0x87, 0xff}},
+		{duration.DecodeDuration(0, 40, 0), []byte{0x16, 0x81, 0xf3, 0xb8, 0xc9, 0x4b, 0xa7, 0xff, 0xff, 0x87, 0xff, 0x87, 0xd7}},
+		{duration.DecodeDuration(1, 0, 0), []byte{0x16, 0x81, 0xf6, 0xca, 0x96, 0xf8, 0xbd, 0xff, 0xff, 0x87, 0xfe, 0x87, 0xff}},
+		{duration.DecodeDuration(0, 1, 0), []byte{0x16, 0x82, 0xb1, 0x6b, 0x6e, 0xb0, 0xff, 0xff, 0x87, 0xff, 0x87, 0xfe}},
+		{duration.DecodeDuration(0, 0, 1), []byte{0x16, 0x87, 0xfe, 0x87, 0xff, 0x87, 0xff}},
+		{duration.DecodeDuration(0, 0, 0), []byte{0x16, 0x87, 0xff, 0x87, 0xff, 0x87, 0xff}},
 	}
 	testBasicEncodeDuration(testCases, EncodeDurationDescending, t)
 	testCustomEncodeDuration(testCases, EncodeDurationDescending, DecodeDurationDescending, t)
@@ -1203,11 +1203,11 @@ func (rd randData) bitArray() bitarray.BitArray {
 }
 
 func (rd randData) duration() duration.Duration {
-	return duration.Duration{
-		Months: rd.Int63n(1000),
-		Days:   rd.Int63n(1000),
-		Nanos:  rd.Int63n(1000000),
-	}
+	return duration.DecodeDuration(
+		rd.Int63n(1000),
+		rd.Int63n(1000),
+		rd.Int63n(1000000),
+	)
 }
 
 func (rd randData) ipAddr() ipaddr.IPAddr {
@@ -2140,7 +2140,7 @@ func TestPrettyPrintValueEncoded(t *testing.T) {
 		{EncodeTimeValue(nil, NoColumnID,
 			time.Date(2016, 6, 29, 16, 2, 50, 5, time.UTC)), "2016-06-29T16:02:50.000000005Z"},
 		{EncodeDurationValue(nil, NoColumnID,
-			duration.Duration{Months: 1, Days: 2, Nanos: 3}), "1 mon 2 days 00:00:00.000000003"},
+			duration.DecodeDuration(1, 2, 3)), "1 mon 2 days 00:00:00+3ns"},
 		{EncodeBytesValue(nil, NoColumnID, []byte{0x1, 0x2, 0xF, 0xFF}), "0x01020fff"},
 		{EncodeBytesValue(nil, NoColumnID, []byte("foo")), "foo"}, // printable bytes
 		{EncodeBytesValue(nil, NoColumnID, []byte{0x89}), "0x89"}, // non-printable bytes

--- a/pkg/util/timeofday/time_of_day.go
+++ b/pkg/util/timeofday/time_of_day.go
@@ -99,12 +99,12 @@ func Random(rng *rand.Rand) TimeOfDay {
 
 // Add adds a Duration to a TimeOfDay, wrapping into the next day if necessary.
 func (t TimeOfDay) Add(d duration.Duration) TimeOfDay {
-	return FromInt(int64(t) + d.Nanos/nanosPerMicro)
+	return FromInt(int64(t) + d.Nanos()/nanosPerMicro)
 }
 
 // Difference returns the interval between t1 and t2, which may be negative.
 func Difference(t1 TimeOfDay, t2 TimeOfDay) duration.Duration {
-	return duration.Duration{Nanos: int64(t1-t2) * nanosPerMicro}
+	return duration.MakeDuration(int64(t1-t2)*nanosPerMicro, 0, 0)
 }
 
 // Hour returns the hour specified by t, in the range [0, 23].

--- a/pkg/util/timeofday/time_of_day_test.go
+++ b/pkg/util/timeofday/time_of_day_test.go
@@ -82,7 +82,7 @@ func TestAdd(t *testing.T) {
 		{Min, -1, Max},
 	}
 	for _, td := range testData {
-		d := duration.Duration{Nanos: td.micros * nanosPerMicro}
+		d := duration.MakeDuration(td.micros*nanosPerMicro, 0, 0)
 		t.Run(fmt.Sprintf("%s,%s", td.t, d), func(t *testing.T) {
 			actual := td.t.Add(d)
 			if actual != td.exp {
@@ -106,7 +106,7 @@ func TestDifference(t *testing.T) {
 	}
 	for _, td := range testData {
 		t.Run(fmt.Sprintf("%s,%s", td.t1, td.t2), func(t *testing.T) {
-			actual := Difference(td.t1, td.t2).Nanos / nanosPerMicro
+			actual := Difference(td.t1, td.t2).Nanos() / nanosPerMicro
 			if actual != td.expMicros {
 				t.Errorf("expected %d, got %d", td.expMicros, actual)
 			}


### PR DESCRIPTION
Nanoseconds were not representable over pgwire binary mode and were being
truncated. We previously encountered this problem with timestamps (#6597)
and removed nanoseconds from timestamps at that time. We should have
done the same for intervals, since they have the same kind of problem,
but did not.

It is no longer possible to create intervals with nanosecond
precision. Parsing from string or converting from float or decimal will
round to the nearest microsecond. Similarly any arithmetic operation
(add, sub, mul, div) on intervals will also round to nearest micro. We
round instead of truncate because that's what Postgres does.

Existing on-disk intervals that contain nanoseconds will retain their
underlying value when doing encode/decode operations (so that indexes can
be correctly maintained. However there is no longer any way to retrieve
the nanosecond part. Converting to string, float, or decimal will first
round and then convert.

The reasoning for this restriction on existing on-disk nanoseconds is
related to the original bug, where we were truncating nanos to micros over
binary pgwire. The problem there was that depending on how you queried
the data (text or binary mode), you would get a different result, and
one of them was wrong. Similarly, it would be wrong to have the results
of an interval -> string conversion return a different result than just
querying the interval.

It is unfortunate that upgrading from 2.1 -> 2.2 will completely remove
the ability for users to continue accessing their nanoseconds. Due to
that, we must describe in the major release notes this change. Users who
require nanoseconds to be present will have to modify their application
to use a different data type before upgrading. Further, applications
that do comparisons on intervals may have some edge cases errors due to
rounding and seeming equality. That is, some intervals with nanos will
be rounded up to the next microsecond, possibly changing the results of
an existing query. Also, it is not possible to compare equality to any
existing interval with on-disk nanos. We believe the number of users
affected by this will be very small, and that it is still a necessary
change because of the unavoidable pgwire binary mode bug above, which
may already have been unknowningly affecting them.

Other implementations were worked on, like one where the user could
specify the desired precision of each operation (similary to how
timestamps work). This ended up being very tedious since there
are many operations and they all required the same microsecond
precision. Timestamps are different since there are some operations
that actually do need nanosecond precision, but intervals have no such
need. Thus, it was better to remove the precision argument and hard
code rounding. Another attempt was made to replace Nanos with Micros,
with an additional nanos field to hold on-disk nanoseconds. This had
difficult problems since all of our encoding infra uses nanoseconds
on disk. Converting the Micros field to nanos increased the possibilty
of overflow due multiplying by 1000. Handling the possibility of this
overflow in all possibly locations would require many large and risky
changes.

The implementation changes here are a bit odd and surprising at
first. This change leaves the duration.Nanos field, but (excepting the
Decode func) automatically rounds Nanos to nearist micro. This does leave
open the possible misuse of the Nanos field, since durations are created
directly instead of via a constructor. However, I think this problem is
less of a risk as the other attempts listed above.

See #6604 and #8864 for previous PRs and discussion about this problem
when we fixed it for timestamps.

Fixes #32143

Release note (sql change): INTERVAL values are now stored with microsecond
precision instead of nanoseconds. Existing intervals with nanoseconds
are no longer able to return their nanosecond part. An existing table t
with nanoseconds in intervals of column s can round them to the nearest
microsecond with `UPDATE t SET s = s + '0s'`. Note that this could
potentially cause uniqueness problems if the interval is a primary key.