### PR TITLE
storage/roachpb: various cleanup around Refresh{Range}Request

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1076,11 +1076,20 @@ func (*ImportRequest) flags() int           { return isAdmin | isAlone }
 func (*AdminScatterRequest) flags() int     { return isAdmin | isAlone | isRange }
 func (*AddSSTableRequest) flags() int       { return isWrite | isAlone | isRange | isUnsplittable }
 
-// RefreshRequest and RefreshRangeRequest both list
-// updates(Read)TSCache, though they actually update the read or write
-// timestamp cache depending on the write parameter in the request.
-func (*RefreshRequest) flags() int      { return isRead | isTxn | updatesReadTSCache }
-func (*RefreshRangeRequest) flags() int { return isRead | isTxn | isRange | updatesReadTSCache }
+// RefreshRequest and RefreshRangeRequest both determine which timestamp cache
+// they update based on their Write parameter.
+func (r *RefreshRequest) flags() int {
+	if r.Write {
+		return isRead | isTxn | updatesWriteTSCache
+	}
+	return isRead | isTxn | updatesReadTSCache
+}
+func (r *RefreshRangeRequest) flags() int {
+	if r.Write {
+		return isRead | isTxn | isRange | updatesWriteTSCache
+	}
+	return isRead | isTxn | isRange | updatesReadTSCache
+}
 
 func (*SubsumeRequest) flags() int { return isRead | isAlone | updatesReadTSCache }
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -103,16 +103,6 @@ var MaxCommandSize = settings.RegisterValidatedByteSizeSetting(
 	},
 )
 
-// FollowerReadsEnabled controls whether replicas attempt to serve follower
-// reads. The closed timestamp machinery is unaffected by this, i.e. the same
-// information is collected and passed around, regardless of the value of this
-// setting.
-var FollowerReadsEnabled = settings.RegisterBoolSetting(
-	"kv.closed_timestamp.follower_reads_enabled",
-	"allow (all) replicas to serve consistent historical reads based on closed timestamp information",
-	false,
-)
-
 type proposalReevaluationReason int
 
 const (

--- a/pkg/storage/replica_follower_read.go
+++ b/pkg/storage/replica_follower_read.go
@@ -18,9 +18,20 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/closedts/ctpb"
 	ctstorage "github.com/cockroachdb/cockroach/pkg/storage/closedts/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// FollowerReadsEnabled controls whether replicas attempt to serve follower
+// reads. The closed timestamp machinery is unaffected by this, i.e. the same
+// information is collected and passed around, regardless of the value of this
+// setting.
+var FollowerReadsEnabled = settings.RegisterBoolSetting(
+	"kv.closed_timestamp.follower_reads_enabled",
+	"allow (all) replicas to serve consistent historical reads based on closed timestamp information",
+	false,
 )
 
 // canServeFollowerRead tests, when a range lease could not be

--- a/pkg/storage/replica_tscache.go
+++ b/pkg/storage/replica_tscache.go
@@ -132,10 +132,6 @@ func (r *Replica) updateTimestampCache(
 						tc.Add(start, end, t.Txn.Timestamp, uuid.UUID{}, true /* readCache */)
 					}
 				}
-			case *roachpb.RefreshRequest:
-				tc.Add(start, end, ts, txnID, !t.Write /* readCache */)
-			case *roachpb.RefreshRangeRequest:
-				tc.Add(start, end, ts, txnID, !t.Write /* readCache */)
 			default:
 				tc.Add(start, end, ts, txnID, !roachpb.UpdatesWriteTimestampCache(args))
 			}


### PR DESCRIPTION
This PR includes a few small changes that I noticed while investigating #34025.