### PR TITLE
release-2.1: sql: list only tables in pg_catalog.pg_tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1662,3 +1662,22 @@ SELECT conkey, confkey FROM pg_catalog.pg_constraint WHERE conname = 'my_fkey'
 ----
 conkey  confkey
 {1}     {1}
+
+subtest regression_34856
+
+statement ok
+CREATE DATABASE d34856
+
+statement ok
+CREATE TABLE d34856.t(x INT);
+  CREATE VIEW d34856.v AS SELECT x FROM d34856.t;
+  CREATE SEQUENCE d34856.s
+
+# Check that only tables show up in pg_tables.
+query T
+SELECT tablename FROM d34856.pg_catalog.pg_tables WHERE schemaname = 'public'
+----
+t
+
+statement ok
+DROP DATABASE d34856 CASCADE

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1880,7 +1880,7 @@ CREATE TABLE pg_catalog.pg_tables (
 		// schema/table names.
 		return forEachTableDesc(ctx, p, dbContext, virtualMany,
 			func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {
-				if table.IsView() {
+				if !table.IsTable() {
 					return nil
 				}
 				return addRow(


### PR DESCRIPTION
Backport 1/1 commits from #34857.

/cc @cockroachdb/release

---
