### PR TITLE
release-2.1: kv: dont wrap a MixedSuccessError within a MixedSuccessError

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -840,7 +840,19 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 			// we're ultimately returning an error, wrap the error with a
 			// MixedSuccessError.
 			if hadSuccessWriting {
-				pErr = roachpb.NewError(&roachpb.MixedSuccessError{Wrapped: pErr})
+				// divideAndSendBatchToRanges can call sendPartialBatch, which in
+				// turn can call divideAndSendBatchToRanges recursively. Therefore,
+				// pErr can already be a MixedSuccessError returned from the
+				// recursive call; do not wrap it in another MixedSuccessError.
+				if _, ok := pErr.GetDetail().(*roachpb.MixedSuccessError); !ok {
+					index := pErr.Index
+					pErr = roachpb.NewError(&roachpb.MixedSuccessError{Wrapped: pErr})
+					// Propagate the index to the MixedSuccessError. Note that the index
+					// is shared by pointer, and when the index is modified as part of
+					// the MixedSuccessError and the MixedSuccessError gets
+					// unwrapped, the original error will contain the modified index.
+					pErr.Index = index
+				}
 			}
 		} else if couldHaveSkippedResponses {
 			fillSkippedResponses(ba, br, seekKey, resumeReason)

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -2336,5 +2336,154 @@ func TestErrorIndexAlignment(t *testing.T) {
 			}
 		})
 	}
+}
 
+// TestMixedSuccessErrorWrapped tests that an internal MixedSuccessError
+// seen by a caller of Send() cannot wrap another MixedSuccessError.
+func TestMixedSuccessErrorWrapped(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+
+	g, clock := makeGossip(t, stopper)
+
+	if err := g.SetNodeDescriptor(newNodeDesc(1)); err != nil {
+		t.Fatal(err)
+	}
+	nd := &roachpb.NodeDescriptor{
+		NodeID:  roachpb.NodeID(1),
+		Address: util.MakeUnresolvedAddr(testAddress.Network(), testAddress.String()),
+	}
+	if err := g.AddInfoProto(gossip.MakeNodeIDKey(roachpb.NodeID(1)), nd, time.Hour); err != nil {
+		t.Fatal(err)
+
+	}
+
+	// Fill MockRangeDescriptorDB with three descriptors.
+	var descriptor1 = roachpb.RangeDescriptor{
+		RangeID:  2,
+		StartKey: testMetaEndKey,
+		EndKey:   roachpb.RKey("b"),
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:  1,
+				StoreID: 1,
+			},
+		},
+	}
+	var descriptor2 = roachpb.RangeDescriptor{
+		RangeID:  3,
+		StartKey: roachpb.RKey("b"),
+		EndKey:   roachpb.RKey("c"),
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:  1,
+				StoreID: 1,
+			},
+		},
+	}
+	var descriptor3 = roachpb.RangeDescriptor{
+		RangeID:  4,
+		StartKey: roachpb.RKey("c"),
+		EndKey:   roachpb.RKeyMax,
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:  1,
+				StoreID: 1,
+			},
+		},
+	}
+
+	descDB := mockRangeDescriptorDBForDescs(
+		testMetaRangeDescriptor,
+		descriptor1,
+		descriptor2,
+		descriptor3,
+	)
+
+	reqNum := 0
+
+	var testFn simpleSendFn = func(
+		_ context.Context,
+		_ SendOptions,
+		_ ReplicaSlice,
+		ba roachpb.BatchRequest,
+	) (*roachpb.BatchResponse, error) {
+		reply := ba.CreateReply()
+		reqNum++
+		// Return an error on the third batch request.
+		if reqNum == 3 {
+			// The relative index is always 1 since
+			// we return an error for the second
+			// request of the 3rd batch.
+			index := &roachpb.ErrPosition{Index: 1}
+
+			// This will be the error that will be wrapped
+			// within a MixedSuccessError. Make this error itself a
+			// MixedSuccessError to test if it escapes the dist-sender.
+			// Set the wrapped index and the MixedSuccessError index to the
+			// same value because that's what the code does.
+			wrapped := roachpb.NewError(errors.Errorf("dummy error"))
+			wrapped.Index = index
+			reply.Error = roachpb.NewError(&roachpb.MixedSuccessError{Wrapped: wrapped})
+			reply.Error.Index = index
+		}
+		return reply, nil
+	}
+
+	cfg := DistSenderConfig{
+		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
+		Clock:      clock,
+		TestingKnobs: ClientTestingKnobs{
+			TransportFactory: adaptSimpleTransport(testFn),
+		},
+		RangeDescriptorDB: descDB,
+	}
+	ds := NewDistSender(cfg, g)
+
+	// Create a batch request with 3 requests that will trigger a
+	// MixedSuccessError.
+	var ba roachpb.BatchRequest
+	ba.Txn = &roachpb.Transaction{Name: "test"}
+	// First batch has 1 request.
+	val := roachpb.MakeValueFromString("val")
+	ba.Add(roachpb.NewPut(roachpb.Key("a"), val))
+	// Second batch has 2 requests.
+	val = roachpb.MakeValueFromString("val")
+	ba.Add(roachpb.NewPut(roachpb.Key("b"), val))
+	val = roachpb.MakeValueFromString("val")
+	ba.Add(roachpb.NewPut(roachpb.Key("bb"), val))
+	// Third batch has 2 request.
+	val = roachpb.MakeValueFromString("val")
+	ba.Add(roachpb.NewPut(roachpb.Key("c"), val))
+	val = roachpb.MakeValueFromString("val")
+	ba.Add(roachpb.NewPut(roachpb.Key("cc"), val))
+
+	_, pErr := ds.Send(context.Background(), ba)
+	if pErr == nil {
+		t.Fatalf("expected an error to be returned from distSender")
+	}
+	mse, ok := pErr.GetDetail().(*roachpb.MixedSuccessError)
+	if !ok {
+		t.Fatal("expected mixed success error")
+	}
+
+	wrapped := mse.Wrapped
+
+	// The error wrapped is not a MixedSuccessError and is the original
+	// wrapped error.
+	if _, ok := wrapped.GetDetail().(*roachpb.MixedSuccessError); ok {
+		t.Fatal("found another mixed success error")
+	}
+	if wrapped.Message != "dummy error" {
+		t.Fatalf("err = %s", wrapped.Message)
+	}
+
+	// The index is correctly set.
+	if wrapped.Index == nil {
+		t.Fatalf("expected error index to be set for err %T", pErr.GetDetail())
+	}
+	if wrapped.Index.Index != 4 {
+		t.Errorf("expected error index to be %d, instead got %d", 3, wrapped.Index.Index)
+	}
 }

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -638,7 +638,7 @@ func (e *MixedSuccessError) Error() string {
 }
 
 func (e *MixedSuccessError) message(_ *Error) string {
-	return "the batch experienced mixed success and failure"
+	return fmt.Sprintf("the batch experienced mixed success and failure: %s", e.Wrapped)
 }
 
 var _ ErrorDetailInterface = &MixedSuccessError{}


### PR DESCRIPTION
Backport 1/1 commits from #32888.

Closes #34822.

/cc @cockroachdb/release

---

divideAndSendBatchToRanges can call sendPartialBatch, which in
turn can call divideAndSendBatchToRanges recursively. Therefore,
the error seen by divideAndSendBatchToRanges can already be a
MixedSuccessError returned from a recursive call.

Also add underlying error string to MixedSuccessError.message

fixes #32499

Release note: None
