### PR TITLE
sql: confine auto-commit to TableWriterBase

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -368,7 +368,6 @@ func (sc *SchemaChanger) truncateIndexes(
 						&desc,
 						resumeAt,
 						chunkSize,
-						noAutoCommit,
 						false, /* traceKV */
 					)
 					done = resume.Key == nil
@@ -1000,7 +999,7 @@ func indexTruncateInTxn(
 			return err
 		}
 		sp, err = td.deleteIndex(
-			ctx, idx, sp, indexTruncateChunkSize, noAutoCommit, traceKV,
+			ctx, idx, sp, indexTruncateChunkSize, traceKV,
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -230,6 +230,9 @@ func (n *createTableNode) startExec(params runParams) error {
 		ti := tableInserterPool.Get().(*tableInserter)
 		*ti = tableInserter{ri: ri}
 		tw := tableWriter(ti)
+		if n.run.autoCommit == autoCommitEnabled {
+			tw.enableAutoCommit()
+		}
 		defer func() {
 			tw.close(params.ctx)
 			*ti = tableInserter{}
@@ -278,7 +281,7 @@ func (n *createTableNode) startExec(params runParams) error {
 					return err
 				}
 				_, err := tw.finalize(
-					params.ctx, n.run.autoCommit, params.extendedEvalCtx.Tracing.KVTracingEnabled())
+					params.ctx, params.extendedEvalCtx.Tracing.KVTracingEnabled())
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -210,10 +210,6 @@ type deleteRun struct {
 	// rows contains the accumulated result rows if rowsNeeded is set.
 	rows *rowcontainer.RowContainer
 
-	// autoCommit indicates whether the last KV batch processed by
-	// this delete will also commit the KV txn.
-	autoCommit autoCommitOpt
-
 	// traceKV caches the current KV tracing flag.
 	traceKV bool
 }
@@ -308,7 +304,7 @@ func (d *deleteNode) BatchedNext(params runParams) (bool, error) {
 	}
 
 	if lastBatch {
-		if _, err := d.run.td.finalize(params.ctx, d.run.autoCommit, d.run.traceKV); err != nil {
+		if _, err := d.run.td.finalize(params.ctx, d.run.traceKV); err != nil {
 			return false, err
 		}
 		// Remember we're done for the next call to BatchedNext().
@@ -446,5 +442,5 @@ func canDeleteFastInterleaved(table *ImmutableTableDescriptor, fkTables row.FkTa
 
 // enableAutoCommit is part of the autoCommitNode interface.
 func (d *deleteNode) enableAutoCommit() {
-	d.run.autoCommit = autoCommitEnabled
+	d.run.td.enableAutoCommit()
 }

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -43,8 +43,6 @@ type deleteRangeNode struct {
 	// we can count the number of rows deleted.
 	fetcher row.Fetcher
 
-	// autoCommit will be set to true at runtime if autocommit is available.
-	autoCommit autoCommitOpt
 	// rowCount will be set to the count of rows deleted.
 	rowCount int
 }
@@ -174,7 +172,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		d.tableWriter.b.DelRange(span.Key, span.EndKey, true /* returnKeys */)
 	}
 
-	if err := d.tableWriter.finalize(ctx, d.autoCommit, d.desc); err != nil {
+	if err := d.tableWriter.finalize(ctx, d.desc); err != nil {
 		return err
 	}
 
@@ -226,5 +224,5 @@ func (*deleteRangeNode) Close(ctx context.Context) {}
 
 // enableAutoCommit implements the autoCommitNode interface.
 func (d *deleteRangeNode) enableAutoCommit() {
-	d.autoCommit = autoCommitEnabled
+	d.tableWriter.enableAutoCommit()
 }

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -379,10 +379,6 @@ type insertRun struct {
 	// index is not public.
 	rowIdxToRetIdx []int
 
-	// autoCommit indicates whether the last KV batch processed by
-	// this update will also commit the KV txn.
-	autoCommit autoCommitOpt
-
 	// traceKV caches the current KV tracing flag.
 	traceKV bool
 }
@@ -509,7 +505,7 @@ func (n *insertNode) BatchedNext(params runParams) (bool, error) {
 	}
 
 	if lastBatch {
-		if _, err := n.run.ti.finalize(params.ctx, n.run.autoCommit, n.run.traceKV); err != nil {
+		if _, err := n.run.ti.finalize(params.ctx, n.run.traceKV); err != nil {
 			return false, err
 		}
 		// Remember we're done for the next call to BatchedNext().
@@ -608,7 +604,7 @@ func (n *insertNode) Close(ctx context.Context) {
 
 // enableAutoCommit is part of the autoCommitNode interface.
 func (n *insertNode) enableAutoCommit() {
-	n.run.autoCommit = autoCommitEnabled
+	n.run.ti.enableAutoCommit()
 }
 
 // GenerateInsertRow prepares a row tuple for insertion. It fills in default

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -54,10 +54,8 @@ func (ti *tableInserter) flushAndStartNewBatch(ctx context.Context) error {
 }
 
 // finalize is part of the tableWriter interface.
-func (ti *tableInserter) finalize(
-	ctx context.Context, autoCommit autoCommitOpt, _ bool,
-) (*rowcontainer.RowContainer, error) {
-	return nil, ti.tableWriterBase.finalize(ctx, autoCommit, ti.tableDesc())
+func (ti *tableInserter) finalize(ctx context.Context, _ bool) (*rowcontainer.RowContainer, error) {
+	return nil, ti.tableWriterBase.finalize(ctx, ti.tableDesc())
 }
 
 // tableDesc is part of the tableWriter interface.

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -64,10 +64,8 @@ func (tu *tableUpdater) flushAndStartNewBatch(ctx context.Context) error {
 }
 
 // finalize is part of the tableWriter interface.
-func (tu *tableUpdater) finalize(
-	ctx context.Context, autoCommit autoCommitOpt, _ bool,
-) (*rowcontainer.RowContainer, error) {
-	return nil, tu.tableWriterBase.finalize(ctx, autoCommit, tu.tableDesc())
+func (tu *tableUpdater) finalize(ctx context.Context, _ bool) (*rowcontainer.RowContainer, error) {
+	return nil, tu.tableWriterBase.finalize(ctx, tu.tableDesc())
 }
 
 // tableDesc is part of the tableWriter interface.

--- a/pkg/sql/tablewriter_upsert.go
+++ b/pkg/sql/tablewriter_upsert.go
@@ -162,9 +162,9 @@ func (tu *tableUpserterBase) close(ctx context.Context) {
 
 // finalize is part of the tableWriter interface.
 func (tu *tableUpserterBase) finalize(
-	ctx context.Context, autoCommit autoCommitOpt, traceKV bool,
+	ctx context.Context, traceKV bool,
 ) (*rowcontainer.RowContainer, error) {
-	return nil, tu.tableWriterBase.finalize(ctx, autoCommit, tu.tableDesc())
+	return nil, tu.tableWriterBase.finalize(ctx, tu.tableDesc())
 }
 
 // makeResultFromRow reshapes a row that was inserted or updated to a row

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -515,7 +515,7 @@ func truncateTableInChunks(
 			if err := td.init(txn, nil /* *tree.EvalContext */); err != nil {
 				return err
 			}
-			resume, err = td.deleteAllRows(ctx, resumeAt, chunkSize, noAutoCommit, traceKV)
+			resume, err = td.deleteAllRows(ctx, resumeAt, chunkSize, traceKV)
 			return err
 		}); err != nil {
 			return err

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -425,10 +425,6 @@ type updateRun struct {
 	// rows contains the accumulated result rows if rowsNeeded is set.
 	rows *rowcontainer.RowContainer
 
-	// autoCommit indicates whether the last KV batch processed by
-	// this update will also commit the KV txn.
-	autoCommit autoCommitOpt
-
 	// traceKV caches the current KV tracing flag.
 	traceKV bool
 
@@ -573,7 +569,7 @@ func (u *updateNode) BatchedNext(params runParams) (bool, error) {
 	}
 
 	if lastBatch {
-		if _, err := u.run.tu.finalize(params.ctx, u.run.autoCommit, u.run.traceKV); err != nil {
+		if _, err := u.run.tu.finalize(params.ctx, u.run.traceKV); err != nil {
 			return false, err
 		}
 		// Remember we're done for the next call to BatchedNext().
@@ -744,7 +740,7 @@ func (u *updateNode) Close(ctx context.Context) {
 
 // enableAutoCommit implements the autoCommitNode interface.
 func (u *updateNode) enableAutoCommit() {
-	u.run.autoCommit = autoCommitEnabled
+	u.run.tu.enableAutoCommit()
 }
 
 // sourceSlot abstracts the idea that our update sources can either be tuples

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -260,10 +260,6 @@ type upsertRun struct {
 	// BatchedNext() has completed the work already.
 	done bool
 
-	// autoCommit indicates whether the last KV batch processed by
-	// this update will also commit the KV txn.
-	autoCommit autoCommitOpt
-
 	// traceKV caches the current KV tracing flag.
 	traceKV bool
 }
@@ -349,7 +345,7 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 	}
 
 	if lastBatch {
-		if _, err := n.run.tw.finalize(params.ctx, n.run.autoCommit, n.run.traceKV); err != nil {
+		if _, err := n.run.tw.finalize(params.ctx, n.run.traceKV); err != nil {
 			return false, err
 		}
 		// Remember we're done for the next call to BatchedNext().
@@ -428,7 +424,7 @@ func (n *upsertNode) Close(ctx context.Context) {
 
 // enableAutoCommit is part of the autoCommitNode interface.
 func (n *upsertNode) enableAutoCommit() {
-	n.run.autoCommit = autoCommitEnabled
+	n.run.tw.enableAutoCommit()
 }
 
 // upsertExcludedTable is the name of a synthetic table used in an upsert's set


### PR DESCRIPTION
auto commit is configured through the call to enableAutoCommit()
and finalize() doesn't allow passing in an auto commit flag.

Release note: None