### PR TITLE
changefeedccl: fix bug with changefeeds on previously backfilled tables

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -776,7 +776,7 @@ func assertPayloads(t testing.TB, f testfeed, expected []string) {
 			log.Infof(context.TODO(), `%v %s: %s->%s`, ok, topic, key, value)
 		}
 		if !ok {
-			break
+			t.Fatalf(`expected another row: %s`, f.Err())
 		} else if key != nil || value != nil {
 			actual = append(actual, fmt.Sprintf(`%s: %s->%s`, topic, key, value))
 		}


### PR DESCRIPTION
An internal sanity assertion was a bit overeager. It double-check that
if a schema change backfill happened, that we've also done the
changefeed backfill, but it was also triggering on schema change
backfills that happened before the changefeed even started.

Closes #34314

Release note (bug fix): `CHANGEFEED` now can be started on tables that
have previously been backfilled by schema changes.