### PR TITLE
sql: fix processing of patterns with custom escape character

### DIFF
--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2281,6 +2281,19 @@ func MatchLikeEscape(
 		}
 	}
 
+	if len(unescaped) == 0 {
+		// An empty string only matches with an empty pattern or a pattern
+		// consisting only of '%' (if this wildcard is not used as a custom escape
+		// character). To match PostgreSQL's behavior, we have a special handling
+		// of this case.
+		for _, c := range pattern {
+			if c != '%' || (c == '%' && escape == `%`) {
+				return DBoolFalse, nil
+			}
+		}
+		return DBoolTrue, nil
+	}
+
 	like, err := optimizedLikeFunc(pattern, caseInsensitive, escapeRune)
 	if err != nil {
 		return DBoolFalse, pgerror.NewErrorf(
@@ -2294,13 +2307,28 @@ func MatchLikeEscape(
 			return DBoolFalse, pgerror.NewErrorf(
 				pgerror.CodeInvalidRegularExpressionError, "LIKE regexp compilation failed: %v", err)
 		}
-		like = re.MatchString
+		like = func(s string) (bool, error) {
+			return re.MatchString(s), nil
+		}
 	}
-	return MakeDBool(DBool(like(unescaped))), nil
+	matches, err := like(unescaped)
+	return MakeDBool(DBool(matches)), err
 }
 
 func matchLike(ctx *EvalContext, left, right Datum, caseInsensitive bool) (Datum, error) {
-	pattern := string(MustBeDString(right))
+	s, pattern := string(MustBeDString(left)), string(MustBeDString(right))
+	if len(s) == 0 {
+		// An empty string only matches with an empty pattern or a pattern
+		// consisting only of '%'. To match PostgreSQL's behavior, we have a
+		// special handling of this case.
+		for _, c := range pattern {
+			if c != '%' {
+				return DBoolFalse, nil
+			}
+		}
+		return DBoolTrue, nil
+	}
+
 	like, err := optimizedLikeFunc(pattern, caseInsensitive, '\\')
 	if err != nil {
 		return DBoolFalse, pgerror.NewErrorf(
@@ -2314,9 +2342,12 @@ func matchLike(ctx *EvalContext, left, right Datum, caseInsensitive bool) (Datum
 			return DBoolFalse, pgerror.NewErrorf(
 				pgerror.CodeInvalidRegularExpressionError, "LIKE regexp compilation failed: %v", err)
 		}
-		like = re.MatchString
+		like = func(s string) (bool, error) {
+			return re.MatchString(s), nil
+		}
 	}
-	return MakeDBool(DBool(like(string(MustBeDString(left))))), nil
+	matches, err := like(s)
+	return MakeDBool(DBool(matches)), err
 }
 
 func matchRegexpWithKey(ctx *EvalContext, str Datum, key RegexpCacheKey) (Datum, error) {
@@ -4088,11 +4119,11 @@ func hasUnescapedSuffix(s string, suffix byte, escapeToken string) bool {
 // if a string starts with a given pattern.
 func optimizedLikeFunc(
 	pattern string, caseInsensitive bool, escape rune,
-) (func(string) bool, error) {
+) (func(string) (bool, error), error) {
 	switch len(pattern) {
 	case 0:
-		return func(s string) bool {
-			return s == ""
+		return func(s string) (bool, error) {
+			return s == "", nil
 		}, nil
 	case 1:
 		switch pattern[0] {
@@ -4100,28 +4131,37 @@ func optimizedLikeFunc(
 			if escape == '%' {
 				return nil, pgerror.NewErrorf(pgerror.CodeInvalidEscapeSequenceError, "LIKE pattern must not end with escape character")
 			}
-			return func(s string) bool {
-				return true
+			return func(s string) (bool, error) {
+				return true, nil
 			}, nil
 		case '_':
 			if escape == '_' {
 				return nil, pgerror.NewErrorf(pgerror.CodeInvalidEscapeSequenceError, "LIKE pattern must not end with escape character")
 			}
-			return func(s string) bool {
-				return len(s) == 1
+			return func(s string) (bool, error) {
+				if len(s) == 0 {
+					return false, nil
+				}
+				firstChar, _ := utf8.DecodeRuneInString(s)
+				if firstChar == utf8.RuneError {
+					return false, errors.Errorf("invalid encoding of the first character in string %s", s)
+				}
+				return len(s) == len(string(firstChar)), nil
 			}, nil
 		}
 	default:
 		if !strings.ContainsAny(pattern[1:len(pattern)-1], "_%") {
-			// Patterns with even number of escape characters preceding the ending `%` will have
-			// anyEnd set to true. Otherwise anyEnd will be set to false.
-			anyEnd := hasUnescapedSuffix(pattern, '%', string(escape))
+			// Patterns with even number of escape characters preceding the ending
+			// `%` will have anyEnd set to true (if `%` itself is not an escape
+			// character). Otherwise anyEnd will be set to false.
+			anyEnd := hasUnescapedSuffix(pattern, '%', string(escape)) && escape != '%'
 			// If '%' is the escape character, then it's not a wildcard.
 			anyStart := pattern[0] == '%' && escape != '%'
 
-			// Patterns with even number of escape characters preceding the ending `_` will have
-			// singleAnyEnd set to true. Otherwise singleAnyEnd will be set to false.
-			singleAnyEnd := hasUnescapedSuffix(pattern, '_', string(escape))
+			// Patterns with even number of escape characters preceding the ending
+			// `_` will have singleAnyEnd set to true (if `_` itself is not an escape
+			// character). Otherwise singleAnyEnd will be set to false.
+			singleAnyEnd := hasUnescapedSuffix(pattern, '_', string(escape)) && escape != '_'
 			// If '_' is the escape character, then it's not a wildcard.
 			singleAnyStart := pattern[0] == '_' && escape != '_'
 
@@ -4130,67 +4170,85 @@ func optimizedLikeFunc(
 			// This is required since we do direct string
 			// comparison.
 			var err error
-			if pattern, err = unescapePattern(pattern, string(escape), escape == '\\'); err != nil {
+			if pattern, err = unescapePattern(pattern, string(escape), true /* emitEscapeCharacterLastError */); err != nil {
 				return nil, err
 			}
 			switch {
 			case anyEnd && anyStart:
-				return func(s string) bool {
+				return func(s string) (bool, error) {
 					substr := pattern[1 : len(pattern)-1]
 					if caseInsensitive {
 						s, substr = strings.ToUpper(s), strings.ToUpper(substr)
 					}
-					return strings.Contains(s, substr)
+					return strings.Contains(s, substr), nil
 				}, nil
 
 			case anyEnd:
-				return func(s string) bool {
+				return func(s string) (bool, error) {
 					prefix := pattern[:len(pattern)-1]
 					if singleAnyStart {
 						if len(s) == 0 {
-							return false
+							return false, nil
 						}
-
 						prefix = prefix[1:]
-						s = s[1:]
+						firstChar, _ := utf8.DecodeRuneInString(s)
+						if firstChar == utf8.RuneError {
+							return false, errors.Errorf("invalid encoding of the first character in string %s", s)
+						}
+						s = s[len(string(firstChar)):]
 					}
 					if caseInsensitive {
 						s, prefix = strings.ToUpper(s), strings.ToUpper(prefix)
 					}
-					return strings.HasPrefix(s, prefix)
+					return strings.HasPrefix(s, prefix), nil
 				}, nil
 
 			case anyStart:
-				return func(s string) bool {
+				return func(s string) (bool, error) {
 					suffix := pattern[1:]
 					if singleAnyEnd {
 						if len(s) == 0 {
-							return false
+							return false, nil
 						}
 
 						suffix = suffix[:len(suffix)-1]
-						s = s[:len(s)-1]
+						lastChar, _ := utf8.DecodeLastRuneInString(s)
+						if lastChar == utf8.RuneError {
+							return false, errors.Errorf("invalid encoding of the last character in string %s", s)
+						}
+						s = s[:len(s)-len(string(lastChar))]
 					}
 					if caseInsensitive {
 						s, suffix = strings.ToUpper(s), strings.ToUpper(suffix)
 					}
-					return strings.HasSuffix(s, suffix)
+					return strings.HasSuffix(s, suffix), nil
 				}, nil
 
 			case singleAnyStart || singleAnyEnd:
-				return func(s string) bool {
-					if len(s) < 1 || (singleAnyStart && singleAnyEnd && len(s) < 2) {
-						return false
+				return func(s string) (bool, error) {
+					if len(s) < 1 {
+						return false, nil
+					}
+					firstChar, _ := utf8.DecodeRuneInString(s)
+					if firstChar == utf8.RuneError {
+						return false, errors.Errorf("invalid encoding of the first character in string %s", s)
+					}
+					lastChar, _ := utf8.DecodeLastRuneInString(s)
+					if lastChar == utf8.RuneError {
+						return false, errors.Errorf("invalid encoding of the last character in string %s", s)
+					}
+					if singleAnyStart && singleAnyEnd && len(string(firstChar))+len(string(lastChar)) > len(s) {
+						return false, nil
 					}
 
 					if singleAnyStart {
 						pattern = pattern[1:]
-						s = s[1:]
+						s = s[len(string(firstChar)):]
 					}
 
 					if singleAnyEnd {
 						pattern = pattern[:len(pattern)-1]
-						s = s[:len(s)-1]
+						s = s[:len(s)-len(string(lastChar))]
 					}
 
 					if caseInsensitive {
@@ -4204,7 +4262,7 @@ func optimizedLikeFunc(
 					//    in case anyStart
 					//  - singleAnyStart && anyEnd handled
 					//    in case anyEnd
-					return s == pattern
+					return s == pattern, nil
 				}, nil
 			}
 		}
@@ -4233,7 +4291,9 @@ type likeKey struct {
 // We need to convert
 //    `\\` --> ``
 //    `\\\\` --> `\\`
-func unescapePattern(pattern, escapeToken string, isEscapeTokenCustom bool) (string, error) {
+func unescapePattern(
+	pattern, escapeToken string, emitEscapeCharacterLastError bool,
+) (string, error) {
 	escapedEscapeToken := escapeToken + escapeToken
 
 	// We need to subtract the escaped escape tokens to avoid double
@@ -4248,7 +4308,7 @@ func unescapePattern(pattern, escapeToken string, isEscapeTokenCustom bool) (str
 	retWidth := 0
 	for i := 0; i < nEscapes; i++ {
 		nextIdx := strings.Index(pattern, escapeToken)
-		if nextIdx == len(pattern)-len(escapeToken) && !isEscapeTokenCustom {
+		if nextIdx == len(pattern)-len(escapeToken) && emitEscapeCharacterLastError {
 			return "", pgerror.NewErrorf(pgerror.CodeInvalidEscapeSequenceError, `LIKE pattern must not end with escape character`)
 		}
 
@@ -4371,7 +4431,7 @@ OldLoop:
 // 1. we replace '@' with '\\' since it's unescaped;
 // 2. we escape single original backslash ('\' is not our escape character, so we want
 // the pattern to understand it) by putting an extra backslash in front of it. However,
-// we later will call unescapePattern, so we need to double our double backslahes.
+// we later will call unescapePattern, so we need to double our double backslashes.
 // Therefore, '\\' is converted into '\\\\'.
 // 3. '@@' is replaced by '@' because it is escaped escape character.
 // 4. '@' is replaced with '\\' since it's unescaped.
@@ -4422,21 +4482,63 @@ func replaceCustomEscape(s string, escape rune) (string, error) {
 				panic("unexpected: escape character is the last one in replaceCustomEscape.")
 			}
 		} else if s[sIndex] == '\\' {
-			// We encountered a backslash which after QuoteMeta should have been doubled.
-			if sIndex+1 == sLen || s[sIndex+1] != '\\' {
-				// This case should never be reached, and it should
+			// We encountered a backslash, so we need to look ahead to figure out how
+			// to process it.
+			if sIndex+1 == sLen {
+				// This case should never be reached since it should
 				// have been caught in calculateLengthAfterReplacingCustomEscape.
-				panic("unexpected: a backslash is not doubled in replaceCustomEscape.")
+				panic("unexpected: a single backslash encountered in replaceCustomEscape.")
+			} else if s[sIndex+1] == '\\' {
+				// We want to escape '\\' to `\\\\` for correct processing later by unescapePattern. See (3).
+				// Since we've added four characters to ret, we advance retIndex by 4.
+				// Since we've already processed two characters in s, we advance sIndex by 2.
+				ret[retIndex] = '\\'
+				ret[retIndex+1] = '\\'
+				ret[retIndex+2] = '\\'
+				ret[retIndex+3] = '\\'
+				retIndex += 4
+				sIndex += 2
+			} else {
+				// A metacharacter other than a backslash is escaped here.
+				// Note: all metacharacters are encoded as a single byte, so it is
+				// correct to just convert it to string and to compare against a char
+				// in s.
+				if string(s[sIndex+1]) == string(escape) {
+					// The metacharacter is our custom escape character. We need to look
+					// ahead to process it.
+					if sIndex+2 == sLen {
+						// Escape character is the last character in s which is an error
+						// that must have been caught in calculateLengthAfterReplacingCustomEscape.
+						panic("unexpected: escape character is the last one in replaceCustomEscape.")
+					}
+					if sIndex+4 <= sLen {
+						if s[sIndex+2] == '\\' && string(s[sIndex+3]) == string(escape) {
+							// We have a sequence of `\`+escape+`\`+escape which is replaced
+							// by `\`+escape.
+							ret[retIndex] = '\\'
+							// Note: all metacharacters are encoded as a single byte, so it
+							// is safe to just convert it to string and take the first
+							// character.
+							ret[retIndex+1] = string(escape)[0]
+							retIndex += 2
+							sIndex += 4
+							continue
+						}
+					}
+					// The metacharacter is escaping something different than itself, so
+					// `\`+escape will be replaced by `\`.
+					ret[retIndex] = '\\'
+					retIndex++
+					sIndex += 2
+				} else {
+					// The metacharacter is not our custom escape character, so we're
+					// simply copying the backslash and the metacharacter.
+					ret[retIndex] = '\\'
+					ret[retIndex+1] = s[sIndex+1]
+					retIndex += 2
+					sIndex += 2
+				}
 			}
-			// We want to escape '\\' to `\\\\` for correct processing later by unescapePattern. See (3).
-			// Since we've added four characters to ret, we advance retIndex by 4.
-			// Since we've already processed two characters in s, we advance sIndex by 2.
-			ret[retIndex] = '\\'
-			ret[retIndex+1] = '\\'
-			ret[retIndex+2] = '\\'
-			ret[retIndex+3] = '\\'
-			retIndex += 4
-			sIndex += 2
 		} else {
 			// Regular character, so we simply copy it.
 			ret[retIndex] = s[sIndex]
@@ -4479,16 +4581,49 @@ func calculateLengthAfterReplacingCustomEscape(s string, escape rune) (bool, int
 				return false, 0, pgerror.NewErrorf(pgerror.CodeInvalidEscapeSequenceError, "LIKE pattern must not end with escape character")
 			}
 		} else if s[i] == '\\' {
-			// We encountered a backslash which after QuoteMeta should have been doubled.
-			if i+1 == sLen || s[i+1] != '\\' {
-				// This case should never be reached.
+			// We encountered a backslash, so we need to look ahead to figure out how
+			// to process it.
+			if i+1 == sLen {
+				// This case should never be reached because the backslash should be
+				// escaping one of regexp metacharacters.
 				return false, 0, pgerror.NewErrorf(pgerror.CodeInvalidEscapeSequenceError, "Unexpected behavior during processing custom escape character.")
+			} else if s[i+1] == '\\' {
+				// We'll want to escape '\\' to `\\\\` for correct processing later by
+				// unescapePattern. See (3) in the comment above replaceCustomEscape.
+				changed = true
+				retLen += 4
+				i += 2
+			} else {
+				// A metacharacter other than a backslash is escaped here.
+				if string(s[i+1]) == string(escape) {
+					// The metacharacter is our custom escape character. We need to look
+					// ahead to process it.
+					if i+2 == sLen {
+						// Escape character is the last character in s, so we need to return an error.
+						return false, 0, pgerror.NewErrorf(pgerror.CodeInvalidEscapeSequenceError, "LIKE pattern must not end with escape character")
+					}
+					if i+4 <= sLen {
+						if s[i+2] == '\\' && string(s[i+3]) == string(escape) {
+							// We have a sequence of `\`+escape+`\`+escape which will be
+							// replaced by `\`+escape.
+							changed = true
+							retLen += 2
+							i += 4
+							continue
+						}
+					}
+					// The metacharacter is escaping something different than itself, so
+					// `\`+escape will be replaced by `\`.
+					changed = true
+					retLen++
+					i += 2
+				} else {
+					// The metacharacter is not our custom escape character, so we're
+					// simply copying the backslash and the metacharacter.
+					retLen += 2
+					i += 2
+				}
 			}
-			// We'll want to escape '\\' to `\\\\` for correct processing later by unescapePattern.
-			// See (3) in the comment above replaceCustomEscape.
-			changed = true
-			retLen += 4
-			i += 2
 		} else {
 			// Regular character, so we'll simply copy it.
 			retLen++
@@ -4503,7 +4638,7 @@ func calculateLengthAfterReplacingCustomEscape(s string, escape rune) (bool, int
 // is to convert all unescaped escape character into '\'.
 // k.escape can either be empty or a single character.
 func (k likeKey) Pattern() (string, error) {
-	// QuoteMeta escapes `\` to `\\`.
+	// QuoteMeta escapes all regexp metacharacters (`\.+*?()|[]{}^$`) with a `\`.
 	pattern := regexp.QuoteMeta(k.s)
 	var err error
 	if k.escape == 0 {
@@ -4522,18 +4657,34 @@ func (k likeKey) Pattern() (string, error) {
 		// If `%` is escape character, then it's not a wildcard.
 		if k.escape != '%' {
 			// Replace LIKE/ILIKE specific wildcards '%' only if it's unescaped.
-			pattern = replaceUnescaped(pattern, `%`, `.*`, string(k.escape))
+			if k.escape == '.' {
+				// '.' is the escape character, so for correct processing later by
+				// replaceCustomEscape we need to escape it by itself.
+				pattern = replaceUnescaped(pattern, `%`, `..*`, regexp.QuoteMeta(string(k.escape)))
+			} else if k.escape == '*' {
+				// '*' is the escape character, so for correct processing later by
+				// replaceCustomEscape we need to escape it by itself.
+				pattern = replaceUnescaped(pattern, `%`, `.**`, regexp.QuoteMeta(string(k.escape)))
+			} else {
+				pattern = replaceUnescaped(pattern, `%`, `.*`, regexp.QuoteMeta(string(k.escape)))
+			}
 		}
 		// If `_` is escape character, then it's not a wildcard.
 		if k.escape != '_' {
 			// Replace LIKE/ILIKE specific wildcards '_' only if it's unescaped.
-			pattern = replaceUnescaped(pattern, `_`, `.`, string(k.escape))
+			if k.escape == '.' {
+				// '.' is the escape character, so for correct processing later by
+				// replaceCustomEscape we need to escape it by itself.
+				pattern = replaceUnescaped(pattern, `_`, `..`, regexp.QuoteMeta(string(k.escape)))
+			} else {
+				pattern = replaceUnescaped(pattern, `_`, `.`, regexp.QuoteMeta(string(k.escape)))
+			}
 		}
 
 		// If a sequence of symbols ` escape+`\\` ` is unescaped, then that escape
 		// character escapes backslash in the original pattern (we need to use double
 		// backslash because of QuoteMeta behavior), so we want to "consume" the escape character.
-		pattern = replaceUnescaped(pattern, string(k.escape)+`\\`, `\\`, string(k.escape))
+		pattern = replaceUnescaped(pattern, string(k.escape)+`\\`, `\\`, regexp.QuoteMeta(string(k.escape)))
 
 		// We want to replace all escape characters with `\\` only
 		// when they are unescaped. When an escape character is escaped,
@@ -4554,7 +4705,11 @@ func (k likeKey) Pattern() (string, error) {
 		// an actual escape character is handled in replaceCustomEscape. For example, with '-' as
 		// the escape character on pattern 'abc\\' we do not want to return an error 'pattern ends
 		// with escape character' because '\\' is not an escape character in this case.
-		if pattern, err = unescapePattern(pattern, `\\`, k.escape == '\\'); err != nil {
+		if pattern, err = unescapePattern(
+			pattern,
+			`\\`,
+			k.escape == '\\', /* emitEscapeCharacterLastError */
+		); err != nil {
 			return "", err
 		}
 	}
@@ -4679,7 +4834,7 @@ func caseInsensitive(pattern string) string {
 }
 
 // anchorPattern surrounds the transformed input string with
-//   ^(?: ... )$
+//   ^(?s: ... )$
 // which requires some explanation.  We need "^" and "$" to force
 // the pattern to match the entire input string as per SQL99 spec.
 // The "(?:" and ")" are a non-capturing set of parens; we have to have
@@ -4687,11 +4842,14 @@ func caseInsensitive(pattern string) string {
 // be bound into the first and last alternatives which is not what we
 // want, and the parens must be non capturing because we don't want them
 // to count when selecting output for SUBSTRING.
+// "?s" turns on "dot all" mode meaning a dot will match any single character
+// (without turning this mode on, the dot matches any single character except
+// for line breaks).
 func anchorPattern(pattern string, caseInsensitive bool) string {
 	if caseInsensitive {
-		return fmt.Sprintf("^(?i:%s)$", pattern)
+		return fmt.Sprintf("^(?si:%s)$", pattern)
 	}
-	return fmt.Sprintf("^(?:%s)$", pattern)
+	return fmt.Sprintf("^(?s:%s)$", pattern)
 }
 
 // FindEqualComparisonFunction looks up an overload of the "=" operator

--- a/pkg/sql/sem/tree/eval_internal_test.go
+++ b/pkg/sql/sem/tree/eval_internal_test.go
@@ -45,7 +45,7 @@ func TestUnescapePattern(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s-->%s Escape=%s", tc.pattern, tc.expected, tc.escapeToken), func(t *testing.T) {
-			actual, err := unescapePattern(tc.pattern, tc.escapeToken, false)
+			actual, err := unescapePattern(tc.pattern, tc.escapeToken, true /* emitEscapeCharacterLastError */)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -74,7 +74,7 @@ func TestUnescapePatternError(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Pattern=%s Escape=%s", tc.pattern, tc.escapeToken), func(t *testing.T) {
-			actual, err := unescapePattern(tc.pattern, tc.escapeToken, false)
+			actual, err := unescapePattern(tc.pattern, tc.escapeToken, true /* emitEscapeCharacterLastError */)
 			if err == nil {
 				t.Fatalf("error not raised. expected error message: %s\ngot unescaped pattern: %s\n", errorMessage, actual)
 			}

--- a/pkg/sql/sem/tree/like_test.go
+++ b/pkg/sql/sem/tree/like_test.go
@@ -22,6 +22,89 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
+func TestLike(t *testing.T) {
+	testData := []struct {
+		expr      string
+		pattern   string
+		matches   Datum
+		erroneous bool
+	}{
+		{``, `{`, DBoolFalse, false},
+		{``, `%%%%%`, DBoolTrue, false},
+		{`a[b]`, `%[[_]`, DBoolFalse, false},
+		{`+`, `++`, DBoolFalse, false},
+		{`a`, `}`, DBoolFalse, false},
+		{`a{}%`, `%\}\%`, DBoolTrue, false},
+		{`a{}%a`, `%\}\%\`, DBoolFalse, true},
+		{`G\n%`, `%__%`, DBoolTrue, false},
+		{``, `\`, DBoolFalse, false},
+		{`_%\b\n`, `%__`, DBoolTrue, false},
+		{`_\nL_`, `%_%`, DBoolTrue, false},
+	}
+	ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	for _, d := range testData {
+		if matches, err := matchLike(ctx, NewDString(d.expr), NewDString(d.pattern), false); err != nil && !d.erroneous {
+			t.Error(err)
+		} else if err == nil && d.erroneous {
+			t.Errorf("%s matching the pattern %s: expected to return an error",
+				d.expr,
+				d.pattern,
+			)
+		} else if matches != d.matches {
+			t.Errorf("%s matching the pattern %s: expected %v but found %v",
+				d.expr,
+				d.pattern,
+				d.matches,
+				matches,
+			)
+		}
+	}
+}
+
+func TestLikeEscape(t *testing.T) {
+	testData := []struct {
+		expr      string
+		pattern   string
+		escape    string
+		matches   Datum
+		erroneous bool
+	}{
+		{``, `{`, string('\x7f'), DBoolFalse, false},
+		{``, `}`, `}`, DBoolFalse, false},
+		{``, `%%%%%`, ``, DBoolTrue, false},
+		{``, `%%%%%`, `\`, DBoolTrue, false},
+		{`a[b]`, `%[[_]`, `[`, DBoolTrue, false},
+		{`+`, `++`, `+`, DBoolTrue, false},
+		{`a`, `}`, `}`, DBoolFalse, true},
+		{`a{}%`, `%}}}%`, `}`, DBoolTrue, false},
+		{`BG_`, `%__`, `.`, DBoolTrue, false},
+		{`_%\b\n`, `%__`, ``, DBoolTrue, false},
+		{`_\nL_`, `%_%`, `{`, DBoolTrue, false},
+		{`_\nL_`, `%_%`, `%`, DBoolFalse, true},
+		{`\n\t`, `_%%_`, string('\x7f'), DBoolTrue, false},
+	}
+	ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	for _, d := range testData {
+		if matches, err := MatchLikeEscape(ctx, d.expr, d.pattern, d.escape, false); err != nil && !d.erroneous {
+			t.Error(err)
+		} else if err == nil && d.erroneous {
+			t.Errorf("%s matching the pattern %s with escape character %s: expected to return an error",
+				d.expr,
+				d.pattern,
+				d.escape,
+			)
+		} else if matches != d.matches {
+			t.Errorf("%s matching the pattern %s with escape character %s: expected %v but found %v",
+				d.expr,
+				d.pattern,
+				d.escape,
+				d.matches,
+				matches,
+			)
+		}
+	}
+}
+
 func TestSimilarEscape(t *testing.T) {
 	testData := []struct {
 		expr     string


### PR DESCRIPTION
Previously, some of the valid patterns could not be compiled due to an
incorrect assumption when regular expressions metacharacters are present
in the pattern. Now, such patterns should be handled correctly.

That incorrect assumption was based on the comment that `regexp.QuoteMeta` escapes a single backslash into a double backslash, so after that method all backslashes should be in pairs in the pattern. However, other metacharacters are also escaped by a single backslash, and I believe we just need to keep those escaped with a single backslash.

Fixes: #34526.

Release note: None