### PR TITLE
opt: remove HasZeroRows

### DIFF
--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -256,11 +256,6 @@ func (c *CustomFuncs) HasNoCols(input memo.RelExpr) bool {
 	return input.Relational().OutputCols.Empty()
 }
 
-// HasZeroRows returns true if the input expression never returns any rows.
-func (c *CustomFuncs) HasZeroRows(input memo.RelExpr) bool {
-	return input.Relational().Cardinality.IsZero()
-}
-
 // HasOneRow returns true if the input expression always returns exactly one
 // row.
 func (c *CustomFuncs) HasOneRow(input memo.RelExpr) bool {

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -325,12 +325,13 @@
 =>
 $left
 
+# TODO(justin): figure out if this rule can still trigger.
 # EliminateAntiJoin discards an AntiJoin operator when it's known that the right
 # input never returns any rows.
 [EliminateAntiJoin, Normalize]
 (AntiJoin | AntiJoinApply
     $left:*
-    $right:* & (HasZeroRows $right)
+    $right:(Values [])
 )
 =>
 $left

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -350,7 +350,7 @@
 [EliminateUnionAllLeft, Normalize]
 (UnionAll
     $left:*
-    $right:* & (HasZeroRows $right)
+    $right:(Values [])
     $colmap:*
 )
 =>
@@ -364,7 +364,7 @@
 # cardinality of zero, with just the right side operand.
 [EliminateUnionAllRight, Normalize]
 (UnionAll
-    $left:* & (HasZeroRows $left)
+    $left:(Values [])
     $right:*
     $colmap:*
 )

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1840,18 +1840,6 @@ scan a
  └── fd: (1)-->(2-5)
 
 # --------------------------------------------------
-# EliminateAntiJoin
-# --------------------------------------------------
-# TODO(justin): figure out if there's a good way to make this still apply.
-opt disable=SimplifyZeroCardinalityGroup expect=EliminateAntiJoin
-SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM (VALUES (k)) OFFSET 1)
-----
-scan a
- ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- ├── key: (1)
- └── fd: (1)-->(2-5)
-
-# --------------------------------------------------
 # EliminateJoinNoColsLeft
 # --------------------------------------------------
 opt expect=EliminateJoinNoColsLeft

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1170,6 +1170,55 @@ project
  └── projections
       └── variable: b.k [type=int, outer=(6)]
 
+opt expect-not=EliminateUnionAllLeft
+SELECT k FROM
+  (SELECT k FROM b)
+  UNION ALL
+  (SELECT * FROM [INSERT INTO b VALUES (1, 1, 1, '') RETURNING 1] WHERE false)
+----
+union-all
+ ├── columns: k:17(int!null)
+ ├── left columns: b.k:1(int)
+ ├── right columns: "?column?":16(int)
+ ├── side-effects, mutations
+ ├── scan b
+ │    ├── columns: b.k:1(int!null)
+ │    └── key: (1)
+ └── project
+      ├── columns: "?column?":16(int!null)
+      ├── cardinality: [0 - 0]
+      ├── side-effects, mutations
+      ├── key: ()
+      ├── fd: ()-->(16)
+      ├── select
+      │    ├── columns: b.k:6(int!null) i:7(int) f:8(float) s:9(string!null) j:10(jsonb)
+      │    ├── cardinality: [0 - 0]
+      │    ├── side-effects, mutations
+      │    ├── key: ()
+      │    ├── fd: ()-->(6-10)
+      │    ├── insert b
+      │    │    ├── columns: b.k:6(int!null) i:7(int) f:8(float) s:9(string!null) j:10(jsonb)
+      │    │    ├── insert-mapping:
+      │    │    │    ├──  column1:11 => b.k:6
+      │    │    │    ├──  column2:12 => i:7
+      │    │    │    ├──  column3:13 => f:8
+      │    │    │    ├──  column4:14 => s:9
+      │    │    │    └──  column15:15 => j:10
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── side-effects, mutations
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(6-10)
+      │    │    └── values
+      │    │         ├── columns: column1:11(int) column2:12(int) column3:13(float) column4:14(string) column15:15(jsonb)
+      │    │         ├── cardinality: [1 - 1]
+      │    │         ├── key: ()
+      │    │         ├── fd: ()-->(11-15)
+      │    │         └── (1, 1, 1.0, '', NULL) [type=tuple{int, int, float, string, jsonb}]
+      │    └── filters
+      │         └── false [type=bool]
+      └── projections
+           └── const: 1 [type=int]
+
 opt
 SELECT k FROM
   (SELECT k FROM b WHERE False)


### PR DESCRIPTION
HasZeroRows was used in an unsafe way in a number of places. Since it
doesn't regard whether the input contained mutations, it could eliminate
subtrees which it shouldn't. Since we now turn side-effect-free
zero-cardinality groups into empty VALUES clauses, it's possible, and
safer to match on that instead. This is still not ideal: we should
probably at some point do some kind of hoisting of mutations to a top
level operator so that we can still eliminate these subtrees.

Release note: None