### PR TITLE
opt: fix zero-column groups in joins colliding

### DIFF
--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -2,14 +2,32 @@
 # join.opt contains exploration rules for the Join operator.
 # =============================================================================
 
+# We don't allow any of the logical join -> logical join rules (CommuteJoin,
+# CommuteLeftJoin, CommuteRightJoin, AssociateJoin) to operate on inputs with
+# no columns. This is because zero-column groups can occur multiple times in
+# the same normalized tree, and exploration can cause group collisions:
+#
+# Let A be the 0-column values node with two rows `VALUES (), ()`,
+# and B be the 0-column values node with three rows `VALUES (), (), ()`.
+#
+# Then consider the following query:
+#
+# (A JOIN B) UNION (B JOIN A)
+#
+# During build, we add `A JOIN B` and `B JOIN A` to *separate memo groups*.
+# Then, during exploration, we apply the `CommuteJoin` rule to transform `A
+# JOIN B` to `B JOIN A`. This attempts to get interned into the same group, but
+# the interner finds that `B JOIN A` already exists in a different group, and
+# panics.
+# TODO(justin): find a more long-term solution to this problem.
 
 # CommuteJoin creates a Join with the left and right inputs swapped. This is
 # useful for other rules that convert joins to other operators (like merge
 # join).
 [CommuteJoin, Explore]
 (InnerJoin | FullJoin
-  $left:*
-  $right:*
+  $left:* & ^(HasNoCols $left)
+  $right:* & ^(HasNoCols $right)
   $on:*
 )
 =>
@@ -18,8 +36,8 @@
 # CommuteLeftJoin creates a Join with the left and right inputs swapped.
 [CommuteLeftJoin, Explore]
 (LeftJoin
-  $left:*
-  $right:*
+  $left:* & ^(HasNoCols $left)
+  $right:* & ^(HasNoCols $left)
   $on:*
 )
 =>
@@ -28,8 +46,8 @@
 # CommuteRightJoin creates a Join with the left and right inputs swapped.
 [CommuteRightJoin, Explore]
 (RightJoin
-  $left:*
-  $right:*
+  $left:* & ^(HasNoCols $left)
+  $right:* & ^(HasNoCols $left)
   $on:*
 )
 =>
@@ -104,11 +122,11 @@
 [AssociateJoin, Explore]
 (InnerJoin
     $left:(InnerJoin
-        $innerLeft:*
-        $innerRight:*
+        $innerLeft:* & ^(HasNoCols $innerLeft)
+        $innerRight:* & ^(HasNoCols $innerRight)
         $innerOn:*
     )
-    $right:* & (ShouldReorderJoins $left $right)
+    $right:* & (ShouldReorderJoins $left $right) & ^(HasNoCols $right)
     $on:*
 )
 =>

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1806,3 +1806,235 @@ inner-join (lookup t5)
  │    └── filters (true)
  └── filters
       └── b @> '{"a": [{"b": "c", "d": 3}, 5]}' [type=bool, outer=(2)]
+
+# Regression test for issue where zero-column expressions could exist multiple
+# times in the tree, causing collisions.
+opt
+SELECT 1 FROM (VALUES (1), (1)) JOIN (VALUES (1), (1), (1)) ON true
+UNION ALL
+SELECT 1 FROM (VALUES (1), (1), (1)) JOIN (VALUES (1), (1)) ON true
+----
+union-all
+ ├── columns: "?column?":7(int!null)
+ ├── left columns: "?column?":3(int)
+ ├── right columns: "?column?":6(int)
+ ├── cardinality: [12 - 12]
+ ├── project
+ │    ├── columns: "?column?":3(int!null)
+ │    ├── cardinality: [6 - 6]
+ │    ├── fd: ()-->(3)
+ │    ├── inner-join
+ │    │    ├── cardinality: [6 - 6]
+ │    │    ├── values
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    └── tuple [type=tuple{}]
+ │    │    ├── values
+ │    │    │    ├── cardinality: [3 - 3]
+ │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    └── tuple [type=tuple{}]
+ │    │    └── filters (true)
+ │    └── projections
+ │         └── const: 1 [type=int]
+ └── project
+      ├── columns: "?column?":6(int!null)
+      ├── cardinality: [6 - 6]
+      ├── fd: ()-->(6)
+      ├── inner-join
+      │    ├── cardinality: [6 - 6]
+      │    ├── values
+      │    │    ├── cardinality: [3 - 3]
+      │    │    ├── tuple [type=tuple{}]
+      │    │    ├── tuple [type=tuple{}]
+      │    │    └── tuple [type=tuple{}]
+      │    ├── values
+      │    │    ├── cardinality: [2 - 2]
+      │    │    ├── tuple [type=tuple{}]
+      │    │    └── tuple [type=tuple{}]
+      │    └── filters (true)
+      └── projections
+           └── const: 1 [type=int]
+
+opt join-limit=3
+SELECT
+    false
+FROM
+    abc AS x JOIN [INSERT INTO abc (a) SELECT 1 FROM abc RETURNING 1] JOIN abc AS y ON true ON false
+----
+project
+ ├── columns: bool:21(bool!null)
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ ├── fd: ()-->(21)
+ ├── inner-join
+ │    ├── cardinality: [0 - 0]
+ │    ├── side-effects, mutations
+ │    ├── values
+ │    │    ├── cardinality: [0 - 0]
+ │    │    └── key: ()
+ │    ├── inner-join
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── side-effects, mutations
+ │    │    ├── project
+ │    │    │    ├── cardinality: [0 - 0]
+ │    │    │    ├── side-effects, mutations
+ │    │    │    └── select
+ │    │    │         ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
+ │    │    │         ├── cardinality: [0 - 0]
+ │    │    │         ├── side-effects, mutations
+ │    │    │         ├── fd: ()-->(5-7)
+ │    │    │         ├── insert abc
+ │    │    │         │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
+ │    │    │         │    ├── insert-mapping:
+ │    │    │         │    │    ├──  "?column?":13 => abc.a:5
+ │    │    │         │    │    ├──  column14:14 => abc.b:6
+ │    │    │         │    │    ├──  column14:14 => abc.c:7
+ │    │    │         │    │    └──  column15:15 => abc.rowid:8
+ │    │    │         │    ├── side-effects, mutations
+ │    │    │         │    ├── fd: ()-->(5-7)
+ │    │    │         │    └── project
+ │    │    │         │         ├── columns: column14:14(int) column15:15(int) "?column?":13(int!null)
+ │    │    │         │         ├── side-effects
+ │    │    │         │         ├── fd: ()-->(13,14)
+ │    │    │         │         ├── scan abc
+ │    │    │         │         └── projections
+ │    │    │         │              ├── null [type=int]
+ │    │    │         │              ├── unique_rowid() [type=int, side-effects]
+ │    │    │         │              └── const: 1 [type=int]
+ │    │    │         └── filters
+ │    │    │              └── false [type=bool]
+ │    │    ├── values
+ │    │    │    ├── cardinality: [0 - 0]
+ │    │    │    └── key: ()
+ │    │    └── filters (true)
+ │    └── filters (true)
+ └── projections
+      └── false [type=bool]
+
+opt join-limit=3
+SELECT 1 FROM ((VALUES (1), (1)) JOIN ((VALUES (1), (1), (1)) JOIN (VALUES (1), (1), (1), (1)) ON true) ON true)
+UNION ALL
+SELECT 1 FROM ((VALUES (1), (1)) JOIN (VALUES (1), (1), (1)) ON true) JOIN (VALUES (1), (1), (1), (1)) ON true
+----
+union-all
+ ├── columns: "?column?":9(int!null)
+ ├── left columns: "?column?":4(int)
+ ├── right columns: "?column?":8(int)
+ ├── cardinality: [48 - 48]
+ ├── project
+ │    ├── columns: "?column?":4(int!null)
+ │    ├── cardinality: [24 - 24]
+ │    ├── fd: ()-->(4)
+ │    ├── inner-join
+ │    │    ├── cardinality: [24 - 24]
+ │    │    ├── values
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    └── tuple [type=tuple{}]
+ │    │    ├── inner-join
+ │    │    │    ├── cardinality: [12 - 12]
+ │    │    │    ├── values
+ │    │    │    │    ├── cardinality: [3 - 3]
+ │    │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    │    └── tuple [type=tuple{}]
+ │    │    │    ├── values
+ │    │    │    │    ├── cardinality: [4 - 4]
+ │    │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    │    └── tuple [type=tuple{}]
+ │    │    │    └── filters (true)
+ │    │    └── filters (true)
+ │    └── projections
+ │         └── const: 1 [type=int]
+ └── project
+      ├── columns: "?column?":8(int!null)
+      ├── cardinality: [24 - 24]
+      ├── fd: ()-->(8)
+      ├── inner-join
+      │    ├── cardinality: [24 - 24]
+      │    ├── inner-join
+      │    │    ├── cardinality: [6 - 6]
+      │    │    ├── values
+      │    │    │    ├── cardinality: [2 - 2]
+      │    │    │    ├── tuple [type=tuple{}]
+      │    │    │    └── tuple [type=tuple{}]
+      │    │    ├── values
+      │    │    │    ├── cardinality: [3 - 3]
+      │    │    │    ├── tuple [type=tuple{}]
+      │    │    │    ├── tuple [type=tuple{}]
+      │    │    │    └── tuple [type=tuple{}]
+      │    │    └── filters (true)
+      │    ├── values
+      │    │    ├── cardinality: [4 - 4]
+      │    │    ├── tuple [type=tuple{}]
+      │    │    ├── tuple [type=tuple{}]
+      │    │    ├── tuple [type=tuple{}]
+      │    │    └── tuple [type=tuple{}]
+      │    └── filters (true)
+      └── projections
+           └── const: 1 [type=int]
+
+opt
+SELECT 1 FROM (VALUES (1), (1)) LEFT JOIN (VALUES (1), (1), (1)) ON random() = 0
+UNION ALL
+SELECT 1 FROM (VALUES (1), (1), (1)) RIGHT JOIN (VALUES (1), (1)) ON random() = 0
+----
+union-all
+ ├── columns: "?column?":7(int!null)
+ ├── left columns: "?column?":3(int)
+ ├── right columns: "?column?":6(int)
+ ├── cardinality: [4 - 12]
+ ├── side-effects
+ ├── project
+ │    ├── columns: "?column?":3(int!null)
+ │    ├── cardinality: [2 - 6]
+ │    ├── side-effects
+ │    ├── fd: ()-->(3)
+ │    ├── left-join
+ │    │    ├── cardinality: [2 - 6]
+ │    │    ├── side-effects
+ │    │    ├── values
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    └── tuple [type=tuple{}]
+ │    │    ├── select
+ │    │    │    ├── cardinality: [0 - 3]
+ │    │    │    ├── side-effects
+ │    │    │    ├── values
+ │    │    │    │    ├── cardinality: [3 - 3]
+ │    │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    │    └── tuple [type=tuple{}]
+ │    │    │    └── filters
+ │    │    │         └── random() = 0.0 [type=bool, side-effects]
+ │    │    └── filters (true)
+ │    └── projections
+ │         └── const: 1 [type=int]
+ └── project
+      ├── columns: "?column?":6(int!null)
+      ├── cardinality: [2 - 6]
+      ├── side-effects
+      ├── fd: ()-->(6)
+      ├── right-join
+      │    ├── cardinality: [2 - 6]
+      │    ├── side-effects
+      │    ├── select
+      │    │    ├── cardinality: [0 - 3]
+      │    │    ├── side-effects
+      │    │    ├── values
+      │    │    │    ├── cardinality: [3 - 3]
+      │    │    │    ├── tuple [type=tuple{}]
+      │    │    │    ├── tuple [type=tuple{}]
+      │    │    │    └── tuple [type=tuple{}]
+      │    │    └── filters
+      │    │         └── random() = 0.0 [type=bool, side-effects]
+      │    ├── values
+      │    │    ├── cardinality: [2 - 2]
+      │    │    ├── tuple [type=tuple{}]
+      │    │    └── tuple [type=tuple{}]
+      │    └── filters (true)
+      └── projections
+           └── const: 1 [type=int]


### PR DESCRIPTION
It's fundamental to the optimizer that any two unrelated (i.e., one is
not the parent of the other) expressions in the tree have disjoint
column sets. Usually, this prevents the same relational expression from
occurring in the tree more than once, but in the case of a group with
zero columns, this is not true.

This allows the following group collision to occur:

Let A be the 0-column values node with two rows `VALUES (), ()`,
and B be the 0-column values node with three rows `VALUES (), (), ()`.

Then consider the following query:
```
(A JOIN B) UNION (B JOIN A)
```

During build, we add A JOIN B and B JOIN A to *separate memo groups*.
Then, during exploration, we apply the `CommuteJoin` rule to transform
`A JOIN B` to `B JOIN A`. This attempts to get interned into the same
group, but the interner finds that `B JOIN A` already exists in a
different group, and panics.

As a side note, a values node with no columns is not valid SQL, but it
can be constructed via the `MergeProjectWithValues` rule:
```
SELECT 1 FROM (VALUES (1))
=> MergeProjectWithValues
SELECT 1 FROM (VALUES ())
```

This commit fixes the problem by simply disabling these types of
explorations on groups with zero columns. This isn't a perfect fix,
since the subtle problem is still lurking, and people going forward need
to understand its implications, but it will fix the problem for the time
being.

Release note (bug fix): fixed several related panics in the optimizer
related to plan exploration.