### PR TITLE
sql: support adding a check with ALTER TABLE ADD COLUMN

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -61,6 +61,8 @@ func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode,
 		return nil, err
 	}
 
+	n.HoistAddColumnConstraints()
+
 	// See if there's any "inject statistics" in the query and type check the
 	// expressions.
 	statsData := make(map[int]tree.TypedExpr)
@@ -97,10 +99,6 @@ func (n *alterTableNode) startExec(params runParams) error {
 		switch t := cmd.(type) {
 		case *tree.AlterTableAddColumn:
 			d := t.ColumnDef
-			if len(d.CheckExprs) > 0 {
-				return pgerror.UnimplementedWithIssueError(29639,
-					"adding a CHECK constraint while also adding a column via ALTER not supported")
-			}
 			if d.HasFKConstraint() {
 				return pgerror.UnimplementedWithIssueError(32917,
 					"adding a REFERENCES constraint while also adding a column via ALTER not supported")

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1379,8 +1379,8 @@ func iterColDescriptorsInExpr(
 			return nil, true, expr
 		}
 
-		col, err := desc.FindActiveColumnByName(string(c.ColumnName))
-		if err != nil {
+		col, dropped, err := desc.FindColumnByName(c.ColumnName)
+		if err != nil || dropped {
 			return pgerror.NewErrorf(pgerror.CodeInvalidTableDefinitionError,
 				"column %q not found, referenced in %q",
 				c.ColumnName, rootExpr), false, nil

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -360,39 +360,75 @@ ALTER TABLE o DROP COLUMN h
 statement ok
 ALTER TABLE o DROP COLUMN h CASCADE
 
-statement error adding a CHECK constraint while also adding a column via ALTER not supported
-ALTER TABLE t ADD f INT CHECK (f>1)
+statement ok
+ALTER TABLE t ADD f INT CHECK (f > 1)
+
+statement ok
+ALTER TABLE t ADD g INT DEFAULT 1 CHECK (g > 0)
+
+statement ok
+ALTER TABLE t ADD h INT CHECK (h > 0) CHECK (h < 10) UNIQUE
+
+statement error pq: validation of CHECK "i < 0" failed on row:.* i=1
+ALTER TABLE t ADD i INT DEFAULT 1 CHECK (i < 0)
+
+statement error pq: validation of CHECK "i < g" failed on row:.* g=1.* i=1
+ALTER TABLE t ADD i INT DEFAULT 1 CHECK (i < g)
+
+statement error pq: validation of CHECK "i > 0" failed on row:.* g=1.* i=0
+ALTER TABLE t ADD i INT AS (g - 1) STORED CHECK (i > 0)
 
 statement error adding a REFERENCES constraint while also adding a column via ALTER not supported
 ALTER TABLE t ADD f INT UNIQUE REFERENCES other
 
+query TTTTB
+SHOW CONSTRAINTS FROM t
+----
+t  check_f   CHECK        CHECK (f > 1)        true
+t  check_g   CHECK        CHECK (g > 0)        true
+t  check_h   CHECK        CHECK (h > 0)        true
+t  check_h1  CHECK        CHECK (h < 10)       true
+t  primary   PRIMARY KEY  PRIMARY KEY (a ASC)  true
+t  t_h_key   UNIQUE       UNIQUE (h ASC)       true
+
+statement ok
+DROP TABLE t
+
 # Test that more than one column with constraints can be added in the same
 # statement. The constraints added here are on columns that are new and both
 # columns and constraints run through the schema change process together.
+
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY)
+
+statement ok
+INSERT INTO t VALUES (1)
+
+# Check references column added in same statement
+statement ok
+ALTER TABLE t ADD b INT DEFAULT 1, ADD c INT DEFAULT 2 CHECK (c > b)
+
 statement ok
 ALTER TABLE t ADD d INT UNIQUE, ADD e INT UNIQUE, ADD f INT
 
-query ITTTIII colnames,rowsort
-SELECT * FROM t
-----
-a   x     y     z     d     e     f
-1   NULL  1.3   1.4   NULL  NULL  NULL
-2   NULL  1.3   1.4   NULL  NULL  NULL
-3   NULL  1.3   1.4   NULL  NULL  NULL
-4   NULL  1.3   1.4   NULL  NULL  NULL
-11  1.0   1.3   1.4   NULL  NULL  NULL
-13  NULL  1.3   1.4   NULL  NULL  NULL
-21  NULL  1.0   1.4   NULL  NULL  NULL
-23  NULL  1.3   1.4   NULL  NULL  NULL
-31  NULL  1.3   1.4   NULL  NULL  NULL
-33  2.0   2.1   2.2   NULL  NULL  NULL
+# TODO (lucy): Add a test like this after #35011 is fixed
+# statement ok
+# ALTER TABLE t ADD d INT UNIQUE, ADD e INT UNIQUE, ADD f INT CHECK (f > e)
+
+# Check references column added in same statement
+statement error pq: validation of CHECK "g = h" failed on row:.* g=3.* h=2
+ALTER TABLE t ADD g INT DEFAULT 3, ADD h INT DEFAULT 2 CHECK (g = h)
 
 query TTTTB
 SHOW CONSTRAINTS FROM t
 ----
-t  primary  PRIMARY KEY  PRIMARY KEY (a ASC)  true
-t  t_d_key  UNIQUE       UNIQUE (d ASC)       true
-t  t_e_key  UNIQUE       UNIQUE (e ASC)       true
+t  check_c_b  CHECK        CHECK (c > b)        true
+t  primary    PRIMARY KEY  PRIMARY KEY (a ASC)  true
+t  t_d_key    UNIQUE       UNIQUE (d ASC)       true
+t  t_e_key    UNIQUE       UNIQUE (e ASC)       true
+
+statement ok
+DROP TABLE t
 
 # Subsequent operations succeed because the table is empty
 statement ok


### PR DESCRIPTION
This PR adds support for adding a check constraint to a column in ALTER TABLE
ADD COLUMN. The approach is to transform the column constraints into top-level
commands in ALTER TABLE, so that, e.g.,
```
ALTER TABLE t ADD COLUMN a INT CHECK (a > 0)
````
is treated like
```
ALTER TABLE t ADD COLUMN a INT, ADD CONSTRAINT check_a CHECK (a > 0)
```
similarly to how column constraints are handled in CREATE TABLE.

For computed columns or columns with default values, the constraint is
validated for the backfilled values before the column becomes public, which is
the existing behavior when ADD COLUMN and ADD CONSTRAINT are in the same
transaction.

Closes #29639.

Release note (sql change): Check constraints can now be added to columns that
are created through ALTER TABLE ADD COLUMN.