### PR TITLE
changefeed: add EXPERIMENTAL to the sinkless syntax

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -296,6 +296,14 @@ func (f *sinklessFeedFactory) Feed(t testing.TB, create string, args ...interfac
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// The syntax for a sinkless changefeed is `EXPERIMENTAL CHANGEFEED FOR ...`
+	// but it's convenient to accept the `CREATE CHANGEFEED` syntax from the
+	// test, so we can keep the current abstraction of running each test over
+	// both types. This bit turns what we received into the real sinkless
+	// syntax.
+	create = strings.Replace(create, `CREATE CHANGEFEED`, `EXPERIMENTAL CHANGEFEED`, 1)
+
 	s.rows, err = s.conn.Query(create, args...)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1234,9 +1234,9 @@ func TestParse(t *testing.T) {
 
 		{`SET ROW (1, true, NULL)`},
 
-		{`CREATE CHANGEFEED FOR TABLE foo`},
-		{`EXPLAIN CREATE CHANGEFEED FOR TABLE foo`},
-		{`CREATE CHANGEFEED FOR TABLE foo, db.bar, schema.db.foo`},
+		{`EXPERIMENTAL CHANGEFEED FOR TABLE foo`},
+		{`EXPLAIN CREATE CHANGEFEED FOR TABLE foo INTO 'sink'`},
+		{`CREATE CHANGEFEED FOR TABLE foo, db.bar, schema.db.foo INTO 'sink'`},
 		{`CREATE CHANGEFEED FOR TABLE foo INTO 'sink'`},
 		// TODO(dan): Implement.
 		// {`CREATE CHANGEFEED FOR TABLE foo VALUES FROM (1) TO (2) INTO 'sink'`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2116,6 +2116,14 @@ create_changefeed_stmt:
       Options: $6.kvOptions(),
     }
   }
+| EXPERIMENTAL CHANGEFEED FOR changefeed_targets opt_with_options
+  {
+    /* SKIP DOC */
+    $$.val = &tree.CreateChangefeed{
+      Targets: $4.targetList(),
+      Options: $5.kvOptions(),
+    }
+  }
 
 changefeed_targets:
   single_table_pattern_list

--- a/pkg/sql/sem/tree/changefeed.go
+++ b/pkg/sql/sem/tree/changefeed.go
@@ -25,7 +25,14 @@ var _ Statement = &CreateChangefeed{}
 
 // Format implements the NodeFormatter interface.
 func (node *CreateChangefeed) Format(ctx *FmtCtx) {
-	ctx.WriteString("CREATE CHANGEFEED FOR ")
+	if node.SinkURI != nil {
+		ctx.WriteString("CREATE ")
+	} else {
+		// Sinkless feeds don't really CREATE anything, so the syntax omits the
+		// prefix. They're also still EXPERIMENTAL, so they get marked as such.
+		ctx.WriteString("EXPERIMENTAL ")
+	}
+	ctx.WriteString("CHANGEFEED FOR ")
 	ctx.FormatNode(&node.Targets)
 	if node.SinkURI != nil {
 		ctx.WriteString(" INTO ")

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -272,7 +272,12 @@ func (*CopyFrom) StatementTag() string { return "COPY" }
 func (*CreateChangefeed) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*CreateChangefeed) StatementTag() string { return "CREATE CHANGEFEED" }
+func (n *CreateChangefeed) StatementTag() string {
+	if n.SinkURI == nil {
+		return "EXPERIMENTAL CHANGEFEED"
+	}
+	return "CREATE CHANGEFEED"
+}
 
 // StatementType implements the Statement interface.
 func (*CreateDatabase) StatementType() StatementType { return DDL }


### PR DESCRIPTION
`CREATE CHANGEFEED FOR` reads oddly for the "sinkless"/direct results
via pgwire/don't need an enterprise license changefeeds which don't
create anything. It reads much better if the `CREATE` prefix is omitted:

    CHANGEFEED FOR table WITH format=json

However, they're still experimental, so add that in as a prefix to end
up at:

    EXPERIMENTAL CHANGEFEED FOR table WITH format=json

Release note (sql change): Introduced a new top-level statement for an
experimental version of `CHANGEFEED`, which doesn't require an
enterprise license and returns results as a stream over the sql
connection.