### PR TITLE
sql: verify index before declaring it public

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -607,7 +607,7 @@ func (s *Server) newConnExecutorWithTxn(
 	memMetrics MemoryMetrics,
 	srvMetrics *Metrics,
 	txn *client.Txn,
-	tcModifier TableCollectionModifier,
+	tcModifier tableCollectionModifier,
 ) (*connExecutor, error) {
 	ex, err := s.newConnExecutor(ctx, sargs, stmtBuf, clientComm, memMetrics, srvMetrics)
 	if err != nil {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -607,6 +607,7 @@ func (s *Server) newConnExecutorWithTxn(
 	memMetrics MemoryMetrics,
 	srvMetrics *Metrics,
 	txn *client.Txn,
+	tcModifier TableCollectionModifier,
 ) (*connExecutor, error) {
 	ex, err := s.newConnExecutor(ctx, sargs, stmtBuf, clientComm, memMetrics, srvMetrics)
 	if err != nil {
@@ -633,6 +634,13 @@ func (s *Server) newConnExecutorWithTxn(
 		tree.ReadWrite,
 		txn,
 		ex.transitionCtx)
+
+	// Modify the TableCollection to match the parent executor's TableCollection.
+	// This allows the InternalExecutor to see schema changes made by the
+	// parent executor.
+	if tcModifier != nil {
+		tcModifier.copyModifiedSchema(&ex.extraTxnState.tables)
+	}
 	return ex, nil
 }
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -958,6 +958,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 		sc.testingKnobs = cfg.SchemaChangerTestingKnobs
 		sc.distSQLPlanner = cfg.DistSQLPlanner
 		sc.settings = cfg.Settings
+		sc.ieFactory = ieFactory
 		for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 			evalCtx := createSchemaChangeEvalCtx(ctx, cfg.Clock.Now(), tracing, ieFactory)
 			if err := sc.exec(ctx, true /* inSession */, &evalCtx); err != nil {

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -83,6 +83,15 @@ type internalExecutorImpl struct {
 	// parent session state if need be, but then we'd need to share a
 	// sessionDataMutator.
 	sessionData *sessiondata.SessionData
+
+	// The internal executor uses its own TableCollection. A TableCollection
+	// is a schema cache for each transaction and contains data like the schema
+	// modified by a transaction. Occasionally an internal executor is called
+	// within the context of a transaction that has modified the schema, the
+	// internal executor should see the modified schema. This interface allows
+	// the internal executor to modify its TableCollection to match the
+	// TableCollection of the parent executor.
+	tcModifier TableCollectionModifier
 }
 
 // MakeInternalExecutor creates an InternalExecutor.
@@ -192,7 +201,8 @@ func (ie *internalExecutorImpl) initConnEx(
 			ie.mon,
 			ie.memMetrics,
 			&ie.s.InternalMetrics,
-			txn)
+			txn,
+			ie.tcModifier)
 	}
 	if err != nil {
 		return nil, nil, err

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -91,7 +91,7 @@ type internalExecutorImpl struct {
 	// internal executor should see the modified schema. This interface allows
 	// the internal executor to modify its TableCollection to match the
 	// TableCollection of the parent executor.
-	tcModifier TableCollectionModifier
+	tcModifier tableCollectionModifier
 }
 
 // MakeInternalExecutor creates an InternalExecutor.

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -115,6 +116,7 @@ type SchemaChanger struct {
 	clock                *hlc.Clock
 	settings             *cluster.Settings
 	execCfg              *ExecutorConfig
+	ieFactory            sqlutil.SessionBoundInternalExecutorFactory
 }
 
 // NewSchemaChangerForTesting only for tests.
@@ -1641,6 +1643,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 					rangeDescriptorCache: s.execCfg.RangeDescriptorCache,
 					clock:                s.execCfg.Clock,
 					settings:             s.execCfg.Settings,
+					ieFactory:            s.ieFactory,
 				}
 
 				execAfter := timeutil.Now().Add(delay)
@@ -1810,6 +1813,7 @@ func createSchemaChangeEvalCtx(
 		DataConversion: sessiondata.DataConversionConfig{
 			Location: dummyLocation,
 		},
+		User: security.NodeUser,
 	}
 
 	evalCtx := extendedEvalContext{

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -671,7 +671,7 @@ func (tc *TableCollection) copyModifiedSchema(to *TableCollection) {
 	// The "to" TableCollection can re-lease the same descriptors.
 }
 
-type TableCollectionModifier interface {
+type tableCollectionModifier interface {
 	copyModifiedSchema(to *TableCollection)
 }
 

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -658,6 +658,23 @@ func (tc *TableCollection) releaseAllDescriptors() {
 	tc.allDescriptors = nil
 }
 
+// Copy the modified schema to the table collection. Used when initializing
+// an InternalExecutor.
+func (tc *TableCollection) copyModifiedSchema(to *TableCollection) {
+	if tc == nil {
+		return
+	}
+	to.uncommittedTables = tc.uncommittedTables
+	to.uncommittedDatabases = tc.uncommittedDatabases
+	// Do not copy the leased descriptors because we do not want
+	// the leased descriptors to be released by the "to" TableCollection.
+	// The "to" TableCollection can re-lease the same descriptors.
+}
+
+type TableCollectionModifier interface {
+	copyModifiedSchema(to *TableCollection)
+}
+
 // createOrUpdateSchemaChangeJob finalizes the current mutations in the table
 // descriptor. If a schema change job in the system.jobs table has not been
 // created for mutations in the current transaction, one is created. The


### PR DESCRIPTION
A new index verification step is added after an index backfill
to verify that the index is indeed valid. This is good practice,
but also necessary with the introduction of the new bulk index
backfill which doesn't have the capability to detect duplicate
index entries.

related to #12424

Release note: None