### PR TITLE
distsqlrun: release flow registry lock before Pushing timeout error

### DIFF
--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -81,7 +81,7 @@ func runTestFlow(
 	flow.Wait()
 	flow.Cleanup(ctx)
 
-	if !rowBuf.ProducerClosed {
+	if !rowBuf.ProducerClosed() {
 		t.Errorf("output not closed")
 	}
 

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -548,6 +548,8 @@ type RowBufferArgs struct {
 	// If it returns an empty row and metadata, then RowBuffer.Next() is allowed
 	// to run normally. Otherwise, the values are returned from RowBuffer.Next().
 	OnNext func(*RowBuffer) (sqlbase.EncDatumRow, *ProducerMetadata)
+	// OnPush, if specified, is called as the first thing in the Push() method.
+	OnPush func(sqlbase.EncDatumRow, *ProducerMetadata)
 }
 
 // NewRowBuffer creates a RowBuffer with the given schema and initial rows.
@@ -568,6 +570,9 @@ func NewRowBuffer(
 
 // Push is part of the RowReceiver interface.
 func (rb *RowBuffer) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) ConsumerStatus {
+	if rb.args.OnPush != nil {
+		rb.args.OnPush(row, meta)
+	}
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 	if rb.mu.producerClosed {

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -507,14 +507,14 @@ type RowBuffer struct {
 	mu struct {
 		syncutil.Mutex
 
+		// producerClosed is used when the RowBuffer is used as a RowReceiver; it is
+		// set to true when the sender calls ProducerDone().
+		producerClosed bool
+
 		// records represent the data that has been buffered. Push appends a row
 		// to the back, Next removes a row from the front.
 		records []BufferedRecord
 	}
-
-	// ProducerClosed is used when the RowBuffer is used as a RowReceiver; it is
-	// set to true when the sender calls ProducerDone().
-	ProducerClosed bool
 
 	// Done is used when the RowBuffer is used as a RowSource; it is set to true
 	// when the receiver read all the rows.
@@ -568,15 +568,15 @@ func NewRowBuffer(
 
 // Push is part of the RowReceiver interface.
 func (rb *RowBuffer) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) ConsumerStatus {
-	if rb.ProducerClosed {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	if rb.mu.producerClosed {
 		panic("Push called after ProducerDone")
 	}
 	// We mimic the behavior of RowChannel.
 	storeRow := func() {
 		rowCopy := append(sqlbase.EncDatumRow(nil), row...)
-		rb.mu.Lock()
 		rb.mu.records = append(rb.mu.records, BufferedRecord{Row: rowCopy, Meta: meta})
-		rb.mu.Unlock()
 	}
 	status := ConsumerStatus(atomic.LoadUint32((*uint32)(&rb.ConsumerStatus)))
 	if rb.args.AccumulateRowsWhileDraining {
@@ -595,12 +595,23 @@ func (rb *RowBuffer) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) Consu
 	return status
 }
 
+// ProducerClosed is a utility function used by tests to check whether the
+// RowBuffer has had ProducerDone() called on it.
+func (rb *RowBuffer) ProducerClosed() bool {
+	rb.mu.Lock()
+	c := rb.mu.producerClosed
+	rb.mu.Unlock()
+	return c
+}
+
 // ProducerDone is part of the RowSource interface.
 func (rb *RowBuffer) ProducerDone() {
-	if rb.ProducerClosed {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	if rb.mu.producerClosed {
 		panic("RowBuffer already closed")
 	}
-	rb.ProducerClosed = true
+	rb.mu.producerClosed = true
 }
 
 // Types is part of the RowReceiver interface.

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -129,7 +129,7 @@ func TestDistinct(t *testing.T) {
 			}
 
 			d.Run(context.Background())
-			if !out.ProducerClosed {
+			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
 			var res sqlbase.EncDatumRows

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -245,9 +245,12 @@ func TestStreamConnectionTimeout(t *testing.T) {
 		return nil
 	})
 
-	if !consumer.ProducerClosed() {
-		t.Fatalf("expected consumer to have been closed when the flow timed out")
-	}
+	testutils.SucceedsSoon(t, func() error {
+		if !consumer.ProducerClosed() {
+			return errors.New("expected consumer to have been closed when the flow timed out")
+		}
+		return nil
+	})
 
 	// Create a dummy server stream to pass to ConnectInboundStream.
 	serverStream, _ /* clientStream */, cleanup, err := createDummyStream()
@@ -586,10 +589,11 @@ func TestInboundStreamTimeoutIsRetryable(t *testing.T) {
 
 	fr := makeFlowRegistry(0)
 	wg := sync.WaitGroup{}
-	rb := &RowBuffer{}
+	rc := &RowChannel{}
+	rc.initWithBufSizeAndNumSenders(oneIntCol, 1 /* chanBufSize */, 1 /* numSenders */)
 	inboundStreams := map[distsqlpb.StreamID]*inboundStreamInfo{
 		0: {
-			receiver:  rb,
+			receiver:  rc,
 			waitGroup: &wg,
 		},
 	}
@@ -600,9 +604,64 @@ func TestInboundStreamTimeoutIsRetryable(t *testing.T) {
 		t.Fatal(err)
 	}
 	wg.Wait()
-	if _, meta := rb.Next(); meta == nil {
+	if _, meta := rc.Next(); meta == nil {
 		t.Fatal("expected error but got no meta")
 	} else if !testutils.IsSQLRetryableError(meta.Err) {
 		t.Fatalf("unexpected error: %v", meta.Err)
 	}
+}
+
+// TestTimeoutPushDoesntBlockRegister verifies that in the case of a timeout
+// error, we are still able to register flows while Pushing the error (#34041).
+func TestTimeoutPushDoesntBlockRegister(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	fr := makeFlowRegistry(0)
+	// pushChan is used to be able to tell when a Push on the RowBuffer has
+	// occurred.
+	pushChan := make(chan *ProducerMetadata)
+	rc := NewRowBuffer(
+		oneIntCol,
+		nil, /* rows */
+		RowBufferArgs{
+			OnPush: func(_ sqlbase.EncDatumRow, meta *ProducerMetadata) {
+				pushChan <- meta
+				<-pushChan
+			},
+		},
+	)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	inboundStreams := map[distsqlpb.StreamID]*inboundStreamInfo{
+		0: {
+			receiver:  rc,
+			waitGroup: &wg,
+		},
+	}
+
+	// RegisterFlow with an immediate timeout.
+	if err := fr.RegisterFlow(
+		ctx, distsqlpb.FlowID{}, &Flow{}, inboundStreams, 0, /* timeout */
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure RegisterFlow performs a Push.
+	meta := <-pushChan
+	if !testutils.IsError(meta.Err, errNoInboundStreamConnection.Error()) {
+		t.Fatalf("unexpected err %v, expected %s", meta.Err, errNoInboundStreamConnection)
+	}
+
+	// Attempt to register a flow. Note that this flow has no inbound streams, so
+	// Pushing to the RowBuffer is unexpected.
+	if err := fr.RegisterFlow(
+		ctx, distsqlpb.FlowID{UUID: uuid.MakeV4()}, &Flow{}, nil /* inboundStreams */, time.Hour, /* timeout */
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unblock the first RegisterFlow.
+	close(pushChan)
 }

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -245,7 +245,7 @@ func TestStreamConnectionTimeout(t *testing.T) {
 		return nil
 	})
 
-	if !consumer.ProducerClosed {
+	if !consumer.ProducerClosed() {
 		t.Fatalf("expected consumer to have been closed when the flow timed out")
 	}
 

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -115,7 +115,7 @@ func TestHashJoiner(t *testing.T) {
 				h.Run(context.Background())
 				side = otherSide(h.storedSide)
 
-				if !out.ProducerClosed {
+				if !out.ProducerClosed() {
 					return errors.New("output RowReceiver not closed")
 				}
 
@@ -232,7 +232,7 @@ func TestHashJoinerError(t *testing.T) {
 			setup(h)
 			h.Run(context.Background())
 
-			if !out.ProducerClosed {
+			if !out.ProducerClosed() {
 				return errors.New("output RowReceiver not closed")
 			}
 
@@ -368,7 +368,7 @@ func TestHashJoinerDrain(t *testing.T) {
 	out.ConsumerDone()
 	h.Run(context.Background())
 
-	if !out.ProducerClosed {
+	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
 	}
 
@@ -492,7 +492,7 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 
 	h.Run(context.Background())
 
-	if !out.ProducerClosed {
+	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
 	}
 

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
@@ -412,7 +412,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 				t.Fatal(err)
 			}
 			irj.Run(ctx)
-			if !out.ProducerClosed {
+			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
 
@@ -613,7 +613,7 @@ func TestInterleavedReaderJoinerTrailingMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	irj.Run(ctx)
-	if !out.ProducerClosed {
+	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
 	}
 

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -352,7 +352,7 @@ func TestJoinReader(t *testing.T) {
 				if !in.Done {
 					t.Fatal("joinReader didn't consume all the rows")
 				}
-				if !out.ProducerClosed {
+				if !out.ProducerClosed() {
 					t.Fatalf("output RowReceiver not closed")
 				}
 

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -716,7 +716,7 @@ func TestMergeJoiner(t *testing.T) {
 
 			m.Run(context.Background())
 
-			if !out.ProducerClosed {
+			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
 
@@ -822,7 +822,7 @@ func TestConsumerClosed(t *testing.T) {
 
 			m.Run(context.Background())
 
-			if !out.ProducerClosed {
+			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
 		})

--- a/pkg/sql/distsqlrun/routers_test.go
+++ b/pkg/sql/distsqlrun/routers_test.go
@@ -152,7 +152,7 @@ func TestRouters(t *testing.T) {
 
 			rows := make([]sqlbase.EncDatumRows, len(bufs))
 			for i, b := range bufs {
-				if !b.ProducerClosed {
+				if !b.ProducerClosed() {
 					t.Fatalf("bucket not closed: %d", i)
 				}
 				rows[i] = b.GetRowsNoMeta(t)

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -332,7 +332,7 @@ func TestSorter(t *testing.T) {
 							}
 						}
 						s.Run(context.Background())
-						if !out.ProducerClosed {
+						if !out.ProducerClosed() {
 							t.Fatalf("output RowReceiver not closed")
 						}
 

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -153,7 +153,7 @@ func TestTableReader(t *testing.T) {
 					results = tr
 				} else {
 					tr.Run(ctx)
-					if !buf.ProducerClosed {
+					if !buf.ProducerClosed() {
 						t.Fatalf("output RowReceiver not closed")
 					}
 					buf.Start(ctx)
@@ -247,7 +247,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 			results = tr
 		} else {
 			tr.Run(ctx)
-			if !buf.ProducerClosed {
+			if !buf.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
 			buf.Start(ctx)

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -370,7 +370,7 @@ func runProcessorTest(
 	}
 
 	p.Run(context.Background())
-	if !out.ProducerClosed {
+	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
 	}
 	var res sqlbase.EncDatumRows

--- a/pkg/sql/distsqlrun/values_test.go
+++ b/pkg/sql/distsqlrun/values_test.go
@@ -84,7 +84,7 @@ func TestValuesProcessor(t *testing.T) {
 						t.Fatal(err)
 					}
 					v.Run(context.Background())
-					if !out.ProducerClosed {
+					if !out.ProducerClosed() {
 						t.Fatalf("output RowReceiver not closed")
 					}
 

--- a/pkg/sql/distsqlrun/zigzagjoiner_test.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner_test.go
@@ -511,7 +511,7 @@ func TestZigzagJoiner(t *testing.T) {
 
 			z.Run(ctx)
 
-			if !out.ProducerClosed {
+			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
 


### PR DESCRIPTION
As this Push might block indefinitely, resulting in blocking new Flow
registration.

Fixes #34041

Release note (bug fix): Fix a back up in flow creation observed by "no
inbound stream connection" caused by not releasing a lock before
attempting a possibly blocking operation.

cc @tim-o 

Will backport to 2.1