### PR TITLE
release-2.1: ccl/storageccl: support HTTP_PROXY env vars

### DIFF
--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -361,7 +361,22 @@ func makeHTTPClient(settings *cluster.Settings) (*http.Client, error) {
 		}
 		tlsConf = &tls.Config{RootCAs: roots}
 	}
-	return &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConf}}, nil
+	// Copy the defaults from http.DefaultTransport. We cannot just copy the
+	// entire struct because it has a sync Mutex. This has the unfortunate problem
+	// that if Go adds fields to DefaultTransport they won't be copied here,
+	// but this is ok for now.
+	t := http.DefaultTransport.(*http.Transport)
+	return &http.Client{Transport: &http.Transport{
+		Proxy:                 t.Proxy,
+		DialContext:           t.DialContext,
+		MaxIdleConns:          t.MaxIdleConns,
+		IdleConnTimeout:       t.IdleConnTimeout,
+		TLSHandshakeTimeout:   t.TLSHandshakeTimeout,
+		ExpectContinueTimeout: t.ExpectContinueTimeout,
+
+		// Add our custom CA.
+		TLSClientConfig: tlsConf,
+	}}, nil
 }
 
 func makeHTTPStorage(base string, settings *cluster.Settings) (ExportStorage, error) {


### PR DESCRIPTION
Backport 1/1 commits from #34067.

/cc @cockroachdb/release

---

HTTP and S3 storage both used a wrapped http.Client, but it didn't copy
and modify http.DefaultTransport, instead making one from scratch. This
meant that the normally supported settings like proxy and timeouts
were zero'd.

Fixes #32803

Release note (enterprise change): Support standard HTTP proxy environment
variables in HTTP and S3 storage.
