### PR TITLE
opt: fix cached plan invalidation with some virtual tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -888,9 +888,33 @@ a  d
 statement ok
 ROLLBACK TRANSACTION
 
+# Same virtual table in different catalogs (these virtual table instances have
+# the same table ID).
+statement ok
+CREATE SEQUENCE seq
+
+statement ok
+PREPARE pg_catalog_query AS SELECT * FROM pg_catalog.pg_sequence
+
+query OOIIIIIB colnames
+EXECUTE pg_catalog_query
+----
+seqrelid    seqtypid  seqstart  seqincrement  seqmax               seqmin  seqcache  seqcycle
+1121544076  20        1         1             9223372036854775807  1       1         false
+
+statement ok
+USE test
+
+query OOIIIIIB colnames
+EXECUTE pg_catalog_query
+----
+seqrelid    seqtypid  seqstart  seqincrement  seqmax               seqmin  seqcache  seqcycle
+
+# Verify error when placeholders are used without prepare.
 statement error no value provided for placeholder: \$1
 SELECT $1:::int
 
+# Verify sequences get re-resolved.
 statement ok
 CREATE SEQUENCE seq
 

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -40,8 +40,11 @@ import (
 // same StableID, they can have different schema if the schema has changed over
 // time. See the Version type comments for more details.
 //
-// For sqlbase objects, the StableID is the 32-bit descriptor ID.
-type StableID uint32
+// For most sqlbase objects, the StableID is the 32-bit descriptor ID. However,
+// this is not always the case. For example, the StableID for virtual tables
+// prepends the database ID, since the same descriptor ID is reused across
+// databases.
+type StableID uint64
 
 // SchemaName is an alias for tree.TableNamePrefix, since it consists of the
 // catalog + schema name.


### PR DESCRIPTION
It turns out that many virtual tables (e.g. in `pg_catalog` schema)
have instances for each catalog (and the context differs within each
catalog). Unfortunately, these instances all share the same virtual
table ID.

This change fixes cached plan invalidation in this case: we now
cross-check the fully qualified table name to verify that they are the
same instance. This works but is a bit hacky - the real problem here
is that the `opt.StableID` contract is not satisfied when it comes to
these tables.

Release note: None