### PR TITLE
sql: lint the names an descriptions of cluster settings

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -88,7 +88,7 @@
 <tr><td><code>sql.query_cache.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable the query cache</td></tr>
 <tr><td><code>sql.stats.experimental_automatic_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>experimental automatic statistics collection mode</td></tr>
 <tr><td><code>sql.stats.experimental_automatic_collection.fraction_idle</code></td><td>float</td><td><code>0.9</code></td><td>fraction of time that automatic statistics sampler processors are idle</td></tr>
-<tr><td><code>sql.stats.post_events</code></td><td>boolean</td><td><code>false</code></td><td>if set, an event is shown for every CREATE STATISTICS job</td></tr>
+<tr><td><code>sql.stats.post_events.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, an event is shown for every CREATE STATISTICS job</td></tr>
 <tr><td><code>sql.tablecache.lease.refresh_limit</code></td><td>integer</td><td><code>50</code></td><td>maximum number of tables to periodically refresh leases for</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>
 <tr><td><code>sql.trace.session_eventlog.enabled</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable session tracing</td></tr>

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -34,8 +34,8 @@
 <tr><td><code>kv.range.backpressure_range_size_multiplier</code></td><td>float</td><td><code>2</code></td><td>multiple of range_max_bytes that a range is allowed to grow to without splitting before writes to that range are blocked, or 0 to disable</td></tr>
 <tr><td><code>kv.range_descriptor_cache.size</code></td><td>integer</td><td><code>1000000</code></td><td>maximum number of entries in the range descriptor and leaseholder caches</td></tr>
 <tr><td><code>kv.range_merge.queue_enabled</code></td><td>boolean</td><td><code>true</code></td><td>whether the automatic merge queue is enabled</td></tr>
-<tr><td><code>kv.range_split.by_load_enabled</code></td><td>boolean</td><td><code>true</code></td><td>allow automatic splits of ranges based on where load is concentrated.</td></tr>
-<tr><td><code>kv.range_split.load_qps_threshold</code></td><td>integer</td><td><code>250</code></td><td>the QPS over which, the range becomes a candidate for load based splitting.</td></tr>
+<tr><td><code>kv.range_split.by_load_enabled</code></td><td>boolean</td><td><code>true</code></td><td>allow automatic splits of ranges based on where load is concentrated</td></tr>
+<tr><td><code>kv.range_split.load_qps_threshold</code></td><td>integer</td><td><code>250</code></td><td>the QPS over which, the range becomes a candidate for load based splitting</td></tr>
 <tr><td><code>kv.rangefeed.concurrent_catchup_iterators</code></td><td>integer</td><td><code>64</code></td><td>number of rangefeeds catchup iterators a store will allow concurrently before queueing</td></tr>
 <tr><td><code>kv.rangefeed.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, rangefeed registration is enabled</td></tr>
 <tr><td><code>kv.snapshot_rebalance.max_rate</code></td><td>byte size</td><td><code>8.0 MiB</code></td><td>the rate limit (bytes/sec) to use for rebalance and upreplication snapshots</td></tr>
@@ -50,16 +50,16 @@
 <tr><td><code>schemachanger.bulk_index_backfill.enabled</code></td><td>boolean</td><td><code>true</code></td><td>backfill indexes in bulk via addsstable</td></tr>
 <tr><td><code>schemachanger.lease.duration</code></td><td>duration</td><td><code>5m0s</code></td><td>the duration of a schema change lease</td></tr>
 <tr><td><code>schemachanger.lease.renew_fraction</code></td><td>float</td><td><code>0.5</code></td><td>the fraction of schemachanger.lease_duration remaining to trigger a renew of the lease</td></tr>
-<tr><td><code>server.clock.forward_jump_check_enabled</code></td><td>boolean</td><td><code>false</code></td><td>if enabled, forward clock jumps > max_offset/2 will cause a panic.</td></tr>
+<tr><td><code>server.clock.forward_jump_check_enabled</code></td><td>boolean</td><td><code>false</code></td><td>if enabled, forward clock jumps > max_offset/2 will cause a panic</td></tr>
 <tr><td><code>server.clock.persist_upper_bound_interval</code></td><td>duration</td><td><code>0s</code></td><td>the interval between persisting the wall time upper bound of the clock. The clock does not generate a wall time greater than the persisted timestamp and will panic if it sees a wall time greater than this value. When cockroach starts, it waits for the wall time to catch-up till this persisted timestamp. This guarantees monotonic wall time across server restarts. Not setting this or setting a value of 0 disables this feature.</td></tr>
 <tr><td><code>server.consistency_check.interval</code></td><td>duration</td><td><code>24h0m0s</code></td><td>the time between range consistency checks; set to 0 to disable consistency checking</td></tr>
 <tr><td><code>server.declined_reservation_timeout</code></td><td>duration</td><td><code>1s</code></td><td>the amount of time to consider the store throttled for up-replication after a reservation was declined</td></tr>
-<tr><td><code>server.eventlog.ttl</code></td><td>duration</td><td><code>2160h0m0s</code></td><td>if nonzero, event log entries older than this duration are deleted every 10m0s. Should not be lowered below 24 hours</td></tr>
+<tr><td><code>server.eventlog.ttl</code></td><td>duration</td><td><code>2160h0m0s</code></td><td>if nonzero, event log entries older than this duration are deleted every 10m0s. Should not be lowered below 24 hours.</td></tr>
 <tr><td><code>server.failed_reservation_timeout</code></td><td>duration</td><td><code>5s</code></td><td>the amount of time to consider the store throttled for up-replication after a failed reservation call</td></tr>
-<tr><td><code>server.heap_profile.max_profiles</code></td><td>integer</td><td><code>5</code></td><td>maximum number of profiles to be kept. Profiles with lower score are GC'ed, but latest profile is always kept</td></tr>
+<tr><td><code>server.heap_profile.max_profiles</code></td><td>integer</td><td><code>5</code></td><td>maximum number of profiles to be kept. Profiles with lower score are GC'ed, but latest profile is always kept.</td></tr>
 <tr><td><code>server.heap_profile.system_memory_threshold_fraction</code></td><td>float</td><td><code>0.85</code></td><td>fraction of system memory beyond which if Rss increases, then heap profile is triggered</td></tr>
 <tr><td><code>server.host_based_authentication.configuration</code></td><td>string</td><td><code></code></td><td>host-based authentication configuration to use during connection authentication</td></tr>
-<tr><td><code>server.rangelog.ttl</code></td><td>duration</td><td><code>720h0m0s</code></td><td>if nonzero, range log entries older than this duration are deleted every 10m0s. Should not be lowered below 24 hours</td></tr>
+<tr><td><code>server.rangelog.ttl</code></td><td>duration</td><td><code>720h0m0s</code></td><td>if nonzero, range log entries older than this duration are deleted every 10m0s. Should not be lowered below 24 hours.</td></tr>
 <tr><td><code>server.remote_debugging.mode</code></td><td>string</td><td><code>local</code></td><td>set to enable remote debugging, localhost-only or disable (any, local, off)</td></tr>
 <tr><td><code>server.shutdown.drain_wait</code></td><td>duration</td><td><code>0s</code></td><td>the amount of time a server waits in an unready state before proceeding with the rest of the shutdown process</td></tr>
 <tr><td><code>server.shutdown.query_wait</code></td><td>duration</td><td><code>10s</code></td><td>the server will wait for at least this amount of time for active queries to finish</td></tr>
@@ -93,13 +93,15 @@
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>
 <tr><td><code>sql.trace.session_eventlog.enabled</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable session tracing</td></tr>
 <tr><td><code>sql.trace.txn.enable_threshold</code></td><td>duration</td><td><code>0s</code></td><td>duration beyond which all transactions are traced (set to 0 to disable)</td></tr>
-<tr><td><code>timeseries.resolution_10s.storage_duration</code></td><td>duration</td><td><code>720h0m0s</code></td><td>deprecated setting: the amount of time to store timeseries data. Replaced by timeseries.storage.10s_resolution_ttl.</td></tr>
-<tr><td><code>timeseries.storage.10s_resolution_ttl</code></td><td>duration</td><td><code>240h0m0s</code></td><td>the maximum age of time series data stored at the 10 second resolution. Data older than this is subject to rollup and deletion.</td></tr>
-<tr><td><code>timeseries.storage.30m_resolution_ttl</code></td><td>duration</td><td><code>2160h0m0s</code></td><td>the maximum age of time series data stored at the 30 minute resolution. Data older than this is subject to deletion.</td></tr>
+<tr><td><code>timeseries.resolution_10s.storage_duration</code></td><td>duration</td><td><code>720h0m0s</code></td><td>do not use - replaced by timeseries.storage.resolution_10s.ttl</td></tr>
+<tr><td><code>timeseries.storage.10s_resolution_ttl</code></td><td>duration</td><td><code>720h0m0s</code></td><td>do not use - replaced by timeseries.storage.resolution_10s.ttl</td></tr>
+<tr><td><code>timeseries.storage.30m_resolution_ttl</code></td><td>duration</td><td><code>2160h0m0s</code></td><td>do not use - replaced by timeseries.storage.resolution_30m.ttl</td></tr>
 <tr><td><code>timeseries.storage.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, periodic timeseries data is stored within the cluster; disabling is not recommended unless you are storing the data elsewhere</td></tr>
+<tr><td><code>timeseries.storage.resolution_10s.ttl</code></td><td>duration</td><td><code>240h0m0s</code></td><td>the maximum age of time series data stored at the 10 second resolution. Data older than this is subject to rollup and deletion.</td></tr>
+<tr><td><code>timeseries.storage.resolution_30m.ttl</code></td><td>duration</td><td><code>2160h0m0s</code></td><td>the maximum age of time series data stored at the 30 minute resolution. Data older than this is subject to deletion.</td></tr>
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
-<tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>2.1-10</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
+<tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>2.1-10</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -1,6 +1,7 @@
 <table>
 <thead><tr><th>Setting</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
 <tbody>
+<tr><td><code>changefeed.experimental_poll_interval</code></td><td>duration</td><td><code>1s</code></td><td>polling interval for the prototype changefeed implementation (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
 <tr><td><code>changefeed.push.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, changed are pushed instead of pulled. This requires the kv.rangefeed.enabled setting. See https://www.cockroachlabs.com/docs/v19.1/change-data-capture.html#enable-rangefeeds-to-reduce-latency</td></tr>
 <tr><td><code>cloudstorage.gs.default.key</code></td><td>string</td><td><code></code></td><td>if set, JSON key to use during Google Cloud Storage operations</td></tr>
 <tr><td><code>cloudstorage.http.custom_ca</code></td><td>string</td><td><code></code></td><td>custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage</td></tr>
@@ -8,6 +9,11 @@
 <tr><td><code>cluster.organization</code></td><td>string</td><td><code></code></td><td>organization name</td></tr>
 <tr><td><code>cluster.preserve_downgrade_option</code></td><td>string</td><td><code></code></td><td>disable (automatic or manual) cluster version upgrade from the specified version until reset</td></tr>
 <tr><td><code>compactor.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when false, the system will reclaim space occupied by deleted data less aggressively</td></tr>
+<tr><td><code>compactor.max_record_age</code></td><td>duration</td><td><code>24h0m0s</code></td><td>discard suggestions not processed within this duration (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
+<tr><td><code>compactor.min_interval</code></td><td>duration</td><td><code>15s</code></td><td>minimum time interval to wait before compacting (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
+<tr><td><code>compactor.threshold_available_fraction</code></td><td>float</td><td><code>0.1</code></td><td>consider suggestions for at least the given percentage of the available logical space (zero to disable) (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
+<tr><td><code>compactor.threshold_bytes</code></td><td>byte size</td><td><code>256 MiB</code></td><td>minimum expected logical space reclamation required before considering an aggregated suggestion (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
+<tr><td><code>compactor.threshold_used_fraction</code></td><td>float</td><td><code>0.1</code></td><td>consider suggestions for at least the given percentage of the used logical space (zero to disable) (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
 <tr><td><code>debug.panic_on_failed_assertions</code></td><td>boolean</td><td><code>false</code></td><td>panic when an assertion fails rather than reporting</td></tr>
 <tr><td><code>diagnostics.forced_stat_reset.interval</code></td><td>duration</td><td><code>2h0m0s</code></td><td>interval after which pending diagnostics statistics should be discarded even if not reported</td></tr>
 <tr><td><code>diagnostics.reporting.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable reporting diagnostic metrics to cockroach labs</td></tr>
@@ -29,11 +35,14 @@
 <tr><td><code>kv.closed_timestamp.close_fraction</code></td><td>float</td><td><code>0.2</code></td><td>fraction of closed timestamp target duration specifying how frequently the closed timestamp is advanced</td></tr>
 <tr><td><code>kv.closed_timestamp.follower_reads_enabled</code></td><td>boolean</td><td><code>false</code></td><td>allow (all) replicas to serve consistent historical reads based on closed timestamp information</td></tr>
 <tr><td><code>kv.closed_timestamp.target_duration</code></td><td>duration</td><td><code>30s</code></td><td>if nonzero, attempt to provide closed timestamp notifications for timestamps trailing cluster time by approximately this duration</td></tr>
+<tr><td><code>kv.follower_read.target_multiple</code></td><td>float</td><td><code>3</code></td><td>if above 1, encourages the distsender to perform a read against the closest replica if a request is older than kv.closed_timestamp.target_duration * (1 + kv.closed_timestamp.close_fraction * this) less a clock uncertainty interval. This value also is used to create follower_timestamp(). (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
+<tr><td><code>kv.import.batch_size</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the maximum size of the payload in an AddSSTable request (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
 <tr><td><code>kv.raft.command.max_size</code></td><td>byte size</td><td><code>64 MiB</code></td><td>maximum size of a raft command</td></tr>
 <tr><td><code>kv.raft_log.disable_synchronization_unsafe</code></td><td>boolean</td><td><code>false</code></td><td>set to true to disable synchronization on Raft log writes to persistent storage. Setting to true risks data loss or data corruption on server crashes. The setting is meant for internal testing only and SHOULD NOT be used in production.</td></tr>
 <tr><td><code>kv.range.backpressure_range_size_multiplier</code></td><td>float</td><td><code>2</code></td><td>multiple of range_max_bytes that a range is allowed to grow to without splitting before writes to that range are blocked, or 0 to disable</td></tr>
 <tr><td><code>kv.range_descriptor_cache.size</code></td><td>integer</td><td><code>1000000</code></td><td>maximum number of entries in the range descriptor and leaseholder caches</td></tr>
 <tr><td><code>kv.range_merge.queue_enabled</code></td><td>boolean</td><td><code>true</code></td><td>whether the automatic merge queue is enabled</td></tr>
+<tr><td><code>kv.range_merge.queue_interval</code></td><td>duration</td><td><code>1s</code></td><td>how long the merge queue waits between processing replicas (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
 <tr><td><code>kv.range_split.by_load_enabled</code></td><td>boolean</td><td><code>true</code></td><td>allow automatic splits of ranges based on where load is concentrated</td></tr>
 <tr><td><code>kv.range_split.load_qps_threshold</code></td><td>integer</td><td><code>250</code></td><td>the QPS over which, the range becomes a candidate for load based splitting</td></tr>
 <tr><td><code>kv.rangefeed.concurrent_catchup_iterators</code></td><td>integer</td><td><code>64</code></td><td>number of rangefeeds catchup iterators a store will allow concurrently before queueing</td></tr>
@@ -93,9 +102,6 @@
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>
 <tr><td><code>sql.trace.session_eventlog.enabled</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable session tracing</td></tr>
 <tr><td><code>sql.trace.txn.enable_threshold</code></td><td>duration</td><td><code>0s</code></td><td>duration beyond which all transactions are traced (set to 0 to disable)</td></tr>
-<tr><td><code>timeseries.resolution_10s.storage_duration</code></td><td>duration</td><td><code>720h0m0s</code></td><td>do not use - replaced by timeseries.storage.resolution_10s.ttl</td></tr>
-<tr><td><code>timeseries.storage.10s_resolution_ttl</code></td><td>duration</td><td><code>720h0m0s</code></td><td>do not use - replaced by timeseries.storage.resolution_10s.ttl</td></tr>
-<tr><td><code>timeseries.storage.30m_resolution_ttl</code></td><td>duration</td><td><code>2160h0m0s</code></td><td>do not use - replaced by timeseries.storage.resolution_30m.ttl</td></tr>
 <tr><td><code>timeseries.storage.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, periodic timeseries data is stored within the cluster; disabling is not recommended unless you are storing the data elsewhere</td></tr>
 <tr><td><code>timeseries.storage.resolution_10s.ttl</code></td><td>duration</td><td><code>240h0m0s</code></td><td>the maximum age of time series data stored at the 10 second resolution. Data older than this is subject to rollup and deletion.</td></tr>
 <tr><td><code>timeseries.storage.resolution_30m.ttl</code></td><td>duration</td><td><code>2160h0m0s</code></td><td>the maximum age of time series data stored at the 30 minute resolution. Data older than this is subject to deletion.</td></tr>

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -27,15 +27,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-var changefeedPollInterval = settings.RegisterNonNegativeDurationSetting(
-	"changefeed.experimental_poll_interval",
-	"polling interval for the prototype changefeed implementation",
-	1*time.Second,
-)
-
-func init() {
-	changefeedPollInterval.Hide()
-}
+var changefeedPollInterval = func() *settings.DurationSetting {
+	s := settings.RegisterNonNegativeDurationSetting(
+		"changefeed.experimental_poll_interval",
+		"polling interval for the prototype changefeed implementation",
+		1*time.Second,
+	)
+	s.SetSensitive()
+	return s
+}()
 
 // PushEnabled is a cluster setting that triggers all subsequently
 // created/unpaused changefeeds to receive kv changes via RangeFeed push

--- a/pkg/ccl/followerreadsccl/followerreads.go
+++ b/pkg/ccl/followerreadsccl/followerreads.go
@@ -35,22 +35,24 @@ import (
 // which the implementation of the follower read capable replica policy ought
 // to use to determine if a request can be used for reading.
 // FollowerReadMultiple is a hidden setting.
-var followerReadMultiple = settings.RegisterValidatedFloatSetting(
-	"kv.follower_read.target_multiple",
-	"if above 1, encourages the distsender to perform a read against the "+
-		"closest replica if a request is older than kv.closed_timestamp.target_duration"+
-		" * (1 + kv.closed_timestamp.close_fraction * this) less a clock uncertainty "+
-		"interval. This value also is used to create follower_timestamp().",
-	3,
-	func(v float64) error {
-		if v < 1 {
-			return fmt.Errorf("%v is not >= 1", v)
-		}
-		return nil
-	},
-)
-
-func init() { followerReadMultiple.Hide() }
+var followerReadMultiple = func() *settings.FloatSetting {
+	s := settings.RegisterValidatedFloatSetting(
+		"kv.follower_read.target_multiple",
+		"if above 1, encourages the distsender to perform a read against the "+
+			"closest replica if a request is older than kv.closed_timestamp.target_duration"+
+			" * (1 + kv.closed_timestamp.close_fraction * this) less a clock uncertainty "+
+			"interval. This value also is used to create follower_timestamp().",
+		3,
+		func(v float64) error {
+			if v < 1 {
+				return fmt.Errorf("%v is not >= 1", v)
+			}
+			return nil
+		},
+	)
+	s.SetSensitive()
+	return s
+}()
 
 // getFollowerReadOffset returns the offset duration which should be used to as
 // the offset from now to request a follower read. The same value less the clock

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -29,11 +29,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-var importBatchSize = settings.RegisterByteSizeSetting(
-	"kv.import.batch_size",
-	"the maximum size of the payload in an AddSSTable request",
-	32<<20,
-)
+var importBatchSize = func() *settings.ByteSizeSetting {
+	s := settings.RegisterByteSizeSetting(
+		"kv.import.batch_size",
+		"the maximum size of the payload in an AddSSTable request",
+		32<<20,
+	)
+	s.SetSensitive()
+	return s
+}()
 
 // commandMetadataEstimate is an estimate of how much metadata Raft will add to
 // an AddSSTable command. It is intentionally a vast overestimate to avoid
@@ -41,7 +45,6 @@ var importBatchSize = settings.RegisterByteSizeSetting(
 const commandMetadataEstimate = 1 << 20 // 1 MB
 
 func init() {
-	importBatchSize.Hide()
 	storage.SetImportCmd(evalImport)
 
 	// Ensure that the user cannot set the maximum raft command size so low that

--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -19,19 +19,19 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
-var enterpriseLicense = settings.RegisterValidatedStringSetting(
-	"enterprise.license",
-	"the encoded cluster license",
-	"",
-	func(sv *settings.Values, s string) error {
-		_, err := licenseccl.Decode(s)
-		return err
-	},
-)
-
-func init() {
-	enterpriseLicense.Hide()
-}
+var enterpriseLicense = func() *settings.StringSetting {
+	s := settings.RegisterValidatedStringSetting(
+		"enterprise.license",
+		"the encoded cluster license",
+		"",
+		func(sv *settings.Values, s string) error {
+			_, err := licenseccl.Decode(s)
+			return err
+		},
+	)
+	s.SetConfidential()
+	return s
+}()
 
 var testingEnterpriseEnabled = false
 

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -207,6 +207,7 @@ Output the list of cluster settings known to this binary.
 			if !ok {
 				panic(fmt.Sprintf("could not find setting %q", name))
 			}
+
 			typ, ok := settings.ReadableTypes[setting.Typ()]
 			if !ok {
 				panic(fmt.Sprintf("unknown setting type %q", setting.Typ()))

--- a/pkg/server/heapprofiler/heapprofiler.go
+++ b/pkg/server/heapprofiler/heapprofiler.go
@@ -43,7 +43,7 @@ var (
 	maxProfiles = settings.RegisterIntSetting(
 		"server.heap_profile.max_profiles",
 		"maximum number of profiles to be kept. "+
-			"Profiles with lower score are GC'ed, but latest profile is always kept",
+			"Profiles with lower score are GC'ed, but latest profile is always kept.",
 		5,
 	)
 )

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -109,7 +109,7 @@ var (
 
 	forwardClockJumpCheckEnabled = settings.RegisterBoolSetting(
 		"server.clock.forward_jump_check_enabled",
-		"if enabled, forward clock jumps > max_offset/2 will cause a panic.",
+		"if enabled, forward clock jumps > max_offset/2 will cause a panic",
 		false,
 	)
 

--- a/pkg/server/server_systemlog_gc.go
+++ b/pkg/server/server_systemlog_gc.go
@@ -41,7 +41,7 @@ var (
 		"server.rangelog.ttl",
 		fmt.Sprintf(
 			"if nonzero, range log entries older than this duration are deleted every %s. "+
-				"Should not be lowered below 24 hours",
+				"Should not be lowered below 24 hours.",
 			systemLogGCPeriod,
 		),
 		30*24*time.Hour, // 30 days
@@ -53,7 +53,7 @@ var (
 		"server.eventlog.ttl",
 		fmt.Sprintf(
 			"if nonzero, event log entries older than this duration are deleted every %s. "+
-				"Should not be lowered below 24 hours",
+				"Should not be lowered below 24 hours.",
 			systemLogGCPeriod,
 		),
 		90*24*time.Hour, // 90 days

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -102,7 +102,7 @@ var NoSettings *Settings // = nil
 const KeyVersionSetting = "version"
 
 var version = settings.RegisterStateMachineSetting(KeyVersionSetting,
-	"set the active cluster version in the format '<major>.<minor>'.", // hide optional `-<unstable>`
+	"set the active cluster version in the format '<major>.<minor>'", // hide optional `-<unstable>`
 	settings.TransformerFn(versionTransformer),
 )
 

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -170,11 +170,25 @@ func (i common) Hidden() bool {
 	return i.hidden
 }
 
-// Hide prevents a setting from showing up in SHOW ALL CLUSTER SETTINGS. It can
-// still be used with SET and SHOW if the exact setting name is known. Use Hide
-// for in-development features and other settings that should not be
-// user-visible.
-func (i *common) Hide() {
+// SetConfidential prevents a setting from showing up in SHOW ALL
+// CLUSTER SETTINGS. It can still be used with SET and SHOW if the
+// exact setting name is known. Use SetConfidential for data that must
+// be hidden from standard setting report and troubleshooting
+// screenshots, such as license data or keys.
+func (i *common) SetConfidential() {
+	i.hidden = true
+}
+
+// SetSensitive marks the setting as dangerous to modify. Use SetConfidential for settings
+// where the user must be strongly discouraged to tweak the values.
+func (i *common) SetSensitive() {
+	i.description += " (WARNING: may compromise cluster stability or correctness; do not edit without supervision)"
+}
+
+// SetDeprecated marks the setting as obsolete. It also hides
+// it from the output of SHOW CLUSTER SETTINGS.
+func (i *common) SetDeprecated() {
+	i.description = "do not use - " + i.description
 	i.hidden = true
 }
 

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -133,7 +133,7 @@ var byteSize = settings.RegisterByteSizeSetting("zzz", "desc", mb)
 var mA = settings.RegisterStateMachineSetting("statemachine", "foo", dummyTransformer)
 
 func init() {
-	settings.RegisterBoolSetting("sekretz", "desc", false).Hide()
+	settings.RegisterBoolSetting("sekretz", "desc", false).SetConfidential()
 }
 
 var strVal = settings.RegisterValidatedStringSetting(

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -39,7 +39,7 @@ import (
 // createStatsPostEvents controls the cluster setting for enabling
 // automatic table statistics collection.
 var createStatsPostEvents = settings.RegisterBoolSetting(
-	"sql.stats.post_events",
+	"sql.stats.post_events.enabled",
 	"if set, an event is shown for every CREATE STATISTICS job",
 	false,
 )

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -78,7 +78,7 @@ var ClusterSecret = func() *settings.StringSetting {
 		"cluster specific secret",
 		"",
 	)
-	s.Hide()
+	s.SetConfidential()
 	return s
 }()
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_event_log
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_event_log
@@ -6,7 +6,7 @@
 
 # This test verifies that events are posted for table statistics creation.
 statement ok
-SET CLUSTER SETTING sql.stats.post_events = TRUE
+SET CLUSTER SETTING sql.stats.post_events.enabled = TRUE
 
 statement ok
 CREATE TABLE a (id INT PRIMARY KEY, x INT, y INT, INDEX x_idx (x, y))

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -137,7 +137,7 @@ statement ok
 ALTER TABLE users RENAME COLUMN species TO species_old,
                   ADD COLUMN species STRING AS (species_old || ' woo') STORED
 
-query T
+query T rowsort
 SELECT species FROM users
 ----
 cat woo

--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -871,6 +871,29 @@ func SplitFirstStatement(sql string) (pos int, ok bool) {
 	}
 }
 
+// Tokens decomposes the input into lexical tokens.
+func Tokens(sql string) (tokens []TokenString, ok bool) {
+	s := makeScanner(sql)
+	for {
+		var lval sqlSymType
+		s.scan(&lval)
+		if lval.id == ERROR {
+			return nil, false
+		}
+		if lval.id == 0 {
+			break
+		}
+		tokens = append(tokens, TokenString{TokenID: lval.id, Str: lval.str})
+	}
+	return tokens, true
+}
+
+// TokenString is the unit value returned by Tokens.
+type TokenString struct {
+	TokenID int32
+	Str     string
+}
+
 // LastLexicalToken returns the last lexical token. If the string has no lexical
 // tokens, returns 0 and ok=false.
 func LastLexicalToken(sql string) (lastTok int, ok bool) {

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -41,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/kr/pretty"
+	"github.com/pkg/errors"
 )
 
 func TestShowCreateTable(t *testing.T) {
@@ -1109,4 +1112,123 @@ func TestShowJobsWithError(t *testing.T) {
 		t.Fatalf("%d: invalid row", rowNum)
 	}
 	rowNum++
+}
+
+func TestLintClusterSettingNames(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := tests.CreateTestServerParams()
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+
+	rows, err := sqlDB.Query(`SELECT variable, setting_type, description FROM [SHOW ALL CLUSTER SETTINGS]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var varName, sType, desc string
+		if err := rows.Scan(&varName, &sType, &desc); err != nil {
+			t.Fatal(err)
+		}
+
+		if strings.ToLower(varName) != varName {
+			t.Errorf("%s: variable name must be all lowercase", varName)
+		}
+
+		suffixSuggestions := map[string]string{
+			"_ttl":     ".ttl",
+			"_enabled": ".enabled",
+			"_timeout": ".timeout",
+		}
+
+		nameErr := func() error {
+			segments := strings.Split(varName, ".")
+			for _, segment := range segments {
+				if strings.TrimSpace(segment) != segment {
+					return errors.Errorf("%s: part %q has heading or trailing whitespace", varName, segment)
+				}
+				tokens, ok := parser.Tokens(segment)
+				if !ok {
+					return errors.Errorf("%s: part %q does not scan properly", varName, segment)
+				}
+				if len(tokens) == 0 || len(tokens) > 1 {
+					return errors.Errorf("%s: part %q has invalid structure", varName, segment)
+				}
+				if tokens[0].TokenID != parser.IDENT {
+					cat, ok := lex.KeywordsCategories[tokens[0].Str]
+					if !ok {
+						return errors.Errorf("%s: part %q has invalid structure", varName, segment)
+					}
+					if cat == "R" {
+						return errors.Errorf("%s: part %q is a reserved keyword", varName, segment)
+					}
+				}
+			}
+
+			for suffix, repl := range suffixSuggestions {
+				if strings.HasSuffix(varName, suffix) {
+					return errors.Errorf("%s: use %q instead of %q", varName, repl, suffix)
+				}
+			}
+
+			if sType == "b" && !strings.HasSuffix(varName, ".enabled") {
+				return errors.Errorf("%s: use .enabled for booleans", varName)
+			}
+
+			return nil
+		}()
+		if nameErr != nil {
+			var grandFathered = map[string]string{
+				"server.declined_reservation_timeout":                `server.declined_reservation_timeout: use ".timeout" instead of "_timeout"`,
+				"server.failed_reservation_timeout":                  `server.failed_reservation_timeout: use ".timeout" instead of "_timeout"`,
+				"server.web_session_timeout":                         `server.web_session_timeout: use ".timeout" instead of "_timeout"`,
+				"sql.distsql.flow_stream_timeout":                    `sql.distsql.flow_stream_timeout: use ".timeout" instead of "_timeout"`,
+				"debug.panic_on_failed_assertions":                   `debug.panic_on_failed_assertions: use .enabled for booleans`,
+				"diagnostics.reporting.send_crash_reports":           `diagnostics.reporting.send_crash_reports: use .enabled for booleans`,
+				"kv.closed_timestamp.follower_reads_enabled":         `kv.closed_timestamp.follower_reads_enabled: use ".enabled" instead of "_enabled"`,
+				"kv.raft_log.disable_synchronization_unsafe":         `kv.raft_log.disable_synchronization_unsafe: use .enabled for booleans`,
+				"kv.range_merge.queue_enabled":                       `kv.range_merge.queue_enabled: use ".enabled" instead of "_enabled"`,
+				"kv.range_split.by_load_enabled":                     `kv.range_split.by_load_enabled: use ".enabled" instead of "_enabled"`,
+				"kv.transaction.write_pipelining_enabled":            `kv.transaction.write_pipelining_enabled: use ".enabled" instead of "_enabled"`,
+				"server.clock.forward_jump_check_enabled":            `server.clock.forward_jump_check_enabled: use ".enabled" instead of "_enabled"`,
+				"sql.defaults.experimental_optimizer_mutations":      `sql.defaults.experimental_optimizer_mutations: use .enabled for booleans`,
+				"sql.distsql.distribute_index_joins":                 `sql.distsql.distribute_index_joins: use .enabled for booleans`,
+				"sql.distsql.temp_storage.joins":                     `sql.distsql.temp_storage.joins: use .enabled for booleans`,
+				"sql.distsql.temp_storage.sorts":                     `sql.distsql.temp_storage.sorts: use .enabled for booleans`,
+				"sql.metrics.statement_details.dump_to_logs":         `sql.metrics.statement_details.dump_to_logs: use .enabled for booleans`,
+				"sql.metrics.statement_details.sample_logical_plans": `sql.metrics.statement_details.sample_logical_plans: use .enabled for booleans`,
+				"sql.trace.log_statement_execute":                    `sql.trace.log_statement_execute: use .enabled for booleans`,
+				"trace.debug.enable":                                 `trace.debug.enable: use .enabled for booleans`,
+				// These two settings have been deprecated in favor of a new (better named) setting
+				// but the old name is still around to support migrations.
+				// TODO(knz): remove these cases when these settings are retired.
+				"timeseries.storage.10s_resolution_ttl": `timeseries.storage.10s_resolution_ttl: part "10s_resolution_ttl" has invalid structure`,
+				"timeseries.storage.30m_resolution_ttl": `timeseries.storage.30m_resolution_ttl: part "30m_resolution_ttl" has invalid structure`,
+			}
+			expectedErr, found := grandFathered[varName]
+			if !found || expectedErr != nameErr.Error() {
+				t.Error(nameErr)
+			}
+		}
+
+		if strings.TrimSpace(desc) != desc {
+			t.Errorf("%s: description %q has heading or trailing whitespace", varName, desc)
+		}
+
+		if len(desc) == 0 {
+			t.Errorf("%s: description is empty", varName)
+		}
+
+		if len(desc) > 0 {
+			if strings.ToLower(desc[0:1]) != desc[0:1] {
+				t.Errorf("%s: description %q must not start with capital", varName, desc)
+			}
+			if strings.Contains(desc, ". ") != (desc[len(desc)-1] == '.') {
+				t.Errorf("%s: description %q must end with period if and only if it contains a secondary sentence", varName, desc)
+			}
+		}
+	}
+
 }

--- a/pkg/storage/merge_queue.go
+++ b/pkg/storage/merge_queue.go
@@ -54,7 +54,7 @@ var MergeQueueInterval = func() *settings.DurationSetting {
 		"how long the merge queue waits between processing replicas",
 		time.Second,
 	)
-	s.Hide()
+	s.SetSensitive()
 	return s
 }()
 

--- a/pkg/storage/replica_split_load.go
+++ b/pkg/storage/replica_split_load.go
@@ -22,14 +22,14 @@ import (
 // SplitByLoadEnabled wraps "kv.range_split.by_load_enabled".
 var SplitByLoadEnabled = settings.RegisterBoolSetting(
 	"kv.range_split.by_load_enabled",
-	"allow automatic splits of ranges based on where load is concentrated.",
+	"allow automatic splits of ranges based on where load is concentrated",
 	true,
 )
 
 // SplitByLoadQPSThreshold wraps "kv.range_split.load_qps_threshold".
 var SplitByLoadQPSThreshold = settings.RegisterIntSetting(
 	"kv.range_split.load_qps_threshold",
-	"the QPS over which, the range becomes a candidate for load based splitting.",
+	"the QPS over which, the range becomes a candidate for load based splitting",
 	250, // 250 req/s
 )
 

--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -48,14 +48,9 @@ var TimeseriesStorageEnabled = settings.RegisterBoolSetting(
 	true,
 )
 
-// DeprecatedResolution10StoreDuration is a deprecated setting that previously configured
-// how long time series data was retained; it has been replaced with
-// Resolution10sStorageTTL. We retain this setting for backwards compatibility
-// during a version upgrade.
-var DeprecatedResolution10StoreDuration = settings.RegisterDurationSetting(
-	"timeseries.resolution_10s.storage_duration",
-	"deprecated setting: the amount of time to store timeseries data. "+
-		"Replaced by timeseries.storage.10s_resolution_ttl.",
+// deprecatedResolution10StoreDuration is retained for backward compatibility during a version upgrade.
+var deprecatedResolution10StoreDuration = settings.RegisterDurationSetting(
+	"timeseries.storage.10s_resolution_ttl", "replaced by timeseries.storage.resolution_10s.ttl",
 	deprecatedResolution10sDefaultPruneThreshold,
 )
 
@@ -63,17 +58,30 @@ var DeprecatedResolution10StoreDuration = settings.RegisterDurationSetting(
 // at he 10 second resolution. Data older than this is subject to being "rolled
 // up" into the 30 minute resolution and then deleted.
 var Resolution10sStorageTTL = settings.RegisterDurationSetting(
-	"timeseries.storage.10s_resolution_ttl",
+	"timeseries.storage.resolution_10s.ttl",
 	"the maximum age of time series data stored at the 10 second resolution. Data older than this "+
 		"is subject to rollup and deletion.",
 	resolution10sDefaultRollupThreshold,
 )
 
+// deprecatedResolution30StoreDuration is retained for backward compatibility during a version upgrade.
+var deprecatedResolution30StoreDuration = settings.RegisterDurationSetting(
+	"timeseries.storage.30m_resolution_ttl", "replaced by timeseries.storage.resolution_30m.ttl",
+	resolution30mDefaultPruneThreshold,
+)
+
+func init() {
+	// The setting is not used any more, but we need to keep its
+	// definition for backward compatibility until the next release
+	// cycle.
+	_ = deprecatedResolution30StoreDuration
+}
+
 // Resolution30mStorageTTL defines the maximum age of data that will be
 // retained at he 30 minute resolution. Data older than this is subject to
 // deletion.
 var Resolution30mStorageTTL = settings.RegisterDurationSetting(
-	"timeseries.storage.30m_resolution_ttl",
+	"timeseries.storage.resolution_30m.ttl",
 	"the maximum age of time series data stored at the 30 minute resolution. Data older than this "+
 		"is subject to deletion.",
 	resolution30mDefaultPruneThreshold,
@@ -103,7 +111,7 @@ func NewDB(db *client.DB, settings *cluster.Settings) *DB {
 			if settings.Version.IsActive(cluster.VersionColumnarTimeSeries) {
 				return Resolution10sStorageTTL.Get(&settings.SV).Nanoseconds()
 			}
-			return DeprecatedResolution10StoreDuration.Get(&settings.SV).Nanoseconds()
+			return deprecatedResolution10StoreDuration.Get(&settings.SV).Nanoseconds()
 		},
 		Resolution30m:  func() int64 { return Resolution30mStorageTTL.Get(&settings.SV).Nanoseconds() },
 		resolution1ns:  func() int64 { return resolution1nsDefaultRollupThreshold.Nanoseconds() },

--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -49,10 +49,14 @@ var TimeseriesStorageEnabled = settings.RegisterBoolSetting(
 )
 
 // deprecatedResolution10StoreDuration is retained for backward compatibility during a version upgrade.
-var deprecatedResolution10StoreDuration = settings.RegisterDurationSetting(
-	"timeseries.storage.10s_resolution_ttl", "replaced by timeseries.storage.resolution_10s.ttl",
-	deprecatedResolution10sDefaultPruneThreshold,
-)
+var deprecatedResolution10StoreDuration = func() *settings.DurationSetting {
+	s := settings.RegisterDurationSetting(
+		"timeseries.storage.10s_resolution_ttl", "replaced by timeseries.storage.resolution_10s.ttl",
+		deprecatedResolution10sDefaultPruneThreshold,
+	)
+	s.SetDeprecated()
+	return s
+}()
 
 // Resolution10sStorageTTL defines the maximum age of data that will be retained
 // at he 10 second resolution. Data older than this is subject to being "rolled
@@ -65,10 +69,14 @@ var Resolution10sStorageTTL = settings.RegisterDurationSetting(
 )
 
 // deprecatedResolution30StoreDuration is retained for backward compatibility during a version upgrade.
-var deprecatedResolution30StoreDuration = settings.RegisterDurationSetting(
-	"timeseries.storage.30m_resolution_ttl", "replaced by timeseries.storage.resolution_30m.ttl",
-	resolution30mDefaultPruneThreshold,
-)
+var deprecatedResolution30StoreDuration = func() *settings.DurationSetting {
+	s := settings.RegisterDurationSetting(
+		"timeseries.storage.30m_resolution_ttl", "replaced by timeseries.storage.resolution_30m.ttl",
+		resolution30mDefaultPruneThreshold,
+	)
+	s.SetDeprecated()
+	return s
+}()
 
 func init() {
 	// The setting is not used any more, but we need to keep its

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -74,7 +74,7 @@ var lightstepToken = settings.RegisterStringSetting(
 
 var zipkinCollector = settings.RegisterStringSetting(
 	"trace.zipkin.collector",
-	"if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.",
+	"if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set",
 	envutil.EnvOrDefaultString("COCKROACH_TEST_ZIPKIN_COLLECTOR", ""),
 )
 


### PR DESCRIPTION
Fixes #34222.

This patch adds a linter on cluster setting names and
descriptions. These were discussed previously in the RFC
on setting names.

Here's an example output of the linter prior to this patch:

```
show_test.go:1180: kv.range_split.by_load_enabled: description "allow automatic splits of ranges based on where load is concentrated." must end with period if and only if it contains a secondary sentence
show_test.go:1180: kv.range_split.load_qps_threshold: description "the QPS over which, the range becomes a candidate for load based splitting." must end with period if and only if it contains a secondary sentence
show_test.go:1180: server.clock.forward_jump_check_enabled: description "if enabled, forward clock jumps > max_offset/2 will cause a panic." must end with period if and only if it contains a secondary sentence
show_test.go:1180: server.eventlog.ttl: description "if nonzero, event log entries older than this duration are deleted every 10m0s. Should not be lowered below 24 hours" must end with period if and only if it contains a secondary sentence
show_test.go:1180: server.heap_profile.max_profiles: description "maximum number of profiles to be kept. Profiles with lower score are GC'ed, but latest profile is always kept" must end with period if and only if it contains a secondary sentence
show_test.go:1180: server.rangelog.ttl: description "if nonzero, range log entries older than this duration are deleted every 10m0s. Should not be lowered below 24 hours" must end with period if and only if it contains a secondary sentence
show_test.go:1151: timeseries.storage.10s_resolution_ttl: part "10s_resolution_ttl" has invalid structure
show_test.go:1151: timeseries.storage.30m_resolution_ttl: part "30m_resolution_ttl" has invalid structure
show_test.go:1180: trace.zipkin.collector: description "if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set." must end with period if and only if it contains a secondary sentence
show_test.go:1180: version: description "set the active cluster version in the format '<major>.<minor>'." must end with period if and only if it contains a secondary sentence
```

The patch also fixes these existing linter errors.

A few setting names that are not "up to specs" but are inconvenient to
rename are kept and "grandfathered" as expected failures in the linter.

Release note (general change): The cluster settings
`timeseries.storage.10s_resolution_ttl` and
`timeseries.storage.30m_resolution_ttl` have been renamed to
`timeseries.storage.resolution_10s.ttl` and
`timeseries.storage.resolution_30m.ttl` for ease of use in SQL
clients. Any value set using the previous setting name in existing
clusters is migrated over to the new name; subsequent changes using
the old name will be ignored.