### PR TITLE
pgwire: implement cancellation protocol

### DIFF
--- a/pkg/sql/cluster_wide_id.go
+++ b/pkg/sql/cluster_wide_id.go
@@ -53,3 +53,9 @@ func BytesToClusterWideID(b []byte) ClusterWideID {
 func (id ClusterWideID) GetNodeID() int32 {
 	return int32(0xFFFFFFFF & id.Lo)
 }
+
+// GetPGWireCancelInfo extracts the timestamp of the cluster wide ID as 2
+// int32s, for use by the pgwire cancellation protocol.
+func (id ClusterWideID) GetPGWireCancelInfo() (int32, int32) {
+	return int32(id.Hi >> 32), int32(0xFFFFFFFF & id.Hi)
+}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -461,6 +461,13 @@ func (h ConnectionHandler) GetParamStatus(ctx context.Context, varName string) s
 	return defVal
 }
 
+// GetStatusParam retrieves the configured value of the session
+// variable identified by varName. This is used for the initial
+// message sent to a client during a session set-up.
+func (h ConnectionHandler) GetSessionID() ClusterWideID {
+	return h.ex.sessionID
+}
+
 // ServeConn serves a client connection by reading commands from the stmtBuf
 // embedded in the ConnHandler.
 //
@@ -655,6 +662,7 @@ func (s *Server) newConnExecutor(
 		settings:          s.cfg.Settings,
 	}
 	ex.extraTxnState.txnRewindPos = -1
+	ex.sessionID = ex.generateID()
 	ex.mu.ActiveQueries = make(map[ClusterWideID]*queryMeta)
 	ex.machine = fsm.MakeMachine(TxnStateTransitions, stateNoTxn{}, &ex.state)
 
@@ -1282,7 +1290,6 @@ func (ex *connExecutor) run(
 	ex.ctxHolder.connCtx = ctx
 	ex.onCancelSession = onCancel
 
-	ex.sessionID = ex.generateID()
 	ex.server.cfg.SessionRegistry.register(ex.sessionID, ex)
 	ex.planner.extendedEvalCtx.setSessionID(ex.sessionID)
 	defer ex.server.cfg.SessionRegistry.deregister(ex.sessionID)
@@ -2207,6 +2214,15 @@ func (ex *connExecutor) cancelQuery(queryID ClusterWideID) bool {
 		return true
 	}
 	return false
+}
+
+// cancelCurrentQueries is part of the registrySession interface.
+func (ex *connExecutor) cancelCurrentQueries() {
+	ex.mu.Lock()
+	defer ex.mu.Unlock()
+	for _, queryMeta := range ex.mu.ActiveQueries {
+		queryMeta.cancel()
+	}
 }
 
 // cancelSession is part of the registrySession interface.

--- a/pkg/sql/pgwire/pgwirebase/msg.go
+++ b/pkg/sql/pgwire/pgwirebase/msg.go
@@ -37,6 +37,7 @@ const (
 	ClientMsgTerminate   ClientMessageType = 'X'
 
 	ServerMsgAuth                 ServerMessageType = 'R'
+	ServerMsgBackendKeyData       ServerMessageType = 'K'
 	ServerMsgBindComplete         ServerMessageType = '2'
 	ServerMsgCommandComplete      ServerMessageType = 'C'
 	ServerMsgCloseComplete        ServerMessageType = '3'

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -542,8 +542,15 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn, socketType Socket
 		// If the client is really issuing a cancel request, close the door
 		// in their face (we don't support it yet). Make a note of that use
 		// in telemetry.
-		telemetry.Inc(sqltelemetry.CancelRequestCounter)
-		_ = conn.Close()
+		code, err := buf.GetUint32()
+		if err != nil {
+			return err
+		}
+		secret, err := buf.GetUint32()
+		if err != nil {
+			return err
+		}
+		s.execCfg.SessionRegistry.CancelQueryByPGWire(code, secret)
 		return nil
 
 	case version30:


### PR DESCRIPTION
PGWire connections now send back the PID/secret combo at the start of a
connection that permits PGWire-based cancellation messages to do their
job. This allows lib/pq context cancellations from a client to propagate
all the way up into a running query in the CockroachDB server and cancel
it gracefully.

closes #41335

Release note (sql change): Postgres wire protocol cancellation messages
are now respected by the server.