### PR TITLE
roachtest: run YCSB and kv tests on 32 core machine in addtion to current 8 core

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -54,20 +54,28 @@ func registerKV(r *registry) {
 	for _, p := range []int{0, 95} {
 		p := p
 		for _, n := range []int{1, 3} {
-			for _, e := range []bool{false, true} {
-				e := e
-				minVersion := "v2.0.0"
-				if e {
-					minVersion = "v2.1.0"
+			for _, cpus := range []int{8, 32} {
+				for _, e := range []bool{false, true} {
+					e := e
+					minVersion := "v2.0.0"
+					if e {
+						minVersion = "v2.1.0"
+					}
+					var name string
+					if cpus == 8 { // support legacy test name which didn't include cpu
+						name = fmt.Sprintf("kv%d/encrypt=%t/nodes=%d", p, e, n)
+					} else {
+						name = fmt.Sprintf("kv%d/encrypt=%t/nodes=%d/cpu=%d", p, e, n, cpus)
+					}
+					r.Add(testSpec{
+						Name:       name,
+						MinVersion: minVersion,
+						Cluster:    makeClusterSpec(n+1, cpu(cpus)),
+						Run: func(ctx context.Context, t *test, c *cluster) {
+							runKV(ctx, t, c, p, startArgs(fmt.Sprintf("--encrypt=%t", e)))
+						},
+					})
 				}
-				r.Add(testSpec{
-					Name:       fmt.Sprintf("kv%d/encrypt=%t/nodes=%d", p, e, n),
-					MinVersion: minVersion,
-					Cluster:    makeClusterSpec(n+1, cpu(8)),
-					Run: func(ctx context.Context, t *test, c *cluster) {
-						runKV(ctx, t, c, p, startArgs(fmt.Sprintf("--encrypt=%t", e)))
-					},
-				})
 			}
 		}
 	}

--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -50,14 +50,21 @@ func registerYCSB(r *registry) {
 			// See TODOs in workload/ycsb/ycsb.go.
 			continue
 		}
-
-		wl := wl
-		r.Add(testSpec{
-			Name:    fmt.Sprintf("ycsb/%s/nodes=3", wl),
-			Cluster: makeClusterSpec(4, cpu(8)),
-			Run: func(ctx context.Context, t *test, c *cluster) {
-				runYCSB(ctx, t, c, wl)
-			},
-		})
+		for _, cpus := range []int{8, 32} {
+			wl := wl
+			var name string
+			if cpus == 8 { // support legacy test name which didn't include cpu
+				name = fmt.Sprintf("ycsb/%s/nodes=3", wl)
+			} else {
+				name = fmt.Sprintf("ycsb/%s/nodes=3/cpu=%d", wl, cpus)
+			}
+			r.Add(testSpec{
+				Name:    name,
+				Cluster: makeClusterSpec(4, cpu(cpus)),
+				Run: func(ctx context.Context, t *test, c *cluster) {
+					runYCSB(ctx, t, c, wl)
+				},
+			})
+		}
 	}
 }


### PR DESCRIPTION
It will be good to understand how our performance changes on larger machines.
Backfill of data to follow.

Adds the CPU portion of #24277.

Release note: None