### PR TITLE
sql: add microbenchmark for windower

### DIFF
--- a/pkg/sql/distsql_plan_window.go
+++ b/pkg/sql/distsql_plan_window.go
@@ -195,18 +195,6 @@ func (s *windowPlanState) adjustColumnIndices(funcsInProgress []*windowFuncHolde
 	}
 }
 
-func createWindowerSpecFunc(funcStr string) (distsqlpb.WindowerSpec_Func, error) {
-	if aggBuiltin, ok := distsqlpb.AggregatorSpec_Func_value[funcStr]; ok {
-		aggSpec := distsqlpb.AggregatorSpec_Func(aggBuiltin)
-		return distsqlpb.WindowerSpec_Func{AggregateFunc: &aggSpec}, nil
-	} else if winBuiltin, ok := distsqlpb.WindowerSpec_WindowFunc_value[funcStr]; ok {
-		winSpec := distsqlpb.WindowerSpec_WindowFunc(winBuiltin)
-		return distsqlpb.WindowerSpec_Func{WindowFunc: &winSpec}, nil
-	} else {
-		return distsqlpb.WindowerSpec_Func{}, errors.Errorf("unknown aggregate/window function %s", funcStr)
-	}
-}
-
 func (s *windowPlanState) createWindowFnSpec(
 	funcInProgress *windowFuncHolder,
 ) (distsqlpb.WindowerSpec_WindowFn, sqlbase.ColumnType, error) {
@@ -215,7 +203,7 @@ func (s *windowPlanState) createWindowFnSpec(
 	}
 	// Figure out which built-in to compute.
 	funcStr := strings.ToUpper(funcInProgress.expr.Func.String())
-	funcSpec, err := createWindowerSpecFunc(funcStr)
+	funcSpec, err := distsqlrun.CreateWindowerSpecFunc(funcStr)
 	if err != nil {
 		return distsqlpb.WindowerSpec_WindowFn{}, sqlbase.ColumnType{}, err
 	}

--- a/pkg/sql/distsqlrun/windower.go
+++ b/pkg/sql/distsqlrun/windower.go
@@ -786,6 +786,20 @@ func (ir indexedRow) GetDatums(startColIdx, endColIdx int) tree.Datums {
 	return datums
 }
 
+// CreateWindowerSpecFunc creates a WindowerSpec_Func based on the function
+// name or returns an error if unknown function name is provided.
+func CreateWindowerSpecFunc(funcStr string) (distsqlpb.WindowerSpec_Func, error) {
+	if aggBuiltin, ok := distsqlpb.AggregatorSpec_Func_value[funcStr]; ok {
+		aggSpec := distsqlpb.AggregatorSpec_Func(aggBuiltin)
+		return distsqlpb.WindowerSpec_Func{AggregateFunc: &aggSpec}, nil
+	} else if winBuiltin, ok := distsqlpb.WindowerSpec_WindowFunc_value[funcStr]; ok {
+		winSpec := distsqlpb.WindowerSpec_WindowFunc(winBuiltin)
+		return distsqlpb.WindowerSpec_Func{WindowFunc: &winSpec}, nil
+	} else {
+		return distsqlpb.WindowerSpec_Func{}, errors.Errorf("unknown aggregate/window function %s", funcStr)
+	}
+}
+
 var _ distsqlpb.DistSQLSpanStats = &WindowerStats{}
 
 const windowerTagPrefix = "windower."

--- a/pkg/sql/distsqlrun/windower_test.go
+++ b/pkg/sql/distsqlrun/windower_test.go
@@ -1,0 +1,175 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlrun
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+)
+
+type windowTestSpec struct {
+	// The column indices of PARTITION BY clause.
+	partitionBy []uint32
+	// Window function to be computed.
+	windowFn windowFnTestSpec
+}
+
+type windowFnTestSpec struct {
+	funcName       string
+	argIdxStart    uint32
+	argCount       uint32
+	columnOrdering sqlbase.ColumnOrdering
+}
+
+func windows(windowTestSpecs []windowTestSpec) ([]distsqlpb.WindowerSpec, error) {
+	windows := make([]distsqlpb.WindowerSpec, len(windowTestSpecs))
+	for i, spec := range windowTestSpecs {
+		windows[i].PartitionBy = spec.partitionBy
+		windows[i].WindowFns = make([]distsqlpb.WindowerSpec_WindowFn, 1)
+		windowFnSpec := distsqlpb.WindowerSpec_WindowFn{}
+		fnSpec, err := CreateWindowerSpecFunc(spec.windowFn.funcName)
+		if err != nil {
+			return nil, err
+		}
+		windowFnSpec.Func = fnSpec
+		windowFnSpec.ArgIdxStart = spec.windowFn.argIdxStart
+		windowFnSpec.ArgCount = spec.windowFn.argCount
+		if spec.windowFn.columnOrdering != nil {
+			ordCols := make([]distsqlpb.Ordering_Column, 0, len(spec.windowFn.columnOrdering))
+			for _, column := range spec.windowFn.columnOrdering {
+				ordCols = append(ordCols, distsqlpb.Ordering_Column{
+					ColIdx: uint32(column.ColIdx),
+					// We need this -1 because encoding.Direction has extra value "_"
+					// as zeroth "entry" which its proto equivalent doesn't have.
+					Direction: distsqlpb.Ordering_Column_Direction(column.Direction - 1),
+				})
+			}
+			windowFnSpec.Ordering = distsqlpb.Ordering{Columns: ordCols}
+		}
+		windows[i].WindowFns[0] = windowFnSpec
+	}
+	return windows, nil
+}
+
+func BenchmarkWindower(b *testing.B) {
+	const numCols = 3
+	const numRows = 100000
+
+	specs, err := windows([]windowTestSpec{
+		{ // sum(@1) OVER ()
+			partitionBy: []uint32{},
+			windowFn: windowFnTestSpec{
+				funcName:    "SUM",
+				argIdxStart: uint32(0),
+				argCount:    uint32(1),
+			},
+		},
+		{ // sum(@1) OVER (ORDER BY @3)
+			windowFn: windowFnTestSpec{
+				funcName:       "SUM",
+				argIdxStart:    uint32(0),
+				argCount:       uint32(1),
+				columnOrdering: sqlbase.ColumnOrdering{{ColIdx: 2, Direction: encoding.Ascending}},
+			},
+		},
+		{ // sum(@1) OVER (PARTITION BY @2)
+			partitionBy: []uint32{1},
+			windowFn: windowFnTestSpec{
+				funcName:    "SUM",
+				argIdxStart: uint32(0),
+				argCount:    uint32(1),
+			},
+		},
+		{ // sum(@1) OVER (PARTITION BY @2 ORDER BY @3)
+			partitionBy: []uint32{1},
+			windowFn: windowFnTestSpec{
+				funcName:       "SUM",
+				argIdxStart:    uint32(0),
+				argCount:       uint32(1),
+				columnOrdering: sqlbase.ColumnOrdering{{ColIdx: 2, Direction: encoding.Ascending}},
+			},
+		},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+
+	flowCtx := &FlowCtx{
+		Settings: st,
+		EvalCtx:  &evalCtx,
+	}
+
+	rowsGenerators := []func(int, int) sqlbase.EncDatumRows{
+		makeIntRows,
+		func(numRows, numCols int) sqlbase.EncDatumRows {
+			return makeRepeatedIntRows(numRows/100, numRows, numCols)
+		},
+	}
+	skipRepeatedSpecs := map[int]bool{0: true, 1: true}
+
+	for j, rowsGenerator := range rowsGenerators {
+		for i, spec := range specs {
+			if skipRepeatedSpecs[i] && j == 1 {
+				continue
+			}
+			runName := fmt.Sprintf("%s() OVER (", spec.WindowFns[0].Func.AggregateFunc.String())
+			if len(spec.PartitionBy) > 0 {
+				runName = runName + "PARTITION BY"
+				if j == 0 {
+					runName = runName + "/* SINGLE ROW PARTITIONS */"
+				} else {
+					runName = runName + "/* MULTIPLE ROWS PARTITIONS */"
+				}
+			}
+			if len(spec.PartitionBy) > 0 && spec.WindowFns[0].Ordering.Columns != nil {
+				runName = runName + " "
+			}
+			if spec.WindowFns[0].Ordering.Columns != nil {
+				runName = runName + "ORDER BY"
+			}
+			runName = runName + ")"
+
+			b.Run(runName, func(b *testing.B) {
+				post := &distsqlpb.PostProcessSpec{}
+				disposer := &RowDisposer{}
+				input := NewRepeatableRowSource(threeIntCols, rowsGenerator(numRows, numCols))
+
+				b.SetBytes(int64(8 * numRows * numCols))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					d, err := newWindower(flowCtx, 0 /* processorID */, &spec, input, post, disposer)
+					if err != nil {
+						b.Fatal(err)
+					}
+					d.Run(context.TODO())
+					input.Reset()
+				}
+				b.StopTimer()
+			})
+		}
+	}
+}


### PR DESCRIPTION
Adds a simple microbenchmark for windower running 4 queries
(SUM (@1) OVER (), SUM(@1) OVER (PARTITION BY @2),
SUM(@1) OVER (ORDER BY @3), SUM(@1) OVER (PARTITION BY @2 ORDER BY @3)).

Release note: None