### PR TITLE
sql: remove EvalContext.ActiveMemAcc

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -414,12 +414,6 @@ func (ex *connExecutor) execStmtInOpenState(
 	// contexts.
 	p.cancelChecker = sqlbase.NewCancelChecker(ctx)
 
-	// constantMemAcc accounts for all constant folded values that are computed
-	// prior to any rows being computed.
-	constantMemAcc := p.EvalContext().Mon.MakeBoundAccount()
-	p.EvalContext().ActiveMemAcc = &constantMemAcc
-	defer constantMemAcc.Close(ctx)
-
 	if runInParallel {
 		cols, err := ex.execStmtInParallel(ctx, p, queryDone)
 		queryDone = nil

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -190,12 +190,6 @@ func (ex *connExecutor) populatePrepared(
 	prepared := stmt.Prepared
 
 	p.extendedEvalCtx.PrepareOnly = true
-	p.extendedEvalCtx.ActiveMemAcc = &prepared.memAcc
-	// constantMemAcc accounts for all constant folded values that are computed
-	// prior to any rows being computed.
-	constantMemAcc := p.extendedEvalCtx.Mon.MakeBoundAccount()
-	p.extendedEvalCtx.ActiveMemAcc = &constantMemAcc
-	defer constantMemAcc.Close(ctx)
 
 	protoTS, err := p.isAsOf(stmt.AST, ex.server.cfg.Clock.Now() /* max */)
 	if err != nil {

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -659,8 +659,6 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	subqueryMemAccount := subqueryMonitor.MakeBoundAccount()
 	defer subqueryMemAccount.Close(ctx)
 
-	evalCtx.ActiveMemAcc = &subqueryMemAccount
-
 	var subqueryPlanCtx *PlanningCtx
 	var distributeSubquery bool
 	if maybeDistribute {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -489,11 +489,6 @@ func (dc *databaseCacheHolder) updateSystemConfig(cfg *config.SystemConfig) {
 func forEachRow(params runParams, p planNode, f func(tree.Datums) error) error {
 	next, err := p.Next(params)
 	for ; next; next, err = p.Next(params) {
-		// If we're tracking memory, clear the previous row's memory account.
-		if params.extendedEvalCtx.ActiveMemAcc != nil {
-			params.extendedEvalCtx.ActiveMemAcc.Clear(params.ctx)
-		}
-
 		if err := f(p.Values()); err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -262,7 +262,7 @@ SELECT repeat('Pg', -1) || 'empty'
 ----
 empty
 
-statement error pq: repeat\(\): .* memory budget exceeded
+statement error pq: repeat\(\): requested length too large
 SELECT repeat('s', 9223372036854775807)
 
 # Regression for #19035.
@@ -2012,10 +2012,10 @@ SELECT lpad('abc', 5, ''), rpad('abc', 5, '')
 ----
 abc  abc
 
-query error memory budget exceeded
+query error requested length too large
 SELECT lpad('abc', 100000000000000)
 
-query error memory budget exceeded
+query error requested length too large
 SELECT rpad('abc', 100000000000000)
 
 query TT

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -161,10 +161,6 @@ func (p *planNodeToRowSource) Next() (sqlbase.EncDatumRow, *distsqlrun.ProducerM
 			// by Nexting our source until exhaustion.
 			next, err := p.node.Next(p.params)
 			for ; next; next, err = p.node.Next(p.params) {
-				// If we're tracking memory, clear the previous row's memory account.
-				if p.params.extendedEvalCtx.ActiveMemAcc != nil {
-					p.params.extendedEvalCtx.ActiveMemAcc.Clear(p.params.ctx)
-				}
 				count++
 			}
 			if err != nil {

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -155,7 +155,6 @@ func insertNodeWithValuesSpans(
 	// completed, so that the values don't need to be computed again during
 	// plan execution.
 	rowAcc := params.extendedEvalCtx.Mon.MakeBoundAccount()
-	params.extendedEvalCtx.ActiveMemAcc = &rowAcc
 	defer rowAcc.Close(params.ctx)
 
 	defer v.Reset(params.ctx)

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -546,7 +546,8 @@ func scrubRunDistSQL(
 	columnTypes []sqlbase.ColumnType,
 ) (*rowcontainer.RowContainer, error) {
 	ci := sqlbase.ColTypeInfoFromColTypes(columnTypes)
-	rows := rowcontainer.NewRowContainer(*p.extendedEvalCtx.ActiveMemAcc, ci, 0 /* rowCapacity */)
+	acc := p.extendedEvalCtx.Mon.MakeBoundAccount()
+	rows := rowcontainer.NewRowContainer(acc, ci, 0 /* rowCapacity */)
 	rowResultWriter := NewRowResultWriter(rows)
 	recv := MakeDistSQLReceiver(
 		ctx,

--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -192,7 +192,7 @@ func TestEscapeFormatRandom(t *testing.T) {
 
 func TestLPadRPad(t *testing.T) {
 	testCases := []struct {
-		padFn    func(*tree.EvalContext, string, int, string) (string, error)
+		padFn    func(string, int, string) (string, error)
 		str      string
 		length   int
 		fill     string
@@ -228,9 +228,8 @@ func TestLPadRPad(t *testing.T) {
 		{rpad, "Hello", 8, "世界", "Hello世界世"},
 		{rpad, "foo", -1, "世界", ""},
 	}
-	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	for _, tc := range testCases {
-		out, err := tc.padFn(evalCtx, tc.str, tc.length, tc.fill)
+		out, err := tc.padFn(tc.str, tc.length, tc.fill)
 		if err != nil {
 			t.Errorf("Found err %v, expected nil", err)
 		}

--- a/pkg/sql/sem/tree/constant_eval_test.go
+++ b/pkg/sql/sem/tree/constant_eval_test.go
@@ -41,7 +41,6 @@ func TestConstantEvalArrayComparison(t *testing.T) {
 
 	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer ctx.Mon.Stop(context.Background())
-	defer ctx.ActiveMemAcc.Close(context.Background())
 	c := tree.MakeConstantEvalVisitor(ctx)
 	expr, _ = tree.WalkExpr(&c, typedExpr)
 	if err := c.Err(); err != nil {

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2514,11 +2514,6 @@ type EvalContext struct {
 	TestingKnobs EvalContextTestingKnobs
 
 	Mon *mon.BytesMonitor
-
-	// ActiveMemAcc is the account to which values are allocated during
-	// evaluation. It can change over the course of evaluation, such as on a
-	// per-row basis.
-	ActiveMemAcc *mon.BoundAccount
 }
 
 // MakeTestingEvalContext returns an EvalContext that includes a MemoryMonitor.
@@ -2547,8 +2542,6 @@ func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonit
 	monitor.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	ctx.Mon = monitor
 	ctx.Context = context.TODO()
-	acc := monitor.MakeBoundAccount()
-	ctx.ActiveMemAcc = &acc
 	now := timeutil.Now()
 	ctx.SetTxnTimestamp(now)
 	ctx.SetStmtTimestamp(now)

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -36,10 +36,7 @@ import (
 
 func TestEval(t *testing.T) {
 	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-	// We have to manually close this account because we're doing the evaluations
-	// ourselves.
-	defer ctx.Mon.Stop(context.Background())
-	defer ctx.ActiveMemAcc.Close(context.Background())
+	defer ctx.Stop(context.Background())
 
 	walk := func(t *testing.T, getExpr func(tree.TypedExpr) (tree.TypedExpr, error)) {
 		datadriven.Walk(t, filepath.Join("testdata", "eval"), func(t *testing.T, path string) {

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -289,7 +289,6 @@ func TestNormalizeExpr(t *testing.T) {
 			rOrig := typedExpr.String()
 			ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer ctx.Mon.Stop(context.Background())
-			defer ctx.ActiveMemAcc.Close(context.Background())
 			r, err := ctx.NormalizeExpr(typedExpr)
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)


### PR DESCRIPTION
This memory account was used to track allocations performed by builtins
that allocated memory, mainly string manipulation builtins. It was
pretty hard to use this correctly, as the lifetimes of the account were
never particularly clear.

There were a couple of hacks in place to try to clear the memory at the
right times, but they didn't work correctly, leading to crashes that
were hard to diagnose.

Rather than try to make this work perfectly, this commit removes the
memory accounting for these builtins and replaces it with a hard cap on
the size of string allocations - set arbitrarily to 64 MB at this time.

Release note: None