### PR TITLE
backport-2.1: Fix log truncation bug intro'ed via cherry-pick

### DIFF
--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -111,7 +111,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (*truncateDecision, er
 	// RangeMaxBytes). This captures the heuristic that at some point, it's more
 	// efficient to catch up via a snapshot than via applying a long tail of log
 	// entries.
-	targetSize := r.mu.state.Stats.Total()
+	targetSize := r.store.cfg.RaftLogTruncationThreshold
 	if targetSize > r.mu.maxBytes {
 		targetSize = r.mu.maxBytes
 	}


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/34269#issuecomment-457847809.

Release note (bug fix): Fixed a bug that would delay Raft log
truncations.