### PR TITLE
ui: implement logical plan design

### DIFF
--- a/pkg/ui/src/views/statements/planView.tsx
+++ b/pkg/ui/src/views/statements/planView.tsx
@@ -16,115 +16,322 @@ import _ from "lodash";
 import React from "react";
 
 import { cockroach } from "src/js/protos";
-import { intersperse } from "src/util/intersperse";
+import IAttr = cockroach.sql.ExplainTreePlanNode.IAttr;
 import IExplainTreePlanNode = cockroach.sql.IExplainTreePlanNode;
-import ExplainTreePlanNode_IAttr = cockroach.sql.ExplainTreePlanNode.IAttr;
+import { ToolTipWrapper } from "src/views/shared/components/toolTip";
+
+const WARNING_ICON = (
+  <svg className="warning-icon" width="17" height="17" viewBox="0 0 24 22" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M15.7798 2.18656L23.4186 15.5005C25.0821 18.4005 22.9761 21.9972 19.6387 21.9972H4.3619C1.02395 21.9972 -1.08272 18.4009 0.582041 15.5005M0.582041 15.5005L8.21987 2.18656C9.89189 -0.728869 14.1077 -0.728837 15.7798 2.18656M13.4002 7.07075C13.4002 6.47901 12.863 5.99932 12.2002 5.99932C11.5375 5.99932 11.0002 6.47901 11.0002 7.07075V13.4993C11.0002 14.0911 11.5375 14.5707 12.2002 14.5707C12.863 14.5707 13.4002 14.0911 13.4002 13.4993V7.07075ZM13.5717 17.2774C13.5717 16.5709 12.996 15.9981 12.286 15.9981C11.5759 15.9981 11.0002 16.5709 11.0002 17.2774V17.2902C11.0002 17.9967 11.5759 18.5695 12.286 18.5695C12.996 18.5695 13.5717 17.9967 13.5717 17.2902V17.2774Z"/>
+  </svg>
+);
+const NODE_ICON = (
+  <span className="node-icon">&#x26AC;</span>
+);
+const UP_ARROW_ICON = (
+  <svg className="arrow-icon" viewBox="0 0 20 11" width="10" height="10">
+    <polyline
+      stroke-linecap="round"
+      points="2,10 10,1 18,10"
+    />
+  </svg>
+);
+const DOWN_ARROW_ICON = (
+  <svg className="arrow-icon" viewBox="0 0 20 11" width="10" height="10">
+    <polyline
+      stroke-linecap="round"
+      points="2,1 10,10 18,1"
+    />
+  </svg>
+);
+
+// FlatPlanNode contains details for the flattened representation of
+// IExplainTreePlanNode.
+//
+// Note that the function that flattens IExplainTreePlanNode returns
+// an array of FlatPlanNode (not a single FlatPlanNode). E.g.:
+//
+//  flattenTree(IExplainTreePlanNode) => FlatPlanNode[]
+//
+export interface FlatPlanNode {
+  name: string;
+  attrs: IAttr[];
+  children: FlatPlanNode[][];
+}
+
+/* ************************* HELPER FUNCTIONS ************************* */
+
+// flattenTree takes a tree representation of a logical plan
+// (IExplainTreePlanNode) and flattens any single child paths.
+// For example, if an IExplainTreePlanNode was visually displayed
+// as:
+//
+//    root
+//       |
+//       |___ single_grandparent
+//                  |
+//                  |____ parent_1
+//                  |         |
+//                  |         |______ single_child
+//                  |
+//                  |____ parent_2
+//
+// Then its FlatPlanNode[] equivalent would be visually displayed
+// as:
+//
+//    root
+//       |
+//    single_grandparent
+//       |
+//       |____ parent_1
+//       |          |
+//       |     single_child
+//       |
+//       |____ parent_2
+//
+export function flattenTree(treePlan: IExplainTreePlanNode): FlatPlanNode[] {
+  const flattenedPlan: FlatPlanNode[] = [
+    {
+      "name": treePlan.name,
+      "attrs": treePlan.attrs,
+      "children": [],
+    },
+  ];
+
+  if (treePlan.children.length === 0) {
+    return flattenedPlan;
+  }
+  const flattenedChildren =
+    treePlan.children
+      .map( (child) => flattenTree(child));
+  if (treePlan.children.length === 1) {
+    // Append single child into same list that contains parent node.
+    flattenedPlan.push(...flattenedChildren[0]);
+  } else {
+    // Only add to children property if there are multiple children.
+    flattenedPlan[0].children = flattenedChildren;
+  }
+  return flattenedPlan;
+}
+
+interface PlanNodeHeaderProps {
+  title: string;
+  subtitle: string;
+  warn: boolean;
+}
+
+// planNodeHeaderProps looks at a node's name and attributes and determines if:
+// 1) We should warn the user about this particular node,
+// 2) We should include any attribute details in the collapsed node view.
+export function planNodeHeaderProps(node: FlatPlanNode): PlanNodeHeaderProps {
+  let title = node.name;
+  let subtitle = null;
+  let warn = false;
+
+  switch (node.name) {
+    case "scan":
+      if (_.find(node.attrs, {key: "spans", value: "ALL"})) {
+        const tableAttr = _.filter(node.attrs, (attr) => ( attr.key === "table"));
+        if (tableAttr.length >= 1) {
+          title = "table scan";
+          warn = true;
+          subtitle = tableAttr[0].value;
+          const ampersandPosition = subtitle.indexOf("@");
+          if (ampersandPosition > 0) {
+            subtitle = subtitle.substring(0, ampersandPosition);
+          }
+        }
+      }
+      break;
+    case "join":
+      const typeAttr = _.filter(node.attrs, (attr) => ( attr.key === "type"));
+      title = typeAttr[0].value + " " + node.name;
+      break;
+    default:
+      break;
+  }
+
+  return {
+    title, subtitle, warn,
+  };
+}
+
+/* ************************* PLAN NODES ************************* */
+
+interface PlanNodeDetailProps {
+  node: FlatPlanNode;
+}
+
+interface PlanNodeDetailState {
+  expanded: boolean;
+}
+
+class PlanNodeDetails extends React.Component<PlanNodeDetailProps, PlanNodeDetailState> {
+  constructor(props: PlanNodeDetailProps) {
+    super(props);
+    this.state = {
+      expanded: false,
+    };
+  }
+
+  toggleExpanded = () => {
+    this.setState(state => ({
+      expanded: !state.expanded,
+    }));
+  }
+
+  renderPlanNodeHeader(props: PlanNodeHeaderProps) {
+    return (
+      <span>
+        {props.warn && WARNING_ICON}
+          {!props.warn && NODE_ICON}
+          {_.capitalize(props.title)}
+          {props.subtitle &&
+          <span>: <b>{props.subtitle}</b></span>
+          }
+      </span>
+    );
+  }
+
+  renderArrow() {
+    const node = this.props.node;
+    if (node.attrs && node.attrs.length > 0) {
+      if (this.state.expanded) {
+        return <div className="arrow-expanded">{UP_ARROW_ICON}</div>;
+      }
+      return <div className="arrow">{DOWN_ARROW_ICON}</div>;
+    }
+  }
+
+  renderMaybeExpandedDetail() {
+    const node = this.props.node;
+    if (node.attrs && node.attrs.length > 0) {
+      if (this.state.expanded) {
+        return (
+          <div className="nodeAttributes">
+            {node.attrs.map( (attr) => (
+              <div key={attr.key} className="attr">
+                {attr.key}
+                {attr.value &&
+                  <span>={attr.value}</span>
+                }
+              </div>
+            ))}
+          </div>
+        );
+      }
+    }
+  }
+
+  renderClassName(warn: boolean) {
+    const node = this.props.node;
+    if (node.attrs && node.attrs.length > 0 && this.state.expanded) {
+      if (warn) {
+        return "nodeDetails warn expanded";
+      }
+      return "nodeDetails expanded";
+    } else if (warn) {
+      return "nodeDetails warn";
+    }
+    return "nodeDetails";
+  }
+
+  render() {
+    const node = this.props.node;
+    const headerProps = planNodeHeaderProps(node);
+    return (
+      <div
+        className={this.renderClassName(headerProps.warn)}
+        onClick={() => this.toggleExpanded()}
+      >
+        {this.renderPlanNodeHeader(headerProps)} {this.renderArrow()}
+        {this.renderMaybeExpandedDetail()}
+      </div>
+    );
+  }
+}
+
+interface PlanNodeProps {
+  node: FlatPlanNode;
+}
+
+class PlanNode extends React.Component<PlanNodeProps> {
+  render() {
+    const node = this.props.node;
+    return (
+      <li>
+        <PlanNodeDetails
+          node={node}
+        />
+        {node.children && node.children.map( (child) => (
+          <PlanNodes
+            nodes={child}
+          />
+        ))
+        }
+      </li>
+    );
+  }
+}
+
+function PlanNodes(props: {
+  nodes: FlatPlanNode[],
+}): React.ReactElement<{}> {
+  const nodes = props.nodes;
+  return (
+    <ul>
+      {nodes.map( (node) => {
+        return <PlanNode node={node}/>;
+      })}
+    </ul>
+  );
+}
 
 export function PlanView(props: {
   title: string,
   plan: IExplainTreePlanNode,
 }) {
-  if (!props.plan) {
-    return <div className="plan-view">
-      <h3>{props.title}</h3>
-      <p>No plan captured yet.</p>
-    </div>;
-  }
-  return <div className="plan-view">
-    <h3>{props.title}</h3>
-    <div className="plan-node">
-      <ul>
-        <li>
-          <PlanNode node={props.plan} />
-        </li>
-      </ul>
-    </div>
-  </div>;
-}
+  const flattenedPlanNodes = flattenTree(props.plan);
 
-interface PlanNodeProps {
-  node: IExplainTreePlanNode;
-}
-
-function PlanNode(props: PlanNodeProps) {
-  const node = props.node;
-  const collapsedAttrs = collapseRepeatedAttrs(node.attrs);
-  return (
-    <div>
-      <span className="plan-node__name">{node.name}</span>
-      <span className="plan-node__attrs">
-        {collapsedAttrs.map((attr) => (
-          <span className="plan-node__attr" key={attr.key}>
-            <span className="plan-node__attr-key">{attr.key}</span>
-            <span className="plan-node__attr-eq">=</span>
-            { renderAttrValueList(attr.value) }
-          </span>
-        ))}
-      </span>
-      { renderChildren(node.children) }
-    </div>
+  const lastSampledHelpText = (
+    <React.Fragment>
+      If the time from the last sample is greater than 5 minutes, a new
+      plan will be sampled. This frequency can be configured
+      with the cluster setting{" "}
+      <code>
+        <pre style={{ display: "inline-block" }}>
+          sql.metrics.statement_details.plan_collection.period
+        </pre>
+      </code>.
+    </React.Fragment>
   );
-}
 
-function renderChildren(children: cockroach.sql.IExplainTreePlanNode[]|null): React.ReactElement<PlanNodeProps> {
-  if (!children) {
-    return null;
-  }
   return (
-    <ul>
-      {children.map((child, idx) => (
-        <li>
-          <PlanNode key={idx} node={child} />
-        </li>
-      ))}
-    </ul>
+    <table className="plan-view-table">
+      <thead>
+      <tr className="plan-view-table__row--header">
+        <th className="plan-view-table__cell">
+          {props.title}
+          <div className="plan-view-table__tooltip">
+            <ToolTipWrapper
+              text={lastSampledHelpText}>
+              <div className="plan-view-table__tooltip-hover-area">
+                <div className="plan-view-table__info-icon">i</div>
+              </div>
+            </ToolTipWrapper>
+          </div>
+        </th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr className="plan-view-table__row--body">
+        <td className="plan-view plan-view-table__cell" style={{ textAlign: "left" }}>
+          <PlanNodes
+            nodes={flattenedPlanNodes}
+          />
+        </td>
+      </tr>
+      </tbody>
+    </table>
   );
-}
-
-function renderAttrValueList(values: string[]) {
-  return (
-    <span className="plan-node__attr-value-list">
-      [
-      {intersperse(
-        values.map((value, idx) => (
-          <span className="plan-node__attr-value" key={idx}>{value}</span>
-        )),
-        <span>, </span>,
-      )}
-      ]
-    </span>
-  );
-}
-
-interface CollapsedPlanAttr {
-  key: string;
-  value: string[];
-}
-
-export function collapseRepeatedAttrs(attrs: ExplainTreePlanNode_IAttr[]): CollapsedPlanAttr[] {
-  if (!attrs) {
-    return [];
-  }
-  const collapsed: { [key: string]: CollapsedPlanAttr } = {};
-
-  attrs.forEach((attr) => {
-    if (attr.key === null || attr.value === null) {
-      return;
-    }
-    const existingAttr = collapsed[attr.key];
-    if (!existingAttr) {
-      collapsed[attr.key] = {
-        key: attr.key,
-        value: [attr.value],
-      };
-      return;
-    } else {
-      collapsed[attr.key].value.push(attr.value);
-    }
-  });
-
-  const collapsedAttrs = _.values(collapsed);
-  return _.sortBy(collapsedAttrs, (ca) => (
-    ca.key === "table" ? "table" : "z" + ca.key
-  ));
 }

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -34,7 +34,7 @@
   padding 12px 24px
   color $body-color
 
-.last-cleared-tooltip, .numeric-stats-table
+.last-cleared-tooltip, .numeric-stats-table, .plan-view-table
   &__tooltip
     width 36px  // Reserve space for 10px padding around centered 16px icon
     height 16px
@@ -169,25 +169,140 @@
       top 8px
       background-color $warning-color
 
-.plan-node
-  font-family monospace
+$plan-node-line-color = #DADADA                                 // connecting line: light gray
+$plan-node-warning-color = #D18737                              // dark orange
+$plan-node-warning-background-color = rgba(209, 135, 55, 0.06)  // light orange
+$plan-node-warning-border-color = rgba(209, 135, 55, 0.3)       // dark orange 2
+$plan-node-details-background-color = #F6F6F6                   // grayish-white
+$plan-node-details-border-color = #ACB8CB                       // dark gray
 
-  ul
-    padding-left 20px
+.plan-view-table
+  @extend $table-base
+  &__row
+    &--body
+      border-top $table-cell-border
+      &:nth-child(odd)
+        background-color $stats-table-tr--bg
 
-  &__name
-    font-weight bold
+  &__tooltip
+    width 520px
 
-  &__attr-key
-    color orange
-    margin-left 5px
-
-  &__attr-value
-    color green
+    .hover-tooltip__text
+      width 520px
 
 .plan-view
-  margin-top 10px
-  padding-left 30px
-  background-color white
-  padding-top 5px
-  padding-bottom 5px
+  color $body-color
+  position relative
+
+  .arrow-icon
+    margin-left 8px
+    polyline
+      fill none
+      stroke $body-color
+      stroke-width 2
+
+  .node-icon
+    margin 0 10px 0 12px
+
+  .warning-icon
+    margin 0 6px 0 8px
+    position relative
+    top 3px
+    path
+      fill $plan-node-warning-color
+
+  .warn
+    position relative
+    color $plan-node-warning-color
+    background-color $plan-node-warning-background-color
+
+    .arrow-icon
+      polyline
+        fill none
+        stroke $plan-node-warning-color
+        stroke-width 2
+
+  .arrow
+    font-size smaller
+    display none
+
+  .arrow-expanded
+    font-size smaller
+    display inline
+
+  .nodeDetails
+    position relative
+    padding 6px 0
+    border 1px solid transparent
+    border-radius 3px
+
+    &.expanded
+      border 1px solid $plan-node-details-border-color
+
+    &.expanded
+    &:hover
+      background-color $plan-node-details-background-color
+
+    &:hover
+      cursor pointer
+
+      .arrow
+        display inline
+
+    &.warn
+      &.expanded
+      &:hover
+        position relative
+        background-color $plan-node-warning-background-color
+        border 1px solid $plan-node-warning-border-color
+
+  .nodeAttributes
+    color $body-color
+    padding 14px 16px
+    margin 6px 0 4px 0
+    border 1px solid $plan-node-line-color
+    background-color white
+    border-radius 2px
+
+  ul
+    padding 0
+    margin 0
+    li
+      padding 0
+      margin 0
+      position relative
+      list-style-type none
+
+      // vertical line, to previous node (above)
+      &:not(:first-child):after
+        content ''
+        width 1px
+        height 19px
+        background-color $plan-node-line-color
+        position absolute
+        top -10px
+        left 17px
+
+      ul
+        padding-left 40px
+
+        li
+          // first node: horizontal line, to parent
+          &:first-child:after
+            content ''
+            height 1px
+            width 34px
+            background-color $plan-node-line-color
+            position absolute
+            top 17px
+            left -22px
+
+          // vertical line, to parent
+          &:before
+            content ''
+            width 1px
+            height 100%
+            background-color $plan-node-line-color
+            position absolute
+            top -10px
+            left -23px


### PR DESCRIPTION
This commit implements the designs as specified in
Zeplin design "Logical Plans - v1":
https://app.zeplin.io/project/5c40e9dab2616abf79e3eb99/screen/5c4b6f23143de2bfcb12ae4e

Note that remaining design items will be addressed in future commits (tracked in #34545).

![logical-plans](https://user-images.githubusercontent.com/3051672/52312291-11070d80-2978-11e9-8ecc-42ab4a859371.gif)

Release note: None