### PR TITLE
release-2.1: jobs: fix potential npe on not-found job

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -500,6 +500,9 @@ func (j *Job) updateRow(
 		if err != nil {
 			return err
 		}
+		if row == nil {
+			return errors.Errorf("no such job %d found", *j.id)
+		}
 		statusString, ok := row[0].(*tree.DString)
 		if !ok {
 			return errors.Errorf("Job: expected string status on job %d, but got %T", *j.id, statusString)


### PR DESCRIPTION
Backport 1/1 commits from #34574.

/cc @cockroachdb/release

---

Fixes #34495.

Release note (bug fix): prevent crash when updating a job that doesn't
exist.
