### PR TITLE
storage: rework load-based splitting

### DIFF
--- a/pkg/storage/replica_split_load.go
+++ b/pkg/storage/replica_split_load.go
@@ -15,11 +15,8 @@
 package storage
 
 import (
-	"time"
-
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/storage/split"
 )
 
 // SplitByLoadEnabled wraps "kv.range_split.by_load_enabled".
@@ -48,42 +45,4 @@ func (r *Replica) SplitByLoadEnabled() bool {
 	return SplitByLoadEnabled.Get(&r.store.cfg.Settings.SV) &&
 		r.store.ClusterSettings().Version.IsActive(cluster.VersionLoadSplits) &&
 		!r.store.TestingKnobs().DisableLoadBasedSplitting
-}
-
-// needsSplitByLoadLocked returns two bools indicating first, whether
-// the range is over the threshold for splitting by load and second,
-// whether the range is ready to be added to the split queue.
-func (r *Replica) needsSplitByLoadLocked() (bool, bool) {
-	// First compute requests per second since the last check.
-	nowTime := r.store.Clock().PhysicalTime()
-	duration := nowTime.Sub(r.splitMu.lastReqTime)
-	if duration < time.Second {
-		return r.splitMu.splitFinder != nil, false
-	}
-
-	// Update the QPS and reset the time and request counter.
-	r.splitMu.qps = (float64(r.splitMu.count) / float64(duration)) * 1e9
-	r.splitMu.lastReqTime = nowTime
-	r.splitMu.count = 0
-
-	// If the QPS for the range exceeds the threshold, start actively
-	// tracking potential for splitting this range based on load.
-	// This tracking will begin by initiating a splitFinder so it can
-	// begin to Record requests so it can find a split point. If a
-	// splitFinder already exists, we check if a split point is ready
-	// to be used.
-	if r.splitMu.qps >= r.SplitByLoadQPSThreshold() {
-		if r.splitMu.splitFinder != nil {
-			if r.splitMu.splitFinder.Ready(nowTime) {
-				// We're ready to add this range to the split queue.
-				return true, true
-			}
-		} else {
-			r.splitMu.splitFinder = split.New(nowTime)
-		}
-		return true, false
-	}
-
-	r.splitMu.splitFinder = nil
-	return false, false
 }

--- a/pkg/storage/split/decider.go
+++ b/pkg/storage/split/decider.go
@@ -1,0 +1,151 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// TODO(tbg): rename this package. `lbsplit`?
+
+package split
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+const minSplitSuggestionInterval = time.Minute
+
+// A Decider collects measurements about the activity (measured in qps) on a
+// Replica and, assuming that qps thresholds are exceeded, tries to determine
+// a split key that would approximately result in halving the load on each of
+// the resultant ranges.
+//
+// Operations should call `Record` with a current timestamp. Operation counts
+// are aggregated over a second and a qps computed. If the QPS is above threshold,
+// a split finder is instantiated and the spans supplied to Record are sampled
+// for a duration (on the order of ten seconds). Assuming that load consistently
+// remains over threshold, and the workload touches a diverse enough set of keys
+// to benefit from a split, sampling will eventually instruct a caller of Record
+// to carry out a split. When the split is initiated, it can obtain the suggested
+// split point from MaybeSplitKey (which may have disappeared either due to a drop
+// in qps or a change in the workload).
+type Decider struct {
+	intn         func(n int) int // supplied to Init
+	qpsThreshold func() float64  // supplied to Init
+
+	mu struct {
+		syncutil.Mutex
+		lastQPSRollover time.Time // most recent time recorded by requests.
+		qps             float64   // last reqs/s rate as of lastQPSRollover
+
+		count               int64     // number of requests recorded since last rollover
+		splitFinder         *Finder   // populated when engaged or decided
+		lastSplitSuggestion time.Time // last stipulation to client to carry out split
+	}
+}
+
+// Init initializes a Decider (which is assumed to be zero). The signature allows
+// embedding the Decider into a larger struct outside of the scope of this package
+// without incurring a pointer reference. This is relevant since many Deciders
+// may exist in the system at any given point in time.
+func Init(lbs *Decider, intn func(n int) int, qpsThreshold func() float64) {
+	lbs.intn = intn
+	lbs.qpsThreshold = qpsThreshold
+}
+
+// Record notifies the Decider that 'n' operations are being carried out which
+// operate on the span returned by the supplied method. The closure will only
+// be called when necessary, that is, when the Decider is considering a split
+// and is sampling key spans to determine a suitable split point.
+//
+// If the returned boolean is true, a split key is available (though it may
+// disappear as more keys are sampled) and should be initiated by the caller,
+// which can call MaybeSplitKey to retrieve the suggested key.
+func (d *Decider) Record(now time.Time, n int, span func() roachpb.Span) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.recordLocked(now, n, span)
+}
+
+func (d *Decider) recordLocked(now time.Time, n int, span func() roachpb.Span) bool {
+	d.mu.count += int64(n)
+
+	// First compute requests per second since the last check.
+	elapsedSinceLastQPS := now.Sub(d.mu.lastQPSRollover)
+	if elapsedSinceLastQPS >= time.Second {
+		if elapsedSinceLastQPS > 2*time.Second {
+			// Force a QPS of zero; there wasn't any activity within the last
+			// second at all.
+			d.mu.count = 0
+		}
+		// Update the QPS and reset the time and request counter.
+		d.mu.qps = (float64(d.mu.count) / float64(elapsedSinceLastQPS)) * 1e9
+		d.mu.lastQPSRollover = now
+		d.mu.count = 0
+
+		// If the QPS for the range exceeds the threshold, start actively
+		// tracking potential for splitting this range based on load.
+		// This tracking will begin by initiating a splitFinder so it can
+		// begin to Record requests so it can find a split point. If a
+		// splitFinder already exists, we check if a split point is ready
+		// to be used.
+		if d.mu.qps >= d.qpsThreshold() {
+			if d.mu.splitFinder == nil {
+				d.mu.splitFinder = NewFinder(now)
+			}
+		} else {
+			d.mu.splitFinder = nil
+		}
+	}
+
+	if d.mu.splitFinder != nil && n != 0 {
+		s := span()
+		if s.Key != nil {
+			d.mu.splitFinder.Record(span(), d.intn)
+		}
+		if now.Sub(d.mu.lastSplitSuggestion) > minSplitSuggestionInterval && d.mu.splitFinder.Ready(now) && d.mu.splitFinder.Key() != nil {
+			d.mu.lastSplitSuggestion = now
+			return true
+		}
+	}
+	return false
+}
+
+// LastQPS returns the most recent QPS measurement.
+func (d *Decider) LastQPS(now time.Time) float64 {
+	d.mu.Lock()
+	d.recordLocked(now, 0, nil)
+	qps := d.mu.qps
+	d.mu.Unlock()
+
+	return qps
+}
+
+// MaybeSplitKey returns a key to perform a split at. The return value will be
+// nil if either the Decider hasn't decided that a split should be carried out
+// or if it wasn't able to determine a suitable split key.
+//
+// It is legal to call MaybeSplitKey at any time.
+func (d *Decider) MaybeSplitKey(now time.Time) roachpb.Key {
+	var key roachpb.Key
+
+	d.mu.Lock()
+	d.recordLocked(now, 0, nil)
+	if d.mu.splitFinder != nil && d.mu.splitFinder.Ready(now) {
+		key = d.mu.splitFinder.Key()
+	}
+	d.mu.Unlock()
+
+	return key
+}

--- a/pkg/storage/split/decider_test.go
+++ b/pkg/storage/split/decider_test.go
@@ -1,0 +1,158 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package split
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecider(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	intn := rand.New(rand.NewSource(12)).Intn
+
+	var d Decider
+	Init(&d, intn, func() float64 { return 10.0 })
+
+	ms := func(i int) time.Time {
+		ts, err := time.Parse(time.RFC3339, "2000-01-01T00:00:00Z")
+		assert.NoError(t, err)
+		return ts.Add(time.Duration(i) * time.Millisecond)
+	}
+
+	op := func(s string) func() roachpb.Span {
+		return func() roachpb.Span { return roachpb.Span{Key: roachpb.Key(s)} }
+	}
+
+	assertQPS := func(i int, expQPS float64) {
+		t.Helper()
+		qps := d.LastQPS(ms(i))
+		assert.Equal(t, expQPS, qps)
+	}
+
+	assert.Equal(t, false, d.Record(ms(100), 1, nil))
+	assertQPS(100, 0)
+
+	// The first operation was interpreted as having happened after an eternity
+	// of no activity, and rolled over the qps to mark the beginning of a new
+	// second. The next qps computation is expected for timestamps >= 1100.
+	assert.Equal(t, ms(100), d.mu.lastQPSRollover)
+	assert.EqualValues(t, 0, d.mu.count)
+
+	assert.Equal(t, false, d.Record(ms(400), 4, nil))
+	assertQPS(100, 0)
+	assertQPS(700, 0)
+
+	assert.Equal(t, false, d.Record(ms(300), 3, nil))
+	assertQPS(100, 0)
+
+	assert.Equal(t, false, d.Record(ms(900), 1, nil))
+	assertQPS(0, 0)
+
+	assert.Equal(t, false, d.Record(ms(1099), 1, nil))
+	assertQPS(0, 0)
+
+	// Now 9 operations happened in the interval [100, 1099]. The next higher
+	// timestamp will decide whether to engage the split finder.
+
+	// It won't engage because the duration between the rollovers is 1.1s, and
+	// we had 10 events over that interval.
+	assert.Equal(t, false, d.Record(ms(1200), 1, nil))
+	assertQPS(0, float64(10)/float64(1.1))
+	assert.Equal(t, ms(1200), d.mu.lastQPSRollover)
+
+	var nilFinder *Finder
+
+	assert.Equal(t, nilFinder, d.mu.splitFinder)
+
+	assert.Equal(t, false, d.Record(ms(2199), 12, nil))
+	assert.Equal(t, nilFinder, d.mu.splitFinder)
+
+	// 2200 is the next rollover point, and 12+1=13 qps should be computed.
+	assert.Equal(t, false, d.Record(ms(2200), 1, op("a")))
+	assert.Equal(t, ms(2200), d.mu.lastQPSRollover)
+	assertQPS(0, float64(13))
+
+	assert.NotNil(t, d.mu.splitFinder)
+	assert.False(t, d.mu.splitFinder.Ready(ms(10)))
+
+	// With continued partitioned write load, split finder eventually tells us
+	// to split. We don't test the details of exactly when that happens because
+	// this is done in the finder tests.
+	tick := 2200
+	for o := op("a"); !d.Record(ms(tick), 11, o); tick += 1000 {
+		if tick/1000%2 == 0 {
+			o = op("z")
+		} else {
+			o = op("a")
+		}
+	}
+
+	assert.Equal(t, roachpb.Key("z"), d.MaybeSplitKey(ms(tick)))
+
+	// We were told to split, but won't be told to split again for some time
+	// to avoid busy-looping on split attempts.
+	for i := 0; i <= int(minSplitSuggestionInterval/time.Second); i++ {
+		o := op("z")
+		if i%2 != 0 {
+			o = op("a")
+		}
+		assert.False(t, d.Record(ms(tick), 11, o))
+		assert.True(t, d.LastQPS(ms(tick)) > 1.0)
+		// Even though the split key remains.
+		assert.Equal(t, roachpb.Key("z"), d.MaybeSplitKey(ms(tick+999)))
+		tick += 1000
+	}
+	// But after minSplitSuggestionInterval of ticks, we get another one.
+	assert.True(t, d.Record(ms(tick), 11, op("a")))
+	assert.True(t, d.LastQPS(ms(tick)) > 1.0)
+
+	// Split key suggestion vanishes once qps drops.
+	tick += 1000
+	assert.False(t, d.Record(ms(tick), 9, op("a")))
+	assert.Equal(t, roachpb.Key(nil), d.MaybeSplitKey(ms(tick)))
+	assert.Equal(t, nilFinder, d.mu.splitFinder)
+
+	// Hammer a key with writes above threshold. There shouldn't be a split
+	// since everyone is hitting the same key and load can't be balanced.
+	for i := 0; i < 1000; i++ {
+		assert.False(t, d.Record(ms(tick), 11, op("q")))
+		tick += 1000
+	}
+	assert.True(t, d.mu.splitFinder.Ready(ms(tick)))
+	assert.Equal(t, roachpb.Key(nil), d.MaybeSplitKey(ms(tick)))
+
+	// But the finder keeps sampling to adapt to changing workload...
+	for i := 0; i < 1000; i++ {
+		assert.False(t, d.Record(ms(tick), 11, op("p")))
+		tick += 1000
+	}
+
+	// ... which we verify by looking at its samples directly.
+	for _, sample := range d.mu.splitFinder.samples {
+		assert.Equal(t, roachpb.Key("p"), sample.key)
+	}
+
+	// Since the new workload is also not partitionable, nothing changes in
+	// the decision.
+	assert.True(t, d.mu.splitFinder.Ready(ms(tick)))
+	assert.Equal(t, roachpb.Key(nil), d.MaybeSplitKey(ms(tick)))
+}

--- a/pkg/storage/split/finder.go
+++ b/pkg/storage/split/finder.go
@@ -69,8 +69,8 @@ type Finder struct {
 	count     int
 }
 
-// New initiates a Finder with the given time.
-func New(startTime time.Time) *Finder {
+// NewFinder initiates a Finder with the given time.
+func NewFinder(startTime time.Time) *Finder {
 	return &Finder{
 		startTime: startTime,
 	}
@@ -122,11 +122,11 @@ func (f *Finder) Record(span roachpb.Span, intNFn func(int) int) {
 	f.samples[idx] = sample{key: span.Key}
 }
 
-// Key finds an appropriate split point based on the Reservoir
-// sampling method.
-func (f *Finder) Key() (bool, roachpb.Key) {
+// Key finds an appropriate split point based on the Reservoir sampling method.
+// Returns a nil key if no appropriate key was found.
+func (f *Finder) Key() roachpb.Key {
 	if f == nil {
-		return false, nil
+		return nil
 	}
 
 	var bestIdx = -1
@@ -149,7 +149,7 @@ func (f *Finder) Key() (bool, roachpb.Key) {
 	}
 
 	if bestIdx == -1 {
-		return false, nil
+		return nil
 	}
-	return true, f.samples[bestIdx].key
+	return f.samples[bestIdx].key
 }


### PR DESCRIPTION
The old code was difficult to reason about and interspersed with the
replica code. Factor out a component Decider which encapsulates the
state and logic of load-based splitting.

The reason I originally looked at this was that I had introduced a guard
in the split queue that was supposed to check whether the load based
split was still recommended (time may have passed since it was
originally computed). This was frail since the method I called would
only recommend the split once, even though this was only obvious upon
closer examination. The new API prevents such mistakes.

Fixes #34114.

Release note: None