### PR TITLE
*: replace use of context.WithTimeout with a wrapper

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2305,6 +2305,7 @@ writing ` + os.DevNull + `
   debug/rangelog
   debug/liveness
   debug/settings
+  debug/reports/problemranges
   debug/gossip/liveness
   debug/gossip/network
   debug/gossip/nodes
@@ -2335,7 +2336,6 @@ writing ` + os.DevNull + `
   debug/nodes/1/ranges/18
   debug/nodes/1/ranges/19
   debug/nodes/1/ranges/20
-  debug/reports/problemranges
   debug/schema/defaultdb@details
   debug/schema/postgres@details
   debug/schema/system@details

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -364,44 +365,43 @@ func (s *statusServer) AllocatorRange(
 
 	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
-	nodeCtx, cancel := context.WithTimeout(ctx, base.NetworkTimeout)
-	defer cancel()
-
 	isLiveMap := s.nodeLiveness.GetIsLiveMap()
 	type nodeResponse struct {
 		nodeID roachpb.NodeID
 		resp   *serverpb.AllocatorResponse
 		err    error
 	}
-
 	responses := make(chan nodeResponse)
 	// TODO(bram): consider abstracting out this repeated pattern.
 	for nodeID := range isLiveMap {
 		nodeID := nodeID
 		if err := s.stopper.RunAsyncTask(
-			nodeCtx,
+			ctx,
 			"server.statusServer: requesting remote Allocator simulation",
 			func(ctx context.Context) {
-				status, err := s.dialNode(ctx, nodeID)
-				var allocatorResponse *serverpb.AllocatorResponse
-				if err == nil {
-					allocatorRequest := &serverpb.AllocatorRequest{
-						RangeIDs: []roachpb.RangeID{roachpb.RangeID(req.RangeId)},
+				_ = contextutil.RunWithTimeout(ctx, "allocator range", base.NetworkTimeout, func(ctx context.Context) error {
+					status, err := s.dialNode(ctx, nodeID)
+					var allocatorResponse *serverpb.AllocatorResponse
+					if err == nil {
+						allocatorRequest := &serverpb.AllocatorRequest{
+							RangeIDs: []roachpb.RangeID{roachpb.RangeID(req.RangeId)},
+						}
+						allocatorResponse, err = status.Allocator(ctx, allocatorRequest)
 					}
-					allocatorResponse, err = status.Allocator(ctx, allocatorRequest)
-				}
-				response := nodeResponse{
-					nodeID: nodeID,
-					resp:   allocatorResponse,
-					err:    err,
-				}
+					response := nodeResponse{
+						nodeID: nodeID,
+						resp:   allocatorResponse,
+						err:    err,
+					}
 
-				select {
-				case responses <- response:
-					// Response processed.
-				case <-ctx.Done():
-					// Context completed, response no longer needed.
-				}
+					select {
+					case responses <- response:
+						// Response processed.
+					case <-ctx.Done():
+						// Context completed, response no longer needed.
+					}
+					return nil
+				})
 			}); err != nil {
 			return nil, grpcstatus.Errorf(codes.Internal, err.Error())
 		}
@@ -1040,14 +1040,6 @@ func (s *statusServer) RaftDebug(
 		},
 	}
 
-	// Subtract base.NetworkTimeout from the deadline so we have time to process
-	// the results and return them.
-	if deadline, ok := ctx.Deadline(); ok {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithDeadline(ctx, deadline.Add(-base.NetworkTimeout))
-		defer cancel()
-	}
-
 	// Parallelize fetching of ranges to minimize total time.
 	var wg sync.WaitGroup
 	for _, node := range nodes.Nodes {
@@ -1493,10 +1485,12 @@ func (s *statusServer) iterateNodes(
 	responseChan := make(chan nodeResponse, numNodes)
 
 	nodeQuery := func(ctx context.Context, nodeID roachpb.NodeID) {
-		rpcCtx, cancel := context.WithTimeout(ctx, base.NetworkTimeout)
-		defer cancel()
-
-		client, err := dialFn(rpcCtx, nodeID)
+		var client interface{}
+		err := contextutil.RunWithTimeout(ctx, "dial node", base.NetworkTimeout, func(ctx context.Context) error {
+			var err error
+			client, err = dialFn(ctx, nodeID)
+			return err
+		})
 		if err != nil {
 			err = errors.Wrapf(err, "failed to dial into node %d (%s)",
 				nodeID, nodeStatuses[nodeID].LivenessStatus)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/tscache"
 	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -1044,27 +1045,26 @@ func (s *Store) SetDraining(drain bool) {
 
 	transferAllAway()
 
-	var cancel func()
-	ctx, cancel = context.WithTimeout(ctx, raftLeadershipTransferWait)
-	defer cancel()
-
-	opts := retry.Options{
-		InitialBackoff: 10 * time.Millisecond,
-		MaxBackoff:     time.Second,
-		Multiplier:     2,
-	}
-	// Avoid retry.ForDuration because of https://github.com/cockroachdb/cockroach/issues/25091.
-	everySecond := log.Every(time.Second)
-	if err := retry.WithMaxAttempts(ctx, opts, 10000, func() error {
-		if numRemaining := transferAllAway(); numRemaining > 0 {
-			err := errors.Errorf("waiting for %d replicas to transfer their lease away", numRemaining)
-			if everySecond.ShouldLog() {
-				log.Info(ctx, err)
+	if err := contextutil.RunWithTimeout(ctx, "wait for raft leadership transfer", raftLeadershipTransferWait,
+		func(ctx context.Context) error {
+			opts := retry.Options{
+				InitialBackoff: 10 * time.Millisecond,
+				MaxBackoff:     time.Second,
+				Multiplier:     2,
 			}
-			return err
-		}
-		return nil
-	}); err != nil {
+			// Avoid retry.ForDuration because of https://github.com/cockroachdb/cockroach/issues/25091.
+			everySecond := log.Every(time.Second)
+			return retry.WithMaxAttempts(ctx, opts, 10000, func() error {
+				if numRemaining := transferAllAway(); numRemaining > 0 {
+					err := errors.Errorf("waiting for %d replicas to transfer their lease away", numRemaining)
+					if everySecond.ShouldLog() {
+						log.Info(ctx, err)
+					}
+					return err
+				}
+				return nil
+			})
+		}); err != nil {
 		// You expect this message when shutting down a server in an unhealthy
 		// cluster. If we see it on healthy ones, there's likely something to fix.
 		log.Warningf(ctx, "unable to drain cleanly within %s, service might briefly deteriorate: %s", raftLeadershipTransferWait, err)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -404,6 +404,44 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	t.Run("TestContext", func(t *testing.T) {
+		t.Parallel()
+		cmd, stderr, filter, err := dirCmd(
+			pkgDir,
+			"git",
+			"grep",
+			"-nE",
+			`\bcontext\.With(Deadline|Timeout)\(`,
+			"--",
+			"*.go",
+			":!util/contextutil/context.go",
+			// TODO(jordan): ban these too?
+			":!server/debug/**",
+			":!workload/**",
+			":!*_test.go",
+			":!cmd/**",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			t.Errorf("\n%s <- forbidden; use 'contextutil.RunWithTimeout' instead", s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
 	t.Run("TestGrpc", func(t *testing.T) {
 		t.Parallel()
 		cmd, stderr, filter, err := dirCmd(


### PR DESCRIPTION
context.WithTimeout is a tricky beast. If you're not careful, you'll add
timeouts to lots of contexts but keep the naive error propagation paths
we're all used to: passing up an error if we get one.

This oftentimes leads to opaque and confusing error messages for the
user and for us as developers. "context deadline exceeded" is often
unactionable, and often makes it tough to track down what actually went
wrong underneath the hood.

This patch adds a wrapper, contextutil.RunWithTimeout, that runs an
anonymous function with a timeout and returns a prettier error if the
function does in fact time out. The error will include an operation name
and the deadline that was exceeded.

This patch also removes all usages of context.WithTimeout and
context.WithDeadline with contextutil.RunWithTimeout and
contextutil.RunWithDeadline.

Also, add a lint to prevent them from creeping back in.