### PR TITLE
wip: vectorized merge join operator

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -247,6 +247,74 @@ func newColOperator(
 			core.HashJoiner.Type,
 		)
 
+	case core.MergeJoiner != nil:
+		if err := checkNumIn(inputs, 2); err != nil {
+			return nil, err
+		}
+
+		if !core.MergeJoiner.OnExpr.Empty() {
+			return nil, errors.New("can't plan merge join with on expressions")
+		}
+
+		if len(core.MergeJoiner.LeftOrdering.Columns) > 1 || len(core.MergeJoiner.RightOrdering.Columns) > 1 {
+			return nil, errors.New("multi column merge join is still unsupported")
+		}
+
+		leftTypes := types.FromColumnTypes(spec.Input[0].ColumnTypes)
+		rightTypes := types.FromColumnTypes(spec.Input[1].ColumnTypes)
+
+		nLeftCols := uint32(len(leftTypes))
+		nRightCols := uint32(len(rightTypes))
+
+		leftEqCols := make([]uint32, 0, nLeftCols)
+		rightEqCols := make([]uint32, 0, nRightCols)
+
+		for _, oCol := range core.MergeJoiner.LeftOrdering.Columns {
+			if leftTypes[oCol.ColIdx] != types.Int64 {
+				return nil, errors.New("merge join equality is only supported on Int64")
+			}
+			leftEqCols = append(leftEqCols, oCol.ColIdx)
+		}
+
+		for _, oCol := range core.MergeJoiner.RightOrdering.Columns {
+			if rightTypes[oCol.ColIdx] != types.Int64 {
+				return nil, errors.New("merge join equality is only supported on Int64")
+			}
+			rightEqCols = append(rightEqCols, oCol.ColIdx)
+		}
+
+		leftOutCols := make([]uint32, 0, nLeftCols)
+		rightOutCols := make([]uint32, 0, nRightCols)
+
+		if post.Projection {
+			for _, col := range post.OutputColumns {
+				if col < nLeftCols {
+					leftOutCols = append(leftOutCols, col)
+				} else {
+					rightOutCols = append(rightOutCols, col-nLeftCols)
+				}
+			}
+		} else {
+			for i := uint32(0); i < nLeftCols; i++ {
+				leftOutCols = append(leftOutCols, i)
+			}
+
+			for i := uint32(0); i < nRightCols; i++ {
+				rightOutCols = append(rightOutCols, i)
+			}
+		}
+
+		op = exec.NewMergeJoinOp(
+			inputs[0],
+			inputs[1],
+			leftOutCols,
+			rightOutCols,
+			leftTypes,
+			rightTypes,
+			leftEqCols,
+			rightEqCols,
+		)
+
 	case core.JoinReader != nil:
 		if err := checkNumIn(inputs, 1); err != nil {
 			return nil, err

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -61,12 +61,24 @@ type ColVec interface {
 	// elements of this ColVec, assuming that both ColVecs are of type colType.
 	Append(vec ColVec, colType types.T, toLength uint64, fromLength uint16)
 
+	// AppendSlice appends vec[sourceStartIdx:sourceEndIdx] elements to
+	// this ColVec starting at destinationStartIdx.
+	AppendSlice(vec ColVec, colType types.T, destinationStartIdx uint64, sourceStartIdx uint16, sourceEndIdx uint16)
+
 	// AppendWithSel appends into itself another column vector from a ColBatch with
 	// maximum size of ColBatchSize, filtered by the given selection vector.
 	AppendWithSel(vec ColVec, sel []uint16, batchSize uint16, colType types.T, toLength uint64)
 
+	// AppendSlice appends sourceEndIdx - sourceStartIdx elements to this ColVec starting
+	// at destinationStartIdx. These elements come from vec, filtered by the selection
+	// vector sel.
+	AppendSliceWithSel(vec ColVec, colType types.T, destinationStartIdx uint64, sourceStartIdx uint16, sourceEndIdx uint16, sel []uint16)
+
 	// Copy copies src[srcStartIdx:srcEndIdx] into this ColVec.
 	Copy(src ColVec, srcStartIdx, srcEndIdx uint64, typ types.T)
+
+	// Copy copies src[srcStartIdx:srcEndIdx] into this ColVec starting at destStartIdx.
+	CopyAt(src ColVec, destStartIdx, srcStartIdx, srcEndIdx uint64, typ types.T)
 
 	// CopyWithSelInt64 copies vec, filtered by sel, into this ColVec. It replaces
 	// the contents of this ColVec.

--- a/pkg/sql/exec/colvec_tmpl.go
+++ b/pkg/sql/exec/colvec_tmpl.go
@@ -64,6 +64,40 @@ func (m *memColumn) Append(vec ColVec, colType types.T, toLength uint64, fromLen
 	}
 }
 
+func (m *memColumn) AppendSlice(
+	vec ColVec, colType types.T, destStartIdx uint64, srcStartIdx uint16, srcEndIdx uint16,
+) {
+	batchSize := srcEndIdx - srcStartIdx
+	outputLen := destStartIdx + uint64(batchSize)
+
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		if outputLen > uint64(len(m._TemplateType())) {
+			m.col = append(m._TemplateType()[:destStartIdx], vec._TemplateType()[srcStartIdx:srcEndIdx]...)
+		} else {
+			copy(m._TemplateType()[destStartIdx:], vec._TemplateType()[srcStartIdx:srcEndIdx])
+		}
+
+		// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+
+	if batchSize > 0 {
+		if uint64(cap(m.nulls)) < outputLen/64 {
+			m.nulls = append(m.nulls, make([]int64, 16)...) // 16 = 1024/64
+		}
+		if vec.HasNulls() {
+			for i := uint16(0); i < batchSize; i++ {
+				if vec.NullAt(srcStartIdx + i) {
+					m.SetNull64(destStartIdx + uint64(i))
+				}
+			}
+		}
+	}
+}
+
 func (m *memColumn) AppendWithSel(
 	vec ColVec, sel []uint16, batchSize uint16, colType types.T, toLength uint64,
 ) {
@@ -93,11 +127,54 @@ func (m *memColumn) AppendWithSel(
 	}
 }
 
+func (m *memColumn) AppendSliceWithSel(
+	vec ColVec,
+	colType types.T,
+	destStartIdx uint64,
+	srcStartIdx uint16,
+	srcEndIdx uint16,
+	sel []uint16,
+) {
+	batchSize := srcEndIdx - srcStartIdx
+	outputLen := destStartIdx + uint64(batchSize)
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		toCol := append(m._TemplateType()[:destStartIdx], make([]_GOTYPE, batchSize)...)
+		fromCol := vec._TemplateType()
+
+		for i := 0; i < int(batchSize); i++ {
+			toCol[uint64(i)+destStartIdx] = fromCol[sel[i+int(srcStartIdx)]]
+		}
+
+		m.col = toCol
+		// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+
+	if batchSize > 0 {
+		if uint64(cap(m.nulls)) < outputLen/64 {
+			m.nulls = append(m.nulls, make([]int64, 16)...) // 16 = 1024/64
+		}
+
+		for i := srcStartIdx; i < srcEndIdx; i++ {
+			if vec.NullAt(sel[i]) {
+				m.SetNull64(destStartIdx + uint64(i))
+			}
+		}
+	}
+}
+
 func (m *memColumn) Copy(src ColVec, srcStartIdx, srcEndIdx uint64, typ types.T) {
+	m.CopyAt(src, 0, srcStartIdx, srcEndIdx, typ)
+}
+
+func (m *memColumn) CopyAt(src ColVec, destStartIdx, srcStartIdx, srcEndIdx uint64, typ types.T) {
 	switch typ {
 	// {{range .}}
 	case _TYPES_T:
-		copy(m._TemplateType(), src._TemplateType()[srcStartIdx:srcEndIdx])
+		copy(m._TemplateType()[destStartIdx:], src._TemplateType()[srcStartIdx:srcEndIdx])
 		// {{end}}
 	default:
 		panic(fmt.Sprintf("unhandled type %d", typ))

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -1,0 +1,355 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import "github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+
+type side int
+
+const (
+	left  side = 0
+	right side = 1
+)
+
+type mergeJoinInput struct {
+	// `eqCols` specify the indices of the source table equality columns during the
+	// merge join.
+	eqCols []uint32
+
+	// `outCols` specify the indices of the columns that should be outputted by the
+	// merge joiner.
+	outCols []uint32
+
+	// `sourceTypes` specify the types of the input columns of the source table for
+	// the merge joiner.
+	sourceTypes []types.T
+
+	// `source` specifies the input operator to the merge join.
+	source Operator
+}
+
+// `mergeJoinOp` is an operator that implements sort-merge join.
+// It performs a merge on the left and right input sources, based on the equality
+// columns, assuming both inputs are in sorted order.
+
+// The idea is to keep two main indices (one for the left column and one for the
+// right), incrementing one or the other. If the value at the left index is <= the
+// value at the right index, we increment the left index, otherwise we increment
+// the right index. If there is a match between the left and right equality columns
+// and there is a run of duplicate values, the left index is incremented until we
+// hit the end of the run, saving the batch of columns into `lGroup`.
+// When we finish a run, we increment the right index, creating a cross product with
+// `lGroup` for each row until we hit a value that does not match anymore.
+
+// If we overflow our output buffer `out` at any point, we use `savedOutput` to buffer
+// the remaining rows.
+// In this case, we also save the current state of our left and right input batches
+// and the respective indices to the operator state to be able to resume in the
+// next call to `Next()`.
+type mergeJoinOp struct {
+	left  mergeJoinInput
+	right mergeJoinInput
+
+	// Fields to save the "working" batches to state in between outputs.
+	savedLeftBatch  ColBatch
+	savedLeftIdx    int
+	savedRightBatch ColBatch
+	savedRightIdx   int
+
+	// Output overflow buffer definition.
+	savedOutput       ColBatch // for the cross product entries that don't fit in the current batch.
+	savedOutputEndIdx int
+
+	// Output buffer definition.
+	out             ColBatch
+	outputBatchSize int
+
+	// Local buffer for the cross product batch from the left column.
+	lGroup []ColVec
+}
+
+// NewMergeJoinOp returns a new merge join operator with the given spec.
+func NewMergeJoinOp(
+	left Operator,
+	right Operator,
+	leftOutCols []uint32,
+	rightOutCols []uint32,
+	leftTypes []types.T,
+	rightTypes []types.T,
+	leftEqCols []uint32,
+	rightEqCols []uint32,
+) Operator {
+	c := &mergeJoinOp{
+		left:              mergeJoinInput{source: left, outCols: leftOutCols, sourceTypes: leftTypes, eqCols: leftEqCols},
+		right:             mergeJoinInput{source: right, outCols: rightOutCols, sourceTypes: rightTypes, eqCols: rightEqCols},
+		savedLeftBatch:    nil,
+		savedLeftIdx:      0,
+		savedRightBatch:   nil,
+		savedRightIdx:     0,
+		savedOutputEndIdx: 0,
+	}
+	return c
+}
+
+func (c *mergeJoinOp) Init() {
+	c.InitWithBatchSize(ColBatchSize)
+}
+
+func (c *mergeJoinOp) InitWithBatchSize(outBatchSize int) {
+	outColTypes := make([]types.T, len(c.left.sourceTypes)+len(c.right.sourceTypes))
+	copy(outColTypes, c.left.sourceTypes)
+	copy(outColTypes[len(c.left.sourceTypes):], c.right.sourceTypes)
+
+	c.out = NewMemBatchWithSize(outColTypes, outBatchSize)
+	c.savedOutput = NewMemBatchWithSize(outColTypes, ColBatchSize)
+	c.left.source.Init()
+	c.right.source.Init()
+	c.outputBatchSize = outBatchSize
+
+	c.lGroup = make([]ColVec, len(c.left.outCols))
+	for i, idx := range c.left.outCols {
+		c.lGroup[i] = newMemColumn(c.left.sourceTypes[idx], ColBatchSize)
+	}
+}
+
+func (c *mergeJoinOp) getNextColBatch(s side) (ColBatch, []uint16) {
+	if s == left {
+		if c.savedLeftBatch != nil {
+			return c.savedLeftBatch, c.savedLeftBatch.Selection()
+		}
+
+		n := c.left.source.Next()
+		return n, n.Selection()
+	}
+
+	if c.savedRightBatch != nil {
+		return c.savedRightBatch, c.savedRightBatch.Selection()
+	}
+
+	n := c.right.source.Next()
+	return n, n.Selection()
+}
+
+func getValForIdx(colvec []int64, idx int, sel []uint16) int64 {
+	if sel != nil {
+		return colvec[sel[idx]]
+	}
+
+	return colvec[idx]
+}
+
+func (c *mergeJoinOp) buildSavedOutput() uint16 {
+	toAppend := uint16(c.savedOutputEndIdx)
+	if toAppend > uint16(c.outputBatchSize) {
+		toAppend = uint16(c.outputBatchSize)
+	}
+	for gi, idx := range c.left.outCols {
+		c.out.ColVec(int(idx)).AppendSlice(c.savedOutput.ColVec(gi), c.left.sourceTypes[idx], 0, 0, toAppend)
+	}
+	for gi, idx := range c.right.outCols {
+		c.out.ColVec(len(c.left.sourceTypes)+int(idx)).AppendSlice(c.savedOutput.ColVec(len(c.left.outCols)+gi), c.right.sourceTypes[idx], 0, 0, toAppend)
+	}
+
+	if c.savedOutputEndIdx > int(toAppend) {
+		for gi, idx := range c.left.outCols {
+			c.savedOutput.ColVec(int(idx)).Copy(c.savedOutput.ColVec(gi), uint64(toAppend), uint64(c.savedOutputEndIdx), c.left.sourceTypes[idx])
+		}
+		for gi, idx := range c.right.outCols {
+			c.savedOutput.ColVec(len(c.left.sourceTypes)+int(idx)).Copy(c.savedOutput.ColVec(len(c.left.outCols)+gi), uint64(toAppend), uint64(c.savedOutputEndIdx), c.right.sourceTypes[idx])
+		}
+	}
+	c.savedOutputEndIdx -= int(toAppend)
+	return toAppend
+}
+
+func getValInNextBatch(input *mergeJoinInput) (int, int, ColBatch, []uint16) {
+	bat := input.source.Next()
+	sel := bat.Selection()
+
+	return 0, int(bat.Length()), bat, sel
+}
+
+func (c *mergeJoinOp) isOutputBatchFullOrAnInputBatchFullyProcessed(
+	count uint16, i int, llength int, j int, rlength int,
+) bool {
+	return count == uint16(c.outputBatchSize) || (count > 0 && (i == llength || j == rlength))
+}
+
+func (c *mergeJoinOp) saveRelevantBatchesToState(
+	i int, llength int, lbat ColBatch, j int, rlength int, rbat ColBatch,
+) {
+	if i != llength {
+		c.savedLeftIdx = i
+		c.savedLeftBatch = lbat
+	} else {
+		c.savedLeftIdx = 0
+		c.savedLeftBatch = nil
+	}
+
+	if j != rlength {
+		c.savedRightIdx = j
+		c.savedRightBatch = rbat
+	} else {
+		c.savedRightIdx = 0
+		c.savedRightBatch = nil
+	}
+}
+
+func addSliceToColVec(
+	dest ColVec,
+	bat ColBatch,
+	sel []uint16,
+	input *mergeJoinInput,
+	inputIdx uint32,
+	destinationStartIdx int,
+	sourceStartIdx int,
+	sourceEndIdx int,
+) {
+	if sel != nil {
+		dest.AppendSliceWithSel(bat.ColVec(int(inputIdx)), input.sourceTypes[inputIdx], uint64(destinationStartIdx), uint16(sourceStartIdx), uint16(sourceEndIdx), sel)
+	} else {
+		dest.AppendSlice(bat.ColVec(int(inputIdx)), input.sourceTypes[inputIdx], uint64(destinationStartIdx), uint16(sourceStartIdx), uint16(sourceEndIdx))
+	}
+}
+
+func (c *mergeJoinOp) Next() ColBatch {
+	lbat, lsel := c.getNextColBatch(left)
+	rbat, rsel := c.getNextColBatch(right)
+	eqColIdx := 0
+	for {
+
+		// Return some/all of the saved output if it exists.
+		if c.savedOutputEndIdx > 0 {
+			count := c.buildSavedOutput()
+			c.out.SetLength(count)
+			return c.out
+		}
+
+		llength := int(lbat.Length())
+		rlength := int(rbat.Length())
+		if llength == 0 || rlength == 0 { // the OR here is because one of the tables could be empty: TODO (georgeutsin): check for non inner joins
+			c.out.SetLength(0)
+			return c.out
+		}
+
+		lkeys := lbat.ColVec(int(c.left.eqCols[eqColIdx])).Int64()
+		rkeys := rbat.ColVec(int(c.right.eqCols[eqColIdx])).Int64()
+
+		count := uint16(0)
+		for i, j := c.savedLeftIdx, c.savedRightIdx; i < llength && j < rlength && count < uint16(c.outputBatchSize); {
+			lval := getValForIdx(lkeys, i, lsel)
+			rval := getValForIdx(rkeys, j, rsel)
+			if lval == rval { // match
+				testval := lval
+				lGroupEndIdx := 0
+
+				// Build the left group.
+				sliceStartIdx := i
+				for llength > 0 && getValForIdx(lkeys, i, lsel) == testval {
+					if i == llength-1 {
+						for gi, idx := range c.left.outCols {
+							addSliceToColVec(c.lGroup[gi], lbat, lsel, &c.left, idx, lGroupEndIdx, sliceStartIdx, llength)
+						}
+						lGroupEndIdx += llength - sliceStartIdx
+						i, llength, lbat, lsel = getValInNextBatch(&c.left)
+						if llength > 0 { // TODO(georgeutsin): test that needs this is the benchmark, but unit tests pass without this
+							lkeys = lbat.ColVec(int(c.left.eqCols[eqColIdx])).Int64() // TODO(georgeutsin): tests still passed without this line, add a test that exercises this line/fails without it
+						}
+						sliceStartIdx = 0
+					} else {
+						i++
+					}
+				}
+
+				// Handle the edge case of there being a run that doesn't end with the batch.
+				if llength > 0 { // check if left batch is valid, TODO(georgeutsin): this seems wrong, test that needs this is the benchmark
+					for gi, idx := range c.left.outCols {
+						addSliceToColVec(c.lGroup[gi], lbat, lsel, &c.left, idx, lGroupEndIdx, sliceStartIdx, i) // TODO(georgeutsin): unit tests passed when i was llength, add a test that exercises the edge case
+					}
+				}
+
+				lGroupEndIdx += i - sliceStartIdx
+
+				// As we scan through the right group, build out the cross product.
+				// Currently, we evaluate the complete "run" of duplicates in the right table (and append to saved out) before breaking out.
+				for rlength > 0 && getValForIdx(rkeys, j, rsel) == testval {
+					// We have a match, so we cross multiply the current right element with the left group.
+					// `toAppend` is the min of the size of the left group or the remaining spots left in the output buffer.
+					toAppend := lGroupEndIdx
+					if toAppend > c.outputBatchSize-int(count) {
+						toAppend = c.outputBatchSize - int(count)
+					}
+					// Add `toAppend` from the left group to the output, and the remaining elements to savedOutput.
+					for gi, idx := range c.left.outCols { // Append to out.
+						c.out.ColVec(int(idx)).CopyAt(c.lGroup[gi], uint64(count), 0, uint64(toAppend), c.left.sourceTypes[idx])
+						if toAppend != lGroupEndIdx { // Append overflow to saved out.
+							c.savedOutput.ColVec(int(idx)).AppendSlice(c.lGroup[gi], c.left.sourceTypes[idx], uint64(c.savedOutputEndIdx), uint16(toAppend), uint16(lGroupEndIdx))
+						}
+					}
+					// Add all the columns from the right table to the output.
+					for _, idx := range c.right.outCols {
+						for x := 0; x < lGroupEndIdx; x++ { // Duplicate the row lGroupEndIdx = (length of the left group) times.
+							if x < toAppend { // Append to out.
+								addSliceToColVec(c.out.ColVec(int(idx)+len(c.left.sourceTypes)), rbat, rsel, &c.right, idx, int(count)+x, j, j+1)
+							} else { // Append overflow to saved out.
+								addSliceToColVec(c.savedOutput.ColVec(int(idx)+len(c.left.sourceTypes)), rbat, rsel, &c.right, idx, c.savedOutputEndIdx+(x-toAppend), j, j+1)
+							}
+						}
+					}
+					count += uint16(toAppend)
+					c.savedOutputEndIdx += lGroupEndIdx - toAppend
+
+					// Increment the index on the right.
+					if j == rlength-1 {
+						j, rlength, rbat, rsel = getValInNextBatch(&c.right)
+					} else {
+						j++
+					}
+				}
+
+			} else { // Mismatch.
+				// Default to incrementing left index if we have mismatch.
+				if lval <= rval {
+					i++
+				} else {
+					j++
+				}
+			}
+
+			// Avoid empty output batches.
+			if count == 0 {
+				// But only do this check when we've reached the end of one of the colbatches (with no matches).
+				if i == llength {
+					i, llength, lbat, lsel = getValInNextBatch(&c.left)
+				}
+				if j == rlength {
+					j, rlength, rbat, rsel = getValInNextBatch(&c.right)
+				}
+			}
+
+			// Save the current state of the batches being "worked on" if they aren't completed yet.
+			if c.isOutputBatchFullOrAnInputBatchFullyProcessed(count, i, llength, j, rlength) {
+				c.saveRelevantBatchesToState(i, llength, lbat, j, rlength, rbat)
+			}
+		}
+
+		c.out.SetLength(count)
+
+		if count > 0 {
+			return c.out
+		}
+
+	}
+}

--- a/pkg/sql/exec/mergejoiner_test.go
+++ b/pkg/sql/exec/mergejoiner_test.go
@@ -1,0 +1,332 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func TestMergeJoiner(t *testing.T) {
+	tcs := []struct {
+		leftTuples      []tuple
+		leftTypes       []types.T
+		leftOutCols     []uint32
+		rightTuples     []tuple
+		rightTypes      []types.T
+		rightOutCols    []uint32
+		expected        []tuple
+		expectedOutCols []int
+		outputBatchSize int
+	}{
+		{ // basic test
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {2}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // basic test, L missing
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {3}, {4}},
+			rightTuples:     tuples{{1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // basic test, R missing
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // basic test, L duplicate
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {1}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {2}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // basic test, R duplicate
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {2}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // basic test, L+R duplicates
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {1}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {1}, {1}, {2}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // basic test, L+R duplicate, multiple runs
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {2}, {2}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {2}, {2}, {2}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // cross product test, batch size = 1024 (ColBatchSize)
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {1}, {1}, {1}},
+			rightTuples:     tuples{{1}, {1}, {1}, {1}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // cross product test, batch size = 4 (small even)
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {1}, {1}, {1}},
+			rightTuples:     tuples{{1}, {1}, {1}, {1}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
+			expectedOutCols: []int{0},
+			outputBatchSize: 4,
+		},
+		{ // cross product test, batch size = 3 (small odd)
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {1}, {1}, {1}},
+			rightTuples:     tuples{{1}, {1}, {1}, {1}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
+			expectedOutCols: []int{0},
+			outputBatchSize: 3,
+		},
+		{ // cross product test, batch size = 1 (unit)
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {1}, {1}, {1}},
+			rightTuples:     tuples{{1}, {1}, {1}, {1}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
+			expectedOutCols: []int{0},
+			outputBatchSize: 1,
+		},
+		{ // multi output column test, basic
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0, 1},
+			rightOutCols:    []uint32{0, 1},
+			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // multi output column test, batch size = 1
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0, 1},
+			rightOutCols:    []uint32{0, 1},
+			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: 1,
+		},
+		{ // multi output column test, test out col projection
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
+			expectedOutCols: []int{0, 2},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // multi output column test, test out col projection
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{1},
+			rightOutCols:    []uint32{1},
+			expected:        tuples{{10, 11}, {20, 12}, {30, 13}, {40, 14}},
+			expectedOutCols: []int{1, 3},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // multi output column test, L run
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {2, 21}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0, 1},
+			rightOutCols:    []uint32{0, 1},
+			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {2, 21, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // multi output column test, L run, batch size = 1
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {2, 21}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0, 1},
+			rightOutCols:    []uint32{0, 1},
+			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {2, 21, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: 1,
+		},
+		{ // multi output column test, R run
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {1, 111}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0, 1},
+			rightOutCols:    []uint32{0, 1},
+			expected:        tuples{{1, 10, 1, 11}, {1, 10, 1, 111}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: ColBatchSize,
+		},
+		{ // multi output column test, R run, batch size = 1
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {1, 111}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0, 1},
+			rightOutCols:    []uint32{0, 1},
+			expected:        tuples{{1, 10, 1, 11}, {1, 10, 1, 111}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: 1,
+		},
+		{ // logic test
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{-1, -1}, {0, 4}, {2, 1}, {3, 4}, {5, 4}},
+			rightTuples:     tuples{{0, 5}, {1, 3}, {3, 2}, {4, 6}},
+			leftOutCols:     []uint32{1},
+			rightOutCols:    []uint32{1},
+			expected:        tuples{{5, 4}, {2, 4}},
+			expectedOutCols: []int{3, 1},
+			outputBatchSize: ColBatchSize,
+		},
+	}
+
+	for _, tc := range tcs {
+		runTests(t, []tuples{tc.leftTuples, tc.rightTuples}, []types.T{}, func(t *testing.T, input []Operator) {
+			s := NewMergeJoinOp(input[0], input[1], tc.leftOutCols, tc.rightOutCols, tc.leftTypes, tc.rightTypes, []uint32{0}, []uint32{0})
+
+			out := newOpTestOutput(s, tc.expectedOutCols, tc.expected)
+			s.(*mergeJoinOp).InitWithBatchSize(tc.outputBatchSize)
+
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func BenchmarkMergeJoiner(b *testing.B) {
+	nCols := 4
+	sourceTypes := make([]types.T, nCols)
+
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		sourceTypes[colIdx] = types.Int64
+	}
+
+	batch := NewMemBatch(sourceTypes)
+
+	// TODO(georgeutsin): add row initializers for runs on Left, runs on Right, runs on both
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		col := batch.ColVec(colIdx).Int64()
+		for i := 0; i < ColBatchSize; i++ {
+			col[i] = int64(i)
+		}
+	}
+
+	batch.SetLength(ColBatchSize)
+
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		vec := batch.ColVec(colIdx)
+		vec.UnsetNulls()
+	}
+
+	for _, nBatches := range []int{1, 4, 16, 1024} {
+		b.Run(fmt.Sprintf("rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
+			// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+			// batch) * nCols (number of columns / row) * 2 (number of sources).
+			b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols * 2))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				leftSource := newFiniteBatchSource(batch, nBatches)
+				rightSource := newFiniteBatchSource(batch, nBatches)
+
+				s := mergeJoinOp{
+					left: mergeJoinInput{
+						eqCols:      []uint32{0},
+						outCols:     []uint32{0, 1},
+						sourceTypes: sourceTypes,
+						source:      leftSource,
+					},
+
+					right: mergeJoinInput{
+						eqCols:      []uint32{0},
+						outCols:     []uint32{2, 3},
+						sourceTypes: sourceTypes,
+						source:      rightSource,
+					},
+				}
+
+				s.Init()
+
+				for i := 0; i < nBatches; i++ {
+					s.Next()
+				}
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Current implementation only works on an inner join
with a single equality column of Int64s.

Idea is to build a buffer for the left table when processing duplicate equality values,
and build the cross product out one row (from the right table) at a time.

Some preliminary benchmarking results:
```
   BenchmarkMergeJoiner/rows=1024-8         	    5000	    246903 ns/op	 265.43 MB/s
   BenchmarkMergeJoiner/rows=4096-8         	    2000	    818305 ns/op	 320.35 MB/s
   BenchmarkMergeJoiner/rows=16384-8        	     500	   3081277 ns/op	 340.31 MB/s
   BenchmarkMergeJoiner/rows=1048576-8      	      10	 191384634 ns/op	 350.65 MB/s
```

Release note: None

Side question: `go fmt` uses tabs but old files use two spaces. Which one should I stay consistent with?