### PR TITLE
release-2.0: sql: prevent UPDATE from crashing if subquery returns no rows

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -550,3 +550,20 @@ UPDATE t32477 SET (y,z) = (rank() OVER (), rank() OVER ())
 
 statement error value type setof tuple{int} doesn't match type INT of column "x"
 UPDATE t32477 SET x = generate_series(1, 2)
+
+#regression test for #32054
+subtest empty_update_subquery
+
+statement ok
+CREATE TABLE t32054(x,y) AS SELECT 1,2
+
+statement ok
+CREATE TABLE t32054_empty(x INT, y INT)
+
+statement ok
+UPDATE t32054 SET (x,y) = (SELECT x,y FROM t32054_empty)
+
+query II
+SELECT * FROM t32054
+----
+NULL  NULL


### PR DESCRIPTION
Backport 1/1 commits from #34804.

/cc @cockroachdb/release

---

Fixes #32054.

Release note (bug fix): When using `UPDATE SET (a,b)
= (...subquery...)`, CockroachDb will not crash any more if the
subquery returns no rows.
