### PR TITLE
sql: reuse builtin instances when computing window functions

### DIFF
--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -478,6 +478,9 @@ func (a *anyNotNullAggregate) Result() (tree.Datum, error) {
 	return a.val, nil
 }
 
+// Reset implements tree.AggregateFunc interface.
+func (a *anyNotNullAggregate) Reset(context.Context) {}
+
 // Close is no-op in aggregates using constant space.
 func (a *anyNotNullAggregate) Close(context.Context) {}
 
@@ -515,6 +518,12 @@ func (a *arrayAggregate) Result() (tree.Datum, error) {
 		return &arrCopy, nil
 	}
 	return tree.DNull, nil
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *arrayAggregate) Reset(ctx context.Context) {
+	a.arr = tree.NewDArray(a.arr.ParamTyp)
+	a.acc.Empty(ctx)
 }
 
 // Close allows the aggregate to release the memory it requested during
@@ -580,6 +589,12 @@ func (a *avgAggregate) Result() (tree.Datum, error) {
 	default:
 		return nil, pgerror.AssertionFailedf("unexpected SUM result type: %s", t)
 	}
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *avgAggregate) Reset(ctx context.Context) {
+	a.agg.Reset(ctx)
+	a.count = 0
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -680,6 +695,12 @@ func (a *concatAggregate) Result() (tree.Datum, error) {
 	return &res, nil
 }
 
+// Reset implements tree.AggregateFunc interface.
+func (a *concatAggregate) Reset(context.Context) {
+	a.sawNonNull = false
+	a.result.Reset()
+}
+
 // Close allows the aggregate to release the memory it requested during
 // operation.
 func (a *concatAggregate) Close(ctx context.Context) {
@@ -719,6 +740,12 @@ func (a *boolAndAggregate) Result() (tree.Datum, error) {
 	return tree.MakeDBool(tree.DBool(a.result)), nil
 }
 
+// Reset implements tree.AggregateFunc interface.
+func (a *boolAndAggregate) Reset(context.Context) {
+	a.sawNonNull = false
+	a.result = false
+}
+
 // Close is part of the tree.AggregateFunc interface.
 func (a *boolAndAggregate) Close(context.Context) {}
 
@@ -752,6 +779,12 @@ func (a *boolOrAggregate) Result() (tree.Datum, error) {
 	return tree.MakeDBool(tree.DBool(a.result)), nil
 }
 
+// Reset implements tree.AggregateFunc interface.
+func (a *boolOrAggregate) Reset(context.Context) {
+	a.sawNonNull = false
+	a.result = false
+}
+
 // Close is part of the tree.AggregateFunc interface.
 func (a *boolOrAggregate) Close(context.Context) {}
 
@@ -780,6 +813,11 @@ func (a *countAggregate) Result() (tree.Datum, error) {
 	return tree.NewDInt(tree.DInt(a.count)), nil
 }
 
+// Reset implements tree.AggregateFunc interface.
+func (a *countAggregate) Reset(context.Context) {
+	a.count = 0
+}
+
 // Close is part of the tree.AggregateFunc interface.
 func (a *countAggregate) Close(context.Context) {}
 
@@ -803,6 +841,11 @@ func (a *countRowsAggregate) Add(_ context.Context, _ tree.Datum, _ ...tree.Datu
 
 func (a *countRowsAggregate) Result() (tree.Datum, error) {
 	return tree.NewDInt(tree.DInt(a.count)), nil
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *countRowsAggregate) Reset(context.Context) {
+	a.count = 0
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -847,6 +890,9 @@ func (a *MaxAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.Datu
 		return nil
 	}
 	if a.max == nil {
+		if err := a.acc.ResizeTo(ctx, int64(datum.Size())); err != nil {
+			return err
+		}
 		a.max = datum
 		return nil
 	}
@@ -868,6 +914,11 @@ func (a *MaxAggregate) Result() (tree.Datum, error) {
 		return tree.DNull, nil
 	}
 	return a.max, nil
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *MaxAggregate) Reset(ctx context.Context) {
+	a.max = nil
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -915,6 +966,9 @@ func (a *MinAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.Datu
 		return nil
 	}
 	if a.min == nil {
+		if err := a.acc.ResizeTo(ctx, int64(datum.Size())); err != nil {
+			return err
+		}
 		a.min = datum
 		return nil
 	}
@@ -936,6 +990,11 @@ func (a *MinAggregate) Result() (tree.Datum, error) {
 		return tree.DNull, nil
 	}
 	return a.min, nil
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *MinAggregate) Reset(context.Context) {
+	a.min = nil
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -974,6 +1033,12 @@ func (a *smallIntSumAggregate) Result() (tree.Datum, error) {
 		return tree.DNull, nil
 	}
 	return tree.NewDInt(tree.DInt(a.sum)), nil
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *smallIntSumAggregate) Reset(context.Context) {
+	a.sum = 0
+	a.seenNonNull = false
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -1053,6 +1118,16 @@ func (a *intSumAggregate) Result() (tree.Datum, error) {
 	return dd, nil
 }
 
+// Reset implements tree.AggregateFunc interface.
+func (a *intSumAggregate) Reset(context.Context) {
+	// We choose not to reset apd.Decimal's since they will be set to appropriate
+	// values when overflow occurs - we simply force the aggregate to use Go
+	// types (at least, at first).
+	a.seenNonNull = false
+	a.intSum = 0
+	a.large = false
+}
+
 // Close is part of the tree.AggregateFunc interface.
 func (a *intSumAggregate) Close(ctx context.Context) {
 	a.acc.Close(ctx)
@@ -1104,6 +1179,13 @@ func (a *decimalSumAggregate) Result() (tree.Datum, error) {
 	return dd, nil
 }
 
+// Reset implements tree.AggregateFunc interface.
+func (a *decimalSumAggregate) Reset(ctx context.Context) {
+	a.sum.SetFinite(0, 0)
+	a.sawNonNull = false
+	a.acc.Empty(ctx)
+}
+
 // Close is part of the tree.AggregateFunc interface.
 func (a *decimalSumAggregate) Close(ctx context.Context) {
 	a.acc.Close(ctx)
@@ -1142,6 +1224,12 @@ func (a *floatSumAggregate) Result() (tree.Datum, error) {
 	return tree.NewDFloat(tree.DFloat(a.sum)), nil
 }
 
+// Reset implements tree.AggregateFunc interface.
+func (a *floatSumAggregate) Reset(context.Context) {
+	a.sawNonNull = false
+	a.sum = 0
+}
+
 // Close is part of the tree.AggregateFunc interface.
 func (a *floatSumAggregate) Close(context.Context) {}
 
@@ -1176,6 +1264,12 @@ func (a *intervalSumAggregate) Result() (tree.Datum, error) {
 		return tree.DNull, nil
 	}
 	return &tree.DInterval{Duration: a.sum}, nil
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *intervalSumAggregate) Reset(context.Context) {
+	a.sum = a.sum.Sub(a.sum)
+	a.sawNonNull = false
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -1229,6 +1323,11 @@ func (a *intSqrDiffAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tr
 
 func (a *intSqrDiffAggregate) Result() (tree.Datum, error) {
 	return a.agg.Result()
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *intSqrDiffAggregate) Reset(ctx context.Context) {
+	a.agg.Reset(ctx)
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -1288,6 +1387,13 @@ func (a *floatSqrDiffAggregate) Result() (tree.Datum, error) {
 		return tree.DNull, nil
 	}
 	return tree.NewDFloat(tree.DFloat(a.sqrDiff)), nil
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *floatSqrDiffAggregate) Reset(context.Context) {
+	a.count = 0
+	a.mean = 0
+	a.sqrDiff = 0
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -1379,6 +1485,13 @@ func (a *decimalSqrDiffAggregate) Result() (tree.Datum, error) {
 	return dd, nil
 }
 
+// Reset implements tree.AggregateFunc interface.
+func (a *decimalSqrDiffAggregate) Reset(context.Context) {
+	a.count.SetFinite(0, 0)
+	a.mean.SetFinite(0, 0)
+	a.sqrDiff.SetFinite(0, 0)
+}
+
 // Close is part of the tree.AggregateFunc interface.
 func (a *decimalSqrDiffAggregate) Close(ctx context.Context) {
 	a.acc.Close(ctx)
@@ -1449,6 +1562,13 @@ func (a *floatSumSqrDiffsAggregate) Result() (tree.Datum, error) {
 		return tree.DNull, nil
 	}
 	return tree.NewDFloat(tree.DFloat(a.sqrDiff)), nil
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *floatSumSqrDiffsAggregate) Reset(context.Context) {
+	a.count = 0
+	a.mean = 0
+	a.sqrDiff = 0
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -1558,6 +1678,13 @@ func (a *decimalSumSqrDiffsAggregate) Result() (tree.Datum, error) {
 	}
 	dd := &tree.DDecimal{Decimal: a.sqrDiff}
 	return dd, nil
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *decimalSumSqrDiffsAggregate) Reset(context.Context) {
+	a.count.SetFinite(0, 0)
+	a.mean.SetFinite(0, 0)
+	a.sqrDiff.SetFinite(0, 0)
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -1679,6 +1806,11 @@ func (a *decimalVarianceAggregate) Result() (tree.Datum, error) {
 	return dd, nil
 }
 
+// Reset implements tree.AggregateFunc interface.
+func (a *floatVarianceAggregate) Reset(ctx context.Context) {
+	a.agg.Reset(ctx)
+}
+
 // Close is part of the tree.AggregateFunc interface.
 func (a *floatVarianceAggregate) Close(ctx context.Context) {
 	a.agg.Close(ctx)
@@ -1687,6 +1819,11 @@ func (a *floatVarianceAggregate) Close(ctx context.Context) {
 // Size is part of the tree.AggregateFunc interface.
 func (a *floatVarianceAggregate) Size() int64 {
 	return sizeOfFloatVarianceAggregate
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *decimalVarianceAggregate) Reset(ctx context.Context) {
+	a.agg.Reset(ctx)
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -1795,6 +1932,11 @@ func (a *decimalStdDevAggregate) Result() (tree.Datum, error) {
 	return varianceDec, err
 }
 
+// Reset implements tree.AggregateFunc interface.
+func (a *floatStdDevAggregate) Reset(ctx context.Context) {
+	a.agg.Reset(ctx)
+}
+
 // Close is part of the tree.AggregateFunc interface.
 func (a *floatStdDevAggregate) Close(ctx context.Context) {
 	a.agg.Close(ctx)
@@ -1803,6 +1945,11 @@ func (a *floatStdDevAggregate) Close(ctx context.Context) {
 // Size is part of the tree.AggregateFunc interface.
 func (a *floatStdDevAggregate) Size() int64 {
 	return sizeOfFloatStdDevAggregate
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *decimalStdDevAggregate) Reset(ctx context.Context) {
+	a.agg.Reset(ctx)
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -1853,6 +2000,12 @@ func (a *bytesXorAggregate) Result() (tree.Datum, error) {
 	return tree.NewDBytes(tree.DBytes(a.sum)), nil
 }
 
+// Reset implements tree.AggregateFunc interface.
+func (a *bytesXorAggregate) Reset(context.Context) {
+	a.sum = nil
+	a.sawNonNull = false
+}
+
 // Close is part of the tree.AggregateFunc interface.
 func (a *bytesXorAggregate) Close(context.Context) {}
 
@@ -1887,6 +2040,12 @@ func (a *intXorAggregate) Result() (tree.Datum, error) {
 		return tree.DNull, nil
 	}
 	return tree.NewDInt(tree.DInt(a.sum)), nil
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *intXorAggregate) Reset(context.Context) {
+	a.sum = 0
+	a.sawNonNull = false
 }
 
 // Close is part of the tree.AggregateFunc interface.
@@ -1932,6 +2091,13 @@ func (a *jsonAggregate) Result() (tree.Datum, error) {
 		return tree.NewDJSON(a.builder.Build()), nil
 	}
 	return tree.DNull, nil
+}
+
+// Reset implements tree.AggregateFunc interface.
+func (a *jsonAggregate) Reset(ctx context.Context) {
+	a.builder = json.NewArrayBuilderWithCounter()
+	a.acc.Empty(ctx)
+	a.sawNonNull = false
 }
 
 // Close allows the aggregate to release the memory it requested during

--- a/pkg/sql/sem/builtins/window_frame_builtins.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins.go
@@ -87,6 +87,10 @@ func (sw *slidingWindow) string() string {
 	return builder.String()
 }
 
+func (sw *slidingWindow) reset() {
+	sw.values.Reset()
+}
+
 type slidingWindowFunc struct {
 	sw      *slidingWindow
 	prevEnd int
@@ -147,6 +151,12 @@ func max(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// Reset implements tree.WindowFunc interface.
+func (w *slidingWindowFunc) Reset(context.Context) {
+	w.prevEnd = 0
+	w.sw.reset()
 }
 
 // Close implements WindowFunc interface.
@@ -264,6 +274,13 @@ func (w *slidingWindowSumFunc) Compute(
 	return w.agg.Result()
 }
 
+// Reset implements tree.WindowFunc interface.
+func (w *slidingWindowSumFunc) Reset(ctx context.Context) {
+	w.prevStart = 0
+	w.prevEnd = 0
+	w.agg.Reset(ctx)
+}
+
 // Close implements WindowFunc interface.
 func (w *slidingWindowSumFunc) Close(ctx context.Context, _ *tree.EvalContext) {
 	w.agg.Close(ctx)
@@ -337,6 +354,11 @@ func (w *avgWindowFunc) Compute(
 	default:
 		return nil, pgerror.AssertionFailedf("unexpected SUM result type: %s", t)
 	}
+}
+
+// Reset implements tree.WindowFunc interface.
+func (w *avgWindowFunc) Reset(ctx context.Context) {
+	w.sum.Reset(ctx)
 }
 
 // Close implements WindowFunc interface.

--- a/pkg/sql/sem/tree/aggregate_funcs.go
+++ b/pkg/sql/sem/tree/aggregate_funcs.go
@@ -30,6 +30,11 @@ type AggregateFunc interface {
 	// it will not be mutated by additional calls to Add.
 	Result() (Datum, error)
 
+	// Reset resets the aggregate function which allows for reusing the same
+	// instance for computation without the need to create a new instance.
+	// Any memory is kept, if possible.
+	Reset(context.Context)
+
 	// Close closes out the AggregateFunc and allows it to release any memory it
 	// requested during aggregation, and must be called upon completion of the
 	// aggregation.

--- a/pkg/sql/sem/tree/window_funcs.go
+++ b/pkg/sql/sem/tree/window_funcs.go
@@ -519,6 +519,10 @@ type WindowFunc interface {
 	// not present any exploitable associativity/commutativity for optimization.
 	Compute(context.Context, *EvalContext, *WindowFrameRun) (Datum, error)
 
+	// Reset resets the window function which allows for reusing it when
+	// computing over different partitions.
+	Reset(context.Context)
+
 	// Close allows the window function to free any memory it requested during execution,
 	// such as during the execution of an aggregation like CONCAT_AGG or ARRAY_AGG.
 	Close(context.Context, *EvalContext)


### PR DESCRIPTION
Previously, windowers would create a new instance of a builtin for
every partition and for every window function which is quite
inefficient in terms of memory usage.

Reset() method is now added to aggregate and window functions
builtins, and now windowers can create a single instance for each
window function and reuse it later on every partition.

Fixes: #34316.

Release note: None