### PR TITLE
ui: add a metrics dashboard for changefeeds

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
@@ -1,0 +1,46 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+import React from "react";
+
+import { LineGraph } from "src/views/cluster/components/linegraph";
+import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
+
+import { GraphDashboardProps } from "./dashboardUtils";
+
+export default function (props: GraphDashboardProps) {
+  const { storeSources } = props;
+
+  return [
+    <LineGraph title="Sink Byte Traffic" sources={storeSources}>
+      <Axis units={AxisUnits.Bytes} label="bytes">
+        <Metric name="cr.node.changefeed.emitted_bytes" title="Emitted Bytes" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="Sink Timings" sources={storeSources}>
+      <Axis units={AxisUnits.Duration} label="time">
+        <Metric name="cr.node.changefeed.emit_nanos" title="Message Emit Time" nonNegativeRate />
+        <Metric name="cr.node.changefeed.flush_nanos" title="Flush Time" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="Sink Counts" sources={storeSources}>
+      <Axis units={AxisUnits.Count} label="actions">
+        <Metric name="cr.node.changefeed.emitted_messages" title="Messages" nonNegativeRate />
+        <Metric name="cr.node.changefeed.flushes" title="Flushes" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+  ];
+}

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -49,6 +49,7 @@ import distributedDashboard from "./dashboards/distributed";
 import queuesDashboard from "./dashboards/queues";
 import requestsDashboard from "./dashboards/requests";
 import hardwareDashboard from "./dashboards/hardware";
+import changefeedsDashboard from "./dashboards/changefeeds";
 
 interface GraphDashboard {
   label: string;
@@ -65,6 +66,7 @@ const dashboards: {[key: string]: GraphDashboard} = {
   "distributed": { label: "Distributed", component: distributedDashboard },
   "queues": { label: "Queues", component: queuesDashboard },
   "requests": { label: "Slow Requests", component: requestsDashboard },
+  "changefeeds": { label: "Changefeeds", component: changefeedsDashboard },
 };
 
 const defaultDashboard = "overview";


### PR DESCRIPTION
These metrics have proven useful for introspecting changefeed behavior,
so adding them as a dashboard in case any users hit something that needs
debugging. Also will be useful for users to see what's going on in the
cluster's changefeeds.

Release note (admin ui change): `CHANGEFEED` metrics are now exposed in
the UI.