### PR TITLE
opt: Prune Delete operator input columns

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -553,7 +553,7 @@ func (c *tableFeed) Next(
 		// which seems limiting.
 		var err error
 		c.rows, err = c.db.Query(
-			`DELETE FROM sqlsink ORDER BY PRIMARY KEY sqlsink RETURNING *`)
+			`SELECT * FROM [DELETE FROM sqlsink RETURNING *] ORDER BY topic, partition, message_id`)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -57,6 +57,9 @@ var _ batchedPlanNode = &deleteRangeNode{}
 // canDeleteFast determines if the deletion of `rows` can be done
 // without actually scanning them.
 // This should be called after plan simplification for optimal results.
+//
+// This logic should be kept in sync with exec.Builder.canUseDeleteRange.
+// TODO(andyk): Remove when the heuristic planner code is removed.
 func maybeCreateDeleteFastNode(
 	ctx context.Context,
 	source planNode,

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -124,16 +124,25 @@ k v
 5 6
 7 8
 
+statement count 4
+DELETE FROM unindexed
+
+# Delete of range with limit.
+statement count 4
+INSERT INTO unindexed VALUES (1, 2), (3, 4), (5, 6), (7, 8)
+
+statement count 1
+DELETE FROM unindexed WHERE k >= 4 ORDER BY k LIMIT 1
+
 query II colnames,rowsort
 SELECT k, v FROM unindexed
 ----
 k v
 1 2
 3 4
-5 6
 7 8
 
-statement count 4
+statement count 3
 DELETE FROM unindexed
 
 query II colnames
@@ -241,3 +250,28 @@ query II
 DELETE FROM t33361 RETURNING *; COMMIT
 ----
 1 3
+
+# Test that delete works with column families (no indexes, so fast path).
+statement ok
+CREATE TABLE family (
+    x INT PRIMARY KEY,
+    y INT,
+    FAMILY (x),
+    FAMILY (y)
+);
+INSERT INTO family VALUES (1, 1), (2, 2), (3, 3)
+
+statement ok
+BEGIN; ALTER TABLE family ADD COLUMN z INT CREATE FAMILY
+
+statement ok
+DELETE FROM family WHERE x=2
+
+statement ok
+COMMIT
+
+query III rowsort
+SELECT x, y, z FROM family
+----
+1  1  NULL
+3  3  NULL

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -123,14 +123,8 @@ SET experimental_optimizer_mutations = false
 statement error pq: no data source matches prefix: t
 UPDATE t SET v=(SELECT v+1 FROM t AS t2 WHERE t2.k=t.k)
 
-statement error pq: no data source matches prefix: t
-DELETE FROM t WHERE EXISTS(SELECT * FROM t AS t2 WHERE t2.k=t.k)
-
 statement ok
 SET experimental_optimizer_mutations = true
 
 statement ok
 UPDATE t SET v=(SELECT v+1 FROM t AS t2 WHERE t2.k=t.k)
-
-statement ok
-DELETE FROM t WHERE EXISTS(SELECT * FROM t AS t2 WHERE t2.k=t.k)

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -460,8 +460,7 @@ UPDATE t29494 SET x = 124 WHERE x = 12 RETURNING *
 ----
 124
 
-# The HP and CBO show different errors for this case.
-statement error [column "y" does not exist | column "y" is being backfilled]
+statement error column "y" does not exist
 UPDATE t29494 SET y = 123
 
 # Check the new column is not usable in assignments. We need to

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -214,12 +214,6 @@ func (f *stubFactory) ConstructUpdate(
 	return struct{}{}, nil
 }
 
-func (f *stubFactory) ConstructCreateTable(
-	input exec.Node, schema cat.Schema, ct *tree.CreateTable,
-) (exec.Node, error) {
-	return struct{}{}, nil
-}
-
 func (f *stubFactory) ConstructUpsert(
 	input exec.Node,
 	table cat.Table,
@@ -235,6 +229,18 @@ func (f *stubFactory) ConstructUpsert(
 
 func (f *stubFactory) ConstructDelete(
 	input exec.Node, table cat.Table, fetchCols exec.ColumnOrdinalSet, rowsNeeded bool,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructDeleteRange(
+	table cat.Table, needed exec.ColumnOrdinalSet, indexConstraint *constraint.Constraint,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructCreateTable(
+	input exec.Node, schema cat.Schema, ct *tree.CreateTable,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -69,22 +69,8 @@ type Column interface {
 	ComputedExprStr() string
 }
 
-// MutationColumn describes a single column that is being added to a table or
-// dropped from a table. Mutation columns require special handling by mutation
-// operators like Insert, Update, and Delete.
-type MutationColumn struct {
-	// Column is the Table.Column that is being added or dropped.
-	Column
-
-	// IsDeleteOnly is true if the column only needs special handling by Delete
-	// operations; Update and Insert operations can ignore the column. See
-	// sqlbase.DescriptorMutation_DELETE_ONLY for more information.
-	IsDeleteOnly bool
-}
-
 // IsMutationColumn is a convenience function that returns true if the column at
 // the given ordinal position is a mutation column.
-func IsMutationColumn(table Table, i int) bool {
-	_, ok := table.Column(i).(*MutationColumn)
-	return ok
+func IsMutationColumn(table Table, ord int) bool {
+	return ord >= table.ColumnCount()
 }

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -119,6 +119,16 @@ type Index interface {
 	ForeignKey() (ForeignKeyReference, bool)
 }
 
+type MutationIndex struct {
+	// Index is the Table.Index that is being added or dropped.
+	Index
+
+	// IsDeleteOnly is true if the index only needs special handling by Delete
+	// operations; Update and Insert operations can ignore the index. See
+	// sqlbase.DescriptorMutation_DELETE_ONLY for more information.
+	IsDeleteOnly bool
+}
+
 // IndexColumn describes a single column that is part of an index definition.
 type IndexColumn struct {
 	// Column is a reference to the column returned by Table.Column, given the

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -119,16 +119,6 @@ type Index interface {
 	ForeignKey() (ForeignKeyReference, bool)
 }
 
-type MutationIndex struct {
-	// Index is the Table.Index that is being added or dropped.
-	Index
-
-	// IsDeleteOnly is true if the index only needs special handling by Delete
-	// operations; Update and Insert operations can ignore the index. See
-	// sqlbase.DescriptorMutation_DELETE_ONLY for more information.
-	IsDeleteOnly bool
-}
-
 // IndexColumn describes a single column that is part of an index definition.
 type IndexColumn struct {
 	// Column is a reference to the column returned by Table.Column, given the
@@ -142,4 +132,10 @@ type IndexColumn struct {
 	// Descending is true if the index is ordered from greatest to least on
 	// this column, rather than least to greatest.
 	Descending bool
+}
+
+// IsMutationIndex is a convenience function that returns true if the index at
+// the given ordinal position is a mutation index.
+func IsMutationIndex(table Table, ord int) bool {
+	return ord >= table.IndexCount()
 }

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -49,6 +49,14 @@ type Table interface {
 	// information_schema tables.
 	IsVirtualTable() bool
 
+	// IsInterleaved returns true if any of this table's indexes are interleaved
+	// with index(es) from other table(s).
+	IsInterleaved() bool
+
+	// IsReferenced returns true if this table is referenced by at least one
+	// foreign key defined on another table (or this one if self-referential).
+	IsReferenced() bool
+
 	// ColumnCount returns the number of public columns in the table. Public
 	// columns are not currently being added or dropped from the table. This
 	// method should be used when mutation columns can be ignored (the common

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -301,7 +301,7 @@ func (b *Builder) getColumns(
 	needed := exec.ColumnOrdinalSet{}
 	output := opt.ColMap{}
 
-	columnCount := b.mem.Metadata().Table(tableID).ColumnCount()
+	columnCount := b.mem.Metadata().Table(tableID).DeletableColumnCount()
 	n := 0
 	for i := 0; i < columnCount; i++ {
 		colID := tableID.ColumnID(i)
@@ -1539,7 +1539,7 @@ func mutationOutputColMap(mutation memo.RelExpr) opt.ColMap {
 
 	var colMap opt.ColMap
 	ord := 0
-	for i, n := 0, tab.ColumnCount(); i < n; i++ {
+	for i, n := 0, tab.DeletableColumnCount(); i < n; i++ {
 		colID := int(private.Table.ColumnID(i))
 		if outCols.Contains(colID) {
 			colMap.Set(colID, ord)

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -1298,6 +1298,11 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 }
 
 func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
+	// Check for the fast-path delete case that can use a range delete.
+	if b.canUseDeleteRange(del) {
+		return b.buildDeleteRange(del)
+	}
+
 	// Build the input query and ensure that the fetch columns are projected.
 	input, err := b.buildRelational(del.Input)
 	if err != nil {
@@ -1308,7 +1313,9 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
 	//
 	// TODO(andyk): Using ensureColumns here can result in an extra Render.
 	// Upgrade execution engine to not require this.
-	input, err = b.ensureColumns(input, del.FetchCols, nil, del.ProvidedPhysical().Ordering)
+	colList := make(opt.ColList, 0, len(del.FetchCols))
+	colList = appendColsWhenPresent(colList, del.FetchCols)
+	input, err = b.ensureColumns(input, colList, nil, del.ProvidedPhysical().Ordering)
 	if err != nil {
 		return execPlan{}, err
 	}
@@ -1328,6 +1335,58 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
 		ep.outputCols = mutationOutputColMap(del)
 	}
 	return ep, nil
+}
+
+// canUseDeleteRange checks whether a logical Delete operator can be implemented
+// by a fast delete range execution operator. This logic should be kept in sync
+// with canDeleteFast.
+func (b *Builder) canUseDeleteRange(del *memo.DeleteExpr) bool {
+	// If rows need to be returned from the Delete operator (i.e. RETURNING
+	// clause), no fast path is possible, because row values must be fetched.
+	if del.NeedResults {
+		return false
+	}
+
+	tab := b.mem.Metadata().Table(del.Table)
+	if tab.DeletableIndexCount() > 1 {
+		// Any secondary index prevents fast path, because separate delete batches
+		// must be formulated to delete rows from them.
+		return false
+	}
+	if tab.IsInterleaved() {
+		// There is a separate fast path for interleaved tables in sql/delete.go.
+		return false
+	}
+	if tab.IsReferenced() {
+		// If the table is referenced by other tables' foreign keys, no fast path
+		// is possible, because the integrity of those references must be checked.
+		return false
+	}
+
+	// Check for simple Scan input operator without a limit; anything else is not
+	// supported by a range delete.
+	if scan, ok := del.Input.(*memo.ScanExpr); !ok || scan.HardLimit != 0 {
+		return false
+	}
+
+	return true
+}
+
+// buildDeleteRange constructs a DeleteRange operator that deletes contiguous
+// rows in the primary index. canUseDeleteRange should have already been called.
+func (b *Builder) buildDeleteRange(del *memo.DeleteExpr) (execPlan, error) {
+	// canUseDeleteRange has already validated that input is a Scan operator.
+	scan := del.Input.(*memo.ScanExpr)
+	tab := b.mem.Metadata().Table(scan.Table)
+	needed, output := b.getColumns(scan.Cols, scan.Table)
+	res := execPlan{outputCols: output}
+
+	root, err := b.factory.ConstructDeleteRange(tab, needed, scan.Constraint)
+	if err != nil {
+		return execPlan{}, err
+	}
+	res.root = root
+	return res, nil
 }
 
 func (b *Builder) buildCreateTable(ct *memo.CreateTableExpr) (execPlan, error) {
@@ -1385,9 +1444,11 @@ func (b *Builder) needProjection(
 			return nil, false
 		}
 	}
-	cols := make([]exec.ColumnOrdinal, len(colList))
-	for i, col := range colList {
-		cols[i] = input.getColumnOrdinal(col)
+	cols := make([]exec.ColumnOrdinal, 0, len(colList))
+	for _, col := range colList {
+		if col != 0 {
+			cols = append(cols, input.getColumnOrdinal(col))
+		}
 	}
 	return cols, true
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -116,20 +116,17 @@ count           ·         ·
 ·               spans     /1-
 ·               limit     1
 
-# TODO(andyk): Prune columns so that index-join is not necessary.
 query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10
 ----
-count                 ·         ·
- └── delete           ·         ·
-      │               from      indexed
-      │               strategy  deleter
-      └── index-join  ·         ·
-           │          table     indexed@primary
-           └── scan   ·         ·
-·                     table     indexed@indexed_value_idx
-·                     spans     /5-/6
-·                     limit     10
+count           ·         ·
+ └── delete     ·         ·
+      │         from      indexed
+      │         strategy  deleter
+      └── scan  ·         ·
+·               table     indexed@indexed_value_idx
+·               spans     /5-/6
+·               limit     10
 
 query TTT
 EXPLAIN DELETE FROM indexed LIMIT 10
@@ -139,7 +136,7 @@ count           ·         ·
       │         from      indexed
       │         strategy  deleter
       └── scan  ·         ·
-·               table     indexed@primary
+·               table     indexed@indexed_value_idx
 ·               spans     ALL
 ·               limit     10
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -319,6 +319,17 @@ type Factory interface {
 		input Node, table cat.Table, fetchCols ColumnOrdinalSet, rowsNeeded bool,
 	) (Node, error)
 
+	// ConstructDeleteRange creates a node that efficiently deletes contiguous
+	// rows stored in the given table's primary index. This fast path is only
+	// possible when certain conditions hold true (see canUseDeleteRange for more
+	// details). See the comment for ConstructScan for descriptions of the
+	// parameters, since FastDelete combines Delete + Scan into a single operator.
+	ConstructDeleteRange(
+		table cat.Table,
+		needed ColumnOrdinalSet,
+		indexConstraint *constraint.Constraint,
+	) (Node, error)
+
 	// ConstructCreateTable returns a node that implements a CREATE TABLE
 	// statement.
 	ConstructCreateTable(input Node, schema cat.Schema, ct *tree.CreateTable) (Node, error)

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -335,7 +335,7 @@ func (m *MutationPrivate) MapToInputCols(tabCols opt.ColSet) opt.ColSet {
 // AddEquivTableCols adds an FD to the given set that declares an equivalence
 // between each table column and its corresponding input column.
 func (m *MutationPrivate) AddEquivTableCols(md *opt.Metadata, fdset *props.FuncDepSet) {
-	for i, n := 0, md.Table(m.Table).ColumnCount(); i < n; i++ {
+	for i, n := 0, md.Table(m.Table).DeletableColumnCount(); i < n; i++ {
 		t := m.Table.ColumnID(i)
 		id := m.MapToInputID(t)
 		if id != 0 {

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -655,7 +655,9 @@ func (f *ExprFmtCtx) formatColList(
 		f.Buffer.Reset()
 		f.Buffer.WriteString(heading)
 		for _, col := range colList {
-			formatCol(f, "" /* label */, col, notNullCols, false /* omitType */)
+			if col != 0 {
+				formatCol(f, "" /* label */, col, notNullCols, false /* omitType */)
+			}
 		}
 		tp.Child(f.Buffer.String())
 	}

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -752,9 +752,9 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		// Don't output name of index if it's the primary index.
 		tab := f.Memo.metadata.Table(t.Table)
 		if t.Index == cat.PrimaryIndex {
-			fmt.Fprintf(f.Buffer, " %s", tableName(f, t.Table))
+			fmt.Fprintf(f.Buffer, " %s", tableAlias(f, t.Table))
 		} else {
-			fmt.Fprintf(f.Buffer, " %s@%s", tableName(f, t.Table), tab.Index(t.Index).Name())
+			fmt.Fprintf(f.Buffer, " %s@%s", tableAlias(f, t.Table), tab.Index(t.Index).Name())
 		}
 		if ScanIsReverseFn(f.Memo.Metadata(), t, &physProps.Ordering) {
 			f.Buffer.WriteString(",rev")
@@ -770,7 +770,7 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		fmt.Fprintf(f.Buffer, " %s", seq.Name())
 
 	case *MutationPrivate:
-		fmt.Fprintf(f.Buffer, " %s", tableName(f, t.Table))
+		fmt.Fprintf(f.Buffer, " %s", tableAlias(f, t.Table))
 
 	case *RowNumberPrivate:
 		if !t.Ordering.Any() {
@@ -826,13 +826,13 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 	}
 }
 
-// tableName returns the alias for a table to be used for pretty-printing.
-func tableName(f *ExprFmtCtx, tabID opt.TableID) string {
+// tableAlias returns the alias for a table to be used for pretty-printing.
+func tableAlias(f *ExprFmtCtx, tabID opt.TableID) string {
+	tabMeta := f.Memo.metadata.TableMeta(tabID)
 	if f.HasFlags(ExprFmtHideQualifications) {
-		tabMeta := f.Memo.metadata.TableMeta(tabID)
-		return tabMeta.Name()
+		return tabMeta.Alias.String()
 	}
-	return f.Memo.metadata.Table(tabID).Name().String()
+	return tabMeta.Table.Name().FQString()
 }
 
 // isSimpleColumnName returns true if the given label consists of only ASCII

--- a/pkg/sql/opt/memo/testdata/logprops/delete
+++ b/pkg/sql/opt/memo/testdata/logprops/delete
@@ -13,7 +13,7 @@ TABLE abcde
  ├── c int not null
  ├── d int
  ├── rowid int not null (hidden)
- ├── e int not null
+ ├── e int not null (mutation)
  └── INDEX primary
       └── rowid int not null (hidden)
 

--- a/pkg/sql/opt/memo/testdata/logprops/insert
+++ b/pkg/sql/opt/memo/testdata/logprops/insert
@@ -13,7 +13,7 @@ TABLE abcde
  ├── c int not null
  ├── d int
  ├── rowid int not null (hidden)
- ├── e int
+ ├── e int (mutation)
  └── INDEX primary
       └── rowid int not null (hidden)
 

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -13,7 +13,7 @@ TABLE abcde
  ├── c int not null
  ├── d int
  ├── rowid int not null (hidden)
- ├── e int not null
+ ├── e int not null (mutation)
  └── INDEX primary
       └── rowid int not null (hidden)
 

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -254,16 +254,24 @@ func (md *Metadata) Schema(schID SchemaID) cat.Schema {
 	return md.schemas[schID-1]
 }
 
-// AddTable indexes a new reference to a table within the query. Separate
-// references to the same table are assigned different table ids (e.g. in a
-// self-join query). All columns are added to the metadata. If mutation columns
-// are present, they are added after active columns.
+// AddTable is a helper that calls AddTableWithAlias with tab.Name() as the
+// table's alias.
 func (md *Metadata) AddTable(tab cat.Table) TableID {
+	return md.AddTableWithAlias(tab, tab.Name())
+}
+
+// AddTableWithAlias indexes a new reference to a table within the query.
+// Separate references to the same table are assigned different table ids (e.g.
+// in a self-join query). All columns are added to the metadata. If mutation
+// columns are present, they are added after active columns. The table's alias
+// is passed separately so that its original formatting is preserved for error
+// messages, pretty-printing, etc.
+func (md *Metadata) AddTableWithAlias(tab cat.Table, alias *tree.TableName) TableID {
 	tabID := makeTableID(len(md.tables), ColumnID(len(md.cols)+1))
 	if md.tables == nil {
 		md.tables = make([]TableMeta, 0, 4)
 	}
-	md.tables = append(md.tables, TableMeta{MetaID: tabID, Table: tab})
+	md.tables = append(md.tables, TableMeta{MetaID: tabID, Table: tab, Alias: *alias})
 	tabMeta := md.TableMeta(tabID)
 
 	colCount := tab.DeletableColumnCount()

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -266,7 +266,7 @@ func (md *Metadata) AddTable(tab cat.Table) TableID {
 	md.tables = append(md.tables, TableMeta{MetaID: tabID, Table: tab})
 	tabMeta := md.TableMeta(tabID)
 
-	colCount := tab.ColumnCount()
+	colCount := tab.DeletableColumnCount()
 	if md.cols == nil {
 		md.cols = make([]ColumnMeta, 0, colCount)
 	}

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -363,3 +363,18 @@
     $projections
     $passthrough
 )
+
+# PruneMutationCols discards mutation operator columns that are never used. This
+# includes input columns as well as corresponding InsertCols, FetchCols,
+# UpdateCols, and CheckCols in the mutation private.
+# TODO(andyk): Add support for other mutation operators.
+[PruneMutationCols, Normalize]
+(Delete
+    $input:*
+    $mutationPrivate:* & (CanPruneCols $input $needed:(NeededColsMutation $mutationPrivate))
+)
+=>
+(Delete
+    (PruneCols $input $needed)
+    (PruneMutationCols $mutationPrivate $needed)
+)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -161,19 +161,17 @@ DELETE FROM xy WHERE EXISTS(SELECT * FROM uv WHERE u=x)
 ----
 delete xy
  ├── columns: <none>
- ├── fetch columns: x:3(int) y:4(int)
+ ├── fetch columns: x:3(int)
  ├── cardinality: [0 - 0]
  ├── side-effects, mutations
  └── semi-join (merge)
-      ├── columns: x:3(int!null) y:4(int)
+      ├── columns: x:3(int!null)
       ├── left ordering: +3
       ├── right ordering: +5
       ├── key: (3)
-      ├── fd: (3)-->(4)
       ├── scan xy
-      │    ├── columns: x:3(int!null) y:4(int)
+      │    ├── columns: x:3(int!null)
       │    ├── key: (3)
-      │    ├── fd: (3)-->(4)
       │    └── ordering: +3
       ├── scan uv
       │    ├── columns: u:5(int!null) v:6(int)

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -464,11 +464,11 @@ project
       │    ├── side-effects
       │    ├── project
       │    │    ├── columns: c0:6(int) c1:7(int)
-      │    │    ├── scan zones
-      │    │    │    └── columns: zones.zone_id:1(int!null)
+      │    │    ├── scan crdb_internal.public.zones
+      │    │    │    └── columns: crdb_internal.public.zones.zone_id:1(int!null)
       │    │    └── projections
-      │    │         ├── zones.zone_id + 1 [type=int, outer=(1)]
-      │    │         └── zones.zone_id + 2 [type=int, outer=(1)]
+      │    │         ├── crdb_internal.public.zones.zone_id + 1 [type=int, outer=(1)]
+      │    │         └── crdb_internal.public.zones.zone_id + 2 [type=int, outer=(1)]
       │    └── filters
       │         └── le [type=bool, outer=(6,7), side-effects]
       │              ├── case [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -41,6 +41,33 @@ TABLE abcde
       ├── c int
       └── a int not null (storing)
 
+exec-ddl
+CREATE TABLE mutation (
+    a INT PRIMARY KEY,
+    b INT,
+    c INT,
+    "d:write-only" INT,
+    "e:delete-only" INT,
+    UNIQUE INDEX "idx1:write-only" (b, d),
+    INDEX "idx2:delete-only" (e)
+)
+----
+TABLE mutation
+ ├── a int not null
+ ├── b int
+ ├── c int
+ ├── d int (mutation)
+ ├── e int (mutation)
+ ├── INDEX primary
+ │    └── a int not null
+ ├── INDEX idx1 (mutation)
+ │    ├── b int
+ │    ├── d int
+ │    └── a int not null (storing)
+ └── INDEX idx2 (mutation)
+      ├── e int
+      └── a int not null
+
 # --------------------------------------------------
 # PruneProjectCols
 # --------------------------------------------------
@@ -1604,3 +1631,108 @@ distinct-on
            │    └── variable: k [type=int]
            └── function: length [type=int, outer=(4)]
                 └── variable: s [type=string]
+
+# --------------------------------------------------
+# PruneMutationCols
+# --------------------------------------------------
+
+# Prune all but the key column.
+opt expect=PruneMutationCols
+DELETE FROM a
+----
+delete a
+ ├── columns: <none>
+ ├── fetch columns: k:5(int)
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── scan a
+      ├── columns: k:5(int!null)
+      └── key: (5)
+
+# Prune when computed ordering column is present.
+opt expect=PruneMutationCols
+DELETE FROM a WHERE i > 0 ORDER BY i*2 LIMIT 10
+----
+delete a
+ ├── columns: <none>
+ ├── fetch columns: k:5(int)
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── limit
+      ├── columns: k:5(int!null) column9:9(int)
+      ├── internal-ordering: +9
+      ├── cardinality: [0 - 10]
+      ├── key: (5)
+      ├── fd: (5)-->(9)
+      ├── sort
+      │    ├── columns: k:5(int!null) column9:9(int)
+      │    ├── key: (5)
+      │    ├── fd: (5)-->(9)
+      │    ├── ordering: +9
+      │    └── project
+      │         ├── columns: column9:9(int) k:5(int!null)
+      │         ├── key: (5)
+      │         ├── fd: (5)-->(9)
+      │         ├── select
+      │         │    ├── columns: k:5(int!null) i:6(int!null)
+      │         │    ├── key: (5)
+      │         │    ├── fd: (5)-->(6)
+      │         │    ├── scan a
+      │         │    │    ├── columns: k:5(int!null) i:6(int)
+      │         │    │    ├── key: (5)
+      │         │    │    └── fd: (5)-->(6)
+      │         │    └── filters
+      │         │         └── i > 0 [type=bool, outer=(6), constraints=(/6: [/1 - ]; tight)]
+      │         └── projections
+      │              └── i * 2 [type=int, outer=(6)]
+      └── const: 10 [type=int]
+
+# Prune when a secondary index is present on the table.
+opt expect=PruneMutationCols
+DELETE FROM abcde WHERE a > 0
+----
+delete abcde
+ ├── columns: <none>
+ ├── fetch columns: a:6(int) b:7(int) c:8(int)
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── scan abcde
+      ├── columns: a:6(int!null) b:7(int) c:8(int)
+      ├── constraint: /6: [/1 - ]
+      ├── key: (6)
+      └── fd: (6)-->(7,8), (7,8)~~>(6)
+
+# Prune when mutation columns/indexes exist.
+opt expect=PruneMutationCols
+DELETE FROM mutation
+----
+delete mutation
+ ├── columns: <none>
+ ├── fetch columns: a:6(int) b:7(int) d:9(int) e:10(int)
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ └── scan mutation
+      ├── columns: a:6(int!null) b:7(int) d:9(int) e:10(int)
+      ├── key: (6)
+      └── fd: (6)-->(7,9,10)
+
+# No pruning when RETURNING clause is present.
+# TODO(andyk): Need to prune output columns.
+opt expect-not=PruneMutationCols
+DELETE FROM a RETURNING k, s
+----
+project
+ ├── columns: k:1(int!null) s:4(string)
+ ├── side-effects, mutations
+ ├── key: (1)
+ ├── fd: (1)-->(4)
+ └── delete a
+      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
+      ├── fetch columns: k:5(int) i:6(int) f:7(float) s:8(string)
+      ├── side-effects, mutations
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      └── scan a
+           ├── columns: k:5(int!null) i:6(int) f:7(float) s:8(string)
+           ├── key: (5)
+           └── fd: (5)-->(6-8)

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -34,10 +34,6 @@ import (
 // mutations are applied, or the order of any returned rows (i.e. it won't
 // become a physical property required of the Delete operator).
 func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope) {
-	if !b.evalCtx.SessionData.OptimizerMutations {
-		panic(unimplementedf("cost-based optimizer is not planning DELETE statements"))
-	}
-
 	// UX friendliness safeguard.
 	if del.Where == nil && b.evalCtx.SessionData.SafeUpdates {
 		panic(builderError{pgerror.NewDangerousStatementErrorf("DELETE without WHERE clause")})

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -67,7 +67,7 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 	b.checkPrivilege(tn, tab, privilege.SELECT)
 
 	var mb mutationBuilder
-	mb.init(b, opt.DeleteOp, tab, alias)
+	mb.init(b, opt.DeleteOp, tab, *alias)
 
 	// Build the input expression that selects the rows that will be deleted:
 	//

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -405,7 +405,7 @@ func (mb *mutationBuilder) checkForeignKeysForInsert() {
 }
 
 // addTargetTableColsForInsert adds up to maxCols columns to the list of columns
-// that will be set by an INSERT operation. Non-mutation olumns are added from
+// that will be set by an INSERT operation. Non-mutation columns are added from
 // the target table in the same order they appear in its schema. This method is
 // used when the target columns are not explicitly specified in the INSERT
 // statement:
@@ -589,7 +589,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, onConflict *tr
 		// the two tables in the self-join.
 		tn := mb.tab.Name().TableName
 		alias := tree.MakeUnqualifiedTableName(tree.Name(fmt.Sprintf("%s_%d", tn, idx+1)))
-		tabID := mb.md.AddTableWithAlias(mb.tab, alias)
+		tabID := mb.md.AddTableWithAlias(mb.tab, &alias)
 		scanScope := mb.b.buildScan(
 			tabID,
 			nil, /* ordinals */
@@ -671,7 +671,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 	// Build the right side of the left outer join. Include mutation columns
 	// because they can be used by computed update expressions. Use a different
 	// instance of table metadata so that col IDs do not overlap.
-	inputTabID := mb.md.AddTableWithAlias(mb.tab, mb.alias)
+	inputTabID := mb.md.AddTableWithAlias(mb.tab, &mb.alias)
 	fetchScope := mb.b.buildScan(
 		inputTabID,
 		nil, /* ordinals */

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -109,13 +109,8 @@ func (mb *mutationBuilder) init(b *Builder, op opt.Operator, tab cat.Table, alia
 	mb.md = b.factory.Metadata()
 	mb.op = op
 	mb.tab = tab
-	mb.targetColList = make(opt.ColList, 0, tab.ColumnCount())
-
-	if alias != nil {
-		mb.alias = alias
-	} else {
-		mb.alias = tab.Name()
-	}
+	mb.alias = alias
+	mb.targetColList = make(opt.ColList, 0, tab.DeletableColumnCount())
 
 	// Add the table and its columns (including mutation columns) to metadata.
 	mb.tabID = mb.md.AddTable(tab)
@@ -314,15 +309,11 @@ func (mb *mutationBuilder) addSynthesizedCols(
 ) {
 	var projectionsScope *scope
 
-	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
+	// Skip delete-only mutation columns, since they are ignored by all mutation
+	// operators that synthesize columns.
+	for i, n := 0, mb.tab.WritableColumnCount(); i < n; i++ {
 		// Skip columns that are already specified.
 		if colList[i] != 0 {
-			continue
-		}
-
-		// Skip delete-only mutation columns, since they are ignored by all
-		// mutation operators that synthesize columns.
-		if mut, ok := mb.tab.Column(i).(*cat.MutationColumn); ok && mut.IsDeleteOnly {
 			continue
 		}
 
@@ -412,10 +403,6 @@ func (mb *mutationBuilder) buildReturning(returning tree.ReturningExprs) {
 	inScope.expr = mb.outScope.expr
 	inScope.cols = make([]scopeColumn, 0, mb.tab.ColumnCount())
 	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
-		if cat.IsMutationColumn(mb.tab, i) {
-			continue
-		}
-
 		tabCol := mb.tab.Column(i)
 		inScope.cols = append(inScope.cols, scopeColumn{
 			name:   tabCol.ColName(),
@@ -456,7 +443,7 @@ func (mb *mutationBuilder) checkNumCols(expected, actual int) {
 // reuse.
 func (mb *mutationBuilder) parseDefaultOrComputedExpr(colID opt.ColumnID) tree.Expr {
 	if mb.parsedExprs == nil {
-		mb.parsedExprs = make([]tree.Expr, mb.tab.ColumnCount())
+		mb.parsedExprs = make([]tree.Expr, mb.tab.DeletableColumnCount())
 	}
 
 	// Return expression from cache, if it was already parsed previously.

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -113,7 +113,7 @@ func (mb *mutationBuilder) init(b *Builder, op opt.Operator, tab cat.Table, alia
 	mb.targetColList = make(opt.ColList, 0, tab.DeletableColumnCount())
 
 	// Add the table and its columns (including mutation columns) to metadata.
-	mb.tabID = mb.md.AddTableWithAlias(tab, alias)
+	mb.tabID = mb.md.AddTableWithAlias(tab, &mb.alias)
 }
 
 // buildInputForUpdateOrDelete constructs a Select expression from the fields in
@@ -135,7 +135,7 @@ func (mb *mutationBuilder) buildInputForUpdateOrDelete(
 	//
 	//   UPDATE abc SET a=b
 	//
-	inputTabID := mb.md.AddTableWithAlias(mb.tab, mb.alias)
+	inputTabID := mb.md.AddTableWithAlias(mb.tab, &mb.alias)
 
 	// FROM
 	mb.outScope = mb.b.buildScan(

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -89,7 +89,7 @@ func (b *Builder) buildDataSource(
 		ds, resName := b.resolveDataSource(tn, privilege.SELECT)
 		switch t := ds.(type) {
 		case cat.Table:
-			tabID := b.factory.Metadata().AddTableWithAlias(t, resName)
+			tabID := b.factory.Metadata().AddTableWithAlias(t, &resName)
 			return b.buildScan(tabID, nil /* ordinals */, indexFlags, excludeMutations, inScope)
 		case cat.View:
 			return b.buildView(t, inScope)

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -89,7 +89,8 @@ func (b *Builder) buildDataSource(
 		ds, resName := b.resolveDataSource(tn, privilege.SELECT)
 		switch t := ds.(type) {
 		case cat.Table:
-			return b.buildScan(t, &resName, nil /* ordinals */, indexFlags, excludeMutations, inScope)
+			tabID := b.factory.Metadata().AddTableWithAlias(t, resName)
+			return b.buildScan(tabID, nil /* ordinals */, indexFlags, excludeMutations, inScope)
 		case cat.View:
 			return b.buildView(t, inScope)
 		case cat.Sequence:
@@ -216,7 +217,7 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 		scan, isScan := scope.expr.(*memo.ScanExpr)
 		if isScan {
 			tabMeta := b.factory.Metadata().TableMeta(scan.ScanPrivate.Table)
-			tabMeta.Alias = string(as.Alias)
+			tabMeta.Alias = tree.MakeUnqualifiedTableName(as.Alias)
 		}
 
 		if len(colAlias) > 0 {
@@ -285,7 +286,9 @@ func (b *Builder) buildScanFromTableRef(
 			ordinals[i] = ord
 		}
 	}
-	return b.buildScan(tab, tab.Name(), ordinals, indexFlags, excludeMutations, inScope)
+
+	tabID := b.factory.Metadata().AddTable(tab)
+	return b.buildScan(tabID, ordinals, indexFlags, excludeMutations, inScope)
 }
 
 // buildScan builds a memo group for a ScanOp or VirtualScanOp expression on the
@@ -300,19 +303,15 @@ func (b *Builder) buildScanFromTableRef(
 // See Builder.buildStmt for a description of the remaining input and return
 // values.
 func (b *Builder) buildScan(
-	tab cat.Table,
-	tn *tree.TableName,
+	tabID opt.TableID,
 	ordinals []int,
 	indexFlags *tree.IndexFlags,
 	scanMutationCols bool,
 	inScope *scope,
 ) (outScope *scope) {
 	md := b.factory.Metadata()
-	tabID := md.AddTable(tab)
-	if tn.CatalogName == "" {
-		// This is an unqualified name, so must be an alias.
-		md.TableMeta(tabID).Alias = string(tn.TableName)
-	}
+	tabMeta := md.TableMeta(tabID)
+	tab := tabMeta.Table
 
 	colCount := len(ordinals)
 	if colCount == 0 {
@@ -342,7 +341,7 @@ func (b *Builder) buildScan(
 		outScope.cols = append(outScope.cols, scopeColumn{
 			id:       colID,
 			name:     name,
-			table:    *tn,
+			table:    tabMeta.Alias,
 			typ:      col.DatumType(),
 			hidden:   col.IsHidden() || isMutation,
 			mutation: isMutation,

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -55,8 +55,8 @@ CREATE TABLE mutation (
 TABLE mutation
  ├── m int not null
  ├── n int
- ├── o int
- ├── p int
+ ├── o int (mutation)
+ ├── p int (mutation)
  └── INDEX primary
       └── m int not null
 

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -49,16 +49,16 @@ CREATE TABLE mutation (
     m INT PRIMARY KEY,
     n INT,
     "o:write-only" INT DEFAULT(10),
-    "p:delete-only" INT,
-    "q:write-only" INT AS (o + n) STORED
+    "p:write-only" INT AS (o + n) STORED,
+    "q:delete-only" INT
 )
 ----
 TABLE mutation
  ├── m int not null
  ├── n int
- ├── o int
- ├── p int
- ├── q int
+ ├── o int (mutation)
+ ├── p int (mutation)
+ ├── q int (mutation)
  └── INDEX primary
       └── m int not null
 
@@ -1183,7 +1183,7 @@ insert mutation
  │    ├──  column1:6 => m:1
  │    ├──  column2:7 => n:2
  │    ├──  column8:8 => o:3
- │    └──  column9:9 => q:5
+ │    └──  column9:9 => p:4
  └── project
       ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
       ├── project
@@ -1210,7 +1210,7 @@ insert mutation
  │    ├──  column1:6 => m:1
  │    ├──  column2:7 => n:2
  │    ├──  column8:8 => o:3
- │    └──  column9:9 => q:5
+ │    └──  column9:9 => p:4
  └── project
       ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
       ├── project
@@ -1241,9 +1241,9 @@ error (42703): column "p" does not exist
 
 # Try to insert into mutation column.
 build
-INSERT INTO mutation (m, n, q) VALUES (1, 2, 3)
+INSERT INTO mutation (m, n, p) VALUES (1, 2, 3)
 ----
-error (42P10): column "q" is being backfilled
+error (42703): column "p" does not exist
 
 # ------------------------------------------------------------------------------
 # Test check constraints

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -1008,7 +1008,7 @@ SELECT a FROM t.public.abcd ORDER BY INDEX t.public.abcd@bcd
 sort
  ├── columns: a:1(int!null)  [hidden: b:2(int) c:3(int) d:4(int)]
  ├── ordering: +2,-3,+4,+1
- └── scan abcd
+ └── scan t.public.abcd
       └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
 
 build
@@ -1017,7 +1017,7 @@ SELECT a FROM t.abcd ORDER BY INDEX t.abcd@bcd
 sort
  ├── columns: a:1(int!null)  [hidden: b:2(int) c:3(int) d:4(int)]
  ├── ordering: +2,-3,+4,+1
- └── scan abcd
+ └── scan t.public.abcd
       └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
 
 build
@@ -1026,7 +1026,7 @@ SELECT a FROM public.abcd ORDER BY INDEX public.abcd@bcd
 sort
  ├── columns: a:1(int!null)  [hidden: b:2(int) c:3(int) d:4(int)]
  ├── ordering: +2,-3,+4,+1
- └── scan abcd
+ └── scan public.abcd
       └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
 
 build

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -55,8 +55,8 @@ CREATE TABLE mutation (
 TABLE mutation
  ├── m int not null
  ├── n int
- ├── o int
- ├── p int
+ ├── o int (mutation)
+ ├── p int (mutation)
  └── INDEX primary
       └── m int not null
 
@@ -1333,7 +1333,7 @@ error (42703): column "o" does not exist
 build
 UPDATE mutation SET o=10
 ----
-error (42P10): column "o" is being backfilled
+error (42703): column "o" does not exist
 
 # Try to use mutation column in WHERE clause.
 build

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -76,9 +76,9 @@ CREATE TABLE mutation (
 TABLE mutation
  ├── m int not null
  ├── n int
- ├── o int
- ├── p int
- ├── q int
+ ├── o int (mutation)
+ ├── p int (mutation)
+ ├── q int (mutation)
  └── INDEX primary
       └── m int not null
 

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -100,7 +100,7 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 	b.checkPrivilege(tn, tab, privilege.SELECT)
 
 	var mb mutationBuilder
-	mb.init(b, opt.UpdateOp, tab, alias)
+	mb.init(b, opt.UpdateOp, tab, *alias)
 
 	// Build the input expression that selects the rows that will be updated:
 	//

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -302,7 +302,7 @@ func (mb *mutationBuilder) addComputedColsForUpdate() {
 	// expressions will refer to the updated value rather than the old column
 	// containing the original value (or even the column containing a value to
 	// be inserted in case of upsert).
-	for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
+	for i, n := 0, mb.tab.DeletableColumnCount(); i < n; i++ {
 		colName := mb.tab.Column(i).ColName()
 		colID := mb.fetchColList[i]
 		if mb.updateColList[i] != 0 {

--- a/pkg/sql/opt/ordering/mutation.go
+++ b/pkg/sql/opt/ordering/mutation.go
@@ -22,9 +22,7 @@ import (
 )
 
 func mutationCanProvideOrdering(expr memo.RelExpr, required *physical.OrderingChoice) bool {
-	// The mutation operator can always pass through ordering to its input. Note
-	// that this is not possible for the Upsert operator, which is handled
-	// separately.
+	// The mutation operator can always pass through ordering to its input.
 	return true
 }
 

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -181,6 +181,11 @@ func init() {
 		buildChildReqOrdering: mutationBuildChildReqOrdering,
 		buildProvidedOrdering: mutationBuildProvided,
 	}
+	funcMap[opt.UpsertOp] = funcs{
+		canProvideOrdering:    mutationCanProvideOrdering,
+		buildChildReqOrdering: mutationBuildChildReqOrdering,
+		buildProvidedOrdering: mutationBuildProvided,
+	}
 	funcMap[opt.DeleteOp] = funcs{
 		canProvideOrdering:    mutationCanProvideOrdering,
 		buildChildReqOrdering: mutationBuildChildReqOrdering,

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -16,6 +16,7 @@ package opt
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -117,21 +118,14 @@ type TableMeta struct {
 	// Table is a reference to the table in the catalog.
 	Table cat.Table
 
-	// Alias is an alternate name for the base table to be used for formatting,
-	// debugging, EXPLAIN output, etc. It is set to "" if no alias was specified.
-	Alias string
+	// Alias stores the identifier used in the query to identify the table. This
+	// might be explicitly qualified (e.g. <catalog>.<schema>.<table>), or not
+	// (e.g. <table>). Or, it may be an alias used in the query, in which case it
+	// is always an unqualified name.
+	Alias tree.TableName
 
 	// anns annotates the table metadata with arbitrary data.
 	anns [maxTableAnnIDCount]interface{}
-}
-
-// Name returns the table alias, if it was specified, or else the table's name
-// as a string.
-func (tm *TableMeta) Name() string {
-	if tm.Alias != "" {
-		return tm.Alias
-	}
-	return string(tm.Table.Name().TableName)
 }
 
 // IndexColumns returns the metadata IDs for the set of columns in the given

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -128,6 +128,15 @@ type TableMeta struct {
 	anns [maxTableAnnIDCount]interface{}
 }
 
+// Columns returns the metadata IDs for all non-mutation columns in the table.
+func (tm *TableMeta) Columns() ColSet {
+	var cols ColSet
+	for i, n := 0, tm.Table.ColumnCount(); i < n; i++ {
+		cols.Add(int(tm.MetaID.ColumnID(i)))
+	}
+	return cols
+}
+
 // IndexColumns returns the metadata IDs for the set of columns in the given
 // index.
 // TODO(justin): cache this value in the table metadata.
@@ -135,7 +144,20 @@ func (tm *TableMeta) IndexColumns(indexOrd int) ColSet {
 	index := tm.Table.Index(indexOrd)
 
 	var indexCols ColSet
-	for i, cnt := 0, index.ColumnCount(); i < cnt; i++ {
+	for i, n := 0, index.ColumnCount(); i < n; i++ {
+		ord := index.Column(i).Ordinal
+		indexCols.Add(int(tm.MetaID.ColumnID(ord)))
+	}
+	return indexCols
+}
+
+// IndexKeyColumns returns the metadata IDs for the set of strict key columns in
+// the given index.
+func (tm *TableMeta) IndexKeyColumns(indexOrd int) ColSet {
+	index := tm.Table.Index(indexOrd)
+
+	var indexCols ColSet
+	for i, n := 0, index.KeyColumnCount(); i < n; i++ {
 		ord := index.Column(i).Ordinal
 		indexCols.Add(int(tm.MetaID.ColumnID(ord)))
 	}

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -63,6 +63,12 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 		tab.IsVirtual = true
 	}
 
+	// TODO(andyk): For now, just remember that the table was interleaved. In the
+	// future, it may be necessary to extract additional metadata.
+	if stmt.Interleave != nil {
+		tab.interleaved = true
+	}
+
 	// Add non-mutation columns.
 	for _, def := range stmt.Defs {
 		switch def := def.(type) {
@@ -152,6 +158,7 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 	}
 
 	targetTable := tc.Table(&d.Table)
+	targetTable.referenced = true
 
 	toCols := make([]int, len(d.ToCols))
 	for i, c := range d.ToCols {

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -448,6 +448,14 @@ type Table struct {
 	deleteOnlyColCount int
 	writeOnlyIdxCount  int
 	deleteOnlyIdxCount int
+
+	// interleaved is true if the table's rows are interleaved with rows from
+	// other table(s).
+	interleaved bool
+
+	// referenced is set to true when another table has referenced this table
+	// via a foreign key.
+	referenced bool
 }
 
 var _ cat.Table = &Table{}
@@ -480,6 +488,16 @@ func (tt *Table) Name() *cat.DataSourceName {
 // IsVirtualTable is part of the cat.Table interface.
 func (tt *Table) IsVirtualTable() bool {
 	return tt.IsVirtual
+}
+
+// IsInterleaved is part of the cat.Table interface.
+func (tt *Table) IsInterleaved() bool {
+	return false
+}
+
+// IsReferenced is part of the cat.Table interface.
+func (tt *Table) IsReferenced() bool {
+	return tt.referenced
 }
 
 // ColumnCount is part of the cat.Table interface.

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -446,6 +446,8 @@ type Table struct {
 
 	writeOnlyColCount  int
 	deleteOnlyColCount int
+	writeOnlyIdxCount  int
+	deleteOnlyIdxCount int
 }
 
 var _ cat.Table = &Table{}
@@ -502,6 +504,16 @@ func (tt *Table) Column(i int) cat.Column {
 
 // IndexCount is part of the cat.Table interface.
 func (tt *Table) IndexCount() int {
+	return len(tt.Indexes) - tt.writeOnlyIdxCount - tt.deleteOnlyIdxCount
+}
+
+// WritableIndexCount is part of the cat.Table interface.
+func (tt *Table) WritableIndexCount() int {
+	return len(tt.Indexes) - tt.deleteOnlyIdxCount
+}
+
+// DeletableIndexCount is part of the cat.Table interface.
+func (tt *Table) DeletableIndexCount() int {
 	return len(tt.Indexes)
 }
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -760,7 +760,7 @@ project
       ├── key: ()
       ├── fd: ()-->(1-6)
       ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
-      └── scan order@secondary,rev
+      └── scan "order"@secondary,rev
            ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
            ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
            ├── limit: 1(rev)
@@ -1064,7 +1064,7 @@ group-by
  ├── ordering: +3,+2
  ├── prune: (9)
  ├── interesting orderings: (+3,+2)
- ├── scan order@order_idx
+ ├── scan "order"@order_idx
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=300000, distinct(2,3)=100, null(2,3)=0]
  │    ├── cost: 321000.01
@@ -1152,7 +1152,7 @@ group-by
  ├── ordering: +3,+2
  ├── prune: (9)
  ├── interesting orderings: (+3,+2)
- ├── scan order
+ ├── scan "order"
  │    ├── columns: o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
  │    ├── stats: [rows=300000, distinct(2,3)=100, null(2,3)=0]
  │    ├── cost: 333000.01
@@ -1227,7 +1227,7 @@ except-all
            ├── fd: ()-->(9)
            ├── prune: (4-6)
            ├── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
-           ├── scan order@order_idx
+           ├── scan "order"@order_idx
            │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            │    ├── stats: [rows=300000, distinct(4)=30000, null(4)=0, distinct(5)=30000, null(5)=0, distinct(6)=10, null(6)=0, distinct(9)=30000, null(9)=3000]
            │    ├── cost: 324000.01
@@ -1266,7 +1266,7 @@ except-all
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
  │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
- │         ├── scan order@order_idx
+ │         ├── scan "order"@order_idx
  │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         │    ├── stats: [rows=300000, distinct(1)=30000, null(1)=0, distinct(2)=30000, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=30000, null(6)=3000]
  │         │    ├── cost: 324000.01
@@ -1306,7 +1306,7 @@ except-all
  ├── right columns: ol_w_id:11(int) ol_d_id:10(int) ol_o_id:9(int) count_rows:19(int)
  ├── stats: [rows=300000]
  ├── cost: 1474000.04
- ├── scan order
+ ├── scan "order"
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
  │    ├── stats: [rows=300000]
  │    ├── cost: 336000.01
@@ -1369,7 +1369,7 @@ except-all
  │    │    └── interesting orderings: (+3,+2,-1)
  │    └── aggregations
  │         └── count-rows [type=int]
- └── scan order
+ └── scan "order"
       ├── columns: o_id:12(int!null) o_d_id:13(int!null) o_w_id:14(int!null) o_ol_cnt:18(int)
       ├── stats: [rows=300000]
       ├── cost: 336000.01
@@ -1429,7 +1429,7 @@ scalar-group-by
  │    │    │         ├── fd: ()-->(6)
  │    │    │         ├── prune: (1-3)
  │    │    │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
- │    │    │         ├── scan order@order_idx
+ │    │    │         ├── scan "order"@order_idx
  │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         │    ├── stats: [rows=300000, distinct(1)=30000, null(1)=0, distinct(2)=30000, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=30000, null(6)=3000]
  │    │    │         │    ├── cost: 324000.01

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -565,7 +565,7 @@ project
       ├── key: ()
       ├── fd: ()-->(1-6)
       ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
-      └── scan order@secondary,rev
+      └── scan "order"@secondary,rev
            ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
            ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
            ├── limit: 1(rev)
@@ -860,7 +860,7 @@ group-by
  ├── ordering: +3,+2
  ├── prune: (9)
  ├── interesting orderings: (+3,+2)
- ├── scan order@order_idx
+ ├── scan "order"@order_idx
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
  │    ├── cost: 1070.01
@@ -948,7 +948,7 @@ group-by
  ├── ordering: +3,+2
  ├── prune: (9)
  ├── interesting orderings: (+3,+2)
- ├── scan order
+ ├── scan "order"
  │    ├── columns: o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
  │    ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
  │    ├── cost: 1110.01
@@ -1018,7 +1018,7 @@ except-all
            ├── fd: ()-->(9)
            ├── prune: (4-6)
            ├── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
-           ├── scan order@order_idx
+           ├── scan "order"@order_idx
            │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            │    ├── stats: [rows=1000, distinct(4)=100, null(4)=0, distinct(5)=100, null(5)=0, distinct(6)=100, null(6)=0, distinct(9)=100, null(9)=10]
            │    ├── cost: 1080.01
@@ -1057,7 +1057,7 @@ except-all
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
  │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
- │         ├── scan order@order_idx
+ │         ├── scan "order"@order_idx
  │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         │    ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=100, null(6)=10]
  │         │    ├── cost: 1080.01
@@ -1097,7 +1097,7 @@ except-all
  ├── right columns: ol_w_id:11(int) ol_d_id:10(int) ol_o_id:9(int) count_rows:19(int)
  ├── stats: [rows=1000]
  ├── cost: 2290.04
- ├── scan order
+ ├── scan "order"
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
  │    ├── stats: [rows=1000]
  │    ├── cost: 1120.01
@@ -1160,7 +1160,7 @@ except-all
  │    │    └── interesting orderings: (+3,+2,-1)
  │    └── aggregations
  │         └── count-rows [type=int]
- └── scan order
+ └── scan "order"
       ├── columns: o_id:12(int!null) o_d_id:13(int!null) o_w_id:14(int!null) o_ol_cnt:18(int)
       ├── stats: [rows=1000]
       ├── cost: 1120.01
@@ -1220,7 +1220,7 @@ scalar-group-by
  │    │    │         ├── fd: ()-->(6)
  │    │    │         ├── prune: (1-3)
  │    │    │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
- │    │    │         ├── scan order@order_idx
+ │    │    │         ├── scan "order"@order_idx
  │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         │    ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=100, null(6)=10]
  │    │    │         │    ├── cost: 1080.01

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1501,7 +1501,7 @@ project
            ├── key: (10)
            ├── fd: (10)-->(6-9)
            ├── ordering: +8,+9
-           ├── prune: (6-10)
+           ├── prune: (6,7,9,10)
            └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
 
 # Verify that provided orderings are derived correctly with equivalence FD.
@@ -1543,7 +1543,7 @@ sort
            │         ├── limit: 10
            │         ├── key: (10)
            │         ├── fd: (10)-->(6-9)
-           │         ├── prune: (6-10)
+           │         ├── prune: (6,7,10)
            │         └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
            └── filters
                 └── b = c [type=bool, outer=(2,3), fd=(2)==(3), (3)==(2)]

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -364,11 +364,6 @@ type optTable struct {
 	// wrappers is a cache of index wrappers that's used to satisfy repeated
 	// calls to the SecondaryIndex method for the same index.
 	wrappers map[*sqlbase.IndexDescriptor]*optIndex
-
-	// mutations is a list of mutation columns associated with this table. These
-	// are present when the table is undergoing an online schema change where one
-	// or more columns are being added or dropped.
-	mutations []cat.MutationColumn
 }
 
 var _ cat.Table = &optTable{}
@@ -392,8 +387,6 @@ func newOptTable(
 		ot.stats = ot.stats[:n]
 	}
 
-	ot.prepareMutationColumns(desc)
-
 	// The cat.Table interface requires that table names be fully qualified.
 	ot.name.ExplicitSchema = true
 	ot.name.ExplicitCatalog = true
@@ -401,26 +394,6 @@ func newOptTable(
 	ot.primary.init(ot, &desc.PrimaryIndex)
 
 	return ot
-}
-
-func (ot *optTable) prepareMutationColumns(desc *sqlbase.ImmutableTableDescriptor) {
-	if len(desc.MutationColumns()) != 0 {
-		ot.mutations = make([]cat.MutationColumn, 0, len(ot.desc.MutationColumns()))
-		writeCols := ot.desc.WriteOnlyColumns()
-		delCols := ot.desc.DeleteOnlyColumns()
-		for i := range writeCols {
-			ot.mutations = append(ot.mutations, cat.MutationColumn{
-				Column:       &writeCols[i],
-				IsDeleteOnly: false,
-			})
-		}
-		for i := range delCols {
-			ot.mutations = append(ot.mutations, cat.MutationColumn{
-				Column:       &delCols[i],
-				IsDeleteOnly: true,
-			})
-		}
-	}
 }
 
 // ID is part of the cat.Object interface.
@@ -461,15 +434,22 @@ func (ot *optTable) IsVirtualTable() bool {
 
 // ColumnCount is part of the cat.Table interface.
 func (ot *optTable) ColumnCount() int {
-	return len(ot.desc.Columns) + len(ot.mutations)
+	return len(ot.desc.Columns)
+}
+
+// WritableColumnCount is part of the cat.Table interface.
+func (ot *optTable) WritableColumnCount() int {
+	return len(ot.desc.WritableColumns())
+}
+
+// DeletableColumnCount is part of the cat.Table interface.
+func (ot *optTable) DeletableColumnCount() int {
+	return len(ot.desc.DeletableColumns())
 }
 
 // Column is part of the cat.Table interface.
 func (ot *optTable) Column(i int) cat.Column {
-	if i < len(ot.desc.Columns) {
-		return &ot.desc.Columns[i]
-	}
-	return &ot.mutations[i-len(ot.desc.Columns)]
+	return &ot.desc.DeletableColumns()[i]
 }
 
 // IndexCount is part of the cat.Table interface.
@@ -515,8 +495,8 @@ func (ot *optTable) Statistic(i int) cat.TableStatistic {
 
 func (ot *optTable) ensureColMap() {
 	if ot.colMap == nil {
-		ot.colMap = make(map[sqlbase.ColumnID]int, ot.ColumnCount())
-		for i, n := 0, ot.ColumnCount(); i < n; i++ {
+		ot.colMap = make(map[sqlbase.ColumnID]int, ot.DeletableColumnCount())
+		for i, n := 0, ot.DeletableColumnCount(); i < n; i++ {
 			ot.colMap[sqlbase.ColumnID(ot.Column(i).ColID())] = i
 		}
 	}
@@ -580,18 +560,18 @@ func (oi *optIndex) init(tab *optTable, desc *sqlbase.IndexDescriptor) {
 		// Although the primary index contains all columns in the table, the index
 		// descriptor does not contain columns that are not explicitly part of the
 		// primary key. Retrieve those columns from the table descriptor.
-		oi.storedCols = make([]sqlbase.ColumnID, 0, tab.ColumnCount()-len(desc.ColumnIDs))
+		oi.storedCols = make([]sqlbase.ColumnID, 0, tab.DeletableColumnCount()-len(desc.ColumnIDs))
 		var pkCols util.FastIntSet
 		for i := range desc.ColumnIDs {
 			pkCols.Add(int(desc.ColumnIDs[i]))
 		}
-		for i, n := 0, tab.ColumnCount(); i < n; i++ {
+		for i, n := 0, tab.DeletableColumnCount(); i < n; i++ {
 			id := tab.Column(i).ColID()
 			if !pkCols.Contains(int(id)) {
 				oi.storedCols = append(oi.storedCols, sqlbase.ColumnID(id))
 			}
 		}
-		oi.numCols = tab.ColumnCount()
+		oi.numCols = tab.DeletableColumnCount()
 	} else {
 		oi.storedCols = desc.StoreColumnIDs
 		oi.numCols = len(desc.ColumnIDs) + len(desc.ExtraColumnIDs) + len(desc.StoreColumnIDs)
@@ -601,7 +581,7 @@ func (oi *optIndex) init(tab *optTable, desc *sqlbase.IndexDescriptor) {
 		notNull := true
 		for _, id := range desc.ColumnIDs {
 			ord, _ := tab.lookupColumnOrdinal(id)
-			if tab.desc.Columns[ord].Nullable {
+			if tab.desc.DeletableColumns()[ord].Nullable {
 				notNull = false
 				break
 			}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -461,6 +461,24 @@ func (ot *optTable) IndexCount() int {
 	return 1 + len(ot.desc.Indexes)
 }
 
+// WritableIndexCount is part of the cat.Table interface.
+func (ot *optTable) WritableIndexCount() int {
+	if ot.desc.IsVirtualTable() {
+		return 0
+	}
+	// Primary index is always present, so count is always >= 1.
+	return 1 + len(ot.desc.WritableIndexes())
+}
+
+// DeletableIndexCount is part of the cat.Table interface.
+func (ot *optTable) DeletableIndexCount() int {
+	if ot.desc.IsVirtualTable() {
+		return 0
+	}
+	// Primary index is always present, so count is always >= 1.
+	return 1 + len(ot.desc.DeletableIndexes())
+}
+
 // Index is part of the cat.Table interface.
 func (ot *optTable) Index(i int) cat.Index {
 	// Primary index is always 0th index.
@@ -468,8 +486,8 @@ func (ot *optTable) Index(i int) cat.Index {
 		return &ot.primary
 	}
 
-	// Bias i to account for lack of primary index in Indexes slice.
-	desc := &ot.desc.Indexes[i-1]
+	// Bias i to account for lack of primary index in DeletableIndexes slice.
+	desc := &ot.desc.DeletableIndexes()[i-1]
 
 	// Check to see if there's already a wrapper for this index descriptor.
 	if ot.wrappers == nil {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -432,6 +432,21 @@ func (ot *optTable) IsVirtualTable() bool {
 	return ot.desc.IsVirtualTable()
 }
 
+// IsInterleaved is part of the cat.Table interface.
+func (ot *optTable) IsInterleaved() bool {
+	return ot.desc.IsInterleaved()
+}
+
+// IsReferenced is part of the cat.Table interface.
+func (ot *optTable) IsReferenced() bool {
+	for i, n := 0, ot.DeletableIndexCount(); i < n; i++ {
+		if len(ot.Index(i).(*optIndex).desc.ReferencedBy) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // ColumnCount is part of the cat.Table interface.
 func (ot *optTable) ColumnCount() int {
 	return len(ot.desc.Columns)

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2735,16 +2735,6 @@ func (desc *ImmutableTableDescriptor) MutationColumns() []ColumnDescriptor {
 	return desc.publicAndNonPublicCols[len(desc.Columns):]
 }
 
-// WriteOnlyColumns returns a list of write-only mutation columns.
-func (desc *ImmutableTableDescriptor) WriteOnlyColumns() []ColumnDescriptor {
-	return desc.publicAndNonPublicCols[len(desc.Columns) : len(desc.Columns)+desc.writeOnlyColCount]
-}
-
-// DeleteOnlyColumns returns a list of delete-only mutation columns.
-func (desc *ImmutableTableDescriptor) DeleteOnlyColumns() []ColumnDescriptor {
-	return desc.publicAndNonPublicCols[len(desc.Columns)+desc.writeOnlyColCount:]
-}
-
 // WritableIndexes returns a list of public and write-only mutation indexes.
 func (desc *ImmutableTableDescriptor) WritableIndexes() []IndexDescriptor {
 	return desc.publicAndNonPublicIndexes[:len(desc.Indexes)+desc.writeOnlyIndexCount]


### PR DESCRIPTION
Prune input columns that are not needed by a Delete operator. Needed
columns include returned columns and index key columns. All other columns
can be pruned.

Pruning Delete columns causes new interactions with the Delete "fast path"
that uses range delete. When multiple column families are in use, the
range delete needs to cover all column families. The "forDelete" flag
is used to construct spans that cover all columns, rather than just
"needed" columns. A new ConstructDeleteRange exec factory function sets
this flag correctly.

After this change, optimizer deletes no longer need to stay behind a
feature flag, as all fast paths should now work at least as well as they
do with the heuristic planner.

Release note: None
