### PR TITLE
sql: move function privilege check to execution time

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -1880,7 +1879,7 @@ func (ex *connExecutor) resetPlanner(
 		p.statsCollector.Reset(&ex.server.sqlStats, ex.appStats, &ex.phaseTimes)
 	}
 
-	p.semaCtx = tree.MakeSemaContext(ex.sessionData.User == security.RootUser)
+	p.semaCtx = tree.MakeSemaContext()
 	p.semaCtx.Location = &ex.sessionData.DataConversion.Location
 	p.semaCtx.SearchPath = ex.sessionData.SearchPath
 	p.semaCtx.AsOfTimestamp = nil

--- a/pkg/sql/distsqlrun/expr.go
+++ b/pkg/sql/distsqlrun/expr.go
@@ -17,7 +17,6 @@ package distsqlrun
 import (
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
@@ -160,7 +159,7 @@ func (eh *exprHelper) init(
 		return nil
 	}
 	var err error
-	semaContext := tree.MakeSemaContext(evalCtx.SessionData.User == security.RootUser)
+	semaContext := tree.MakeSemaContext()
 	eh.expr, err = processExpression(expr, evalCtx, &semaContext, &eh.vars)
 	if err != nil {
 		return err

--- a/pkg/sql/distsqlrun/expr_test.go
+++ b/pkg/sql/distsqlrun/expr_test.go
@@ -49,7 +49,7 @@ func TestProcessExpression(t *testing.T) {
 	h := tree.MakeIndexedVarHelper(testVarContainer{}, 4)
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
-	semaCtx := tree.MakeSemaContext(false)
+	semaCtx := tree.MakeSemaContext()
 	expr, err := processExpression(e, &evalCtx, &semaCtx, &h)
 	if err != nil {
 		t.Fatal(err)
@@ -76,7 +76,7 @@ func TestProcessExpressionConstantEval(t *testing.T) {
 	h := tree.MakeIndexedVarHelper(nil, 0)
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
-	semaCtx := tree.MakeSemaContext(false)
+	semaCtx := tree.MakeSemaContext()
 	expr, err := processExpression(e, &evalCtx, &semaCtx, &h)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -471,7 +471,7 @@ func (h *harness) runUsingServer(tb testing.TB) {
 func (h *harness) prepareUsingAPI(tb testing.TB) {
 	// Clear any state from previous usage of this harness instance.
 	h.ctx = context.Background()
-	h.semaCtx = tree.MakeSemaContext(false /* privileged */)
+	h.semaCtx = tree.MakeSemaContext()
 	h.evalCtx = tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	h.prepMemo = nil
 	h.cat = nil

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -71,7 +71,7 @@ func TestIndexConstraints(t *testing.T) {
 
 	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
 		ctx := context.Background()
-		semaCtx := tree.MakeSemaContext(false /* privileged */)
+		semaCtx := tree.MakeSemaContext()
 		evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
@@ -254,7 +254,7 @@ func BenchmarkIndexConstraints(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			semaCtx := tree.MakeSemaContext(false /* privileged */)
+			semaCtx := tree.MakeSemaContext()
 			evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 			bld := optbuilder.NewScalar(context.Background(), &semaCtx, &evalCtx, &f)
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -67,7 +67,7 @@ func TestMemoInit(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext(false /* privileged */)
+	semaCtx := tree.MakeSemaContext()
 	if err := semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */); err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestMemoIsStale(t *testing.T) {
 	catalog.Table(tree.NewTableName("t", "abc")).Revoked = true
 
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext(false /* privileged */)
+	semaCtx := tree.MakeSemaContext()
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 	// Initialize context with starting values.

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -99,7 +99,7 @@ func TestBuilder(t *testing.T) {
 				}
 
 				ctx := context.Background()
-				semaCtx := tree.MakeSemaContext(false /* privileged */)
+				semaCtx := tree.MakeSemaContext()
 				evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 				var o xform.Optimizer

--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -129,7 +129,7 @@ func NewOptTester(catalog cat.Catalog, sql string) *OptTester {
 		catalog: catalog,
 		sql:     sql,
 		ctx:     context.Background(),
-		semaCtx: tree.MakeSemaContext(false /* privileged */),
+		semaCtx: tree.MakeSemaContext(),
 		evalCtx: tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings()),
 	}
 

--- a/pkg/sql/opt/testutils/testcat/alter_table.go
+++ b/pkg/sql/opt/testutils/testcat/alter_table.go
@@ -48,7 +48,7 @@ func (tc *Catalog) AlterTable(stmt *tree.AlterTable) {
 
 // injectTableStats sets the table statistics as specified by a JSON object.
 func injectTableStats(tt *Table, statsExpr tree.Expr) {
-	semaCtx := tree.MakeSemaContext(false /* privileged */)
+	semaCtx := tree.MakeSemaContext()
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	typedExpr, err := tree.TypeCheckAndRequire(
 		statsExpr, &semaCtx, types.JSON, "INJECT STATISTICS",

--- a/pkg/sql/opt/testutils/utils.go
+++ b/pkg/sql/opt/testutils/utils.go
@@ -54,7 +54,7 @@ func ParseScalarExpr(sql string, ivc tree.IndexedVarContainer) (tree.TypedExpr, 
 		return nil, err
 	}
 
-	sema := tree.MakeSemaContext(false /* privileged */)
+	sema := tree.MakeSemaContext()
 	sema.IVarContainer = ivc
 
 	return expr.TypeCheck(&sema, types.Any)

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -45,7 +45,7 @@ func TestDetachMemo(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext(false /* privileged */)
+	semaCtx := tree.MakeSemaContext()
 	if err := semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/opt_index_selection_test.go
+++ b/pkg/sql/opt_index_selection_test.go
@@ -96,7 +96,7 @@ func makeSpans(
 	for _, c := range desc.Columns {
 		o.Memo().Metadata().AddColumn(c.Name, c.Type.ToDatumType())
 	}
-	semaCtx := tree.MakeSemaContext(false /* privileged */)
+	semaCtx := tree.MakeSemaContext()
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	bld := optbuilder.NewScalar(context.Background(), &semaCtx, &evalCtx, o.Factory())
 	bld.AllowUnsupportedExpr = true

--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -55,7 +55,7 @@ func readEncodingTests(t testing.TB) []*encodingTest {
 	}
 	f.Close()
 
-	sema := tree.MakeSemaContext(false)
+	sema := tree.MakeSemaContext()
 	evalCtx := tree.MakeTestingEvalContext(nil)
 
 	for _, tc := range tests {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
@@ -238,7 +237,7 @@ func newInternalPlanner(
 	p.stmt = nil
 	p.cancelChecker = sqlbase.NewCancelChecker(ctx)
 
-	p.semaCtx = tree.MakeSemaContext(sd.User == security.RootUser /* privileged */)
+	p.semaCtx = tree.MakeSemaContext()
 	p.semaCtx.Location = &sd.DataConversion.Location
 	p.semaCtx.SearchPath = sd.SearchPath
 

--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -200,7 +200,7 @@ func ClassifyConversion(
 	}
 
 	// See if there's existing cast logic.  If so, return general.
-	ctx := tree.MakeSemaContext(false)
+	ctx := tree.MakeSemaContext()
 	if err := ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
 		return ColumnConversionImpossible, err
 	}

--- a/pkg/sql/sem/tree/constant_eval_test.go
+++ b/pkg/sql/sem/tree/constant_eval_test.go
@@ -33,7 +33,7 @@ func TestConstantEvalArrayComparison(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	semaCtx := tree.MakeSemaContext(true /* privileged */)
+	semaCtx := tree.MakeSemaContext()
 	typedExpr, err := expr.TypeCheck(&semaCtx, types.Any)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -267,7 +267,7 @@ func TestFormatExpr(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx := tree.MakeSemaContext(false)
+			ctx := tree.MakeSemaContext()
 			typeChecked, err := tree.TypeCheck(expr, &ctx, types.Any)
 			if err != nil {
 				t.Fatal(err)
@@ -323,7 +323,7 @@ func TestFormatExpr2(t *testing.T) {
 
 	for i, test := range testData {
 		t.Run(fmt.Sprintf("%d %s", i, test.expr), func(t *testing.T) {
-			ctx := tree.MakeSemaContext(false)
+			ctx := tree.MakeSemaContext()
 			typeChecked, err := tree.TypeCheck(test.expr, &ctx, types.Any)
 			if err != nil {
 				t.Fatal(err)
@@ -379,7 +379,7 @@ func TestFormatPgwireText(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx := tree.MakeSemaContext(false)
+			ctx := tree.MakeSemaContext()
 			typeChecked, err := tree.TypeCheck(expr, &ctx, types.Any)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -77,10 +77,6 @@ type FunctionProperties struct {
 	// get rid of this blacklist.
 	DistsqlBlacklist bool
 
-	// Privileged is set to true when the built-in can only be used by
-	// security.RootUser.
-	Privileged bool
-
 	// Class is the kind of built-in function (normal/aggregate/window/etc.)
 	Class FunctionClass
 

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -275,7 +275,7 @@ func TestNormalizeExpr(t *testing.T) {
 		{`(ROW (a) AS a)`, `((a,) AS a)`}, // Tuple
 	}
 
-	semaCtx := tree.MakeSemaContext(true /* privileged */)
+	semaCtx := tree.MakeSemaContext()
 	for _, d := range testData {
 		t.Run(d.expr, func(t *testing.T) {
 			expr, err := parser.ParseExpr(d.expr)

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -244,7 +244,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 	}
 	for i, d := range testData {
 		t.Run(fmt.Sprintf("%v/%v", d.exprs, d.overloads), func(t *testing.T) {
-			ctx := MakeSemaContext(false)
+			ctx := MakeSemaContext()
 			if err := ctx.Placeholders.Init(2 /* numPlaceholders */, nil /* typeHints */); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -37,7 +37,7 @@ func BenchmarkTypeCheck(b *testing.B) {
 	if err != nil {
 		b.Fatalf("%s: %v", expr, err)
 	}
-	ctx := tree.MakeSemaContext(false)
+	ctx := tree.MakeSemaContext()
 	if err := ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
 		b.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestTypeCheckNormalize(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx := tree.MakeSemaContext(false)
+			ctx := tree.MakeSemaContext()
 			typeChecked, err := tree.TypeCheck(expr, &ctx, types.Any)
 			if err != nil {
 				t.Fatal(err)
@@ -181,7 +181,7 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 		test.expectedPTypes = tree.PlaceholderTypes{}
 	}
 	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
-		ctx := tree.MakeSemaContext(false)
+		ctx := tree.MakeSemaContext()
 		if err := ctx.Placeholders.Init(len(test.ptypes), clonePlaceholderTypes(test.ptypes)); err != nil {
 			t.Fatal(err)
 		}
@@ -324,7 +324,7 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 		{ptypesNone, nil, exprs(placeholder(1), placeholder(0)), placeholderErr},
 	}
 	for i, d := range testData {
-		ctx := tree.MakeSemaContext(false)
+		ctx := tree.MakeSemaContext()
 		if err := ctx.Placeholders.Init(len(d.ptypes), d.ptypes); err != nil {
 			t.Error(err)
 			continue

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -173,7 +173,7 @@ func TestTypeCheck(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)
 			}
-			ctx := tree.MakeSemaContext(false)
+			ctx := tree.MakeSemaContext()
 			if err := ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/sqlbase/computed_exprs.go
+++ b/pkg/sql/sqlbase/computed_exprs.go
@@ -169,7 +169,7 @@ func MakeComputedExprs(
 		*tn, ResultColumnsFromColDescs(tableDesc.Columns),
 	)}
 
-	semaCtx := tree.MakeSemaContext(false)
+	semaCtx := tree.MakeSemaContext()
 	semaCtx.IVarContainer = iv
 
 	addColumnInfo := func(col ColumnDescriptor) {

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -38,7 +38,7 @@ func CreateTestTableDescriptor(
 	if err != nil {
 		return sqlbase.TableDescriptor{}, err
 	}
-	semaCtx := tree.MakeSemaContext(false /* privileged */)
+	semaCtx := tree.MakeSemaContext()
 	evalCtx := tree.MakeTestingEvalContext(st)
 	desc, err := MakeTableDesc(
 		ctx,


### PR DESCRIPTION
Addressing this old TODO, as this planning-time check is problematic
from a plan-caching perspective.

Release note: None