### PR TITLE
sql: allocate IDs after each command in ALTER TABLE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -411,21 +411,24 @@ ALTER TABLE t ADD b INT DEFAULT 1, ADD c INT DEFAULT 2 CHECK (c > b)
 statement ok
 ALTER TABLE t ADD d INT UNIQUE, ADD e INT UNIQUE, ADD f INT
 
-# TODO (lucy): Add a test like this after #35011 is fixed
-# statement ok
-# ALTER TABLE t ADD d INT UNIQUE, ADD e INT UNIQUE, ADD f INT CHECK (f > e)
-
 # Check references column added in same statement
 statement error pq: validation of CHECK "g = h" failed on row:.* g=3.* h=2
 ALTER TABLE t ADD g INT DEFAULT 3, ADD h INT DEFAULT 2 CHECK (g = h)
+
+# Multiple unique columns can be added, followed by other commands (#35011)
+statement ok
+ALTER TABLE t ADD COLUMN u INT UNIQUE, ADD COLUMN v INT UNIQUE, ADD CONSTRAINT ck CHECK (a > 0);
 
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
 t  check_c_b  CHECK        CHECK (c > b)        true
+t  ck         CHECK        CHECK (a > 0)        true
 t  primary    PRIMARY KEY  PRIMARY KEY (a ASC)  true
 t  t_d_key    UNIQUE       UNIQUE (d ASC)       true
 t  t_e_key    UNIQUE       UNIQUE (e ASC)       true
+t  t_u_key    UNIQUE       UNIQUE (u ASC)       true
+t  t_v_key    UNIQUE       UNIQUE (v ASC)       true
 
 statement ok
 DROP TABLE t


### PR DESCRIPTION
Currently, when executing an ALTER TABLE statement with multiple commands
(e.g., `ALTER TABLE t ADD COLUMN c INT, ADD CONSTRAINT ck CHECK (c > 0)`),
`AllocateIDs()` is called on the `TableDescriptor` only at the end, after all
changes have been made. This causes problems when later changes refer to IDs
that should have been allocated due to earlier changes. For instance, there's
currently an additional call to `AllocateIDs()` at the beginning of the check
constraint case in `alterTableNode.startExec()` to ensure that columns that
were created earlier in the same transaction have valid IDs for the check
constraint to refer to. This is a tacked-on exception to the fact that
`AllocateIDs()` is otherwise only called once.

In this PR, `AllocateIDs()` is now called after every command in ALTER TABLE.

Fixes #35011.

Release note: None