### PR TITLE
opt: fix race caused by shared table annotations

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -64,7 +64,7 @@ func fmtInterceptor(f *memo.ExprFmtCtx, tp treeprinter.Node, nd opt.Expr) bool {
 	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
 	fmtCtx.SetIndexedVarFormat(func(ctx *tree.FmtCtx, idx int) {
 		fullyQualify := !f.HasFlags(memo.ExprFmtHideQualifications)
-		alias := md.ColumnMeta(opt.ColumnID(idx + 1)).QualifiedAlias(fullyQualify)
+		alias := md.QualifiedAlias(opt.ColumnID(idx+1), fullyQualify)
 		ctx.WriteString(alias)
 	})
 	expr.Format(fmtCtx)

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -715,7 +715,7 @@ func formatCol(
 	colMeta := md.ColumnMeta(id)
 	if label == "" {
 		fullyQualify := !f.HasFlags(ExprFmtHideQualifications)
-		label = colMeta.QualifiedAlias(fullyQualify)
+		label = md.QualifiedAlias(id, fullyQualify)
 	}
 
 	if !isSimpleColumnName(label) {
@@ -752,7 +752,7 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 	switch t := private.(type) {
 	case *opt.ColumnID:
 		fullyQualify := !f.HasFlags(ExprFmtHideQualifications)
-		label := f.Memo.metadata.ColumnMeta(*t).QualifiedAlias(fullyQualify)
+		label := f.Memo.metadata.QualifiedAlias(*t, fullyQualify)
 		fmt.Fprintf(f.Buffer, " %s", label)
 
 	case *TupleOrdinal:

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math/bits"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -274,7 +275,6 @@ func (md *Metadata) AddTableWithAlias(tab cat.Table, alias *tree.TableName) Tabl
 		md.tables = make([]TableMeta, 0, 4)
 	}
 	md.tables = append(md.tables, TableMeta{MetaID: tabID, Table: tab, Alias: *alias})
-	tabMeta := md.TableMeta(tabID)
 
 	colCount := tab.DeletableColumnCount()
 	if md.cols == nil {
@@ -284,7 +284,7 @@ func (md *Metadata) AddTableWithAlias(tab cat.Table, alias *tree.TableName) Tabl
 	for i := 0; i < colCount; i++ {
 		col := tab.Column(i)
 		colID := md.AddColumn(string(col.ColName()), col.DatumType())
-		md.ColumnMeta(colID).TableMeta = tabMeta
+		md.ColumnMeta(colID).Table = tabID
 	}
 
 	return tabID
@@ -327,7 +327,7 @@ func (md *Metadata) AddColumn(alias string, typ types.T) ColumnID {
 		alias = fmt.Sprintf("column%d", len(md.cols)+1)
 	}
 	colID := ColumnID(len(md.cols) + 1)
-	md.cols = append(md.cols, ColumnMeta{MetaID: colID, Alias: alias, Type: typ, md: md})
+	md.cols = append(md.cols, ColumnMeta{MetaID: colID, Alias: alias, Type: typ})
 	return colID
 }
 
@@ -341,6 +341,67 @@ func (md *Metadata) NumColumns() int {
 // and associated with multiple column ids.
 func (md *Metadata) ColumnMeta(colID ColumnID) *ColumnMeta {
 	return &md.cols[colID.index()]
+}
+
+// QualifiedAlias returns the column alias, possibly qualified with the table,
+// schema, or database name:
+//
+//   1. If fullyQualify is true, then the returned alias is prefixed by the
+//      original, fully qualified name of the table: tab.Name().FQString().
+//
+//   2. If there's another column in the metadata with the same column alias but
+//      a different table name, then prefix the column alias with the table
+//      name: "tabName.columnAlias".
+//
+func (md *Metadata) QualifiedAlias(colID ColumnID, fullyQualify bool) string {
+	cm := md.ColumnMeta(colID)
+	if cm.Table == 0 {
+		// Column doesn't belong to a table, so no need to qualify it further.
+		return cm.Alias
+	}
+
+	// If a fully qualified alias has not been requested, then only qualify it if
+	// it would otherwise be ambiguous.
+	var tabAlias tree.TableName
+	qualify := fullyQualify
+	if !fullyQualify {
+		for i := range md.cols {
+			if i == int(cm.MetaID-1) {
+				continue
+			}
+
+			// If there are two columns with same alias, then column is ambiguous.
+			cm2 := &md.cols[i]
+			if cm2.Alias == cm.Alias {
+				tabAlias = md.TableMeta(cm.Table).Alias
+				if cm2.Table == 0 {
+					qualify = true
+				} else {
+					// Only qualify if the qualified names are actually different.
+					tabAlias2 := md.TableMeta(cm2.Table).Alias
+					if tabAlias.String() != tabAlias2.String() {
+						qualify = true
+					}
+				}
+			}
+		}
+	}
+
+	// If the column name should not even be partly qualified, then no more to do.
+	if !qualify {
+		return cm.Alias
+	}
+
+	var sb strings.Builder
+	if fullyQualify {
+		s := md.TableMeta(cm.Table).Table.Name().FQString()
+		sb.WriteString(s)
+	} else {
+		sb.WriteString(tabAlias.String())
+	}
+	sb.WriteRune('.')
+	sb.WriteString(cm.Alias)
+	return sb.String()
 }
 
 // SequenceID uniquely identifies the usage of a sequence within the scope of a

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -15,17 +15,15 @@
 package norm_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
@@ -83,22 +81,9 @@ func TestCopyAndReplace(t *testing.T) {
 	}
 
 	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
-	semaCtx := tree.MakeSemaContext()
 
 	var o xform.Optimizer
-	o.Init(&evalCtx)
-
-	stmt, err := parser.ParseOne("SELECT * FROM ab INNER JOIN cde ON a=c AND d=$1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */); err != nil {
-		t.Fatal(err)
-	}
-	b := optbuilder.New(context.Background(), &semaCtx, &evalCtx, cat, o.Factory(), stmt.AST)
-	if err := b.Build(); err != nil {
-		t.Fatal(err)
-	}
+	testutils.BuildQuery(t, &o, cat, &evalCtx, "SELECT * FROM ab INNER JOIN cde ON a=c AND d=$1")
 
 	if e := o.Optimize(); e.Op() != opt.MergeJoinOp {
 		t.Errorf("expected optimizer to choose merge-join, not %v", e.Op())
@@ -107,12 +92,14 @@ func TestCopyAndReplace(t *testing.T) {
 	m := o.Factory().DetachMemo()
 
 	o.Init(&evalCtx)
-	o.Factory().CopyAndReplace(m.RootExpr().(memo.RelExpr), m.RootProps(), func(e opt.Expr) opt.Expr {
+	var replaceFn norm.ReplaceFunc
+	replaceFn = func(e opt.Expr) opt.Expr {
 		if e.Op() == opt.PlaceholderOp {
 			return o.Factory().ConstructConstVal(tree.NewDInt(1), types.Int)
 		}
-		return e
-	})
+		return o.Factory().CopyAndReplaceDefault(e, replaceFn)
+	}
+	o.Factory().CopyAndReplace(m.RootExpr().(memo.RelExpr), m.RootProps(), replaceFn)
 
 	if e := o.Optimize(); e.Op() != opt.LookupJoinOp {
 		t.Errorf("expected optimizer to choose lookup-join, not %v", e.Op())

--- a/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
@@ -284,11 +284,11 @@ func (g *factoryGen) genReplace() {
 // default traversal and cloning behavior for the factory's CopyAndReplace
 // method.
 func (g *factoryGen) genCopyAndReplaceDefault() {
-	g.w.writeIndent("// copyAndReplaceDefault performs the default traversal and cloning behavior\n")
+	g.w.writeIndent("// CopyAndReplaceDefault performs the default traversal and cloning behavior\n")
 	g.w.writeIndent("// for the CopyAndReplace method. It constructs a copy of the given source\n")
 	g.w.writeIndent("// operator using children copied (and potentially remapped) by the given replace\n")
 	g.w.writeIndent("// function. See comments for CopyAndReplace for more details.\n")
-	g.w.nestIndent("func (f *Factory) copyAndReplaceDefault(src opt.Expr, replace ReplaceFunc) (dst opt.Expr)")
+	g.w.nestIndent("func (f *Factory) CopyAndReplaceDefault(src opt.Expr, replace ReplaceFunc) (dst opt.Expr)")
 	g.w.nest("{\n")
 	g.w.writeIndent("switch t := src.(type) {\n")
 
@@ -376,23 +376,14 @@ func (g *factoryGen) genCopyAndReplaceDefault() {
 		g.w.unnest("}\n\n")
 	}
 
-	g.w.writeIndent("// invokeReplace wraps the user-provided replace function. If replace returns\n")
-	g.w.writeIndent("// its input unchanged, then invokeReplace automatically calls\n")
-	g.w.writeIndent("// copyAndReplaceDefault to get default replace behavior. See comments for\n")
+	g.w.writeIndent("// invokeReplace wraps the user-provided replace function. See comments for\n")
 	g.w.writeIndent("// CopyAndReplace for more details.\n")
 	g.w.nestIndent("func (f *Factory) invokeReplace(src opt.Expr, replace ReplaceFunc) (dst opt.Expr)")
 	g.w.nest("{\n")
 	g.w.nest("if rel, ok := src.(memo.RelExpr); ok {\n")
 	g.w.writeIndent("src = rel.FirstExpr()\n")
-	g.w.writeIndent("dst = replace(src)\n")
-	g.w.unnest("}")
-	g.w.nest(" else {\n")
-	g.w.writeIndent("dst = replace(src)\n")
 	g.w.unnest("}\n")
-	g.w.nest("if src == dst {\n")
-	g.w.writeIndent("return f.copyAndReplaceDefault(src, replace)\n")
-	g.w.unnest("}\n")
-	g.w.writeIndent("return dst\n")
+	g.w.nest("return replace(src)\n")
 	g.w.unnest("}\n\n")
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -218,11 +218,11 @@ func (f *Factory) replaceFiltersExpr(list memo.FiltersExpr, replace ReplaceFunc)
 	return newList, true
 }
 
-// copyAndReplaceDefault performs the default traversal and cloning behavior
+// CopyAndReplaceDefault performs the default traversal and cloning behavior
 // for the CopyAndReplace method. It constructs a copy of the given source
 // operator using children copied (and potentially remapped) by the given replace
 // function. See comments for CopyAndReplace for more details.
-func (f *Factory) copyAndReplaceDefault(src opt.Expr, replace ReplaceFunc) (dst opt.Expr) {
+func (f *Factory) CopyAndReplaceDefault(src opt.Expr, replace ReplaceFunc) (dst opt.Expr) {
 	switch t := src.(type) {
 	case *memo.SelectExpr:
 		return f.ConstructSelect(
@@ -256,21 +256,13 @@ func (f *Factory) copyAndReplaceDefaultFiltersExpr(src memo.FiltersExpr, replace
 	return dst
 }
 
-// invokeReplace wraps the user-provided replace function. If replace returns
-// its input unchanged, then invokeReplace automatically calls
-// copyAndReplaceDefault to get default replace behavior. See comments for
+// invokeReplace wraps the user-provided replace function. See comments for
 // CopyAndReplace for more details.
 func (f *Factory) invokeReplace(src opt.Expr, replace ReplaceFunc) (dst opt.Expr) {
 	if rel, ok := src.(memo.RelExpr); ok {
 		src = rel.FirstExpr()
-		dst = replace(src)
-	} else {
-		dst = replace(src)
 	}
-	if src == dst {
-		return f.copyAndReplaceDefault(src, replace)
-	}
-	return dst
+	return replace(src)
 }
 
 func (f *Factory) DynamicConstruct(op opt.Operator, args ...interface{}) opt.Expr {

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -83,6 +83,11 @@ func (t TableID) index() int {
 // metadata, which can be used to avoid recalculating base table properties or
 // other information each time it's needed.
 //
+// WARNING! When copying memo metadata (which happens when we use a cached
+// memo), the annotations are cleared. Any code using a annotation must treat
+// this as a best-effort cache and be prepared to repopulate the annotation as
+// necessary.
+//
 // To create a TableAnnID, call NewTableAnnID during Go's program initialization
 // phase. The returned TableAnnID never clashes with other annotations on the
 // same table. Here is a usage example:
@@ -126,6 +131,14 @@ type TableMeta struct {
 
 	// anns annotates the table metadata with arbitrary data.
 	anns [maxTableAnnIDCount]interface{}
+}
+
+// clearAnnotations resets all the table annotations; used when copying a
+// Metadata.
+func (tm *TableMeta) clearAnnotations() {
+	for i := range tm.anns {
+		tm.anns[i] = nil
+	}
 }
 
 // IndexColumns returns the metadata IDs for the set of columns in the given

--- a/pkg/sql/opt/testutils/build.go
+++ b/pkg/sql/opt/testutils/build.go
@@ -1,0 +1,47 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// BuildQuery initializes an optimizer and builds the given sql statement.
+func BuildQuery(
+	t *testing.T, o *xform.Optimizer, catalog cat.Catalog, evalCtx *tree.EvalContext, sql string,
+) {
+	stmt, err := parser.ParseOne(sql)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	semaCtx := tree.MakeSemaContext()
+	if err := semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */); err != nil {
+		t.Fatal(err)
+	}
+	o.Init(evalCtx)
+	err = optbuilder.New(ctx, &semaCtx, evalCtx, catalog, o.Factory(), stmt.AST).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
#### opt: test reproducing detached memo race

Test that reproduces #34904. Writing the test exposed a problem in the
`CopyAndReplace` API: there was no way to recursively copy a subtree
when creating an internal node. The API was reverted to the first
iteration Andy had in his PR.

Release note: None

#### opt: replace ColumnMeta.TableMeta with a TableID

The TableMeta field is problematic: it needs to be fixed up when
copying Metadata; and since it points into a slice that we append to,
it may or may not be aliased with the corresponding entry in `tables`.
Avoiding these complication by just storing the TabeID. The `md`
backpointer is also removed and QualifiedAlias is moved to Metadata.

Release note: None

#### opt: fix race caused by shared table annotations

When we assign placeholders on a detached memo, we copy the metadata.
However, this does a shallow copy of table annotations; this is
problematic for the statistics annotation which is a mutable object.

The fix is to register a copy function for each type of table
annotation as part of `NewTableAnnID`.

Fixes #34904.

Release note (bug fix): Fixed a crash related to cached plans.
