### PR TITLE
opt: add stats to tpch xform test

### DIFF
--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -14,17 +14,6 @@ TABLE region
       └── r_regionkey int not null
 
 exec-ddl
-ALTER TABLE region INJECT STATISTICS '[
-  {
-    "columns": ["r_regionkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 5,
-    "distinct_count": 5
-  }
-]'
-----
-
-exec-ddl
 CREATE TABLE public.nation
 (
     n_nationkey int PRIMARY KEY,
@@ -46,23 +35,6 @@ TABLE nation
  │    ├── n_regionkey int not null
  │    └── n_nationkey int not null
  └── FOREIGN KEY (n_regionkey) REFERENCES t.public.region (r_regionkey)
-
-exec-ddl
-ALTER TABLE nation INJECT STATISTICS '[
-  {
-    "columns": ["n_nationkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 25,
-    "distinct_count": 25
-  },
-  {
-    "columns": ["n_regionkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 25,
-    "distinct_count": 5
-  }
-]'
-----
 
 exec-ddl
 CREATE TABLE public.supplier
@@ -94,23 +66,6 @@ TABLE supplier
  └── FOREIGN KEY (s_nationkey) REFERENCES t.public.nation (n_nationkey)
 
 exec-ddl
-ALTER TABLE supplier INJECT STATISTICS '[
-  {
-    "columns": ["s_suppkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10000,
-    "distinct_count": 10000
-  },
-  {
-    "columns": ["s_nationkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10000,
-    "distinct_count": 25
-  }
-]'
-----
-
-exec-ddl
 CREATE TABLE public.part
 (
     p_partkey int PRIMARY KEY,
@@ -136,17 +91,6 @@ TABLE part
  ├── p_comment string not null
  └── INDEX primary
       └── p_partkey int not null
-
-exec-ddl
-ALTER TABLE part INJECT STATISTICS '[
-  {
-    "columns": ["p_partkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 200000,
-    "distinct_count": 200000
-  }
-]'
-----
 
 exec-ddl
 CREATE TABLE public.partsupp
@@ -178,23 +122,6 @@ TABLE partsupp
  └── FOREIGN KEY (ps_suppkey) REFERENCES t.public.supplier (s_suppkey)
 
 exec-ddl
-ALTER TABLE partsupp INJECT STATISTICS '[
-  {
-    "columns": ["ps_partkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 800000,
-    "distinct_count": 200000
-  },
-  {
-    "columns": ["ps_suppkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 800000,
-    "distinct_count": 10000
-  }
-]'
-----
-
-exec-ddl
 CREATE TABLE public.customer
 (
     c_custkey int PRIMARY KEY,
@@ -224,23 +151,6 @@ TABLE customer
  │    ├── c_nationkey int not null
  │    └── c_custkey int not null
  └── FOREIGN KEY (c_nationkey) REFERENCES t.public.nation (n_nationkey)
-
-exec-ddl
-ALTER TABLE customer INJECT STATISTICS '[
-  {
-    "columns": ["c_custkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 150000,
-    "distinct_count": 150000
-  },
-  {
-    "columns": ["c_nationkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 150000,
-    "distinct_count": 25
-  }
-]'
-----
 
 exec-ddl
 CREATE TABLE public.orders
@@ -278,29 +188,6 @@ TABLE orders
  │    ├── o_orderdate date not null
  │    └── o_orderkey int not null
  └── FOREIGN KEY (o_custkey) REFERENCES t.public.customer (c_custkey)
-
-exec-ddl
-ALTER TABLE orders INJECT STATISTICS '[
-  {
-    "columns": ["o_orderkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1500000,
-    "distinct_count": 1500000
-  },
-  {
-    "columns": ["o_custkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1500000,
-    "distinct_count": 10000
-  },
-  {
-    "columns": ["o_orderdate"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1500000,
-    "distinct_count": 2500
-  }
-]'
-----
 
 exec-ddl
 CREATE TABLE public.lineitem
@@ -393,48 +280,6 @@ TABLE lineitem
  ├── FOREIGN KEY (l_partkey) REFERENCES t.public.part (p_partkey)
  ├── FOREIGN KEY (l_suppkey) REFERENCES t.public.supplier (s_suppkey)
  └── FOREIGN KEY (l_partkey, l_suppkey) REFERENCES t.public.partsupp (ps_partkey, ps_suppkey)
-
-exec-ddl
-ALTER TABLE lineitem INJECT STATISTICS '[
-  {
-    "columns": ["l_orderkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6000000,
-    "distinct_count": 1500000
-  },
-  {
-    "columns": ["l_partkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6000000,
-    "distinct_count": 200000
-  },
-  {
-    "columns": ["l_suppkey"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6000000,
-    "distinct_count": 10000
-  },
-  {
-    "columns": ["l_shipdate"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6000000,
-    "distinct_count": 2500
-  },
-  {
-    "columns": ["l_commitdate"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6000000,
-    "distinct_count": 2500
-  },
-  {
-    "columns": ["l_receiptdate"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 6000000,
-    "distinct_count": 2500
-  }
-]'
-----
-
 
 # --------------------------------------------------
 # Q1
@@ -613,36 +458,32 @@ project
       │         │    │    │    │    ├── columns: ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null)
       │         │    │    │    │    ├── key: (29,30)
       │         │    │    │    │    └── fd: (29,30)-->(32)
-      │         │    │    │    ├── inner-join (lookup supplier@s_nk)
+      │         │    │    │    ├── inner-join
       │         │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
-      │         │    │    │    │    ├── key columns: [41] = [37]
       │         │    │    │    │    ├── key: (34)
       │         │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37)
-      │         │    │    │    │    ├── inner-join (merge)
+      │         │    │    │    │    ├── scan supplier@s_nk
+      │         │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null)
+      │         │    │    │    │    │    ├── key: (34)
+      │         │    │    │    │    │    └── fd: (34)-->(37)
+      │         │    │    │    │    ├── inner-join (lookup nation@n_rk)
       │         │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
-      │         │    │    │    │    │    ├── left ordering: +43
-      │         │    │    │    │    │    ├── right ordering: +45
+      │         │    │    │    │    │    ├── key columns: [45] = [43]
       │         │    │    │    │    │    ├── key: (41)
       │         │    │    │    │    │    ├── fd: ()-->(46), (41)-->(43), (43)==(45), (45)==(43)
-      │         │    │    │    │    │    ├── scan nation@n_rk
-      │         │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null)
-      │         │    │    │    │    │    │    ├── key: (41)
-      │         │    │    │    │    │    │    ├── fd: (41)-->(43)
-      │         │    │    │    │    │    │    └── ordering: +43
       │         │    │    │    │    │    ├── select
       │         │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
       │         │    │    │    │    │    │    ├── key: (45)
       │         │    │    │    │    │    │    ├── fd: ()-->(46)
-      │         │    │    │    │    │    │    ├── ordering: +45 opt(46) [actual: +45]
       │         │    │    │    │    │    │    ├── scan region
       │         │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
       │         │    │    │    │    │    │    │    ├── key: (45)
-      │         │    │    │    │    │    │    │    ├── fd: (45)-->(46)
-      │         │    │    │    │    │    │    │    └── ordering: +45 opt(46) [actual: +45]
+      │         │    │    │    │    │    │    │    └── fd: (45)-->(46)
       │         │    │    │    │    │    │    └── filters
       │         │    │    │    │    │    │         └── r_name = 'EUROPE' [type=bool, outer=(46), constraints=(/46: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(46)]
       │         │    │    │    │    │    └── filters (true)
-      │         │    │    │    │    └── filters (true)
+      │         │    │    │    │    └── filters
+      │         │    │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(37,41), constraints=(/37: (/NULL - ]; /41: (/NULL - ]), fd=(37)==(41), (41)==(37)]
       │         │    │    │    └── filters
       │         │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ]), fd=(30)==(34), (34)==(30)]
       │         │    │    ├── inner-join
@@ -661,26 +502,28 @@ project
       │         │    │    │    │    │    │    ├── columns: ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null)
       │         │    │    │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    │    │    └── fd: (17,18)-->(20)
-      │         │    │    │    │    │    ├── inner-join
+      │         │    │    │    │    │    ├── inner-join (lookup nation)
       │         │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    │    ├── key columns: [22] = [22]
       │         │    │    │    │    │    │    ├── key: (22)
       │         │    │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24)
-      │         │    │    │    │    │    │    ├── scan nation
-      │         │    │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null)
+      │         │    │    │    │    │    │    ├── inner-join (lookup nation@n_rk)
+      │         │    │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    │    │    ├── key columns: [26] = [24]
       │         │    │    │    │    │    │    │    ├── key: (22)
-      │         │    │    │    │    │    │    │    └── fd: (22)-->(23,24)
-      │         │    │    │    │    │    │    ├── select
-      │         │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(string!null)
-      │         │    │    │    │    │    │    │    ├── key: (26)
-      │         │    │    │    │    │    │    │    ├── fd: ()-->(27)
-      │         │    │    │    │    │    │    │    ├── scan region
+      │         │    │    │    │    │    │    │    ├── fd: ()-->(27), (22)-->(24), (24)==(26), (26)==(24)
+      │         │    │    │    │    │    │    │    ├── select
       │         │    │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(string!null)
       │         │    │    │    │    │    │    │    │    ├── key: (26)
-      │         │    │    │    │    │    │    │    │    └── fd: (26)-->(27)
-      │         │    │    │    │    │    │    │    └── filters
-      │         │    │    │    │    │    │    │         └── r_name = 'EUROPE' [type=bool, outer=(27), constraints=(/27: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(27)]
-      │         │    │    │    │    │    │    └── filters
-      │         │    │    │    │    │    │         └── n_regionkey = r_regionkey [type=bool, outer=(24,26), constraints=(/24: (/NULL - ]; /26: (/NULL - ]), fd=(24)==(26), (26)==(24)]
+      │         │    │    │    │    │    │    │    │    ├── fd: ()-->(27)
+      │         │    │    │    │    │    │    │    │    ├── scan region
+      │         │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    │    │    │    │    ├── key: (26)
+      │         │    │    │    │    │    │    │    │    │    └── fd: (26)-->(27)
+      │         │    │    │    │    │    │    │    │    └── filters
+      │         │    │    │    │    │    │    │    │         └── r_name = 'EUROPE' [type=bool, outer=(27), constraints=(/27: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(27)]
+      │         │    │    │    │    │    │    │    └── filters (true)
+      │         │    │    │    │    │    │    └── filters (true)
       │         │    │    │    │    │    └── filters (true)
       │         │    │    │    │    ├── scan supplier
       │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null)
@@ -788,22 +631,32 @@ limit
  │         │    ├── inner-join
  │         │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
  │         │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
- │         │    │    ├── inner-join (lookup lineitem)
+ │         │    │    ├── inner-join (merge)
  │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
- │         │    │    │    ├── key columns: [9] = [18]
+ │         │    │    │    ├── left ordering: +9
+ │         │    │    │    ├── right ordering: +18
  │         │    │    │    ├── fd: (9)-->(10,13,16), (9)==(18), (18)==(9)
  │         │    │    │    ├── select
  │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
  │         │    │    │    │    ├── key: (9)
  │         │    │    │    │    ├── fd: (9)-->(10,13,16)
+ │         │    │    │    │    ├── ordering: +9
  │         │    │    │    │    ├── scan orders
  │         │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
  │         │    │    │    │    │    ├── key: (9)
- │         │    │    │    │    │    └── fd: (9)-->(10,13,16)
+ │         │    │    │    │    │    ├── fd: (9)-->(10,13,16)
+ │         │    │    │    │    │    └── ordering: +9
  │         │    │    │    │    └── filters
  │         │    │    │    │         └── o_orderdate < '1995-03-15' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1995-03-14']; tight)]
- │         │    │    │    └── filters
- │         │    │    │         └── l_shipdate > '1995-03-15' [type=bool, outer=(28), constraints=(/28: [/'1995-03-16' - ]; tight)]
+ │         │    │    │    ├── select
+ │         │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
+ │         │    │    │    │    ├── ordering: +18
+ │         │    │    │    │    ├── scan lineitem
+ │         │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
+ │         │    │    │    │    │    └── ordering: +18
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── l_shipdate > '1995-03-15' [type=bool, outer=(28), constraints=(/28: [/'1995-03-16' - ]; tight)]
+ │         │    │    │    └── filters (true)
  │         │    │    ├── select
  │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
  │         │    │    │    ├── key: (1)
@@ -961,32 +814,38 @@ sort
       │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20)
       │    │    │    │    ├── scan lineitem
       │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null)
-      │    │    │    │    ├── inner-join (lookup supplier@s_nk)
+      │    │    │    │    ├── inner-join
       │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
-      │    │    │    │    │    ├── key columns: [41] = [37]
       │    │    │    │    │    ├── key: (34)
       │    │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37)
-      │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    ├── scan supplier@s_nk
+      │    │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null)
+      │    │    │    │    │    │    ├── key: (34)
+      │    │    │    │    │    │    └── fd: (34)-->(37)
+      │    │    │    │    │    ├── inner-join (lookup nation)
       │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    │    ├── key columns: [41] = [41]
       │    │    │    │    │    │    ├── key: (41)
       │    │    │    │    │    │    ├── fd: ()-->(46), (41)-->(42,43), (43)==(45), (45)==(43)
-      │    │    │    │    │    │    ├── scan nation
-      │    │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null)
+      │    │    │    │    │    │    ├── inner-join (lookup nation@n_rk)
+      │    │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    │    │    ├── key columns: [45] = [43]
       │    │    │    │    │    │    │    ├── key: (41)
-      │    │    │    │    │    │    │    └── fd: (41)-->(42,43)
-      │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
-      │    │    │    │    │    │    │    ├── key: (45)
-      │    │    │    │    │    │    │    ├── fd: ()-->(46)
-      │    │    │    │    │    │    │    ├── scan region
+      │    │    │    │    │    │    │    ├── fd: ()-->(46), (41)-->(43), (43)==(45), (45)==(43)
+      │    │    │    │    │    │    │    ├── select
       │    │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
       │    │    │    │    │    │    │    │    ├── key: (45)
-      │    │    │    │    │    │    │    │    └── fd: (45)-->(46)
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── r_name = 'ASIA' [type=bool, outer=(46), constraints=(/46: [/'ASIA' - /'ASIA']; tight), fd=()-->(46)]
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── n_regionkey = r_regionkey [type=bool, outer=(43,45), constraints=(/43: (/NULL - ]; /45: (/NULL - ]), fd=(43)==(45), (45)==(43)]
-      │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(46)
+      │    │    │    │    │    │    │    │    ├── scan region
+      │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    │    │    │    │    ├── key: (45)
+      │    │    │    │    │    │    │    │    │    └── fd: (45)-->(46)
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         └── r_name = 'ASIA' [type=bool, outer=(46), constraints=(/46: [/'ASIA' - /'ASIA']; tight), fd=()-->(46)]
+      │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(37,41), constraints=(/37: (/NULL - ]; /41: (/NULL - ]), fd=(37)==(41), (41)==(37)]
       │    │    │    │    └── filters
       │    │    │    │         └── l_suppkey = s_suppkey [type=bool, outer=(20,34), constraints=(/20: (/NULL - ]; /34: (/NULL - ]), fd=(20)==(34), (34)==(20)]
       │    │    │    ├── index-join orders
@@ -1120,87 +979,79 @@ ORDER BY
     cust_nation,
     l_year;
 ----
-sort
+group-by
  ├── columns: supp_nation:42(string!null) cust_nation:46(string!null) l_year:49(int) revenue:51(float)
+ ├── grouping columns: n1.n_name:42(string!null) n2.n_name:46(string!null) l_year:49(int)
  ├── key: (42,46,49)
  ├── fd: (42,46,49)-->(51)
  ├── ordering: +42,+46,+49
- └── group-by
-      ├── columns: n1.n_name:42(string!null) n2.n_name:46(string!null) l_year:49(int) sum:51(float)
-      ├── grouping columns: n1.n_name:42(string!null) n2.n_name:46(string!null) l_year:49(int)
-      ├── key: (42,46,49)
-      ├── fd: (42,46,49)-->(51)
-      ├── project
-      │    ├── columns: l_year:49(int) volume:50(float) n1.n_name:42(string!null) n2.n_name:46(string!null)
-      │    ├── inner-join
-      │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
-      │    │    ├── fd: (1)-->(4), (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(41), (41)==(4)
-      │    │    ├── inner-join
-      │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
-      │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8)
-      │    │    │    ├── inner-join
-      │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
-      │    │    │    │    ├── key: (24,41)
-      │    │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25)
-      │    │    │    │    ├── scan orders@o_ck
-      │    │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null)
-      │    │    │    │    │    ├── key: (24)
-      │    │    │    │    │    └── fd: (24)-->(25)
-      │    │    │    │    ├── inner-join (merge)
-      │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
-      │    │    │    │    │    ├── left ordering: +36
-      │    │    │    │    │    ├── right ordering: +45
-      │    │    │    │    │    ├── key: (33,41)
-      │    │    │    │    │    ├── fd: (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36)
-      │    │    │    │    │    ├── scan customer@c_nk
-      │    │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null)
-      │    │    │    │    │    │    ├── key: (33)
-      │    │    │    │    │    │    ├── fd: (33)-->(36)
-      │    │    │    │    │    │    └── ordering: +36
-      │    │    │    │    │    ├── sort
-      │    │    │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
-      │    │    │    │    │    │    ├── key: (41,45)
-      │    │    │    │    │    │    ├── fd: (41)-->(42), (45)-->(46)
-      │    │    │    │    │    │    ├── ordering: +45
-      │    │    │    │    │    │    └── inner-join
-      │    │    │    │    │    │         ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
-      │    │    │    │    │    │         ├── key: (41,45)
-      │    │    │    │    │    │         ├── fd: (41)-->(42), (45)-->(46)
-      │    │    │    │    │    │         ├── scan n1
-      │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null)
-      │    │    │    │    │    │         │    ├── key: (41)
-      │    │    │    │    │    │         │    └── fd: (41)-->(42)
-      │    │    │    │    │    │         ├── scan n2
-      │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
-      │    │    │    │    │    │         │    ├── key: (45)
-      │    │    │    │    │    │         │    └── fd: (45)-->(46)
-      │    │    │    │    │    │         └── filters
-      │    │    │    │    │    │              └── ((n1.n_name = 'FRANCE') AND (n2.n_name = 'GERMANY')) OR ((n1.n_name = 'GERMANY') AND (n2.n_name = 'FRANCE')) [type=bool, outer=(42,46)]
-      │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── filters
-      │    │    │    │         └── c_custkey = o_custkey [type=bool, outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
-      │    │    │    ├── index-join lineitem
-      │    │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
-      │    │    │    │    └── scan lineitem@l_sd
-      │    │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
-      │    │    │    │         ├── constraint: /18/8/11: [/'1995-01-01' - /'1996-12-31']
-      │    │    │    │         ├── key: (8,11)
-      │    │    │    │         └── fd: (8,11)-->(18)
-      │    │    │    └── filters
-      │    │    │         └── o_orderkey = l_orderkey [type=bool, outer=(8,24), constraints=(/8: (/NULL - ]; /24: (/NULL - ]), fd=(8)==(24), (24)==(8)]
-      │    │    ├── scan supplier@s_nk
-      │    │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(4)
-      │    │    └── filters
-      │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
-      │    │         └── s_nationkey = n1.n_nationkey [type=bool, outer=(4,41), constraints=(/4: (/NULL - ]; /41: (/NULL - ]), fd=(4)==(41), (41)==(4)]
-      │    └── projections
-      │         ├── extract('year', l_shipdate) [type=int, outer=(18)]
-      │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(13,14)]
-      └── aggregations
-           └── sum [type=float, outer=(50)]
-                └── variable: volume [type=float]
+ ├── sort
+ │    ├── columns: n1.n_name:42(string!null) n2.n_name:46(string!null) l_year:49(int) volume:50(float)
+ │    ├── ordering: +42,+46,+49
+ │    └── project
+ │         ├── columns: l_year:49(int) volume:50(float) n1.n_name:42(string!null) n2.n_name:46(string!null)
+ │         ├── inner-join
+ │         │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    ├── fd: (1)-->(4), (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(41), (41)==(4)
+ │         │    ├── inner-join
+ │         │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8)
+ │         │    │    ├── inner-join
+ │         │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    │    │    ├── key: (24,41)
+ │         │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25)
+ │         │    │    │    ├── inner-join
+ │         │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    │    │    │    ├── key: (33,41)
+ │         │    │    │    │    ├── fd: (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36)
+ │         │    │    │    │    ├── inner-join
+ │         │    │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    │    │    │    │    ├── key: (41,45)
+ │         │    │    │    │    │    ├── fd: (41)-->(42), (45)-->(46)
+ │         │    │    │    │    │    ├── scan n1
+ │         │    │    │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null)
+ │         │    │    │    │    │    │    ├── key: (41)
+ │         │    │    │    │    │    │    └── fd: (41)-->(42)
+ │         │    │    │    │    │    ├── scan n2
+ │         │    │    │    │    │    │    ├── columns: n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    │    │    │    │    │    ├── key: (45)
+ │         │    │    │    │    │    │    └── fd: (45)-->(46)
+ │         │    │    │    │    │    └── filters
+ │         │    │    │    │    │         └── ((n1.n_name = 'FRANCE') AND (n2.n_name = 'GERMANY')) OR ((n1.n_name = 'GERMANY') AND (n2.n_name = 'FRANCE')) [type=bool, outer=(42,46)]
+ │         │    │    │    │    ├── scan customer@c_nk
+ │         │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null)
+ │         │    │    │    │    │    ├── key: (33)
+ │         │    │    │    │    │    └── fd: (33)-->(36)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── c_nationkey = n2.n_nationkey [type=bool, outer=(36,45), constraints=(/36: (/NULL - ]; /45: (/NULL - ]), fd=(36)==(45), (45)==(36)]
+ │         │    │    │    ├── scan orders@o_ck
+ │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null)
+ │         │    │    │    │    ├── key: (24)
+ │         │    │    │    │    └── fd: (24)-->(25)
+ │         │    │    │    └── filters
+ │         │    │    │         └── c_custkey = o_custkey [type=bool, outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
+ │         │    │    ├── index-join lineitem
+ │         │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+ │         │    │    │    └── scan lineitem@l_sd
+ │         │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
+ │         │    │    │         ├── constraint: /18/8/11: [/'1995-01-01' - /'1996-12-31']
+ │         │    │    │         ├── key: (8,11)
+ │         │    │    │         └── fd: (8,11)-->(18)
+ │         │    │    └── filters
+ │         │    │         └── o_orderkey = l_orderkey [type=bool, outer=(8,24), constraints=(/8: (/NULL - ]; /24: (/NULL - ]), fd=(8)==(24), (24)==(8)]
+ │         │    ├── scan supplier@s_nk
+ │         │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null)
+ │         │    │    ├── key: (1)
+ │         │    │    └── fd: (1)-->(4)
+ │         │    └── filters
+ │         │         ├── s_suppkey = l_suppkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │         │         └── s_nationkey = n1.n_nationkey [type=bool, outer=(4,41), constraints=(/4: (/NULL - ]; /41: (/NULL - ]), fd=(4)==(41), (41)==(4)]
+ │         └── projections
+ │              ├── extract('year', l_shipdate) [type=int, outer=(18)]
+ │              └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(13,14)]
+ └── aggregations
+      └── sum [type=float, outer=(50)]
+           └── variable: volume [type=float]
 
 # --------------------------------------------------
 # Q8
@@ -1257,130 +1108,115 @@ GROUP BY
 ORDER BY
     o_year;
 ----
-project
+sort
  ├── columns: o_year:61(int) mkt_share:66(float)
  ├── side-effects
  ├── key: (61)
  ├── fd: (61)-->(66)
  ├── ordering: +61
- ├── group-by
- │    ├── columns: o_year:61(int) sum:64(float) sum:65(float)
- │    ├── grouping columns: o_year:61(int)
- │    ├── key: (61)
- │    ├── fd: (61)-->(64,65)
- │    ├── ordering: +61
- │    ├── sort
- │    │    ├── columns: o_year:61(int) volume:62(float) column63:63(float)
- │    │    ├── ordering: +61
- │    │    └── project
- │    │         ├── columns: column63:63(float) o_year:61(int) volume:62(float)
- │    │         ├── project
- │    │         │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(string!null)
- │    │         │    ├── inner-join
- │    │         │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
- │    │         │    │    ├── inner-join
- │    │         │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    ├── fd: ()-->(59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13)
- │    │         │    │    │    ├── inner-join
- │    │         │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17)
- │    │         │    │    │    │    ├── scan lineitem
- │    │         │    │    │    │    │    └── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null)
- │    │         │    │    │    │    ├── inner-join
- │    │         │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    ├── key: (33,54)
- │    │         │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
- │    │         │    │    │    │    │    ├── inner-join (merge)
- │    │         │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    │    ├── left ordering: +45
- │    │         │    │    │    │    │    │    ├── right ordering: +50
- │    │         │    │    │    │    │    │    ├── key: (42,54)
- │    │         │    │    │    │    │    │    ├── fd: ()-->(59), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45)
- │    │         │    │    │    │    │    │    ├── scan customer@c_nk
- │    │         │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null)
- │    │         │    │    │    │    │    │    │    ├── key: (42)
- │    │         │    │    │    │    │    │    │    ├── fd: (42)-->(45)
- │    │         │    │    │    │    │    │    │    └── ordering: +45
- │    │         │    │    │    │    │    │    ├── sort
- │    │         │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    │    │    ├── key: (50,54)
- │    │         │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
- │    │         │    │    │    │    │    │    │    ├── ordering: +50 opt(59) [actual: +50]
- │    │         │    │    │    │    │    │    │    └── inner-join
- │    │         │    │    │    │    │    │    │         ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    │    │         ├── key: (50,54)
- │    │         │    │    │    │    │    │    │         ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
- │    │         │    │    │    │    │    │    │         ├── inner-join
- │    │         │    │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    │    │         │    ├── key: (54,58)
- │    │         │    │    │    │    │    │    │         │    ├── fd: ()-->(59), (54)-->(55)
- │    │         │    │    │    │    │    │    │         │    ├── scan n2
- │    │         │    │    │    │    │    │    │         │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null)
- │    │         │    │    │    │    │    │    │         │    │    ├── key: (54)
- │    │         │    │    │    │    │    │    │         │    │    └── fd: (54)-->(55)
- │    │         │    │    │    │    │    │    │         │    ├── select
- │    │         │    │    │    │    │    │    │         │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    │    │         │    │    ├── key: (58)
- │    │         │    │    │    │    │    │    │         │    │    ├── fd: ()-->(59)
- │    │         │    │    │    │    │    │    │         │    │    ├── scan region
- │    │         │    │    │    │    │    │    │         │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    │    │         │    │    │    ├── key: (58)
- │    │         │    │    │    │    │    │    │         │    │    │    └── fd: (58)-->(59)
- │    │         │    │    │    │    │    │    │         │    │    └── filters
- │    │         │    │    │    │    │    │    │         │    │         └── r_name = 'AMERICA' [type=bool, outer=(59), constraints=(/59: [/'AMERICA' - /'AMERICA']; tight), fd=()-->(59)]
- │    │         │    │    │    │    │    │    │         │    └── filters (true)
- │    │         │    │    │    │    │    │    │         ├── scan n1@n_rk
- │    │         │    │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null)
- │    │         │    │    │    │    │    │    │         │    ├── key: (50)
- │    │         │    │    │    │    │    │    │         │    └── fd: (50)-->(52)
- │    │         │    │    │    │    │    │    │         └── filters
- │    │         │    │    │    │    │    │    │              └── n1.n_regionkey = r_regionkey [type=bool, outer=(52,58), constraints=(/52: (/NULL - ]; /58: (/NULL - ]), fd=(52)==(58), (58)==(52)]
- │    │         │    │    │    │    │    │    └── filters (true)
- │    │         │    │    │    │    │    ├── index-join orders
- │    │         │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
- │    │         │    │    │    │    │    │    ├── key: (33)
- │    │         │    │    │    │    │    │    ├── fd: (33)-->(34,37)
- │    │         │    │    │    │    │    │    └── scan orders@o_od
- │    │         │    │    │    │    │    │         ├── columns: o_orderkey:33(int!null) o_orderdate:37(date!null)
- │    │         │    │    │    │    │    │         ├── constraint: /37/33: [/'1995-01-01' - /'1996-12-31']
- │    │         │    │    │    │    │    │         ├── key: (33)
- │    │         │    │    │    │    │    │         └── fd: (33)-->(37)
- │    │         │    │    │    │    │    └── filters
- │    │         │    │    │    │    │         └── o_custkey = c_custkey [type=bool, outer=(34,42), constraints=(/34: (/NULL - ]; /42: (/NULL - ]), fd=(34)==(42), (42)==(34)]
- │    │         │    │    │    │    └── filters
- │    │         │    │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(17,33), constraints=(/17: (/NULL - ]; /33: (/NULL - ]), fd=(17)==(33), (33)==(17)]
- │    │         │    │    │    ├── scan supplier@s_nk
- │    │         │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null)
- │    │         │    │    │    │    ├── key: (10)
- │    │         │    │    │    │    └── fd: (10)-->(13)
- │    │         │    │    │    └── filters
- │    │         │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
- │    │         │    │    │         └── s_nationkey = n2.n_nationkey [type=bool, outer=(13,54), constraints=(/13: (/NULL - ]; /54: (/NULL - ]), fd=(13)==(54), (54)==(13)]
- │    │         │    │    ├── select
- │    │         │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null)
- │    │         │    │    │    ├── key: (1)
- │    │         │    │    │    ├── fd: ()-->(5)
- │    │         │    │    │    ├── scan part
- │    │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null)
- │    │         │    │    │    │    ├── key: (1)
- │    │         │    │    │    │    └── fd: (1)-->(5)
- │    │         │    │    │    └── filters
- │    │         │    │    │         └── p_type = 'ECONOMY ANODIZED STEEL' [type=bool, outer=(5), constraints=(/5: [/'ECONOMY ANODIZED STEEL' - /'ECONOMY ANODIZED STEEL']; tight), fd=()-->(5)]
- │    │         │    │    └── filters
- │    │         │    │         └── p_partkey = l_partkey [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
- │    │         │    └── projections
- │    │         │         ├── extract('year', o_orderdate) [type=int, outer=(37)]
- │    │         │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(22,23)]
- │    │         └── projections
- │    │              └── CASE WHEN n2.n_name = 'BRAZIL' THEN volume ELSE 0.0 END [type=float, outer=(55,62)]
- │    └── aggregations
- │         ├── sum [type=float, outer=(63)]
- │         │    └── variable: column63 [type=float]
- │         └── sum [type=float, outer=(62)]
- │              └── variable: volume [type=float]
- └── projections
-      └── sum / sum [type=float, outer=(64,65), side-effects]
+ └── project
+      ├── columns: mkt_share:66(float) o_year:61(int)
+      ├── side-effects
+      ├── key: (61)
+      ├── fd: (61)-->(66)
+      ├── group-by
+      │    ├── columns: o_year:61(int) sum:64(float) sum:65(float)
+      │    ├── grouping columns: o_year:61(int)
+      │    ├── key: (61)
+      │    ├── fd: (61)-->(64,65)
+      │    ├── project
+      │    │    ├── columns: column63:63(float) o_year:61(int) volume:62(float)
+      │    │    ├── project
+      │    │    │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(string!null)
+      │    │    │    ├── inner-join (lookup part)
+      │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    ├── key columns: [18] = [1]
+      │    │    │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
+      │    │    │    │    ├── inner-join
+      │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    ├── fd: ()-->(59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13)
+      │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17)
+      │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    ├── key: (33,54)
+      │    │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
+      │    │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    ├── key: (42,54)
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45)
+      │    │    │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    │    ├── key: (50,54)
+      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
+      │    │    │    │    │    │    │    │    │    ├── inner-join
+      │    │    │    │    │    │    │    │    │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    │    │    ├── key: (54,58)
+      │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (54)-->(55)
+      │    │    │    │    │    │    │    │    │    │    ├── scan n2
+      │    │    │    │    │    │    │    │    │    │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null)
+      │    │    │    │    │    │    │    │    │    │    │    ├── key: (54)
+      │    │    │    │    │    │    │    │    │    │    │    └── fd: (54)-->(55)
+      │    │    │    │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    │    │    │    ├── key: (58)
+      │    │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59)
+      │    │    │    │    │    │    │    │    │    │    │    ├── scan region
+      │    │    │    │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    │    │    │    │    ├── key: (58)
+      │    │    │    │    │    │    │    │    │    │    │    │    └── fd: (58)-->(59)
+      │    │    │    │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │    │    │    │         └── r_name = 'AMERICA' [type=bool, outer=(59), constraints=(/59: [/'AMERICA' - /'AMERICA']; tight), fd=()-->(59)]
+      │    │    │    │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    │    │    │    ├── scan n1@n_rk
+      │    │    │    │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null)
+      │    │    │    │    │    │    │    │    │    │    ├── key: (50)
+      │    │    │    │    │    │    │    │    │    │    └── fd: (50)-->(52)
+      │    │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │    │         └── n1.n_regionkey = r_regionkey [type=bool, outer=(52,58), constraints=(/52: (/NULL - ]; /58: (/NULL - ]), fd=(52)==(58), (58)==(52)]
+      │    │    │    │    │    │    │    │    ├── scan customer@c_nk
+      │    │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null)
+      │    │    │    │    │    │    │    │    │    ├── key: (42)
+      │    │    │    │    │    │    │    │    │    └── fd: (42)-->(45)
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         └── c_nationkey = n1.n_nationkey [type=bool, outer=(45,50), constraints=(/45: (/NULL - ]; /50: (/NULL - ]), fd=(45)==(50), (50)==(45)]
+      │    │    │    │    │    │    │    ├── index-join orders
+      │    │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
+      │    │    │    │    │    │    │    │    ├── key: (33)
+      │    │    │    │    │    │    │    │    ├── fd: (33)-->(34,37)
+      │    │    │    │    │    │    │    │    └── scan orders@o_od
+      │    │    │    │    │    │    │    │         ├── columns: o_orderkey:33(int!null) o_orderdate:37(date!null)
+      │    │    │    │    │    │    │    │         ├── constraint: /37/33: [/'1995-01-01' - /'1996-12-31']
+      │    │    │    │    │    │    │    │         ├── key: (33)
+      │    │    │    │    │    │    │    │         └── fd: (33)-->(37)
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── o_custkey = c_custkey [type=bool, outer=(34,42), constraints=(/34: (/NULL - ]; /42: (/NULL - ]), fd=(34)==(42), (42)==(34)]
+      │    │    │    │    │    │    ├── scan lineitem
+      │    │    │    │    │    │    │    └── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null)
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(17,33), constraints=(/17: (/NULL - ]; /33: (/NULL - ]), fd=(17)==(33), (33)==(17)]
+      │    │    │    │    │    ├── scan supplier@s_nk
+      │    │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null)
+      │    │    │    │    │    │    ├── key: (10)
+      │    │    │    │    │    │    └── fd: (10)-->(13)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
+      │    │    │    │    │         └── s_nationkey = n2.n_nationkey [type=bool, outer=(13,54), constraints=(/13: (/NULL - ]; /54: (/NULL - ]), fd=(13)==(54), (54)==(13)]
+      │    │    │    │    └── filters
+      │    │    │    │         └── p_type = 'ECONOMY ANODIZED STEEL' [type=bool, outer=(5), constraints=(/5: [/'ECONOMY ANODIZED STEEL' - /'ECONOMY ANODIZED STEEL']; tight), fd=()-->(5)]
+      │    │    │    └── projections
+      │    │    │         ├── extract('year', o_orderdate) [type=int, outer=(37)]
+      │    │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(22,23)]
+      │    │    └── projections
+      │    │         └── CASE WHEN n2.n_name = 'BRAZIL' THEN volume ELSE 0.0 END [type=float, outer=(55,62)]
+      │    └── aggregations
+      │         ├── sum [type=float, outer=(63)]
+      │         │    └── variable: column63 [type=float]
+      │         └── sum [type=float, outer=(62)]
+      │              └── variable: volume [type=float]
+      └── projections
+           └── sum / sum [type=float, outer=(64,65), side-effects]
 
 # --------------------------------------------------
 # Q9
@@ -1569,13 +1405,11 @@ limit
  │         ├── project
  │         │    ├── columns: column38:38(float) c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) n_name:35(string!null)
  │         │    ├── fd: (1)-->(2,3,5,6,8,35)
- │         │    ├── inner-join (lookup customer)
+ │         │    ├── inner-join
  │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    ├── key columns: [10] = [1]
  │         │    │    ├── fd: ()-->(26), (1)-->(2-6,8), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(34), (34)==(4)
- │         │    │    ├── inner-join (lookup orders)
+ │         │    │    ├── inner-join
  │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    │    ├── key columns: [18] = [9]
  │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9)
  │         │    │    │    ├── inner-join
  │         │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
@@ -1592,10 +1426,23 @@ limit
  │         │    │    │    │    │    └── filters
  │         │    │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
  │         │    │    │    │    └── filters (true)
+ │         │    │    │    ├── index-join orders
+ │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │    ├── key: (9)
+ │         │    │    │    │    ├── fd: (9)-->(10,13)
+ │         │    │    │    │    └── scan orders@o_od
+ │         │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │         ├── constraint: /13/9: [/'1993-10-01' - /'1993-12-31']
+ │         │    │    │    │         ├── key: (9)
+ │         │    │    │    │         └── fd: (9)-->(13)
  │         │    │    │    └── filters
- │         │    │    │         ├── o_orderdate >= '1993-10-01' [type=bool, outer=(13), constraints=(/13: [/'1993-10-01' - ]; tight)]
- │         │    │    │         └── o_orderdate < '1994-01-01' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1993-12-31']; tight)]
+ │         │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
+ │         │    │    ├── scan customer
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null)
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    └── fd: (1)-->(2-6,8)
  │         │    │    └── filters
+ │         │    │         ├── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
  │         │    │         └── c_nationkey = n_nationkey [type=bool, outer=(4,34), constraints=(/4: (/NULL - ]; /34: (/NULL - ]), fd=(4)==(34), (34)==(4)]
  │         │    └── projections
  │         │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(23,24)]
@@ -1880,10 +1727,13 @@ sort
       │    ├── grouping columns: c_custkey:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(18)
-      │    ├── right-join
+      │    ├── left-join
       │    │    ├── columns: c_custkey:1(int!null) o_orderkey:9(int) o_custkey:10(int) o_comment:17(string)
       │    │    ├── key: (1,9)
       │    │    ├── fd: (9)-->(10,17)
+      │    │    ├── scan customer@c_nk
+      │    │    │    ├── columns: c_custkey:1(int!null)
+      │    │    │    └── key: (1)
       │    │    ├── select
       │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(string!null)
       │    │    │    ├── key: (9)
@@ -1894,9 +1744,6 @@ sort
       │    │    │    │    └── fd: (9)-->(10,17)
       │    │    │    └── filters
       │    │    │         └── o_comment NOT LIKE '%special%requests%' [type=bool, outer=(17), constraints=(/17: (/NULL - ])]
-      │    │    ├── scan customer@c_nk
-      │    │    │    ├── columns: c_custkey:1(int!null)
-      │    │    │    └── key: (1)
       │    │    └── filters
       │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
       │    └── aggregations
@@ -1944,8 +1791,9 @@ project
  │    ├── fd: ()-->(27,29)
  │    ├── project
  │    │    ├── columns: column26:26(float) column28:28(float)
- │    │    ├── inner-join
+ │    │    ├── inner-join (lookup part)
  │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(string!null)
+ │    │    │    ├── key columns: [2] = [17]
  │    │    │    ├── fd: (17)-->(21), (2)==(17), (17)==(2)
  │    │    │    ├── index-join lineitem
  │    │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
@@ -1954,12 +1802,7 @@ project
  │    │    │    │         ├── constraint: /11/1/4: [/'1995-09-01' - /'1995-09-30']
  │    │    │    │         ├── key: (1,4)
  │    │    │    │         └── fd: (1,4)-->(11)
- │    │    │    ├── scan part
- │    │    │    │    ├── columns: p_partkey:17(int!null) p_type:21(string!null)
- │    │    │    │    ├── key: (17)
- │    │    │    │    └── fd: (17)-->(21)
- │    │    │    └── filters
- │    │    │         └── l_partkey = p_partkey [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
+ │    │    │    └── filters (true)
  │    │    └── projections
  │    │         ├── CASE WHEN p_type LIKE 'PROMO%' THEN l_extendedprice * (1.0 - l_discount) ELSE 0.0 END [type=float, outer=(6,7,21)]
  │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(6,7)]
@@ -2019,83 +1862,75 @@ WHERE
 ORDER BY
     s_suppkey;
 ----
-project
+sort
  ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_phone:5(string!null) total_revenue:25(float!null)
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,25)
  ├── ordering: +1
- └── inner-join (merge)
-      ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_phone:5(string!null) l_suppkey:10(int!null) sum:25(float!null)
-      ├── left ordering: +1
-      ├── right ordering: +10
-      ├── key: (10)
-      ├── fd: (1)-->(2,3,5), (10)-->(25), (1)==(10), (10)==(1)
-      ├── ordering: +(1|10) [actual: +1]
-      ├── scan supplier
-      │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_phone:5(string!null)
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2,3,5)
-      │    └── ordering: +1
-      ├── sort
-      │    ├── columns: l_suppkey:10(int!null) sum:25(float!null)
-      │    ├── key: (10)
-      │    ├── fd: (10)-->(25)
-      │    ├── ordering: +10
-      │    └── select
-      │         ├── columns: l_suppkey:10(int!null) sum:25(float!null)
-      │         ├── key: (10)
-      │         ├── fd: (10)-->(25)
-      │         ├── group-by
-      │         │    ├── columns: l_suppkey:10(int!null) sum:25(float)
-      │         │    ├── grouping columns: l_suppkey:10(int!null)
-      │         │    ├── key: (10)
-      │         │    ├── fd: (10)-->(25)
-      │         │    ├── project
-      │         │    │    ├── columns: column24:24(float) l_suppkey:10(int!null)
-      │         │    │    ├── index-join lineitem
-      │         │    │    │    ├── columns: l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
-      │         │    │    │    └── scan lineitem@l_sd
-      │         │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
-      │         │    │    │         ├── constraint: /18/8/11: [/'1996-01-01' - /'1996-03-31']
-      │         │    │    │         ├── key: (8,11)
-      │         │    │    │         └── fd: (8,11)-->(18)
-      │         │    │    └── projections
-      │         │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(13,14)]
-      │         │    └── aggregations
-      │         │         └── sum [type=float, outer=(24)]
-      │         │              └── variable: column24 [type=float]
-      │         └── filters
-      │              └── eq [type=bool, outer=(25), constraints=(/25: (/NULL - ])]
-      │                   ├── variable: sum [type=float]
-      │                   └── subquery [type=float]
-      │                        └── scalar-group-by
-      │                             ├── columns: max:44(float)
-      │                             ├── cardinality: [1 - 1]
-      │                             ├── key: ()
-      │                             ├── fd: ()-->(44)
-      │                             ├── group-by
-      │                             │    ├── columns: l_suppkey:28(int!null) sum:43(float)
-      │                             │    ├── grouping columns: l_suppkey:28(int!null)
-      │                             │    ├── key: (28)
-      │                             │    ├── fd: (28)-->(43)
-      │                             │    ├── project
-      │                             │    │    ├── columns: column42:42(float) l_suppkey:28(int!null)
-      │                             │    │    ├── index-join lineitem
-      │                             │    │    │    ├── columns: l_suppkey:28(int!null) l_extendedprice:31(float!null) l_discount:32(float!null) l_shipdate:36(date!null)
-      │                             │    │    │    └── scan lineitem@l_sd
-      │                             │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
-      │                             │    │    │         ├── constraint: /36/26/29: [/'1996-01-01' - /'1996-03-31']
-      │                             │    │    │         ├── key: (26,29)
-      │                             │    │    │         └── fd: (26,29)-->(36)
-      │                             │    │    └── projections
-      │                             │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(31,32)]
-      │                             │    └── aggregations
-      │                             │         └── sum [type=float, outer=(42)]
-      │                             │              └── variable: column42 [type=float]
-      │                             └── aggregations
-      │                                  └── max [type=float, outer=(43)]
-      │                                       └── variable: sum [type=float]
-      └── filters (true)
+ └── project
+      ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_phone:5(string!null) sum:25(float!null)
+      ├── key: (1)
+      ├── fd: (1)-->(2,3,5,25)
+      └── inner-join (lookup supplier)
+           ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_phone:5(string!null) l_suppkey:10(int!null) sum:25(float!null)
+           ├── key columns: [10] = [1]
+           ├── key: (10)
+           ├── fd: (1)-->(2,3,5), (10)-->(25), (1)==(10), (10)==(1)
+           ├── select
+           │    ├── columns: l_suppkey:10(int!null) sum:25(float!null)
+           │    ├── key: (10)
+           │    ├── fd: (10)-->(25)
+           │    ├── group-by
+           │    │    ├── columns: l_suppkey:10(int!null) sum:25(float)
+           │    │    ├── grouping columns: l_suppkey:10(int!null)
+           │    │    ├── key: (10)
+           │    │    ├── fd: (10)-->(25)
+           │    │    ├── project
+           │    │    │    ├── columns: column24:24(float) l_suppkey:10(int!null)
+           │    │    │    ├── index-join lineitem
+           │    │    │    │    ├── columns: l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+           │    │    │    │    └── scan lineitem@l_sd
+           │    │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
+           │    │    │    │         ├── constraint: /18/8/11: [/'1996-01-01' - /'1996-03-31']
+           │    │    │    │         ├── key: (8,11)
+           │    │    │    │         └── fd: (8,11)-->(18)
+           │    │    │    └── projections
+           │    │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(13,14)]
+           │    │    └── aggregations
+           │    │         └── sum [type=float, outer=(24)]
+           │    │              └── variable: column24 [type=float]
+           │    └── filters
+           │         └── eq [type=bool, outer=(25), constraints=(/25: (/NULL - ])]
+           │              ├── variable: sum [type=float]
+           │              └── subquery [type=float]
+           │                   └── scalar-group-by
+           │                        ├── columns: max:44(float)
+           │                        ├── cardinality: [1 - 1]
+           │                        ├── key: ()
+           │                        ├── fd: ()-->(44)
+           │                        ├── group-by
+           │                        │    ├── columns: l_suppkey:28(int!null) sum:43(float)
+           │                        │    ├── grouping columns: l_suppkey:28(int!null)
+           │                        │    ├── key: (28)
+           │                        │    ├── fd: (28)-->(43)
+           │                        │    ├── project
+           │                        │    │    ├── columns: column42:42(float) l_suppkey:28(int!null)
+           │                        │    │    ├── index-join lineitem
+           │                        │    │    │    ├── columns: l_suppkey:28(int!null) l_extendedprice:31(float!null) l_discount:32(float!null) l_shipdate:36(date!null)
+           │                        │    │    │    └── scan lineitem@l_sd
+           │                        │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
+           │                        │    │    │         ├── constraint: /36/26/29: [/'1996-01-01' - /'1996-03-31']
+           │                        │    │    │         ├── key: (26,29)
+           │                        │    │    │         └── fd: (26,29)-->(36)
+           │                        │    │    └── projections
+           │                        │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(31,32)]
+           │                        │    └── aggregations
+           │                        │         └── sum [type=float, outer=(42)]
+           │                        │              └── variable: column42 [type=float]
+           │                        └── aggregations
+           │                             └── max [type=float, outer=(43)]
+           │                                  └── variable: sum [type=float]
+           └── filters (true)
 
 # --------------------------------------------------
 # Q16
@@ -2369,6 +2204,10 @@ limit
  │         ├── inner-join
  │         │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
  │         │    ├── fd: (1)-->(2), (9)-->(10,12,13), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
+ │         │    ├── scan customer
+ │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null)
+ │         │    │    ├── key: (1)
+ │         │    │    └── fd: (1)-->(2)
  │         │    ├── inner-join (merge)
  │         │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
  │         │    │    ├── left ordering: +9
@@ -2410,10 +2249,6 @@ limit
  │         │    │    │    ├── columns: l_orderkey:18(int!null) l_quantity:22(float!null)
  │         │    │    │    └── ordering: +18
  │         │    │    └── filters (true)
- │         │    ├── scan customer
- │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null)
- │         │    │    ├── key: (1)
- │         │    │    └── fd: (1)-->(2)
  │         │    └── filters
  │         │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
  │         └── aggregations
@@ -2711,20 +2546,20 @@ limit
  │         ├── grouping columns: s_name:2(string!null)
  │         ├── key: (2)
  │         ├── fd: (2)-->(69)
- │         ├── inner-join (lookup supplier)
+ │         ├── inner-join
  │         │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
- │         │    ├── key columns: [10] = [1]
  │         │    ├── fd: ()-->(26,34), (1)-->(2,4), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(33), (33)==(4)
- │         │    ├── inner-join (merge)
+ │         │    ├── scan supplier
+ │         │    │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_nationkey:4(int!null)
+ │         │    │    ├── key: (1)
+ │         │    │    └── fd: (1)-->(2,4)
+ │         │    ├── inner-join
  │         │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    ├── left ordering: +8
- │         │    │    ├── right ordering: +24
  │         │    │    ├── fd: ()-->(26,34), (8)==(24), (24)==(8)
  │         │    │    ├── semi-join (merge)
  │         │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
  │         │    │    │    ├── left ordering: +8
  │         │    │    │    ├── right ordering: +37
- │         │    │    │    ├── ordering: +8
  │         │    │    │    ├── anti-join (merge)
  │         │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
  │         │    │    │    │    ├── left ordering: +8
@@ -2759,38 +2594,35 @@ limit
  │         │    │    │    │    └── ordering: +37
  │         │    │    │    └── filters
  │         │    │    │         └── l2.l_suppkey != l1.l_suppkey [type=bool, outer=(10,39), constraints=(/10: (/NULL - ]; /39: (/NULL - ])]
- │         │    │    ├── sort
+ │         │    │    ├── inner-join
  │         │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
  │         │    │    │    ├── key: (24,33)
  │         │    │    │    ├── fd: ()-->(26,34)
- │         │    │    │    ├── ordering: +24 opt(26,34) [actual: +24]
- │         │    │    │    └── inner-join
- │         │    │    │         ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    │         ├── key: (24,33)
- │         │    │    │         ├── fd: ()-->(26,34)
- │         │    │    │         ├── select
- │         │    │    │         │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
- │         │    │    │         │    ├── key: (24)
- │         │    │    │         │    ├── fd: ()-->(26)
- │         │    │    │         │    ├── scan orders
- │         │    │    │         │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
- │         │    │    │         │    │    ├── key: (24)
- │         │    │    │         │    │    └── fd: (24)-->(26)
- │         │    │    │         │    └── filters
- │         │    │    │         │         └── o_orderstatus = 'F' [type=bool, outer=(26), constraints=(/26: [/'F' - /'F']; tight), fd=()-->(26)]
- │         │    │    │         ├── select
- │         │    │    │         │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    │         │    ├── key: (33)
- │         │    │    │         │    ├── fd: ()-->(34)
- │         │    │    │         │    ├── scan nation
- │         │    │    │         │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    │         │    │    ├── key: (33)
- │         │    │    │         │    │    └── fd: (33)-->(34)
- │         │    │    │         │    └── filters
- │         │    │    │         │         └── n_name = 'SAUDI ARABIA' [type=bool, outer=(34), constraints=(/34: [/'SAUDI ARABIA' - /'SAUDI ARABIA']; tight), fd=()-->(34)]
- │         │    │    │         └── filters (true)
- │         │    │    └── filters (true)
+ │         │    │    │    ├── select
+ │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    │    │    ├── key: (24)
+ │         │    │    │    │    ├── fd: ()-->(26)
+ │         │    │    │    │    ├── scan orders
+ │         │    │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    │    │    │    ├── key: (24)
+ │         │    │    │    │    │    └── fd: (24)-->(26)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── o_orderstatus = 'F' [type=bool, outer=(26), constraints=(/26: [/'F' - /'F']; tight), fd=()-->(26)]
+ │         │    │    │    ├── select
+ │         │    │    │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
+ │         │    │    │    │    ├── key: (33)
+ │         │    │    │    │    ├── fd: ()-->(34)
+ │         │    │    │    │    ├── scan nation
+ │         │    │    │    │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
+ │         │    │    │    │    │    ├── key: (33)
+ │         │    │    │    │    │    └── fd: (33)-->(34)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── n_name = 'SAUDI ARABIA' [type=bool, outer=(34), constraints=(/34: [/'SAUDI ARABIA' - /'SAUDI ARABIA']; tight), fd=()-->(34)]
+ │         │    │    │    └── filters (true)
+ │         │    │    └── filters
+ │         │    │         └── o_orderkey = l1.l_orderkey [type=bool, outer=(8,24), constraints=(/8: (/NULL - ]; /24: (/NULL - ]), fd=(8)==(24), (24)==(8)]
  │         │    └── filters
+ │         │         ├── s_suppkey = l1.l_suppkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
  │         │         └── s_nationkey = n_nationkey [type=bool, outer=(4,33), constraints=(/4: (/NULL - ]; /33: (/NULL - ]), fd=(4)==(33), (33)==(4)]
  │         └── aggregations
  │              └── count-rows [type=int]


### PR DESCRIPTION
Since we have stats by default now, this should be the default testing
mechanism. I left in tpch-no-stats since we also have that for tpcc,
just for safety.

Release note: None