### PR TITLE
storage: InitPut failures only update tscache on ConditionFailed error

### DIFF
--- a/pkg/storage/replica_tscache.go
+++ b/pkg/storage/replica_tscache.go
@@ -92,7 +92,14 @@ func (r *Replica) updateTimestampCache(
 			case *roachpb.ConditionalPutRequest:
 				if pErr != nil {
 					// ConditionalPut still updates on ConditionFailedErrors.
-					// TODO(nvanbenschoten): do we need similar logic for InitPutRequest?
+					if _, ok := pErr.GetDetail().(*roachpb.ConditionFailedError); !ok {
+						continue
+					}
+				}
+				tc.Add(start, end, ts, txnID, true /* readCache */)
+			case *roachpb.InitPutRequest:
+				if pErr != nil {
+					// InitPut still updates on ConditionFailedErrors.
 					if _, ok := pErr.GetDetail().(*roachpb.ConditionFailedError); !ok {
 						continue
 					}


### PR DESCRIPTION
Addresses a TODO.

This was missed from 8faa7bb but was present in 70ef0e1. I noticed the omission because of the lack of symmetry, not because of any observed issues. Still, the new test failed without this, which demonstrates that there was a (performance-only) issue.

Release note: None