### PR TITLE
distsqlrun: routers should respond to cancellation

### DIFF
--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -238,7 +238,7 @@ func (sp *csvWriter) Run(ctx context.Context) {
 				if sp.spec.ChunkRows > 0 && rows >= sp.spec.ChunkRows {
 					break
 				}
-				row, err := input.NextRow()
+				row, err := input.NextRow(ctx)
 				if err != nil {
 					return err
 				}

--- a/pkg/ccl/importccl/sst_writer_proc.go
+++ b/pkg/ccl/importccl/sst_writer_proc.go
@@ -111,7 +111,7 @@ func (sp *sstWriter) Run(ctx context.Context) {
 		batch := store.NewBatchWriter()
 		var key, val []byte
 		for {
-			row, err := input.NextRow()
+			row, err := input.NextRow(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -232,8 +232,10 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 		{RangeID: 3, StartKey: roachpb.RKey("g"), EndKey: roachpb.RKey("z")},
 	}
 
+	ctx := context.Background()
+
 	// Push some metadata and check that the caches are updated with it.
-	status := r.Push(nil /* row */, &distsqlrun.ProducerMetadata{
+	status := r.Push(ctx, nil, &distsqlrun.ProducerMetadata{
 		Ranges: []roachpb.RangeInfo{
 			{
 				Desc: descs[0],
@@ -249,7 +251,7 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 	if status != distsqlrun.NeedMoreRows {
 		t.Fatalf("expected status NeedMoreRows, got: %d", status)
 	}
-	status = r.Push(nil /* row */, &distsqlrun.ProducerMetadata{
+	status = r.Push(ctx, nil, &distsqlrun.ProducerMetadata{
 		Ranges: []roachpb.RangeInfo{
 			{
 				Desc: descs[2],

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -454,7 +454,7 @@ func (r *DistSQLReceiver) SetError(err error) {
 
 // Push is part of the RowReceiver interface.
 func (r *DistSQLReceiver) Push(
-	row sqlbase.EncDatumRow, meta *distsqlrun.ProducerMetadata,
+	ctx context.Context, row sqlbase.EncDatumRow, meta *distsqlrun.ProducerMetadata,
 ) distsqlrun.ConsumerStatus {
 	if meta != nil {
 		if meta.TxnCoordMeta != nil {

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -75,7 +75,7 @@ func (b *backfiller) Run(ctx context.Context) {
 	defer tracing.FinishSpan(span)
 
 	if err := b.mainLoop(ctx); err != nil {
-		b.output.Push(nil /* row */, &ProducerMetadata{Err: err})
+		b.output.Push(ctx, nil, &ProducerMetadata{Err: err})
 	}
 	sendTraceData(ctx, b.output)
 	b.output.ProducerDone()

--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -237,9 +237,7 @@ func (fr *flowRegistry) RegisterFlow(
 				)
 			}
 			for _, r := range timedOutReceivers {
-				r.Push(
-					nil, /* row */
-					&ProducerMetadata{Err: errNoInboundStreamConnection})
+				r.Push(ctx, nil, &ProducerMetadata{Err: errNoInboundStreamConnection})
 				r.ProducerDone()
 			}
 		})

--- a/pkg/sql/distsqlrun/inbound.go
+++ b/pkg/sql/distsqlrun/inbound.go
@@ -63,7 +63,7 @@ func processInboundStreamHelper(
 
 	sendErrToConsumer := func(err error) {
 		if err != nil {
-			dst.Push(nil, &ProducerMetadata{Err: err})
+			dst.Push(ctx, nil, &ProducerMetadata{Err: err})
 		}
 		dst.ProducerDone()
 	}
@@ -121,7 +121,7 @@ func processInboundStreamHelper(
 	// Check for context cancellation while reading from the stream on another
 	// goroutine.
 	select {
-	case <-f.ctxDone:
+	case <-f.ctxForCancel.Done():
 		return sqlbase.QueryCanceledError
 	case err := <-errChan:
 		return err
@@ -179,7 +179,7 @@ func processProducerMessage(
 			// Don't forward data rows when we're draining.
 			continue
 		}
-		switch dst.Push(row, meta) {
+		switch dst.Push(ctx, row, meta) {
 		case NeedMoreRows:
 			continue
 		case DrainRequested:

--- a/pkg/sql/distsqlrun/inbound_test.go
+++ b/pkg/sql/distsqlrun/inbound_test.go
@@ -111,7 +111,7 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 	// the write to the row channel is asynchronous wrt the outbox sending the
 	// row and getting back the updated consumer status.
 	testutils.SucceedsSoon(t, func() error {
-		if cs := outbox.Push(row, nil /* meta */); cs != DrainRequested {
+		if cs := outbox.Push(ctx, row, nil); cs != DrainRequested {
 			return errors.Errorf("unexpected consumer status %s", cs)
 		}
 		return nil

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -399,7 +399,7 @@ func TestJoinReaderDrain(t *testing.T) {
 	t.Run("ConsumerDone", func(t *testing.T) {
 		expectedMetaErr := errors.New("dummy")
 		in := NewRowBuffer(sqlbase.OneIntCol, nil /* rows */, RowBufferArgs{})
-		if status := in.Push(encRow, &ProducerMetadata{Err: expectedMetaErr}); status != NeedMoreRows {
+		if status := in.Push(ctx, encRow, &ProducerMetadata{Err: expectedMetaErr}); status != NeedMoreRows {
 			t.Fatalf("unexpected response: %d", status)
 		}
 

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -85,7 +85,7 @@ func TestOutbox(t *testing.T) {
 			row := sqlbase.EncDatumRow{
 				sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(0))),
 			}
-			if consumerStatus := outbox.Push(row, nil /* meta */); consumerStatus != NeedMoreRows {
+			if consumerStatus := outbox.Push(ctx, row, nil); consumerStatus != NeedMoreRows {
 				return errors.Errorf("expected status: %d, got: %d", NeedMoreRows, consumerStatus)
 			}
 
@@ -94,7 +94,7 @@ func TestOutbox(t *testing.T) {
 				row = sqlbase.EncDatumRow{
 					sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(-1))),
 				}
-				consumerStatus := outbox.Push(row, nil /* meta */)
+				consumerStatus := outbox.Push(ctx, row, nil)
 				if consumerStatus == DrainRequested {
 					break
 				}
@@ -105,13 +105,13 @@ func TestOutbox(t *testing.T) {
 
 			// Now send another row that the outbox will discard.
 			row = sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(2)))}
-			if consumerStatus := outbox.Push(row, nil /* meta */); consumerStatus != DrainRequested {
+			if consumerStatus := outbox.Push(ctx, row, nil); consumerStatus != DrainRequested {
 				return errors.Errorf("expected status: %d, got: %d", NeedMoreRows, consumerStatus)
 			}
 
 			// Send some metadata.
-			outbox.Push(nil /* row */, &ProducerMetadata{Err: errors.Errorf("meta 0")})
-			outbox.Push(nil /* row */, &ProducerMetadata{Err: errors.Errorf("meta 1")})
+			outbox.Push(ctx, nil, &ProducerMetadata{Err: errors.Errorf("meta 0")})
+			outbox.Push(ctx, nil, &ProducerMetadata{Err: errors.Errorf("meta 1")})
 			// Send the termination signal.
 			outbox.ProducerDone()
 

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -254,7 +254,7 @@ func emitHelper(
 			panic("both row data and metadata in the same emitHelper call")
 		}
 		// Bypass EmitRow() and send directly to output.output.
-		consumerStatus = output.output.Push(nil /* row */, meta)
+		consumerStatus = output.output.Push(ctx, nil, meta)
 		if meta.Err != nil {
 			consumerStatus = ConsumerClosed
 		}
@@ -262,7 +262,7 @@ func emitHelper(
 		var err error
 		consumerStatus, err = output.EmitRow(ctx, row)
 		if err != nil {
-			output.output.Push(nil /* row */, &ProducerMetadata{Err: err})
+			output.output.Push(ctx, nil, &ProducerMetadata{Err: err})
 			consumerStatus = ConsumerClosed
 		}
 	}
@@ -317,7 +317,7 @@ func (h *ProcOutputHelper) EmitRow(
 	if log.V(3) {
 		log.InfofDepth(ctx, 1, "pushing row %s", outRow)
 	}
-	if r := h.output.Push(outRow, nil); r != NeedMoreRows {
+	if r := h.output.Push(ctx, outRow, nil); r != NeedMoreRows {
 		log.VEventf(ctx, 1, "no more rows required. drain requested: %t",
 			r == DrainRequested)
 		return r, nil

--- a/pkg/sql/distsqlrun/sample_aggregator_test.go
+++ b/pkg/sql/distsqlrun/sample_aggregator_test.go
@@ -116,6 +116,7 @@ func TestSampleAggregator(t *testing.T) {
 	}
 	// Randomly interleave the output rows from the samplers into a single buffer.
 	samplerResults := NewRowBuffer(samplerOutTypes, nil /* rows */, RowBufferArgs{})
+	ctx := context.Background()
 	for len(outputs) > 0 {
 		i := rng.Intn(len(outputs))
 		row, meta := outputs[i].Next()
@@ -126,7 +127,7 @@ func TestSampleAggregator(t *testing.T) {
 		} else if row == nil {
 			outputs = append(outputs[:i], outputs[i+1:]...)
 		} else {
-			samplerResults.Push(row, nil /* meta */)
+			samplerResults.Push(ctx, row, nil)
 		}
 	}
 

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -97,7 +97,9 @@ type RowDisposer struct{}
 var _ RowReceiver = &RowDisposer{}
 
 // Push is part of the RowReceiver interface.
-func (r *RowDisposer) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) ConsumerStatus {
+func (r *RowDisposer) Push(
+	ctx context.Context, row sqlbase.EncDatumRow, meta *ProducerMetadata,
+) ConsumerStatus {
 	return NeedMoreRows
 }
 


### PR DESCRIPTION
Previously, a deadlock was possible in distsql if a producer was blocked
on pushing to a row channel when a consumer got cancelled. The consumer
would never read from the row channel to signal to the producer that it
could quit to.

Now, Push is extended to have a context, and the only blocking Push
implementation (RowChannel) is extended to select on the context's Done
channel while trying to write to the channel.

Fixes #34796.

Release note (bug fix): correct a stuck query problem when producers
were writing faster than consumers could read while the query was
getting cancelled.