### PR TITLE
roachtest: don't write tpchbench results in scalefactor subdirectory

### DIFF
--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -81,10 +81,9 @@ func runSQL20Bench(ctx context.Context, t *test, c *cluster, b tpchBenchSpec) {
 
 		// Run with only one worker to get best-case single-query performance.
 		cmd := fmt.Sprintf(
-			"./workload run querybench --db=tpch --concurrency=1 --query-file=%s --duration=5m {pgurl%s} --histograms=logs/scalefactor=%d/stats.json",
+			"./workload run querybench --db=tpch --concurrency=1 --query-file=%s --duration=5m {pgurl%s} --histograms=logs/stats.json",
 			filename,
 			roachNodes,
-			b.ScaleFactor,
 		)
 		if err := c.RunE(ctx, loadNode, cmd); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
There was no need to do this, we want to treat scalefactor runs as
different tests (i.e. show performance evolution over time for each one).

Release note: None