### PR TITLE
workload: update tpch to use sample values from spec

### DIFF
--- a/pkg/workload/tpch/queries.go
+++ b/pkg/workload/tpch/queries.go
@@ -56,7 +56,7 @@ SELECT
 FROM
 	lineitem
 WHERE
-	l_shipdate <= DATE '1998-12-01' - INTERVAL '95' DAY
+	l_shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY
 GROUP BY
 	l_returnflag,
 	l_linestatus
@@ -84,11 +84,11 @@ FROM
 WHERE
 	p_partkey = ps_partkey
 	AND s_suppkey = ps_suppkey
-	AND p_size = 42
-	AND p_type LIKE '%STEEL'
+	AND p_size = 15
+	AND p_type LIKE '%BRASS'
 	AND s_nationkey = n_nationkey
 	AND n_regionkey = r_regionkey
-	AND r_name = 'AMERICA'
+	AND r_name = 'EUROPE'
 	AND ps_supplycost = (
 		SELECT
 			min(ps_supplycost)
@@ -108,7 +108,8 @@ ORDER BY
 	s_acctbal DESC,
 	n_name,
 	s_name,
-	p_partkey;
+	p_partkey
+LIMIT 100;
 `
 
 	query3 = `
@@ -122,18 +123,19 @@ FROM
 	orders,
 	lineitem
 WHERE
-	c_mktsegment = 'MACHINERY'
+	c_mktsegment = 'BUILDING'
 	AND c_custkey = o_custkey
 	AND l_orderkey = o_orderkey
-	AND o_orderDATE < DATE '1995-03-10'
-	AND l_shipdate > DATE '1995-03-10'
+	AND o_orderDATE < DATE '1995-03-15'
+	AND l_shipdate > DATE '1995-03-15'
 GROUP BY
 	l_orderkey,
 	o_orderdate,
 	o_shippriority
 ORDER BY
 	revenue DESC,
-	o_orderdate;
+	o_orderdate
+LIMIT 10;
 `
 
 	query4 = `
@@ -143,8 +145,8 @@ SELECT
 FROM
 	orders
 WHERE
-	o_orderdate >= DATE '1994-08-01'
-	AND o_orderdate < DATE '1994-08-01' + INTERVAL '3' MONTH
+	o_orderdate >= DATE '1993-07-01'
+	AND o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH
 	AND EXISTS (
 		SELECT
 			*
@@ -178,9 +180,9 @@ WHERE
 	AND c_nationkey = s_nationkey
 	AND s_nationkey = n_nationkey
 	AND n_regionkey = r_regionkey
-	AND r_name = 'AFRICA'
-	AND o_orderDATE >= DATE '1997-01-01'
-	AND o_orderDATE < DATE '1997-01-01' + INTERVAL '1' YEAR
+	AND r_name = 'ASIA'
+	AND o_orderDATE >= DATE '1994-01-01'
+	AND o_orderDATE < DATE '1994-01-01' + INTERVAL '1' YEAR
 GROUP BY
 	n_name
 ORDER BY
@@ -193,9 +195,9 @@ SELECT
 FROM
 	lineitem
 WHERE
-	l_shipdate >= DATE '1997-01-01'
-	AND l_shipdate < DATE '1997-01-01' + INTERVAL '1' YEAR
-	AND l_discount BETWEEN 0.07 - 0.01 AND 0.07 + 0.01
+	l_shipdate >= DATE '1994-01-01'
+	AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR
+	AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
 	AND l_quantity < 24;
 `
 
@@ -226,8 +228,8 @@ FROM
 			AND s_nationkey = n1.n_nationkey
 			AND c_nationkey = n2.n_nationkey
 			AND (
-				(n1.n_name = 'MOZAMBIQUE' AND n2.n_name = 'CANADA')
-				or (n1.n_name = 'CANADA' AND n2.n_name = 'MOZAMBIQUE')
+				(n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')
+				or (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')
 			)
 			AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
 	) AS shipping
@@ -245,7 +247,7 @@ ORDER BY
 SELECT
 	o_year,
 	sum(CASE
-		WHEN nation = 'CANADA' THEN volume
+		WHEN nation = 'BRAZIL' THEN volume
 		ELSE 0
 	END) / sum(volume) AS mkt_share
 FROM
@@ -273,7 +275,7 @@ FROM
 			AND r_name = 'AMERICA'
 			AND s_nationkey = n2.n_nationkey
 			AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
-			AND p_type = 'ECONOMY POLISHED STEEL'
+			AND p_type = 'ECONOMY ANODIZED STEEL'
 	) AS all_nations
 GROUP BY
 	o_year
@@ -306,7 +308,7 @@ FROM
 			AND p_partkey = l_partkey
 			AND o_orderkey = l_orderkey
 			AND s_nationkey = n_nationkey
-			AND p_name LIKE '%royal%'
+			AND p_name LIKE '%green%'
 	) AS profit
 GROUP BY
 	nation,
@@ -334,8 +336,8 @@ FROM
 WHERE
 	c_custkey = o_custkey
 	AND l_orderkey = o_orderkey
-	AND o_orderDATE >= DATE '1994-12-01'
-	AND o_orderDATE < DATE '1994-12-01' + INTERVAL '3' MONTH
+	AND o_orderDATE >= DATE '1993-10-01'
+	AND o_orderDATE < DATE '1993-10-01' + INTERVAL '3' MONTH
 	AND l_returnflag = 'R'
 	AND c_nationkey = n_nationkey
 GROUP BY
@@ -347,7 +349,8 @@ GROUP BY
 	c_address,
 	c_comment
 ORDER BY
-	revenue DESC;
+	revenue DESC
+LIMIT 20;
 `
 
 	query11 = `
@@ -361,12 +364,12 @@ FROM
 WHERE
 	ps_suppkey = s_suppkey
 	AND s_nationkey = n_nationkey
-	AND n_name = 'ETHIOPIA'
+	AND n_name = 'GERMANY'
 GROUP BY
 	ps_partkey HAVING
 		sum(ps_supplycost * ps_availqty) > (
 			SELECT
-				sum(ps_supplycost * ps_availqty) * 0.0000003333
+				sum(ps_supplycost * ps_availqty) * 0.0001
 			FROM
 				partsupp,
 				supplier,
@@ -374,7 +377,7 @@ GROUP BY
 			WHERE
 				ps_suppkey = s_suppkey
 				AND s_nationkey = n_nationkey
-				AND n_name = 'ETHIOPIA'
+				AND n_name = 'GERMANY'
 		)
 ORDER BY
 	value DESC;
@@ -400,11 +403,11 @@ FROM
 	lineitem
 WHERE
 	o_orderkey = l_orderkey
-	AND l_shipmode IN ('AIR', 'REG AIR')
+	AND l_shipmode IN ('MAIL', 'SHIP')
 	AND l_commitdate < l_receiptdate
 	AND l_shipdate < l_commitdate
-	AND l_receiptdate >= DATE '1997-01-01'
-	AND l_receiptdate < DATE '1997-01-01' + INTERVAL '1' YEAR
+	AND l_receiptdate >= DATE '1994-01-01'
+	AND l_receiptdate < DATE '1994-01-01' + INTERVAL '1' YEAR
 GROUP BY
 	l_shipmode
 ORDER BY
@@ -423,7 +426,7 @@ FROM
 		FROM
 			customer LEFT OUTER JOIN orders ON
 				c_custkey = o_custkey
-				AND o_comment NOT LIKE '%special%deposits%'
+				AND o_comment NOT LIKE '%special%requests%'
 		GROUP BY
 			c_custkey
 	) AS c_orders
@@ -446,8 +449,8 @@ FROM
 	part
 WHERE
 	l_partkey = p_partkey
-	AND l_shipdate >= DATE '1997-04-01'
-	AND l_shipdate < DATE '1997-04-01' + INTERVAL '1' MONTH;
+	AND l_shipdate >= DATE '1995-09-01'
+	AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' MONTH;
 `
 
 	query15 = `
@@ -458,8 +461,8 @@ CREATE VIEW revenue0 (supplier_no, total_revenue) AS
 	FROM
 		lineitem
 	WHERE
-		l_shipdate >= DATE '1997-03-01'
-		AND l_shipdate < DATE '1997-03-01' + INTERVAL '3' MONTH
+		l_shipdate >= DATE '1996-01-01'
+		AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' MONTH
 	GROUP BY
 		l_suppkey;
 
@@ -497,9 +500,9 @@ FROM
 	part
 WHERE
 	p_partkey = ps_partkey
-	AND p_brand <> 'Brand#41'
-	AND p_type NOT LIKE 'ECONOMY BURNISHED%'
-	AND p_size IN (22, 33, 42, 5, 27, 49, 4, 18)
+	AND p_brand <> 'Brand#45'
+	AND p_type NOT LIKE 'MEDIUM POLISHED%'
+	AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
 	AND ps_suppkey NOT IN (
 		SELECT
 			s_suppkey
@@ -527,7 +530,7 @@ FROM
 	part
 WHERE
 	p_partkey = l_partkey
-	AND p_brand = 'Brand#14'
+	AND p_brand = 'Brand#23'
 	AND p_container = 'MED BOX'
 	AND l_quantity < (
 		SELECT
@@ -559,7 +562,7 @@ WHERE
 			lineitem
 		GROUP BY
 			l_orderkey HAVING
-				sum(l_quantity) > 314
+				sum(l_quantity) > 300
 	)
 	AND c_custkey = o_custkey
 	AND o_orderkey = l_orderkey
@@ -571,7 +574,8 @@ GROUP BY
 	o_totalprice
 ORDER BY
 	o_totalprice DESC,
-	o_orderdate;
+	o_orderdate
+LIMIT 100;
 `
 
 	query19 = `
@@ -583,9 +587,9 @@ FROM
 WHERE
 	(
 		p_partkey = l_partkey
-		AND p_brand = 'Brand#34'
+		AND p_brand = 'Brand#12'
 		AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
-		AND l_quantity >= 5 AND l_quantity <= 5 + 10
+		AND l_quantity >= 1 AND l_quantity <= 1 + 10
 		AND p_size BETWEEN 1 AND 5
 		AND l_shipmode IN ('AIR', 'AIR REG')
 		AND l_shipinstruct = 'DELIVER IN PERSON'
@@ -593,9 +597,9 @@ WHERE
 	OR
 	(
 		p_partkey = l_partkey
-		AND p_brand = 'Brand#51'
+		AND p_brand = 'Brand#23'
 		AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
-		AND l_quantity >= 12 AND l_quantity <= 12 + 10
+		AND l_quantity >= 10 AND l_quantity <= 10 + 10
 		AND p_size BETWEEN 1 AND 10
 		AND l_shipmode IN ('AIR', 'AIR REG')
 		AND l_shipinstruct = 'DELIVER IN PERSON'
@@ -603,9 +607,9 @@ WHERE
 	OR
 	(
 		p_partkey = l_partkey
-		AND p_brand = 'Brand#35'
+		AND p_brand = 'Brand#34'
 		AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
-		AND l_quantity >= 30 AND l_quantity <= 30 + 10
+		AND l_quantity >= 20 AND l_quantity <= 20 + 10
 		AND p_size BETWEEN 1 AND 15
 		AND l_shipmode IN ('AIR', 'AIR REG')
 		AND l_shipinstruct = 'DELIVER IN PERSON'
@@ -632,7 +636,7 @@ WHERE
 				FROM
 					part
 				WHERE
-					p_name LIKE 'orange%'
+					p_name LIKE 'forest%'
 			)
 			AND ps_availqty > (
 				SELECT
@@ -642,12 +646,12 @@ WHERE
 				WHERE
 					l_partkey = ps_partkey
 					AND l_suppkey = ps_suppkey
-					AND l_shipdate >= DATE '1997-01-01'
-					AND l_shipdate < DATE '1997-01-01' + INTERVAL '1' YEAR
+					AND l_shipdate >= DATE '1994-01-01'
+					AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR
 			)
 	)
 	AND s_nationkey = n_nationkey
-	AND n_name = 'ALGERIA'
+	AND n_name = 'CANADA'
 ORDER BY
 	s_name;
 `
@@ -691,7 +695,8 @@ GROUP BY
 	s_name
 ORDER BY
 	numwait DESC,
-	s_name;
+	s_name
+LIMIT 100;
 `
 
 	query22 = `
@@ -708,7 +713,7 @@ FROM
 			customer
 		WHERE
 			substring(c_phone FROM 1 FOR 2) in
-				('20', '32', '44', '33', '29', '22', '31')
+        ('13', '31', '23', '29', '30', '18', '17')
 			AND c_acctbal > (
 				SELECT
 					avg(c_acctbal)
@@ -717,7 +722,7 @@ FROM
 				WHERE
 					c_acctbal > 0.00
 					AND substring(c_phone FROM 1 FOR 2) in
-						('20', '32', '44', '33', '29', '22', '31')
+            ('13', '31', '23', '29', '30', '18', '17')
 			)
 			AND NOT EXISTS (
 				SELECT

--- a/pkg/workload/tpch/tpch.go
+++ b/pkg/workload/tpch/tpch.go
@@ -88,15 +88,6 @@ func (w *tpch) Hooks() workload.Hooks {
 	return workload.Hooks{
 		Validate: func() error {
 			for _, queryName := range strings.Split(w.queriesRaw, `,`) {
-				queryName = strings.TrimSpace(queryName)
-				switch queryName {
-				case `2`, `4`, `13`, `16`, `17`, `18`, `20`, `21`, `22`:
-					return errors.Errorf(`query is unsupported: %s`, queryName)
-				case `5`, `6`, `10`, `12`, `14`:
-					return errors.Errorf(`query causes Cockroach panic (see #13692): %s`, queryName)
-				case `11`:
-					return errors.Errorf(`group with having not supported yet: %s`, queryName)
-				}
 				if _, ok := queriesByName[queryName]; !ok {
 					return errors.Errorf(`unknown query: %s`, queryName)
 				}


### PR DESCRIPTION
Our tpch queries previously used some variable values in the queries
that weren't exactly the sample values given by the spec, which was
confusing since everybody else on the internet uses those sample values.

http://www.tpc.org/tpc_documents_current_versions/pdf/tpc-h_v2.17.1.pdf

Update the queries to use those values. Also, add the LIMIT clauses
where they were missing, and remove the "unsupported" messages for
queries - we support them all now.

Release note: None