### PR TITLE
cli: show node status for all nodes

### DIFF
--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -101,4 +101,19 @@ func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 		"false false",
 		"false false",
 	})
+
+	// Stop the cluster and restart only 2 of the nodes. Verify that three nodes
+	// show up in the node status output.
+	c.Stop(ctx, c.Range(1, 3))
+	c.Start(ctx, t, c.Range(1, 2))
+
+	// Wait for the cluster to come back up.
+	waitForFullReplication(t, db)
+
+	waitUntil([]string{
+		"is_available is_live",
+		"true true",
+		"true true",
+		"false false",
+	})
 }


### PR DESCRIPTION
Previously, `node status` would only show status for nodes which had
gossiped a node descriptor. This meant that a node that had been down
for long enough for the gossiped node descriptor TTL to be reached would
disappear from the `node status` output. Similarly, if a cluster was
restarted but one node failed to come up, that node would be omitted
from the `node status` output. The `crdb_internal.gossip_liveness` table
contains a full list of the nodes in the cluster. We simply need to
`LEFT JOIN` instead of `JOIN` with other tables.

Fixes #34435

Release note: None