### PR TITLE
opt: fix panic due to incorrect null counts

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1266,3 +1266,47 @@ select
  │              └── id = customer_id [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  └── filters
       └── (id = 1) AND (name = 'andy') [type=bool, outer=(1,2), constraints=(/1: [/1 - /1]; /2: [/'andy' - /'andy']; tight), fd=()-->(1,2)]
+
+exec-ddl
+CREATE TABLE nulls (x INT, y INT);
+----
+TABLE nulls
+ ├── x int
+ ├── y int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+ALTER TABLE nulls INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 0,
+    "null_count": 1000
+  }
+]'
+----
+
+# Regression test for #34440. Ensure the null count for x is less than or equal
+# to the row count.
+build colstat=1
+SELECT * FROM nulls WHERE y = 3
+----
+project
+ ├── columns: x:1(int) y:2(int!null)
+ ├── stats: [rows=9.9, distinct(1)=0, null(1)=9.9]
+ ├── fd: ()-->(2)
+ └── select
+      ├── columns: x:1(int) y:2(int!null) rowid:3(int!null)
+      ├── stats: [rows=9.9, distinct(1)=0, null(1)=9.9, distinct(2)=1, null(2)=0, distinct(3)=9.9, null(3)=0]
+      ├── key: (3)
+      ├── fd: ()-->(2), (3)-->(1)
+      ├── scan nulls
+      │    ├── columns: x:1(int) y:2(int) rowid:3(int!null)
+      │    ├── stats: [rows=1000, distinct(1)=0, null(1)=1000, distinct(2)=100, null(2)=10, distinct(3)=1000, null(3)=0]
+      │    ├── key: (3)
+      │    └── fd: (3)-->(1,2)
+      └── filters
+           └── y = 3 [type=bool, outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -144,8 +144,13 @@ type ColumnStatistic struct {
 	NullCount float64
 }
 
-// ApplySelectivity updates the distinct count according to a given selectivity.
+// ApplySelectivity updates the distinct count and null count according to a
+// given selectivity.
 func (c *ColumnStatistic) ApplySelectivity(selectivity, inputRows float64) {
+	// Since the null count is a simple count of all null rows, we can
+	// just multiply the selectivity with it.
+	c.NullCount *= selectivity
+
 	if selectivity == 1 || c.DistinctCount == 0 {
 		return
 	}
@@ -165,10 +170,6 @@ func (c *ColumnStatistic) ApplySelectivity(selectivity, inputRows float64) {
 	// This formula returns d * selectivity when d=n but is closer to d
 	// when d << n.
 	c.DistinctCount = d - d*math.Pow(1-selectivity, n/d)
-
-	// Since the null count is a simple count of all null rows, we can
-	// just multiply the selectivity with it.
-	c.NullCount *= selectivity
 }
 
 // ColumnStatistics is a slice of pointers to ColumnStatistic values.


### PR DESCRIPTION
This commit fixes a panic caused by not applying the selectivity
of a `SELECT` operation to the estimated null count for a column,
causing the null count to be higher than the row count. This
panic happens when all values of the column are null.

Fixes #34440

Release note (bug fix): Fixed a panic due to incorrect statistics
calculations when all values of a column are null.