### PR TITLE
storage: fix errant log message caused by load-based splitting

### DIFF
--- a/pkg/storage/split/decider.go
+++ b/pkg/storage/split/decider.go
@@ -149,3 +149,11 @@ func (d *Decider) MaybeSplitKey(now time.Time) roachpb.Key {
 
 	return key
 }
+
+// Reset deactivates any current attempt at determining a split key.
+func (d *Decider) Reset() {
+	d.mu.Lock()
+	d.mu.splitFinder = nil
+	d.mu.count = 0
+	d.mu.Unlock()
+}

--- a/pkg/storage/split/decider_test.go
+++ b/pkg/storage/split/decider_test.go
@@ -155,4 +155,22 @@ func TestDecider(t *testing.T) {
 	// the decision.
 	assert.True(t, d.mu.splitFinder.Ready(ms(tick)))
 	assert.Equal(t, roachpb.Key(nil), d.MaybeSplitKey(ms(tick)))
+
+	// Get the decider engaged again so that we can test Reset().
+	for i := 0; i < 1000; i++ {
+		o := op("z")
+		if i%2 != 0 {
+			o = op("a")
+		}
+		d.Record(ms(tick), 11, o)
+		tick += 500
+	}
+
+	// The finder wants to split, until Reset is called, at which point it starts
+	// back up at zero.
+	assert.True(t, d.mu.splitFinder.Ready(ms(tick)))
+	assert.Equal(t, roachpb.Key("z"), d.MaybeSplitKey(ms(tick)))
+	d.Reset()
+	assert.Nil(t, d.MaybeSplitKey(ms(tick)))
+	assert.Nil(t, d.mu.splitFinder)
 }

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -218,6 +218,8 @@ func (sq *splitQueue) processAttempt(
 		); pErr != nil {
 			return errors.Wrapf(pErr, "unable to split %s at key %q", r, splitByLoadKey)
 		}
+		// Reset the splitter now that the bounds of the range changed.
+		r.loadBasedSplitter.Reset()
 		return nil
 	}
 	return nil


### PR DESCRIPTION
When a load-based split succeeded, the split finder would still be
primed with the same split key for a while; if the split queue picked up
the range again, it would attempt another split at what was already the
range's end key.

Make sure to reset the split finder after a successful load based split.

Closes #34264.

Release note: None