### PR TITLE
intentresolver: move intentresolver from storage into its own package

### DIFF
--- a/pkg/storage/addressing_test.go
+++ b/pkg/storage/addressing_test.go
@@ -63,7 +63,6 @@ func TestUpdateRangeAddressing(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 	store, _ := createTestStore(t, testStoreOpts{createSystemRanges: false}, stopper)
-
 	// When split is false, merging treats the right range as the merged
 	// range. With merging, expNewLeft indicates the addressing keys we
 	// expect to be removed.

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1374,7 +1374,7 @@ func runSetupSplitSnapshotRace(
 	sc.TestingKnobs.DisableReplicateQueue = true
 	// Async intent resolution can sometimes lead to hangs when we stop
 	// most of the stores at the end of this function.
-	sc.TestingKnobs.DisableAsyncIntentResolution = true
+	sc.TestingKnobs.IntentResolverKnobs.DisableAsyncIntentResolution = true
 	// Avoid fighting with the merge queue while trying to reproduce this race.
 	sc.TestingKnobs.DisableMergeQueue = true
 	// Disable the split delay mechanism, or it'll spend 10s going in circles.
@@ -3009,10 +3009,12 @@ func TestStoreSplitRangeLookupRace(t *testing.T) {
 	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &storage.StoreTestingKnobs{
-				DisableSplitQueue:         true,
-				DisableMergeQueue:         true,
-				ForceSyncIntentResolution: true,
-				TestingResponseFilter:     respFilter,
+				DisableSplitQueue:     true,
+				DisableMergeQueue:     true,
+				TestingResponseFilter: respFilter,
+				IntentResolverKnobs: storagebase.IntentResolverTestingKnobs{
+					ForceSyncIntentResolution: true,
+				},
 			},
 		},
 	})
@@ -3090,7 +3092,7 @@ func TestRangeLookupAsyncResolveIntent(t *testing.T) {
 
 	// Disable async tasks in the intent resolver. All tasks will be synchronous.
 	cfg := storage.TestStoreConfig(nil)
-	cfg.TestingKnobs.ForceSyncIntentResolution = true
+	cfg.TestingKnobs.IntentResolverKnobs.ForceSyncIntentResolution = true
 	cfg.TestingKnobs.DisableSplitQueue = true
 	cfg.TestingKnobs.DisableMergeQueue = true
 	cfg.TestingKnobs.TestingProposalFilter =

--- a/pkg/storage/intentresolver/contention_queue.go
+++ b/pkg/storage/intentresolver/contention_queue.go
@@ -1,0 +1,351 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package intentresolver
+
+import (
+	"container/list"
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+type pusher struct {
+	txn      *roachpb.Transaction
+	waitCh   chan *enginepb.TxnMeta
+	detectCh chan struct{}
+}
+
+func newPusher(txn *roachpb.Transaction) *pusher {
+	p := &pusher{
+		txn:    txn,
+		waitCh: make(chan *enginepb.TxnMeta, 1),
+	}
+	if p.activeTxn() {
+		p.detectCh = make(chan struct{}, 1)
+		// Signal the channel in order to begin dependency cycle detection.
+		p.detectCh <- struct{}{}
+	}
+	return p
+}
+
+func (p *pusher) activeTxn() bool {
+	return p.txn != nil && p.txn.Key != nil
+}
+
+type contendedKey struct {
+	ll *list.List
+	// lastTxnMeta is the most recent txn to own the intent. Active
+	// transactions in the contention queue for this intent must push
+	// this txn record in order to detect dependency cycles.
+	lastTxnMeta *enginepb.TxnMeta
+}
+
+func newContendedKey() *contendedKey {
+	return &contendedKey{
+		ll: list.New(),
+	}
+}
+
+// setLastTxnMeta sets the most recent txn meta and sends to all
+// pushers w/ active txns still in the queue to push, to guarantee
+// detection of dependency cycles.
+func (ck *contendedKey) setLastTxnMeta(txnMeta *enginepb.TxnMeta) {
+	ck.lastTxnMeta = txnMeta
+	for e := ck.ll.Front(); e != nil; e = e.Next() {
+		p := e.Value.(*pusher)
+		if p.detectCh != nil {
+			select {
+			case p.detectCh <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+// contentionQueue handles contention on keys with conflicting intents
+// by forming queues of "pushers" which are requests that experienced
+// a WriteIntentError. There is a queue for each key with one or more
+// pushers. Queues are complicated by the difference between pushers
+// with writing transactions (i.e. they may have a transaction record
+// which can be pushed) and non-writing transactions (e.g.,
+// non-transactional requests, and read-only transactions).
+//
+// Queues are linked lists, with each element containing a transaction
+// (can be nil), and a wait channel. The wait channel is closed when
+// the request is dequeued and run to completion, whether to success
+// or failure. Pushers wait on the most recent pusher in the queue to
+// complete. However, pushers with an active transaction (i.e., txns
+// with a non-nil key) must send a PushTxn RPC. This is necessary in
+// order to properly detect dependency cycles.
+type contentionQueue struct {
+	clock *hlc.Clock
+	db    *client.DB
+
+	// keys is a map from key to a linked list of pusher instances,
+	// ordered as a FIFO queue.
+	mu struct {
+		syncutil.Mutex
+		keys map[string]*contendedKey
+	}
+}
+
+func (cq *contentionQueue) numContended(key roachpb.Key) int {
+	cq.mu.Lock()
+	defer cq.mu.Unlock()
+	ck, ok := cq.mu.keys[string(key)]
+	if !ok {
+		return 0
+	}
+	return ck.ll.Len()
+}
+
+func newContentionQueue(clock *hlc.Clock, db *client.DB) *contentionQueue {
+	cq := &contentionQueue{
+		clock: clock,
+		db:    db,
+	}
+	cq.mu.keys = map[string]*contendedKey{}
+	return cq
+}
+
+func txnID(txn *roachpb.Transaction) string {
+	if txn == nil {
+		return "nil txn"
+	}
+	return txn.ID.Short()
+}
+
+// add adds the intent specified in the supplied wiErr to the
+// contention queue. This may block the current goroutine if the
+// pusher has no transaction or the transaction is not yet writing
+// (i.e. read-only or hasn't successfully executed BeginTxn).
+//
+// Note that the supplied wiErr write intent error must have only a
+// single intent (len(wiErr.Intents) == 1).
+//
+// Returns a cleanup function to be invoked by the caller after the
+// original request completes, a possibly updated WriteIntentError and
+// a bool indicating whether the intent resolver should regard the
+// original push / resolve as no longer applicable and skip those
+// steps to retry the original request that generated the
+// WriteIntentError. The cleanup function takes two arguments, a
+// newWIErr, non-nil in case the re-executed request experienced
+// another write intent error and could not complete; and
+// newIntentTxn, nil if the re-executed request left no intent, and
+// non-nil if it did. At most one of these two arguments should be
+// provided.
+func (cq *contentionQueue) add(
+	ctx context.Context, wiErr *roachpb.WriteIntentError, h roachpb.Header,
+) (CleanupFunc, *roachpb.WriteIntentError, bool) {
+	if len(wiErr.Intents) != 1 {
+		log.Fatalf(ctx, "write intent error must contain only a single intent: %s", wiErr)
+	}
+	intent := wiErr.Intents[0]
+	key := string(intent.Span.Key)
+	curPusher := newPusher(h.Txn)
+	log.VEventf(ctx, 3, "adding %s to contention queue on intent %s @%s", txnID(h.Txn), intent.Key, intent.Txn.ID.Short())
+
+	// Consider prior pushers in reverse arrival order to build queue
+	// by waiting on the most recent overlapping pusher.
+	var waitCh chan *enginepb.TxnMeta
+	var curElement *list.Element
+
+	cq.mu.Lock()
+	contended, ok := cq.mu.keys[key]
+	if !ok {
+		contended = newContendedKey()
+		contended.setLastTxnMeta(&intent.Txn)
+		cq.mu.keys[key] = contended
+	} else if contended.lastTxnMeta.ID != intent.Txn.ID {
+		contended.setLastTxnMeta(&intent.Txn)
+	}
+
+	// Get the prior pusher to wait on.
+	if e := contended.ll.Back(); e != nil {
+		p := e.Value.(*pusher)
+		waitCh = p.waitCh
+		log.VEventf(ctx, 3, "%s waiting on %s", txnID(curPusher.txn), txnID(p.txn))
+	}
+
+	// Append the current pusher to the queue.
+	curElement = contended.ll.PushBack(curPusher)
+	cq.mu.Unlock()
+
+	// Delay before pushing in order to detect dependency cycles.
+	const dependencyCyclePushDelay = 100 * time.Millisecond
+
+	// Wait on prior pusher, if applicable.
+	var done bool
+	if waitCh != nil {
+		var detectCh chan struct{}
+		var detectReady <-chan time.Time
+		// If the current pusher has an active txn, we need to push the
+		// transaction which owns the intent to detect dependency cycles.
+		// To avoid unnecessary push traffic, insert a delay by
+		// instantiating the detectReady, which sets detectCh when it
+		// fires. When detectCh receives, it sends a push to the most
+		// recent txn to own the intent.
+		if curPusher.detectCh != nil {
+			detectReady = time.After(dependencyCyclePushDelay)
+		}
+
+	Loop:
+		for {
+			select {
+			case txnMeta, ok := <-waitCh:
+				if !ok {
+					log.Fatalf(ctx, "the wait channel of a prior pusher was used twice (pusher=%s)", txnMeta)
+				}
+				// If the prior pusher wrote an intent, push it instead by
+				// creating a copy of the WriteIntentError with updated txn.
+				if txnMeta != nil {
+					log.VEventf(ctx, 3, "%s exiting contention queue to push %s", txnID(curPusher.txn), txnMeta.ID.Short())
+					wiErrCopy := *wiErr
+					wiErrCopy.Intents = []roachpb.Intent{
+						{
+							Span:   intent.Span,
+							Txn:    *txnMeta,
+							Status: roachpb.PENDING,
+						},
+					}
+					wiErr = &wiErrCopy
+				} else {
+					// No intent was left by the prior pusher; don't push, go
+					// immediately to retrying the conflicted request.
+					log.VEventf(ctx, 3, "%s exiting contention queue to proceed", txnID(curPusher.txn))
+					done = true
+				}
+				break Loop
+
+			case <-ctx.Done():
+				// The pusher's context is done. Return without pushing.
+				done = true
+				break Loop
+
+			case <-detectReady:
+				// When the detect timer fires, set detectCh and loop.
+				log.VEventf(ctx, 3, "%s cycle detection is ready", txnID(curPusher.txn))
+				detectCh = curPusher.detectCh
+
+			case <-detectCh:
+				cq.mu.Lock()
+				frontOfQueue := curElement == contended.ll.Front()
+				pusheeTxn := contended.lastTxnMeta
+				cq.mu.Unlock()
+				// If we're at the start of the queue loop and wait
+				// for the wait channel to signal.
+				if frontOfQueue {
+					log.VEventf(ctx, 3, "%s at front of queue; breaking from loop", txnID(curPusher.txn))
+					break Loop
+				}
+				pushReq := &roachpb.PushTxnRequest{
+					RequestHeader: roachpb.RequestHeader{
+						Key: pusheeTxn.Key,
+					},
+					PusherTxn: getPusherTxn(h),
+					PusheeTxn: *pusheeTxn,
+					PushTo:    h.Timestamp,
+					Now:       cq.clock.Now(),
+					PushType:  roachpb.PUSH_ABORT,
+				}
+				b := &client.Batch{}
+				b.AddRawRequest(pushReq)
+				log.VEventf(ctx, 3, "%s pushing %s to detect dependency cycles", txnID(curPusher.txn), pusheeTxn.ID.Short())
+				if err := cq.db.Run(ctx, b); err != nil {
+					log.VErrEventf(ctx, 2, "while waiting in push contention queue to push %s: %s", pusheeTxn.ID.Short(), b.MustPErr())
+					done = true // done=true to avoid uselessly trying to push and resolve
+					break Loop
+				}
+				// Note that this pusher may have aborted the pushee, but it
+				// should still wait on the previous pusher's wait channel.
+				detectCh = nil
+				detectReady = time.After(dependencyCyclePushDelay)
+			}
+		}
+	}
+
+	return func(newWIErr *roachpb.WriteIntentError, newIntentTxn *enginepb.TxnMeta) {
+		if newWIErr != nil && newIntentTxn != nil {
+			// The need for this implies that the function should be split
+			// into a more rigidly defined handle with multiple accessors.
+			// TODO(nvanbenschoten): clean this up and test better when we're
+			// not intending the change to be backported.
+			panic("newWIErr and newIntentTxn both provided")
+		}
+		if newWIErr == nil {
+			log.VEventf(ctx, 3, "%s finished, leaving intent? %t (owned by %s)", txnID(curPusher.txn), newIntentTxn != nil, newIntentTxn)
+		} else {
+			log.VEventf(ctx, 3, "%s encountered another write intent error %s", txnID(curPusher.txn), newWIErr)
+		}
+		cq.mu.Lock()
+		defer cq.mu.Unlock()
+		// Remove the current element from its list of pushers.
+		// If the current element isn't the front, it's being removed
+		// because its context was canceled. Swap the wait channel with
+		// the previous element.
+		if curElement != contended.ll.Front() {
+			prevPusher := curElement.Prev().Value.(*pusher)
+			if waitCh != nil && prevPusher.waitCh != waitCh {
+				log.Fatalf(ctx, "expected previous pusher's wait channel to be the one current pusher waited on")
+			}
+			prevPusher.waitCh, curPusher.waitCh = curPusher.waitCh, prevPusher.waitCh
+		}
+		contended.ll.Remove(curElement)
+
+		if contended.ll.Len() == 0 {
+			// If the contendedKey's list is now empty, remove it. We don't need
+			// to send on or close our waitCh because no one is or ever will wait
+			// on it.
+			delete(cq.mu.keys, key)
+		} else {
+			// If the pusher re-executed its request and encountered another
+			// write intent error, check if it's for the same intent; if so,
+			// we can set the newIntentTxn to match the new intent. If not,
+			// make sure that we don't pollute the old contendedKey with any
+			// new information.
+			if newWIErr != nil {
+				sameKey := len(newWIErr.Intents) == 1 && newWIErr.Intents[0].Span.Equal(intent.Span)
+				if sameKey {
+					newIntentTxn = &newWIErr.Intents[0].Txn
+				} else {
+					// If the pusher re-executed and found a different intent, make
+					// sure that we don't tell the old contendedKey anything about
+					// the new intent's transaction. This new intent could be from
+					// an earlier request in the batch than the one that previously
+					// hit the error, so we don't know anything about the state of
+					// the old intent.
+					newIntentTxn = nil
+				}
+			}
+			if newIntentTxn != nil {
+				// Shallow copy the TxnMeta. After this request returns (i.e.
+				// now), we might mutate it (DistSender and such), but the
+				// receiver of the channel will read it.
+				newIntentTxnCopy := *newIntentTxn
+				newIntentTxn = &newIntentTxnCopy
+				contended.setLastTxnMeta(newIntentTxn)
+			}
+			curPusher.waitCh <- newIntentTxn
+			close(curPusher.waitCh)
+		}
+	}, wiErr, done
+}

--- a/pkg/storage/intentresolver/intent_resolver_test.go
+++ b/pkg/storage/intentresolver/intent_resolver_test.go
@@ -1,0 +1,746 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package intentresolver
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPushTransactionsWithNonPendingIntent verifies that maybePushIntents
+// returns an error when a non-pending intent is passed.
+func TestPushTransactionsWithNonPendingIntent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	db := client.NewDB(log.AmbientContext{
+		Tracer: tracing.NewTracer(),
+	}, client.NonTransactionalFactoryFunc(func(context.Context, roachpb.BatchRequest) (
+		*roachpb.BatchResponse, *roachpb.Error) {
+		return nil, nil
+	}), clock)
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+	ir := New(Config{
+		Stopper: stopper,
+		DB:      db,
+		Clock:   clock,
+	})
+
+	testCases := [][]roachpb.Intent{
+		{{Span: roachpb.Span{Key: roachpb.Key("a")}, Status: roachpb.PENDING},
+			{Span: roachpb.Span{Key: roachpb.Key("b")}, Status: roachpb.ABORTED}},
+		{{Span: roachpb.Span{Key: roachpb.Key("a")}, Status: roachpb.PENDING},
+			{Span: roachpb.Span{Key: roachpb.Key("b")}, Status: roachpb.COMMITTED}},
+	}
+	for _, intents := range testCases {
+		if _, pErr := ir.MaybePushIntents(
+			context.Background(), intents, roachpb.Header{}, roachpb.PUSH_TOUCH, true,
+		); !testutils.IsPError(pErr, "unexpected (ABORTED|COMMITTED) intent") {
+			t.Errorf("expected error on aborted/resolved intent, but got %s", pErr)
+		}
+		if cnt := len(ir.mu.inFlightPushes); cnt != 0 {
+			t.Errorf("expected no inflight pushes refcount map entries, found %d", cnt)
+		}
+	}
+}
+
+// TestCleanupTxnIntentsOnGCAsync exercises the code which is used to
+// asynchronously clean up transaction intents and then transaction records.
+// This method is invoked from the storage GC queue.
+func TestCleanupTxnIntentsOnGCAsync(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+
+	type testCase struct {
+		txn           *roachpb.Transaction
+		intents       []roachpb.Intent
+		sendFuncs     []sendFunc
+		expectPushed  bool
+		expectSucceed bool
+	}
+
+	// This test creates 3 transaction for use in the below test cases.
+	// A new intent resolver is created for each test case so they operate
+	// completely independently.
+	key := roachpb.Key("a")
+	// Txn0 is in the pending state and is not old enough to have expired to the
+	// code ought to send nothing.
+	txn0 := beginTransaction(t, clock, 1, key, true /* putKey */)
+	// Txn1 is in the pending state but is expired.
+	txn1 := beginTransaction(t, clock, 1, key, true /* putKey */)
+	txn1.OrigTimestamp.WallTime -= int64(100 * time.Second)
+	txn1.LastHeartbeat = txn1.OrigTimestamp
+	// Txn2 is in the Committed state
+	txn2 := beginTransaction(t, clock, 1, key, true /* putKey */)
+	txn2.Status = roachpb.COMMITTED
+	cases := []*testCase{
+		// This one has an unexpired pending transaction so it's skipped
+		{txn: txn0},
+		// Txn1 is pending and expired so the code should attempt to push the txn.
+		// The provided sender will fail on the first request. The callback should
+		// indicate that the transaction was pushed but that the resolution was not
+		// successful.
+		{
+			txn:          txn1,
+			sendFuncs:    []sendFunc{failSendFunc},
+			expectPushed: true,
+		},
+		// Txn1 is pending and expired so the code should attempt to push the txn
+		// and then work to resolve its intents. The intent resolution happens in
+		// different requests for individual keys and then for spans. This case will
+		// allow the individual key intent to be resolved completely but will fail
+		// to resolve the span. The callback should indicate that the transaction
+		// has been pushed but that the garbage collection was not successful.
+		{
+			txn: txn1,
+			intents: []roachpb.Intent{
+				{
+					Span: roachpb.Span{Key: key},
+					Txn:  txn1.TxnMeta,
+				},
+				{
+					Span: roachpb.Span{Key: key, EndKey: roachpb.Key("b")},
+					Txn:  txn1.TxnMeta,
+				},
+			},
+			sendFuncs: []sendFunc{
+				pushTxnSendFunc,
+				resolveIntentsSendFunc,
+				failSendFunc,
+			},
+			expectPushed: true,
+		},
+		// Txn1 is pending and expired so the code should attempt to push the txn
+		// and then work to resolve its intents. The intent resolution happens in
+		// different requests for individual keys and then for spans. This case will
+		// allow the individual key intents to be resolved in one request and for
+		// the span request to be resolved in another. Finally it will succeed on
+		// the GCRequest. This is a positive case and the callback should indicate
+		// that the txn has both been pushed and successfully resolved.
+		{
+			txn: txn1,
+			intents: []roachpb.Intent{
+				{Span: roachpb.Span{Key: key}, Txn: txn1.TxnMeta},
+				{Span: roachpb.Span{Key: roachpb.Key("aa")}, Txn: txn1.TxnMeta},
+				{Span: roachpb.Span{Key: key, EndKey: roachpb.Key("b")}, Txn: txn1.TxnMeta},
+			},
+			sendFuncs: []sendFunc{
+				pushTxnSendFunc,
+				resolveIntentsSendFunc,
+				resolveIntentsSendFunc,
+				gcSendFunc,
+			},
+			expectPushed:  true,
+			expectSucceed: true,
+		},
+		// Txn2 is committed so it should not be pushed. Also it has no intents so
+		// it should only send a GCRequest. The callback should indicate that there
+		// is no push but that the gc has occurred successfully.
+		{
+			txn:           txn2,
+			intents:       []roachpb.Intent{},
+			sendFuncs:     []sendFunc{gcSendFunc},
+			expectSucceed: true,
+		},
+	}
+
+	for _, c := range cases {
+		ir := newIntentResolverWithSendFuncs(stopper, clock, &c.sendFuncs)
+		var didPush, didSucceed bool
+		done := make(chan struct{})
+		onComplete := func(pushed, succeeded bool) {
+			didPush, didSucceed = pushed, succeeded
+			close(done)
+		}
+		err := ir.CleanupTxnIntentsOnGCAsync(ctx, 1, c.txn, c.intents, clock.Now(), onComplete)
+		if err != nil {
+			t.Fatalf("unexpected error sending async transaction")
+		}
+		<-done
+		if len(c.sendFuncs) != 0 {
+			t.Errorf("Not all send funcs called")
+		}
+		if didSucceed != c.expectSucceed {
+			t.Fatalf("unexpected success value: got %v, expected %v", didSucceed, c.expectSucceed)
+		}
+		if didPush != c.expectPushed {
+			t.Fatalf("unexpected pushed value: got %v, expected %v", didPush, c.expectPushed)
+		}
+	}
+}
+
+// TestContendedIntent verifies that multiple transactions, some actively
+// writing and others read-only, are queued if processing write intent
+// errors on a contended key. The test verifies the expected ordering in
+// the queue and then works to invoke the corresponding cleanup functions
+// to exercise the various transaction pushing and intent resolution which
+// should occur.
+func TestContendedIntent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+
+	// The intent resolver's db uses a sender which always resolves intents
+	// and pushes transactions to aborted successfully. All requests are sent to
+	// reqChan so that the test can inspect all sent requests. Given the buffer
+	// size of 2, it is important that the test take care to consume from reqChan
+	// when it expects requests
+	reqChan := make(chan roachpb.BatchRequest, 2)
+	sender := client.NonTransactionalFactoryFunc(
+		func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			resp := &roachpb.BatchResponse{}
+			switch req := ba.Requests[0].GetInner().(type) {
+			case *roachpb.PushTxnRequest:
+				resp.Add(&roachpb.PushTxnResponse{
+					PusheeTxn: roachpb.Transaction{
+						TxnMeta: req.PusheeTxn,
+						Status:  roachpb.ABORTED,
+					},
+				})
+			case *roachpb.ResolveIntentRequest:
+				resp.Add(&roachpb.ResolveIntentRangeResponse{})
+			default:
+				t.Errorf("Unexpected request of type %T", req)
+			}
+			reqChan <- ba
+			return resp, nil
+		})
+	verifyPushTxn := func(ba roachpb.BatchRequest, pusher, pushee uuid.UUID) {
+		if req, ok := ba.Requests[0].GetInner().(*roachpb.PushTxnRequest); ok {
+			if req.PusherTxn.ID != pusher {
+				t.Fatalf("expected pusher to be %v, got %v", pusher, req.PusherTxn.ID)
+			} else if req.PusheeTxn.ID != pushee {
+				t.Fatalf("expected pushee to be %v, got %v", pushee, req.PusheeTxn.ID)
+			}
+		} else {
+			t.Fatalf("expected PushTxnRequest, got %T", ba.Requests[0].GetInner())
+		}
+	}
+	verifyResolveIntent := func(ba roachpb.BatchRequest, key roachpb.Key) {
+		if req, ok := ba.Requests[0].GetInner().(*roachpb.ResolveIntentRequest); ok {
+			key.Equal(req.Key)
+		} else {
+			t.Fatalf("expected PushTxnRequest, got %T", ba.Requests[0].GetInner())
+		}
+	}
+
+	db := client.NewDB(log.AmbientContext{
+		Tracer: tracing.NewTracer(),
+	}, sender, clock)
+	ir := New(Config{
+		Stopper: stopper,
+		DB:      db,
+		Clock:   clock,
+	})
+
+	// The below code constructs 7 transactions which will encounter
+	// WriteIntentErrors for origTxn. These transactions all contend with each
+	// other. The test begins by creating goroutines for each of the 7 txns to
+	// record a WriteIntentError for an intent for keyA. We verify that these
+	// transactions queue up behind eachother in the contention queue.
+	// We then proceed to process their returned CleanupFuncs and verify that
+	// the corresponding requests are sent.
+	//
+	// The expectation which is verified below is that the roTxn1 will lead to
+	// a PushTxn request for origTxn followed by a ResolveIntents request for
+	// origTxn's intent. The rest of the read-only transactions when rapidly
+	// cleaned up should send no requests. Note that roTxn4 gets canceled after
+	// roTxn1 is cleaned up in order to ensure that the cancellation code path
+	// does not interfere with correct code behavior.
+	//
+	// Interesting nuances in resolution begin with rwTxn1 for which we call
+	// the CleanupFunc with now a new WriteIntentError with the unrelatedRWTxn
+	// as the associated transaction. This leads all future push requests to
+	// push the unrelatedRWTxn rather than the origTxn though intent resolution
+	// requests will be for the original key.
+	//
+	// For rwTxn2 we wait for the dependencyCyclePushDelay to trigger the sending
+	// of another Push request for the unrelatedRWTxn and then we call cleanup
+	// for rwTxn2 with a new WriteIntentError on a different intent key which
+	// should not result in any new requests.
+	// Lastly we rapidly resolve the last rwTxn3 with (nil, nil) which also should
+	// lead to no requests being sent.
+
+	keyA := roachpb.Key("a")
+	keyB := roachpb.Key("b")
+	keyC := roachpb.Key("c")
+	origTxn := beginTransaction(t, clock, 1, keyA, true /* putKey */)
+	unrelatedRWTxn := beginTransaction(t, clock, 1, keyB, true /* putKey */)
+
+	roTxn1 := newTransaction("test", keyA, 1, clock)
+	roTxn2 := newTransaction("test", keyA, 1, clock)
+	roTxn3 := newTransaction("test", keyA, 1, clock)
+	roTxn4 := newTransaction("test", keyA, 1, clock) // this one gets canceled
+	rwTxn1 := beginTransaction(t, clock, 1, keyB, true /* putKey */)
+	rwTxn2 := beginTransaction(t, clock, 1, keyC, true /* putKey */)
+	rwTxn3 := beginTransaction(t, clock, 1, keyB, true /* putKey */)
+
+	testCases := []struct {
+		pusher     *roachpb.Transaction
+		expTxns    []*roachpb.Transaction
+		cancelFunc context.CancelFunc
+	}{
+		// First establish a chain of four read-only txns.
+		{pusher: roTxn1, expTxns: []*roachpb.Transaction{roTxn1}},
+		{pusher: roTxn2, expTxns: []*roachpb.Transaction{roTxn1, roTxn2}},
+		{pusher: roTxn3, expTxns: []*roachpb.Transaction{roTxn1, roTxn2, roTxn3}},
+		// The fourth txn will be canceled before its predecessor is cleaned up to
+		// excersize the cancellation code path.
+		{pusher: roTxn4, expTxns: []*roachpb.Transaction{roTxn1, roTxn2, roTxn3, roTxn4}},
+		// Now, verify that a writing txn is inserted at the end of the queue.
+		{pusher: rwTxn1, expTxns: []*roachpb.Transaction{roTxn1, roTxn2, roTxn3, roTxn4, rwTxn1}},
+		// And a second writing txn is inserted after it.
+		{pusher: rwTxn2, expTxns: []*roachpb.Transaction{roTxn1, roTxn2, roTxn3, roTxn4, rwTxn1, rwTxn2}},
+		{pusher: rwTxn3, expTxns: []*roachpb.Transaction{roTxn1, roTxn2, roTxn3, roTxn4, rwTxn1, rwTxn2, rwTxn3}},
+	}
+	var wg sync.WaitGroup
+	cleanupFuncs := make(chan CleanupFunc)
+	for i, tc := range testCases {
+		testCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		testCases[i].cancelFunc = cancel
+		t.Run(tc.pusher.ID.String(), func(t *testing.T) {
+			wiErr := &roachpb.WriteIntentError{Intents: []roachpb.Intent{{
+				Txn:  origTxn.TxnMeta,
+				Span: roachpb.Span{Key: keyA},
+			}}}
+			h := roachpb.Header{Txn: tc.pusher}
+			wg.Add(1)
+			go func() {
+				cleanupFunc, pErr := ir.ProcessWriteIntentError(testCtx, roachpb.NewError(wiErr), nil, h, roachpb.PUSH_ABORT)
+				if pErr != nil {
+					panic(pErr)
+				}
+				cleanupFuncs <- cleanupFunc
+				wg.Done()
+			}()
+			testutils.SucceedsSoon(t, func() error {
+				if lc, let := ir.NumContended(keyA), len(tc.expTxns); lc != let {
+					return errors.Errorf("expected len %d; got %d", let, lc)
+				}
+				ir.contentionQ.mu.Lock()
+				defer ir.contentionQ.mu.Unlock()
+				contended, ok := ir.contentionQ.mu.keys[string(keyA)]
+				if !ok {
+					return errors.Errorf("key not contended")
+				}
+				var idx int
+				for e := contended.ll.Front(); e != nil; e = e.Next() {
+					p := e.Value.(*pusher)
+					if p.txn != tc.expTxns[idx] {
+						return errors.Errorf("expected txn %s at index %d; got %s", tc.expTxns[idx], idx, p.txn)
+					}
+					idx++
+				}
+				return nil
+			})
+		})
+	}
+
+	// Wait until all of the WriteIntentErrors have been processed to stop
+	// processing the cleanupFuncs.
+	go func() { wg.Wait(); close(cleanupFuncs) }()
+	i := 0
+	for f := range cleanupFuncs {
+		switch i {
+		// The read only transactions should be cleaned up with nil, nil.
+		case 0:
+			// There should be a push of orig and then a resolve of intent.
+			verifyPushTxn(<-reqChan, roTxn1.ID, origTxn.ID)
+			verifyResolveIntent(<-reqChan, keyA)
+			fallthrough
+		case 1, 2, 3:
+			// The remaining roTxns should not do anything upon cleanup.
+			f(nil, nil)
+			if i == 1 {
+				testCases[3].cancelFunc()
+			}
+		case 4:
+			// Call the CleanupFunc with a new WriteIntentError with a different
+			// transaction. This should lean to a new push on the new transaction and
+			// an intent resolution of the original intent.
+			f(&roachpb.WriteIntentError{Intents: []roachpb.Intent{{
+				Span: roachpb.Span{Key: keyA},
+				Txn:  unrelatedRWTxn.TxnMeta,
+			}}}, nil)
+			verifyPushTxn(<-reqChan, rwTxn2.ID, unrelatedRWTxn.ID)
+			verifyResolveIntent(<-reqChan, rwTxn1.Key)
+		case 5:
+			verifyPushTxn(<-reqChan, rwTxn3.ID, unrelatedRWTxn.ID)
+			f(&roachpb.WriteIntentError{Intents: []roachpb.Intent{{
+				Span: roachpb.Span{Key: keyB},
+				Txn:  rwTxn1.TxnMeta,
+			}}}, nil)
+		case 6:
+			f(nil, &testCases[i].pusher.TxnMeta)
+		}
+		i++
+	}
+}
+
+// TestCleanupIntentsAsync verifies that CleanupIntentsAsync either runs
+// synchronously or returns an error when there are too many concurrently
+// running tasks.
+func TestCleanupIntentsAsyncThrottled(t *testing.T) {
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+	sendFuncs := []sendFunc{
+		pushTxnSendFunc,
+		resolveIntentsSendFunc,
+	}
+	ir := newIntentResolverWithSendFuncs(stopper, clock, &sendFuncs)
+	// Run defaultTaskLimit tasks which will block until blocker is closed.
+	blocker := make(chan struct{})
+	defer close(blocker)
+	var wg sync.WaitGroup
+	wg.Add(defaultTaskLimit)
+	for i := 0; i < defaultTaskLimit; i++ {
+		if err := ir.runAsyncTask(context.Background(), false, func(context.Context) {
+			wg.Done()
+			<-blocker
+		}); err != nil {
+			t.Fatalf("Failed to run blocking async task: %v", err)
+		}
+	}
+	wg.Wait()
+	testIntentsWithArg := []result.IntentsWithArg{
+		{Intents: []roachpb.Intent{
+			{Span: roachpb.Span{Key: roachpb.Key("a")}},
+		}},
+	}
+	// Running with allowSyncProcessing = false should result in an error and no
+	// requests being sent.
+	err := ir.CleanupIntentsAsync(context.Background(), testIntentsWithArg, false)
+	assert.Equal(t, errors.Cause(err), stop.ErrThrottled)
+	// Running with allowSyncProcessing = true should result in the synchronous
+	// processing of the intents resulting in no error and the consumption of the
+	// sendFuncs.
+	err = ir.CleanupIntentsAsync(context.Background(), testIntentsWithArg, true)
+	assert.Nil(t, err)
+	assert.Len(t, sendFuncs, 0)
+}
+
+// TestCleanupIntentsAsync verifies that CleanupIntentsAsync sends the expected
+// requests.
+func TestCleanupIntentsAsync(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	type testCase struct {
+		intents   []result.IntentsWithArg
+		sendFuncs []sendFunc
+	}
+	testIntentsWithArg := []result.IntentsWithArg{
+		{Intents: []roachpb.Intent{
+			{Span: roachpb.Span{Key: roachpb.Key("a")}},
+		}},
+	}
+	cases := []testCase{
+		{
+			intents: testIntentsWithArg,
+			sendFuncs: []sendFunc{
+				pushTxnSendFunc,
+				resolveIntentsSendFunc,
+			},
+		},
+		{
+			intents: testIntentsWithArg,
+			sendFuncs: []sendFunc{
+				pushTxnSendFunc,
+				failSendFunc,
+			},
+		},
+		{
+			intents: testIntentsWithArg,
+			sendFuncs: []sendFunc{
+				failSendFunc,
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+			stopper := stop.NewStopper()
+			sendFuncs := c.sendFuncs
+			ir := newIntentResolverWithSendFuncs(stopper, clock, &sendFuncs)
+			err := ir.CleanupIntentsAsync(context.Background(), c.intents, true)
+			stopper.Stop(context.Background())
+			assert.Nil(t, err, "error from CleanupIntentsAsync")
+			assert.Len(t, sendFuncs, 0, "did not use all sendFuncs")
+		})
+	}
+}
+
+// TestCleanupTxnIntentsAsync verifies that CleanupTxnIntentsAsync sends the
+// expected requests.
+func TestCleanupTxnIntentsAsync(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	type testCase struct {
+		intents   []result.EndTxnIntents
+		before    func(*testCase, *IntentResolver) func()
+		sendFuncs []sendFunc
+	}
+	testEndTxnIntents := []result.EndTxnIntents{
+		{
+			Txn: roachpb.Transaction{
+				TxnMeta: enginepb.TxnMeta{
+					ID: uuid.MakeV4(),
+				},
+				Intents: []roachpb.Span{
+					{Key: roachpb.Key("a")},
+				},
+			},
+		},
+	}
+	cases := []testCase{
+		{
+			intents:   testEndTxnIntents,
+			sendFuncs: []sendFunc{},
+			before: func(tc *testCase, ir *IntentResolver) func() {
+				_, f := ir.lockInFlightTxnCleanup(context.Background(), tc.intents[0].Txn.ID)
+				return f
+			},
+		},
+		{
+			intents: testEndTxnIntents,
+			sendFuncs: []sendFunc{
+				resolveIntentsSendFunc,
+				gcSendFunc,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			stopper := stop.NewStopper()
+			clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+			sendFuncs := c.sendFuncs
+			ir := newIntentResolverWithSendFuncs(stopper, clock, &sendFuncs)
+			if c.before != nil {
+				defer c.before(&c, ir)()
+			}
+			err := ir.CleanupTxnIntentsAsync(context.Background(), 1, c.intents, false)
+			stopper.Stop(context.Background())
+			assert.Nil(t, err)
+			assert.Len(t, sendFuncs, 0)
+		})
+	}
+}
+
+// TestCleanupIntents verifies that CleanupIntents sends the expected requests
+// and returns the appropriate errors.
+func TestCleanupIntents(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	type testCase struct {
+		intents     []roachpb.Intent
+		sendFuncs   []sendFunc
+		expectedErr bool
+		expectedNum int
+	}
+	testIntents := []roachpb.Intent{
+		{Span: roachpb.Span{Key: roachpb.Key("a")}},
+	}
+	cases := []testCase{
+		{
+			intents: testIntents,
+			sendFuncs: []sendFunc{
+				pushTxnSendFunc,
+				resolveIntentsSendFunc,
+			},
+			expectedNum: 1,
+		},
+		{
+			intents: testIntents,
+			sendFuncs: []sendFunc{
+				failSendFunc,
+			},
+			expectedErr: true,
+		},
+	}
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+			sendFuncs := c.sendFuncs
+			ir := newIntentResolverWithSendFuncs(stopper, clock, &sendFuncs)
+			num, err := ir.CleanupIntents(context.Background(), c.intents, clock.Now(), roachpb.PUSH_ABORT)
+			assert.Equal(t, num, c.expectedNum, "number of resolved intents")
+			assert.Equal(t, err != nil, c.expectedErr, "error during CleanupIntents: %v", err)
+		})
+	}
+}
+
+func beginTxnArgs(
+	key []byte, txn *roachpb.Transaction,
+) (roachpb.BeginTransactionRequest, roachpb.Header) {
+	return roachpb.BeginTransactionRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: txn.Key,
+		},
+	}, roachpb.Header{Txn: txn}
+}
+
+func putArgs(key roachpb.Key, value []byte) roachpb.PutRequest {
+	return roachpb.PutRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: key,
+		},
+		Value: roachpb.MakeValueFromBytes(value),
+	}
+}
+
+func beginTransaction(
+	t *testing.T, clock *hlc.Clock, pri roachpb.UserPriority, key roachpb.Key, putKey bool,
+) *roachpb.Transaction {
+	txn := newTransaction("test", key, pri, clock)
+
+	var ba roachpb.BatchRequest
+	bt, header := beginTxnArgs(key, txn)
+	ba.Header = header
+	ba.Add(&bt)
+	assignSeqNumsForReqs(txn, &bt)
+	if putKey {
+		put := putArgs(key, []byte("value"))
+		ba.Add(&put)
+		assignSeqNumsForReqs(txn, &put)
+	}
+	return txn
+}
+
+func newTransaction(
+	name string, baseKey roachpb.Key, userPriority roachpb.UserPriority, clock *hlc.Clock,
+) *roachpb.Transaction {
+	var offset int64
+	var now hlc.Timestamp
+	if clock != nil {
+		offset = clock.MaxOffset().Nanoseconds()
+		now = clock.Now()
+	}
+	txn := roachpb.MakeTransaction(name, baseKey, userPriority, now, offset)
+	return &txn
+}
+
+// assignSeqNumsForReqs sets sequence numbers for each of the provided requests
+// given a transaction proto. It also updates the proto to reflect the incremented
+// sequence number.
+func assignSeqNumsForReqs(txn *roachpb.Transaction, reqs ...roachpb.Request) {
+	for _, ru := range reqs {
+		txn.Sequence++
+		oldHeader := ru.Header()
+		oldHeader.Sequence = txn.Sequence
+		ru.SetHeader(oldHeader)
+	}
+}
+
+// sendFunc is a function used to control behavior for a specific request that
+// the IntentResolver tries to send. They are used in conjunction with the below
+// function to create an IntentResolver with a slice of sendFuncs.
+// A library of useful sendFuncs are defined below.
+type sendFunc func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)
+
+func newIntentResolverWithSendFuncs(
+	stopper *stop.Stopper, clock *hlc.Clock, sendFuncs *[]sendFunc,
+) *IntentResolver {
+	txnSenderFactory := client.NonTransactionalFactoryFunc(
+		func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			if len(*sendFuncs) == 0 {
+				panic("no send funcs left!")
+			}
+			f := (*sendFuncs)[0]
+			*sendFuncs = (*sendFuncs)[1:]
+			return f(ba)
+		})
+	db := client.NewDB(log.AmbientContext{
+		Tracer: tracing.NewTracer(),
+	}, txnSenderFactory, clock)
+	return New(Config{
+		Stopper: stopper,
+		DB:      db,
+		Clock:   clock,
+	})
+}
+
+var (
+	pushTxnSendFunc sendFunc = func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		if !ba.IsSinglePushTxnRequest() {
+			panic(fmt.Errorf("Expected SinglePushTxnRequest, got %v", ba))
+		}
+		// TODO(ajwerner): assert more things
+		req := ba.Requests[0].GetInner().(*roachpb.PushTxnRequest)
+		txn := req.PusheeTxn
+		resp := &roachpb.BatchResponse{}
+		resp.Add(&roachpb.PushTxnResponse{
+			PusheeTxn: roachpb.Transaction{
+				Status:  roachpb.ABORTED,
+				TxnMeta: txn,
+			},
+		})
+		return resp, nil
+	}
+	resolveIntentsSendFunc sendFunc = func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		resp := &roachpb.BatchResponse{}
+		for _, r := range ba.Requests {
+			if _, ok := r.GetInner().(*roachpb.ResolveIntentRequest); ok {
+				resp.Add(&roachpb.ResolveIntentResponse{})
+			} else if _, ok := r.GetInner().(*roachpb.ResolveIntentRangeRequest); ok {
+				resp.Add(&roachpb.ResolveIntentRangeResponse{})
+			} else {
+				panic(fmt.Errorf("Unexpected request in batch for intent resolution: %T", r.GetInner()))
+			}
+		}
+		return resp, nil
+	}
+	failSendFunc sendFunc = func(roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		return nil, roachpb.NewError(fmt.Errorf("boom"))
+	}
+	gcSendFunc sendFunc = func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		resp := &roachpb.BatchResponse{}
+		for _, r := range ba.Requests {
+			if _, ok := r.GetInner().(*roachpb.GCRequest); ok {
+				resp.Add(&roachpb.GCResponse{})
+			} else {
+				panic(fmt.Errorf("Unexpected request type %T, expecte GCRequest", r.GetInner()))
+			}
+		}
+		return resp, nil
+	}
+)

--- a/pkg/storage/intentresolver/metrics.go
+++ b/pkg/storage/intentresolver/metrics.go
@@ -1,0 +1,41 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package intentresolver
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+var (
+	// Intent resolver metrics.
+	metaIntentResolverAsyncThrottled = metric.Metadata{
+		Name:        "intentresolver.async.throttled",
+		Help:        "Number of intent resolution attempts not run asynchronously due to throttling",
+		Measurement: "Intent Resolutions",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+// Metrics contains the metrics for the IntentResolver.
+type Metrics struct {
+	// Intent resolver metrics.
+	IntentResolverAsyncThrottled *metric.Counter
+}
+
+func makeMetrics() Metrics {
+	// Intent resolver metrics.
+	return Metrics{
+		IntentResolverAsyncThrottled: metric.NewCounter(metaIntentResolverAsyncThrottled),
+	}
+}

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -863,14 +863,6 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 
-	// Intent resolver metrics.
-	metaIntentResolverAsyncThrottled = metric.Metadata{
-		Name:        "intentresolver.async.throttled",
-		Help:        "Number of intent resolution attempts not run asynchronously due to throttling",
-		Measurement: "Intent Resolutions",
-		Unit:        metric.Unit_COUNT,
-	}
-
 	// Slow request metrics.
 	metaLatchRequests = metric.Metadata{
 		Name:        "requests.slow.latch",
@@ -1095,9 +1087,6 @@ type StoreMetrics struct {
 	GCResolveTotal               *metric.Counter
 	GCResolveSuccess             *metric.Counter
 
-	// Intent resolver metrics.
-	IntentResolverAsyncThrottled *metric.Counter
-
 	// Slow request counts.
 	SlowLatchRequests *metric.Gauge
 	SlowLeaseRequests *metric.Gauge
@@ -1287,9 +1276,6 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		GCPushTxn:                    metric.NewCounter(metaGCPushTxn),
 		GCResolveTotal:               metric.NewCounter(metaGCResolveTotal),
 		GCResolveSuccess:             metric.NewCounter(metaGCResolveSuccess),
-
-		// Intent resolver metrics.
-		IntentResolverAsyncThrottled: metric.NewCounter(metaIntentResolverAsyncThrottled),
 
 		// Wedge request counters.
 		SlowLatchRequests: metric.NewGauge(metaLatchRequests),

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1600,6 +1600,7 @@ func (r *Replica) GetLeaseHistory() []roachpb.Lease {
 	if r.leaseHistory == nil {
 		return nil
 	}
+
 	return r.leaseHistory.get()
 }
 

--- a/pkg/storage/replica_gossip.go
+++ b/pkg/storage/replica_gossip.go
@@ -191,7 +191,7 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (*config.SystemConfigEnt
 		// This is called from handleLocalEvalResult (with raftMu locked),
 		// so disallow synchronous processing (which blocks that mutex for
 		// too long and is a potential deadlock).
-		if err := r.store.intentResolver.cleanupIntentsAsync(ctx, r, intents, false /* allowSync */); err != nil {
+		if err := r.store.intentResolver.CleanupIntentsAsync(ctx, intents, false /* allowSync */); err != nil {
 			log.Warning(ctx, err)
 		}
 		return nil, errSystemConfigIntent

--- a/pkg/storage/replica_read.go
+++ b/pkg/storage/replica_read.go
@@ -116,7 +116,7 @@ func (r *Replica) executeReadOnlyBatch(
 		// range descriptor cache has an in-flight RangeLookup request which
 		// prohibits any concurrent requests for the same range. See #17760.
 		allowSyncProcessing := ba.ReadConsistency == roachpb.CONSISTENT
-		if err := r.store.intentResolver.cleanupIntentsAsync(ctx, r, intents, allowSyncProcessing); err != nil {
+		if err := r.store.intentResolver.CleanupIntentsAsync(ctx, intents, allowSyncProcessing); err != nil {
 			log.Warning(ctx, err)
 		}
 	}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/intentresolver"
 	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
@@ -3838,12 +3839,12 @@ func TestEndTransactionRollbackAbortedTransaction(t *testing.T) {
 				t.Fatal("txn record missing")
 			}
 
-			if pErr := tc.store.intentResolver.resolveIntents(context.TODO(),
+			if pErr := tc.store.intentResolver.ResolveIntents(context.TODO(),
 				[]roachpb.Intent{{
 					Span:   roachpb.Span{Key: key},
 					Txn:    txnRecord.TxnMeta,
 					Status: txnRecord.Status,
-				}}, ResolveOptions{Wait: true, Poison: true}); pErr != nil {
+				}}, intentresolver.ResolveOptions{Wait: true, Poison: true}); pErr != nil {
 				t.Fatal(pErr)
 			}
 		}
@@ -4530,12 +4531,12 @@ func TestReplicaResolveIntentNoWait(t *testing.T) {
 	setupResolutionTest(t, tc, roachpb.Key("a") /* irrelevant */, splitKey, true /* commit */)
 	txn := newTransaction("name", key, 1, tc.Clock())
 	txn.Status = roachpb.COMMITTED
-	if pErr := tc.store.intentResolver.resolveIntents(context.Background(),
+	if pErr := tc.store.intentResolver.ResolveIntents(context.Background(),
 		[]roachpb.Intent{{
 			Span:   roachpb.Span{Key: key},
 			Txn:    txn.TxnMeta,
 			Status: txn.Status,
-		}}, ResolveOptions{Wait: false, Poison: true /* irrelevant */}); pErr != nil {
+		}}, intentresolver.ResolveOptions{Wait: false, Poison: true /* irrelevant */}); pErr != nil {
 		t.Fatal(pErr)
 	}
 	testutils.SucceedsSoon(t, func() error {

--- a/pkg/storage/replica_write.go
+++ b/pkg/storage/replica_write.go
@@ -209,12 +209,12 @@ func (r *Replica) tryExecuteWriteBatch(
 				// both leave intents to GC that don't hit this code path. No good
 				// solution presents itself at the moment and such intents will be
 				// resolved on reads.
-				if err := r.store.intentResolver.cleanupIntentsAsync(ctx, r, propResult.Intents, true /* allowSync */); err != nil {
+				if err := r.store.intentResolver.CleanupIntentsAsync(ctx, propResult.Intents, true /* allowSync */); err != nil {
 					log.Warning(ctx, err)
 				}
 			}
 			if len(propResult.EndTxns) > 0 {
-				if err := r.store.intentResolver.cleanupTxnIntentsAsync(ctx, r, propResult.EndTxns, true /* allowSync */); err != nil {
+				if err := r.store.intentResolver.CleanupTxnIntentsAsync(ctx, r.RangeID, propResult.EndTxns, true /* allowSync */); err != nil {
 					log.Warning(ctx, err)
 				}
 			}

--- a/pkg/storage/storagebase/knobs.go
+++ b/pkg/storage/storagebase/knobs.go
@@ -44,3 +44,17 @@ type BatchEvalTestingKnobs struct {
 	// assertion can be performed unconditionally.
 	DisallowUnsequencedTransactionalWrites bool
 }
+
+// IntentResolverTestingKnobs contains testing helpers that are used during
+// intent resolution.
+type IntentResolverTestingKnobs struct {
+	// DisableAsyncIntentResolution disables the async intent resolution
+	// path (but leaves synchronous resolution). This can avoid some
+	// edge cases in tests that start and stop servers.
+	DisableAsyncIntentResolution bool
+
+	// ForceSyncIntentResolution forces all asynchronous intent resolution to be
+	// performed synchronously. It is equivalent to setting IntentResolverTaskLimit
+	// to -1.
+	ForceSyncIntentResolution bool
+}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -411,7 +411,8 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
-
+	factory := &testSenderFactory{}
+	cfg.DB = client.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
 	{
 		store := NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 		// Can't start as haven't bootstrapped.

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -31,7 +31,8 @@ import (
 // particular point is reached) or to change the behavior by returning
 // an error (which aborts all further processing for the command).
 type StoreTestingKnobs struct {
-	EvalKnobs storagebase.BatchEvalTestingKnobs
+	EvalKnobs           storagebase.BatchEvalTestingKnobs
+	IntentResolverKnobs storagebase.IntentResolverTestingKnobs
 
 	// TestingRequestFilter is called before evaluating each command on a
 	// replica. The filter is run before the request acquires latches, so
@@ -160,14 +161,6 @@ type StoreTestingKnobs struct {
 	// SkipMinSizeCheck, if set, makes the store creation process skip the check
 	// for a minimum size.
 	SkipMinSizeCheck bool
-	// DisableAsyncIntentResolution disables the async intent resolution
-	// path (but leaves synchronous resolution). This can avoid some
-	// edge cases in tests that start and stop servers.
-	DisableAsyncIntentResolution bool
-	// ForceSyncIntentResolution forces all asynchronous intent resolution to be
-	// performed synchronously. It is equivalent to setting IntentResolverTaskLimit
-	// to -1.
-	ForceSyncIntentResolution bool
 	// DisableLeaseCapacityGossip disables the ability of a changing number of
 	// leases to trigger the store to gossip its capacity. With this enabled,
 	// only changes in the number of replicas can cause the store to gossip its


### PR DESCRIPTION
This PR lays the groundwork for future changes to intent resolution.
It was created in anticipation of a PR to address #33574.

This diff seeks to clarify the separation between intent resolution and the rest
of storage. Most of the changes are cosmetic with the largest being the moving
of the construction of the IntentResolver struct into the Store's start method
in order to provide the IntentResolver to a handle to the Store's stopper without
the need to use store.Stopper(). The other contribution of this PR is a glut of
new unit tests to augment the existing `storage/intent_resolver_test.go` tests
which exercise functionality outside of the IntentResolver. Most of those tests
are moved to `intent_resolver_integration_test.go`.

Part of me feels that this diff has proven to be as much for my own edification
as it is for future code cleanliness. After some light musing I ended up not
majorly modifying the interface between the store and IntentResolver but I hope
that this change inspires future attempts at abstraction purification.

Release note: None