### PR TITLE
workloadccl: benchmark `fixtures import` for single-node tpcc 1

### DIFF
--- a/pkg/ccl/workloadccl/cliccl/fixtures.go
+++ b/pkg/ccl/workloadccl/cliccl/fixtures.go
@@ -23,6 +23,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/cockroachdb/cockroach/pkg/ccl/workloadccl"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	workloadcli "github.com/cockroachdb/cockroach/pkg/workload/cli"
@@ -305,9 +306,11 @@ func fixturesImport(gen workload.Generator, urls []string, dbName string) error 
 	}
 
 	directIngestion := *fixturesImportDirectIngestionTable
-	if err := workloadccl.ImportFixture(ctx, sqlDB, gen, dbName, directIngestion); err != nil {
+	bytes, err := workloadccl.ImportFixture(ctx, sqlDB, gen, dbName, directIngestion)
+	if err != nil {
 		return errors.Wrap(err, `importing fixture`)
 	}
+	log.Infof(ctx, "imported %s bytes in %d tables", humanizeutil.IBytes(bytes), len(gen.Tables()))
 
 	if hooks, ok := gen.(workload.Hookser); *fixturesRunChecks && ok {
 		if consistencyCheckFn := hooks.Hooks().CheckConsistency; consistencyCheckFn != nil {


### PR DESCRIPTION
So we can track our progress in #34809.

Diff between distsql IMPORT and direct IMPORT

    name                 old time/op    new time/op    delta
    ImportFixtureTPCC-8     7.74s ± 3%     4.09s ± 6%  -47.18%  (p=0.008 n=5+5)

    name                 old speed      new speed      delta
    ImportFixtureTPCC-8  11.4MB/s ± 3%  21.7MB/s ± 6%  +89.46%  (p=0.008 n=5+5)

    name                 old alloc/op   new alloc/op   delta
    ImportFixtureTPCC-8    7.18GB ± 0%    4.12GB ± 0%  -42.62%  (p=0.008 n=5+5)

    name                 old allocs/op  new allocs/op  delta
    ImportFixtureTPCC-8     89.0M ± 0%     39.5M ± 0%  -55.56%  (p=0.008 n=5+5)

Release note: None