### PR TITLE
distsqlrun: log outbox error

### DIFF
--- a/pkg/sql/distsqlrun/outbox.go
+++ b/pkg/sql/distsqlrun/outbox.go
@@ -421,6 +421,9 @@ func (m *outbox) listenForDrainSignalFromConsumer(ctx context.Context) (<-chan d
 
 func (m *outbox) run(ctx context.Context, wg *sync.WaitGroup) {
 	err := m.mainLoop(ctx)
+	if err != nil {
+		log.Errorf(ctx, "outbox main loop for flow %s encountered error %s", m.flowCtx.id, err)
+	}
 	if stream, ok := m.stream.(distsqlpb.DistSQL_FlowStreamClient); ok {
 		closeErr := stream.CloseSend()
 		if err == nil {


### PR DESCRIPTION
This is a useful log message to record any errors on remote node
outboxes involved in a flow that cannot push this error back to
the gateway due to possible connectivity issues.

Release note: None

cc @RaduBerinde @andreimatei 