### PR TITLE
util/log: ensure the logging GC daemon stops when the rest stops

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -594,6 +594,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		sqlExecutorTestingKnobs = new(sql.ExecutorTestingKnobs)
 	}
 
+	loggerCtx, _ := s.stopper.WithCancelOnStop(ctx)
+
 	execCfg = sql.ExecutorConfig{
 		Settings:                s.st,
 		NodeInfo:                nodeInfo,
@@ -638,11 +640,11 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		),
 
 		ExecLogger: log.NewSecondaryLogger(
-			nil /* dirName */, "sql-exec", true /* enableGc */, false, /*forceSyncWrites*/
+			loggerCtx, nil /* dirName */, "sql-exec", true /* enableGc */, false, /*forceSyncWrites*/
 		),
 
 		AuditLogger: log.NewSecondaryLogger(
-			s.cfg.SQLAuditLogDirName, "sql-audit", true /*enableGc*/, true, /*forceSyncWrites*/
+			loggerCtx, s.cfg.SQLAuditLogDirName, "sql-audit", true /*enableGc*/, true, /*forceSyncWrites*/
 		),
 
 		QueryCache: querycache.New(s.cfg.SQLQueryCacheSize),

--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -53,8 +53,6 @@ func interestingGoroutines() map[int64]string {
 		}
 
 		if stack == "" ||
-			strings.Contains(stack, "github.com/cockroachdb/cockroach/pkg/util/log.init") ||
-			strings.Contains(stack, "github.com/cockroachdb/cockroach/pkg/util/log.NewSecondaryLogger") ||
 			// Ignore HTTP keep alives
 			strings.Contains(stack, ").readLoop(") ||
 			strings.Contains(stack, ").writeLoop(") ||

--- a/pkg/util/log/secondary_log.go
+++ b/pkg/util/log/secondary_log.go
@@ -45,8 +45,10 @@ var secondaryLogRegistry struct {
 // The given directory name can be either nil or empty, in which case
 // the global logger's own dirName is used; or non-nil and non-empty,
 // in which case it specifies the directory for that new logger.
+//
+// The logger's GC daemon stops when the provided context is canceled.
 func NewSecondaryLogger(
-	dirName *DirName, fileNamePrefix string, enableGc, forceSyncWrites bool,
+	ctx context.Context, dirName *DirName, fileNamePrefix string, enableGc, forceSyncWrites bool,
 ) *SecondaryLogger {
 	logging.mu.Lock()
 	defer logging.mu.Unlock()
@@ -78,7 +80,7 @@ func NewSecondaryLogger(
 
 	if enableGc {
 		// Start the log file GC for the secondary logger.
-		go l.logger.gcDaemon()
+		go l.logger.gcDaemon(ctx)
 	}
 
 	return l

--- a/pkg/util/log/secondary_log_test.go
+++ b/pkg/util/log/secondary_log_test.go
@@ -20,20 +20,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logtags"
 )
 
 func TestSecondaryLog(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	s := ScopeWithoutShowLogs(t)
 	defer s.Close(t)
 	setFlags()
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Make a new logger, in the same directory.
-	l := NewSecondaryLogger(&logging.logDir, "woo", false, false)
+	l := NewSecondaryLogger(ctx, &logging.logDir, "woo", true, false)
 
 	// Interleave some messages.
 	Infof(context.Background(), "test1")
-	ctx := logtags.AddTag(context.Background(), "hello", "world")
+	ctx = logtags.AddTag(ctx, "hello", "world")
 	l.Logf(ctx, "story time")
 	Infof(context.Background(), "test2")
 


### PR DESCRIPTION
Helps with #34735.

The logging daemon gc loop did not have a way to be stopped "from the
outside". This patch adds this via the `context.Context` cancellation
protocol.

It then links the cancellation of the two secondary loggers to each
server's stopper.

Release note: None