### PR TITLE
sql: turn on query cache

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -82,7 +82,7 @@
 <tr><td><code>sql.metrics.statement_details.plan_collection.period</code></td><td>duration</td><td><code>5m0s</code></td><td>the time until a new logical plan is collected</td></tr>
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statistics to be collected</td></tr>
 <tr><td><code>sql.parallel_scans.enabled</code></td><td>boolean</td><td><code>true</code></td><td>parallelizes scanning different ranges when the maximum result size can be deduced</td></tr>
-<tr><td><code>sql.query_cache.enabled</code></td><td>boolean</td><td><code>false</code></td><td>enable the query cache</td></tr>
+<tr><td><code>sql.query_cache.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable the query cache</td></tr>
 <tr><td><code>sql.stats.experimental_automatic_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>experimental automatic statistics collection mode</td></tr>
 <tr><td><code>sql.tablecache.lease.refresh_limit</code></td><td>integer</td><td><code>50</code></td><td>maximum number of tables to periodically refresh leases for</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -642,10 +642,6 @@ var maxStmtStatReset = settings.RegisterNonNegativeDurationSetting(
 	time.Hour*2, // 2 x diagnosticReportFrequency
 )
 
-var queryCacheEnabled = settings.RegisterBoolSetting(
-	"sql.query_cache.enabled", "enable the query cache", false,
-)
-
 // PeriodicallyClearStmtStats runs a loop to ensure that sql stats are reset.
 // Usually we expect those stats to be reset by diagnostics reporting, after it
 // generates its reports. However if the diagnostics loop crashes and stops

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
+	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -283,6 +284,7 @@ func startConnExecutor(
 			dummyLivenessProvider{}, /* liveness */
 			nil,                     /* nodeDialer */
 		),
+		QueryCache:   querycache.New(0),
 		TestingKnobs: &ExecutorTestingKnobs{},
 	}
 	pool := mon.MakeUnlimitedMonitor(

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -86,6 +86,7 @@ func (mt mutationTest) makeMutationsActive() {
 		}
 	}
 	mt.tableDesc.Mutations = nil
+	mt.tableDesc.Version++
 	if err := mt.tableDesc.ValidateTable(cluster.MakeTestingClusterSettings()); err != nil {
 		mt.Fatal(err)
 	}
@@ -141,6 +142,7 @@ func (mt mutationTest) writeMutation(m sqlbase.DescriptorMutation) {
 		}
 	}
 	mt.tableDesc.Mutations = append(mt.tableDesc.Mutations, m)
+	mt.tableDesc.Version++
 	if err := mt.tableDesc.ValidateTable(cluster.MakeTestingClusterSettings()); err != nil {
 		mt.Fatal(err)
 	}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -137,6 +137,7 @@ type Memo struct {
 	dataConversion    sessiondata.DataConversionConfig
 	reorderJoinsLimit int
 	zigzagJoinEnabled bool
+	safeUpdates       bool
 
 	// curID is the highest currently in-use scalar expression ID.
 	curID opt.ScalarID
@@ -254,7 +255,8 @@ func (m *Memo) IsStale(
 	// changed.
 	if !m.dataConversion.Equals(&evalCtx.SessionData.DataConversion) ||
 		m.reorderJoinsLimit != evalCtx.SessionData.ReorderJoinsLimit ||
-		m.zigzagJoinEnabled != evalCtx.SessionData.ZigzagJoinEnabled {
+		m.zigzagJoinEnabled != evalCtx.SessionData.ZigzagJoinEnabled ||
+		m.safeUpdates != evalCtx.SessionData.SafeUpdates {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -169,6 +169,24 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData.DataConversion.ExtraFloatDigits = 0
 	notStale()
 
+	// Stale reorder joins limit.
+	evalCtx.SessionData.ReorderJoinsLimit = 4
+	stale()
+	evalCtx.SessionData.ReorderJoinsLimit = 0
+	notStale()
+
+	// Stale zig zag join enable.
+	evalCtx.SessionData.ZigzagJoinEnabled = true
+	stale()
+	evalCtx.SessionData.ZigzagJoinEnabled = false
+	notStale()
+
+	// Stale safe updates.
+	evalCtx.SessionData.SafeUpdates = true
+	stale()
+	evalCtx.SessionData.SafeUpdates = false
+	notStale()
+
 	// Stale data sources and schema. Create new catalog so that data sources are
 	// recreated and can be modified independently.
 	catalog = testcat.New()


### PR DESCRIPTION
Release note (performance improvement): A query plan cache saves a
portion of the planning time for frequent queries.

Some benchmarks with KV: https://docs.google.com/spreadsheets/d/1n818OsKTWsatbpXo5ddOJ53mL4hY-JhNJEuIlytilLc/edit#gid=0

While there is some improvement, the implicit prepare case is still nowhere close to prepare-once; I plan to benchmark and do more work on the prepare path. I think it's a good idea to enable the cache now though, so we get more time to weed out any problems. 