### PR TITLE
partitionccl: skip TestInitialPartitioning on testshort

### DIFF
--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1158,7 +1158,10 @@ func TestInitialPartitioning(t *testing.T) {
 	// This test configures many sub-tests and is too slow to run under nightly
 	// race stress.
 	if testutils.NightlyStress() && util.RaceEnabled {
-		t.Skip()
+		t.Skip("too big for nightly stress race")
+	}
+	if testing.Short() {
+		t.Skip("short")
 	}
 
 	rng, _ := randutil.NewPseudoRand()


### PR DESCRIPTION
It's taking half a core for 117s on my laptop.

Release note: None