### PR TITLE
storage/raftentry: fix bug caused by concurrent Add and Get operations

### DIFF
--- a/pkg/storage/raftentry/ring_buffer.go
+++ b/pkg/storage/raftentry/ring_buffer.go
@@ -184,6 +184,9 @@ func computeExtension(b *ringBuf, lo, hi uint64) (before, after int, ok bool) {
 type iterator int
 
 func iterateFrom(b *ringBuf, index uint64) (_ iterator, ok bool) {
+	if b.len == 0 {
+		return -1, false
+	}
 	offset := int(index) - int(first(b).index(b))
 	if offset < 0 || offset >= b.len {
 		return -1, false


### PR DESCRIPTION
The gist of the bug is that we need to check the length of a partition to get
an iterator. The check was initially omitted because it was wrongly assumed
that operations on a partition would occur after the partition had been added to
at least once, in which case its buffer would have a non-nil slice. If the
ringBuffer were empty but had at some point contained data, it would have a
slice of entries and would not have panicked when trying to initialize the
iterator.

Fixes #35023.

Release note: None