### PR TITLE
sql: Update error message for multi-column stats

### DIFF
--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/axiomhq/hyperloglog"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
@@ -86,7 +87,7 @@ func newSamplerProcessor(
 			return nil, errors.Errorf("unsupported sketch type %s", s.SketchType)
 		}
 		if len(s.Columns) != 1 {
-			return nil, errors.Errorf("multi-column sketches not supported yet")
+			return nil, pgerror.UnimplementedWithIssueError(34422, "multi-column statistics are not supported yet.")
 		}
 	}
 


### PR DESCRIPTION
Updated the error message as follows:

- Changed from referencing "multi-column sketches" (which are not
  mentioned in our docs anywhere) to "multi-column statistics"

- Added link to CockroachDB issue discussing multi-column stats for the
  user's reference.

See also: #34422.

Release note: None