### PR TITLE
storage: stop sending BeginTxn requests in merge transactions, remove EagerRecord

### DIFF
--- a/pkg/internal/client/sender.go
+++ b/pkg/internal/client/sender.go
@@ -170,13 +170,6 @@ type TxnSender interface {
 	// like the transaction that merges ranges together.
 	DisablePipelining() error
 
-	// EagerRecord instructs the transaction write its transaction record as soon as
-	// possible, instead of waiting for the transaction's first heartbeat or for the
-	// end of the transaction to write it.
-	//
-	// TODO(nvanbenschoten): Fix up flaky tests to allow us to get rid of this.
-	EagerRecord() error
-
 	// OrigTimestamp returns the transaction's starting timestamp.
 	// Note a transaction can be internally pushed forward in time before
 	// committing so this is not guaranteed to be the commit timestamp.
@@ -376,9 +369,6 @@ func (m *MockTransactionalSender) UpdateStateOnRemoteRetryableErr(
 
 // DisablePipelining is part of the client.TxnSender interface.
 func (m *MockTransactionalSender) DisablePipelining() error { return nil }
-
-// EagerRecord is part of the client.TxnSender interface.
-func (m *MockTransactionalSender) EagerRecord() error { return nil }
 
 // MockTxnSenderFactory is a TxnSenderFactory producing MockTxnSenders.
 type MockTxnSenderFactory struct {

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -294,18 +294,6 @@ func (txn *Txn) DisablePipelining() error {
 	return txn.mu.sender.DisablePipelining()
 }
 
-// EagerRecord instructs the transaction write its transaction record as soon as
-// possible, instead of waiting for the transaction's first heartbeat or for the
-// end of the transaction to write it.
-//
-// EagerRecord must be called before any operations are performed on the
-// transaction.
-func (txn *Txn) EagerRecord() error {
-	txn.mu.Lock()
-	defer txn.mu.Unlock()
-	return txn.mu.sender.EagerRecord()
-}
-
 // NewBatch creates and returns a new empty batch object for use with the Txn.
 func (txn *Txn) NewBatch() *Batch {
 	return &Batch{txn: txn}

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -600,17 +600,6 @@ func (tc *TxnCoordSender) DisablePipelining() error {
 	return nil
 }
 
-// EagerRecord is part of the client.TxnSender interface.
-func (tc *TxnCoordSender) EagerRecord() error {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
-	if tc.mu.active {
-		return errors.Errorf("cannot request an eager transaction record write on a running transaction")
-	}
-	tc.interceptorAlloc.txnHeartbeater.eagerRecord = true
-	return nil
-}
-
 // commitReadOnlyTxnLocked "commits" a read-only txn. It is equivalent, but
 // cheaper than, sending an EndTransactionRequest. A read-only txn doesn't have
 // a transaction record, so there's no need to send any request to the server.

--- a/pkg/kv/txn_interceptor_heartbeater.go
+++ b/pkg/kv/txn_interceptor_heartbeater.go
@@ -86,10 +86,6 @@ type txnHeartbeater struct {
 	// is to notify the TxnCoordSender to shut itself down.
 	asyncAbortCallbackLocked func(context.Context)
 
-	// When set to true, the transaction will always send a BeginTxn request to
-	// lay down a transaction record as early as possible.
-	eagerRecord bool
-
 	// mu contains state protected by the TxnCoordSender's mutex.
 	mu struct {
 		sync.Locker
@@ -186,7 +182,7 @@ func (h *txnHeartbeater) SendLocked(
 			ba.Txn.Key = anchor
 		}
 
-		if h.eagerRecord || !h.st.Version.IsActive(cluster.VersionLazyTxnRecord) {
+		if !h.st.Version.IsActive(cluster.VersionLazyTxnRecord) {
 			addedBeginTxn = true
 
 			// Set the key in the begin transaction request to the txn's anchor key.

--- a/pkg/storage/batcheval/cmd_lease_request.go
+++ b/pkg/storage/batcheval/cmd_lease_request.go
@@ -82,7 +82,7 @@ func RequestLease(
 		// time here, which makes it not Equivalent() to the preceding lease for the
 		// same store.
 		//
-		// Note also that leastPostApply makes sure to update the timestamp cache in
+		// Note also that leasePostApply makes sure to update the timestamp cache in
 		// this case: even though the lease holder does not change, the the sequence
 		// number does and this triggers a low water mark bump.
 		//

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1395,6 +1395,17 @@ func truncateLogArgs(index uint64, rangeID roachpb.RangeID) *roachpb.TruncateLog
 	}
 }
 
+func heartbeatArgs(
+	txn *roachpb.Transaction, now hlc.Timestamp,
+) (*roachpb.HeartbeatTxnRequest, roachpb.Header) {
+	return &roachpb.HeartbeatTxnRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: txn.Key,
+		},
+		Now: now,
+	}, roachpb.Header{Txn: txn}
+}
+
 func TestSortRangeDescByAge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var replicaDescs []roachpb.ReplicaDescriptor

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -395,14 +395,6 @@ func (r *Replica) AdminMerge(
 		// TODO(benesch): expose a proper API for preventing the fast path.
 		_ = txn.CommitTimestamp()
 
-		// Multiple merge tests rely on a transaction record being written as
-		// early as possible in the lifecycle of a transaction. They aren't
-		// prepared for an untimely lease transfer to cause a restart.
-		// TODO(nvanbenschoten): Remove this once the tests are fixed.
-		if err := txn.EagerRecord(); err != nil {
-			return err
-		}
-
 		// Pipelining might send QueryIntent requests to the RHS after the RHS has
 		// noticed the merge and started blocking all traffic. This causes the merge
 		// transaction to deadlock. Just turn pipelining off; the structure of the


### PR DESCRIPTION
Closes #33656.

This fixes the root problem instead of sending BeginTxn requests to appease the test.

This is an important change to make now because if we left merges using BeginTxn requests in 19.1 then we wouldn't be able to remove BeginTxn support in 19.2.

The PR then removes the EagerRecord transaction option entirely.