### PR TITLE
sql: introduce tree.UnresolvedObjectName

### DIFF
--- a/pkg/sql/comment_on_column.go
+++ b/pkg/sql/comment_on_column.go
@@ -30,11 +30,10 @@ type commentOnColumnNode struct {
 // CommentOnColumn add comment on a column.
 // Privileges: CREATE on table.
 func (p *planner) CommentOnColumn(ctx context.Context, n *tree.CommentOnColumn) (planNode, error) {
-	tableName, err := tree.NormalizeTableName(&n.ColumnItem.TableName)
-	if err != nil {
-		return nil, err
+	var tableName tree.TableName
+	if n.ColumnItem.TableName != nil {
+		tableName = n.ColumnItem.TableName.ToTableName()
 	}
-
 	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &tableName, true, requireTableDesc)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -282,7 +282,7 @@ func colIdxByProjectionAlias(expr tree.Expr, op string, scope *scope) int {
 			panic(builderError{err})
 		}
 
-		if c, ok := v.(*tree.ColumnItem); ok && c.TableName.Parts[0] == "" {
+		if c, ok := v.(*tree.ColumnItem); ok && c.TableName == nil {
 			// Look for an output column that matches the name. This
 			// handles cases like:
 			//

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -652,7 +652,7 @@ func (r *renderNode) colIdxByRenderAlias(
 			return 0, err
 		}
 
-		if c, ok := v.(*tree.ColumnItem); ok && c.TableName.Parts[0] == "" {
+		if c, ok := v.(*tree.ColumnItem); ok && c.TableName == nil {
 			// Look for an output column that matches the name. This
 			// handles cases like:
 			//

--- a/pkg/sql/sem/tree/name_part_test.go
+++ b/pkg/sql/sem/tree/name_part_test.go
@@ -1,0 +1,71 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+)
+
+func TestUnresolvedObjectName(t *testing.T) {
+	testCases := []struct {
+		in, out  string
+		expanded string
+		err      string
+	}{
+		{`a`, `a`, `""."".a`, ``},
+		{`a.b`, `a.b`, `"".a.b`, ``},
+		{`a.b.c`, `a.b.c`, `a.b.c`, ``},
+		{`a.b.c.d`, ``, ``, `syntax error at or near "\."`},
+		{`a.""`, ``, ``, `invalid table name: a\.""`},
+		{`a.b.""`, ``, ``, `invalid table name: a\.b\.""`},
+		{`a.b.c.""`, ``, ``, `syntax error at or near "\."`},
+		{`a."".c`, ``, ``, `invalid table name: a\.""\.c`},
+
+		// CockroachDB extension: empty catalog name.
+		{`"".b.c`, `"".b.c`, `"".b.c`, ``},
+
+		// Check keywords: disallowed in first position, ok afterwards.
+		{`user.x.y`, ``, ``, `syntax error`},
+		{`"user".x.y`, `"user".x.y`, `"user".x.y`, ``},
+		{`x.user.y`, `x."user".y`, `x."user".y`, ``},
+		{`x.user`, `x."user"`, `"".x."user"`, ``},
+
+		{`foo@bar`, ``, ``, `syntax error at or near "@"`},
+		{`test.*`, ``, ``, `syntax error at or near "\*"`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.in, func(t *testing.T) {
+			tn, err := parser.ParseTableName(tc.in)
+			if !testutils.IsError(err, tc.err) {
+				t.Fatalf("%s: expected %s, but found %v", tc.in, tc.err, err)
+			}
+			if tc.err != "" {
+				return
+			}
+			if out := tn.String(); tc.out != out {
+				t.Fatalf("%s: expected %s, but found %s", tc.in, tc.out, out)
+			}
+			tn.ExplicitSchema = true
+			tn.ExplicitCatalog = true
+			if out := tn.String(); tc.expanded != out {
+				t.Fatalf("%s: expected full %s, but found %s", tc.in, tc.expanded, out)
+			}
+		})
+	}
+}

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -33,32 +33,6 @@ import (
 //   or pattern to something looked up from the database.
 //
 
-// NormalizeTableName transforms an UnresolvedName into a TableName.
-// This does not perform name resolution.
-func NormalizeTableName(n *UnresolvedName) (res TableName, err error) {
-	if n.NumParts < 1 || n.NumParts > 3 || n.Star {
-		// The Star part of the condition is really an assertion. The
-		// parser should not have let this star propagate to a point where
-		// this method is called.
-		return res, newInvTableNameError(n)
-	}
-
-	// Check that all the parts specified are not empty.
-	// It's OK if the catalog name is empty.
-	// We allow this in e.g. `select * from "".crdb_internal.tables`.
-	lastCheck := n.NumParts
-	if lastCheck > 2 {
-		lastCheck = 2
-	}
-	for i := 0; i < lastCheck; i++ {
-		if len(n.Parts[i]) == 0 {
-			return res, newInvTableNameError(n)
-		}
-	}
-
-	return makeTableNameFromUnresolvedName(n), nil
-}
-
 // classifyTablePattern distinguishes between a TableName (last name
 // part is a table name) and an AllTablesSelector.
 // Used e.g. for GRANT.
@@ -119,12 +93,16 @@ func classifyColumnItem(n *UnresolvedName) (VarName, error) {
 	}
 
 	// Construct the result.
-	tn := UnresolvedName{
-		NumParts: n.NumParts - 1,
-		Parts:    NameParts{n.Parts[1], n.Parts[2], n.Parts[3]},
+	var tn *UnresolvedObjectName
+	if n.NumParts > 1 {
+		var err error
+		tn, err = NewUnresolvedObjectName(n.NumParts-1, [3]string{n.Parts[1], n.Parts[2], n.Parts[3]})
+		if err != nil {
+			return nil, err
+		}
 	}
 	if n.Star {
-		return &AllColumnsSelector{tn}, nil
+		return &AllColumnsSelector{TableName: tn}, nil
 	}
 	return &ColumnItem{TableName: tn, ColumnName: Name(n.Parts[0])}, nil
 }
@@ -192,7 +170,7 @@ type ColumnResolutionResult interface {
 func (a *AllColumnsSelector) Resolve(
 	ctx context.Context, r ColumnItemResolver,
 ) (srcName *TableName, srcMeta ColumnSourceMeta, err error) {
-	prefix := makeTableNameFromUnresolvedName(&a.TableName)
+	prefix := a.TableName.ToTableName()
 
 	// Is there a data source with this prefix?
 	var res NumResolutionResults
@@ -223,7 +201,7 @@ func (c *ColumnItem) Resolve(
 	ctx context.Context, r ColumnItemResolver,
 ) (ColumnResolutionResult, error) {
 	colName := c.ColumnName
-	if c.TableName.NumParts == 0 {
+	if c.TableName == nil {
 		// Naked column name: simple case.
 		srcName, srcMeta, cHint, err := r.FindSourceProvidingColumn(ctx, colName)
 		if err != nil {
@@ -233,7 +211,7 @@ func (c *ColumnItem) Resolve(
 	}
 
 	// There is a prefix. We need to search for it.
-	prefix := makeTableNameFromUnresolvedName(&c.TableName)
+	prefix := c.TableName.ToTableName()
 
 	// Is there a data source with this prefix?
 	res, srcName, srcMeta, err := r.FindSourceMatchingName(ctx, prefix)
@@ -253,7 +231,7 @@ func (c *ColumnItem) Resolve(
 		}
 	}
 	if res == NoResults {
-		return nil, newSourceNotFoundError("no data source matches prefix: %s", &c.TableName)
+		return nil, newSourceNotFoundError("no data source matches prefix: %s", c.TableName)
 	}
 	return r.Resolve(ctx, srcName, srcMeta, -1, colName)
 }

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -511,7 +511,7 @@ func newInvColRef(fmt string, n *UnresolvedName) error {
 	return pgerror.NewErrorWithDepthf(1, pgerror.CodeInvalidColumnReferenceError, fmt, n)
 }
 
-func newInvTableNameError(n *UnresolvedName) error {
+func newInvTableNameError(n fmt.Stringer) error {
 	return pgerror.NewErrorWithDepthf(1, pgerror.CodeInvalidNameError,
 		"invalid table name: %s", n)
 }

--- a/pkg/sql/sem/tree/name_resolution_test.go
+++ b/pkg/sql/sem/tree/name_resolution_test.go
@@ -27,55 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 )
 
-func TestNormalizeTableName(t *testing.T) {
-	testCases := []struct {
-		in, out  string
-		expanded string
-		err      string
-	}{
-		{`a`, `a`, `""."".a`, ``},
-		{`a.b`, `a.b`, `"".a.b`, ``},
-		{`a.b.c`, `a.b.c`, `a.b.c`, ``},
-		{`a.b.c.d`, ``, ``, `syntax error at or near "\."`},
-		{`a.""`, ``, ``, `invalid table name: a\.""`},
-		{`a.b.""`, ``, ``, `invalid table name: a\.b\.""`},
-		{`a.b.c.""`, ``, ``, `syntax error at or near "\."`},
-		{`a."".c`, ``, ``, `invalid table name: a\.""\.c`},
-
-		// CockroachDB extension: empty catalog name.
-		{`"".b.c`, `"".b.c`, `"".b.c`, ``},
-
-		// Check keywords: disallowed in first position, ok afterwards.
-		{`user.x.y`, ``, ``, `syntax error`},
-		{`"user".x.y`, `"user".x.y`, `"user".x.y`, ``},
-		{`x.user.y`, `x."user".y`, `x."user".y`, ``},
-		{`x.user`, `x."user"`, `"".x."user"`, ``},
-
-		{`foo@bar`, ``, ``, `syntax error at or near "@"`},
-		{`test.*`, ``, ``, `syntax error at or near "\*"`},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.in, func(t *testing.T) {
-			tn, err := parser.ParseTableName(tc.in)
-			if !testutils.IsError(err, tc.err) {
-				t.Fatalf("%s: expected %s, but found %v", tc.in, tc.err, err)
-			}
-			if tc.err != "" {
-				return
-			}
-			if out := tn.String(); tc.out != out {
-				t.Fatalf("%s: expected %s, but found %s", tc.in, tc.out, out)
-			}
-			tn.ExplicitSchema = true
-			tn.ExplicitCatalog = true
-			if out := tn.String(); tc.expanded != out {
-				t.Fatalf("%s: expected full %s, but found %s", tc.in, tc.expanded, out)
-			}
-		})
-	}
-}
-
 func TestClassifyTablePattern(t *testing.T) {
 	testCases := []struct {
 		in, out  string

--- a/pkg/sql/sem/tree/name_resolution_test.go
+++ b/pkg/sql/sem/tree/name_resolution_test.go
@@ -108,7 +108,7 @@ func TestClassifyTablePattern(t *testing.T) {
 		{`*.b`, ``, ``, `syntax error at or near "\."`},
 		{`"".*`, ``, ``, `invalid table name: "".\*`},
 		{`a."".*`, ``, ``, `invalid table name: a\.""\.\*`},
-		{`a.b."".*`, ``, ``, `syntax error at or near "\."`},
+		{`a.b."".*`, ``, ``, `invalid table name: a.b.""`},
 		// CockroachDB extension: empty catalog name.
 		{`"".b.*`, `"".b.*`, `"".b.*`, ``},
 

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -17,8 +17,7 @@ package tree
 // TableName corresponds to the name of a table in a FROM clause,
 // INSERT or UPDATE statement, etc.
 //
-// This is constructed for incoming SQL queries by normalizing an
-// UnresolvedName using NormalizeTableName.
+// This is constructed for incoming SQL queries from an UnresolvedObjectName,
 //
 // Internal uses of this struct should not construct instances of
 // TableName directly, and instead use the NewTableName /

--- a/pkg/sql/sem/tree/var_name.go
+++ b/pkg/sql/sem/tree/var_name.go
@@ -93,14 +93,13 @@ func (n *UnresolvedName) NormalizeVarName() (VarName, error) {
 // columns in a table when used in a SELECT clause.
 // (e.g. `table.*`).
 type AllColumnsSelector struct {
-	// TableName corresponds to the table prefix, before the star. The
-	// UnresolvedName within is guaranteed to not contain a star itself.
-	TableName UnresolvedName
+	// TableName corresponds to the table prefix, before the star.
+	TableName *UnresolvedObjectName
 }
 
 // Format implements the NodeFormatter interface.
 func (a *AllColumnsSelector) Format(ctx *FmtCtx) {
-	ctx.FormatNode(&a.TableName)
+	ctx.FormatNode(a.TableName)
 	ctx.WriteString(".*")
 }
 func (a *AllColumnsSelector) String() string { return AsString(a) }
@@ -120,13 +119,14 @@ func (*AllColumnsSelector) ResolvedType() types.T {
 
 // ColumnItem corresponds to the name of a column in an expression.
 type ColumnItem struct {
-	// TableName holds the table prefix, if the name refers to a column.
+	// TableName holds the table prefix, if the name refers to a column. It is
+	// optional.
 	//
-	// This uses UnresolvedName because we need to preserve the
+	// This uses UnresolvedObjectName because we need to preserve the
 	// information about which parts were initially specified in the SQL
 	// text. ColumnItems are intermediate data structures anyway, that
 	// still need to undergo name resolution.
-	TableName UnresolvedName
+	TableName *UnresolvedObjectName
 	// ColumnName names the designated column.
 	ColumnName Name
 
@@ -139,7 +139,7 @@ type ColumnItem struct {
 
 // Format implements the NodeFormatter interface.
 func (c *ColumnItem) Format(ctx *FmtCtx) {
-	if c.TableName.NumParts > 0 {
+	if c.TableName != nil {
 		c.TableName.Format(ctx)
 		ctx.WriteByte('.')
 	}
@@ -179,18 +179,19 @@ func NewColumnItem(tn *TableName, colName Name) *ColumnItem {
 // MakeColumnItem constructs a column item from an already valid
 // TableName. This can be used for e.g. pretty-printing.
 func MakeColumnItem(tn *TableName, colName Name) ColumnItem {
-	c := ColumnItem{
-		TableName: UnresolvedName{
-			Parts: NameParts{tn.Table(), tn.Schema(), tn.Catalog()},
-		},
-		ColumnName: colName,
-	}
-	if tn.ExplicitCatalog {
-		c.TableName.NumParts = 3
-	} else if tn.ExplicitSchema {
-		c.TableName.NumParts = 2
-	} else {
-		c.TableName.NumParts = 1
+	c := ColumnItem{ColumnName: colName}
+	if tn.Table() != "" {
+		numParts := 1
+		if tn.ExplicitCatalog {
+			numParts = 3
+		} else if tn.ExplicitSchema {
+			numParts = 2
+		}
+
+		c.TableName = &UnresolvedObjectName{
+			NumParts: numParts,
+			Parts:    [3]string{tn.Table(), tn.Schema(), tn.Catalog()},
+		}
 	}
 	return c
 }


### PR DESCRIPTION
#### sql: introduce tree.UnresolvedObjectName

This change introduces `UnresolvedObjectName` which is a more
restrictive form of `UnresolvedName`. Creating such an object is only
possible if the name is well formed (at most three parts, etc). This
early error checking removes the need for error checking later
(by NormalizeTableName).

Release note: None

#### sql: use UnresoledObjectName in ColumnItem / AllColumnsSelector

Switch to using `UnresolvedObjectName` for column selectors. This
removes the last usage of `NormalizeTableName`.

Release note: None

Part of #34240.