### PR TITLE
sql: tune performance of bulk index backfill

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -42,7 +42,7 @@
 <tr><td><code>kv.transaction.write_pipelining_enabled</code></td><td>boolean</td><td><code>true</code></td><td>if enabled, transactional writes are pipelined through Raft consensus</td></tr>
 <tr><td><code>kv.transaction.write_pipelining_max_batch_size</code></td><td>integer</td><td><code>128</code></td><td>if non-zero, defines that maximum size batch that will be pipelined through Raft consensus</td></tr>
 <tr><td><code>rocksdb.min_wal_sync_interval</code></td><td>duration</td><td><code>0s</code></td><td>minimum duration between syncs of the RocksDB WAL</td></tr>
-<tr><td><code>schemachanger.bulk_index_backfill.batch_size</code></td><td>integer</td><td><code>1000000</code></td><td>number of rows to process at a time during bulk index backfill</td></tr>
+<tr><td><code>schemachanger.bulk_index_backfill.batch_size</code></td><td>integer</td><td><code>5000000</code></td><td>number of rows to process at a time during bulk index backfill</td></tr>
 <tr><td><code>schemachanger.bulk_index_backfill.enabled</code></td><td>boolean</td><td><code>false</code></td><td>backfill indexes in bulk via addsstable</td></tr>
 <tr><td><code>schemachanger.lease.duration</code></td><td>duration</td><td><code>5m0s</code></td><td>the duration of a schema change lease</td></tr>
 <tr><td><code>schemachanger.lease.renew_fraction</code></td><td>float</td><td><code>0.5</code></td><td>the fraction of schemachanger.lease_duration remaining to trigger a renew of the lease</td></tr>

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -58,13 +58,13 @@ const (
 
 	// checkpointInterval is the interval after which a checkpoint of the
 	// schema change is posted.
-	checkpointInterval = 2 * time.Minute
+	checkpointInterval = 1 * time.Minute
 )
 
 var indexBulkBackfillChunkSize = settings.RegisterIntSetting(
 	"schemachanger.bulk_index_backfill.batch_size",
 	"number of rows to process at a time during bulk index backfill",
-	1000000,
+	5000000,
 )
 
 var _ sort.Interface = columnsByID{}

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -281,9 +281,10 @@ func WriteResumeSpan(
 				return SetResumeSpansInJob(ctx, resumeSpans, mutationIdx, txn, job)
 			}
 		}
-		// Unable to find a span containing origSpan.
-		return errors.Errorf(
-			"span %+v not found among %+v", origSpan, resumeSpans,
-		)
+		// Unable to find a span containing origSpan. This can happen if the
+		// coordinator node looses its schema change lease and another node takes
+		// over and updates the checkpoint.
+		log.Warningf(ctx, "span %+v not found among %+v", origSpan, resumeSpans)
+		return nil
 	})
 }

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -97,7 +97,7 @@ type FlowCtx struct {
 
 	// BulkAdder is used by backfill/bulk-ingestion processors to ingest large
 	// amounts of data in bulk as SSTs.
-	BullkAdder storagebase.BulkAdderFactory
+	BulkAdder storagebase.BulkAdderFactory
 
 	// diskMonitor is used to monitor temporary storage disk usage.
 	diskMonitor *mon.BytesMonitor

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -446,7 +446,7 @@ func (ds *ServerImpl) setupFlow(
 		testingKnobs:   ds.TestingKnobs,
 		nodeID:         nodeID,
 		TempStorage:    ds.TempStorage,
-		BullkAdder:     ds.BulkAdder,
+		BulkAdder:      ds.BulkAdder,
 		diskMonitor:    ds.DiskMonitor,
 		JobRegistry:    ds.ServerConfig.JobRegistry,
 		traceKV:        req.TraceKV,


### PR DESCRIPTION
The main improvement (> 20x) comes from increasing the SST buffer
size from 32K to 32M. With this change I'm seeing a 30M row table
take less than 2 minutes to backfill.

Reduce the checkpoint interval to 1 minute to reduce the chance of
a loss of a schema change lease. Also make the checkpoint write
failure a temporary failure.

Log index backfill stats.

s/BullkAddr/BulkAddr

related to #12424

Release note: None