### PR TITLE
ui: fix logical plan design nits

### DIFF
--- a/pkg/ui/src/views/statements/planView.tsx
+++ b/pkg/ui/src/views/statements/planView.tsx
@@ -225,15 +225,15 @@ class PlanNodeDetails extends React.Component<PlanNodeDetailProps, PlanNodeDetai
 
   renderClassName(warn: boolean) {
     const node = this.props.node;
-    if (node.attrs && node.attrs.length > 0 && this.state.expanded) {
-      if (warn) {
-        return "nodeDetails warn expanded";
-      }
-      return "nodeDetails expanded";
-    } else if (warn) {
-      return "nodeDetails warn";
+    const hasAttributes = node.attrs && node.attrs.length > 0;
+    const warnClassName = (warn && " warn" || "");
+    if (!hasAttributes) {
+      return "nodeDetails" + warnClassName;
     }
-    return "nodeDetails";
+    if (this.state.expanded) {
+      return "nodeDetails hasAttributes expanded" + warnClassName;
+    }
+    return "nodeDetails hasAttributes" + warnClassName;
   }
 
   render() {

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -193,6 +193,7 @@ $plan-node-details-border-color = #ACB8CB                       // dark gray
 .plan-view
   color $body-color
   position relative
+  padding-left 6px
 
   .arrow-icon
     margin-left 8px
@@ -230,9 +231,17 @@ $plan-node-details-border-color = #ACB8CB                       // dark gray
     font-size smaller
     display inline
 
+  .hasAttributes
+    &:hover
+      cursor pointer
+
+      .arrow
+        display inline
+
   .nodeDetails
     position relative
     padding 6px 0
+    margin 2px 0
     border 1px solid transparent
     border-radius 3px
 
@@ -242,12 +251,6 @@ $plan-node-details-border-color = #ACB8CB                       // dark gray
     &.expanded
     &:hover
       background-color $plan-node-details-background-color
-
-    &:hover
-      cursor pointer
-
-      .arrow
-        display inline
 
     &.warn
       &.expanded
@@ -259,7 +262,7 @@ $plan-node-details-border-color = #ACB8CB                       // dark gray
   .nodeAttributes
     color $body-color
     padding 14px 16px
-    margin 6px 0 4px 0
+    margin 6px 10px 4px 15px
     border 1px solid $plan-node-line-color
     background-color white
     border-radius 2px


### PR DESCRIPTION
This commit fixes the following UI nits on Logical Plans:

- Added some vertical air between nodes.
- Left-aligned root bullet under "Logical Plan" header.
- Added some left air between expanded node border and inner attributes border
- For non-expandable nodes, removed "pointer" cursor.

Before:

<img src="https://user-images.githubusercontent.com/3051672/52510991-32f8ce00-2bcc-11e9-8c37-81fec05ef021.gif" width="500" />

After:

<img src="https://user-images.githubusercontent.com/3051672/52510912-e9a87e80-2bcb-11e9-8801-6dc9b49c708e.gif" width="500" />

Release note: None