### PR TITLE
opt: set join reorder limit to 4 by default

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1341,7 +1341,7 @@ default_transaction_read_only      off           NULL      NULL        NULL     
 distsql                            off           NULL      NULL        NULL        string
 experimental_enable_zigzag_join    off           NULL      NULL        NULL        string
 experimental_force_split_at        off           NULL      NULL        NULL        string
-experimental_reorder_joins_limit   0             NULL      NULL        NULL        string
+experimental_reorder_joins_limit   4             NULL      NULL        NULL        string
 experimental_serial_normalization  rowid         NULL      NULL        NULL        string
 experimental_vectorize             off           NULL      NULL        NULL        string
 extra_float_digits                 0             NULL      NULL        NULL        string
@@ -1387,7 +1387,7 @@ default_transaction_read_only      off           NULL  user     NULL      off   
 distsql                            off           NULL  user     NULL      off           off
 experimental_enable_zigzag_join    off           NULL  user     NULL      off           off
 experimental_force_split_at        off           NULL  user     NULL      off           off
-experimental_reorder_joins_limit   0             NULL  user     NULL      0             0
+experimental_reorder_joins_limit   4             NULL  user     NULL      4             4
 experimental_serial_normalization  rowid         NULL  user     NULL      rowid         rowid
 experimental_vectorize             off           NULL  user     NULL      off           off
 extra_float_digits                 0             NULL  user     NULL      0             2

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -38,7 +38,7 @@ default_transaction_read_only      off
 distsql                            off
 experimental_enable_zigzag_join    off
 experimental_force_split_at        off
-experimental_reorder_joins_limit   0
+experimental_reorder_joins_limit   4
 experimental_serial_normalization  rowid
 experimental_vectorize             off
 extra_float_digits                 0

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -97,27 +97,34 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
 ]
 ----
-limit                     ·         ·
- │                        count     1
- └── join                 ·         ·
-      │                   type      inner
-      │                   equality  (x) = (x)
-      │                   pred      x = x
-      ├── join            ·         ·
-      │    │              type      inner
-      │    │              equality  (x) = (x)
-      │    ├── join       ·         ·
-      │    │    │         type      cross
-      │    │    ├── scan  ·         ·
-      │    │    │         table     onecolumn@primary
-      │    │    │         spans     ALL
-      │    │    └── scan  ·         ·
-      │    │              table     twocolumn@primary
-      │    │              spans     ALL
-      │    └── scan       ·         ·
-      │                   table     onecolumn@primary
-      │                   spans     ALL
-      └── scan            ·         ·
+render                    ·         ·
+ │                        render 0  x
+ │                        render 1  x
+ │                        render 2  y
+ │                        render 3  x
+ │                        render 4  x
+ │                        render 5  y
+ └── limit                ·         ·
+      │                   count     1
+      └── join            ·         ·
+           │              type      inner
+           │              equality  (x) = (x)
+           ├── join       ·         ·
+           │    │         type      inner
+           │    │         equality  (x) = (x)
+           │    ├── scan  ·         ·
+           │    │         table     twocolumn@primary
+           │    │         spans     ALL
+           │    └── scan  ·         ·
+           │              table     onecolumn@primary
+           │              spans     ALL
+           └── join       ·         ·
+                │         type      inner
+                │         equality  (x) = (x)
+                ├── scan  ·         ·
+                │         table     onecolumn@primary
+                │         spans     ALL
+                └── scan  ·         ·
 ·                         table     twocolumn@primary
 ·                         spans     ALL
 
@@ -337,88 +344,87 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 2   ·              render 12  relname
 3   join           ·          ·
 3   ·              type       inner
-3   ·              equality   (relnamespace) = (oid)
+3   ·              equality   (oid) = (attrelid)
+3   ·              pred       confrelid = oid
 4   join           ·          ·
 4   ·              type       inner
-4   ·              equality   (attrelid) = (oid)
-4   ·              pred       confrelid = oid
-5   join           ·          ·
-5   ·              type       inner
-5   ·              equality   (attnum) = (column167)
-6   virtual table  ·          ·
-6   ·              source     ·
-6   render         ·          ·
-6   ·              render 0   confkey[generate_series]
-6   ·              render 1   nspname
-6   ·              render 2   relname
-6   ·              render 3   attname
-6   ·              render 4   conname
-6   ·              render 5   condeferrable
-6   ·              render 6   condeferred
-6   ·              render 7   confrelid
-6   ·              render 8   confupdtype
-6   ·              render 9   confdeltype
-6   ·              render 10  generate_series
-6   ·              render 11  relname
-7   join           ·          ·
-7   ·              type       inner
-7   ·              equality   (relnamespace) = (oid)
+4   ·              equality   (relnamespace) = (oid)
+5   virtual table  ·          ·
+5   ·              source     ·
+5   virtual table  ·          ·
+5   ·              source     ·
+4   join           ·          ·
+4   ·              type       inner
+4   ·              equality   (attnum) = (column167)
+5   virtual table  ·          ·
+5   ·              source     ·
+5   render         ·          ·
+5   ·              render 0   confkey[generate_series]
+5   ·              render 1   nspname
+5   ·              render 2   relname
+5   ·              render 3   attname
+5   ·              render 4   conname
+5   ·              render 5   condeferrable
+5   ·              render 6   condeferred
+5   ·              render 7   confrelid
+5   ·              render 8   confupdtype
+5   ·              render 9   confdeltype
+5   ·              render 10  generate_series
+5   ·              render 11  relname
+6   join           ·          ·
+6   ·              type       inner
+6   ·              equality   (conrelid, column166) = (oid, attnum)
+7   render         ·          ·
+7   ·              render 0   conkey[generate_series]
+7   ·              render 1   conname
+7   ·              render 2   condeferrable
+7   ·              render 3   condeferred
+7   ·              render 4   conrelid
+7   ·              render 5   confrelid
+7   ·              render 6   confupdtype
+7   ·              render 7   confdeltype
+7   ·              render 8   confkey
+7   ·              render 9   generate_series
+7   ·              render 10  relname
 8   join           ·          ·
-8   ·              type       inner
-8   ·              equality   (attrelid) = (oid)
-8   ·              pred       conrelid = oid
+8   ·              type       cross
 9   join           ·          ·
 9   ·              type       inner
-9   ·              equality   (attnum) = (column166)
-10  virtual table  ·          ·
-10  ·              source     ·
-10  render         ·          ·
-10  ·              render 0   conkey[generate_series]
-10  ·              render 1   conname
-10  ·              render 2   condeferrable
-10  ·              render 3   condeferred
-10  ·              render 4   conrelid
-10  ·              render 5   confrelid
-10  ·              render 6   confupdtype
-10  ·              render 7   confdeltype
-10  ·              render 8   confkey
-10  ·              render 9   generate_series
-10  ·              render 10  relname
-11  join           ·          ·
-11  ·              type       inner
-11  ·              equality   (objid) = (oid)
-12  join           ·          ·
-12  ·              type       cross
-13  join           ·          ·
-13  ·              type       inner
-13  ·              equality   (refobjid) = (oid)
-14  filter         ·          ·
-14  ·              filter     (classid = 139623798) AND (refclassid = 1411792157)
-15  virtual table  ·          ·
-15  ·              source     ·
-14  filter         ·          ·
-14  ·              filter     relkind = 'i'
-15  virtual table  ·          ·
-15  ·              source     ·
-13  project set    ·          ·
-13  ·              render 0   generate_series(1, 32)
-14  emptyrow       ·          ·
-12  filter         ·          ·
-12  ·              filter     contype = 'f'
-13  virtual table  ·          ·
-13  ·              source     ·
+9   ·              equality   (objid) = (oid)
+10  join           ·          ·
+10  ·              type       inner
+10  ·              equality   (refobjid) = (oid)
+11  filter         ·          ·
+11  ·              filter     (classid = 139623798) AND (refclassid = 1411792157)
+12  virtual table  ·          ·
+12  ·              source     ·
+11  filter         ·          ·
+11  ·              filter     relkind = 'i'
+12  virtual table  ·          ·
+12  ·              source     ·
+10  filter         ·          ·
+10  ·              filter     contype = 'f'
+11  virtual table  ·          ·
+11  ·              source     ·
+9   project set    ·          ·
+9   ·              render 0   generate_series(1, 32)
+10  emptyrow       ·          ·
+7   join           ·          ·
+7   ·              type       inner
+7   ·              equality   (attrelid) = (oid)
+8   virtual table  ·          ·
+8   ·              source     ·
+8   join           ·          ·
+8   ·              type       inner
+8   ·              equality   (relnamespace) = (oid)
 9   filter         ·          ·
 9   ·              filter     relname = 'orders'
 10  virtual table  ·          ·
 10  ·              source     ·
-8   filter         ·          ·
-8   ·              filter     nspname = 'public'
-9   virtual table  ·          ·
-9   ·              source     ·
-5   virtual table  ·          ·
-5   ·              source     ·
-4   virtual table  ·          ·
-4   ·              source     ·
+9   filter         ·          ·
+9   ·              filter     nspname = 'public'
+10  virtual table  ·          ·
+10  ·              source     ·
 
 # Ensure that left joins on non-null foreign keys turn into inner joins
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -26,6 +26,9 @@ CREATE TABLE abc (
   d INT
 )
 
+statement ok
+SET experimental_reorder_joins_limit = 0
+
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -200,26 +200,24 @@ ALTER TABLE authors INJECT STATISTICS '[
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT authors.name FROM books AS b1, books2 AS b2, authors WHERE b1.title = b2.title AND authors.book = b1.title AND b1.shelf <> b2.shelf
 ----
-tree                      field        description                          columns                                   ordering
-distinct                  ·            ·                                    (name)                                    weak-key(name)
- │                        distinct on  name                                 ·                                         ·
- └── render               ·            ·                                    (name)                                    ·
-      │                   render 0     name                                 ·                                         ·
-      └── join            ·            ·                                    (title, shelf, name, book, title, shelf)  ·
-           │              type         inner                                ·                                         ·
-           │              equality     (title) = (title)                    ·                                         ·
-           │              pred         (book = title) AND (shelf != shelf)  ·                                         ·
-           ├── join       ·            ·                                    (title, shelf, name, book)                ·
-           │    │         type         cross                                ·                                         ·
-           │    ├── scan  ·            ·                                    (title, shelf)                            ·
-           │    │         table        books2@primary                       ·                                         ·
-           │    │         spans        ALL                                  ·                                         ·
-           │    └── scan  ·            ·                                    (name, book)                              ·
-           │              table        authors@primary                      ·                                         ·
-           │              spans        ALL                                  ·                                         ·
-           └── scan       ·            ·                                    (title, shelf)                            ·
-·                         table        books@primary                        ·                                         ·
-·                         spans        ALL                                  ·                                         ·
+tree                        field        description       columns                                   ordering
+distinct                    ·            ·                 (name)                                    weak-key(name)
+ │                          distinct on  name              ·                                         ·
+ └── render                 ·            ·                 (name)                                    ·
+      │                     render 0     name              ·                                         ·
+      └── join              ·            ·                 (title, shelf, title, shelf, name, book)  ·
+           │                type         inner             ·                                         ·
+           │                equality     (title) = (book)  ·                                         ·
+           ├── lookup-join  ·            ·                 (title, shelf, title, shelf)              ·
+           │    │           table        books2@primary    ·                                         ·
+           │    │           type         inner             ·                                         ·
+           │    │           pred         @2 != @4          ·                                         ·
+           │    └── scan    ·            ·                 (title, shelf)                            ·
+           │                table        books@primary     ·                                         ·
+           │                spans        ALL               ·                                         ·
+           └── scan         ·            ·                 (name, book)                              ·
+·                           table        authors@primary   ·                                         ·
+·                           spans        ALL               ·                                         ·
 
 # Verify data placement.
 query TTTI colnames
@@ -233,7 +231,7 @@ NULL       NULL     {5}       5
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT authors.name FROM books AS b1, books2 AS b2, authors WHERE b1.title = b2.title AND authors.book = b1.title AND b1.shelf <> b2.shelf]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJzEk09r3DAQxe_9FOqcdkHBlv8FDAsq5ND04JS0t7IHxZruijqSkWRoCfvdi23oxu5aqffSmy3Nb-a9N-gFtJFYiWd0UH4DBhRy2FNoranROWP747HoXv6EMqagdNv5_nhPoTYWoXwBr3yDUEJlbkwbFUBBoheqGcpOFEznz5Dz4oBQ3p7oq8Ys3PireGrwEYVEG8WT9tBa9SzsL_5kzA-XAIUvrdCuJDdA4aHzJeGM8hSWZLBrZbDLMkTnj31sl3UkizqSRR3n8Z02VqJFOQ_47ZILZj4Kd_xklEYbJVMvZ7mUp5Rni6LTa8NLAztcvcLsf0aXTZ00-N1vONvurDoch6_eQ0U2PCM7wvMt-VDdkQ0vyPsd4cn2j8Nle_makO-U80rXPsqnujhb7F9M-r_xwh_RtUY7_KcnHvfZoTzguAtnOlvjZ2vqYcz4-zBww4FE58fb2_HnXo9XvcDXMAvC6QRmczhZASdzOA3CeXhytgL-a3IehItwYEUQjmfw_vTudwAAAP__beT76A==
+https://cockroachdb.github.io/distsqlplan/decode.html#eJyck89q3DAQh-99CndOCSjYku0cDAEdemhK2ZS0t7IHxZruqnE0RpKhJey7F9mlWZu10s1Rf76Zb362nsGSxo16Qg_Nd-DAoIYtg95Ri96Ti9vTpVv9C5qCgbH9EOL2lkFLDqF5hmBCh9DAhq6oz2tgoDEo043XDgxoCC-QD2qH0Fwf2FFhni78TT10eI9Ko8uLWXnonXlS7rd8IHr0wOBrr6xvsitgcDeEJpOcyRLWLPg5Fp_I2L8SPCEhgMFnosehz36SsRnZaBF9NpkU2fubTNbHdoLJksl61VG8NSlxWlINYR-_7OmsxKpHuerx0n6w5DQ61Mt_4PUrJ4b5qPw-ho4uL-ezdPgjXEh-eePMbh8upLj8N8N6kNU5QX4wPhjbhryad5Z8tX49q__KW7lH35P1-F-PpYjpoN7hlLanwbX4xVE7tpmWdyM3bmj0YTq9nha3djqKgscwT8IiDYskXM1gvoTLM2CxhKskXKe16yRcLODt4d2fAAAA__8CwK1z
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT a.name FROM authors AS a JOIN books2 AS b2 ON a.book = b2.title ORDER BY a.name

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -48,20 +48,25 @@ CREATE TABLE u (b string)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
 ----
-join                ·         ·                      (a, b, generate_series, generate_series)  ·
- │                  type      cross                  ·                                         ·
- ├── join           ·         ·                      (a, b)                                    ·
- │    │             type      cross                  ·                                         ·
- │    ├── scan      ·         ·                      (a)                                       ·
- │    │             table     t@primary              ·                                         ·
- │    │             spans     ALL                    ·                                         ·
- │    └── scan      ·         ·                      (b)                                       ·
- │                  table     u@primary              ·                                         ·
- │                  spans     ALL                    ·                                         ·
- └── project set    ·         ·                      (generate_series, generate_series)        ·
-      │             render 0  generate_series(1, 2)  ·                                         ·
-      │             render 1  generate_series(3, 4)  ·                                         ·
-      └── emptyrow  ·         ·                      ()                                        ·
+render                        ·         ·                      (a, b, generate_series, generate_series)  ·
+ │                            render 0  a                      ·                                         ·
+ │                            render 1  b                      ·                                         ·
+ │                            render 2  generate_series        ·                                         ·
+ │                            render 3  generate_series        ·                                         ·
+ └── join                     ·         ·                      (b, generate_series, generate_series, a)  ·
+      │                       type      cross                  ·                                         ·
+      ├── join                ·         ·                      (b, generate_series, generate_series)     ·
+      │    │                  type      cross                  ·                                         ·
+      │    ├── scan           ·         ·                      (b)                                       ·
+      │    │                  table     u@primary              ·                                         ·
+      │    │                  spans     ALL                    ·                                         ·
+      │    └── project set    ·         ·                      (generate_series, generate_series)        ·
+      │         │             render 0  generate_series(1, 2)  ·                                         ·
+      │         │             render 1  generate_series(3, 4)  ·                                         ·
+      │         └── emptyrow  ·         ·                      ()                                        ·
+      └── scan                ·         ·                      (a)                                       ·
+·                             table     t@primary              ·                                         ·
+·                             spans     ALL                    ·                                         ·
 
 subtest correlated_SRFs
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -356,7 +356,7 @@ var varGen = map[string]sessionVar{
 			return strconv.FormatInt(int64(evalCtx.SessionData.ReorderJoinsLimit), 10)
 		},
 		GlobalDefault: func(_ *settings.Values) string {
-			return "0"
+			return "4"
 		},
 	},
 


### PR DESCRIPTION
Release note (sql change): The cost-based optimizer will now reorder up
to 4 joins by default to attempt to find a better ordering of them. This
behaviour can be disabled per-session by setting the
`experimental_reorder_joins_limit` session variable to 0.