### PR TITLE
sql: ensure spans get anonymized in plan collection

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -386,7 +387,21 @@ func (e *explainer) observer() planObserver {
 		enterNode: e.enterNode,
 		expr:      e.expr,
 		attr:      e.attr,
+		spans:     e.spans,
 		leaveNode: e.leaveNode,
+	}
+}
+
+// spans implements the planObserver interface.
+func (e *explainer) spans(
+	nodeName, fieldName string, index *sqlbase.IndexDescriptor, spans []roachpb.Span,
+) {
+	spanss := sqlbase.PrettySpans(index, spans, 2)
+	if spanss != "" {
+		if spanss == "-" {
+			spanss = "ALL"
+		}
+		e.attr(nodeName, fieldName, spanss)
 	}
 }
 

--- a/pkg/sql/logictest/testdata/planner_test/delete
+++ b/pkg/sql/logictest/testdata/planner_test/delete
@@ -61,7 +61,7 @@ tree               field  description
 count              ·      ·
  └── delete range  ·      ·
 ·                  from   unindexed
-·                  spans  -
+·                  spans  ALL
 
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -60,7 +60,7 @@ EXPLAIN DELETE FROM unindexed
 tree          field  description
 delete range  ·      ·
 ·             from   unindexed
-·             spans  -
+·             spans  ALL
 
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v LIMIT 10


### PR DESCRIPTION
Fixes #34889.

Release note (bug fix): The logical plans collected for display in the
web UI now also hide the details of which key ranges are scanned in
table lookups.