### PR TITLE
sql: use SQL views to implement pg_catalog views

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -233,9 +233,9 @@ query TTTTBBBB colnames
 SELECT * FROM constraint_db.pg_catalog.pg_tables WHERE schemaname = 'public'
 ----
 schemaname  tablename  tableowner  tablespace  hasindexes  hasrules  hastriggers  rowsecurity
-public      t1         NULL        NULL        true        false     false        false
-public      t2         NULL        NULL        true        false     false        false
-public      t3         NULL        NULL        true        false     false        false
+public      t1         NULL        pg_default  true        false     false        false
+public      t2         NULL        pg_default  true        false     false        false
+public      t3         NULL        pg_default  true        false     false        false
 
 query TB colnames
 SELECT tablename, hasindexes FROM pg_catalog.pg_tables WHERE schemaname = 'information_schema' AND tablename LIKE '%table%'
@@ -1537,7 +1537,7 @@ SET DATABASE = 'constraint_db'
 query I
 SELECT count(*) FROM pg_catalog.pg_tables WHERE schemaname='public'
 ----
-3
+0
 
 user root
 
@@ -1713,4 +1713,6 @@ CREATE TABLE d34856.t(x INT);
 query T
 SELECT tablename FROM d34856.pg_catalog.pg_tables WHERE schemaname = 'public'
 ----
-t
+coltab
+a
+b

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1698,3 +1698,19 @@ SELECT conkey, confkey FROM pg_catalog.pg_constraint WHERE conname = 'my_fkey'
 ----
 conkey  confkey
 {1}     {1}
+
+subtest regression_34856
+
+statement ok
+CREATE DATABASE d34856
+
+statement ok
+CREATE TABLE d34856.t(x INT);
+  CREATE VIEW d34856.v AS SELECT x FROM d34856.t;
+  CREATE SEQUENCE d34856.s
+
+# Check that only tables show up in pg_tables.
+query T
+SELECT tablename FROM d34856.pg_catalog.pg_tables WHERE schemaname = 'public'
+----
+t

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1899,7 +1899,7 @@ CREATE TABLE pg_catalog.pg_tables (
 		// schema/table names.
 		return forEachTableDesc(ctx, p, dbContext, virtualMany,
 			func(db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor) error {
-				if table.IsView() {
+				if !table.IsTable() {
 					return nil
 				}
 				return addRow(

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -169,7 +169,7 @@ func ShowCreateTable(
 		}
 		f.WriteString("\n\t")
 		f.WriteString(col.SQLString())
-		if desc.IsPhysicalTable() && desc.PrimaryIndex.ColumnIDs[0] == col.ID {
+		if len(desc.PrimaryIndex.ColumnIDs) > 0 && desc.PrimaryIndex.ColumnIDs[0] == col.ID {
 			// Only set primaryKeyIsOnVisibleColumn to true if the primary key
 			// is on a visible column (not rowid).
 			primaryKeyIsOnVisibleColumn = true


### PR DESCRIPTION
This aims to support the resolution of  #34776.

First commit from #34857.

Some items in PostgreSQL's `pg_catalog` schema are real tables; others
are actually views. For example, `pg_tables` is a view over
`pg_class`.

Now that CockroachDB supports views in virtual schemas, we should do
the same: it enables better optimizations and join eliminations for
introspection queries.

Unfortunately, this is (still) difficult to do because the content of
vtables is dependent on the database on which they are applied. For
example, `d1.pg_catalog.pg_tables` should only render tables in `d1`,
and `d2.pg_catalog.pg_tables` should only render tables in
d2. Conceptually, We need a different instance of the view in every
database. However, currently the vtable/vview objects are shared
between all databases.

This makes this patch (as-is) not-work. It needs to be extended before
the approach can be generalized.
