### PR TITLE
storage: remove replicaID dependency from sideloaded storage

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -97,6 +97,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>2.1-8</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>2.1-9</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
 </tbody>
 </table>

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -64,6 +64,7 @@ const (
 	VersionUnreplicatedRaftTruncatedState // see versionsSingleton for details
 	VersionCreateStats
 	VersionDirectImport
+	VersionSideloadedStorageNoReplicaID // see versionsSingleton for details
 
 	// Add new versions here (step one of two).
 
@@ -416,6 +417,24 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 	{
 		Key:     VersionDirectImport,
 		Version: roachpb.Version{Major: 2, Minor: 1, Unstable: 8},
+	},
+	{
+		// VersionSideloadedStorageNoReplicaID is https://github.com/cockroachdb/cockroach/pull/35035.
+		//
+		// It moves from a sideloaded directory naming scheme of
+		// <rangeID>.<replicaID> to one that only depends on the rangeID. The
+		// migration itself happens in storage.newDiskSideloadStorage, via
+		// (*Replica).setReplicaIDRaftMuLockedMuLocked and is thus expected to
+		// have completed when cluster version has been bumped and the cluster
+		// restarted at least once post the bump (as calls to NewReplica then
+		// carry out the migration for all replicas). We can thus safely remove
+		// support for the legacy directory scheme in 2020.1 or we do it in
+		// 2019.2 but have to require that all nodes be restarted at least once
+		// while running 2019.1. It is straightforward to detect whether legacy
+		// directories exist, so by adding code to 2020.1 to error out in this
+		// case we can make removal in 2019.2 safe.
+		Key:     VersionSideloadedStorageNoReplicaID,
+		Version: roachpb.Version{Major: 2, Minor: 1, Unstable: 9},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -266,9 +266,9 @@ select crdb_internal.set_vmodule('')
 0
 
 query T
-select crdb_internal.node_executable_version()
+select regexp_replace(crdb_internal.node_executable_version()::string, '-\d+', '-x');
 ----
-2.1-9
+2.1-x
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -363,9 +363,9 @@ select * from crdb_internal.gossip_alerts
 
 # Anyone can see the executable version.
 query T
-select crdb_internal.node_executable_version()
+select regexp_replace(crdb_internal.node_executable_version()::string, '-\d+', '-x');
 ----
-2.1-9
+2.1-x
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -268,7 +268,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-2.1-8
+2.1-9
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -365,7 +365,7 @@ select * from crdb_internal.gossip_alerts
 query T
 select crdb_internal.node_executable_version()
 ----
-2.1-8
+2.1-9
 
 user root
 


### PR DESCRIPTION
I can't think of a good reason I introduced this initially. Sideloaded
entries belong to Raft entries. Raft entries don't care about the
replicaID, so neither should sideloaded ones. In fact, we had to write
extra code that would move the directories every time the replicaID
changed, and had to reinitialize the sideloaded storage. None of that
should be necessary, which will be a nice simplification once the
migration can be deleted.

Determine the sideloaded directory based on the RangeID alone. The
migration is straightforward: when the new version is active but there's
an old directory, move it to where it ought to be. I factored out the
code that would move the directories prior to the migration to be able
to test that they interact favorably with the migration (not true before
this commit).

NB: the migration can only be deleted safely once we know that there
aren't any deprecated sideloaded directories around when the cluster
version is bumped. But a) this is our expectation and b) it's easy
enough to add a hook to the startup process that enforces it. This
isn't done in this commit, though.

Release note: None