### PR TITLE
sql: don't hide children of rowSourceToPlanNode in UI

### DIFF
--- a/pkg/sql/explain_tree.go
+++ b/pkg/sql/explain_tree.go
@@ -47,6 +47,14 @@ import (
 func planToTree(ctx context.Context, top *planTop) *roachpb.ExplainTreePlanNode {
 	nodeStack := &planNodeStack{}
 	observer := planObserver{
+		// We set followRowSourceToPlanNode to true, to instruct the plan observer
+		// to follow the edges from rowSourceToPlanNodes (indicating that the prior
+		// node was not plannable by DistSQL) to the original planNodes that were
+		// replaced by DistSQL nodes. This prevents the walk from ending at these
+		// special replacement nodes.
+		// TODO(jordan): this is pretty hacky. We should modify DistSQL physical
+		//  planning to avoid mutating its input planNode tree instead.
+		followRowSourceToPlanNode: true,
 		enterNode: func(ctx context.Context, nodeName string, plan planNode) (bool, error) {
 			nodeStack.push(&roachpb.ExplainTreePlanNode{
 				Name: nodeName,


### PR DESCRIPTION
Previously, the explain tree walker used to generate UI-visible explain
trees didn't correctly interpret plans that had been modified due to
DistSQL physical planning, leading to confusing results. Now, the tree
walker will follow the entire plan, even if it had been partially
wrapped due to non distributable plans.

Release note: None