### PR TITLE
exprgen: populate physical properties, cost

### DIFF
--- a/pkg/sql/opt/optgen/exprgen/custom_funcs.go
+++ b/pkg/sql/opt/optgen/exprgen/custom_funcs.go
@@ -118,3 +118,22 @@ func (c *customFuncs) MakeLookupJoin(
 ) memo.RelExpr {
 	return c.f.ConstructLookupJoin(input, on, lookupJoinPrivate)
 }
+
+// Sort adds a sort enforcer which sorts according to the ordering that will be
+// required by its parent.
+func (c *customFuncs) Sort(input memo.RelExpr) memo.RelExpr {
+	return &memo.SortExpr{Input: input}
+}
+
+// rootSentinel is used as the root value when Required is used.
+type rootSentinel struct {
+	expr     memo.RelExpr
+	required *physical.Required
+}
+
+// Require can be used only at the top level on an expression, to annotate the
+// root with a required ordering. The operator must be able to provide that
+// ordering.
+func (c *customFuncs) Require(root memo.RelExpr, ordering physical.OrderingChoice) *rootSentinel {
+	return &rootSentinel{expr: root, required: &physical.Required{Ordering: ordering}}
+}

--- a/pkg/sql/opt/optgen/exprgen/testdata/join
+++ b/pkg/sql/opt/optgen/exprgen/testdata/join
@@ -34,13 +34,16 @@ expr
 inner-join
  ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int) t.public.abc.c:3(int) t.public.def.d:5(int!null) t.public.def.e:6(int) t.public.def.f:7(int)
  ├── stats: [rows=10000, distinct(1)=100, null(1)=0, distinct(5)=100, null(5)=0]
+ ├── cost: 2270.03
  ├── fd: (1)==(5), (5)==(1)
  ├── scan t.public.abc
  │    ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int) t.public.abc.c:3(int)
- │    └── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    └── cost: 1070.01
  ├── scan t.public.def
  │    ├── columns: t.public.def.d:5(int) t.public.def.e:6(int) t.public.def.f:7(int)
- │    └── stats: [rows=1000, distinct(5)=100, null(5)=10]
+ │    ├── stats: [rows=1000, distinct(5)=100, null(5)=10]
+ │    └── cost: 1070.01
  └── filters
       └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
            ├── variable: t.public.abc.a [type=int]
@@ -57,9 +60,11 @@ left-join (lookup abc@ab)
  ├── columns: t.public.abc.a:5(int) t.public.abc.b:6(int)
  ├── key columns: [5] = [5]
  ├── stats: [rows=333333.333]
+ ├── cost: 355060.02
  ├── scan t.public.def
  │    ├── columns: t.public.def.d:1(int) t.public.def.e:2(int)
- │    └── stats: [rows=1000]
+ │    ├── stats: [rows=1000]
+ │    └── cost: 1060.01
  └── filters
       └── gt [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ])]
            ├── variable: t.public.abc.a [type=int]

--- a/pkg/sql/opt/optgen/exprgen/testdata/limit
+++ b/pkg/sql/opt/optgen/exprgen/testdata/limit
@@ -13,7 +13,6 @@ TABLE abc
       ├── b int
       └── rowid int not null (hidden)
 
-# TODO(radu): fill in physical properties (the scan node should have an ordering).
 expr
 (Limit
   (Scan [ (Table "abc") (Index "abc@ab") (Cols "a,b") ])
@@ -26,7 +25,34 @@ limit
  ├── internal-ordering: +1
  ├── cardinality: [0 - 10]
  ├── stats: [rows=10]
+ ├── cost: 1050.12
  ├── scan t.public.abc@ab
  │    ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
- │    └── stats: [rows=1000]
+ │    ├── stats: [rows=1000]
+ │    ├── cost: 1050.01
+ │    └── ordering: +1
+ └── const: 10 [type=int]
+
+expr
+(Limit
+  (Sort (Scan [ (Table "abc") (Cols "a,b") ]))
+  (Const 10)
+  (OrderingChoice "+a")
+)
+----
+limit
+ ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
+ ├── internal-ordering: +1
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10]
+ ├── cost: 1279.44569
+ ├── sort
+ │    ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
+ │    ├── stats: [rows=1000]
+ │    ├── cost: 1279.33569
+ │    ├── ordering: +1
+ │    └── scan t.public.abc
+ │         ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
+ │         ├── stats: [rows=1000]
+ │         └── cost: 1060.01
  └── const: 10 [type=int]

--- a/pkg/sql/opt/optgen/exprgen/testdata/scan
+++ b/pkg/sql/opt/optgen/exprgen/testdata/scan
@@ -18,14 +18,28 @@ expr
 ----
 scan t.public.abc
  ├── columns: t.public.abc.a:1(int)
- └── stats: [rows=1000]
+ ├── stats: [rows=1000]
+ └── cost: 1050.01
 
 expr
 (Scan [ (Table "abc") (Index "abc@ab") (Cols "a,b") ])
 ----
 scan t.public.abc@ab
  ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
- └── stats: [rows=1000]
+ ├── stats: [rows=1000]
+ └── cost: 1050.01
+
+expr
+(Require
+  (Scan [ (Table "abc") (Index "abc@ab") (Cols "a,b") ])
+  (OrderingChoice "+a,+b")
+)
+----
+scan t.public.abc@ab
+ ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
+ ├── stats: [rows=1000]
+ ├── cost: 1050.01
+ └── ordering: +1,+2
 
 expr
 (Select
@@ -36,10 +50,12 @@ expr
 select
  ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int) t.public.abc.c:3(int)
  ├── stats: [rows=9.9, distinct(1)=1, null(1)=0]
+ ├── cost: 1080.02
  ├── fd: ()-->(1)
  ├── scan t.public.abc
  │    ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int) t.public.abc.c:3(int)
- │    └── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    └── cost: 1070.01
  └── filters
       └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
            ├── variable: t.public.abc.a [type=int]

--- a/pkg/sql/opt/optgen/exprgen/testdata/values
+++ b/pkg/sql/opt/optgen/exprgen/testdata/values
@@ -11,6 +11,7 @@ values
  ├── columns: a:1(int) b:2(int)
  ├── cardinality: [2 - 2]
  ├── stats: [rows=2]
+ ├── cost: 0.03
  ├── tuple [type=tuple{int, int}]
  │    ├── const: 1 [type=int]
  │    └── const: 1 [type=int]

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -59,6 +59,13 @@ type coster struct {
 	perturbation float64
 }
 
+var _ Coster = &coster{}
+
+// MakeDefaultCoster creates an instance of the default coster.
+func MakeDefaultCoster(mem *memo.Memo) Coster {
+	return &coster{mem: mem}
+}
+
 const (
 	// These costs have been copied from the Postgres optimizer:
 	// https://github.com/postgres/postgres/blob/master/src/include/optimizer/cost.h
@@ -81,10 +88,9 @@ func (c *coster) Init(mem *memo.Memo, perturbation float64) {
 	c.perturbation = perturbation
 }
 
-// computeCost calculates the estimated cost of the candidate best expression,
-// based on its logical properties as well as the cost of its children. Each
-// expression's cost must always be >= the total costs of its children, so that
-// branch-and-bound pruning will work properly.
+// ComputeCost calculates the estimated cost of the top-level operator in a
+// candidate best expression, based on its logical properties and those of its
+// children.
 //
 // Note: each custom function to compute the cost of an operator calculates
 // the cost based on Big-O estimated complexity. Most constant factors are

--- a/pkg/sql/opt/xform/memo_format.go
+++ b/pkg/sql/opt/xform/memo_format.go
@@ -247,7 +247,7 @@ func (mf *memoFormatter) formatBest(best memo.RelExpr, required *physical.Requir
 		fmt.Fprintf(mf.buf, " G%d", mf.group(best.Child(i))+1)
 
 		// Print properties required of the child if they are interesting.
-		childReq := mf.o.buildChildPhysicalProps(best, i, required)
+		childReq := BuildChildPhysicalProps(mf.o.mem, best, i, required)
 		if childReq.Defined() {
 			fmt.Fprintf(mf.buf, "=\"%s\"", childReq)
 		}

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -463,12 +463,12 @@ func (o *Optimizer) optimizeGroupMember(
 	// properties? That case is taken care of by enforceProps, which will
 	// recursively optimize the group with property subsets and then add
 	// enforcers to provide the remainder.
-	if o.canProvidePhysicalProps(member, required) {
+	if CanProvidePhysicalProps(member, required) {
 		var cost memo.Cost
 		for i, n := 0, member.ChildCount(); i < n; i++ {
 			// Given required parent properties, get the properties required from
 			// the nth child.
-			childRequired := o.buildChildPhysicalProps(member, i, required)
+			childRequired := BuildChildPhysicalProps(o.mem, member, i, required)
 
 			// Optimize the child with respect to those properties.
 			childCost, childOptimized := o.optimizeExpr(member.Child(i), childRequired)
@@ -500,7 +500,7 @@ func (o *Optimizer) optimizeScalarExpr(
 ) (cost memo.Cost, fullyOptimized bool) {
 	fullyOptimized = true
 	for i, n := 0, scalar.ChildCount(); i < n; i++ {
-		childProps := o.buildChildPhysicalPropsScalar(scalar, i)
+		childProps := BuildChildPhysicalPropsScalar(o.mem, scalar, i)
 		childCost, childOptimized := o.optimizeExpr(scalar.Child(i), childProps)
 
 		// Accumulate cost of children.
@@ -633,9 +633,9 @@ func (o *Optimizer) setLowestCostTree(parent opt.Expr, parentProps *physical.Req
 		before := parent.Child(i)
 
 		if relParent != nil {
-			childProps = o.buildChildPhysicalProps(relParent, i, parentProps)
+			childProps = BuildChildPhysicalProps(o.mem, relParent, i, parentProps)
 		} else {
-			childProps = o.buildChildPhysicalPropsScalar(parent, i)
+			childProps = BuildChildPhysicalPropsScalar(o.mem, parent, i)
 		}
 
 		after := o.setLowestCostTree(before, childProps)


### PR DESCRIPTION
Post-process the expression to figure out physical properties and
cost. Each operator must support the physical properties required of
it; sort enforcers can be added with `(Sort ...)` as needed.

Also add a way of specifying a required ordering on the root, via a
`Require` custom function.

Informs #30273.

Release note: None