### PR TITLE
intentresolver: batch intent resolution across transactions by range

### DIFF
--- a/pkg/internal/client/requestbatcher/batcher.go
+++ b/pkg/internal/client/requestbatcher/batcher.go
@@ -64,9 +64,10 @@ import (
 // no data dependencies between operations and the only key will be the guess
 // for where an operation should go.
 
-// TODO(ajwerner): Consider providing a limit on maximum number of requests in
-// flight at a time. This may ultimately lead to a need for queuing. Furthermore
-// consider using batch time to dynamically tune the amount of time we wait.
+// TODO(ajwerner): Consider a more sophisticated mechanism to limit on maximum
+// number of requests in flight at a time. This may ultimately lead to a need
+// for queuing. Furthermore consider using batch time to dynamically tune the
+// amount of time we wait.
 
 // TODO(ajwerner): Consider filtering requests which might have been canceled
 // before sending a batch.
@@ -121,6 +122,37 @@ type Config struct {
 	// when throughput is low. If MaxWait is <= 0 then no wait timeout is
 	// enforced. It is inadvisable to disable both MaxIdle and MaxWait.
 	MaxIdle time.Duration
+
+	// InFlightBackpressureLimit is the number of batches in flight above which
+	// sending clients should experience backpressure. If the batcher has more
+	// requests than this in flight it will not accept new requests until the
+	// number of in flight batches is again below this threshold. This value does
+	// not limit the number of batches which may ultimately be in flight as
+	// batches which are queued to send but not yet in flight will still send.
+	// Note that values	less than or equal to zero will result in the use of
+	// DefaultInFlightBackpressureLimit.
+	InFlightBackpressureLimit int
+}
+
+const (
+	// DefaultInFlightBackpressureLimit is the InFlightBackpressureLimit used if
+	// a zero value for that setting is passed in a Config to New.
+	// TODO(ajwerner): Justify this number.
+	DefaultInFlightBackpressureLimit = 1000
+
+	// BackpressureRecoveryFraction is the fraction of InFlightBackpressureLimit
+	// used to detect when enough in flight requests have completed such that more
+	// requests should now be accepted. A value less than 1 is chosen in order to
+	// avoid thrashing on backpressure which might ultimately defeat the purpose
+	// of the RequestBatcher.
+	backpressureRecoveryFraction = .8
+)
+
+func backpressureRecoveryThreshold(limit int) int {
+	if l := int(float64(limit) * backpressureRecoveryFraction); l > 0 {
+		return l
+	}
+	return 1 // don't allow the recovery threshold to be 0
 }
 
 // RequestBatcher batches requests destined for a single range based on
@@ -131,7 +163,8 @@ type RequestBatcher struct {
 
 	batches batchQueue
 
-	requestChan chan *request
+	requestChan  chan *request
+	sendDoneChan chan struct{}
 }
 
 // Response is exported for use with the channel-oriented SendWithChan method.
@@ -145,10 +178,11 @@ type Response struct {
 func New(cfg Config) *RequestBatcher {
 	validateConfig(&cfg)
 	b := &RequestBatcher{
-		cfg:         cfg,
-		pool:        makePool(),
-		batches:     makeBatchQueue(),
-		requestChan: make(chan *request),
+		cfg:          cfg,
+		pool:         makePool(),
+		batches:      makeBatchQueue(),
+		requestChan:  make(chan *request),
+		sendDoneChan: make(chan struct{}),
 	}
 	if err := cfg.Stopper.RunAsyncTask(context.Background(), b.cfg.Name, b.run); err != nil {
 		panic(err)
@@ -161,6 +195,9 @@ func validateConfig(cfg *Config) {
 		panic("cannot construct a Batcher with a nil Stopper")
 	} else if cfg.Sender == nil {
 		panic("cannot construct a Batcher with a nil Sender")
+	}
+	if cfg.InFlightBackpressureLimit <= 0 {
+		cfg.InFlightBackpressureLimit = DefaultInFlightBackpressureLimit
 	}
 }
 
@@ -204,8 +241,16 @@ func (b *RequestBatcher) Send(
 	}
 }
 
+func (b *RequestBatcher) sendDone() {
+	select {
+	case b.sendDoneChan <- struct{}{}:
+	case <-b.cfg.Stopper.ShouldQuiesce():
+	}
+}
+
 func (b *RequestBatcher) sendBatch(ctx context.Context, ba *batch) {
 	b.cfg.Stopper.RunWorker(ctx, func(ctx context.Context) {
+		defer b.sendDone()
 		resp, pErr := b.cfg.Sender.Send(ctx, ba.batchRequest())
 		for i, r := range ba.reqs {
 			res := Response{}
@@ -252,28 +297,38 @@ func (b *RequestBatcher) cleanup(err error) {
 }
 
 func (b *RequestBatcher) run(ctx context.Context) {
-	var deadline time.Time
-	timer := timeutil.NewTimer()
-	maybeSetTimer := func() {
-		var nextDeadline time.Time
-		if next := b.batches.peekFront(); next != nil {
-			nextDeadline = next.deadline
+	var (
+		// inFlight tracks the number of batches currently being sent.
+		// true.
+		inFlight = 0
+		// inBackPressure indicates whether the reqChan is enabled.
+		// It becomes true when inFlight exceeds b.cfg.InFlightBackpressureLimit.
+		inBackPressure = false
+		// recoveryThreshold is the number of in flight requests below which the
+		// the inBackPressure state should exit.
+		recoveryThreshold = backpressureRecoveryThreshold(b.cfg.InFlightBackpressureLimit)
+		// reqChan consults inBackPressure to determine whether the goroutine is
+		// accepting new requests.
+		reqChan = func() <-chan *request {
+			if inBackPressure {
+				return nil
+			}
+			return b.requestChan
 		}
-		if !deadline.Equal(nextDeadline) {
-			deadline = nextDeadline
-			if !deadline.IsZero() {
-				timer.Reset(time.Until(deadline))
-			} else {
-				// Clear the current timer due to a sole batch already sent before
-				// the timer fired.
-				timer.Stop()
-				timer = timeutil.NewTimer()
+		sendBatch = func(ba *batch) {
+			inFlight++
+			if inFlight >= b.cfg.InFlightBackpressureLimit {
+				inBackPressure = true
+			}
+			b.sendBatch(ctx, ba)
+		}
+		handleSendDone = func() {
+			inFlight--
+			if inFlight < recoveryThreshold {
+				inBackPressure = false
 			}
 		}
-	}
-	for {
-		select {
-		case req := <-b.requestChan:
+		handleRequest = func(req *request) {
 			now := timeutil.Now()
 			ba, existsInQueue := b.batches.get(req.rangeID)
 			if !existsInQueue {
@@ -283,15 +338,43 @@ func (b *RequestBatcher) run(ctx context.Context) {
 				if existsInQueue {
 					b.batches.remove(ba)
 				}
-				b.sendBatch(ctx, ba)
+				sendBatch(ba)
 			} else {
 				b.batches.upsert(ba)
 			}
+		}
+		deadline      time.Time
+		timer         = timeutil.NewTimer()
+		maybeSetTimer = func() {
+			var nextDeadline time.Time
+			if next := b.batches.peekFront(); next != nil {
+				nextDeadline = next.deadline
+			}
+			if !deadline.Equal(nextDeadline) {
+				deadline = nextDeadline
+				if !deadline.IsZero() {
+					timer.Reset(time.Until(deadline))
+				} else {
+					// Clear the current timer due to a sole batch already sent before
+					// the timer fired.
+					timer.Stop()
+					timer = timeutil.NewTimer()
+				}
+				deadline = nextDeadline
+			}
+		}
+	)
+	for {
+		select {
+		case req := <-reqChan():
+			handleRequest(req)
 			maybeSetTimer()
 		case <-timer.C:
 			timer.Read = true
-			b.sendBatch(ctx, b.batches.popFront())
+			sendBatch(b.batches.popFront())
 			maybeSetTimer()
+		case <-b.sendDoneChan:
+			handleSendDone()
 		case <-b.cfg.Stopper.ShouldQuiesce():
 			b.cleanup(stop.ErrUnavailable)
 			return

--- a/pkg/internal/client/requestbatcher/batcher.go
+++ b/pkg/internal/client/requestbatcher/batcher.go
@@ -134,6 +134,13 @@ type RequestBatcher struct {
 	requestChan chan *request
 }
 
+// Response is exported for use with the channel-oriented SendWithChan method.
+// At least one of Resp or Err will be populated for every sent Response.
+type Response struct {
+	Resp roachpb.Response
+	Err  error
+}
+
 // New creates a new RequestBatcher.
 func New(cfg Config) *RequestBatcher {
 	validateConfig(&cfg)
@@ -157,25 +164,39 @@ func validateConfig(cfg *Config) {
 	}
 }
 
+// SendWithChan sends a request with a client provided response channel. The
+// client is responsible for ensuring that the passed respChan has a buffer at
+// least as large as the number of responses it expects to receive. Using an
+// insufficiently buffered channel can lead to deadlocks and unintended delays
+// processing requests inside the RequestBatcher.
+func (b *RequestBatcher) SendWithChan(
+	ctx context.Context, respChan chan<- Response, rangeID roachpb.RangeID, req roachpb.Request,
+) error {
+	select {
+	case b.requestChan <- b.pool.newRequest(ctx, rangeID, req, respChan):
+		return nil
+	case <-b.cfg.Stopper.ShouldQuiesce():
+		return stop.ErrUnavailable
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // Send sends req as a part of a batch. An error is returned if the context
 // is canceled before the sending of the request completes.
 func (b *RequestBatcher) Send(
 	ctx context.Context, rangeID roachpb.RangeID, req roachpb.Request,
 ) (roachpb.Response, error) {
 	responseChan := b.pool.getResponseChan()
-	select {
-	case b.requestChan <- b.pool.newRequest(ctx, rangeID, req, responseChan):
-	case <-b.cfg.Stopper.ShouldQuiesce():
-		return nil, stop.ErrUnavailable
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	if err := b.SendWithChan(ctx, responseChan, rangeID, req); err != nil {
+		return nil, err
 	}
 	select {
 	case resp := <-responseChan:
 		// It's only safe to put responseChan back in the pool if it has been
 		// received from.
 		b.pool.putResponseChan(responseChan)
-		return resp.resp, resp.err
+		return resp.Resp, resp.Err
 	case <-b.cfg.Stopper.ShouldQuiesce():
 		return nil, stop.ErrUnavailable
 	case <-ctx.Done():
@@ -187,19 +208,19 @@ func (b *RequestBatcher) sendBatch(ctx context.Context, ba *batch) {
 	b.cfg.Stopper.RunWorker(ctx, func(ctx context.Context) {
 		resp, pErr := b.cfg.Sender.Send(ctx, ba.batchRequest())
 		for i, r := range ba.reqs {
-			res := response{}
+			res := Response{}
 			if resp != nil && i < len(resp.Responses) {
-				res.resp = resp.Responses[i].GetInner()
+				res.Resp = resp.Responses[i].GetInner()
 			}
 			if pErr != nil {
-				res.err = pErr.GoError()
+				res.Err = pErr.GoError()
 			}
 			b.sendResponse(r, res)
 		}
 	})
 }
 
-func (b *RequestBatcher) sendResponse(req *request, resp response) {
+func (b *RequestBatcher) sendResponse(req *request, resp Response) {
 	// This send should never block because responseChan is buffered.
 	req.responseChan <- resp
 	b.pool.putRequest(req)
@@ -225,7 +246,7 @@ func addRequestToBatch(cfg *Config, now time.Time, ba *batch, r *request) (shoul
 func (b *RequestBatcher) cleanup(err error) {
 	for ba := b.batches.popFront(); ba != nil; ba = b.batches.popFront() {
 		for _, r := range ba.reqs {
-			b.sendResponse(r, response{err: err})
+			b.sendResponse(r, Response{Err: err})
 		}
 	}
 }
@@ -285,12 +306,7 @@ type request struct {
 	ctx          context.Context
 	req          roachpb.Request
 	rangeID      roachpb.RangeID
-	responseChan chan<- response
-}
-
-type response struct {
-	resp roachpb.Response
-	err  error
+	responseChan chan<- Response
 }
 
 type batch struct {
@@ -334,7 +350,7 @@ type pool struct {
 func makePool() pool {
 	return pool{
 		responseChanPool: sync.Pool{
-			New: func() interface{} { return make(chan response, 1) },
+			New: func() interface{} { return make(chan Response, 1) },
 		},
 		batchPool: sync.Pool{
 			New: func() interface{} { return &batch{} },
@@ -345,16 +361,16 @@ func makePool() pool {
 	}
 }
 
-func (p *pool) getResponseChan() chan response {
-	return p.responseChanPool.Get().(chan response)
+func (p *pool) getResponseChan() chan Response {
+	return p.responseChanPool.Get().(chan Response)
 }
 
-func (p *pool) putResponseChan(r chan response) {
+func (p *pool) putResponseChan(r chan Response) {
 	p.responseChanPool.Put(r)
 }
 
 func (p *pool) newRequest(
-	ctx context.Context, rangeID roachpb.RangeID, req roachpb.Request, responseChan chan<- response,
+	ctx context.Context, rangeID roachpb.RangeID, req roachpb.Request, responseChan chan<- Response,
 ) *request {
 	r := p.requestPool.Get().(*request)
 	*r = request{

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -453,7 +453,7 @@ func (ds *DistSender) CountRanges(ctx context.Context, rs roachpb.RSpan) (int64,
 func (ds *DistSender) getDescriptor(
 	ctx context.Context, descKey roachpb.RKey, evictToken *EvictionToken, useReverseScan bool,
 ) (*roachpb.RangeDescriptor, *EvictionToken, error) {
-	desc, returnToken, err := ds.rangeCache.LookupRangeDescriptor(
+	desc, returnToken, err := ds.rangeCache.LookupRangeDescriptorWithEvictionToken(
 		ctx, descKey, evictToken, useReverseScan,
 	)
 	if err != nil {

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -428,7 +428,7 @@ func (mdb MockRangeDescriptorDB) withMetaRecursion(
 	return func(key roachpb.RKey, useReverseScan bool) (rs, preRs []roachpb.RangeDescriptor, err error) {
 		metaKey := keys.RangeMetaKey(key)
 		if !metaKey.Equal(roachpb.RKeyMin) {
-			_, _, err := rdc.LookupRangeDescriptor(context.Background(), metaKey, nil, useReverseScan)
+			_, _, err := rdc.LookupRangeDescriptorWithEvictionToken(context.Background(), metaKey, nil, useReverseScan)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -882,7 +882,7 @@ func TestEvictOnFirstRangeGossip(t *testing.T) {
 	rAnyKey := keys.MustAddr(anyKey)
 
 	call := func() {
-		if _, _, err := ds.rangeCache.LookupRangeDescriptor(
+		if _, _, err := ds.rangeCache.LookupRangeDescriptorWithEvictionToken(
 			context.Background(), rAnyKey, nil, false,
 		); err != nil {
 			t.Fatal(err)

--- a/pkg/kv/kvbase/range_cache.go
+++ b/pkg/kv/kvbase/range_cache.go
@@ -1,0 +1,33 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+// Package kvbase exports kv level interfaces to avoid dependency cycles.
+package kvbase
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// RangeDescriptorCache is a simplified interface to the kv.RangeDescriptorCache
+// for use at lower levels of the stack like storage.
+type RangeDescriptorCache interface {
+
+	// LookupRangeDescritor looks up a range descriptor based on a key.
+	LookupRangeDescriptor(
+		ctx context.Context, key roachpb.RKey,
+	) (*roachpb.RangeDescriptor, error)
+}

--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -139,7 +139,7 @@ func (db *testDescriptorDB) simulateLookupScan(
 ) error {
 	metaKey := keys.RangeMetaKey(key)
 	for {
-		desc, _, err := db.cache.LookupRangeDescriptor(ctx, metaKey, nil, useReverseScan)
+		desc, _, err := db.cache.LookupRangeDescriptorWithEvictionToken(ctx, metaKey, nil, useReverseScan)
 		if err != nil {
 			return err
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -446,6 +446,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		StorePool:               s.storePool,
 		SQLExecutor:             internalExecutor,
 		LogRangeEvents:          s.cfg.EventLogEnabled,
+		RangeDescriptorCache:    s.distSender.RangeDescriptorCache(),
 		TimeSeriesDataStore:     s.tsDB,
 
 		// Initialize the closed timestamp subsystem. Note that it won't

--- a/pkg/storage/bulk/sst_batcher_test.go
+++ b/pkg/storage/bulk/sst_batcher_test.go
@@ -120,7 +120,7 @@ func runTestImport(t *testing.T, batchSize int64) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			r, _, err := s.DistSender().RangeDescriptorCache().LookupRangeDescriptor(ctx, addr, nil, false)
+			r, _, err := s.DistSender().RangeDescriptorCache().LookupRangeDescriptorWithEvictionToken(ctx, addr, nil, false)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -674,7 +674,11 @@ func TestGCQueueTransactionTable(t *testing.T) {
 	}
 
 	var resolved syncmap.Map
-
+	// Set the MaxIntentResolutionBatchSize to 1 so that the injected error for
+	// resolution of "g" does not lead to the failure of resolution of "f".
+	// The need to set this highlights the "fate sharing" aspect of batching
+	// intent resolution.
+	tsc.TestingKnobs.IntentResolverKnobs.MaxIntentResolutionBatchSize = 1
 	tsc.TestingKnobs.EvalKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if resArgs, ok := filterArgs.Req.(*roachpb.ResolveIntentRequest); ok {

--- a/pkg/storage/storagebase/knobs.go
+++ b/pkg/storage/storagebase/knobs.go
@@ -48,4 +48,8 @@ type IntentResolverTestingKnobs struct {
 	// performed synchronously. It is equivalent to setting IntentResolverTaskLimit
 	// to -1.
 	ForceSyncIntentResolution bool
+
+	// MaxIntentResolutionBatchSize overrides the maximum number of intent
+	// resolution requests which can be sent in a single batch.
+	MaxIntentResolutionBatchSize int
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
@@ -594,15 +595,16 @@ type StoreConfig struct {
 	AmbientCtx log.AmbientContext
 	base.RaftConfig
 
-	Settings     *cluster.Settings
-	Clock        *hlc.Clock
-	DB           *client.DB
-	Gossip       *gossip.Gossip
-	NodeLiveness *NodeLiveness
-	StorePool    *StorePool
-	Transport    *RaftTransport
-	NodeDialer   *nodedialer.Dialer
-	RPCContext   *rpc.Context
+	Settings             *cluster.Settings
+	Clock                *hlc.Clock
+	DB                   *client.DB
+	Gossip               *gossip.Gossip
+	NodeLiveness         *NodeLiveness
+	StorePool            *StorePool
+	Transport            *RaftTransport
+	NodeDialer           *nodedialer.Dialer
+	RPCContext           *rpc.Context
+	RangeDescriptorCache kvbase.RangeDescriptorCache
 
 	ClosedTimestamp *container.Container
 
@@ -1262,12 +1264,13 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 
 	// create the intent resolver
 	s.intentResolver = intentresolver.New(intentresolver.Config{
-		Clock:        s.cfg.Clock,
-		DB:           s.db,
-		Stopper:      stopper,
-		TaskLimit:    s.cfg.IntentResolverTaskLimit,
-		AmbientCtx:   s.cfg.AmbientCtx,
-		TestingKnobs: s.cfg.TestingKnobs.IntentResolverKnobs,
+		Clock:                s.cfg.Clock,
+		DB:                   s.db,
+		Stopper:              stopper,
+		TaskLimit:            s.cfg.IntentResolverTaskLimit,
+		AmbientCtx:           s.cfg.AmbientCtx,
+		TestingKnobs:         s.cfg.TestingKnobs.IntentResolverKnobs,
+		RangeDescriptorCache: s.cfg.RangeDescriptorCache,
 	})
 
 	s.metrics.registry.AddMetricStruct(s.intentResolver.Metrics)


### PR DESCRIPTION
This PR modifies the IntentResolver to batch intent resolution across different                                                                                                                                    
transactions on a (best effort) per range basis. It acheives this batching by                                                                                                                                      
plumbing RangeDescriptorCache into the IntentResolver so that an intent-range                                                                                                                                      
mapping can be determined and then using the RequestBatcher introduced in                                                                                                                                          
concurrently without requiring additional goroutines this change extends the                                                                                                                                       
interface to allow the client to provide the response channel.                                                                                                                                                     
                                                                                                                                                                    
**Performance Wins**                                                                                                                                                                                               
                                                                                                                                                                                                                   
The change yields significant throughput wins in targeted benchmarks. We expect                                                                                                                                   
that write-heavy workloads which generate a large number of intents scattered                                                                                                                                      
over ranges to benefit most from this change. The following benchmarks were run                                                                                                                                    
using kv0 with a batch size of 10 and secondary indices enabled (see command).                                                                                                                                     
On both 4- and 32-core nodes a ~30% throughput increase is observed.                                                                                                                                               
                                                                                                                                                                                                                   
```                                                                                                                                                                                                                
./workload run kv '{pgurl:1-3}' --init --splits=256 --duration 90s --batch 10 --secondary-index --read-percent=0 --concurrency=512                                                                                 
```                                                                                                                                                                                                                
                                                                                                                                                                                                                   
8-Core                                                                                                                                                                                                             
```                                                                                                                                                                                                                
name       old ops/s  new ops/s  delta                                                                                                                                                                             
KV0        510 ± 3%   651 ± 7%  +27.58%  (p=0.008 n=5+5)                                                                                                                                                          
```                                                                                                                                                                                                                
                                                                                                                                                                                                                   
32-core                                                                                                                                                                                                            
```                                                                                                                                                                                                                
name       old ops/s   new ops/s   delta                                                                                                                                                                           
KV0        1.01k ± 3%  1.32k ± 1%  +30.78%  (p=0.008 n=5+5)                                                                                                                                                        
``` 
                                                                                                                                                                                                                   
No change in performance for TPCC was observed:                                                                                                                                                                    
                                                                                                                                                                                                                   
8-Core (400 warehouses)                                                                                                                                                                                            
```                                                                                                                                                                                                                
_elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)                                                                                                                                   
  300.0s     6073.2  94.5%    180.0    167.8    268.4    318.8    402.7   2013.3                                                                                                                                   
name       old ops/s   new ops/s   delta                                                                                                                                                                           
tpmc        6.09k ± 1%  6.08k ± 0%   ~     (p=0.886 n=4+4)                                                                                                                                                          
```                                                                                                                                                                                                                
                                                                                                                                                                                                                   
32-Core (1500 warehouses)                                                                                                                                                                                          
```                                                                                                                                                                                                                
_elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)                                                                                                                                   
  300.0s    19303.0  93.8%    342.5    335.5    453.0    520.1    704.6   3623.9                                                                                                                                   
name       old ops/s   new ops/s   delta                                                                                                                                                                           
tpmc      19.3k ± 0%  19.3k ± 0%   ~     (p=1.000 n=4+4)                                                                                                                                                           
```                                               

Highly Contended Workload:

The worst case workload for this change ought to be one that has contention on transactions but not too much contention that the increase in the contention footprint caused by this change gets caught in the noise. To evaluate this workload we run the kv0 benchmark with a secondary index and a short cycle length. With a very short cycle length the change shows no change to a modest win. Surprisingly with a longer cycle length such that the expected contention is lower it shows a real win in throughput and tail latency with

32 core, cycle length 16, 256 splits, concurrency 64
```
name       old ops/s  new ops/s  delta
KV0        472 ± 3%   483 ± 1%  +2.35%  (p=0.016 n=5+5)
```

32 core, cycle length 16, splits 512, concurrency 256
```
name       old ops/s  new ops/s  delta
KV0        487 ± 2%   491 ± 2%   ~     (p=0.841 n=5+5)
```

8 core, cycle length 128, splits 256, concurrency 256
```
name       old ops/s  new ops/s  delta
KV0        201 ± 7%   356 ± 7%  +77.08%  (p=0.016 n=5+4)
```

Fixes #30780
                                                                                                                      
Release note (performance improvement): Increase write throughput for workloads                                                                                                                                    
which write large numbers of intents by coalescing intent resolution requests                                                                                                                                      
across transactions. 