### PR TITLE
sql: plumb through presizing for in-memory row container

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -205,10 +205,10 @@ func newHashJoiner(
 	}
 
 	h.rows[leftSide].InitWithMon(
-		nil /* ordering */, h.leftSource.OutputTypes(), h.evalCtx, h.MemMonitor,
+		nil /* ordering */, h.leftSource.OutputTypes(), h.evalCtx, h.MemMonitor, 0, /* rowCapacity */
 	)
 	h.rows[rightSide].InitWithMon(
-		nil /* ordering */, h.rightSource.OutputTypes(), h.evalCtx, h.MemMonitor,
+		nil /* ordering */, h.rightSource.OutputTypes(), h.evalCtx, h.MemMonitor, 0, /* rowCapacity */
 	)
 
 	if h.joinType == sqlbase.IntersectAllJoin || h.joinType == sqlbase.ExceptAllJoin {

--- a/pkg/sql/distsqlrun/routers.go
+++ b/pkg/sql/distsqlrun/routers.go
@@ -261,6 +261,7 @@ func (rb *routerBase) init(ctx context.Context, flowCtx *FlowCtx, types []sqlbas
 			flowCtx.TempStorage,
 			memoryMonitor,
 			diskMonitor,
+			0, /* rowCapacity */
 		)
 		rb.outputs[i].memoryMonitor = memoryMonitor
 		rb.outputs[i].diskMonitor = diskMonitor

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -95,11 +95,12 @@ func (s *sorterBase) init(
 			flowCtx.TempStorage,
 			memMonitor,
 			s.diskMonitor,
+			0, /* rowCapacity */
 		)
 		s.rows = &rc
 	} else {
 		rc := rowcontainer.MemRowContainer{}
-		rc.InitWithMon(ordering, input.OutputTypes(), s.evalCtx, memMonitor)
+		rc.InitWithMon(ordering, input.OutputTypes(), s.evalCtx, memMonitor, 0 /* rowCapacity */)
 		s.rows = &rc
 	}
 

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -780,7 +780,7 @@ func (h *HashDiskBackedRowContainer) Init(
 	}
 	if h.mrc == nil {
 		h.mrc = &MemRowContainer{}
-		h.mrc.InitWithMon(ordering, types, h.evalCtx, h.memoryMonitor)
+		h.mrc.InitWithMon(ordering, types, h.evalCtx, h.memoryMonitor, 0 /* rowCapacity */)
 	}
 	hmrc := MakeHashMemRowContainer(h.mrc)
 	h.hmrc = &hmrc

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -100,7 +100,7 @@ func TestRowContainerReplaceMax(t *testing.T) {
 	var mc MemRowContainer
 	mc.InitWithMon(
 		sqlbase.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}},
-		[]sqlbase.ColumnType{typeInt, typeStr}, evalCtx, &m,
+		[]sqlbase.ColumnType{typeInt, typeStr}, evalCtx, &m, 0, /* rowCapacity */
 	)
 	defer mc.Close(ctx)
 
@@ -227,6 +227,7 @@ func TestDiskBackedRowContainer(t *testing.T) {
 		tempEngine,
 		&memoryMonitor,
 		&diskMonitor,
+		0, /* rowCapacity */
 	)
 	defer rc.Close(ctx)
 


### PR DESCRIPTION
Adds an additional argument used for presizing the in-memory row
container.

Release note: None