### PR TITLE
opt: Fix panic when folding expressions into NULL values

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -429,6 +429,9 @@ query II
 EXECUTE x21701c(NULL)
 ----
 
+statement ok
+DROP TABLE kv
+
 # Test that a PREPARE statement after a CREATE TABLE in the same TRANSACTION
 # doesn't hang.
 subtest 24578
@@ -941,3 +944,13 @@ query IIB
 EXECUTE seqsel
 ----
 0  0  true
+
+# Null placeholder values need to be assigned static types. Otherwise, we won't
+# be able to disambiguate the concat function overloads.
+statement ok
+PREPARE foobar AS VALUES ($1:::string || $2:::string)
+
+query T
+EXECUTE foobar(NULL, NULL)
+----
+NULL

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -191,6 +192,11 @@ func (m *Memo) checkExpr(e opt.Expr) {
 	case *AggDistinctExpr:
 		if t.Input.Op() == opt.AggFilterOp {
 			panic("AggFilter should always be on top of AggDistinct")
+		}
+
+	case *ConstExpr:
+		if t.Value == tree.DNull {
+			panic("NULL values should always use NullExpr, not ConstExpr")
 		}
 
 	default:

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -236,6 +236,17 @@ values
  ├── fd: ()-->(1)
  └── (ARRAY[1,2,3],) [type=tuple{int[]}]
 
+# Regression test for #34270.
+opt expect=FoldBinary
+VALUES ((e'{}' ->> 0) || (e'{}' ->> 0))
+----
+values
+ ├── columns: column1:1(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,) [type=tuple{string}]
+
 # --------------------------------------------------
 # FoldUnary
 # --------------------------------------------------

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -308,7 +308,7 @@ func (b *Builder) buildScalar(
 			if err != nil {
 				panic(builderError{err})
 			}
-			out = b.factory.ConstructConstVal(d)
+			out = b.factory.ConstructConstVal(d, t.ResolvedType())
 		} else {
 			out = b.factory.ConstructPlaceholder(t)
 		}
@@ -376,7 +376,7 @@ func (b *Builder) buildScalar(
 	// tree.Datum case needs to occur after *tree.Placeholder which implements
 	// Datum.
 	case tree.Datum:
-		out = b.factory.ConstructConstVal(t)
+		out = b.factory.ConstructConstVal(t, t.ResolvedType())
 
 	default:
 		if b.AllowUnsupportedExpr {

--- a/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
@@ -304,7 +304,7 @@ func (g *factoryGen) genAssignPlaceholders() {
 			g.w.nestIndent("if err != nil {\n")
 			g.w.writeIndent("panic(placeholderError{err})\n")
 			g.w.unnest("}\n")
-			g.w.writeIndent("return f.ConstructConstVal(d)\n")
+			g.w.writeIndent("return f.ConstructConstVal(d, t.DataType())\n")
 			g.w.unnest("\n")
 			continue
 		}

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -876,8 +876,9 @@ func (c *CustomFuncs) fixedColsForZigzag(
 		if !ok {
 			break
 		}
-		vals = append(vals, c.e.f.ConstructConstVal(val))
-		types = append(types, index.Column(i).DatumType())
+		dt := index.Column(i).DatumType()
+		vals = append(vals, c.e.f.ConstructConstVal(val, dt))
+		types = append(types, dt)
 		fixedCols = append(fixedCols, colID)
 	}
 	return fixedCols, vals, types
@@ -1171,9 +1172,9 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 			leftVal := constraint.Spans.Get(0).StartKey().Value(i)
 			rightVal := constraint2.Spans.Get(0).StartKey().Value(i)
 
-			leftVals[i] = c.e.f.ConstructConstVal(leftVal)
+			leftVals[i] = c.e.f.ConstructConstVal(leftVal, leftVal.ResolvedType())
 			leftTypes[i] = leftVal.ResolvedType()
-			rightVals[i] = c.e.f.ConstructConstVal(rightVal)
+			rightVals[i] = c.e.f.ConstructConstVal(rightVal, rightVal.ResolvedType())
 			rightTypes[i] = rightVal.ResolvedType()
 			zigzagJoin.LeftFixedCols[i] = constraint.Columns.Get(i).ID()
 			zigzagJoin.RightFixedCols[i] = constraint.Columns.Get(i).ID()


### PR DESCRIPTION
When an expression is folded into NULL, the static type of the original
expression was not propagated to the new Null operator. This caused
typing problems further up the operator tree. For example:

  VALUES ((e'{}' ->> 0) || (e'{}' ->> 0))

In this example, the two sub-expressions get folded to NULL:::unknown
rather than NULL:::string. That then caused a concat lookup failure,
since there's no overload for concatenating unknown-typed values.

The fix is for any folding rule to propagate the static type of the
expression to the resulting Null expression.

In addition, I strengthened check_expr.go so that we disallow a ConstExpr
with a DNull value. We should always use NullExpr for that case.

Fixes #34270

Release note: None