### PR TITLE
sql: implement apply join

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -1,0 +1,337 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// applyJoinNode implements apply join: the execution component of correlated
+// subqueries. Note that only correlated subqueries that the optimizer's
+// tranformations couldn't decorrelate get planned using apply joins.
+// The node reads rows from the left planDataSource, and for each
+// row, re-plans the right side of the join after replacing its outer columns
+// with the corresponding values from the current row on the left. The new right
+// plan is then executed and joined with the left row according to normal join
+// semantics. This node doesn't support right or full outer joins, or set
+// operations.
+type applyJoinNode struct {
+	joinType sqlbase.JoinType
+
+	optimizer xform.Optimizer
+
+	// The memo for the right side of the join - the one with the outer columns.
+	rightMemo *memo.Memo
+
+	// The data source with no outer columns.
+	input planDataSource
+
+	// leftBoundColMap maps an outer opt column id, bound by this apply join, to
+	// the position in the left plan's row that contains the binding.
+	leftBoundColMap opt.ColMap
+
+	// pred represents the join predicate.
+	pred *joinPredicate
+
+	// columns contains the metadata for the results of this node.
+	columns sqlbase.ResultColumns
+
+	// rightCols contains the metadata for the result of the right side of this
+	// apply join, as built in the optimization phase. Later on, every re-planning
+	// of the right side will emit these same columns.
+	rightCols sqlbase.ResultColumns
+
+	// rightProps are the required physical properties that the optimizer has
+	// imposed for the right side of this apply join, specifically containing
+	// the required presentation (order of output columns) for the right side
+	// of the join. Since the optimizer will re-plan the right expression every
+	// time a new left row is seen, it's possible that some values of the left row
+	// would cause a right plan that was different from that in `rightCols` above.
+	// This would cause issues, so we pin the right side's output columns with
+	// these properties.
+	rightProps *physical.Required
+
+	// right is the optimizer expression that represents the right side of the
+	// join. It still contains outer columns and VariableExprs that we will be
+	// replacing on every new left row, and as such isn't yet suitable for
+	// direct use.
+	right memo.RelExpr
+
+	run struct {
+		// emptyRight is a cached, all-NULL slice that's used for left outer joins
+		// in the case of finding no match on the left.
+		emptyRight tree.Datums
+		// leftRow is the current left row being processed.
+		leftRow tree.Datums
+		// leftRowFoundAMatch is set to true when a left row found any match at all,
+		// so that left outer joins and antijoins can know to output a row.
+		leftRowFoundAMatch bool
+		// rightRows will be populated with the result of the right side of the join
+		// each time it's run.
+		rightRows *rowcontainer.RowContainer
+		// curRightRow is the index into rightRows of the current right row being
+		// processed.
+		curRightRow int
+		// out is the full result row, populated on each call to Next.
+		out tree.Datums
+		// done is true if the left side has been exhausted.
+		done bool
+	}
+}
+
+// Set to true to enable ultra verbose debug logging.
+func newApplyJoinNode(
+	joinType sqlbase.JoinType,
+	left planDataSource,
+	leftBoundColMap opt.ColMap,
+	rightProps *physical.Required,
+	rightCols sqlbase.ResultColumns,
+	right memo.RelExpr,
+	pred *joinPredicate,
+	memo *memo.Memo,
+) (planNode, error) {
+	switch joinType {
+	case sqlbase.JoinType_RIGHT_OUTER, sqlbase.JoinType_FULL_OUTER:
+		return nil, errors.New("unsupported right outer apply join")
+	case sqlbase.JoinType_EXCEPT_ALL, sqlbase.JoinType_INTERSECT_ALL:
+		return nil, errors.New("unsupported apply set op")
+	}
+
+	return &applyJoinNode{
+		joinType:        joinType,
+		input:           left,
+		leftBoundColMap: leftBoundColMap,
+		pred:            pred,
+		rightMemo:       memo,
+		rightProps:      rightProps,
+		rightCols:       rightCols,
+		right:           right,
+		columns:         pred.info.SourceColumns,
+	}, nil
+}
+
+func (a *applyJoinNode) startExec(params runParams) error {
+	// If needed, pre-allocate a left row of NULL tuples for when the
+	// join predicate fails to match.
+	if a.joinType == sqlbase.LeftOuterJoin {
+		a.run.emptyRight = make(tree.Datums, a.right.Relational().OutputCols.Len())
+		for i := range a.run.emptyRight {
+			a.run.emptyRight[i] = tree.DNull
+		}
+	}
+	a.run.out = make(tree.Datums, len(a.columns))
+	ci := sqlbase.ColTypeInfoFromResCols(a.rightCols)
+	acc := params.EvalContext().Mon.MakeBoundAccount()
+	a.run.rightRows = rowcontainer.NewRowContainer(acc, ci, 0 /* rowCapacity */)
+	return nil
+}
+
+func (a *applyJoinNode) Next(params runParams) (bool, error) {
+	if a.run.done {
+		return false, nil
+	}
+
+	for {
+		for a.run.curRightRow < a.run.rightRows.Len() {
+			// We have right rows set up - check the next one for a match.
+			rrow := a.run.rightRows.At(a.run.curRightRow)
+			a.run.curRightRow++
+			// Compute join.
+			predMatched, err := a.pred.eval(params.EvalContext(), a.run.leftRow, rrow)
+			if err != nil {
+				return false, err
+			}
+			if !predMatched {
+				// Didn't match? Try with the next right-side row.
+				continue
+			}
+
+			a.run.leftRowFoundAMatch = true
+			if a.joinType == sqlbase.JoinType_LEFT_ANTI ||
+				a.joinType == sqlbase.JoinType_LEFT_SEMI {
+				// We found a match, but we're doing an anti or semi join, so we're
+				// done with this left row.
+				break
+			}
+			// We're doing an ordinary join, so prep the row and emit it.
+			a.pred.prepareRow(a.run.out, a.run.leftRow, rrow)
+			return true, nil
+		}
+		// We're out of right side rows. Clear them, and reset the match state for
+		// next time.
+		a.run.rightRows.Clear(params.ctx)
+		foundAMatch := a.run.leftRowFoundAMatch
+		a.run.leftRowFoundAMatch = false
+
+		if a.run.leftRow != nil {
+			// If we have a left row already, we have to check to see if we need to
+			// emit rows for semi, outer, or anti joins.
+			if foundAMatch {
+				if a.joinType == sqlbase.JoinType_LEFT_SEMI {
+					// We found a match, and we're doing an semi-join, so we're done
+					// with this left row after we output it.
+					a.pred.prepareRow(a.run.out, a.run.leftRow, nil)
+					a.run.leftRow = nil
+					return true, nil
+				}
+			} else {
+				// We found no match. Output LEFT OUTER or ANTI match if necessary.
+				switch a.joinType {
+				case sqlbase.JoinType_LEFT_OUTER:
+					a.pred.prepareRow(a.run.out, a.run.leftRow, a.run.emptyRight)
+					a.run.leftRow = nil
+					return true, nil
+				case sqlbase.JoinType_LEFT_ANTI:
+					a.pred.prepareRow(a.run.out, a.run.leftRow, nil)
+					a.run.leftRow = nil
+					return true, nil
+				}
+			}
+		}
+
+		// We need a new row on the left.
+		ok, err := a.input.plan.Next(params)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			// No more rows on the left. Goodbye!
+			a.run.done = true
+			return false, nil
+		}
+
+		// Extract the values of the outer columns of the other side of the apply
+		// from the latest input row.
+		row := a.input.plan.Values()
+		a.run.leftRow = row
+
+		// At this point, it's time to do the major lift of apply join: re-planning
+		// the right side of the join using the optimizer, with all outer columns
+		// in the right side replaced by the bindings that were defined by the most
+		// recently read left row.
+		//
+		// We have a cached optimizer here that we'll use to re-plan that right
+		// side. Now, we'll essentially go through an entire recursive planning and
+		// execution phase. Initialize the optimizer, replace the outer columns,
+		// run the optimizer on the replaced right side, transform the optimized
+		// expression into logical planNodes, perform physical planning on the
+		// logical planNodes, and finally(!) run the physical plan. That will
+		// produce n new rows from the right side of the join, which we'll join to
+		// the current left row using the ordinary join semantics defined by the
+		// type of join we've been instructed to do (inner, left outer, semi, or
+		// anti).
+
+		a.optimizer.Init(params.p.EvalContext())
+
+		bindings := make(map[opt.ColumnID]tree.Datum, a.leftBoundColMap.Len())
+		a.leftBoundColMap.ForEach(func(k, v int) {
+			bindings[opt.ColumnID(k)] = row[v]
+		})
+
+		// Replace the outer VariableExprs that this applyJoin node is responsible
+		// for with the constant values in the latest left row.
+		factory := a.optimizer.Factory()
+		execbuilder.ReplaceVars(factory, a.right, a.rightProps, bindings)
+
+		a.optimizer.Memo().SetRoot(a.optimizer.Memo().RootExpr().(memo.RelExpr), a.rightProps)
+
+		a.optimizer.Optimize()
+
+		newRightSide := a.optimizer.Memo().RootExpr()
+
+		execFactory := makeExecFactory(params.p)
+		p, err := execbuilder.New(&execFactory, factory.Memo(), newRightSide, params.EvalContext()).Build()
+		if err != nil {
+			return false, err
+		}
+		plan := p.(*planTop)
+
+		if len(plan.subqueryPlans) > 0 {
+			return false, pgerror.NewAssertionErrorf("apply join found an "+
+				"unexpected re-optimized right-hand-side with non-zero subqueries:\n%s",
+				newRightSide)
+		}
+
+		if err := a.runRightSidePlan(params, plan); err != nil {
+			return false, err
+		}
+
+		// We've got fresh right rows. Continue along in the loop, which will deal
+		// with joining the right plan's output with our left row.
+	}
+}
+
+// runRightSidePlan runs a planTop that's been generated based on the
+// re-optimized right hand side of the apply join, stashing the result in
+// a.run.rightRows, ready for retrieval. An error indicates that something went
+// wrong during execution of the right hand side of the join, and that we should
+// completely give up on the outer join.
+func (a *applyJoinNode) runRightSidePlan(params runParams, plan *planTop) error {
+	a.run.curRightRow = 0
+	a.run.rightRows.Clear(params.ctx)
+	rowResultWriter := NewRowResultWriter(a.run.rightRows)
+	recv := MakeDistSQLReceiver(
+		params.ctx, rowResultWriter, tree.Rows,
+		params.extendedEvalCtx.ExecCfg.RangeDescriptorCache,
+		params.extendedEvalCtx.ExecCfg.LeaseHolderCache,
+		params.p.Txn(),
+		func(ts hlc.Timestamp) {
+			_ = params.extendedEvalCtx.ExecCfg.Clock.Update(ts)
+		},
+		params.p.extendedEvalCtx.Tracing,
+	)
+	defer recv.Release()
+
+	// Make a copy of the EvalContext so it can be safely modified.
+	evalCtx := *params.p.ExtendedEvalContext()
+	planCtx := params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.newLocalPlanningCtx(params.ctx, &evalCtx)
+	// Always plan local.
+	planCtx.isLocal = true
+	plannerCopy := *params.p
+	planCtx.planner = &plannerCopy
+	planCtx.planner.curPlan = *plan
+	planCtx.stmtType = recv.stmtType
+
+	params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.PlanAndRun(
+		params.ctx, &evalCtx, planCtx, params.p.Txn(), plan.plan, recv)
+	if recv.commErr != nil {
+		return recv.commErr
+	}
+	return nil
+
+}
+
+func (a *applyJoinNode) Values() tree.Datums {
+	return a.run.out
+}
+
+func (a *applyJoinNode) Close(ctx context.Context) {
+	a.input.plan.Close(ctx)
+	if a.run.rightRows != nil {
+		a.run.rightRows.Close(ctx)
+	}
+}

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -266,6 +266,23 @@ func (p *joinPredicate) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 	return p.rightInfo.NodeFormatter(idx - p.numLeftCols)
 }
 
+// eval for joinPredicate runs the on condition across the columns that do
+// not participate in the equality (the equality columns are checked
+// in the join algorithm already).
+// Returns true if there is no on condition or the on condition accepts the
+// row.
+func (p *joinPredicate) eval(ctx *tree.EvalContext, leftRow, rightRow tree.Datums) (bool, error) {
+	if p.onCond != nil {
+		copy(p.curRow[:len(leftRow)], leftRow)
+		copy(p.curRow[len(leftRow):], rightRow)
+		ctx.PushIVarContainer(p.iVarHelper.Container())
+		pred, err := sqlbase.RunFilter(p.onCond, ctx)
+		ctx.PopIVarContainer()
+		return pred, err
+	}
+	return true, nil
+}
+
 // getNeededColumns figures out the columns needed for the two
 // sources.  This takes into account both the equality columns and the
 // predicate expression.
@@ -290,6 +307,13 @@ func (p *joinPredicate) getNeededColumns(neededJoined []bool) ([]bool, []bool) {
 		rightNeeded[p.rightEqualityIndices[i]] = true
 	}
 	return leftNeeded, rightNeeded
+}
+
+// prepareRow prepares the output row by combining values from the
+// input data sources.
+func (p *joinPredicate) prepareRow(result, leftRow, rightRow tree.Datums) {
+	copy(result[:len(leftRow)], leftRow)
+	copy(result[len(leftRow):], rightRow)
 }
 
 // usingColumns captures the information about equality columns

--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -1,0 +1,151 @@
+# LogicTest: local-opt
+
+statement ok
+CREATE TABLE t (k INT PRIMARY KEY, str STRING);
+CREATE TABLE u (l INT PRIMARY KEY, str2 STRING);
+CREATE TABLE v (m INT PRIMARY KEY, str3 STRING);
+INSERT INTO t SELECT i, to_english(i) FROM generate_series(1, 5) AS g(i);
+INSERT INTO u SELECT i, to_english(i) FROM generate_series(1, 5) AS g(i);
+INSERT INTO v SELECT i, to_english(i) FROM generate_series(1, 5) AS g(i);
+
+statement ok
+SET allow_prepare_as_opt_plan = ON
+
+# InnerJoinApply tests.
+
+statement ok
+PREPARE a AS OPT PLAN '
+(Root
+  (InnerJoinApply
+    (Scan [(Table "t") (Cols "k,str") ])
+    (Select
+      (Scan [(Table "u") (Cols "l,str2") ])
+      [ (Eq (Var "k") (Var "l") )]
+     )
+    []
+    []
+  )
+  (Presentation "k,str,l,str2")
+  (NoOrdering)
+)'
+
+query ITIT rowsort
+EXECUTE a
+----
+1  one    1  one
+2  two    2  two
+3  three  3  three
+4  four   4  four
+5  five   5  five
+
+# LeftJoinApply tests.
+
+statement ok
+PREPARE b AS OPT PLAN '
+(Root
+  (LeftJoinApply
+    (Scan [(Table "t") (Cols "k,str") ])
+    (Select
+      (Scan [(Table "u") (Cols "l,str2") ])
+      [ (Eq (Plus (Var "k") (Const 1)) (Var "l") )]
+     )
+    []
+    []
+  )
+  (Presentation "k,str,l,str2")
+  (NoOrdering)
+)'
+
+query ITIT rowsort
+EXECUTE b
+----
+1  one      2  two
+2  two      3  three
+3  three    4  four
+4  four     5  five
+5  five     NULL NULL
+
+# SemiJoinApply tests.
+
+statement ok
+PREPARE c AS OPT PLAN '
+(Root
+  (SemiJoinApply
+    (Scan [(Table "t") (Cols "k,str") ])
+    (Select
+      (Scan [(Table "u") (Cols "l,str2") ])
+      [ (Eq (Plus (Var "k") (Const 1)) (Var "l") )]
+     )
+    []
+    []
+  )
+  (Presentation "k,str")
+  (NoOrdering)
+)'
+
+query IT rowsort
+EXECUTE c
+----
+1  one
+2  two
+3  three
+4  four
+
+# AntiJoinApply tests.
+
+statement ok
+PREPARE d AS OPT PLAN '
+(Root
+  (AntiJoinApply
+    (Scan [(Table "t") (Cols "k,str") ])
+    (Select
+      (Scan [(Table "u") (Cols "l,str2") ])
+      [ (Eq (Plus (Var "k") (Const 1)) (Var "l") )]
+     )
+    []
+    []
+  )
+  (Presentation "k,str")
+  (NoOrdering)
+)'
+
+query IT rowsort
+EXECUTE d
+----
+5  five
+
+# Nested Apply, with outer columns of the outer apply on the left and right of
+# the inner apply.
+
+statement ok
+PREPARE e AS OPT PLAN '
+(Root
+  (InnerJoinApply
+    (Scan [(Table "t") (Cols "k,str") ])
+    (InnerJoinApply
+      (Select
+        (Scan [(Table "u") (Cols "l,str2") ])
+        [ (Eq (Var "k") (Var "l") )]
+      )
+      (Select
+        (Scan [(Table "v") (Cols "m,str3") ])
+        [ (Eq (Var "k") (Var "m") )]
+      )
+      [ (Eq (Var "k") (Var "l")) ]
+      []
+    )
+    []
+    []
+  )
+  (Presentation "k,str,l,str2,m,str3")
+  (NoOrdering)
+)'
+
+query ITITIT rowsort
+EXECUTE e
+----
+1  one    1  one    1  one
+2  two    2  two    2  two
+3  three  3  three  3  three
+4  four   4  four   4  four
+5  five   5  five   5  five

--- a/pkg/sql/logictest/testdata/logic_test/orms-opt
+++ b/pkg/sql/logictest/testdata/logic_test/orms-opt
@@ -1,0 +1,90 @@
+# LogicTest: local-opt fakedist-opt
+
+## This test file contains various complex queries that ORMs issue during
+## startup or general use, that pre-CBO code can't handle. This file should be
+## merged with the orms test file once the heuristic planner is gone.
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY)
+
+# ActiveRecord query that needs apply join.
+query TTTBTITT
+SELECT a.attname,
+  format_type(a.atttypid, a.atttypmod),
+  pg_get_expr(d.adbin, d.adrelid),
+  a.attnotnull,
+  a.atttypid,
+  a.atttypmod,
+  (SELECT c.collname
+   FROM pg_collation c, pg_type t
+   WHERE c.oid = a.attcollation
+   AND t.oid = a.atttypid
+   AND a.attcollation <> t.typcollation),
+   col_description(a.attrelid, a.attnum) AS comment
+FROM pg_attribute a LEFT JOIN pg_attrdef d
+ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+WHERE a.attrelid = '"a"'::regclass
+AND a.attnum > 0 AND NOT a.attisdropped
+ORDER BY a.attnum
+----
+a  bigint  NULL  true  20  -1  NULL  NULL
+
+# Navicat metadata query.
+
+query TTBBB
+SELECT
+    attname AS name,
+    attrelid AS tid,
+    COALESCE(
+        (
+            SELECT
+                attnum = ANY conkey
+            FROM
+                pg_constraint
+            WHERE
+                contype = 'p' AND conrelid = attrelid
+        ),
+        false
+    )
+        AS primarykey,
+    NOT (attnotnull) AS allownull,
+    (
+        SELECT
+            seq.oid
+        FROM
+            pg_class AS seq
+            LEFT JOIN pg_depend AS dep
+            ON seq.oid = dep.objid
+        WHERE
+            (
+                seq.relkind = 'S'::CHAR
+                AND dep.refobjsubid = attnum
+            )
+            AND dep.refobjid = attrelid
+    )
+    IS NOT NULL
+        AS autoincrement
+FROM
+    pg_attribute
+WHERE
+    (
+        attisdropped = false
+        AND attrelid
+            = (
+                    SELECT
+                        tbl.oid
+                    FROM
+                        pg_class AS tbl
+                        LEFT JOIN pg_namespace AS sch
+                        ON tbl.relnamespace = sch.oid
+                    WHERE
+                        (
+                            tbl.relkind = 'r'::"char"
+                            AND tbl.relname = 'a'
+                        )
+                        AND sch.nspname = 'public'
+                )
+    )
+    AND attname = 'a';
+----
+a  53  true  false  false

--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -245,12 +245,6 @@ WHERE
 ----
 1  CA
 
-# For now, we can't decorrelate semi-join-apply cases.
-statement error could not decorrelate subquery
-SELECT *
-FROM c
-WHERE (SELECT min(ship) FROM o WHERE o.c_id=c.c_id) IN (SELECT ship FROM o WHERE o.c_id=c.c_id);
-
 # Customers with more than one order.
 query IT rowsort
 SELECT * FROM c WHERE (SELECT count(*) FROM o WHERE o.c_id=c.c_id) > 1;
@@ -384,11 +378,12 @@ ORDER BY c_id
 2  TX
 4  TX
 
-# Max1Row prevents decorrelation.
-statement error could not decorrelate subquery
+# Apply
+query IT rowsort
 SELECT *
 FROM c
 WHERE (SELECT o_id FROM o WHERE o.c_id=c.c_id AND ship='WY')=4;
+----
 
 # ------------------------------------------------------------------------------
 # Subqueries in projection lists.
@@ -710,11 +705,16 @@ ORDER BY c_id;
 5  false
 6  false
 
-# For now, we can't decorrelate semi-join-apply cases.
-statement error could not decorrelate subquery
+# Apply.
+query IT rowsort
 SELECT *
 FROM c
 WHERE (SELECT min(ship) FROM o WHERE o.c_id=c.c_id) IN (SELECT ship FROM o WHERE o.c_id=c.c_id);
+----
+1  CA
+2  TX
+4  TX
+6  FL
 
 # Customers with at least one shipping address = minimum shipping address.
 query IB
@@ -928,12 +928,13 @@ ON c.c_id=o.c_id AND EXISTS(SELECT * FROM o WHERE o.c_id=c.c_id AND ship IS NULL
 4  70
 4  80
 
-# Can't decorrelate this case.
-statement error could not decorrelate subquery
+query II rowsort
 SELECT c.c_id, o.o_id
 FROM c
 INNER JOIN o
 ON c.c_id=o.c_id AND o.ship = (SELECT o.ship FROM o WHERE o.c_id=c.c_id);
+----
+6  90
 
 statement error AS OF SYSTEM TIME must be provided on a top-level statement
 SELECT (SELECT c_id FROM o AS OF SYSTEM TIME '-1us')
@@ -975,6 +976,27 @@ SELECT
   c_id,
   ARRAY(SELECT (o_id, ship) FROM o WHERE o.c_id = c.c_id ORDER BY o_id)
 FROM c ORDER BY c_id
+
+# Regression for issue #24676: missing support for correlated subquery in JSON
+# operator.
+statement ok
+CREATE TABLE groups(
+  id SERIAL PRIMARY KEY,
+  data JSONB
+);
+INSERT INTO groups(data) VALUES('{"name": "Group 1", "members": [{"name": "admin", "type": "USER"}, {"name": "user", "type": "USER"}]}');
+INSERT INTO groups(data) VALUES('{"name": "Group 2", "members": [{"name": "admin2", "type": "USER"}]}');
+
+query TT
+SELECT
+  g.data->>'name' AS group_name,
+  jsonb_array_elements( (SELECT gg.data->'members' FROM groups gg WHERE gg.data->>'name' = g.data->>'name') )
+FROM
+  groups g
+----
+Group 1	{"name": "admin", "type": "USER"}
+Group 1	{"name": "user", "type": "USER"}
+Group 2	{"name": "admin2", "type": "USER"}
 
 # ------------------------------------------------------------------------------
 # Regression test cases.

--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -15,9 +15,12 @@
 package bench
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -72,6 +75,19 @@ func (f *stubFactory) ConstructHashJoin(
 	leftEqCols, rightEqCols []exec.ColumnOrdinal,
 	leftEqColsAreKey, rightEqColsAreKey bool,
 	extraOnCond tree.TypedExpr,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
+func (f *stubFactory) ConstructApplyJoin(
+	joinType sqlbase.JoinType,
+	left exec.Node,
+	leftBoundColMap opt.ColMap,
+	memo *memo.Memo,
+	rightProps *physical.Required,
+	fakeRight exec.Node,
+	right memo.RelExpr,
+	onCond tree.TypedExpr,
 ) (exec.Node, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -35,6 +35,12 @@ type Builder struct {
 	// expressions we built. Each entry is associated with a tree.Subquery
 	// expression node.
 	subqueries []exec.Subquery
+
+	// nullifyMissingVarExprs, if greater than 0, tells the builder to replace
+	// VariableExprs that have no bindings with DNull. This is useful for apply
+	// join, which needs to be able to create a plan that has outer columns.
+	// The number indicates the depth of apply joins.
+	nullifyMissingVarExprs int
 }
 
 // New constructs an instance of the execution node builder using the

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -142,6 +142,9 @@ func (b *Builder) indexedVar(
 ) tree.TypedExpr {
 	idx, ok := ctx.ivarMap.Get(int(colID))
 	if !ok {
+		if b.nullifyMissingVarExprs > 0 {
+			return tree.DNull
+		}
 		panic(fmt.Sprintf("cannot map variable %d to an indexed var", colID))
 	}
 	return ctx.ivh.IndexedVarWithType(idx, md.ColumnMeta(colID).Type)

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -196,12 +196,23 @@ CREATE TABLE groups(
   primary key (id)
 )
 
-query error could not decorrelate subquery
+query TTTTT
 EXPLAIN (VERBOSE) SELECT
   g.data->>'name' AS group_name,
   jsonb_array_elements( (SELECT gg.data->'members' FROM groups gg WHERE gg.data->>'name' = g.data->>'name') )
 FROM
   groups g
+----
+render                ·         ·                         (group_name, jsonb_array_elements)        ·
+ │                    render 0  data->>'name'             ·                                         ·
+ │                    render 1  jsonb_array_elements      ·                                         ·
+ └── project set      ·         ·                         (data, "?column?", jsonb_array_elements)  ·
+      │               render 0  jsonb_array_elements(@2)  ·                                         ·
+      └── apply-join  ·         ·                         (data, "?column?")                        ·
+           │          type      left outer                ·                                         ·
+           └── scan   ·         ·                         (data)                                    ·
+·                     table     groups@primary            ·                                         ·
+·                     spans     ALL                       ·                                         ·
 
 # Regression test for #32162.
 query TTTTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -233,8 +233,15 @@ root            ·              ·                  ("array")  ·
 ·               spans          ALL                ·          ·
 
 # Case where the plan has an apply join.
-query error could not decorrelate subquery
-SELECT * FROM abc WHERE EXISTS(SELECT * FROM (VALUES (a), (b)) WHERE column1=a)
+query TTTTT
+EXPLAIN(verbose) SELECT * FROM abc WHERE EXISTS(SELECT * FROM (VALUES (a), (b)) WHERE column1=a)
+----
+apply-join  ·      ·            (a, b, c)  ·
+ │          type   semi         ·          ·
+ │          pred   column1 = a  ·          ·
+ └── scan   ·      ·            (a, b, c)  ·
+·           table  abc@primary  ·          ·
+·           spans  ALL          ·          ·
 
 # Case where the EXISTS subquery still has outer columns in the subquery
 # (regression test for #28816).

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -236,6 +236,9 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *showTraceNode:
 	case *scatterNode:
 
+	case *applyJoinNode:
+		// The apply join node is only planned by the optimizer.
+
 	case *lookupJoinNode:
 		// The lookup join node is only planned by the optimizer.
 

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -91,6 +91,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.resultColumns
 	case *projectSetNode:
 		return n.columns
+	case *applyJoinNode:
+		return n.columns
 	case *lookupJoinNode:
 		return n.columns
 	case *zigzagJoinNode:

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -90,6 +90,7 @@ func planPhysicalProps(plan planNode) physicalProps {
 		return n.props
 	case *zigzagJoinNode:
 		return n.props
+	case *applyJoinNode:
 
 	// Every other node simply has no guarantees on its output rows.
 	case *CreateUserNode:

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -259,6 +259,15 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			}
 		}
 
+	case *applyJoinNode:
+		if v.observer.attr != nil {
+			v.observer.attr(name, "type", joinTypeStr(n.joinType))
+		}
+		if v.observer.expr != nil {
+			v.expr(name, "pred", -1, n.pred.onCond)
+		}
+		n.input.plan = v.visit(n.input.plan)
+
 	case *joinNode:
 		if v.observer.attr != nil {
 			jType := joinTypeStr(n.joinType)
@@ -701,6 +710,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&alterSequenceNode{}):        "alter sequence",
 	reflect.TypeOf(&alterTableNode{}):           "alter table",
 	reflect.TypeOf(&alterUserSetPasswordNode{}): "alter user",
+	reflect.TypeOf(&applyJoinNode{}):            "apply-join",
 	reflect.TypeOf(&commentOnColumnNode{}):      "comment on column",
 	reflect.TypeOf(&commentOnDatabaseNode{}):    "comment on database",
 	reflect.TypeOf(&commentOnTableNode{}):       "comment on table",


### PR DESCRIPTION
This commit adds the implementation of the apply join operator, which is
built by the optimizer in some cases for correlated subqueries.

Apply join is like an ordinary join operator in that it joins the output
of 2 other operators. The special thing about apply join is that its
right side operator has outer columns (columns that don't yet have
values), and at runtime, the values of each row from the left operator
are used to fill in the outer columns of the right side operator. Once
the outer columns of the right side operator are filled, apply join
recursively re-plans the right side operator and runs it, joining the
resultant rows with the left side row that was used to fill the outer
columns.

Apply join isn't distributable because it requires passing around
optimizer memo and plan data structures, which are not marshallable to
bytes that could be distributed at this time.

Closes #32786.
Closes #25678.

Release note (sql change): many more correlated subqueries are now
runnable.