### PR TITLE
importccl: skip detour though CSV when importing from workload

### DIFF
--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -67,6 +68,16 @@ func (c *csvInputReader) start(group ctxgroup.Group) {
 
 func (c *csvInputReader) inputFinished(_ context.Context) {
 	close(c.recordCh)
+}
+
+func (c *csvInputReader) readFiles(
+	ctx context.Context,
+	dataFiles map[int32]string,
+	format roachpb.IOFileFormat,
+	progressFn func(float32) error,
+	settings *cluster.Settings,
+) error {
+	return readInputFiles(ctx, dataFiles, format, c.readFile, progressFn, settings)
 }
 
 func (c *csvInputReader) flushBatch(ctx context.Context, finished bool, progFn progressFn) error {

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -17,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
@@ -74,6 +76,16 @@ func (m *mysqldumpReader) start(ctx ctxgroup.Group) {
 
 func (m *mysqldumpReader) inputFinished(ctx context.Context) {
 	close(m.kvCh)
+}
+
+func (m *mysqldumpReader) readFiles(
+	ctx context.Context,
+	dataFiles map[int32]string,
+	format roachpb.IOFileFormat,
+	progressFn func(float32) error,
+	settings *cluster.Settings,
+) error {
+	return readInputFiles(ctx, dataFiles, format, m.readFile, progressFn, settings)
 }
 
 func (m *mysqldumpReader) readFile(

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -15,6 +15,7 @@ import (
 	"unicode"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -48,6 +49,16 @@ func (d *mysqloutfileReader) start(ctx ctxgroup.Group) {
 
 func (d *mysqloutfileReader) inputFinished(ctx context.Context) {
 	close(d.conv.kvCh)
+}
+
+func (d *mysqloutfileReader) readFiles(
+	ctx context.Context,
+	dataFiles map[int32]string,
+	format roachpb.IOFileFormat,
+	progressFn func(float32) error,
+	settings *cluster.Settings,
+) error {
+	return readInputFiles(ctx, dataFiles, format, d.readFile, progressFn, settings)
 }
 
 func (d *mysqloutfileReader) readFile(

--- a/pkg/ccl/importccl/read_import_pgcopy.go
+++ b/pkg/ccl/importccl/read_import_pgcopy.go
@@ -18,6 +18,7 @@ import (
 	"unicode"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -56,6 +57,16 @@ func (d *pgCopyReader) start(ctx ctxgroup.Group) {
 
 func (d *pgCopyReader) inputFinished(ctx context.Context) {
 	close(d.conv.kvCh)
+}
+
+func (d *pgCopyReader) readFiles(
+	ctx context.Context,
+	dataFiles map[int32]string,
+	format roachpb.IOFileFormat,
+	progressFn func(float32) error,
+	settings *cluster.Settings,
+) error {
+	return readInputFiles(ctx, dataFiles, format, d.readFile, progressFn, settings)
 }
 
 type postgreStreamCopy struct {

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -423,6 +423,16 @@ func (m *pgDumpReader) inputFinished(ctx context.Context) {
 	close(m.kvCh)
 }
 
+func (m *pgDumpReader) readFiles(
+	ctx context.Context,
+	dataFiles map[int32]string,
+	format roachpb.IOFileFormat,
+	progressFn func(float32) error,
+	settings *cluster.Settings,
+) error {
+	return readInputFiles(ctx, dataFiles, format, m.readFile, progressFn, settings)
+}
+
 func (m *pgDumpReader) readFile(
 	ctx context.Context, input io.Reader, inputIdx int32, inputName string, progressFn progressFn,
 ) error {

--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -367,7 +367,7 @@ type progressFn func(finished bool) error
 
 type inputConverter interface {
 	start(group ctxgroup.Group)
-	readFile(ctx context.Context, input io.Reader, fileIdx int32, filename string, progress progressFn) error
+	readFiles(ctx context.Context, dataFiles map[int32]string, format roachpb.IOFileFormat, progressFn func(float32) error, settings *cluster.Settings) error
 	inputFinished(ctx context.Context)
 }
 
@@ -471,7 +471,7 @@ func (cp *readImportDataProcessor) doRun(ctx context.Context) error {
 			})
 		}
 
-		return readInputFiles(ctx, cp.spec.Uri, cp.spec.Format, conv.readFile, progFn, cp.flowCtx.Settings)
+		return conv.readFiles(ctx, cp.spec.Uri, cp.spec.Format, progFn, cp.flowCtx.Settings)
 	})
 
 	if cp.spec.IngestDirectly {

--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -1,0 +1,160 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package importccl
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/pkg/errors"
+)
+
+type workloadReader struct {
+	conv *rowConverter
+	kvCh chan kvBatch
+}
+
+var _ inputConverter = &workloadReader{}
+
+func newWorkloadReader(
+	kvCh chan kvBatch, table *sqlbase.TableDescriptor, evalCtx *tree.EvalContext,
+) (*workloadReader, error) {
+	conv, err := newRowConverter(table, evalCtx, kvCh)
+	if err != nil {
+		return nil, err
+	}
+	return &workloadReader{kvCh: kvCh, conv: conv}, nil
+}
+
+func (w *workloadReader) start(ctx ctxgroup.Group) {
+}
+
+func (w *workloadReader) inputFinished(ctx context.Context) {
+	close(w.kvCh)
+}
+
+// makeDatumFromRaw tries to fast-path a few workload-generated types into
+// directly datums, to dodge making a string and then the parsing it.
+func makeDatumFromRaw(
+	alloc *sqlbase.DatumAlloc, datum interface{}, hint types.T, evalCtx *tree.EvalContext,
+) (tree.Datum, error) {
+	if datum == nil {
+		return tree.DNull, nil
+	}
+	switch t := datum.(type) {
+	case int:
+		return alloc.NewDInt(tree.DInt(t)), nil
+	case int64:
+		return alloc.NewDInt(tree.DInt(t)), nil
+	case []byte:
+		return alloc.NewDBytes(tree.DBytes(t)), nil
+	case time.Time:
+		switch hint {
+		case types.TimestampTZ:
+			return tree.MakeDTimestampTZ(t, time.Microsecond), nil
+		case types.Timestamp:
+			return tree.MakeDTimestamp(t, time.Microsecond), nil
+		}
+	case string:
+		return tree.ParseDatumStringAs(hint, t, evalCtx)
+	}
+	return tree.ParseDatumStringAs(hint, fmt.Sprint(datum), evalCtx)
+}
+
+func (w *workloadReader) readFiles(
+	ctx context.Context,
+	dataFiles map[int32]string,
+	format roachpb.IOFileFormat,
+	progressFn func(float32) error,
+	settings *cluster.Settings,
+) error {
+	var alloc sqlbase.DatumAlloc
+
+	numFiles := float32(len(dataFiles))
+	var filesCompleted int
+	for inputIdx, fileName := range dataFiles {
+		file, err := url.Parse(fileName)
+		if err != nil {
+			return err
+		}
+		conf, err := storageccl.ParseWorkloadConfig(file)
+		if err != nil {
+			return err
+		}
+		meta, err := workload.Get(conf.Generator)
+		if err != nil {
+			return err
+		}
+		// Different versions of the workload could generate different data, so
+		// disallow this.
+		if meta.Version != conf.Version {
+			return errors.Errorf(
+				`expected %s version "%s" but got "%s"`, meta.Name, conf.Version, meta.Version)
+		}
+		gen := meta.New()
+		if f, ok := gen.(workload.Flagser); ok {
+			if err := f.Flags().Parse(conf.Flags); err != nil {
+				return errors.Wrapf(err, `parsing parameters %s`, strings.Join(conf.Flags, ` `))
+			}
+		}
+		var t workload.Table
+		for _, tbl := range gen.Tables() {
+			if tbl.Name == conf.Table {
+				t = tbl
+				break
+			}
+		}
+		if t.Name == `` {
+			return errors.Wrapf(err, `unknown table %s for generator %s`, conf.Table, meta.Name)
+		}
+
+		// how is this reader, before starting this file.
+		initialProgress := float32(filesCompleted) / numFiles
+		numBatches := conf.BatchEnd - conf.BatchBegin
+		var rows int64
+		lastProgress := rows
+		for b := conf.BatchBegin; b < conf.BatchEnd; b++ {
+			if rows-lastProgress > 10000 {
+				// how far we are on this file
+				fileProgress := float32(b) / float32(numBatches)
+				progress := initialProgress + fileProgress/numFiles
+				if err := progressFn(progress); err != nil {
+					return err
+				}
+				lastProgress = rows
+			}
+			for _, row := range t.InitialRows.Batch(int(b)) {
+				rows++
+				for i, value := range row {
+					converted, err := makeDatumFromRaw(&alloc, value, w.conv.visibleColTypes[i], w.conv.evalCtx)
+					if err != nil {
+						return err
+					}
+					w.conv.datums[i] = converted
+				}
+				if err := w.conv.row(ctx, inputIdx, rows); err != nil {
+					return err
+				}
+			}
+		}
+		filesCompleted++
+	}
+	return w.conv.sendBatch(ctx)
+}

--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -164,7 +164,7 @@ func ExportStorageConfFromURI(path string) (roachpb.ExportStorage, error) {
 		conf.LocalFile.NodeID = roachpb.NodeID(nodeID)
 	case "experimental-workload":
 		conf.Provider = roachpb.ExportStorageProvider_Workload
-		if conf.WorkloadConfig, err = parseWorkloadConfig(uri); err != nil {
+		if conf.WorkloadConfig, err = ParseWorkloadConfig(uri); err != nil {
 			return conf, err
 		}
 	default:
@@ -927,7 +927,8 @@ func (s *azureStorage) Close() error {
 	return nil
 }
 
-func parseWorkloadConfig(uri *url.URL) (*roachpb.ExportStorage_Workload, error) {
+// ParseWorkloadConfig parses a workload config URI to a proto config.
+func ParseWorkloadConfig(uri *url.URL) (*roachpb.ExportStorage_Workload, error) {
 	c := &roachpb.ExportStorage_Workload{}
 	pathParts := strings.Split(strings.Trim(uri.Path, `/`), `/`)
 	if len(pathParts) != 3 {


### PR DESCRIPTION
Based on some recent suggestions from @danhhz, while I was thinking about ways to fix job progress reporting for workload imports, I looked at how hard it would be to skip our detour though CSV when importing on-the-fly workload-generated data, since that detour is what made progress reporting hard. Specifically, it was harder because the on-the-fly CSV generation doesn't know up front how many bytes it will return. The usual IMPORT progress tracking used by the file-reading frontends is`num_bytes_read/num_bytes` but that doesn't work if you don't know `num_bytes`. 

However, the workload generator itself certainly know how many rows it has generated and how many it will generate as it goes. If we hook it up directly, without a detour though a "file" of CSV data, we can just report that number for progress directly. 

That is what got me looking at this, but more importantly, skipping the detour to CSV lets us skip a lot of expensive string encoding and decoding in some cases.

This is just a first pass at this -- mostly to prove it works and solved my original progress concern, but this initial implementation does not even begin to exploit all the possible optimizations. However it likely makes testing some of them much easier.

The specialized frontend is automatically by reader process when it is configured to read CSV data and all files URIs are pointing to workload generation-backed storage. In that case, it uses the workload configuration values from those file URIs to setup a generator directly and then writes its output to the same row-converter that the CSV reader would have -- simply cutting the CSV encoder and decoder out of the middle.

This is currently gated behind the `COCKROACH_IMPORT_WORKLOAD_FASTER` env var.

This is a baby-step towards one of the areas identified in #34809.

Release note: none.