### PR TITLE
sql: set the deadline at commit time

### DIFF
--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -449,7 +449,8 @@ func TestBatchMixRawRequest(t *testing.T) {
 	}
 }
 
-func TestUpdateDeadlineMaybe(t *testing.T) {
+// TestSetDeadline tests SetDeadline().
+func TestSetDeadline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
@@ -470,26 +471,18 @@ func TestUpdateDeadlineMaybe(t *testing.T) {
 	}
 
 	deadline := hlc.Timestamp{WallTime: 10, Logical: 1}
-	if !txn.UpdateDeadlineMaybe(ctx, deadline) {
-		t.Errorf("expected update, but it didn't happen")
+	if err := txn.SetDeadline(deadline); err != nil {
+		t.Errorf("expected update, but it didn't happen: %s", err)
 	}
 	if d := *txn.deadline(); d != deadline {
 		t.Errorf("unexpected deadline: %s", d)
 	}
 
 	futureDeadline := hlc.Timestamp{WallTime: 11, Logical: 1}
-	if txn.UpdateDeadlineMaybe(ctx, futureDeadline) {
+	if err := txn.SetDeadline(futureDeadline); err == nil {
 		t.Errorf("expected no update, but update happened")
 	}
 	if d := *txn.deadline(); d != deadline {
-		t.Errorf("unexpected deadline: %s", d)
-	}
-
-	pastDeadline := hlc.Timestamp{WallTime: 9, Logical: 1}
-	if !txn.UpdateDeadlineMaybe(ctx, pastDeadline) {
-		t.Errorf("expected update, but it didn't happen")
-	}
-	if d := *txn.deadline(); d != pastDeadline {
 		t.Errorf("unexpected deadline: %s", d)
 	}
 }

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -615,6 +615,12 @@ func (ex *connExecutor) commitSQLTransaction(
 		return ex.makeErrEvent(err, stmt)
 	}
 
+	// Set the txn deadline before committing.
+	if deadline := ex.extraTxnState.tables.deadline(); !deadline.IsEmpty() {
+		if err := ex.state.mu.txn.SetDeadline(deadline); err != nil {
+			return ex.makeErrEvent(err, stmt)
+		}
+	}
 	if err := ex.state.mu.txn.Commit(ctx); err != nil {
 		return ex.makeErrEvent(err, stmt)
 	}

--- a/pkg/sql/delayed.go
+++ b/pkg/sql/delayed.go
@@ -47,9 +47,9 @@ func (d *delayedNode) Close(ctx context.Context) {
 }
 
 // enableAutoCommit is part of the autoCommitNode interface.
-func (d *delayedNode) enableAutoCommit() {
+func (d *delayedNode) enableAutoCommit(txnDeadline txnDeadline) {
 	if ac, ok := d.plan.(autoCommitNode); ok {
-		ac.enableAutoCommit()
+		ac.enableAutoCommit(txnDeadline)
 	}
 }
 

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -441,6 +441,6 @@ func canDeleteFastInterleaved(table *ImmutableTableDescriptor, fkTables row.FkTa
 }
 
 // enableAutoCommit is part of the autoCommitNode interface.
-func (d *deleteNode) enableAutoCommit() {
-	d.run.td.enableAutoCommit()
+func (d *deleteNode) enableAutoCommit(txnDeadline txnDeadline) {
+	d.run.td.enableAutoCommit(txnDeadline)
 }

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -223,6 +223,6 @@ func (*deleteRangeNode) Values() tree.Datums {
 func (*deleteRangeNode) Close(ctx context.Context) {}
 
 // enableAutoCommit implements the autoCommitNode interface.
-func (d *deleteRangeNode) enableAutoCommit() {
-	d.tableWriter.enableAutoCommit()
+func (d *deleteRangeNode) enableAutoCommit(txnDeadline txnDeadline) {
+	d.tableWriter.enableAutoCommit(txnDeadline)
 }

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -40,7 +40,7 @@ func (p *planner) expandPlan(ctx context.Context, plan planNode) (planNode, erro
 
 	if p.autoCommit {
 		if ac, ok := plan.(autoCommitNode); ok {
-			ac.enableAutoCommit()
+			ac.enableAutoCommit(p.extendedEvalCtx.Tables)
 		}
 	}
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -603,8 +603,8 @@ func (n *insertNode) Close(ctx context.Context) {
 }
 
 // enableAutoCommit is part of the autoCommitNode interface.
-func (n *insertNode) enableAutoCommit() {
-	n.run.ti.enableAutoCommit()
+func (n *insertNode) enableAutoCommit(txnDeadline txnDeadline) {
+	n.run.ti.enableAutoCommit(txnDeadline)
 }
 
 // GenerateInsertRow prepares a row tuple for insertion. It fills in default

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -783,7 +783,7 @@ func (ef *execFactory) ConstructPlan(
 	// Enable auto-commit if the planner setting allows it.
 	if ef.planner.autoCommit {
 		if ac, ok := root.(autoCommitNode); ok {
-			ac.enableAutoCommit()
+			ac.enableAutoCommit(ef.planner.extendedEvalCtx.Tables)
 		}
 	}
 	// No need to spool at the root.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -482,7 +482,7 @@ func startPlan(params runParams, plan planNode) error {
 type autoCommitNode interface {
 	// enableAutoCommit is called on the root planNode (if it implements this
 	// interface).
-	enableAutoCommit()
+	enableAutoCommit(txnDeadline txnDeadline)
 }
 
 var _ autoCommitNode = &createTableNode{}

--- a/pkg/sql/plan_batch.go
+++ b/pkg/sql/plan_batch.go
@@ -144,7 +144,9 @@ func (s *serializeNode) FastPathResults() (int, bool) {
 func (s *serializeNode) requireSpool() {}
 
 // enableAutocommit implements the autoCommitNode interface.
-func (s *serializeNode) enableAutoCommit() { s.source.enableAutoCommit() }
+func (s *serializeNode) enableAutoCommit(txnDeadline txnDeadline) {
+	s.source.enableAutoCommit(txnDeadline)
+}
 
 // rowCountNode serializes the results of a batchedPlanNode into a
 // plain planNode interface that has guaranteed FastPathResults
@@ -187,4 +189,6 @@ func (r *rowCountNode) Close(ctx context.Context)           { r.source.Close(ctx
 func (r *rowCountNode) FastPathResults() (int, bool) { return r.rowCount, true }
 
 // enableAutocommit implements the autoCommitNode interface.
-func (r *rowCountNode) enableAutoCommit() { r.source.enableAutoCommit() }
+func (r *rowCountNode) enableAutoCommit(txnDeadline txnDeadline) {
+	r.source.enableAutoCommit(txnDeadline)
+}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -739,8 +739,8 @@ func (u *updateNode) Close(ctx context.Context) {
 }
 
 // enableAutoCommit implements the autoCommitNode interface.
-func (u *updateNode) enableAutoCommit() {
-	u.run.tu.enableAutoCommit()
+func (u *updateNode) enableAutoCommit(txnDeadline txnDeadline) {
+	u.run.tu.enableAutoCommit(txnDeadline)
 }
 
 // sourceSlot abstracts the idea that our update sources can either be tuples

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -423,8 +423,8 @@ func (n *upsertNode) Close(ctx context.Context) {
 }
 
 // enableAutoCommit is part of the autoCommitNode interface.
-func (n *upsertNode) enableAutoCommit() {
-	n.run.tw.enableAutoCommit()
+func (n *upsertNode) enableAutoCommit(txnDeadline txnDeadline) {
+	n.run.tw.enableAutoCommit(txnDeadline)
 }
 
 // upsertExcludedTable is the name of a synthetic table used in an upsert's set


### PR DESCRIPTION
This change does all the plumbing to set the
deadline at commit time. The deadline itself is not
extended in this change.

The enableAutoCommit() method is passed a txnDeadline
interface that allows the auto commit code to fetch the
deadline before committing.

tested by TestTxnObeysTableModificationTime

related to #18684

Release note: None