### PR TITLE
release-2.1: cli: show node status for all nodes

### DIFF
--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -137,41 +137,33 @@ func runStatusNodeInner(showDecommissioned bool, args []string) ([]string, [][]s
 				query = q
 				continue
 			}
-			query = "(" + query + ") JOIN (" + q + ") USING (id)"
+			query = "(" + query + ") LEFT JOIN (" + q + ") USING (id)"
 		}
 		return
 	}
 
 	maybeAddActiveNodesFilter := func(query string) string {
-		activeNodesFilter := "decommissioning = false OR split_part(expiration,',',1)::decimal > now()::decimal"
 		if !showDecommissioned {
-			query += " WHERE " + activeNodesFilter
+			query += " WHERE decommissioning = false OR split_part(expiration,',',1)::decimal > now()::decimal"
 		}
 		return query
 	}
 
-	baseQuery := joinUsingID(
-		[]string{`
-SELECT node_id AS id,
-       address,
-       build_tag AS build,
-       started_at,
-       updated_at
-FROM crdb_internal.gossip_liveness JOIN crdb_internal.gossip_nodes USING (node_id)`,
-			maybeAddActiveNodesFilter(
-				`SELECT node_id AS id,
-                CASE WHEN split_part(expiration,',',1)::decimal > now()::decimal
-                     THEN true
-                     ELSE false
-                     END AS is_available
-         FROM crdb_internal.gossip_liveness`,
-			),
-			`SELECT node_id AS id, is_live
-         FROM crdb_internal.gossip_nodes`,
-		},
+	baseQuery := maybeAddActiveNodesFilter(
+		`SELECT node_id AS id,
+            address,
+            build_tag AS build,
+            started_at,
+            updated_at,
+            CASE WHEN split_part(expiration,',',1)::decimal > now()::decimal
+                 THEN true
+                 ELSE false
+                 END AS is_available,
+            ifnull(is_live, false)
+     FROM crdb_internal.gossip_liveness LEFT JOIN crdb_internal.gossip_nodes USING (node_id)`,
 	)
 
-	rangesQuery := `
+	const rangesQuery = `
 SELECT node_id AS id,
        sum((metrics->>'replicas.leaders')::DECIMAL)::INT AS replicas_leaders,
        sum((metrics->>'replicas.leaseholders')::DECIMAL)::INT AS replicas_leaseholders,
@@ -181,7 +173,7 @@ SELECT node_id AS id,
 FROM crdb_internal.kv_store_status
 GROUP BY node_id`
 
-	statsQuery := `
+	const statsQuery = `
 SELECT node_id AS id,
        sum((metrics->>'livebytes')::DECIMAL)::INT AS live_bytes,
        sum((metrics->>'keybytes')::DECIMAL)::INT AS key_bytes,
@@ -191,12 +183,12 @@ SELECT node_id AS id,
 FROM crdb_internal.kv_store_status
 GROUP BY node_id`
 
-	decommissionQuery := `
+	const decommissionQuery = `
 SELECT node_id AS id,
        ranges AS gossiped_replicas,
        decommissioning AS is_decommissioning,
        draining AS is_draining
-FROM crdb_internal.gossip_liveness JOIN crdb_internal.gossip_nodes USING (node_id)`
+FROM crdb_internal.gossip_liveness LEFT JOIN crdb_internal.gossip_nodes USING (node_id)`
 
 	conn, err := getPasswordAndMakeSQLClient("cockroach node status")
 	if err != nil {
@@ -222,7 +214,7 @@ FROM crdb_internal.gossip_liveness JOIN crdb_internal.gossip_nodes USING (node_i
 		}
 	}
 
-	queryString := "SELECT * FROM " + joinUsingID(queriesToJoin)
+	queryString := "SELECT * FROM (" + joinUsingID(queriesToJoin) + ")"
 
 	switch len(args) {
 	case 0:

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -101,4 +101,19 @@ func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 		"false false",
 		"false false",
 	})
+
+	// Stop the cluster and restart only 2 of the nodes. Verify that three nodes
+	// show up in the node status output.
+	c.Stop(ctx, c.Range(1, 3))
+	c.Start(ctx, c.Range(1, 2))
+
+	// Wait for the cluster to come back up.
+	waitForFullReplication(t, db)
+
+	waitUntil([]string{
+		"is_available is_live",
+		"true true",
+		"true true",
+		"false false",
+	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #34448.

/cc @cockroachdb/release

---

Previously, `node status` would only show status for nodes which had
gossiped a node descriptor. This meant that a node that had been down
for long enough for the gossiped node descriptor TTL to be reached would
disappear from the `node status` output. Similarly, if a cluster was
restarted but one node failed to come up, that node would be omitted
from the `node status` output. The `crdb_internal.gossip_liveness` table
contains a full list of the nodes in the cluster. We simply need to
`LEFT JOIN` instead of `JOIN` with other tables.

Fixes #34435

Release note: None
