### PR TITLE
roachtest: fix cdc/*/rangefeed=false

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -71,10 +71,12 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(
-		`SET CLUSTER SETTING changefeed.push.enabled = $1`, args.rangefeed,
-	); err != nil {
-		t.Fatal(err)
+	if args.rangefeed {
+		if _, err := db.Exec(
+			`SET CLUSTER SETTING changefeed.push.enabled = $1`, args.rangefeed,
+		); err != nil {
+			t.Fatal(err)
+		}
 	}
 	kafka := kafkaManager{
 		c:     c,


### PR DESCRIPTION
The `changefeed.push.enabled` setting doesn't exist on release-2.1, so
don't try setting it.

Closes #34698
Closes #34699
Closes #34697
Closes #34696
Closes #34389

Release note: None