### PR TITLE
distsql: close the row container in HashJoiner at all times

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -601,6 +601,10 @@ func (h *hashJoiner) close() {
 		}
 		if h.storedRows != nil {
 			h.storedRows.Close(h.Ctx)
+		} else {
+			// h.storedRows has not been initialized, so we need to close the stored
+			// side container explicitly.
+			h.rows[h.storedSide].Close(h.Ctx)
 		}
 		if h.probingRowState.iter != nil {
 			h.probingRowState.iter.Close()


### PR DESCRIPTION
The assumption that storedRows container being initialized over a stored
side row container at all times is incorrect. For example, if a query
is cancelled, storedRows might remain nil.

Fixes: #34405.

Release note: None