### PR TITLE
changefeedccl: stop blocking between RangeFeed and the buffer

### DIFF
--- a/pkg/ccl/changefeedccl/buffer.go
+++ b/pkg/ccl/changefeedccl/buffer.go
@@ -14,7 +14,13 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -74,4 +80,142 @@ func (b *buffer) Get(ctx context.Context) (bufferEntry, error) {
 		e.bufferGetTimestamp = timeutil.Now()
 		return e, nil
 	}
+}
+
+var memBufferColTypes = []sqlbase.ColumnType{
+	{SemanticType: sqlbase.ColumnType_BYTES}, // kv.Key
+	{SemanticType: sqlbase.ColumnType_BYTES}, // kv.Value
+	{SemanticType: sqlbase.ColumnType_BYTES}, // span.Key
+	{SemanticType: sqlbase.ColumnType_BYTES}, // span.EndKey
+	{SemanticType: sqlbase.ColumnType_INT},   // ts.WallTime
+	{SemanticType: sqlbase.ColumnType_INT},   // ts.Logical
+	{SemanticType: sqlbase.ColumnType_INT},   // schemaTimestamp.WallTime
+	{SemanticType: sqlbase.ColumnType_INT},   // schemaTimestamp.Logical
+}
+
+// memBuffer is an in-memory buffer for changed KV and resolved timestamp
+// events. It's size is limited only by the BoundAccount passed to the
+// constructor.
+type memBuffer struct {
+	mu struct {
+		syncutil.Mutex
+		entries rowcontainer.RowContainer
+	}
+
+	allocMu struct {
+		syncutil.Mutex
+		a sqlbase.DatumAlloc
+	}
+}
+
+func makeMemBuffer(acc mon.BoundAccount) *memBuffer {
+	b := &memBuffer{}
+	b.mu.entries.Init(acc, sqlbase.ColTypeInfoFromColTypes(memBufferColTypes), 0 /* rowCapacity */)
+	return b
+}
+
+func (b *memBuffer) Close(ctx context.Context) {
+	b.mu.Lock()
+	b.mu.entries.Close(ctx)
+	b.mu.Unlock()
+}
+
+// AddKV inserts a changed kv into the buffer.
+func (b *memBuffer) AddKV(
+	ctx context.Context, kv roachpb.KeyValue, schemaTimestamp hlc.Timestamp,
+) error {
+	b.allocMu.Lock()
+	row := tree.Datums{
+		b.allocMu.a.NewDBytes(tree.DBytes(kv.Key)),
+		b.allocMu.a.NewDBytes(tree.DBytes(kv.Value.RawBytes)),
+		tree.DNull,
+		tree.DNull,
+		b.allocMu.a.NewDInt(tree.DInt(kv.Value.Timestamp.WallTime)),
+		b.allocMu.a.NewDInt(tree.DInt(kv.Value.Timestamp.Logical)),
+		b.allocMu.a.NewDInt(tree.DInt(schemaTimestamp.WallTime)),
+		b.allocMu.a.NewDInt(tree.DInt(schemaTimestamp.Logical)),
+	}
+	b.allocMu.Unlock()
+	return b.addRow(ctx, row)
+}
+
+// AddResolved inserts a resolved timestamp notification in the buffer.
+func (b *memBuffer) AddResolved(ctx context.Context, span roachpb.Span, ts hlc.Timestamp) error {
+	b.allocMu.Lock()
+	row := tree.Datums{
+		tree.DNull,
+		tree.DNull,
+		b.allocMu.a.NewDBytes(tree.DBytes(span.Key)),
+		b.allocMu.a.NewDBytes(tree.DBytes(span.EndKey)),
+		b.allocMu.a.NewDInt(tree.DInt(ts.WallTime)),
+		b.allocMu.a.NewDInt(tree.DInt(ts.Logical)),
+		tree.DNull,
+		tree.DNull,
+	}
+	b.allocMu.Unlock()
+	return b.addRow(ctx, row)
+}
+
+// Get returns an entry from the buffer. They are handed out in an order that
+// (if it is maintained all the way to the sink) meets our external guarantees.
+func (b *memBuffer) Get(ctx context.Context) (bufferEntry, error) {
+	row, err := b.getRow(ctx)
+	if err != nil {
+		return bufferEntry{}, err
+	}
+	e := bufferEntry{bufferGetTimestamp: timeutil.Now()}
+	ts := hlc.Timestamp{
+		WallTime: int64(*row[4].(*tree.DInt)),
+		Logical:  int32(*row[5].(*tree.DInt)),
+	}
+	if row[0] != tree.DNull {
+		e.kv = roachpb.KeyValue{
+			Key: []byte(*row[0].(*tree.DBytes)),
+			Value: roachpb.Value{
+				RawBytes:  []byte(*row[1].(*tree.DBytes)),
+				Timestamp: ts,
+			},
+		}
+		e.schemaTimestamp = hlc.Timestamp{
+			WallTime: int64(*row[6].(*tree.DInt)),
+			Logical:  int32(*row[7].(*tree.DInt)),
+		}
+		return e, nil
+	}
+	e.resolved = &jobspb.ResolvedSpan{
+		Span: roachpb.Span{
+			Key:    []byte(*row[2].(*tree.DBytes)),
+			EndKey: []byte(*row[3].(*tree.DBytes)),
+		},
+		Timestamp: ts,
+	}
+	return e, nil
+}
+
+func (b *memBuffer) addRow(ctx context.Context, row tree.Datums) error {
+	b.mu.Lock()
+	_, err := b.mu.entries.AddRow(ctx, row)
+	b.mu.Unlock()
+	return err
+}
+
+func (b *memBuffer) getRow(ctx context.Context) (tree.Datums, error) {
+	retryOpts := retry.Options{
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Second,
+	}
+
+	var row tree.Datums
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		b.mu.Lock()
+		if b.mu.entries.Len() > 0 {
+			row = b.mu.entries.At(0)
+			b.mu.entries.PopFirst()
+		}
+		b.mu.Unlock()
+		if row != nil {
+			return row, nil
+		}
+	}
+	return nil, ctx.Err()
 }

--- a/pkg/ccl/changefeedccl/table_history.go
+++ b/pkg/ccl/changefeedccl/table_history.go
@@ -224,7 +224,7 @@ func fetchTableDescriptorVersions(
 	targets jobspb.ChangefeedTargets,
 ) ([]*sqlbase.TableDescriptor, error) {
 	if log.V(2) {
-		log.Infof(ctx, `fetching table descs [%s,%s)`, startTS, endTS)
+		log.Infof(ctx, `fetching table descs (%s,%s]`, startTS, endTS)
 	}
 	start := timeutil.Now()
 	span := roachpb.Span{Key: keys.MakeTablePrefix(keys.DescriptorTableID)}
@@ -239,11 +239,10 @@ func fetchTableDescriptorVersions(
 	}
 	res, pErr := client.SendWrappedWith(ctx, db.NonTransactionalSender(), header, req)
 	if log.V(2) {
-		log.Infof(ctx, `fetched table descs [%s,%s) took %s`, startTS, endTS, timeutil.Since(start))
+		log.Infof(ctx, `fetched table descs (%s,%s] took %s`, startTS, endTS, timeutil.Since(start))
 	}
 	if pErr != nil {
-		return nil, errors.Wrapf(
-			pErr.GoError(), `fetching changes for [%s,%s)`, span.Key, span.EndKey)
+		return nil, errors.Wrapf(pErr.GoError(), `fetching changes for %s`, span)
 	}
 
 	var tableDescs []*sqlbase.TableDescriptor


### PR DESCRIPTION
To avoid blocking raft, RangeFeed puts all entries in a server side
buffer. But to keep things simple, it's a small fixed-sized buffer. This
means we need to ingest everything we get back as quickly as possible.
Previously, there was a `tableHist.WaitForTS` call between RangeFeed and
the buffer, which blocked on fetching table descriptors for at least the
timestamp in the changed kv. This caused the internal RangeFeed event
buffers to overflow and throw REASON_SLOW_CONSUMER errors.

Ideally, we'd resolve this by making the buffer between the poller and
the rest of the system a memBuffer. Unfortuanately, some code structure
issues mean we still wouldn't be able to move the `tableHist.WaitForTS`
after that buffer. So instead, we put the memBuffer inside poller and
keep the one between poller and the rest of the system unchanged.
Definitely, a cleanup is in order.

This fixes the cdc/ledger roachtest. I tried writing a unit test that
overloaded the buffers without this change, but eventually ran into
buffering in the grpc stream that I don't know how to turn off. Test
will have to be a followup.

This commit also cleans up a few of the log messages in changefeedccl.
Spans are now printed using the standard `roachpb.Span.String()` and the
inclusive/exclusive bounds on some time ranges are swapped to now be
correct.

Closes #34391

Release note: None