### PR TITLE
server: log rocks stats when crashing due to hang

### DIFF
--- a/pkg/server/server_engine_health.go
+++ b/pkg/server/server_engine_health.go
@@ -58,9 +58,13 @@ func assertEngineHealth(ctx context.Context, engines []engine.Engine, maxDuratio
 	for _, eng := range engines {
 		func() {
 			t := time.AfterFunc(maxDuration, func() {
+				var stats string
+				if rocks, ok := eng.(*engine.RocksDB); ok {
+					stats = "\n" + rocks.GetCompactionStats()
+				}
 				// NB: the disk-stall-detected roachtest matches on this message.
-				guaranteedExitFatal(ctx, "disk stall detected: unable to write to %s within %s",
-					eng, maxSyncDuration,
+				guaranteedExitFatal(ctx, "disk stall detected: unable to write to %s within %s %s",
+					eng, maxSyncDuration, stats,
 				)
 			})
 			defer t.Stop()


### PR DESCRIPTION
By default we only log these stats, which includes info on stalls, every 10m.
However, if we are crashing due to a stall, this information could be really interesting.

Release note: none.