### PR TITLE
sql,settings: add cluster version for create statistics

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -96,6 +96,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>2.1-6</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>2.1-7</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
 </tbody>
 </table>

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -62,6 +62,7 @@ const (
 	VersionLazyTxnRecord
 	VersionSequencedReads
 	VersionUnreplicatedRaftTruncatedState // see versionsSingleton for details
+	VersionCreateStats
 
 	// Add new versions here (step one of two).
 
@@ -405,6 +406,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// @enduml
 		Key:     VersionUnreplicatedRaftTruncatedState,
 		Version: roachpb.Version{Major: 2, Minor: 1, Unstable: 6},
+	},
+	{
+		// VersionCreateStats is https://github.com/cockroachdb/cockroach/pull/34842.
+		Key:     VersionCreateStats,
+		Version: roachpb.Version{Major: 2, Minor: 1, Unstable: 7},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -89,6 +89,12 @@ func (*createStatsNode) Values() tree.Datums   { return nil }
 
 // startJob starts a CreateStats job to plan and execute statistics creation.
 func (n *createStatsNode) startJob(ctx context.Context, resultsCh chan<- tree.Datums) error {
+	if !n.p.ExecCfg().Settings.Version.IsActive(cluster.VersionCreateStats) {
+		return errors.Errorf(`CREATE STATISTICS requires all nodes to be upgraded to %s`,
+			cluster.VersionByKey(cluster.VersionCreateStats),
+		)
+	}
+
 	var tableDesc *ImmutableTableDescriptor
 	var err error
 	switch t := n.Table.(type) {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -268,7 +268,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-2.1-6
+2.1-7
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -365,7 +365,7 @@ select * from crdb_internal.gossip_alerts
 query T
 select crdb_internal.node_executable_version()
 ----
-2.1-6
+2.1-7
 
 user root
 


### PR DESCRIPTION
If there are multiple versions of CockroachDB running in the same
cluster, it's possible that some versions include the `CreateStats`
job details while others don't. This commit adds a cluster version
for `CreateStats`, and does not execute `CREATE STATISTICS` if some
nodes are running an older version.

Fixes #34742

Release note (bug fix): Fixed a panic that occurred when CREATE
STATISTICS was run on clusters containing nodes with different
versions of CockroachDB.