### PR TITLE
roachtest: create new large write kv roachtests

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -29,55 +30,94 @@ import (
 )
 
 func registerKV(r *registry) {
-	runKV := func(ctx context.Context, t *test, c *cluster, percent int, encryption option) {
+	type kvOptions struct {
+		nodes       int
+		cpus        int
+		readPercent int
+		blockSize   int
+		encryption  bool
+	}
+	runKV := func(ctx context.Context, t *test, c *cluster, opts kvOptions) {
 		nodes := c.nodes - 1
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
-		c.Start(ctx, t, c.Range(1, nodes), encryption)
+		c.Start(ctx, t, c.Range(1, nodes), startArgs(fmt.Sprintf("--encrypt=%t", opts.encryption)))
 
 		t.Status("running workload")
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			concurrency := ifLocal("", " --concurrency="+fmt.Sprint(nodes*64))
 			duration := " --duration=" + ifLocal("10s", "10m")
+			readPercent := fmt.Sprintf(" --read-percent=%d", opts.readPercent)
+			var blockSize string
+			if opts.blockSize > 0 {
+				blockSize = fmt.Sprintf(" --min-block-bytes=%d --max-block-bytes=%d",
+					opts.blockSize, opts.blockSize+1)
+			}
+
 			cmd := fmt.Sprintf(
-				"./workload run kv --init --read-percent=%d --splits=1000 --histograms=logs/stats.json"+
-					concurrency+duration+
-					" {pgurl:1-%d}",
-				percent, nodes)
+				"./workload run kv --init --splits=1000 --histograms=logs/stats.json"+
+					concurrency+duration+readPercent+blockSize+" {pgurl:1-%d}",
+				nodes)
 			c.Run(ctx, c.Node(nodes+1), cmd)
 			return nil
 		})
 		m.Wait()
 	}
 
-	for _, p := range []int{0, 95} {
-		p := p
-		for _, n := range []int{1, 3} {
-			for _, cpus := range []int{8, 32} {
-				for _, e := range []bool{false, true} {
-					e := e
-					minVersion := "v2.0.0"
-					if e {
-						minVersion = "v2.1.0"
-					}
-					var name string
-					if cpus == 8 { // support legacy test name which didn't include cpu
-						name = fmt.Sprintf("kv%d/encrypt=%t/nodes=%d", p, e, n)
-					} else {
-						name = fmt.Sprintf("kv%d/encrypt=%t/nodes=%d/cpu=%d", p, e, n, cpus)
-					}
-					r.Add(testSpec{
-						Name:       name,
-						MinVersion: minVersion,
-						Cluster:    makeClusterSpec(n+1, cpu(cpus)),
-						Run: func(ctx context.Context, t *test, c *cluster) {
-							runKV(ctx, t, c, p, startArgs(fmt.Sprintf("--encrypt=%t", e)))
-						},
-					})
-				}
-			}
+	for _, opts := range []kvOptions{
+		// Standard configs.
+		{nodes: 1, cpus: 8, readPercent: 0},
+		{nodes: 1, cpus: 8, readPercent: 95},
+		{nodes: 1, cpus: 32, readPercent: 0},
+		{nodes: 1, cpus: 32, readPercent: 95},
+		{nodes: 3, cpus: 8, readPercent: 0},
+		{nodes: 3, cpus: 8, readPercent: 95},
+		{nodes: 3, cpus: 32, readPercent: 0},
+		{nodes: 3, cpus: 32, readPercent: 95},
+
+		// Configs with large block sizes.
+		{nodes: 3, cpus: 8, readPercent: 0, blockSize: 1 << 12 /* 4 KB */},
+		{nodes: 3, cpus: 8, readPercent: 95, blockSize: 1 << 12 /* 4 KB */},
+		{nodes: 3, cpus: 32, readPercent: 0, blockSize: 1 << 12 /* 4 KB */},
+		{nodes: 3, cpus: 32, readPercent: 95, blockSize: 1 << 12 /* 4 KB */},
+		{nodes: 3, cpus: 8, readPercent: 0, blockSize: 1 << 16 /* 64 KB */},
+		{nodes: 3, cpus: 8, readPercent: 95, blockSize: 1 << 16 /* 64 KB */},
+		{nodes: 3, cpus: 32, readPercent: 0, blockSize: 1 << 16 /* 64 KB */},
+		{nodes: 3, cpus: 32, readPercent: 95, blockSize: 1 << 16 /* 64 KB */},
+
+		// Configs with encryption.
+		{nodes: 1, cpus: 8, readPercent: 0, encryption: true},
+		{nodes: 1, cpus: 8, readPercent: 95, encryption: true},
+		{nodes: 3, cpus: 8, readPercent: 0, encryption: true},
+		{nodes: 3, cpus: 8, readPercent: 95, encryption: true},
+	} {
+		opts := opts
+
+		var nameParts []string
+		nameParts = append(nameParts, fmt.Sprintf("kv%d", opts.readPercent))
+		nameParts = append(nameParts, fmt.Sprintf("enc=%t", opts.encryption))
+		nameParts = append(nameParts, fmt.Sprintf("nodes=%d", opts.nodes))
+		if opts.cpus != 8 { // support legacy test name which didn't include cpu
+			nameParts = append(nameParts, fmt.Sprintf("cpu=%d", opts.cpus))
 		}
+		if opts.blockSize != 0 { // support legacy test name which didn't include block size
+			nameParts = append(nameParts, fmt.Sprintf("size=%dkb", opts.blockSize>>10))
+		}
+
+		minVersion := "v2.0.0"
+		if opts.encryption {
+			minVersion = "v2.1.0"
+		}
+
+		r.Add(testSpec{
+			Name:       strings.Join(nameParts, "/"),
+			MinVersion: minVersion,
+			Cluster:    makeClusterSpec(opts.nodes+1, cpu(opts.cpus)),
+			Run: func(ctx context.Context, t *test, c *cluster) {
+				runKV(ctx, t, c, opts)
+			},
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #34840.

This commit adds new kv roachtests that read and write 4KB and 64KB blocks instead of the standard 1B block.

NOTE: because of the restriction on the size of test names, this PR also slightly adjusts the naming scheme for the `kv` roachtests. The `encrypt=%t` component is now `enc=%t`. We'll need to adjust roachperf to handle this.

Release note: None