### PR TITLE
logictestccl: add logic test for experimental_follower_read_timestamp

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -1,0 +1,10 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE t (i INT)
+
+statement ok
+INSERT INTO t VALUES (2)
+
+statement error pq: relation "t" does not exist
+SELECT * FROM t AS OF SYSTEM TIME experimental_follower_read_timestamp()


### PR DESCRIPTION
I wrote this but forgot to add it to the original follower read diff.

Release note: None