### PR TITLE
sqlsmith: testing enhancements; testing knob to prevent sql panics

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -221,7 +221,7 @@ WHERE
 	NOT proisagg
 	AND NOT proiswindow
 	AND NOT proretset
-	AND proname NOT IN ('crdb_internal.force_panic', 'crdb_internal.force_log_fatal')
+	AND proname NOT IN ('crdb_internal.force_panic', 'crdb_internal.force_log_fatal', 'crdb_internal.force_error', 'crdb_internal.force_assertion_error')
 `)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -345,6 +345,11 @@ func (s *Server) GetStmtStatsLastReset() time.Time {
 	return s.sqlStats.getLastReset()
 }
 
+// GetExecutorConfig returns this server's executor config.
+func (s *Server) GetExecutorConfig() *ExecutorConfig {
+	return s.cfg
+}
+
 // SetupConn creates a connExecutor for the client connection.
 //
 // When this method returns there are no resources allocated yet that

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -427,6 +427,11 @@ type ExecutorTestingKnobs struct {
 	// optimization). This is only called when the Executor is the one doing the
 	// committing.
 	BeforeAutoCommit func(ctx context.Context, stmt string) error
+
+	// CatchPanics causes the connExecutor to recover from panics in its execution
+	// thread and return them as errors to the client, closing the connection
+	// afterward.
+	CatchPanics bool
 }
 
 // databaseCacheHolder is a thread-safe container for a *databaseCache.


### PR DESCRIPTION
The first commit introduces a testing knob that catches panics from the SQL Executor and converts them into pgwire errors.

The second commit introduces a bunch of little improvements to sqlsmith:
- add list of common benign errors that are ignored
- log other errors
- log crashing errors
- log schema at the end for easy reproduction
