### PR TITLE
opt: improve memo dependency staleness check

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -541,7 +541,33 @@ query error pq: relation "othertable" does not exist
 EXECUTE change_db_2
 
 statement ok
+CREATE TABLE othertable (a INT PRIMARY KEY, b INT); INSERT INTO othertable (a, b) VALUES (2, 20)
+
+query II
+EXECUTE change_db_2
+----
+2  20
+
+# Same test with a query which refers to the same table twice initially, but
+# later the two tables are different.
+statement ok
+PREPARE change_db_3 AS SELECT * from othertable AS t1, test.othertable AS t2
+
+query IIII
+EXECUTE change_db_3
+----
+2 20 2 20
+
+statement ok
 USE otherdb
+
+query IIII
+EXECUTE change_db_3
+----
+1 10 2 20
+
+statement ok
+DROP TABLE test.othertable
 
 ## Search path change: Change the search path and ensure that the prepared plan
 ## is invalidated.
@@ -558,6 +584,49 @@ SET search_path = pg_catalog
 
 query error pq: relation "othertable" does not exist
 EXECUTE change_search_path
+
+## New table in search path: check tricky case where originally resolved table
+## still exists but re-resolving with new search path yields another table.
+statement ok
+SET search_path=public,pg_catalog
+
+# During prepare, pg_type resolves to pg_catalog.pg_type.
+statement ok
+PREPARE new_table_in_search_path AS SELECT typname FROM pg_type
+
+statement ok
+CREATE TABLE pg_type(typname STRING); INSERT INTO pg_type VALUES('test')
+
+# Now, it should resolve to the table we just created.
+query T
+EXECUTE new_table_in_search_path
+----
+test
+
+statement ok
+DROP TABLE pg_type
+
+## Even more tricky case: the query has two table references that resolve to
+## the same table now, but later resolve to separate tables.
+statement ok
+PREPARE new_table_in_search_path_2 AS
+  SELECT a.typname, b.typname FROM pg_type AS a, pg_catalog.pg_type AS b ORDER BY a.typname, b.typname LIMIT 1
+
+query TT
+EXECUTE new_table_in_search_path_2
+----
+_bit _bit
+
+statement ok
+CREATE TABLE pg_type(typname STRING); INSERT INTO pg_type VALUES('test')
+
+query TT
+EXECUTE new_table_in_search_path_2
+----
+test _bit
+
+statement ok
+DROP TABLE pg_type
 
 statement ok
 RESET search_path

--- a/pkg/sql/opt/cat/data_source.go
+++ b/pkg/sql/opt/cat/data_source.go
@@ -30,12 +30,4 @@ type DataSource interface {
 	// ExplicitCatalog and ExplicitSchema fields will always be true, since all
 	// parts of the name are always specified.
 	Name() *DataSourceName
-
-	// Equals returns true if this DataSource is identical to the given
-	// DataSource.
-	//
-	// This is used for invalidating cached plans and must return false whenever
-	// the schema or statistics of a data source changed between the times the two
-	// data sources were resolved.
-	Equals(other DataSource) bool
 }

--- a/pkg/sql/opt/cat/object.go
+++ b/pkg/sql/opt/cat/object.go
@@ -19,4 +19,13 @@ type Object interface {
 	// ID is the unique, stable identifier for this object. See the comment for
 	// StableID for more detail.
 	ID() StableID
+
+	// Equals returns true if this object is identical to the given Object.
+	//
+	// Two objects are identical if they have the same identifier and there were
+	// no changes to schema or table statistics between the times the two objects
+	// were resolved.
+	//
+	// Used for invalidating cached plans.
+	Equals(other Object) bool
 }

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -130,7 +130,7 @@ func TestMemoIsStale(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	o.Memo().Metadata().AddDependency(catalog.Schema(), privilege.CREATE)
+	o.Memo().Metadata().AddSchemaDependency(catalog.Schema().Name(), catalog.Schema(), privilege.CREATE)
 	o.Memo().Metadata().AddSchema(catalog.Schema())
 
 	if isStale, err := o.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
@@ -138,30 +138,6 @@ func TestMemoIsStale(t *testing.T) {
 	} else if isStale {
 		t.Errorf("memo should not be stale")
 	}
-
-	// Stale current database.
-	evalCtx.SessionData.Database = "newdb"
-	if isStale, err := o.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
-		t.Fatal(err)
-	} else if !isStale {
-		t.Errorf("expected stale current database")
-	}
-	evalCtx.SessionData.Database = "t"
-
-	// Stale search path.
-	evalCtx.SessionData.SearchPath = sessiondata.SearchPath{}
-	if isStale, err := o.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
-		t.Fatal(err)
-	} else if !isStale {
-		t.Errorf("expected stale search path")
-	}
-	evalCtx.SessionData.SearchPath = sessiondata.MakeSearchPath([]string{"path1", "path2"})
-	if isStale, err := o.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
-		t.Fatal(err)
-	} else if isStale {
-		t.Errorf("memo should not be stale")
-	}
-	evalCtx.SessionData.SearchPath = sessiondata.MakeSearchPath(searchPath)
 
 	// Stale location.
 	evalCtx.SessionData.DataConversion.Location = time.FixedZone("PST", -8*60*60)

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -49,15 +49,15 @@ func TestMetadata(t *testing.T) {
 		t.Fatalf("unexpected table id")
 	}
 
-	md.AddDependency(tab, privilege.CREATE)
+	md.AddDataSourceDependency(tab.Name(), tab, privilege.CREATE)
 	depsUpToDate, err := md.CheckDependencies(context.TODO(), testCat)
 	if err == nil || depsUpToDate {
 		t.Fatalf("expected table privilege to be revoked")
 	}
 
-	// Call AddMetadata and verify that same objects are present in new metadata.
+	// Call CopyFrom and verify that same objects are present in new metadata.
 	var mdNew opt.Metadata
-	mdNew.AddMetadata(&md)
+	mdNew.CopyFrom(&md)
 	if mdNew.Schema(schID) != testCat.Schema() {
 		t.Fatalf("unexpected schema")
 	}

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -185,7 +185,7 @@ func (f *Factory) AssignPlaceholders(from *memo.Memo) (err error) {
 
 	// Copy all metadata so that referenced tables and columns can keep the same
 	// ids they had in the "from" memo.
-	f.mem.Metadata().AddMetadata(from.Metadata())
+	f.mem.Metadata().CopyFrom(from.Metadata())
 
 	// Replace all placeholders with their assigned values.
 	dst := f.assignPlaceholders(src)

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -64,7 +64,7 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 	}
 
 	// Check Select permission as well, since existing values must be read.
-	b.checkPrivilege(tab, privilege.SELECT)
+	b.checkPrivilege(tn, tab, privilege.SELECT)
 
 	var mb mutationBuilder
 	mb.init(b, opt.DeleteOp, tab, alias)

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -163,12 +163,12 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 	if ins.OnConflict != nil {
 		// UPSERT and INDEX ON CONFLICT will read from the table to check for
 		// duplicates.
-		b.checkPrivilege(tab, privilege.SELECT)
+		b.checkPrivilege(tn, tab, privilege.SELECT)
 
 		if !ins.OnConflict.DoNothing {
 			// UPSERT and INDEX ON CONFLICT DO UPDATE may modify rows if the
 			// DO NOTHING clause is not present.
-			b.checkPrivilege(tab, privilege.UPDATE)
+			b.checkPrivilege(tn, tab, privilege.UPDATE)
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -97,7 +97,7 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 	}
 
 	// Check Select permission as well, since existing values must be read.
-	b.checkPrivilege(tab, privilege.SELECT)
+	b.checkPrivilege(tn, tab, privilege.SELECT)
 
 	var mb mutationBuilder
 	mb.init(b, opt.UpdateOp, tab, alias)

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -359,9 +359,15 @@ type Schema struct {
 
 var _ cat.Schema = &Schema{}
 
-// ID is part of the cat.Schema interface.
+// ID is part of the cat.Object interface.
 func (s *Schema) ID() cat.StableID {
 	return s.SchemaID
+}
+
+// Equals is part of the cat.Object interface.
+func (s *Schema) Equals(other cat.Object) bool {
+	otherSchema, ok := other.(*Schema)
+	return ok && s.SchemaID == otherSchema.SchemaID
 }
 
 // Name is part of the cat.Schema interface.
@@ -394,8 +400,8 @@ func (tv *View) ID() cat.StableID {
 	return tv.ViewID
 }
 
-// Equals is part of the cat.DataSource interface.
-func (tv *View) Equals(other cat.DataSource) bool {
+// Equals is part of the cat.Object interface.
+func (tv *View) Equals(other cat.Object) bool {
 	otherView, ok := other.(*View)
 	if !ok {
 		return false
@@ -453,8 +459,8 @@ func (tt *Table) ID() cat.StableID {
 	return tt.TabID
 }
 
-// Equals is part of the cat.DataSource interface.
-func (tt *Table) Equals(other cat.DataSource) bool {
+// Equals is part of the cat.Object interface.
+func (tt *Table) Equals(other cat.Object) bool {
 	otherTable, ok := other.(*Table)
 	if !ok {
 		return false
@@ -757,8 +763,8 @@ func (ts *Sequence) ID() cat.StableID {
 	return ts.SeqID
 }
 
-// Equals is part of the cat.DataSource interface.
-func (ts *Sequence) Equals(other cat.DataSource) bool {
+// Equals is part of the cat.Object interface.
+func (ts *Sequence) Equals(other cat.Object) bool {
 	otherSequence, ok := other.(*Sequence)
 	if !ok {
 		return false

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -69,6 +69,12 @@ func (os *optSchema) ID() cat.StableID {
 	return cat.StableID(os.desc.ID)
 }
 
+// Equals is part of the cat.Object interface.
+func (os *optSchema) Equals(other cat.Object) bool {
+	otherSchema, ok := other.(*optSchema)
+	return ok && os.desc.ID == otherSchema.desc.ID
+}
+
 // Name is part of the cat.Schema interface.
 func (os *optSchema) Name() *cat.SchemaName {
 	return &os.name
@@ -228,8 +234,8 @@ func (ov *optView) ID() cat.StableID {
 	return cat.StableID(ov.desc.ID)
 }
 
-// Equals is part of the cat.DataSource interface.
-func (ov *optView) Equals(other cat.DataSource) bool {
+// Equals is part of the cat.Object interface.
+func (ov *optView) Equals(other cat.Object) bool {
 	otherView, ok := other.(*optView)
 	if !ok {
 		return false
@@ -285,8 +291,8 @@ func (os *optSequence) ID() cat.StableID {
 	return cat.StableID(os.desc.ID)
 }
 
-// Equals is part of the cat.DataSource interface.
-func (os *optSequence) Equals(other cat.DataSource) bool {
+// Equals is part of the cat.Object interface.
+func (os *optSequence) Equals(other cat.Object) bool {
 	otherSeq, ok := other.(*optSequence)
 	if !ok {
 		return false
@@ -386,8 +392,8 @@ func (ot *optTable) ID() cat.StableID {
 	return cat.StableID(ot.desc.ID)
 }
 
-// Equals is part of the cat.DataSource interface.
-func (ot *optTable) Equals(other cat.DataSource) bool {
+// Equals is part of the cat.Object interface.
+func (ot *optTable) Equals(other cat.Object) bool {
 	otherTable, ok := other.(*optTable)
 	if !ok {
 		return false

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -77,6 +77,12 @@ func (tp *TableNamePrefix) Catalog() string {
 	return string(tp.CatalogName)
 }
 
+// Equals returns true if the two table name prefixes are identical (including
+// the ExplicitSchema/ExplicitCatalog flags).
+func (tp *TableNamePrefix) Equals(other *TableNamePrefix) bool {
+	return *tp == *other
+}
+
 // Format implements the NodeFormatter interface.
 func (t *TableName) Format(ctx *FmtCtx) {
 	if ctx.tableNameFormatter != nil {
@@ -100,6 +106,12 @@ func (t *TableName) FQString() string {
 // Table retrieves the unqualified table name.
 func (t *TableName) Table() string {
 	return string(t.TableName)
+}
+
+// Equals returns true if the two table names are identical (including
+// the ExplicitSchema/ExplicitCatalog flags).
+func (t *TableName) Equals(other *TableName) bool {
+	return *t == *other
 }
 
 // tableExpr implements the TableExpr interface.


### PR DESCRIPTION
When reusing a memo, we re-resolve all datasources and schemas and
verify that they are the same. The problem is that we re-resolve using
the fully qualified name that was resolved when the memo was first
created.

For example: the table in `SELECT * FROM t` might resolve to `db1.t`
now but later might resolve to `db2.t`. To avoid these cases, the code
has specific checks for the current database and search path and only
reuses a memo if those haven't changed. These checks are acceptable
for the prepare plan caching but too big of a hammer for a global
query cache (two clients that have different default databases
wouldn't be able to reuse each other's queries, even if those don't
even involve the current databases). In addition, there are some
corner cases which these checks don't cover, outlined in #33626.

This change fixes these issues by keeping the original, unresolved
name around and re-resolving using that original name. The
dependencies are now stored in a slice, and de-duplicated only when
both the object and the unresolved name match. This is the correct
solution for all these cases, and we can remove the current database
and search path checks.

Release note: None