### PR TITLE
storage: regression test leaked intents on bounced proposal

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -2992,7 +2992,7 @@ func TestStoreRangeMergeDuringShutdown(t *testing.T) {
 		rhsDesc        *roachpb.RangeDescriptor
 		stop, stopping bool
 	}
-	storeCfg.TestingKnobs.TestingPostApplyFilter = func(args storagebase.ApplyFilterArgs) *roachpb.Error {
+	storeCfg.TestingKnobs.TestingPostApplyFilter = func(args storagebase.ApplyFilterArgs) (int, *roachpb.Error) {
 		state.Lock()
 		if state.stop && !state.stopping && args.RangeID == state.rhsDesc.RangeID && args.IsLeaseRequest {
 			// Shut down the store. The lease acquisition will notice that a merge is
@@ -3010,7 +3010,7 @@ func TestStoreRangeMergeDuringShutdown(t *testing.T) {
 		} else {
 			state.Unlock()
 		}
-		return nil
+		return 0, nil
 	}
 
 	mtc = &multiTestContext{

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -126,13 +126,13 @@ func TestCheckConsistencyReplay(t *testing.T) {
 
 	// Arrange to count the number of times each checksum command applies to each
 	// store.
-	storeCfg.TestingKnobs.TestingApplyFilter = func(args storagebase.ApplyFilterArgs) *roachpb.Error {
+	storeCfg.TestingKnobs.TestingApplyFilter = func(args storagebase.ApplyFilterArgs) (int, *roachpb.Error) {
 		state.Lock()
 		defer state.Unlock()
 		if ccr := args.ComputeChecksum; ccr != nil {
 			state.applies[applyKey{ccr.ChecksumID, args.StoreID}]++
 		}
-		return nil
+		return 0, nil
 	}
 
 	// Arrange to trigger a retry when a ComputeChecksum request arrives.

--- a/pkg/storage/storagebase/base.go
+++ b/pkg/storage/storagebase/base.go
@@ -94,8 +94,11 @@ type ReplicaCommandFilter func(args FilterArgs) *roachpb.Error
 type ReplicaProposalFilter func(args ProposalFilterArgs) *roachpb.Error
 
 // A ReplicaApplyFilter can be used in testing to influence the error returned
-// from proposals after they apply.
-type ReplicaApplyFilter func(args ApplyFilterArgs) *roachpb.Error
+// from proposals after they apply. The returned int is treated as a
+// storage.proposalReevaluationReason and will only take an effect when it is
+// nonzero and the existing reason is zero. Similarly, the error is only applied
+// if there's no error so far.
+type ReplicaApplyFilter func(args ApplyFilterArgs) (int, *roachpb.Error)
 
 // ReplicaResponseFilter is used in unittests to modify the outbound
 // response returned to a waiting client after a replica command has


### PR DESCRIPTION
This adds the test promised in the PR below. When a transaction
committed but the commit applied at an invalid lease applied index,
we'd formerly (due to a recent change) leak the intents as committed
which would cause dirty writes. Adapt an existing test to roughly
do the following to prevent regression.

The test (now) sets up two ranges and lets a transaction (anchored on
the left) write to both of them. It then starts readers for both keys
written by the txn and waits for them to enter the txn wait queue. Next,
it lets the txn attempt to commit but injects a forced error below Raft.
The bugs would formerly notify the txn wait queue that the transaction
had committed (not true) and that its external intent (i.e. the one on
the right range) could be resolved (not true). Verify that neither
occurs.

See #34659.

Release note: None