### PR TITLE
sql: increase max size of query in crash report

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -999,7 +999,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 	return firstError
 }
 
-const panicLogOutputCutoffChars = 500
+const panicLogOutputCutoffChars = 10000
 
 func anonymizeStmtAndConstants(stmt tree.Statement) string {
 	return tree.AsStringWithFlags(stmt, tree.FmtAnonymize|tree.FmtHideConstants)


### PR DESCRIPTION
It's been frustrating seeing crashes with cut-off queries - there's no
reason for the limit to be so low (500). This bumps it up by a lot.

Release note (general change): increase the maximum length of queries in
crash reports, to make debugging easier.