### PR TITLE
sql: plumb through context argument to IndexedRows methods

### DIFF
--- a/pkg/sql/distsqlrun/windower.go
+++ b/pkg/sql/distsqlrun/windower.go
@@ -642,7 +642,7 @@ func (w *windower) computeWindowFunctions(ctx context.Context, evalCtx *tree.Eva
 					if err != nil {
 						return err
 					}
-					row, err := frameRun.Rows.GetRow(frameRun.RowIdx)
+					row, err := frameRun.Rows.GetRow(ctx, frameRun.RowIdx)
 					if err != nil {
 						return err
 					}
@@ -786,7 +786,7 @@ func (ir indexedRows) Len() int {
 }
 
 // GetRow implements tree.IndexedRows interface.
-func (ir indexedRows) GetRow(idx int) (tree.IndexedRow, error) {
+func (ir indexedRows) GetRow(_ context.Context, idx int) (tree.IndexedRow, error) {
 	return ir.rows[idx], nil
 }
 

--- a/pkg/sql/sem/builtins/window_frame_builtins.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins.go
@@ -96,13 +96,13 @@ type slidingWindowFunc struct {
 
 // Compute implements WindowFunc interface.
 func (w *slidingWindowFunc) Compute(
-	_ context.Context, evalCtx *tree.EvalContext, wfr *tree.WindowFrameRun,
+	ctx context.Context, evalCtx *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	frameStartIdx, err := wfr.FrameStartIdx(evalCtx)
+	frameStartIdx, err := wfr.FrameStartIdx(ctx, evalCtx)
 	if err != nil {
 		return nil, err
 	}
-	frameEndIdx, err := wfr.FrameEndIdx(evalCtx)
+	frameEndIdx, err := wfr.FrameEndIdx(ctx, evalCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (w *slidingWindowFunc) Compute(
 	// added yet.
 	for idx := max(w.prevEnd, frameStartIdx); idx < frameEndIdx; idx++ {
 		if wfr.FilterColIdx != noFilterIdx {
-			row, err := wfr.Rows.GetRow(idx)
+			row, err := wfr.Rows.GetRow(ctx, idx)
 			if err != nil {
 				return nil, err
 			}
@@ -126,7 +126,7 @@ func (w *slidingWindowFunc) Compute(
 				continue
 			}
 		}
-		args, err := wfr.ArgsByRowIdx(idx)
+		args, err := wfr.ArgsByRowIdx(ctx, idx)
 		if err != nil {
 			return nil, err
 		}
@@ -169,13 +169,13 @@ type slidingWindowSumFunc struct {
 func (w *slidingWindowSumFunc) removeAllBefore(
 	ctx context.Context, evalCtx *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) error {
-	frameStartIdx, err := wfr.FrameStartIdx(evalCtx)
+	frameStartIdx, err := wfr.FrameStartIdx(ctx, evalCtx)
 	if err != nil {
 		return err
 	}
 	for idx := w.prevStart; idx < frameStartIdx && idx < w.prevEnd; idx++ {
 		if wfr.FilterColIdx != noFilterIdx {
-			row, err := wfr.Rows.GetRow(idx)
+			row, err := wfr.Rows.GetRow(ctx, idx)
 			if err != nil {
 				return err
 			}
@@ -187,7 +187,7 @@ func (w *slidingWindowSumFunc) removeAllBefore(
 				continue
 			}
 		}
-		args, err := wfr.ArgsByRowIdx(idx)
+		args, err := wfr.ArgsByRowIdx(ctx, idx)
 		if err != nil {
 			return err
 		}
@@ -217,11 +217,11 @@ func (w *slidingWindowSumFunc) removeAllBefore(
 func (w *slidingWindowSumFunc) Compute(
 	ctx context.Context, evalCtx *tree.EvalContext, wfr *tree.WindowFrameRun,
 ) (tree.Datum, error) {
-	frameStartIdx, err := wfr.FrameStartIdx(evalCtx)
+	frameStartIdx, err := wfr.FrameStartIdx(ctx, evalCtx)
 	if err != nil {
 		return nil, err
 	}
-	frameEndIdx, err := wfr.FrameEndIdx(evalCtx)
+	frameEndIdx, err := wfr.FrameEndIdx(ctx, evalCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (w *slidingWindowSumFunc) Compute(
 	// added yet.
 	for idx := max(w.prevEnd, frameStartIdx); idx < frameEndIdx; idx++ {
 		if wfr.FilterColIdx != noFilterIdx {
-			row, err := wfr.Rows.GetRow(idx)
+			row, err := wfr.Rows.GetRow(ctx, idx)
 			if err != nil {
 				return nil, err
 			}
@@ -247,7 +247,7 @@ func (w *slidingWindowSumFunc) Compute(
 				continue
 			}
 		}
-		args, err := wfr.ArgsByRowIdx(idx)
+		args, err := wfr.ArgsByRowIdx(ctx, idx)
 		if err != nil {
 			return nil, err
 		}
@@ -293,16 +293,16 @@ func (w *avgWindowFunc) Compute(
 
 	var frameSize int
 	if wfr.FilterColIdx != noFilterIdx {
-		frameStartIdx, err := wfr.FrameStartIdx(evalCtx)
+		frameStartIdx, err := wfr.FrameStartIdx(ctx, evalCtx)
 		if err != nil {
 			return nil, err
 		}
-		frameEndIdx, err := wfr.FrameEndIdx(evalCtx)
+		frameEndIdx, err := wfr.FrameEndIdx(ctx, evalCtx)
 		if err != nil {
 			return nil, err
 		}
 		for idx := frameStartIdx; idx < frameEndIdx; idx++ {
-			row, err := wfr.Rows.GetRow(idx)
+			row, err := wfr.Rows.GetRow(ctx, idx)
 			if err != nil {
 				return nil, err
 			}
@@ -316,7 +316,7 @@ func (w *avgWindowFunc) Compute(
 			frameSize++
 		}
 	} else {
-		if frameSize, err = wfr.FrameSize(evalCtx); err != nil {
+		if frameSize, err = wfr.FrameSize(ctx, evalCtx); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/sem/tree/window_funcs_test.go
+++ b/pkg/sql/sem/tree/window_funcs_test.go
@@ -84,16 +84,16 @@ func testStartPreceding(
 		}
 		wfr.StartBoundOffset = typedOffset
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
-			frameStartIdx, err := wfr.FrameStartIdx(evalCtx)
+			frameStartIdx, err := wfr.FrameStartIdx(evalCtx.Ctx(), evalCtx)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			value, err := wfr.getValueByOffset(evalCtx, typedOffset, true /* negative */)
+			value, err := wfr.getValueByOffset(evalCtx.Ctx(), evalCtx, typedOffset, true /* negative */)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 			for idx := 0; idx <= wfr.RowIdx; idx++ {
-				valueAt, err := wfr.valueAt(idx)
+				valueAt, err := wfr.valueAt(evalCtx.Ctx(), idx)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
@@ -101,7 +101,7 @@ func testStartPreceding(
 					if idx != frameStartIdx {
 						t.Errorf("FrameStartIdx returned wrong result on Preceding: expected %+v, found %+v", idx, frameStartIdx)
 						t.Errorf("Search for %+v when wfr.RowIdx=%+v", value, wfr.RowIdx)
-						t.Errorf(partitionToString(wfr.Rows))
+						t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
 						panic("")
 					}
 					break
@@ -134,11 +134,11 @@ func testStartFollowing(
 		}
 		wfr.StartBoundOffset = typedOffset
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
-			frameStartIdx, err := wfr.FrameStartIdx(evalCtx)
+			frameStartIdx, err := wfr.FrameStartIdx(evalCtx.Ctx(), evalCtx)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			value, err := wfr.getValueByOffset(evalCtx, typedOffset, false /* negative */)
+			value, err := wfr.getValueByOffset(evalCtx.Ctx(), evalCtx, typedOffset, false /* negative */)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -147,12 +147,12 @@ func testStartFollowing(
 					if idx != frameStartIdx {
 						t.Errorf("FrameStartIdx returned wrong result on Following: expected %+v, found %+v", idx, frameStartIdx)
 						t.Errorf("Search for %+v when wfr.RowIdx=%+v", value, wfr.RowIdx)
-						t.Errorf(partitionToString(wfr.Rows))
+						t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
 						panic("")
 					}
 					break
 				}
-				valueAt, err := wfr.valueAt(idx)
+				valueAt, err := wfr.valueAt(evalCtx.Ctx(), idx)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
@@ -160,7 +160,7 @@ func testStartFollowing(
 					if idx != frameStartIdx {
 						t.Errorf("FrameStartIdx returned wrong result on Following: expected %+v, found %+v", idx, frameStartIdx)
 						t.Errorf("Search for %+v when wfr.RowIdx=%+v", value, wfr.RowIdx)
-						t.Errorf(partitionToString(wfr.Rows))
+						t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
 						panic("")
 					}
 					break
@@ -191,16 +191,16 @@ func testEndPreceding(t *testing.T, evalCtx *EvalContext, wfr *WindowFrameRun, o
 		}
 		wfr.EndBoundOffset = typedOffset
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
-			frameEndIdx, err := wfr.FrameEndIdx(evalCtx)
+			frameEndIdx, err := wfr.FrameEndIdx(evalCtx.Ctx(), evalCtx)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			value, err := wfr.getValueByOffset(evalCtx, typedOffset, true /* negative */)
+			value, err := wfr.getValueByOffset(evalCtx.Ctx(), evalCtx, typedOffset, true /* negative */)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 			for idx := wfr.RowIdx; idx >= 0; idx-- {
-				valueAt, err := wfr.valueAt(idx)
+				valueAt, err := wfr.valueAt(evalCtx.Ctx(), idx)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
@@ -208,7 +208,7 @@ func testEndPreceding(t *testing.T, evalCtx *EvalContext, wfr *WindowFrameRun, o
 					if idx+1 != frameEndIdx {
 						t.Errorf("FrameEndIdx returned wrong result on Preceding: expected %+v, found %+v", idx+1, frameEndIdx)
 						t.Errorf("Search for %+v when wfr.RowIdx=%+v", value, wfr.RowIdx)
-						t.Errorf(partitionToString(wfr.Rows))
+						t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
 						panic("")
 					}
 					break
@@ -239,16 +239,16 @@ func testEndFollowing(t *testing.T, evalCtx *EvalContext, wfr *WindowFrameRun, o
 		}
 		wfr.EndBoundOffset = typedOffset
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
-			frameEndIdx, err := wfr.FrameEndIdx(evalCtx)
+			frameEndIdx, err := wfr.FrameEndIdx(evalCtx.Ctx(), evalCtx)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			value, err := wfr.getValueByOffset(evalCtx, typedOffset, false /* negative */)
+			value, err := wfr.getValueByOffset(evalCtx.Ctx(), evalCtx, typedOffset, false /* negative */)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 			for idx := wfr.PartitionSize() - 1; idx >= wfr.RowIdx; idx-- {
-				valueAt, err := wfr.valueAt(idx)
+				valueAt, err := wfr.valueAt(evalCtx.Ctx(), idx)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
@@ -256,7 +256,7 @@ func testEndFollowing(t *testing.T, evalCtx *EvalContext, wfr *WindowFrameRun, o
 					if idx+1 != frameEndIdx {
 						t.Errorf("FrameEndIdx returned wrong result on Following: expected %+v, found %+v", idx+1, frameEndIdx)
 						t.Errorf("Search for %+v when wfr.RowIdx=%+v", value, wfr.RowIdx)
-						t.Errorf(partitionToString(wfr.Rows))
+						t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
 						panic("")
 					}
 					break
@@ -322,13 +322,13 @@ func makeDecimalSortedPartition(count int) indexedRows {
 	return partition
 }
 
-func partitionToString(partition IndexedRows) string {
+func partitionToString(ctx context.Context, partition IndexedRows) string {
 	var buffer bytes.Buffer
 	var err error
 	var row IndexedRow
 	buffer.WriteString("\n")
 	for idx := 0; idx < partition.Len(); idx++ {
-		if row, err = partition.GetRow(idx); err != nil {
+		if row, err = partition.GetRow(ctx, idx); err != nil {
 			return err.Error()
 		}
 		buffer.WriteString(fmt.Sprintf("%+v\n", row))
@@ -354,7 +354,7 @@ func (ir indexedRows) Len() int {
 }
 
 // GetRow implements IndexedRows interface.
-func (ir indexedRows) GetRow(idx int) (IndexedRow, error) {
+func (ir indexedRows) GetRow(_ context.Context, idx int) (IndexedRow, error) {
 	return ir.rows[idx], nil
 }
 

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -1161,7 +1161,7 @@ func (ir indexedRows) Len() int {
 }
 
 // GetRow implements tree.IndexedRows interface.
-func (ir indexedRows) GetRow(idx int) (tree.IndexedRow, error) {
+func (ir indexedRows) GetRow(_ context.Context, idx int) (tree.IndexedRow, error) {
 	return ir.rows[idx], nil
 }
 


### PR DESCRIPTION
Adds plumbing for passing through a context which might be needed
for some implementations of GetRow() method.

Needed for: #34196. 

Release note: None