### PR TITLE
cli/sql,sql/parser: fix LastLexicalToken

### DIFF
--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -879,9 +879,6 @@ func LastLexicalToken(sql string) (lastTok int, ok bool) {
 	for {
 		last := lval.id
 		s.scan(&lval)
-		if lval.id == ERROR {
-			return ERROR, true
-		}
 		if lval.id == 0 {
 			return int(last), last != 0
 		}

--- a/pkg/sql/parser/scan_test.go
+++ b/pkg/sql/parser/scan_test.go
@@ -444,6 +444,10 @@ func TestLastLexicalToken(t *testing.T) {
 			s:   `SELECT 'unfinished`,
 			res: ERROR,
 		},
+		{
+			s:   `SELECT e'\xaa';`, // invalid token but last token is semicolon
+			res: ';',
+		},
 	}
 
 	for i, tc := range tests {


### PR DESCRIPTION
Found while investigating #34441. Regression introduced in #32881.

It's possible for an error token to be followed by valid tokens. This
is especially important when a user enters some invalid tokens
followed by a semicolon: in that case we want the CLI shell to process
the line (and show the error), instead of asking for more input.

Release note: None