### PR TITLE
util/encoding: don't panic on empty mantissa during decimal decode

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -366,3 +366,11 @@ query T
 select crdb_internal.node_executable_version()
 ----
 2.1-4
+
+user root
+
+# Regression test for #34441
+query T
+SELECT crdb_internal.pretty_key(e'\\xa82a00918ed9':::BYTES, (-5096189069466142898):::INT8);
+----
+/Table/32/???/9/6/81

--- a/pkg/util/encoding/decimal.go
+++ b/pkg/util/encoding/decimal.go
@@ -355,17 +355,16 @@ func getDecimalLen(buf []byte) (int, error) {
 // makeDecimalFromMandE reconstructs the decimal from the mantissa M and
 // exponent E.
 func makeDecimalFromMandE(negative bool, e int, m []byte, tmp []byte) (apd.Decimal, error) {
+	if len(m) == 0 {
+		return apd.Decimal{}, errors.New("expected mantissa, got zero bytes")
+	}
 	// ±dddd.
 	b := tmp[:0]
 	if n := len(m)*2 + 1; cap(b) < n {
 		b = make([]byte, 0, n)
 	}
-	for i, v := range m {
-		t := int(v)
-		if i == len(m) {
-			t--
-		}
-		t /= 2
+	for _, v := range m {
+		t := int(v) / 2
 		if t < 0 || t > 99 {
 			return apd.Decimal{}, errors.Errorf("base-100 encoded digit %d out of range [0,99]", t)
 		}


### PR DESCRIPTION
This is a condition that shouldn't happen normally, but
crdb_internal.pretty_key is able to skip the normal encoding and so can
produce bogus inputs. Check for an empty mantissa before processing.

While here, remove an impossible condition. It's unclear why it was
here before. Seems likely it was a leftover during inital work before
the for loop was changed to use a range.

Fixes #34441

Release note (bug fix): Fix a possible panic in crdb_internal.pretty_key().