### PR TITLE
storage: hook rangefeed iter limiter to a cluster setting

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -36,6 +36,7 @@
 <tr><td><code>kv.range_merge.queue_enabled</code></td><td>boolean</td><td><code>true</code></td><td>whether the automatic merge queue is enabled</td></tr>
 <tr><td><code>kv.range_split.by_load_enabled</code></td><td>boolean</td><td><code>true</code></td><td>allow automatic splits of ranges based on where load is concentrated.</td></tr>
 <tr><td><code>kv.range_split.load_qps_threshold</code></td><td>integer</td><td><code>250</code></td><td>the QPS over which, the range becomes a candidate for load based splitting.</td></tr>
+<tr><td><code>kv.rangefeed.concurrent_catchup_iterators</code></td><td>integer</td><td><code>64</code></td><td>number of rangefeeds catchup iterators a store will allow concurrently before queueing</td></tr>
 <tr><td><code>kv.rangefeed.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, rangefeed registration is enabled</td></tr>
 <tr><td><code>kv.snapshot_rebalance.max_rate</code></td><td>byte size</td><td><code>2.0 MiB</code></td><td>the rate limit (bytes/sec) to use for rebalance snapshots</td></tr>
 <tr><td><code>kv.snapshot_recovery.max_rate</code></td><td>byte size</td><td><code>8.0 MiB</code></td><td>the rate limit (bytes/sec) to use for recovery snapshots</td></tr>


### PR DESCRIPTION
Addresses a TODO. The sibling limiters all have one and this is a pretty
good CYA.

Closes #34692

Release note (enterprise change): the limit on rangefeed catchup
iterator concurrency is now controllabtle by the
`kv.rangefeed.concurrent_catchup_iterators` cluster setting