### PR TITLE
opt: move opttester to separate package

### DIFF
--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -22,14 +22,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
-	opttestutils "github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/opttester"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	testutils "github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datadriven"
 )
 
@@ -246,7 +246,7 @@ func runDataDrivenTest(t *testing.T, path string, fmtFlags memo.ExprFmtFlags) {
 	datadriven.Walk(t, path, func(t *testing.T, path string) {
 		catalog := testcat.New()
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
-			tester := opttestutils.NewOptTester(catalog, d.Input)
+			tester := opttester.New(catalog, d.Input)
 			tester.Flags.ExprFormat = fmtFlags
 			return tester.RunCommand(t, d)
 		})

--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/opttester"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datadriven"
@@ -46,7 +46,7 @@ func TestNormRules(t *testing.T) {
 	datadriven.Walk(t, "testdata/rules", func(t *testing.T, path string) {
 		catalog := testcat.New()
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
-			tester := testutils.NewOptTester(catalog, d.Input)
+			tester := opttester.New(catalog, d.Input)
 			tester.Flags.ExprFormat = fmtFlags
 			return tester.RunCommand(t, d)
 		})

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/opttester"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
@@ -64,7 +65,7 @@ func TestBuilder(t *testing.T) {
 			var iVarHelper tree.IndexedVarHelper
 			var err error
 
-			tester := testutils.NewOptTester(catalog, d.Input)
+			tester := opttester.New(catalog, d.Input)
 			tester.Flags.ExprFormat = memo.ExprFmtHideMiscProps |
 				memo.ExprFmtHideConstraints |
 				memo.ExprFmtHideFuncDeps |

--- a/pkg/sql/opt/testutils/opttester/explore_trace.go
+++ b/pkg/sql/opt/testutils/opttester/explore_trace.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package testutils
+package opttester
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"

--- a/pkg/sql/opt/testutils/opttester/forcing_opt.go
+++ b/pkg/sql/opt/testutils/opttester/forcing_opt.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package testutils
+package opttester
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"

--- a/pkg/sql/opt/testutils/opttester/opt_steps.go
+++ b/pkg/sql/opt/testutils/opttester/opt_steps.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package testutils
+package opttester
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package testutils
+package opttester
 
 import (
 	"bytes"
@@ -56,7 +56,7 @@ type RuleSet = util.FastIntSet
 //
 // The OptTester is used by tests in various sub-packages of the opt package.
 type OptTester struct {
-	Flags OptTesterFlags
+	Flags Flags
 
 	catalog   cat.Catalog
 	sql       string
@@ -68,9 +68,9 @@ type OptTester struct {
 	builder strings.Builder
 }
 
-// OptTesterFlags are control knobs for tests. Note that specific testcases can
+// Flags are control knobs for tests. Note that specific testcases can
 // override these defaults.
-type OptTesterFlags struct {
+type Flags struct {
 	// ExprFormat controls the output detail of build / opt/ optsteps command
 	// directives.
 	ExprFormat memo.ExprFmtFlags
@@ -123,9 +123,9 @@ type OptTesterFlags struct {
 	JoinLimit int
 }
 
-// NewOptTester constructs a new instance of the OptTester for the given SQL
-// statement. Metadata used by the SQL query is accessed via the catalog.
-func NewOptTester(catalog cat.Catalog, sql string) *OptTester {
+// New constructs a new instance of the OptTester for the given SQL statement.
+// Metadata used by the SQL query is accessed via the catalog.
+func New(catalog cat.Catalog, sql string) *OptTester {
 	ot := &OptTester{
 		catalog: catalog,
 		sql:     sql,
@@ -382,7 +382,7 @@ func ruleNamesToRuleSet(args []string) (RuleSet, error) {
 
 // Set parses an argument that refers to a flag.
 // See OptTester.RunCommand for supported flags.
-func (f *OptTesterFlags) Set(arg datadriven.CmdArg) error {
+func (f *Flags) Set(arg datadriven.CmdArg) error {
 	switch arg.Key {
 	case "format":
 		f.ExprFormat = 0

--- a/pkg/sql/opt/testutils/opttester/path_cache.go
+++ b/pkg/sql/opt/testutils/opttester/path_cache.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package testutils
+package opttester
 
 import (
 	"bytes"

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/opttester"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -145,7 +145,7 @@ func TestRuleProps(t *testing.T) {
 	datadriven.Walk(t, "testdata/ruleprops", func(t *testing.T, path string) {
 		catalog := testcat.New()
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
-			tester := testutils.NewOptTester(catalog, d.Input)
+			tester := opttester.New(catalog, d.Input)
 			tester.Flags.ExprFormat = memo.ExprFmtHideStats | memo.ExprFmtHideCost |
 				memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars
 			return tester.RunCommand(t, d)
@@ -203,7 +203,7 @@ func runDataDrivenTest(t *testing.T, path string, fmtFlags memo.ExprFmtFlags) {
 	datadriven.Walk(t, path, func(t *testing.T, path string) {
 		catalog := testcat.New()
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
-			tester := testutils.NewOptTester(catalog, d.Input)
+			tester := opttester.New(catalog, d.Input)
 			tester.Flags.ExprFormat = fmtFlags
 			return tester.RunCommand(t, d)
 		})


### PR DESCRIPTION
Moving OptTester to an `opttester` sub-package. This allows code that
opttester depends on to use the remaining test utils.

Release note: None