### PR TITLE
stats: don't reschedule automatic stats refreshes in case of error

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -337,7 +337,9 @@ func checkRunningJobs(ctx context.Context, job *jobs.Job, p *planner) error {
 
 			// This is not the first CreateStats job running. This job should fail
 			// so that the earlier job can succeed.
-			return errors.New("another CREATE STATISTICS job is already running")
+			return pgerror.NewError(
+				pgerror.CodeLockNotAvailableError, "another CREATE STATISTICS job is already running",
+			)
 		}
 	}
 	return nil


### PR DESCRIPTION
Prior to this commit, we would always reschedule an automatic stats
refresh if a previous attempt to refresh caused an error. However, this
could cause endless retries for permanent errors such as a dropped table.
This commit fixes the problem so that we only reschedule a refresh for
the error that happens when another stats job is already running. For all
other errors, we simply log the error and return.

Release note (bug fix): Fixed an issue where servers would endlessly
try to refresh table statistics on dropped tables.