### PR TITLE
changefeedccl: support more columns types with avro

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1353,11 +1353,11 @@ func TestChangefeedErrors(t *testing.T) {
 		`EXPERIMENTAL CHANGEFEED FOR dec WITH format=$1, confluent_schema_registry=$2`,
 		optFormatAvro, `bar`,
 	)
-	sqlDB.Exec(t, `CREATE TABLE "uuid" (a UUID PRIMARY KEY)`)
-	sqlDB.Exec(t, `INSERT INTO "uuid" VALUES (gen_random_uuid())`)
+	sqlDB.Exec(t, `CREATE TABLE "oid" (a OID PRIMARY KEY)`)
+	sqlDB.Exec(t, `INSERT INTO "oid" VALUES (3::OID)`)
 	sqlDB.ExpectErr(
-		t, `pq: column a: type UUID not yet supported with avro`,
-		`EXPERIMENTAL CHANGEFEED FOR "uuid" WITH format=$1, confluent_schema_registry=$2`,
+		t, `pq: column a: type OID not yet supported with avro`,
+		`EXPERIMENTAL CHANGEFEED FOR "oid" WITH format=$1, confluent_schema_registry=$2`,
 		optFormatAvro, `bar`,
 	)
 

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -323,7 +323,7 @@ func TestAvroEncoder(t *testing.T) {
 	t.Run(`poller`, pollerTest(sinklessTest, testFn))
 }
 
-func TestAvroSchemaChange(t *testing.T) {
+func TestAvroMigrateToUnsupportedColumn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
@@ -342,10 +342,10 @@ func TestAvroSchemaChange(t *testing.T) {
 			`foo: {"a":{"long":1}}->{"after":{"foo":{"a":{"long":1}}}}`,
 		})
 
-		sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN b UUID`)
-		sqlDB.Exec(t, `INSERT INTO foo VALUES (2, gen_random_uuid())`)
-		if _, err := foo.Next(); !testutils.IsError(err, `type UUID not yet supported with avro`) {
-			t.Fatalf(`expected "type UUID not yet supported with avro" error got: %+v`, err)
+		sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN b OID`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (2, 3::OID)`)
+		if _, err := foo.Next(); !testutils.IsError(err, `type OID not yet supported with avro`) {
+			t.Fatalf(`expected "type OID not yet supported with avro" error got: %+v`, err)
 		}
 	}
 


### PR DESCRIPTION
This adds support for sql DATE, TIME, UUID, INET, and JSONB columns with
the `experimental_avro` CHANGEFEED format.

It also adds a set of "golden" tests for what avro schema each of our
sql column types map to.

INTERVAL has a corresponding avro logical type, but is left
unimplemented for now because our INTERVALs have a larger domain of
values than avro's: 8 bytes vs 4.

ARRAY, BIT, and COLLATEDSTRING are a little tricker, so we'll wait for
customer demand. These are expected to be safe enough to backport if we
need them.

Closes #32472
Closes #34421
Closes #34417

Release note (enterprise change): the `CHANGEFEED` `experimental_avro`
format now supports sql columns of type DATE, TIME, UUID, INET, and
JSONB.