### PR TITLE
distsqlrun: sanity check sortTopKProcessor's parameters

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -245,6 +245,12 @@ SELECT * FROM xyzw LIMIT -100
 query error negative value for OFFSET
 SELECT * FROM xyzw OFFSET -100
 
+query error numeric constant out of int64 range
+SELECT * FROM xyzw LIMIT 9223372036854775808
+
+query error numeric constant out of int64 range
+SELECT * FROM xyzw OFFSET 9223372036854775808
+
 query IIII
 SELECT * FROM xyzw ORDER BY x OFFSET 1 + 0.0
 ----


### PR DESCRIPTION
- Change k to a uint64
- Error with a zero k value

We've seen a bug in the wild #33225 where a sortTopKProcessor could have
possibly been created with an invalid k value. This commit ensures that this
state does not crash a server by being overly cautious about the
sorter's k parameter.

Release note: None