### PR TITLE
changefeed: add `envelope=wrapped` support everywhere and make it the default

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -507,12 +507,16 @@ func (r *avroEnvelopeRecord) BinaryFromRow(
 		}
 	}
 	// WIP verify that meta is now empty
-	if row != nil {
-		afterNative, err := r.after.nativeFromRow(row)
-		if err != nil {
-			return nil, err
+	if r.opts.afterField {
+		if row == nil {
+			native[`after`] = nil
+		} else {
+			afterNative, err := r.after.nativeFromRow(row)
+			if err != nil {
+				return nil, err
+			}
+			native[`after`] = goavro.Union(avroUnionKey(&r.after.avroRecord), afterNative)
 		}
-		native[`after`] = goavro.Union(avroUnionKey(&r.after.avroRecord), afterNative)
 	}
 	return r.codec.BinaryFromNative(buf, native)
 }

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -48,10 +48,9 @@ const (
 	optResolvedTimestamps      = `resolved`
 	optUpdatedTimestamps       = `updated`
 
-	optEnvelopeDiff      envelopeType = `diff`
-	optEnvelopeKeyOnly   envelopeType = `key_only`
-	optEnvelopeRow       envelopeType = `row`
-	optEnvelopeValueOnly envelopeType = `value_only`
+	optEnvelopeKeyOnly envelopeType = `key_only`
+	optEnvelopeRow     envelopeType = `row`
+	optEnvelopeWrapped envelopeType = `wrapped`
 
 	optFormatJSON formatType = `json`
 	optFormatAvro formatType = `experimental_avro`
@@ -320,11 +319,8 @@ func validateDetails(details jobspb.ChangefeedDetails) (jobspb.ChangefeedDetails
 		details.Opts[optEnvelope] = string(optEnvelopeRow)
 	case optEnvelopeKeyOnly:
 		details.Opts[optEnvelope] = string(optEnvelopeKeyOnly)
-	case optEnvelopeValueOnly:
-		details.Opts[optEnvelope] = string(optEnvelopeValueOnly)
-	case optEnvelopeDiff:
-		return jobspb.ChangefeedDetails{}, errors.Errorf(
-			`%s=%s is not yet supported`, optEnvelope, optEnvelopeDiff)
+	case optEnvelopeWrapped:
+		details.Opts[optEnvelope] = string(optEnvelopeWrapped)
 	default:
 		return jobspb.ChangefeedDetails{}, errors.Errorf(
 			`unknown %s: %s`, optEnvelope, details.Opts[optEnvelope])

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -48,9 +48,10 @@ const (
 	optResolvedTimestamps      = `resolved`
 	optUpdatedTimestamps       = `updated`
 
-	optEnvelopeKeyOnly envelopeType = `key_only`
-	optEnvelopeRow     envelopeType = `row`
-	optEnvelopeWrapped envelopeType = `wrapped`
+	optEnvelopeKeyOnly       envelopeType = `key_only`
+	optEnvelopeRow           envelopeType = `row`
+	optEnvelopeDeprecatedRow envelopeType = `deprecated_row`
+	optEnvelopeWrapped       envelopeType = `wrapped`
 
 	optFormatJSON formatType = `json`
 	optFormatAvro formatType = `experimental_avro`
@@ -315,11 +316,11 @@ func validateDetails(details jobspb.ChangefeedDetails) (jobspb.ChangefeedDetails
 	}
 
 	switch envelopeType(details.Opts[optEnvelope]) {
-	case ``, optEnvelopeRow:
+	case optEnvelopeRow, optEnvelopeDeprecatedRow:
 		details.Opts[optEnvelope] = string(optEnvelopeRow)
 	case optEnvelopeKeyOnly:
 		details.Opts[optEnvelope] = string(optEnvelopeKeyOnly)
-	case optEnvelopeWrapped:
+	case ``, optEnvelopeWrapped:
 		details.Opts[optEnvelope] = string(optEnvelopeWrapped)
 	default:
 		return jobspb.ChangefeedDetails{}, errors.Errorf(

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -57,24 +57,24 @@ func TestChangefeedBasics(t *testing.T) {
 		// 'initial' is skipped because only the latest value ('updated') is
 		// emitted by the initial scan.
 		assertPayloads(t, foo, []string{
-			`foo: [0]->{"a": 0, "b": "updated"}`,
+			`foo: [0]->{"after": {"a": 0, "b": "updated"}}`,
 		})
 
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a'), (2, 'b')`)
 		assertPayloads(t, foo, []string{
-			`foo: [1]->{"a": 1, "b": "a"}`,
-			`foo: [2]->{"a": 2, "b": "b"}`,
+			`foo: [1]->{"after": {"a": 1, "b": "a"}}`,
+			`foo: [2]->{"after": {"a": 2, "b": "b"}}`,
 		})
 
 		sqlDB.Exec(t, `UPSERT INTO foo VALUES (2, 'c'), (3, 'd')`)
 		assertPayloads(t, foo, []string{
-			`foo: [2]->{"a": 2, "b": "c"}`,
-			`foo: [3]->{"a": 3, "b": "d"}`,
+			`foo: [2]->{"after": {"a": 2, "b": "c"}}`,
+			`foo: [3]->{"after": {"a": 3, "b": "d"}}`,
 		})
 
 		sqlDB.Exec(t, `DELETE FROM foo WHERE a = 1`)
 		assertPayloads(t, foo, []string{
-			`foo: [1]->`,
+			`foo: [1]->{"after": null}`,
 		})
 	}
 
@@ -93,6 +93,11 @@ func TestChangefeedEnvelope(t *testing.T) {
 
 		t.Run(`envelope=row`, func(t *testing.T) {
 			foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH envelope='row'`)
+			defer foo.Close(t)
+			assertPayloads(t, foo, []string{`foo: [1]->{"a": 1, "b": "a"}`})
+		})
+		t.Run(`envelope=deprecated_row`, func(t *testing.T) {
+			foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH envelope='deprecated_row'`)
 			defer foo.Close(t)
 			assertPayloads(t, foo, []string{`foo: [1]->{"a": 1, "b": "a"}`})
 		})
@@ -127,8 +132,8 @@ func TestChangefeedMultiTable(t *testing.T) {
 		defer fooAndBar.Close(t)
 
 		assertPayloads(t, fooAndBar, []string{
-			`foo: [1]->{"a": 1, "b": "a"}`,
-			`bar: [2]->{"a": 2, "b": "b"}`,
+			`foo: [1]->{"after": {"a": 1, "b": "a"}}`,
+			`bar: [2]->{"after": {"a": 2, "b": "b"}}`,
 		})
 	}
 
@@ -162,21 +167,21 @@ func TestChangefeedCursor(t *testing.T) {
 		fooLogical := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH cursor=$1`, tsLogical)
 		defer fooLogical.Close(t)
 		assertPayloads(t, fooLogical, []string{
-			`foo: [2]->{"a": 2, "b": "after"}`,
+			`foo: [2]->{"after": {"a": 2, "b": "after"}}`,
 		})
 
 		nanosStr := strconv.FormatInt(tsClock.UnixNano(), 10)
 		fooNanosStr := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH cursor=$1`, nanosStr)
 		defer fooNanosStr.Close(t)
 		assertPayloads(t, fooNanosStr, []string{
-			`foo: [2]->{"a": 2, "b": "after"}`,
+			`foo: [2]->{"after": {"a": 2, "b": "after"}}`,
 		})
 
 		timeStr := tsClock.Format(`2006-01-02 15:04:05.999999`)
 		fooString := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH cursor=$1`, timeStr)
 		defer fooString.Close(t)
 		assertPayloads(t, fooString, []string{
-			`foo: [2]->{"a": 2, "b": "after"}`,
+			`foo: [2]->{"after": {"a": 2, "b": "after"}}`,
 		})
 
 		// Check that the cursor is properly hooked up to the job statement
@@ -264,11 +269,11 @@ func TestChangefeedTimestamps(t *testing.T) {
 		if err := gojson.Unmarshal(v, &out); err != nil {
 			t.Fatal(err)
 		}
-		if a, e := out["a"].(float64), float64(0); a != e {
+		after := out["after"].(map[string]interface{})
+		if a, e := after["a"].(float64), float64(0); a != e {
 			t.Fatalf("column a got value %f, wanted %f", a, e)
 		}
-		tsStr := out["__crdb__"].(map[string]interface{})["updated"].(string)
-		tsApd, _, err := apd.NewFromString(tsStr)
+		tsApd, _, err := apd.NewFromString(out["updated"].(string))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -282,7 +287,7 @@ func TestChangefeedTimestamps(t *testing.T) {
 		// Assert the remaining key using assertPayloads, since we know the exact
 		// timestamp expected.
 		assertPayloads(t, foo, []string{
-			`foo: [1]->{"__crdb__": {"updated": "` + ts1 + `"}, "a": 1}`,
+			`foo: [1]->{"after": {"a": 1}, "updated": "` + ts1 + `"}`,
 		})
 
 		// Check that we eventually get a resolved timestamp greater than ts1.
@@ -353,11 +358,11 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 			historical := f.Feed(t, `CREATE CHANGEFEED FOR historical WITH cursor=$1`, start)
 			defer historical.Close(t)
 			assertPayloads(t, historical, []string{
-				`historical: [0]->{"a": 0, "b": "0"}`,
-				`historical: [1]->{"a": 1, "b": "before"}`,
-				`historical: [2]->{"a": 2, "b": "after"}`,
-				`historical: [3]->{"a": 3, "b": "after", "c": null}`,
-				`historical: [4]->{"a": 4, "b": "after", "c": 14}`,
+				`historical: [0]->{"after": {"a": 0, "b": "0"}}`,
+				`historical: [1]->{"after": {"a": 1, "b": "before"}}`,
+				`historical: [2]->{"after": {"a": 2, "b": "after"}}`,
+				`historical: [3]->{"after": {"a": 3, "b": "after", "c": null}}`,
+				`historical: [4]->{"after": {"a": 4, "b": "after", "c": 14}}`,
 			})
 		})
 
@@ -368,12 +373,12 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 			addColumn := f.Feed(t, `CREATE CHANGEFEED FOR add_column`)
 			defer addColumn.Close(t)
 			assertPayloads(t, addColumn, []string{
-				`add_column: [1]->{"a": 1}`,
+				`add_column: [1]->{"after": {"a": 1}}`,
 			})
 			sqlDB.Exec(t, `ALTER TABLE add_column ADD COLUMN b STRING`)
 			sqlDB.Exec(t, `INSERT INTO add_column VALUES (2, '2')`)
 			assertPayloads(t, addColumn, []string{
-				`add_column: [2]->{"a": 2, "b": "2"}`,
+				`add_column: [2]->{"after": {"a": 2, "b": "2"}}`,
 			})
 		})
 
@@ -383,12 +388,12 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 			renameColumn := f.Feed(t, `CREATE CHANGEFEED FOR rename_column`)
 			defer renameColumn.Close(t)
 			assertPayloads(t, renameColumn, []string{
-				`rename_column: [1]->{"a": 1, "b": "1"}`,
+				`rename_column: [1]->{"after": {"a": 1, "b": "1"}}`,
 			})
 			sqlDB.Exec(t, `ALTER TABLE rename_column RENAME COLUMN b TO c`)
 			sqlDB.Exec(t, `INSERT INTO rename_column VALUES (2, '2')`)
 			assertPayloads(t, renameColumn, []string{
-				`rename_column: [2]->{"a": 2, "c": "2"}`,
+				`rename_column: [2]->{"after": {"a": 2, "c": "2"}}`,
 			})
 		})
 
@@ -400,8 +405,8 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 			sqlDB.Exec(t, `ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 'd'`)
 			sqlDB.Exec(t, `INSERT INTO add_default (a) VALUES (2)`)
 			assertPayloads(t, addDefault, []string{
-				`add_default: [1]->{"a": 1, "b": "1"}`,
-				`add_default: [2]->{"a": 2, "b": "d"}`,
+				`add_default: [1]->{"after": {"a": 1, "b": "1"}}`,
+				`add_default: [2]->{"after": {"a": 2, "b": "d"}}`,
 			})
 		})
 
@@ -413,8 +418,8 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 			sqlDB.Exec(t, `ALTER TABLE drop_default ALTER COLUMN b DROP DEFAULT`)
 			sqlDB.Exec(t, `INSERT INTO drop_default (a) VALUES (2)`)
 			assertPayloads(t, dropDefault, []string{
-				`drop_default: [1]->{"a": 1, "b": "d"}`,
-				`drop_default: [2]->{"a": 2, "b": null}`,
+				`drop_default: [1]->{"after": {"a": 1, "b": "d"}}`,
+				`drop_default: [2]->{"after": {"a": 2, "b": null}}`,
 			})
 		})
 
@@ -426,8 +431,8 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 			sqlDB.Exec(t, `ALTER TABLE drop_notnull ALTER b DROP NOT NULL`)
 			sqlDB.Exec(t, `INSERT INTO drop_notnull VALUES (2, NULL)`)
 			assertPayloads(t, dropNotNull, []string{
-				`drop_notnull: [1]->{"a": 1, "b": "1"}`,
-				`drop_notnull: [2]->{"a": 2, "b": null}`,
+				`drop_notnull: [1]->{"after": {"a": 1, "b": "1"}}`,
+				`drop_notnull: [2]->{"after": {"a": 2, "b": null}}`,
 			})
 		})
 
@@ -443,10 +448,10 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 			sqlDB.Exec(t, `ALTER TABLE checks DROP CONSTRAINT c`)
 			sqlDB.Exec(t, `INSERT INTO checks VALUES (6)`)
 			assertPayloads(t, checks, []string{
-				`checks: [1]->{"a": 1}`,
-				`checks: [2]->{"a": 2}`,
-				`checks: [3]->{"a": 3}`,
-				`checks: [6]->{"a": 6}`,
+				`checks: [1]->{"after": {"a": 1}}`,
+				`checks: [2]->{"after": {"a": 2}}`,
+				`checks: [3]->{"after": {"a": 3}}`,
+				`checks: [6]->{"after": {"a": 6}}`,
 			})
 		})
 
@@ -459,8 +464,8 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 			sqlDB.Exec(t, `SELECT * FROM add_index@b_idx`)
 			sqlDB.Exec(t, `INSERT INTO add_index VALUES (2, '2')`)
 			assertPayloads(t, addIndex, []string{
-				`add_index: [1]->{"a": 1, "b": "1"}`,
-				`add_index: [2]->{"a": 2, "b": "2"}`,
+				`add_index: [1]->{"after": {"a": 1, "b": "1"}}`,
+				`add_index: [2]->{"after": {"a": 2, "b": "2"}}`,
 			})
 		})
 
@@ -472,8 +477,8 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 			sqlDB.Exec(t, `ALTER TABLE "unique" ADD CONSTRAINT u UNIQUE (b)`)
 			sqlDB.Exec(t, `INSERT INTO "unique" VALUES (2, '2')`)
 			assertPayloads(t, unique, []string{
-				`unique: [1]->{"a": 1, "b": "1"}`,
-				`unique: [2]->{"a": 2, "b": "2"}`,
+				`unique: [1]->{"after": {"a": 1, "b": "1"}}`,
+				`unique: [2]->{"after": {"a": 2, "b": "2"}}`,
 			})
 		})
 
@@ -486,8 +491,8 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 			sqlDB.Exec(t, `ALTER TABLE alter_default ALTER COLUMN b SET DEFAULT 'after'`)
 			sqlDB.Exec(t, `INSERT INTO alter_default (a) VALUES (2)`)
 			assertPayloads(t, alterDefault, []string{
-				`alter_default: [1]->{"a": 1, "b": "before"}`,
-				`alter_default: [2]->{"a": 2, "b": "after"}`,
+				`alter_default: [1]->{"after": {"a": 1, "b": "before"}}`,
+				`alter_default: [2]->{"after": {"a": 2, "b": "after"}}`,
 			})
 		})
 	}
@@ -522,7 +527,7 @@ func TestChangefeedSchemaChangeNoAllowBackfill(t *testing.T) {
 			addColumnDef := f.Feed(t, `CREATE CHANGEFEED FOR add_column_def`)
 			defer addColumnDef.Close(t)
 			assertPayloads(t, addColumnDef, []string{
-				`add_column_def: [1]->{"a": 1}`,
+				`add_column_def: [1]->{"after": {"a": 1}}`,
 			})
 			sqlDB.Exec(t, `ALTER TABLE add_column_def ADD COLUMN b STRING DEFAULT 'd'`)
 			sqlDB.Exec(t, `INSERT INTO add_column_def VALUES (2, '2')`)
@@ -540,7 +545,7 @@ func TestChangefeedSchemaChangeNoAllowBackfill(t *testing.T) {
 			addColComp := f.Feed(t, `CREATE CHANGEFEED FOR add_col_comp`)
 			defer addColComp.Close(t)
 			assertPayloads(t, addColComp, []string{
-				`add_col_comp: [1]->{"a": 1, "b": 6}`,
+				`add_col_comp: [1]->{"after": {"a": 1, "b": 6}}`,
 			})
 			sqlDB.Exec(t, `ALTER TABLE add_col_comp ADD COLUMN c INT AS (a + 10) STORED`)
 			sqlDB.Exec(t, `INSERT INTO add_col_comp (a) VALUES (2)`)
@@ -558,7 +563,7 @@ func TestChangefeedSchemaChangeNoAllowBackfill(t *testing.T) {
 			dropColumn := f.Feed(t, `CREATE CHANGEFEED FOR drop_column`)
 			defer dropColumn.Close(t)
 			assertPayloads(t, dropColumn, []string{
-				`drop_column: [1]->{"a": 1, "b": "1"}`,
+				`drop_column: [1]->{"after": {"a": 1, "b": "1"}}`,
 			})
 			sqlDB.Exec(t, `ALTER TABLE drop_column DROP COLUMN b`)
 			sqlDB.Exec(t, `INSERT INTO drop_column VALUES (2)`)
@@ -591,16 +596,16 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 			addColumnDef := f.Feed(t, `CREATE CHANGEFEED FOR add_column_def`)
 			defer addColumnDef.Close(t)
 			assertPayloads(t, addColumnDef, []string{
-				`add_column_def: [1]->{"a": 1}`,
-				`add_column_def: [2]->{"a": 2}`,
+				`add_column_def: [1]->{"after": {"a": 1}}`,
+				`add_column_def: [2]->{"after": {"a": 2}}`,
 			})
 			sqlDB.Exec(t, `ALTER TABLE add_column_def ADD COLUMN b STRING DEFAULT 'd'`)
 			assertPayloads(t, addColumnDef, []string{
 				// TODO(dan): Track duplicates more precisely in sinklessFeed/tableFeed.
-				// `add_column_def: [1]->{"a": 1}`,
-				// `add_column_def: [2]->{"a": 2}`,
-				`add_column_def: [1]->{"a": 1, "b": "d"}`,
-				`add_column_def: [2]->{"a": 2, "b": "d"}`,
+				// `add_column_def: [1]->{"after": {"a": 1}}`,
+				// `add_column_def: [2]->{"after": {"a": 2}}`,
+				`add_column_def: [1]->{"after": {"a": 1, "b": "d"}}`,
+				`add_column_def: [2]->{"after": {"a": 2, "b": "d"}}`,
 			})
 		})
 
@@ -611,16 +616,16 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 			addColComp := f.Feed(t, `CREATE CHANGEFEED FOR add_col_comp`)
 			defer addColComp.Close(t)
 			assertPayloads(t, addColComp, []string{
-				`add_col_comp: [1]->{"a": 1, "b": 6}`,
-				`add_col_comp: [2]->{"a": 2, "b": 7}`,
+				`add_col_comp: [1]->{"after": {"a": 1, "b": 6}}`,
+				`add_col_comp: [2]->{"after": {"a": 2, "b": 7}}`,
 			})
 			sqlDB.Exec(t, `ALTER TABLE add_col_comp ADD COLUMN c INT AS (a + 10) STORED`)
 			assertPayloads(t, addColComp, []string{
 				// TODO(dan): Track duplicates more precisely in sinklessFeed/tableFeed.
-				// `add_col_comp: [1]->{"a": 1, "b": 6}`,
-				// `add_col_comp: [2]->{"a": 2, "b": 7}`,
-				`add_col_comp: [1]->{"a": 1, "b": 6, "c": 11}`,
-				`add_col_comp: [2]->{"a": 2, "b": 7, "c": 12}`,
+				// `add_col_comp: [1]->{"after": {"a": 1, "b": 6}}`,
+				// `add_col_comp: [2]->{"after": {"a": 2, "b": 7}}`,
+				`add_col_comp: [1]->{"after": {"a": 1, "b": 6, "c": 11}}`,
+				`add_col_comp: [2]->{"after": {"a": 2, "b": 7, "c": 12}}`,
 			})
 		})
 
@@ -631,19 +636,19 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 			dropColumn := f.Feed(t, `CREATE CHANGEFEED FOR drop_column`)
 			defer dropColumn.Close(t)
 			assertPayloads(t, dropColumn, []string{
-				`drop_column: [1]->{"a": 1, "b": "1"}`,
-				`drop_column: [2]->{"a": 2, "b": "2"}`,
+				`drop_column: [1]->{"after": {"a": 1, "b": "1"}}`,
+				`drop_column: [2]->{"after": {"a": 2, "b": "2"}}`,
 			})
 			sqlDB.Exec(t, `ALTER TABLE drop_column DROP COLUMN b`)
 			sqlDB.Exec(t, `INSERT INTO drop_column VALUES (3)`)
 			// Dropped columns are immediately invisible.
 			assertPayloads(t, dropColumn, []string{
-				`drop_column: [1]->{"a": 1}`,
-				`drop_column: [2]->{"a": 2}`,
-				`drop_column: [3]->{"a": 3}`,
+				`drop_column: [1]->{"after": {"a": 1}}`,
+				`drop_column: [2]->{"after": {"a": 2}}`,
+				`drop_column: [3]->{"after": {"a": 3}}`,
 				// TODO(dan): Track duplicates more precisely in sinklessFeed/tableFeed.
-				// `drop_column: [1]->{"a": 1}`,
-				// `drop_column: [2]->{"a": 2}`,
+				// `drop_column: [1]->{"after": {"a": 1}}`,
+				// `drop_column: [2]->{"after": {"a": 2}}`,
 			})
 		})
 
@@ -666,8 +671,8 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 			multipleAlters := f.Feed(t, `CREATE CHANGEFEED FOR multiple_alters`)
 			defer multipleAlters.Close(t)
 			assertPayloads(t, multipleAlters, []string{
-				`multiple_alters: [1]->{"a": 1, "b": "1"}`,
-				`multiple_alters: [2]->{"a": 2, "b": "2"}`,
+				`multiple_alters: [1]->{"after": {"a": 1, "b": "1"}}`,
+				`multiple_alters: [2]->{"after": {"a": 2, "b": "2"}}`,
 			})
 
 			// Wait on the next emit, queue up three ALTERs. The next poll process
@@ -680,26 +685,26 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 
 			assertPayloads(t, multipleAlters, []string{
 				// Backfill no-ops for DROP. Dropped columns are immediately invisible.
-				`multiple_alters: [1]->{"a": 1}`,
-				`multiple_alters: [2]->{"a": 2}`,
+				`multiple_alters: [1]->{"after": {"a": 1}}`,
+				`multiple_alters: [2]->{"after": {"a": 2}}`,
 				// Scan output for DROP
 				// TODO(dan): Track duplicates more precisely in sinklessFeed/tableFeed.
-				// `multiple_alters: [1]->{"a": 1}`,
-				// `multiple_alters: [2]->{"a": 2}`,
+				// `multiple_alters: [1]->{"after": {"a": 1}}`,
+				// `multiple_alters: [2]->{"after": {"a": 2}}`,
 				// Backfill no-ops for column C
 				// TODO(dan): Track duplicates more precisely in sinklessFeed/tableFeed.
-				// `multiple_alters: [1]->{"a": 1}`,
-				// `multiple_alters: [2]->{"a": 2}`,
+				// `multiple_alters: [1]->{"after": {"a": 1}}`,
+				// `multiple_alters: [2]->{"after": {"a": 2}}`,
 				// Scan output for column C
-				`multiple_alters: [1]->{"a": 1, "c": "cee"}`,
-				`multiple_alters: [2]->{"a": 2, "c": "cee"}`,
+				`multiple_alters: [1]->{"after": {"a": 1, "c": "cee"}}`,
+				`multiple_alters: [2]->{"after": {"a": 2, "c": "cee"}}`,
 				// Backfill no-ops for column D (C schema change is complete)
 				// TODO(dan): Track duplicates more precisely in sinklessFeed/tableFeed.
-				// `multiple_alters: [1]->{"a": 1, "c": "cee"}`,
-				// `multiple_alters: [2]->{"a": 2, "c": "cee"}`,
+				// `multiple_alters: [1]->{"after": {"a": 1, "c": "cee"}}`,
+				// `multiple_alters: [2]->{"after": {"a": 2, "c": "cee"}}`,
 				// Scan output for column C
-				`multiple_alters: [1]->{"a": 1, "c": "cee", "d": "dee"}`,
-				`multiple_alters: [2]->{"a": 2, "c": "cee", "d": "dee"}`,
+				`multiple_alters: [1]->{"after": {"a": 1, "c": "cee", "d": "dee"}}`,
+				`multiple_alters: [2]->{"after": {"a": 2, "c": "cee", "d": "dee"}}`,
 			})
 		})
 	}
@@ -722,8 +727,8 @@ func TestChangefeedAfterSchemaChangeBackfill(t *testing.T) {
 		afterBackfill := f.Feed(t, `CREATE CHANGEFEED FOR after_backfill`)
 		defer afterBackfill.Close(t)
 		assertPayloads(t, afterBackfill, []string{
-			`after_backfill: [0]->{"a": 0, "b": 1}`,
-			`after_backfill: [2]->{"a": 2, "b": 3}`,
+			`after_backfill: [0]->{"after": {"a": 0, "b": 1}}`,
+			`after_backfill: [2]->{"after": {"a": 2, "b": 3}}`,
 		})
 	}
 
@@ -743,7 +748,7 @@ func TestChangefeedInterleaved(t *testing.T) {
 		grandparent := f.Feed(t, `CREATE CHANGEFEED FOR grandparent`)
 		defer grandparent.Close(t)
 		assertPayloads(t, grandparent, []string{
-			`grandparent: [0]->{"a": 0, "b": "grandparent-0"}`,
+			`grandparent: [0]->{"after": {"a": 0, "b": "grandparent-0"}}`,
 		})
 
 		sqlDB.Exec(t,
@@ -754,10 +759,10 @@ func TestChangefeedInterleaved(t *testing.T) {
 		parent := f.Feed(t, `CREATE CHANGEFEED FOR parent`)
 		defer parent.Close(t)
 		assertPayloads(t, grandparent, []string{
-			`grandparent: [1]->{"a": 1, "b": "grandparent-1"}`,
+			`grandparent: [1]->{"after": {"a": 1, "b": "grandparent-1"}}`,
 		})
 		assertPayloads(t, parent, []string{
-			`parent: [1]->{"a": 1, "b": "parent-1"}`,
+			`parent: [1]->{"after": {"a": 1, "b": "parent-1"}}`,
 		})
 
 		sqlDB.Exec(t,
@@ -768,13 +773,13 @@ func TestChangefeedInterleaved(t *testing.T) {
 		child := f.Feed(t, `CREATE CHANGEFEED FOR child`)
 		defer child.Close(t)
 		assertPayloads(t, grandparent, []string{
-			`grandparent: [2]->{"a": 2, "b": "grandparent-2"}`,
+			`grandparent: [2]->{"after": {"a": 2, "b": "grandparent-2"}}`,
 		})
 		assertPayloads(t, parent, []string{
-			`parent: [2]->{"a": 2, "b": "parent-2"}`,
+			`parent: [2]->{"after": {"a": 2, "b": "parent-2"}}`,
 		})
 		assertPayloads(t, child, []string{
-			`child: [2]->{"a": 2, "b": "child-2"}`,
+			`child: [2]->{"after": {"a": 2, "b": "child-2"}}`,
 		})
 	}
 
@@ -802,7 +807,7 @@ func TestChangefeedColumnFamily(t *testing.T) {
 		bar := f.Feed(t, `CREATE CHANGEFEED FOR bar`)
 		defer bar.Close(t)
 		assertPayloads(t, bar, []string{
-			`bar: [0]->{"a": 0}`,
+			`bar: [0]->{"after": {"a": 0}}`,
 		})
 		sqlDB.Exec(t, `ALTER TABLE bar ADD COLUMN b STRING CREATE FAMILY f_b`)
 		sqlDB.Exec(t, `INSERT INTO bar VALUES (1)`)
@@ -832,12 +837,12 @@ func TestChangefeedComputedColumn(t *testing.T) {
 		defer cc.Close(t)
 
 		assertPayloads(t, cc, []string{
-			`cc: [2, 1]->{"a": 1, "b": 2, "c": 3}`,
+			`cc: [2, 1]->{"after": {"a": 1, "b": 2, "c": 3}}`,
 		})
 
 		sqlDB.Exec(t, `INSERT INTO cc (a) VALUES (10)`)
 		assertPayloads(t, cc, []string{
-			`cc: [11, 10]->{"a": 10, "b": 11, "c": 12}`,
+			`cc: [11, 10]->{"after": {"a": 10, "b": 11, "c": 12}}`,
 		})
 	}
 
@@ -859,18 +864,18 @@ func TestChangefeedUpdatePrimaryKey(t *testing.T) {
 		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo`)
 		defer foo.Close(t)
 		assertPayloads(t, foo, []string{
-			`foo: [0]->{"a": 0, "b": "bar"}`,
+			`foo: [0]->{"after": {"a": 0, "b": "bar"}}`,
 		})
 
 		sqlDB.Exec(t, `UPDATE foo SET a = 1`)
 		assertPayloads(t, foo, []string{
-			`foo: [0]->`,
-			`foo: [1]->{"a": 1, "b": "bar"}`,
+			`foo: [0]->{"after": null}`,
+			`foo: [1]->{"after": {"a": 1, "b": "bar"}}`,
 		})
 
 		sqlDB.Exec(t, `DELETE FROM foo`)
 		assertPayloads(t, foo, []string{
-			`foo: [1]->`,
+			`foo: [1]->{"after": null}`,
 		})
 	}
 
@@ -890,7 +895,7 @@ func TestChangefeedTruncateRenameDrop(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO truncate VALUES (1)`)
 		truncate := f.Feed(t, `CREATE CHANGEFEED FOR truncate`)
 		defer truncate.Close(t)
-		assertPayloads(t, truncate, []string{`truncate: [1]->{"a": 1}`})
+		assertPayloads(t, truncate, []string{`truncate: [1]->{"after": {"a": 1}}`})
 		sqlDB.Exec(t, `TRUNCATE TABLE truncate`)
 		truncate.Next(t)
 		if err := truncate.Err(); !testutils.IsError(err, `"truncate" was dropped or truncated`) {
@@ -901,7 +906,7 @@ func TestChangefeedTruncateRenameDrop(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO rename VALUES (1)`)
 		rename := f.Feed(t, `CREATE CHANGEFEED FOR rename`)
 		defer rename.Close(t)
-		assertPayloads(t, rename, []string{`rename: [1]->{"a": 1}`})
+		assertPayloads(t, rename, []string{`rename: [1]->{"after": {"a": 1}}`})
 		sqlDB.Exec(t, `ALTER TABLE rename RENAME TO renamed`)
 		sqlDB.Exec(t, `INSERT INTO renamed VALUES (2)`)
 		rename.Next(t)
@@ -913,7 +918,7 @@ func TestChangefeedTruncateRenameDrop(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO drop VALUES (1)`)
 		drop := f.Feed(t, `CREATE CHANGEFEED FOR drop`)
 		defer drop.Close(t)
-		assertPayloads(t, drop, []string{`drop: [1]->{"a": 1}`})
+		assertPayloads(t, drop, []string{`drop: [1]->{"after": {"a": 1}}`})
 		sqlDB.Exec(t, `DROP TABLE drop`)
 		drop.Next(t)
 		if err := drop.Err(); !testutils.IsError(err, `"drop" was dropped or truncated`) {
@@ -972,8 +977,8 @@ func TestChangefeedMonitoring(t *testing.T) {
 			if c := s.MustGetSQLCounter(`changefeed.emitted_messages`); c != 1 {
 				return errors.Errorf(`expected 1 got %d`, c)
 			}
-			if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 11 {
-				return errors.Errorf(`expected 11 got %d`, c)
+			if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 22 {
+				return errors.Errorf(`expected 22 got %d`, c)
 			}
 			if c := s.MustGetSQLCounter(`changefeed.emit_nanos`); c <= 0 {
 				return errors.Errorf(`expected > 0 got %d`, c)
@@ -1024,8 +1029,8 @@ func TestChangefeedMonitoring(t *testing.T) {
 			if c := s.MustGetSQLCounter(`changefeed.emitted_messages`); c != 4 {
 				return errors.Errorf(`expected 4 got %d`, c)
 			}
-			if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 44 {
-				return errors.Errorf(`expected 44 got %d`, c)
+			if c := s.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 88 {
+				return errors.Errorf(`expected 88 got %d`, c)
 			}
 			return nil
 		})
@@ -1377,14 +1382,14 @@ func TestChangefeedErrors(t *testing.T) {
 	sqlDB.Exec(t, `INSERT INTO dec VALUES (1.0)`)
 	sqlDB.ExpectErr(
 		t, `pq: column a: decimal with no precision`,
-		`CREATE CHANGEFEED FOR dec WITH envelope=wrapped, format=$1, confluent_schema_registry=$2`,
+		`CREATE CHANGEFEED FOR dec WITH format=$1, confluent_schema_registry=$2`,
 		optFormatAvro, `bar`,
 	)
 	sqlDB.Exec(t, `CREATE TABLE "uuid" (a UUID PRIMARY KEY)`)
 	sqlDB.Exec(t, `INSERT INTO "uuid" VALUES (gen_random_uuid())`)
 	sqlDB.ExpectErr(
 		t, `pq: column a: type UUID not yet supported with avro`,
-		`CREATE CHANGEFEED FOR "uuid" WITH envelope=wrapped, format=$1, confluent_schema_registry=$2`,
+		`CREATE CHANGEFEED FOR "uuid" WITH format=$1, confluent_schema_registry=$2`,
 		optFormatAvro, `bar`,
 	)
 
@@ -1509,11 +1514,11 @@ func TestChangefeedPauseUnpause(t *testing.T) {
 		defer foo.Close(t)
 
 		assertPayloads(t, foo, []string{
-			`foo: [1]->{"a": 1, "b": "a"}`,
-			`foo: [2]->{"a": 2, "b": "b"}`,
-			`foo: [4]->{"a": 4, "b": "c"}`,
-			`foo: [7]->{"a": 7, "b": "d"}`,
-			`foo: [8]->{"a": 8, "b": "e"}`,
+			`foo: [1]->{"after": {"a": 1, "b": "a"}}`,
+			`foo: [2]->{"after": {"a": 2, "b": "b"}}`,
+			`foo: [4]->{"after": {"a": 4, "b": "c"}}`,
+			`foo: [7]->{"after": {"a": 7, "b": "d"}}`,
+			`foo: [8]->{"after": {"a": 8, "b": "e"}}`,
 		})
 
 		// Wait for the high-water mark on the job to be updated after the initial
@@ -1527,7 +1532,7 @@ func TestChangefeedPauseUnpause(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (16, 'f')`)
 		sqlDB.Exec(t, `RESUME JOB $1`, foo.jobID)
 		assertPayloads(t, foo, []string{
-			`foo: [16]->{"a": 16, "b": "f"}`,
+			`foo: [16]->{"after": {"a": 16, "b": "f"}}`,
 		})
 	}
 
@@ -1552,35 +1557,35 @@ func TestManyChangefeedsOneTable(t *testing.T) {
 		defer foo3.Close(t)
 
 		// Make sure all the changefeeds are going.
-		assertPayloads(t, foo1, []string{`foo: [0]->{"a": 0, "b": "init"}`})
-		assertPayloads(t, foo2, []string{`foo: [0]->{"a": 0, "b": "init"}`})
-		assertPayloads(t, foo3, []string{`foo: [0]->{"a": 0, "b": "init"}`})
+		assertPayloads(t, foo1, []string{`foo: [0]->{"after": {"a": 0, "b": "init"}}`})
+		assertPayloads(t, foo2, []string{`foo: [0]->{"after": {"a": 0, "b": "init"}}`})
+		assertPayloads(t, foo3, []string{`foo: [0]->{"after": {"a": 0, "b": "init"}}`})
 
 		sqlDB.Exec(t, `UPSERT INTO foo VALUES (0, 'v0')`)
 		assertPayloads(t, foo1, []string{
-			`foo: [0]->{"a": 0, "b": "v0"}`,
+			`foo: [0]->{"after": {"a": 0, "b": "v0"}}`,
 		})
 
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'v1')`)
 		assertPayloads(t, foo1, []string{
-			`foo: [1]->{"a": 1, "b": "v1"}`,
+			`foo: [1]->{"after": {"a": 1, "b": "v1"}}`,
 		})
 		assertPayloads(t, foo2, []string{
-			`foo: [0]->{"a": 0, "b": "v0"}`,
-			`foo: [1]->{"a": 1, "b": "v1"}`,
+			`foo: [0]->{"after": {"a": 0, "b": "v0"}}`,
+			`foo: [1]->{"after": {"a": 1, "b": "v1"}}`,
 		})
 
 		sqlDB.Exec(t, `UPSERT INTO foo VALUES (0, 'v2')`)
 		assertPayloads(t, foo1, []string{
-			`foo: [0]->{"a": 0, "b": "v2"}`,
+			`foo: [0]->{"after": {"a": 0, "b": "v2"}}`,
 		})
 		assertPayloads(t, foo2, []string{
-			`foo: [0]->{"a": 0, "b": "v2"}`,
+			`foo: [0]->{"after": {"a": 0, "b": "v2"}}`,
 		})
 		assertPayloads(t, foo3, []string{
-			`foo: [0]->{"a": 0, "b": "v0"}`,
-			`foo: [0]->{"a": 0, "b": "v2"}`,
-			`foo: [1]->{"a": 1, "b": "v1"}`,
+			`foo: [0]->{"after": {"a": 0, "b": "v0"}}`,
+			`foo: [0]->{"after": {"a": 0, "b": "v2"}}`,
+			`foo: [1]->{"after": {"a": 1, "b": "v1"}}`,
 		})
 	}
 
@@ -1605,8 +1610,8 @@ func TestUnspecifiedPrimaryKey(t *testing.T) {
 		sqlDB.QueryRow(t, `INSERT INTO foo VALUES (1) RETURNING rowid`).Scan(&id1)
 
 		assertPayloads(t, foo, []string{
-			fmt.Sprintf(`foo: [%d]->{"a": 0, "rowid": %d}`, id0, id0),
-			fmt.Sprintf(`foo: [%d]->{"a": 1, "rowid": %d}`, id1, id1),
+			fmt.Sprintf(`foo: [%d]->{"after": {"a": 0, "rowid": %d}}`, id0, id0),
+			fmt.Sprintf(`foo: [%d]->{"after": {"a": 1, "rowid": %d}}`, id1, id1),
 		})
 	}
 
@@ -1661,8 +1666,8 @@ func TestChangefeedNodeShutdown(t *testing.T) {
 
 	sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'second')`)
 	assertPayloads(t, foo, []string{
-		`foo: [0]->{"a": 0, "b": "initial"}`,
-		`foo: [1]->{"a": 1, "b": "second"}`,
+		`foo: [0]->{"after": {"a": 0, "b": "initial"}}`,
+		`foo: [1]->{"after": {"a": 1, "b": "second"}}`,
 	})
 
 	// TODO(mrtracy): At this point we need to wait for a resolved timestamp,
@@ -1679,8 +1684,8 @@ func TestChangefeedNodeShutdown(t *testing.T) {
 	sqlDB.Exec(t, `INSERT INTO foo VALUES (3, 'third')`)
 
 	assertPayloads(t, foo, []string{
-		`foo: [0]->{"a": 0, "b": "updated"}`,
-		`foo: [3]->{"a": 3, "b": "third"}`,
+		`foo: [0]->{"after": {"a": 0, "b": "updated"}}`,
+		`foo: [3]->{"after": {"a": 3, "b": "third"}}`,
 	})
 
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -101,10 +101,10 @@ func TestChangefeedEnvelope(t *testing.T) {
 			defer foo.Close(t)
 			assertPayloads(t, foo, []string{`foo: [1]->`})
 		})
-		t.Run(`envelope=value_only`, func(t *testing.T) {
-			foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH envelope='value_only'`)
+		t.Run(`envelope=wrapped`, func(t *testing.T) {
+			foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH envelope='wrapped'`)
 			defer foo.Close(t)
-			assertPayloads(t, foo, []string{`foo: ->{"a": 1, "b": "a"}`})
+			assertPayloads(t, foo, []string{`foo: [1]->{"after": {"a": 1, "b": "a"}}`})
 		})
 	}
 
@@ -1317,10 +1317,6 @@ func TestChangefeedErrors(t *testing.T) {
 	)
 
 	sqlDB.ExpectErr(
-		t, `envelope=diff is not yet supported`,
-		`CREATE CHANGEFEED FOR foo WITH envelope=diff`,
-	)
-	sqlDB.ExpectErr(
 		t, `unknown envelope: nope`,
 		`CREATE CHANGEFEED FOR foo WITH envelope=nope`,
 	)
@@ -1381,14 +1377,14 @@ func TestChangefeedErrors(t *testing.T) {
 	sqlDB.Exec(t, `INSERT INTO dec VALUES (1.0)`)
 	sqlDB.ExpectErr(
 		t, `pq: column a: decimal with no precision`,
-		`CREATE CHANGEFEED FOR dec WITH format=$1, confluent_schema_registry=$2`,
+		`CREATE CHANGEFEED FOR dec WITH envelope=wrapped, format=$1, confluent_schema_registry=$2`,
 		optFormatAvro, `bar`,
 	)
 	sqlDB.Exec(t, `CREATE TABLE "uuid" (a UUID PRIMARY KEY)`)
 	sqlDB.Exec(t, `INSERT INTO "uuid" VALUES (gen_random_uuid())`)
 	sqlDB.ExpectErr(
 		t, `pq: column a: type UUID not yet supported with avro`,
-		`CREATE CHANGEFEED FOR "uuid" WITH format=$1, confluent_schema_registry=$2`,
+		`CREATE CHANGEFEED FOR "uuid" WITH envelope=wrapped, format=$1, confluent_schema_registry=$2`,
 		optFormatAvro, `bar`,
 	)
 

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -131,7 +131,7 @@ func (e *jsonEncoder) EncodeKey(row encodeRow) ([]byte, error) {
 
 // EncodeValue implements the Encoder interface.
 func (e *jsonEncoder) EncodeValue(row encodeRow) ([]byte, error) {
-	if e.keyOnly || !e.wrapped && row.deleted {
+	if e.keyOnly || (!e.wrapped && row.deleted) {
 		return nil, nil
 	}
 

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -33,21 +33,38 @@ const (
 	confluentAvroWireFormatMagic = byte(0)
 )
 
+// encodeRow holds all the pieces necessary to encode a row change into a key or
+// value.
+type encodeRow struct {
+	// datums is the new value of a changed table row.
+	datums sqlbase.EncDatumRow
+	// updated is the mvcc timestamp corresponding to the latest update in
+	// `datums`.
+	updated hlc.Timestamp
+	// deleted is true if row is a deletion. In this case, only the primary
+	// key columns are guaranteed to be set in `datums`.
+	deleted bool
+	// tableDesc is a TableDescriptor for the table containing `datums`.
+	// It's valid for interpreting the row at `updated`.
+	tableDesc *sqlbase.TableDescriptor
+}
+
 // Encoder turns a row into a serialized changefeed key, value, or resolved
 // timestamp. It represents one of the `format=` changefeed options.
 type Encoder interface {
 	// EncodeKey encodes the primary key of the given row. The columns of the
-	// row are expected to match 1:1 with the `Columns` field of the
+	// datums are expected to match 1:1 with the `Columns` field of the
 	// `TableDescriptor`, but only the primary key fields will be used. The
 	// returned bytes are only valid until the next call to Encode*.
-	EncodeKey(*sqlbase.TableDescriptor, sqlbase.EncDatumRow) ([]byte, error)
+	EncodeKey(encodeRow) ([]byte, error)
 	// EncodeValue encodes the primary key of the given row. The columns of the
-	// row are expected to match 1:1 with the `Columns` field of the
+	// datums are expected to match 1:1 with the `Columns` field of the
 	// `TableDescriptor`. The returned bytes are only valid until the next call
 	// to Encode*.
-	EncodeValue(*sqlbase.TableDescriptor, sqlbase.EncDatumRow, hlc.Timestamp) ([]byte, error)
-	// EncodeResolvedTimestamp encodes a resolved timestamp payload. The
-	// returned bytes are only valid until the next call to Encode*.
+	EncodeValue(encodeRow) ([]byte, error)
+	// EncodeResolvedTimestamp encodes a resolved timestamp payload for the
+	// given topic name. The returned bytes are only valid until the next call
+	// to Encode*.
 	EncodeResolvedTimestamp(string, hlc.Timestamp) ([]byte, error)
 }
 
@@ -67,7 +84,7 @@ func getEncoder(opts map[string]string) (Encoder, error) {
 // to its value. Updated timestamps in rows and resolved timestamp payloads are
 // stored in a sub-object under the `__crdb__` key in the top-level JSON object.
 type jsonEncoder struct {
-	opts map[string]string
+	updatedField, wrapped, keyOnly bool
 
 	alloc sqlbase.DatumAlloc
 	buf   bytes.Buffer
@@ -76,21 +93,24 @@ type jsonEncoder struct {
 var _ Encoder = &jsonEncoder{}
 
 func makeJSONEncoder(opts map[string]string) *jsonEncoder {
-	return &jsonEncoder{opts: opts}
+	e := &jsonEncoder{
+		keyOnly: envelopeType(opts[optEnvelope]) == optEnvelopeKeyOnly,
+		wrapped: envelopeType(opts[optEnvelope]) == optEnvelopeWrapped,
+	}
+	_, e.updatedField = opts[optUpdatedTimestamps]
+	return e
 }
 
 // EncodeKey implements the Encoder interface.
-func (e *jsonEncoder) EncodeKey(
-	tableDesc *sqlbase.TableDescriptor, row sqlbase.EncDatumRow,
-) ([]byte, error) {
-	colIdxByID := tableDesc.ColumnIdxMap()
-	jsonEntries := make([]interface{}, len(tableDesc.PrimaryIndex.ColumnIDs))
-	for i, colID := range tableDesc.PrimaryIndex.ColumnIDs {
+func (e *jsonEncoder) EncodeKey(row encodeRow) ([]byte, error) {
+	colIdxByID := row.tableDesc.ColumnIdxMap()
+	jsonEntries := make([]interface{}, len(row.tableDesc.PrimaryIndex.ColumnIDs))
+	for i, colID := range row.tableDesc.PrimaryIndex.ColumnIDs {
 		idx, ok := colIdxByID[colID]
 		if !ok {
 			return nil, errors.Errorf(`unknown column id: %d`, colID)
 		}
-		datum, col := row[idx], tableDesc.Columns[idx]
+		datum, col := row.datums[idx], row.tableDesc.Columns[idx]
 		if err := datum.EnsureDecoded(&col.Type, &e.alloc); err != nil {
 			return nil, err
 		}
@@ -110,27 +130,50 @@ func (e *jsonEncoder) EncodeKey(
 }
 
 // EncodeValue implements the Encoder interface.
-func (e *jsonEncoder) EncodeValue(
-	tableDesc *sqlbase.TableDescriptor, row sqlbase.EncDatumRow, updated hlc.Timestamp,
-) ([]byte, error) {
-	columns := tableDesc.Columns
-	jsonEntries := make(map[string]interface{}, len(columns))
-	if _, ok := e.opts[optUpdatedTimestamps]; ok {
-		jsonEntries[jsonMetaSentinel] = map[string]interface{}{
-			`updated`: tree.TimestampToDecimal(updated).Decimal.String(),
+func (e *jsonEncoder) EncodeValue(row encodeRow) ([]byte, error) {
+	if e.keyOnly || !e.wrapped && row.deleted {
+		return nil, nil
+	}
+
+	var after map[string]interface{}
+	if !row.deleted {
+		columns := row.tableDesc.Columns
+		after = make(map[string]interface{}, len(columns))
+		for i, col := range columns {
+			datum := row.datums[i]
+			if err := datum.EnsureDecoded(&col.Type, &e.alloc); err != nil {
+				return nil, err
+			}
+			var err error
+			after[col.Name], err = tree.AsJSON(datum.Datum)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
-	for i, col := range columns {
-		datum := row[i]
-		if err := datum.EnsureDecoded(&col.Type, &e.alloc); err != nil {
-			return nil, err
+
+	var jsonEntries map[string]interface{}
+	if e.wrapped {
+		if after != nil {
+			jsonEntries = map[string]interface{}{`after`: after}
+		} else {
+			jsonEntries = map[string]interface{}{`after`: nil}
 		}
-		var err error
-		jsonEntries[col.Name], err = tree.AsJSON(datum.Datum)
-		if err != nil {
-			return nil, err
-		}
+	} else {
+		jsonEntries = after
 	}
+
+	if e.updatedField {
+		var meta map[string]interface{}
+		if e.wrapped {
+			meta = jsonEntries
+		} else {
+			meta = make(map[string]interface{}, 1)
+			jsonEntries[jsonMetaSentinel] = meta
+		}
+		meta[`updated`] = row.updated.AsOfSystemTime()
+	}
+
 	j, err := json.MakeJSON(jsonEntries)
 	if err != nil {
 		return nil, err
@@ -142,20 +185,26 @@ func (e *jsonEncoder) EncodeValue(
 
 // EncodeResolvedTimestamp implements the Encoder interface.
 func (e *jsonEncoder) EncodeResolvedTimestamp(_ string, resolved hlc.Timestamp) ([]byte, error) {
-	resolvedMetaRaw := map[string]interface{}{
-		jsonMetaSentinel: map[string]interface{}{
-			`resolved`: tree.TimestampToDecimal(resolved).Decimal.String(),
-		},
+	meta := map[string]interface{}{
+		`resolved`: tree.TimestampToDecimal(resolved).Decimal.String(),
 	}
-	return gojson.Marshal(resolvedMetaRaw)
+	var jsonEntries interface{}
+	if e.wrapped {
+		jsonEntries = meta
+	} else {
+		jsonEntries = map[string]interface{}{
+			jsonMetaSentinel: meta,
+		}
+	}
+	return gojson.Marshal(jsonEntries)
 }
 
 // confluentAvroEncoder encodes changefeed entries as Avro's binary or textual
 // JSON format. Keys are the primary key columns in a record. Values are all
 // columns in a record.
 type confluentAvroEncoder struct {
-	registryURL string
-	opts        map[string]string
+	registryURL           string
+	updatedField, keyOnly bool
 
 	keyCache      map[tableIDAndVersion]confluentRegisteredKeySchema
 	valueCache    map[tableIDAndVersion]confluentRegisteredEnvelopeSchema
@@ -186,33 +235,38 @@ func newConfluentAvroEncoder(opts map[string]string) (*confluentAvroEncoder, err
 		return nil, errors.Errorf(`WITH option %s is required for %s=%s`,
 			optConfluentSchemaRegistry, optFormat, optFormatAvro)
 	}
-	e := &confluentAvroEncoder{
-		registryURL:   registryURL,
-		opts:          opts,
-		keyCache:      make(map[tableIDAndVersion]confluentRegisteredKeySchema),
-		valueCache:    make(map[tableIDAndVersion]confluentRegisteredEnvelopeSchema),
-		resolvedCache: make(map[string]confluentRegisteredEnvelopeSchema),
-	}
+	e := &confluentAvroEncoder{registryURL: registryURL}
 
+	switch opts[optEnvelope] {
+	case string(optEnvelopeKeyOnly):
+		e.keyOnly = true
+	case string(optEnvelopeWrapped):
+	default:
+		return nil, errors.Errorf(`%s=%s is not supported with %s=%s`,
+			optEnvelope, opts[optEnvelope], optFormat, optFormatAvro)
+	}
+	_, e.updatedField = opts[optUpdatedTimestamps]
+
+	e.keyCache = make(map[tableIDAndVersion]confluentRegisteredKeySchema)
+	e.valueCache = make(map[tableIDAndVersion]confluentRegisteredEnvelopeSchema)
+	e.resolvedCache = make(map[string]confluentRegisteredEnvelopeSchema)
 	return e, nil
 }
 
 // EncodeKey implements the Encoder interface.
-func (e *confluentAvroEncoder) EncodeKey(
-	tableDesc *sqlbase.TableDescriptor, row sqlbase.EncDatumRow,
-) ([]byte, error) {
-	cacheKey := makeTableIDAndVersion(tableDesc.ID, tableDesc.Version)
+func (e *confluentAvroEncoder) EncodeKey(row encodeRow) ([]byte, error) {
+	cacheKey := makeTableIDAndVersion(row.tableDesc.ID, row.tableDesc.Version)
 	registered, ok := e.keyCache[cacheKey]
 	if !ok {
 		var err error
-		registered.schema, err = indexToAvroSchema(tableDesc, &tableDesc.PrimaryIndex)
+		registered.schema, err = indexToAvroSchema(row.tableDesc, &row.tableDesc.PrimaryIndex)
 		if err != nil {
 			return nil, err
 		}
 
 		// NB: This uses the kafka name escaper because it has to match the name
 		// of the kafka topic.
-		subject := SQLNameToKafkaName(tableDesc.Name) + confluentSubjectSuffixKey
+		subject := SQLNameToKafkaName(row.tableDesc.Name) + confluentSubjectSuffixKey
 		registered.registryID, err = e.register(&registered.schema.avroRecord, subject)
 		if err != nil {
 			return nil, err
@@ -227,31 +281,32 @@ func (e *confluentAvroEncoder) EncodeKey(
 		0, 0, 0, 0, // Placeholder for the ID.
 	}
 	binary.BigEndian.PutUint32(header[1:5], uint32(registered.registryID))
-	return registered.schema.BinaryFromRow(header, row)
+	return registered.schema.BinaryFromRow(header, row.datums)
 }
 
 // EncodeValue implements the Encoder interface.
-func (e *confluentAvroEncoder) EncodeValue(
-	tableDesc *sqlbase.TableDescriptor, row sqlbase.EncDatumRow, updated hlc.Timestamp,
-) ([]byte, error) {
-	cacheKey := makeTableIDAndVersion(tableDesc.ID, tableDesc.Version)
+func (e *confluentAvroEncoder) EncodeValue(row encodeRow) ([]byte, error) {
+	if e.keyOnly {
+		return nil, nil
+	}
+
+	cacheKey := makeTableIDAndVersion(row.tableDesc.ID, row.tableDesc.Version)
 	registered, ok := e.valueCache[cacheKey]
 	if !ok {
-		afterDataSchema, err := tableToAvroSchema(tableDesc)
+		afterDataSchema, err := tableToAvroSchema(row.tableDesc)
 		if err != nil {
 			return nil, err
 		}
 
-		opts := avroEnvelopeOpts{afterField: true}
-		_, opts.updatedField = e.opts[optUpdatedTimestamps]
-		registered.schema, err = envelopeToAvroSchema(tableDesc.Name, opts, afterDataSchema)
+		opts := avroEnvelopeOpts{afterField: true, updatedField: e.updatedField}
+		registered.schema, err = envelopeToAvroSchema(row.tableDesc.Name, opts, afterDataSchema)
 		if err != nil {
 			return nil, err
 		}
 
 		// NB: This uses the kafka name escaper because it has to match the name
 		// of the kafka topic.
-		subject := SQLNameToKafkaName(tableDesc.Name) + confluentSubjectSuffixValue
+		subject := SQLNameToKafkaName(row.tableDesc.Name) + confluentSubjectSuffixValue
 		registered.registryID, err = e.register(&registered.schema.avroRecord, subject)
 		if err != nil {
 			return nil, err
@@ -262,8 +317,12 @@ func (e *confluentAvroEncoder) EncodeValue(
 	var meta avroMetadata
 	if registered.schema.opts.updatedField {
 		meta = map[string]interface{}{
-			`updated`: updated,
+			`updated`: row.updated,
 		}
+	}
+	var datums sqlbase.EncDatumRow
+	if !row.deleted {
+		datums = row.datums
 	}
 	// https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format
 	header := []byte{
@@ -271,7 +330,7 @@ func (e *confluentAvroEncoder) EncodeValue(
 		0, 0, 0, 0, // Placeholder for the ID.
 	}
 	binary.BigEndian.PutUint32(header[1:5], uint32(registered.registryID))
-	return registered.schema.BinaryFromRow(header, meta, row)
+	return registered.schema.BinaryFromRow(header, meta, datums)
 }
 
 // EncodeResolvedTimestamp implements the Encoder interface.
@@ -280,8 +339,7 @@ func (e *confluentAvroEncoder) EncodeResolvedTimestamp(
 ) ([]byte, error) {
 	registered, ok := e.resolvedCache[topic]
 	if !ok {
-		var opts avroEnvelopeOpts
-		_, opts.resolvedField = e.opts[optResolvedTimestamps]
+		opts := avroEnvelopeOpts{resolvedField: true}
 		var err error
 		registered.schema, err = envelopeToAvroSchema(topic, opts, nil /* after */)
 		if err != nil {

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -283,7 +283,7 @@ func TestAvroEncoder(t *testing.T) {
 		).Scan(&ts1)
 
 		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo `+
-			`WITH envelope=wrapped, format=$1, confluent_schema_registry=$2, resolved`,
+			`WITH format=$1, confluent_schema_registry=$2, resolved`,
 			optFormatAvro, reg.server.URL)
 		defer foo.Close(t)
 		assertPayloadsAvro(t, reg, foo, []string{
@@ -296,7 +296,7 @@ func TestAvroEncoder(t *testing.T) {
 		}
 
 		fooUpdated := f.Feed(t, `CREATE CHANGEFEED FOR foo `+
-			`WITH envelope=wrapped, format=$1, confluent_schema_registry=$2, updated`,
+			`WITH format=$1, confluent_schema_registry=$2, updated`,
 			optFormatAvro, reg.server.URL)
 		defer fooUpdated.Close(t)
 		// Skip over the first two rows since we don't know the statement timestamp.
@@ -334,7 +334,7 @@ func TestAvroSchemaChange(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
 
 		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo `+
-			`WITH envelope=wrapped, format=$1, confluent_schema_registry=$2`,
+			`WITH format=$1, confluent_schema_registry=$2`,
 			optFormatAvro, reg.server.URL)
 		defer foo.Close(t)
 		assertPayloadsAvro(t, reg, foo, []string{
@@ -369,7 +369,7 @@ func TestAvroLedger(t *testing.T) {
 		require.NoError(t, err)
 
 		ledger := f.Feed(t, `CREATE CHANGEFEED FOR customer, transaction, entry, session
-	                       WITH envelope=wrapped, format=$1, confluent_schema_registry=$2
+	                       WITH format=$1, confluent_schema_registry=$2
 	               `, optFormatAvro, reg.server.URL)
 		defer ledger.Close(t)
 

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -13,13 +13,17 @@ import (
 	gosql "database/sql"
 	"encoding/binary"
 	gojson "encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
@@ -28,6 +32,165 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
+
+func TestEncoders(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tableDesc, err := parseTableDesc(`CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+	require.NoError(t, err)
+	row := sqlbase.EncDatumRow{
+		sqlbase.EncDatum{Datum: tree.NewDInt(1)},
+		sqlbase.EncDatum{Datum: tree.NewDString(`bar`)},
+	}
+	ts := hlc.Timestamp{WallTime: 1, Logical: 2}
+
+	var opts []map[string]string
+	for _, f := range []string{string(optFormatJSON), string(optFormatAvro)} {
+		for _, e := range []string{
+			string(optEnvelopeKeyOnly), string(optEnvelopeRow), string(optEnvelopeWrapped),
+		} {
+			opts = append(opts,
+				map[string]string{optFormat: f, optEnvelope: e},
+				map[string]string{optFormat: f, optEnvelope: e, optUpdatedTimestamps: ``},
+			)
+		}
+	}
+
+	expecteds := map[string]struct {
+		// Either err is set or all of insert, delete, and resolved are.
+		err      string
+		insert   string
+		delete   string
+		resolved string
+	}{
+		`format=json,envelope=key_only`: {
+			insert:   `[1]->`,
+			delete:   `[1]->`,
+			resolved: `{"__crdb__":{"resolved":"1.0000000002"}}`,
+		},
+		`format=json,envelope=key_only,updated`: {
+			insert:   `[1]->`,
+			delete:   `[1]->`,
+			resolved: `{"__crdb__":{"resolved":"1.0000000002"}}`,
+		},
+		`format=json,envelope=row`: {
+			insert:   `[1]->{"a": 1, "b": "bar"}`,
+			delete:   `[1]->`,
+			resolved: `{"__crdb__":{"resolved":"1.0000000002"}}`,
+		},
+		`format=json,envelope=row,updated`: {
+			insert:   `[1]->{"__crdb__": {"updated": "1.0000000002"}, "a": 1, "b": "bar"}`,
+			delete:   `[1]->`,
+			resolved: `{"__crdb__":{"resolved":"1.0000000002"}}`,
+		},
+		`format=json,envelope=wrapped`: {
+			insert:   `[1]->{"after": {"a": 1, "b": "bar"}}`,
+			delete:   `[1]->{"after": null}`,
+			resolved: `{"resolved":"1.0000000002"}`,
+		},
+		`format=json,envelope=wrapped,updated`: {
+			insert:   `[1]->{"after": {"a": 1, "b": "bar"}, "updated": "1.0000000002"}`,
+			delete:   `[1]->{"after": null, "updated": "1.0000000002"}`,
+			resolved: `{"resolved":"1.0000000002"}`,
+		},
+		`format=experimental_avro,envelope=key_only`: {
+			insert:   `{"a":{"long":1}}->`,
+			delete:   `{"a":{"long":1}}->`,
+			resolved: `{"resolved":{"string":"1.0000000002"}}`,
+		},
+		`format=experimental_avro,envelope=key_only,updated`: {
+			insert:   `{"a":{"long":1}}->`,
+			delete:   `{"a":{"long":1}}->`,
+			resolved: `{"resolved":{"string":"1.0000000002"}}`,
+		},
+		`format=experimental_avro,envelope=row`: {
+			err: `envelope=row is not supported with format=experimental_avro`,
+		},
+		`format=experimental_avro,envelope=row,updated`: {
+			err: `envelope=row is not supported with format=experimental_avro`,
+		},
+		`format=experimental_avro,envelope=wrapped`: {
+			insert: `{"a":{"long":1}}->` +
+				`{"after":{"foo":{"a":{"long":1},"b":{"string":"bar"}}}}`,
+			delete:   `{"a":{"long":1}}->{"after":null}`,
+			resolved: `{"resolved":{"string":"1.0000000002"}}`,
+		},
+		`format=experimental_avro,envelope=wrapped,updated`: {
+			insert: `{"a":{"long":1}}->` +
+				`{"after":{"foo":{"a":{"long":1},"b":{"string":"bar"}}},` +
+				`"updated":{"string":"1.0000000002"}}`,
+			delete:   `{"a":{"long":1}}->{"after":null,"updated":{"string":"1.0000000002"}}`,
+			resolved: `{"resolved":{"string":"1.0000000002"}}`,
+		},
+	}
+
+	for _, o := range opts {
+		name := fmt.Sprintf("format=%s,envelope=%s", o[optFormat], o[optEnvelope])
+		if _, ok := o[optUpdatedTimestamps]; ok {
+			name += `,updated`
+		}
+		t.Run(name, func(t *testing.T) {
+			expected := expecteds[name]
+
+			var rowStringFn func([]byte, []byte) string
+			var resolvedStringFn func([]byte) string
+			switch o[optFormat] {
+			case string(optFormatJSON):
+				rowStringFn = func(k, v []byte) string { return fmt.Sprintf(`%s->%s`, k, v) }
+				resolvedStringFn = func(r []byte) string { return string(r) }
+			case string(optFormatAvro):
+				reg := makeTestSchemaRegistry()
+				defer reg.Close()
+				o[optConfluentSchemaRegistry] = reg.server.URL
+				rowStringFn = func(k, v []byte) string {
+					key, value := avroToJSON(t, reg, k), avroToJSON(t, reg, v)
+					return fmt.Sprintf(`%s->%s`, key, value)
+				}
+				resolvedStringFn = func(r []byte) string {
+					return string(avroToJSON(t, reg, r))
+				}
+			default:
+				t.Fatalf(`unknown format: %s`, o[optFormat])
+			}
+
+			e, err := getEncoder(o)
+			if len(expected.err) > 0 {
+				require.EqualError(t, err, expected.err)
+				return
+			}
+			require.NoError(t, err)
+
+			rowInsert := encodeRow{
+				datums:    row,
+				updated:   ts,
+				tableDesc: tableDesc,
+			}
+			keyInsert, err := e.EncodeKey(rowInsert)
+			require.NoError(t, err)
+			keyInsert = append([]byte(nil), keyInsert...)
+			valueInsert, err := e.EncodeValue(rowInsert)
+			require.NoError(t, err)
+			require.Equal(t, expected.insert, rowStringFn(keyInsert, valueInsert))
+
+			rowDelete := encodeRow{
+				datums:    row,
+				deleted:   true,
+				updated:   ts,
+				tableDesc: tableDesc,
+			}
+			keyDelete, err := e.EncodeKey(rowDelete)
+			require.NoError(t, err)
+			keyDelete = append([]byte(nil), keyDelete...)
+			valueDelete, err := e.EncodeValue(rowDelete)
+			require.NoError(t, err)
+			require.Equal(t, expected.delete, rowStringFn(keyDelete, valueDelete))
+
+			resolved, err := e.EncodeResolvedTimestamp(tableDesc.Name, ts)
+			require.NoError(t, err)
+			require.Equal(t, expected.resolved, resolvedStringFn(resolved))
+		})
+	}
+}
 
 type testSchemaRegistry struct {
 	server *httptest.Server
@@ -119,8 +282,8 @@ func TestAvroEncoder(t *testing.T) {
 			`INSERT INTO foo VALUES (1, 'bar'), (2, NULL) RETURNING cluster_logical_timestamp()`,
 		).Scan(&ts1)
 
-		foo := f.Feed(t,
-			`CREATE CHANGEFEED FOR foo WITH format=$1, confluent_schema_registry=$2, resolved`,
+		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo `+
+			`WITH envelope=wrapped, format=$1, confluent_schema_registry=$2, resolved`,
 			optFormatAvro, reg.server.URL)
 		defer foo.Close(t)
 		assertPayloadsAvro(t, reg, foo, []string{
@@ -132,8 +295,8 @@ func TestAvroEncoder(t *testing.T) {
 			t.Fatalf(`expected a resolved timestamp greater than %s got %s`, ts, resolved)
 		}
 
-		fooUpdated := f.Feed(t,
-			`CREATE CHANGEFEED FOR foo WITH format=$1, confluent_schema_registry=$2, updated`,
+		fooUpdated := f.Feed(t, `CREATE CHANGEFEED FOR foo `+
+			`WITH envelope=wrapped, format=$1, confluent_schema_registry=$2, updated`,
 			optFormatAvro, reg.server.URL)
 		defer fooUpdated.Close(t)
 		// Skip over the first two rows since we don't know the statement timestamp.
@@ -170,7 +333,8 @@ func TestAvroSchemaChange(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
 
-		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH format=$1, confluent_schema_registry=$2`,
+		foo := f.Feed(t, `CREATE CHANGEFEED FOR foo `+
+			`WITH envelope=wrapped, format=$1, confluent_schema_registry=$2`,
 			optFormatAvro, reg.server.URL)
 		defer foo.Close(t)
 		assertPayloadsAvro(t, reg, foo, []string{
@@ -204,9 +368,8 @@ func TestAvroLedger(t *testing.T) {
 		_, err := workload.Setup(ctx, db, gen, 0, 0)
 		require.NoError(t, err)
 
-		ledger := f.Feed(t, `CREATE CHANGEFEED FOR
-	                       customer, transaction, entry, session
-	                       WITH format=$1, confluent_schema_registry=$2
+		ledger := f.Feed(t, `CREATE CHANGEFEED FOR customer, transaction, entry, session
+	                       WITH envelope=wrapped, format=$1, confluent_schema_registry=$2
 	               `, optFormatAvro, reg.server.URL)
 		defer ledger.Close(t)
 

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -792,29 +792,22 @@ func assertPayloads(t testing.TB, f testfeed, expected []string) {
 	}
 }
 
-func jsonKeyValueAvro(
-	t testing.TB, reg *testSchemaRegistry, keyBytes, valueBytes []byte,
-) ([]byte, []byte) {
-	keyNative, err := reg.encodedAvroToNative(keyBytes)
-	if err != nil {
-		t.Fatal(err)
+func avroToJSON(t testing.TB, reg *testSchemaRegistry, avroBytes []byte) []byte {
+	if len(avroBytes) == 0 {
+		return nil
 	}
-	valueNative, err := reg.encodedAvroToNative(valueBytes)
+	native, err := reg.encodedAvroToNative(avroBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// The avro textual format is a more natural fit, but it's non-deterministic
 	// because of go's randomized map ordering. Instead, we use gojson.Marshal,
 	// which sorts its object keys and so is deterministic.
-	key, err := gojson.Marshal(keyNative)
+	json, err := gojson.Marshal(native)
 	if err != nil {
 		t.Fatal(err)
 	}
-	value, err := gojson.Marshal(valueNative)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return key, value
+	return json
 }
 
 func assertPayloadsAvro(t testing.TB, reg *testSchemaRegistry, f testfeed, expected []string) {
@@ -826,7 +819,7 @@ func assertPayloadsAvro(t testing.TB, reg *testSchemaRegistry, f testfeed, expec
 		if !ok {
 			break
 		} else if keyBytes != nil || valueBytes != nil {
-			key, value := jsonKeyValueAvro(t, reg, keyBytes, valueBytes)
+			key, value := avroToJSON(t, reg, keyBytes), avroToJSON(t, reg, valueBytes)
 			actual = append(actual, fmt.Sprintf(`%s: %s->%s`, topic, key, value))
 		}
 	}
@@ -892,7 +885,7 @@ func expectResolvedTimestampAvro(t testing.TB, reg *testSchemaRegistry, f testfe
 	t.Helper()
 	topic, _, keyBytes, valueBytes, resolvedBytes, _ := f.Next(t)
 	if keyBytes != nil || valueBytes != nil {
-		key, value := jsonKeyValueAvro(t, reg, keyBytes, valueBytes)
+		key, value := avroToJSON(t, reg, keyBytes), avroToJSON(t, reg, valueBytes)
 		t.Fatalf(`unexpected row %s: %s -> %s`, topic, key, value)
 	}
 	if resolvedBytes == nil {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -870,15 +870,13 @@ func expectResolvedTimestamp(t testing.TB, f testfeed) hlc.Timestamp {
 	}
 
 	var valueRaw struct {
-		CRDB struct {
-			Resolved string `json:"resolved"`
-		} `json:"__crdb__"`
+		Resolved string `json:"resolved"`
 	}
 	if err := gojson.Unmarshal(resolved, &valueRaw); err != nil {
 		t.Fatal(err)
 	}
 
-	return parseTimeToHLC(t, valueRaw.CRDB.Resolved)
+	return parseTimeToHLC(t, valueRaw.Resolved)
 }
 
 func expectResolvedTimestampAvro(t testing.TB, reg *testSchemaRegistry, f testfeed) hlc.Timestamp {

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -131,7 +131,7 @@ func makeCloudStorageSink(
 	}
 
 	switch envelopeType(opts[optEnvelope]) {
-	case optEnvelopeValueOnly:
+	case optEnvelopeWrapped:
 	default:
 		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
 			optEnvelope, opts[optEnvelope])

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -69,7 +69,7 @@ func TestCloudStorageSink(t *testing.T) {
 		optEnvelope: string(optEnvelopeWrapped),
 	}
 	ts := func(i int64) hlc.Timestamp { return hlc.Timestamp{WallTime: i} }
-	e := &jsonEncoder{}
+	e := makeJSONEncoder(opts)
 
 	t.Run(`single-node`, func(t *testing.T) {
 		t1 := &sqlbase.TableDescriptor{Name: `t1`}
@@ -263,7 +263,7 @@ func TestCloudStorageSink(t *testing.T) {
 		require.Equal(t, []string{
 			"v1\nv2\nv3\n",
 			"v4\nv5\n",
-			`{"__crdb__":{"resolved":"5.0000000000"}}`,
+			`{"resolved":"5.0000000000"}`,
 			"v6\nv7\nv8\n",
 		}, slurpDir(t, dir))
 
@@ -272,7 +272,7 @@ func TestCloudStorageSink(t *testing.T) {
 		require.Equal(t, []string{
 			"v1\nv2\nv3\n",
 			"v4\nv5\n",
-			`{"__crdb__":{"resolved":"5.0000000000"}}`,
+			`{"resolved":"5.0000000000"}`,
 			"v6\nv7\nv8\n",
 			"v9\n",
 		}, slurpDir(t, dir))
@@ -304,11 +304,11 @@ func TestCloudStorageSink(t *testing.T) {
 
 		require.Equal(t, []string{
 			"is1\nis2\n",
-			`{"__crdb__":{"resolved":"1.0000000000"}}`,
+			`{"resolved":"1.0000000000"}`,
 			"e2\ne3prev\ne3\n",
-			`{"__crdb__":{"resolved":"3.0000000000"}}`,
+			`{"resolved":"3.0000000000"}`,
 			"e3next\n",
-			`{"__crdb__":{"resolved":"4.0000000000"}}`,
+			`{"resolved":"4.0000000000"}`,
 		}, slurpDir(t, dir))
 	})
 }
@@ -348,7 +348,7 @@ func TestCloudStorage(t *testing.T) {
 	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
 	sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
 
-	foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH resolved, envelope=wrapped`)
+	foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH resolved`)
 
 	sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN b STRING`)
 	sqlDB.Exec(t, `INSERT INTO foo VALUES (2, 'b')`)

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -66,7 +66,7 @@ func TestCloudStorageSink(t *testing.T) {
 	settings.ExternalIODir = dir
 	opts := map[string]string{
 		optFormat:   string(optFormatJSON),
-		optEnvelope: string(optEnvelopeValueOnly),
+		optEnvelope: string(optEnvelopeWrapped),
 	}
 	ts := func(i int64) hlc.Timestamp { return hlc.Timestamp{WallTime: i} }
 	e := &jsonEncoder{}
@@ -348,13 +348,13 @@ func TestCloudStorage(t *testing.T) {
 	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
 	sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
 
-	foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH resolved, envelope=value_only`)
+	foo := f.Feed(t, `CREATE CHANGEFEED FOR foo WITH resolved, envelope=wrapped`)
 
 	sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN b STRING`)
 	sqlDB.Exec(t, `INSERT INTO foo VALUES (2, 'b')`)
 
 	assertPayloads(t, foo, []string{
-		`foo: ->{"a": 1}`,
-		`foo: ->{"a": 2, "b": "b"}`,
+		`foo: ->{"after": {"a": 1}}`,
+		`foo: ->{"after": {"a": 2, "b": "b"}}`,
 	})
 }

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -167,14 +167,8 @@ func TestKafkaSinkEscaping(t *testing.T) {
 
 type testEncoder struct{}
 
-func (testEncoder) EncodeKey(t *sqlbase.TableDescriptor, _ sqlbase.EncDatumRow) ([]byte, error) {
-	panic(`unimplemented`)
-}
-func (testEncoder) EncodeValue(
-	t *sqlbase.TableDescriptor, _ sqlbase.EncDatumRow, _ hlc.Timestamp,
-) ([]byte, error) {
-	panic(`unimplemented`)
-}
+func (testEncoder) EncodeKey(encodeRow) ([]byte, error)   { panic(`unimplemented`) }
+func (testEncoder) EncodeValue(encodeRow) ([]byte, error) { panic(`unimplemented`) }
 func (testEncoder) EncodeResolvedTimestamp(_ string, ts hlc.Timestamp) ([]byte, error) {
 	return []byte(ts.String()), nil
 }

--- a/pkg/ccl/changefeedccl/validator_test.go
+++ b/pkg/ccl/changefeedccl/validator_test.go
@@ -131,7 +131,7 @@ func TestFingerprintValidator(t *testing.T) {
 	t.Run(`wrong_data`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE wrong_data (k INT PRIMARY KEY, v INT)`)
 		v := NewFingerprintValidator(sqlDBRaw, `foo`, `wrong_data`, []string{`p`})
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":10}`, ts[1])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":10}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
 		assertValidatorFailures(t, v,
 			`fingerprints did not match at `+ts[1].AsOfSystemTime()+
@@ -144,12 +144,12 @@ func TestFingerprintValidator(t *testing.T) {
 		if err := v.NoteResolved(`p`, ts[0]); err != nil {
 			t.Fatal(err)
 		}
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
-		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
 		noteResolved(t, v, `p`, ts[2])
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":3}`, ts[3])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
 		noteResolved(t, v, `p`, ts[3])
 		noteResolved(t, v, `p`, ts[4])
 		assertValidatorFailures(t, v)
@@ -157,10 +157,10 @@ func TestFingerprintValidator(t *testing.T) {
 	t.Run(`rows_unsorted`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE rows_unsorted (k INT PRIMARY KEY, v INT)`)
 		v := NewFingerprintValidator(sqlDBRaw, `foo`, `rows_unsorted`, []string{`p`})
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":3}`, ts[3])
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
-		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
 		noteResolved(t, v, `p`, ts[4])
 		assertValidatorFailures(t, v)
 	})
@@ -169,8 +169,8 @@ func TestFingerprintValidator(t *testing.T) {
 		v := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_initial`, []string{`p`})
 		noteResolved(t, v, `p`, ts[0])
 		// Intentionally missing {"k":1,"v":1} at ts[1].
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
-		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
 		noteResolved(t, v, `p`, ts[2])
 		assertValidatorFailures(t, v,
 			`fingerprints did not match at `+ts[2].Prev().AsOfSystemTime()+
@@ -181,10 +181,10 @@ func TestFingerprintValidator(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE missed_middle (k INT PRIMARY KEY, v INT)`)
 		v := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_middle`, []string{`p`})
 		noteResolved(t, v, `p`, ts[0])
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		// Intentionally missing {"k":1,"v":2} at ts[2].
-		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":3}`, ts[3])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
 		noteResolved(t, v, `p`, ts[3])
 		assertValidatorFailures(t, v,
 			`fingerprints did not match at `+ts[2].AsOfSystemTime()+
@@ -197,9 +197,9 @@ func TestFingerprintValidator(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE missed_end (k INT PRIMARY KEY, v INT)`)
 		v := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_end`, []string{`p`})
 		noteResolved(t, v, `p`, ts[0])
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
-		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[2])
 		// Intentionally missing {"k":1,"v":3} at ts[3].
 		noteResolved(t, v, `p`, ts[3])
 		assertValidatorFailures(t, v,
@@ -210,8 +210,8 @@ func TestFingerprintValidator(t *testing.T) {
 	t.Run(`initial_scan`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE initial_scan (k INT PRIMARY KEY, v INT)`)
 		v := NewFingerprintValidator(sqlDBRaw, `foo`, `initial_scan`, []string{`p`})
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":3}`, ts[4])
-		v.NoteRow(ignored, `[1]`, `{"k":2,"v":2}`, ts[4])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[4])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":2,"v":2}}`, ts[4])
 		noteResolved(t, v, `p`, ts[4])
 		assertValidatorFailures(t, v)
 	})
@@ -224,7 +224,7 @@ func TestFingerprintValidator(t *testing.T) {
 	t.Run(`resolved_unsorted`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE resolved_unsorted (k INT PRIMARY KEY, v INT)`)
 		v := NewFingerprintValidator(sqlDBRaw, `foo`, `resolved_unsorted`, []string{`p`})
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
 		noteResolved(t, v, `p`, ts[0])
@@ -233,8 +233,8 @@ func TestFingerprintValidator(t *testing.T) {
 	t.Run(`two_partitions`, func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE two_partitions (k INT PRIMARY KEY, v INT)`)
 		v := NewFingerprintValidator(sqlDBRaw, `foo`, `two_partitions`, []string{`p0`, `p1`})
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":1}`, ts[1])
-		v.NoteRow(ignored, `[1]`, `{"k":1,"v":2}`, ts[2])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
+		v.NoteRow(ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
 		// Intentionally missing {"k":2,"v":2}.
 		noteResolved(t, v, `p0`, ts[2])
 		noteResolved(t, v, `p0`, ts[4])


### PR DESCRIPTION
Because of avro limitations, our avro format can't be made to support anything like `envelope=row`. Instead, we had to put everything in a wrapper. Both because this wrapper ended up being a better format as well as so json and avro match, change the default for json to be `envelope=wrapper` as well. Deprecate `envelope=row` but keep it around for another release.