### PR TITLE
[DNM] closedts: shorten target_duration to 5s

### DIFF
--- a/pkg/ccl/followerreadsccl/followerreads_test.go
+++ b/pkg/ccl/followerreadsccl/followerreads_test.go
@@ -32,7 +32,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
-const expectedFollowerReadOffset = -1 * (30 * (1 + .2*3)) * time.Second
+const (
+	defaultInterval            = 3
+	defaultFraction            = .2
+	defaultMultiple            = 3
+	expectedFollowerReadOffset = -(defaultInterval * (1 + defaultFraction*defaultMultiple)) * time.Second
+)
 
 func TestEvalFollowerReadOffset(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/storage/closedts/setting.go
+++ b/pkg/storage/closedts/setting.go
@@ -21,7 +21,7 @@ import (
 var TargetDuration = settings.RegisterNonNegativeDurationSetting(
 	"kv.closed_timestamp.target_duration",
 	"if nonzero, attempt to provide closed timestamp notifications for timestamps trailing cluster time by approximately this duration",
-	30*time.Second,
+	3*time.Second,
 )
 
 // CloseFraction is the fraction of TargetDuration determining how often closed


### PR DESCRIPTION
I want to see what tests fail, if any.

Release note: None