### PR TITLE
opt: add JoinPrivate

### DIFF
--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -147,7 +147,11 @@ var ScalarListWithEmptyTuple = ScalarListExpr{EmptyTuple}
 
 // EmptyGroupingPrivate is a global instance of a GroupingPrivate that has no
 // grouping columns and no ordering.
-var EmptyGroupingPrivate = GroupingPrivate{}
+var EmptyGroupingPrivate = &GroupingPrivate{}
+
+// EmptyJoinPrivate is a global instance of a JoinPrivate that has no fields
+// set.
+var EmptyJoinPrivate = &JoinPrivate{}
 
 // LastGroupMember returns the last member in the same memo group of the given
 // relational expression.

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -828,6 +828,9 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 			fmt.Fprintf(f.Buffer, " ordering=%s", t)
 		}
 
+	case *JoinPrivate:
+		// TODO(radu): add code here when we add fields to JoinPrivate.
+
 	case *ExplainPrivate, *opt.ColSet, *opt.ColList, *SetPrivate, types.T:
 		// Don't show anything, because it's mostly redundant.
 

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -282,33 +282,33 @@ func (f *Factory) ConstructZeroValues() memo.RelExpr {
 // ConstructJoin constructs the join operator that corresponds to the given join
 // operator type.
 func (f *Factory) ConstructJoin(
-	joinOp opt.Operator, left, right memo.RelExpr, on memo.FiltersExpr,
+	joinOp opt.Operator, left, right memo.RelExpr, on memo.FiltersExpr, private *memo.JoinPrivate,
 ) memo.RelExpr {
 	switch joinOp {
 	case opt.InnerJoinOp:
-		return f.ConstructInnerJoin(left, right, on)
+		return f.ConstructInnerJoin(left, right, on, private)
 	case opt.InnerJoinApplyOp:
-		return f.ConstructInnerJoinApply(left, right, on)
+		return f.ConstructInnerJoinApply(left, right, on, private)
 	case opt.LeftJoinOp:
-		return f.ConstructLeftJoin(left, right, on)
+		return f.ConstructLeftJoin(left, right, on, private)
 	case opt.LeftJoinApplyOp:
-		return f.ConstructLeftJoinApply(left, right, on)
+		return f.ConstructLeftJoinApply(left, right, on, private)
 	case opt.RightJoinOp:
-		return f.ConstructRightJoin(left, right, on)
+		return f.ConstructRightJoin(left, right, on, private)
 	case opt.RightJoinApplyOp:
-		return f.ConstructRightJoinApply(left, right, on)
+		return f.ConstructRightJoinApply(left, right, on, private)
 	case opt.FullJoinOp:
-		return f.ConstructFullJoin(left, right, on)
+		return f.ConstructFullJoin(left, right, on, private)
 	case opt.FullJoinApplyOp:
-		return f.ConstructFullJoinApply(left, right, on)
+		return f.ConstructFullJoinApply(left, right, on, private)
 	case opt.SemiJoinOp:
-		return f.ConstructSemiJoin(left, right, on)
+		return f.ConstructSemiJoin(left, right, on, private)
 	case opt.SemiJoinApplyOp:
-		return f.ConstructSemiJoinApply(left, right, on)
+		return f.ConstructSemiJoinApply(left, right, on, private)
 	case opt.AntiJoinOp:
-		return f.ConstructAntiJoin(left, right, on)
+		return f.ConstructAntiJoin(left, right, on, private)
 	case opt.AntiJoinApplyOp:
-		return f.ConstructAntiJoinApply(left, right, on)
+		return f.ConstructAntiJoinApply(left, right, on, private)
 	}
 	panic(fmt.Sprintf("unexpected join operator: %v", joinOp))
 }

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -41,9 +41,10 @@
     $left:*
     $right:* & ^(IsCorrelated $right $left)
     $on:*
+    $private:*
 )
 =>
-(ConstructNonApplyJoin (OpName) $left $right $on)
+(ConstructNonApplyJoin (OpName) $left $right $on $private)
 
 # DecorrelateProjectSet pulls an input relation outside of a ProjectSet if the
 # input is not correlated with any of the functions in the ProjectSet. The
@@ -66,6 +67,7 @@
         $zip
     )
     []
+    (EmptyJoinPrivate)
 )
 
 # TryDecorrelateSelect "pushes down" the join apply into the select operator,
@@ -87,12 +89,14 @@
     $left:*
     $right:* & (HasOuterCols $right) & (Select $input:* $filters:*)
     $on:*
+    $private:*
 )
 =>
 ((OpName)
     $left
     $input
     (ConcatFilters $on $filters)
+    $private
 )
 
 # TryDecorrelateProject "pushes down" a Join into a Project operator, in an
@@ -109,6 +113,7 @@
         (HasOuterCols $right) &
         (Project $input:* $projections:* $passthrough:*)
     $on:*
+    $private:*
 )
 =>
 (Select
@@ -117,6 +122,7 @@
             $left
             $input
             []
+            $private
         )
         $projections
         (UnionCols (OutputCols $left) $passthrough)
@@ -141,6 +147,7 @@
         $passthrough:*
     )
     $on:*
+    $private:*
 )
 =>
 (Project
@@ -152,6 +159,7 @@
             (UnionCols $passthrough (OutputCols $selectInput))
         )
         (ConcatFilters $on $filters)
+        $private
     )
     []
     (OutputCols2 $left $right)
@@ -171,11 +179,13 @@
             $innerLeft:*
             $innerRight:*
             $innerOn:* & ^(FiltersBoundBy $innerOn (OutputCols2 $innerLeft $innerRight))
+            $innerPrivate:*
         )
         $projections:*
         $passthrough:*
     )
     $on:*
+    $private:*
 )
 =>
 (Project
@@ -186,11 +196,13 @@
                 $innerLeft
                 $innerRight
                 []
+                $innerPrivate
             )
             $projections
             (UnionCols $passthrough (OutputCols $join))
         )
         (ConcatFilters $on $innerOn)
+        $private
     )
     []
     (OutputCols2 $left $right)
@@ -212,8 +224,10 @@
             $innerLeft:*
             $innerRight:*
             $innerOn:* & ^(FiltersBoundBy $innerOn (OutputCols2 $innerLeft $innerRight))
+            $innerPrivate:*
         )
     $on:*
+    $private:*
 )
 =>
 ((OpName)
@@ -222,8 +236,10 @@
         $innerLeft
         $innerRight
         []
+        $innerPrivate
     )
     (ConcatFilters $on $innerOn)
+    $private
 )
 
 # TryDecorrelateInnerLeftJoin tries to decorrelate a LeftJoin operator nested
@@ -242,8 +258,10 @@
             $innerLeft:*
             $innerRight:*
             $innerOn:*
+            $innerPrivate:*
         )
     $on:* & (FiltersBoundBy $on (OutputCols2 $left $innerLeft))
+    $private:*
 )
 =>
 (LeftJoinApply
@@ -251,9 +269,11 @@
         $left
         $innerLeft
         $on
+        $innerPrivate
     )
     $innerRight
     $innerOn
+    $private
 )
 
 # TryDecorrelateGroupBy "pushes down" a Join into a GroupBy operator, in an
@@ -304,6 +324,7 @@
         ) &
         (IsUnorderedGrouping $groupingPrivate)
     $on:*
+    $private:*
 )
 =>
 (Select
@@ -312,6 +333,7 @@
             $newLeft:(EnsureKey $left)
             $input
             []
+            $private
         )
         (AppendAggCols
             $aggregations
@@ -421,6 +443,7 @@
         ) &
         (AggsCanBeDecorrelated $aggregations)
     $on:*
+    $private:*
 )
 =>
 (Select
@@ -437,6 +460,7 @@
                     $canaryCol:(EnsureCanaryCol $input $aggregations)
                 )
                 []
+                $private
             )
             (AppendAggCols2
                 $translatedAggs:(EnsureAggsCanIgnoreNulls
@@ -470,6 +494,7 @@
         (CanHaveZeroRows $right) & # Let EliminateExistsGroupBy match instead.
         (GroupBy | DistinctOn | Project | ProjectSet)
     $on:*
+    $private:*
 )
 =>
 (GroupBy
@@ -477,6 +502,7 @@
         $newLeft:(EnsureKey $left)
         $right
         $on
+        $private
     )
     (MakeAggCols ConstAgg (NonKeyCols $newLeft))
     (MakeGrouping (KeyCols $newLeft))
@@ -503,6 +529,7 @@
         (HasOuterCols $right) &
         (Limit $input:* (Const 1) $ordering:*)
     $on:*
+    $private:*
 )
 =>
 (DistinctOn
@@ -510,6 +537,7 @@
         $newLeft:(EnsureKey $left)
         $input
         $on
+        $private
     )
     (MakeAggCols2
         ConstAgg (NonKeyCols $newLeft)
@@ -531,6 +559,7 @@
         $zip:*
     )
     $on:*
+    $private:*
 )
 =>
 (Select
@@ -539,6 +568,7 @@
             $left
             $input
             []
+            $private
         )
         $zip
     )
@@ -571,6 +601,7 @@
         $input
         $subquery
         []
+        (EmptyJoinPrivate)
     )
     (RemoveFiltersItem $filters $item)
 )
@@ -597,6 +628,7 @@
         $input
         $subquery
         []
+        (EmptyJoinPrivate)
     )
     (RemoveFiltersItem $filters $item)
 )
@@ -645,9 +677,10 @@
     $left:*
     $right:*
     $on:[ ... $item:* & (HasHoistableSubquery $item) ... ]
+    $private:*
 )
 =>
-(HoistJoinSubquery (OpName) $left $right $on)
+(HoistJoinSubquery (OpName) $left $right $on $private)
 
 # HoistValuesSubquery extracts subqueries from row tuples and joins them with
 # the Values operator. This and other subquery hoisting patterns create a
@@ -713,6 +746,7 @@
     $left:*
     $right:*
     $on:[ ... $item:(FiltersItem (Any $anyInput:* $scalar:* $anyPrivate:*)) ... ]
+    $private:*
 )
 =>
 ((OpName)
@@ -729,6 +763,7 @@
             $anyPrivate
         )
     )
+    $private
 )
 
 # NormalizeSelectNotAnyFilter rewrites a Not Any expression that is a top-level
@@ -778,6 +813,7 @@
     $left:*
     $right:*
     $on:[ ... $item:(FiltersItem (Not (Any $anyInput:* $scalar:* $anyPrivate:*))) ... ]
+    $private:*
 )
 =>
 ((OpName)
@@ -803,4 +839,5 @@
             )
         )
     )
+    $private
 )

--- a/pkg/sql/opt/norm/rules/inline.opt
+++ b/pkg/sql/opt/norm/rules/inline.opt
@@ -58,12 +58,14 @@
     $left:* & ^(ColsAreEmpty $constCols:(FindInlinableConstants $left))
     $right:*
     $on:[ ... $item:* & (ColsIntersect (OuterCols $item) $constCols) ... ]
+    $private:*
 )
 =>
 ((OpName)
     $left
     $right
     (InlineFilterConstants $on $left $constCols)
+    $private
 )
 
 # InlineJoinConstantsRight finds variable references in a join condition that
@@ -76,12 +78,14 @@
     $left:*
     $right:* & ^(ColsAreEmpty $constCols:(FindInlinableConstants $right))
     $on:[ ... $item:* & (ColsIntersect (OuterCols $item) $constCols) ... ]
+    $private:*
 )
 =>
 ((OpName)
     $left
     $right
     (InlineFilterConstants $on $right $constCols)
+    $private
 )
 
 # PushSelectIntoInlinableProject pushes the Select operator into a Project, even

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -10,12 +10,14 @@
     $left:*
     $right:*
     $on:[ ... (FiltersItem (And | True | False | Null)) ... ] & ^(IsFilterFalse $on)
+    $private:*
 )
 =>
 ((OpName)
     $left
     $right
     (SimplifyFilters $on)
+    $private
 )
 
 # DetectJoinContradiction replaces a Join condition with False if it detects a
@@ -25,12 +27,14 @@
     $left:*
     $right:*
     [ ... $item:(FiltersItem) & (IsContradiction $item) ... ]
+    $private:*
 )
 =>
 ((OpName)
     $left
     $right
     [ (FiltersItem (False)) ]
+    $private
 )
 
 # PushFilterIntoJoinLeftAndRight pushes a filter into both the left and right
@@ -65,6 +69,7 @@
             (CanMap $on $item $right)
         ...
     ]
+    $private:*
 )
 =>
 ((OpName)
@@ -77,6 +82,7 @@
         [ (FiltersItem (Map $on $item $right)) ]
     )
     (RemoveFiltersItem $on $item)
+    $private
 )
 
 # MapFilterIntoJoinLeft maps a filter that is not bound by the left side of
@@ -106,12 +112,14 @@
             (CanMap $on $item $left)
         ...
     ]
+    $private:*
 )
 =>
 ((OpName)
     $left
     $right
     (ReplaceFiltersItem $on $item (Map $on $item $left))
+    $private
 )
 
 # MapFilterIntoJoinRight is symmetric with MapFilterIntoJoinLeft. It maps
@@ -130,12 +138,14 @@
             (CanMap $on $item $right)
         ...
     ]
+    $private:*
 )
 =>
 ((OpName)
     $left
     $right
     (ReplaceFiltersItem $on $item (Map $on $item $right))
+    $private
 )
 
 # PushFilterIntoJoinLeft pushes Join filter conditions into the left side of the
@@ -169,6 +179,7 @@
         $item:* & (IsBoundBy $item $leftCols:(OutputCols $left))
         ...
     ]
+    $private:*
 )
 =>
 ((OpName)
@@ -178,6 +189,7 @@
     )
     $right
     (ExtractUnboundConditions $on $leftCols)
+    $private
 )
 
 # PushFilterIntoJoinRight is symmetric with PushFilterIntoJoinLeft. It pushes
@@ -193,6 +205,7 @@
         $item:* & (IsBoundBy $item $rightCols:(OutputCols $right))
         ...
     ]
+    $private:*
 )
 =>
 ((OpName)
@@ -202,6 +215,7 @@
         (ExtractBoundConditions $on $rightCols)
     )
     (ExtractUnboundConditions $on $rightCols)
+    $private
 )
 
 # SimplifyLeftJoinWithoutFilters reduces a LeftJoin operator to an InnerJoin
@@ -214,6 +228,7 @@
     $left:*
     $right:* & ^(CanHaveZeroRows $right)
     $on:[]
+    $private:*
 )
 =>
 (ConstructNonLeftJoin
@@ -221,6 +236,7 @@
     $left
     $right
     $on
+    $private
 )
 
 # SimplifyRightJoinWithoutFilters reduces a RightJoin operator to an InnerJoin
@@ -233,6 +249,7 @@
     $left:* & ^(CanHaveZeroRows $left)
     $right:*
     $on:[]
+    $private:*
 )
 =>
 (ConstructNonRightJoin
@@ -240,6 +257,7 @@
     $left
     $right
     $on
+    $private
 )
 
 # SimplifyLeftJoinWithFilters reduces a LeftJoin operator to an InnerJoin
@@ -264,6 +282,7 @@
     $left:*
     $right:*
     $on:^[] & (JoinFiltersMatchAllLeftRows $left $right $on)
+    $private:*
 )
 =>
 (ConstructNonLeftJoin
@@ -271,6 +290,7 @@
     $left
     $right
     $on
+    $private
 )
 
 # SimplifyRightJoinWithFilters reduces a RightJoin operator to an InnerJoin
@@ -283,6 +303,7 @@
     $left:*
     $right:*
     $on:^[] & (JoinFiltersMatchAllLeftRows $right $left $on)
+    $private:*
 )
 =>
 (ConstructNonRightJoin
@@ -290,6 +311,7 @@
     $left
     $right
     $on
+    $private
 )
 
 # EliminateSemiJoin discards a SemiJoin operator when it's known that the right
@@ -309,7 +331,6 @@ $left
 (AntiJoin | AntiJoinApply
     $left:*
     $right:* & (HasZeroRows $right)
-    *
 )
 =>
 $left
@@ -357,6 +378,7 @@ $left
     $left:*
     $right:(Project $input:* $projections:[])
     $on:*
+    $private:*
 )
 =>
 (Project
@@ -364,6 +386,7 @@ $left
         $left
         $input
         $on
+        $private
     )
     $projections
     (OutputCols2 $left $right)
@@ -376,6 +399,7 @@ $left
     $left:(Project $input:* $projections:[])
     $right:*
     $on:*
+    $private:*
 )
 =>
 (Project
@@ -383,6 +407,7 @@ $left
         $input
         $right
         $on
+        $private
     )
     $projections
     (OutputCols2 $left $right)
@@ -418,6 +443,7 @@ $left
         )
         ...
     ]
+    $private:*
 )
 =>
 ((OpName)
@@ -432,6 +458,7 @@ $left
             (OpName $cnst)
         )
     )
+    $private
 )
 
 # ExtractJoinEqualities finds equality conditions such that one side only
@@ -463,9 +490,10 @@ $left
         )
         ...
     ]
+    $private:*
 )
 =>
-(ExtractJoinEquality (OpName) $left $right $on $item)
+(ExtractJoinEquality (OpName) $left $right $on $item $private)
 
 # SortFiltersInJoin ensures that any filters in an inner join are canonicalized
 # by sorting them.
@@ -474,10 +502,12 @@ $left
     $left:*
     $right:*
     $on:* & ^(AreFiltersSorted $on)
+    $private:*
 )
 =>
 (InnerJoin
-  $left
-  $right
-  (SortFilters $on)
+    $left
+    $right
+    (SortFilters $on)
+    $private
 )

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -177,6 +177,7 @@
         $left:*
         $right:*
         $on:*
+        $private:*
     )
     $projections:*
     $passthrough:* &
@@ -196,6 +197,7 @@
         (PruneCols $left $needed)
         $right
         $on
+        $private
     )
     $projections
     $passthrough
@@ -213,6 +215,7 @@
         $left:*
         $right:*
         $on:*
+        $private:*
     )
     $projections:*
     $passthrough:* &
@@ -231,6 +234,7 @@
         $left
         (PruneCols $right $needed)
         $on
+        $private
     )
     $projections
     $passthrough

--- a/pkg/sql/opt/norm/rules/reject_nulls.opt
+++ b/pkg/sql/opt/norm/rules/reject_nulls.opt
@@ -62,6 +62,7 @@
         $left:*
         $right:*
         $on:*
+        $private:*
     )
     $filters:* & (HasNullRejectingFilter $filters (OutputCols $right))
 )
@@ -72,6 +73,7 @@
         $left
         $right
         $on
+        $private
     )
     $filters
 )
@@ -88,6 +90,7 @@
         $left:*
         $right:*
         $on:*
+        $private:*
     )
     $filters:* & (HasNullRejectingFilter $filters (OutputCols $left))
 )
@@ -98,6 +101,7 @@
         $left
         $right
         $on
+        $private
     )
     $filters
 )

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -100,6 +100,7 @@
         $left:*
         $right:*
         $on:*
+        $private:*
     )
     $filters:*
 )
@@ -108,6 +109,7 @@
     $left
     $right
     (ConcatFilters $on $filters)
+    $private
 )
 
 # PushSelectCondLeftIntoJoinLeftAndRight applies to the case when a condition
@@ -138,6 +140,7 @@
         $left:*
         $right:*
         $on:*
+        $private:*
     )
     $filters:[
         ...
@@ -159,6 +162,7 @@
             [ (FiltersItem (Map $on $item $right)) ]
         )
         $on
+        $private
     )
     (RemoveFiltersItem $filters $item)
 )
@@ -176,6 +180,7 @@
         $left:*
         $right:*
         $on:*
+        $private:*
     )
     $filters:[
         ...
@@ -197,6 +202,7 @@
             [ (FiltersItem $condition) ]
         )
         $on
+        $private
     )
     (RemoveFiltersItem $filters $item)
 )
@@ -222,6 +228,7 @@
         $left:*
         $right:*
         $on:*
+        $private:*
     )
     $filters:[
         ...
@@ -238,6 +245,7 @@
         )
         $right
         $on
+        $private
     )
     (ExtractUnboundConditions $filters $leftCols)
 )
@@ -251,6 +259,7 @@
         $left:*
         $right:*
         $on:*
+        $private:*
     )
     $filters:[
         ...
@@ -267,6 +276,7 @@
             (ExtractBoundConditions $filters $rightCols)
         )
         $on
+        $private
     )
     (ExtractUnboundConditions $filters $rightCols)
 )

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -164,6 +164,8 @@ define InnerJoin {
     Left  RelExpr
     Right RelExpr
     On    FiltersExpr
+
+    _ JoinPrivate
 }
 
 [Relational, Join, JoinNonApply]
@@ -171,6 +173,8 @@ define LeftJoin {
     Left  RelExpr
     Right RelExpr
     On    FiltersExpr
+
+   _ JoinPrivate
 }
 
 [Relational, Join, JoinNonApply]
@@ -178,6 +182,8 @@ define RightJoin {
     Left  RelExpr
     Right RelExpr
     On    FiltersExpr
+
+    _ JoinPrivate
 }
 
 [Relational, Join, JoinNonApply]
@@ -185,6 +191,8 @@ define FullJoin {
     Left  RelExpr
     Right RelExpr
     On    FiltersExpr
+
+    _ JoinPrivate
 }
 
 [Relational, Join, JoinNonApply]
@@ -192,6 +200,8 @@ define SemiJoin {
     Left  RelExpr
     Right RelExpr
     On    FiltersExpr
+
+    _ JoinPrivate
 }
 
 [Relational, Join, JoinNonApply]
@@ -199,6 +209,14 @@ define AntiJoin {
     Left  RelExpr
     Right RelExpr
     On    FiltersExpr
+
+    _ JoinPrivate
+}
+
+# JoinPrivate is shared between the various join operators including apply
+# variants, but excluding IndexJoin, LookupJoin, MergeJoin.
+[Private]
+define JoinPrivate {
 }
 
 # IndexJoin represents an inner join between an input expression and a primary
@@ -376,6 +394,8 @@ define InnerJoinApply {
     Left  RelExpr
     Right RelExpr
     On    FiltersExpr
+
+    _ JoinPrivate
 }
 
 [Relational, Join, JoinApply]
@@ -383,6 +403,8 @@ define LeftJoinApply {
     Left  RelExpr
     Right RelExpr
     On    FiltersExpr
+
+    _ JoinPrivate
 }
 
 [Relational, Join, JoinApply]
@@ -390,6 +412,8 @@ define RightJoinApply {
     Left  RelExpr
     Right RelExpr
     On    FiltersExpr
+
+    _ JoinPrivate
 }
 
 [Relational, Join, JoinApply]
@@ -397,6 +421,8 @@ define FullJoinApply {
     Left  RelExpr
     Right RelExpr
     On    FiltersExpr
+
+    _ JoinPrivate
 }
 
 [Relational, Join, JoinApply]
@@ -404,6 +430,8 @@ define SemiJoinApply {
     Left  RelExpr
     Right RelExpr
     On    FiltersExpr
+
+    _ JoinPrivate
 }
 
 [Relational, Join, JoinApply]
@@ -411,6 +439,8 @@ define AntiJoinApply {
     Left  RelExpr
     Right RelExpr
     On    FiltersExpr
+
+    _ JoinPrivate
 }
 
 # GroupBy computes aggregate functions over groups of input rows. Input rows

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -672,6 +672,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, onConflict *tr
 					mb.outScope.expr,
 					scanScope.expr,
 					on,
+					memo.EmptyJoinPrivate,
 				),
 				memo.FiltersExpr{memo.FiltersItem{
 					Condition: mb.b.factory.ConstructIs(
@@ -764,6 +765,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 		mb.outScope.expr,
 		fetchScope.expr,
 		on,
+		memo.EmptyJoinPrivate,
 	)
 
 	// Add a filter from the WHERE clause if one exists.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -750,7 +750,7 @@ func (b *Builder) buildFromTables(tables tree.TableExprs, inScope *scope) (outSc
 
 	left := outScope.expr.(memo.RelExpr)
 	right := tableScope.expr.(memo.RelExpr)
-	outScope.expr = b.factory.ConstructInnerJoin(left, right, memo.TrueFilter)
+	outScope.expr = b.factory.ConstructInnerJoin(left, right, memo.TrueFilter, memo.EmptyJoinPrivate)
 	return outScope
 }
 

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -261,6 +261,7 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 					mb.outScope.expr,
 					mb.b.factory.ConstructMax1Row(subqueryScope.expr),
 					memo.TrueFilter,
+					memo.EmptyJoinPrivate,
 				)
 
 				// Project all subquery output columns.

--- a/pkg/sql/opt/optgen/exprgen/expr_gen_test.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/datadriven"
 )
 
-func TestPlanGen(t *testing.T) {
+func TestExprGen(t *testing.T) {
 	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
 		catalog := testcat.New()
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {

--- a/pkg/sql/opt/optgen/exprgen/testdata/join
+++ b/pkg/sql/opt/optgen/exprgen/testdata/join
@@ -29,6 +29,7 @@ expr
   (Scan [ (Table "abc") (Cols "a,b,c") ])
   (Scan [ (Table "def") (Cols "d,e,f") ])
   [ (Eq (Var "a") (Var "d")) ]
+  [ ]
 )
 ----
 inner-join

--- a/pkg/sql/opt/optgen/lang/compiler.go
+++ b/pkg/sql/opt/optgen/lang/compiler.go
@@ -348,6 +348,12 @@ func (c *ruleCompiler) inferTypes(e Expr, suggested DataType) {
 		// match. The matching is checked in ruleContentCompiler.compileFunc.
 		prototype := defType.Defines[0]
 
+		if len(t.Args) > len(prototype.Fields) {
+			err := fmt.Errorf("%s has too many args", e.Op())
+			c.compiler.addErr(t.Source(), err)
+			break
+		}
+
 		// Recurse on name and arguments.
 		c.inferTypes(t.Name, AnyDataType)
 		for i, arg := range t.Args {

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -548,7 +548,11 @@ func (c *CustomFuncs) GenerateLimitedScans(
 
 // GenerateMergeJoins spawns MergeJoinOps, based on any interesting orderings.
 func (c *CustomFuncs) GenerateMergeJoins(
-	grp memo.RelExpr, originalOp opt.Operator, left, right memo.RelExpr, on memo.FiltersExpr,
+	grp memo.RelExpr,
+	originalOp opt.Operator,
+	left, right memo.RelExpr,
+	on memo.FiltersExpr,
+	joinPrivate *memo.JoinPrivate,
 ) {
 	leftProps := left.Relational()
 	rightProps := right.Relational()
@@ -662,6 +666,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 	input memo.RelExpr,
 	scanPrivate *memo.ScanPrivate,
 	on memo.FiltersExpr,
+	joinPrivate *memo.JoinPrivate,
 ) {
 	inputProps := input.Relational()
 

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -29,9 +29,10 @@
   $left:* & ^(HasNoCols $left)
   $right:* & ^(HasNoCols $right)
   $on:*
+  $private:*
 )
 =>
-((OpName) $right $left $on)
+((OpName) $right $left $on $private)
 
 # CommuteLeftJoin creates a Join with the left and right inputs swapped.
 [CommuteLeftJoin, Explore]
@@ -39,9 +40,10 @@
   $left:* & ^(HasNoCols $left)
   $right:* & ^(HasNoCols $left)
   $on:*
+  $private:*
 )
 =>
-(RightJoin $right $left $on)
+(RightJoin $right $left $on $private)
 
 # CommuteRightJoin creates a Join with the left and right inputs swapped.
 [CommuteRightJoin, Explore]
@@ -49,16 +51,17 @@
   $left:* & ^(HasNoCols $left)
   $right:* & ^(HasNoCols $left)
   $on:*
+  $private:*
 )
 =>
-(LeftJoin $right $left $on)
+(LeftJoin $right $left $on $private)
 
 # GenerateMergeJoins creates MergeJoin operators for the join, using the
 # interesting orderings property.
 [GenerateMergeJoins, Explore]
-(JoinNonApply $left:* $right:* $on:*)
+(JoinNonApply $left:* $right:* $on:* $private:*)
 =>
-(GenerateMergeJoins (OpName) $left $right $on)
+(GenerateMergeJoins (OpName) $left $right $on $private)
 
 # GenerateLookupJoins creates LookupJoin operators for all indexes (of the Scan
 # table) which allow it (including non-covering indexes). See the
@@ -68,9 +71,10 @@
     $left:*
     (Scan $scanPrivate:*) & (IsCanonicalScan $scanPrivate)
     $on:*
+    $private:*
 )
 =>
-(GenerateLookupJoins (OpName) $left $scanPrivate $on)
+(GenerateLookupJoins (OpName) $left $scanPrivate $on $private)
 
 # GenerateZigzagJoins creates ZigzagJoin operators for all index pairs (of the
 # Scan table) where the prefix column(s) of both indexes is/are fixed to
@@ -110,15 +114,18 @@
         $filters:*
     )
     $on:*
+    $private:*
 )
 =>
-(GenerateLookupJoins (OpName) $left $scanPrivate (ConcatFilters $on $filters))
+(GenerateLookupJoins (OpName) $left $scanPrivate (ConcatFilters $on $filters) $private)
 
 # AssociateJoin applies the rule of join associativity. It converts an
 # expression like:
 #   (A JOIN B ON A.y = B.y) JOIN C ON B.x = C.x
 # to the logically equivalent expression:
 #   A JOIN (B JOIN C ON B.x = C.x) ON A.y = B.y
+#
+# TODO(radu): handle the scan privates.
 [AssociateJoin, Explore]
 (InnerJoin
     $left:(InnerJoin
@@ -136,6 +143,7 @@
         $innerRight
         $right
         (ExtractBoundConditions $on (OutputCols2 $innerRight $right))
+        (EmptyJoinPrivate)
     )
     (SortFilters
         (ConcatFilters
@@ -143,4 +151,5 @@
             $innerOn
         )
     )
+    (EmptyJoinPrivate)
 )


### PR DESCRIPTION
To implement join hints, we need a `JoinPrivate`. Because there
are a ton of rules to adjust, in this change I'm just adding an empty
`JoinPrivate` and making the necessary fixes.

Release note: None