### PR TITLE
opt: rename "provided" to "actual" in expressions

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -662,7 +662,7 @@ sort
  ├── stats: [rows=9.9, distinct(1)=1, null(1)=0]
  ├── cost: 51.3728708
  ├── fd: ()-->(1)
- ├── ordering: +2 opt(1) [provided: +2]
+ ├── ordering: +2 opt(1) [actual: +2]
  ├── prune: (2)
  └── index-join tc
       ├── columns: a:1 b:2
@@ -686,7 +686,7 @@ sort
  ├── stats: [rows=9.9, distinct(1)=1, null(1)=0]
  ├── cost: 51.3728708
  ├── fd: ()-->(1)
- ├── ordering: +2 opt(1) [provided: +2]
+ ├── ordering: +2 opt(1) [actual: +2]
  ├── prune: (2)
  └── index-join tc
       ├── columns: a:1(int!null) b:2(int)

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -422,7 +422,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			if provStr == reqStr {
 				tp.Childf("ordering: %s", required.Ordering.String())
 			} else {
-				tp.Childf("ordering: %s [provided: %s]", required.Ordering.String(), provided.String())
+				tp.Childf("ordering: %s [actual: %s]", required.Ordering.String(), provided.String())
 			}
 		}
 	}

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -358,13 +358,13 @@ GenerateMergeJoins
          │    ├── columns: k:1(int!null) i:2(int!null) s:4(string)
          │    ├── key: (1)
          │    ├── fd: ()-->(2), (1)-->(4)
-  +      │    ├── ordering: +1 opt(2) [provided: +1]
+  +      │    ├── ordering: +1 opt(2) [actual: +1]
          │    ├── scan a
          │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
          │    │    ├── key: (1)
   -      │    │    └── fd: (1)-->(2,4)
   +      │    │    ├── fd: (1)-->(2,4)
-  +      │    │    └── ordering: +1 opt(2) [provided: +1]
+  +      │    │    └── ordering: +1 opt(2) [actual: +1]
          │    └── filters
          │         └── i = 9 [type=bool, outer=(2), constraints=(/2: [/9 - /9]; tight), fd=()-->(2)]
   -      └── filters
@@ -392,12 +392,12 @@ GenerateLookupJoins
          │    ├── columns: k:1(int!null) i:2(int!null) s:4(string)
          │    ├── key: (1)
          │    ├── fd: ()-->(2), (1)-->(4)
-  -      │    ├── ordering: +1 opt(2) [provided: +1]
+  -      │    ├── ordering: +1 opt(2) [actual: +1]
          │    ├── scan a
          │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
          │    │    ├── key: (1)
   -      │    │    ├── fd: (1)-->(2,4)
-  -      │    │    └── ordering: +1 opt(2) [provided: +1]
+  -      │    │    └── ordering: +1 opt(2) [actual: +1]
   +      │    │    └── fd: (1)-->(2,4)
          │    └── filters
          │         └── i = 9 [type=bool, outer=(2), constraints=(/2: [/9 - /9]; tight), fd=()-->(2)]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -947,7 +947,7 @@ project
  │    │    │    │    ├── right ordering: +8
  │    │    │    │    ├── key: (8)
  │    │    │    │    ├── fd: (6)-->(7), (8)-->(9), (6)==(8), (8)==(6)
- │    │    │    │    ├── ordering: +(6|8) [provided: +6]
+ │    │    │    │    ├── ordering: +(6|8) [actual: +6]
  │    │    │    │    ├── scan xy
  │    │    │    │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    │    │    │    ├── key: (6)
@@ -994,7 +994,7 @@ semi-join (merge)
  │    ├── right ordering: +8
  │    ├── key: (8)
  │    ├── fd: (6)-->(7), (8)-->(9), (6)==(8), (8)==(6)
- │    ├── ordering: +(6|8) [provided: +6]
+ │    ├── ordering: +(6|8) [actual: +6]
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
@@ -1031,7 +1031,7 @@ anti-join (merge)
  │    ├── right ordering: +8
  │    ├── key: (8)
  │    ├── fd: (6)-->(7), (8)-->(9), (6)==(8), (8)==(6)
- │    ├── ordering: +(6|8) [provided: +6]
+ │    ├── ordering: +(6|8) [actual: +6]
  │    ├── scan xy
  │    │    ├── columns: x:6(int!null) y:7(int)
  │    │    ├── key: (6)
@@ -1086,7 +1086,7 @@ project
       │    │    │    ├── right ordering: +8
       │    │    │    ├── key: (8)
       │    │    │    ├── fd: (6)==(8), (8)==(6)
-      │    │    │    ├── ordering: +(6|8) [provided: +6]
+      │    │    │    ├── ordering: +(6|8) [actual: +6]
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:6(int!null)
       │    │    │    │    ├── key: (6)
@@ -2605,7 +2605,7 @@ project
       │    │    ├── columns: x:1(int!null) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string)
       │    │    ├── key: (1,3)
       │    │    ├── fd: (1)-->(2), (3)-->(4-6)
-      │    │    ├── ordering: +5,+6 opt(4) [provided: +5,+6]
+      │    │    ├── ordering: +5,+6 opt(4) [actual: +5,+6]
       │    │    └── left-join
       │    │         ├── columns: x:1(int!null) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string)
       │    │         ├── key: (1,3)
@@ -2666,12 +2666,12 @@ semi-join (merge)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
- │    ├── ordering: +1 opt(4) [provided: +1]
+ │    ├── ordering: +1 opt(4) [actual: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1 opt(4) [provided: +1]
+ │    │    └── ordering: +1 opt(4) [actual: +1]
  │    └── filters
  │         ├── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  │         └── i > 1 [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
@@ -2803,12 +2803,12 @@ anti-join (merge)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string!null) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
- │    ├── ordering: +1 opt(4) [provided: +1]
+ │    ├── ordering: +1 opt(4) [actual: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1 opt(4) [provided: +1]
+ │    │    └── ordering: +1 opt(4) [actual: +1]
  │    └── filters
  │         ├── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  │         └── i > 1 [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
@@ -3358,7 +3358,7 @@ project
       │    │    │    ├── columns: true:10(bool!null) x:8(int!null)
       │    │    │    ├── key: (8)
       │    │    │    ├── fd: ()-->(10)
-      │    │    │    ├── ordering: +8 opt(10) [provided: +8]
+      │    │    │    ├── ordering: +8 opt(10) [actual: +8]
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:8(int!null)
       │    │    │    │    ├── key: (8)

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -585,7 +585,7 @@ limit
  ├── sort
  │    ├── columns: b:2(int!null) c:3(int!null)
  │    ├── fd: ()-->(2)
- │    ├── ordering: +3 opt(2) [provided: +3]
+ │    ├── ordering: +3 opt(2) [actual: +3]
  │    └── select
  │         ├── columns: b:2(int!null) c:3(int!null)
  │         ├── fd: ()-->(2)

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -172,12 +172,12 @@ right-join (merge)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string!null) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
- │    ├── ordering: +1 opt(4) [provided: +1]
+ │    ├── ordering: +1 opt(4) [actual: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1 opt(4) [provided: +1]
+ │    │    └── ordering: +1 opt(4) [actual: +1]
  │    └── filters
  │         ├── (i < 0) OR (i > 10) [type=bool, outer=(2)]
  │         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
@@ -226,12 +226,12 @@ semi-join (merge)
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string!null) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
- │    ├── ordering: +1 opt(4) [provided: +1]
+ │    ├── ordering: +1 opt(4) [actual: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1 opt(4) [provided: +1]
+ │    │    └── ordering: +1 opt(4) [actual: +1]
  │    └── filters
  │         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  ├── scan b
@@ -305,12 +305,12 @@ left-join (merge)
  │    ├── columns: k:3(int!null) i:4(int) f:5(float!null) s:6(string!null) j:7(jsonb)
  │    ├── key: (3)
  │    ├── fd: ()-->(6), (3)-->(4,5,7)
- │    ├── ordering: +3 opt(6) [provided: +3]
+ │    ├── ordering: +3 opt(6) [actual: +3]
  │    ├── scan a
  │    │    ├── columns: k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
  │    │    ├── key: (3)
  │    │    ├── fd: (3)-->(4-7)
- │    │    └── ordering: +3 opt(6) [provided: +3]
+ │    │    └── ordering: +3 opt(6) [actual: +3]
  │    └── filters
  │         ├── (i < 0) OR (i > 10) [type=bool, outer=(4)]
  │         └── s = 'foo' [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight), fd=()-->(6)]
@@ -1932,12 +1932,12 @@ project
       │    ├── columns: x:6(int!null) y:7(int!null)
       │    ├── key: (6)
       │    ├── fd: ()-->(7)
-      │    ├── ordering: +6 opt(7) [provided: +6]
+      │    ├── ordering: +6 opt(7) [actual: +6]
       │    ├── scan b
       │    │    ├── columns: x:6(int!null) y:7(int)
       │    │    ├── key: (6)
       │    │    ├── fd: (6)-->(7)
-      │    │    └── ordering: +6 opt(7) [provided: +6]
+      │    │    └── ordering: +6 opt(7) [actual: +6]
       │    └── filters
       │         └── y = 10 [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
       └── filters (true)

--- a/pkg/sql/opt/norm/testdata/rules/ordering
+++ b/pkg/sql/opt/norm/testdata/rules/ordering
@@ -64,12 +64,12 @@ limit
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: ()-->(4,5), (1)-->(2,3), (2,3)~~>(1)
- ├── ordering: +2,+3,+1 opt(4,5) [provided: +2,+3,+1]
+ ├── ordering: +2,+3,+1 opt(4,5) [actual: +2,+3,+1]
  ├── sort
  │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int!null) e:5(int!null)
  │    ├── key: (1)
  │    ├── fd: ()-->(4,5), (1)-->(2,3), (2,3)~~>(1)
- │    ├── ordering: +2,+3,+1 opt(4,5) [provided: +2,+3,+1]
+ │    ├── ordering: +2,+3,+1 opt(4,5) [actual: +2,+3,+1]
  │    └── select
  │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int!null) e:5(int!null)
  │         ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1557,7 +1557,7 @@ explain
            ├── constraint: /2/3: (/1/NULL - /1]
            ├── key: (1)
            ├── fd: ()-->(2), (1)-->(3), (3)-->(1)
-           └── ordering: +3 opt(2) [provided: +3]
+           └── ordering: +3 opt(2) [actual: +3]
 
 # --------------------------------------------------
 # PruneProjectSetCols

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -442,7 +442,7 @@ project
       │    │    ├── right ordering: +5
       │    │    ├── key: (5)
       │    │    ├── fd: (1)-->(2-4), (1)==(5), (5)==(1)
-      │    │    ├── ordering: +(1|5) [provided: +1]
+      │    │    ├── ordering: +(1|5) [actual: +1]
       │    │    ├── scan a
       │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
       │    │    │    ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1160,7 +1160,7 @@ project
  │    │    ├── columns: b.i:2(int) a.k:7(int) a.i:8(int) rownum:15(int!null)
  │    │    ├── key: (7,15)
  │    │    ├── fd: (15)-->(2), (7)-->(8)
- │    │    ├── ordering: +7 opt(8) [provided: +7]
+ │    │    ├── ordering: +7 opt(8) [actual: +7]
  │    │    └── left-join
  │    │         ├── columns: b.i:2(int) a.k:7(int) a.i:8(int) rownum:15(int!null)
  │    │         ├── key: (7,15)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -527,12 +527,12 @@ semi-join (merge)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(2), (1)-->(3-5)
- │    ├── ordering: +1 opt(2) [provided: +1]
+ │    ├── ordering: +1 opt(2) [actual: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1 opt(2) [provided: +1]
+ │    │    └── ordering: +1 opt(2) [actual: +1]
  │    └── filters
  │         └── i = 0 [type=bool, outer=(2), constraints=(/2: [/0 - /0]; tight), fd=()-->(2)]
  ├── scan xy
@@ -556,12 +556,12 @@ anti-join (merge)
  │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    ├── fd: ()-->(2), (1)-->(3-5)
- │    ├── ordering: +1 opt(2) [provided: +1]
+ │    ├── ordering: +1 opt(2) [actual: +1]
  │    ├── scan a
  │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-5)
- │    │    └── ordering: +1 opt(2) [provided: +1]
+ │    │    └── ordering: +1 opt(2) [actual: +1]
  │    └── filters
  │         └── i = 0 [type=bool, outer=(2), constraints=(/2: [/0 - /0]; tight), fd=()-->(2)]
  ├── scan xy
@@ -917,7 +917,7 @@ select
  │    │    ├── columns: k:1(int!null) i:2(int!null) s:4(string)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(4), (1)==(2), (2)==(1)
- │    │    ├── ordering: +(1|2) [provided: +1]
+ │    │    ├── ordering: +(1|2) [actual: +1]
  │    │    ├── scan a
  │    │    │    ├── columns: k:1(int!null) i:2(int) s:4(string)
  │    │    │    ├── key: (1)

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -139,23 +139,23 @@ project
       ├── cardinality: [0 - 50]
       ├── key: (1)
       ├── fd: ()-->(9), (1)-->(2,3,5-8,10)
-      ├── ordering: +1 opt(9) [provided: +1]
+      ├── ordering: +1 opt(9) [actual: +1]
       ├── index-join article
       │    ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) title:5(string) summary:6(string) content:7(string) link:8(string) read:9(bool!null) date:10(timestamptz)
       │    ├── key: (1)
       │    ├── fd: ()-->(9), (1)-->(2,3,5-8,10)
-      │    ├── ordering: +1 opt(9) [provided: +1]
+      │    ├── ordering: +1 opt(9) [actual: +1]
       │    └── select
       │         ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) read:9(bool!null)
       │         ├── key: (1)
       │         ├── fd: ()-->(9), (1)-->(2,3)
-      │         ├── ordering: +1 opt(9) [provided: +1]
+      │         ├── ordering: +1 opt(9) [actual: +1]
       │         ├── scan article@article_idx_read_key
       │         │    ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) read:9(bool)
       │         │    ├── constraint: /1: [/1 - ]
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2,3,9)
-      │         │    └── ordering: +1 opt(9) [provided: +1]
+      │         │    └── ordering: +1 opt(9) [actual: +1]
       │         └── filters
       │              └── NOT read [type=bool, outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
       └── const: 50 [type=int]
@@ -178,24 +178,24 @@ project
       ├── cardinality: [0 - 50]
       ├── key: (1)
       ├── fd: ()-->(9), (1)-->(2,3,5-8,10)
-      ├── ordering: +1 opt(9) [provided: +1]
+      ├── ordering: +1 opt(9) [actual: +1]
       ├── index-join article
       │    ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) title:5(string) summary:6(string) content:7(string) link:8(string) read:9(bool!null) date:10(timestamptz)
       │    ├── key: (1)
       │    ├── fd: ()-->(9), (1)-->(2,3,5-8,10)
-      │    ├── ordering: +1 opt(9) [provided: +1]
+      │    ├── ordering: +1 opt(9) [actual: +1]
       │    └── select
       │         ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) read:9(bool!null)
       │         ├── key: (1)
       │         ├── fd: ()-->(9), (1)-->(2,3)
-      │         ├── ordering: +1 opt(9) [provided: +1]
+      │         ├── ordering: +1 opt(9) [actual: +1]
       │         ├── scan article@article_idx_read_key
       │         │    ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) read:9(bool)
       │         │    ├── constraint: /1: [/1 - ]
       │         │    ├── flags: force-index=article_idx_read_key
       │         │    ├── key: (1)
       │         │    ├── fd: (1)-->(2,3,9)
-      │         │    └── ordering: +1 opt(9) [provided: +1]
+      │         │    └── ordering: +1 opt(9) [actual: +1]
       │         └── filters
       │              └── NOT read [type=bool, outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
       └── const: 50 [type=int]
@@ -210,18 +210,18 @@ limit
  ├── cardinality: [0 - 5]
  ├── key: (1)
  ├── fd: ()-->(9)
- ├── ordering: +1 opt(9) [provided: +1]
+ ├── ordering: +1 opt(9) [actual: +1]
  ├── select
  │    ├── columns: id:1(int!null) read:9(bool!null)
  │    ├── key: (1)
  │    ├── fd: ()-->(9)
- │    ├── ordering: +1 opt(9) [provided: +1]
+ │    ├── ordering: +1 opt(9) [actual: +1]
  │    ├── scan article@article_idx_read_key
  │    │    ├── columns: id:1(int!null) read:9(bool)
  │    │    ├── constraint: /1: [/1 - ]
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
- │    │    └── ordering: +1 opt(9) [provided: +1]
+ │    │    └── ordering: +1 opt(9) [actual: +1]
  │    └── filters
  │         └── NOT read [type=bool, outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
  └── const: 5 [type=int]
@@ -308,13 +308,13 @@ project
  ├── columns: score:9(int!null) expires_at:15(int!null)  [hidden: updated_at_inverse:14(int!null)]
  ├── cardinality: [0 - 50]
  ├── fd: ()-->(15)
- ├── ordering: -9,-14 opt(15) [provided: -9,-14]
+ ├── ordering: -9,-14 opt(15) [actual: -9,-14]
  └── scan leaderboard_record@test_idx,rev
       ├── columns: id:1(bytes!null) leaderboard_id:2(bytes!null) score:9(int!null) updated_at_inverse:14(int!null) expires_at:15(int!null)
       ├── constraint: /2/15/9/14/1/3: [/'\x74657374'/0 - /'\x74657374'/0/100/500/'\x736f6d655f6964')
       ├── limit: 50(rev)
       ├── fd: ()-->(2,15)
-      └── ordering: -9,-14 opt(2,15) [provided: -9,-14]
+      └── ordering: -9,-14 opt(2,15) [actual: -9,-14]
 
 # ------------------------------------------------------------------------------
 # Github Issue 26444: Ensure that optimizer uses a merge join using the
@@ -538,12 +538,12 @@ limit
  ├── cardinality: [0 - 50]
  ├── key: (1)
  ├── fd: ()-->(3,5), (1)-->(2,4,6-11)
- ├── ordering: +4 opt(3,5) [provided: +4]
+ ├── ordering: +4 opt(3,5) [actual: +4]
  ├── sort
  │    ├── columns: remote_id:1(uuid!null) conflict_remote_id:2(uuid) user_id:3(uuid!null) last_sync_id:4(int!null) data_type:5(string!null) sync_data:6(string) deleted:7(bool!null) create_device_id:8(string!null) original_data_id:9(string!null) create_time:10(int!null) last_update_time:11(int!null)
  │    ├── key: (1)
  │    ├── fd: ()-->(3,5), (1)-->(2,4,6-11)
- │    ├── ordering: +4 opt(3,5) [provided: +4]
+ │    ├── ordering: +4 opt(3,5) [actual: +4]
  │    └── select
  │         ├── columns: remote_id:1(uuid!null) conflict_remote_id:2(uuid) user_id:3(uuid!null) last_sync_id:4(int!null) data_type:5(string!null) sync_data:6(string) deleted:7(bool!null) create_device_id:8(string!null) original_data_id:9(string!null) create_time:10(int!null) last_update_time:11(int!null)
  │         ├── key: (1)

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -1260,7 +1260,7 @@ semi-join (merge)
  ├── sort
  │    ├── columns: person_id:10(int) order_id:11(int!null)
  │    ├── fd: ()-->(11)
- │    ├── ordering: +10 opt(11) [provided: +10]
+ │    ├── ordering: +10 opt(11) [actual: +10]
  │    └── select
  │         ├── columns: person_id:10(int) order_id:11(int!null)
  │         ├── fd: ()-->(11)
@@ -1486,10 +1486,10 @@ semi-join (merge)
  ├── select
  │    ├── columns: person_id:7(int!null) addresses:8(string!null)
  │    ├── fd: ()-->(8)
- │    ├── ordering: +7 opt(8) [provided: +7]
+ │    ├── ordering: +7 opt(8) [actual: +7]
  │    ├── scan addresses1_
  │    │    ├── columns: person_id:7(int!null) addresses:8(string)
- │    │    └── ordering: +7 opt(8) [provided: +7]
+ │    │    └── ordering: +7 opt(8) [actual: +7]
  │    └── filters
  │         └── addresses = 'Home address' [type=bool, outer=(8), constraints=(/8: [/'Home address' - /'Home address']; tight), fd=()-->(8)]
  └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -278,7 +278,7 @@ ORDER BY schemaname, tablename
 sort
  ├── columns: oid:1(oid) schemaname:29(string) tablename:2(string) relacl:26(string[]) tableowner:133(string) description:134(string) relkind:17(string) cluster:92(string) hasoids:20(bool) hasindexes:13(bool) hasrules:22(bool) tablespace:33(string) param:27(string[]) hastriggers:23(bool) unlogged:15(string) ftoptions:120(string[]) srvname:122(string) reltuples:10(float) inhtable:135(bool) inhschemaname:69(string) inhtablename:42(string)
  ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,133,134)
- ├── ordering: +2 opt(29) [provided: +2]
+ ├── ordering: +2 opt(29) [actual: +2]
  └── project
       ├── columns: tableowner:133(string) description:134(string) inhtable:135(bool) c.oid:1(oid) c.relname:2(string) c.reltuples:10(float) c.relhasindex:13(bool) c.relpersistence:15(string) c.relkind:17(string) c.relhasoids:20(bool) c.relhasrules:22(bool) c.relhastriggers:23(bool) c.relacl:26(string[]) c.reloptions:27(string[]) n.nspname:29(string) spcname:33(string) c2.relname:42(string) n2.nspname:69(string) ci.relname:92(string) ftoptions:120(string[]) srvname:122(string)
       ├── fd: ()-->(29), (1)-->(2,10,13,15,17,20,22,23,26,27,133,134), (2)-->(1,10,13,15,17,20,22,23,26,27,133,134)

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -337,7 +337,7 @@ left-join (merge)
  │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
  │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── fd: ()-->(22)
- │         │    │    │    │    │    ├── ordering: +17 opt(22) [provided: +17]
+ │         │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
  │         │    │    │    │    │    │    ├── has-placeholder
@@ -456,7 +456,7 @@ sort
  ├── side-effects, has-placeholder
  ├── key: (1,34)
  ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
- ├── ordering: +7 opt(11) [provided: +7]
+ ├── ordering: +7 opt(11) [actual: +7]
  └── right-join
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs_1.id:34(int) key:35(string) value:36(string) flavor_extra_specs_1.flavor_id:37(int) flavor_extra_specs_1.created_at:38(timestamp) flavor_extra_specs_1.updated_at:39(timestamp)
       ├── side-effects, has-placeholder
@@ -483,13 +483,13 @@ sort
       │         │    ├── has-placeholder
       │         │    ├── key: (1)
       │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    ├── ordering: +7 opt(11) [provided: +7]
+      │         │    ├── ordering: +7 opt(11) [actual: +7]
       │         │    ├── sort
       │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
       │         │    │    ├── has-placeholder
       │         │    │    ├── key: (1)
       │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │    ├── ordering: +7 opt(11) [provided: +7]
+      │         │    │    ├── ordering: +7 opt(11) [actual: +7]
       │         │    │    └── select
       │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
       │         │    │         ├── has-placeholder
@@ -508,50 +508,50 @@ sort
       │         │    │         │    │    ├── right ordering: +23
       │         │    │         │    │    ├── has-placeholder
       │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(31)
-      │         │    │         │    │    ├── ordering: +1 opt(11) [provided: +1]
+      │         │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
       │         │    │         │    │    ├── project
       │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── key: (1)
       │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │    ├── ordering: +1 opt(11) [provided: +1]
+      │         │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
       │         │    │         │    │    │    └── select
       │         │    │         │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
       │         │    │         │    │    │         ├── has-placeholder
       │         │    │         │    │    │         ├── key: (1)
       │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │         ├── ordering: +1 opt(11) [provided: +1]
+      │         │    │         │    │    │         ├── ordering: +1 opt(11) [actual: +1]
       │         │    │         │    │    │         ├── group-by
       │         │    │         │    │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
       │         │    │         │    │    │         │    ├── grouping columns: flavors.id:1(int!null)
       │         │    │         │    │    │         │    ├── has-placeholder
       │         │    │         │    │    │         │    ├── key: (1)
       │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │         │    ├── ordering: +1 opt(11) [provided: +1]
+      │         │    │         │    │    │         │    ├── ordering: +1 opt(11) [actual: +1]
       │         │    │         │    │    │         │    ├── left-join (merge)
       │         │    │         │    │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:28(bool)
       │         │    │         │    │    │         │    │    ├── left ordering: +1
       │         │    │         │    │    │         │    │    ├── right ordering: +17
       │         │    │         │    │    │         │    │    ├── has-placeholder
       │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(28)
-      │         │    │         │    │    │         │    │    ├── ordering: +1 opt(11) [provided: +1]
+      │         │    │         │    │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
       │         │    │         │    │    │         │    │    ├── select
       │         │    │         │    │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
       │         │    │         │    │    │         │    │    │    ├── key: (1)
       │         │    │         │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11) [provided: +1]
+      │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
       │         │    │         │    │    │         │    │    │    ├── scan flavors
       │         │    │         │    │    │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
       │         │    │         │    │    │         │    │    │    │    ├── key: (1)
       │         │    │         │    │    │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11) [provided: +1]
+      │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11) [actual: +1]
       │         │    │         │    │    │         │    │    │    └── filters
       │         │    │         │    │    │         │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
       │         │    │         │    │    │         │    │    ├── project
       │         │    │         │    │    │         │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:17(int!null)
       │         │    │         │    │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │         │    │    │    ├── fd: ()-->(28)
-      │         │    │         │    │    │         │    │    │    ├── ordering: +17 opt(28) [provided: +17]
+      │         │    │         │    │    │         │    │    │    ├── ordering: +17 opt(28) [actual: +17]
       │         │    │         │    │    │         │    │    │    ├── select
       │         │    │         │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
       │         │    │         │    │    │         │    │    │    │    ├── has-placeholder
@@ -601,7 +601,7 @@ sort
       │         │    │         │    │    │    ├── columns: true:31(bool!null) flavor_projects.flavor_id:23(int!null)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── fd: ()-->(31)
-      │         │    │         │    │    │    ├── ordering: +23 opt(31) [provided: +23]
+      │         │    │         │    │    │    ├── ordering: +23 opt(31) [actual: +23]
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
       │         │    │         │    │    │    │    ├── has-placeholder
@@ -794,7 +794,7 @@ sort
       │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── fd: ()-->(25)
-      │         │    │         │    │    │    ├── ordering: +18 opt(25) [provided: +18]
+      │         │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
       │         │    │         │    │    │    │    ├── has-placeholder
@@ -952,7 +952,7 @@ sort
       │         │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:26(int!null)
       │         │    │    │    ├── has-placeholder
       │         │    │    │    ├── fd: ()-->(33)
-      │         │    │    │    ├── ordering: +26 opt(33) [provided: +26]
+      │         │    │    │    ├── ordering: +26 opt(33) [actual: +26]
       │         │    │    │    ├── select
       │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
       │         │    │    │    │    ├── has-placeholder
@@ -1127,7 +1127,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
  │    │         │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    ├── fd: ()-->(25)
- │    │         │    │    │    │    │    ├── ordering: +18 opt(25) [provided: +18]
+ │    │         │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
  │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │    │    │    │    │    ├── has-placeholder
@@ -1305,7 +1305,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
  │    │         │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    ├── fd: ()-->(25)
- │    │         │    │    │    │    │    ├── ordering: +18 opt(25) [provided: +18]
+ │    │         │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
  │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │    │    │    │    │    ├── has-placeholder
@@ -1471,7 +1471,7 @@ right-join
  │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
  │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── fd: ()-->(22)
- │         │    │    │    │    │    ├── ordering: +17 opt(22) [provided: +17]
+ │         │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
  │         │    │    │    │    │    │    ├── has-placeholder
@@ -1630,7 +1630,7 @@ right-join
  │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
  │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── fd: ()-->(22)
- │         │    │    │    │    │    ├── ordering: +17 opt(22) [provided: +17]
+ │         │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
  │         │    │    │    │    │    │    ├── has-placeholder
@@ -1808,7 +1808,7 @@ sort
       │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── fd: ()-->(22)
-      │         │    │         │    │    │    ├── ordering: +17 opt(22) [provided: +17]
+      │         │    │         │    │    │    ├── ordering: +17 opt(22) [actual: +17]
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
       │         │    │         │    │    │    │    ├── has-placeholder
@@ -2000,7 +2000,7 @@ sort
       │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── fd: ()-->(25)
-      │         │    │         │    │    │    ├── ordering: +18 opt(25) [provided: +18]
+      │         │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
       │         │    │         │    │    │    │    ├── has-placeholder
@@ -2177,7 +2177,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
  │    │         │    │    │    │    │    ├── has-placeholder
  │    │         │    │    │    │    │    ├── fd: ()-->(25)
- │    │         │    │    │    │    │    ├── ordering: +18 opt(25) [provided: +18]
+ │    │         │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
  │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │    │    │    │    │    ├── has-placeholder
@@ -2313,7 +2313,7 @@ sort
       │         │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:23(int!null)
       │         │    │    │    ├── has-placeholder
       │         │    │    │    ├── fd: ()-->(28)
-      │         │    │    │    ├── ordering: +23 opt(28) [provided: +23]
+      │         │    │    │    ├── ordering: +23 opt(28) [actual: +23]
       │         │    │    │    ├── select
       │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
       │         │    │    │    │    ├── has-placeholder
@@ -2501,7 +2501,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
  │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(25)
- │    │         │    │         │    │    │    ├── ordering: +18 opt(25) [provided: +18]
+ │    │         │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │         │    │    │    │    ├── has-placeholder
@@ -2674,7 +2674,7 @@ sort
       │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
       │         │    │         │    │    │    ├── has-placeholder
       │         │    │         │    │    │    ├── fd: ()-->(22)
-      │         │    │         │    │    │    ├── ordering: +17 opt(22) [provided: +17]
+      │         │    │         │    │    │    ├── ordering: +17 opt(22) [actual: +17]
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
       │         │    │         │    │    │    │    ├── has-placeholder
@@ -2798,40 +2798,40 @@ left-join (lookup instance_type_extra_specs)
  ├── side-effects, has-placeholder
  ├── key: (1,39)
  ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
- ├── ordering: +7,+1 opt(11) [provided: +7,+1]
+ ├── ordering: +7,+1 opt(11) [actual: +7,+1]
  ├── left-join (lookup instance_type_extra_specs@secondary)
  │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs_1.id:39(int) key:40(string) instance_type_extra_specs_1.instance_type_id:42(int) instance_type_extra_specs_1.deleted:43(bool)
  │    ├── key columns: [1] = [42]
  │    ├── side-effects, has-placeholder
  │    ├── key: (1,39)
  │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40,42,43), (40,42,43)~~>(39)
- │    ├── ordering: +7,+1 opt(11) [provided: +7,+1]
+ │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
  │    ├── project
  │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
  │    │    ├── side-effects, has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │    ├── ordering: +7,+1 opt(11) [provided: +7,+1]
+ │    │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
  │    │    └── limit
  │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
  │    │         ├── internal-ordering: +7,+1 opt(11)
  │    │         ├── side-effects, has-placeholder
  │    │         ├── key: (1)
  │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         ├── ordering: +7,+1 opt(11) [provided: +7,+1]
+ │    │         ├── ordering: +7,+1 opt(11) [actual: +7,+1]
  │    │         ├── offset
  │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
  │    │         │    ├── internal-ordering: +7,+1 opt(11)
  │    │         │    ├── has-placeholder
  │    │         │    ├── key: (1)
  │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    ├── ordering: +7,+1 opt(11) [provided: +7,+1]
+ │    │         │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
  │    │         │    ├── sort
  │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
  │    │         │    │    ├── has-placeholder
  │    │         │    │    ├── key: (1)
  │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │    ├── ordering: +7,+1 opt(11) [provided: +7,+1]
+ │    │         │    │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
  │    │         │    │    └── select
  │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
  │    │         │    │         ├── has-placeholder
@@ -2850,44 +2850,44 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    ├── right ordering: +26
  │    │         │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(36)
- │    │         │    │         │    │    ├── ordering: +1 opt(11) [provided: +1]
+ │    │         │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
  │    │         │    │         │    │    ├── project
  │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
  │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── key: (1)
  │    │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │    ├── ordering: +1 opt(11) [provided: +1]
+ │    │         │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
  │    │         │    │         │    │    │    └── select
  │    │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
  │    │         │    │         │    │    │         ├── has-placeholder
  │    │         │    │         │    │    │         ├── key: (1)
  │    │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │         ├── ordering: +1 opt(11) [provided: +1]
+ │    │         │    │         │    │    │         ├── ordering: +1 opt(11) [actual: +1]
  │    │         │    │         │    │    │         ├── group-by
  │    │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
  │    │         │    │         │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
  │    │         │    │         │    │    │         │    ├── has-placeholder
  │    │         │    │         │    │    │         │    ├── key: (1)
  │    │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │         │    ├── ordering: +1 opt(11) [provided: +1]
+ │    │         │    │         │    │    │         │    ├── ordering: +1 opt(11) [actual: +1]
  │    │         │    │         │    │    │         │    ├── left-join (merge)
  │    │         │    │         │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:33(bool)
  │    │         │    │         │    │    │         │    │    ├── left ordering: +1
  │    │         │    │         │    │    │         │    │    ├── right ordering: +18
  │    │         │    │         │    │    │         │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(33)
- │    │         │    │         │    │    │         │    │    ├── ordering: +1 opt(11) [provided: +1]
+ │    │         │    │         │    │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
  │    │         │    │         │    │    │         │    │    ├── select
  │    │         │    │         │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
  │    │         │    │         │    │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    │    ├── key: (1)
  │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11) [provided: +1]
+ │    │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
  │    │         │    │         │    │    │         │    │    │    ├── scan instance_types
  │    │         │    │         │    │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
  │    │         │    │         │    │    │         │    │    │    │    ├── key: (1)
  │    │         │    │         │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11) [provided: +1]
+ │    │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11) [actual: +1]
  │    │         │    │         │    │    │         │    │    │    └── filters
  │    │         │    │         │    │    │         │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
  │    │         │    │         │    │    │         │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
@@ -2895,7 +2895,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │         │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:18(int!null)
  │    │         │    │         │    │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(33)
- │    │         │    │         │    │    │         │    │    │    ├── ordering: +18 opt(33) [provided: +18]
+ │    │         │    │         │    │    │         │    │    │    ├── ordering: +18 opt(33) [actual: +18]
  │    │         │    │         │    │    │         │    │    │    ├── select
  │    │         │    │         │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │         │    │    │         │    │    │    │    ├── has-placeholder
@@ -2950,7 +2950,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │    ├── columns: true:36(bool!null) instance_type_projects.instance_type_id:26(int!null)
  │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(36)
- │    │         │    │         │    │    │    ├── ordering: +26 opt(36) [provided: +26]
+ │    │         │    │         │    │    │    ├── ordering: +26 opt(36) [actual: +26]
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
  │    │         │    │         │    │    │    │    ├── has-placeholder
@@ -3145,7 +3145,7 @@ left-join (lookup instance_type_extra_specs)
  │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
  │    │         │    │         │    │    │    ├── has-placeholder
  │    │         │    │         │    │    │    ├── fd: ()-->(25)
- │    │         │    │         │    │    │    ├── ordering: +18 opt(25) [provided: +18]
+ │    │         │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
  │    │         │    │         │    │    │    ├── select
  │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
  │    │         │    │         │    │    │    │    ├── has-placeholder
@@ -3310,7 +3310,7 @@ right-join
  │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
  │         │    │    │    │    │    ├── has-placeholder
  │         │    │    │    │    │    ├── fd: ()-->(22)
- │         │    │    │    │    │    ├── ordering: +17 opt(22) [provided: +17]
+ │         │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
  │         │    │    │    │    │    │    ├── has-placeholder
@@ -3472,7 +3472,7 @@ sort
       │         │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
       │         │         │    │    │    ├── has-placeholder
       │         │         │    │    │    ├── fd: ()-->(22)
-      │         │         │    │    │    ├── ordering: +17 opt(22) [provided: +17]
+      │         │         │    │    │    ├── ordering: +17 opt(22) [actual: +17]
       │         │         │    │    │    ├── select
       │         │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
       │         │         │    │    │    │    ├── has-placeholder

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -633,7 +633,7 @@ project
       ├── cost: 6.26
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
-      ├── ordering: +1 opt(2) [provided: +1]
+      ├── ordering: +1 opt(2) [actual: +1]
       ├── prune: (1-3,8,14-17)
       └── interesting orderings: (+2,+1) (+1,+2)
 
@@ -667,7 +667,7 @@ project
       ├── cost: 0.0100363
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4)
-      ├── ordering: +4 opt(2,3,6) [provided: +4]
+      ├── ordering: +4 opt(2,3,6) [actual: +4]
       ├── prune: (1-4,6)
       └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
 
@@ -724,7 +724,7 @@ project
       ├── cost: 0.02017787
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
-      ├── ordering: +4 opt(2,3,6) [provided: +4]
+      ├── ordering: +4 opt(2,3,6) [actual: +4]
       ├── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
       └── scan customer@customer_idx
            ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
@@ -733,7 +733,7 @@ project
            ├── cost: 0.0100363
            ├── key: (1)
            ├── fd: ()-->(2,3,6), (1)-->(4)
-           ├── ordering: +4 opt(2,3,6) [provided: +4]
+           ├── ordering: +4 opt(2,3,6) [actual: +4]
            ├── prune: (1-4,6)
            └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -438,7 +438,7 @@ project
       ├── cost: 0.635
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
-      ├── ordering: +1 opt(2) [provided: +1]
+      ├── ordering: +1 opt(2) [actual: +1]
       ├── prune: (1-3,8,14-17)
       └── interesting orderings: (+2,+1) (+1,+2)
 
@@ -472,7 +472,7 @@ project
       ├── cost: 0.011089
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4)
-      ├── ordering: +4 opt(2,3,6) [provided: +4]
+      ├── ordering: +4 opt(2,3,6) [actual: +4]
       ├── prune: (1-4,6)
       └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
 
@@ -529,7 +529,7 @@ project
       ├── cost: 0.0253361
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
-      ├── ordering: +4 opt(2,3,6) [provided: +4]
+      ├── ordering: +4 opt(2,3,6) [actual: +4]
       ├── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
       └── scan customer@customer_idx
            ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
@@ -538,7 +538,7 @@ project
            ├── cost: 0.011089
            ├── key: (1)
            ├── fd: ()-->(2,3,6), (1)-->(4)
-           ├── ordering: +4 opt(2,3,6) [provided: +4]
+           ├── ordering: +4 opt(2,3,6) [actual: +4]
            ├── prune: (1-4,6)
            └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
 

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -431,12 +431,12 @@ project
       ├── cardinality: [0 - 100]
       ├── key: (17,18)
       ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
-      ├── ordering: -15,+23,+11,+(1|17) [provided: -15,+23,+11,+1]
+      ├── ordering: -15,+23,+11,+(1|17) [actual: -15,+23,+11,+1]
       ├── sort
       │    ├── columns: p_partkey:1(int) p_mfgr:3(string) s_name:11(string) s_address:12(string) s_phone:14(string) s_acctbal:15(float) s_comment:16(string) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(string) min:48(float!null)
       │    ├── key: (17,18)
       │    ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
-      │    ├── ordering: -15,+23,+11,+(1|17) [provided: -15,+23,+11,+1]
+      │    ├── ordering: -15,+23,+11,+(1|17) [actual: -15,+23,+11,+1]
       │    └── select
       │         ├── columns: p_partkey:1(int) p_mfgr:3(string) s_name:11(string) s_address:12(string) s_phone:14(string) s_acctbal:15(float) s_comment:16(string) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(string) min:48(float!null)
       │         ├── key: (17,18)
@@ -2102,23 +2102,23 @@ project
  │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null) l_partkey:27(int) l_quantity:30(float)
  │    │    │    │    │    │    ├── key columns: [26 29] = [26 29]
  │    │    │    │    │    │    ├── fd: ()-->(20,23)
- │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [provided: +17]
+ │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [actual: +17]
  │    │    │    │    │    │    ├── left-join (lookup lineitem@l_pk)
  │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null) l_orderkey:26(int) l_partkey:27(int) l_linenumber:29(int)
  │    │    │    │    │    │    │    ├── key columns: [17] = [27]
  │    │    │    │    │    │    │    ├── key: (17,26,29)
  │    │    │    │    │    │    │    ├── fd: ()-->(20,23), (26,29)-->(27)
- │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [provided: +17]
+ │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [actual: +17]
  │    │    │    │    │    │    │    ├── select
  │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null)
  │    │    │    │    │    │    │    │    ├── key: (17)
  │    │    │    │    │    │    │    │    ├── fd: ()-->(20,23)
- │    │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [provided: +17]
+ │    │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [actual: +17]
  │    │    │    │    │    │    │    │    ├── scan part
  │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null)
  │    │    │    │    │    │    │    │    │    ├── key: (17)
  │    │    │    │    │    │    │    │    │    ├── fd: (17)-->(20,23)
- │    │    │    │    │    │    │    │    │    └── ordering: +17 opt(20,23) [provided: +17]
+ │    │    │    │    │    │    │    │    │    └── ordering: +17 opt(20,23) [actual: +17]
  │    │    │    │    │    │    │    │    └── filters
  │    │    │    │    │    │    │    │         ├── p_brand = 'Brand#23' [type=bool, outer=(20), constraints=(/20: [/'Brand#23' - /'Brand#23']; tight), fd=()-->(20)]
  │    │    │    │    │    │    │    │         └── p_container = 'MED BOX' [type=bool, outer=(23), constraints=(/23: [/'MED BOX' - /'MED BOX']; tight), fd=()-->(23)]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1247,7 +1247,7 @@ sort
  ├── cardinality: [0 - 2]
  ├── side-effects, mutations
  ├── fd: (1)==(2), (2)==(1)
- ├── ordering: +(1|2) [provided: +1]
+ ├── ordering: +(1|2) [actual: +1]
  └── select
       ├── columns: x:1(int!null) y:2(int!null) z:3(int!null)
       ├── cardinality: [0 - 2]
@@ -1364,7 +1364,7 @@ sort
  ├── cardinality: [0 - 10]
  ├── side-effects, mutations
  ├── fd: (2)==(3), (3)==(2)
- ├── ordering: +(2|3),+4 [provided: +2,+4]
+ ├── ordering: +(2|3),+4 [actual: +2,+4]
  ├── prune: (1-4)
  └── project
       ├── columns: a:1(int) b:2(int!null) c:3(int!null) d:4(int)
@@ -1517,7 +1517,7 @@ sort
  ├── cardinality: [0 - 10]
  ├── side-effects, mutations
  ├── fd: (2)==(3), (3)==(2)
- ├── ordering: +(2|3),+4 [provided: +2,+4]
+ ├── ordering: +(2|3),+4 [actual: +2,+4]
  ├── prune: (1-4)
  └── project
       ├── columns: a:1(int) b:2(int!null) c:3(int!null) d:4(int)

--- a/pkg/sql/opt/xform/testdata/ruleprops/orderings
+++ b/pkg/sql/opt/xform/testdata/ruleprops/orderings
@@ -139,7 +139,7 @@ group-by
  │    ├── columns: a:1(int) b:2(int) c:3(int)
  │    ├── lax-key: (1-3)
  │    ├── fd: (3)~~>(1,2)
- │    ├── ordering: +1 opt(2,3) [provided: +1]
+ │    ├── ordering: +1 opt(2,3) [actual: +1]
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+1,+2) (+3)
  │    └── scan abc

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -709,7 +709,7 @@ right-join (merge)
  │    ├── left ordering: +1,+2
  │    ├── right ordering: +5,+6
  │    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
- │    ├── ordering: +(1|5) [provided: +1]
+ │    ├── ordering: +(1|5) [actual: +1]
  │    ├── scan abc@ab
  │    │    ├── columns: a:1(int) b:2(int) c:3(int)
  │    │    └── ordering: +1,+2
@@ -740,7 +740,7 @@ left-join (merge)
  │    ├── left ordering: +1,+2
  │    ├── right ordering: +5,+6
  │    ├── fd: (1)==(5), (5)==(1), (2)==(6), (6)==(2)
- │    ├── ordering: +(1|5),+(2|6) [provided: +1,+2]
+ │    ├── ordering: +(1|5),+(2|6) [actual: +1,+2]
  │    ├── scan abc@ab
  │    │    ├── columns: a:1(int) b:2(int) c:3(int)
  │    │    └── ordering: +1,+2

--- a/pkg/sql/opt/xform/testdata/rules/manual
+++ b/pkg/sql/opt/xform/testdata/rules/manual
@@ -63,7 +63,7 @@ project
       ├── constraint: /2/3: (/1/NULL - /1]
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3), (3)-->(1)
-      └── ordering: +3 opt(2) [provided: +3]
+      └── ordering: +3 opt(2) [actual: +3]
 
 # d is required for the ordering, so requires a lookup-join.
 opt
@@ -73,7 +73,7 @@ sort
  ├── columns: a:1(int!null)  [hidden: b:2(int!null) c:3(int) d:4(int)]
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3,4), (2,3)~~>(1,4)
- ├── ordering: +3,+4 opt(2) [provided: +3,+4]
+ ├── ordering: +3,+4 opt(2) [actual: +3,+4]
  └── index-join abcde
       ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int)
       ├── key: (1)
@@ -131,7 +131,7 @@ project
       ├── constraint: /2/3: [/1 - /1]
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3), (2,3)~~>(1)
-      └── ordering: +3 opt(2) [provided: +3]
+      └── ordering: +3 opt(2) [actual: +3]
 
 # Filter "b", but do not use it in the projection or ORDER BY. Add an additional
 # column to the ordering that triggers lookup-join.

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -243,12 +243,12 @@ Source expression:
    ├── columns: s:4(string!null) i:2(int) f:3(float)  [hidden: k:1(int!null)]
    ├── key: (1)
    ├── fd: ()-->(4), (1)-->(2,3)
-   ├── ordering: +1 opt(4) [provided: +1]
+   ├── ordering: +1 opt(4) [actual: +1]
    ├── scan a@s_idx
    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
    │    ├── key: (1)
    │    ├── fd: (1)-->(2-4)
-   │    └── ordering: +1 opt(4) [provided: +4,+1]
+   │    └── ordering: +1 opt(4) [actual: +4,+1]
    └── filters
         └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
@@ -258,14 +258,14 @@ New expression 1 of 2:
    ├── constraint: /4/1: [/'foo' - /'foo']
    ├── key: (1)
    ├── fd: ()-->(4), (1)-->(2,3)
-   └── ordering: +1 opt(4) [provided: +1]
+   └── ordering: +1 opt(4) [actual: +1]
 
 New expression 2 of 2:
   sort
    ├── columns: s:4(string!null) i:2(int) f:3(float)  [hidden: k:1(int!null)]
    ├── key: (1)
    ├── fd: ()-->(4), (1)-->(2,3)
-   ├── ordering: +1 opt(4) [provided: +1]
+   ├── ordering: +1 opt(4) [actual: +1]
    └── index-join a
         ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null)
         ├── key: (1)


### PR DESCRIPTION
The `provided` label matches terminology used in the code but is
otherwise confusing when looking at formatted expressions. This change
renames it to `actual`.

Release note: None