### PR TITLE
sql: use InternalExecutor for validating checks

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -499,8 +499,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 					panic("constraint returned by GetConstraintInfo not found")
 				}
 				ck := n.tableDesc.Checks[idx]
-				if err := params.p.validateCheckExpr(
-					params.ctx, ck.Expr, &n.n.Table, n.tableDesc.TableDesc(),
+				if err := validateCheckExpr(
+					params.ctx, ck.Expr, &n.n.Table, n.tableDesc.TableDesc(), params.EvalContext(),
 				); err != nil {
 					return err
 				}


### PR DESCRIPTION
Use `InternalExecutor` for validating check constraints. The point of this is
to separate out the validation implementation from the planner used for the
ALTER TABLE query, so that `validateCheckExpr` can be called when the
constraint validation moves through the schema changer (to come in a later
change).

Release note: None