### PR TITLE
importccl: skip TestImportCSVStmt

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -867,6 +867,7 @@ func TestImportCSVStmt(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short")
 	}
+	t.Skip(`#34568`)
 
 	const (
 		nodes       = 3


### PR DESCRIPTION
It's breaking the master build. See #34568.

Release note: None