### PR TITLE
exec: verify test results based on set or ordered comparison

### DIFF
--- a/pkg/sql/exec/aggregator_test.go
+++ b/pkg/sql/exec/aggregator_test.go
@@ -241,7 +241,7 @@ func TestAggregatorOneFunc(t *testing.T) {
 			// Explicitly reinitialize the aggregator with the given output batch
 			// size.
 			a.(*orderedAggregator).initWithBatchSize(tc.batchSize, tc.outputBatchSize)
-			if err := out.Verify(); err != nil {
+			if err := out.VerifyAnyOrder(); err != nil {
 				t.Fatal(err)
 			}
 
@@ -255,7 +255,7 @@ func TestAggregatorOneFunc(t *testing.T) {
 						t.Fatal(err)
 					}
 					out := newOpTestOutput(a, []int{0}, tc.expected)
-					if err := out.Verify(); err != nil {
+					if err := out.VerifyAnyOrder(); err != nil {
 						t.Fatal(err)
 					}
 				})
@@ -341,7 +341,7 @@ func TestAggregatorMultiFunc(t *testing.T) {
 					t.Fatal(err)
 				}
 				out := newOpTestOutput(a, []int{0, 1}, tc.expected)
-				if err := out.Verify(); err != nil {
+				if err := out.VerifyAnyOrder(); err != nil {
 					t.Fatal(err)
 				}
 			})
@@ -392,7 +392,7 @@ func TestAggregatorKitchenSink(t *testing.T) {
 					t.Fatal(err)
 				}
 				out := newOpTestOutput(a, []int{0, 1, 2, 3}, tc.expected)
-				if err := out.Verify(); err != nil {
+				if err := out.VerifyAnyOrder(); err != nil {
 					t.Fatal(err)
 				}
 			})

--- a/pkg/sql/exec/count_test.go
+++ b/pkg/sql/exec/count_test.go
@@ -35,7 +35,7 @@ func TestCount(t *testing.T) {
 			count := NewCountOp(input[0])
 			out := newOpTestOutput(count, []int{0}, tc.expected)
 
-			if err := out.Verify(); err != nil {
+			if err := out.VerifyAnyOrder(); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/pkg/sql/exec/distinct_test.go
+++ b/pkg/sql/exec/distinct_test.go
@@ -58,7 +58,7 @@ func TestSortedDistinct(t *testing.T) {
 			}
 			out := newOpTestOutput(distinct, []int{0, 1, 2, 3}, tc.expected)
 
-			if err := out.Verify(); err != nil {
+			if err := out.VerifyAnyOrder(); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -738,7 +738,7 @@ func TestHashJoinerInt64(t *testing.T) {
 
 					out := newOpTestOutput(hj, cols, tc.expectedTuples)
 
-					if err := out.Verify(); err != nil {
+					if err := out.VerifyAnyOrder(); err != nil {
 						t.Fatal(err)
 					}
 				})

--- a/pkg/sql/exec/limit_test.go
+++ b/pkg/sql/exec/limit_test.go
@@ -64,7 +64,7 @@ func TestLimit(t *testing.T) {
 			limit := NewLimitOp(input[0], tc.limit)
 			out := newOpTestOutput(limit, []int{0}, tc.expected)
 
-			if err := out.Verify(); err != nil {
+			if err := out.VerifyAnyOrder(); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/pkg/sql/exec/offset_test.go
+++ b/pkg/sql/exec/offset_test.go
@@ -58,7 +58,7 @@ func TestOffset(t *testing.T) {
 			s := NewOffsetOp(input[0], tc.offset)
 			out := newOpTestOutput(s, []int{0}, tc.expected)
 
-			if err := out.Verify(); err != nil {
+			if err := out.VerifyAnyOrder(); err != nil {
 				t.Fatal(err)
 			}
 		})


### PR DESCRIPTION
Before my recent change (#34924), test results were compared in
order; after the change, test results are compared using a set
comparison (i.e. whether two sets contain the same tuples).
However, we should be able to use one or the other based on what
we are testing, and this commit adds this ability.

Release note: None