### PR TITLE
importccl: send correct number of values back

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -55,11 +55,12 @@ import (
 
 func TestImportData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	const nodes = 3
 	ctx := context.Background()
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(db)
+	tc := testcluster.StartTestCluster(t, nodes, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+	conn := tc.Conns[0]
+	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	tests := []struct {
 		name   string

--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -501,6 +501,7 @@ func (cp *readImportDataProcessor) doRun(ctx context.Context) error {
 			}
 			cs, err := cp.out.EmitRow(ctx, sqlbase.EncDatumRow{
 				sqlbase.DatumToEncDatum(typeBytes, tree.NewDBytes(tree.DBytes(countsBytes))),
+				sqlbase.DatumToEncDatum(typeBytes, tree.NewDBytes(tree.DBytes([]byte{}))),
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
I removed the extra nil thinking we didn't need it since the reader only read the one row.
However I forgot that the flow is setup with the types, so it gets angry when you don't meet them.
This slipped past the tests since it is off by default, and the test that turns it on is single-node.

Release note: none.