### PR TITLE
opt: direct generation of expressions from tests

### DIFF
--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -69,10 +69,12 @@ type Metadata struct {
 	// schemas stores each schema used in the query, indexed by SchemaID.
 	schemas []cat.Schema
 
-	// cols stores information about each metadata column, indexed by ColumnID.
+	// cols stores information about each metadata column, indexed by
+	// ColumnID.index().
 	cols []ColumnMeta
 
-	// tables stores information about each metadata table, indexed by TableID.
+	// tables stores information about each metadata table, indexed by
+	// TableID.index().
 	tables []TableMeta
 
 	// sequences stores information about each metadata sequence, indexed by SequenceID.
@@ -299,6 +301,12 @@ func (md *Metadata) TableMeta(tabID TableID) *TableMeta {
 // same table can be associated with multiple metadata ids.
 func (md *Metadata) Table(tabID TableID) cat.Table {
 	return md.TableMeta(tabID).Table
+}
+
+// AllTables returns the metadata for all tables. The result must not be
+// modified.
+func (md *Metadata) AllTables() []TableMeta {
+	return md.tables
 }
 
 // TableByStableID looks up the catalog table associated with the given

--- a/pkg/sql/opt/optgen/exprgen/custom_funcs.go
+++ b/pkg/sql/opt/optgen/exprgen/custom_funcs.go
@@ -1,0 +1,120 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exprgen
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+)
+
+type customFuncs struct {
+	f   *norm.Factory
+	mem *memo.Memo
+	cat cat.Catalog
+}
+
+// NewColumn creates a new column in the metadata.
+func (c *customFuncs) NewColumn(name, typeStr string) opt.ColumnID {
+	typ, err := testutils.ParseType(typeStr)
+	if err != nil {
+		panic(exprGenErr{err})
+	}
+	return c.f.Metadata().AddColumn(name, typ)
+}
+
+// LookupColumn looks up a column that was already specified in the expression
+// so far (either via NewColumn or by using a table).
+func (c *customFuncs) LookupColumn(name string) opt.ColumnID {
+	md := c.f.Metadata()
+
+	var res opt.ColumnID
+	for colID := opt.ColumnID(1); int(colID) <= md.NumColumns(); colID++ {
+		if md.ColumnMeta(colID).Alias == name {
+			if res != 0 {
+				panic(errorf("ambigous column %s", name))
+			}
+			res = colID
+		}
+	}
+	if res == 0 {
+		panic(errorf("unknown column %s", name))
+	}
+	return res
+}
+
+// Var creates a VariableOp for the given column. It allows (Var "name") as a
+// shorthand for (Variable (LookupColumn "name")).
+func (c *customFuncs) Var(colName string) opt.ScalarExpr {
+	return c.f.ConstructVariable(c.LookupColumn(colName))
+}
+
+// OrderingChoice parses a string like "+a,-(b|c)" into an OrderingChoice.
+func (c *customFuncs) OrderingChoice(str string) physical.OrderingChoice {
+	return physical.ParseOrderingChoice(c.substituteCols(str))
+}
+
+// substituteCols extracts every word (sequence of letters) from the string,
+// looks up the column with that name, and replaces the string with the column
+// ID. E.g.: "+a,+b" -> "+1,+2".
+func (c *customFuncs) substituteCols(str string) string {
+	var b strings.Builder
+	lastPos := -1
+	maybeEmit := func(curPos int) {
+		if lastPos != -1 {
+			col := str[lastPos:curPos]
+			fmt.Fprintf(&b, "%d", c.LookupColumn(col))
+		}
+		lastPos = -1
+	}
+	for i, r := range str {
+		if unicode.IsLetter(r) {
+			if lastPos == -1 {
+				lastPos = i
+			}
+			continue
+		}
+		maybeEmit(i)
+		b.WriteRune(r)
+	}
+	maybeEmit(len(str))
+	return b.String()
+}
+
+// MakeLookupJoin is a wrapper around ConstructLookupJoin that swaps the order
+// of the private and the filters. This is useful because the expressions are
+// evaluated in order, and we want to be able to refer to the lookup columns in
+// the ON expression. For example:
+//
+//   (MakeLookupJoin
+//     (Scan [ (Table "def") (Cols "d,e") ])
+//     [ (JoinType "left-join") (Table "abc") (Index "abc@ab") (KeyCols "a") (Cols "a,b") ]
+//     [ (Gt (Var "a") (Var "e")) ]
+//   )
+//
+// If the order of the last two was swapped, we wouldn't be able to look up
+// column a.
+func (c *customFuncs) MakeLookupJoin(
+	input memo.RelExpr, lookupJoinPrivate *memo.LookupJoinPrivate, on memo.FiltersExpr,
+) memo.RelExpr {
+	return c.f.ConstructLookupJoin(input, on, lookupJoinPrivate)
+}

--- a/pkg/sql/opt/optgen/exprgen/expr_gen.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen.go
@@ -1,0 +1,274 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exprgen
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// Build generates an expression from an optgen string (the kind of expression
+// that would show up in the replace side of a rule).
+//
+// For example, if the input is "(Eq (Const 1) (Const 2))", the output is the
+// corresponding expression tree:
+//   eq [type=bool]
+//    ├── const: 1 [type=int]
+//    └── const: 2 [type=int]
+//
+// There are some peculiarities compared to the usual opt-gen replace syntax:
+//
+//  - Filters are specified as simply [ <condition> ... ]; no FiltersItem is
+//    necessary.
+//
+//  - Various implicit conversions are allowed for convenience, e.g. list of
+//    columns to ColList/ColSet.
+//
+//  - Operation privates (e.g. ScanPrivate) are specified as lists of fields
+//    of the form [ (FiledName <value>) ]. For example:
+//      [ (Table "abc") (Index "abc@ab") (Cols "a,b") ]
+//    Implicit conversions are allowed here for column lists, orderings, etc.
+//
+// For more examples, see the various testdata/ files.
+//
+func Build(catalog cat.Catalog, factory *norm.Factory, input string) (_ opt.Expr, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(exprGenErr); ok {
+				err = e.error
+			} else {
+				panic(r)
+			}
+		}
+	}()
+
+	eg := exprGen{
+		customFuncs: customFuncs{
+			f:   factory,
+			mem: factory.Memo(),
+			cat: catalog,
+		},
+	}
+
+	// To create a valid optgen "file", we create a rule with a bogus match.
+	contents := "[FakeRule] (True) => " + input
+	parsed := eg.parse(contents)
+	res := eg.eval(parsed.Rules[0].Replace)
+
+	// TODO(radu): fill in best props (cost, physical props etc).
+	return res.(opt.Expr), nil
+}
+
+type exprGen struct {
+	customFuncs
+}
+
+type exprGenErr struct {
+	error
+}
+
+func errorf(format string, a ...interface{}) error {
+	return exprGenErr{fmt.Errorf(format, a...)}
+}
+
+// Parses the input (with replace-side rule syntax) into an optgen expression
+// tree.
+func (eg *exprGen) parse(contents string) *lang.RootExpr {
+	p := lang.NewParser("fake.opt")
+	p.SetFileResolver(func(name string) (io.Reader, error) {
+		if name == "fake.opt" {
+			return strings.NewReader(contents), nil
+		}
+		return nil, fmt.Errorf("unknown file '%s'", name)
+	})
+	parsed := p.Parse()
+	if parsed == nil {
+		errStr := "Errors during parsing:\n"
+		for _, err := range p.Errors() {
+			errStr = fmt.Sprintf("%s%s\n", errStr, err.Error())
+		}
+		panic(errorf("%s", errStr))
+	}
+	return parsed
+}
+
+// Evaluates the corresponding expression.
+func (eg *exprGen) eval(expr lang.Expr) interface{} {
+	switch expr := expr.(type) {
+	case *lang.FuncExpr:
+		if expr.HasDynamicName() {
+			panic(errorf("dynamic functions not supported: %s", expr))
+		}
+
+		name := expr.SingleName()
+		// Search for a factory function.
+		method := reflect.ValueOf(eg.f).MethodByName("Construct" + name)
+		if !method.IsValid() {
+			// Search for a custom function.
+			method = reflect.ValueOf(&eg.customFuncs).MethodByName(name)
+			if !method.IsValid() {
+				panic(errorf("unknown operator or function %s", name))
+			}
+		}
+		return eg.call(name, method, expr.Args)
+
+	case *lang.ListExpr:
+		// Return a list expression as []interface{}.
+		list := make([]interface{}, len(expr.Items))
+		for i, e := range expr.Items {
+			list[i] = eg.eval(e)
+		}
+		return list
+
+	case *lang.NumberExpr:
+		return tree.NewDInt(tree.DInt(*expr))
+
+	case *lang.StringExpr:
+		return string(*expr)
+
+	default:
+		panic(errorf("unsupported expression %s", expr.Op()))
+	}
+}
+
+// Calls a function (custom function or factory method) with the given
+// arguments. Various implicit conversions are allowed.
+func (eg *exprGen) call(name string, method reflect.Value, args lang.SliceExpr) interface{} {
+	fnTyp := method.Type()
+	if fnTyp.NumIn() != len(args) {
+		panic(errorf("%s expects %d arguments", name, fnTyp.NumIn()))
+	}
+	argVals := make([]reflect.Value, len(args))
+	for i := range args {
+		desiredType := fnTyp.In(i)
+
+		// Special case for privates.
+		if desiredType.Kind() == reflect.Ptr && desiredType.Elem().Kind() == reflect.Struct &&
+			strings.HasSuffix(desiredType.Elem().Name(), "Private") {
+			argVals[i] = reflect.ValueOf(eg.evalPrivate(desiredType.Elem(), args[i]))
+			continue
+		}
+
+		arg := eg.eval(args[i])
+		argVals[i] = eg.castToDesiredType(arg, desiredType)
+		if !argVals[i].IsValid() {
+			panic(errorf("%s: using %T as type %s", name, arg, desiredType))
+		}
+	}
+	return method.Call(argVals)[0].Interface()
+}
+
+// castToDesiredType tries to convert the given argument to a value of the given
+// type.
+func (eg *exprGen) castToDesiredType(arg interface{}, desiredType reflect.Type) reflect.Value {
+	actualType := reflect.TypeOf(arg)
+	if actualType.AssignableTo(desiredType) {
+		return reflect.ValueOf(arg)
+	}
+
+	if slice, ok := arg.([]interface{}); ok {
+		// Special case for converting slice of ColumnIDs to a ColSet.
+		if desiredType == reflect.TypeOf(opt.ColSet{}) {
+			var set opt.ColSet
+			for i := range slice {
+				col, ok := slice[i].(opt.ColumnID)
+				if !ok {
+					return reflect.Value{}
+				}
+				set.Add(int(col))
+			}
+			return reflect.ValueOf(set)
+		}
+
+		if desiredType.Kind() != reflect.Slice {
+			return reflect.Value{}
+		}
+
+		// See if we can convert all elements to the desired slice element type.
+		converted := convertSlice(slice, desiredType, func(v interface{}) reflect.Value {
+			if val := reflect.ValueOf(v); val.Type().AssignableTo(desiredType.Elem()) {
+				return val.Convert(desiredType.Elem())
+			}
+			return reflect.Value{}
+		})
+		if converted.IsValid() {
+			return converted
+		}
+
+		// Special case for converting slice of values implementing ScalarExpr to a
+		// FiltersExpr.
+		if desiredType == reflect.TypeOf(memo.FiltersExpr{}) {
+			converted := convertSlice(slice, desiredType, func(v interface{}) reflect.Value {
+				expr, ok := v.(opt.ScalarExpr)
+				if !ok {
+					return reflect.Value{}
+				}
+				return reflect.ValueOf(memo.FiltersItem{Condition: expr})
+			})
+			if converted.IsValid() {
+				return converted
+			}
+		}
+	}
+
+	if str, ok := arg.(string); ok {
+		// String to type.
+		if desiredType == reflect.TypeOf((*types.T)(nil)).Elem() {
+			typ, err := testutils.ParseType(str)
+			if err != nil {
+				panic(exprGenErr{err})
+			}
+			return reflect.ValueOf(typ)
+		}
+
+		// String to OrderingChoice.
+		if desiredType == reflect.TypeOf(physical.OrderingChoice{}) {
+			return reflect.ValueOf(physical.ParseOrderingChoice(eg.substituteCols(str)))
+		}
+	}
+	return reflect.Value{}
+}
+
+// convertSlice tries to create a slice of the given type; each element is the
+// result of calling mapFn on the input slice element.
+//
+// If mapFn returns an invalid Value, convertSlice also returns an invalid
+// Value.
+func convertSlice(
+	slice []interface{}, toType reflect.Type, mapFn func(v interface{}) reflect.Value,
+) reflect.Value {
+	res := reflect.MakeSlice(toType, len(slice), len(slice))
+
+	for i, v := range slice {
+		val := mapFn(v)
+		if !val.IsValid() {
+			return reflect.Value{}
+		}
+		res.Index(i).Set(val)
+	}
+	return res
+}

--- a/pkg/sql/opt/optgen/exprgen/expr_gen_test.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen_test.go
@@ -1,0 +1,33 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exprgen_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/opttester"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datadriven"
+)
+
+func TestPlanGen(t *testing.T) {
+	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
+		catalog := testcat.New()
+		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+			tester := opttester.New(catalog, d.Input)
+			return tester.RunCommand(t, d)
+		})
+	})
+}

--- a/pkg/sql/opt/optgen/exprgen/private.go
+++ b/pkg/sql/opt/optgen/exprgen/private.go
@@ -1,0 +1,157 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exprgen
+
+import (
+	"context"
+	"reflect"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// evalPrivate evaluates a list of the form
+//   [ (FieldName <value>) ... ]
+// into an operation private of the given type (e.g. ScanPrivate, etc).
+//
+// Various implicit conversions are supported. Examples:
+//  - table ID: "table"
+//  - index ordinal: "table@index"
+//  - column lists or sets: "a,b,c"
+//  - orderings and ordering choices: "+a,-b"
+//  - operators: "inner-join"
+//
+func (eg *exprGen) evalPrivate(privType reflect.Type, expr lang.Expr) interface{} {
+	if expr.Op() != lang.ListOp {
+		panic(errorf("private must be a list of the form [ (FieldName Value) ... ]"))
+	}
+
+	items := expr.(*lang.ListExpr).Items
+
+	result := reflect.New(privType)
+
+	for _, item := range items {
+		// Each item must be of the form (FieldName Value).
+		fn, ok := item.(*lang.FuncExpr)
+		if !ok || len(fn.Args) != 1 {
+			panic(errorf("private list must contain items of the form (FieldName Value)"))
+		}
+		fieldName := fn.SingleName()
+		field := result.Elem().FieldByName(fieldName)
+		if !field.IsValid() {
+			panic(errorf("invalid field %s for %s", fieldName, privType))
+		}
+		val := eg.convertPrivateFieldValue(privType, fieldName, field.Type(), eg.eval(fn.Args[0]))
+		field.Set(reflect.ValueOf(val))
+	}
+	return result.Interface()
+}
+
+func (eg *exprGen) convertPrivateFieldValue(
+	privType reflect.Type, fieldName string, fieldType reflect.Type, value interface{},
+) interface{} {
+
+	// This code handles the conversion of a user-friendly value and the value of
+	// the field in the private structure.
+
+	if str, ok := value.(string); ok {
+		switch fieldType {
+		case reflect.TypeOf(opt.TableID(0)):
+			return eg.addTable(str)
+
+		case reflect.TypeOf(opt.ColSet{}), reflect.TypeOf(opt.ColList{}):
+			var cols opt.ColList
+			for _, col := range strings.Split(str, ",") {
+				cols = append(cols, eg.LookupColumn(col))
+			}
+			if fieldType == reflect.TypeOf(opt.ColSet{}) {
+				return cols.ToSet()
+			}
+			return cols
+
+		case reflect.TypeOf(0):
+			return eg.findIndex(str)
+
+		case reflect.TypeOf(opt.Operator(0)):
+			return eg.opFromStr(str)
+
+		case reflect.TypeOf(opt.Ordering{}):
+			return physical.ParseOrdering(eg.substituteCols(str))
+
+		case reflect.TypeOf(physical.OrderingChoice{}):
+			return eg.OrderingChoice(str)
+		}
+	}
+
+	// TODO(radu): handle more kinds of fields.
+	panic(errorf("invalid value for %s.%s: %v", privType, fieldName, value))
+}
+
+// addTable resolves the given table name and adds the table to the metadata.
+func (eg *exprGen) addTable(name string) opt.TableID {
+	tn := tree.MakeUnqualifiedTableName(tree.Name(name))
+	ds, _, err := eg.cat.ResolveDataSource(context.Background(), &tn)
+	if err != nil {
+		panic(exprGenErr{err})
+	}
+	tab, ok := ds.(cat.Table)
+	if !ok {
+		panic(errorf("non-table datasource %s not supported", name))
+	}
+	return eg.mem.Metadata().AddTable(tab)
+}
+
+// findIndex looks for an index specified as "table@idx_name" among the tables
+// already added to the metadata.
+func (eg *exprGen) findIndex(str string) int {
+	a := strings.Split(str, "@")
+	if len(a) != 2 {
+		panic(errorf("index must be specified as table@index"))
+	}
+	table, index := a[0], a[1]
+	var tab cat.Table
+	for _, meta := range eg.mem.Metadata().AllTables() {
+		if meta.Alias.Table() == table {
+			if tab != nil {
+				panic(errorf("ambiguous table name %s", table))
+			}
+			tab = meta.Table
+		}
+	}
+	if tab == nil {
+		panic(errorf("unknown table %s", table))
+	}
+	for i := 0; i < tab.IndexCount(); i++ {
+		if string(tab.Index(i).Name()) == index {
+			return i
+		}
+	}
+	panic(errorf("index %s not found for table %s", index, table))
+}
+
+// opFromStr converts an operator string like "inner-join" to the corresponding
+// operator.
+func (eg *exprGen) opFromStr(str string) opt.Operator {
+	for i := opt.Operator(1); i < opt.NumOperators; i++ {
+		if i.String() == str {
+			return i
+		}
+	}
+	panic(errorf("unknown operator %s", str))
+}

--- a/pkg/sql/opt/optgen/exprgen/testdata/join
+++ b/pkg/sql/opt/optgen/exprgen/testdata/join
@@ -1,0 +1,84 @@
+exec-ddl
+CREATE TABLE abc (a INT, b INT, c INT, INDEX ab(a, b))
+----
+TABLE abc
+ ├── a int
+ ├── b int
+ ├── c int
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ └── INDEX ab
+      ├── a int
+      ├── b int
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE TABLE def (d INT, e INT, f INT)
+----
+TABLE def
+ ├── d int
+ ├── e int
+ ├── f int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+expr
+(InnerJoin
+  (Scan [ (Table "abc") (Cols "a,b,c") ])
+  (Scan [ (Table "def") (Cols "d,e,f") ])
+  [ (Eq (Var "a") (Var "d")) ]
+)
+----
+inner-join
+ ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int) t.public.abc.c:3(int) t.public.def.d:5(int!null) t.public.def.e:6(int) t.public.def.f:7(int)
+ ├── stats: [rows=10000, distinct(1)=100, null(1)=0, distinct(5)=100, null(5)=0]
+ ├── fd: (1)==(5), (5)==(1)
+ ├── scan t.public.abc
+ │    ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int) t.public.abc.c:3(int)
+ │    └── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ ├── scan t.public.def
+ │    ├── columns: t.public.def.d:5(int) t.public.def.e:6(int) t.public.def.f:7(int)
+ │    └── stats: [rows=1000, distinct(5)=100, null(5)=10]
+ └── filters
+      └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+           ├── variable: t.public.abc.a [type=int]
+           └── variable: t.public.def.d [type=int]
+
+expr
+(MakeLookupJoin
+  (Scan [ (Table "def") (Cols "d,e") ])
+  [ (JoinType "left-join") (Table "abc") (Index "abc@ab") (KeyCols "a") (Cols "a,b") ]
+  [ (Gt (Var "a") (Var "e")) ]
+)
+----
+left-join (lookup abc@ab)
+ ├── columns: t.public.abc.a:5(int) t.public.abc.b:6(int)
+ ├── key columns: [5] = [5]
+ ├── stats: [rows=333333.333]
+ ├── scan t.public.def
+ │    ├── columns: t.public.def.d:1(int) t.public.def.e:2(int)
+ │    └── stats: [rows=1000]
+ └── filters
+      └── gt [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ])]
+           ├── variable: t.public.abc.a [type=int]
+           └── variable: t.public.def.e [type=int]
+
+# TODO(radu): support merge joins (we can't generate them because we don't have
+# code for generating relational properties for merge join).
+#
+# expr
+# (MergeJoin
+#   (Scan [ (Table "abc") (Cols "a,b,c") ])
+#   (Scan [ (Table "def") (Cols "d,e,f") ])
+#   [ ]
+#   [
+#     (JoinType "inner-join")
+#     (LeftEq "+a")
+#     (RightEq "+d")
+#     (LeftOrdering "+a")
+#     (RightOrdering "+d")
+#   ]
+# )
+# ----

--- a/pkg/sql/opt/optgen/exprgen/testdata/limit
+++ b/pkg/sql/opt/optgen/exprgen/testdata/limit
@@ -1,0 +1,32 @@
+exec-ddl
+CREATE TABLE abc (a INT, b INT, c INT, INDEX ab(a, b))
+----
+TABLE abc
+ ├── a int
+ ├── b int
+ ├── c int
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ └── INDEX ab
+      ├── a int
+      ├── b int
+      └── rowid int not null (hidden)
+
+# TODO(radu): fill in physical properties (the scan node should have an ordering).
+expr
+(Limit
+  (Scan [ (Table "abc") (Index "abc@ab") (Cols "a,b") ])
+  (Const 10)
+  (OrderingChoice "+a")
+)
+----
+limit
+ ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
+ ├── internal-ordering: +1
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10]
+ ├── scan t.public.abc@ab
+ │    ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
+ │    └── stats: [rows=1000]
+ └── const: 10 [type=int]

--- a/pkg/sql/opt/optgen/exprgen/testdata/scalar
+++ b/pkg/sql/opt/optgen/exprgen/testdata/scalar
@@ -1,0 +1,25 @@
+expr
+(True)
+----
+true [type=bool]
+
+expr
+(Eq (True) (False))
+----
+eq [type=bool]
+ ├── true [type=bool]
+ └── false [type=bool]
+
+expr
+(Plus (Const 1) (Const 2))
+----
+plus [type=int]
+ ├── const: 1 [type=int]
+ └── const: 2 [type=int]
+
+expr
+(Tuple [ (True) (False) ] "tuple{bool, bool}" )
+----
+tuple [type=tuple{bool, bool}]
+ ├── true [type=bool]
+ └── false [type=bool]

--- a/pkg/sql/opt/optgen/exprgen/testdata/scan
+++ b/pkg/sql/opt/optgen/exprgen/testdata/scan
@@ -1,0 +1,46 @@
+exec-ddl
+CREATE TABLE abc (a INT, b INT, c INT, INDEX ab(a, b))
+----
+TABLE abc
+ ├── a int
+ ├── b int
+ ├── c int
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ └── INDEX ab
+      ├── a int
+      ├── b int
+      └── rowid int not null (hidden)
+
+expr
+(Scan [ (Table "abc") (Cols "a") ])
+----
+scan t.public.abc
+ ├── columns: t.public.abc.a:1(int)
+ └── stats: [rows=1000]
+
+expr
+(Scan [ (Table "abc") (Index "abc@ab") (Cols "a,b") ])
+----
+scan t.public.abc@ab
+ ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
+ └── stats: [rows=1000]
+
+expr
+(Select
+  (Scan [ (Table "abc") (Cols "a,b,c") ])
+  [ (Eq (Var "a") (Const 1)) ]
+)
+----
+select
+ ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int) t.public.abc.c:3(int)
+ ├── stats: [rows=9.9, distinct(1)=1, null(1)=0]
+ ├── fd: ()-->(1)
+ ├── scan t.public.abc
+ │    ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int) t.public.abc.c:3(int)
+ │    └── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ └── filters
+      └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+           ├── variable: t.public.abc.a [type=int]
+           └── const: 1 [type=int]

--- a/pkg/sql/opt/optgen/exprgen/testdata/values
+++ b/pkg/sql/opt/optgen/exprgen/testdata/values
@@ -1,0 +1,19 @@
+expr
+(Values
+  [
+    (Tuple [ (Const 1) (Const 1) ] "tuple{int, int}" )
+    (Tuple [ (Const 2) (Const 2) ] "tuple{int, int}" )
+  ]
+  [ (NewColumn "a" "int") (NewColumn "b" "int") ]
+)
+----
+values
+ ├── columns: a:1(int) b:2(int)
+ ├── cardinality: [2 - 2]
+ ├── stats: [rows=2]
+ ├── tuple [type=tuple{int, int}]
+ │    ├── const: 1 [type=int]
+ │    └── const: 1 [type=int]
+ └── tuple [type=tuple{int, int}]
+      ├── const: 2 [type=int]
+      └── const: 2 [type=int]

--- a/pkg/sql/opt/ordering/lookup_join_test.go
+++ b/pkg/sql/opt/ordering/lookup_join_test.go
@@ -100,7 +100,7 @@ func TestLookupJoinProvided(t *testing.T) {
 			input := &testexpr.Instance{
 				Rel: &props.Relational{},
 				Provided: &physical.Provided{
-					Ordering: parseOrdering(tc.input),
+					Ordering: physical.ParseOrdering(tc.input),
 				},
 			}
 			lookupJoin := f.Memo().MemoizeLookupJoin(

--- a/pkg/sql/opt/ordering/ordering_test.go
+++ b/pkg/sql/opt/ordering/ordering_test.go
@@ -59,7 +59,7 @@ func TestTrimProvided(t *testing.T) {
 	for tcIdx, tc := range testCases {
 		t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
 			req := physical.ParseOrderingChoice(tc.req)
-			prov := parseOrdering(tc.prov)
+			prov := physical.ParseOrdering(tc.prov)
 			res := trimProvided(prov, &req, &tc.fds).String()
 			if res != tc.exp {
 				t.Errorf("expected %s, got %s", tc.exp, res)
@@ -112,27 +112,13 @@ func TestRemapProvided(t *testing.T) {
 	}
 	for tcIdx, tc := range testCases {
 		t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
-			prov := parseOrdering(tc.prov)
+			prov := physical.ParseOrdering(tc.prov)
 			res := remapProvided(prov, &tc.fds, tc.cols).String()
 			if res != tc.exp {
 				t.Errorf("expected %s, got %s", tc.exp, res)
 			}
 		})
 	}
-}
-
-// parseOrdering parses a simple opt.Ordering.
-func parseOrdering(str string) opt.Ordering {
-	prov := physical.ParseOrderingChoice(str)
-	if !prov.Optional.Empty() {
-		panic(fmt.Sprintf("invalid ordering %s", str))
-	}
-	for i := range prov.Columns {
-		if prov.Columns[i].Group.Len() != 1 {
-			panic(fmt.Sprintf("invalid ordering %s", str))
-		}
-	}
-	return prov.ToOrdering()
 }
 
 // testFDs returns FDs that can be used for testing:

--- a/pkg/sql/opt/ordering/row_number_test.go
+++ b/pkg/sql/opt/ordering/row_number_test.go
@@ -82,7 +82,7 @@ func TestRowNumberProvided(t *testing.T) {
 			input := &testexpr.Instance{
 				Rel: &props.Relational{OutputCols: util.MakeFastIntSet(1, 2, 3, 4, 5)},
 				Provided: &physical.Provided{
-					Ordering: parseOrdering(tc.input),
+					Ordering: physical.ParseOrdering(tc.input),
 				},
 			}
 			r := f.Memo().MemoizeRowNumber(input, &memo.RowNumberPrivate{ColID: 10})

--- a/pkg/sql/opt/props/physical/ordering_choice.go
+++ b/pkg/sql/opt/props/physical/ordering_choice.go
@@ -184,6 +184,23 @@ func ParseOrderingChoice(s string) OrderingChoice {
 	return ordering
 }
 
+// ParseOrdering parses a simple opt.Ordering; for example: "+1,-3".
+//
+// The input string is expected to be valid; ParseOrdering will panic if it is
+// not.
+func ParseOrdering(str string) opt.Ordering {
+	prov := ParseOrderingChoice(str)
+	if !prov.Optional.Empty() {
+		panic(fmt.Sprintf("invalid ordering %s", str))
+	}
+	for i := range prov.Columns {
+		if prov.Columns[i].Group.Len() != 1 {
+			panic(fmt.Sprintf("invalid ordering %s", str))
+		}
+	}
+	return prov.ToOrdering()
+}
+
 // Any is true if this instance allows any ordering (any length, any columns).
 func (oc *OrderingChoice) Any() bool {
 	return len(oc.Columns) == 0

--- a/pkg/sql/opt/testutils/utils.go
+++ b/pkg/sql/opt/testutils/utils.go
@@ -15,7 +15,9 @@
 package testutils
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
@@ -25,7 +27,27 @@ import (
 )
 
 // ParseType parses a string describing a type.
+// It supports tuples using the syntax "tuple{<type>, <type>, ...}" but does not
+// support tuples of tuples.
 func ParseType(typeStr string) (types.T, error) {
+	// Special case for tuples for which there is no SQL syntax.
+	if strings.HasPrefix(typeStr, "tuple{") && strings.HasSuffix(typeStr, "}") {
+		s := strings.TrimPrefix(typeStr, "tuple{")
+		s = strings.TrimSuffix(s, "}")
+		// Hijack the PREPARE syntax which takes a list of types.
+		// TODO(radu): this won't work for tuples of tuples; we would need to add
+		// some special syntax.
+		parsed, err := parser.ParseOne(fmt.Sprintf("PREPARE x ( %s ) AS SELECT 1", s))
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse %s as a type: %s", typeStr, err)
+		}
+		colTypes := parsed.AST.(*tree.Prepare).Types
+		res := types.TTuple{Types: make([]types.T, len(colTypes))}
+		for i := range colTypes {
+			res.Types[i] = coltypes.CastTargetToDatumType(colTypes[i])
+		}
+		return res, nil
+	}
 	colType, err := parser.ParseType(typeStr)
 	if err != nil {
 		return nil, err

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -870,6 +870,10 @@ func TestLint(t *testing.T) {
 				&lint.GlobIgnore{Pattern: "github.com/cockroachdb/cockroach/pkg/sql/parser/sql.go", Checks: []string{"U1000"}},
 				// Generated file containing many unused postgres error codes.
 				&lint.GlobIgnore{Pattern: "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror/codes.go", Checks: []string{"U1000"}},
+
+				// The methods in exprgen.customFuncs are used via reflection.
+				// sql/opt/testutils/exprgen/custom_funcs.go:xx:yy: func (*customFuncs).zz is unused (U1000)
+				&lint.GlobIgnore{Pattern: "github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/exprgen/custom_funcs.go", Checks: []string{"U1000"}},
 			},
 		}
 		for _, p := range linter.Lint(lprog, &conf) {


### PR DESCRIPTION
Initial commit for infrastructure for specifying an opt expression
directly from tests.

The what
--------

We add support for building an expression directly from a test using
optgen replace-side syntax, with various improvements for convenience.
Most importantly, we specify Privates using lists of the
form `[ (FieldName <value>) ... ]`. For example:
```
(Scan [ (Table "abc") (Cols "a,b,c") ])
```

The why
-------

In many areas of the optimizer (e.g. logical properties, stats), we
have testcases where we need a specific plan, and we sometimes jump
through hoops to get a SQL query to generate a particular plan. This
wastes time and is also fragile - when some aspect of the optimizer
changes (e.g. cost model), some of the queries might generate
different plans and the tests become ineffective.

Another motivation is generating specific plans to benchmark various
operators for comparing against (and improving) the cost model.

The how
-------

We use the optgen parser and then we recursively evaluate the parsed
tree. We support custom functions like usual, and allow for various
implicit conversions. The main evaluation logic is in `expr_gen.go`
and the private-specific evaluation is in `private.go`.

Informs #30273.

Release note: None