### PR TITLE
kv: clean up and better document txnInterceptor stack

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -150,10 +150,10 @@ type TxnCoordSender struct {
 	interceptorAlloc struct {
 		arr [6]txnInterceptor
 		txnHeartbeater
+		txnSeqNumAllocator
 		txnIntentCollector
 		txnPipeliner
 		txnSpanRefresher
-		txnSeqNumAllocator
 		txnMetricRecorder
 		txnLockGatekeeper // not in interceptorStack array.
 	}
@@ -409,7 +409,8 @@ func (tcf *TxnCoordSenderFactory) TransactionalSender(
 	// this stack are pre-allocated on the TxnCoordSender struct, so this just
 	// initializes the interceptors and pieces them together. It then adds a
 	// txnLockGatekeeper at the bottom of the stack to connect it with the
-	// TxnCoordSender's wrapped sender.
+	// TxnCoordSender's wrapped sender. First, each of the interceptor objects
+	// is initialized.
 	var ri *RangeIterator
 	if ds, ok := tcf.wrapped.(*DistSender); ok {
 		ri = NewRangeIterator(ds)
@@ -427,10 +428,14 @@ func (tcf *TxnCoordSenderFactory) TransactionalSender(
 			tcs.stopper,
 			tcs.cleanupTxnLocked,
 		)
-		tcs.interceptorAlloc.txnMetricRecorder.init(&tcs.mu.txn, tcs.clock, &tcs.metrics)
 		tcs.interceptorAlloc.txnIntentCollector = txnIntentCollector{
 			st: tcf.st,
 			ri: ri,
+		}
+		tcs.interceptorAlloc.txnMetricRecorder = txnMetricRecorder{
+			metrics: &tcs.metrics,
+			clock:   tcs.clock,
+			txn:     &tcs.mu.txn,
 		}
 	}
 	tcs.interceptorAlloc.txnPipeliner = txnPipeliner{
@@ -448,31 +453,51 @@ func (tcf *TxnCoordSenderFactory) TransactionalSender(
 	}
 	tcs.interceptorAlloc.txnLockGatekeeper = txnLockGatekeeper{
 		wrapped: tcs.wrapped,
-		mu:      &tcs.mu,
+		mu:      &tcs.mu.Mutex,
 	}
-	if typ == client.RootTxn {
+
+	// Once the interceptors are initialized, piece them all together in the
+	// correct order.
+	switch typ {
+	case client.RootTxn:
 		tcs.interceptorAlloc.arr = [...]txnInterceptor{
 			&tcs.interceptorAlloc.txnHeartbeater,
-			// The seq num allocator is below the txnHeartbeater so that it sees the
-			// BeginTransaction prepended by that interceptor. (An alternative would
-			// be to not assign seq nums to BeginTransaction; it doesn't need it.)
-			// Note though that it skips assigning seq nums to heartbeats.
+			// Various interceptors below rely on sequence number allocation,
+			// so the sequence number allocator is near the top of the stack.
 			&tcs.interceptorAlloc.txnSeqNumAllocator,
 			&tcs.interceptorAlloc.txnIntentCollector,
+			// The pipelinger sits above the span refresher because it will
+			// never generate transaction retry errors that could be avoided
+			// with a refresh.
 			&tcs.interceptorAlloc.txnPipeliner,
+			// The span refresher may resend entire batches to avoid transaction
+			// retries. Because of that, we need to be careful which interceptors
+			// sit below it in the stack.
 			&tcs.interceptorAlloc.txnSpanRefresher,
+			// The metrics recorder sits at the bottom of the stack so that it
+			// can observe all transformations performed by other interceptors.
 			&tcs.interceptorAlloc.txnMetricRecorder,
 		}
 		tcs.interceptorStack = tcs.interceptorAlloc.arr[:]
-	} else {
+	case client.LeafTxn:
+		// LeafTxns never perform writes so the sequence number allocator should
+		// never increment its sequence number counter over its lifetime, but it
+		// still plays the important role of assigning each read request the
+		// latest sequence number.
 		tcs.interceptorAlloc.arr[0] = &tcs.interceptorAlloc.txnSeqNumAllocator
+		// The pipeliner is needed on leaves to ensure that in-flight writes are
+		// chained onto by reads that should see them.
 		tcs.interceptorAlloc.arr[1] = &tcs.interceptorAlloc.txnPipeliner
-		// The txnSpanRefresher was configured above to not actually perform
-		// refreshes for leaves. It is still needed for accumulating the spans to be
-		// reported to the Root. But the gateway doesn't do much with them; see
-		// #24798.
+		// The span refresher was configured above to not actually perform
+		// refreshes for leaves. It is still needed for accumulating the spans
+		// to be reported to the Root. But the gateway doesn't do much with
+		// them; see #24798.
 		tcs.interceptorAlloc.arr[2] = &tcs.interceptorAlloc.txnSpanRefresher
+		// All other interceptors are absent from a LeafTxn's interceptor stack
+		// because they do not serve a role on leaves.
 		tcs.interceptorStack = tcs.interceptorAlloc.arr[:3]
+	default:
+		panic(fmt.Sprintf("unknown TxnType %v", typ))
 	}
 	for i, reqInt := range tcs.interceptorStack {
 		if i < len(tcs.interceptorStack)-1 {

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -206,14 +206,8 @@ type txnInterceptor interface {
 	epochBumpedLocked()
 
 	// closeLocked closes the interceptor. It is called when the TxnCoordSender
-	// shuts down due to either a txn commit or a txn abort.
-	//
-	// This method can be called multiple times (e.g. if the txn is aborted by the
-	// heartbeat loop and then upon a client rollback); implementers beware.
-	//
-	// Note that EndTransaction(commit=false) requests can still be sent (via the
-	// lockedSender interface) after this is called, and they're expected to be
-	// forwarded along. The idea for this method is to stop background tasks.
+	// shuts down due to either a txn commit or a txn abort. The method will
+	// be called exactly once from cleanupTxnLocked.
 	closeLocked()
 }
 

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -154,7 +154,7 @@ type TxnCoordSender struct {
 		txnPipeliner
 		txnSpanRefresher
 		txnSeqNumAllocator
-		txnMetrics
+		txnMetricRecorder
 		txnLockGatekeeper // not in interceptorStack array.
 	}
 
@@ -433,7 +433,7 @@ func (tcf *TxnCoordSenderFactory) TransactionalSender(
 			tcs.stopper,
 			tcs.cleanupTxnLocked,
 		)
-		tcs.interceptorAlloc.txnMetrics.init(&tcs.mu.txn, tcs.clock, &tcs.metrics)
+		tcs.interceptorAlloc.txnMetricRecorder.init(&tcs.mu.txn, tcs.clock, &tcs.metrics)
 		tcs.interceptorAlloc.txnIntentCollector = txnIntentCollector{
 			st: tcf.st,
 			ri: ri,
@@ -467,7 +467,7 @@ func (tcf *TxnCoordSenderFactory) TransactionalSender(
 			&tcs.interceptorAlloc.txnIntentCollector,
 			&tcs.interceptorAlloc.txnPipeliner,
 			&tcs.interceptorAlloc.txnSpanRefresher,
-			&tcs.interceptorAlloc.txnMetrics,
+			&tcs.interceptorAlloc.txnMetricRecorder,
 		}
 		tcs.interceptorStack = tcs.interceptorAlloc.arr[:]
 	} else {

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -73,7 +73,7 @@ func makeTS(walltime int64, logical int32) hlc.Timestamp {
 func (tc *TxnCoordSender) isTracking() bool {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
-	return tc.interceptorAlloc.txnHeartbeat.mu.txnEnd != nil
+	return tc.interceptorAlloc.txnHeartbeater.mu.txnEnd != nil
 }
 
 // Test that the Transaction.Writing flag is set after performing any writes.
@@ -2333,7 +2333,7 @@ func TestAnchorKey(t *testing.T) {
 // TestCommitTurnedToRollback tests that the TxnCoordSender (or, rather, one of
 // the interceptors) turns a commit into a rollback in situations where a txn
 // has performed writes at old epochs but no writes at the current epoch. See
-// the comment in txnHeartbeat about why this is needed.
+// the comment in txnHeartbeater about why this is needed.
 // We check that the transformation happened (by looking at a trace) and that
 // other things (e.g. the proto status) look like a committed transaction even
 // though we technically performed a rollback.

--- a/pkg/kv/txn_interceptor_heartbeater.go
+++ b/pkg/kv/txn_interceptor_heartbeater.go
@@ -28,17 +28,42 @@ import (
 )
 
 const (
-	turningCommitToRollbackMsg string = "Turning commit to rollback. All writes are part of old epochs."
+	turningCommitToRollbackMsg = "Turning commit to rollback. All writes are part of old epochs."
 )
 
-// txnHeartbeat is a txnInterceptor in charge of the txn's heartbeat loop.
-// The heartbeat loop is started upon the first write. txnHeartbeat is also in
-// charge of prepending a BeginTransaction to the first write batch and possibly
-// eliding EndTransaction requests on read-only transactions.
+// txnHeartbeater is a txnInterceptor in charge of a transaction's heartbeat
+// loop. Transaction coordinators heartbeat their transaction record
+// periodically to indicate the liveness of their transaction. Other actors like
+// concurrent transactions and GC processes observe a transaction record's last
+// heartbeat time to learn about its disposition and to determine whether it
+// should be considered abandoned. When a transaction is considered abandoned,
+// other actors are free to abort it at will. As such, it is important for a
+// transaction coordinator to heartbeat its transaction record with a
+// periodicity well below the abandonment threshold.
 //
-// txnHeartbeat should only be used for root transactions; leafs don't perform
-// writes and don't need any of the functionality here.
-type txnHeartbeat struct {
+// Transaction coordinators only need to perform heartbeats for transactions
+// that risk running for longer than the abandonment duration. For transactions
+// that finish well beneath this time, a heartbeat will never be sent and the
+// EndTransaction request will create and immediately finalize the transaction.
+// However, for transactions that live long enough that they risk running into
+// issues with other's perceiving them as abandoned, the first HeartbeatTxn
+// request they send will create the transaction record in the PENDING state.
+// Future heartbeats will update the transaction record to indicate
+// progressively larger heartbeat timestamps.
+//
+// NOTE: there are other mechanisms by which concurrent actors could determine
+// the liveness of transactions. One proposal is to have concurrent actors
+// communicate directly with transaction coordinators themselves. This would
+// avoid the need for transaction heartbeats and the PENDING transaction state
+// entirely. Another proposal is to detect abandoned transactions and failed
+// coordinators at an entirely different level - by maintaining a node health
+// plane. This would function under the idea that if the node a transaction's
+// coordinator is running on is alive then that transaction is still in-progress
+// unless it specifies otherwise. These are both approaches we could consider in
+// the future.
+//
+// TODO(nvanbenschoten): Unit test this file.
+type txnHeartbeater struct {
 	log.AmbientContext
 
 	// wrapped is the next sender in the stack
@@ -111,9 +136,9 @@ type txnHeartbeat struct {
 	}
 }
 
-// init initializes the txnHeartbeat. This method exists instead of a
-// constructor because txnHeartbeats live in a pool in the TxnCoordSender.
-func (h *txnHeartbeat) init(
+// init initializes the txnHeartbeater. This method exists instead of a
+// constructor because txnHeartbeaters live in a pool in the TxnCoordSender.
+func (h *txnHeartbeater) init(
 	mu sync.Locker,
 	txn *roachpb.Transaction,
 	st *cluster.Settings,
@@ -137,7 +162,7 @@ func (h *txnHeartbeat) init(
 }
 
 // SendLocked is part of the txnInteceptor interface.
-func (h *txnHeartbeat) SendLocked(
+func (h *txnHeartbeater) SendLocked(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	// If finalErr is set, we reject everything but rollbacks.
@@ -323,23 +348,23 @@ func (h *txnHeartbeat) SendLocked(
 }
 
 // setWrapped is part of the txnInteceptor interface.
-func (h *txnHeartbeat) setWrapped(wrapped lockedSender) {
+func (h *txnHeartbeater) setWrapped(wrapped lockedSender) {
 	h.wrapped = wrapped
 }
 
 // populateMetaLocked is part of the txnInteceptor interface.
-func (h *txnHeartbeat) populateMetaLocked(*roachpb.TxnCoordMeta) {}
+func (h *txnHeartbeater) populateMetaLocked(*roachpb.TxnCoordMeta) {}
 
 // augmentMetaLocked is part of the txnInteceptor interface.
-func (h *txnHeartbeat) augmentMetaLocked(roachpb.TxnCoordMeta) {}
+func (h *txnHeartbeater) augmentMetaLocked(roachpb.TxnCoordMeta) {}
 
 // epochBumpedLocked is part of the txnInteceptor interface.
-func (h *txnHeartbeat) epochBumpedLocked() {
+func (h *txnHeartbeater) epochBumpedLocked() {
 	h.mu.needBeginTxn = true
 }
 
 // closeLocked is part of the txnInteceptor interface.
-func (h *txnHeartbeat) closeLocked() {
+func (h *txnHeartbeater) closeLocked() {
 	// If the heartbeat loop has already finished, there's nothing more to do.
 	if h.mu.txnEnd == nil {
 		return
@@ -349,7 +374,7 @@ func (h *txnHeartbeat) closeLocked() {
 }
 
 // startHeartbeatLoopLocked starts a heartbeat loop in a different goroutine.
-func (h *txnHeartbeat) startHeartbeatLoopLocked(ctx context.Context) error {
+func (h *txnHeartbeater) startHeartbeatLoopLocked(ctx context.Context) error {
 	if h.mu.txnEnd != nil {
 		log.Fatal(ctx, "attempting to start a second heartbeat loop ")
 	}
@@ -374,7 +399,7 @@ func (h *txnHeartbeat) startHeartbeatLoopLocked(ctx context.Context) error {
 // heartbeatLoop periodically sends a HeartbeatTxn request to the transaction
 // record, stopping in the event the transaction is aborted or committed after
 // attempting to resolve the intents.
-func (h *txnHeartbeat) heartbeatLoop(ctx context.Context) {
+func (h *txnHeartbeater) heartbeatLoop(ctx context.Context) {
 	var tickChan <-chan time.Time
 	{
 		ticker := time.NewTicker(h.heartbeatInterval)
@@ -417,7 +442,7 @@ func (h *txnHeartbeat) heartbeatLoop(ctx context.Context) {
 			}
 		case <-closer:
 			// Transaction finished normally.
-			finalErr = roachpb.NewErrorf("txnHeartbeat already closed")
+			finalErr = roachpb.NewErrorf("txnHeartbeater already closed")
 			return
 		case <-h.stopper.ShouldQuiesce():
 			finalErr = roachpb.NewErrorf("node already quiescing")
@@ -431,7 +456,7 @@ func (h *txnHeartbeat) heartbeatLoop(ctx context.Context) {
 // update the txn. Other errors are swallowed.
 // Returns true if heartbeating should continue, false if the transaction is no
 // longer Pending and so there's no point in heartbeating further.
-func (h *txnHeartbeat) heartbeat(ctx context.Context) bool {
+func (h *txnHeartbeater) heartbeat(ctx context.Context) bool {
 	// Like with the TxnCoordSender, the locking here is peculiar. The lock is not
 	// held continuously throughout this method: we acquire the lock here and
 	// then, inside the wrapped.Send() call, the interceptor at the bottom of the
@@ -441,7 +466,7 @@ func (h *txnHeartbeat) heartbeat(ctx context.Context) bool {
 
 	// If the txn is no longer pending, there's nothing for us to heartbeat.
 	// This h.heartbeat() call could have raced with a response that updated the
-	// status. That response is supposed to have closed the txnHeartbeat.
+	// status. That response is supposed to have closed the txnHeartbeater.
 	if h.mu.txn.Status != roachpb.PENDING {
 		if h.mu.txnEnd != nil {
 			log.Fatalf(ctx,
@@ -529,7 +554,7 @@ func (h *txnHeartbeat) heartbeat(ctx context.Context) bool {
 
 // abortTxnAsyncLocked send an EndTransaction(commmit=false) asynchronously.
 // The asyncAbortCallbackLocked callback is also called.
-func (h *txnHeartbeat) abortTxnAsyncLocked(ctx context.Context) {
+func (h *txnHeartbeater) abortTxnAsyncLocked(ctx context.Context) {
 	if h.mu.txn.Status != roachpb.ABORTED {
 		log.Fatalf(ctx, "abortTxnAsyncLocked called for non-aborted txn: %s", h.mu.txn)
 	}
@@ -552,7 +577,7 @@ func (h *txnHeartbeat) abortTxnAsyncLocked(ctx context.Context) {
 
 	log.VEventf(ctx, 2, "async abort for txn: %s", txn)
 	if err := h.stopper.RunAsyncTask(
-		ctx, "txnHeartbeat: aborting txn", func(ctx context.Context) {
+		ctx, "txnHeartbeater: aborting txn", func(ctx context.Context) {
 			// Send the abort request through the interceptor stack. This is important
 			// because we need the txnIntentCollector to append intents to the
 			// EndTransaction request.

--- a/pkg/kv/txn_interceptor_metric_recorder.go
+++ b/pkg/kv/txn_interceptor_metric_recorder.go
@@ -38,14 +38,6 @@ type txnMetricRecorder struct {
 	onePCCommit   bool
 }
 
-// init initializes the txnMetricRecorder. This method exists instead of a
-// constructor because txnMetricRecorder lives in a pool in the TxnCoordSender.
-func (m *txnMetricRecorder) init(txn *roachpb.Transaction, clock *hlc.Clock, metrics *TxnMetrics) {
-	m.clock = clock
-	m.metrics = metrics
-	m.txn = txn
-}
-
 // SendLocked is part of the txnInterceptor interface.
 func (m *txnMetricRecorder) SendLocked(
 	ctx context.Context, ba roachpb.BatchRequest,

--- a/pkg/kv/txn_interceptor_metric_recorder.go
+++ b/pkg/kv/txn_interceptor_metric_recorder.go
@@ -36,7 +36,6 @@ type txnMetricRecorder struct {
 	txn           *roachpb.Transaction
 	txnStartNanos int64
 	onePCCommit   bool
-	closed        bool
 }
 
 // init initializes the txnMetricRecorder. This method exists instead of a
@@ -74,11 +73,6 @@ func (*txnMetricRecorder) epochBumpedLocked() {}
 
 // closeLocked is part of the txnInterceptor interface.
 func (m *txnMetricRecorder) closeLocked() {
-	if m.closed {
-		return
-	}
-	m.closed = true
-
 	if m.onePCCommit {
 		m.metrics.Commits1PC.Inc(1)
 	}

--- a/pkg/kv/txn_interceptor_seq_num_allocator.go
+++ b/pkg/kv/txn_interceptor_seq_num_allocator.go
@@ -58,7 +58,6 @@ import (
 //    returned. Likewise, if an intent with the same sequence is present but its
 //    value is different than what we recompute, an error is returned.
 //
-// TODO(nvanbenschoten): Unit test this file.
 type txnSeqNumAllocator struct {
 	wrapped lockedSender
 	seqGen  int32

--- a/pkg/kv/txn_interceptor_seq_num_allocator_test.go
+++ b/pkg/kv/txn_interceptor_seq_num_allocator_test.go
@@ -1,0 +1,254 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package kv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func makeMockTxnSeqNumAllocator() (txnSeqNumAllocator, *mockLockedSender) {
+	mockSender := &mockLockedSender{}
+	return txnSeqNumAllocator{
+		wrapped: mockSender,
+	}, mockSender
+}
+
+// TestSequenceNumberAllocation tests the basics of sequence number allocation.
+// It verifies that read-only requests are assigned the current largest sequence
+// number and that write requests are assigned a sequence number larger than any
+// previously allocated.
+func TestSequenceNumberAllocation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	s, mockSender := makeMockTxnSeqNumAllocator()
+
+	txn := makeTxnProto()
+	keyA, keyB := roachpb.Key("a"), roachpb.Key("b")
+
+	// Read-only requests are not given unique sequence numbers.
+	var ba roachpb.BatchRequest
+	ba.Header = roachpb.Header{Txn: &txn}
+	ba.Add(&roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.ScanRequest{RequestHeader: roachpb.RequestHeader{Key: keyA, EndKey: keyB}})
+
+	mockSender.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		require.Equal(t, 2, len(ba.Requests))
+		require.Equal(t, int32(0), ba.Requests[0].GetInner().Header().Sequence)
+		require.Equal(t, int32(0), ba.Requests[1].GetInner().Header().Sequence)
+
+		br := ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr := s.SendLocked(ctx, ba)
+	require.NotNil(t, br)
+	require.Nil(t, pErr)
+
+	// Write requests each get a unique sequence number.
+	ba.Requests = nil
+	ba.Add(&roachpb.ConditionalPutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.InitPutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.ScanRequest{RequestHeader: roachpb.RequestHeader{Key: keyA, EndKey: keyB}})
+
+	mockSender.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		require.Equal(t, 4, len(ba.Requests))
+		require.Equal(t, int32(1), ba.Requests[0].GetInner().Header().Sequence)
+		require.Equal(t, int32(1), ba.Requests[1].GetInner().Header().Sequence)
+		require.Equal(t, int32(2), ba.Requests[2].GetInner().Header().Sequence)
+		require.Equal(t, int32(2), ba.Requests[3].GetInner().Header().Sequence)
+
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr = s.SendLocked(ctx, ba)
+	require.NotNil(t, br)
+	require.Nil(t, pErr)
+
+	// EndTransaction requests also get a unique sequence number.
+	ba.Requests = nil
+	ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.ScanRequest{RequestHeader: roachpb.RequestHeader{Key: keyA, EndKey: keyB}})
+	ba.Add(&roachpb.EndTransactionRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+
+	mockSender.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		require.Equal(t, 3, len(ba.Requests))
+		require.Equal(t, int32(3), ba.Requests[0].GetInner().Header().Sequence)
+		require.Equal(t, int32(3), ba.Requests[1].GetInner().Header().Sequence)
+		require.Equal(t, int32(4), ba.Requests[2].GetInner().Header().Sequence)
+
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr = s.SendLocked(ctx, ba)
+	require.NotNil(t, br)
+	require.Nil(t, pErr)
+}
+
+// TestSequenceNumberAllocationTxnRequests tests sequence number allocation's
+// interaction with transaction state requests (BeginTxn, HeartbeatTxn, and
+// EndTxn). Only EndTxn requests should be assigned unique sequence numbers.
+func TestSequenceNumberAllocationTxnRequests(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	s, mockSender := makeMockTxnSeqNumAllocator()
+
+	txn := makeTxnProto()
+	keyA := roachpb.Key("a")
+
+	var ba roachpb.BatchRequest
+	ba.Header = roachpb.Header{Txn: &txn}
+	ba.Add(&roachpb.BeginTransactionRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.HeartbeatTxnRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.EndTransactionRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+
+	mockSender.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		require.Equal(t, 3, len(ba.Requests))
+		require.Equal(t, int32(0), ba.Requests[0].GetInner().Header().Sequence)
+		require.Equal(t, int32(0), ba.Requests[1].GetInner().Header().Sequence)
+		require.Equal(t, int32(1), ba.Requests[2].GetInner().Header().Sequence)
+
+		br := ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr := s.SendLocked(ctx, ba)
+	require.NotNil(t, br)
+	require.Nil(t, pErr)
+}
+
+// TestSequenceNumberAllocationAfterEpochBump tests that sequence number
+// allocation resets to zero after an transaction epoch bump.
+func TestSequenceNumberAllocationAfterEpochBump(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	s, mockSender := makeMockTxnSeqNumAllocator()
+
+	txn := makeTxnProto()
+	keyA, keyB := roachpb.Key("a"), roachpb.Key("b")
+
+	// Perform a few writes to increase the sequence number counter.
+	var ba roachpb.BatchRequest
+	ba.Header = roachpb.Header{Txn: &txn}
+	ba.Add(&roachpb.ConditionalPutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.InitPutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+
+	mockSender.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		require.Equal(t, 3, len(ba.Requests))
+		require.Equal(t, int32(1), ba.Requests[0].GetInner().Header().Sequence)
+		require.Equal(t, int32(1), ba.Requests[1].GetInner().Header().Sequence)
+		require.Equal(t, int32(2), ba.Requests[2].GetInner().Header().Sequence)
+
+		br := ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr := s.SendLocked(ctx, ba)
+	require.NotNil(t, br)
+	require.Nil(t, pErr)
+
+	// Bump the transaction's epoch.
+	s.epochBumpedLocked()
+
+	// Perform a few more writes. The sequence numbers assigned to requests
+	// should have started back at zero again.
+	ba.Requests = nil
+	ba.Add(&roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.ConditionalPutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.ScanRequest{RequestHeader: roachpb.RequestHeader{Key: keyA, EndKey: keyB}})
+	ba.Add(&roachpb.InitPutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+
+	mockSender.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		require.Equal(t, 4, len(ba.Requests))
+		require.Equal(t, int32(0), ba.Requests[0].GetInner().Header().Sequence)
+		require.Equal(t, int32(1), ba.Requests[1].GetInner().Header().Sequence)
+		require.Equal(t, int32(1), ba.Requests[2].GetInner().Header().Sequence)
+		require.Equal(t, int32(2), ba.Requests[3].GetInner().Header().Sequence)
+
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr = s.SendLocked(ctx, ba)
+	require.NotNil(t, br)
+	require.Nil(t, pErr)
+}
+
+// TestSequenceNumberAllocationAfterAugmentation tests that the sequence number
+// allocator updates its sequence counter based on the provided TxnCoordMeta.
+func TestSequenceNumberAllocationAfterAugmentation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	s, mockSender := makeMockTxnSeqNumAllocator()
+
+	txn := makeTxnProto()
+	keyA := roachpb.Key("a")
+
+	// Create a TxnCoordMeta object. This simulates the interceptor living
+	// on a Leaf transaction coordinator and being initialized by the Root
+	// coordinator.
+	var inMeta roachpb.TxnCoordMeta
+	inMeta.Txn.Sequence = 4
+	s.augmentMetaLocked(inMeta)
+
+	// Ensure that the update round-trips.
+	var outMeta roachpb.TxnCoordMeta
+	s.populateMetaLocked(&outMeta)
+	require.Equal(t, int32(4), outMeta.Txn.Sequence)
+
+	// Perform a few reads and writes. The sequence numbers assigned should
+	// start at the sequence number provided in the TxnCoordMeta.
+	var ba roachpb.BatchRequest
+	ba.Header = roachpb.Header{Txn: &txn}
+	ba.Add(&roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.ConditionalPutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.GetRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+	ba.Add(&roachpb.InitPutRequest{RequestHeader: roachpb.RequestHeader{Key: keyA}})
+
+	mockSender.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		require.Equal(t, 4, len(ba.Requests))
+		require.Equal(t, int32(4), ba.Requests[0].GetInner().Header().Sequence)
+		require.Equal(t, int32(5), ba.Requests[1].GetInner().Header().Sequence)
+		require.Equal(t, int32(5), ba.Requests[2].GetInner().Header().Sequence)
+		require.Equal(t, int32(6), ba.Requests[3].GetInner().Header().Sequence)
+
+		br := ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr := s.SendLocked(ctx, ba)
+	require.NotNil(t, br)
+	require.Nil(t, pErr)
+
+	// Ensure that the updated sequence counter is reflected in a TxnCoordMeta.
+	outMeta = roachpb.TxnCoordMeta{}
+	s.populateMetaLocked(&outMeta)
+	require.Equal(t, int32(6), outMeta.Txn.Sequence)
+}

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1044,10 +1044,7 @@ func (*ResolveIntentRequest) flags() int      { return isWrite }
 func (*ResolveIntentRangeRequest) flags() int { return isWrite | isRange }
 func (*TruncateLogRequest) flags() int        { return isWrite }
 func (*MergeRequest) flags() int              { return isWrite }
-
-func (*RequestLeaseRequest) flags() int {
-	return isWrite | isAlone | skipLeaseCheck
-}
+func (*RequestLeaseRequest) flags() int       { return isWrite | isAlone | skipLeaseCheck }
 
 // LeaseInfoRequest is usually executed in an INCONSISTENT batch, which has the
 // effect of the `skipLeaseCheck` flag that lease write operations have.
@@ -1091,8 +1088,7 @@ func (r *RefreshRangeRequest) flags() int {
 	return isRead | isTxn | isRange | updatesReadTSCache
 }
 
-func (*SubsumeRequest) flags() int { return isRead | isAlone | updatesReadTSCache }
-
+func (*SubsumeRequest) flags() int    { return isRead | isAlone | updatesReadTSCache }
 func (*RangeStatsRequest) flags() int { return isRead }
 
 // Keys returns credentials in an aws.Config.

--- a/pkg/roachpb/errors.pb.go
+++ b/pkg/roachpb/errors.pb.go
@@ -114,7 +114,7 @@ func (x *TransactionAbortedReason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionAbortedReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{0}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{0}
 }
 
 // TransactionRetryReason specifies what caused a transaction retry.
@@ -167,7 +167,7 @@ func (x *TransactionRetryReason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionRetryReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{1}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{1}
 }
 
 // TransactionRestart indicates how an error should be handled in a
@@ -175,11 +175,11 @@ func (TransactionRetryReason) EnumDescriptor() ([]byte, []int) {
 type TransactionRestart int32
 
 const (
-	//  NONE (the default) is used for errors which have no effect on the
-	//  transaction state. That is, a transactional operation which receives such
-	//  an error is still PENDING and does not need to restart (at least not as a
-	//  result of the error). Examples are a CPut whose condition wasn't met, or
-	//  a spurious RPC error.
+	// NONE (the default) is used for errors which have no effect on the
+	// transaction state. That is, a transactional operation which receives such
+	// an error is still PENDING and does not need to restart (at least not as a
+	// result of the error). Examples are a CPut whose condition wasn't met, or
+	// a spurious RPC error.
 	TransactionRestart_NONE TransactionRestart = 0
 	// BACKOFF is for errors that can retried by restarting the transaction
 	// after an exponential backoff.
@@ -218,7 +218,7 @@ func (x *TransactionRestart) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionRestart) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{2}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{2}
 }
 
 // Reason specifies what caused the error.
@@ -261,7 +261,7 @@ func (x *TransactionStatusError_Reason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (TransactionStatusError_Reason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{9, 0}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{9, 0}
 }
 
 // Reason specifies what caused the error.
@@ -317,7 +317,7 @@ func (x *RangeFeedRetryError_Reason) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (RangeFeedRetryError_Reason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{29, 0}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{29, 0}
 }
 
 // A NotLeaseHolderError indicates that the current range is not the lease
@@ -346,7 +346,7 @@ func (m *NotLeaseHolderError) Reset()         { *m = NotLeaseHolderError{} }
 func (m *NotLeaseHolderError) String() string { return proto.CompactTextString(m) }
 func (*NotLeaseHolderError) ProtoMessage()    {}
 func (*NotLeaseHolderError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{0}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{0}
 }
 func (m *NotLeaseHolderError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -383,7 +383,7 @@ func (m *NodeUnavailableError) Reset()         { *m = NodeUnavailableError{} }
 func (m *NodeUnavailableError) String() string { return proto.CompactTextString(m) }
 func (*NodeUnavailableError) ProtoMessage()    {}
 func (*NodeUnavailableError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{1}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{1}
 }
 func (m *NodeUnavailableError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -419,7 +419,7 @@ func (m *UnsupportedRequestError) Reset()         { *m = UnsupportedRequestError
 func (m *UnsupportedRequestError) String() string { return proto.CompactTextString(m) }
 func (*UnsupportedRequestError) ProtoMessage()    {}
 func (*UnsupportedRequestError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{2}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{2}
 }
 func (m *UnsupportedRequestError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -458,7 +458,7 @@ func (m *RangeNotFoundError) Reset()         { *m = RangeNotFoundError{} }
 func (m *RangeNotFoundError) String() string { return proto.CompactTextString(m) }
 func (*RangeNotFoundError) ProtoMessage()    {}
 func (*RangeNotFoundError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{3}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{3}
 }
 func (m *RangeNotFoundError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -504,7 +504,7 @@ func (m *RangeKeyMismatchError) Reset()         { *m = RangeKeyMismatchError{} }
 func (m *RangeKeyMismatchError) String() string { return proto.CompactTextString(m) }
 func (*RangeKeyMismatchError) ProtoMessage()    {}
 func (*RangeKeyMismatchError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{4}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{4}
 }
 func (m *RangeKeyMismatchError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -552,7 +552,7 @@ func (m *ReadWithinUncertaintyIntervalError) Reset()         { *m = ReadWithinUn
 func (m *ReadWithinUncertaintyIntervalError) String() string { return proto.CompactTextString(m) }
 func (*ReadWithinUncertaintyIntervalError) ProtoMessage()    {}
 func (*ReadWithinUncertaintyIntervalError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{5}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{5}
 }
 func (m *ReadWithinUncertaintyIntervalError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -597,7 +597,7 @@ func (m *TransactionAbortedError) Reset()         { *m = TransactionAbortedError
 func (m *TransactionAbortedError) String() string { return proto.CompactTextString(m) }
 func (*TransactionAbortedError) ProtoMessage()    {}
 func (*TransactionAbortedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{6}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{6}
 }
 func (m *TransactionAbortedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -635,7 +635,7 @@ func (m *TransactionPushError) Reset()         { *m = TransactionPushError{} }
 func (m *TransactionPushError) String() string { return proto.CompactTextString(m) }
 func (*TransactionPushError) ProtoMessage()    {}
 func (*TransactionPushError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{7}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{7}
 }
 func (m *TransactionPushError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -672,7 +672,7 @@ func (m *TransactionRetryError) Reset()         { *m = TransactionRetryError{} }
 func (m *TransactionRetryError) String() string { return proto.CompactTextString(m) }
 func (*TransactionRetryError) ProtoMessage()    {}
 func (*TransactionRetryError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{8}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{8}
 }
 func (m *TransactionRetryError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -714,7 +714,7 @@ func (m *TransactionStatusError) Reset()         { *m = TransactionStatusError{}
 func (m *TransactionStatusError) String() string { return proto.CompactTextString(m) }
 func (*TransactionStatusError) ProtoMessage()    {}
 func (*TransactionStatusError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{9}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{9}
 }
 func (m *TransactionStatusError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -754,7 +754,7 @@ func (m *WriteIntentError) Reset()         { *m = WriteIntentError{} }
 func (m *WriteIntentError) String() string { return proto.CompactTextString(m) }
 func (*WriteIntentError) ProtoMessage()    {}
 func (*WriteIntentError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{10}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{10}
 }
 func (m *WriteIntentError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -794,7 +794,7 @@ func (m *WriteTooOldError) Reset()         { *m = WriteTooOldError{} }
 func (m *WriteTooOldError) String() string { return proto.CompactTextString(m) }
 func (*WriteTooOldError) ProtoMessage()    {}
 func (*WriteTooOldError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{11}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{11}
 }
 func (m *WriteTooOldError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -832,7 +832,7 @@ func (m *OpRequiresTxnError) Reset()         { *m = OpRequiresTxnError{} }
 func (m *OpRequiresTxnError) String() string { return proto.CompactTextString(m) }
 func (*OpRequiresTxnError) ProtoMessage()    {}
 func (*OpRequiresTxnError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{12}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{12}
 }
 func (m *OpRequiresTxnError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -871,7 +871,7 @@ func (m *ConditionFailedError) Reset()         { *m = ConditionFailedError{} }
 func (m *ConditionFailedError) String() string { return proto.CompactTextString(m) }
 func (*ConditionFailedError) ProtoMessage()    {}
 func (*ConditionFailedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{13}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{13}
 }
 func (m *ConditionFailedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -910,7 +910,7 @@ func (m *LeaseRejectedError) Reset()         { *m = LeaseRejectedError{} }
 func (m *LeaseRejectedError) String() string { return proto.CompactTextString(m) }
 func (*LeaseRejectedError) ProtoMessage()    {}
 func (*LeaseRejectedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{14}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{14}
 }
 func (m *LeaseRejectedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -947,7 +947,7 @@ func (m *SendError) Reset()         { *m = SendError{} }
 func (m *SendError) String() string { return proto.CompactTextString(m) }
 func (*SendError) ProtoMessage()    {}
 func (*SendError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{15}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{15}
 }
 func (m *SendError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -987,7 +987,7 @@ func (m *AmbiguousResultError) Reset()         { *m = AmbiguousResultError{} }
 func (m *AmbiguousResultError) String() string { return proto.CompactTextString(m) }
 func (*AmbiguousResultError) ProtoMessage()    {}
 func (*AmbiguousResultError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{16}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{16}
 }
 func (m *AmbiguousResultError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1023,7 +1023,7 @@ func (m *RaftGroupDeletedError) Reset()         { *m = RaftGroupDeletedError{} }
 func (m *RaftGroupDeletedError) String() string { return proto.CompactTextString(m) }
 func (*RaftGroupDeletedError) ProtoMessage()    {}
 func (*RaftGroupDeletedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{17}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{17}
 }
 func (m *RaftGroupDeletedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1063,7 +1063,7 @@ func (m *ReplicaCorruptionError) Reset()         { *m = ReplicaCorruptionError{}
 func (m *ReplicaCorruptionError) String() string { return proto.CompactTextString(m) }
 func (*ReplicaCorruptionError) ProtoMessage()    {}
 func (*ReplicaCorruptionError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{18}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{18}
 }
 func (m *ReplicaCorruptionError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1102,7 +1102,7 @@ func (m *ReplicaTooOldError) Reset()         { *m = ReplicaTooOldError{} }
 func (m *ReplicaTooOldError) String() string { return proto.CompactTextString(m) }
 func (*ReplicaTooOldError) ProtoMessage()    {}
 func (*ReplicaTooOldError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{19}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{19}
 }
 func (m *ReplicaTooOldError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1139,7 +1139,7 @@ func (m *StoreNotFoundError) Reset()         { *m = StoreNotFoundError{} }
 func (m *StoreNotFoundError) String() string { return proto.CompactTextString(m) }
 func (*StoreNotFoundError) ProtoMessage()    {}
 func (*StoreNotFoundError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{20}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{20}
 }
 func (m *StoreNotFoundError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1187,7 +1187,7 @@ func (m *UnhandledRetryableError) Reset()         { *m = UnhandledRetryableError
 func (m *UnhandledRetryableError) String() string { return proto.CompactTextString(m) }
 func (*UnhandledRetryableError) ProtoMessage()    {}
 func (*UnhandledRetryableError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{21}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{21}
 }
 func (m *UnhandledRetryableError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1241,7 +1241,7 @@ func (m *TransactionRetryWithProtoRefreshError) Reset()         { *m = Transacti
 func (m *TransactionRetryWithProtoRefreshError) String() string { return proto.CompactTextString(m) }
 func (*TransactionRetryWithProtoRefreshError) ProtoMessage()    {}
 func (*TransactionRetryWithProtoRefreshError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{22}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{22}
 }
 func (m *TransactionRetryWithProtoRefreshError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1281,7 +1281,7 @@ func (m *TxnAlreadyEncounteredErrorError) Reset()         { *m = TxnAlreadyEncou
 func (m *TxnAlreadyEncounteredErrorError) String() string { return proto.CompactTextString(m) }
 func (*TxnAlreadyEncounteredErrorError) ProtoMessage()    {}
 func (*TxnAlreadyEncounteredErrorError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{23}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{23}
 }
 func (m *TxnAlreadyEncounteredErrorError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1320,7 +1320,7 @@ func (m *IntegerOverflowError) Reset()         { *m = IntegerOverflowError{} }
 func (m *IntegerOverflowError) String() string { return proto.CompactTextString(m) }
 func (*IntegerOverflowError) ProtoMessage()    {}
 func (*IntegerOverflowError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{24}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{24}
 }
 func (m *IntegerOverflowError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1358,7 +1358,7 @@ func (m *MixedSuccessError) Reset()         { *m = MixedSuccessError{} }
 func (m *MixedSuccessError) String() string { return proto.CompactTextString(m) }
 func (*MixedSuccessError) ProtoMessage()    {}
 func (*MixedSuccessError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{25}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{25}
 }
 func (m *MixedSuccessError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1396,7 +1396,7 @@ func (m *BatchTimestampBeforeGCError) Reset()         { *m = BatchTimestampBefor
 func (m *BatchTimestampBeforeGCError) String() string { return proto.CompactTextString(m) }
 func (*BatchTimestampBeforeGCError) ProtoMessage()    {}
 func (*BatchTimestampBeforeGCError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{26}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{26}
 }
 func (m *BatchTimestampBeforeGCError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1435,7 +1435,7 @@ func (m *IntentMissingError) Reset()         { *m = IntentMissingError{} }
 func (m *IntentMissingError) String() string { return proto.CompactTextString(m) }
 func (*IntentMissingError) ProtoMessage()    {}
 func (*IntentMissingError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{27}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{27}
 }
 func (m *IntentMissingError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1474,7 +1474,7 @@ func (m *MergeInProgressError) Reset()         { *m = MergeInProgressError{} }
 func (m *MergeInProgressError) String() string { return proto.CompactTextString(m) }
 func (*MergeInProgressError) ProtoMessage()    {}
 func (*MergeInProgressError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{28}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{28}
 }
 func (m *MergeInProgressError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1511,7 +1511,7 @@ func (m *RangeFeedRetryError) Reset()         { *m = RangeFeedRetryError{} }
 func (m *RangeFeedRetryError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRetryError) ProtoMessage()    {}
 func (*RangeFeedRetryError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{29}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{29}
 }
 func (m *RangeFeedRetryError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1577,7 +1577,7 @@ func (m *ErrorDetail) Reset()         { *m = ErrorDetail{} }
 func (m *ErrorDetail) String() string { return proto.CompactTextString(m) }
 func (*ErrorDetail) ProtoMessage()    {}
 func (*ErrorDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{30}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{30}
 }
 func (m *ErrorDetail) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2537,7 +2537,7 @@ func (m *ErrPosition) Reset()         { *m = ErrPosition{} }
 func (m *ErrPosition) String() string { return proto.CompactTextString(m) }
 func (*ErrPosition) ProtoMessage()    {}
 func (*ErrPosition) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{31}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{31}
 }
 func (m *ErrPosition) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2593,7 +2593,7 @@ type Error struct {
 func (m *Error) Reset()      { *m = Error{} }
 func (*Error) ProtoMessage() {}
 func (*Error) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errors_62b74ae3fb677e28, []int{32}
+	return fileDescriptor_errors_2f91914b0d06d64b, []int{32}
 }
 func (m *Error) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -10599,9 +10599,9 @@ var (
 	ErrIntOverflowErrors   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/errors.proto", fileDescriptor_errors_62b74ae3fb677e28) }
+func init() { proto.RegisterFile("roachpb/errors.proto", fileDescriptor_errors_2f91914b0d06d64b) }
 
-var fileDescriptor_errors_62b74ae3fb677e28 = []byte{
+var fileDescriptor_errors_2f91914b0d06d64b = []byte{
 	// 2819 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x58, 0xcb, 0x6f, 0xe3, 0xd6,
 	0xd5, 0x17, 0x65, 0xd9, 0xb2, 0x8f, 0x5f, 0xf4, 0x1d, 0xc7, 0xc3, 0xf1, 0x64, 0x64, 0x8f, 0x27,

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -528,11 +528,11 @@ message ErrorDetail {
 // TransactionRestart indicates how an error should be handled in a
 // transactional context.
 enum TransactionRestart {
-  //  NONE (the default) is used for errors which have no effect on the
-  //  transaction state. That is, a transactional operation which receives such
-  //  an error is still PENDING and does not need to restart (at least not as a
-  //  result of the error). Examples are a CPut whose condition wasn't met, or
-  //  a spurious RPC error.
+  // NONE (the default) is used for errors which have no effect on the
+  // transaction state. That is, a transactional operation which receives such
+  // an error is still PENDING and does not need to restart (at least not as a
+  // result of the error). Examples are a CPut whose condition wasn't met, or
+  // a spurious RPC error.
   NONE = 0;
 
   // BACKOFF is for errors that can retried by restarting the transaction


### PR DESCRIPTION
This PR includes a series of cleanup steps surrounding the `TxnCoordSender` and the `txnInterceptor` stack. The primary goal of this was to unify the interceptors where possible and to improve their documentation. The PR also adds some missing unit tests and points out where more should be added.