### PR TITLE
roachtest: register sql20 benchmark as a test to run nightly

### DIFF
--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -74,6 +74,7 @@ func registerTests(r *registry) {
 	registerUpgrade(r)
 	registerVersion(r)
 	registerYCSB(r)
+	registerSQL20Bench(r)
 }
 
 func registerBenchmarks(r *registry) {


### PR DESCRIPTION
Release note: None