### PR TITLE
sql: check invalid table identifier

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1486,6 +1486,10 @@ CockroachDB supports the following flags:
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
+				_, err := tree.NewUnresolvedName(string(name)).NormalizeTablePattern()
+				if err != nil {
+					return nil, err
+				}
 				qualifiedName, err := evalCtx.Sequence.ParseQualifiedTableName(evalCtx.Ctx(), string(name))
 				if err != nil {
 					return nil, err

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -52,7 +52,10 @@ func classifyTablePattern(n *UnresolvedName) (TablePattern, error) {
 		lastCheck = 2
 	}
 	for i := firstCheck; i < lastCheck; i++ {
-		if len(n.Parts[i]) == 0 {
+		part := n.Parts[i]
+		// An identifier can not empty or begin with a digit.
+		if len(part) == 0 ||
+			('0' <= part[0] && part[0] <= '9') {
 			return nil, newInvTableNameError(n)
 		}
 	}


### PR DESCRIPTION
Fixes #34527

This commit checks table name identifier when they use `TablePattern`.

Release note (sql change): builtin function `currval` returned the appropriate error associated with the table name.