### PR TITLE
stop: allow double-calling Stop()

### DIFF
--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -123,6 +123,8 @@ type Stopper struct {
 		idAlloc   int
 		qCancels  map[int]func()
 		sCancels  map[int]func()
+
+		stopCalled bool // turns all but first call to Stop into noop
 	}
 }
 
@@ -448,6 +450,15 @@ func (s *Stopper) runningTasksLocked() TaskMap {
 // Stop signals all live workers to stop and then waits for each to
 // confirm it has stopped.
 func (s *Stopper) Stop(ctx context.Context) {
+	s.mu.Lock()
+	stopCalled := s.mu.stopCalled
+	s.mu.stopCalled = true
+	s.mu.Unlock()
+
+	if stopCalled {
+		return
+	}
+
 	defer s.Recover(ctx)
 	defer unregister(s)
 

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -108,6 +108,8 @@ func TestStopperIsStopped(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("stopper should have finished stopping")
 	}
+
+	s.Stop(context.Background())
 }
 
 func TestStopperMultipleStopees(t *testing.T) {


### PR DESCRIPTION
Stop() can be called multiple times and it's better to embrace that fact
than to try to fight it. See

https://github.com/cockroachdb/cockroach/blob/89ce71e9b733df3855b370aa20bb809db3d4362c/pkg/cli/start.go#L794-L809

Fixes #34572

Release note (bug fix): Fix a rare crash ("close of closed channel")
that could occur when shutting down a server.