### PR TITLE
exec: remove extra cols in tests and modify tuples comparison

### DIFF
--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -247,7 +247,7 @@ func TestAggregatorOneFunc(t *testing.T) {
 
 			// Run randomized tests on this test case.
 			t.Run(fmt.Sprintf("Randomized"), func(t *testing.T) {
-				runTests(t, []tuples{tc.input}, nil, func(t *testing.T, input []Operator) {
+				runTests(t, []tuples{tc.input}, func(t *testing.T, input []Operator) {
 					a, err := NewOrderedAggregator(
 						input[0], tc.groupCols, tc.groupTypes, tc.aggFns, tc.aggCols, tc.aggTypes,
 					)
@@ -333,7 +333,7 @@ func TestAggregatorMultiFunc(t *testing.T) {
 			if err := tc.init(); err != nil {
 				t.Fatal(err)
 			}
-			runTests(t, []tuples{tc.input}, nil, func(t *testing.T, input []Operator) {
+			runTests(t, []tuples{tc.input}, func(t *testing.T, input []Operator) {
 				a, err := NewOrderedAggregator(
 					input[0], tc.groupCols, tc.groupTypes, tc.aggFns, tc.aggCols, tc.aggTypes,
 				)
@@ -384,7 +384,7 @@ func TestAggregatorKitchenSink(t *testing.T) {
 			if err := tc.init(); err != nil {
 				t.Fatal(err)
 			}
-			runTests(t, []tuples{tc.input}, nil, func(t *testing.T, input []Operator) {
+			runTests(t, []tuples{tc.input}, func(t *testing.T, input []Operator) {
 				a, err := NewOrderedAggregator(
 					input[0], tc.groupCols, tc.groupTypes, tc.aggFns, tc.aggCols, tc.aggTypes,
 				)

--- a/pkg/sql/exec/coalescer_test.go
+++ b/pkg/sql/exec/coalescer_test.go
@@ -53,7 +53,7 @@ func TestCoalescer(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
 			coalescer := NewCoalescerOp(input[0], tc.colTypes)
 
 			colIndices := make([]int, len(tc.colTypes))

--- a/pkg/sql/exec/count_test.go
+++ b/pkg/sql/exec/count_test.go
@@ -14,11 +14,7 @@
 
 package exec
 
-import (
-	"testing"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
-)
+import "testing"
 
 func TestCount(t *testing.T) {
 	tcs := []struct {
@@ -35,7 +31,7 @@ func TestCount(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
 			count := NewCountOp(input[0])
 			out := newOpTestOutput(count, []int{0}, tc.expected)
 

--- a/pkg/sql/exec/distinct_test.go
+++ b/pkg/sql/exec/distinct_test.go
@@ -51,7 +51,7 @@ func TestSortedDistinct(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
 			distinct, err := NewOrderedDistinct(input[0], tc.distinctCols, tc.colTypes)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -709,7 +709,7 @@ func TestHashJoinerInt64(t *testing.T) {
 
 		for _, buildDistinct := range buildFlags {
 			t.Run(fmt.Sprintf("buildDistinct=%v", buildDistinct), func(t *testing.T) {
-				runTests(t, inputs, []types.T{types.Bool}, func(t *testing.T, sources []Operator) {
+				runTests(t, inputs, func(t *testing.T, sources []Operator) {
 					leftSource, rightSource := sources[0], sources[1]
 
 					hj, err := NewEqHashJoinerOp(

--- a/pkg/sql/exec/limit_test.go
+++ b/pkg/sql/exec/limit_test.go
@@ -14,11 +14,7 @@
 
 package exec
 
-import (
-	"testing"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
-)
+import "testing"
 
 func TestLimit(t *testing.T) {
 	tcs := []struct {
@@ -64,7 +60,7 @@ func TestLimit(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
 			limit := NewLimitOp(input[0], tc.limit)
 			out := newOpTestOutput(limit, []int{0}, tc.expected)
 

--- a/pkg/sql/exec/offset_test.go
+++ b/pkg/sql/exec/offset_test.go
@@ -54,7 +54,7 @@ func TestOffset(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
 			s := NewOffsetOp(input[0], tc.offset)
 			out := newOpTestOutput(s, []int{0}, tc.expected)
 

--- a/pkg/sql/exec/projection_ops_test.go
+++ b/pkg/sql/exec/projection_ops_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestProjPlusInt64Int64ConstOp(t *testing.T) {
-	runTests(t, []tuples{{{1}, {2}}}, []types.T{types.Int64}, func(t *testing.T, input []Operator) {
+	runTests(t, []tuples{{{1}, {2}}}, func(t *testing.T, input []Operator) {
 		op := projPlusInt64Int64ConstOp{
 			input:     input[0],
 			colIdx:    0,
@@ -41,7 +41,7 @@ func TestProjPlusInt64Int64ConstOp(t *testing.T) {
 }
 
 func TestProjPlusInt64Int64Op(t *testing.T) {
-	runTests(t, []tuples{{{1, 2}, {3, 4}}}, []types.T{types.Int64}, func(t *testing.T, input []Operator) {
+	runTests(t, []tuples{{{1, 2}, {3, 4}}}, func(t *testing.T, input []Operator) {
 		op := projPlusInt64Int64Op{
 			input:     input[0],
 			col1Idx:   0,

--- a/pkg/sql/exec/selection_ops_test.go
+++ b/pkg/sql/exec/selection_ops_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestSelLTInt64Int64ConstOp(t *testing.T) {
 	tups := tuples{{0}, {1}, {2}}
-	runTests(t, []tuples{tups}, nil /* extraTypes */, func(t *testing.T, input []Operator) {
+	runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
 		op := selLTInt64Int64ConstOp{
 			input:    input[0],
 			colIdx:   0,
@@ -47,7 +47,7 @@ func TestSelLTInt64Int64(t *testing.T) {
 		{1, 0},
 		{1, 1},
 	}
-	runTests(t, []tuples{tups}, nil /* extraTypes */, func(t *testing.T, input []Operator) {
+	runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
 		op := selLTInt64Int64Op{
 			input:   input[0],
 			col1Idx: 0,

--- a/pkg/sql/exec/simple_project_test.go
+++ b/pkg/sql/exec/simple_project_test.go
@@ -14,11 +14,7 @@
 
 package exec
 
-import (
-	"testing"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
-)
+import "testing"
 
 func TestSimpleProjectOp(t *testing.T) {
 	tcs := []struct {
@@ -61,7 +57,7 @@ func TestSimpleProjectOp(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
 			count := NewSimpleProjectOp(input[0], tc.colsToKeep)
 			out := newOpTestOutput(count, []int{0, 1}, tc.expected)
 
@@ -72,7 +68,7 @@ func TestSimpleProjectOp(t *testing.T) {
 	}
 
 	// Empty projection.
-	runTests(t, []tuples{{{1, 2, 3}, {1, 2, 3}}}, []types.T{}, func(t *testing.T, input []Operator) {
+	runTests(t, []tuples{{{1, 2, 3}, {1, 2, 3}}}, func(t *testing.T, input []Operator) {
 		count := NewSimpleProjectOp(input[0], nil)
 		out := newOpTestOutput(count, []int{}, tuples{{}, {}})
 		if err := out.Verify(); err != nil {

--- a/pkg/sql/exec/sort_test.go
+++ b/pkg/sql/exec/sort_test.go
@@ -113,7 +113,7 @@ func TestSort(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		runTests(t, []tuples{tc.tuples}, []types.T{}, func(t *testing.T, input []Operator) {
+		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
 			sort, err := NewSorter(input[0], tc.typ, tc.ordCols)
 			if err != nil {
 				t.Fatal(err)
@@ -165,7 +165,7 @@ func TestSortRandomized(t *testing.T) {
 		return false
 	})
 
-	runTests(t, []tuples{tups}, []types.T{}, func(t *testing.T, input []Operator) {
+	runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
 		sorter, err := NewSorter(input[0], typs, ordCols)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Removes the extra cols of the test infrastructure which seem to
be a remnant of previous iterations of tests/code and are no longer
needed. Also, modifies `assertTuplesEquals` to check the tuples in
any order to have a "set-comparison" behavior as described in the
comment to the function.

Release note: None