### PR TITLE
sql: enable automatic statistics by default

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -84,7 +84,7 @@
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statistics to be collected</td></tr>
 <tr><td><code>sql.parallel_scans.enabled</code></td><td>boolean</td><td><code>true</code></td><td>parallelizes scanning different ranges when the maximum result size can be deduced</td></tr>
 <tr><td><code>sql.query_cache.enabled</code></td><td>boolean</td><td><code>false</code></td><td>enable the query cache</td></tr>
-<tr><td><code>sql.stats.experimental_automatic_collection.enabled</code></td><td>boolean</td><td><code>false</code></td><td>experimental automatic statistics collection mode</td></tr>
+<tr><td><code>sql.stats.experimental_automatic_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>experimental automatic statistics collection mode</td></tr>
 <tr><td><code>sql.tablecache.lease.refresh_limit</code></td><td>integer</td><td><code>50</code></td><td>maximum number of tables to periodically refresh leases for</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>
 <tr><td><code>sql.trace.session_eventlog.enabled</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable session tracing</td></tr>

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -389,6 +389,8 @@ type testClusterConfig struct {
 	overrideDistSQLMode string
 	// if non-empty, overrides the default experimental_vectorize mode.
 	overrideExpVectorize string
+	// if non-empty, overrides the default automatic statistics mode.
+	overrideAutoStats string
 	// if set, queries using distSQL processors that can fall back to disk do
 	// so immediately, using only their disk-based implementation.
 	distSQLUseDisk bool
@@ -427,18 +429,18 @@ var logicTestConfigs = []testClusterConfig{
 		serverVersion:  roachpb.Version{Major: 1, Minor: 1},
 		disableUpgrade: true,
 	},
-	{name: "local-opt", numNodes: 1, overrideDistSQLMode: "off", overrideOptimizerMode: "on"},
+	{name: "local-opt", numNodes: 1, overrideDistSQLMode: "off", overrideOptimizerMode: "on", overrideAutoStats: "false"},
 	{name: "local-parallel-stmts", numNodes: 1, parallelStmts: true, overrideDistSQLMode: "off", overrideOptimizerMode: "off"},
 	{name: "local-vec", numNodes: 1, overrideOptimizerMode: "off", overrideExpVectorize: "on"},
 	{name: "fakedist", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "off"},
-	{name: "fakedist-opt", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "on"},
+	{name: "fakedist-opt", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "on", overrideAutoStats: "false"},
 	{name: "fakedist-metadata", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "off",
 		distSQLMetadataTestEnabled: true, skipShort: true},
 	{name: "fakedist-disk", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "on", overrideOptimizerMode: "off",
 		distSQLUseDisk: true, skipShort: true},
 	{name: "5node-local", numNodes: 5, overrideDistSQLMode: "off", overrideOptimizerMode: "off"},
 	{name: "5node-dist", numNodes: 5, overrideDistSQLMode: "on", overrideOptimizerMode: "off"},
-	{name: "5node-dist-opt", numNodes: 5, overrideDistSQLMode: "on", overrideOptimizerMode: "on"},
+	{name: "5node-dist-opt", numNodes: 5, overrideDistSQLMode: "on", overrideOptimizerMode: "on", overrideAutoStats: "false"},
 	{name: "5node-dist-metadata", numNodes: 5, overrideDistSQLMode: "on", distSQLMetadataTestEnabled: true,
 		skipShort: true, overrideOptimizerMode: "off"},
 	{name: "5node-dist-disk", numNodes: 5, overrideDistSQLMode: "on", distSQLUseDisk: true, skipShort: true,
@@ -1071,6 +1073,13 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 	if cfg.overrideExpVectorize != "" {
 		if _, err := t.cluster.ServerConn(0).Exec(
 			"SET CLUSTER SETTING sql.defaults.experimental_vectorize = $1::string", cfg.overrideExpVectorize,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if cfg.overrideAutoStats != "" {
+		if _, err := t.cluster.ServerConn(0).Exec(
+			"SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = $1::bool", cfg.overrideAutoStats,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -32,6 +32,7 @@ ALTER TABLE t ADD CONSTRAINT foo UNIQUE (b)
 query TTTTRT
 SELECT job_type, description, user_name, status, fraction_completed, error
 FROM crdb_internal.jobs
+WHERE job_type = 'SCHEMA CHANGE'
 ORDER BY created DESC
 LIMIT 1
 ----
@@ -71,6 +72,7 @@ ALTER TABLE t ADD CONSTRAINT bar UNIQUE (c)
 query TTTTTRT
 SELECT job_type, regexp_replace(description, 'JOB \d+', 'JOB ...'), user_name, status, running_status, fraction_completed::decimal(10,2), error
 FROM crdb_internal.jobs
+WHERE job_type = 'SCHEMA CHANGE'
 ORDER BY created DESC
 LIMIT 2
 ----
@@ -181,6 +183,7 @@ DROP INDEX foo CASCADE
 query TTTTTRT
 SELECT job_type, description, user_name, status, running_status, fraction_completed, error
 FROM crdb_internal.jobs
+WHERE job_type = 'SCHEMA CHANGE'
 ORDER BY created DESC
 LIMIT 1
 ----
@@ -264,6 +267,7 @@ DROP INDEX t@t_f_idx
 query TTTTTRT
 SELECT job_type, description, user_name, status, running_status, fraction_completed, error
 FROM crdb_internal.jobs
+WHERE job_type = 'SCHEMA CHANGE'
 ORDER BY created DESC
 LIMIT 1
 ----
@@ -650,7 +654,8 @@ SELECT count(distinct a) FROM impure
 
 # No orphaned schema change jobs.
 query I
-SELECT count(*) FROM crdb_internal.jobs WHERE status = 'pending' OR status = 'started'
+SELECT count(*) FROM crdb_internal.jobs
+WHERE job_type = 'SCHEMA CHANGE' AND status = 'pending' OR status = 'started'
 ----
 0
 

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -231,6 +231,10 @@ COMMIT
 
 subtest regression_33361
 
+# Disable automatic stats to avoid flakiness (sometimes causes retry errors).
+statement ok
+SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+
 statement ok
 CREATE TABLE t33361(x INT PRIMARY KEY, y INT UNIQUE, z INT); INSERT INTO t33361 VALUES (1, 2, 3)
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1,5 +1,9 @@
 # LogicTest: 5node-dist 5node-dist-opt 5node-dist-metadata
 
+# Disable automatic stats.
+statement ok
+SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d), INDEX c_idx (c, d))
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -26,7 +26,7 @@ statement ok
 DROP TABLE a
 
 query TT
-SELECT status, running_status FROM [SHOW JOBS]
+SELECT status, running_status FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE'
 ----
 running  waiting for GC TTL
 

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -342,6 +342,7 @@ SELECT "targetID", "reportingID", "info"
 FROM system.eventlog
 WHERE "eventType" = 'set_cluster_setting'
 AND info NOT LIKE '%version%' AND info NOT LIKE '%sql.defaults.distsql%' AND info NOT LIKE '%cluster.secret%'
+AND info NOT LIKE '%sql.stats.experimental_automatic_collection.enabled%'
 ORDER BY "timestamp"
 ----
 0  1  {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"root"}

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1,5 +1,9 @@
 # LogicTest: local local-opt local-parallel-stmts fakedist fakedist-opt fakedist-metadata
 
+# Disable automatic stats to avoid flakiness.
+statement ok
+SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+
 statement ok
 CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE)
 

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -90,10 +90,6 @@ SELECT * FROM tview
 3  30
 4  40
 
-query I rowsort
-SELECT job_id FROM crdb_internal.jobs
-----
-
 statement ok
 SET OPTIMIZER = ALWAYS
 

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -1,5 +1,9 @@
 # LogicTest: local local-opt local-parallel-stmts fakedist fakedist-opt fakedist-metadata
 
+# Disable automatic stats to avoid flakiness.
+statement ok
+SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+
 # Test default table-level permissions.
 # Default user is root.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1,5 +1,9 @@
 # LogicTest: local local-opt local-parallel-stmts fakedist fakedist-opt fakedist-metadata
 
+# Disable automatic stats to avoid flakiness (sometimes causes retry errors).
+statement ok
+SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+
 subtest create_and_add_fk_in_same_txn
 
 statement ok
@@ -718,7 +722,7 @@ query TTT
 SELECT status,
        running_status,
        regexp_replace(description, 'ROLL BACK JOB \d+.*', 'ROLL BACK JOB') as description
-  FROM [SHOW JOBS] ORDER BY job_id DESC LIMIT 2
+  FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE' ORDER BY job_id DESC LIMIT 2
 ----
 running  waiting for GC TTL  ROLL BACK JOB
 failed   NULL                ALTER TABLE test.public.customers ADD COLUMN i INT8 DEFAULT 5;ALTER TABLE test.public.customers ADD COLUMN j INT8 DEFAULT 4;ALTER TABLE test.public.customers ADD COLUMN l INT8 DEFAULT 3;ALTER TABLE test.public.customers ADD COLUMN m CHAR;ALTER TABLE test.public.customers ADD COLUMN n CHAR DEFAULT 'a';CREATE INDEX j_idx ON test.public.customers (j);CREATE INDEX l_idx ON test.public.customers (l);CREATE INDEX m_idx ON test.public.customers (m);CREATE UNIQUE INDEX i_idx ON test.public.customers (i);CREATE UNIQUE INDEX n_idx ON test.public.customers (n)
@@ -748,7 +752,8 @@ x  5  4  15  19
 z  5  4  15  19
 
 query TT
-SELECT status, description FROM [SHOW JOBS] ORDER BY job_id DESC LIMIT 1
+SELECT status, description FROM [SHOW JOBS]
+WHERE job_type = 'SCHEMA CHANGE' ORDER BY job_id DESC LIMIT 1
 ----
 succeeded  ALTER TABLE test.public.customers ADD COLUMN i INT8 DEFAULT 5;ALTER TABLE test.public.customers ADD COLUMN j INT8 AS (i - 1) STORED;ALTER TABLE test.public.customers ADD COLUMN d INT8 DEFAULT 15, ADD COLUMN e INT8 AS (d + j) STORED
 

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -442,6 +442,7 @@ query T
 SELECT name
 FROM system.settings
 WHERE name != 'sql.defaults.distsql'
+AND name != 'sql.stats.experimental_automatic_collection.enabled'
 ORDER BY name
 ----
 cluster.secret
@@ -456,7 +457,8 @@ INSERT INTO system.settings (name, value) VALUES ('somesetting', 'somevalue')
 query TT
 SELECT name, value
 FROM system.settings
-WHERE name NOT IN ('version', 'sql.defaults.distsql', 'cluster.secret')
+WHERE name NOT IN ('version', 'sql.defaults.distsql', 'cluster.secret',
+  'sql.stats.experimental_automatic_collection.enabled')
 ORDER BY name
 ----
 diagnostics.reporting.enabled  true

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -51,7 +51,7 @@ SELECT * FROM kview
 ----
 
 query TT
-SELECT status, running_status FROM [SHOW JOBS]
+SELECT status, running_status FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE'
 ----
 running  waiting for GC TTL
 

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -1,5 +1,9 @@
 # LogicTest: local local-vec
 
+# Disable automatic stats.
+statement ok
+SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+
 statement ok
 CREATE TABLE a (a INT, b INT, PRIMARY KEY (a, b))
 

--- a/pkg/sql/logictest/testdata/planner_test/show_trace
+++ b/pkg/sql/logictest/testdata/planner_test/show_trace
@@ -1,5 +1,9 @@
 # LogicTest: local
 
+# Disable automatic stats.
+statement ok
+SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+
 # Check SHOW KV TRACE FOR SESSION.
 
 statement ok

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -63,14 +63,14 @@ func TestMaybeRefreshStats(t *testing.T) {
 
 	// There are no stats yet, so this must refresh the statistics on table t
 	// even though rowsAffected=0.
-	refresher.maybeRefreshStats(ctx, descA.ID, 0 /* rowsAffected */, 0 /* asOf */)
+	refresher.maybeRefreshStats(ctx, s.Stopper(), descA.ID, 0 /* rowsAffected */, 0 /* asOf */)
 	if err := checkStatsCount(ctx, cache, descA.ID, 1 /* expected */); err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to refresh again. With rowsAffected=0, the probability of a refresh
 	// is 0, so refreshing will not succeed.
-	refresher.maybeRefreshStats(ctx, descA.ID, 0 /* rowsAffected */, 0 /* asOf */)
+	refresher.maybeRefreshStats(ctx, s.Stopper(), descA.ID, 0 /* rowsAffected */, 0 /* asOf */)
 	if err := checkStatsCount(ctx, cache, descA.ID, 1 /* expected */); err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,9 @@ func TestMaybeRefreshStats(t *testing.T) {
 	// With rowsAffected=10, refreshing should work. Since there are more rows
 	// updated than exist in the table, the probability of a refresh is 100%.
 	// Use a non-zero asOf time to test that the thread will sleep if necessary.
-	refresher.maybeRefreshStats(ctx, descA.ID, 10 /* rowsAffected */, time.Second /* asOf */)
+	refresher.maybeRefreshStats(
+		ctx, s.Stopper(), descA.ID, 10 /* rowsAffected */, time.Second, /* asOf */
+	)
 	if err := checkStatsCount(ctx, cache, descA.ID, 2 /* expected */); err != nil {
 		t.Fatal(err)
 	}
@@ -247,7 +249,7 @@ func TestAverageRefreshTime(t *testing.T) {
 	// average time between refreshes, so this call is not required to refresh
 	// the statistics on table t. With rowsAffected=0, the probability of refresh
 	// is 0.
-	refresher.maybeRefreshStats(ctx, tableID, 0 /* rowsAffected */, 0 /* asOf */)
+	refresher.maybeRefreshStats(ctx, s.Stopper(), tableID, 0 /* rowsAffected */, 0 /* asOf */)
 	if err := checkStatsCount(ctx, cache, tableID, 20 /* expected */); err != nil {
 		t.Fatal(err)
 	}
@@ -292,7 +294,7 @@ func TestAverageRefreshTime(t *testing.T) {
 	// on table t even though rowsAffected=0. After refresh, only 15 stats should
 	// remain (5 from column k and 10 from column v), since the old stats on k
 	// were deleted.
-	refresher.maybeRefreshStats(ctx, tableID, 0 /* rowsAffected */, 0 /* asOf */)
+	refresher.maybeRefreshStats(ctx, s.Stopper(), tableID, 0 /* rowsAffected */, 0 /* asOf */)
 	if err := checkStatsCount(ctx, cache, tableID, 15 /* expected */); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This commit changes the default value of the cluster setting
`sql.stats.experimental_automatic_collection.enabled` to true.
As a result, automatic statistics collection is now enabled by
default. It can still be disabled by setting
`sql.stats.experimental_automatic_collection.enabled=false`.

Release note (sql change): Enabled automatic statistics collection.