### PR TITLE
opt: add JoinLimit session variable

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1660,8 +1660,8 @@ func (m *sessionDataMutator) SetZigzagJoinEnabled(val bool) {
 	m.data.ZigzagJoinEnabled = val
 }
 
-func (m *sessionDataMutator) SetReorderJoins(val bool) {
-	m.data.ReorderJoins = val
+func (m *sessionDataMutator) SetReorderJoinsLimit(val int) {
+	m.data.ReorderJoinsLimit = val
 }
 
 func (m *sessionDataMutator) SetVectorize(val sessiondata.VectorizeExecMode) {

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1341,7 +1341,7 @@ default_transaction_read_only      off           NULL      NULL        NULL     
 distsql                            off           NULL      NULL        NULL        string
 experimental_enable_zigzag_join    off           NULL      NULL        NULL        string
 experimental_force_split_at        off           NULL      NULL        NULL        string
-experimental_reorder_joins         off           NULL      NULL        NULL        string
+experimental_reorder_joins_limit   0             NULL      NULL        NULL        string
 experimental_serial_normalization  rowid         NULL      NULL        NULL        string
 experimental_vectorize             off           NULL      NULL        NULL        string
 extra_float_digits                 0             NULL      NULL        NULL        string
@@ -1386,7 +1386,7 @@ default_transaction_read_only      off           NULL  user     NULL      off   
 distsql                            off           NULL  user     NULL      off           off
 experimental_enable_zigzag_join    off           NULL  user     NULL      off           off
 experimental_force_split_at        off           NULL  user     NULL      off           off
-experimental_reorder_joins         off           NULL  user     NULL      off           off
+experimental_reorder_joins_limit   0             NULL  user     NULL      0             0
 experimental_serial_normalization  rowid         NULL  user     NULL      rowid         rowid
 experimental_vectorize             off           NULL  user     NULL      off           off
 extra_float_digits                 0             NULL  user     NULL      0             2
@@ -1428,7 +1428,7 @@ distsql                            NULL    NULL     NULL     NULL        NULL
 experimental_enable_zigzag_join    NULL    NULL     NULL     NULL        NULL
 experimental_force_split_at        NULL    NULL     NULL     NULL        NULL
 experimental_optimizer_mutations   NULL    NULL     NULL     NULL        NULL
-experimental_reorder_joins         NULL    NULL     NULL     NULL        NULL
+experimental_reorder_joins_limit   NULL    NULL     NULL     NULL        NULL
 experimental_serial_normalization  NULL    NULL     NULL     NULL        NULL
 experimental_vectorize             NULL    NULL     NULL     NULL        NULL
 extra_float_digits                 NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -38,7 +38,7 @@ default_transaction_read_only      off
 distsql                            off
 experimental_enable_zigzag_join    off
 experimental_force_split_at        off
-experimental_reorder_joins         off
+experimental_reorder_joins_limit   0
 experimental_serial_normalization  rowid
 experimental_vectorize             off
 extra_float_digits                 0

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -56,7 +56,7 @@ render               ·                   ·                (a, b, c, d, b, x, c
 ·                    spans               /1-/1/#          ·                         ·
 
 statement ok
-SET experimental_reorder_joins = true
+SET experimental_reorder_joins_limit = 3
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -438,6 +438,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if len(r.InterestingOrderings) > 0 {
 			tp.Childf("interesting orderings: %s", r.InterestingOrderings.String())
 		}
+		if r.JoinSize > 1 {
+			tp.Childf("join-size: %d", r.JoinSize)
+		}
 	}
 
 	switch t := e.(type) {

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -135,7 +135,7 @@ type Memo struct {
 	// The following are selected fields from SessionData which can affect
 	// planning. We need to cross-check these before reusing a cached memo.
 	dataConversion    sessiondata.DataConversionConfig
-	reorderJoins      bool
+	reorderJoinsLimit int
 	zigzagJoinEnabled bool
 
 	// curID is the highest currently in-use scalar expression ID.
@@ -157,7 +157,7 @@ func (m *Memo) Init(evalCtx *tree.EvalContext) {
 	m.memEstimate = 0
 
 	m.dataConversion = evalCtx.SessionData.DataConversion
-	m.reorderJoins = evalCtx.SessionData.ReorderJoins
+	m.reorderJoinsLimit = evalCtx.SessionData.ReorderJoinsLimit
 	m.zigzagJoinEnabled = evalCtx.SessionData.ZigzagJoinEnabled
 }
 
@@ -253,7 +253,7 @@ func (m *Memo) IsStale(
 	// Memo is stale if fields from SessionData that can affect planning have
 	// changed.
 	if !m.dataConversion.Equals(&evalCtx.SessionData.DataConversion) ||
-		m.reorderJoins != evalCtx.SessionData.ReorderJoins ||
+		m.reorderJoinsLimit != evalCtx.SessionData.ReorderJoinsLimit ||
 		m.zigzagJoinEnabled != evalCtx.SessionData.ZigzagJoinEnabled {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -130,7 +130,7 @@ WHERE a.y>1 AND a.x::string=b.x
 ORDER BY y
 LIMIT 10
 ----
-memo (optimized, ~15KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
+memo (optimized, ~16KB, required=[presentation: y:2,x:3,c:6] [ordering: +2])
  ├── G1: (project G2 G3 y x)
  │    ├── [presentation: y:2,x:3,c:6] [ordering: +2]
  │    │    ├── best: (project G2="[ordering: +2]" G3 y x)

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1486,9 +1486,3 @@ func (c *CustomFuncs) SortFilters(f memo.FiltersExpr) memo.FiltersExpr {
 	})
 	return result
 }
-
-// ShouldReorderJoins returns whether the optimizer should attempt to find
-// a better ordering of inner joins.
-func (c *CustomFuncs) ShouldReorderJoins() bool {
-	return c.f.evalCtx.SessionData.ReorderJoins
-}

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -44,6 +44,9 @@ const (
 	// HasHoistableSubquery is set when the Scalar.Rule.HasHoistableSubquery
 	// is populated.
 	HasHoistableSubquery
+
+	// JoinSize is set when the Scalar.Rule.JoinSize field is populated.
+	JoinSize
 )
 
 // Shared are properties that are shared by both relational and scalar
@@ -315,6 +318,11 @@ type Relational struct {
 		// and SimplifyRightJoinWithFilters rules. It is only valid once the
 		// Rule.Available.UnfilteredCols bit has been set.
 		UnfilteredCols opt.ColSet
+
+		// JoinSize is the number of relations being *inner* joined underneath
+		// this node. It is used to only reorder joins via AssociateJoin up to
+		// a certain limit.
+		JoinSize int
 	}
 }
 

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -103,12 +103,12 @@
 #   A JOIN (B JOIN C ON B.x = C.x) ON A.y = B.y
 [AssociateJoin, Explore]
 (InnerJoin
-    (InnerJoin
-        $innerLeft:* & (ShouldReorderJoins)
+    $left:(InnerJoin
+        $innerLeft:*
         $innerRight:*
         $innerOn:*
     )
-    $right:*
+    $right:* & (ShouldReorderJoins $left $right)
     $on:*
 )
 =>

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -263,7 +263,7 @@ sort
 memo
 SELECT y, z FROM a WHERE x>y ORDER BY y
 ----
-memo (optimized, ~4KB, required=[presentation: y:2,z:3] [ordering: +2])
+memo (optimized, ~5KB, required=[presentation: y:2,z:3] [ordering: +2])
  ├── G1: (project G2 G3 y z)
  │    ├── [presentation: y:2,z:3] [ordering: +2]
  │    │    ├── best: (sort G1)
@@ -566,7 +566,7 @@ memo (optimized, ~3KB, required=[presentation: y:2] [ordering: +5])
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY -ordinality
 ----
-memo (optimized, ~4KB, required=[presentation: y:2] [ordering: +6])
+memo (optimized, ~5KB, required=[presentation: y:2] [ordering: +6])
  ├── G1: (project G2 G3 y)
  │    ├── [presentation: y:2] [ordering: +6]
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -849,7 +849,7 @@ memo (optimized, ~5KB, required=[presentation: array_agg:5])
 memo
 SELECT array_agg(k) FROM (SELECT * FROM kuvw WHERE u=v ORDER BY u) GROUP BY w
 ----
-memo (optimized, ~8KB, required=[presentation: array_agg:5])
+memo (optimized, ~9KB, required=[presentation: array_agg:5])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:5]
  │         ├── best: (project G2 G3 array_agg)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -414,7 +414,7 @@ inner-join
 memo
 SELECT * FROM stu AS l JOIN stu AS r ON (l.s, l.t, l.u) = (r.s, r.t, r.u)
 ----
-memo (optimized, ~9KB, required=[presentation: s:1,t:2,u:3,s:4,t:5,u:6])
+memo (optimized, ~10KB, required=[presentation: s:1,t:2,u:3,s:4,t:5,u:6])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+2,+3,+4,+5,+6) (merge-join G2 G3 G5 inner-join,+3,+2,+1,+6,+5,+4) (lookup-join G2 G5 stu,keyCols=[1 2 3],outCols=(1-6)) (lookup-join G2 G5 stu@uts,keyCols=[3 2 1],outCols=(1-6)) (merge-join G3 G2 G5 inner-join,+4,+5,+6,+1,+2,+3) (merge-join G3 G2 G5 inner-join,+6,+5,+4,+3,+2,+1) (lookup-join G3 G5 stu,keyCols=[4 5 6],outCols=(1-6)) (lookup-join G3 G5 stu@uts,keyCols=[6 5 4],outCols=(1-6))
  │    └── [presentation: s:1,t:2,u:3,s:4,t:5,u:6]
  │         ├── best: (merge-join G2="[ordering: +1,+2,+3]" G3="[ordering: +4,+5,+6]" G5 inner-join,+1,+2,+3,+4,+5,+6)
@@ -617,7 +617,7 @@ left-join (merge)
 memo
 SELECT * FROM abc JOIN xyz ON a=b
 ----
-memo (optimized, ~11KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
  │         ├── best: (inner-join G3 G2 G4)
@@ -1554,7 +1554,7 @@ inner-join (zigzag pqr@q pqr@s)
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
-memo (optimized, ~31KB, required=[presentation: p:1,q:2,r:3,s:4])
+memo (optimized, ~32KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G1: (select G2 G3) (lookup-join G4 G5 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G6 G7 pqr,keyCols=[1],outCols=(1-4)) (lookup-join G8 G7 pqr,keyCols=[1],outCols=(1-4)) (lookup-join G9 G7 pqr,keyCols=[1],outCols=(1-4)) (select G10 G11) (select G12 G13) (select G14 G7) (select G15 G7)
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
@@ -1757,7 +1757,7 @@ inner-join (lookup t5)
 memo
 SELECT a FROM t5 WHERE b @> '{"a":1, "c":2}'
 ----
-memo (optimized, ~10KB, required=[presentation: a:1])
+memo (optimized, ~11KB, required=[presentation: a:1])
  ├── G1: (project G2 G3 a)
  │    └── [presentation: a:1]
  │         ├── best: (project G2 G3 a)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -50,7 +50,7 @@ TABLE abc
  └── INDEX primary
       └── a int not null
 
-opt reorder-joins
+opt join-limit=3
 SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
 inner-join (lookup bx)
@@ -74,7 +74,7 @@ inner-join (lookup bx)
  │    └── filters (true)
  └── filters (true)
 
-opt reorder-joins
+opt join-limit=3
 SELECT * FROM bx, abc, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
 inner-join (lookup bx)
@@ -98,7 +98,7 @@ inner-join (lookup bx)
  │    └── filters (true)
  └── filters (true)
 
-opt reorder-joins
+opt join-limit=3
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
 inner-join (lookup bx)
@@ -122,7 +122,31 @@ inner-join (lookup bx)
  │    └── filters (true)
  └── filters (true)
 
-memo reorder-joins
+opt join-limit=2 expect-not=AssociateJoin
+SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
+----
+inner-join (lookup bx)
+ ├── columns: b:1(int!null) x:2(int) c:3(int!null) y:4(int) a:5(int!null) b:6(int!null) c:7(int!null) d:8(int)
+ ├── key columns: [6] = [1]
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-8)
+ ├── inner-join (lookup cy)
+ │    ├── columns: cy.c:3(int!null) y:4(int) a:5(int!null) abc.b:6(int) abc.c:7(int!null) d:8(int)
+ │    ├── key columns: [7] = [3]
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(3-8)
+ │    ├── scan abc
+ │    │    ├── columns: a:5(int!null) abc.b:6(int) abc.c:7(int) d:8(int)
+ │    │    ├── constraint: /5: [/1 - /1]
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(5-8)
+ │    └── filters (true)
+ └── filters (true)
+
+memo join-limit=3
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
 memo (optimized, ~17KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
@@ -179,7 +203,7 @@ memo (optimized, ~17KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8]
  ├── G21: (variable a)
  └── G22: (const 1)
 
-opt reorder-joins
+opt join-limit=4
 SELECT * FROM bx, cy, dz, abc WHERE a = 1
 ----
 inner-join
@@ -214,6 +238,73 @@ inner-join
  │    ├── columns: bx.b:1(int!null) x:2(int)
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
+ └── filters (true)
+
+opt join-limit=3 format=show-all
+SELECT * FROM abc, bx, cy, dz WHERE a = 1
+----
+inner-join
+ ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int) b:5(int!null) x:6(int) c:7(int!null) y:8(int) d:9(int!null) z:10(int)
+ ├── stats: [rows=1e+09]
+ ├── cost: 32525668.7
+ ├── key: (5,7,9)
+ ├── fd: ()-->(1-4), (5)-->(6), (7)-->(8), (9)-->(10)
+ ├── prune: (2-10)
+ ├── interesting orderings: (+7) (+9) (+5) (+1)
+ ├── inner-join
+ │    ├── columns: t.public.bx.b:5(int!null) t.public.bx.x:6(int) t.public.cy.c:7(int!null) t.public.cy.y:8(int) t.public.dz.d:9(int!null) t.public.dz.z:10(int)
+ │    ├── stats: [rows=1e+09]
+ │    ├── cost: 10025667.5
+ │    ├── key: (5,7,9)
+ │    ├── fd: (5)-->(6), (7)-->(8), (9)-->(10)
+ │    ├── prune: (5-10)
+ │    ├── interesting orderings: (+7) (+9) (+5)
+ │    ├── join-size: 3
+ │    ├── inner-join
+ │    │    ├── columns: t.public.cy.c:7(int!null) t.public.cy.y:8(int) t.public.dz.d:9(int!null) t.public.dz.z:10(int)
+ │    │    ├── stats: [rows=1000000]
+ │    │    ├── cost: 12110.03
+ │    │    ├── key: (7,9)
+ │    │    ├── fd: (7)-->(8), (9)-->(10)
+ │    │    ├── prune: (7-10)
+ │    │    ├── interesting orderings: (+7) (+9)
+ │    │    ├── join-size: 2
+ │    │    ├── scan t.public.cy
+ │    │    │    ├── columns: t.public.cy.c:7(int!null) t.public.cy.y:8(int)
+ │    │    │    ├── stats: [rows=1000]
+ │    │    │    ├── cost: 1040.01
+ │    │    │    ├── key: (7)
+ │    │    │    ├── fd: (7)-->(8)
+ │    │    │    ├── prune: (7,8)
+ │    │    │    └── interesting orderings: (+7)
+ │    │    ├── scan t.public.dz
+ │    │    │    ├── columns: t.public.dz.d:9(int!null) t.public.dz.z:10(int)
+ │    │    │    ├── stats: [rows=1000]
+ │    │    │    ├── cost: 1040.01
+ │    │    │    ├── key: (9)
+ │    │    │    ├── fd: (9)-->(10)
+ │    │    │    ├── prune: (9,10)
+ │    │    │    └── interesting orderings: (+9)
+ │    │    └── filters (true)
+ │    ├── scan t.public.bx
+ │    │    ├── columns: t.public.bx.b:5(int!null) t.public.bx.x:6(int)
+ │    │    ├── stats: [rows=1000]
+ │    │    ├── cost: 1040.01
+ │    │    ├── key: (5)
+ │    │    ├── fd: (5)-->(6)
+ │    │    ├── prune: (5,6)
+ │    │    └── interesting orderings: (+5)
+ │    └── filters (true)
+ ├── scan t.public.abc
+ │    ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int) t.public.abc.c:3(int) t.public.abc.d:4(int)
+ │    ├── constraint: /1: [/1 - /1]
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ │    ├── cost: 1.09
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-4)
+ │    ├── prune: (2-4)
+ │    └── interesting orderings: (+1)
  └── filters (true)
 
 # Note the difference in memo size for with and without reorder-joins, for only four tables.
@@ -261,7 +352,7 @@ memo (optimized, ~11KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,
  ├── G12: (variable a)
  └── G13: (const 1)
 
-memo reorder-joins
+memo join-limit=4
 SELECT * FROM bx, cy, dz, abc WHERE a = 1
 ----
 memo (optimized, ~25KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -135,7 +135,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k = 5
 ----
-memo (optimized, ~6KB, required=[presentation: k:1])
+memo (optimized, ~7KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -234,7 +234,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND v = 5
 ----
-memo (optimized, ~7KB, required=[presentation: k:1])
+memo (optimized, ~8KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -65,9 +65,9 @@ type SessionData struct {
 	// ZigzagJoinEnabled indicates whether the optimizer should try and plan a
 	// zigzag join.
 	ZigzagJoinEnabled bool
-	// ReorderJoins indicates whether the optimizer should try to reorder the
-	// joins in a query.
-	ReorderJoins bool
+	// ReorderJoinsLimit indicates the number of joins at which the optimizer should
+	// stop attempting to reorder.
+	ReorderJoinsLimit int
 	// SequenceState gives access to the SQL sequences that have been manipulated
 	// by the session.
 	SequenceState *SequenceState

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -342,20 +342,22 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
-	`experimental_reorder_joins`: {
-		GetStringVal: makeBoolGetStringValFn(`experimental_reorder_joins`),
+	`experimental_reorder_joins_limit`: {
+		GetStringVal: makeIntGetStringValFn(`experimental_reorder_joins_limit`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
-			b, err := parsePostgresBool(s)
+			b, err := strconv.ParseInt(s, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.SetReorderJoins(b)
+			m.SetReorderJoinsLimit(int(b))
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData.ReorderJoins)
+			return strconv.FormatInt(int64(evalCtx.SessionData.ReorderJoinsLimit), 10)
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: func(_ *settings.Values) string {
+			return "0"
+		},
 	},
 
 	// CockroachDB extension.


### PR DESCRIPTION
This commit introduces the JoinLimit session variable, which enables a
transformation-based search of potential join orderings when a query
contains no more than a specified number of joins. I think we could
theoretically safely set this value to a default of 4 or 5 today, and I
suspect without too much trouble we can speed it up enough to bump it up
to 6 or 7.

This is sort of a crude heuristic: we count the number of joins
*globally*, even though those might not all be part of the same join
expression.

I briefly tried to compute the size of the biggest join tree via a
logical property, but that wasn't great, since we'd want it to be a Rule
property, and the Shared properties don't have those. In the end I
decided this was probably simplest (we just walk the tree after build).

This method does have some perf impact:

Before:
```
BenchmarkPhases/kv-read/Explore-8         	  100000	     12449 ns/op
BenchmarkPhases/kv-read-no-prep/Explore-8 	   30000	     40384 ns/op
BenchmarkPhases/kv-read-const/Explore-8   	10000000	       120 ns/op
BenchmarkPhases/tpcc-new-order/Explore-8  	   30000	     41891 ns/op
BenchmarkPhases/tpcc-delivery/Explore-8   	   50000	     26807 ns/op
BenchmarkPhases/tpcc-stock-level/Explore-8     	   10000	    134082 ns/op
```

After:
```
BenchmarkPhases/kv-read/Explore-8         	  100000	     12216 ns/op
BenchmarkPhases/kv-read-no-prep/Explore-8 	   30000	     41637 ns/op
BenchmarkPhases/kv-read-const/Explore-8   	10000000	       123 ns/op
BenchmarkPhases/tpcc-new-order/Explore-8  	   30000	     42511 ns/op
BenchmarkPhases/tpcc-delivery/Explore-8   	   50000	     27790 ns/op
BenchmarkPhases/tpcc-stock-level/Explore-8         10000	    137069 ns/op
```

Alternatively we could increment the counter in the memo during
the build phase, which might reduce the perf impact.

Next steps also include adding reordering rules for outer joins.

Planning time for chain queries:
<img width="658" alt="image" src="https://user-images.githubusercontent.com/409075/51936630-a2094200-23d6-11e9-847c-5b12ab976fff.png">

Release note (sql change): replaced experimental_reorder_joins session
variable with experimental_join_limit, which will reorder joins in
queries with fewer than the specified number of joins.