### PR TITLE
storage: on unquiesce, only bump lastUpdateTimes for replicating followers

### DIFF
--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -198,9 +198,12 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	// For all our followers, overwrite the RecentActive field (which is always
 	// true since we don't use CheckQuorum) with our own activity check.
 	r.mu.RLock()
+	log.Eventf(ctx, "raft status before lastUpdateTimes check: %+v", raftStatus.Progress)
+	log.Eventf(ctx, "lastUpdateTimes: %+v", r.mu.lastUpdateTimes)
 	updateRaftProgressFromActivity(
 		ctx, raftStatus.Progress, r.descRLocked().Replicas, r.mu.lastUpdateTimes, now,
 	)
+	log.Eventf(ctx, "raft status after lastUpdateTimes check: %+v", raftStatus.Progress)
 	r.mu.RUnlock()
 
 	if pr, ok := raftStatus.Progress[raftStatus.Lead]; ok {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -315,6 +315,11 @@ type Replica struct {
 		// is always true unless CheckQuorum is active, which at the time of writing in
 		// CockroachDB is not the case.
 		//
+		// The lastUpdateTimes map is also updated when a leaseholder steps up
+		// (making the assumption that all followers are live at that point),
+		// and when the range unquiesces (marking all replicating followers as
+		// live).
+		//
 		// TODO(tschottdorf): keeping a map on each replica seems to be
 		// overdoing it. We should map the replicaID to a NodeID and then use
 		// node liveness (or any sensible measure of the peer being around).

--- a/pkg/storage/replica_proposal_quota.go
+++ b/pkg/storage/replica_proposal_quota.go
@@ -128,10 +128,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 			// hands.
 			r.mu.proposalQuota = newQuotaPool(r.store.cfg.RaftProposalQuota)
 			r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]time.Time)
-			now := timeutil.Now()
-			for _, desc := range r.mu.state.Desc.Replicas {
-				r.mu.lastUpdateTimes.update(desc.ReplicaID, now)
-			}
+			r.mu.lastUpdateTimes.updateOnBecomeLeader(r.mu.state.Desc.Replicas, timeutil.Now())
 			r.mu.commandSizes = make(map[storagebase.CmdIDKey]int)
 		} else if r.mu.proposalQuota != nil {
 			// We're becoming a follower.

--- a/pkg/storage/replica_raft_quiesce.go
+++ b/pkg/storage/replica_raft_quiesce.go
@@ -78,10 +78,10 @@ func (r *Replica) unquiesceWithOptionsLocked(campaignOnWake bool) {
 		if campaignOnWake {
 			r.maybeCampaignOnWakeLocked(ctx)
 		}
-		now := timeutil.Now()
-		for _, desc := range r.mu.state.Desc.Replicas {
-			r.mu.lastUpdateTimes.update(desc.ReplicaID, now)
-		}
+		// NB: we know there's a non-nil RaftStatus because internalRaftGroup isn't nil.
+		r.mu.lastUpdateTimes.updateOnUnquiesce(
+			r.mu.state.Desc.Replicas, r.raftStatusRLocked().Progress, timeutil.Now(),
+		)
 	}
 }
 

--- a/pkg/storage/replica_raft_test.go
+++ b/pkg/storage/replica_raft_test.go
@@ -1,0 +1,61 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
+	"go.etcd.io/etcd/raft"
+)
+
+func TestLastUpdateTimesMap(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	m := make(lastUpdateTimesMap)
+	t1 := time.Time{}.Add(time.Second)
+	t2 := t1.Add(time.Second)
+	m.update(3, t1)
+	m.update(1, t2)
+	assert.EqualValues(t, map[roachpb.ReplicaID]time.Time{1: t2, 3: t1}, m)
+	descs := []roachpb.ReplicaDescriptor{{ReplicaID: 1}, {ReplicaID: 2}, {ReplicaID: 3}, {ReplicaID: 4}}
+
+	t3 := t2.Add(time.Second)
+	m.updateOnBecomeLeader(descs, t3)
+	assert.EqualValues(t, map[roachpb.ReplicaID]time.Time{1: t3, 2: t3, 3: t3, 4: t3}, m)
+
+	t4 := t3.Add(time.Second)
+	descs = append(descs, []roachpb.ReplicaDescriptor{{ReplicaID: 5}, {ReplicaID: 6}}...)
+	prs := map[uint64]raft.Progress{
+		1: {State: raft.ProgressStateReplicate}, // should be updated
+		// 2 is missing because why not
+		3: {State: raft.ProgressStateProbe},     // should be ignored
+		4: {State: raft.ProgressStateSnapshot},  // should be ignored
+		5: {State: raft.ProgressStateProbe},     // should be ignored
+		6: {State: raft.ProgressStateReplicate}, // should be added
+		7: {State: raft.ProgressStateReplicate}, // ignored, not in descs
+	}
+	m.updateOnUnquiesce(descs, prs, t4)
+	assert.EqualValues(t, map[roachpb.ReplicaID]time.Time{
+		1: t4,
+		2: t3,
+		3: t3,
+		4: t3,
+		6: t4,
+	}, m)
+}


### PR DESCRIPTION
On a range that unquiesces every couple of seconds (not untypical),
followers always seem alive. Probing followers can block Raft log
truncation, so this is problematic.

This problem is arguably better fixed by rethinking the log truncation
heuristics, but this is a larger project.

Release note (bug fix): Prevent down nodes from obstructing log truncation
on ranges they are a member of. This problem could cause replication to
fail due to an overly large Raft log.