### PR TITLE
ui: hide `row source to planNode` logical plan nodes

### DIFF
--- a/pkg/ui/src/views/statements/planView.tsx
+++ b/pkg/ui/src/views/statements/planView.tsx
@@ -156,6 +156,20 @@ export function planNodeHeaderProps(node: FlatPlanNode): PlanNodeHeaderProps {
   };
 }
 
+// shouldHideNode looks at node name to determine whether we should hide
+// node from logical plan tree.
+//
+// Currently we're hiding `row source to planNode`, which is a node
+// generated during execution (e.g. this is an internal implementation
+// detail that will add more confusion than help to user). See #34594
+// for details.
+function shouldHideNode(nodeName: string): boolean {
+  if (nodeName === "row source to plan node") {
+    return true;
+  }
+  return false;
+}
+
 /* ************************* PLAN NODES ************************* */
 
 interface PlanNodeDetailProps {
@@ -257,6 +271,9 @@ interface PlanNodeProps {
 
 class PlanNode extends React.Component<PlanNodeProps> {
   render() {
+    if (shouldHideNode(this.props.node.name)) {
+      return null;
+    }
     const node = this.props.node;
     return (
       <li>


### PR DESCRIPTION
Fixes #34594 (See issue 1 in comment)

We're seeing `row source to planNode` because we don't have a DistSQL
physical processor equivalent for the previous node. This is because
either:

1- Query doesn't make sense to be distributed (e.g. `INSERT` or
   `CREATE TABLE`), or
2- We haven't implemented this yet for particular node, but
   should / will.

This commit hides `row source to planNode` nodes from the user, as
this internal implementation detail will add more confusion than
help to user.

Before:
<img width="350" alt="max1 before" src="https://user-images.githubusercontent.com/3051672/52862803-20b6ec80-3104-11e9-881d-d40a1574ee1e.png">

After (example 1):
<img width="300" alt="max1 after" src="https://user-images.githubusercontent.com/3051672/52862802-20b6ec80-3104-11e9-96af-fd2d0a0e01bc.png">

After (example 2):
<img width="450" alt="hide-row-source after" src="https://user-images.githubusercontent.com/3051672/54457918-0c810200-4739-11e9-892f-600aaea766fa.gif">

Release note: None