### PR TITLE
sql: fix missing null check in json sub array

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -665,5 +665,11 @@ SELECT '{"b": [], "c": {"a": "b"}}'::JSONB - array['a'];
 ----
 {"b": [], "c": {"a": "b"}}
 
+# Regression test for #34756.
+query T
+SELECT '{"b": [], "c": {"a": "b"}}'::JSONB - array['foo', NULL]
+----
+{"b": [], "c": {"a": "b"}}
+
 statement error pgcode 22P02 a path element is not an integer: foo
 SELECT '{"a": {"b": ["foo"]}}'::JSONB #- ARRAY['a', 'b', 'foo']

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -880,6 +880,9 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				arr := *MustBeDArray(right)
 
 				for _, str := range arr.Array {
+					if str == DNull {
+						continue
+					}
 					var err error
 					j, _, err = j.RemoveString(string(MustBeDString(str)))
 					if err != nil {


### PR DESCRIPTION
Fixes #34756.

Release note (bug fix): fix panic when subtracting an array containing
null from a json datum.