### PR TITLE
internal/sqlsmith: ignore all crdb_internal.force_* functions

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -221,7 +221,7 @@ WHERE
 	NOT proisagg
 	AND NOT proiswindow
 	AND NOT proretset
-	AND proname NOT IN ('crdb_internal.force_panic', 'crdb_internal.force_log_fatal', 'crdb_internal.force_error', 'crdb_internal.force_assertion_error')
+	AND proname NOT LIKE 'crdb_internal.force_%'
 `)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
crdb_internal.force_retry was causing the randomized tests to fail with
a timeout. Just block all of those.

Release note: None