### PR TITLE
sem/tree: use StmtTimestamp as max for AsOf, enforce non-zero intervals

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -854,7 +854,7 @@ func backupPlanHook(
 		endTime := p.ExecCfg().Clock.Now()
 		if backupStmt.AsOf.Expr != nil {
 			var err error
-			if endTime, err = p.EvalAsOfTimestamp(backupStmt.AsOf, endTime); err != nil {
+			if endTime, err = p.EvalAsOfTimestamp(backupStmt.AsOf); err != nil {
 				return err
 			}
 		}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2798,7 +2798,7 @@ func TestCreateStatsAfterRestore(t *testing.T) {
 		stats.DefaultAsOfTime = oldAsOf
 	}(stats.DefaultRefreshInterval, stats.DefaultAsOfTime)
 	stats.DefaultRefreshInterval = time.Millisecond
-	stats.DefaultAsOfTime = 0
+	stats.DefaultAsOfTime = time.Microsecond
 
 	const numAccounts = 1
 	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -1293,10 +1293,8 @@ func restorePlanHook(
 		}
 		var endTime hlc.Timestamp
 		if restoreStmt.AsOf.Expr != nil {
-			// Use Now() for the max timestamp because Restore does its own
-			// (more restrictive) check.
 			var err error
-			endTime, err = p.EvalAsOfTimestamp(restoreStmt.AsOf, p.ExecCfg().Clock.Now())
+			endTime, err = p.EvalAsOfTimestamp(restoreStmt.AsOf)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -146,12 +146,14 @@ func changefeedPlanHook(
 
 		jobDescription := changefeedJobDescription(changefeedStmt, sinkURI, opts)
 
-		statementTime := p.ExecCfg().Clock.Now()
+		statementTime := hlc.Timestamp{
+			WallTime: p.ExtendedEvalContext().GetStmtTimestamp().UnixNano(),
+		}
 		var initialHighWater hlc.Timestamp
 		if cursor, ok := opts[optCursor]; ok {
 			asOf := tree.AsOfClause{Expr: tree.NewStrVal(cursor)}
 			var err error
-			if initialHighWater, err = p.EvalAsOfTimestamp(asOf, statementTime); err != nil {
+			if initialHighWater, err = p.EvalAsOfTimestamp(asOf); err != nil {
 				return err
 			}
 			statementTime = initialHighWater

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -2436,7 +2436,7 @@ func TestCreateStatsAfterImport(t *testing.T) {
 		stats.DefaultAsOfTime = oldAsOf
 	}(stats.DefaultRefreshInterval, stats.DefaultAsOfTime)
 	stats.DefaultRefreshInterval = time.Millisecond
-	stats.DefaultAsOfTime = 0
+	stats.DefaultAsOfTime = time.Microsecond
 
 	const nodes = 1
 	ctx := context.Background()

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1751,8 +1751,8 @@ func (ex *connExecutor) setTransactionModes(modes tree.TransactionModes) error {
 	}
 	rwMode := modes.ReadWriteMode
 	if modes.AsOf.Expr != nil {
-		now := ex.server.cfg.Clock.Now()
-		ts, err := ex.planner.EvalAsOfTimestamp(modes.AsOf, now)
+
+		ts, err := ex.planner.EvalAsOfTimestamp(modes.AsOf)
 		if err != nil {
 			ex.state.mu.Unlock()
 			return err

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -371,7 +371,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	}
 
 	if os.ImplicitTxn.Get() {
-		asOfTs, err := p.isAsOf(stmt.AST, ex.server.cfg.Clock.Now())
+		asOfTs, err := p.isAsOf(stmt.AST)
 		if err != nil {
 			return makeErrEvent(err)
 		}
@@ -385,7 +385,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		// the transaction's timestamp. This is useful for running AOST statements
 		// using the InternalExecutor inside an external transaction; one might want
 		// to do that to force p.avoidCachedDescriptors to be set below.
-		ts, err := p.isAsOf(stmt.AST, ex.server.cfg.Clock.Now())
+		ts, err := p.isAsOf(stmt.AST)
 		if err != nil {
 			return makeErrEvent(err)
 		}
@@ -1071,7 +1071,7 @@ func (ex *connExecutor) beginTransactionTimestampsAndReadMode(
 	}
 	p := &ex.planner
 	ex.resetPlanner(ctx, p, nil /* txn */, now.GoTime())
-	ts, err := p.EvalAsOfTimestamp(s.Modes.AsOf, now)
+	ts, err := p.EvalAsOfTimestamp(s.Modes.AsOf)
 	if err != nil {
 		return 0, time.Time{}, nil, err
 	}

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -191,7 +191,7 @@ func (ex *connExecutor) populatePrepared(
 
 	p.extendedEvalCtx.PrepareOnly = true
 
-	protoTS, err := p.isAsOf(stmt.AST, ex.server.cfg.Clock.Now() /* max */)
+	protoTS, err := p.isAsOf(stmt.AST)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -152,7 +152,7 @@ func (n *createStatsNode) startJob(ctx context.Context, resultsCh chan<- tree.Da
 	// Evaluate the AS OF time, if any.
 	var asOf *hlc.Timestamp
 	if n.AsOf.Expr != nil {
-		asOfTs, err := n.p.EvalAsOfTimestamp(n.AsOf, n.p.ExecCfg().Clock.Now())
+		asOfTs, err := n.p.EvalAsOfTimestamp(n.AsOf)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1025,7 +1025,7 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 	}
 
 	// Update the defaults for automatic statistics to avoid delays in testing.
-	stats.DefaultAsOfTime = 0
+	stats.DefaultAsOfTime = time.Microsecond
 	stats.DefaultRefreshInterval = time.Millisecond
 
 	t.cluster = serverutils.StartTestCluster(t.t, cfg.numNodes, params)

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -8,24 +8,19 @@ INSERT INTO t VALUES (2)
 
 # Verify strings can be parsed as intervals.
 query I
-SELECT * FROM t AS OF SYSTEM TIME '-0ns'
-----
-2
-
-query I
-SELECT * FROM t AS OF SYSTEM TIME '-1ns'
+SELECT * FROM t AS OF SYSTEM TIME '-1us'
 ----
 2
 
 # Verify a forced interval type works.
 query I
-SELECT * FROM t AS OF SYSTEM TIME INTERVAL '-1ns'
+SELECT * FROM t AS OF SYSTEM TIME INTERVAL '-1us'
 ----
 2
 
 # Verify that we can use computed expressions.
 query I
-SELECT * FROM t AS OF SYSTEM TIME -( ('1' || 'ns')::INTERVAL )
+SELECT * FROM t AS OF SYSTEM TIME -( ('1000' || 'ns')::INTERVAL )
 ----
 2
 
@@ -57,3 +52,20 @@ query T
 SELECT * FROM (SELECT now()) AS OF SYSTEM TIME '2018-01-01'
 ----
 2018-01-01 00:00:00 +0000 UTC
+
+# Verify that zero intervals indistinguishable from zero cause an error.
+
+statement error pq: AS OF SYSTEM TIME: interval value '100ns' too small, must be <= -1µs
+SELECT * FROM t AS OF SYSTEM TIME '100ns'
+
+statement error pq: AS OF SYSTEM TIME: interval value '0,0' too small, must be <= -1µs
+SELECT * FROM t AS OF SYSTEM TIME '0,0'
+
+statement error pq: AS OF SYSTEM TIME: interval value '0.000000000,0' too small, must be <= -1µs
+SELECT * FROM t AS OF SYSTEM TIME '0.000000000,0'
+
+statement error pq: AS OF SYSTEM TIME: interval value '-100ns' too small, must be <= -1µs
+SELECT * FROM t AS OF SYSTEM TIME '-100ns'
+
+statement error pq: AS OF SYSTEM TIME: zero timestamp is invalid
+SELECT * FROM t AS OF SYSTEM TIME '0'

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -126,7 +126,7 @@ statement error pgcode 42P01 relation "data" does not exist
 CREATE STATISTICS s2 ON a FROM data AS OF SYSTEM TIME '2017'
 
 statement ok
-CREATE STATISTICS s2 ON a FROM data AS OF SYSTEM TIME '-1ns'
+CREATE STATISTICS s2 ON a FROM data AS OF SYSTEM TIME '-1us'
 
 query TTIII colnames
 SELECT statistics_name, column_names, row_count, distinct_count, null_count FROM [SHOW STATISTICS FOR TABLE data]

--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -936,7 +936,7 @@ INNER JOIN o
 ON c.c_id=o.c_id AND o.ship = (SELECT o.ship FROM o WHERE o.c_id=c.c_id);
 
 statement error AS OF SYSTEM TIME must be provided on a top-level statement
-SELECT (SELECT c_id FROM o AS OF SYSTEM TIME '-0ns')
+SELECT (SELECT c_id FROM o AS OF SYSTEM TIME '-1us')
 FROM c
 WHERE EXISTS(SELECT * FROM o WHERE o.c_id=c.c_id)
 

--- a/pkg/sql/logictest/testdata/logic_test/txn_as_of
+++ b/pkg/sql/logictest/testdata/logic_test/txn_as_of
@@ -22,7 +22,7 @@ statement ok
 COMMIT
 
 statement ok
-BEGIN AS OF SYSTEM TIME '-1ns'
+BEGIN AS OF SYSTEM TIME '-1us'
 
 query I
 SELECT * FROM t
@@ -33,7 +33,7 @@ statement ok
 COMMIT
 
 statement ok
-BEGIN; SET TRANSACTION AS OF SYSTEM TIME '-1ns'
+BEGIN; SET TRANSACTION AS OF SYSTEM TIME '-1us'
 
 query I
 SELECT * FROM t
@@ -76,7 +76,7 @@ COMMIT
 # Verify transactions with a historical timestamps imply READ ONLY.
 
 statement ok
-BEGIN; SET TRANSACTION AS OF SYSTEM TIME '-1ns'
+BEGIN; SET TRANSACTION AS OF SYSTEM TIME '-1us'
 
 statement error pq: cannot execute INSERT in a read-only transaction
 INSERT INTO t VALUES (3)
@@ -85,7 +85,7 @@ statement ok
 COMMIT
 
 statement ok
-BEGIN AS OF SYSTEM TIME '-1ns'
+BEGIN AS OF SYSTEM TIME '-1us'
 
 statement error pq: cannot execute INSERT in a read-only transaction
 INSERT INTO t VALUES (3)
@@ -97,7 +97,7 @@ COMMIT
 # the previous value.
 
 statement ok
-BEGIN AS OF SYSTEM TIME '-1h'; SET TRANSACTION AS OF SYSTEM TIME '-1ns';
+BEGIN AS OF SYSTEM TIME '-1h'; SET TRANSACTION AS OF SYSTEM TIME '-1us';
 
 query I
 SELECT * FROM t

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/pkg/errors"
 )
 
@@ -760,7 +759,7 @@ func (b *Builder) buildFromTables(tables tree.TableExprs, inScope *scope) (outSc
 // validateAsOf ensures that any AS OF SYSTEM TIME timestamp is consistent with
 // that of the root statement.
 func (b *Builder) validateAsOf(asOf tree.AsOfClause) {
-	ts, err := tree.EvalAsOfTimestamp(asOf, hlc.MaxTimestamp, b.semaCtx, b.evalCtx)
+	ts, err := tree.EvalAsOfTimestamp(asOf, b.semaCtx, b.evalCtx)
 	if err != nil {
 		panic(builderError{err})
 	}

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1125,7 +1125,7 @@ select
 # This is slightly funky, because the AS OF SYSTEM TIME timestamp only gets
 # interpreted by the executor, which obviously is not at play in these tests.
 build
-SELECT * FROM a AS OF SYSTEM TIME '10ns'
+SELECT * FROM a AS OF SYSTEM TIME '-1000ns'
 ----
 error: AS OF SYSTEM TIME must be provided on a top-level statement
 

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -91,7 +91,7 @@ type PlanHookState interface {
 	GetAllUsersAndRoles(ctx context.Context) (map[string]bool, error)
 	BumpRoleMembershipTableVersion(ctx context.Context) error
 	Select(ctx context.Context, n *tree.Select, desiredTypes []types.T) (planNode, error)
-	EvalAsOfTimestamp(asOf tree.AsOfClause, max hlc.Timestamp) (hlc.Timestamp, error)
+	EvalAsOfTimestamp(asOf tree.AsOfClause) (hlc.Timestamp, error)
 	ResolveUncachedDatabaseByName(
 		ctx context.Context, dbName string, required bool) (*UncachedDatabaseDescriptor, error)
 }

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -484,7 +484,7 @@ func (p *planner) getTimestamp(asOf tree.AsOfClause) (hlc.Timestamp, bool, error
 		// level. We accept AS OF SYSTEM TIME in multiple places (e.g. in
 		// subqueries or view queries) but they must all point to the same
 		// timestamp.
-		ts, err := p.EvalAsOfTimestamp(asOf, hlc.MaxTimestamp)
+		ts, err := p.EvalAsOfTimestamp(asOf)
 		if err != nil {
 			return hlc.MaxTimestamp, false, err
 		}

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -56,7 +56,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	descA := sqlbase.GetTableDescriptor(s.DB(), "t", "a")
 	cache := NewTableStatisticsCache(10 /* cacheSize */, s.Gossip(), kvDB, executor)
-	refresher := MakeRefresher(executor, cache, 0 /* asOfTime */)
+	refresher := MakeRefresher(executor, cache, time.Microsecond /* asOfTime */)
 
 	// There should not be any stats yet.
 	if err := checkStatsCount(ctx, cache, descA.ID, 0 /* expected */); err != nil {
@@ -65,14 +65,14 @@ func TestMaybeRefreshStats(t *testing.T) {
 
 	// There are no stats yet, so this must refresh the statistics on table t
 	// even though rowsAffected=0.
-	refresher.maybeRefreshStats(ctx, s.Stopper(), descA.ID, 0 /* rowsAffected */, 0 /* asOf */)
+	refresher.maybeRefreshStats(ctx, s.Stopper(), descA.ID, 0 /* rowsAffected */, time.Microsecond /* asOf */)
 	if err := checkStatsCount(ctx, cache, descA.ID, 1 /* expected */); err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to refresh again. With rowsAffected=0, the probability of a refresh
 	// is 0, so refreshing will not succeed.
-	refresher.maybeRefreshStats(ctx, s.Stopper(), descA.ID, 0 /* rowsAffected */, 0 /* asOf */)
+	refresher.maybeRefreshStats(ctx, s.Stopper(), descA.ID, 0 /* rowsAffected */, time.Microsecond /* asOf */)
 	if err := checkStatsCount(ctx, cache, descA.ID, 1 /* expected */); err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestAverageRefreshTime(t *testing.T) {
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	tableID := sqlbase.GetTableDescriptor(s.DB(), "t", "a").ID
 	cache := NewTableStatisticsCache(10 /* cacheSize */, s.Gossip(), kvDB, executor)
-	refresher := MakeRefresher(executor, cache, 0 /* asOfTime */)
+	refresher := MakeRefresher(executor, cache, time.Microsecond /* asOfTime */)
 
 	checkAverageRefreshTime := func(expected time.Duration) error {
 		cache.InvalidateTableStats(ctx, tableID)
@@ -262,7 +262,7 @@ func TestAverageRefreshTime(t *testing.T) {
 	// average time between refreshes, so this call is not required to refresh
 	// the statistics on table t. With rowsAffected=0, the probability of refresh
 	// is 0.
-	refresher.maybeRefreshStats(ctx, s.Stopper(), tableID, 0 /* rowsAffected */, 0 /* asOf */)
+	refresher.maybeRefreshStats(ctx, s.Stopper(), tableID, 0 /* rowsAffected */, time.Microsecond /* asOf */)
 	if err := checkStatsCount(ctx, cache, tableID, 20 /* expected */); err != nil {
 		t.Fatal(err)
 	}
@@ -307,7 +307,7 @@ func TestAverageRefreshTime(t *testing.T) {
 	// on table t even though rowsAffected=0. After refresh, only 15 stats should
 	// remain (5 from column k and 10 from column v), since the old stats on k
 	// were deleted.
-	refresher.maybeRefreshStats(ctx, s.Stopper(), tableID, 0 /* rowsAffected */, 0 /* asOf */)
+	refresher.maybeRefreshStats(ctx, s.Stopper(), tableID, 0 /* rowsAffected */, time.Microsecond /* asOf */)
 	if err := checkStatsCount(ctx, cache, tableID, 15 /* expected */); err != nil {
 		t.Fatal(err)
 	}
@@ -332,7 +332,7 @@ func TestAutoStatsReadOnlyTables(t *testing.T) {
 
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	cache := NewTableStatisticsCache(10 /* cacheSize */, s.Gossip(), kvDB, executor)
-	refresher := MakeRefresher(executor, cache, 0 /* asOfTime */)
+	refresher := MakeRefresher(executor, cache, time.Microsecond /* asOfTime */)
 
 	AutomaticStatisticsClusterMode.Override(&st.SV, true)
 


### PR DESCRIPTION
Before this PR there was some unexpected behavior when using AOST clauses with
literals which were very small. There are two culprits. The first is that the
logic to evaluate the AOST took a maximum value that was different and always
greater than the statement time which is the timestamp from which intervals
literals are used to compute a timestamp. That means that if the interval
literal were positive but smaller than the difference between the "max" and
the statement time, they would be judged to be valid. There's no reason we need
to compute an additional maximum, instead we just use statement time as the
maximum. Another issue is that values smaller than 1 microsecond are rounded to
zero so `100ns`, `0,0` and `-100ns` are equivalent as far as the evaluation
code was concerned. This diff makes all of these intervals which are rounded to
zero illegal.

Fixes #34371.

Release note (sql change): Disallow `AS OF SYSTEM TIME` interval expressions
less than 1 microsecond in the past.