### PR TITLE
roachtest: turn on bulk insert backfill in schema change tpcc

### DIFF
--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -60,6 +60,8 @@ func registerTests(r *registry) {
 	registerSchemaChangeKV(r)
 	registerSchemaChangeIndexTPCC100(r)
 	registerSchemaChangeIndexTPCC1000(r)
+	registerSchemaChangeBulkInsertIndexTPCC100(r)
+	registerSchemaChangeBulkInsertIndexTPCC1000(r)
 	registerScrubAllChecksTPCC(r)
 	registerScrubIndexOnlyTPCC(r)
 	registerSchemaChangeCancelIndexTPCC1000(r)


### PR DESCRIPTION
For now this makes a copy of the test so the original implementation
is still being tested.

Release note: None