### PR TITLE
jobs: only include running and very recently finished jobs in SHOW JOBS

### DIFF
--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -110,11 +110,13 @@ drop database  ·  ·
 query TTT
 EXPLAIN SHOW JOBS
 ----
-sort              ·      ·
- │                order  -"coalesce",-started
- └── render       ·      ·
-      └── values  ·      ·
-·                 size   15 columns, 0 rows
+sort                   ·       ·
+ │                     order   -"coalesce",-started
+ └── render            ·       ·
+      └── filter       ·       ·
+           │           filter  (finished IS NULL) OR (finished > (now() - '12:00:00'))
+           └── values  ·       ·
+·                      size    15 columns, 0 rows
 
 statement ok
 CREATE INDEX a ON foo(x)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -101,11 +101,13 @@ drop database  ·  ·
 query TTT
 EXPLAIN SHOW JOBS
 ----
-sort              ·      ·
- │                order  -"coalesce",-started
- └── render       ·      ·
-      └── values  ·      ·
-·                 size   15 columns, 0 rows
+sort                   ·       ·
+ │                     order   -"coalesce",-started
+ └── render            ·       ·
+      └── filter       ·       ·
+           │           filter  (finished IS NULL) OR (finished > (now() - '12:00:00'))
+           └── values  ·       ·
+·                      size    15 columns, 0 rows
 
 statement ok
 CREATE INDEX a ON foo(x)

--- a/pkg/sql/show_jobs.go
+++ b/pkg/sql/show_jobs.go
@@ -31,7 +31,8 @@ func (p *planner) ShowJobs(ctx context.Context, n *tree.ShowJobs) (planNode, err
 	return p.delegateQuery(ctx, "SHOW JOBS",
 		`SELECT job_id, job_type, description, user_name, status, running_status, created,
             started, finished, modified, fraction_completed, error, coordinator_id
-       FROM crdb_internal.jobs
-   ORDER BY COALESCE(finished, now()) DESC, started DESC`,
+		FROM crdb_internal.jobs
+		WHERE finished IS NULL OR finished > now() - '12h':::interval
+		ORDER BY COALESCE(finished, now()) DESC, started DESC`,
 		nil, nil)
 }


### PR DESCRIPTION
On a cluster that has been running for a long time or with frequent periodic jobs, SHOW JOBS can output an unbounded, massive wall of text.
This makes it hard to find the jobs you are likely interested in -- those that are running or have very recently finished.

This changes SHOW JOBS to only include running jobs or those that finished in the last 12h.
The full listing of jobs is still available via crdb_internal.jobs.

Release note (general change): SHOW JOBS only returns running and recently finished jobs. Older jobs can still be inspected via the crdb_internal.jobs table.