### PR TITLE
release-2.1: distsqlrun: release flow registry lock before Pushing timeout error

### DIFF
--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -80,7 +80,7 @@ func runTestFlow(
 	flow.Wait()
 	flow.Cleanup(ctx)
 
-	if !rowBuf.ProducerClosed {
+	if !rowBuf.ProducerClosed() {
 		t.Errorf("output not closed")
 	}
 

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -541,6 +541,8 @@ type RowBufferArgs struct {
 	// If it returns an empty row and metadata, then RowBuffer.Next() is allowed
 	// to run normally. Otherwise, the values are returned from RowBuffer.Next().
 	OnNext func(*RowBuffer) (sqlbase.EncDatumRow, *ProducerMetadata)
+	// OnPush, if specified, is called as the first thing in the Push() method.
+	OnPush func(sqlbase.EncDatumRow, *ProducerMetadata)
 }
 
 // NewRowBuffer creates a RowBuffer with the given schema and initial rows.
@@ -561,6 +563,9 @@ func NewRowBuffer(
 
 // Push is part of the RowReceiver interface.
 func (rb *RowBuffer) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) ConsumerStatus {
+	if rb.args.OnPush != nil {
+		rb.args.OnPush(row, meta)
+	}
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 	if rb.mu.producerClosed {

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -16,9 +16,8 @@ package distsqlrun
 
 import (
 	"context"
-	"testing"
-
 	"fmt"
+	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -129,7 +128,7 @@ func TestDistinct(t *testing.T) {
 			}
 
 			d.Run(context.Background(), nil /* wg */)
-			if !out.ProducerClosed {
+			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
 			var res sqlbase.EncDatumRows

--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -29,6 +29,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var errNoInboundStreamConnection = errors.New("no inbound stream connection")
+
 var settingFlowStreamTimeout = settings.RegisterNonNegativeDurationSetting(
 	"sql.distsql.flow_stream_timeout",
 	"amount of time incoming streams wait for a flow to be set up before erroring out",
@@ -207,24 +209,20 @@ func (fr *flowRegistry) RegisterFlow(
 	if len(inboundStreams) > 0 {
 		// Set up a function to time out inbound streams after a while.
 		entry.streamTimer = time.AfterFunc(timeout, func() {
+			var timedOutReceivers []RowReceiver
 			fr.Lock()
-			defer fr.Unlock()
-			numTimedOut := 0
 			for streamID, is := range entry.inboundStreams {
 				if !is.connected && !is.canceled {
 					is.canceled = true
-					numTimedOut++
-					// We're giving up waiting for this inbound stream. Send an error to
-					// its consumer; the error will propagate and eventually drain all the
-					// processors.
-					is.receiver.Push(
-						nil, /* row */
-						&ProducerMetadata{Err: errors.Errorf("no inbound stream connection")})
-					is.receiver.ProducerDone()
+					// We're giving up waiting for this inbound stream. We will push an
+					// error to its consumer after fr.Unlock; the error will propagate and
+					// eventually drain all the processors.
+					timedOutReceivers = append(timedOutReceivers, is.receiver)
 					fr.finishInboundStreamLocked(id, streamID)
 				}
 			}
-			if numTimedOut != 0 {
+			fr.Unlock()
+			if len(timedOutReceivers) != 0 {
 				// The span in the context might be finished by the time this runs. In
 				// principle, we could ForkCtxSpan() beforehand, but we don't want to
 				// create the extra span every time.
@@ -233,9 +231,15 @@ func (fr *flowRegistry) RegisterFlow(
 					timeoutCtx,
 					"flow id:%s : %d inbound streams timed out after %s; propagated error throughout flow",
 					id,
-					numTimedOut,
+					len(timedOutReceivers),
 					timeout,
 				)
+			}
+			for _, r := range timedOutReceivers {
+				r.Push(
+					nil, /* row */
+					&ProducerMetadata{Err: errNoInboundStreamConnection})
+				r.ProducerDone()
 			}
 		})
 	}

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -242,9 +242,12 @@ func TestStreamConnectionTimeout(t *testing.T) {
 		return nil
 	})
 
-	if !consumer.ProducerClosed() {
-		t.Fatalf("expected consumer to have been closed when the flow timed out")
-	}
+	testutils.SucceedsSoon(t, func() error {
+		if !consumer.ProducerClosed() {
+			return errors.New("expected consumer to have been closed when the flow timed out")
+		}
+		return nil
+	})
 
 	// Create a dummy server stream to pass to ConnectInboundStream.
 	serverStream, _ /* clientStream */, cleanup, err := createDummyStream()
@@ -583,10 +586,11 @@ func TestInboundStreamTimeoutIsRetryable(t *testing.T) {
 
 	fr := makeFlowRegistry(0)
 	wg := sync.WaitGroup{}
-	rb := &RowBuffer{}
+	rc := &RowChannel{}
+	rc.initWithBufSizeAndNumSenders(oneIntCol, 1 /* chanBufSize */, 1 /* numSenders */)
 	inboundStreams := map[StreamID]*inboundStreamInfo{
 		0: {
-			receiver:  rb,
+			receiver:  rc,
 			waitGroup: &wg,
 		},
 	}
@@ -597,9 +601,64 @@ func TestInboundStreamTimeoutIsRetryable(t *testing.T) {
 		t.Fatal(err)
 	}
 	wg.Wait()
-	if _, meta := rb.Next(); meta == nil {
+	if _, meta := rc.Next(); meta == nil {
 		t.Fatal("expected error but got no meta")
 	} else if !testutils.IsSQLRetryableError(meta.Err) {
 		t.Fatalf("unexpected error: %v", meta.Err)
 	}
+}
+
+// TestTimeoutPushDoesntBlockRegister verifies that in the case of a timeout
+// error, we are still able to register flows while Pushing the error (#34041).
+func TestTimeoutPushDoesntBlockRegister(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	fr := makeFlowRegistry(0)
+	// pushChan is used to be able to tell when a Push on the RowBuffer has
+	// occurred.
+	pushChan := make(chan *ProducerMetadata)
+	rc := NewRowBuffer(
+		oneIntCol,
+		nil, /* rows */
+		RowBufferArgs{
+			OnPush: func(_ sqlbase.EncDatumRow, meta *ProducerMetadata) {
+				pushChan <- meta
+				<-pushChan
+			},
+		},
+	)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	inboundStreams := map[StreamID]*inboundStreamInfo{
+		0: {
+			receiver:  rc,
+			waitGroup: &wg,
+		},
+	}
+
+	// RegisterFlow with an immediate timeout.
+	if err := fr.RegisterFlow(
+		ctx, FlowID{}, &Flow{}, inboundStreams, 0, /* timeout */
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure RegisterFlow performs a Push.
+	meta := <-pushChan
+	if !testutils.IsError(meta.Err, errNoInboundStreamConnection.Error()) {
+		t.Fatalf("unexpected err %v, expected %s", meta.Err, errNoInboundStreamConnection)
+	}
+
+	// Attempt to register a flow. Note that this flow has no inbound streams, so
+	// Pushing to the RowBuffer is unexpected.
+	if err := fr.RegisterFlow(
+		ctx, FlowID{UUID: uuid.MakeV4()}, &Flow{}, nil /* inboundStreams */, time.Hour, /* timeout */
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unblock the first RegisterFlow.
+	close(pushChan)
 }

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -242,7 +242,7 @@ func TestStreamConnectionTimeout(t *testing.T) {
 		return nil
 	})
 
-	if !consumer.ProducerClosed {
+	if !consumer.ProducerClosed() {
 		t.Fatalf("expected consumer to have been closed when the flow timed out")
 	}
 

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -114,7 +114,7 @@ func TestHashJoiner(t *testing.T) {
 				h.Run(context.Background(), nil /* wg */)
 				side = otherSide(h.storedSide)
 
-				if !out.ProducerClosed {
+				if !out.ProducerClosed() {
 					return errors.New("output RowReceiver not closed")
 				}
 
@@ -231,7 +231,7 @@ func TestHashJoinerError(t *testing.T) {
 			setup(h)
 			h.Run(context.Background(), nil /* wg */)
 
-			if !out.ProducerClosed {
+			if !out.ProducerClosed() {
 				return errors.New("output RowReceiver not closed")
 			}
 
@@ -367,7 +367,7 @@ func TestHashJoinerDrain(t *testing.T) {
 	out.ConsumerDone()
 	h.Run(context.Background(), nil /* wg */)
 
-	if !out.ProducerClosed {
+	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
 	}
 
@@ -491,7 +491,7 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 
 	h.Run(context.Background(), nil /* wg */)
 
-	if !out.ProducerClosed {
+	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
 	}
 

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
@@ -411,7 +411,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 				t.Fatal(err)
 			}
 			irj.Run(ctx, nil /* wg */)
-			if !out.ProducerClosed {
+			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
 
@@ -612,7 +612,7 @@ func TestInterleavedReaderJoinerTrailingMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	irj.Run(ctx, nil /* wg */)
-	if !out.ProducerClosed {
+	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
 	}
 

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -351,7 +351,7 @@ func TestJoinReader(t *testing.T) {
 				if !in.Done {
 					t.Fatal("joinReader didn't consume all the rows")
 				}
-				if !out.ProducerClosed {
+				if !out.ProducerClosed() {
 					t.Fatalf("output RowReceiver not closed")
 				}
 

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -715,7 +715,7 @@ func TestMergeJoiner(t *testing.T) {
 
 			m.Run(context.Background(), nil /* wg */)
 
-			if !out.ProducerClosed {
+			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
 
@@ -821,7 +821,7 @@ func TestConsumerClosed(t *testing.T) {
 
 			m.Run(context.Background(), nil /* wg */)
 
-			if !out.ProducerClosed {
+			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
 		})

--- a/pkg/sql/distsqlrun/routers_test.go
+++ b/pkg/sql/distsqlrun/routers_test.go
@@ -152,7 +152,7 @@ func TestRouters(t *testing.T) {
 
 			rows := make([]sqlbase.EncDatumRows, len(bufs))
 			for i, b := range bufs {
-				if !b.ProducerClosed {
+				if !b.ProducerClosed() {
 					t.Fatalf("bucket not closed: %d", i)
 				}
 				rows[i] = b.GetRowsNoMeta(t)

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -331,7 +331,7 @@ func TestSorter(t *testing.T) {
 							}
 						}
 						s.Run(context.Background(), nil /* wg */)
-						if !out.ProducerClosed {
+						if !out.ProducerClosed() {
 							t.Fatalf("output RowReceiver not closed")
 						}
 

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -152,7 +152,7 @@ func TestTableReader(t *testing.T) {
 					results = tr
 				} else {
 					tr.Run(ctx, nil /* wg */)
-					if !buf.ProducerClosed {
+					if !buf.ProducerClosed() {
 						t.Fatalf("output RowReceiver not closed")
 					}
 					buf.Start(ctx)
@@ -246,7 +246,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 			results = tr
 		} else {
 			tr.Run(ctx, nil /* wg */)
-			if !buf.ProducerClosed {
+			if !buf.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
 			buf.Start(ctx)

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -363,7 +363,7 @@ func runProcessorTest(
 	}
 
 	p.Run(context.Background(), nil /* wg */)
-	if !out.ProducerClosed {
+	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
 	}
 	var res sqlbase.EncDatumRows

--- a/pkg/sql/distsqlrun/values_test.go
+++ b/pkg/sql/distsqlrun/values_test.go
@@ -83,7 +83,7 @@ func TestValuesProcessor(t *testing.T) {
 						t.Fatal(err)
 					}
 					v.Run(context.Background(), nil)
-					if !out.ProducerClosed {
+					if !out.ProducerClosed() {
 						t.Fatalf("output RowReceiver not closed")
 					}
 

--- a/pkg/sql/distsqlrun/zigzagjoiner_test.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner_test.go
@@ -510,7 +510,7 @@ func TestZigzagJoiner(t *testing.T) {
 
 			z.Run(ctx, nil /* wg */)
 
-			if !out.ProducerClosed {
+			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
 


### PR DESCRIPTION
Backport 2/2 commits from #34218.

/cc @cockroachdb/release

---

As this Push might block indefinitely, resulting in blocking new Flow
registration.

Fixes #34041

Release note (bug fix): Fix a back up in flow creation observed by "no
inbound stream connection" caused by not releasing a lock before
attempting a possibly blocking operation.

cc @tim-o 

Note that this is an effective 28 LOC change. The rest are changes to test files and a struct used only in tests (necessary to prevent a race condition).