### PR TITLE
release-2.1: sql: prevent UPDATE from crashing if subquery returns no rows

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -495,3 +495,20 @@ UPDATE t32477 SET x = rank(x) OVER ()
 
 statement error generator functions are not allowed in UPDATE SET
 UPDATE t32477 SET x = generate_series(1,2)
+
+#regression test for #32054
+subtest empty_update_subquery
+
+statement ok
+CREATE TABLE t32054(x,y) AS SELECT 1,2
+
+statement ok
+CREATE TABLE t32054_empty(x INT, y INT)
+
+statement ok
+UPDATE t32054 SET (x,y) = (SELECT x,y FROM t32054_empty)
+
+query II
+SELECT * FROM t32054
+----
+NULL  NULL

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -329,10 +329,15 @@ func (p *planner) Update(
 
 				colIdx := render.addOrReuseRender(col, expr, false)
 
-				sourceSlots = append(sourceSlots, tupleSlot{
+				tSlot := tupleSlot{
 					columns:     updateCols[currentUpdateIdx : currentUpdateIdx+len(setExpr.Names)],
+					emptySlot:   make(tree.Datums, len(setExpr.Names)),
 					sourceIndex: colIdx,
-				})
+				}
+				for i := range tSlot.emptySlot {
+					tSlot.emptySlot[i] = tree.DNull
+				}
+				sourceSlots = append(sourceSlots, tSlot)
 				currentUpdateIdx += len(setExpr.Names)
 			default:
 				panic(fmt.Sprintf("assigning to tuple with expression that is neither a tuple nor a subquery: %s", setExpr.Expr))
@@ -740,9 +745,15 @@ type sourceSlot interface {
 type tupleSlot struct {
 	columns     []sqlbase.ColumnDescriptor
 	sourceIndex int
+	// emptySlot is to be returned when the source subquery
+	// returns no rows.
+	emptySlot tree.Datums
 }
 
 func (ts tupleSlot) extractValues(row tree.Datums) tree.Datums {
+	if row[ts.sourceIndex] == tree.DNull {
+		return ts.emptySlot
+	}
 	return row[ts.sourceIndex].(*tree.DTuple).D
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #34804.

/cc @cockroachdb/release

---

Fixes #32054.

Note: only the heuristic planner was affected. The CBO was handling
this case fine already.

Release note (bug fix): When using `UPDATE SET (a,b)
= (...subquery...)`, CockroachDb will not crash any more if the
subquery returns no rows.
