### PR TITLE
opt: distinguish VALUES clauses by a unique id

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -805,6 +805,9 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 			fmt.Fprintf(f.Buffer, " %s@%s", tab.Name().TableName, tab.Index(t.Index).Name())
 		}
 
+	case *ValuesPrivate:
+		fmt.Fprintf(f.Buffer, " id=v%d", t.ID)
+
 	case *ZigzagJoinPrivate:
 		leftTab := f.Memo.metadata.Table(t.LeftTable)
 		rightTab := f.Memo.metadata.Table(t.RightTable)

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -458,6 +458,10 @@ func (h *hasher) HashSequenceID(val opt.SequenceID) {
 	h.HashUint64(uint64(val))
 }
 
+func (h *hasher) HashValuesID(val opt.ValuesID) {
+	h.HashUint64(uint64(val))
+}
+
 func (h *hasher) HashScanLimit(val ScanLimit) {
 	h.HashUint64(uint64(val))
 }
@@ -714,6 +718,10 @@ func (h *hasher) IsTableIDEqual(l, r opt.TableID) bool {
 }
 
 func (h *hasher) IsSequenceIDEqual(l, r opt.SequenceID) bool {
+	return l == r
+}
+
+func (h *hasher) IsValuesIDEqual(l, r opt.ValuesID) bool {
 	return l == r
 }
 

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -363,9 +363,9 @@ memo (optimized, ~5KB, required=[presentation: field:3])
  │         ├── best: (explain G4="[presentation: k:1]" [presentation: k:1])
  │         └── cost: 0.03
  ├── G3: (aggregations)
- ├── G4: (values G5)
+ ├── G4: (values G5 id=v1)
  │    └── [presentation: k:1]
- │         ├── best: (values G5)
+ │         ├── best: (values G5 id=v1)
  │         └── cost: 0.02
  ├── G5: (scalar-list G6)
  ├── G6: (tuple G7)

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -80,6 +80,9 @@ type Metadata struct {
 	// sequences stores information about each metadata sequence, indexed by SequenceID.
 	sequences []cat.Sequence
 
+	// values is the highest id for a Values clause that has been assigned.
+	values ValuesID
+
 	// deps stores information about all catalog objects depended on by the query,
 	// as well as the privileges required to access those objects. The objects are
 	// deduplicated: any name/object pair shows up at most once.
@@ -375,4 +378,17 @@ func (md *Metadata) AddSequence(seq cat.Sequence) SequenceID {
 // same sequence can be associated with multiple metadata ids.
 func (md *Metadata) Sequence(seqID SequenceID) cat.Sequence {
 	return md.sequences[seqID.index()]
+}
+
+// ValuesID uniquely identifies the usage of a values clause within the scope of a
+// query.
+//
+// See the comment for Metadata for more details on identifiers.
+type ValuesID uint64
+
+// NextValuesID returns a fresh ValuesID which is guaranteed to never have been
+// allocated prior in this memo.
+func (md *Metadata) NextValuesID() ValuesID {
+	md.values++
+	return md.values
 }

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -611,7 +611,10 @@ func (c *CustomFuncs) MergeProjectWithValues(
 	}
 
 	rows := memo.ScalarListExpr{c.f.ConstructTuple(newExprs, types.TTuple{Types: newTypes})}
-	return c.f.ConstructValues(rows, newCols)
+	return c.f.ConstructValues(rows, &memo.ValuesPrivate{
+		Cols: newCols,
+		ID:   values.ID,
+	})
 }
 
 // ProjectionCols returns the ids of the columns synthesized by the given
@@ -770,7 +773,10 @@ func (c *CustomFuncs) ConstructEmptyValues(cols opt.ColSet) memo.RelExpr {
 	for i, ok := cols.Next(0); ok; i, ok = cols.Next(i + 1) {
 		colList = append(colList, opt.ColumnID(i))
 	}
-	return c.f.ConstructValues(memo.EmptyScalarListExpr, colList)
+	return c.f.ConstructValues(memo.EmptyScalarListExpr, &memo.ValuesPrivate{
+		Cols: colList,
+		ID:   c.mem.Metadata().NextValuesID(),
+	})
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -276,7 +276,10 @@ func (f *Factory) onConstructScalar(scalar opt.ScalarExpr) opt.ScalarExpr {
 // ConstructZeroValues constructs a Values operator with zero rows and zero
 // columns. It is used to create a dummy input for operators like CreateTable.
 func (f *Factory) ConstructZeroValues() memo.RelExpr {
-	return f.ConstructValues(memo.EmptyScalarListExpr, opt.ColList{})
+	return f.ConstructValues(memo.EmptyScalarListExpr, &memo.ValuesPrivate{
+		Cols: opt.ColList{},
+		ID:   f.Metadata().NextValuesID(),
+	})
 }
 
 // ConstructJoin constructs the join operator that corresponds to the given join

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -50,7 +50,10 @@ func TestSimplifyFilters(t *testing.T) {
 	eq := f.ConstructEq(variable, constant)
 
 	// Filters expression evaluates to False if any operand is False.
-	vals := f.ConstructValues(memo.ScalarListWithEmptyTuple, opt.ColList{})
+	vals := f.ConstructValues(memo.ScalarListWithEmptyTuple, &memo.ValuesPrivate{
+		Cols: opt.ColList{},
+		ID:   f.Metadata().NextValuesID(),
+	})
 	filters := memo.FiltersExpr{{Condition: eq}, {Condition: &memo.FalseFilter}, {Condition: eq}}
 	sel := f.ConstructSelect(vals, filters)
 	if sel.Relational().Cardinality.Max == 0 {

--- a/pkg/sql/opt/norm/prune_cols.go
+++ b/pkg/sql/opt/norm/prune_cols.go
@@ -316,7 +316,10 @@ func (c *CustomFuncs) pruneValuesCols(values *memo.ValuesExpr, neededCols opt.Co
 		newRows[irow] = c.f.ConstructTuple(newElems, typ)
 	}
 
-	return c.f.ConstructValues(newRows, newCols)
+	return c.f.ConstructValues(newRows, &memo.ValuesPrivate{
+		Cols: newCols,
+		ID:   values.ID,
+	})
 }
 
 // PruneOrderingGroupBy removes any columns referenced by the Ordering inside

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -690,10 +690,10 @@
 [HoistValuesSubquery, Normalize, LowPriority]
 (Values
     $rows:[ ... $item:* & (HasHoistableSubquery $item) ... ]
-    $cols:*
+    $private:*
 )
 =>
-(HoistValuesSubquery $rows $cols)
+(HoistValuesSubquery $rows $private)
 
 # HoistProjectSetSubquery extracts subqueries from zipped functions and joins
 # them with the ProjectSet operator's input. This and other subquery hoisting

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -125,7 +125,19 @@ define SequenceSelectPrivate {
 [Relational]
 define Values {
     Rows ScalarListExpr
+
+    _    ValuesPrivate
+}
+
+[Private]
+define ValuesPrivate {
     Cols ColList
+
+    # ID is a memo-unique identifier which distinguishes between identical
+    # Values expressions which appear in different places in the query. In most
+    # cases the column set is sufficient to do this, but various rules make it
+    # possible to construct Values expressions with no columns.
+    ID ValuesID
 }
 
 # Select filters rows from its input result set, based on the boolean filter

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -492,7 +492,10 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 	// Handle DEFAULT VALUES case by creating a single empty row as input.
 	if inputRows == nil {
 		mb.outScope = inScope.push()
-		mb.outScope.expr = mb.b.factory.ConstructValues(memo.ScalarListWithEmptyTuple, opt.ColList{})
+		mb.outScope.expr = mb.b.factory.ConstructValues(memo.ScalarListWithEmptyTuple, &memo.ValuesPrivate{
+			Cols: opt.ColList{},
+			ID:   mb.md.NextValuesID(),
+		})
 		return
 	}
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -686,7 +686,10 @@ func (b *Builder) buildFrom(from *tree.From, inScope *scope) (outScope *scope) {
 		outScope = b.buildFromTables(from.Tables, inScope)
 	} else {
 		outScope = inScope.push()
-		outScope.expr = b.factory.ConstructValues(memo.ScalarListWithEmptyTuple, opt.ColList{})
+		outScope.expr = b.factory.ConstructValues(memo.ScalarListWithEmptyTuple, &memo.ValuesPrivate{
+			Cols: opt.ColList{},
+			ID:   b.factory.Metadata().NextValuesID(),
+		})
 	}
 
 	return outScope

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -114,7 +114,10 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 	}
 
 	// Construct the zip as a ProjectSet with empty input.
-	input := b.factory.ConstructValues(memo.ScalarListWithEmptyTuple, opt.ColList{})
+	input := b.factory.ConstructValues(memo.ScalarListWithEmptyTuple, &memo.ValuesPrivate{
+		Cols: opt.ColList{},
+		ID:   b.factory.Metadata().NextValuesID(),
+	})
 	outScope.expr = b.factory.ConstructProjectSet(input, zip)
 	return outScope
 }

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -87,7 +87,10 @@ func (b *Builder) buildValuesClause(
 	}
 
 	colList := colsToColList(outScope.cols)
-	outScope.expr = b.factory.ConstructValues(rows, colList)
+	outScope.expr = b.factory.ConstructValues(rows, &memo.ValuesPrivate{
+		Cols: colList,
+		ID:   b.factory.Metadata().NextValuesID(),
+	})
 	return outScope
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -153,6 +153,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"TableID":        {fullName: "opt.TableID", passByVal: true},
 		"SchemaID":       {fullName: "opt.SchemaID", passByVal: true},
 		"SequenceID":     {fullName: "opt.SequenceID", passByVal: true},
+		"ValuesID":       {fullName: "opt.ValuesID", passByVal: true},
 		"Ordering":       {fullName: "opt.Ordering", passByVal: true},
 		"OrderingChoice": {fullName: "physical.OrderingChoice", passByVal: true},
 		"TupleOrdinal":   {fullName: "memo.TupleOrdinal", passByVal: true},

--- a/pkg/sql/opt/optgen/exprgen/testdata/values
+++ b/pkg/sql/opt/optgen/exprgen/testdata/values
@@ -4,7 +4,7 @@ expr
     (Tuple [ (Const 1) (Const 1) ] "tuple{int, int}" )
     (Tuple [ (Const 2) (Const 2) ] "tuple{int, int}" )
   ]
-  [ (NewColumn "a" "int") (NewColumn "b" "int") ]
+  [ (Cols [ (NewColumn "a" "int") (NewColumn "b" "int") ]) ]
 )
 ----
 values
@@ -23,7 +23,7 @@ expr
 (Project
   (Values
     [ (Tuple [ (Const 1) ] "tuple{int}" ) ]
-    [ (NewColumn "x" "int") ]
+    [ (Cols [ (NewColumn "x" "int") ]) ]
   )
   [ (ProjectionItem (Plus (Var "x") (Const 10)) (NewColumn "y" "int")) ]
   "x"

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -26,8 +26,8 @@
 # join).
 [CommuteJoin, Explore]
 (InnerJoin | FullJoin
-  $left:* & ^(HasNoCols $left)
-  $right:* & ^(HasNoCols $right)
+  $left:*
+  $right:*
   $on:*
   $private:*
 )
@@ -37,8 +37,8 @@
 # CommuteLeftJoin creates a Join with the left and right inputs swapped.
 [CommuteLeftJoin, Explore]
 (LeftJoin
-  $left:* & ^(HasNoCols $left)
-  $right:* & ^(HasNoCols $left)
+  $left:*
+  $right:*
   $on:*
   $private:*
 )
@@ -48,8 +48,8 @@
 # CommuteRightJoin creates a Join with the left and right inputs swapped.
 [CommuteRightJoin, Explore]
 (RightJoin
-  $left:* & ^(HasNoCols $left)
-  $right:* & ^(HasNoCols $left)
+  $left:*
+  $right:*
   $on:*
   $private:*
 )
@@ -129,11 +129,11 @@
 [AssociateJoin, Explore]
 (InnerJoin
     $left:(InnerJoin
-        $innerLeft:* & ^(HasNoCols $innerLeft)
-        $innerRight:* & ^(HasNoCols $innerRight)
+        $innerLeft:*
+        $innerRight:*
         $innerOn:*
     )
-    $right:* & (ShouldReorderJoins $left $right) & ^(HasNoCols $right)
+    $right:* & (ShouldReorderJoins $left $right)
     $on:*
 )
 =>

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1826,12 +1826,12 @@ union-all
  │    ├── inner-join
  │    │    ├── cardinality: [6 - 6]
  │    │    ├── values
- │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── cardinality: [3 - 3]
+ │    │    │    ├── tuple [type=tuple{}]
  │    │    │    ├── tuple [type=tuple{}]
  │    │    │    └── tuple [type=tuple{}]
  │    │    ├── values
- │    │    │    ├── cardinality: [3 - 3]
- │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    ├── cardinality: [2 - 2]
  │    │    │    ├── tuple [type=tuple{}]
  │    │    │    └── tuple [type=tuple{}]
  │    │    └── filters (true)
@@ -1856,6 +1856,56 @@ union-all
       └── projections
            └── const: 1 [type=int]
 
+memo
+SELECT 1 FROM (VALUES (1), (1)) JOIN (VALUES (1), (1), (1)) ON true
+UNION ALL
+SELECT 1 FROM (VALUES (1), (1), (1)) JOIN (VALUES (1), (1)) ON true
+----
+memo (optimized, ~17KB, required=[presentation: ?column?:7])
+ ├── G1: (union-all G2 G3)
+ │    └── [presentation: ?column?:7]
+ │         ├── best: (union-all G2 G3)
+ │         └── cost: 0.82
+ ├── G2: (project G4 G5)
+ │    └── []
+ │         ├── best: (project G4 G5)
+ │         └── cost: 0.34
+ ├── G3: (project G6 G5)
+ │    └── []
+ │         ├── best: (project G6 G5)
+ │         └── cost: 0.34
+ ├── G4: (inner-join G7 G8 G9) (inner-join G8 G7 G9)
+ │    └── []
+ │         ├── best: (inner-join G8 G7 G9)
+ │         └── cost: 0.21
+ ├── G5: (projections G10)
+ ├── G6: (inner-join G11 G12 G9) (inner-join G12 G11 G9)
+ │    └── []
+ │         ├── best: (inner-join G11 G12 G9)
+ │         └── cost: 0.21
+ ├── G7: (values G13 id=v1)
+ │    └── []
+ │         ├── best: (values G13 id=v1)
+ │         └── cost: 0.03
+ ├── G8: (values G14 id=v2)
+ │    └── []
+ │         ├── best: (values G14 id=v2)
+ │         └── cost: 0.04
+ ├── G9: (filters)
+ ├── G10: (const 1)
+ ├── G11: (values G14 id=v3)
+ │    └── []
+ │         ├── best: (values G14 id=v3)
+ │         └── cost: 0.04
+ ├── G12: (values G13 id=v4)
+ │    └── []
+ │         ├── best: (values G13 id=v4)
+ │         └── cost: 0.03
+ ├── G13: (scalar-list G15 G15)
+ ├── G14: (scalar-list G15 G15 G15)
+ ├── G15: (tuple G16)
+ └── G16: (scalar-list)
+
 opt join-limit=3
 SELECT
     false
@@ -1872,43 +1922,34 @@ project
  │    ├── cardinality: [0 - 0]
  │    ├── side-effects, mutations
  │    ├── fd: ()-->(5-7)
- │    ├── values
- │    │    ├── cardinality: [0 - 0]
- │    │    └── key: ()
- │    ├── inner-join
+ │    ├── select
  │    │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
  │    │    ├── cardinality: [0 - 0]
  │    │    ├── side-effects, mutations
  │    │    ├── fd: ()-->(5-7)
- │    │    ├── select
+ │    │    ├── insert abc
  │    │    │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
- │    │    │    ├── cardinality: [0 - 0]
+ │    │    │    ├── insert-mapping:
+ │    │    │    │    ├──  "?column?":13 => abc.a:5
+ │    │    │    │    ├──  column14:14 => abc.b:6
+ │    │    │    │    ├──  column14:14 => abc.c:7
+ │    │    │    │    └──  column15:15 => abc.rowid:8
  │    │    │    ├── side-effects, mutations
  │    │    │    ├── fd: ()-->(5-7)
- │    │    │    ├── insert abc
- │    │    │    │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
- │    │    │    │    ├── insert-mapping:
- │    │    │    │    │    ├──  "?column?":13 => abc.a:5
- │    │    │    │    │    ├──  column14:14 => abc.b:6
- │    │    │    │    │    ├──  column14:14 => abc.c:7
- │    │    │    │    │    └──  column15:15 => abc.rowid:8
- │    │    │    │    ├── side-effects, mutations
- │    │    │    │    ├── fd: ()-->(5-7)
- │    │    │    │    └── project
- │    │    │    │         ├── columns: column14:14(int) column15:15(int) "?column?":13(int!null)
- │    │    │    │         ├── side-effects
- │    │    │    │         ├── fd: ()-->(13,14)
- │    │    │    │         ├── scan abc
- │    │    │    │         └── projections
- │    │    │    │              ├── null [type=int]
- │    │    │    │              ├── unique_rowid() [type=int, side-effects]
- │    │    │    │              └── const: 1 [type=int]
- │    │    │    └── filters
- │    │    │         └── false [type=bool]
- │    │    ├── values
- │    │    │    ├── cardinality: [0 - 0]
- │    │    │    └── key: ()
- │    │    └── filters (true)
+ │    │    │    └── project
+ │    │    │         ├── columns: column14:14(int) column15:15(int) "?column?":13(int!null)
+ │    │    │         ├── side-effects
+ │    │    │         ├── fd: ()-->(13,14)
+ │    │    │         ├── scan abc
+ │    │    │         └── projections
+ │    │    │              ├── null [type=int]
+ │    │    │              ├── unique_rowid() [type=int, side-effects]
+ │    │    │              └── const: 1 [type=int]
+ │    │    └── filters
+ │    │         └── false [type=bool]
+ │    ├── values
+ │    │    ├── cardinality: [0 - 0]
+ │    │    └── key: ()
  │    └── filters (true)
  └── projections
       └── false [type=bool]
@@ -1929,24 +1970,24 @@ union-all
  │    ├── fd: ()-->(4)
  │    ├── inner-join
  │    │    ├── cardinality: [24 - 24]
- │    │    ├── values
- │    │    │    ├── cardinality: [2 - 2]
- │    │    │    ├── tuple [type=tuple{}]
- │    │    │    └── tuple [type=tuple{}]
  │    │    ├── inner-join
- │    │    │    ├── cardinality: [12 - 12]
+ │    │    │    ├── cardinality: [6 - 6]
  │    │    │    ├── values
  │    │    │    │    ├── cardinality: [3 - 3]
  │    │    │    │    ├── tuple [type=tuple{}]
  │    │    │    │    ├── tuple [type=tuple{}]
  │    │    │    │    └── tuple [type=tuple{}]
  │    │    │    ├── values
- │    │    │    │    ├── cardinality: [4 - 4]
- │    │    │    │    ├── tuple [type=tuple{}]
- │    │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    │    ├── cardinality: [2 - 2]
  │    │    │    │    ├── tuple [type=tuple{}]
  │    │    │    │    └── tuple [type=tuple{}]
  │    │    │    └── filters (true)
+ │    │    ├── values
+ │    │    │    ├── cardinality: [4 - 4]
+ │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    ├── tuple [type=tuple{}]
+ │    │    │    └── tuple [type=tuple{}]
  │    │    └── filters (true)
  │    └── projections
  │         └── const: 1 [type=int]
@@ -1959,12 +2000,12 @@ union-all
       │    ├── inner-join
       │    │    ├── cardinality: [6 - 6]
       │    │    ├── values
-      │    │    │    ├── cardinality: [2 - 2]
+      │    │    │    ├── cardinality: [3 - 3]
+      │    │    │    ├── tuple [type=tuple{}]
       │    │    │    ├── tuple [type=tuple{}]
       │    │    │    └── tuple [type=tuple{}]
       │    │    ├── values
-      │    │    │    ├── cardinality: [3 - 3]
-      │    │    │    ├── tuple [type=tuple{}]
+      │    │    │    ├── cardinality: [2 - 2]
       │    │    │    ├── tuple [type=tuple{}]
       │    │    │    └── tuple [type=tuple{}]
       │    │    └── filters (true)
@@ -2019,9 +2060,13 @@ union-all
       ├── cardinality: [2 - 6]
       ├── side-effects
       ├── fd: ()-->(6)
-      ├── right-join
+      ├── left-join
       │    ├── cardinality: [2 - 6]
       │    ├── side-effects
+      │    ├── values
+      │    │    ├── cardinality: [2 - 2]
+      │    │    ├── tuple [type=tuple{}]
+      │    │    └── tuple [type=tuple{}]
       │    ├── select
       │    │    ├── cardinality: [0 - 3]
       │    │    ├── side-effects
@@ -2032,10 +2077,6 @@ union-all
       │    │    │    └── tuple [type=tuple{}]
       │    │    └── filters
       │    │         └── random() = 0.0 [type=bool, side-effects]
-      │    ├── values
-      │    │    ├── cardinality: [2 - 2]
-      │    │    ├── tuple [type=tuple{}]
-      │    │    └── tuple [type=tuple{}]
       │    └── filters (true)
       └── projections
            └── const: 1 [type=int]


### PR DESCRIPTION
Previously, identical VALUES clauses could appear multiple times in the
same tree by constructing them to have zero columns. This commit forbids
this, by making sure all VALUES clauses are completely unique via a
unique identifier. This eliminates a lot of problems we were having with
respect to the order in which groups can be visited.

Release note: None