### PR TITLE
storage: don't consult TxnSpanGCThreshold when creating txn records

### DIFF
--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -69,7 +69,7 @@ func (x ReadConsistencyType) String() string {
 	return proto.EnumName(ReadConsistencyType_name, int32(x))
 }
 func (ReadConsistencyType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{0}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{0}
 }
 
 // ScanFormat is an enumeration of the available response formats for MVCCScan
@@ -97,7 +97,7 @@ func (x ScanFormat) String() string {
 	return proto.EnumName(ScanFormat_name, int32(x))
 }
 func (ScanFormat) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{1}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{1}
 }
 
 // PushTxnType determines what action to take when pushing a transaction.
@@ -128,7 +128,7 @@ func (x PushTxnType) String() string {
 	return proto.EnumName(PushTxnType_name, int32(x))
 }
 func (PushTxnType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{2}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{2}
 }
 
 type ExportStorageProvider int32
@@ -166,7 +166,7 @@ func (x ExportStorageProvider) String() string {
 	return proto.EnumName(ExportStorageProvider_name, int32(x))
 }
 func (ExportStorageProvider) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{3}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{3}
 }
 
 type MVCCFilter int32
@@ -189,7 +189,7 @@ func (x MVCCFilter) String() string {
 	return proto.EnumName(MVCCFilter_name, int32(x))
 }
 func (MVCCFilter) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{4}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{4}
 }
 
 type ResponseHeader_ResumeReason int32
@@ -221,7 +221,7 @@ func (x ResponseHeader_ResumeReason) String() string {
 	return proto.EnumName(ResponseHeader_ResumeReason_name, int32(x))
 }
 func (ResponseHeader_ResumeReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{2, 0}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{2, 0}
 }
 
 type QueryIntentRequest_IfMissingBehavior int32
@@ -257,7 +257,7 @@ func (x QueryIntentRequest_IfMissingBehavior) String() string {
 	return proto.EnumName(QueryIntentRequest_IfMissingBehavior_name, int32(x))
 }
 func (QueryIntentRequest_IfMissingBehavior) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{50, 0}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{50, 0}
 }
 
 // RangeInfo describes a range which executed a request. It contains
@@ -273,7 +273,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{0}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{0}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -318,7 +318,7 @@ func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
 func (m *RequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RequestHeader) ProtoMessage()    {}
 func (*RequestHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{1}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{1}
 }
 func (m *RequestHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -378,7 +378,7 @@ func (m *ResponseHeader) Reset()         { *m = ResponseHeader{} }
 func (m *ResponseHeader) String() string { return proto.CompactTextString(m) }
 func (*ResponseHeader) ProtoMessage()    {}
 func (*ResponseHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{2}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{2}
 }
 func (m *ResponseHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -414,7 +414,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{3}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{3}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -454,7 +454,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{4}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{4}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -499,7 +499,7 @@ func (m *PutRequest) Reset()         { *m = PutRequest{} }
 func (m *PutRequest) String() string { return proto.CompactTextString(m) }
 func (*PutRequest) ProtoMessage()    {}
 func (*PutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{5}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{5}
 }
 func (m *PutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -535,7 +535,7 @@ func (m *PutResponse) Reset()         { *m = PutResponse{} }
 func (m *PutResponse) String() string { return proto.CompactTextString(m) }
 func (*PutResponse) ProtoMessage()    {}
 func (*PutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{6}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{6}
 }
 func (m *PutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -586,7 +586,7 @@ func (m *ConditionalPutRequest) Reset()         { *m = ConditionalPutRequest{} }
 func (m *ConditionalPutRequest) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutRequest) ProtoMessage()    {}
 func (*ConditionalPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{7}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{7}
 }
 func (m *ConditionalPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -623,7 +623,7 @@ func (m *ConditionalPutResponse) Reset()         { *m = ConditionalPutResponse{}
 func (m *ConditionalPutResponse) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutResponse) ProtoMessage()    {}
 func (*ConditionalPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{8}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{8}
 }
 func (m *ConditionalPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -671,7 +671,7 @@ func (m *InitPutRequest) Reset()         { *m = InitPutRequest{} }
 func (m *InitPutRequest) String() string { return proto.CompactTextString(m) }
 func (*InitPutRequest) ProtoMessage()    {}
 func (*InitPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{9}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{9}
 }
 func (m *InitPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -707,7 +707,7 @@ func (m *InitPutResponse) Reset()         { *m = InitPutResponse{} }
 func (m *InitPutResponse) String() string { return proto.CompactTextString(m) }
 func (*InitPutResponse) ProtoMessage()    {}
 func (*InitPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{10}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{10}
 }
 func (m *InitPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -749,7 +749,7 @@ func (m *IncrementRequest) Reset()         { *m = IncrementRequest{} }
 func (m *IncrementRequest) String() string { return proto.CompactTextString(m) }
 func (*IncrementRequest) ProtoMessage()    {}
 func (*IncrementRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{11}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{11}
 }
 func (m *IncrementRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -788,7 +788,7 @@ func (m *IncrementResponse) Reset()         { *m = IncrementResponse{} }
 func (m *IncrementResponse) String() string { return proto.CompactTextString(m) }
 func (*IncrementResponse) ProtoMessage()    {}
 func (*IncrementResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{12}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{12}
 }
 func (m *IncrementResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -824,7 +824,7 @@ func (m *DeleteRequest) Reset()         { *m = DeleteRequest{} }
 func (m *DeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRequest) ProtoMessage()    {}
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{13}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{13}
 }
 func (m *DeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -860,7 +860,7 @@ func (m *DeleteResponse) Reset()         { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()    {}
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{14}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{14}
 }
 func (m *DeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -911,7 +911,7 @@ func (m *DeleteRangeRequest) Reset()         { *m = DeleteRangeRequest{} }
 func (m *DeleteRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeRequest) ProtoMessage()    {}
 func (*DeleteRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{15}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{15}
 }
 func (m *DeleteRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -950,7 +950,7 @@ func (m *DeleteRangeResponse) Reset()         { *m = DeleteRangeResponse{} }
 func (m *DeleteRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeResponse) ProtoMessage()    {}
 func (*DeleteRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{16}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{16}
 }
 func (m *DeleteRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -999,7 +999,7 @@ func (m *ClearRangeRequest) Reset()         { *m = ClearRangeRequest{} }
 func (m *ClearRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeRequest) ProtoMessage()    {}
 func (*ClearRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{17}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{17}
 }
 func (m *ClearRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1035,7 +1035,7 @@ func (m *ClearRangeResponse) Reset()         { *m = ClearRangeResponse{} }
 func (m *ClearRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeResponse) ProtoMessage()    {}
 func (*ClearRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{18}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{18}
 }
 func (m *ClearRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1106,7 +1106,7 @@ func (m *ScanOptions) Reset()         { *m = ScanOptions{} }
 func (m *ScanOptions) String() string { return proto.CompactTextString(m) }
 func (*ScanOptions) ProtoMessage()    {}
 func (*ScanOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{19}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{19}
 }
 func (m *ScanOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1148,7 +1148,7 @@ func (m *ScanRequest) Reset()         { *m = ScanRequest{} }
 func (m *ScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ScanRequest) ProtoMessage()    {}
 func (*ScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{20}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{20}
 }
 func (m *ScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1197,7 +1197,7 @@ func (m *ScanResponse) Reset()         { *m = ScanResponse{} }
 func (m *ScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ScanResponse) ProtoMessage()    {}
 func (*ScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{21}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{21}
 }
 func (m *ScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1239,7 +1239,7 @@ func (m *ReverseScanRequest) Reset()         { *m = ReverseScanRequest{} }
 func (m *ReverseScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanRequest) ProtoMessage()    {}
 func (*ReverseScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{22}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{22}
 }
 func (m *ReverseScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1288,7 +1288,7 @@ func (m *ReverseScanResponse) Reset()         { *m = ReverseScanResponse{} }
 func (m *ReverseScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanResponse) ProtoMessage()    {}
 func (*ReverseScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{23}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{23}
 }
 func (m *ReverseScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1329,7 +1329,7 @@ func (m *CheckConsistencyRequest) Reset()         { *m = CheckConsistencyRequest
 func (m *CheckConsistencyRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyRequest) ProtoMessage()    {}
 func (*CheckConsistencyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{24}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{24}
 }
 func (m *CheckConsistencyRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1366,7 +1366,7 @@ func (m *CheckConsistencyResponse) Reset()         { *m = CheckConsistencyRespon
 func (m *CheckConsistencyResponse) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse) ProtoMessage()    {}
 func (*CheckConsistencyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{25}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{25}
 }
 func (m *CheckConsistencyResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1416,7 +1416,7 @@ func (m *RecomputeStatsRequest) Reset()         { *m = RecomputeStatsRequest{} }
 func (m *RecomputeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsRequest) ProtoMessage()    {}
 func (*RecomputeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{26}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{26}
 }
 func (m *RecomputeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1454,7 +1454,7 @@ func (m *RecomputeStatsResponse) Reset()         { *m = RecomputeStatsResponse{}
 func (m *RecomputeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsResponse) ProtoMessage()    {}
 func (*RecomputeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{27}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{27}
 }
 func (m *RecomputeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1490,7 +1490,7 @@ func (m *BeginTransactionRequest) Reset()         { *m = BeginTransactionRequest
 func (m *BeginTransactionRequest) String() string { return proto.CompactTextString(m) }
 func (*BeginTransactionRequest) ProtoMessage()    {}
 func (*BeginTransactionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{28}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{28}
 }
 func (m *BeginTransactionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1526,7 +1526,7 @@ func (m *BeginTransactionResponse) Reset()         { *m = BeginTransactionRespon
 func (m *BeginTransactionResponse) String() string { return proto.CompactTextString(m) }
 func (*BeginTransactionResponse) ProtoMessage()    {}
 func (*BeginTransactionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{29}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{29}
 }
 func (m *BeginTransactionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1600,7 +1600,7 @@ func (m *EndTransactionRequest) Reset()         { *m = EndTransactionRequest{} }
 func (m *EndTransactionRequest) String() string { return proto.CompactTextString(m) }
 func (*EndTransactionRequest) ProtoMessage()    {}
 func (*EndTransactionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{30}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{30}
 }
 func (m *EndTransactionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1646,7 +1646,7 @@ func (m *EndTransactionResponse) Reset()         { *m = EndTransactionResponse{}
 func (m *EndTransactionResponse) String() string { return proto.CompactTextString(m) }
 func (*EndTransactionResponse) ProtoMessage()    {}
 func (*EndTransactionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{31}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{31}
 }
 func (m *EndTransactionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1702,7 +1702,7 @@ func (m *AdminSplitRequest) Reset()         { *m = AdminSplitRequest{} }
 func (m *AdminSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitRequest) ProtoMessage()    {}
 func (*AdminSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{32}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{32}
 }
 func (m *AdminSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1739,7 +1739,7 @@ func (m *AdminSplitResponse) Reset()         { *m = AdminSplitResponse{} }
 func (m *AdminSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitResponse) ProtoMessage()    {}
 func (*AdminSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{33}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{33}
 }
 func (m *AdminSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1783,7 +1783,7 @@ func (m *AdminMergeRequest) Reset()         { *m = AdminMergeRequest{} }
 func (m *AdminMergeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeRequest) ProtoMessage()    {}
 func (*AdminMergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{34}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{34}
 }
 func (m *AdminMergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1820,7 +1820,7 @@ func (m *AdminMergeResponse) Reset()         { *m = AdminMergeResponse{} }
 func (m *AdminMergeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeResponse) ProtoMessage()    {}
 func (*AdminMergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{35}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{35}
 }
 func (m *AdminMergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1860,7 +1860,7 @@ func (m *AdminTransferLeaseRequest) Reset()         { *m = AdminTransferLeaseReq
 func (m *AdminTransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseRequest) ProtoMessage()    {}
 func (*AdminTransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{36}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{36}
 }
 func (m *AdminTransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1895,7 +1895,7 @@ func (m *AdminTransferLeaseResponse) Reset()         { *m = AdminTransferLeaseRe
 func (m *AdminTransferLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseResponse) ProtoMessage()    {}
 func (*AdminTransferLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{37}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{37}
 }
 func (m *AdminTransferLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1935,7 +1935,7 @@ func (m *AdminChangeReplicasRequest) Reset()         { *m = AdminChangeReplicasR
 func (m *AdminChangeReplicasRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasRequest) ProtoMessage()    {}
 func (*AdminChangeReplicasRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{38}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{38}
 }
 func (m *AdminChangeReplicasRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1970,7 +1970,7 @@ func (m *AdminChangeReplicasResponse) Reset()         { *m = AdminChangeReplicas
 func (m *AdminChangeReplicasResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasResponse) ProtoMessage()    {}
 func (*AdminChangeReplicasResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{39}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{39}
 }
 func (m *AdminChangeReplicasResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2009,7 +2009,7 @@ func (m *AdminRelocateRangeRequest) Reset()         { *m = AdminRelocateRangeReq
 func (m *AdminRelocateRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeRequest) ProtoMessage()    {}
 func (*AdminRelocateRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{40}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{40}
 }
 func (m *AdminRelocateRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2044,7 +2044,7 @@ func (m *AdminRelocateRangeResponse) Reset()         { *m = AdminRelocateRangeRe
 func (m *AdminRelocateRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeResponse) ProtoMessage()    {}
 func (*AdminRelocateRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{41}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{41}
 }
 func (m *AdminRelocateRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2085,7 +2085,7 @@ func (m *HeartbeatTxnRequest) Reset()         { *m = HeartbeatTxnRequest{} }
 func (m *HeartbeatTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnRequest) ProtoMessage()    {}
 func (*HeartbeatTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{42}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{42}
 }
 func (m *HeartbeatTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2124,7 +2124,7 @@ func (m *HeartbeatTxnResponse) Reset()         { *m = HeartbeatTxnResponse{} }
 func (m *HeartbeatTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnResponse) ProtoMessage()    {}
 func (*HeartbeatTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{43}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{43}
 }
 func (m *HeartbeatTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2158,6 +2158,8 @@ type GCRequest struct {
 	Threshold hlc.Timestamp `protobuf:"bytes,4,opt,name=threshold,proto3" json:"threshold"`
 	// TxnSpanGCThreshold is the timestamp below which inactive transactions were
 	// considered for GC (and thus might have been removed).
+	// TODO(nvanbenschoten): Remove this in 2.3, at which point we won't need to
+	// update it because no nodes in the cluster will ever consult it.
 	TxnSpanGCThreshold   hlc.Timestamp `protobuf:"bytes,5,opt,name=txn_span_gc_threshold,json=txnSpanGcThreshold,proto3" json:"txn_span_gc_threshold"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -2167,7 +2169,7 @@ func (m *GCRequest) Reset()         { *m = GCRequest{} }
 func (m *GCRequest) String() string { return proto.CompactTextString(m) }
 func (*GCRequest) ProtoMessage()    {}
 func (*GCRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{44}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{44}
 }
 func (m *GCRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2203,7 +2205,7 @@ func (m *GCRequest_GCKey) Reset()         { *m = GCRequest_GCKey{} }
 func (m *GCRequest_GCKey) String() string { return proto.CompactTextString(m) }
 func (*GCRequest_GCKey) ProtoMessage()    {}
 func (*GCRequest_GCKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{44, 0}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{44, 0}
 }
 func (m *GCRequest_GCKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2239,7 +2241,7 @@ func (m *GCResponse) Reset()         { *m = GCResponse{} }
 func (m *GCResponse) String() string { return proto.CompactTextString(m) }
 func (*GCResponse) ProtoMessage()    {}
 func (*GCResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{45}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{45}
 }
 func (m *GCResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2315,7 +2317,7 @@ func (m *PushTxnRequest) Reset()         { *m = PushTxnRequest{} }
 func (m *PushTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*PushTxnRequest) ProtoMessage()    {}
 func (*PushTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{46}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{46}
 }
 func (m *PushTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2360,7 +2362,7 @@ func (m *PushTxnResponse) Reset()         { *m = PushTxnResponse{} }
 func (m *PushTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*PushTxnResponse) ProtoMessage()    {}
 func (*PushTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{47}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{47}
 }
 func (m *PushTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2406,7 +2408,7 @@ func (m *QueryTxnRequest) Reset()         { *m = QueryTxnRequest{} }
 func (m *QueryTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnRequest) ProtoMessage()    {}
 func (*QueryTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{48}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{48}
 }
 func (m *QueryTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2447,7 +2449,7 @@ func (m *QueryTxnResponse) Reset()         { *m = QueryTxnResponse{} }
 func (m *QueryTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnResponse) ProtoMessage()    {}
 func (*QueryTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{49}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{49}
 }
 func (m *QueryTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2509,7 +2511,7 @@ func (m *QueryIntentRequest) Reset()         { *m = QueryIntentRequest{} }
 func (m *QueryIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentRequest) ProtoMessage()    {}
 func (*QueryIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{50}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{50}
 }
 func (m *QueryIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2547,7 +2549,7 @@ func (m *QueryIntentResponse) Reset()         { *m = QueryIntentResponse{} }
 func (m *QueryIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentResponse) ProtoMessage()    {}
 func (*QueryIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{51}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{51}
 }
 func (m *QueryIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2593,7 +2595,7 @@ func (m *ResolveIntentRequest) Reset()         { *m = ResolveIntentRequest{} }
 func (m *ResolveIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRequest) ProtoMessage()    {}
 func (*ResolveIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{52}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{52}
 }
 func (m *ResolveIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2630,7 +2632,7 @@ func (m *ResolveIntentResponse) Reset()         { *m = ResolveIntentResponse{} }
 func (m *ResolveIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentResponse) ProtoMessage()    {}
 func (*ResolveIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{53}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{53}
 }
 func (m *ResolveIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2680,7 +2682,7 @@ func (m *ResolveIntentRangeRequest) Reset()         { *m = ResolveIntentRangeReq
 func (m *ResolveIntentRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeRequest) ProtoMessage()    {}
 func (*ResolveIntentRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{54}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{54}
 }
 func (m *ResolveIntentRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2717,7 +2719,7 @@ func (m *ResolveIntentRangeResponse) Reset()         { *m = ResolveIntentRangeRe
 func (m *ResolveIntentRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeResponse) ProtoMessage()    {}
 func (*ResolveIntentRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{55}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{55}
 }
 func (m *ResolveIntentRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2756,7 +2758,7 @@ func (m *MergeRequest) Reset()         { *m = MergeRequest{} }
 func (m *MergeRequest) String() string { return proto.CompactTextString(m) }
 func (*MergeRequest) ProtoMessage()    {}
 func (*MergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{56}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{56}
 }
 func (m *MergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2792,7 +2794,7 @@ func (m *MergeResponse) Reset()         { *m = MergeResponse{} }
 func (m *MergeResponse) String() string { return proto.CompactTextString(m) }
 func (*MergeResponse) ProtoMessage()    {}
 func (*MergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{57}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{57}
 }
 func (m *MergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2839,7 +2841,7 @@ func (m *TruncateLogRequest) Reset()         { *m = TruncateLogRequest{} }
 func (m *TruncateLogRequest) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogRequest) ProtoMessage()    {}
 func (*TruncateLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{58}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{58}
 }
 func (m *TruncateLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2875,7 +2877,7 @@ func (m *TruncateLogResponse) Reset()         { *m = TruncateLogResponse{} }
 func (m *TruncateLogResponse) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogResponse) ProtoMessage()    {}
 func (*TruncateLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{59}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{59}
 }
 func (m *TruncateLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2921,7 +2923,7 @@ func (m *RequestLeaseRequest) Reset()         { *m = RequestLeaseRequest{} }
 func (m *RequestLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseRequest) ProtoMessage()    {}
 func (*RequestLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{60}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{60}
 }
 func (m *RequestLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2972,7 +2974,7 @@ func (m *TransferLeaseRequest) Reset()         { *m = TransferLeaseRequest{} }
 func (m *TransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*TransferLeaseRequest) ProtoMessage()    {}
 func (*TransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{61}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{61}
 }
 func (m *TransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3011,7 +3013,7 @@ func (m *LeaseInfoRequest) Reset()         { *m = LeaseInfoRequest{} }
 func (m *LeaseInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoRequest) ProtoMessage()    {}
 func (*LeaseInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{62}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{62}
 }
 func (m *LeaseInfoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3050,7 +3052,7 @@ func (m *LeaseInfoResponse) Reset()         { *m = LeaseInfoResponse{} }
 func (m *LeaseInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoResponse) ProtoMessage()    {}
 func (*LeaseInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{63}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{63}
 }
 func (m *LeaseInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3087,7 +3089,7 @@ func (m *RequestLeaseResponse) Reset()         { *m = RequestLeaseResponse{} }
 func (m *RequestLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseResponse) ProtoMessage()    {}
 func (*RequestLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{64}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{64}
 }
 func (m *RequestLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3132,7 +3134,7 @@ func (m *ComputeChecksumRequest) Reset()         { *m = ComputeChecksumRequest{}
 func (m *ComputeChecksumRequest) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumRequest) ProtoMessage()    {}
 func (*ComputeChecksumRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{65}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{65}
 }
 func (m *ComputeChecksumRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3171,7 +3173,7 @@ func (m *ComputeChecksumResponse) Reset()         { *m = ComputeChecksumResponse
 func (m *ComputeChecksumResponse) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumResponse) ProtoMessage()    {}
 func (*ComputeChecksumResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{66}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{66}
 }
 func (m *ComputeChecksumResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3212,7 +3214,7 @@ func (m *ExportStorage) Reset()         { *m = ExportStorage{} }
 func (m *ExportStorage) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage) ProtoMessage()    {}
 func (*ExportStorage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{67}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{67}
 }
 func (m *ExportStorage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3248,7 +3250,7 @@ func (m *ExportStorage_LocalFilePath) Reset()         { *m = ExportStorage_Local
 func (m *ExportStorage_LocalFilePath) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_LocalFilePath) ProtoMessage()    {}
 func (*ExportStorage_LocalFilePath) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{67, 0}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{67, 0}
 }
 func (m *ExportStorage_LocalFilePath) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3283,7 +3285,7 @@ func (m *ExportStorage_Http) Reset()         { *m = ExportStorage_Http{} }
 func (m *ExportStorage_Http) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_Http) ProtoMessage()    {}
 func (*ExportStorage_Http) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{67, 1}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{67, 1}
 }
 func (m *ExportStorage_Http) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3324,7 +3326,7 @@ func (m *ExportStorage_S3) Reset()         { *m = ExportStorage_S3{} }
 func (m *ExportStorage_S3) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_S3) ProtoMessage()    {}
 func (*ExportStorage_S3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{67, 2}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{67, 2}
 }
 func (m *ExportStorage_S3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3365,7 +3367,7 @@ func (m *ExportStorage_GCS) Reset()         { *m = ExportStorage_GCS{} }
 func (m *ExportStorage_GCS) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_GCS) ProtoMessage()    {}
 func (*ExportStorage_GCS) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{67, 3}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{67, 3}
 }
 func (m *ExportStorage_GCS) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3403,7 +3405,7 @@ func (m *ExportStorage_Azure) Reset()         { *m = ExportStorage_Azure{} }
 func (m *ExportStorage_Azure) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_Azure) ProtoMessage()    {}
 func (*ExportStorage_Azure) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{67, 4}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{67, 4}
 }
 func (m *ExportStorage_Azure) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3444,7 +3446,7 @@ func (m *ExportStorage_Workload) Reset()         { *m = ExportStorage_Workload{}
 func (m *ExportStorage_Workload) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_Workload) ProtoMessage()    {}
 func (*ExportStorage_Workload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{67, 5}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{67, 5}
 }
 func (m *ExportStorage_Workload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3486,7 +3488,7 @@ func (m *WriteBatchRequest) Reset()         { *m = WriteBatchRequest{} }
 func (m *WriteBatchRequest) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchRequest) ProtoMessage()    {}
 func (*WriteBatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{68}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{68}
 }
 func (m *WriteBatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3522,7 +3524,7 @@ func (m *WriteBatchResponse) Reset()         { *m = WriteBatchResponse{} }
 func (m *WriteBatchResponse) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchResponse) ProtoMessage()    {}
 func (*WriteBatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{69}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{69}
 }
 func (m *WriteBatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3569,7 +3571,7 @@ func (m *ExportRequest) Reset()         { *m = ExportRequest{} }
 func (m *ExportRequest) String() string { return proto.CompactTextString(m) }
 func (*ExportRequest) ProtoMessage()    {}
 func (*ExportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{70}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{70}
 }
 func (m *ExportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3607,7 +3609,7 @@ func (m *BulkOpSummary) Reset()         { *m = BulkOpSummary{} }
 func (m *BulkOpSummary) String() string { return proto.CompactTextString(m) }
 func (*BulkOpSummary) ProtoMessage()    {}
 func (*BulkOpSummary) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{71}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{71}
 }
 func (m *BulkOpSummary) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3645,7 +3647,7 @@ func (m *ExportResponse) Reset()         { *m = ExportResponse{} }
 func (m *ExportResponse) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse) ProtoMessage()    {}
 func (*ExportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{72}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{72}
 }
 func (m *ExportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3686,7 +3688,7 @@ func (m *ExportResponse_File) Reset()         { *m = ExportResponse_File{} }
 func (m *ExportResponse_File) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse_File) ProtoMessage()    {}
 func (*ExportResponse_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{72, 0}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{72, 0}
 }
 func (m *ExportResponse_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3738,7 +3740,7 @@ func (m *ImportRequest) Reset()         { *m = ImportRequest{} }
 func (m *ImportRequest) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest) ProtoMessage()    {}
 func (*ImportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{73}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{73}
 }
 func (m *ImportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3775,7 +3777,7 @@ func (m *ImportRequest_File) Reset()         { *m = ImportRequest_File{} }
 func (m *ImportRequest_File) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_File) ProtoMessage()    {}
 func (*ImportRequest_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{73, 0}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{73, 0}
 }
 func (m *ImportRequest_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3813,7 +3815,7 @@ func (m *ImportRequest_TableRekey) Reset()         { *m = ImportRequest_TableRek
 func (m *ImportRequest_TableRekey) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_TableRekey) ProtoMessage()    {}
 func (*ImportRequest_TableRekey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{73, 1}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{73, 1}
 }
 func (m *ImportRequest_TableRekey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3850,7 +3852,7 @@ func (m *ImportResponse) Reset()         { *m = ImportResponse{} }
 func (m *ImportResponse) String() string { return proto.CompactTextString(m) }
 func (*ImportResponse) ProtoMessage()    {}
 func (*ImportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{74}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{74}
 }
 func (m *ImportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3890,7 +3892,7 @@ func (m *AdminScatterRequest) Reset()         { *m = AdminScatterRequest{} }
 func (m *AdminScatterRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterRequest) ProtoMessage()    {}
 func (*AdminScatterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{75}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{75}
 }
 func (m *AdminScatterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3927,7 +3929,7 @@ func (m *AdminScatterResponse) Reset()         { *m = AdminScatterResponse{} }
 func (m *AdminScatterResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse) ProtoMessage()    {}
 func (*AdminScatterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{76}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{76}
 }
 func (m *AdminScatterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3962,7 +3964,7 @@ func (m *AdminScatterResponse_Range) Reset()         { *m = AdminScatterResponse
 func (m *AdminScatterResponse_Range) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse_Range) ProtoMessage()    {}
 func (*AdminScatterResponse_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{76, 0}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{76, 0}
 }
 func (m *AdminScatterResponse_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4000,7 +4002,7 @@ func (m *AddSSTableRequest) Reset()         { *m = AddSSTableRequest{} }
 func (m *AddSSTableRequest) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableRequest) ProtoMessage()    {}
 func (*AddSSTableRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{77}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{77}
 }
 func (m *AddSSTableRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4036,7 +4038,7 @@ func (m *AddSSTableResponse) Reset()         { *m = AddSSTableResponse{} }
 func (m *AddSSTableResponse) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableResponse) ProtoMessage()    {}
 func (*AddSSTableResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{78}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{78}
 }
 func (m *AddSSTableResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4082,7 +4084,7 @@ func (m *RefreshRequest) Reset()         { *m = RefreshRequest{} }
 func (m *RefreshRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRequest) ProtoMessage()    {}
 func (*RefreshRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{79}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{79}
 }
 func (m *RefreshRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4118,7 +4120,7 @@ func (m *RefreshResponse) Reset()         { *m = RefreshResponse{} }
 func (m *RefreshResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshResponse) ProtoMessage()    {}
 func (*RefreshResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{80}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{80}
 }
 func (m *RefreshResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4160,7 +4162,7 @@ func (m *RefreshRangeRequest) Reset()         { *m = RefreshRangeRequest{} }
 func (m *RefreshRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeRequest) ProtoMessage()    {}
 func (*RefreshRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{81}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{81}
 }
 func (m *RefreshRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4196,7 +4198,7 @@ func (m *RefreshRangeResponse) Reset()         { *m = RefreshRangeResponse{} }
 func (m *RefreshRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeResponse) ProtoMessage()    {}
 func (*RefreshRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{82}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{82}
 }
 func (m *RefreshRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4244,7 +4246,7 @@ func (m *SubsumeRequest) Reset()         { *m = SubsumeRequest{} }
 func (m *SubsumeRequest) String() string { return proto.CompactTextString(m) }
 func (*SubsumeRequest) ProtoMessage()    {}
 func (*SubsumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{83}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{83}
 }
 func (m *SubsumeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4291,7 +4293,7 @@ func (m *SubsumeResponse) Reset()         { *m = SubsumeResponse{} }
 func (m *SubsumeResponse) String() string { return proto.CompactTextString(m) }
 func (*SubsumeResponse) ProtoMessage()    {}
 func (*SubsumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{84}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{84}
 }
 func (m *SubsumeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4328,7 +4330,7 @@ func (m *RangeStatsRequest) Reset()         { *m = RangeStatsRequest{} }
 func (m *RangeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsRequest) ProtoMessage()    {}
 func (*RangeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{85}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{85}
 }
 func (m *RangeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4369,7 +4371,7 @@ func (m *RangeStatsResponse) Reset()         { *m = RangeStatsResponse{} }
 func (m *RangeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsResponse) ProtoMessage()    {}
 func (*RangeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{86}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{86}
 }
 func (m *RangeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4451,7 +4453,7 @@ func (m *RequestUnion) Reset()         { *m = RequestUnion{} }
 func (m *RequestUnion) String() string { return proto.CompactTextString(m) }
 func (*RequestUnion) ProtoMessage()    {}
 func (*RequestUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{87}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{87}
 }
 func (m *RequestUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -5810,7 +5812,7 @@ func (m *ResponseUnion) Reset()         { *m = ResponseUnion{} }
 func (m *ResponseUnion) String() string { return proto.CompactTextString(m) }
 func (*ResponseUnion) ProtoMessage()    {}
 func (*ResponseUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{88}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{88}
 }
 func (m *ResponseUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7159,7 +7161,7 @@ func (m *Header) Reset()         { *m = Header{} }
 func (m *Header) String() string { return proto.CompactTextString(m) }
 func (*Header) ProtoMessage()    {}
 func (*Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{89}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{89}
 }
 func (m *Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7197,7 +7199,7 @@ type BatchRequest struct {
 func (m *BatchRequest) Reset()      { *m = BatchRequest{} }
 func (*BatchRequest) ProtoMessage() {}
 func (*BatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{90}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{90}
 }
 func (m *BatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7236,7 +7238,7 @@ type BatchResponse struct {
 func (m *BatchResponse) Reset()      { *m = BatchResponse{} }
 func (*BatchResponse) ProtoMessage() {}
 func (*BatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{91}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{91}
 }
 func (m *BatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7297,7 +7299,7 @@ func (m *BatchResponse_Header) Reset()         { *m = BatchResponse_Header{} }
 func (m *BatchResponse_Header) String() string { return proto.CompactTextString(m) }
 func (*BatchResponse_Header) ProtoMessage()    {}
 func (*BatchResponse_Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{91, 0}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{91, 0}
 }
 func (m *BatchResponse_Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7335,7 +7337,7 @@ func (m *RangeFeedRequest) Reset()         { *m = RangeFeedRequest{} }
 func (m *RangeFeedRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRequest) ProtoMessage()    {}
 func (*RangeFeedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{92}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{92}
 }
 func (m *RangeFeedRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7373,7 +7375,7 @@ func (m *RangeFeedValue) Reset()         { *m = RangeFeedValue{} }
 func (m *RangeFeedValue) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedValue) ProtoMessage()    {}
 func (*RangeFeedValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{93}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{93}
 }
 func (m *RangeFeedValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7413,7 +7415,7 @@ func (m *RangeFeedCheckpoint) Reset()         { *m = RangeFeedCheckpoint{} }
 func (m *RangeFeedCheckpoint) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedCheckpoint) ProtoMessage()    {}
 func (*RangeFeedCheckpoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{94}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{94}
 }
 func (m *RangeFeedCheckpoint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7452,7 +7454,7 @@ func (m *RangeFeedError) Reset()         { *m = RangeFeedError{} }
 func (m *RangeFeedError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedError) ProtoMessage()    {}
 func (*RangeFeedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{95}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{95}
 }
 func (m *RangeFeedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7491,7 +7493,7 @@ func (m *RangeFeedEvent) Reset()         { *m = RangeFeedEvent{} }
 func (m *RangeFeedEvent) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedEvent) ProtoMessage()    {}
 func (*RangeFeedEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_65a86b9bedf9cb24, []int{96}
+	return fileDescriptor_api_2d1e6ce3f1ebc34e, []int{96}
 }
 func (m *RangeFeedEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -33501,9 +33503,9 @@ var (
 	ErrIntOverflowApi   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_65a86b9bedf9cb24) }
+func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_2d1e6ce3f1ebc34e) }
 
-var fileDescriptor_api_65a86b9bedf9cb24 = []byte{
+var fileDescriptor_api_2d1e6ce3f1ebc34e = []byte{
 	// 6173 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x3d, 0x4b, 0x6c, 0x23, 0xc9,
 	0x75, 0x6a, 0x92, 0x92, 0xc8, 0x47, 0x91, 0x6a, 0x95, 0xe6, 0xc3, 0xd1, 0xcc, 0x0e, 0x35, 0x9c,

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -676,6 +676,8 @@ message GCRequest {
   util.hlc.Timestamp threshold = 4 [(gogoproto.nullable) = false];
   // TxnSpanGCThreshold is the timestamp below which inactive transactions were
   // considered for GC (and thus might have been removed).
+  // TODO(nvanbenschoten): Remove this in 2.3, at which point we won't need to
+  // update it because no nodes in the cluster will ever consult it.
   util.hlc.Timestamp txn_span_gc_threshold = 5 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "TxnSpanGCThreshold"];
 }

--- a/pkg/roachpb/errors.pb.go
+++ b/pkg/roachpb/errors.pb.go
@@ -46,6 +46,8 @@ const (
 	// the TxnSpanGCThreshold, so there might have been an ABORTED txn record that
 	// got GCed (so, we might be in the ABORT_REASON_ABORTED_RECORD_FOUND case and
 	// not know).
+	// TODO(nvanbenschoten): Remove this error reason in 2.3, at which point no
+	// nodes in the cluster will ever return it.
 	ABORT_REASON_NEW_TXN_RECORD_TOO_OLD TransactionAbortedReason = 2
 	// The client is trying to use a transaction that's already been aborted. The
 	// TxnCoordSender detects this. Either the client is misusing a txn, or the
@@ -112,7 +114,7 @@ func (x *TransactionAbortedReason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionAbortedReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{0}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{0}
 }
 
 // TransactionRetryReason specifies what caused a transaction retry.
@@ -165,7 +167,7 @@ func (x *TransactionRetryReason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionRetryReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{1}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{1}
 }
 
 // TransactionRestart indicates how an error should be handled in a
@@ -216,7 +218,7 @@ func (x *TransactionRestart) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionRestart) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{2}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{2}
 }
 
 // Reason specifies what caused the error.
@@ -259,7 +261,7 @@ func (x *TransactionStatusError_Reason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionStatusError_Reason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{9, 0}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{9, 0}
 }
 
 // Reason specifies what caused the error.
@@ -315,7 +317,7 @@ func (x *RangeFeedRetryError_Reason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (RangeFeedRetryError_Reason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{29, 0}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{29, 0}
 }
 
 // A NotLeaseHolderError indicates that the current range is not the lease
@@ -344,7 +346,7 @@ func (m *NotLeaseHolderError) Reset()         { *m = NotLeaseHolderError{} }
 func (m *NotLeaseHolderError) String() string { return proto.CompactTextString(m) }
 func (*NotLeaseHolderError) ProtoMessage()    {}
 func (*NotLeaseHolderError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{0}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{0}
 }
 func (m *NotLeaseHolderError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -381,7 +383,7 @@ func (m *NodeUnavailableError) Reset()         { *m = NodeUnavailableError{} }
 func (m *NodeUnavailableError) String() string { return proto.CompactTextString(m) }
 func (*NodeUnavailableError) ProtoMessage()    {}
 func (*NodeUnavailableError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{1}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{1}
 }
 func (m *NodeUnavailableError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -417,7 +419,7 @@ func (m *UnsupportedRequestError) Reset()         { *m = UnsupportedRequestError
 func (m *UnsupportedRequestError) String() string { return proto.CompactTextString(m) }
 func (*UnsupportedRequestError) ProtoMessage()    {}
 func (*UnsupportedRequestError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{2}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{2}
 }
 func (m *UnsupportedRequestError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -456,7 +458,7 @@ func (m *RangeNotFoundError) Reset()         { *m = RangeNotFoundError{} }
 func (m *RangeNotFoundError) String() string { return proto.CompactTextString(m) }
 func (*RangeNotFoundError) ProtoMessage()    {}
 func (*RangeNotFoundError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{3}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{3}
 }
 func (m *RangeNotFoundError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -502,7 +504,7 @@ func (m *RangeKeyMismatchError) Reset()         { *m = RangeKeyMismatchError{} }
 func (m *RangeKeyMismatchError) String() string { return proto.CompactTextString(m) }
 func (*RangeKeyMismatchError) ProtoMessage()    {}
 func (*RangeKeyMismatchError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{4}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{4}
 }
 func (m *RangeKeyMismatchError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -550,7 +552,7 @@ func (m *ReadWithinUncertaintyIntervalError) Reset()         { *m = ReadWithinUn
 func (m *ReadWithinUncertaintyIntervalError) String() string { return proto.CompactTextString(m) }
 func (*ReadWithinUncertaintyIntervalError) ProtoMessage()    {}
 func (*ReadWithinUncertaintyIntervalError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{5}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{5}
 }
 func (m *ReadWithinUncertaintyIntervalError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -595,7 +597,7 @@ func (m *TransactionAbortedError) Reset()         { *m = TransactionAbortedError
 func (m *TransactionAbortedError) String() string { return proto.CompactTextString(m) }
 func (*TransactionAbortedError) ProtoMessage()    {}
 func (*TransactionAbortedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{6}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{6}
 }
 func (m *TransactionAbortedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -633,7 +635,7 @@ func (m *TransactionPushError) Reset()         { *m = TransactionPushError{} }
 func (m *TransactionPushError) String() string { return proto.CompactTextString(m) }
 func (*TransactionPushError) ProtoMessage()    {}
 func (*TransactionPushError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{7}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{7}
 }
 func (m *TransactionPushError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -670,7 +672,7 @@ func (m *TransactionRetryError) Reset()         { *m = TransactionRetryError{} }
 func (m *TransactionRetryError) String() string { return proto.CompactTextString(m) }
 func (*TransactionRetryError) ProtoMessage()    {}
 func (*TransactionRetryError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{8}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{8}
 }
 func (m *TransactionRetryError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -712,7 +714,7 @@ func (m *TransactionStatusError) Reset()         { *m = TransactionStatusError{}
 func (m *TransactionStatusError) String() string { return proto.CompactTextString(m) }
 func (*TransactionStatusError) ProtoMessage()    {}
 func (*TransactionStatusError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{9}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{9}
 }
 func (m *TransactionStatusError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -752,7 +754,7 @@ func (m *WriteIntentError) Reset()         { *m = WriteIntentError{} }
 func (m *WriteIntentError) String() string { return proto.CompactTextString(m) }
 func (*WriteIntentError) ProtoMessage()    {}
 func (*WriteIntentError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{10}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{10}
 }
 func (m *WriteIntentError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -792,7 +794,7 @@ func (m *WriteTooOldError) Reset()         { *m = WriteTooOldError{} }
 func (m *WriteTooOldError) String() string { return proto.CompactTextString(m) }
 func (*WriteTooOldError) ProtoMessage()    {}
 func (*WriteTooOldError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{11}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{11}
 }
 func (m *WriteTooOldError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -830,7 +832,7 @@ func (m *OpRequiresTxnError) Reset()         { *m = OpRequiresTxnError{} }
 func (m *OpRequiresTxnError) String() string { return proto.CompactTextString(m) }
 func (*OpRequiresTxnError) ProtoMessage()    {}
 func (*OpRequiresTxnError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{12}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{12}
 }
 func (m *OpRequiresTxnError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -869,7 +871,7 @@ func (m *ConditionFailedError) Reset()         { *m = ConditionFailedError{} }
 func (m *ConditionFailedError) String() string { return proto.CompactTextString(m) }
 func (*ConditionFailedError) ProtoMessage()    {}
 func (*ConditionFailedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{13}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{13}
 }
 func (m *ConditionFailedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -908,7 +910,7 @@ func (m *LeaseRejectedError) Reset()         { *m = LeaseRejectedError{} }
 func (m *LeaseRejectedError) String() string { return proto.CompactTextString(m) }
 func (*LeaseRejectedError) ProtoMessage()    {}
 func (*LeaseRejectedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{14}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{14}
 }
 func (m *LeaseRejectedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -945,7 +947,7 @@ func (m *SendError) Reset()         { *m = SendError{} }
 func (m *SendError) String() string { return proto.CompactTextString(m) }
 func (*SendError) ProtoMessage()    {}
 func (*SendError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{15}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{15}
 }
 func (m *SendError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -985,7 +987,7 @@ func (m *AmbiguousResultError) Reset()         { *m = AmbiguousResultError{} }
 func (m *AmbiguousResultError) String() string { return proto.CompactTextString(m) }
 func (*AmbiguousResultError) ProtoMessage()    {}
 func (*AmbiguousResultError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{16}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{16}
 }
 func (m *AmbiguousResultError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1021,7 +1023,7 @@ func (m *RaftGroupDeletedError) Reset()         { *m = RaftGroupDeletedError{} }
 func (m *RaftGroupDeletedError) String() string { return proto.CompactTextString(m) }
 func (*RaftGroupDeletedError) ProtoMessage()    {}
 func (*RaftGroupDeletedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{17}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{17}
 }
 func (m *RaftGroupDeletedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1061,7 +1063,7 @@ func (m *ReplicaCorruptionError) Reset()         { *m = ReplicaCorruptionError{}
 func (m *ReplicaCorruptionError) String() string { return proto.CompactTextString(m) }
 func (*ReplicaCorruptionError) ProtoMessage()    {}
 func (*ReplicaCorruptionError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{18}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{18}
 }
 func (m *ReplicaCorruptionError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1100,7 +1102,7 @@ func (m *ReplicaTooOldError) Reset()         { *m = ReplicaTooOldError{} }
 func (m *ReplicaTooOldError) String() string { return proto.CompactTextString(m) }
 func (*ReplicaTooOldError) ProtoMessage()    {}
 func (*ReplicaTooOldError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{19}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{19}
 }
 func (m *ReplicaTooOldError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1137,7 +1139,7 @@ func (m *StoreNotFoundError) Reset()         { *m = StoreNotFoundError{} }
 func (m *StoreNotFoundError) String() string { return proto.CompactTextString(m) }
 func (*StoreNotFoundError) ProtoMessage()    {}
 func (*StoreNotFoundError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{20}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{20}
 }
 func (m *StoreNotFoundError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1185,7 +1187,7 @@ func (m *UnhandledRetryableError) Reset()         { *m = UnhandledRetryableError
 func (m *UnhandledRetryableError) String() string { return proto.CompactTextString(m) }
 func (*UnhandledRetryableError) ProtoMessage()    {}
 func (*UnhandledRetryableError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{21}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{21}
 }
 func (m *UnhandledRetryableError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1239,7 +1241,7 @@ func (m *TransactionRetryWithProtoRefreshError) Reset()         { *m = Transacti
 func (m *TransactionRetryWithProtoRefreshError) String() string { return proto.CompactTextString(m) }
 func (*TransactionRetryWithProtoRefreshError) ProtoMessage()    {}
 func (*TransactionRetryWithProtoRefreshError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{22}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{22}
 }
 func (m *TransactionRetryWithProtoRefreshError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1279,7 +1281,7 @@ func (m *TxnAlreadyEncounteredErrorError) Reset()         { *m = TxnAlreadyEncou
 func (m *TxnAlreadyEncounteredErrorError) String() string { return proto.CompactTextString(m) }
 func (*TxnAlreadyEncounteredErrorError) ProtoMessage()    {}
 func (*TxnAlreadyEncounteredErrorError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{23}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{23}
 }
 func (m *TxnAlreadyEncounteredErrorError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1318,7 +1320,7 @@ func (m *IntegerOverflowError) Reset()         { *m = IntegerOverflowError{} }
 func (m *IntegerOverflowError) String() string { return proto.CompactTextString(m) }
 func (*IntegerOverflowError) ProtoMessage()    {}
 func (*IntegerOverflowError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{24}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{24}
 }
 func (m *IntegerOverflowError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1356,7 +1358,7 @@ func (m *MixedSuccessError) Reset()         { *m = MixedSuccessError{} }
 func (m *MixedSuccessError) String() string { return proto.CompactTextString(m) }
 func (*MixedSuccessError) ProtoMessage()    {}
 func (*MixedSuccessError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{25}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{25}
 }
 func (m *MixedSuccessError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1394,7 +1396,7 @@ func (m *BatchTimestampBeforeGCError) Reset()         { *m = BatchTimestampBefor
 func (m *BatchTimestampBeforeGCError) String() string { return proto.CompactTextString(m) }
 func (*BatchTimestampBeforeGCError) ProtoMessage()    {}
 func (*BatchTimestampBeforeGCError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{26}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{26}
 }
 func (m *BatchTimestampBeforeGCError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1433,7 +1435,7 @@ func (m *IntentMissingError) Reset()         { *m = IntentMissingError{} }
 func (m *IntentMissingError) String() string { return proto.CompactTextString(m) }
 func (*IntentMissingError) ProtoMessage()    {}
 func (*IntentMissingError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{27}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{27}
 }
 func (m *IntentMissingError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1472,7 +1474,7 @@ func (m *MergeInProgressError) Reset()         { *m = MergeInProgressError{} }
 func (m *MergeInProgressError) String() string { return proto.CompactTextString(m) }
 func (*MergeInProgressError) ProtoMessage()    {}
 func (*MergeInProgressError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{28}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{28}
 }
 func (m *MergeInProgressError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1509,7 +1511,7 @@ func (m *RangeFeedRetryError) Reset()         { *m = RangeFeedRetryError{} }
 func (m *RangeFeedRetryError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRetryError) ProtoMessage()    {}
 func (*RangeFeedRetryError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{29}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{29}
 }
 func (m *RangeFeedRetryError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1575,7 +1577,7 @@ func (m *ErrorDetail) Reset()         { *m = ErrorDetail{} }
 func (m *ErrorDetail) String() string { return proto.CompactTextString(m) }
 func (*ErrorDetail) ProtoMessage()    {}
 func (*ErrorDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{30}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{30}
 }
 func (m *ErrorDetail) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2535,7 +2537,7 @@ func (m *ErrPosition) Reset()         { *m = ErrPosition{} }
 func (m *ErrPosition) String() string { return proto.CompactTextString(m) }
 func (*ErrPosition) ProtoMessage()    {}
 func (*ErrPosition) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{31}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{31}
 }
 func (m *ErrPosition) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2591,7 +2593,7 @@ type Error struct {
 func (m *Error) Reset()      { *m = Error{} }
 func (*Error) ProtoMessage() {}
 func (*Error) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_cef0c035f29ecf49, []int{32}
+	return fileDescriptor_errors_62b74ae3fb677e28, []int{32}
 }
 func (m *Error) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -10597,9 +10599,9 @@ var (
 	ErrIntOverflowErrors   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/errors.proto", fileDescriptor_errors_cef0c035f29ecf49) }
+func init() { proto.RegisterFile("roachpb/errors.proto", fileDescriptor_errors_62b74ae3fb677e28) }
 
-var fileDescriptor_errors_cef0c035f29ecf49 = []byte{
+var fileDescriptor_errors_62b74ae3fb677e28 = []byte{
 	// 2819 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x58, 0xcb, 0x6f, 0xe3, 0xd6,
 	0xd5, 0x17, 0x65, 0xd9, 0xb2, 0x8f, 0x5f, 0xf4, 0x1d, 0xc7, 0xc3, 0xf1, 0x64, 0x64, 0x8f, 0x27,

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -135,6 +135,8 @@ enum TransactionAbortedReason {
   // the TxnSpanGCThreshold, so there might have been an ABORTED txn record that
   // got GCed (so, we might be in the ABORT_REASON_ABORTED_RECORD_FOUND case and
   // not know).
+  // TODO(nvanbenschoten): Remove this error reason in 2.3, at which point no
+  // nodes in the cluster will ever return it.
   ABORT_REASON_NEW_TXN_RECORD_TOO_OLD = 2;
 
   // The client is trying to use a transaction that's already been aborted. The

--- a/pkg/storage/batcheval/cmd_begin_transaction.go
+++ b/pkg/storage/batcheval/cmd_begin_transaction.go
@@ -40,9 +40,6 @@ func declareKeysWriteTransaction(
 		spans.Add(spanset.SpanReadWrite, roachpb.Span{
 			Key: keys.TransactionKey(req.Header().Key, header.Txn.ID),
 		})
-		spans.Add(spanset.SpanReadOnly, roachpb.Span{
-			Key: keys.RangeTxnSpanGCThresholdKey(header.RangeID),
-		})
 	}
 }
 

--- a/pkg/storage/batcheval/cmd_push_txn.go
+++ b/pkg/storage/batcheval/cmd_push_txn.go
@@ -39,7 +39,6 @@ func declareKeysPushTransaction(
 	pr := req.(*roachpb.PushTxnRequest)
 	spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.TransactionKey(pr.PusheeTxn.Key, pr.PusheeTxn.ID)})
 	spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.AbortSpanKey(header.RangeID, pr.PusheeTxn.ID)})
-	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeTxnSpanGCThresholdKey(header.RangeID)})
 }
 
 // PushTxn resolves conflicts between concurrent txns (or between

--- a/pkg/storage/batcheval/cmd_query_txn.go
+++ b/pkg/storage/batcheval/cmd_query_txn.go
@@ -36,7 +36,6 @@ func declareKeysQueryTransaction(
 ) {
 	qr := req.(*roachpb.QueryTxnRequest)
 	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.TransactionKey(qr.Txn.Key, qr.Txn.ID)})
-	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeTxnSpanGCThresholdKey(header.RangeID)})
 }
 
 // QueryTxn fetches the current state of a transaction.

--- a/pkg/storage/batcheval/eval_context.go
+++ b/pkg/storage/batcheval/eval_context.go
@@ -73,9 +73,6 @@ type EvalContext interface {
 	// CanCreateTxnRecord determines whether a transaction record can be created
 	// for the provided transaction information. See Replica.CanCreateTxnRecord
 	// for details about its arguments, return values, and preconditions.
-	//
-	// NOTE: To call this method, a command must declare (at least) a read on
-	// both the transaction's key and on the txn span GC threshold key.
 	CanCreateTxnRecord(
 		txnID uuid.UUID, txnKey []byte, txnMinTSUpperBound hlc.Timestamp,
 	) (ok bool, minCommitTS hlc.Timestamp, reason roachpb.TransactionAbortedReason)
@@ -94,6 +91,8 @@ type EvalContext interface {
 	GetSplitQPS() float64
 
 	GetGCThreshold() hlc.Timestamp
+	// TODO(nvanbenschoten): Remove this in 2.3, at which point no request type
+	// will ever need to consult the threshold.
 	GetTxnSpanGCThreshold() hlc.Timestamp
 	GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error)
 	GetLease() (roachpb.Lease, roachpb.Lease)

--- a/pkg/storage/replica_eval_context_span.go
+++ b/pkg/storage/replica_eval_context_span.go
@@ -152,9 +152,6 @@ func (rec SpanSetReplicaEvalContext) CanCreateTxnRecord(
 	rec.ss.AssertAllowed(spanset.SpanReadOnly,
 		roachpb.Span{Key: keys.TransactionKey(txnKey, txnID)},
 	)
-	rec.ss.AssertAllowed(spanset.SpanReadOnly,
-		roachpb.Span{Key: keys.RangeTxnSpanGCThresholdKey(rec.GetRangeID())},
-	)
 	return rec.i.CanCreateTxnRecord(txnID, txnKey, txnMinTSUpperBound)
 }
 

--- a/pkg/storage/storagepb/state.pb.go
+++ b/pkg/storage/storagepb/state.pb.go
@@ -64,6 +64,8 @@ type ReplicaState struct {
 	// records may have been garbage collected (as measured by txn.LastActive()).
 	// Transactions at lower timestamps must not be allowed to write their initial
 	// transaction entry.
+	// TODO(nvanbenschoten): Remove this in 2.3, at which point we won't need to
+	// maintain it because no nodes in the cluster will ever consult it.
 	TxnSpanGCThreshold *hlc.Timestamp `protobuf:"bytes,9,opt,name=txn_span_gc_threshold,json=txnSpanGcThreshold,proto3" json:"txn_span_gc_threshold,omitempty" cockroachdb:"randnullable"`
 	// using_applied_state_key specifies whether the Range has been upgraded
 	// to begin using the RangeAppliedState key. This key holds a combination
@@ -82,7 +84,7 @@ func (m *ReplicaState) Reset()         { *m = ReplicaState{} }
 func (m *ReplicaState) String() string { return proto.CompactTextString(m) }
 func (*ReplicaState) ProtoMessage()    {}
 func (*ReplicaState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_state_4f04d354e3a91f1b, []int{0}
+	return fileDescriptor_state_f6cb1cac1eee55bd, []int{0}
 }
 func (m *ReplicaState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -130,7 +132,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_state_4f04d354e3a91f1b, []int{1}
+	return fileDescriptor_state_f6cb1cac1eee55bd, []int{1}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -168,7 +170,7 @@ func (m *LatchManagerInfo) Reset()         { *m = LatchManagerInfo{} }
 func (m *LatchManagerInfo) String() string { return proto.CompactTextString(m) }
 func (*LatchManagerInfo) ProtoMessage()    {}
 func (*LatchManagerInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_state_4f04d354e3a91f1b, []int{2}
+	return fileDescriptor_state_f6cb1cac1eee55bd, []int{2}
 }
 func (m *LatchManagerInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1272,10 +1274,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("storage/storagepb/state.proto", fileDescriptor_state_4f04d354e3a91f1b)
+	proto.RegisterFile("storage/storagepb/state.proto", fileDescriptor_state_f6cb1cac1eee55bd)
 }
 
-var fileDescriptor_state_4f04d354e3a91f1b = []byte{
+var fileDescriptor_state_f6cb1cac1eee55bd = []byte{
 	// 756 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x54, 0xcf, 0x6e, 0xdb, 0x36,
 	0x1c, 0x8e, 0x62, 0x39, 0xb3, 0xa9, 0x64, 0xf1, 0xb8, 0x6c, 0x13, 0x1c, 0xd8, 0x0e, 0x34, 0x6c,

--- a/pkg/storage/storagepb/state.proto
+++ b/pkg/storage/storagepb/state.proto
@@ -68,6 +68,8 @@ message ReplicaState {
   // records may have been garbage collected (as measured by txn.LastActive()).
   // Transactions at lower timestamps must not be allowed to write their initial
   // transaction entry.
+  // TODO(nvanbenschoten): Remove this in 2.3, at which point we won't need to
+  // maintain it because no nodes in the cluster will ever consult it.
   util.hlc.Timestamp txn_span_gc_threshold = 9 [(gogoproto.customname) = "TxnSpanGCThreshold", (gogoproto.moretags) = "cockroachdb:\"randnullable\""];
   reserved 10;
   // using_applied_state_key specifies whether the Range has been upgraded


### PR DESCRIPTION
Cleanup from #33523.

This commit weakens the semantics of `Replica.CanCreateTxnRecord` slightly to
allow it to ignore the `TxnSpanGCThreshold`. `CanCreateTxnRecord` no longer
consults the `TxnSpanGCThreshold`, so it doesn't prevent the creation of new
transaction records beneath it. That's ok though, because we still prevent the
recreation of aborted and GCed transaction records, which was the important part
of the check. This protection is now provided by updating the write timestamp
cache on successful `TxnPush(ABORT)` requests (added in #33523). The GC queue
will always `PushTxn(ABORT)` transactions if it finds them `PENDING`, so the
`TxnSpanGCThreshold` check isn't giving us anything important.

For a visual summary of this change, look at the update to the state machine
diagram in `replica_tscache.go`.

### Migration Safety

In the next release cycle, this change will allow us to remove the
`TxnSpanGCThreshold` entirely because the protection it was providing is
now entirely handled by the timestamp cache.

In the meantime, we need to keep setting it to ensure that the protection still
works properly on old (v2.1) leaseholders. However, we're safe to no-longer
consult it at all on new (v2.2) leaseholders. This is because even if a new node
is given the lease from an old node that isn't correctly bumping the timestamp
cache on `PushTxn` requests, we know that the old node will have a clock at
least as large as a txn in question's OrigTimestamp. That means that the new
leaseholder will necessarily bump its write timestamp cache to at least as large
as this txn's OrigTimestamp, so `Replica.CanCreateTxnRecord` will always fail.

Release note: None