### PR TITLE
exec: vectorized merge join operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -738,6 +738,7 @@ EXECGEN_TARGETS = \
   pkg/sql/exec/colvec.eg.go \
   pkg/sql/exec/distinct.eg.go \
   pkg/sql/exec/hashjoiner.eg.go \
+  pkg/sql/exec/mergejoiner.eg.go \
   pkg/sql/exec/projection_ops.eg.go \
   pkg/sql/exec/quicksort.eg.go \
   pkg/sql/exec/rowstovec.eg.go \
@@ -1387,6 +1388,7 @@ pkg/sql/exec/avg_agg.eg.go: pkg/sql/exec/avg_agg_tmpl.go
 pkg/sql/exec/colvec.eg.go: pkg/sql/exec/colvec_tmpl.go
 pkg/sql/exec/distinct.eg.go: pkg/sql/exec/distinct_tmpl.go
 pkg/sql/exec/hashjoiner.eg.go: pkg/sql/exec/hashjoiner_tmpl.go
+pkg/sql/exec/mergejoiner.eg.go: pkg/sql/exec/mergejoiner_tmpl.go
 pkg/sql/exec/quicksort.eg.go: pkg/sql/exec/quicksort_tmpl.go
 pkg/sql/exec/sort.eg.go: pkg/sql/exec/sort_tmpl.go
 pkg/sql/exec/sum_agg.eg.go: pkg/sql/exec/sum_agg_tmpl.go

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -53,6 +53,9 @@ type ColVec interface {
 	// Col returns the raw, typeless backing storage for this ColVec.
 	Col() interface{}
 
+	// SetCol sets the member column (in the case of mutable columns).
+	SetCol(interface{})
+
 	// TemplateType returns an []interface{} and is used for operator templates.
 	// Do not call this from normal code - it'll always panic.
 	_TemplateType() []interface{}
@@ -61,9 +64,18 @@ type ColVec interface {
 	// elements of this ColVec, assuming that both ColVecs are of type colType.
 	Append(vec ColVec, colType types.T, toLength uint64, fromLength uint16)
 
+	// AppendSlice appends vec[srcStartIdx:srcEndIdx] elements to
+	// this ColVec starting at destStartIdx.
+	AppendSlice(vec ColVec, colType types.T, destStartIdx uint64, srcStartIdx uint16, srcEndIdx uint16)
+
 	// AppendWithSel appends into itself another column vector from a ColBatch with
 	// maximum size of ColBatchSize, filtered by the given selection vector.
 	AppendWithSel(vec ColVec, sel []uint16, batchSize uint16, colType types.T, toLength uint64)
+
+	// AppendSliceWithSel appends srcEndIdx - srcStartIdx elements to this ColVec starting
+	// at destStartIdx. These elements come from vec, filtered by the selection
+	// vector sel.
+	AppendSliceWithSel(vec ColVec, colType types.T, destStartIdx uint64, srcStartIdx uint16, srcEndIdx uint16, sel []uint16)
 
 	// Copy copies src[srcStartIdx:srcEndIdx] into this ColVec.
 	Copy(src ColVec, srcStartIdx, srcEndIdx uint64, typ types.T)
@@ -71,9 +83,11 @@ type ColVec interface {
 	// CopyWithSelInt64 copies vec, filtered by sel, into this ColVec. It replaces
 	// the contents of this ColVec.
 	CopyWithSelInt64(vec ColVec, sel []uint64, nSel uint16, colType types.T)
+
 	// CopyWithSelInt16 copies vec, filtered by sel, into this ColVec. It replaces
 	// the contents of this ColVec.
 	CopyWithSelInt16(vec ColVec, sel []uint16, nSel uint16, colType types.T)
+
 	// CopyWithSelAndNilsInt64 copies vec, filtered by sel, unless nils is set,
 	// into ColVec. It replaces the contents of this ColVec.
 	CopyWithSelAndNilsInt64(vec ColVec, sel []uint64, nSel uint16, nils []bool, colType types.T)
@@ -85,6 +99,15 @@ type ColVec interface {
 	// PrettyValueAt returns a "pretty"value for the idx'th value in this ColVec.
 	// It uses the reflect package and is not suitable for calling in hot paths.
 	PrettyValueAt(idx uint16, colType types.T) string
+
+	// ExtendNulls extends the null member of a ColVec to accommodate toAppend tuples
+	// and sets the right indexes to null, needed when the length of the underlying column changes.
+	ExtendNulls(vec ColVec, destStartIdx uint64, srcStartIdx uint16, toAppend uint16)
+
+	// ExtendNullsWithSel extends the null member of a ColVec to accommodate toAppend tuples
+	// and sets the right indexes to null with the selection vector in mind, needed when the
+	// length of the underlying column changes.
+	ExtendNullsWithSel(vec ColVec, destStartIdx uint64, srcStartIdx uint16, toAppend uint16, sel []uint16)
 }
 
 // Nulls represents a list of potentially nullable values.
@@ -180,6 +203,10 @@ func (m *memColumn) NullAt(i uint16) bool {
 
 func (m *memColumn) SetNull(i uint16) {
 	m.SetNull64(uint64(i))
+}
+
+func (m *memColumn) SetCol(col interface{}) {
+	m.col = col
 }
 
 func (m *memColumn) UnsetNulls() {

--- a/pkg/sql/exec/colvec.go
+++ b/pkg/sql/exec/colvec.go
@@ -74,10 +74,13 @@ type ColVec interface {
 	// CopyWithSelInt16 copies vec, filtered by sel, into this ColVec. It replaces
 	// the contents of this ColVec.
 	CopyWithSelInt16(vec ColVec, sel []uint16, nSel uint16, colType types.T)
-
 	// CopyWithSelAndNilsInt64 copies vec, filtered by sel, unless nils is set,
 	// into ColVec. It replaces the contents of this ColVec.
 	CopyWithSelAndNilsInt64(vec ColVec, sel []uint64, nSel uint16, nils []bool, colType types.T)
+
+	// Slice returns a new ColVec representing a slice of the current ColVec from
+	// [start, end).
+	Slice(colType types.T, start uint64, end uint64) ColVec
 
 	// PrettyValueAt returns a "pretty"value for the idx'th value in this ColVec.
 	// It uses the reflect package and is not suitable for calling in hot paths.

--- a/pkg/sql/exec/colvec_tmpl.go
+++ b/pkg/sql/exec/colvec_tmpl.go
@@ -200,6 +200,20 @@ func (m *memColumn) CopyWithSelAndNilsInt64(
 	}
 }
 
+func (m *memColumn) Slice(colType types.T, start uint64, end uint64) ColVec {
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		col := m._TemplateType()
+		return &memColumn{
+			col: col[start:end],
+		}
+	// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
+
 func (m *memColumn) PrettyValueAt(colIdx uint16, colType types.T) string {
 	if m.NullAt(colIdx) {
 		return "NULL"

--- a/pkg/sql/exec/colvec_tmpl.go
+++ b/pkg/sql/exec/colvec_tmpl.go
@@ -64,6 +64,28 @@ func (m *memColumn) Append(vec ColVec, colType types.T, toLength uint64, fromLen
 	}
 }
 
+func (m *memColumn) AppendSlice(
+	vec ColVec, colType types.T, destStartIdx uint64, srcStartIdx uint16, srcEndIdx uint16,
+) {
+	batchSize := srcEndIdx - srcStartIdx
+	outputLen := destStartIdx + uint64(batchSize)
+
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		if outputLen > uint64(len(m._TemplateType())) {
+			m.col = append(m._TemplateType()[:destStartIdx], vec._TemplateType()[srcStartIdx:srcEndIdx]...)
+		} else {
+			copy(m._TemplateType()[destStartIdx:], vec._TemplateType()[srcStartIdx:srcEndIdx])
+		}
+	// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+
+	m.ExtendNulls(vec, destStartIdx, srcStartIdx, batchSize)
+}
+
 func (m *memColumn) AppendWithSel(
 	vec ColVec, sel []uint16, batchSize uint16, colType types.T, toLength uint64,
 ) {
@@ -93,12 +115,44 @@ func (m *memColumn) AppendWithSel(
 	}
 }
 
+func (m *memColumn) AppendSliceWithSel(
+	vec ColVec,
+	colType types.T,
+	destStartIdx uint64,
+	srcStartIdx uint16,
+	srcEndIdx uint16,
+	sel []uint16,
+) {
+	batchSize := srcEndIdx - srcStartIdx
+	switch colType {
+	// {{range .}}
+	case _TYPES_T:
+		toCol := append(m._TemplateType()[:destStartIdx], make([]_GOTYPE, batchSize)...)
+		fromCol := vec._TemplateType()
+
+		for i := 0; i < int(batchSize); i++ {
+			toCol[uint64(i)+destStartIdx] = fromCol[sel[i+int(srcStartIdx)]]
+		}
+
+		m.col = toCol
+	// {{end}}
+	default:
+		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+
+	m.ExtendNullsWithSel(vec, destStartIdx, srcStartIdx, batchSize, sel)
+}
+
 func (m *memColumn) Copy(src ColVec, srcStartIdx, srcEndIdx uint64, typ types.T) {
+	m.CopyAt(src, 0, srcStartIdx, srcEndIdx, typ)
+}
+
+func (m *memColumn) CopyAt(src ColVec, destStartIdx, srcStartIdx, srcEndIdx uint64, typ types.T) {
 	switch typ {
 	// {{range .}}
 	case _TYPES_T:
-		copy(m._TemplateType(), src._TemplateType()[srcStartIdx:srcEndIdx])
-		// {{end}}
+		copy(m._TemplateType()[destStartIdx:], src._TemplateType()[srcStartIdx:srcEndIdx])
+	// {{end}}
 	default:
 		panic(fmt.Sprintf("unhandled type %d", typ))
 	}
@@ -225,5 +279,39 @@ func (m *memColumn) PrettyValueAt(colIdx uint16, colType types.T) string {
 	// {{end}}
 	default:
 		panic(fmt.Sprintf("unhandled type %d", colType))
+	}
+}
+
+func (m *memColumn) ExtendNulls(
+	vec ColVec, destStartIdx uint64, srcStartIdx uint16, toAppend uint16,
+) {
+	outputLen := destStartIdx + uint64(toAppend)
+	if uint64(cap(m.nulls)) < outputLen/64 {
+		// (batchSize-1)>>6+1 is the number of Int64s needed to encode the additional elements/nulls in the ColVec.
+		// This is equivalent to ceil(batchSize/64).
+		m.nulls = append(m.nulls, make([]int64, (toAppend-1)>>6+1)...)
+	}
+	if vec.HasNulls() {
+		for i := uint16(0); i < toAppend; i++ {
+			if vec.NullAt(srcStartIdx + i) {
+				m.SetNull64(destStartIdx + uint64(i))
+			}
+		}
+	}
+}
+
+func (m *memColumn) ExtendNullsWithSel(
+	vec ColVec, destStartIdx uint64, srcStartIdx uint16, toAppend uint16, sel []uint16,
+) {
+	outputLen := destStartIdx + uint64(toAppend)
+	if uint64(cap(m.nulls)) < outputLen/64 {
+		// (batchSize-1)>>6+1 is the number of Int64s needed to encode the additional elements/nulls in the ColVec.
+		// This is equivalent to ceil(batchSize/64).
+		m.nulls = append(m.nulls, make([]int64, (toAppend-1)>>6+1)...)
+	}
+	for i := uint16(0); i < toAppend; i++ {
+		if vec.NullAt(sel[srcStartIdx+i]) {
+			m.SetNull64(destStartIdx + uint64(i))
+		}
 	}
 }

--- a/pkg/sql/exec/execgen/cmd/execgen/mergejoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/mergejoiner_gen.go
@@ -1,0 +1,58 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func genMergeJoinOps(wr io.Writer) error {
+	d, err := ioutil.ReadFile("pkg/sql/exec/mergejoiner_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(d)
+
+	// Replace the template variables.
+	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
+	s = strings.Replace(s, "_TYPES_T", "types.{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+
+	addSliceWithSel := makeFunctionRegex("_ADD_SLICE_TO_COLVEC_WITH_SEL", 6)
+	s = addSliceWithSel.ReplaceAllString(s, `{{template "addSliceToColVecWithSel" . }}`)
+
+	addSlice := makeFunctionRegex("_ADD_SLICE_TO_COLVEC", 5)
+	s = addSlice.ReplaceAllString(s, `{{template "addSliceToColVec" . }}`)
+
+	copyWithSel := makeFunctionRegex("_COPY_WITH_SEL", 5)
+	s = copyWithSel.ReplaceAllString(s, `{{template "copyWithSel" . }}`)
+
+	// Now, generate the op, from the template.
+	tmpl, err := template.New("mergejoin_op").Parse(s)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, comparisonOpToOverloads[tree.EQ])
+}
+func init() {
+	registerGenerator(genMergeJoinOps, "mergejoiner.eg.go")
+}

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -1,0 +1,456 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import "github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+
+// side is an enum that allows for switching between the left and right
+// input sources, useful for abstraction.
+type side int
+
+const (
+	left  side = 0
+	right side = 1
+)
+
+// group is an ADT representing a run, and numRepeats is used when
+// expanding each run into a cross product in the build phase.
+// Note that a run becomes a group when it is finished and the number
+// of times it is repeated in the cross product is determined.
+type group struct {
+	rowStartIdx int
+	rowEndIdx   int
+	numRepeats  int
+}
+
+type mergeJoinInput struct {
+	// eqCols specify the indices of the source table equality columns during the
+	// merge join.
+	eqCols []uint32
+
+	// outCols specify the indices of the columns that should be outputted by the
+	// merge joiner.
+	outCols []uint32
+
+	// sourceTypes specify the types of the input columns of the source table for
+	// the merge joiner.
+	sourceTypes []types.T
+
+	// source specifies the input operator to the merge join.
+	source Operator
+}
+
+// mergeJoinOp is an operator that implements sort-merge join.
+// It performs a merge on the left and right input sources, based on the equality
+// columns, assuming both inputs are in sorted order.
+
+// The merge join operator uses a "two scan" approach to generate the join.
+// What this means is that instead of going through and expanding the cross product
+// row by row, the operator performs two passes.
+// The first pass generates a list of groups of matching rows based on the equality
+// column. A group is an ADT representing a run, or in other words, multiple
+// repeated values. This run is represented as the starting row ordinal, the ending
+// row ordinal, and the number of times this group is expanded/repeated.
+// The second pass is where each of these groups are either expanded or repeated
+// into the output or savedOutput buffer, saving big on the type introspection.
+
+// TODO(georgeutsin): Add outer joins functionality and templating to support different equality types
+
+// Two buffers are used, one for the run on the left table and one for the run on the
+// right table. These buffers are only used if the run ends with a batch, to make sure
+// that we don't miss any cross product entries while expanding the groups
+// (leftGroups and rightGroups) when a run spans multiple batches.
+
+// There is also a savedOutput buffer in the case that the cross product overflows
+// the output buffer.
+type mergeJoinOp struct {
+	left  mergeJoinInput
+	right mergeJoinInput
+
+	// Fields to save the "working" batches to state in between outputs.
+	savedLeftBatch  ColBatch
+	savedLeftIdx    int
+	savedRightBatch ColBatch
+	savedRightIdx   int
+
+	// Output overflow buffer definition for the cross product entries
+	// that don't fit in the current batch.
+	savedOutput       ColBatch
+	savedOutputEndIdx int
+
+	// Member to keep track of count overflow, in the case that getExpectedOutCount
+	// returns a number that doesn't fit into a uint16.
+	countOverflow uint64
+
+	// Output buffer definition.
+	output          ColBatch
+	outputBatchSize int
+
+	// Local buffer for the last left and right saved runs.
+	// Used when the run ends with a batch and the run on each side needs to be saved to state
+	// in order to be able to continue it in the next batch.
+	lRun       ColBatch
+	lRunEndIdx int
+	rRun       ColBatch
+	rRunEndIdx int
+	matchVal   int64
+
+	// Local buffer for the "working" repeated groups.
+	leftGroups  []group
+	rightGroups []group
+}
+
+// NewMergeJoinOp returns a new merge join operator with the given spec.
+func NewMergeJoinOp(
+	left Operator,
+	right Operator,
+	leftOutCols []uint32,
+	rightOutCols []uint32,
+	leftTypes []types.T,
+	rightTypes []types.T,
+	leftEqCols []uint32,
+	rightEqCols []uint32,
+) Operator {
+	c := &mergeJoinOp{
+		left:  mergeJoinInput{source: left, outCols: leftOutCols, sourceTypes: leftTypes, eqCols: leftEqCols},
+		right: mergeJoinInput{source: right, outCols: rightOutCols, sourceTypes: rightTypes, eqCols: rightEqCols},
+	}
+	return c
+}
+
+func (c *mergeJoinOp) Init() {
+	c.initWithBatchSize(ColBatchSize)
+}
+
+func (c *mergeJoinOp) initWithBatchSize(outBatchSize int) {
+	outColTypes := make([]types.T, len(c.left.sourceTypes)+len(c.right.sourceTypes))
+	copy(outColTypes, c.left.sourceTypes)
+	copy(outColTypes[len(c.left.sourceTypes):], c.right.sourceTypes)
+
+	c.output = NewMemBatchWithSize(outColTypes, outBatchSize)
+	c.savedOutput = NewMemBatchWithSize(outColTypes, ColBatchSize)
+	c.left.source.Init()
+	c.right.source.Init()
+	c.outputBatchSize = outBatchSize
+
+	c.lRun = NewMemBatchWithSize(c.left.sourceTypes, ColBatchSize)
+	c.rRun = NewMemBatchWithSize(c.right.sourceTypes, ColBatchSize)
+
+	c.leftGroups = make([]group, ColBatchSize)
+	c.rightGroups = make([]group, ColBatchSize)
+}
+
+// getBatch takes a side as input and returns either the next batch (from source),
+// or the saved batch from state (if it exists).
+func (c *mergeJoinOp) getBatch(s side) (ColBatch, []uint16) {
+	batch := c.savedLeftBatch
+	source := c.left.source
+
+	if s == right {
+		batch = c.savedRightBatch
+		source = c.right.source
+	}
+
+	if batch != nil {
+		return batch, batch.Selection()
+	}
+
+	n := source.Next()
+	return n, n.Selection()
+}
+
+// nextBatch takes a mergeJoinInput and returns the next batch. Also returns other handy state
+// such as the starting index (always 0) and selection vector.
+func nextBatch(input *mergeJoinInput) (int, ColBatch, []uint16) {
+	bat := input.source.Next()
+	sel := bat.Selection()
+
+	return 0, bat, sel
+}
+
+// getValForIdx returns the value for comparison given a slice and an index.
+// TODO(georgeutsin): template this to work for all types.
+func getValForIdx(keys []int64, idx int, sel []uint16) int64 {
+	if sel != nil {
+		return keys[sel[idx]]
+	}
+
+	return keys[idx]
+}
+
+// buildSavedOutput flushes the savedOutput to output.
+func (c *mergeJoinOp) buildSavedOutput() uint16 {
+	toAppend := uint16(c.savedOutputEndIdx)
+	offset := len(c.left.sourceTypes)
+	if toAppend > uint16(c.outputBatchSize) {
+		toAppend = uint16(c.outputBatchSize)
+	}
+
+	for _, idx := range c.left.outCols {
+		c.output.ColVec(int(idx)).AppendSlice(c.savedOutput.ColVec(int(idx)), c.left.sourceTypes[idx], 0 /* destStartIdx */, 0 /* srcStartIdx */, toAppend)
+	}
+	for _, idx := range c.right.outCols {
+		c.output.ColVec(offset+int(idx)).AppendSlice(c.savedOutput.ColVec(offset+int(idx)), c.right.sourceTypes[idx], 0 /* destStartIdx */, 0 /* srcStartIdx */, toAppend)
+	}
+
+	if c.savedOutputEndIdx > int(toAppend) {
+		for _, idx := range c.left.outCols {
+			c.savedOutput.ColVec(int(idx)).Copy(c.savedOutput.ColVec(int(idx)), uint64(toAppend), uint64(c.savedOutputEndIdx), c.left.sourceTypes[idx])
+		}
+		for _, idx := range c.right.outCols {
+			c.savedOutput.ColVec(offset+int(idx)).Copy(c.savedOutput.ColVec(offset+int(idx)), uint64(toAppend), uint64(c.savedOutputEndIdx), c.right.sourceTypes[idx])
+		}
+	}
+	c.savedOutputEndIdx -= int(toAppend)
+	return toAppend
+}
+
+// saveBatchesToState puts both "working" batches in state to have the ability to resume them
+// in the next call to Next().
+func (c *mergeJoinOp) saveBatchesToState(lIdx int, lBat ColBatch, rIdx int, rBat ColBatch) {
+	c.savedLeftIdx = lIdx
+	c.savedLeftBatch = lBat
+
+	c.savedRightIdx = rIdx
+	c.savedRightBatch = rBat
+}
+
+// getRunLengthForValue is a helper function that gets the length of the current run in a batch
+// starting at idx, given the comparison value. Also returns a boolean indicating whether the run
+// is known to be complete.
+func getRunLengthForValue(
+	idx int, length int, keys []int64, sel []uint16, compVal int64,
+) (int, bool) {
+	if length == 0 {
+		return 0, true
+	}
+
+	runLength := 0
+	for idx < length {
+		if getValForIdx(keys, idx, sel) != compVal {
+			return runLength, true
+		}
+		runLength++
+		idx++
+	}
+	return runLength, false
+}
+
+// getExpectedOutCount is a helper function to generate the right length of output,
+// if there are no output columns. ex: in the case of a COUNT().
+func (c *mergeJoinOp) getExpectedOutCount(groups []group, groupsLen int) uint16 {
+	count := uint64(0)
+	for i := 0; i < groupsLen; i++ {
+		count += uint64((groups[i].rowEndIdx - groups[i].rowStartIdx) * groups[i].numRepeats)
+	}
+
+	// Add count to overflow if it is larger than a uint16.
+	if count > (1<<16 - 1) {
+		c.countOverflow = count - (1<<16 - 1)
+		count = 1<<16 - 1
+	}
+
+	return uint16(count)
+}
+
+// saveRunToState puts each column of the batch in a run into state, to be able to build
+// output from this run later.
+// SIDE EFFECT: increments destStartIdx by the runLength.
+func (c *mergeJoinOp) saveRunToState(
+	idx int,
+	runLength int,
+	bat ColBatch,
+	sel []uint16,
+	src *mergeJoinInput,
+	destBatch ColBatch,
+	destStartIdx *int,
+) {
+	endIdx := idx + runLength
+	if sel != nil {
+		for _, cIdx := range src.outCols {
+			destBatch.ColVec(int(cIdx)).AppendSliceWithSel(bat.ColVec(int(cIdx)), src.sourceTypes[cIdx], uint64(*destStartIdx), uint16(idx), uint16(endIdx), sel)
+		}
+	} else {
+		for _, cIdx := range src.outCols {
+			destBatch.ColVec(int(cIdx)).AppendSlice(bat.ColVec(int(cIdx)), src.sourceTypes[cIdx], uint64(*destStartIdx), uint16(idx), uint16(endIdx))
+		}
+	}
+
+	*destStartIdx += runLength
+}
+
+// buildSavedRuns expands the left and right runs in state into their cross product, dumping it
+// into the output buffer (and savedOutput overflow buffer if necessary).
+func (c *mergeJoinOp) buildSavedRuns() uint16 {
+	leftGroups := []group{{0, c.lRunEndIdx, c.rRunEndIdx}}
+	rightGroups := []group{{0, c.rRunEndIdx, c.lRunEndIdx}}
+
+	outCount, savedOutCount := c.buildLeftGroups(leftGroups, 1, 0, &c.left, c.lRun, nil, 0)
+	c.buildRightGroups(rightGroups, 1, len(c.left.sourceTypes), &c.right, c.rRun, nil, 0)
+
+	c.savedOutputEndIdx += savedOutCount
+	c.lRunEndIdx = 0
+	c.rRunEndIdx = 0
+
+	return outCount
+}
+
+func (c *mergeJoinOp) Next() ColBatch {
+	if c.savedOutputEndIdx > 0 {
+		count := c.buildSavedOutput()
+		c.output.SetLength(count)
+		return c.output
+	}
+
+	if c.countOverflow > 0 {
+		outCount := c.countOverflow
+		if outCount > (1<<16 - 1) {
+			outCount = 1<<16 - 1
+		}
+		c.countOverflow -= outCount
+		c.output.SetLength(uint16(outCount))
+		return c.output
+	}
+
+	lBat, lSel := c.getBatch(left)
+	rBat, rSel := c.getBatch(right)
+	eqColIdx := 0
+	lIdx, rIdx := c.savedLeftIdx, c.savedRightIdx
+
+	for {
+		outCount := uint16(0)
+
+		lLength := int(lBat.Length())
+		rLength := int(rBat.Length())
+
+		// If one of the sources is finished, then build the runs and return.
+		// The (lLength == 0 || rLength == 0) clause is specifically for inner joins.
+		// TODO (georgeutsin): update this logic to be able to support joins other than INNER.
+		if lLength == 0 || rLength == 0 {
+			outCount = c.buildSavedRuns()
+			c.output.SetLength(outCount)
+			return c.output
+		}
+
+		lKeys := lBat.ColVec(int(c.left.eqCols[eqColIdx])).Int64()
+		rKeys := rBat.ColVec(int(c.right.eqCols[eqColIdx])).Int64()
+
+		// Phase 0: finish previous run if it exists (mini probe and build).
+		if c.lRunEndIdx > 0 || c.rRunEndIdx > 0 {
+			isLRunComplete := false
+			for !isLRunComplete {
+				// Find the length of the run.
+				runLength, complete := getRunLengthForValue(lIdx, lLength, lKeys, lSel, c.matchVal)
+				isLRunComplete = complete
+
+				// Save the run to state.
+				c.saveRunToState(lIdx, runLength, lBat, lSel, &c.left, c.lRun, &c.lRunEndIdx)
+				lIdx += runLength
+
+				// Get the next batch if we hit the end.
+				if lIdx == lLength {
+					lIdx, lBat, lSel = nextBatch(&c.left)
+					lLength = int(lBat.Length())
+					lKeys = lBat.ColVec(int(c.left.eqCols[eqColIdx])).Int64()
+				}
+			}
+
+			isRRunComplete := false
+			for !isRRunComplete {
+				// Find the length of the run.
+				runLength, complete := getRunLengthForValue(rIdx, rLength, rKeys, rSel, c.matchVal)
+				isRRunComplete = complete
+
+				// Save the run to state.
+				c.saveRunToState(rIdx, runLength, rBat, rSel, &c.right, c.rRun, &c.rRunEndIdx)
+				rIdx += runLength
+
+				// Get the next batch if we hit the end.
+				if rIdx == rLength {
+					rIdx, rBat, rSel = nextBatch(&c.right)
+					rLength = int(rBat.Length())
+					rKeys = rBat.ColVec(int(c.right.eqCols[eqColIdx])).Int64()
+				}
+			}
+
+			outCount = c.buildSavedRuns()
+		}
+
+		// Phase 1: probe.
+		leftGroupsLen := 0
+		rightGroupsLen := 0
+		for lIdx < lLength && rIdx < rLength {
+			lVal := getValForIdx(lKeys, lIdx, lSel)
+			rVal := getValForIdx(rKeys, rIdx, rSel)
+
+			if lVal == rVal { // match
+				// Find the length of the runs on each side.
+				lRunLength, _ := getRunLengthForValue(lIdx, lLength, lKeys, lSel, lVal)
+				rRunLength, _ := getRunLengthForValue(rIdx, rLength, rKeys, rSel, rVal)
+
+				// Either run ends with a batch. Save state and have it handled in the next iteration.
+				if lRunLength+lIdx >= lLength || rRunLength+rIdx >= rLength {
+					c.saveRunToState(lIdx, lRunLength, lBat, lSel, &c.left, c.lRun, &c.lRunEndIdx)
+					lIdx += lRunLength
+					c.saveRunToState(rIdx, rRunLength, rBat, rSel, &c.right, c.rRun, &c.rRunEndIdx)
+					rIdx += rRunLength
+
+					c.matchVal = lVal
+					break
+				}
+
+				// Neither run ends with the batch so convert the runs to groups and increment the indices.
+				c.leftGroups[leftGroupsLen] = group{lIdx, lIdx + lRunLength, rRunLength}
+				leftGroupsLen++
+				lIdx += lRunLength
+
+				c.rightGroups[rightGroupsLen] = group{rIdx, rIdx + rRunLength, lRunLength}
+				rightGroupsLen++
+				rIdx += rRunLength
+			} else { // mismatch
+				if lVal < rVal {
+					lIdx++
+				} else {
+					rIdx++
+				}
+			}
+		}
+
+		// Phase 2: build.
+		rowOutCount, savedOutCount := c.buildLeftGroups(c.leftGroups, leftGroupsLen, 0 /* colOffset */, &c.left, lBat, lSel, outCount)
+		c.buildRightGroups(c.rightGroups, rightGroupsLen, len(c.left.sourceTypes), &c.right, rBat, rSel, outCount)
+		c.savedOutputEndIdx += savedOutCount
+		outCount += rowOutCount
+
+		// Avoid empty output batches.
+		if outCount == 0 {
+			// But only do this check when we've reached the end of one of the input batches (with no matches).
+			if lIdx == lLength {
+				lIdx, lBat, lSel = nextBatch(&c.left)
+			}
+			if rIdx == rLength {
+				rIdx, rBat, rSel = nextBatch(&c.right)
+			}
+		}
+
+		c.saveBatchesToState(lIdx, lBat, rIdx, rBat)
+
+		c.output.SetLength(outCount)
+
+		if outCount > 0 {
+			return c.output
+		}
+	}
+}

--- a/pkg/sql/exec/mergejoiner_test.go
+++ b/pkg/sql/exec/mergejoiner_test.go
@@ -1,0 +1,605 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func TestMergeJoiner(t *testing.T) {
+	tcs := []struct {
+		description     string
+		leftTuples      []tuple
+		leftTypes       []types.T
+		leftOutCols     []uint32
+		rightTuples     []tuple
+		rightTypes      []types.T
+		rightOutCols    []uint32
+		expected        []tuple
+		expectedOutCols []int
+		outputBatchSize int
+	}{
+		{
+			description:     "basic test",
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {2}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "basic test, no out cols",
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{},
+			rightOutCols:    []uint32{},
+			expected:        tuples{{}, {}, {}, {}},
+			expectedOutCols: []int{},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "basic test, L missing",
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {3}, {4}},
+			rightTuples:     tuples{{1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "basic test, R missing",
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "basic test, L duplicate",
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {1}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {2}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "basic test, R duplicate",
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {2}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "basic test, L+R duplicates",
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {1}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {1}, {1}, {2}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "basic test, L+R duplicate, multiple runs",
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {2}, {2}, {2}, {3}, {4}},
+			rightTuples:     tuples{{1}, {1}, {2}, {3}, {4}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {2}, {2}, {2}, {3}, {4}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "cross product test, batch size = 1024 (ColBatchSize)",
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {1}, {1}, {1}},
+			rightTuples:     tuples{{1}, {1}, {1}, {1}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
+			expectedOutCols: []int{0},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "cross product test, batch size = 4 (small even)",
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {1}, {1}, {1}},
+			rightTuples:     tuples{{1}, {1}, {1}, {1}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
+			expectedOutCols: []int{0},
+			outputBatchSize: 4,
+		},
+		{
+			description:     "cross product test, batch size = 3 (small odd)",
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {1}, {1}, {1}},
+			rightTuples:     tuples{{1}, {1}, {1}, {1}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
+			expectedOutCols: []int{0},
+			outputBatchSize: 3,
+		},
+		{
+			description:     "cross product test, batch size = 1 (unit)",
+			leftTypes:       []types.T{types.Int64},
+			rightTypes:      []types.T{types.Int64},
+			leftTuples:      tuples{{1}, {1}, {1}, {1}},
+			rightTuples:     tuples{{1}, {1}, {1}, {1}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
+			expectedOutCols: []int{0},
+			outputBatchSize: 1,
+		},
+		{
+			description:     "multi output column test, basic",
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0, 1},
+			rightOutCols:    []uint32{0, 1},
+			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "multi output column test, batch size = 1",
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0, 1},
+			rightOutCols:    []uint32{0, 1},
+			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: 1,
+		},
+		{
+			description:     "multi output column test, test output col projection",
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0},
+			rightOutCols:    []uint32{0},
+			expected:        tuples{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
+			expectedOutCols: []int{0, 2},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "multi output column test, test output col projection",
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{1},
+			rightOutCols:    []uint32{1},
+			expected:        tuples{{10, 11}, {20, 12}, {30, 13}, {40, 14}},
+			expectedOutCols: []int{1, 3},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "multi output column test, L run",
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {2, 21}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0, 1},
+			rightOutCols:    []uint32{0, 1},
+			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {2, 21, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "multi output column test, L run, batch size = 1",
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {2, 21}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0, 1},
+			rightOutCols:    []uint32{0, 1},
+			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {2, 21, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: 1,
+		},
+		{
+			description:     "multi output column test, R run",
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {1, 111}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0, 1},
+			rightOutCols:    []uint32{0, 1},
+			expected:        tuples{{1, 10, 1, 11}, {1, 10, 1, 111}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:     "multi output column test, R run, batch size = 1",
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:     tuples{{1, 11}, {1, 111}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:     []uint32{0, 1},
+			rightOutCols:    []uint32{0, 1},
+			expected:        tuples{{1, 10, 1, 11}, {1, 10, 1, 111}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: 1,
+		},
+		{
+			description:     "logic test",
+			leftTypes:       []types.T{types.Int64, types.Int64},
+			rightTypes:      []types.T{types.Int64, types.Int64},
+			leftTuples:      tuples{{-1, -1}, {0, 4}, {2, 1}, {3, 4}, {5, 4}},
+			rightTuples:     tuples{{0, 5}, {1, 3}, {3, 2}, {4, 6}},
+			leftOutCols:     []uint32{1},
+			rightOutCols:    []uint32{1},
+			expected:        tuples{{5, 4}, {2, 4}},
+			expectedOutCols: []int{3, 1},
+			outputBatchSize: ColBatchSize,
+		},
+		{
+			description:  "multi output column test, batch size = 1 and runs (to test saved output), reordered out columns",
+			leftTypes:    []types.T{types.Int64, types.Int64},
+			rightTypes:   []types.T{types.Int64, types.Int64},
+			leftTuples:   tuples{{1, 10}, {1, 10}, {1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:  tuples{{1, 11}, {1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{1, 0},
+			rightOutCols: []uint32{1, 0},
+			expected: tuples{
+				{10, 1, 11, 1},
+				{10, 1, 11, 1},
+				{10, 1, 11, 1},
+				{10, 1, 11, 1},
+				{10, 1, 11, 1},
+				{10, 1, 11, 1},
+				{20, 2, 12, 2},
+				{30, 3, 13, 3},
+				{40, 4, 14, 4},
+			},
+			expectedOutCols: []int{1, 0, 3, 2},
+			outputBatchSize: 1,
+		},
+		{
+			description:  "multi output column test, batch size = 1 and runs (to test saved output), reordered out columns that dont start at 0",
+			leftTypes:    []types.T{types.Int64, types.Int64},
+			rightTypes:   []types.T{types.Int64, types.Int64},
+			leftTuples:   tuples{{1, 10}, {1, 10}, {1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:  tuples{{1, 11}, {1, 11}, {2, 12}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{1, 0},
+			rightOutCols: []uint32{1},
+			expected: tuples{
+				{10, 1, 11},
+				{10, 1, 11},
+				{10, 1, 11},
+				{10, 1, 11},
+				{10, 1, 11},
+				{10, 1, 11},
+				{20, 2, 12},
+				{30, 3, 13},
+				{40, 4, 14},
+			},
+			expectedOutCols: []int{1, 0, 3},
+			outputBatchSize: 1,
+		},
+	}
+
+	for _, tc := range tcs {
+		runTests(t, []tuples{tc.leftTuples, tc.rightTuples}, func(t *testing.T, input []Operator) {
+			s := NewMergeJoinOp(input[0], input[1], tc.leftOutCols, tc.rightOutCols, tc.leftTypes, tc.rightTypes, []uint32{0}, []uint32{0})
+
+			out := newOpTestOutput(s, tc.expectedOutCols, tc.expected)
+			s.(*mergeJoinOp).initWithBatchSize(tc.outputBatchSize)
+
+			if err := out.Verify(); err != nil {
+				t.Fatalf("Test case description: '%s'\n%v", tc.description, err)
+			}
+		})
+	}
+}
+
+func TestMergeJoinerLongMultiBatch(t *testing.T) {
+	// This test creates one long input of a 1:1 join, and keeps track of the expected
+	// output to make sure the join output is batched correctly.
+	for _, groupSize := range []int{1, 2, ColBatchSize / 4, ColBatchSize / 2} {
+		for _, numInputBatches := range []int{1, 2, 16} {
+			for _, outBatchSize := range []int{1, 16, ColBatchSize} {
+				t.Run(fmt.Sprintf("groupSize=%d/numInputBatches=%d", groupSize, numInputBatches),
+					func(t *testing.T) {
+						nTuples := ColBatchSize * numInputBatches
+						typs := []types.T{types.Int64}
+						cols := []ColVec{newMemColumn(typs[0], nTuples)}
+						groups := cols[0].Int64()
+						for i := range groups {
+							groups[i] = int64(i)
+						}
+
+						leftSource := newChunkingBatchSource(typs, cols, uint64(nTuples))
+						rightSource := newChunkingBatchSource(typs, cols, uint64(nTuples))
+
+						a := NewMergeJoinOp(
+							leftSource,
+							rightSource,
+							[]uint32{0},
+							[]uint32{0},
+							typs,
+							typs,
+							[]uint32{0},
+							[]uint32{0},
+						)
+
+						a.(*mergeJoinOp).initWithBatchSize(outBatchSize)
+
+						i := 0
+						// Keep track of the last comparison value.
+						lastVal := int64(0)
+						for b := a.Next(); b.Length() != 0; b = a.Next() {
+							outCol := b.ColVec(0).Int64()
+							for j := int64(0); j < int64(b.Length()); j++ {
+								outVal := outCol[j]
+								expVal := lastVal
+								if outVal != expVal {
+									t.Fatalf("Found val %d, expected %d, idx %d of batch %d", outVal, expVal, j, i)
+								}
+								lastVal++
+							}
+							i++
+						}
+					})
+			}
+		}
+	}
+}
+
+func TestMergeJoinerLongMultiBatchCount(t *testing.T) {
+	// This test creates one long input of a 1:1 join, and keeps track of the expected
+	// count to make sure the join output is batched correctly.
+	for _, groupSize := range []int{1, 2, ColBatchSize / 4, ColBatchSize / 2} {
+		for _, numInputBatches := range []int{1, 2, 16} {
+			for _, outBatchSize := range []int{1, 16, ColBatchSize} {
+				t.Run(fmt.Sprintf("groupSize=%d/numInputBatches=%d", groupSize, numInputBatches),
+					func(t *testing.T) {
+						nTuples := ColBatchSize * numInputBatches
+						typs := []types.T{types.Int64}
+						cols := []ColVec{newMemColumn(typs[0], nTuples)}
+						groups := cols[0].Int64()
+						for i := range groups {
+							groups[i] = int64(i)
+						}
+
+						leftSource := newChunkingBatchSource(typs, cols, uint64(nTuples))
+						rightSource := newChunkingBatchSource(typs, cols, uint64(nTuples))
+
+						a := NewMergeJoinOp(
+							leftSource,
+							rightSource,
+							[]uint32{},
+							[]uint32{},
+							typs,
+							typs,
+							[]uint32{0},
+							[]uint32{0},
+						)
+
+						a.(*mergeJoinOp).initWithBatchSize(outBatchSize)
+
+						count := 0
+						for b := a.Next(); b.Length() != 0; b = a.Next() {
+							count += int(b.Length())
+						}
+						if count != nTuples {
+							t.Fatalf("Found count %d, expected count %d", count, nTuples)
+						}
+					})
+			}
+		}
+	}
+}
+
+func newBatchOfIntRows(nCols int, batch ColBatch) ColBatch {
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		col := batch.ColVec(colIdx).Int64()
+		for i := 0; i < ColBatchSize; i++ {
+			col[i] = int64(i)
+		}
+	}
+
+	batch.SetLength(ColBatchSize)
+
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		vec := batch.ColVec(colIdx)
+		vec.UnsetNulls()
+	}
+	return batch
+}
+
+func newBatchOfRepeatedIntRows(nCols int, batch ColBatch, numRepeats int) ColBatch {
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		col := batch.ColVec(colIdx).Int64()
+		for i := 0; i < ColBatchSize; i++ {
+			col[i] = int64((i + 1) / numRepeats)
+		}
+	}
+
+	batch.SetLength(ColBatchSize)
+
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		vec := batch.ColVec(colIdx)
+		vec.UnsetNulls()
+	}
+	return batch
+}
+
+func BenchmarkMergeJoiner(b *testing.B) {
+	nCols := 4
+	sourceTypes := make([]types.T, nCols)
+
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		sourceTypes[colIdx] = types.Int64
+	}
+
+	batch := NewMemBatch(sourceTypes)
+
+	// 1:1
+	for _, nBatches := range []int{1, 4, 16, 1024} {
+		b.Run(fmt.Sprintf("rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
+			// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+			// batch) * nCols (number of columns / row) * 2 (number of sources).
+			b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols * 2))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				leftSource := newFiniteBatchSource(newBatchOfIntRows(nCols, batch), nBatches)
+				rightSource := newFiniteBatchSource(newBatchOfIntRows(nCols, batch), nBatches)
+
+				s := mergeJoinOp{
+					left: mergeJoinInput{
+						eqCols:      []uint32{0},
+						outCols:     []uint32{0, 1},
+						sourceTypes: sourceTypes,
+						source:      leftSource,
+					},
+
+					right: mergeJoinInput{
+						eqCols:      []uint32{0},
+						outCols:     []uint32{2, 3},
+						sourceTypes: sourceTypes,
+						source:      rightSource,
+					},
+				}
+
+				s.Init()
+
+				b.StartTimer()
+				for i := 0; i < nBatches; i++ {
+					s.Next()
+				}
+				b.StopTimer()
+			}
+		})
+	}
+
+	// left repeats
+	for _, nBatches := range []int{1, 4, 16, 1024} {
+		b.Run(fmt.Sprintf("oneSideRepeat-rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
+			// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+			// batch) * nCols (number of columns / row) * 2 (number of sources).
+			b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols * 2))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				leftSource := newFiniteBatchSource(newBatchOfRepeatedIntRows(nCols, batch, nBatches), nBatches)
+				rightSource := newFiniteBatchSource(newBatchOfIntRows(nCols, batch), nBatches)
+
+				s := mergeJoinOp{
+					left: mergeJoinInput{
+						eqCols:      []uint32{0},
+						outCols:     []uint32{0, 1},
+						sourceTypes: sourceTypes,
+						source:      leftSource,
+					},
+
+					right: mergeJoinInput{
+						eqCols:      []uint32{0},
+						outCols:     []uint32{2, 3},
+						sourceTypes: sourceTypes,
+						source:      rightSource,
+					},
+				}
+
+				s.Init()
+
+				b.StartTimer()
+				for i := 0; i < nBatches; i++ {
+					s.Next()
+				}
+				b.StopTimer()
+			}
+		})
+	}
+
+	// both repeats
+	for _, nBatches := range []int{1, 4, 16, 1024} {
+		b.Run(fmt.Sprintf("bothSidesRepeat-rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
+			// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+			// batch) * nCols (number of columns / row) * 2 (number of sources).
+			b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols * 2))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				leftSource := newFiniteBatchSource(newBatchOfRepeatedIntRows(nCols, batch, nBatches), nBatches)
+				rightSource := newFiniteBatchSource(newBatchOfRepeatedIntRows(nCols, batch, nBatches), nBatches)
+
+				s := mergeJoinOp{
+					left: mergeJoinInput{
+						eqCols:      []uint32{0},
+						outCols:     []uint32{0, 1},
+						sourceTypes: sourceTypes,
+						source:      leftSource,
+					},
+
+					right: mergeJoinInput{
+						eqCols:      []uint32{0},
+						outCols:     []uint32{2, 3},
+						sourceTypes: sourceTypes,
+						source:      rightSource,
+					},
+				}
+
+				s.Init()
+
+				b.StartTimer()
+				for i := 0; i < nBatches; i++ {
+					s.Next()
+				}
+				b.StopTimer()
+			}
+		})
+	}
+
+}

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -1,0 +1,356 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for mergejoiner.eg.go. It's formatted in a
+// special way, so it's both valid Go and a valid text/template input. This
+// permits editing this file with editor support.
+//
+// */}}
+
+package exec
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+// {{/*
+// _TYPES_T is the template type variable for types.T. It will be replaced by
+// types.Foo for each type Foo in the types.T type.
+const _TYPES_T = types.Unhandled
+
+// _GOTYPE is the template Go type variable for this operator. It will be
+// replaced by the Go type equivalent for each type in types.T, for example
+// int64 for types.Int64.
+type _GOTYPE interface{}
+
+// Dummy import to pull in "apd" package.
+var _ apd.Decimal
+
+// */}}
+
+// {{/*
+func _ADD_SLICE_TO_COLVEC_WITH_SEL(
+	t_dest ColVec,
+	t_destStartIdx int,
+	t_src ColVec,
+	t_srcStartIdx int,
+	t_srcEndIdx int,
+	t_sel []uint16,
+) { // */}}
+	// {{define "addSliceToColVecWithSel"}}
+	batchSize := t_srcEndIdx - t_srcStartIdx
+
+	toCol := append(t_dest._TemplateType()[:t_destStartIdx], make([]_GOTYPE, batchSize)...)
+	fromCol := t_src._TemplateType()
+
+	for i := 0; i < batchSize; i++ {
+		toCol[i+t_destStartIdx] = fromCol[t_sel[i+t_srcStartIdx]]
+	}
+
+	savedOut.SetCol(toCol)
+
+	if batchSize > 0 {
+		savedOut.ExtendNullsWithSel(t_src, uint64(t_destStartIdx), uint16(t_srcStartIdx), uint16(batchSize), t_sel)
+	}
+	// {{end}}
+	// {{/*
+}
+
+// */}}
+
+// {{/*
+func _ADD_SLICE_TO_COLVEC(
+	t_dest ColVec, t_destStartIdx int, t_src ColVec, t_srcStartIdx int, t_srcEndIdx int,
+) { // */}}
+	// {{define "addSliceToColVec"}}
+	batchSize := t_srcEndIdx - t_srcStartIdx
+	outputLen := t_destStartIdx + batchSize
+
+	if outputLen > (len(savedOut._TemplateType())) {
+		t_dest.SetCol(append(t_dest._TemplateType()[:t_destStartIdx], t_src._TemplateType()[t_srcStartIdx:t_srcEndIdx]...))
+	} else {
+		copy(t_dest._TemplateType()[t_destStartIdx:], t_src._TemplateType()[t_srcStartIdx:t_srcEndIdx])
+	}
+
+	if batchSize > 0 {
+		t_dest.ExtendNulls(src, uint64(t_destStartIdx), uint16(t_srcStartIdx), uint16(batchSize))
+	}
+	// {{end}}
+	// {{/*
+}
+
+// */}}
+
+// {{/*
+func _COPY_WITH_SEL(
+	t_dest ColVec,
+	t_destStartIdx int,
+	t_src ColVec,
+	t_srcStartIdx int,
+	t_srcEndIdx int,
+	t_sel []uint16,
+) { // */}}
+	// {{define "copyWithSel"}}
+	batchSize := t_srcEndIdx - t_srcStartIdx
+	for i := 0; i < batchSize; i++ {
+		t_dest._TemplateType()[i+t_destStartIdx] = t_src._TemplateType()[t_sel[i+t_srcStartIdx]]
+	}
+	// {{end}}
+	// {{/*
+}
+
+// */}}
+
+// buildLeftGroups takes a []group and expands each group into the output by repeating
+// each row in the group numRepeats times. For example, given an input table:
+//  L1 |  L2
+//  --------
+//  1  |  a
+//  1  |  b
+// and leftGroups = [{startIdx: 0, endIdx: 2, numRepeats: 3}]
+// then buildLeftGroups expands this to
+//  L1 |  L2
+//  --------
+//  1  |  a
+//  1  |  a
+//  1  |  a
+//  1  |  b
+//  1  |  b
+//  1  |  b
+// Note: this is different from buildRightGroups in that each row of group is repeated
+// numRepeats times, instead of a simple copy of the group as a whole.
+// SIDE EFFECTS: writes into c.output (and c.savedOutput if applicable).
+func (c *mergeJoinOp) buildLeftGroups(
+	leftGroups []group,
+	groupsLen int,
+	colOffset int,
+	input *mergeJoinInput,
+	bat ColBatch,
+	sel []uint16,
+	destStartIdx uint16,
+) (uint16, int) {
+	savedOutCount := 0
+	outCount := uint16(0)
+	// Loop over every column.
+	for _, colIdx := range input.outCols {
+		savedOutCount = 0
+		outCount = 0
+		outStartIdx := int(destStartIdx)
+		out := c.output.ColVec(int(colIdx))
+		savedOut := c.savedOutput.ColVec(int(colIdx))
+		src := bat.ColVec(int(colIdx))
+		colType := input.sourceTypes[colIdx]
+
+		switch colType {
+		// {{range .}}
+		case _TYPES_T:
+			srcCol := src._TemplateType()
+			outCol := out._TemplateType()
+
+			if sel != nil {
+				// Loop over every group.
+				for i := 0; i < groupsLen; i++ {
+					leftGroup := leftGroups[i]
+					// Loop over every row in the group.
+					for curSrcStartIdx := leftGroup.rowStartIdx; curSrcStartIdx < leftGroup.rowEndIdx; curSrcStartIdx++ {
+						// Repeat each row numRepeats times.
+						for k := 0; k < leftGroup.numRepeats; k++ {
+							srcStartIdx := curSrcStartIdx
+							srcEndIdx := curSrcStartIdx + 1
+							if outStartIdx < c.outputBatchSize {
+
+								// TODO (georgeutsin): update template language to automatically generate template function function parameter definitions from expressions passed in.
+								t_dest := out
+								t_destStartIdx := outStartIdx
+								t_src := src
+								t_srcStartIdx := srcStartIdx
+								t_srcEndIdx := srcEndIdx
+								t_sel := sel
+								_COPY_WITH_SEL(t_dest, t_destStartIdx, t_src, t_srcStartIdx, t_srcEndIdx, t_sel)
+
+								outStartIdx++
+								outCount++
+							} else {
+								t_dest := savedOut
+								t_destStartIdx := c.savedOutputEndIdx + savedOutCount
+								t_src := src
+								t_srcStartIdx := srcStartIdx
+								t_srcEndIdx := srcEndIdx
+								t_sel := sel
+								_ADD_SLICE_TO_COLVEC_WITH_SEL(t_dest, t_destStartIdx, t_src, t_srcStartIdx, t_srcEndIdx, t_sel)
+
+								savedOutCount++
+							}
+						}
+					}
+				}
+			} else {
+				// Loop over every group.
+				for i := 0; i < groupsLen; i++ {
+					leftGroup := leftGroups[i]
+					// Loop over every row in the group.
+					for curSrcStartIdx := leftGroup.rowStartIdx; curSrcStartIdx < leftGroup.rowEndIdx; curSrcStartIdx++ {
+						// Repeat each row numRepeats times.
+						for k := 0; k < leftGroup.numRepeats; k++ {
+							srcStartIdx := curSrcStartIdx
+							srcEndIdx := curSrcStartIdx + 1
+							if outStartIdx < c.outputBatchSize {
+
+								copy(outCol[outStartIdx:], srcCol[srcStartIdx:srcEndIdx])
+
+								outStartIdx++
+								outCount++
+							} else {
+								t_dest := savedOut
+								t_destStartIdx := c.savedOutputEndIdx + savedOutCount
+								t_src := src
+								t_srcStartIdx := srcStartIdx
+								t_srcEndIdx := srcEndIdx
+								_ADD_SLICE_TO_COLVEC(t_dest, t_destStartIdx, t_src, t_srcStartIdx, t_srcEndIdx)
+
+								savedOutCount++
+							}
+						}
+					}
+				}
+			}
+		// {{end}}
+		default:
+			panic(fmt.Sprintf("unhandled type %d", colType))
+		}
+	}
+
+	if len(input.outCols) == 0 {
+		outCount = c.getExpectedOutCount(leftGroups, groupsLen)
+	}
+
+	return outCount, savedOutCount
+}
+
+// buildRightGroups takes a []group and repeats each group numRepeats times.
+// For example, given an input table:
+//  R1 |  R2
+//  --------
+//  1  |  a
+//  1  |  b
+// and rightGroups = [{startIdx: 0, endIdx: 2, numRepeats: 3}]
+// then buildRightGroups expands this to
+//  R1 |  R2
+//  --------
+//  1  |  a
+//  1  |  b
+//  1  |  a
+//  1  |  b
+//  1  |  a
+//  1  |  b
+// Note: this is different from buildLeftGroups in that each group is not expanded,
+// but directly copied numRepeats times.
+// SIDE EFFECTS: writes into c.output (and c.savedOutput if applicable).
+func (c *mergeJoinOp) buildRightGroups(
+	rightGroups []group,
+	groupsLen int,
+	colOffset int,
+	input *mergeJoinInput,
+	bat ColBatch,
+	sel []uint16,
+	destStartIdx uint16,
+) {
+	savedOutputCount := 0
+	// Loop over every column.
+	for _, colIdx := range input.outCols {
+		savedOutputCount = 0
+		outStartIdx := int(destStartIdx)
+		out := c.output.ColVec(int(colIdx) + colOffset)
+		savedOut := c.savedOutput.ColVec(int(colIdx) + colOffset)
+		src := bat.ColVec(int(colIdx))
+		colType := input.sourceTypes[colIdx]
+
+		switch colType {
+		// {{range .}}
+		case _TYPES_T:
+			srcCol := src._TemplateType()
+			outCol := out._TemplateType()
+
+			if sel != nil {
+				// Loop over every group.
+				for i := 0; i < groupsLen; i++ {
+					rightGroup := rightGroups[i]
+					// Repeat every group numRepeats times.
+					for k := 0; k < rightGroup.numRepeats; k++ {
+						toAppend := rightGroup.rowEndIdx - rightGroup.rowStartIdx
+						if outStartIdx+toAppend > c.outputBatchSize {
+							toAppend = c.outputBatchSize - outStartIdx
+						}
+
+						t_dest := out
+						t_destStartIdx := outStartIdx
+						t_src := src
+						t_srcStartIdx := rightGroup.rowStartIdx
+						t_srcEndIdx := rightGroup.rowStartIdx + toAppend
+						t_sel := sel
+						_COPY_WITH_SEL(t_dest, t_destStartIdx, t_src, t_srcStartIdx, t_srcEndIdx, t_sel)
+
+						if toAppend < rightGroup.rowEndIdx-rightGroup.rowStartIdx {
+							t_dest := savedOut
+							t_destStartIdx := c.savedOutputEndIdx + savedOutputCount
+							t_src := src
+							t_srcStartIdx := (rightGroup.rowStartIdx) + toAppend
+							t_srcEndIdx := rightGroup.rowEndIdx
+							t_sel := sel
+							_ADD_SLICE_TO_COLVEC_WITH_SEL(t_dest, t_destStartIdx, t_src, t_srcStartIdx, t_srcEndIdx, t_sel)
+						}
+
+						outStartIdx += toAppend
+						savedOutputCount += (rightGroup.rowEndIdx - rightGroup.rowStartIdx) - toAppend
+					}
+				}
+			} else {
+				// Loop over every group.
+				for i := 0; i < groupsLen; i++ {
+					rightGroup := rightGroups[i]
+					// Repeat every group numRepeats times.
+					for k := 0; k < rightGroup.numRepeats; k++ {
+						toAppend := rightGroup.rowEndIdx - rightGroup.rowStartIdx
+						if outStartIdx+toAppend > c.outputBatchSize {
+							toAppend = c.outputBatchSize - outStartIdx
+						}
+
+						copy(outCol[outStartIdx:], srcCol[rightGroup.rowStartIdx:rightGroup.rowStartIdx+toAppend])
+
+						if toAppend < rightGroup.rowEndIdx-rightGroup.rowStartIdx {
+							t_dest := savedOut
+							t_destStartIdx := c.savedOutputEndIdx + savedOutputCount
+							t_src := src
+							t_srcStartIdx := (rightGroup.rowStartIdx) + toAppend
+							t_srcEndIdx := rightGroup.rowEndIdx
+							_ADD_SLICE_TO_COLVEC(t_dest, t_destStartIdx, t_src, t_srcStartIdx, t_srcEndIdx)
+						}
+
+						outStartIdx += toAppend
+						savedOutputCount += (rightGroup.rowEndIdx - rightGroup.rowStartIdx) - toAppend
+					}
+				}
+			}
+		// {{end}}
+		default:
+			panic(fmt.Sprintf("unhandled type %d", colType))
+		}
+	}
+}


### PR DESCRIPTION
mergeJoinOp is an operator that implements sort-merge join.
It performs a merge on the left and right input sources, based on the equality
columns, assuming both inputs are in sorted order.

The merge join operator uses a "two scan" approach to generate the join.
What this means is that instead of going through and expanding the cross
product row by row, the operator performs two passes.
The first pass generates a list of groups of matching rows based on the
equality column. A group is an ADT representing a run, or in other words,
multiple repeated values. This run is represented as the starting row ordinal,
the ending row ordinal, and the number of times this group is
expanded/repeated.
The second pass is where each of these groups are either expanded or repeated
into the output or savedOutput buffer, saving big on the type introspection.

Two buffers are used, one for the run on the left table and one for the run on
the right table. These buffers are only used if the run ends with a batch, to
make sure that we don't miss any cross product entries while expanding the
groups (leftGroups and rightGroups) when a run spans multiple batches.

Some preliminary benchmarking results:
```
BenchmarkMergeJoiner/rows=1024-8                      	   20000	     66913 ns/op	 979.42 MB/s
BenchmarkMergeJoiner/rows=4096-8                      	    5000	    265602 ns/op	 986.98 MB/s
BenchmarkMergeJoiner/rows=16384-8                     	    2000	   1042486 ns/op	1005.84 MB/s
BenchmarkMergeJoiner/rows=1048576-8                   	      20	  65653445 ns/op	1022.17 MB/s

BenchmarkMergeJoiner/oneSideRepeat-rows=1024-8         	   20000	     68281 ns/op	 959.79 MB/s
BenchmarkMergeJoiner/oneSideRepeat-rows=4096-8         	    5000	    267793 ns/op	 978.90 MB/s
BenchmarkMergeJoiner/oneSideRepeat-rows=16384-8        	    2000	   1049688 ns/op	 998.94 MB/s
BenchmarkMergeJoiner/oneSideRepeat-rows=1048576-8      	      20	  67160497 ns/op	 999.23 MB/s

BenchmarkMergeJoiner/bothSidesRepeat-rows=1024-8       	   20000	     69234 ns/op	 946.58 MB/s
BenchmarkMergeJoiner/bothSidesRepeat-rows=4096-8       	    2000	    605505 ns/op	 432.93 MB/s
BenchmarkMergeJoiner/bothSidesRepeat-rows=16384-8      	     500	   2841285 ns/op	 369.05 MB/s
BenchmarkMergeJoiner/bothSidesRepeat-rows=1048576-8    	       3	 428893269 ns/op	 156.47 MB/s
```

Comparing this to the previous iteration
```
BenchmarkMergeJoiner/rows=1024-8                      	    5000	    246388 ns/op	 265.99 MB/s
BenchmarkMergeJoiner/rows=4096-8                       	    2000	    838724 ns/op	 312.55 MB/s
BenchmarkMergeJoiner/rows=16384-8                      	     500	   3105394 ns/op	 337.66 MB/s
BenchmarkMergeJoiner/rows=1048576-8                    	      10	 202760327 ns/op	 330.98 MB/s

BenchmarkMergeJoiner/oneSideRepeat-rows=1024-8         	    5000	    286032 ns/op	 229.12 MB/s
BenchmarkMergeJoiner/oneSideRepeat-rows=4096-8         	    2000	    856202 ns/op	 306.17 MB/s
BenchmarkMergeJoiner/oneSideRepeat-rows=16384-8        	     500	   3128651 ns/op	 335.15 MB/s
BenchmarkMergeJoiner/oneSideRepeat-rows=1048576-8      	      10	 194073135 ns/op	 345.79 MB/s

BenchmarkMergeJoiner/bothSidesRepeat-rows=1024-8       	    5000	    329374 ns/op	 198.97 MB/s
BenchmarkMergeJoiner/bothSidesRepeat-rows=4096-8       	    3000	    463981 ns/op	 564.99 MB/s
BenchmarkMergeJoiner/bothSidesRepeat-rows=16384-8      	    1000	   1190897 ns/op	 880.49 MB/s
BenchmarkMergeJoiner/bothSidesRepeat-rows=1048576-8							DNF (test was broken when I ran this ¯\_(ツ)_/¯)
```

Note that V2 outperforms V1 in every case except some of the degenerate `bothSidesRepeat` cases with a lot of rows. In this case, the cross product blows up and spends a bunch of time allocating memory (which didn't happen in V1 due to the row by row approach).

Release note: None