### PR TITLE
sql: enable bulk index backfill by default

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -45,7 +45,7 @@
 <tr><td><code>kv.transaction.write_pipelining_max_batch_size</code></td><td>integer</td><td><code>128</code></td><td>if non-zero, defines that maximum size batch that will be pipelined through Raft consensus</td></tr>
 <tr><td><code>rocksdb.min_wal_sync_interval</code></td><td>duration</td><td><code>0s</code></td><td>minimum duration between syncs of the RocksDB WAL</td></tr>
 <tr><td><code>schemachanger.bulk_index_backfill.batch_size</code></td><td>integer</td><td><code>5000000</code></td><td>number of rows to process at a time during bulk index backfill</td></tr>
-<tr><td><code>schemachanger.bulk_index_backfill.enabled</code></td><td>boolean</td><td><code>false</code></td><td>backfill indexes in bulk via addsstable</td></tr>
+<tr><td><code>schemachanger.bulk_index_backfill.enabled</code></td><td>boolean</td><td><code>true</code></td><td>backfill indexes in bulk via addsstable</td></tr>
 <tr><td><code>schemachanger.lease.duration</code></td><td>duration</td><td><code>5m0s</code></td><td>the duration of a schema change lease</td></tr>
 <tr><td><code>schemachanger.lease.renew_fraction</code></td><td>float</td><td><code>0.5</code></td><td>the fraction of schemachanger.lease_duration remaining to trigger a renew of the lease</td></tr>
 <tr><td><code>server.clock.forward_jump_check_enabled</code></td><td>boolean</td><td><code>false</code></td><td>if enabled, forward clock jumps > max_offset/2 will cause a panic.</td></tr>

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -659,8 +659,8 @@ func (sc *SchemaChanger) validateIndexes(
 						// TODO(vivek): find the offending row and include it in the error.
 						return pgerror.NewErrorf(
 							pgerror.CodeUniqueViolationError,
-							"index %q uniqueness violation: %d entries, expected %d",
-							idx.Name, idxLen, tableRowCount,
+							"%d entries, expected %d violates unique constraint %q",
+							idxLen, tableRowCount, idx.Name,
 						)
 					}
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -65,19 +65,19 @@ ALTER TABLE t ADD c INT
 statement ok
 INSERT INTO t VALUES (2, 9, 1, 1), (3, 9, 2, 1)
 
-statement error duplicate key value \(c\)=\(1\) violates unique constraint "bar"
+statement error pgcode 23505 violates unique constraint "bar"
 ALTER TABLE t ADD CONSTRAINT bar UNIQUE (c)
 
 # Test that rollback was successful
-query TTTTTRT
-SELECT job_type, regexp_replace(description, 'JOB \d+', 'JOB ...'), user_name, status, running_status, fraction_completed::decimal(10,2), error
+query TTTTTR
+SELECT job_type, regexp_replace(description, 'JOB \d+', 'JOB ...'), user_name, status, running_status, fraction_completed::decimal(10,2)
 FROM crdb_internal.jobs
 WHERE job_type = 'SCHEMA CHANGE'
 ORDER BY created DESC
 LIMIT 2
 ----
-SCHEMA CHANGE  ROLL BACK JOB ...: ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)  root  running  waiting for GC TTL  0.00  ·
-SCHEMA CHANGE  ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)                     root  failed   NULL                0.00  duplicate key value (c)=(1) violates unique constraint "bar"
+SCHEMA CHANGE  ROLL BACK JOB ...: ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)  root  running  waiting for GC TTL  0.00
+SCHEMA CHANGE  ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)                     root  failed   NULL                0.00
 
 query IIII colnames,rowsort
 SELECT * FROM t
@@ -526,7 +526,7 @@ SELECT a,b,f FROM add_default
 
 # Adding a unique column to an existing table with data with a default value
 # is illegal
-statement error duplicate key value .* violates unique constraint \"add_default_g_key\"
+statement error pgcode 23505 violates unique constraint \"add_default_g_key\"
 ALTER TABLE add_default ADD g INT UNIQUE DEFAULT 1
 
 # various default evaluation errors

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -36,7 +36,7 @@ t           foo         true        2             a            ASC        false 
 statement ok
 INSERT INTO t VALUES (2,1)
 
-statement error duplicate key value \(b\)=\(1\) violates unique constraint "bar"
+statement error pgcode 23505 violates unique constraint "bar"
 CREATE UNIQUE INDEX bar ON t (b)
 
 query TTBITTBB colnames

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -104,7 +104,7 @@ WHERE "eventType" = 'alter_table'
 statement ok
 INSERT INTO a VALUES (1, 1), (2, 1)
 
-statement error pq: duplicate key value \(val\)=\(1\) violates unique constraint \"foo\"
+statement error pgcode 23505 violates unique constraint \"foo\"
 ALTER TABLE a ADD CONSTRAINT foo UNIQUE(val)
 
 query IIT rowsort

--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -79,7 +79,7 @@ SELECT * FROM i WHERE f = 0
 -0
 0
 
-statement error duplicate key value
+statement error violates unique constraint
 CREATE UNIQUE INDEX ON i (f)
 
 subtest extra_float_digits

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -428,7 +428,7 @@ BEGIN
 statement count 3
 CREATE TABLE shopping (item, quantity) AS VALUES ('cups', 10), ('plates', 30), ('forks', 10)
 
-statement error pgcode 23505 duplicate key value \(quantity\)=\(10\) violates unique constraint "bar"
+statement error pgcode 23505 violates unique constraint "bar"
 CREATE UNIQUE INDEX bar ON shopping (quantity)
 
 statement ok
@@ -707,7 +707,7 @@ CREATE UNIQUE INDEX i_idx ON customers (i)
 statement ok
 CREATE UNIQUE INDEX n_idx ON customers (n)
 
-statement error pq: duplicate key value \(i\)=\(5\) violates unique constraint "i_idx"
+statement error violates unique constraint "i_idx"
 COMMIT
 
 query TTBTTTB

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
@@ -64,60 +63,7 @@ func ConvertBatchError(
 	result := b.Results[j]
 	if cErr, ok := origPErr.GetDetail().(*roachpb.ConditionFailedError); ok && len(result.Rows) > 0 {
 		key := result.Rows[0].Key
-		// TODO(dan): There's too much internal knowledge of the sql table
-		// encoding here (and this callsite is the only reason
-		// DecodeIndexKeyPrefix is exported). Refactor this bit out.
-		indexID, _, err := sqlbase.DecodeIndexKeyPrefix(tableDesc.TableDesc(), key)
-		if err != nil {
-			return err
-		}
-		index, err := tableDesc.FindIndexByID(indexID)
-		if err != nil {
-			return err
-		}
-		var rf Fetcher
-
-		var valNeededForCol util.FastIntSet
-		valNeededForCol.AddRange(0, len(index.ColumnIDs)-1)
-
-		colIdxMap := make(map[sqlbase.ColumnID]int, len(index.ColumnIDs))
-		cols := make([]sqlbase.ColumnDescriptor, len(index.ColumnIDs))
-		for i, colID := range index.ColumnIDs {
-			colIdxMap[colID] = i
-			col, err := tableDesc.FindColumnByID(colID)
-			if err != nil {
-				return err
-			}
-			cols[i] = *col
-		}
-
-		tableArgs := FetcherTableArgs{
-			Desc:             tableDesc,
-			Index:            index,
-			ColIdxMap:        colIdxMap,
-			IsSecondaryIndex: indexID != tableDesc.PrimaryIndex.ID,
-			Cols:             cols,
-			ValNeededForCol:  valNeededForCol,
-		}
-		if err := rf.Init(
-			false /* reverse */, false /* returnRangeInfo */, false /* isCheck */, &sqlbase.DatumAlloc{}, tableArgs,
-		); err != nil {
-			return err
-		}
-		f := singleKVFetcher{kvs: [1]roachpb.KeyValue{{Key: key}}}
-		if cErr.ActualValue != nil {
-			f.kvs[0].Value = *cErr.ActualValue
-		}
-		// Use the Fetcher to decode the single kv pair above by passing in
-		// this singleKVFetcher implementation, which doesn't actually hit KV.
-		if err := rf.StartScanFrom(ctx, &f); err != nil {
-			return err
-		}
-		datums, _, _, err := rf.NextRowDecoded(ctx)
-		if err != nil {
-			return err
-		}
-		return NewUniquenessConstraintViolationError(index, datums)
+		return NewUniquenessConstraintViolationError(ctx, tableDesc, key, cErr.ActualValue)
 	}
 	return origPErr.GoError()
 }
@@ -125,10 +71,67 @@ func ConvertBatchError(
 // NewUniquenessConstraintViolationError creates an error that represents a
 // violation of a UNIQUE constraint.
 func NewUniquenessConstraintViolationError(
-	index *sqlbase.IndexDescriptor, vals []tree.Datum,
+	ctx context.Context,
+	tableDesc *sqlbase.ImmutableTableDescriptor,
+	key roachpb.Key,
+	value *roachpb.Value,
 ) error {
-	valStrs := make([]string, 0, len(vals))
-	for _, val := range vals {
+	// TODO(dan): There's too much internal knowledge of the sql table
+	// encoding here (and this callsite is the only reason
+	// DecodeIndexKeyPrefix is exported). Refactor this bit out.
+	indexID, _, err := sqlbase.DecodeIndexKeyPrefix(tableDesc.TableDesc(), key)
+	if err != nil {
+		return err
+	}
+	index, err := tableDesc.FindIndexByID(indexID)
+	if err != nil {
+		return err
+	}
+	var rf Fetcher
+
+	var valNeededForCol util.FastIntSet
+	valNeededForCol.AddRange(0, len(index.ColumnIDs)-1)
+
+	colIdxMap := make(map[sqlbase.ColumnID]int, len(index.ColumnIDs))
+	cols := make([]sqlbase.ColumnDescriptor, len(index.ColumnIDs))
+	for i, colID := range index.ColumnIDs {
+		colIdxMap[colID] = i
+		col, err := tableDesc.FindColumnByID(colID)
+		if err != nil {
+			return err
+		}
+		cols[i] = *col
+	}
+
+	tableArgs := FetcherTableArgs{
+		Desc:             tableDesc,
+		Index:            index,
+		ColIdxMap:        colIdxMap,
+		IsSecondaryIndex: indexID != tableDesc.PrimaryIndex.ID,
+		Cols:             cols,
+		ValNeededForCol:  valNeededForCol,
+	}
+	if err := rf.Init(
+		false /* reverse */, false /* returnRangeInfo */, false /* isCheck */, &sqlbase.DatumAlloc{}, tableArgs,
+	); err != nil {
+		return err
+	}
+	f := singleKVFetcher{kvs: [1]roachpb.KeyValue{{Key: key}}}
+	if value != nil {
+		f.kvs[0].Value = *value
+	}
+	// Use the Fetcher to decode the single kv pair above by passing in
+	// this singleKVFetcher implementation, which doesn't actually hit KV.
+	if err := rf.StartScanFrom(ctx, &f); err != nil {
+		return err
+	}
+	datums, _, _, err := rf.NextRowDecoded(ctx)
+	if err != nil {
+		return err
+	}
+
+	valStrs := make([]string, 0, len(datums))
+	for _, val := range datums {
 		valStrs = append(valStrs, val.String())
 	}
 


### PR DESCRIPTION
Add a unique constraint violation error if one is seen
while constructing an SST. There are two places where a
unique constraint violation can be uncovered:
1. during SST creation when a violating row can be returned
2. during index validation when a violating row is still
not returned.

Make some adjustments to memory allocations made by the
backfiller for test cases that run with small indexes.

fixes #12424

Release note: CREATE INDEX is much faster (~10x).