### PR TITLE
sql/sem/tree: add keyword doc to pretty printing

### DIFF
--- a/pkg/sql/sem/tree/pretty_test.go
+++ b/pkg/sql/sem/tree/pretty_test.go
@@ -201,7 +201,7 @@ func BenchmarkPrettyData(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, doc := range docs {
 			for _, w := range []int{1, 30, 80} {
-				pretty.Pretty(doc, w, true /*useTabs*/, 4 /*tabWidth*/)
+				pretty.Pretty(doc, w, true /*useTabs*/, 4 /*tabWidth*/, nil /* keywordTransform */)
 			}
 		}
 	}

--- a/pkg/util/pretty/document.go
+++ b/pkg/util/pretty/document.go
@@ -54,6 +54,7 @@ func (*union) isDoc()    {}
 func (*scolumn) isDoc()  {}
 func (*snesting) isDoc() {}
 func (pad) isDoc()       {}
+func (keyword) isDoc()   {}
 
 //
 // Implementations of Doc ("DOC" in paper).
@@ -164,7 +165,7 @@ func flatten(d Doc) Doc {
 		return NestT(flatten(t.d))
 	case nests:
 		return NestS(t.n, flatten(t.d))
-	case text:
+	case text, keyword:
 		return d
 	case line:
 		return textSpace
@@ -244,4 +245,14 @@ func Align(d Doc) Doc {
 // described above.
 type pad struct {
 	n int16
+}
+
+type keyword string
+
+// Keyword is identical to Text except they are filtered by
+// keywordTransform. The computed width is always len(s), regardless of
+// the result of the result of the transform. This allows for things like
+// coloring and other control characters in the output.
+func Keyword(s string) Doc {
+	return keyword(s)
 }

--- a/pkg/util/pretty/pretty_test.go
+++ b/pkg/util/pretty/pretty_test.go
@@ -27,7 +27,7 @@ func Example_align() {
 			pretty.Text("aaa"),
 			pretty.Text("bbb"),
 			pretty.Text("ccc")),
-		pretty.RLTable(true,
+		pretty.RLTable(true, pretty.Text,
 			pretty.RLTableRow{Label: "SELECT",
 				Doc: pretty.Join(",",
 					pretty.Text("aaa"),
@@ -40,7 +40,7 @@ func Example_align() {
 					pretty.Text("u"),
 					pretty.Text("v")),
 			}),
-		pretty.RLTable(true,
+		pretty.RLTable(true, pretty.Text,
 			pretty.RLTableRow{Label: "woo", Doc: nil}, // check nil rows are omitted
 			pretty.RLTableRow{Label: "", Doc: pretty.Nil},
 			pretty.RLTableRow{Label: "KEY", Doc: pretty.Text("VALUE")},
@@ -51,7 +51,7 @@ func Example_align() {
 	for _, n := range []int{1, 15, 30, 80} {
 		fmt.Printf("%d:\n", n)
 		for _, doc := range testData {
-			p := pretty.Pretty(doc, n, true /*useTabs*/, 4 /*tabWidth*/)
+			p := pretty.Pretty(doc, n, true /*useTabs*/, 4 /*tabWidth*/, nil /*keywordTransform*/)
 			fmt.Printf("%s\n\n", p)
 		}
 	}
@@ -188,7 +188,7 @@ func Example_tree() {
 		))
 	}
 	for _, n := range []int{1, 30, 80} {
-		p := pretty.Pretty(showTree(tree), n, false /*useTabs*/, 4 /*tabWidth*/)
+		p := pretty.Pretty(showTree(tree), n, false /*useTabs*/, 4 /*tabWidth*/, nil /*keywordTransform*/)
 		fmt.Printf("%d:\n%s\n\n", n, p)
 	}
 	// Output:

--- a/pkg/util/pretty/util.go
+++ b/pkg/util/pretty/util.go
@@ -175,9 +175,10 @@ func simplifyNil(a, b Doc, fn func(Doc, Doc) Doc) Doc {
 // only done if there are enough "simple spaces" (as per previous uses
 // of Align) to de-indent. No attempt is made to de-indent hard tabs,
 // otherwise alignment may break on output devices with a different
-// physical tab width.
-func JoinNestedOuter(lbl string, d ...Doc) Doc {
-	sep := Text(lbl)
+// physical tab width. docFn should be set to Text or Keyword and will be
+// used when converting lbl to a Doc.
+func JoinNestedOuter(lbl string, docFn func(string) Doc, d ...Doc) Doc {
+	sep := docFn(lbl)
 	return &snesting{
 		f: func(k int16) Doc {
 			if k < int16(len(lbl)+1) {
@@ -229,7 +230,10 @@ type RLTableRow struct {
 // For convenience, the function also takes a boolean "align" which,
 // if false, skips the alignment and only produces the section-based
 // output.
-func RLTable(align bool, rows ...RLTableRow) Doc {
+//
+// docFn should be set to Text or Keyword and will be used when converting
+// RLTableRow label's to Docs.
+func RLTable(align bool, docFn func(string) Doc, rows ...RLTableRow) Doc {
 	items := make([]Doc, 0, len(rows))
 
 	// Compute the nested formatting in "sections". It's simple.
@@ -240,7 +244,7 @@ func RLTable(align bool, rows ...RLTableRow) Doc {
 			continue
 		}
 		if r.Label != "" {
-			d := simplifyNil(Text(r.Label), r.Doc,
+			d := simplifyNil(docFn(r.Label), r.Doc,
 				func(a, b Doc) Doc {
 					return Concat(a, NestT(Concat(Line, Group(b))))
 				})
@@ -271,7 +275,7 @@ func RLTable(align bool, rows ...RLTableRow) Doc {
 				continue
 			}
 			if r.Label != "" {
-				d := simplifyNil(Text(r.Label), r.Doc,
+				d := simplifyNil(docFn(r.Label), r.Doc,
 					func(a, b Doc) Doc {
 						return ConcatSpace(a, Align(Group(b)))
 					})


### PR DESCRIPTION
The keyword doc is the same as text, but it is wrapped by a conversion
function only during the final layout phase. This allows for arbitrary
transformation of some text without affecting its computed width and
can be used to add color codes or other control characters. A simpler
use case is also to change the casing of case-insensitive strings for
those who prefer upper or lower case SQL keywords.

Some new helper functions were added to easily wrap keywords aside
whitespace, braces, and brackets.

Release note: None