### PR TITLE
build: fix gceworker creation script by removing interactivity

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -12,7 +12,7 @@ curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 
 sudo apt-get update
-sudo apt-get dist-upgrade -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
 sudo apt-get install -y --no-install-recommends \
   mosh \
   autoconf \


### PR DESCRIPTION
In the process of creating a gceworker, the bootstrap-debian.sh
script executed the command `sudo apt-get dist-upgrade -y` on the
virtual machine. This caused the VM to expect interaction from the
caller, which is not possible when executing the command remotely.
As a result, the command hung, and the gceworker was not configured
successfully. This commit fixes the issue by changing the command to
```
sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y \
 -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
```

Release note: None