### PR TITLE
roachtest: binary finding improvements

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -141,19 +141,19 @@ func findBinary(binary, defValue string) (string, error) {
 			binSuffix = ".docker_amd64"
 		}
 		dirs := []string{
-			"/src/github.com/cockroachdb/cockroach/",
-			"/src/github.com/cockroachdb/cockroach/bin" + binSuffix,
-			filepath.Join(os.ExpandEnv("PWD"), "bin"+binSuffix),
+			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/"),
+			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/bin"+binSuffix),
+			filepath.Join(os.ExpandEnv("$PWD"), "bin"+binSuffix),
 		}
 		for _, dir := range dirs {
-			path = filepath.Join(gopath, dir, binary)
+			path = filepath.Join(dir, binary)
 			var err2 error
 			path, err2 = exec.LookPath(path)
 			if err2 == nil {
 				return filepathAbs(path)
 			}
 		}
-		return "", errors.WithStack(err)
+		return "", fmt.Errorf("failed to find %q in $PATH or any of %s", binary, dirs)
 	}
 	return filepathAbs(path)
 }


### PR DESCRIPTION
Before this patch, when roachtest would look for a binary and it didn't
find it, it would complain about it not being in the $PATH, although
that's just one of the many places it looks for it (and not where it
usually finds stuff).

Also, the code intended to also look in the current dir, but I think
that was very broken - first, it expended PWD instead of $PWD and second
it was prepending the gopath.

Release note: None