### PR TITLE
storage: remove DisallowUnsequencedTransactionalWrites

### DIFF
--- a/pkg/storage/storagebase/knobs.go
+++ b/pkg/storage/storagebase/knobs.go
@@ -34,15 +34,6 @@ type BatchEvalTestingKnobs struct {
 	// NumKeysEvaluatedForRangeIntentResolution is set by the stores to the
 	// number of keys evaluated for range intent resolution.
 	NumKeysEvaluatedForRangeIntentResolution *int64
-	// DisallowUnsequencedTransactionalWrites enables an assertion that all
-	// transactional writes include Request-scoped sequence numbers. This
-	// assertion is not safe to enable by default, because it would trigger
-	// in mixed-version clusters. However, it is useful in testing to ensure
-	// that tests properly assign these sequence numbers.
-	//
-	// TODO(nvanbenschoten): Remove this testing knob in 2.2. The corresponding
-	// assertion can be performed unconditionally.
-	DisallowUnsequencedTransactionalWrites bool
 }
 
 // IntentResolverTestingKnobs contains testing helpers that are used during

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -154,10 +154,6 @@ func TestStoreConfig(clock *hlc.Clock) StoreConfig {
 		ClosedTimestamp:             container.NoopContainer(),
 	}
 
-	// Tests should never send unsequenced transactional writes,
-	// so we set this testing knob in all tests.
-	sc.TestingKnobs.EvalKnobs.DisallowUnsequencedTransactionalWrites = true
-
 	// Use shorter Raft tick settings in order to minimize start up and failover
 	// time in tests.
 	sc.RaftElectionTimeoutTicks = 3


### PR DESCRIPTION
The assertion is no longer necessary and wasn't even being used anymore.

Release note: None