### PR TITLE
storage: helpful error when split fails due to mono-row range

### DIFF
--- a/pkg/storage/replica_backpressure.go
+++ b/pkg/storage/replica_backpressure.go
@@ -153,7 +153,7 @@ func (r *Replica) maybeBackpressureWriteBatch(ctx context.Context, ba roachpb.Ba
 			return errors.Wrap(ctx.Err(), "aborted while applying backpressure")
 		case err := <-splitC:
 			if err != nil {
-				return errors.Wrap(err, "split failed while applying backpressure")
+				return errors.Wrap(err, "split failed while applying backpressure; are rows updated in a tight loop?")
 			}
 		}
 	}


### PR DESCRIPTION
A range which consists mostly of versions of a single row cannot be
split since we can't split between MVCC versions. This is frequently
hit by users (most recently by our own @jseldess), so it makes sense
to give them an idea of what might be going wrong, even though the
split may also have failed for other reasons.

Touches https://github.com/cockroachdb/docs/issues/4295.

Release note: None