### PR TITLE
opt: add HoistJoinProjectLeft norm rule

### DIFF
--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -344,15 +344,15 @@ $left
     $on
 )
 
-# HoistJoinProject lifts a passthrough Project operator from within a Join
-# operator to outside the join. This often allows the Project operator to be
-# merged with an outer Project. Since Project operators tend to prevent other
-# rules from matching, this and other rules try to either push them down (to
-# prune columns), or else to pull them up (to get them out of the way of other
-# operators).
+# HoistJoinProjectRight lifts a passthrough Project operator from within a Join
+# operator's right input to outside the join. This often allows the Project
+# operator to be merged with an outer Project. Since Project operators tend to
+# prevent other rules from matching, this and other rules try to either push
+# them down (to prune columns), or else to pull them up (to get them out of the
+# way of other operators).
 #
 # TODO(andyk): Add other join types.
-[HoistJoinProject, Normalize]
+[HoistJoinProjectRight, Normalize]
 (InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply
     $left:*
     $right:(Project $input:* $projections:[])
@@ -363,6 +363,25 @@ $left
     ((OpName)
         $left
         $input
+        $on
+    )
+    $projections
+    (OutputCols2 $left $right)
+)
+
+# HoistJoinProjectLeft is the same as HoistJoinProjectRight, but for the left
+# input of the join.
+[HoistJoinProjectLeft, Normalize]
+(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply
+    $left:(Project $input:* $projections:[])
+    $right:*
+    $on:*
+)
+=>
+(Project
+    ((OpName)
+        $input
+        $right
         $on
     )
     $projections

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -4133,30 +4133,28 @@ project
       ├── project
       │    ├── columns: y:7(int) v:9(int)
       │    └── left-join (merge)
-      │         ├── columns: k:1(int!null) y:7(int) u:8(int) v:9(int)
+      │         ├── columns: k:1(int!null) x:6(int) y:7(int) u:8(int) v:9(int)
       │         ├── left ordering: +1
       │         ├── right ordering: +8
-      │         ├── fd: (8)-->(9)
-      │         ├── project
-      │         │    ├── columns: k:1(int!null) y:7(int)
+      │         ├── key: (1,6,8)
+      │         ├── fd: (6)-->(7), (8)-->(9)
+      │         ├── left-join (merge)
+      │         │    ├── columns: k:1(int!null) x:6(int) y:7(int)
+      │         │    ├── left ordering: +1
+      │         │    ├── right ordering: +6
+      │         │    ├── key: (1,6)
+      │         │    ├── fd: (6)-->(7)
       │         │    ├── ordering: +1
-      │         │    └── left-join (merge)
-      │         │         ├── columns: k:1(int!null) x:6(int) y:7(int)
-      │         │         ├── left ordering: +1
-      │         │         ├── right ordering: +6
-      │         │         ├── key: (1,6)
-      │         │         ├── fd: (6)-->(7)
-      │         │         ├── ordering: +1
-      │         │         ├── scan a
-      │         │         │    ├── columns: k:1(int!null)
-      │         │         │    ├── key: (1)
-      │         │         │    └── ordering: +1
-      │         │         ├── scan xy
-      │         │         │    ├── columns: x:6(int!null) y:7(int)
-      │         │         │    ├── key: (6)
-      │         │         │    ├── fd: (6)-->(7)
-      │         │         │    └── ordering: +6
-      │         │         └── filters (true)
+      │         │    ├── scan a
+      │         │    │    ├── columns: k:1(int!null)
+      │         │    │    ├── key: (1)
+      │         │    │    └── ordering: +1
+      │         │    ├── scan xy
+      │         │    │    ├── columns: x:6(int!null) y:7(int)
+      │         │    │    ├── key: (6)
+      │         │    │    ├── fd: (6)-->(7)
+      │         │    │    └── ordering: +6
+      │         │    └── filters (true)
       │         ├── scan uv
       │         │    ├── columns: u:8(int!null) v:9(int)
       │         │    ├── key: (8)
@@ -4179,37 +4177,38 @@ project
  ├── columns: generate_series:8(int) information_schema._pg_expandarray:13(tuple{int AS x, int AS n})
  ├── side-effects
  ├── project-set
- │    ├── columns: k:1(int!null) v:7(int) generate_series:8(int) xy.x:9(int) x:11(int) n:12(int)
+ │    ├── columns: v:7(int) generate_series:8(int) xy.x:9(int) x:11(int) n:12(int)
  │    ├── side-effects
- │    ├── left-join (merge)
- │    │    ├── columns: k:1(int!null) v:7(int) xy.x:9(int)
- │    │    ├── left ordering: +1
- │    │    ├── right ordering: +9
- │    │    ├── project
- │    │    │    ├── columns: k:1(int!null) v:7(int)
- │    │    │    ├── ordering: +1
- │    │    │    └── left-join (merge)
- │    │    │         ├── columns: k:1(int!null) u:6(int) v:7(int)
- │    │    │         ├── left ordering: +1
- │    │    │         ├── right ordering: +6
- │    │    │         ├── key: (1,6)
- │    │    │         ├── fd: (6)-->(7)
- │    │    │         ├── ordering: +1
- │    │    │         ├── scan a
- │    │    │         │    ├── columns: k:1(int!null)
- │    │    │         │    ├── key: (1)
- │    │    │         │    └── ordering: +1
- │    │    │         ├── scan uv
- │    │    │         │    ├── columns: u:6(int!null) v:7(int)
- │    │    │         │    ├── key: (6)
- │    │    │         │    ├── fd: (6)-->(7)
- │    │    │         │    └── ordering: +6
- │    │    │         └── filters (true)
- │    │    ├── scan xy
- │    │    │    ├── columns: xy.x:9(int!null)
- │    │    │    ├── key: (9)
- │    │    │    └── ordering: +9
- │    │    └── filters (true)
+ │    ├── project
+ │    │    ├── columns: v:7(int) xy.x:9(int)
+ │    │    └── left-join (merge)
+ │    │         ├── columns: k:1(int!null) u:6(int) v:7(int) xy.x:9(int)
+ │    │         ├── left ordering: +1
+ │    │         ├── right ordering: +9
+ │    │         ├── key: (1,6,9)
+ │    │         ├── fd: (6)-->(7)
+ │    │         ├── left-join (merge)
+ │    │         │    ├── columns: k:1(int!null) u:6(int) v:7(int)
+ │    │         │    ├── left ordering: +1
+ │    │         │    ├── right ordering: +6
+ │    │         │    ├── key: (1,6)
+ │    │         │    ├── fd: (6)-->(7)
+ │    │         │    ├── ordering: +1
+ │    │         │    ├── scan a
+ │    │         │    │    ├── columns: k:1(int!null)
+ │    │         │    │    ├── key: (1)
+ │    │         │    │    └── ordering: +1
+ │    │         │    ├── scan uv
+ │    │         │    │    ├── columns: u:6(int!null) v:7(int)
+ │    │         │    │    ├── key: (6)
+ │    │         │    │    ├── fd: (6)-->(7)
+ │    │         │    │    └── ordering: +6
+ │    │         │    └── filters (true)
+ │    │         ├── scan xy
+ │    │         │    ├── columns: xy.x:9(int!null)
+ │    │         │    ├── key: (9)
+ │    │         │    └── ordering: +9
+ │    │         └── filters (true)
  │    └── zip
  │         ├── function: generate_series [type=int, outer=(7), side-effects]
  │         │    ├── const: 1 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1880,12 +1880,12 @@ select
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
 # --------------------------------------------------
-# HoistJoinProject
+# HoistJoinProjectRight
 #   InnerJoinApply and LeftJoinApply tested by TryDecorrelateLimitOne tests.
 # --------------------------------------------------
 
 # Inner-join case.
-opt expect=HoistJoinProject
+opt expect=HoistJoinProjectRight
 SELECT * FROM a INNER JOIN (SELECT x FROM b WHERE y=10) ON x=k
 ----
 project
@@ -1910,7 +1910,7 @@ project
       └── filters (true)
 
 # Left-join case.
-opt expect=HoistJoinProject
+opt expect=HoistJoinProjectRight
 SELECT * FROM a LEFT JOIN (SELECT x FROM b WHERE y=10) ON x=k
 ----
 project
@@ -1940,6 +1940,60 @@ project
       │    │    └── ordering: +6 opt(7) [actual: +6]
       │    └── filters
       │         └── y = 10 [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
+      └── filters (true)
+
+# --------------------------------------------------
+# HoistJoinProjectLeft
+# --------------------------------------------------
+
+# Inner-join case.
+opt expect=HoistJoinProjectLeft
+SELECT * FROM (SELECT x FROM b WHERE y=10) INNER JOIN a ON x=k
+----
+project
+ ├── columns: x:1(int!null) k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
+ ├── key: (3)
+ ├── fd: (3)-->(4-7), (1)==(3), (3)==(1)
+ └── inner-join (lookup a)
+      ├── columns: x:1(int!null) y:2(int!null) k:3(int!null) i:4(int) f:5(float!null) s:6(string) j:7(jsonb)
+      ├── key columns: [1] = [3]
+      ├── key: (3)
+      ├── fd: ()-->(2), (3)-->(4-7), (1)==(3), (3)==(1)
+      ├── select
+      │    ├── columns: x:1(int!null) y:2(int!null)
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2)
+      │    ├── scan b
+      │    │    ├── columns: x:1(int!null) y:2(int)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    └── filters
+      │         └── y = 10 [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
+      └── filters (true)
+
+# Left-join case.
+opt expect=HoistJoinProjectLeft
+SELECT * FROM (SELECT x FROM b WHERE y=10) LEFT JOIN a ON x=k
+----
+project
+ ├── columns: x:1(int!null) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
+ ├── key: (1,3)
+ ├── fd: (3)-->(4-7)
+ └── left-join (lookup a)
+      ├── columns: x:1(int!null) y:2(int!null) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
+      ├── key columns: [1] = [3]
+      ├── key: (1,3)
+      ├── fd: ()-->(2), (3)-->(4-7)
+      ├── select
+      │    ├── columns: x:1(int!null) y:2(int!null)
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2)
+      │    ├── scan b
+      │    │    ├── columns: x:1(int!null) y:2(int)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    └── filters
+      │         └── y = 10 [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
       └── filters (true)
 
 # --------------------------------------------------

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -179,50 +179,50 @@ SELECT *
 FROM (SELECT * FROM a FULL JOIN xy ON True)
 WHERE (SELECT u FROM uv WHERE v=k)=i
 ----
-right-join
+project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int) y:6(int)
  ├── key: (1,5)
  ├── fd: (1)-->(2-4), (5)-->(6)
- ├── scan xy
- │    ├── columns: x:5(int!null) y:6(int)
- │    ├── key: (5)
- │    └── fd: (5)-->(6)
- ├── project
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-4)
- │    └── inner-join-apply
- │         ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) u:7(int!null)
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-4,7), (2)==(7), (7)==(2)
- │         ├── scan a
- │         │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
- │         │    ├── key: (1)
- │         │    └── fd: (1)-->(2-4)
- │         ├── max1-row
- │         │    ├── columns: u:7(int!null)
- │         │    ├── outer: (1)
- │         │    ├── cardinality: [0 - 1]
- │         │    ├── key: ()
- │         │    ├── fd: ()-->(7)
- │         │    └── project
- │         │         ├── columns: u:7(int!null)
- │         │         ├── outer: (1)
- │         │         ├── key: (7)
- │         │         └── select
- │         │              ├── columns: u:7(int!null) v:8(int!null)
- │         │              ├── outer: (1)
- │         │              ├── key: (7)
- │         │              ├── fd: ()-->(8)
- │         │              ├── scan uv
- │         │              │    ├── columns: u:7(int!null) v:8(int)
- │         │              │    ├── key: (7)
- │         │              │    └── fd: (7)-->(8)
- │         │              └── filters
- │         │                   └── v = k [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
- │         └── filters
- │              └── i = u [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
- └── filters (true)
+ └── right-join
+      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) x:5(int) y:6(int) u:7(int!null)
+      ├── key: (1,5)
+      ├── fd: (1)-->(2-4,7), (2)==(7), (7)==(2), (5)-->(6)
+      ├── scan xy
+      │    ├── columns: x:5(int!null) y:6(int)
+      │    ├── key: (5)
+      │    └── fd: (5)-->(6)
+      ├── inner-join-apply
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) u:7(int!null)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4,7), (2)==(7), (7)==(2)
+      │    ├── scan a
+      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2-4)
+      │    ├── max1-row
+      │    │    ├── columns: u:7(int!null)
+      │    │    ├── outer: (1)
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(7)
+      │    │    └── project
+      │    │         ├── columns: u:7(int!null)
+      │    │         ├── outer: (1)
+      │    │         ├── key: (7)
+      │    │         └── select
+      │    │              ├── columns: u:7(int!null) v:8(int!null)
+      │    │              ├── outer: (1)
+      │    │              ├── key: (7)
+      │    │              ├── fd: ()-->(8)
+      │    │              ├── scan uv
+      │    │              │    ├── columns: u:7(int!null) v:8(int)
+      │    │              │    ├── key: (7)
+      │    │              │    └── fd: (7)-->(8)
+      │    │              └── filters
+      │    │                   └── v = k [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      │    └── filters
+      │         └── i = u [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+      └── filters (true)
 
 # ----------------------------------------------------------
 # RejectNullsGroupBy

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -272,129 +272,129 @@ from (select flavors.created_at as flavors_created_at,
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 order by anon_1.flavors_id asc
 ----
-left-join (merge)
+project
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
- ├── left ordering: +1
- ├── right ordering: +28
  ├── side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +1
- ├── project
- │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │    ├── side-effects, has-placeholder
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │    ├── ordering: +1
- │    └── limit
- │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         ├── internal-ordering: +1
- │         ├── side-effects, has-placeholder
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         ├── ordering: +1
- │         ├── offset
- │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         │    ├── internal-ordering: +1
- │         │    ├── has-placeholder
- │         │    ├── key: (1)
- │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    ├── ordering: +1
- │         │    ├── select
- │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         │    │    ├── has-placeholder
- │         │    │    ├── key: (1)
- │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    ├── ordering: +1
- │         │    │    ├── group-by
- │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         │    │    │    ├── grouping columns: flavors.id:1(int!null)
- │         │    │    │    ├── has-placeholder
- │         │    │    │    ├── key: (1)
- │         │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    │    ├── ordering: +1
- │         │    │    │    ├── left-join (merge)
- │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
- │         │    │    │    │    ├── left ordering: +1
- │         │    │    │    │    ├── right ordering: +17
- │         │    │    │    │    ├── has-placeholder
- │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
- │         │    │    │    │    ├── ordering: +1
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │         │    │    │    │    │    ├── has-placeholder
- │         │    │    │    │    │    ├── key: (1)
- │         │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    │    │    │    ├── ordering: +1
- │         │    │    │    │    │    ├── scan flavors
- │         │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │         │    │    │    │    │    │    ├── key: (1)
- │         │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    │    │    │    │    └── ordering: +1
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── flavorid = $2 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
- │         │    │    │    │    ├── project
- │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
- │         │    │    │    │    │    ├── has-placeholder
- │         │    │    │    │    │    ├── fd: ()-->(22)
- │         │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
- │         │    │    │    │    │    ├── select
- │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
- │         │    │    │    │    │    │    ├── has-placeholder
- │         │    │    │    │    │    │    ├── key: (17,18)
- │         │    │    │    │    │    │    ├── ordering: +17
- │         │    │    │    │    │    │    ├── scan flavor_projects@secondary
- │         │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
- │         │    │    │    │    │    │    │    ├── key: (17,18)
- │         │    │    │    │    │    │    │    └── ordering: +17
- │         │    │    │    │    │    │    └── filters
- │         │    │    │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
- │         │    │    │    │    │    └── projections
- │         │    │    │    │    │         └── true [type=bool]
- │         │    │    │    │    └── filters (true)
- │         │    │    │    └── aggregations
- │         │    │    │         ├── const-not-null-agg [type=bool, outer=(22)]
- │         │    │    │         │    └── variable: true [type=bool]
- │         │    │    │         ├── const-agg [type=string, outer=(2)]
- │         │    │    │         │    └── variable: name [type=string]
- │         │    │    │         ├── const-agg [type=int, outer=(3)]
- │         │    │    │         │    └── variable: memory_mb [type=int]
- │         │    │    │         ├── const-agg [type=int, outer=(4)]
- │         │    │    │         │    └── variable: vcpus [type=int]
- │         │    │    │         ├── const-agg [type=int, outer=(5)]
- │         │    │    │         │    └── variable: root_gb [type=int]
- │         │    │    │         ├── const-agg [type=int, outer=(6)]
- │         │    │    │         │    └── variable: ephemeral_gb [type=int]
- │         │    │    │         ├── const-agg [type=string, outer=(7)]
- │         │    │    │         │    └── variable: flavorid [type=string]
- │         │    │    │         ├── const-agg [type=int, outer=(8)]
- │         │    │    │         │    └── variable: swap [type=int]
- │         │    │    │         ├── const-agg [type=float, outer=(9)]
- │         │    │    │         │    └── variable: rxtx_factor [type=float]
- │         │    │    │         ├── const-agg [type=int, outer=(10)]
- │         │    │    │         │    └── variable: vcpu_weight [type=int]
- │         │    │    │         ├── const-agg [type=bool, outer=(11)]
- │         │    │    │         │    └── variable: disabled [type=bool]
- │         │    │    │         ├── const-agg [type=bool, outer=(12)]
- │         │    │    │         │    └── variable: is_public [type=bool]
- │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
- │         │    │    │         │    └── variable: flavors.created_at [type=timestamp]
- │         │    │    │         └── const-agg [type=timestamp, outer=(15)]
- │         │    │    │              └── variable: flavors.updated_at [type=timestamp]
- │         │    │    └── filters
- │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
- │         │    └── placeholder: $3 [type=int]
- │         └── placeholder: $4 [type=int]
- ├── sort
- │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
- │    ├── key: (25)
- │    ├── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
- │    ├── ordering: +28
- │    └── scan flavor_extra_specs_1
- │         ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
- │         ├── key: (25)
- │         └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
- └── filters (true)
+ └── left-join (merge)
+      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+      ├── left ordering: +1
+      ├── right ordering: +28
+      ├── side-effects, has-placeholder
+      ├── key: (1,25)
+      ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── ordering: +1
+      ├── limit
+      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    ├── internal-ordering: +1
+      │    ├── side-effects, has-placeholder
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    ├── ordering: +1
+      │    ├── offset
+      │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    │    ├── internal-ordering: +1
+      │    │    ├── has-placeholder
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    ├── ordering: +1
+      │    │    ├── select
+      │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    ├── ordering: +1
+      │    │    │    ├── group-by
+      │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    │    │    │    ├── grouping columns: flavors.id:1(int!null)
+      │    │    │    │    ├── has-placeholder
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    ├── ordering: +1
+      │    │    │    │    ├── left-join (merge)
+      │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+      │    │    │    │    │    ├── left ordering: +1
+      │    │    │    │    │    ├── right ordering: +17
+      │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+      │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    ├── select
+      │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    │    ├── scan flavors
+      │    │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    │    │    │    └── ordering: +1
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── flavorid = $2 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── fd: ()-->(22)
+      │    │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    ├── key: (17,18)
+      │    │    │    │    │    │    │    ├── ordering: +17
+      │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
+      │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │    │    │    │    │    │    │    │    ├── key: (17,18)
+      │    │    │    │    │    │    │    │    └── ordering: +17
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── true [type=bool]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── const-not-null-agg [type=bool, outer=(22)]
+      │    │    │    │         │    └── variable: true [type=bool]
+      │    │    │    │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │         │    └── variable: name [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │         │    └── variable: memory_mb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │         │    └── variable: vcpus [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │         │    └── variable: root_gb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │         │    └── variable: flavorid [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │         │    └── variable: swap [type=int]
+      │    │    │    │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │         │    └── variable: disabled [type=bool]
+      │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │         │    └── variable: is_public [type=bool]
+      │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │         │    └── variable: flavors.created_at [type=timestamp]
+      │    │    │    │         └── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │              └── variable: flavors.updated_at [type=timestamp]
+      │    │    │    └── filters
+      │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
+      │    │    └── placeholder: $3 [type=int]
+      │    └── placeholder: $4 [type=int]
+      ├── sort
+      │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+      │    ├── key: (25)
+      │    ├── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+      │    ├── ordering: +28
+      │    └── scan flavor_extra_specs_1
+      │         ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+      │         ├── key: (25)
+      │         └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+      └── filters (true)
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -457,200 +457,194 @@ sort
  ├── key: (1,34)
  ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
  ├── ordering: +7 opt(11) [actual: +7]
- └── right-join
+ └── project
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs_1.id:34(int) key:35(string) value:36(string) flavor_extra_specs_1.flavor_id:37(int) flavor_extra_specs_1.created_at:38(timestamp) flavor_extra_specs_1.updated_at:39(timestamp)
       ├── side-effects, has-placeholder
       ├── key: (1,34)
       ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
-      ├── scan flavor_extra_specs_1
-      │    ├── columns: flavor_extra_specs_1.id:34(int!null) key:35(string!null) value:36(string) flavor_extra_specs_1.flavor_id:37(int!null) flavor_extra_specs_1.created_at:38(timestamp) flavor_extra_specs_1.updated_at:39(timestamp)
-      │    ├── key: (34)
-      │    └── fd: (34)-->(35-39), (35,37)-->(34,36,38,39)
-      ├── project
-      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │    ├── side-effects, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │    └── limit
-      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
-      │         ├── internal-ordering: +7 opt(11)
-      │         ├── side-effects, has-placeholder
-      │         ├── key: (1)
-      │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         ├── offset
-      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
-      │         │    ├── internal-ordering: +7 opt(11)
-      │         │    ├── has-placeholder
-      │         │    ├── key: (1)
-      │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    ├── ordering: +7 opt(11) [actual: +7]
-      │         │    ├── sort
-      │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
-      │         │    │    ├── has-placeholder
-      │         │    │    ├── key: (1)
-      │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │    ├── ordering: +7 opt(11) [actual: +7]
-      │         │    │    └── select
-      │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
-      │         │    │         ├── has-placeholder
-      │         │    │         ├── key: (1)
-      │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         ├── group-by
-      │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
-      │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
-      │         │    │         │    ├── internal-ordering: +1 opt(11)
-      │         │    │         │    ├── has-placeholder
-      │         │    │         │    ├── key: (1)
-      │         │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    ├── left-join (merge)
-      │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true:31(bool)
-      │         │    │         │    │    ├── left ordering: +1
-      │         │    │         │    │    ├── right ordering: +23
-      │         │    │         │    │    ├── has-placeholder
-      │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(31)
-      │         │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
-      │         │    │         │    │    ├── project
-      │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │         │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    ├── key: (1)
-      │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
-      │         │    │         │    │    │    └── select
-      │         │    │         │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
-      │         │    │         │    │    │         ├── has-placeholder
-      │         │    │         │    │    │         ├── key: (1)
-      │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │         ├── ordering: +1 opt(11) [actual: +1]
-      │         │    │         │    │    │         ├── group-by
-      │         │    │         │    │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
-      │         │    │         │    │    │         │    ├── grouping columns: flavors.id:1(int!null)
-      │         │    │         │    │    │         │    ├── has-placeholder
-      │         │    │         │    │    │         │    ├── key: (1)
-      │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │         │    ├── ordering: +1 opt(11) [actual: +1]
-      │         │    │         │    │    │         │    ├── left-join (merge)
-      │         │    │         │    │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:28(bool)
-      │         │    │         │    │    │         │    │    ├── left ordering: +1
-      │         │    │         │    │    │         │    │    ├── right ordering: +17
-      │         │    │         │    │    │         │    │    ├── has-placeholder
-      │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(28)
-      │         │    │         │    │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
-      │         │    │         │    │    │         │    │    ├── select
-      │         │    │         │    │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │         │    │    │         │    │    │    ├── key: (1)
-      │         │    │         │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-      │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
-      │         │    │         │    │    │         │    │    │    ├── scan flavors
-      │         │    │         │    │    │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │         │    │    │         │    │    │    │    ├── key: (1)
-      │         │    │         │    │    │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11) [actual: +1]
-      │         │    │         │    │    │         │    │    │    └── filters
-      │         │    │         │    │    │         │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
-      │         │    │         │    │    │         │    │    ├── project
-      │         │    │         │    │    │         │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:17(int!null)
-      │         │    │         │    │    │         │    │    │    ├── has-placeholder
-      │         │    │         │    │    │         │    │    │    ├── fd: ()-->(28)
-      │         │    │         │    │    │         │    │    │    ├── ordering: +17 opt(28) [actual: +17]
-      │         │    │         │    │    │         │    │    │    ├── select
-      │         │    │         │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
-      │         │    │         │    │    │         │    │    │    │    ├── has-placeholder
-      │         │    │         │    │    │         │    │    │    │    ├── key: (17,18)
-      │         │    │         │    │    │         │    │    │    │    ├── ordering: +17
-      │         │    │         │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
-      │         │    │         │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
-      │         │    │         │    │    │         │    │    │    │    │    ├── key: (17,18)
-      │         │    │         │    │    │         │    │    │    │    │    └── ordering: +17
-      │         │    │         │    │    │         │    │    │    │    └── filters
-      │         │    │         │    │    │         │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
-      │         │    │         │    │    │         │    │    │    └── projections
-      │         │    │         │    │    │         │    │    │         └── true [type=bool]
-      │         │    │         │    │    │         │    │    └── filters (true)
-      │         │    │         │    │    │         │    └── aggregations
-      │         │    │         │    │    │         │         ├── const-not-null-agg [type=bool, outer=(28)]
-      │         │    │         │    │    │         │         │    └── variable: true [type=bool]
-      │         │    │         │    │    │         │         ├── const-agg [type=string, outer=(2)]
-      │         │    │         │    │    │         │         │    └── variable: name [type=string]
-      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(3)]
-      │         │    │         │    │    │         │         │    └── variable: memory_mb [type=int]
-      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(4)]
-      │         │    │         │    │    │         │         │    └── variable: vcpus [type=int]
-      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(5)]
-      │         │    │         │    │    │         │         │    └── variable: root_gb [type=int]
-      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(6)]
-      │         │    │         │    │    │         │         │    └── variable: ephemeral_gb [type=int]
-      │         │    │         │    │    │         │         ├── const-agg [type=string, outer=(7)]
-      │         │    │         │    │    │         │         │    └── variable: flavorid [type=string]
-      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(8)]
-      │         │    │         │    │    │         │         │    └── variable: swap [type=int]
-      │         │    │         │    │    │         │         ├── const-agg [type=float, outer=(9)]
-      │         │    │         │    │    │         │         │    └── variable: rxtx_factor [type=float]
-      │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(10)]
-      │         │    │         │    │    │         │         │    └── variable: vcpu_weight [type=int]
-      │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(11)]
-      │         │    │         │    │    │         │         │    └── variable: disabled [type=bool]
-      │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(12)]
-      │         │    │         │    │    │         │         │    └── variable: is_public [type=bool]
-      │         │    │         │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │    │         │    │    │         │         │    └── variable: flavors.created_at [type=timestamp]
-      │         │    │         │    │    │         │         └── const-agg [type=timestamp, outer=(15)]
-      │         │    │         │    │    │         │              └── variable: flavors.updated_at [type=timestamp]
-      │         │    │         │    │    │         └── filters
-      │         │    │         │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,29)]
-      │         │    │         │    │    ├── project
-      │         │    │         │    │    │    ├── columns: true:31(bool!null) flavor_projects.flavor_id:23(int!null)
-      │         │    │         │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    ├── fd: ()-->(31)
-      │         │    │         │    │    │    ├── ordering: +23 opt(31) [actual: +23]
-      │         │    │         │    │    │    ├── select
-      │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
-      │         │    │         │    │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    │    ├── key: (23,24)
-      │         │    │         │    │    │    │    ├── ordering: +23
-      │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
-      │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
-      │         │    │         │    │    │    │    │    ├── key: (23,24)
-      │         │    │         │    │    │    │    │    └── ordering: +23
-      │         │    │         │    │    │    │    └── filters
-      │         │    │         │    │    │    │         └── project_id = $2 [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
-      │         │    │         │    │    │    └── projections
-      │         │    │         │    │    │         └── true [type=bool]
-      │         │    │         │    │    └── filters (true)
-      │         │    │         │    └── aggregations
-      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(31)]
-      │         │    │         │         │    └── variable: true [type=bool]
-      │         │    │         │         ├── const-agg [type=string, outer=(2)]
-      │         │    │         │         │    └── variable: name [type=string]
-      │         │    │         │         ├── const-agg [type=int, outer=(3)]
-      │         │    │         │         │    └── variable: memory_mb [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(4)]
-      │         │    │         │         │    └── variable: vcpus [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(5)]
-      │         │    │         │         │    └── variable: root_gb [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(6)]
-      │         │    │         │         │    └── variable: ephemeral_gb [type=int]
-      │         │    │         │         ├── const-agg [type=string, outer=(7)]
-      │         │    │         │         │    └── variable: flavorid [type=string]
-      │         │    │         │         ├── const-agg [type=int, outer=(8)]
-      │         │    │         │         │    └── variable: swap [type=int]
-      │         │    │         │         ├── const-agg [type=float, outer=(9)]
-      │         │    │         │         │    └── variable: rxtx_factor [type=float]
-      │         │    │         │         ├── const-agg [type=int, outer=(10)]
-      │         │    │         │         │    └── variable: vcpu_weight [type=int]
-      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
-      │         │    │         │         │    └── variable: disabled [type=bool]
-      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
-      │         │    │         │         │    └── variable: is_public [type=bool]
-      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │    │         │         │    └── variable: flavors.created_at [type=timestamp]
-      │         │    │         │         └── const-agg [type=timestamp, outer=(15)]
-      │         │    │         │              └── variable: flavors.updated_at [type=timestamp]
-      │         │    │         └── filters
-      │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,32)]
-      │         │    └── placeholder: $3 [type=int]
-      │         └── placeholder: $4 [type=int]
-      └── filters
-           └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,37), constraints=(/1: (/NULL - ]; /37: (/NULL - ]), fd=(1)==(37), (37)==(1)]
+      └── right-join
+           ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool) flavor_extra_specs_1.id:34(int) key:35(string) value:36(string) flavor_extra_specs_1.flavor_id:37(int) flavor_extra_specs_1.created_at:38(timestamp) flavor_extra_specs_1.updated_at:39(timestamp)
+           ├── side-effects, has-placeholder
+           ├── key: (1,34)
+           ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (34)-->(35-39), (35,37)-->(34,36,38,39)
+           ├── scan flavor_extra_specs_1
+           │    ├── columns: flavor_extra_specs_1.id:34(int!null) key:35(string!null) value:36(string) flavor_extra_specs_1.flavor_id:37(int!null) flavor_extra_specs_1.created_at:38(timestamp) flavor_extra_specs_1.updated_at:39(timestamp)
+           │    ├── key: (34)
+           │    └── fd: (34)-->(35-39), (35,37)-->(34,36,38,39)
+           ├── limit
+           │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+           │    ├── internal-ordering: +7 opt(11)
+           │    ├── side-effects, has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    ├── offset
+           │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+           │    │    ├── internal-ordering: +7 opt(11)
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    ├── ordering: +7 opt(11) [actual: +7]
+           │    │    ├── sort
+           │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │    ├── ordering: +7 opt(11) [actual: +7]
+           │    │    │    └── select
+           │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+           │    │    │         ├── has-placeholder
+           │    │    │         ├── key: (1)
+           │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         ├── group-by
+           │    │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:32(bool)
+           │    │    │         │    ├── grouping columns: flavors.id:1(int!null)
+           │    │    │         │    ├── internal-ordering: +1 opt(11)
+           │    │    │         │    ├── has-placeholder
+           │    │    │         │    ├── key: (1)
+           │    │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    ├── left-join (merge)
+           │    │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true_agg:29(bool) true:31(bool)
+           │    │    │         │    │    ├── left ordering: +1
+           │    │    │         │    │    ├── right ordering: +23
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(31)
+           │    │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
+           │    │    │         │    │    ├── select
+           │    │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (1)
+           │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+           │    │    │         │    │    │    ├── group-by
+           │    │    │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
+           │    │    │         │    │    │    │    ├── grouping columns: flavors.id:1(int!null)
+           │    │    │         │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    ├── key: (1)
+           │    │    │         │    │    │    │    ├── fd: ()-->(11), (1)-->(2-12,14,15,29), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+           │    │    │         │    │    │    │    ├── left-join (merge)
+           │    │    │         │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:28(bool)
+           │    │    │         │    │    │    │    │    ├── left ordering: +1
+           │    │    │         │    │    │    │    │    ├── right ordering: +17
+           │    │    │         │    │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), ()~~>(28)
+           │    │    │         │    │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+           │    │    │         │    │    │    │    │    ├── select
+           │    │    │         │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+           │    │    │         │    │    │    │    │    │    ├── key: (1)
+           │    │    │         │    │    │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    │    │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+           │    │    │         │    │    │    │    │    │    ├── scan flavors
+           │    │    │         │    │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+           │    │    │         │    │    │    │    │    │    │    ├── key: (1)
+           │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    │    │    │    │    │    │    └── ordering: +1 opt(11) [actual: +1]
+           │    │    │         │    │    │    │    │    │    └── filters
+           │    │    │         │    │    │    │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
+           │    │    │         │    │    │    │    │    ├── project
+           │    │    │         │    │    │    │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:17(int!null)
+           │    │    │         │    │    │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    │    │    ├── fd: ()-->(28)
+           │    │    │         │    │    │    │    │    │    ├── ordering: +17 opt(28) [actual: +17]
+           │    │    │         │    │    │    │    │    │    ├── select
+           │    │    │         │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+           │    │    │         │    │    │    │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    │    │    │    ├── key: (17,18)
+           │    │    │         │    │    │    │    │    │    │    ├── ordering: +17
+           │    │    │         │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
+           │    │    │         │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+           │    │    │         │    │    │    │    │    │    │    │    ├── key: (17,18)
+           │    │    │         │    │    │    │    │    │    │    │    └── ordering: +17
+           │    │    │         │    │    │    │    │    │    │    └── filters
+           │    │    │         │    │    │    │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+           │    │    │         │    │    │    │    │    │    └── projections
+           │    │    │         │    │    │    │    │    │         └── true [type=bool]
+           │    │    │         │    │    │    │    │    └── filters (true)
+           │    │    │         │    │    │    │    └── aggregations
+           │    │    │         │    │    │    │         ├── const-not-null-agg [type=bool, outer=(28)]
+           │    │    │         │    │    │    │         │    └── variable: true [type=bool]
+           │    │    │         │    │    │    │         ├── const-agg [type=string, outer=(2)]
+           │    │    │         │    │    │    │         │    └── variable: name [type=string]
+           │    │    │         │    │    │    │         ├── const-agg [type=int, outer=(3)]
+           │    │    │         │    │    │    │         │    └── variable: memory_mb [type=int]
+           │    │    │         │    │    │    │         ├── const-agg [type=int, outer=(4)]
+           │    │    │         │    │    │    │         │    └── variable: vcpus [type=int]
+           │    │    │         │    │    │    │         ├── const-agg [type=int, outer=(5)]
+           │    │    │         │    │    │    │         │    └── variable: root_gb [type=int]
+           │    │    │         │    │    │    │         ├── const-agg [type=int, outer=(6)]
+           │    │    │         │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+           │    │    │         │    │    │    │         ├── const-agg [type=string, outer=(7)]
+           │    │    │         │    │    │    │         │    └── variable: flavorid [type=string]
+           │    │    │         │    │    │    │         ├── const-agg [type=int, outer=(8)]
+           │    │    │         │    │    │    │         │    └── variable: swap [type=int]
+           │    │    │         │    │    │    │         ├── const-agg [type=float, outer=(9)]
+           │    │    │         │    │    │    │         │    └── variable: rxtx_factor [type=float]
+           │    │    │         │    │    │    │         ├── const-agg [type=int, outer=(10)]
+           │    │    │         │    │    │    │         │    └── variable: vcpu_weight [type=int]
+           │    │    │         │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+           │    │    │         │    │    │    │         │    └── variable: disabled [type=bool]
+           │    │    │         │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+           │    │    │         │    │    │    │         │    └── variable: is_public [type=bool]
+           │    │    │         │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+           │    │    │         │    │    │    │         │    └── variable: flavors.created_at [type=timestamp]
+           │    │    │         │    │    │    │         └── const-agg [type=timestamp, outer=(15)]
+           │    │    │         │    │    │    │              └── variable: flavors.updated_at [type=timestamp]
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,29)]
+           │    │    │         │    │    ├── project
+           │    │    │         │    │    │    ├── columns: true:31(bool!null) flavor_projects.flavor_id:23(int!null)
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── fd: ()-->(31)
+           │    │    │         │    │    │    ├── ordering: +23 opt(31) [actual: +23]
+           │    │    │         │    │    │    ├── select
+           │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
+           │    │    │         │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    ├── key: (23,24)
+           │    │    │         │    │    │    │    ├── ordering: +23
+           │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
+           │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
+           │    │    │         │    │    │    │    │    ├── key: (23,24)
+           │    │    │         │    │    │    │    │    └── ordering: +23
+           │    │    │         │    │    │    │    └── filters
+           │    │    │         │    │    │    │         └── project_id = $2 [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
+           │    │    │         │    │    │    └── projections
+           │    │    │         │    │    │         └── true [type=bool]
+           │    │    │         │    │    └── filters (true)
+           │    │    │         │    └── aggregations
+           │    │    │         │         ├── const-not-null-agg [type=bool, outer=(31)]
+           │    │    │         │         │    └── variable: true [type=bool]
+           │    │    │         │         ├── const-agg [type=string, outer=(2)]
+           │    │    │         │         │    └── variable: name [type=string]
+           │    │    │         │         ├── const-agg [type=int, outer=(3)]
+           │    │    │         │         │    └── variable: memory_mb [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(4)]
+           │    │    │         │         │    └── variable: vcpus [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(5)]
+           │    │    │         │         │    └── variable: root_gb [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(6)]
+           │    │    │         │         │    └── variable: ephemeral_gb [type=int]
+           │    │    │         │         ├── const-agg [type=string, outer=(7)]
+           │    │    │         │         │    └── variable: flavorid [type=string]
+           │    │    │         │         ├── const-agg [type=int, outer=(8)]
+           │    │    │         │         │    └── variable: swap [type=int]
+           │    │    │         │         ├── const-agg [type=float, outer=(9)]
+           │    │    │         │         │    └── variable: rxtx_factor [type=float]
+           │    │    │         │         ├── const-agg [type=int, outer=(10)]
+           │    │    │         │         │    └── variable: vcpu_weight [type=int]
+           │    │    │         │         ├── const-agg [type=bool, outer=(11)]
+           │    │    │         │         │    └── variable: disabled [type=bool]
+           │    │    │         │         ├── const-agg [type=bool, outer=(12)]
+           │    │    │         │         │    └── variable: is_public [type=bool]
+           │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+           │    │    │         │         │    └── variable: flavors.created_at [type=timestamp]
+           │    │    │         │         └── const-agg [type=timestamp, outer=(15)]
+           │    │    │         │              └── variable: flavors.updated_at [type=timestamp]
+           │    │    │         └── filters
+           │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,32)]
+           │    │    └── placeholder: $3 [type=int]
+           │    └── placeholder: $4 [type=int]
+           └── filters
+                └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,37), constraints=(/1: (/NULL - ]; /37: (/NULL - ]), fd=(1)==(37), (37)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -718,138 +712,138 @@ sort
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
- └── right-join
+ └── project
       ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
       ├── side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
-      ├── select
-      │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool!null) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
-      │    ├── has-placeholder
-      │    ├── key: (28)
-      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
-      │    ├── scan instance_type_extra_specs_1
-      │    │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
-      │    │    ├── key: (28)
-      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
-      │    └── filters
-      │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
-      ├── project
-      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │    ├── side-effects, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    └── limit
-      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │         ├── internal-ordering: +7,+1
-      │         ├── side-effects, has-placeholder
-      │         ├── key: (1)
-      │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         ├── offset
-      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │         │    ├── internal-ordering: +7,+1
-      │         │    ├── has-placeholder
-      │         │    ├── key: (1)
-      │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    ├── ordering: +7,+1
-      │         │    ├── sort
-      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │         │    │    ├── has-placeholder
-      │         │    │    ├── key: (1)
-      │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │    ├── ordering: +7,+1
-      │         │    │    └── select
-      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │         │    │         ├── has-placeholder
-      │         │    │         ├── key: (1)
-      │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │         ├── group-by
-      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
-      │         │    │         │    ├── internal-ordering: +1
-      │         │    │         │    ├── has-placeholder
-      │         │    │         │    ├── key: (1)
-      │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │         │    ├── left-join (merge)
-      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
-      │         │    │         │    │    ├── left ordering: +1
-      │         │    │         │    │    ├── right ordering: +18
-      │         │    │         │    │    ├── has-placeholder
-      │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
-      │         │    │         │    │    ├── ordering: +1
-      │         │    │         │    │    ├── select
-      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │         │    │         │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    ├── key: (1)
-      │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │         │    │    │    ├── ordering: +1
-      │         │    │         │    │    │    ├── scan instance_types
-      │         │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │         │    │         │    │    │    │    ├── key: (1)
-      │         │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │         │    │    │    │    └── ordering: +1
-      │         │    │         │    │    │    └── filters
-      │         │    │         │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
-      │         │    │         │    │    ├── project
-      │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
-      │         │    │         │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    ├── fd: ()-->(25)
-      │         │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
-      │         │    │         │    │    │    ├── select
-      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
-      │         │    │         │    │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    │    ├── key: (18-20)
-      │         │    │         │    │    │    │    ├── ordering: +18
-      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
-      │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
-      │         │    │         │    │    │    │    │    ├── lax-key: (18-20)
-      │         │    │         │    │    │    │    │    └── ordering: +18
-      │         │    │         │    │    │    │    └── filters
-      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
-      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $3 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
-      │         │    │         │    │    │    │         └── project_id = $4 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
-      │         │    │         │    │    │    └── projections
-      │         │    │         │    │    │         └── true [type=bool]
-      │         │    │         │    │    └── filters (true)
-      │         │    │         │    └── aggregations
-      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
-      │         │    │         │         │    └── variable: true [type=bool]
-      │         │    │         │         ├── const-agg [type=string, outer=(2)]
-      │         │    │         │         │    └── variable: name [type=string]
-      │         │    │         │         ├── const-agg [type=int, outer=(3)]
-      │         │    │         │         │    └── variable: memory_mb [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(4)]
-      │         │    │         │         │    └── variable: vcpus [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(5)]
-      │         │    │         │         │    └── variable: root_gb [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(6)]
-      │         │    │         │         │    └── variable: ephemeral_gb [type=int]
-      │         │    │         │         ├── const-agg [type=string, outer=(7)]
-      │         │    │         │         │    └── variable: flavorid [type=string]
-      │         │    │         │         ├── const-agg [type=int, outer=(8)]
-      │         │    │         │         │    └── variable: swap [type=int]
-      │         │    │         │         ├── const-agg [type=float, outer=(9)]
-      │         │    │         │         │    └── variable: rxtx_factor [type=float]
-      │         │    │         │         ├── const-agg [type=int, outer=(10)]
-      │         │    │         │         │    └── variable: vcpu_weight [type=int]
-      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
-      │         │    │         │         │    └── variable: disabled [type=bool]
-      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
-      │         │    │         │         │    └── variable: is_public [type=bool]
-      │         │    │         │         ├── const-agg [type=bool, outer=(13)]
-      │         │    │         │         │    └── variable: instance_types.deleted [type=bool]
-      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp]
-      │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
-      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp]
-      │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
-      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp]
-      │         │    │         └── filters
-      │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
-      │         │    └── placeholder: $5 [type=int]
-      │         └── placeholder: $6 [type=int]
-      └── filters
-           └── instance_type_extra_specs_1.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+      └── right-join
+           ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+           ├── side-effects, has-placeholder
+           ├── key: (1,28)
+           ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+           ├── select
+           │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool!null) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+           │    ├── has-placeholder
+           │    ├── key: (28)
+           │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+           │    ├── scan instance_type_extra_specs_1
+           │    │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+           │    │    ├── key: (28)
+           │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+           │    └── filters
+           │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+           ├── limit
+           │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+           │    ├── internal-ordering: +7,+1
+           │    ├── side-effects, has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── offset
+           │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+           │    │    ├── internal-ordering: +7,+1
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── ordering: +7,+1
+           │    │    ├── sort
+           │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── ordering: +7,+1
+           │    │    │    └── select
+           │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+           │    │    │         ├── has-placeholder
+           │    │    │         ├── key: (1)
+           │    │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── group-by
+           │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+           │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+           │    │    │         │    ├── internal-ordering: +1
+           │    │    │         │    ├── has-placeholder
+           │    │    │         │    ├── key: (1)
+           │    │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── left-join (merge)
+           │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+           │    │    │         │    │    ├── left ordering: +1
+           │    │    │         │    │    ├── right ordering: +18
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+           │    │    │         │    │    ├── ordering: +1
+           │    │    │         │    │    ├── select
+           │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (1)
+           │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    │    ├── ordering: +1
+           │    │    │         │    │    │    ├── scan instance_types
+           │    │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+           │    │    │         │    │    │    │    ├── key: (1)
+           │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    │    │    └── ordering: +1
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+           │    │    │         │    │    ├── project
+           │    │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── fd: ()-->(25)
+           │    │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
+           │    │    │         │    │    │    ├── select
+           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+           │    │    │         │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    ├── key: (18-20)
+           │    │    │         │    │    │    │    ├── ordering: +18
+           │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+           │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+           │    │    │         │    │    │    │    │    ├── lax-key: (18-20)
+           │    │    │         │    │    │    │    │    └── ordering: +18
+           │    │    │         │    │    │    │    └── filters
+           │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+           │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $3 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+           │    │    │         │    │    │    │         └── project_id = $4 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+           │    │    │         │    │    │    └── projections
+           │    │    │         │    │    │         └── true [type=bool]
+           │    │    │         │    │    └── filters (true)
+           │    │    │         │    └── aggregations
+           │    │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
+           │    │    │         │         │    └── variable: true [type=bool]
+           │    │    │         │         ├── const-agg [type=string, outer=(2)]
+           │    │    │         │         │    └── variable: name [type=string]
+           │    │    │         │         ├── const-agg [type=int, outer=(3)]
+           │    │    │         │         │    └── variable: memory_mb [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(4)]
+           │    │    │         │         │    └── variable: vcpus [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(5)]
+           │    │    │         │         │    └── variable: root_gb [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(6)]
+           │    │    │         │         │    └── variable: ephemeral_gb [type=int]
+           │    │    │         │         ├── const-agg [type=string, outer=(7)]
+           │    │    │         │         │    └── variable: flavorid [type=string]
+           │    │    │         │         ├── const-agg [type=int, outer=(8)]
+           │    │    │         │         │    └── variable: swap [type=int]
+           │    │    │         │         ├── const-agg [type=float, outer=(9)]
+           │    │    │         │         │    └── variable: rxtx_factor [type=float]
+           │    │    │         │         ├── const-agg [type=int, outer=(10)]
+           │    │    │         │         │    └── variable: vcpu_weight [type=int]
+           │    │    │         │         ├── const-agg [type=bool, outer=(11)]
+           │    │    │         │         │    └── variable: disabled [type=bool]
+           │    │    │         │         ├── const-agg [type=bool, outer=(12)]
+           │    │    │         │         │    └── variable: is_public [type=bool]
+           │    │    │         │         ├── const-agg [type=bool, outer=(13)]
+           │    │    │         │         │    └── variable: instance_types.deleted [type=bool]
+           │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+           │    │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp]
+           │    │    │         │         ├── const-agg [type=timestamp, outer=(15)]
+           │    │    │         │         │    └── variable: instance_types.created_at [type=timestamp]
+           │    │    │         │         └── const-agg [type=timestamp, outer=(16)]
+           │    │    │         │              └── variable: instance_types.updated_at [type=timestamp]
+           │    │    │         └── filters
+           │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+           │    │    └── placeholder: $5 [type=int]
+           │    └── placeholder: $6 [type=int]
+           └── filters
+                └── instance_type_extra_specs_1.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
 
 opt
 select instance_types.created_at as instance_types_created_at,
@@ -895,116 +889,116 @@ sort
  ├── key: (1,17)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
  ├── ordering: +7,+1
- └── right-join
+ └── project
       ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs_1.id:17(int) key:18(string) value:19(string) instance_type_extra_specs_1.instance_type_id:20(int) instance_type_extra_specs_1.deleted:21(bool) instance_type_extra_specs_1.deleted_at:22(timestamp) instance_type_extra_specs_1.created_at:23(timestamp) instance_type_extra_specs_1.updated_at:24(timestamp)
       ├── has-placeholder
       ├── key: (1,17)
       ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
-      ├── select
-      │    ├── columns: instance_type_extra_specs_1.id:17(int!null) key:18(string) value:19(string) instance_type_extra_specs_1.instance_type_id:20(int!null) instance_type_extra_specs_1.deleted:21(bool!null) instance_type_extra_specs_1.deleted_at:22(timestamp) instance_type_extra_specs_1.created_at:23(timestamp) instance_type_extra_specs_1.updated_at:24(timestamp)
-      │    ├── has-placeholder
-      │    ├── key: (17)
-      │    ├── fd: (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
-      │    ├── scan instance_type_extra_specs_1
-      │    │    ├── columns: instance_type_extra_specs_1.id:17(int!null) key:18(string) value:19(string) instance_type_extra_specs_1.instance_type_id:20(int!null) instance_type_extra_specs_1.deleted:21(bool) instance_type_extra_specs_1.deleted_at:22(timestamp) instance_type_extra_specs_1.created_at:23(timestamp) instance_type_extra_specs_1.updated_at:24(timestamp)
-      │    │    ├── key: (17)
-      │    │    └── fd: (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
-      │    └── filters
-      │         └── instance_type_extra_specs_1.deleted = $1 [type=bool, outer=(21), constraints=(/21: (/NULL - ])]
-      ├── project
-      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │    ├── has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    └── select
-      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
-      │         ├── has-placeholder
-      │         ├── key: (1)
-      │         ├── fd: (1)-->(2-16,34), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         ├── group-by
-      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
-      │         │    ├── grouping columns: instance_types.id:1(int!null)
-      │         │    ├── internal-ordering: +1
-      │         │    ├── has-placeholder
-      │         │    ├── key: (1)
-      │         │    ├── fd: (1)-->(2-16,34), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    ├── left-join (merge)
-      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true:33(bool)
-      │         │    │    ├── left ordering: +1
-      │         │    │    ├── right ordering: +26
-      │         │    │    ├── has-placeholder
-      │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(33)
-      │         │    │    ├── ordering: +1
-      │         │    │    ├── select
-      │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │         │    │    │    ├── has-placeholder
-      │         │    │    │    ├── key: (1)
-      │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │    │    ├── ordering: +1
-      │         │    │    │    ├── scan instance_types
-      │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │         │    │    │    │    ├── key: (1)
-      │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │    │    │    └── ordering: +1
-      │         │    │    │    └── filters
-      │         │    │    │         └── instance_types.deleted = $2 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
-      │         │    │    ├── project
-      │         │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:26(int!null)
-      │         │    │    │    ├── has-placeholder
-      │         │    │    │    ├── fd: ()-->(33)
-      │         │    │    │    ├── ordering: +26 opt(33) [actual: +26]
-      │         │    │    │    ├── select
-      │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
-      │         │    │    │    │    ├── has-placeholder
-      │         │    │    │    │    ├── key: (26-28)
-      │         │    │    │    │    ├── ordering: +26
-      │         │    │    │    │    ├── scan instance_type_projects@secondary
-      │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string) instance_type_projects.deleted:28(bool)
-      │         │    │    │    │    │    ├── lax-key: (26-28)
-      │         │    │    │    │    │    └── ordering: +26
-      │         │    │    │    │    └── filters
-      │         │    │    │    │         ├── instance_type_projects.deleted = $3 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
-      │         │    │    │    │         └── project_id = $4 [type=bool, outer=(27), constraints=(/27: (/NULL - ])]
-      │         │    │    │    └── projections
-      │         │    │    │         └── true [type=bool]
-      │         │    │    └── filters (true)
-      │         │    └── aggregations
-      │         │         ├── const-not-null-agg [type=bool, outer=(33)]
-      │         │         │    └── variable: true [type=bool]
-      │         │         ├── const-agg [type=string, outer=(2)]
-      │         │         │    └── variable: name [type=string]
-      │         │         ├── const-agg [type=int, outer=(3)]
-      │         │         │    └── variable: memory_mb [type=int]
-      │         │         ├── const-agg [type=int, outer=(4)]
-      │         │         │    └── variable: vcpus [type=int]
-      │         │         ├── const-agg [type=int, outer=(5)]
-      │         │         │    └── variable: root_gb [type=int]
-      │         │         ├── const-agg [type=int, outer=(6)]
-      │         │         │    └── variable: ephemeral_gb [type=int]
-      │         │         ├── const-agg [type=string, outer=(7)]
-      │         │         │    └── variable: flavorid [type=string]
-      │         │         ├── const-agg [type=int, outer=(8)]
-      │         │         │    └── variable: swap [type=int]
-      │         │         ├── const-agg [type=float, outer=(9)]
-      │         │         │    └── variable: rxtx_factor [type=float]
-      │         │         ├── const-agg [type=int, outer=(10)]
-      │         │         │    └── variable: vcpu_weight [type=int]
-      │         │         ├── const-agg [type=bool, outer=(11)]
-      │         │         │    └── variable: disabled [type=bool]
-      │         │         ├── const-agg [type=bool, outer=(12)]
-      │         │         │    └── variable: is_public [type=bool]
-      │         │         ├── const-agg [type=bool, outer=(13)]
-      │         │         │    └── variable: instance_types.deleted [type=bool]
-      │         │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │         │    └── variable: instance_types.deleted_at [type=timestamp]
-      │         │         ├── const-agg [type=timestamp, outer=(15)]
-      │         │         │    └── variable: instance_types.created_at [type=timestamp]
-      │         │         └── const-agg [type=timestamp, outer=(16)]
-      │         │              └── variable: instance_types.updated_at [type=timestamp]
-      │         └── filters
-      │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,34)]
-      └── filters
-           └── instance_type_extra_specs_1.instance_type_id = instance_types.id [type=bool, outer=(1,20), constraints=(/1: (/NULL - ]; /20: (/NULL - ]), fd=(1)==(20), (20)==(1)]
+      └── right-join
+           ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs_1.id:17(int) key:18(string) value:19(string) instance_type_extra_specs_1.instance_type_id:20(int) instance_type_extra_specs_1.deleted:21(bool) instance_type_extra_specs_1.deleted_at:22(timestamp) instance_type_extra_specs_1.created_at:23(timestamp) instance_type_extra_specs_1.updated_at:24(timestamp) true_agg:34(bool)
+           ├── has-placeholder
+           ├── key: (1,17)
+           ├── fd: (1)-->(2-16,34), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
+           ├── select
+           │    ├── columns: instance_type_extra_specs_1.id:17(int!null) key:18(string) value:19(string) instance_type_extra_specs_1.instance_type_id:20(int!null) instance_type_extra_specs_1.deleted:21(bool!null) instance_type_extra_specs_1.deleted_at:22(timestamp) instance_type_extra_specs_1.created_at:23(timestamp) instance_type_extra_specs_1.updated_at:24(timestamp)
+           │    ├── has-placeholder
+           │    ├── key: (17)
+           │    ├── fd: (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
+           │    ├── scan instance_type_extra_specs_1
+           │    │    ├── columns: instance_type_extra_specs_1.id:17(int!null) key:18(string) value:19(string) instance_type_extra_specs_1.instance_type_id:20(int!null) instance_type_extra_specs_1.deleted:21(bool) instance_type_extra_specs_1.deleted_at:22(timestamp) instance_type_extra_specs_1.created_at:23(timestamp) instance_type_extra_specs_1.updated_at:24(timestamp)
+           │    │    ├── key: (17)
+           │    │    └── fd: (17)-->(18-24), (18,20,21)~~>(17,19,22-24)
+           │    └── filters
+           │         └── instance_type_extra_specs_1.deleted = $1 [type=bool, outer=(21), constraints=(/21: (/NULL - ])]
+           ├── select
+           │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
+           │    ├── has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-16,34), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── group-by
+           │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
+           │    │    ├── grouping columns: instance_types.id:1(int!null)
+           │    │    ├── internal-ordering: +1
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: (1)-->(2-16,34), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── left-join (merge)
+           │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true:33(bool)
+           │    │    │    ├── left ordering: +1
+           │    │    │    ├── right ordering: +26
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(33)
+           │    │    │    ├── ordering: +1
+           │    │    │    ├── select
+           │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+           │    │    │    │    ├── has-placeholder
+           │    │    │    │    ├── key: (1)
+           │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    │    ├── ordering: +1
+           │    │    │    │    ├── scan instance_types
+           │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+           │    │    │    │    │    ├── key: (1)
+           │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    │    │    └── ordering: +1
+           │    │    │    │    └── filters
+           │    │    │    │         └── instance_types.deleted = $2 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+           │    │    │    ├── project
+           │    │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:26(int!null)
+           │    │    │    │    ├── has-placeholder
+           │    │    │    │    ├── fd: ()-->(33)
+           │    │    │    │    ├── ordering: +26 opt(33) [actual: +26]
+           │    │    │    │    ├── select
+           │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
+           │    │    │    │    │    ├── has-placeholder
+           │    │    │    │    │    ├── key: (26-28)
+           │    │    │    │    │    ├── ordering: +26
+           │    │    │    │    │    ├── scan instance_type_projects@secondary
+           │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string) instance_type_projects.deleted:28(bool)
+           │    │    │    │    │    │    ├── lax-key: (26-28)
+           │    │    │    │    │    │    └── ordering: +26
+           │    │    │    │    │    └── filters
+           │    │    │    │    │         ├── instance_type_projects.deleted = $3 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
+           │    │    │    │    │         └── project_id = $4 [type=bool, outer=(27), constraints=(/27: (/NULL - ])]
+           │    │    │    │    └── projections
+           │    │    │    │         └── true [type=bool]
+           │    │    │    └── filters (true)
+           │    │    └── aggregations
+           │    │         ├── const-not-null-agg [type=bool, outer=(33)]
+           │    │         │    └── variable: true [type=bool]
+           │    │         ├── const-agg [type=string, outer=(2)]
+           │    │         │    └── variable: name [type=string]
+           │    │         ├── const-agg [type=int, outer=(3)]
+           │    │         │    └── variable: memory_mb [type=int]
+           │    │         ├── const-agg [type=int, outer=(4)]
+           │    │         │    └── variable: vcpus [type=int]
+           │    │         ├── const-agg [type=int, outer=(5)]
+           │    │         │    └── variable: root_gb [type=int]
+           │    │         ├── const-agg [type=int, outer=(6)]
+           │    │         │    └── variable: ephemeral_gb [type=int]
+           │    │         ├── const-agg [type=string, outer=(7)]
+           │    │         │    └── variable: flavorid [type=string]
+           │    │         ├── const-agg [type=int, outer=(8)]
+           │    │         │    └── variable: swap [type=int]
+           │    │         ├── const-agg [type=float, outer=(9)]
+           │    │         │    └── variable: rxtx_factor [type=float]
+           │    │         ├── const-agg [type=int, outer=(10)]
+           │    │         │    └── variable: vcpu_weight [type=int]
+           │    │         ├── const-agg [type=bool, outer=(11)]
+           │    │         │    └── variable: disabled [type=bool]
+           │    │         ├── const-agg [type=bool, outer=(12)]
+           │    │         │    └── variable: is_public [type=bool]
+           │    │         ├── const-agg [type=bool, outer=(13)]
+           │    │         │    └── variable: instance_types.deleted [type=bool]
+           │    │         ├── const-agg [type=timestamp, outer=(14)]
+           │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
+           │    │         ├── const-agg [type=timestamp, outer=(15)]
+           │    │         │    └── variable: instance_types.created_at [type=timestamp]
+           │    │         └── const-agg [type=timestamp, outer=(16)]
+           │    │              └── variable: instance_types.updated_at [type=timestamp]
+           │    └── filters
+           │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,34)]
+           └── filters
+                └── instance_type_extra_specs_1.instance_type_id = instance_types.id [type=bool, outer=(1,20), constraints=(/1: (/NULL - ]; /20: (/NULL - ]), fd=(1)==(20), (20)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -1063,126 +1057,126 @@ from (select instance_types.created_at as instance_types_created_at,
      on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
         and instance_type_extra_specs_1.deleted = $7
 ----
-left-join (lookup instance_type_extra_specs)
+project
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
- ├── key columns: [28] = [28]
  ├── side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
- │    ├── key columns: [1] = [31]
- │    ├── side-effects, has-placeholder
- │    ├── key: (1,28)
- │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── side-effects, has-placeholder
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         ├── side-effects, has-placeholder
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    ├── has-placeholder
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
- │    │         │    ├── select
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    ├── has-placeholder
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
- │    │         │    │    ├── group-by
- │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │    │    ├── internal-ordering: +1
- │    │         │    │    │    ├── has-placeholder
- │    │         │    │    │    ├── key: (1)
- │    │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
- │    │         │    │    │    ├── left-join (merge)
- │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
- │    │         │    │    │    │    ├── left ordering: +1
- │    │         │    │    │    │    ├── right ordering: +18
- │    │         │    │    │    │    ├── has-placeholder
- │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), ()~~>(25)
- │    │         │    │    │    │    ├── ordering: +1
- │    │         │    │    │    │    ├── select
- │    │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │    │    │    │    ├── has-placeholder
- │    │         │    │    │    │    │    ├── key: (1)
- │    │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
- │    │         │    │    │    │    │    ├── ordering: +1
- │    │         │    │    │    │    │    ├── scan instance_types
- │    │         │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │    │    │    │    │    ├── key: (1)
- │    │         │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    │    │    │    │    └── ordering: +1
- │    │         │    │    │    │    │    └── filters
- │    │         │    │    │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │    │    │    │         └── name = $4 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
- │    │         │    │    │    │    ├── project
- │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │    │    │    │    ├── has-placeholder
- │    │         │    │    │    │    │    ├── fd: ()-->(25)
- │    │         │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
- │    │         │    │    │    │    │    ├── select
- │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │    │    │    │    │    ├── has-placeholder
- │    │         │    │    │    │    │    │    ├── key: (18-20)
- │    │         │    │    │    │    │    │    ├── ordering: +18
- │    │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │    │    │    │    │    │    ├── lax-key: (18-20)
- │    │         │    │    │    │    │    │    │    └── ordering: +18
- │    │         │    │    │    │    │    │    └── filters
- │    │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │    │    │    │    └── projections
- │    │         │    │    │    │    │         └── true [type=bool]
- │    │         │    │    │    │    └── filters (true)
- │    │         │    │    │    └── aggregations
- │    │         │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
- │    │         │    │    │         │    └── variable: true [type=bool]
- │    │         │    │    │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │    │         │    └── variable: name [type=string]
- │    │         │    │    │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │    │         │    └── variable: memory_mb [type=int]
- │    │         │    │    │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │    │         │    └── variable: vcpus [type=int]
- │    │         │    │    │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │    │         │    └── variable: root_gb [type=int]
- │    │         │    │    │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │    │         │    └── variable: ephemeral_gb [type=int]
- │    │         │    │    │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │    │         │    └── variable: flavorid [type=string]
- │    │         │    │    │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │    │         │    └── variable: swap [type=int]
- │    │         │    │    │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │    │         │    └── variable: rxtx_factor [type=float]
- │    │         │    │    │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │    │         │    └── variable: vcpu_weight [type=int]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │    │         │    └── variable: disabled [type=bool]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │    │         │    └── variable: is_public [type=bool]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │    │         │    └── variable: instance_types.deleted [type=bool]
- │    │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
- │    │         │    │    │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
- │    │         │    │    │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │    │              └── variable: instance_types.updated_at [type=timestamp]
- │    │         │    │    └── filters
- │    │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
- │    │         │    └── placeholder: $5 [type=int]
- │    │         └── placeholder: $6 [type=int]
- │    └── filters
- │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
- └── filters (true)
+ └── left-join (lookup instance_type_extra_specs)
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+      ├── key columns: [28] = [28]
+      ├── side-effects, has-placeholder
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── left-join (lookup instance_type_extra_specs@secondary)
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
+      │    ├── key columns: [1] = [31]
+      │    ├── side-effects, has-placeholder
+      │    ├── key: (1,28)
+      │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
+      │    ├── limit
+      │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    ├── side-effects, has-placeholder
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+      │    │    ├── offset
+      │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │    ├── has-placeholder
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+      │    │    │    │    ├── group-by
+      │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+      │    │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+      │    │    │    │    │    ├── left-join (merge)
+      │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │    │    │    │    │    │    ├── left ordering: +1
+      │    │    │    │    │    │    ├── right ordering: +18
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), ()~~>(25)
+      │    │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+      │    │    │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    │    │    ├── scan instance_types
+      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    │    │    │    │    └── ordering: +1
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │    │    │    │         └── name = $4 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+      │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    ├── fd: ()-->(25)
+      │    │    │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │    │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    │    ├── key: (18-20)
+      │    │    │    │    │    │    │    │    ├── ordering: +18
+      │    │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+      │    │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │    │    │    │    │    │    │    │    │    ├── lax-key: (18-20)
+      │    │    │    │    │    │    │    │    │    └── ordering: +18
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │    │    │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │    │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │    │         └── true [type=bool]
+      │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
+      │    │    │    │    │         │    └── variable: true [type=bool]
+      │    │    │    │    │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │    │         │    └── variable: name [type=string]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │    │         │    └── variable: memory_mb [type=int]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │    │         │    └── variable: vcpus [type=int]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │    │         │    └── variable: root_gb [type=int]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │    │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │    │         │    └── variable: flavorid [type=string]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │    │         │    └── variable: swap [type=int]
+      │    │    │    │    │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │    │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │    │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │    │         │    └── variable: disabled [type=bool]
+      │    │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │    │         │    └── variable: is_public [type=bool]
+      │    │    │    │    │         ├── const-agg [type=bool, outer=(13)]
+      │    │    │    │    │         │    └── variable: instance_types.deleted [type=bool]
+      │    │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
+      │    │    │    │    │         ├── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
+      │    │    │    │    │         └── const-agg [type=timestamp, outer=(16)]
+      │    │    │    │    │              └── variable: instance_types.updated_at [type=timestamp]
+      │    │    │    │    └── filters
+      │    │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+      │    │    │    └── placeholder: $5 [type=int]
+      │    │    └── placeholder: $6 [type=int]
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      └── filters (true)
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -1241,127 +1235,127 @@ from (select instance_types.created_at as instance_types_created_at,
      on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
         and instance_type_extra_specs_1.deleted = $7
 ----
-left-join (lookup instance_type_extra_specs)
+project
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
- ├── key columns: [28] = [28]
  ├── side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
- │    ├── key columns: [1] = [31]
- │    ├── side-effects, has-placeholder
- │    ├── key: (1,28)
- │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── side-effects, has-placeholder
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         ├── side-effects, has-placeholder
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    ├── has-placeholder
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    ├── select
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    ├── has-placeholder
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    ├── group-by
- │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │    │    ├── internal-ordering: +1
- │    │         │    │    │    ├── has-placeholder
- │    │         │    │    │    ├── key: (1)
- │    │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    │    ├── left-join (merge)
- │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
- │    │         │    │    │    │    ├── left ordering: +1
- │    │         │    │    │    │    ├── right ordering: +18
- │    │         │    │    │    │    ├── has-placeholder
- │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
- │    │         │    │    │    │    ├── ordering: +1
- │    │         │    │    │    │    ├── select
- │    │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │    │    │    │    ├── has-placeholder
- │    │         │    │    │    │    │    ├── key: (1)
- │    │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    │    │    │    ├── ordering: +1
- │    │         │    │    │    │    │    ├── scan instance_types
- │    │         │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │    │    │    │    │    ├── key: (1)
- │    │         │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    │    │    │    │    └── ordering: +1
- │    │         │    │    │    │    │    └── filters
- │    │         │    │    │    │    │         ├── instance_types.id = $4 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
- │    │         │    │    │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │    │    │    ├── project
- │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │    │    │    │    ├── has-placeholder
- │    │         │    │    │    │    │    ├── fd: ()-->(25)
- │    │         │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
- │    │         │    │    │    │    │    ├── select
- │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │    │    │    │    │    ├── has-placeholder
- │    │         │    │    │    │    │    │    ├── key: (18-20)
- │    │         │    │    │    │    │    │    ├── ordering: +18
- │    │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │    │    │    │    │    │    ├── lax-key: (18-20)
- │    │         │    │    │    │    │    │    │    └── ordering: +18
- │    │         │    │    │    │    │    │    └── filters
- │    │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │    │    │    │    │         ├── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │    │    │    │    │         └── instance_type_projects.instance_type_id = $4 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
- │    │         │    │    │    │    │    └── projections
- │    │         │    │    │    │    │         └── true [type=bool]
- │    │         │    │    │    │    └── filters (true)
- │    │         │    │    │    └── aggregations
- │    │         │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
- │    │         │    │    │         │    └── variable: true [type=bool]
- │    │         │    │    │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │    │         │    └── variable: name [type=string]
- │    │         │    │    │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │    │         │    └── variable: memory_mb [type=int]
- │    │         │    │    │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │    │         │    └── variable: vcpus [type=int]
- │    │         │    │    │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │    │         │    └── variable: root_gb [type=int]
- │    │         │    │    │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │    │         │    └── variable: ephemeral_gb [type=int]
- │    │         │    │    │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │    │         │    └── variable: flavorid [type=string]
- │    │         │    │    │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │    │         │    └── variable: swap [type=int]
- │    │         │    │    │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │    │         │    └── variable: rxtx_factor [type=float]
- │    │         │    │    │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │    │         │    └── variable: vcpu_weight [type=int]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │    │         │    └── variable: disabled [type=bool]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │    │         │    └── variable: is_public [type=bool]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │    │         │    └── variable: instance_types.deleted [type=bool]
- │    │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
- │    │         │    │    │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
- │    │         │    │    │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │    │              └── variable: instance_types.updated_at [type=timestamp]
- │    │         │    │    └── filters
- │    │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
- │    │         │    └── placeholder: $5 [type=int]
- │    │         └── placeholder: $6 [type=int]
- │    └── filters
- │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
- └── filters (true)
+ └── left-join (lookup instance_type_extra_specs)
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+      ├── key columns: [28] = [28]
+      ├── side-effects, has-placeholder
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── left-join (lookup instance_type_extra_specs@secondary)
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
+      │    ├── key columns: [1] = [31]
+      │    ├── side-effects, has-placeholder
+      │    ├── key: (1,28)
+      │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
+      │    ├── limit
+      │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    ├── side-effects, has-placeholder
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    ├── offset
+      │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │    ├── has-placeholder
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    ├── group-by
+      │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+      │    │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    │    ├── left-join (merge)
+      │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │    │    │    │    │    │    ├── left ordering: +1
+      │    │    │    │    │    │    ├── right ordering: +18
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │    │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    │    │    ├── scan instance_types
+      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    │    │    │    │    └── ordering: +1
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         ├── instance_types.id = $4 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      │    │    │    │    │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    ├── fd: ()-->(25)
+      │    │    │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │    │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    │    ├── key: (18-20)
+      │    │    │    │    │    │    │    │    ├── ordering: +18
+      │    │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+      │    │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │    │    │    │    │    │    │    │    │    ├── lax-key: (18-20)
+      │    │    │    │    │    │    │    │    │    └── ordering: +18
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │    │    │    │    │    │    │    │         ├── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │    │    │    │    │    │    │    │         └── instance_type_projects.instance_type_id = $4 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │    │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │    │         └── true [type=bool]
+      │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
+      │    │    │    │    │         │    └── variable: true [type=bool]
+      │    │    │    │    │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │    │         │    └── variable: name [type=string]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │    │         │    └── variable: memory_mb [type=int]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │    │         │    └── variable: vcpus [type=int]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │    │         │    └── variable: root_gb [type=int]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │    │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │    │         │    └── variable: flavorid [type=string]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │    │         │    └── variable: swap [type=int]
+      │    │    │    │    │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │    │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │    │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │    │         │    └── variable: disabled [type=bool]
+      │    │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │    │         │    └── variable: is_public [type=bool]
+      │    │    │    │    │         ├── const-agg [type=bool, outer=(13)]
+      │    │    │    │    │         │    └── variable: instance_types.deleted [type=bool]
+      │    │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
+      │    │    │    │    │         ├── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
+      │    │    │    │    │         └── const-agg [type=timestamp, outer=(16)]
+      │    │    │    │    │              └── variable: instance_types.updated_at [type=timestamp]
+      │    │    │    │    └── filters
+      │    │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+      │    │    │    └── placeholder: $5 [type=int]
+      │    │    └── placeholder: $6 [type=int]
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      └── filters (true)
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -1411,116 +1405,116 @@ from (select flavors.created_at as flavors_created_at,
      left join flavor_extra_specs as flavor_extra_specs_1
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 ----
-right-join
+project
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
  ├── side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
- ├── scan flavor_extra_specs_1
- │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
- │    ├── key: (25)
- │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
- ├── project
- │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │    ├── side-effects, has-placeholder
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │    └── limit
- │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         ├── side-effects, has-placeholder
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         ├── offset
- │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         │    ├── has-placeholder
- │         │    ├── key: (1)
- │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    ├── select
- │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         │    │    ├── has-placeholder
- │         │    │    ├── key: (1)
- │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    ├── group-by
- │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         │    │    │    ├── grouping columns: flavors.id:1(int!null)
- │         │    │    │    ├── internal-ordering: +1
- │         │    │    │    ├── has-placeholder
- │         │    │    │    ├── key: (1)
- │         │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    │    ├── left-join (merge)
- │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
- │         │    │    │    │    ├── left ordering: +1
- │         │    │    │    │    ├── right ordering: +17
- │         │    │    │    │    ├── has-placeholder
- │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
- │         │    │    │    │    ├── ordering: +1
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │         │    │    │    │    │    ├── has-placeholder
- │         │    │    │    │    │    ├── key: (1)
- │         │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    │    │    │    ├── ordering: +1
- │         │    │    │    │    │    ├── scan flavors
- │         │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │         │    │    │    │    │    │    ├── key: (1)
- │         │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    │    │    │    │    └── ordering: +1
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── name = $2 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
- │         │    │    │    │    ├── project
- │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
- │         │    │    │    │    │    ├── has-placeholder
- │         │    │    │    │    │    ├── fd: ()-->(22)
- │         │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
- │         │    │    │    │    │    ├── select
- │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
- │         │    │    │    │    │    │    ├── has-placeholder
- │         │    │    │    │    │    │    ├── key: (17,18)
- │         │    │    │    │    │    │    ├── ordering: +17
- │         │    │    │    │    │    │    ├── scan flavor_projects@secondary
- │         │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
- │         │    │    │    │    │    │    │    ├── key: (17,18)
- │         │    │    │    │    │    │    │    └── ordering: +17
- │         │    │    │    │    │    │    └── filters
- │         │    │    │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
- │         │    │    │    │    │    └── projections
- │         │    │    │    │    │         └── true [type=bool]
- │         │    │    │    │    └── filters (true)
- │         │    │    │    └── aggregations
- │         │    │    │         ├── const-not-null-agg [type=bool, outer=(22)]
- │         │    │    │         │    └── variable: true [type=bool]
- │         │    │    │         ├── const-agg [type=string, outer=(2)]
- │         │    │    │         │    └── variable: name [type=string]
- │         │    │    │         ├── const-agg [type=int, outer=(3)]
- │         │    │    │         │    └── variable: memory_mb [type=int]
- │         │    │    │         ├── const-agg [type=int, outer=(4)]
- │         │    │    │         │    └── variable: vcpus [type=int]
- │         │    │    │         ├── const-agg [type=int, outer=(5)]
- │         │    │    │         │    └── variable: root_gb [type=int]
- │         │    │    │         ├── const-agg [type=int, outer=(6)]
- │         │    │    │         │    └── variable: ephemeral_gb [type=int]
- │         │    │    │         ├── const-agg [type=string, outer=(7)]
- │         │    │    │         │    └── variable: flavorid [type=string]
- │         │    │    │         ├── const-agg [type=int, outer=(8)]
- │         │    │    │         │    └── variable: swap [type=int]
- │         │    │    │         ├── const-agg [type=float, outer=(9)]
- │         │    │    │         │    └── variable: rxtx_factor [type=float]
- │         │    │    │         ├── const-agg [type=int, outer=(10)]
- │         │    │    │         │    └── variable: vcpu_weight [type=int]
- │         │    │    │         ├── const-agg [type=bool, outer=(11)]
- │         │    │    │         │    └── variable: disabled [type=bool]
- │         │    │    │         ├── const-agg [type=bool, outer=(12)]
- │         │    │    │         │    └── variable: is_public [type=bool]
- │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
- │         │    │    │         │    └── variable: flavors.created_at [type=timestamp]
- │         │    │    │         └── const-agg [type=timestamp, outer=(15)]
- │         │    │    │              └── variable: flavors.updated_at [type=timestamp]
- │         │    │    └── filters
- │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
- │         │    └── placeholder: $3 [type=int]
- │         └── placeholder: $4 [type=int]
- └── filters
-      └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+ └── right-join
+      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+      ├── side-effects, has-placeholder
+      ├── key: (1,25)
+      ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── scan flavor_extra_specs_1
+      │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+      │    ├── key: (25)
+      │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── limit
+      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    ├── side-effects, has-placeholder
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    ├── offset
+      │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    │    ├── has-placeholder
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    ├── select
+      │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    ├── group-by
+      │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    │    │    │    ├── grouping columns: flavors.id:1(int!null)
+      │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    ├── has-placeholder
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    ├── left-join (merge)
+      │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+      │    │    │    │    │    ├── left ordering: +1
+      │    │    │    │    │    ├── right ordering: +17
+      │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+      │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    ├── select
+      │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    │    ├── scan flavors
+      │    │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    │    │    │    └── ordering: +1
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── name = $2 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── fd: ()-->(22)
+      │    │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    ├── key: (17,18)
+      │    │    │    │    │    │    │    ├── ordering: +17
+      │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
+      │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │    │    │    │    │    │    │    │    ├── key: (17,18)
+      │    │    │    │    │    │    │    │    └── ordering: +17
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── true [type=bool]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── const-not-null-agg [type=bool, outer=(22)]
+      │    │    │    │         │    └── variable: true [type=bool]
+      │    │    │    │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │         │    └── variable: name [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │         │    └── variable: memory_mb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │         │    └── variable: vcpus [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │         │    └── variable: root_gb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │         │    └── variable: flavorid [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │         │    └── variable: swap [type=int]
+      │    │    │    │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │         │    └── variable: disabled [type=bool]
+      │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │         │    └── variable: is_public [type=bool]
+      │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │         │    └── variable: flavors.created_at [type=timestamp]
+      │    │    │    │         └── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │              └── variable: flavors.updated_at [type=timestamp]
+      │    │    │    └── filters
+      │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
+      │    │    └── placeholder: $3 [type=int]
+      │    └── placeholder: $4 [type=int]
+      └── filters
+           └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -1570,116 +1564,116 @@ from (select flavors.created_at as flavors_created_at,
      left join flavor_extra_specs as flavor_extra_specs_1
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 ----
-right-join
+project
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
  ├── side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
- ├── scan flavor_extra_specs_1
- │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
- │    ├── key: (25)
- │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
- ├── project
- │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │    ├── side-effects, has-placeholder
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │    └── limit
- │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         ├── side-effects, has-placeholder
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         ├── offset
- │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         │    ├── has-placeholder
- │         │    ├── key: (1)
- │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    ├── select
- │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         │    │    ├── has-placeholder
- │         │    │    ├── key: (1)
- │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    ├── group-by
- │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         │    │    │    ├── grouping columns: flavors.id:1(int!null)
- │         │    │    │    ├── internal-ordering: +1
- │         │    │    │    ├── has-placeholder
- │         │    │    │    ├── key: (1)
- │         │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    │    ├── left-join (merge)
- │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
- │         │    │    │    │    ├── left ordering: +1
- │         │    │    │    │    ├── right ordering: +17
- │         │    │    │    │    ├── has-placeholder
- │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
- │         │    │    │    │    ├── ordering: +1
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │         │    │    │    │    │    ├── has-placeholder
- │         │    │    │    │    │    ├── key: (1)
- │         │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    │    │    │    ├── ordering: +1
- │         │    │    │    │    │    ├── scan flavors
- │         │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │         │    │    │    │    │    │    ├── key: (1)
- │         │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    │    │    │    │    └── ordering: +1
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── flavorid = $2 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
- │         │    │    │    │    ├── project
- │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
- │         │    │    │    │    │    ├── has-placeholder
- │         │    │    │    │    │    ├── fd: ()-->(22)
- │         │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
- │         │    │    │    │    │    ├── select
- │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
- │         │    │    │    │    │    │    ├── has-placeholder
- │         │    │    │    │    │    │    ├── key: (17,18)
- │         │    │    │    │    │    │    ├── ordering: +17
- │         │    │    │    │    │    │    ├── scan flavor_projects@secondary
- │         │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
- │         │    │    │    │    │    │    │    ├── key: (17,18)
- │         │    │    │    │    │    │    │    └── ordering: +17
- │         │    │    │    │    │    │    └── filters
- │         │    │    │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
- │         │    │    │    │    │    └── projections
- │         │    │    │    │    │         └── true [type=bool]
- │         │    │    │    │    └── filters (true)
- │         │    │    │    └── aggregations
- │         │    │    │         ├── const-not-null-agg [type=bool, outer=(22)]
- │         │    │    │         │    └── variable: true [type=bool]
- │         │    │    │         ├── const-agg [type=string, outer=(2)]
- │         │    │    │         │    └── variable: name [type=string]
- │         │    │    │         ├── const-agg [type=int, outer=(3)]
- │         │    │    │         │    └── variable: memory_mb [type=int]
- │         │    │    │         ├── const-agg [type=int, outer=(4)]
- │         │    │    │         │    └── variable: vcpus [type=int]
- │         │    │    │         ├── const-agg [type=int, outer=(5)]
- │         │    │    │         │    └── variable: root_gb [type=int]
- │         │    │    │         ├── const-agg [type=int, outer=(6)]
- │         │    │    │         │    └── variable: ephemeral_gb [type=int]
- │         │    │    │         ├── const-agg [type=string, outer=(7)]
- │         │    │    │         │    └── variable: flavorid [type=string]
- │         │    │    │         ├── const-agg [type=int, outer=(8)]
- │         │    │    │         │    └── variable: swap [type=int]
- │         │    │    │         ├── const-agg [type=float, outer=(9)]
- │         │    │    │         │    └── variable: rxtx_factor [type=float]
- │         │    │    │         ├── const-agg [type=int, outer=(10)]
- │         │    │    │         │    └── variable: vcpu_weight [type=int]
- │         │    │    │         ├── const-agg [type=bool, outer=(11)]
- │         │    │    │         │    └── variable: disabled [type=bool]
- │         │    │    │         ├── const-agg [type=bool, outer=(12)]
- │         │    │    │         │    └── variable: is_public [type=bool]
- │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
- │         │    │    │         │    └── variable: flavors.created_at [type=timestamp]
- │         │    │    │         └── const-agg [type=timestamp, outer=(15)]
- │         │    │    │              └── variable: flavors.updated_at [type=timestamp]
- │         │    │    └── filters
- │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
- │         │    └── placeholder: $3 [type=int]
- │         └── placeholder: $4 [type=int]
- └── filters
-      └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+ └── right-join
+      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+      ├── side-effects, has-placeholder
+      ├── key: (1,25)
+      ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── scan flavor_extra_specs_1
+      │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+      │    ├── key: (25)
+      │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── limit
+      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    ├── side-effects, has-placeholder
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    ├── offset
+      │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    │    ├── has-placeholder
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    ├── select
+      │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    ├── group-by
+      │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    │    │    │    ├── grouping columns: flavors.id:1(int!null)
+      │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    ├── has-placeholder
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    ├── left-join (merge)
+      │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+      │    │    │    │    │    ├── left ordering: +1
+      │    │    │    │    │    ├── right ordering: +17
+      │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+      │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    ├── select
+      │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    │    ├── scan flavors
+      │    │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    │    │    │    └── ordering: +1
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── flavorid = $2 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── fd: ()-->(22)
+      │    │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    ├── key: (17,18)
+      │    │    │    │    │    │    │    ├── ordering: +17
+      │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
+      │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │    │    │    │    │    │    │    │    ├── key: (17,18)
+      │    │    │    │    │    │    │    │    └── ordering: +17
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── true [type=bool]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── const-not-null-agg [type=bool, outer=(22)]
+      │    │    │    │         │    └── variable: true [type=bool]
+      │    │    │    │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │         │    └── variable: name [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │         │    └── variable: memory_mb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │         │    └── variable: vcpus [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │         │    └── variable: root_gb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │         │    └── variable: flavorid [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │         │    └── variable: swap [type=int]
+      │    │    │    │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │         │    └── variable: disabled [type=bool]
+      │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │         │    └── variable: is_public [type=bool]
+      │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │         │    └── variable: flavors.created_at [type=timestamp]
+      │    │    │    │         └── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │              └── variable: flavors.updated_at [type=timestamp]
+      │    │    │    └── filters
+      │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
+      │    │    └── placeholder: $3 [type=int]
+      │    └── placeholder: $4 [type=int]
+      └── filters
+           └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -1739,125 +1733,125 @@ sort
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +7
- └── right-join
+ └── project
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
       ├── side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
-      ├── scan flavor_extra_specs_1
-      │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
-      │    ├── key: (25)
-      │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
-      ├── project
-      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │    ├── side-effects, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    └── limit
-      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         ├── internal-ordering: +7
-      │         ├── side-effects, has-placeholder
-      │         ├── key: (1)
-      │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         ├── offset
-      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         │    ├── internal-ordering: +7
-      │         │    ├── has-placeholder
-      │         │    ├── key: (1)
-      │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    ├── ordering: +7
-      │         │    ├── sort
-      │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         │    │    ├── has-placeholder
-      │         │    │    ├── key: (1)
-      │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │    ├── ordering: +7
-      │         │    │    └── select
-      │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         │    │         ├── has-placeholder
-      │         │    │         ├── key: (1)
-      │         │    │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         ├── group-by
-      │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
-      │         │    │         │    ├── internal-ordering: +1
-      │         │    │         │    ├── has-placeholder
-      │         │    │         │    ├── key: (1)
-      │         │    │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         │    ├── left-join (merge)
-      │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
-      │         │    │         │    │    ├── left ordering: +1
-      │         │    │         │    │    ├── right ordering: +17
-      │         │    │         │    │    ├── has-placeholder
-      │         │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
-      │         │    │         │    │    ├── ordering: +1
-      │         │    │         │    │    ├── select
-      │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │         │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    ├── key: (1)
-      │         │    │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         │    │    │    ├── ordering: +1
-      │         │    │         │    │    │    ├── scan flavors
-      │         │    │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │         │    │    │    │    ├── key: (1)
-      │         │    │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         │    │    │    │    └── ordering: +1
-      │         │    │         │    │    │    └── filters
-      │         │    │         │    │    │         └── (flavorid > $2) OR ((flavorid = $3) AND (flavors.id > $4)) [type=bool, outer=(1,7)]
-      │         │    │         │    │    ├── project
-      │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
-      │         │    │         │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    ├── fd: ()-->(22)
-      │         │    │         │    │    │    ├── ordering: +17 opt(22) [actual: +17]
-      │         │    │         │    │    │    ├── select
-      │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
-      │         │    │         │    │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    │    ├── key: (17,18)
-      │         │    │         │    │    │    │    ├── ordering: +17
-      │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
-      │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
-      │         │    │         │    │    │    │    │    ├── key: (17,18)
-      │         │    │         │    │    │    │    │    └── ordering: +17
-      │         │    │         │    │    │    │    └── filters
-      │         │    │         │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
-      │         │    │         │    │    │    └── projections
-      │         │    │         │    │    │         └── true [type=bool]
-      │         │    │         │    │    └── filters (true)
-      │         │    │         │    └── aggregations
-      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(22)]
-      │         │    │         │         │    └── variable: true [type=bool]
-      │         │    │         │         ├── const-agg [type=string, outer=(2)]
-      │         │    │         │         │    └── variable: name [type=string]
-      │         │    │         │         ├── const-agg [type=int, outer=(3)]
-      │         │    │         │         │    └── variable: memory_mb [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(4)]
-      │         │    │         │         │    └── variable: vcpus [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(5)]
-      │         │    │         │         │    └── variable: root_gb [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(6)]
-      │         │    │         │         │    └── variable: ephemeral_gb [type=int]
-      │         │    │         │         ├── const-agg [type=string, outer=(7)]
-      │         │    │         │         │    └── variable: flavorid [type=string]
-      │         │    │         │         ├── const-agg [type=int, outer=(8)]
-      │         │    │         │         │    └── variable: swap [type=int]
-      │         │    │         │         ├── const-agg [type=float, outer=(9)]
-      │         │    │         │         │    └── variable: rxtx_factor [type=float]
-      │         │    │         │         ├── const-agg [type=int, outer=(10)]
-      │         │    │         │         │    └── variable: vcpu_weight [type=int]
-      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
-      │         │    │         │         │    └── variable: disabled [type=bool]
-      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
-      │         │    │         │         │    └── variable: is_public [type=bool]
-      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │    │         │         │    └── variable: flavors.created_at [type=timestamp]
-      │         │    │         │         └── const-agg [type=timestamp, outer=(15)]
-      │         │    │         │              └── variable: flavors.updated_at [type=timestamp]
-      │         │    │         └── filters
-      │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
-      │         │    └── placeholder: $5 [type=int]
-      │         └── placeholder: $6 [type=int]
-      └── filters
-           └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+      └── right-join
+           ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+           ├── side-effects, has-placeholder
+           ├── key: (1,25)
+           ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+           ├── scan flavor_extra_specs_1
+           │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+           │    ├── key: (25)
+           │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+           ├── limit
+           │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    ├── internal-ordering: +7
+           │    ├── side-effects, has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── offset
+           │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │    ├── internal-ordering: +7
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── ordering: +7
+           │    │    ├── sort
+           │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    ├── ordering: +7
+           │    │    │    └── select
+           │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │    │         ├── has-placeholder
+           │    │    │         ├── key: (1)
+           │    │    │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         ├── group-by
+           │    │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │    │         │    ├── grouping columns: flavors.id:1(int!null)
+           │    │    │         │    ├── internal-ordering: +1
+           │    │    │         │    ├── has-placeholder
+           │    │    │         │    ├── key: (1)
+           │    │    │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    ├── left-join (merge)
+           │    │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+           │    │    │         │    │    ├── left ordering: +1
+           │    │    │         │    │    ├── right ordering: +17
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+           │    │    │         │    │    ├── ordering: +1
+           │    │    │         │    │    ├── select
+           │    │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (1)
+           │    │    │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    │    │    ├── ordering: +1
+           │    │    │         │    │    │    ├── scan flavors
+           │    │    │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+           │    │    │         │    │    │    │    ├── key: (1)
+           │    │    │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    │    │    │    └── ordering: +1
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         └── (flavorid > $2) OR ((flavorid = $3) AND (flavors.id > $4)) [type=bool, outer=(1,7)]
+           │    │    │         │    │    ├── project
+           │    │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── fd: ()-->(22)
+           │    │    │         │    │    │    ├── ordering: +17 opt(22) [actual: +17]
+           │    │    │         │    │    │    ├── select
+           │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+           │    │    │         │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    ├── key: (17,18)
+           │    │    │         │    │    │    │    ├── ordering: +17
+           │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
+           │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+           │    │    │         │    │    │    │    │    ├── key: (17,18)
+           │    │    │         │    │    │    │    │    └── ordering: +17
+           │    │    │         │    │    │    │    └── filters
+           │    │    │         │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+           │    │    │         │    │    │    └── projections
+           │    │    │         │    │    │         └── true [type=bool]
+           │    │    │         │    │    └── filters (true)
+           │    │    │         │    └── aggregations
+           │    │    │         │         ├── const-not-null-agg [type=bool, outer=(22)]
+           │    │    │         │         │    └── variable: true [type=bool]
+           │    │    │         │         ├── const-agg [type=string, outer=(2)]
+           │    │    │         │         │    └── variable: name [type=string]
+           │    │    │         │         ├── const-agg [type=int, outer=(3)]
+           │    │    │         │         │    └── variable: memory_mb [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(4)]
+           │    │    │         │         │    └── variable: vcpus [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(5)]
+           │    │    │         │         │    └── variable: root_gb [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(6)]
+           │    │    │         │         │    └── variable: ephemeral_gb [type=int]
+           │    │    │         │         ├── const-agg [type=string, outer=(7)]
+           │    │    │         │         │    └── variable: flavorid [type=string]
+           │    │    │         │         ├── const-agg [type=int, outer=(8)]
+           │    │    │         │         │    └── variable: swap [type=int]
+           │    │    │         │         ├── const-agg [type=float, outer=(9)]
+           │    │    │         │         │    └── variable: rxtx_factor [type=float]
+           │    │    │         │         ├── const-agg [type=int, outer=(10)]
+           │    │    │         │         │    └── variable: vcpu_weight [type=int]
+           │    │    │         │         ├── const-agg [type=bool, outer=(11)]
+           │    │    │         │         │    └── variable: disabled [type=bool]
+           │    │    │         │         ├── const-agg [type=bool, outer=(12)]
+           │    │    │         │         │    └── variable: is_public [type=bool]
+           │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+           │    │    │         │         │    └── variable: flavors.created_at [type=timestamp]
+           │    │    │         │         └── const-agg [type=timestamp, outer=(15)]
+           │    │    │         │              └── variable: flavors.updated_at [type=timestamp]
+           │    │    │         └── filters
+           │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
+           │    │    └── placeholder: $5 [type=int]
+           │    └── placeholder: $6 [type=int]
+           └── filters
+                └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -1924,137 +1918,137 @@ sort
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
- └── right-join
+ └── project
       ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
       ├── side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
-      ├── select
-      │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool!null) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
-      │    ├── has-placeholder
-      │    ├── key: (28)
-      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
-      │    ├── scan instance_type_extra_specs_1
-      │    │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
-      │    │    ├── key: (28)
-      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
-      │    └── filters
-      │         └── instance_type_extra_specs_1.deleted = $6 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
-      ├── project
-      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │    ├── side-effects, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    └── limit
-      │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │         ├── internal-ordering: +7,+1
-      │         ├── side-effects, has-placeholder
-      │         ├── key: (1)
-      │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         ├── offset
-      │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │         │    ├── internal-ordering: +7,+1
-      │         │    ├── has-placeholder
-      │         │    ├── key: (1)
-      │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    ├── ordering: +7,+1
-      │         │    ├── sort
-      │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │         │    │    ├── has-placeholder
-      │         │    │    ├── key: (1)
-      │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │    ├── ordering: +7,+1
-      │         │    │    └── select
-      │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │         │    │         ├── has-placeholder
-      │         │    │         ├── key: (1)
-      │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │         ├── group-by
-      │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
-      │         │    │         │    ├── internal-ordering: +1
-      │         │    │         │    ├── has-placeholder
-      │         │    │         │    ├── key: (1)
-      │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │         │    ├── left-join (merge)
-      │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
-      │         │    │         │    │    ├── left ordering: +1
-      │         │    │         │    │    ├── right ordering: +18
-      │         │    │         │    │    ├── has-placeholder
-      │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
-      │         │    │         │    │    ├── ordering: +1
-      │         │    │         │    │    ├── select
-      │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │         │    │         │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    ├── key: (1)
-      │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │         │    │    │    ├── ordering: +1
-      │         │    │         │    │    │    ├── scan instance_types
-      │         │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │         │    │         │    │    │    │    ├── key: (1)
-      │         │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │         │    │         │    │    │    │    └── ordering: +1
-      │         │    │         │    │    │    └── filters
-      │         │    │         │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
-      │         │    │         │    │    ├── project
-      │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
-      │         │    │         │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    ├── fd: ()-->(25)
-      │         │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
-      │         │    │         │    │    │    ├── select
-      │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
-      │         │    │         │    │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    │    ├── key: (18-20)
-      │         │    │         │    │    │    │    ├── ordering: +18
-      │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
-      │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
-      │         │    │         │    │    │    │    │    ├── lax-key: (18-20)
-      │         │    │         │    │    │    │    │    └── ordering: +18
-      │         │    │         │    │    │    │    └── filters
-      │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
-      │         │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
-      │         │    │         │    │    │    └── projections
-      │         │    │         │    │    │         └── true [type=bool]
-      │         │    │         │    │    └── filters (true)
-      │         │    │         │    └── aggregations
-      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
-      │         │    │         │         │    └── variable: true [type=bool]
-      │         │    │         │         ├── const-agg [type=string, outer=(2)]
-      │         │    │         │         │    └── variable: name [type=string]
-      │         │    │         │         ├── const-agg [type=int, outer=(3)]
-      │         │    │         │         │    └── variable: memory_mb [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(4)]
-      │         │    │         │         │    └── variable: vcpus [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(5)]
-      │         │    │         │         │    └── variable: root_gb [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(6)]
-      │         │    │         │         │    └── variable: ephemeral_gb [type=int]
-      │         │    │         │         ├── const-agg [type=string, outer=(7)]
-      │         │    │         │         │    └── variable: flavorid [type=string]
-      │         │    │         │         ├── const-agg [type=int, outer=(8)]
-      │         │    │         │         │    └── variable: swap [type=int]
-      │         │    │         │         ├── const-agg [type=float, outer=(9)]
-      │         │    │         │         │    └── variable: rxtx_factor [type=float]
-      │         │    │         │         ├── const-agg [type=int, outer=(10)]
-      │         │    │         │         │    └── variable: vcpu_weight [type=int]
-      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
-      │         │    │         │         │    └── variable: disabled [type=bool]
-      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
-      │         │    │         │         │    └── variable: is_public [type=bool]
-      │         │    │         │         ├── const-agg [type=bool, outer=(13)]
-      │         │    │         │         │    └── variable: instance_types.deleted [type=bool]
-      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp]
-      │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
-      │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp]
-      │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
-      │         │    │         │              └── variable: instance_types.updated_at [type=timestamp]
-      │         │    │         └── filters
-      │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
-      │         │    └── placeholder: $4 [type=int]
-      │         └── placeholder: $5 [type=int]
-      └── filters
-           └── instance_type_extra_specs_1.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
+      └── right-join
+           ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+           ├── side-effects, has-placeholder
+           ├── key: (1,28)
+           ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+           ├── select
+           │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool!null) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+           │    ├── has-placeholder
+           │    ├── key: (28)
+           │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+           │    ├── scan instance_type_extra_specs_1
+           │    │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+           │    │    ├── key: (28)
+           │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+           │    └── filters
+           │         └── instance_type_extra_specs_1.deleted = $6 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+           ├── limit
+           │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+           │    ├── internal-ordering: +7,+1
+           │    ├── side-effects, has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── offset
+           │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+           │    │    ├── internal-ordering: +7,+1
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── ordering: +7,+1
+           │    │    ├── sort
+           │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── ordering: +7,+1
+           │    │    │    └── select
+           │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+           │    │    │         ├── has-placeholder
+           │    │    │         ├── key: (1)
+           │    │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── group-by
+           │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+           │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+           │    │    │         │    ├── internal-ordering: +1
+           │    │    │         │    ├── has-placeholder
+           │    │    │         │    ├── key: (1)
+           │    │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── left-join (merge)
+           │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+           │    │    │         │    │    ├── left ordering: +1
+           │    │    │         │    │    ├── right ordering: +18
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+           │    │    │         │    │    ├── ordering: +1
+           │    │    │         │    │    ├── select
+           │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (1)
+           │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    │    ├── ordering: +1
+           │    │    │         │    │    │    ├── scan instance_types
+           │    │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+           │    │    │         │    │    │    │    ├── key: (1)
+           │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    │    │    └── ordering: +1
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+           │    │    │         │    │    ├── project
+           │    │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── fd: ()-->(25)
+           │    │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
+           │    │    │         │    │    │    ├── select
+           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+           │    │    │         │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    ├── key: (18-20)
+           │    │    │         │    │    │    │    ├── ordering: +18
+           │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+           │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+           │    │    │         │    │    │    │    │    ├── lax-key: (18-20)
+           │    │    │         │    │    │    │    │    └── ordering: +18
+           │    │    │         │    │    │    │    └── filters
+           │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+           │    │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+           │    │    │         │    │    │    └── projections
+           │    │    │         │    │    │         └── true [type=bool]
+           │    │    │         │    │    └── filters (true)
+           │    │    │         │    └── aggregations
+           │    │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
+           │    │    │         │         │    └── variable: true [type=bool]
+           │    │    │         │         ├── const-agg [type=string, outer=(2)]
+           │    │    │         │         │    └── variable: name [type=string]
+           │    │    │         │         ├── const-agg [type=int, outer=(3)]
+           │    │    │         │         │    └── variable: memory_mb [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(4)]
+           │    │    │         │         │    └── variable: vcpus [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(5)]
+           │    │    │         │         │    └── variable: root_gb [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(6)]
+           │    │    │         │         │    └── variable: ephemeral_gb [type=int]
+           │    │    │         │         ├── const-agg [type=string, outer=(7)]
+           │    │    │         │         │    └── variable: flavorid [type=string]
+           │    │    │         │         ├── const-agg [type=int, outer=(8)]
+           │    │    │         │         │    └── variable: swap [type=int]
+           │    │    │         │         ├── const-agg [type=float, outer=(9)]
+           │    │    │         │         │    └── variable: rxtx_factor [type=float]
+           │    │    │         │         ├── const-agg [type=int, outer=(10)]
+           │    │    │         │         │    └── variable: vcpu_weight [type=int]
+           │    │    │         │         ├── const-agg [type=bool, outer=(11)]
+           │    │    │         │         │    └── variable: disabled [type=bool]
+           │    │    │         │         ├── const-agg [type=bool, outer=(12)]
+           │    │    │         │         │    └── variable: is_public [type=bool]
+           │    │    │         │         ├── const-agg [type=bool, outer=(13)]
+           │    │    │         │         │    └── variable: instance_types.deleted [type=bool]
+           │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+           │    │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp]
+           │    │    │         │         ├── const-agg [type=timestamp, outer=(15)]
+           │    │    │         │         │    └── variable: instance_types.created_at [type=timestamp]
+           │    │    │         │         └── const-agg [type=timestamp, outer=(16)]
+           │    │    │         │              └── variable: instance_types.updated_at [type=timestamp]
+           │    │    │         └── filters
+           │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+           │    │    └── placeholder: $4 [type=int]
+           │    └── placeholder: $5 [type=int]
+           └── filters
+                └── instance_type_extra_specs_1.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -2113,126 +2107,126 @@ from (select instance_types.created_at as instance_types_created_at,
      on instance_type_extra_specs_1.instance_type_id = anon_1.instance_types_id
         and instance_type_extra_specs_1.deleted = $7
 ----
-left-join (lookup instance_type_extra_specs)
+project
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
- ├── key columns: [28] = [28]
  ├── side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
- │    ├── key columns: [1] = [31]
- │    ├── side-effects, has-placeholder
- │    ├── key: (1,28)
- │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── side-effects, has-placeholder
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         ├── side-effects, has-placeholder
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    ├── has-placeholder
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    ├── select
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    ├── has-placeholder
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    ├── group-by
- │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │    │    ├── internal-ordering: +1
- │    │         │    │    │    ├── has-placeholder
- │    │         │    │    │    ├── key: (1)
- │    │         │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    │    ├── left-join (merge)
- │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
- │    │         │    │    │    │    ├── left ordering: +1
- │    │         │    │    │    │    ├── right ordering: +18
- │    │         │    │    │    │    ├── has-placeholder
- │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
- │    │         │    │    │    │    ├── ordering: +1
- │    │         │    │    │    │    ├── select
- │    │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │    │    │    │    ├── has-placeholder
- │    │         │    │    │    │    │    ├── key: (1)
- │    │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    │    │    │    ├── ordering: +1
- │    │         │    │    │    │    │    ├── scan instance_types
- │    │         │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │    │    │    │    │    ├── key: (1)
- │    │         │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    │    │    │    │    └── ordering: +1
- │    │         │    │    │    │    │    └── filters
- │    │         │    │    │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │    │    │    │         └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
- │    │         │    │    │    │    ├── project
- │    │         │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │    │    │    │    ├── has-placeholder
- │    │         │    │    │    │    │    ├── fd: ()-->(25)
- │    │         │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
- │    │         │    │    │    │    │    ├── select
- │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │    │    │    │    │    ├── has-placeholder
- │    │         │    │    │    │    │    │    ├── key: (18-20)
- │    │         │    │    │    │    │    │    ├── ordering: +18
- │    │         │    │    │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │    │    │    │    │    │    ├── lax-key: (18-20)
- │    │         │    │    │    │    │    │    │    └── ordering: +18
- │    │         │    │    │    │    │    │    └── filters
- │    │         │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │    │    │    │    └── projections
- │    │         │    │    │    │    │         └── true [type=bool]
- │    │         │    │    │    │    └── filters (true)
- │    │         │    │    │    └── aggregations
- │    │         │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
- │    │         │    │    │         │    └── variable: true [type=bool]
- │    │         │    │    │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │    │         │    └── variable: name [type=string]
- │    │         │    │    │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │    │         │    └── variable: memory_mb [type=int]
- │    │         │    │    │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │    │         │    └── variable: vcpus [type=int]
- │    │         │    │    │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │    │         │    └── variable: root_gb [type=int]
- │    │         │    │    │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │    │         │    └── variable: ephemeral_gb [type=int]
- │    │         │    │    │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │    │         │    └── variable: flavorid [type=string]
- │    │         │    │    │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │    │         │    └── variable: swap [type=int]
- │    │         │    │    │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │    │         │    └── variable: rxtx_factor [type=float]
- │    │         │    │    │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │    │         │    └── variable: vcpu_weight [type=int]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │    │         │    └── variable: disabled [type=bool]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │    │         │    └── variable: is_public [type=bool]
- │    │         │    │    │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │    │         │    └── variable: instance_types.deleted [type=bool]
- │    │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
- │    │         │    │    │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
- │    │         │    │    │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │    │              └── variable: instance_types.updated_at [type=timestamp]
- │    │         │    │    └── filters
- │    │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
- │    │         │    └── placeholder: $5 [type=int]
- │    │         └── placeholder: $6 [type=int]
- │    └── filters
- │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
- └── filters (true)
+ └── left-join (lookup instance_type_extra_specs)
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+      ├── key columns: [28] = [28]
+      ├── side-effects, has-placeholder
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── left-join (lookup instance_type_extra_specs@secondary)
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
+      │    ├── key columns: [1] = [31]
+      │    ├── side-effects, has-placeholder
+      │    ├── key: (1,28)
+      │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
+      │    ├── limit
+      │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    ├── side-effects, has-placeholder
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    ├── offset
+      │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │    ├── has-placeholder
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    ├── group-by
+      │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+      │    │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    │    ├── left-join (merge)
+      │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │    │    │    │    │    │    ├── left ordering: +1
+      │    │    │    │    │    │    ├── right ordering: +18
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │    │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    │    │    ├── scan instance_types
+      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    │    │    │    │    └── ordering: +1
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │    │    │    │         └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+      │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    ├── fd: ()-->(25)
+      │    │    │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │    │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    │    ├── key: (18-20)
+      │    │    │    │    │    │    │    │    ├── ordering: +18
+      │    │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+      │    │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │    │    │    │    │    │    │    │    │    ├── lax-key: (18-20)
+      │    │    │    │    │    │    │    │    │    └── ordering: +18
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │    │    │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │    │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │    │         └── true [type=bool]
+      │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
+      │    │    │    │    │         │    └── variable: true [type=bool]
+      │    │    │    │    │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │    │         │    └── variable: name [type=string]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │    │         │    └── variable: memory_mb [type=int]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │    │         │    └── variable: vcpus [type=int]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │    │         │    └── variable: root_gb [type=int]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │    │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │    │         │    └── variable: flavorid [type=string]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │    │         │    └── variable: swap [type=int]
+      │    │    │    │    │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │    │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │    │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │    │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │    │         │    └── variable: disabled [type=bool]
+      │    │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │    │         │    └── variable: is_public [type=bool]
+      │    │    │    │    │         ├── const-agg [type=bool, outer=(13)]
+      │    │    │    │    │         │    └── variable: instance_types.deleted [type=bool]
+      │    │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
+      │    │    │    │    │         ├── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
+      │    │    │    │    │         └── const-agg [type=timestamp, outer=(16)]
+      │    │    │    │    │              └── variable: instance_types.updated_at [type=timestamp]
+      │    │    │    │    └── filters
+      │    │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+      │    │    │    └── placeholder: $5 [type=int]
+      │    │    └── placeholder: $6 [type=int]
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      └── filters (true)
 
 opt
 select flavors.created_at as flavors_created_at,
@@ -2271,96 +2265,96 @@ sort
  ├── key: (1,16)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (16)-->(17-21), (17,19)-->(16,18,20,21)
  ├── ordering: +7
- └── right-join
+ └── project
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs_1.id:16(int) key:17(string) value:18(string) flavor_extra_specs_1.flavor_id:19(int) flavor_extra_specs_1.created_at:20(timestamp) flavor_extra_specs_1.updated_at:21(timestamp)
       ├── has-placeholder
       ├── key: (1,16)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (16)-->(17-21), (17,19)-->(16,18,20,21)
-      ├── scan flavor_extra_specs_1
-      │    ├── columns: flavor_extra_specs_1.id:16(int!null) key:17(string!null) value:18(string) flavor_extra_specs_1.flavor_id:19(int!null) flavor_extra_specs_1.created_at:20(timestamp) flavor_extra_specs_1.updated_at:21(timestamp)
-      │    ├── key: (16)
-      │    └── fd: (16)-->(17-21), (17,19)-->(16,18,20,21)
-      ├── project
-      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │    ├── has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    └── select
-      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
-      │         ├── has-placeholder
-      │         ├── key: (1)
-      │         ├── fd: (1)-->(2-12,14,15,29), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         ├── group-by
-      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
-      │         │    ├── grouping columns: flavors.id:1(int!null)
-      │         │    ├── internal-ordering: +1
-      │         │    ├── has-placeholder
-      │         │    ├── key: (1)
-      │         │    ├── fd: (1)-->(2-12,14,15,29), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    ├── left-join (merge)
-      │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true:28(bool)
-      │         │    │    ├── left ordering: +1
-      │         │    │    ├── right ordering: +23
-      │         │    │    ├── has-placeholder
-      │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(28)
-      │         │    │    ├── ordering: +1
-      │         │    │    ├── scan flavors
-      │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │    │    ├── key: (1)
-      │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │    │    └── ordering: +1
-      │         │    │    ├── project
-      │         │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:23(int!null)
-      │         │    │    │    ├── has-placeholder
-      │         │    │    │    ├── fd: ()-->(28)
-      │         │    │    │    ├── ordering: +23 opt(28) [actual: +23]
-      │         │    │    │    ├── select
-      │         │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
-      │         │    │    │    │    ├── has-placeholder
-      │         │    │    │    │    ├── key: (23,24)
-      │         │    │    │    │    ├── ordering: +23
-      │         │    │    │    │    ├── scan flavor_projects@secondary
-      │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
-      │         │    │    │    │    │    ├── key: (23,24)
-      │         │    │    │    │    │    └── ordering: +23
-      │         │    │    │    │    └── filters
-      │         │    │    │    │         └── project_id = $1 [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
-      │         │    │    │    └── projections
-      │         │    │    │         └── true [type=bool]
-      │         │    │    └── filters (true)
-      │         │    └── aggregations
-      │         │         ├── const-not-null-agg [type=bool, outer=(28)]
-      │         │         │    └── variable: true [type=bool]
-      │         │         ├── const-agg [type=string, outer=(2)]
-      │         │         │    └── variable: name [type=string]
-      │         │         ├── const-agg [type=int, outer=(3)]
-      │         │         │    └── variable: memory_mb [type=int]
-      │         │         ├── const-agg [type=int, outer=(4)]
-      │         │         │    └── variable: vcpus [type=int]
-      │         │         ├── const-agg [type=int, outer=(5)]
-      │         │         │    └── variable: root_gb [type=int]
-      │         │         ├── const-agg [type=int, outer=(6)]
-      │         │         │    └── variable: ephemeral_gb [type=int]
-      │         │         ├── const-agg [type=string, outer=(7)]
-      │         │         │    └── variable: flavorid [type=string]
-      │         │         ├── const-agg [type=int, outer=(8)]
-      │         │         │    └── variable: swap [type=int]
-      │         │         ├── const-agg [type=float, outer=(9)]
-      │         │         │    └── variable: rxtx_factor [type=float]
-      │         │         ├── const-agg [type=int, outer=(10)]
-      │         │         │    └── variable: vcpu_weight [type=int]
-      │         │         ├── const-agg [type=bool, outer=(11)]
-      │         │         │    └── variable: disabled [type=bool]
-      │         │         ├── const-agg [type=bool, outer=(12)]
-      │         │         │    └── variable: is_public [type=bool]
-      │         │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │         │    └── variable: flavors.created_at [type=timestamp]
-      │         │         └── const-agg [type=timestamp, outer=(15)]
-      │         │              └── variable: flavors.updated_at [type=timestamp]
-      │         └── filters
-      │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,29)]
-      └── filters
-           └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,19), constraints=(/1: (/NULL - ]; /19: (/NULL - ]), fd=(1)==(19), (19)==(1)]
+      └── right-join
+           ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs_1.id:16(int) key:17(string) value:18(string) flavor_extra_specs_1.flavor_id:19(int) flavor_extra_specs_1.created_at:20(timestamp) flavor_extra_specs_1.updated_at:21(timestamp) true_agg:29(bool)
+           ├── has-placeholder
+           ├── key: (1,16)
+           ├── fd: (1)-->(2-12,14,15,29), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (16)-->(17-21), (17,19)-->(16,18,20,21)
+           ├── scan flavor_extra_specs_1
+           │    ├── columns: flavor_extra_specs_1.id:16(int!null) key:17(string!null) value:18(string) flavor_extra_specs_1.flavor_id:19(int!null) flavor_extra_specs_1.created_at:20(timestamp) flavor_extra_specs_1.updated_at:21(timestamp)
+           │    ├── key: (16)
+           │    └── fd: (16)-->(17-21), (17,19)-->(16,18,20,21)
+           ├── select
+           │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
+           │    ├── has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-12,14,15,29), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── group-by
+           │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:29(bool)
+           │    │    ├── grouping columns: flavors.id:1(int!null)
+           │    │    ├── internal-ordering: +1
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: (1)-->(2-12,14,15,29), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── left-join (merge)
+           │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:23(int) true:28(bool)
+           │    │    │    ├── left ordering: +1
+           │    │    │    ├── right ordering: +23
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(28)
+           │    │    │    ├── ordering: +1
+           │    │    │    ├── scan flavors
+           │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+           │    │    │    │    ├── key: (1)
+           │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    │    └── ordering: +1
+           │    │    │    ├── project
+           │    │    │    │    ├── columns: true:28(bool!null) flavor_projects.flavor_id:23(int!null)
+           │    │    │    │    ├── has-placeholder
+           │    │    │    │    ├── fd: ()-->(28)
+           │    │    │    │    ├── ordering: +23 opt(28) [actual: +23]
+           │    │    │    │    ├── select
+           │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
+           │    │    │    │    │    ├── has-placeholder
+           │    │    │    │    │    ├── key: (23,24)
+           │    │    │    │    │    ├── ordering: +23
+           │    │    │    │    │    ├── scan flavor_projects@secondary
+           │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:23(int!null) project_id:24(string!null)
+           │    │    │    │    │    │    ├── key: (23,24)
+           │    │    │    │    │    │    └── ordering: +23
+           │    │    │    │    │    └── filters
+           │    │    │    │    │         └── project_id = $1 [type=bool, outer=(24), constraints=(/24: (/NULL - ])]
+           │    │    │    │    └── projections
+           │    │    │    │         └── true [type=bool]
+           │    │    │    └── filters (true)
+           │    │    └── aggregations
+           │    │         ├── const-not-null-agg [type=bool, outer=(28)]
+           │    │         │    └── variable: true [type=bool]
+           │    │         ├── const-agg [type=string, outer=(2)]
+           │    │         │    └── variable: name [type=string]
+           │    │         ├── const-agg [type=int, outer=(3)]
+           │    │         │    └── variable: memory_mb [type=int]
+           │    │         ├── const-agg [type=int, outer=(4)]
+           │    │         │    └── variable: vcpus [type=int]
+           │    │         ├── const-agg [type=int, outer=(5)]
+           │    │         │    └── variable: root_gb [type=int]
+           │    │         ├── const-agg [type=int, outer=(6)]
+           │    │         │    └── variable: ephemeral_gb [type=int]
+           │    │         ├── const-agg [type=string, outer=(7)]
+           │    │         │    └── variable: flavorid [type=string]
+           │    │         ├── const-agg [type=int, outer=(8)]
+           │    │         │    └── variable: swap [type=int]
+           │    │         ├── const-agg [type=float, outer=(9)]
+           │    │         │    └── variable: rxtx_factor [type=float]
+           │    │         ├── const-agg [type=int, outer=(10)]
+           │    │         │    └── variable: vcpu_weight [type=int]
+           │    │         ├── const-agg [type=bool, outer=(11)]
+           │    │         │    └── variable: disabled [type=bool]
+           │    │         ├── const-agg [type=bool, outer=(12)]
+           │    │         │    └── variable: is_public [type=bool]
+           │    │         ├── const-agg [type=timestamp, outer=(14)]
+           │    │         │    └── variable: flavors.created_at [type=timestamp]
+           │    │         └── const-agg [type=timestamp, outer=(15)]
+           │    │              └── variable: flavors.updated_at [type=timestamp]
+           │    └── filters
+           │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,29)]
+           └── filters
+                └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,19), constraints=(/1: (/NULL - ]; /19: (/NULL - ]), fd=(1)==(19), (19)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -2424,139 +2418,139 @@ from (select instance_types.created_at as instance_types_created_at,
 order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
-left-join (lookup instance_type_extra_specs)
+project
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
- ├── key columns: [28] = [28]
  ├── side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +7,+1
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
- │    ├── key columns: [1] = [31]
- │    ├── side-effects, has-placeholder
- │    ├── key: (1,28)
- │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
- │    ├── ordering: +7,+1
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── side-effects, has-placeholder
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │    ├── ordering: +7,+1
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         ├── internal-ordering: +7,+1
- │    │         ├── side-effects, has-placeholder
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         ├── ordering: +7,+1
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    ├── internal-ordering: +7,+1
- │    │         │    ├── has-placeholder
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    ├── ordering: +7,+1
- │    │         │    ├── sort
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    ├── has-placeholder
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    ├── ordering: +7,+1
- │    │         │    │    └── select
- │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │         ├── has-placeholder
- │    │         │    │         ├── key: (1)
- │    │         │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         ├── group-by
- │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │         │    ├── internal-ordering: +1
- │    │         │    │         │    ├── has-placeholder
- │    │         │    │         │    ├── key: (1)
- │    │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    ├── left-join (merge)
- │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
- │    │         │    │         │    │    ├── left ordering: +1
- │    │         │    │         │    │    ├── right ordering: +18
- │    │         │    │         │    │    ├── has-placeholder
- │    │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
- │    │         │    │         │    │    ├── ordering: +1
- │    │         │    │         │    │    ├── select
- │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │    ├── has-placeholder
- │    │         │    │         │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │    ├── ordering: +1
- │    │         │    │         │    │    │    ├── scan instance_types
- │    │         │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │    │    └── ordering: +1
- │    │         │    │         │    │    │    └── filters
- │    │         │    │         │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │         │    │    │         └── (flavorid > $4) OR ((flavorid = $5) AND (instance_types.id > $6)) [type=bool, outer=(1,7)]
- │    │         │    │         │    │    ├── project
- │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │         │    │    │    ├── has-placeholder
- │    │         │    │         │    │    │    ├── fd: ()-->(25)
- │    │         │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
- │    │         │    │         │    │    │    ├── select
- │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │         │    │    │    │    ├── has-placeholder
- │    │         │    │         │    │    │    │    ├── key: (18-20)
- │    │         │    │         │    │    │    │    ├── ordering: +18
- │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │         │    │    │    │    │    ├── lax-key: (18-20)
- │    │         │    │         │    │    │    │    │    └── ordering: +18
- │    │         │    │         │    │    │    │    └── filters
- │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │         │    │    │    └── projections
- │    │         │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    └── filters (true)
- │    │         │    │         │    └── aggregations
- │    │         │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
- │    │         │    │         │         │    └── variable: true [type=bool]
- │    │         │    │         │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │         │         │    └── variable: name [type=string]
- │    │         │    │         │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │         │         │    └── variable: memory_mb [type=int]
- │    │         │    │         │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │         │         │    └── variable: vcpus [type=int]
- │    │         │    │         │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │         │         │    └── variable: root_gb [type=int]
- │    │         │    │         │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │         │         │    └── variable: ephemeral_gb [type=int]
- │    │         │    │         │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │         │         │    └── variable: flavorid [type=string]
- │    │         │    │         │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │         │         │    └── variable: swap [type=int]
- │    │         │    │         │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │         │         │    └── variable: rxtx_factor [type=float]
- │    │         │    │         │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │         │         │    └── variable: vcpu_weight [type=int]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │         │         │    └── variable: disabled [type=bool]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │         │         │    └── variable: is_public [type=bool]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │         │         │    └── variable: instance_types.deleted [type=bool]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp]
- │    │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │         │              └── variable: instance_types.updated_at [type=timestamp]
- │    │         │    │         └── filters
- │    │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
- │    │         │    └── placeholder: $7 [type=int]
- │    │         └── placeholder: $8 [type=int]
- │    └── filters
- │         └── instance_type_extra_specs_1.deleted = $9 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
- └── filters (true)
+ └── left-join (lookup instance_type_extra_specs)
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+      ├── key columns: [28] = [28]
+      ├── side-effects, has-placeholder
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── ordering: +7,+1
+      ├── left-join (lookup instance_type_extra_specs@secondary)
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
+      │    ├── key columns: [1] = [31]
+      │    ├── side-effects, has-placeholder
+      │    ├── key: (1,28)
+      │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
+      │    ├── ordering: +7,+1
+      │    ├── limit
+      │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    ├── internal-ordering: +7,+1
+      │    │    ├── side-effects, has-placeholder
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    ├── ordering: +7,+1
+      │    │    ├── offset
+      │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    ├── internal-ordering: +7,+1
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    ├── ordering: +7,+1
+      │    │    │    ├── sort
+      │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │    ├── has-placeholder
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    ├── ordering: +7,+1
+      │    │    │    │    └── select
+      │    │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │         ├── has-placeholder
+      │    │    │    │         ├── key: (1)
+      │    │    │    │         ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │         ├── group-by
+      │    │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │    │    │    │         │    ├── internal-ordering: +1
+      │    │    │    │         │    ├── has-placeholder
+      │    │    │    │         │    ├── key: (1)
+      │    │    │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │         │    ├── left-join (merge)
+      │    │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │    │    │    │         │    │    ├── left ordering: +1
+      │    │    │    │         │    │    ├── right ordering: +18
+      │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │    │    │    │         │    │    ├── ordering: +1
+      │    │    │    │         │    │    ├── select
+      │    │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │         │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    ├── key: (1)
+      │    │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │         │    │    │    ├── ordering: +1
+      │    │    │    │         │    │    │    ├── scan instance_types
+      │    │    │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │         │    │    │    │    ├── key: (1)
+      │    │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │         │    │    │    │    └── ordering: +1
+      │    │    │    │         │    │    │    └── filters
+      │    │    │    │         │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │         │    │    │         └── (flavorid > $4) OR ((flavorid = $5) AND (instance_types.id > $6)) [type=bool, outer=(1,7)]
+      │    │    │    │         │    │    ├── project
+      │    │    │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │    │    │    │         │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    ├── fd: ()-->(25)
+      │    │    │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
+      │    │    │    │         │    │    │    ├── select
+      │    │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │    │    │    │         │    │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    │    ├── key: (18-20)
+      │    │    │    │         │    │    │    │    ├── ordering: +18
+      │    │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │    │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │    │    │    │         │    │    │    │    │    ├── lax-key: (18-20)
+      │    │    │    │         │    │    │    │    │    └── ordering: +18
+      │    │    │    │         │    │    │    │    └── filters
+      │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │    │    │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │    │    │    │         │    │    │    └── projections
+      │    │    │    │         │    │    │         └── true [type=bool]
+      │    │    │    │         │    │    └── filters (true)
+      │    │    │    │         │    └── aggregations
+      │    │    │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
+      │    │    │    │         │         │    └── variable: true [type=bool]
+      │    │    │    │         │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │         │         │    └── variable: name [type=string]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │         │         │    └── variable: memory_mb [type=int]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │         │         │    └── variable: vcpus [type=int]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │         │         │    └── variable: root_gb [type=int]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │         │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │         │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │         │         │    └── variable: flavorid [type=string]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │         │         │    └── variable: swap [type=int]
+      │    │    │    │         │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │         │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │         │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │         │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │         │         │    └── variable: disabled [type=bool]
+      │    │    │    │         │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │         │         │    └── variable: is_public [type=bool]
+      │    │    │    │         │         ├── const-agg [type=bool, outer=(13)]
+      │    │    │    │         │         │    └── variable: instance_types.deleted [type=bool]
+      │    │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp]
+      │    │    │    │         │         ├── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │         │         │    └── variable: instance_types.created_at [type=timestamp]
+      │    │    │    │         │         └── const-agg [type=timestamp, outer=(16)]
+      │    │    │    │         │              └── variable: instance_types.updated_at [type=timestamp]
+      │    │    │    │         └── filters
+      │    │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+      │    │    │    └── placeholder: $7 [type=int]
+      │    │    └── placeholder: $8 [type=int]
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted = $9 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      └── filters (true)
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -2613,117 +2607,117 @@ sort
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +7
- └── right-join
+ └── project
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
       ├── side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
-      ├── scan flavor_extra_specs_1
-      │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
-      │    ├── key: (25)
-      │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
-      ├── project
-      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │    ├── side-effects, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    └── limit
-      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         ├── internal-ordering: +7
-      │         ├── side-effects, has-placeholder
-      │         ├── key: (1)
-      │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         ├── offset
-      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         │    ├── internal-ordering: +7
-      │         │    ├── has-placeholder
-      │         │    ├── key: (1)
-      │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    ├── ordering: +7
-      │         │    ├── sort
-      │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         │    │    ├── has-placeholder
-      │         │    │    ├── key: (1)
-      │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │    ├── ordering: +7
-      │         │    │    └── select
-      │         │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         │    │         ├── has-placeholder
-      │         │    │         ├── key: (1)
-      │         │    │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         ├── group-by
-      │         │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         │    │         │    ├── grouping columns: flavors.id:1(int!null)
-      │         │    │         │    ├── internal-ordering: +1
-      │         │    │         │    ├── has-placeholder
-      │         │    │         │    ├── key: (1)
-      │         │    │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         │    ├── left-join (merge)
-      │         │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
-      │         │    │         │    │    ├── left ordering: +1
-      │         │    │         │    │    ├── right ordering: +17
-      │         │    │         │    │    ├── has-placeholder
-      │         │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
-      │         │    │         │    │    ├── ordering: +1
-      │         │    │         │    │    ├── scan flavors
-      │         │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │    │         │    │    │    ├── key: (1)
-      │         │    │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │         │    │         │    │    │    └── ordering: +1
-      │         │    │         │    │    ├── project
-      │         │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
-      │         │    │         │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    ├── fd: ()-->(22)
-      │         │    │         │    │    │    ├── ordering: +17 opt(22) [actual: +17]
-      │         │    │         │    │    │    ├── select
-      │         │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
-      │         │    │         │    │    │    │    ├── has-placeholder
-      │         │    │         │    │    │    │    ├── key: (17,18)
-      │         │    │         │    │    │    │    ├── ordering: +17
-      │         │    │         │    │    │    │    ├── scan flavor_projects@secondary
-      │         │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
-      │         │    │         │    │    │    │    │    ├── key: (17,18)
-      │         │    │         │    │    │    │    │    └── ordering: +17
-      │         │    │         │    │    │    │    └── filters
-      │         │    │         │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
-      │         │    │         │    │    │    └── projections
-      │         │    │         │    │    │         └── true [type=bool]
-      │         │    │         │    │    └── filters (true)
-      │         │    │         │    └── aggregations
-      │         │    │         │         ├── const-not-null-agg [type=bool, outer=(22)]
-      │         │    │         │         │    └── variable: true [type=bool]
-      │         │    │         │         ├── const-agg [type=string, outer=(2)]
-      │         │    │         │         │    └── variable: name [type=string]
-      │         │    │         │         ├── const-agg [type=int, outer=(3)]
-      │         │    │         │         │    └── variable: memory_mb [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(4)]
-      │         │    │         │         │    └── variable: vcpus [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(5)]
-      │         │    │         │         │    └── variable: root_gb [type=int]
-      │         │    │         │         ├── const-agg [type=int, outer=(6)]
-      │         │    │         │         │    └── variable: ephemeral_gb [type=int]
-      │         │    │         │         ├── const-agg [type=string, outer=(7)]
-      │         │    │         │         │    └── variable: flavorid [type=string]
-      │         │    │         │         ├── const-agg [type=int, outer=(8)]
-      │         │    │         │         │    └── variable: swap [type=int]
-      │         │    │         │         ├── const-agg [type=float, outer=(9)]
-      │         │    │         │         │    └── variable: rxtx_factor [type=float]
-      │         │    │         │         ├── const-agg [type=int, outer=(10)]
-      │         │    │         │         │    └── variable: vcpu_weight [type=int]
-      │         │    │         │         ├── const-agg [type=bool, outer=(11)]
-      │         │    │         │         │    └── variable: disabled [type=bool]
-      │         │    │         │         ├── const-agg [type=bool, outer=(12)]
-      │         │    │         │         │    └── variable: is_public [type=bool]
-      │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │    │         │         │    └── variable: flavors.created_at [type=timestamp]
-      │         │    │         │         └── const-agg [type=timestamp, outer=(15)]
-      │         │    │         │              └── variable: flavors.updated_at [type=timestamp]
-      │         │    │         └── filters
-      │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
-      │         │    └── placeholder: $2 [type=int]
-      │         └── placeholder: $3 [type=int]
-      └── filters
-           └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+      └── right-join
+           ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+           ├── side-effects, has-placeholder
+           ├── key: (1,25)
+           ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+           ├── scan flavor_extra_specs_1
+           │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+           │    ├── key: (25)
+           │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+           ├── limit
+           │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    ├── internal-ordering: +7
+           │    ├── side-effects, has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── offset
+           │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │    ├── internal-ordering: +7
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── ordering: +7
+           │    │    ├── sort
+           │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    ├── ordering: +7
+           │    │    │    └── select
+           │    │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │    │         ├── has-placeholder
+           │    │    │         ├── key: (1)
+           │    │    │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         ├── group-by
+           │    │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │    │         │    ├── grouping columns: flavors.id:1(int!null)
+           │    │    │         │    ├── internal-ordering: +1
+           │    │    │         │    ├── has-placeholder
+           │    │    │         │    ├── key: (1)
+           │    │    │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    ├── left-join (merge)
+           │    │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+           │    │    │         │    │    ├── left ordering: +1
+           │    │    │         │    │    ├── right ordering: +17
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+           │    │    │         │    │    ├── ordering: +1
+           │    │    │         │    │    ├── scan flavors
+           │    │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+           │    │    │         │    │    │    ├── key: (1)
+           │    │    │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    │    │    └── ordering: +1
+           │    │    │         │    │    ├── project
+           │    │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── fd: ()-->(22)
+           │    │    │         │    │    │    ├── ordering: +17 opt(22) [actual: +17]
+           │    │    │         │    │    │    ├── select
+           │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+           │    │    │         │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    ├── key: (17,18)
+           │    │    │         │    │    │    │    ├── ordering: +17
+           │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
+           │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+           │    │    │         │    │    │    │    │    ├── key: (17,18)
+           │    │    │         │    │    │    │    │    └── ordering: +17
+           │    │    │         │    │    │    │    └── filters
+           │    │    │         │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+           │    │    │         │    │    │    └── projections
+           │    │    │         │    │    │         └── true [type=bool]
+           │    │    │         │    │    └── filters (true)
+           │    │    │         │    └── aggregations
+           │    │    │         │         ├── const-not-null-agg [type=bool, outer=(22)]
+           │    │    │         │         │    └── variable: true [type=bool]
+           │    │    │         │         ├── const-agg [type=string, outer=(2)]
+           │    │    │         │         │    └── variable: name [type=string]
+           │    │    │         │         ├── const-agg [type=int, outer=(3)]
+           │    │    │         │         │    └── variable: memory_mb [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(4)]
+           │    │    │         │         │    └── variable: vcpus [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(5)]
+           │    │    │         │         │    └── variable: root_gb [type=int]
+           │    │    │         │         ├── const-agg [type=int, outer=(6)]
+           │    │    │         │         │    └── variable: ephemeral_gb [type=int]
+           │    │    │         │         ├── const-agg [type=string, outer=(7)]
+           │    │    │         │         │    └── variable: flavorid [type=string]
+           │    │    │         │         ├── const-agg [type=int, outer=(8)]
+           │    │    │         │         │    └── variable: swap [type=int]
+           │    │    │         │         ├── const-agg [type=float, outer=(9)]
+           │    │    │         │         │    └── variable: rxtx_factor [type=float]
+           │    │    │         │         ├── const-agg [type=int, outer=(10)]
+           │    │    │         │         │    └── variable: vcpu_weight [type=int]
+           │    │    │         │         ├── const-agg [type=bool, outer=(11)]
+           │    │    │         │         │    └── variable: disabled [type=bool]
+           │    │    │         │         ├── const-agg [type=bool, outer=(12)]
+           │    │    │         │         │    └── variable: is_public [type=bool]
+           │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+           │    │    │         │         │    └── variable: flavors.created_at [type=timestamp]
+           │    │    │         │         └── const-agg [type=timestamp, outer=(15)]
+           │    │    │         │              └── variable: flavors.updated_at [type=timestamp]
+           │    │    │         └── filters
+           │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
+           │    │    └── placeholder: $2 [type=int]
+           │    └── placeholder: $3 [type=int]
+           └── filters
+                └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -2792,221 +2786,215 @@ from (select instance_types.created_at as instance_types_created_at,
 order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
-left-join (lookup instance_type_extra_specs)
+project
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:45(timestamp) instance_type_extra_specs_1_updated_at:46(timestamp) instance_type_extra_specs_1_deleted_at:44(timestamp) instance_type_extra_specs_1_deleted:43(bool) instance_type_extra_specs_1_id:39(int) instance_type_extra_specs_1_key:40(string) instance_type_extra_specs_1_value:41(string) instance_type_extra_specs_1_instance_type_id:42(int)
- ├── key columns: [39] = [39]
  ├── side-effects, has-placeholder
  ├── key: (1,39)
  ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
  ├── ordering: +7,+1 opt(11) [actual: +7,+1]
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs_1.id:39(int) key:40(string) instance_type_extra_specs_1.instance_type_id:42(int) instance_type_extra_specs_1.deleted:43(bool)
- │    ├── key columns: [1] = [42]
- │    ├── side-effects, has-placeholder
- │    ├── key: (1,39)
- │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40,42,43), (40,42,43)~~>(39)
- │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── side-effects, has-placeholder
- │    │    ├── key: (1)
- │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
- │    │         ├── internal-ordering: +7,+1 opt(11)
- │    │         ├── side-effects, has-placeholder
- │    │         ├── key: (1)
- │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         ├── ordering: +7,+1 opt(11) [actual: +7,+1]
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
- │    │         │    ├── internal-ordering: +7,+1 opt(11)
- │    │         │    ├── has-placeholder
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
- │    │         │    ├── sort
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
- │    │         │    │    ├── has-placeholder
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
- │    │         │    │    └── select
- │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
- │    │         │    │         ├── has-placeholder
- │    │         │    │         ├── key: (1)
- │    │         │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         ├── group-by
- │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
- │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │         │    ├── internal-ordering: +1 opt(11)
- │    │         │    │         │    ├── has-placeholder
- │    │         │    │         │    ├── key: (1)
- │    │         │    │         │    ├── fd: ()-->(11), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    ├── left-join (merge)
- │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true:36(bool)
- │    │         │    │         │    │    ├── left ordering: +1
- │    │         │    │         │    │    ├── right ordering: +26
- │    │         │    │         │    │    ├── has-placeholder
- │    │         │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(36)
- │    │         │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
- │    │         │    │         │    │    ├── project
- │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │    ├── has-placeholder
- │    │         │    │         │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
- │    │         │    │         │    │    │    └── select
- │    │         │    │         │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
- │    │         │    │         │    │    │         ├── has-placeholder
- │    │         │    │         │    │    │         ├── key: (1)
- │    │         │    │         │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │         ├── ordering: +1 opt(11) [actual: +1]
- │    │         │    │         │    │    │         ├── group-by
- │    │         │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
- │    │         │    │         │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │         │    │    │         │    ├── has-placeholder
- │    │         │    │         │    │    │         │    ├── key: (1)
- │    │         │    │         │    │    │         │    ├── fd: ()-->(11), (1)-->(2-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │         │    ├── ordering: +1 opt(11) [actual: +1]
- │    │         │    │         │    │    │         │    ├── left-join (merge)
- │    │         │    │         │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:33(bool)
- │    │         │    │         │    │    │         │    │    ├── left ordering: +1
- │    │         │    │         │    │    │         │    │    ├── right ordering: +18
- │    │         │    │         │    │    │         │    │    ├── has-placeholder
- │    │         │    │         │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(33)
- │    │         │    │         │    │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
- │    │         │    │         │    │    │         │    │    ├── select
- │    │         │    │         │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │         │    │    │    ├── has-placeholder
- │    │         │    │         │    │    │         │    │    │    ├── key: (1)
- │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
- │    │         │    │         │    │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
- │    │         │    │         │    │    │         │    │    │    ├── scan instance_types
- │    │         │    │         │    │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │         │    │    │    │    ├── key: (1)
- │    │         │    │         │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │         │    │    │    │    └── ordering: +1 opt(11) [actual: +1]
- │    │         │    │         │    │    │         │    │    │    └── filters
- │    │         │    │         │    │    │         │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │         │    │    │         │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
- │    │         │    │         │    │    │         │    │    ├── project
- │    │         │    │         │    │    │         │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │         │    │    │         │    │    │    ├── has-placeholder
- │    │         │    │         │    │    │         │    │    │    ├── fd: ()-->(33)
- │    │         │    │         │    │    │         │    │    │    ├── ordering: +18 opt(33) [actual: +18]
- │    │         │    │         │    │    │         │    │    │    ├── select
- │    │         │    │         │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │         │    │    │         │    │    │    │    ├── has-placeholder
- │    │         │    │         │    │    │         │    │    │    │    ├── key: (18-20)
- │    │         │    │         │    │    │         │    │    │    │    ├── ordering: +18
- │    │         │    │         │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │         │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │         │    │    │         │    │    │    │    │    ├── lax-key: (18-20)
- │    │         │    │         │    │    │         │    │    │    │    │    └── ordering: +18
- │    │         │    │         │    │    │         │    │    │    │    └── filters
- │    │         │    │         │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │         │    │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │         │    │    │         │    │    │    └── projections
- │    │         │    │         │    │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    │         │    │    └── filters (true)
- │    │         │    │         │    │    │         │    └── aggregations
- │    │         │    │         │    │    │         │         ├── const-not-null-agg [type=bool, outer=(33)]
- │    │         │    │         │    │    │         │         │    └── variable: true [type=bool]
- │    │         │    │         │    │    │         │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │         │    │    │         │         │    └── variable: name [type=string]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │         │    │    │         │         │    └── variable: memory_mb [type=int]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │         │    │    │         │         │    └── variable: vcpus [type=int]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │         │    │    │         │         │    └── variable: root_gb [type=int]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │         │    │    │         │         │    └── variable: ephemeral_gb [type=int]
- │    │         │    │         │    │    │         │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │         │    │    │         │         │    └── variable: flavorid [type=string]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │         │    │    │         │         │    └── variable: swap [type=int]
- │    │         │    │         │    │    │         │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │         │    │    │         │         │    └── variable: rxtx_factor [type=float]
- │    │         │    │         │    │    │         │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │         │    │    │         │         │    └── variable: vcpu_weight [type=int]
- │    │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │         │    │    │         │         │    └── variable: disabled [type=bool]
- │    │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │         │    │    │         │         │    └── variable: is_public [type=bool]
- │    │         │    │         │    │    │         │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │         │    │    │         │         │    └── variable: instance_types.deleted [type=bool]
- │    │         │    │         │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │         │    │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp]
- │    │         │    │         │    │    │         │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │         │    │    │         │         │    └── variable: instance_types.created_at [type=timestamp]
- │    │         │    │         │    │    │         │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │         │    │    │         │              └── variable: instance_types.updated_at [type=timestamp]
- │    │         │    │         │    │    │         └── filters
- │    │         │    │         │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,34)]
- │    │         │    │         │    │    ├── project
- │    │         │    │         │    │    │    ├── columns: true:36(bool!null) instance_type_projects.instance_type_id:26(int!null)
- │    │         │    │         │    │    │    ├── has-placeholder
- │    │         │    │         │    │    │    ├── fd: ()-->(36)
- │    │         │    │         │    │    │    ├── ordering: +26 opt(36) [actual: +26]
- │    │         │    │         │    │    │    ├── select
- │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
- │    │         │    │         │    │    │    │    ├── has-placeholder
- │    │         │    │         │    │    │    │    ├── key: (26-28)
- │    │         │    │         │    │    │    │    ├── ordering: +26
- │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string) instance_type_projects.deleted:28(bool)
- │    │         │    │         │    │    │    │    │    ├── lax-key: (26-28)
- │    │         │    │         │    │    │    │    │    └── ordering: +26
- │    │         │    │         │    │    │    │    └── filters
- │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $4 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
- │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $5 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
- │    │         │    │         │    │    │    │         └── project_id = $6 [type=bool, outer=(27), constraints=(/27: (/NULL - ])]
- │    │         │    │         │    │    │    └── projections
- │    │         │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    └── filters (true)
- │    │         │    │         │    └── aggregations
- │    │         │    │         │         ├── const-not-null-agg [type=bool, outer=(36)]
- │    │         │    │         │         │    └── variable: true [type=bool]
- │    │         │    │         │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │         │         │    └── variable: name [type=string]
- │    │         │    │         │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │         │         │    └── variable: memory_mb [type=int]
- │    │         │    │         │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │         │         │    └── variable: vcpus [type=int]
- │    │         │    │         │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │         │         │    └── variable: root_gb [type=int]
- │    │         │    │         │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │         │         │    └── variable: ephemeral_gb [type=int]
- │    │         │    │         │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │         │         │    └── variable: flavorid [type=string]
- │    │         │    │         │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │         │         │    └── variable: swap [type=int]
- │    │         │    │         │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │         │         │    └── variable: rxtx_factor [type=float]
- │    │         │    │         │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │         │         │    └── variable: vcpu_weight [type=int]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │         │         │    └── variable: disabled [type=bool]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │         │         │    └── variable: is_public [type=bool]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │         │         │    └── variable: instance_types.deleted [type=bool]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp]
- │    │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │         │              └── variable: instance_types.updated_at [type=timestamp]
- │    │         │    │         └── filters
- │    │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,37)]
- │    │         │    └── placeholder: $7 [type=int]
- │    │         └── placeholder: $8 [type=int]
- │    └── filters
- │         └── instance_type_extra_specs_1.deleted = $9 [type=bool, outer=(43), constraints=(/43: (/NULL - ])]
- └── filters (true)
+ └── left-join (lookup instance_type_extra_specs)
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool) instance_type_extra_specs_1.id:39(int) key:40(string) value:41(string) instance_type_extra_specs_1.instance_type_id:42(int) instance_type_extra_specs_1.deleted:43(bool) instance_type_extra_specs_1.deleted_at:44(timestamp) instance_type_extra_specs_1.created_at:45(timestamp) instance_type_extra_specs_1.updated_at:46(timestamp)
+      ├── key columns: [39] = [39]
+      ├── side-effects, has-placeholder
+      ├── key: (1,39)
+      ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40-46), (40,42,43)~~>(39,41,44-46)
+      ├── ordering: +7,+1 opt(11) [actual: +7,+1]
+      ├── left-join (lookup instance_type_extra_specs@secondary)
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool) instance_type_extra_specs_1.id:39(int) key:40(string) instance_type_extra_specs_1.instance_type_id:42(int) instance_type_extra_specs_1.deleted:43(bool)
+      │    ├── key columns: [1] = [42]
+      │    ├── side-effects, has-placeholder
+      │    ├── key: (1,39)
+      │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (39)-->(40,42,43), (40,42,43)~~>(39)
+      │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
+      │    ├── limit
+      │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+      │    │    ├── internal-ordering: +7,+1 opt(11)
+      │    │    ├── side-effects, has-placeholder
+      │    │    ├── key: (1)
+      │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
+      │    │    ├── offset
+      │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+      │    │    │    ├── internal-ordering: +7,+1 opt(11)
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
+      │    │    │    ├── sort
+      │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+      │    │    │    │    ├── has-placeholder
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
+      │    │    │    │    └── select
+      │    │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+      │    │    │    │         ├── has-placeholder
+      │    │    │    │         ├── key: (1)
+      │    │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │         ├── group-by
+      │    │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:37(bool)
+      │    │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │    │    │    │         │    ├── internal-ordering: +1 opt(11)
+      │    │    │    │         │    ├── has-placeholder
+      │    │    │    │         │    ├── key: (1)
+      │    │    │    │         │    ├── fd: ()-->(11), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │         │    ├── left-join (merge)
+      │    │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:26(int) true_agg:34(bool) true:36(bool)
+      │    │    │    │         │    │    ├── left ordering: +1
+      │    │    │    │         │    │    ├── right ordering: +26
+      │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(36)
+      │    │    │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
+      │    │    │    │         │    │    ├── select
+      │    │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
+      │    │    │    │         │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    ├── key: (1)
+      │    │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+      │    │    │    │         │    │    │    ├── group-by
+      │    │    │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:34(bool)
+      │    │    │    │         │    │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+      │    │    │    │         │    │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    │    ├── key: (1)
+      │    │    │    │         │    │    │    │    ├── fd: ()-->(11), (1)-->(2-16,34), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │         │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+      │    │    │    │         │    │    │    │    ├── left-join (merge)
+      │    │    │    │         │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:33(bool)
+      │    │    │    │         │    │    │    │    │    ├── left ordering: +1
+      │    │    │    │         │    │    │    │    │    ├── right ordering: +18
+      │    │    │    │         │    │    │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), ()~~>(33)
+      │    │    │    │         │    │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+      │    │    │    │         │    │    │    │    │    ├── select
+      │    │    │    │         │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool!null) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │         │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │         │    │    │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+      │    │    │    │         │    │    │    │    │    │    ├── scan instance_types
+      │    │    │    │         │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │         │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │         │    │    │    │    │    │    │    └── ordering: +1 opt(11) [actual: +1]
+      │    │    │    │         │    │    │    │    │    │    └── filters
+      │    │    │    │         │    │    │    │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │         │    │    │    │    │    │         └── disabled = false [type=bool, outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
+      │    │    │    │         │    │    │    │    │    ├── project
+      │    │    │    │         │    │    │    │    │    │    ├── columns: true:33(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │    │    │    │         │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(33)
+      │    │    │    │         │    │    │    │    │    │    ├── ordering: +18 opt(33) [actual: +18]
+      │    │    │    │         │    │    │    │    │    │    ├── select
+      │    │    │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │    │    │    │         │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    │    │    │    │    ├── key: (18-20)
+      │    │    │    │         │    │    │    │    │    │    │    ├── ordering: +18
+      │    │    │    │         │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+      │    │    │    │         │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │    │    │    │         │    │    │    │    │    │    │    │    ├── lax-key: (18-20)
+      │    │    │    │         │    │    │    │    │    │    │    │    └── ordering: +18
+      │    │    │    │         │    │    │    │    │    │    │    └── filters
+      │    │    │    │         │    │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │    │    │    │         │    │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │    │    │    │         │    │    │    │    │    │    └── projections
+      │    │    │    │         │    │    │    │    │    │         └── true [type=bool]
+      │    │    │    │         │    │    │    │    │    └── filters (true)
+      │    │    │    │         │    │    │    │    └── aggregations
+      │    │    │    │         │    │    │    │         ├── const-not-null-agg [type=bool, outer=(33)]
+      │    │    │    │         │    │    │    │         │    └── variable: true [type=bool]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │         │    │    │    │         │    └── variable: name [type=string]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │         │    │    │    │         │    └── variable: memory_mb [type=int]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │         │    │    │    │         │    └── variable: vcpus [type=int]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │         │    │    │    │         │    └── variable: root_gb [type=int]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │         │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │         │    │    │    │         │    └── variable: flavorid [type=string]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │         │    │    │    │         │    └── variable: swap [type=int]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │         │    │    │    │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │         │    │    │    │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │         │    │    │    │         │    └── variable: disabled [type=bool]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │         │    │    │    │         │    └── variable: is_public [type=bool]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=bool, outer=(13)]
+      │    │    │    │         │    │    │    │         │    └── variable: instance_types.deleted [type=bool]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │         │    │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
+      │    │    │    │         │    │    │    │         ├── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │         │    │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
+      │    │    │    │         │    │    │    │         └── const-agg [type=timestamp, outer=(16)]
+      │    │    │    │         │    │    │    │              └── variable: instance_types.updated_at [type=timestamp]
+      │    │    │    │         │    │    │    └── filters
+      │    │    │    │         │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,34)]
+      │    │    │    │         │    │    ├── project
+      │    │    │    │         │    │    │    ├── columns: true:36(bool!null) instance_type_projects.instance_type_id:26(int!null)
+      │    │    │    │         │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    ├── fd: ()-->(36)
+      │    │    │    │         │    │    │    ├── ordering: +26 opt(36) [actual: +26]
+      │    │    │    │         │    │    │    ├── select
+      │    │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string!null) instance_type_projects.deleted:28(bool!null)
+      │    │    │    │         │    │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    │    ├── key: (26-28)
+      │    │    │    │         │    │    │    │    ├── ordering: +26
+      │    │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │    │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:26(int!null) project_id:27(string) instance_type_projects.deleted:28(bool)
+      │    │    │    │         │    │    │    │    │    ├── lax-key: (26-28)
+      │    │    │    │         │    │    │    │    │    └── ordering: +26
+      │    │    │    │         │    │    │    │    └── filters
+      │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $4 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
+      │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $5 [type=bool, outer=(28), constraints=(/28: (/NULL - ])]
+      │    │    │    │         │    │    │    │         └── project_id = $6 [type=bool, outer=(27), constraints=(/27: (/NULL - ])]
+      │    │    │    │         │    │    │    └── projections
+      │    │    │    │         │    │    │         └── true [type=bool]
+      │    │    │    │         │    │    └── filters (true)
+      │    │    │    │         │    └── aggregations
+      │    │    │    │         │         ├── const-not-null-agg [type=bool, outer=(36)]
+      │    │    │    │         │         │    └── variable: true [type=bool]
+      │    │    │    │         │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │         │         │    └── variable: name [type=string]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │         │         │    └── variable: memory_mb [type=int]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │         │         │    └── variable: vcpus [type=int]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │         │         │    └── variable: root_gb [type=int]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │         │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │         │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │         │         │    └── variable: flavorid [type=string]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │         │         │    └── variable: swap [type=int]
+      │    │    │    │         │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │         │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │         │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │         │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │         │         │    └── variable: disabled [type=bool]
+      │    │    │    │         │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │         │         │    └── variable: is_public [type=bool]
+      │    │    │    │         │         ├── const-agg [type=bool, outer=(13)]
+      │    │    │    │         │         │    └── variable: instance_types.deleted [type=bool]
+      │    │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp]
+      │    │    │    │         │         ├── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │         │         │    └── variable: instance_types.created_at [type=timestamp]
+      │    │    │    │         │         └── const-agg [type=timestamp, outer=(16)]
+      │    │    │    │         │              └── variable: instance_types.updated_at [type=timestamp]
+      │    │    │    │         └── filters
+      │    │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,37)]
+      │    │    │    └── placeholder: $7 [type=int]
+      │    │    └── placeholder: $8 [type=int]
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted = $9 [type=bool, outer=(43), constraints=(/43: (/NULL - ])]
+      └── filters (true)
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -3068,139 +3056,139 @@ from (select instance_types.created_at as instance_types_created_at,
 order by anon_1.instance_types_deleted asc,
          anon_1.instance_types_id asc
 ----
-left-join (lookup instance_type_extra_specs)
+project
  ├── columns: anon_1_instance_types_created_at:15(timestamp) anon_1_instance_types_updated_at:16(timestamp) anon_1_instance_types_deleted_at:14(timestamp) anon_1_instance_types_deleted:13(bool) anon_1_instance_types_id:1(int!null) anon_1_instance_types_name:2(string) anon_1_instance_types_memory_mb:3(int) anon_1_instance_types_vcpus:4(int) anon_1_instance_types_root_gb:5(int) anon_1_instance_types_ephemeral_gb:6(int) anon_1_instance_types_flavorid:7(string) anon_1_instance_types_swap:8(int) anon_1_instance_types_rxtx_factor:9(float) anon_1_instance_types_vcpu_weight:10(int) anon_1_instance_types_disabled:11(bool) anon_1_instance_types_is_public:12(bool) instance_type_extra_specs_1_created_at:34(timestamp) instance_type_extra_specs_1_updated_at:35(timestamp) instance_type_extra_specs_1_deleted_at:33(timestamp) instance_type_extra_specs_1_deleted:32(bool) instance_type_extra_specs_1_id:28(int) instance_type_extra_specs_1_key:29(string) instance_type_extra_specs_1_value:30(string) instance_type_extra_specs_1_instance_type_id:31(int)
- ├── key columns: [28] = [28]
  ├── side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
  ├── ordering: +13,+1
- ├── left-join (lookup instance_type_extra_specs@secondary)
- │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
- │    ├── key columns: [1] = [31]
- │    ├── side-effects, has-placeholder
- │    ├── key: (1,28)
- │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
- │    ├── ordering: +13,+1
- │    ├── project
- │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │    ├── side-effects, has-placeholder
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │    ├── ordering: +13,+1
- │    │    └── limit
- │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         ├── internal-ordering: +13,+1
- │    │         ├── side-effects, has-placeholder
- │    │         ├── key: (1)
- │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         ├── ordering: +13,+1
- │    │         ├── offset
- │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    ├── internal-ordering: +13,+1
- │    │         │    ├── has-placeholder
- │    │         │    ├── key: (1)
- │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    ├── ordering: +13,+1
- │    │         │    ├── sort
- │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │    ├── has-placeholder
- │    │         │    │    ├── key: (1)
- │    │         │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │    ├── ordering: +13,+1
- │    │         │    │    └── select
- │    │         │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │         ├── has-placeholder
- │    │         │    │         ├── key: (1)
- │    │         │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         ├── group-by
- │    │         │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
- │    │         │    │         │    ├── grouping columns: instance_types.id:1(int!null)
- │    │         │    │         │    ├── internal-ordering: +1
- │    │         │    │         │    ├── has-placeholder
- │    │         │    │         │    ├── key: (1)
- │    │         │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    ├── left-join (merge)
- │    │         │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
- │    │         │    │         │    │    ├── left ordering: +1
- │    │         │    │         │    │    ├── right ordering: +18
- │    │         │    │         │    │    ├── has-placeholder
- │    │         │    │         │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
- │    │         │    │         │    │    ├── ordering: +1
- │    │         │    │         │    │    ├── select
- │    │         │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │    ├── has-placeholder
- │    │         │    │         │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │    ├── ordering: +1
- │    │         │    │         │    │    │    ├── scan instance_types
- │    │         │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
- │    │         │    │         │    │    │    │    ├── key: (1)
- │    │         │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
- │    │         │    │         │    │    │    │    └── ordering: +1
- │    │         │    │         │    │    │    └── filters
- │    │         │    │         │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
- │    │         │    │         │    │    │         └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
- │    │         │    │         │    │    ├── project
- │    │         │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
- │    │         │    │         │    │    │    ├── has-placeholder
- │    │         │    │         │    │    │    ├── fd: ()-->(25)
- │    │         │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
- │    │         │    │         │    │    │    ├── select
- │    │         │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
- │    │         │    │         │    │    │    │    ├── has-placeholder
- │    │         │    │         │    │    │    │    ├── key: (18-20)
- │    │         │    │         │    │    │    │    ├── ordering: +18
- │    │         │    │         │    │    │    │    ├── scan instance_type_projects@secondary
- │    │         │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
- │    │         │    │         │    │    │    │    │    ├── lax-key: (18-20)
- │    │         │    │         │    │    │    │    │    └── ordering: +18
- │    │         │    │         │    │    │    │    └── filters
- │    │         │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
- │    │         │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
- │    │         │    │         │    │    │    └── projections
- │    │         │    │         │    │    │         └── true [type=bool]
- │    │         │    │         │    │    └── filters (true)
- │    │         │    │         │    └── aggregations
- │    │         │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
- │    │         │    │         │         │    └── variable: true [type=bool]
- │    │         │    │         │         ├── const-agg [type=string, outer=(2)]
- │    │         │    │         │         │    └── variable: name [type=string]
- │    │         │    │         │         ├── const-agg [type=int, outer=(3)]
- │    │         │    │         │         │    └── variable: memory_mb [type=int]
- │    │         │    │         │         ├── const-agg [type=int, outer=(4)]
- │    │         │    │         │         │    └── variable: vcpus [type=int]
- │    │         │    │         │         ├── const-agg [type=int, outer=(5)]
- │    │         │    │         │         │    └── variable: root_gb [type=int]
- │    │         │    │         │         ├── const-agg [type=int, outer=(6)]
- │    │         │    │         │         │    └── variable: ephemeral_gb [type=int]
- │    │         │    │         │         ├── const-agg [type=string, outer=(7)]
- │    │         │    │         │         │    └── variable: flavorid [type=string]
- │    │         │    │         │         ├── const-agg [type=int, outer=(8)]
- │    │         │    │         │         │    └── variable: swap [type=int]
- │    │         │    │         │         ├── const-agg [type=float, outer=(9)]
- │    │         │    │         │         │    └── variable: rxtx_factor [type=float]
- │    │         │    │         │         ├── const-agg [type=int, outer=(10)]
- │    │         │    │         │         │    └── variable: vcpu_weight [type=int]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(11)]
- │    │         │    │         │         │    └── variable: disabled [type=bool]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(12)]
- │    │         │    │         │         │    └── variable: is_public [type=bool]
- │    │         │    │         │         ├── const-agg [type=bool, outer=(13)]
- │    │         │    │         │         │    └── variable: instance_types.deleted [type=bool]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(14)]
- │    │         │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp]
- │    │         │    │         │         ├── const-agg [type=timestamp, outer=(15)]
- │    │         │    │         │         │    └── variable: instance_types.created_at [type=timestamp]
- │    │         │    │         │         └── const-agg [type=timestamp, outer=(16)]
- │    │         │    │         │              └── variable: instance_types.updated_at [type=timestamp]
- │    │         │    │         └── filters
- │    │         │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
- │    │         │    └── placeholder: $5 [type=int]
- │    │         └── placeholder: $6 [type=int]
- │    └── filters
- │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
- └── filters (true)
+ └── left-join (lookup instance_type_extra_specs)
+      ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+      ├── key columns: [28] = [28]
+      ├── side-effects, has-placeholder
+      ├── key: (1,28)
+      ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      ├── ordering: +13,+1
+      ├── left-join (lookup instance_type_extra_specs@secondary)
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
+      │    ├── key columns: [1] = [31]
+      │    ├── side-effects, has-placeholder
+      │    ├── key: (1,28)
+      │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
+      │    ├── ordering: +13,+1
+      │    ├── limit
+      │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    ├── internal-ordering: +13,+1
+      │    │    ├── side-effects, has-placeholder
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    ├── ordering: +13,+1
+      │    │    ├── offset
+      │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    ├── internal-ordering: +13,+1
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    ├── ordering: +13,+1
+      │    │    │    ├── sort
+      │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │    ├── has-placeholder
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    ├── ordering: +13,+1
+      │    │    │    │    └── select
+      │    │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │         ├── has-placeholder
+      │    │    │    │         ├── key: (1)
+      │    │    │    │         ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │         ├── group-by
+      │    │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
+      │    │    │    │         │    ├── internal-ordering: +1
+      │    │    │    │         │    ├── has-placeholder
+      │    │    │    │         │    ├── key: (1)
+      │    │    │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │         │    ├── left-join (merge)
+      │    │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │    │    │    │         │    │    ├── left ordering: +1
+      │    │    │    │         │    │    ├── right ordering: +18
+      │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │         │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │    │    │    │         │    │    ├── ordering: +1
+      │    │    │    │         │    │    ├── select
+      │    │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │         │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    ├── key: (1)
+      │    │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │         │    │    │    ├── ordering: +1
+      │    │    │    │         │    │    │    ├── scan instance_types
+      │    │    │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │         │    │    │    │    ├── key: (1)
+      │    │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │         │    │    │    │    └── ordering: +1
+      │    │    │    │         │    │    │    └── filters
+      │    │    │    │         │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │         │    │    │         └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+      │    │    │    │         │    │    ├── project
+      │    │    │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │    │    │    │         │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    ├── fd: ()-->(25)
+      │    │    │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
+      │    │    │    │         │    │    │    ├── select
+      │    │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
+      │    │    │    │         │    │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    │    ├── key: (18-20)
+      │    │    │    │         │    │    │    │    ├── ordering: +18
+      │    │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
+      │    │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │    │    │    │         │    │    │    │    │    ├── lax-key: (18-20)
+      │    │    │    │         │    │    │    │    │    └── ordering: +18
+      │    │    │    │         │    │    │    │    └── filters
+      │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │    │    │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │    │    │    │         │    │    │    └── projections
+      │    │    │    │         │    │    │         └── true [type=bool]
+      │    │    │    │         │    │    └── filters (true)
+      │    │    │    │         │    └── aggregations
+      │    │    │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
+      │    │    │    │         │         │    └── variable: true [type=bool]
+      │    │    │    │         │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │         │         │    └── variable: name [type=string]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │         │         │    └── variable: memory_mb [type=int]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │         │         │    └── variable: vcpus [type=int]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │         │         │    └── variable: root_gb [type=int]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │         │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │         │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │         │         │    └── variable: flavorid [type=string]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │         │         │    └── variable: swap [type=int]
+      │    │    │    │         │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │         │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │         │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │         │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │         │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │         │         │    └── variable: disabled [type=bool]
+      │    │    │    │         │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │         │         │    └── variable: is_public [type=bool]
+      │    │    │    │         │         ├── const-agg [type=bool, outer=(13)]
+      │    │    │    │         │         │    └── variable: instance_types.deleted [type=bool]
+      │    │    │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │         │         │    └── variable: instance_types.deleted_at [type=timestamp]
+      │    │    │    │         │         ├── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │         │         │    └── variable: instance_types.created_at [type=timestamp]
+      │    │    │    │         │         └── const-agg [type=timestamp, outer=(16)]
+      │    │    │    │         │              └── variable: instance_types.updated_at [type=timestamp]
+      │    │    │    │         └── filters
+      │    │    │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+      │    │    │    └── placeholder: $5 [type=int]
+      │    │    └── placeholder: $6 [type=int]
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      └── filters (true)
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -3250,117 +3238,117 @@ from (select flavors.created_at as flavors_created_at,
      left join flavor_extra_specs as flavor_extra_specs_1
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 ----
-right-join
+project
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
  ├── side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
- ├── scan flavor_extra_specs_1
- │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
- │    ├── key: (25)
- │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
- ├── project
- │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │    ├── side-effects, has-placeholder
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │    └── limit
- │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         ├── side-effects, has-placeholder
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         ├── offset
- │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         │    ├── has-placeholder
- │         │    ├── key: (1)
- │         │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    ├── select
- │         │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         │    │    ├── has-placeholder
- │         │    │    ├── key: (1)
- │         │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    ├── group-by
- │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
- │         │    │    │    ├── grouping columns: flavors.id:1(int!null)
- │         │    │    │    ├── internal-ordering: +1
- │         │    │    │    ├── has-placeholder
- │         │    │    │    ├── key: (1)
- │         │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    │    ├── left-join (merge)
- │         │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
- │         │    │    │    │    ├── left ordering: +1
- │         │    │    │    │    ├── right ordering: +17
- │         │    │    │    │    ├── has-placeholder
- │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
- │         │    │    │    │    ├── ordering: +1
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │         │    │    │    │    │    ├── has-placeholder
- │         │    │    │    │    │    ├── key: (1)
- │         │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    │    │    │    ├── ordering: +1
- │         │    │    │    │    │    ├── scan flavors
- │         │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
- │         │    │    │    │    │    │    ├── key: (1)
- │         │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
- │         │    │    │    │    │    │    └── ordering: +1
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── flavors.id = $2 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
- │         │    │    │    │    ├── project
- │         │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
- │         │    │    │    │    │    ├── has-placeholder
- │         │    │    │    │    │    ├── fd: ()-->(22)
- │         │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
- │         │    │    │    │    │    ├── select
- │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
- │         │    │    │    │    │    │    ├── has-placeholder
- │         │    │    │    │    │    │    ├── key: (17,18)
- │         │    │    │    │    │    │    ├── ordering: +17
- │         │    │    │    │    │    │    ├── scan flavor_projects@secondary
- │         │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
- │         │    │    │    │    │    │    │    ├── key: (17,18)
- │         │    │    │    │    │    │    │    └── ordering: +17
- │         │    │    │    │    │    │    └── filters
- │         │    │    │    │    │    │         ├── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
- │         │    │    │    │    │    │         └── flavor_projects.flavor_id = $2 [type=bool, outer=(17), constraints=(/17: (/NULL - ])]
- │         │    │    │    │    │    └── projections
- │         │    │    │    │    │         └── true [type=bool]
- │         │    │    │    │    └── filters (true)
- │         │    │    │    └── aggregations
- │         │    │    │         ├── const-not-null-agg [type=bool, outer=(22)]
- │         │    │    │         │    └── variable: true [type=bool]
- │         │    │    │         ├── const-agg [type=string, outer=(2)]
- │         │    │    │         │    └── variable: name [type=string]
- │         │    │    │         ├── const-agg [type=int, outer=(3)]
- │         │    │    │         │    └── variable: memory_mb [type=int]
- │         │    │    │         ├── const-agg [type=int, outer=(4)]
- │         │    │    │         │    └── variable: vcpus [type=int]
- │         │    │    │         ├── const-agg [type=int, outer=(5)]
- │         │    │    │         │    └── variable: root_gb [type=int]
- │         │    │    │         ├── const-agg [type=int, outer=(6)]
- │         │    │    │         │    └── variable: ephemeral_gb [type=int]
- │         │    │    │         ├── const-agg [type=string, outer=(7)]
- │         │    │    │         │    └── variable: flavorid [type=string]
- │         │    │    │         ├── const-agg [type=int, outer=(8)]
- │         │    │    │         │    └── variable: swap [type=int]
- │         │    │    │         ├── const-agg [type=float, outer=(9)]
- │         │    │    │         │    └── variable: rxtx_factor [type=float]
- │         │    │    │         ├── const-agg [type=int, outer=(10)]
- │         │    │    │         │    └── variable: vcpu_weight [type=int]
- │         │    │    │         ├── const-agg [type=bool, outer=(11)]
- │         │    │    │         │    └── variable: disabled [type=bool]
- │         │    │    │         ├── const-agg [type=bool, outer=(12)]
- │         │    │    │         │    └── variable: is_public [type=bool]
- │         │    │    │         ├── const-agg [type=timestamp, outer=(14)]
- │         │    │    │         │    └── variable: flavors.created_at [type=timestamp]
- │         │    │    │         └── const-agg [type=timestamp, outer=(15)]
- │         │    │    │              └── variable: flavors.updated_at [type=timestamp]
- │         │    │    └── filters
- │         │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
- │         │    └── placeholder: $3 [type=int]
- │         └── placeholder: $4 [type=int]
- └── filters
-      └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+ └── right-join
+      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+      ├── side-effects, has-placeholder
+      ├── key: (1,25)
+      ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── scan flavor_extra_specs_1
+      │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+      │    ├── key: (25)
+      │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+      ├── limit
+      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    ├── side-effects, has-placeholder
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    ├── offset
+      │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    │    ├── has-placeholder
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    ├── select
+      │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    ├── group-by
+      │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+      │    │    │    │    ├── grouping columns: flavors.id:1(int!null)
+      │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    ├── has-placeholder
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    ├── left-join (merge)
+      │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+      │    │    │    │    │    ├── left ordering: +1
+      │    │    │    │    │    ├── right ordering: +17
+      │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+      │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    ├── select
+      │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    │    ├── scan flavors
+      │    │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+      │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    │    │    │    └── ordering: +1
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── flavors.id = $2 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── fd: ()-->(22)
+      │    │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    ├── key: (17,18)
+      │    │    │    │    │    │    │    ├── ordering: +17
+      │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
+      │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+      │    │    │    │    │    │    │    │    ├── key: (17,18)
+      │    │    │    │    │    │    │    │    └── ordering: +17
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         ├── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │    │    │    │    │    │    │         └── flavor_projects.flavor_id = $2 [type=bool, outer=(17), constraints=(/17: (/NULL - ])]
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── true [type=bool]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── const-not-null-agg [type=bool, outer=(22)]
+      │    │    │    │         │    └── variable: true [type=bool]
+      │    │    │    │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │         │    └── variable: name [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │         │    └── variable: memory_mb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │         │    └── variable: vcpus [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │         │    └── variable: root_gb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │         │    └── variable: flavorid [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │         │    └── variable: swap [type=int]
+      │    │    │    │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │         │    └── variable: disabled [type=bool]
+      │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │         │    └── variable: is_public [type=bool]
+      │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │         │    └── variable: flavors.created_at [type=timestamp]
+      │    │    │    │         └── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │              └── variable: flavors.updated_at [type=timestamp]
+      │    │    │    └── filters
+      │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
+      │    │    └── placeholder: $3 [type=int]
+      │    └── placeholder: $4 [type=int]
+      └── filters
+           └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -3418,108 +3406,108 @@ sort
  ├── key: (1,25)
  ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +7
- └── right-join
+ └── project
       ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
       ├── side-effects, has-placeholder
       ├── key: (1,25)
       ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
-      ├── scan flavor_extra_specs_1
-      │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
-      │    ├── key: (25)
-      │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
-      ├── project
-      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │    ├── side-effects, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
-      │    └── limit
-      │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         ├── internal-ordering: +7
-      │         ├── side-effects, has-placeholder
-      │         ├── key: (1)
-      │         ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
-      │         ├── sort
-      │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         │    ├── has-placeholder
-      │         │    ├── key: (1)
-      │         │    ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
-      │         │    ├── ordering: +7
-      │         │    └── select
-      │         │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         │         ├── has-placeholder
-      │         │         ├── key: (1)
-      │         │         ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
-      │         │         ├── group-by
-      │         │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │         │         │    ├── grouping columns: flavors.id:1(int!null)
-      │         │         │    ├── internal-ordering: +1
-      │         │         │    ├── has-placeholder
-      │         │         │    ├── key: (1)
-      │         │         │    ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
-      │         │         │    ├── left-join (merge)
-      │         │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
-      │         │         │    │    ├── left ordering: +1
-      │         │         │    │    ├── right ordering: +17
-      │         │         │    │    ├── has-placeholder
-      │         │         │    │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), ()~~>(22)
-      │         │         │    │    ├── ordering: +1
-      │         │         │    │    ├── scan flavors
-      │         │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │         │         │    │    │    ├── key: (1)
-      │         │         │    │    │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
-      │         │         │    │    │    └── ordering: +1
-      │         │         │    │    ├── project
-      │         │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
-      │         │         │    │    │    ├── has-placeholder
-      │         │         │    │    │    ├── fd: ()-->(22)
-      │         │         │    │    │    ├── ordering: +17 opt(22) [actual: +17]
-      │         │         │    │    │    ├── select
-      │         │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
-      │         │         │    │    │    │    ├── has-placeholder
-      │         │         │    │    │    │    ├── key: (17,18)
-      │         │         │    │    │    │    ├── ordering: +17
-      │         │         │    │    │    │    ├── scan flavor_projects@secondary
-      │         │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
-      │         │         │    │    │    │    │    ├── key: (17,18)
-      │         │         │    │    │    │    │    └── ordering: +17
-      │         │         │    │    │    │    └── filters
-      │         │         │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
-      │         │         │    │    │    └── projections
-      │         │         │    │    │         └── true [type=bool]
-      │         │         │    │    └── filters (true)
-      │         │         │    └── aggregations
-      │         │         │         ├── const-not-null-agg [type=bool, outer=(22)]
-      │         │         │         │    └── variable: true [type=bool]
-      │         │         │         ├── const-agg [type=string, outer=(2)]
-      │         │         │         │    └── variable: name [type=string]
-      │         │         │         ├── const-agg [type=int, outer=(3)]
-      │         │         │         │    └── variable: memory_mb [type=int]
-      │         │         │         ├── const-agg [type=int, outer=(4)]
-      │         │         │         │    └── variable: vcpus [type=int]
-      │         │         │         ├── const-agg [type=int, outer=(5)]
-      │         │         │         │    └── variable: root_gb [type=int]
-      │         │         │         ├── const-agg [type=int, outer=(6)]
-      │         │         │         │    └── variable: ephemeral_gb [type=int]
-      │         │         │         ├── const-agg [type=string, outer=(7)]
-      │         │         │         │    └── variable: flavorid [type=string]
-      │         │         │         ├── const-agg [type=int, outer=(8)]
-      │         │         │         │    └── variable: swap [type=int]
-      │         │         │         ├── const-agg [type=float, outer=(9)]
-      │         │         │         │    └── variable: rxtx_factor [type=float]
-      │         │         │         ├── const-agg [type=int, outer=(10)]
-      │         │         │         │    └── variable: vcpu_weight [type=int]
-      │         │         │         ├── const-agg [type=bool, outer=(11)]
-      │         │         │         │    └── variable: disabled [type=bool]
-      │         │         │         ├── const-agg [type=bool, outer=(12)]
-      │         │         │         │    └── variable: is_public [type=bool]
-      │         │         │         ├── const-agg [type=string, outer=(13)]
-      │         │         │         │    └── variable: description [type=string]
-      │         │         │         ├── const-agg [type=timestamp, outer=(14)]
-      │         │         │         │    └── variable: flavors.created_at [type=timestamp]
-      │         │         │         └── const-agg [type=timestamp, outer=(15)]
-      │         │         │              └── variable: flavors.updated_at [type=timestamp]
-      │         │         └── filters
-      │         │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
-      │         └── placeholder: $2 [type=int]
-      └── filters
-           └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
+      └── right-join
+           ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+           ├── side-effects, has-placeholder
+           ├── key: (1,25)
+           ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+           ├── scan flavor_extra_specs_1
+           │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+           │    ├── key: (25)
+           │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+           ├── limit
+           │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    ├── internal-ordering: +7
+           │    ├── side-effects, has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    ├── sort
+           │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │    ├── ordering: +7
+           │    │    └── select
+           │    │         ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │         ├── has-placeholder
+           │    │         ├── key: (1)
+           │    │         ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │         ├── group-by
+           │    │         │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │         │    ├── grouping columns: flavors.id:1(int!null)
+           │    │         │    ├── internal-ordering: +1
+           │    │         │    ├── has-placeholder
+           │    │         │    ├── key: (1)
+           │    │         │    ├── fd: (1)-->(2-15,23), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │         │    ├── left-join (merge)
+           │    │         │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+           │    │         │    │    ├── left ordering: +1
+           │    │         │    │    ├── right ordering: +17
+           │    │         │    │    ├── has-placeholder
+           │    │         │    │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), ()~~>(22)
+           │    │         │    │    ├── ordering: +1
+           │    │         │    │    ├── scan flavors
+           │    │         │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) description:13(string) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+           │    │         │    │    │    ├── key: (1)
+           │    │         │    │    │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │         │    │    │    └── ordering: +1
+           │    │         │    │    ├── project
+           │    │         │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+           │    │         │    │    │    ├── has-placeholder
+           │    │         │    │    │    ├── fd: ()-->(22)
+           │    │         │    │    │    ├── ordering: +17 opt(22) [actual: +17]
+           │    │         │    │    │    ├── select
+           │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+           │    │         │    │    │    │    ├── has-placeholder
+           │    │         │    │    │    │    ├── key: (17,18)
+           │    │         │    │    │    │    ├── ordering: +17
+           │    │         │    │    │    │    ├── scan flavor_projects@secondary
+           │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+           │    │         │    │    │    │    │    ├── key: (17,18)
+           │    │         │    │    │    │    │    └── ordering: +17
+           │    │         │    │    │    │    └── filters
+           │    │         │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+           │    │         │    │    │    └── projections
+           │    │         │    │    │         └── true [type=bool]
+           │    │         │    │    └── filters (true)
+           │    │         │    └── aggregations
+           │    │         │         ├── const-not-null-agg [type=bool, outer=(22)]
+           │    │         │         │    └── variable: true [type=bool]
+           │    │         │         ├── const-agg [type=string, outer=(2)]
+           │    │         │         │    └── variable: name [type=string]
+           │    │         │         ├── const-agg [type=int, outer=(3)]
+           │    │         │         │    └── variable: memory_mb [type=int]
+           │    │         │         ├── const-agg [type=int, outer=(4)]
+           │    │         │         │    └── variable: vcpus [type=int]
+           │    │         │         ├── const-agg [type=int, outer=(5)]
+           │    │         │         │    └── variable: root_gb [type=int]
+           │    │         │         ├── const-agg [type=int, outer=(6)]
+           │    │         │         │    └── variable: ephemeral_gb [type=int]
+           │    │         │         ├── const-agg [type=string, outer=(7)]
+           │    │         │         │    └── variable: flavorid [type=string]
+           │    │         │         ├── const-agg [type=int, outer=(8)]
+           │    │         │         │    └── variable: swap [type=int]
+           │    │         │         ├── const-agg [type=float, outer=(9)]
+           │    │         │         │    └── variable: rxtx_factor [type=float]
+           │    │         │         ├── const-agg [type=int, outer=(10)]
+           │    │         │         │    └── variable: vcpu_weight [type=int]
+           │    │         │         ├── const-agg [type=bool, outer=(11)]
+           │    │         │         │    └── variable: disabled [type=bool]
+           │    │         │         ├── const-agg [type=bool, outer=(12)]
+           │    │         │         │    └── variable: is_public [type=bool]
+           │    │         │         ├── const-agg [type=string, outer=(13)]
+           │    │         │         │    └── variable: description [type=string]
+           │    │         │         ├── const-agg [type=timestamp, outer=(14)]
+           │    │         │         │    └── variable: flavors.created_at [type=timestamp]
+           │    │         │         └── const-agg [type=timestamp, outer=(15)]
+           │    │         │              └── variable: flavors.updated_at [type=timestamp]
+           │    │         └── filters
+           │    │              └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
+           │    └── placeholder: $2 [type=int]
+           └── filters
+                └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1868,42 +1868,43 @@ project
  ├── side-effects, mutations
  ├── fd: ()-->(21)
  ├── inner-join
+ │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
  │    ├── cardinality: [0 - 0]
  │    ├── side-effects, mutations
+ │    ├── fd: ()-->(5-7)
  │    ├── values
  │    │    ├── cardinality: [0 - 0]
  │    │    └── key: ()
  │    ├── inner-join
+ │    │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
  │    │    ├── cardinality: [0 - 0]
  │    │    ├── side-effects, mutations
- │    │    ├── project
+ │    │    ├── fd: ()-->(5-7)
+ │    │    ├── select
+ │    │    │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
  │    │    │    ├── cardinality: [0 - 0]
  │    │    │    ├── side-effects, mutations
- │    │    │    └── select
- │    │    │         ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
- │    │    │         ├── cardinality: [0 - 0]
- │    │    │         ├── side-effects, mutations
- │    │    │         ├── fd: ()-->(5-7)
- │    │    │         ├── insert abc
- │    │    │         │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
- │    │    │         │    ├── insert-mapping:
- │    │    │         │    │    ├──  "?column?":13 => abc.a:5
- │    │    │         │    │    ├──  column14:14 => abc.b:6
- │    │    │         │    │    ├──  column14:14 => abc.c:7
- │    │    │         │    │    └──  column15:15 => abc.rowid:8
- │    │    │         │    ├── side-effects, mutations
- │    │    │         │    ├── fd: ()-->(5-7)
- │    │    │         │    └── project
- │    │    │         │         ├── columns: column14:14(int) column15:15(int) "?column?":13(int!null)
- │    │    │         │         ├── side-effects
- │    │    │         │         ├── fd: ()-->(13,14)
- │    │    │         │         ├── scan abc
- │    │    │         │         └── projections
- │    │    │         │              ├── null [type=int]
- │    │    │         │              ├── unique_rowid() [type=int, side-effects]
- │    │    │         │              └── const: 1 [type=int]
- │    │    │         └── filters
- │    │    │              └── false [type=bool]
+ │    │    │    ├── fd: ()-->(5-7)
+ │    │    │    ├── insert abc
+ │    │    │    │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
+ │    │    │    │    ├── insert-mapping:
+ │    │    │    │    │    ├──  "?column?":13 => abc.a:5
+ │    │    │    │    │    ├──  column14:14 => abc.b:6
+ │    │    │    │    │    ├──  column14:14 => abc.c:7
+ │    │    │    │    │    └──  column15:15 => abc.rowid:8
+ │    │    │    │    ├── side-effects, mutations
+ │    │    │    │    ├── fd: ()-->(5-7)
+ │    │    │    │    └── project
+ │    │    │    │         ├── columns: column14:14(int) column15:15(int) "?column?":13(int!null)
+ │    │    │    │         ├── side-effects
+ │    │    │    │         ├── fd: ()-->(13,14)
+ │    │    │    │         ├── scan abc
+ │    │    │    │         └── projections
+ │    │    │    │              ├── null [type=int]
+ │    │    │    │              ├── unique_rowid() [type=int, side-effects]
+ │    │    │    │              └── const: 1 [type=int]
+ │    │    │    └── filters
+ │    │    │         └── false [type=bool]
  │    │    ├── values
  │    │    │    ├── cardinality: [0 - 0]
  │    │    │    └── key: ()

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -425,3 +425,87 @@ memo (optimized, ~25KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,
  ├── G19: (eq G20 G21)
  ├── G20: (variable a)
  └── G21: (const 1)
+
+# Regression test for #34795.
+exec-ddl
+CREATE TABLE a (id INT8 PRIMARY KEY)
+----
+TABLE a
+ ├── id int not null
+ └── INDEX primary
+      └── id int not null
+
+opt join-limit=4
+SELECT
+    1
+FROM
+    a as a1
+    INNER JOIN a as a2 ON 1 = a2.id
+    INNER JOIN a AS a3 ON a1.id = a3.id
+    CROSS JOIN a as a4
+WHERE
+    a4.id = 1 AND (SELECT true FROM a WHERE a1.id = 1)
+----
+project
+ ├── columns: "?column?":7(int!null)
+ ├── fd: ()-->(7)
+ ├── inner-join
+ │    ├── columns: a1.id:1(int!null) a2.id:2(int!null) a3.id:3(int!null) a4.id:4(int!null) bool:6(bool!null)
+ │    ├── key: (3)
+ │    ├── fd: ()-->(2,4,6), (1)==(3), (3)==(1)
+ │    ├── scan a3
+ │    │    ├── columns: a3.id:3(int!null)
+ │    │    └── key: (3)
+ │    ├── inner-join
+ │    │    ├── columns: a1.id:1(int!null) a2.id:2(int!null) a4.id:4(int!null) bool:6(bool!null)
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(2,4,6)
+ │    │    ├── inner-join-apply
+ │    │    │    ├── columns: a1.id:1(int!null) bool:6(bool!null)
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: ()-->(6)
+ │    │    │    ├── scan a1
+ │    │    │    │    ├── columns: a1.id:1(int!null)
+ │    │    │    │    └── key: (1)
+ │    │    │    ├── max1-row
+ │    │    │    │    ├── columns: bool:6(bool!null)
+ │    │    │    │    ├── outer: (1)
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(6)
+ │    │    │    │    └── project
+ │    │    │    │         ├── columns: bool:6(bool!null)
+ │    │    │    │         ├── outer: (1)
+ │    │    │    │         ├── fd: ()-->(6)
+ │    │    │    │         ├── select
+ │    │    │    │         │    ├── outer: (1)
+ │    │    │    │         │    ├── scan a
+ │    │    │    │         │    └── filters
+ │    │    │    │         │         └── a1.id = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    │    │    │         └── projections
+ │    │    │    │              └── true [type=bool]
+ │    │    │    └── filters
+ │    │    │         └── variable: bool [type=bool, outer=(6), constraints=(/6: [/true - /true]; tight), fd=()-->(6)]
+ │    │    ├── inner-join
+ │    │    │    ├── columns: a2.id:2(int!null) a4.id:4(int!null)
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(2,4)
+ │    │    │    ├── scan a2
+ │    │    │    │    ├── columns: a2.id:2(int!null)
+ │    │    │    │    ├── constraint: /2: [/1 - /1]
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    └── fd: ()-->(2)
+ │    │    │    ├── scan a4
+ │    │    │    │    ├── columns: a4.id:4(int!null)
+ │    │    │    │    ├── constraint: /4: [/1 - /1]
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    └── fd: ()-->(4)
+ │    │    │    └── filters (true)
+ │    │    └── filters (true)
+ │    └── filters
+ │         └── a1.id = a3.id [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+ └── projections
+      └── const: 1 [type=int]


### PR DESCRIPTION
Fixes #34795.

This commit introduces HoistJoinProjectLeft to complement the existing
HoistJoinProject[Right] rule. This rule addresses a problem that could
occur during exploration, in which via reaching a group where
HoistJoinProjectRight via *exploration at the root* would not cause the
rule to trigger, but reaching it via exploration where it was *not* the
root *would* cause it to trigger, possibly causing collisions when we
explored via CommuteJoin.

The long-term solution to this is to support group merging.

Release note (bug fix): fixed a panic that could occur when planning
certain complex join queries.