### PR TITLE
distsqlplan: fix error in union planning

### DIFF
--- a/pkg/sql/distsqlplan/physical_plan.go
+++ b/pkg/sql/distsqlplan/physical_plan.go
@@ -283,12 +283,19 @@ func (p *PhysicalPlan) CheckLastStagePost() error {
 	// verify this assumption.
 	for i := 1; i < len(p.ResultRouters); i++ {
 		pi := &p.Processors[p.ResultRouters[i]].Spec.Post
-		if pi.Filter != post.Filter || pi.Projection != post.Projection ||
-			len(pi.OutputColumns) != len(post.OutputColumns) {
+		if pi.Filter != post.Filter ||
+			pi.Projection != post.Projection ||
+			len(pi.OutputColumns) != len(post.OutputColumns) ||
+			len(pi.RenderExprs) != len(post.RenderExprs) {
 			return errors.Errorf("inconsistent post-processing: %v vs %v", post, pi)
 		}
 		for j, col := range pi.OutputColumns {
 			if col != post.OutputColumns[j] {
+				return errors.Errorf("inconsistent post-processing: %v vs %v", post, pi)
+			}
+		}
+		for j, col := range pi.RenderExprs {
+			if col != post.RenderExprs[j] {
 				return errors.Errorf("inconsistent post-processing: %v vs %v", post, pi)
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/sqlsmith
+++ b/pkg/sql/logictest/testdata/logic_test/sqlsmith
@@ -16,3 +16,16 @@ CREATE TABLE a (a INT PRIMARY KEY);
 
 statement ok
 SELECT true FROM (SELECT ref_1.a AS c0 FROM crdb_internal.cluster_queries AS ref_0 JOIN a AS ref_1 ON (ref_0.node_id = ref_1.a) WHERE (SELECT a from a limit 1 offset 1) is null);
+
+# Regression: #34437 (union all could produce panic in distsql planning)
+
+statement ok
+CREATE TABLE table8 (col1 TIME, col2 BYTES, col4 OID, col6 NAME, col9 TIMESTAMP, PRIMARY KEY (col1));
+
+statement ok
+CREATE TABLE table5 (col0 TIME NULL, col1 OID, col3 INET, PRIMARY KEY (col1 ASC));
+
+statement ok
+INSERT INTO table8 (col1, col2, col4, col6)
+VALUES ('19:06:18.321589', NULL, NULL, NULL)
+UNION ALL (SELECT NULL, NULL, NULL, NULL FROM table5 AS tab_8);

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -246,6 +246,11 @@ query I
 SELECT a FROM a WHERE a > 2 UNION ALL (SELECT a FROM c WHERE b > 2) LIMIT 1;
 ----
 
+query III
+select *,1 from (values(1,2) union all select 2,2 from c);
+----
+1 2 1
+
 statement ok
 INSERT INTO a VALUES (1)
 


### PR DESCRIPTION
Previously, if 2 inputs to a UNION ALL had identical post processing
except for renders, further post processing on top of that union all
could invalidate the plan and cause errors or crashes.

Fixes #34437.

Release note (bug fix): fix a planning crash during UNION ALL operations
that had projections, filters or renders directly on top of the UNION
ALL in some cases.