### PR TITLE
changefeedccl: default to RangeFeed

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -1,6 +1,7 @@
 <table>
 <thead><tr><th>Setting</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
 <tbody>
+<tr><td><code>changefeed.push.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, changed are pushed instead of pulled. This requires the kv.rangefeed.enabled setting.</td></tr>
 <tr><td><code>cloudstorage.gs.default.key</code></td><td>string</td><td><code></code></td><td>if set, JSON key to use during Google Cloud Storage operations</td></tr>
 <tr><td><code>cloudstorage.http.custom_ca</code></td><td>string</td><td><code></code></td><td>custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage</td></tr>
 <tr><td><code>cloudstorage.timeout</code></td><td>duration</td><td><code>10m0s</code></td><td>the timeout for import/export storage operations</td></tr>

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -36,6 +36,16 @@ func init() {
 	changefeedPollInterval.Hide()
 }
 
+// PushEnabled is a cluster setting that triggers all subsequently
+// created/unpaused changefeeds to receive kv changes via RangeFeed push
+// (instead of ExportRequest polling).
+var PushEnabled = settings.RegisterBoolSetting(
+	"changefeed.push.enabled",
+	"if set, changed are pushed instead of pulled. This requires the "+
+		"kv.rangefeed.enabled setting.",
+	true,
+)
+
 const (
 	jsonMetaSentinel = `__crdb__`
 )

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -172,7 +171,7 @@ func (ca *changeAggregator) Start(ctx context.Context) context.Context {
 		ca.pollerDoneCh = make(chan struct{})
 		defer close(ca.pollerDoneCh)
 		var err error
-		if storage.RangefeedEnabled.Get(&ca.flowCtx.Settings.SV) {
+		if PushEnabled.Get(&ca.flowCtx.Settings.SV) {
 			err = ca.poller.RunUsingRangefeeds(ctx)
 		} else {
 			err = ca.poller.Run(ctx)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -81,7 +81,7 @@ func TestChangefeedBasics(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedEnvelope(t *testing.T) {
@@ -116,7 +116,7 @@ func TestChangefeedEnvelope(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedMultiTable(t *testing.T) {
@@ -140,7 +140,7 @@ func TestChangefeedMultiTable(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedCursor(t *testing.T) {
@@ -199,7 +199,7 @@ func TestChangefeedCursor(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedTimestamps(t *testing.T) {
@@ -302,7 +302,7 @@ func TestChangefeedTimestamps(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedResolvedFrequency(t *testing.T) {
@@ -333,7 +333,7 @@ func TestChangefeedResolvedFrequency(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 // Test how Changefeeds react to schema changes that do not require a backfill
@@ -500,7 +500,7 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedSchemaChangeNoAllowBackfill(t *testing.T) {
@@ -579,7 +579,7 @@ func TestChangefeedSchemaChangeNoAllowBackfill(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 // Test schema changes that require a backfill when the backfill option is
@@ -712,7 +712,7 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 // Regression test for #34314
@@ -735,7 +735,7 @@ func TestChangefeedAfterSchemaChangeBackfill(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedInterleaved(t *testing.T) {
@@ -786,7 +786,7 @@ func TestChangefeedInterleaved(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedColumnFamily(t *testing.T) {
@@ -821,7 +821,7 @@ func TestChangefeedColumnFamily(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedComputedColumn(t *testing.T) {
@@ -850,7 +850,7 @@ func TestChangefeedComputedColumn(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedUpdatePrimaryKey(t *testing.T) {
@@ -883,7 +883,7 @@ func TestChangefeedUpdatePrimaryKey(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedTruncateRenameDrop(t *testing.T) {
@@ -930,7 +930,7 @@ func TestChangefeedTruncateRenameDrop(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedMonitoring(t *testing.T) {
@@ -1052,7 +1052,7 @@ func TestChangefeedMonitoring(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedRetryableSinkError(t *testing.T) {
@@ -1160,6 +1160,10 @@ func TestChangefeedDataTTL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f testfeedFactory) {
+		if PushEnabled.Get(&f.Server().ClusterSettings().SV) {
+			t.Skip(`#34456`)
+		}
+
 		// Set a very simple channel-based, wait-and-resume function as the
 		// BeforeEmitRow hook.
 		var shouldWait int32
@@ -1227,7 +1231,7 @@ func TestChangefeedDataTTL(t *testing.T) {
 
 	t.Run("sinkless", sinklessTest(testFn))
 	t.Run("enterprise", enterpriseTest(testFn))
-	// TODO(dan): t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 // TestChangefeedSchemaTTL ensures that changefeeds fail with an error in the case
@@ -1305,7 +1309,7 @@ func TestChangefeedSchemaTTL(t *testing.T) {
 
 	t.Run("sinkless", sinklessTest(testFn))
 	t.Run("enterprise", enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedErrors(t *testing.T) {
@@ -1317,6 +1321,16 @@ func TestChangefeedErrors(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 	sqlDB.Exec(t, `CREATE DATABASE d`)
+
+	// Changefeeds default to rangefeed, but for now, rangefeed defaults to off.
+	// Verify that this produces a useful error.
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = false`)
+	sqlDB.Exec(t, `CREATE TABLE rangefeed_off (a INT PRIMARY KEY)`)
+	sqlDB.ExpectErr(
+		t, `rangefeeds are not enabled. See kv.rangefeed.enabled.`,
+		`EXPERIMENTAL CHANGEFEED FOR rangefeed_off`,
+	)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled TO DEFAULT`)
 
 	sqlDB.ExpectErr(
 		t, `unknown format: nope`,
@@ -1468,7 +1482,7 @@ func TestChangefeedPermissions(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestChangefeedDescription(t *testing.T) {
@@ -1505,7 +1519,7 @@ func TestChangefeedDescription(t *testing.T) {
 
 	// Only the enterprise version uses jobs.
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(enterpriseTest, testFn))
+	t.Run(`poller`, pollerTest(enterpriseTest, testFn))
 }
 
 func TestChangefeedPauseUnpause(t *testing.T) {
@@ -1547,7 +1561,7 @@ func TestChangefeedPauseUnpause(t *testing.T) {
 
 	// Only the enterprise version uses jobs.
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(enterpriseTest, testFn))
+	t.Run(`poller`, pollerTest(enterpriseTest, testFn))
 }
 
 func TestManyChangefeedsOneTable(t *testing.T) {
@@ -1600,7 +1614,7 @@ func TestManyChangefeedsOneTable(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestUnspecifiedPrimaryKey(t *testing.T) {
@@ -1626,7 +1640,7 @@ func TestUnspecifiedPrimaryKey(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 // TestChangefeedNodeShutdown ensures that an enterprise changefeed continues

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -319,7 +319,7 @@ func TestAvroEncoder(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestAvroSchemaChange(t *testing.T) {
@@ -353,7 +353,7 @@ func TestAvroSchemaChange(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestAvroLedger(t *testing.T) {
@@ -391,5 +391,5 @@ func TestAvroLedger(t *testing.T) {
 
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -918,6 +918,16 @@ func sinklessTest(testFn func(*testing.T, *gosql.DB, testfeedFactory)) func(*tes
 		})
 		defer s.Stopper().Stop(ctx)
 		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+		// TODO(dan): We currently have to set this to an extremely conservative
+		// value because otherwise schema changes become flaky (they don't commit
+		// their txn in time, get pushed by closed timestamps, and retry forever).
+		// This is more likely when the tests run slower (race builds or inside
+		// docker). The conservative value makes our tests take a lot longer,
+		// though. Figure out some way to speed this up.
+		sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s'`)
+		// TODO(dan): This is still needed to speed up table_history, that should be
+		// moved to RangeFeed as well.
 		sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'`)
 		sqlDB.Exec(t, `CREATE DATABASE d`)
 
@@ -948,6 +958,10 @@ func enterpriseTest(testFn func(*testing.T, *gosql.DB, testfeedFactory)) func(*t
 		})
 		defer s.Stopper().Stop(ctx)
 		sqlDB := sqlutils.MakeSQLRunner(db)
+		// TODO(dan): Switch this to RangeFeed, too. It seems wasteful right now
+		// because the RangeFeed version of the tests take longer due to
+		// closed_timestamp.target_duration's interaction with schema changes.
+		sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.push.enabled = false`)
 		sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'`)
 		sqlDB.Exec(t, `CREATE DATABASE d`)
 		f := makeTable(s, db, flushCh)
@@ -956,22 +970,15 @@ func enterpriseTest(testFn func(*testing.T, *gosql.DB, testfeedFactory)) func(*t
 	}
 }
 
-func rangefeedTest(
+func pollerTest(
 	metaTestFn func(func(*testing.T, *gosql.DB, testfeedFactory)) func(*testing.T),
 	testFn func(*testing.T, *gosql.DB, testfeedFactory),
 ) func(*testing.T) {
 	return func(t *testing.T) {
 		metaTestFn(func(t *testing.T, db *gosql.DB, f testfeedFactory) {
 			sqlDB := sqlutils.MakeSQLRunner(db)
-			sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-			// TODO(dan): We currently have to set this to an extremely
-			// conservative value because otherwise schema changes become flaky
-			// (they don't commit their txn in time, get pushed by closed
-			// timestamps, and retry forever). This is more likely when the
-			// tests run slower (race builds or inside docker). The conservative
-			// value makes our tests take a long longer, though. Figure out some
-			// way to speed this up.
-			sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s'`)
+			sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.push.enabled = false`)
+			sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'`)
 			testFn(t, db, f)
 		})(t)
 	}

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -340,7 +340,8 @@ func TestCloudStorage(t *testing.T) {
 	})
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
-	sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s'`)
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 
 	f := makeCloud(s, db, dir, flushCh)

--- a/pkg/ccl/changefeedccl/validations_test.go
+++ b/pkg/ccl/changefeedccl/validations_test.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"math/rand"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -36,7 +35,7 @@ func TestValidations(t *testing.T) {
 		// also a short lead time for rangefeed-based feeds before the
 		// first checkpoint. This means that a much larger number of transfers
 		// happens, and the validator gets overwhelmed by fingerprints.
-		slowWrite := strings.Contains(t.Name(), `rangefeed`)
+		slowWrite := PushEnabled.Get(&f.Server().ClusterSettings().SV)
 		sqlDB := sqlutils.MakeSQLRunner(db)
 
 		t.Run("bank", func(t *testing.T) {
@@ -116,7 +115,7 @@ func TestValidations(t *testing.T) {
 	}
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 func TestCatchupScanOrdering(t *testing.T) {
@@ -189,7 +188,7 @@ func TestCatchupScanOrdering(t *testing.T) {
 	}
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`rangefeed`, rangefeedTest(sinklessTest, testFn))
+	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
 // TODO(dan): This bit is copied from the bank workload. It's

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -74,7 +74,11 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 	); err != nil {
 		t.Fatal(err)
 	}
-
+	if _, err := db.Exec(
+		`SET CLUSTER SETTING changefeed.push.enabled = $1`, args.rangefeed,
+	); err != nil {
+		t.Fatal(err)
+	}
 	kafka := kafkaManager{
 		c:     c,
 		nodes: kafkaNode,
@@ -242,7 +246,12 @@ func runCDCBank(ctx context.Context, t *test, c *cluster) {
 	defer stopFeeds(db)
 
 	if _, err := db.Exec(
-		`SET CLUSTER SETTING changefeed.experimental_poll_interval = '0ns'`,
+		`SET CLUSTER SETTING kv.rangefeed.enabled = true`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(
+		`SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'`,
 	); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
We don't want to default `kv.rangefeed.enabled` on, since the logical
ops will have some perf penality that non-changefeed users shouldn't
pay, but we want to default changefeeds to the RangeFeed impl in the
next release. We were previously also triggering whether changefeeds
used RangeFeeds with the `kv.rangefeed.enabled`, but instead introduce a
second one, `changefeed.push.enabled`, so we can have a different
default.

The actual perf penalty of logical ops is currently understudied, but
this is coming soon.

Note that this means a new cluster will error the first changefeed,
directing the user to the `kv.rangefeed.enabled` setting. This is
unfortunate, but the easiest thing for now and we'll be sure to document
it. The `kv.rangefeed.enabled` setting turns on logical ops for all
ranges in the cluster, even if the changefeed is only running on a small
part of it, so something should be done about this in the long run.

This change also replaces the "rangefeed" variant of each of our unit
tests with a "poller" variant, to reflect that this is the new
non-default setting. The "enterprise" variant of the tests inherits the
default of RangeFeed, but switching "sinkless" is left as a TODO, since
there's currently an issue (#34455) with RangeFeed tests taking longer.

Closes #31206

Release note (enterprise change): `CHANGEFEED`s now operate on an
end-to-end "push" model, reducing latency of row changes. Some workloads
will also see fewer transaction restarts on tables being watched by
`CHANGEFEED`s.