### PR TITLE
sql: add inverted index validation after backfill

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -948,6 +948,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.force_retry(val: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
+<tr><td><code>crdb_internal.json_num_index_entries(val: jsonb) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
 <tr><td><code>crdb_internal.lease_holder(key: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used to fetch the leaseholder corresponding to a request key</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.no_constant_folding(input: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -3977,7 +3978,7 @@ func TestBlockedSchemaChange(t *testing.T) {
 	wg.Wait()
 }
 
-// Tests index baxckfill validation step by purposely deleting an index
+// Tests index backfill validation step by purposely deleting an index
 // value during the index backfill and checking that the validation
 // fails.
 func TestIndexBackfillValidation(t *testing.T) {
@@ -4045,5 +4046,141 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	tableDesc = sqlbase.GetTableDescriptor(kvDB, "t", "test")
 	if len(tableDesc.Indexes) > 0 || len(tableDesc.Mutations) > 0 {
 		t.Fatalf("descriptor broken %d, %d", len(tableDesc.Indexes), len(tableDesc.Mutations))
+	}
+}
+
+// Tests inverted index backfill validation step by purposely deleting an index
+// value during the index backfill and checking that the validation fails.
+func TestInvertedIndexBackfillValidation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	params, _ := tests.CreateTestServerParams()
+	const maxValue = 1000
+	backfillCount := int64(0)
+	var db *client.DB
+	var tableDesc *sqlbase.TableDescriptor
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			BackfillChunkSize: maxValue / 5,
+		},
+		DistSQL: &distsqlrun.TestingKnobs{
+			RunAfterBackfillChunk: func() {
+				count := atomic.AddInt64(&backfillCount, 1)
+				if count == 2 {
+					// drop an index value before validation.
+					keyEnc := keys.MakeTablePrefix(uint32(tableDesc.ID))
+					key := roachpb.Key(encoding.EncodeUvarintAscending(keyEnc, uint64(tableDesc.NextIndexID)))
+					kv, err := db.Scan(context.TODO(), key, key.PrefixEnd(), 1)
+					if err != nil {
+						t.Error(err)
+					}
+					if err := db.Del(context.TODO(), kv[0].Key); err != nil {
+						t.Error(err)
+					}
+				}
+			},
+		},
+		// Disable backfill migrations, we still need the jobs table migration.
+		SQLMigrationManager: &sqlmigrations.MigrationManagerTestingKnobs{
+			DisableBackfillMigrations: true,
+		},
+	}
+	server, sqlDB, kvDB := serverutils.StartServer(t, params)
+	db = kvDB
+	defer server.Stopper().Stop(context.TODO())
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT PRIMARY KEY, v JSON);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	tableDesc = sqlbase.GetTableDescriptor(kvDB, "t", "test")
+
+	r := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	// Insert enough rows to exceed the chunk size.
+	for i := 0; i < maxValue+1; i++ {
+		jsonVal, err := json.Random(20, r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sqlDB.Exec(`INSERT INTO t.test VALUES ($1, $2)`, i, jsonVal.String()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Start schema change that eventually runs a backfill.
+	if _, err := sqlDB.Exec(`CREATE INVERTED INDEX foo ON t.test (v)`); !testutils.IsError(
+		err, "validation of index foo failed",
+	) {
+		t.Fatal(err)
+	}
+
+	tableDesc = sqlbase.GetTableDescriptor(kvDB, "t", "test")
+	if len(tableDesc.Indexes) > 0 || len(tableDesc.Mutations) > 0 {
+		t.Fatalf("descriptor broken %d, %d", len(tableDesc.Indexes), len(tableDesc.Mutations))
+	}
+}
+
+// Test multiple index backfills (for forward and inverted indexes) from the
+// same transaction.
+func TestMultipleIndexBackfills(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	params, _ := tests.CreateTestServerParams()
+	const maxValue = 1000
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			BackfillChunkSize: maxValue / 5,
+		},
+		// Disable backfill migrations, we still need the jobs table migration.
+		SQLMigrationManager: &sqlmigrations.MigrationManagerTestingKnobs{
+			DisableBackfillMigrations: true,
+		},
+	}
+	server, sqlDB, _ := serverutils.StartServer(t, params)
+	defer server.Stopper().Stop(context.TODO())
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (a INT, b INT, c JSON, d JSON);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	r := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	// Insert enough rows to exceed the chunk size.
+	for i := 0; i < maxValue+1; i++ {
+		jsonVal1, err := json.Random(20, r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		jsonVal2, err := json.Random(20, r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sqlDB.Exec(`INSERT INTO t.test VALUES ($1, $2, $3, $4)`, i, i, jsonVal1.String(), jsonVal2.String()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Start schema changes.
+	tx, err := sqlDB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(`CREATE INDEX idx_a ON t.test (a)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(`CREATE INDEX idx_b ON t.test (b)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(`CREATE INVERTED INDEX idx_c ON t.test (c)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(`CREATE INVERTED INDEX idx_d ON t.test (d)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2993,6 +2993,25 @@ may increase either contention or retry errors, or both.`,
 				"Raising the verbosity can severely affect performance.",
 		},
 	),
+
+	// Returns the number of distinct inverted index entries that would be generated for a JSON value.
+	"crdb_internal.json_num_index_entries": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySystemInfo,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"val", types.JSON}},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				n, err := json.NumInvertedIndexEntries(tree.MustBeDJSON(args[0]).JSON)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDInt(tree.DInt(n)), nil
+			},
+			Info: "This function is used only by CockroachDB's developers for testing purposes.",
+		},
+	),
 }
 
 var lengthImpls = makeBuiltin(tree.FunctionProperties{Category: categoryString},

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -1287,6 +1287,41 @@ func TestEncodeJSONInvertedIndex(t *testing.T) {
 	}
 }
 
+func TestNumInvertedIndexEntries(t *testing.T) {
+	testCases := []struct {
+		value    string
+		expCount int
+	}{
+		{`1`, 1},
+		{`"a"`, 1},
+		{`null`, 1},
+		{`false`, 1},
+		{`true`, 1},
+		{`[]`, 1},
+		{`{}`, 1},
+		{`[[[]]]`, 1},
+		{`[[{}]]`, 1},
+		{`[{}, []]`, 2},
+		{`[1, 2]`, 2},
+		{`[1, [1]]`, 2},
+		{`[1, 2, 1, 2]`, 2},
+		{`[[1, 2], [2, 3]]`, 3},
+		{`[{"a": 1, "b": 2}]`, 2},
+		{`[{"a": 1, "b": 2}, {"a": 1, "b": 3}]`, 3},
+		{`[{"a": [1, 2], "b": 2}, {"a": [1, 3], "b": 3}]`, 5},
+	}
+	for _, c := range testCases {
+		n, err := NumInvertedIndexEntries(jsonTestShorthand(c.value))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != c.expCount {
+			t.Errorf("unexpected count of index entries for %v. expected %d, got %d",
+				c.value, c.expCount, n)
+		}
+	}
+}
+
 const expectError = "<<error>>"
 
 func TestConcat(t *testing.T) {


### PR DESCRIPTION
This change adds a validation step after backfilling an inverted index, before
the index is made public. The validation is performed by counting the number of
index entries (using a KV scan) and comparing the count to the expected number
of index entries, which is computed from a newly added builtin function.

Release note: None