### PR TITLE
roachtest: disable follower_reads test for versions prior to v2.2.0

### DIFF
--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -40,7 +40,8 @@ func registerFollowerReads(r *registry) {
 			CPUs:      2,
 			Geo:       true,
 		},
-		Run: runFollowerReadsTest,
+		MinVersion: "v2.2.0",
+		Run:        runFollowerReadsTest,
 	})
 }
 


### PR DESCRIPTION
Fixed #34814

Release note: None