### PR TITLE
opt: refresh stats for read-only tables on startup

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1603,7 +1603,9 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	// Start the background thread for periodically refreshing table statistics.
-	if err := s.statsRefresher.Start(ctx, s.stopper, stats.DefaultRefreshInterval); err != nil {
+	if err := s.statsRefresher.Start(
+		ctx, &s.st.SV, s.stopper, stats.DefaultRefreshInterval,
+	); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Prior to this commit, the only way for a table to have statistics
automatically created or refreshed was if that table was updated
periodically. This commit adds logic which automatically tries to
creates statistics on all tables in the database when a server starts
up, regardless of update frequency. Note that if stats for a given
table were refreshed recently, they may not be refreshed at startup.

As with the rest of automatic statistics, this feature is controlled
by the cluster setting `sql.stats.experimental_automatic_collection.enabled`,
which is currently disabled by default.

Release note: None