### PR TITLE
sql: provide table comments for virtual tables

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1476,7 +1476,7 @@ func (s *adminServer) DataDistribution(
 	// and deleted tables (as opposed to e.g. information_schema) because we are interested
 	// in the data for all ranges, not just ranges for visible tables.
 	userName := s.getUser(req)
-	tablesQuery := `SELECT name, table_id, database_name, drop_time FROM "".crdb_internal.tables`
+	tablesQuery := `SELECT name, table_id, database_name, drop_time FROM "".crdb_internal.tables WHERE schema_name = 'public'`
 	rows1, _ /* cols */, err := s.server.internalExecutor.QueryWithUser(
 		ctx, "admin-replica-matrix", nil /* txn */, userName, tablesQuery,
 	)

--- a/pkg/sql/comment_on_column.go
+++ b/pkg/sql/comment_on_column.go
@@ -24,7 +24,7 @@ import (
 
 type commentOnColumnNode struct {
 	n         *tree.CommentOnColumn
-	tableDesc *MutableTableDescriptor
+	tableDesc *ImmutableTableDescriptor
 }
 
 // CommentOnColumn add comment on a column.
@@ -34,7 +34,7 @@ func (p *planner) CommentOnColumn(ctx context.Context, n *tree.CommentOnColumn) 
 	if n.ColumnItem.TableName != nil {
 		tableName = n.ColumnItem.TableName.ToTableName()
 	}
-	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &tableName, true, requireTableDesc)
+	tableDesc, err := p.ResolveUncachedTableDescriptor(ctx, &tableName, true, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/comment_on_table.go
+++ b/pkg/sql/comment_on_table.go
@@ -24,7 +24,7 @@ import (
 
 type commentOnTableNode struct {
 	n         *tree.CommentOnTable
-	tableDesc *MutableTableDescriptor
+	tableDesc *ImmutableTableDescriptor
 }
 
 // CommentOnTable add comment on a table.
@@ -32,7 +32,7 @@ type commentOnTableNode struct {
 //   notes: postgres requires CREATE on the table.
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) CommentOnTable(ctx context.Context, n *tree.CommentOnTable) (planNode, error) {
-	tableDesc, err := p.ResolveMutableTableDescriptor(ctx, &n.Table, true, requireTableDesc)
+	tableDesc, err := p.ResolveUncachedTableDescriptor(ctx, &n.Table, true, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -200,6 +201,9 @@ func validateInformationSchemaTable(table *sqlbase.TableDescriptor) error {
 }
 
 var informationSchemaAdministrableRoleAuthorizations = virtualSchemaTable{
+	comment: `roles for which the current user has admin option
+` + base.DocsURL("information-schema.html#administrable_role_authorizations") + `
+https://www.postgresql.org/docs/9.5/infoschema-administrable-role-authorizations.html`,
 	schema: vtable.InformationSchemaAdministrableRoleAuthorizations,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		currentUser := p.SessionData().User
@@ -229,6 +233,9 @@ var informationSchemaAdministrableRoleAuthorizations = virtualSchemaTable{
 }
 
 var informationSchemaApplicableRoles = virtualSchemaTable{
+	comment: `roles available to the current user
+` + base.DocsURL("information-schema.html#applicable_roles") + `
+https://www.postgresql.org/docs/9.5/infoschema-applicable-roles.html`,
 	schema: vtable.InformationSchemaApplicableRoles,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		currentUser := p.SessionData().User
@@ -254,6 +261,9 @@ var informationSchemaApplicableRoles = virtualSchemaTable{
 }
 
 var informationSchemaColumnPrivileges = virtualSchemaTable{
+	comment: `column privilege grants (incomplete)
+` + base.DocsURL("information-schema.html#column_privileges") + `
+https://www.postgresql.org/docs/9.5/infoschema-column-privileges.html`,
 	schema: vtable.InformationSchemaColumnPrivileges,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, virtualMany, func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {
@@ -286,6 +296,9 @@ var informationSchemaColumnPrivileges = virtualSchemaTable{
 }
 
 var informationSchemaColumnsTable = virtualSchemaTable{
+	comment: `table and view columns (incomplete)
+` + base.DocsURL("information-schema.html#columns") + `
+https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 	schema: vtable.InformationSchemaColumns,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, virtualMany, func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {
@@ -325,9 +338,10 @@ var informationSchemaColumnsTable = virtualSchemaTable{
 	},
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-enabled-roles.html
-// MySQL:    missing
 var informationSchemaEnabledRoles = virtualSchemaTable{
+	comment: `roles for the current user
+` + base.DocsURL("information-schema.html#enabled_roles") + `
+https://www.postgresql.org/docs/9.5/infoschema-enabled-roles.html`,
 	schema: `
 CREATE TABLE information_schema.enabled_roles (
 	ROLE_NAME STRING NOT NULL
@@ -383,9 +397,9 @@ func datetimePrecision(colType sqlbase.ColumnType) tree.Datum {
 	return tree.DNull
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-constraint-column-usage.html
-// MySQL:    missing
 var informationSchemaConstraintColumnUsageTable = virtualSchemaTable{
+	comment: `columns usage by constraints
+https://www.postgresql.org/docs/9.5/infoschema-constraint-column-usage.html`,
 	schema: `
 CREATE TABLE information_schema.constraint_column_usage (
 	TABLE_CATALOG      STRING NOT NULL,
@@ -441,9 +455,11 @@ CREATE TABLE information_schema.constraint_column_usage (
 	},
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-key-column-usage.html
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/key-column-usage-table.html
 var informationSchemaKeyColumnUsageTable = virtualSchemaTable{
+	comment: `column usage by indexes and key constraints
+` + base.DocsURL("information-schema.html#key_column_usage") + `
+https://www.postgresql.org/docs/9.5/infoschema-key-column-usage.html`,
 	schema: `
 CREATE TABLE information_schema.key_column_usage (
 	CONSTRAINT_CATALOG STRING NOT NULL,
@@ -511,6 +527,8 @@ CREATE TABLE information_schema.key_column_usage (
 // Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-parameters.html
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/parameters-table.html
 var informationSchemaParametersTable = virtualSchemaTable{
+	comment: `built-in function parameters (empty - introspection not yet supported)
+https://www.postgresql.org/docs/9.5/infoschema-parameters.html`,
 	schema: `
 CREATE TABLE information_schema.parameters (
 	SPECIFIC_CATALOG STRING,
@@ -585,9 +603,11 @@ func dStringForFKAction(action sqlbase.ForeignKeyReference_Action) tree.Datum {
 	panic(errors.Errorf("unexpected ForeignKeyReference_Action: %v", action))
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-referential-constraints.html
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/referential-constraints-table.html
 var informationSchemaReferentialConstraintsTable = virtualSchemaTable{
+	comment: `foreign key constraints
+` + base.DocsURL("information-schema.html#referential_constraints") + `
+https://www.postgresql.org/docs/9.5/infoschema-referential-constraints.html`,
 	schema: `
 CREATE TABLE information_schema.referential_constraints (
 	CONSTRAINT_CATALOG        STRING NOT NULL,
@@ -651,6 +671,9 @@ CREATE TABLE information_schema.referential_constraints (
 // Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-role-table-grants.html
 // MySQL:    missing
 var informationSchemaRoleTableGrants = virtualSchemaTable{
+	comment: `privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+` + base.DocsURL("information-schema.html#role_table_grants") + `
+https://www.postgresql.org/docs/9.5/infoschema-role-table-grants.html`,
 	schema: `
 CREATE TABLE information_schema.role_table_grants (
 	GRANTOR        STRING,
@@ -668,9 +691,10 @@ CREATE TABLE information_schema.role_table_grants (
 	populate: populateTablePrivileges,
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-routines.html
 // MySQL:    https://dev.mysql.com/doc/mysql-infoschema-excerpt/5.7/en/routines-table.html
 var informationSchemaRoutineTable = virtualSchemaTable{
+	comment: `built-in functions (empty - introspection not yet supported)
+https://www.postgresql.org/docs/9.5/infoschema-routines.html`,
 	schema: `
 CREATE TABLE information_schema.routines (
 	SPECIFIC_CATALOG STRING,
@@ -760,9 +784,11 @@ CREATE TABLE information_schema.routines (
 	},
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-schemata.html
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/schemata-table.html
 var informationSchemaSchemataTable = virtualSchemaTable{
+	comment: `database schemas (may contain schemata without permission)
+` + base.DocsURL("information-schema.html#schemata") + `
+https://www.postgresql.org/docs/9.5/infoschema-schemata.html`,
 	schema: vtable.InformationSchemaSchemata,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, dbContext, func(db *sqlbase.DatabaseDescriptor) error {
@@ -778,9 +804,10 @@ var informationSchemaSchemataTable = virtualSchemaTable{
 	},
 }
 
-// Postgres: missing
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/schema-privileges-table.html
 var informationSchemaSchemataTablePrivileges = virtualSchemaTable{
+	comment: `schema privileges (incomplete; may contain excess users or roles)
+` + base.DocsURL("information-schema.html#schema_privileges"),
 	schema: `
 CREATE TABLE information_schema.schema_privileges (
 	GRANTEE         STRING NOT NULL,
@@ -833,9 +860,10 @@ func dStringForIndexDirection(dir sqlbase.IndexDescriptor_Direction) tree.Datum 
 	panic("unreachable")
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-sequences.html
-// MySQL:    missing
 var informationSchemaSequences = virtualSchemaTable{
+	comment: `sequences
+` + base.DocsURL("information-schema.html#sequences") + `
+https://www.postgresql.org/docs/9.5/infoschema-sequences.html`,
 	schema: `
 CREATE TABLE information_schema.sequences (
     SEQUENCE_CATALOG         STRING NOT NULL,
@@ -878,6 +906,8 @@ CREATE TABLE information_schema.sequences (
 // Postgres: missing
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/statistics-table.html
 var informationSchemaStatisticsTable = virtualSchemaTable{
+	comment: `index metadata and statistics (incomplete)
+` + base.DocsURL("information-schema.html#statistics"),
 	schema: `
 CREATE TABLE information_schema.statistics (
 	TABLE_CATALOG STRING NOT NULL,
@@ -974,9 +1004,11 @@ CREATE TABLE information_schema.statistics (
 	},
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-table-constraints.html
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/table-constraints-table.html
 var informationSchemaTableConstraintTable = virtualSchemaTable{
+	comment: `table constraints
+` + base.DocsURL("information-schema.html#table_constraints") + `
+https://www.postgresql.org/docs/9.5/infoschema-table-constraints.html`,
 	schema: `
 CREATE TABLE information_schema.table_constraints (
 	CONSTRAINT_CATALOG STRING NOT NULL,
@@ -1026,9 +1058,11 @@ CREATE TABLE information_schema.table_constraints (
 	},
 }
 
-// Postgres: missing
+// Postgres: not provided
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/user-privileges-table.html
+// TODO(knz): this introspection facility is of dubious utility.
 var informationSchemaUserPrivileges = virtualSchemaTable{
+	comment: `grantable privileges (incomplete)`,
 	schema: `
 CREATE TABLE information_schema.user_privileges (
 	GRANTEE        STRING NOT NULL,
@@ -1057,9 +1091,11 @@ CREATE TABLE information_schema.user_privileges (
 	},
 }
 
-// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-table-privileges.html
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/table-privileges-table.html
 var informationSchemaTablePrivileges = virtualSchemaTable{
+	comment: `privileges granted on table or views (incomplete; may contain excess users or roles)
+` + base.DocsURL("information-schema.html#table_privileges") + `
+https://www.postgresql.org/docs/9.5/infoschema-table-privileges.html`,
 	schema: `
 CREATE TABLE information_schema.table_privileges (
 	GRANTOR        STRING,
@@ -1112,6 +1148,9 @@ var (
 )
 
 var informationSchemaTablesTable = virtualSchemaTable{
+	comment: `tables and views
+` + base.DocsURL("information-schema.html#tables") + `
+https://www.postgresql.org/docs/9.5/infoschema-tables.html`,
 	schema: vtable.InformationSchemaTables,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, virtualMany,
@@ -1146,6 +1185,9 @@ var informationSchemaTablesTable = virtualSchemaTable{
 // Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-views.html
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/views-table.html
 var informationSchemaViewsTable = virtualSchemaTable{
+	comment: `views (incomplete)
+` + base.DocsURL("information-schema.html#views") + `
+https://www.postgresql.org/docs/9.5/infoschema-views.html`,
 	schema: `
 CREATE TABLE information_schema.views (
     TABLE_CATALOG              STRING NOT NULL,

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1912,14 +1912,36 @@ FOREIGN KEY (a) REFERENCES pg_indexdef_test (a) ON DELETE CASCADE
 CHECK (c > a)
 UNIQUE (b ASC)
 
-# These functions always return NULL since we don't support comments.
-query TTTT
+# These functions always return NULL since we don't support comments on vtable columns and databases.
+query TT
 SELECT col_description('pg_class'::regclass::oid, 2),
-       obj_description('pg_class'::regclass::oid, 'pg_class'),
-       obj_description('pg_class'::regclass::oid),
        shobj_description('pg_class'::regclass::oid, 'pg_class')
 ----
-NULL  NULL  NULL  NULL
+NULL  NULL
+
+# vtable comments are supported
+query TT
+SELECT regexp_replace(obj_description('pg_class'::regclass::oid), e' .*', '') AS comment1,
+       regexp_replace(obj_description('pg_class'::regclass::oid, 'test'), e' .*', '') AS comment2
+----
+tables tables
+
+# Regular table column comments are supported.
+statement ok
+CREATE TABLE t(x INT);
+
+statement ok
+COMMENT ON TABLE t IS 'waa'
+
+statement ok
+COMMENT ON COLUMN t.x IS 'woo'
+
+query TTT
+SELECT obj_description('t'::regclass::oid),
+       obj_description('t'::regclass::oid, 'test'),
+       col_description('t'::regclass, 1)
+----
+waa  waa  woo
 
 # Check that base function names are also visible in namespace pg_catalog.
 query I

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -36,6 +36,7 @@ node_runtime_info
 node_sessions
 node_statement_statistics
 partitions
+predefined_comments
 ranges
 ranges_no_leases
 schema_changes
@@ -71,11 +72,11 @@ SELECT * FROM crdb_internal.schema_changes
 ----
 table_id parent_id name type target_id target_name state direction
 
-query IITTITRTTTTTT colnames
+query IITTITRTTTTTTT colnames
 SELECT * FROM crdb_internal.tables WHERE NAME = 'namespace'
 ----
-table_id  parent_id  name       database_name  version  mod_time                         mod_time_logical  format_version            state   sc_lease_node_id  sc_lease_expiration_time  drop_time  audit_mode
-2         1          namespace  system         1        1970-01-01 00:00:00 +0000 +0000  0E-10             InterleavedFormatVersion  PUBLIC  NULL              NULL                      NULL       DISABLED
+table_id  parent_id  name       database_name  version  mod_time                         mod_time_logical  format_version            state   sc_lease_node_id  sc_lease_expiration_time  drop_time  audit_mode  schema_name
+2         1          namespace  system         1        1970-01-01 00:00:00 +0000 +0000  0E-10             InterleavedFormatVersion  PUBLIC  NULL              NULL                      NULL       DISABLED    public
 
 # Verify that table names are not double escaped.
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -57,6 +57,7 @@ test           crdb_internal       node_runtime_info                  public   S
 test           crdb_internal       node_sessions                      public   SELECT
 test           crdb_internal       node_statement_statistics          public   SELECT
 test           crdb_internal       partitions                         public   SELECT
+test           crdb_internal       predefined_comments                public   SELECT
 test           crdb_internal       ranges                             public   SELECT
 test           crdb_internal       ranges_no_leases                   public   SELECT
 test           crdb_internal       schema_changes                     public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -235,6 +235,7 @@ crdb_internal       node_runtime_info
 crdb_internal       node_sessions
 crdb_internal       node_statement_statistics
 crdb_internal       partitions
+crdb_internal       predefined_comments
 crdb_internal       ranges
 crdb_internal       ranges_no_leases
 crdb_internal       schema_changes
@@ -361,6 +362,7 @@ node_runtime_info
 node_sessions
 node_statement_statistics
 partitions
+predefined_comments
 ranges
 ranges_no_leases
 schema_changes
@@ -494,6 +496,7 @@ system         crdb_internal       node_runtime_info                  SYSTEM VIE
 system         crdb_internal       node_sessions                      SYSTEM VIEW  NO                  1
 system         crdb_internal       node_statement_statistics          SYSTEM VIEW  NO                  1
 system         crdb_internal       partitions                         SYSTEM VIEW  NO                  1
+system         crdb_internal       predefined_comments                SYSTEM VIEW  NO                  1
 system         crdb_internal       ranges                             SYSTEM VIEW  NO                  1
 system         crdb_internal       ranges_no_leases                   SYSTEM VIEW  NO                  1
 system         crdb_internal       schema_changes                     SYSTEM VIEW  NO                  1
@@ -593,8 +596,9 @@ user testuser
 query TTTTTI colnames
 SELECT * FROM other_db.information_schema.tables WHERE table_catalog = 'other_db' AND table_schema = 'public'
 ----
-table_catalog  table_schema  table_name  table_type  is_insertable_into version
-other_db       public        xyz         BASE TABLE  YES                6
+table_catalog  table_schema  table_name  table_type  is_insertable_into  version
+other_db       public        xyz         BASE TABLE  YES                 6
+
 
 user root
 
@@ -607,9 +611,9 @@ user testuser
 query TTTTTI colnames
 SELECT * FROM other_db.information_schema.tables WHERE table_catalog = 'other_db' AND table_schema = 'public' ORDER BY 1, 3
 ----
-table_catalog  table_schema  table_name  table_type  is_insertable_into version
-other_db       public        abc         VIEW        NO                 2
-other_db       public        xyz         BASE TABLE  YES                6
+table_catalog  table_schema  table_name  table_type  is_insertable_into  version
+other_db       public        abc         VIEW        NO                  2
+other_db       public        xyz         BASE TABLE  YES                 6
 
 user root
 
@@ -1072,6 +1076,7 @@ NULL     public   system         crdb_internal       node_runtime_info          
 NULL     public   system         crdb_internal       node_sessions                      SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_statement_statistics          SELECT          NULL          YES
 NULL     public   system         crdb_internal       partitions                         SELECT          NULL          YES
+NULL     public   system         crdb_internal       predefined_comments                SELECT          NULL          YES
 NULL     public   system         crdb_internal       ranges                             SELECT          NULL          YES
 NULL     public   system         crdb_internal       ranges_no_leases                   SELECT          NULL          YES
 NULL     public   system         crdb_internal       schema_changes                     SELECT          NULL          YES
@@ -1311,6 +1316,7 @@ NULL     public   system         crdb_internal       node_runtime_info          
 NULL     public   system         crdb_internal       node_sessions                      SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_statement_statistics          SELECT          NULL          YES
 NULL     public   system         crdb_internal       partitions                         SELECT          NULL          YES
+NULL     public   system         crdb_internal       predefined_comments                SELECT          NULL          YES
 NULL     public   system         crdb_internal       ranges                             SELECT          NULL          YES
 NULL     public   system         crdb_internal       ranges_no_leases                   SELECT          NULL          YES
 NULL     public   system         crdb_internal       schema_changes                     SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -771,8 +771,8 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-4294967233  178791267   0         4294967235  450499961  0            n
-4294967233  3318155331  0         4294967235  450499960  0            n
+4294967232  178791267   0         4294967234  450499961  0            n
+4294967232  3318155331  0         4294967234  450499960  0            n
 
 # All entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table.
@@ -784,7 +784,7 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-4294967233  4294967235  pg_constraint  pg_class
+4294967232  4294967234  pg_constraint  pg_class
 
 # All entries in pg_depend are foreign key constraints that reference an index
 # in pg_class.
@@ -1257,9 +1257,101 @@ testuser  2264919399  false        false     false    false         ********  NU
 ## pg_catalog.pg_description
 
 query OOIT colnames
-SELECT objoid, classoid, objsubid, description FROM pg_catalog.pg_description
+SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS description
+  FROM pg_catalog.pg_description
 ----
-objoid  classoid  objsubid  description
+objoid      classoid  objsubid  description
+4294967294  0         0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967292  0         0         built-in functions (RAM/static)
+4294967291  0         0         running queries visible by current user (cluster RPC; expensive!)
+4294967290  0         0         running sessions visible to current user (cluster RPC; expensive!)
+4294967289  0         0         cluster settings (RAM)
+4294967288  0         0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
+4294967287  0         0         telemetry counters (RAM; local node only)
+4294967286  0         0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967284  0         0         locally known gossiped health alerts (RAM; local node only)
+4294967283  0         0         locally known gossiped node liveness (RAM; local node only)
+4294967282  0         0         locally known edges in the gossip network (RAM; local node only)
+4294967285  0         0         locally known gossiped node details (RAM; local node only)
+4294967281  0         0         index columns for all indexes accessible by current user in current database (KV scan)
+4294967280  0         0         decoded job metadata from system.jobs (KV scan)
+4294967279  0         0         node details across the entire cluster (cluster RPC; expensive!)
+4294967278  0         0         store details and status (cluster RPC; expensive!)
+4294967277  0         0         acquired table leases (RAM; local node only)
+4294967293  0         0         detailed identification strings (RAM, local node only)
+4294967274  0         0         current values for metrics (RAM; local node only)
+4294967276  0         0         running queries visible by current user (RAM; local node only)
+4294967269  0         0         server parameters, useful to construct connection URLs (RAM, local node only)
+4294967275  0         0         running sessions visible by current user (RAM; local node only)
+4294967265  0         0         statement statistics (RAM; local node only)
+4294967273  0         0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
+4294967272  0         0         comments for predefined virtual tables (RAM/static)
+4294967271  0         0         range metadata without leaseholder details (KV join; expensive!)
+4294967268  0         0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
+4294967267  0         0         session trace accumulated so far (RAM)
+4294967266  0         0         session variables (RAM)
+4294967264  0         0         details for all columns accessible by current user in current database (KV scan)
+4294967263  0         0         indexes accessible by current user in current database (KV scan)
+4294967262  0         0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
+4294967261  0         0         decoded zone configurations from system.zones (KV scan)
+4294967259  0         0         roles for which the current user has admin option
+4294967258  0         0         roles available to the current user
+4294967257  0         0         column privilege grants (incomplete)
+4294967256  0         0         table and view columns (incomplete)
+4294967255  0         0         columns usage by constraints
+4294967254  0         0         roles for the current user
+4294967253  0         0         column usage by indexes and key constraints
+4294967252  0         0         built-in function parameters (empty - introspection not yet supported)
+4294967251  0         0         foreign key constraints
+4294967250  0         0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+4294967249  0         0         built-in functions (empty - introspection not yet supported)
+4294967247  0         0         schema privileges (incomplete; may contain excess users or roles)
+4294967248  0         0         database schemas (may contain schemata without permission)
+4294967246  0         0         sequences
+4294967245  0         0         index metadata and statistics (incomplete)
+4294967244  0         0         table constraints
+4294967243  0         0         privileges granted on table or views (incomplete; may contain excess users or roles)
+4294967242  0         0         tables and views
+4294967240  0         0         grantable privileges (incomplete)
+4294967241  0         0         views (incomplete)
+4294967238  0         0         index access methods (incomplete)
+4294967237  0         0         column default values
+4294967236  0         0         table columns (incomplete - see also information_schema.columns)
+4294967235  0         0         role membership
+4294967234  0         0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
+4294967233  0         0         available collations (incomplete)
+4294967232  0         0         table constraints (incomplete - see also information_schema.table_constraints)
+4294967231  0         0         available databases (incomplete)
+4294967230  0         0         dependency relationships (incomplete)
+4294967229  0         0         object comments
+4294967227  0         0         enum types and labels (empty - feature does not exist)
+4294967226  0         0         installed extensions (empty - feature does not exist)
+4294967225  0         0         foreign data wrappers (empty - feature does not exist)
+4294967224  0         0         foreign servers (empty - feature does not exist)
+4294967223  0         0         foreign tables (empty  - feature does not exist)
+4294967222  0         0         indexes (incomplete)
+4294967221  0         0         index creation statements
+4294967220  0         0         table inheritance hierarchy (empty - feature does not exist)
+4294967219  0         0         available languages (empty - feature does not exist)
+4294967218  0         0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967217  0         0         operators (incomplete)
+4294967216  0         0         built-in functions (incomplete)
+4294967215  0         0         range types (empty - feature does not exist)
+4294967214  0         0         rewrite rules (empty - feature does not exist)
+4294967213  0         0         database roles
+4294967202  0         0         security labels (empty - feature does not exist)
+4294967212  0         0         sequences (see also information_schema.sequences)
+4294967211  0         0         session variables (incomplete)
+4294967228  0         0         shared object comments (empty - feature does not exist)
+4294967201  0         0         shared security labels (empty - feature not supported)
+4294967203  0         0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967208  0         0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967207  0         0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967206  0         0         triggers (empty - feature does not exist)
+4294967205  0         0         scalar types (incomplete)
+4294967210  0         0         database users
+4294967209  0         0         local to remote user mapping (empty - feature does not exist)
+4294967204  0         0         view definitions (incomplete - see also information_schema.views)
 
 ## pg_catalog.pg_shdescription
 
@@ -1839,4 +1931,3 @@ SELECT  pg_catalog.set_config('woo', 'woo', false)
 
 query error configuration setting.*not supported
 SELECT  pg_catalog.set_config('vacuum_cost_delay', '0', false)
-

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -61,7 +61,7 @@ pg_constraint  pg_constraint
 query OO
 SELECT 'pg_constraint '::REGCLASS, '"pg_constraint"'::REGCLASS::OID
 ----
-pg_constraint  4294967233
+pg_constraint  4294967232
 
 query O
 SELECT 4061301040::REGCLASS
@@ -73,7 +73,7 @@ SELECT oid, oid::regclass, oid::regclass::int, oid::regclass::int::regclass, oid
 FROM pg_class
 WHERE relname = 'pg_constraint'
 ----
-4294967233  pg_constraint  4294967233  pg_constraint  pg_constraint
+4294967232  pg_constraint  4294967232  pg_constraint  pg_constraint
 
 query OOOO
 SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE, 'pg_catalog.upper'::REGPROCEDURE, 'upper'::REGPROC::OID
@@ -160,7 +160,7 @@ pg_constraint
 query OO
 SELECT ('pg_constraint')::REGCLASS, ('pg_constraint')::REGCLASS::OID
 ----
-pg_constraint  4294967233
+pg_constraint  4294967232
 
 ## Test visibility of pg_* via oid casts.
 

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -175,21 +175,21 @@ query TT colnames
 SELECT * FROM [SHOW TABLES FROM system WITH COMMENT]
 ----
 table_name        comment
-comments          NULL
-descriptor        NULL
-eventlog          NULL
-jobs              NULL
-lease             NULL
-locations         NULL
-namespace         NULL
-rangelog          NULL
-role_members      NULL
-settings          NULL
-table_statistics  NULL
-ui                NULL
-users             NULL
-web_sessions      NULL
-zones             NULL
+namespace         ·
+descriptor        ·
+users             ·
+zones             ·
+settings          ·
+lease             ·
+eventlog          ·
+rangelog          ·
+ui                ·
+jobs              ·
+web_sessions      ·
+table_statistics  ·
+locations         ·
+role_members      ·
+comments          ·
 
 query ITTT colnames
 SELECT node_id, user_name, application_name, active_queries

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -120,12 +120,12 @@ c            INT8       false        NULL            ·                      {pr
 query TT
 SHOW TABLES FROM test WITH COMMENT
 ----
-a a_comment
-b NULL
-c NULL
-d NULL
-e NULL
-f NULL
+a  a_comment
+b  ·
+c  ·
+d  ·
+e  ·
+f  ·
 
 statement ok
 SET DATABASE = ""

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -167,24 +167,22 @@ sort                   ·       ·
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE field != 'size'
 ----
-sort                                  ·         ·
- │                                    order     +table_schema,+table_name
- └── render                           ·         ·
-      └── join                        ·         ·
-           │                          type      left outer
-           │                          equality  (table_id) = (object_id)
-           ├── filter                 ·         ·
-           │    │                     filter    ((state = 'PUBLIC') OR (state IS NULL)) AND ((database_name = 'test') OR (database_name IS NULL))
-           │    └── join              ·         ·
-           │         │                type      left outer
-           │         │                equality  (table_name, table_catalog) = (name, database_name)
-           │         ├── filter       ·         ·
-           │         │    │           filter    table_schema = 'public'
-           │         │    └── values  ·         ·
-           │         └── values       ·         ·
-           └── scan                   ·         ·
-·                                     table     comments@primary
-·                                     spans     ALL
+render                      ·         ·
+ └── join                   ·         ·
+      │                     type      left outer
+      │                     equality  (oid) = (objoid)
+      ├── join              ·         ·
+      │    │                type      inner
+      │    │                equality  (relnamespace) = (oid)
+      │    ├── filter       ·         ·
+      │    │    │           filter    relkind IN ('r', 'v')
+      │    │    └── values  ·         ·
+      │    └── filter       ·         ·
+      │         │           filter    nspname = 'public'
+      │         └── values  ·         ·
+      └── filter            ·         ·
+           │                filter    objsubid = 0
+           └── values       ·         ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW DATABASE] WHERE field != 'size'

--- a/pkg/sql/logictest/testdata/planner_test/join
+++ b/pkg/sql/logictest/testdata/planner_test/join
@@ -388,7 +388,7 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 10  ·            type       inner
 10  ·            equality   (refobjid) = (oid)
 11  filter       ·          ·
-11  ·            filter     (dep.classid = 4294967233) AND (dep.refclassid = 4294967235)
+11  ·            filter     (dep.classid = 4294967232) AND (dep.refclassid = 4294967234)
 11  filter       ·          ·
 11  ·            filter     pkic.relkind = 'i'
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -157,24 +157,22 @@ sort                   ·       ·
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE field != 'size'
 ----
-sort                                  ·         ·
- │                                    order     +table_schema,+table_name
- └── render                           ·         ·
-      └── join                        ·         ·
-           │                          type      left outer
-           │                          equality  (table_id) = (object_id)
-           ├── filter                 ·         ·
-           │    │                     filter    ((state = 'PUBLIC') OR (state IS NULL)) AND ((database_name = 'test') OR (database_name IS NULL))
-           │    └── join              ·         ·
-           │         │                type      left outer
-           │         │                equality  (table_name, table_catalog) = (name, database_name)
-           │         ├── filter       ·         ·
-           │         │    │           filter    table_schema = 'public'
-           │         │    └── values  ·         ·
-           │         └── values       ·         ·
-           └── scan                   ·         ·
-·                                     table     comments@primary
-·                                     spans     ALL
+render                      ·         ·
+ └── join                   ·         ·
+      │                     type      left outer
+      │                     equality  (oid) = (objoid)
+      ├── join              ·         ·
+      │    │                type      inner
+      │    │                equality  (relnamespace) = (oid)
+      │    ├── filter       ·         ·
+      │    │    │           filter    relkind IN ('r', 'v')
+      │    │    └── values  ·         ·
+      │    └── filter       ·         ·
+      │         │           filter    nspname = 'public'
+      │         └── values  ·         ·
+      └── filter            ·         ·
+           │                filter    objsubid = 0
+           └── values       ·         ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW DATABASE] WHERE field != 'size'

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -376,7 +376,7 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 10  ·              type       inner
 10  ·              equality   (refobjid) = (oid)
 11  filter         ·          ·
-11  ·              filter     (classid = 4294967233) AND (refclassid = 4294967235)
+11  ·              filter     (classid = 4294967232) AND (refclassid = 4294967234)
 12  virtual table  ·          ·
 12  ·              source     ·
 11  filter         ·          ·

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1986,7 +1986,8 @@ comment_stmt:
 comment_text:
   SCONST
   {
-    $$.val = &$1
+    t := $1
+    $$.val = &t
   }
 | NULL
   {

--- a/pkg/sql/sqlbase/constants.go
+++ b/pkg/sql/sqlbase/constants.go
@@ -57,6 +57,7 @@ const (
 	CrdbInternalLocalSessionsTableID
 	CrdbInternalLocalMetricsTableID
 	CrdbInternalPartitionsTableID
+	CrdbInternalPredefinedCommentsTableID
 	CrdbInternalRangesNoLeasesTableID
 	CrdbInternalRangesViewID
 	CrdbInternalRuntimeInfoTableID

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -273,7 +273,7 @@ func (r *Refresher) ensureAllTables(
 
 	// Use a historical read so as to disable txn contention resolution.
 	getAllTablesQuery := fmt.Sprintf(
-		`SELECT table_id FROM crdb_internal.tables AS OF SYSTEM TIME '-%s'`,
+		`SELECT table_id FROM crdb_internal.tables AS OF SYSTEM TIME '-%s' WHERE schema_name = 'public'`,
 		initialTableCollectionDelay)
 
 	rows, err := r.ex.Query(


### PR DESCRIPTION
Fixes #32964
Fixes #35581

Release note (sql change): CockroachDB now provides usable comments
with optional documentation URLs for the virtual tables in
`pg_catalog`, `information_schema` and `crdb_internal`. Use `SHOW
TABLES [FROM ...] WITH COMMENT` to read. Note that `crdb_internal`
tables remain an experimental feature subject to change without
notice.