### PR TITLE
storage/bulk: split and scatter during ingest

### DIFF
--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -129,7 +129,8 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 		iters = append(iters, iter)
 	}
 
-	batcher, err := bulk.MakeSSTBatcher(ctx, db, MaxImportBatchSize(cArgs.EvalCtx.ClusterSettings()))
+	const presplit = false // RESTORE does its own split-and-scatter.
+	batcher, err := bulk.MakeSSTBatcher(ctx, db, MaxImportBatchSize(cArgs.EvalCtx.ClusterSettings()), presplit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When many processes are concurrently bulk-ingesting without explicit
pre-splitting, it is easy for them to all suddenly overwhelm a given
range with SSTs, before it gets a chance update its stats and start to
split.

True pre-splitting is sometimes difficult -- absent a pre-read to smaple
the data to ingest or an external source of that information (like a
BACKUP descriptor), until we actually read the data and are ready to
ingest it, we don't know where to split.

However, if we produce an SST large enough that we opt to flush it based
on its size, given that we usually chunk at known range boundaries, we
can reasonably assume it will make a decently full range. Thus, it
probably would be helpful to split off, and scatter, a new range for it
before we send it out.

As the target key-space becomes more split, the range-aware chunking
will mean we start flushing smaller SSTs. We have no idea when sending a
small SST if it is going to cause the target range to be over-full or
not, so it doesn't make sense to indecriminately pre-split it. But
happily, we probably don't need to -- the fact that we chunked based on
a known split suggests the target keyspace is already well enough split
that we're at least reouting work to different ranges, so we can let
the ranges split themselves as they fill up from there on.

Release note: none.