### PR TITLE
util: fix NoCopy on go1.11 and later

### DIFF
--- a/pkg/base/node_id.go
+++ b/pkg/base/node_id.go
@@ -28,7 +28,7 @@ import (
 // multiple layers. It allows setting and getting the value. Once a value is
 // set, the value cannot change.
 type NodeIDContainer struct {
-	noCopy util.NoCopy
+	_ util.NoCopy
 
 	// nodeID is atomically updated under the mutex; it can be read atomically
 	// without the mutex.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -233,7 +233,7 @@ var noteworthyMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY
 // Server is the top level singleton for handling SQL connections. It creates
 // connExecutors to server every incoming connection.
 type Server struct {
-	noCopy util.NoCopy
+	_ util.NoCopy
 
 	cfg *ExecutorConfig
 
@@ -776,7 +776,7 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 }
 
 type connExecutor struct {
-	noCopy util.NoCopy
+	_ util.NoCopy
 
 	// The server to which this connExecutor is attached. The reference is used
 	// for getting access to configuration settings.

--- a/pkg/sql/distsqlrun/expr.go
+++ b/pkg/sql/distsqlrun/expr.go
@@ -99,7 +99,7 @@ func processExpression(
 // exprHelper implements the common logic around evaluating an expression that
 // depends on a set of values.
 type exprHelper struct {
-	noCopy util.NoCopy
+	_ util.NoCopy
 
 	expr tree.TypedExpr
 	// vars is used to generate IndexedVars that are "backed" by the values in

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -72,7 +72,7 @@ type joinPredicate struct {
 	// IndexedVarContainer and the IndexedVar objects in sub-expressions
 	// will link to it by reference after checkRenderStar / analyzeExpr.
 	// Enforce this using NoCopy.
-	noCopy util.NoCopy
+	_ util.NoCopy
 }
 
 // tryAddEqualityFilter attempts to turn the given filter expression into

--- a/pkg/sql/pgwire/write_buffer.go
+++ b/pkg/sql/pgwire/write_buffer.go
@@ -29,7 +29,7 @@ import (
 // for writing PGWire results. The buffer preserves any errors it encounters when writing,
 // and will turn all subsequent write attempts into no-ops until finishMsg is called.
 type writeBuffer struct {
-	noCopy util.NoCopy
+	_ util.NoCopy
 
 	wrapped bytes.Buffer
 	err     error

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -87,7 +87,7 @@ type renderNode struct {
 	// IndexedVarContainer and the IndexedVar objects in sub-expressions
 	// will link to it by reference after checkRenderStar / analyzeExpr.
 	// Enforce this using NoCopy.
-	noCopy util.NoCopy
+	_ util.NoCopy
 }
 
 // Select selects rows from a SELECT/UNION/VALUES, ordering and/or limiting them.

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -110,7 +110,7 @@ type scanNode struct {
 	// IndexedVarContainer and the IndexedVar objects in sub-expressions
 	// will link to it by reference after checkRenderStar / analyzeExpr.
 	// Enforce this using NoCopy.
-	noCopy util.NoCopy
+	_ util.NoCopy
 
 	// Set when the scanNode is created via the exec factory.
 	createdByOpt bool

--- a/pkg/sql/sqlbase/row_container.go
+++ b/pkg/sql/sqlbase/row_container.go
@@ -74,7 +74,7 @@ type RowContainer struct {
 
 	// We should not copy this structure around; each copy would have a different
 	// memAcc (among other things like aliasing chunks).
-	noCopy util.NoCopy
+	_ util.NoCopy
 }
 
 // ColTypeInfo is a type that allows multiple representations of column type

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -503,7 +503,7 @@ type upsertHelper struct {
 	// IndexedVarContainer and the IndexedVar objects in sub-expressions
 	// will link to it by reference after checkRenderStar / analyzeExpr.
 	// Enforce this using NoCopy.
-	noCopy util.NoCopy
+	_ util.NoCopy
 }
 
 var _ tableUpsertEvaler = (*upsertHelper)(nil)

--- a/pkg/util/nocopy.go
+++ b/pkg/util/nocopy.go
@@ -21,5 +21,11 @@ package util
 // for details.
 type NoCopy struct{}
 
+// Silence unused warnings.
+var _ = NoCopy{}
+
 // Lock is a no-op used by -copylocks checker from `go vet`.
 func (*NoCopy) Lock() {}
+
+// Unlock is a no-op used by -copylocks checker from `go vet`.
+func (*NoCopy) Unlock() {}


### PR DESCRIPTION
Vet now requires that `NoCopy` structure has both `Lock` and `Unlock`
methods.

Fixes #34278

Release note: None