### PR TITLE
kv: avoid immediately launching goroutine for txn heartbeat loop

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -343,7 +343,7 @@ type TxnCoordSenderFactory struct {
 	clock             *hlc.Clock
 	heartbeatInterval time.Duration
 	linearizable      bool // enables linearizable behavior
-	stopper           *stop.Stopper
+	stopper           *stop.DelayedStopper
 	metrics           TxnMetrics
 
 	testingKnobs ClientTestingKnobs
@@ -377,7 +377,7 @@ func NewTxnCoordSenderFactory(
 		st:                cfg.Settings,
 		wrapped:           wrapped,
 		clock:             cfg.Clock,
-		stopper:           cfg.Stopper,
+		stopper:           stop.NewDelayedStopper(cfg.Stopper),
 		linearizable:      cfg.Linearizable,
 		heartbeatInterval: cfg.HeartbeatInterval,
 		metrics:           cfg.Metrics,

--- a/pkg/kv/txn_coord_sender_server_test.go
+++ b/pkg/kv/txn_coord_sender_server_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -34,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
 )
 
 // Test that a transaction gets cleaned up when the heartbeat loop finds out
@@ -137,63 +135,5 @@ func TestHeartbeatFindsOutAboutAbortedTransaction(t *testing.T) {
 		err, "TransactionRetryWithProtoRefreshError: TransactionAbortedError",
 	) {
 		t.Fatalf("expected aborted error, got: %s", err)
-	}
-}
-
-// Test that, when a transaction restarts, we don't get a second heartbeat loop
-// for it. This bug happened in the past.
-//
-// The test traces the restarting transaction and looks in it to see how many
-// times a heartbeat loop was started.
-func TestNoDuplicateHeartbeatLoops(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
-	ctx := context.Background()
-	defer s.Stopper().Stop(ctx)
-
-	key := roachpb.Key("a")
-
-	tracer := tracing.NewTracer()
-	sp := tracer.StartSpan("test", tracing.Recordable)
-	tracing.StartRecording(sp, tracing.SingleNodeRecording)
-	txnCtx := opentracing.ContextWithSpan(context.Background(), sp)
-
-	push := func(ctx context.Context, key roachpb.Key) error {
-		return db.Put(ctx, key, "push")
-	}
-
-	var attempts int
-	err := db.Txn(txnCtx, func(ctx context.Context, txn *client.Txn) error {
-		attempts++
-		if attempts == 1 {
-			if err := push(context.Background() /* keep the contexts separate */, key); err != nil {
-				return err
-			}
-		}
-		if _, err := txn.Get(ctx, key); err != nil {
-			return err
-		}
-		return txn.Put(ctx, key, "val")
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if attempts != 2 {
-		t.Fatalf("expected 2 attempts, got: %d", attempts)
-	}
-	sp.Finish()
-	recording := tracing.GetRecording(sp)
-	var foundHeartbeatLoop bool
-	for _, sp := range recording {
-		if strings.Contains(sp.Operation, "heartbeat loop") {
-			if foundHeartbeatLoop {
-				t.Fatal("second heartbeat loop found")
-			}
-			foundHeartbeatLoop = true
-		}
-	}
-	if !foundHeartbeatLoop {
-		t.Fatal("no heartbeat loop found. Test rotted?")
 	}
 }

--- a/pkg/util/stop/delayed_stopper.go
+++ b/pkg/util/stop/delayed_stopper.go
@@ -1,0 +1,185 @@
+package stop
+
+import (
+	"container/heap"
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// DelayedStopper extends Stopper to manage queuing and cancellation of
+// delayed tasks.
+type DelayedStopper struct {
+	*Stopper
+	tasks      taskQueue
+	taskChan   chan *DelayedTask
+	cancelChan chan *DelayedTask
+}
+
+// NewDelayedStopper creates a new DelayedStopper from a Stopper.
+func NewDelayedStopper(stopper *Stopper) *DelayedStopper {
+	ds := &DelayedStopper{
+		Stopper: stopper,
+
+		taskChan:   make(chan *DelayedTask),
+		cancelChan: make(chan *DelayedTask),
+	}
+	_ = ds.RunAsyncTask(context.Background(), "delayed stopper", ds.run)
+	return ds
+}
+
+// DelayedTask is returned from RunDelayedAsyncTask.
+// It exposes a Cancel method which can be used to cancel the task before it
+// has been started.
+type DelayedTask struct {
+	ds        *DelayedStopper
+	ctx       context.Context
+	taskName  string
+	f         func(context.Context)
+	startTime time.Time
+
+	idx int // idx is the index into a taskQueue
+}
+
+// Cancel attempts to prevent execution of the DelayedTask before it has been
+// started. Calls to Cancel after the task has been run are a no-op.
+func (t *DelayedTask) Cancel() {
+	if t.ds == nil {
+		return
+	}
+	select {
+	case t.ds.cancelChan <- t:
+	case <-t.ds.ShouldQuiesce():
+	}
+}
+
+// RunDelayedAsyncTask queues a task for executaion after the provided delay.
+// An error is returned if the context is cancelled or the DelayedStopper is
+// shutting down before the task can be queued. Otherwise the returned object
+// can be used to cancel the task while its queued. The method task an optional
+// DelayedTask pointer to allow clients to avoid an allocation by storing the
+// DelayedTask struct as a member of another struct.
+func (ds *DelayedStopper) RunDelayedAsyncTask(
+	ctx context.Context,
+	taskName string,
+	f func(context.Context),
+	delay time.Duration,
+	t *DelayedTask,
+) (*DelayedTask, error) {
+	if t == nil {
+		t = &DelayedTask{}
+	}
+	initTask(ctx, t, ds, taskName, f, delay)
+	select {
+	case <-ds.ShouldQuiesce():
+		return nil, ErrUnavailable
+	case ds.taskChan <- t:
+		return t, nil
+	}
+}
+
+func initTask(
+	ctx context.Context,
+	t *DelayedTask,
+	ds *DelayedStopper,
+	taskName string,
+	f func(context.Context),
+	delay time.Duration,
+) {
+	*t = DelayedTask{
+		ds:        ds,
+		idx:       -1,
+		ctx:       ctx,
+		taskName:  taskName,
+		f:         f,
+		startTime: timeutil.Now().Add(delay),
+	}
+}
+
+func (ds *DelayedStopper) run(ctx context.Context) {
+	var (
+		startTime     time.Time
+		timer         = timeutil.NewTimer()
+		maybeSetTimer = func() {
+			var nextStartTime time.Time
+			if next := ds.tasks.peekFront(); next != nil {
+				nextStartTime = next.startTime
+			}
+			if !startTime.Equal(nextStartTime) {
+				startTime = nextStartTime
+				if !startTime.IsZero() {
+					timer.Reset(time.Until(startTime))
+				} else {
+					// Clear the current timer due to a sole batch already sent before
+					// the timer fired.
+					timer.Stop()
+					timer = timeutil.NewTimer()
+				}
+			}
+		}
+	)
+	for {
+		select {
+		case t := <-ds.taskChan:
+			heap.Push(&ds.tasks, t)
+		case t := <-ds.cancelChan:
+			if t.idx != -1 {
+				ds.tasks.remove(t)
+			}
+		case <-timer.C:
+			timer.Read = true
+			t := ds.tasks.popFront()
+			_ = ds.RunAsyncTask(t.ctx, t.taskName, t.f)
+		case <-ds.ShouldQuiesce():
+			return
+		}
+		maybeSetTimer()
+	}
+}
+
+type taskQueue []*DelayedTask
+
+func (q *taskQueue) remove(t *DelayedTask) {
+	heap.Remove(q, t.idx)
+}
+
+func (q *taskQueue) peekFront() *DelayedTask {
+	if len(*q) == 0 {
+		return nil
+	}
+	return (*q)[0]
+}
+
+func (q *taskQueue) popFront() *DelayedTask {
+	if len(*q) == 0 {
+		return nil
+	}
+	return heap.Pop(q).(*DelayedTask)
+}
+
+func (q *taskQueue) Len() int {
+	return len(*q)
+}
+
+func (q *taskQueue) Less(i, j int) bool {
+	return (*q)[i].startTime.Before((*q)[j].startTime)
+}
+
+func (q *taskQueue) Swap(i, j int) {
+	(*q)[i], (*q)[j] = (*q)[j], (*q)[i]
+	(*q)[i].idx, (*q)[j].idx = i, j
+}
+
+func (q *taskQueue) Push(v interface{}) {
+	t := v.(*DelayedTask)
+	t.idx = len(*q)
+	*q = append(*q, t)
+}
+
+func (q *taskQueue) Pop() interface{} {
+	t := (*q)[len(*q)-1]
+	t.idx = -1
+	(*q) = (*q)[:len(*q)-1]
+	return t
+}

--- a/pkg/util/stop/delayed_stopper.go
+++ b/pkg/util/stop/delayed_stopper.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package stop
 
 import (
@@ -55,7 +69,7 @@ func (t *DelayedTask) Cancel() {
 }
 
 // RunDelayedAsyncTask queues a task for executaion after the provided delay.
-// An error is returned if the context is cancelled or the DelayedStopper is
+// An error is returned if the context is canceled or the DelayedStopper is
 // shutting down before the task can be queued. Otherwise the returned object
 // can be used to cancel the task while its queued. The method task an optional
 // DelayedTask pointer to allow clients to avoid an allocation by storing the

--- a/pkg/util/stop/delayed_stopper_test.go
+++ b/pkg/util/stop/delayed_stopper_test.go
@@ -1,0 +1,53 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stop_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDelayedTask(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ds := stop.NewDelayedStopper(stop.NewStopper())
+	ctx := context.Background()
+	dt1, err := ds.RunDelayedAsyncTask(ctx, "foo", func(context.Context) {}, time.Minute, nil)
+	assert.Nil(t, err)
+	var dt stop.DelayedTask
+	dt.Cancel() // ensure that Cancel on a zero value is safe.
+	dt2, err := ds.RunDelayedAsyncTask(ctx, "foo", func(context.Context) {}, 2*time.Minute, &dt)
+	assert.Nil(t, err)
+	assert.Equal(t, dt2, &dt)
+	dt3, err := ds.RunDelayedAsyncTask(ctx, "foo", func(context.Context) {}, 2*time.Minute, nil)
+	assert.Nil(t, err)
+	c := make(chan struct{})
+	_, err = ds.RunDelayedAsyncTask(ctx, "foo", func(context.Context) {
+		close(c)
+	}, time.Microsecond, nil)
+	assert.Nil(t, err)
+	<-c
+	dt1.Cancel()
+	dt2.Cancel()
+	dt3.Cancel()
+	ds.Stop(ctx)
+	dt4, err := ds.RunDelayedAsyncTask(ctx, "foo", func(context.Context) {}, 2*time.Minute, nil)
+	assert.Equal(t, err, stop.ErrUnavailable)
+	assert.Nil(t, dt4)
+}


### PR DESCRIPTION
This PR comes in two commits. The first extends the stop.Stopper infrastructure to support delaying async tasks. The second adopts this new RunDelayedAsyncTask mechanism to avoid immediately launching goroutines for the txn heartbeat loop. 

Note I still need to add unit testing to the kv portion of the code. Just want to get this out there and see if it's what you had in mind. 

Fixes #35009
