### PR TITLE
roachtest: easy cdc fixes

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -107,6 +107,10 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 			// if it attempts to use the node which was brought down by chaos.
 			tolerateErrors: args.crdbChaos,
 		}
+		// TODO(dan): Remove this when we fix whatever is causing the "duplicate key
+		// value" errors #34025.
+		tpcc.tolerateErrors = true
+
 		tpcc.install(ctx, c)
 		// TODO(dan,ajwerner): sleeping momentarily before running the workload
 		// mitigates errors like "error in newOrder: missing stock row" from tpcc.
@@ -755,7 +759,7 @@ func createChangefeed(db *gosql.DB, targets, sinkURL string, args cdcTestArgs) (
 	createStmt := fmt.Sprintf(`CREATE CHANGEFEED FOR %s INTO $1`, targets)
 	extraArgs := []interface{}{sinkURL}
 	if args.cloudStorageSink {
-		createStmt += ` WITH resolved='10s', envelope=value_only`
+		createStmt += ` WITH resolved='10s', envelope=wrapped`
 	} else {
 		createStmt += ` WITH resolved`
 	}


### PR DESCRIPTION
The cdc/tpcc-1000 test has been failing with "duplicate key value"
errors from workload from before we switched the roachtests to
rangefeed. cdc/cloud-sink was broken by #34309.

I think I know what's going on with cdc/ledger but the fix will have to
wait for tomorrow and I'd like to get these two fixes in for tonight.

Release note: None