### PR TITLE
opt: fold EXISTS operators where possible

### DIFF
--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -256,6 +256,12 @@ func (c *CustomFuncs) HasNoCols(input memo.RelExpr) bool {
 	return input.Relational().OutputCols.Empty()
 }
 
+// CanHaveSide effects returns true if the input expression can have
+// side effects.
+func (c *CustomFuncs) CanHaveSideEffects(input memo.RelExpr) bool {
+	return input.Relational().CanHaveSideEffects
+}
+
 // HasZeroRows returns true if the input expression never returns any rows.
 func (c *CustomFuncs) HasZeroRows(input memo.RelExpr) bool {
 	return input.Relational().Cardinality.IsZero()

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -314,6 +314,7 @@
     $private
 )
 
+# TODO(justin): figure out if this rule can still trigger.
 # EliminateSemiJoin discards a SemiJoin operator when it's known that the right
 # input never returns zero rows, and there is no join condition.
 [EliminateSemiJoin, Normalize]

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -153,6 +153,16 @@
     $result
 )
 
+# FoldExistsEmpty discards an EXISTS operator whose input is known to have
+# zero rows.
+[FoldExistsEmpty, Normalize]
+(Exists (Values [])) => (False)
+
+# FoldExistsNonempty discards an EXISTS operator whose input is known to have
+# at least one row and no side-effects.
+[FoldExistsNonempty, Normalize]
+(Exists $input:* & ^(CanHaveZeroRows $input) & ^(CanHaveSideEffects $input)) => (True)
+
 # EliminateExistsProject discards a Project input to the Exists operator. The
 # Project operator never changes the row cardinality of its input, and row
 # cardinality is the only thing that Exists cares about, so Project is a no-op.

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1829,17 +1829,6 @@ right-join
       └── k = x [type=bool, outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(11), (11)==(1)]
 
 # --------------------------------------------------
-# EliminateSemiJoin
-# --------------------------------------------------
-opt expect=EliminateSemiJoin
-SELECT * FROM a WHERE EXISTS(SELECT count(*) FROM b WHERE x=k)
-----
-scan a
- ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
- ├── key: (1)
- └── fd: (1)-->(2-5)
-
-# --------------------------------------------------
 # EliminateAntiJoin
 # --------------------------------------------------
 # TODO(justin): figure out if there's a good way to make this still apply.

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -358,6 +358,83 @@ project
       └── s NOT IN ('foo', s || 'foo', 'bar', length(s)::STRING, NULL) [type=bool, outer=(4)]
 
 # --------------------------------------------------
+# FoldExistsEmpty
+# --------------------------------------------------
+opt expect=FoldExistsEmpty
+SELECT * FROM a WHERE EXISTS(SELECT * FROM a WHERE false)
+----
+values
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-6)
+
+opt expect-not=FoldExistsEmpty
+SELECT * FROM a WHERE EXISTS(SELECT * FROM a)
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ └── filters
+      └── exists [type=bool]
+           └── scan a
+                ├── columns: k:7(int!null) i:8(int) f:9(float) s:10(string) j:11(jsonb) arr:12(int[])
+                ├── limit: 1
+                ├── key: ()
+                └── fd: ()-->(7-12)
+
+# --------------------------------------------------
+# FoldExistsNonempty
+# --------------------------------------------------
+opt expect=FoldExistsNonempty
+SELECT * FROM a WHERE EXISTS(VALUES (1))
+----
+scan a
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ ├── key: (1)
+ └── fd: (1)-->(2-6)
+
+opt expect-not=FoldExistsNonempty
+SELECT * FROM a WHERE EXISTS(SELECT * FROM [INSERT INTO a VALUES (1) RETURNING 1])
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ ├── side-effects, mutations
+ ├── key: (1)
+ ├── fd: (1)-->(2-6)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) arr:6(int[])
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6)
+ └── filters
+      └── exists [type=bool, side-effects]
+           └── insert a
+                ├── columns: k:7(int!null) i:8(int) f:9(float) s:10(string) j:11(jsonb) arr:12(int[])
+                ├── insert-mapping:
+                │    ├──  column1:13 => k:7
+                │    ├──  column14:14 => i:8
+                │    ├──  column15:15 => f:9
+                │    ├──  column16:16 => s:10
+                │    ├──  column17:17 => j:11
+                │    └──  column18:18 => arr:12
+                ├── cardinality: [1 - 1]
+                ├── side-effects, mutations
+                ├── key: ()
+                ├── fd: ()-->(7-12)
+                └── values
+                     ├── columns: column1:13(int) column14:14(int) column15:15(float) column16:16(string) column17:17(jsonb) column18:18(int[])
+                     ├── cardinality: [1 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(13-18)
+                     └── (1, NULL, NULL, NULL, NULL, NULL) [type=tuple{int, int, float, string, jsonb, int[]}]
+
+
+# --------------------------------------------------
 # EliminateExistsProject
 # --------------------------------------------------
 opt expect=EliminateExistsProject
@@ -384,7 +461,7 @@ select
 # --------------------------------------------------
 
 # Scalar group by shouldn't get eliminated.
-opt expect-not=EliminateExistsGroupBy
+opt expect-not=EliminateExistsGroupBy disable=FoldExistsNonempty
 SELECT * FROM a WHERE EXISTS(SELECT max(s) FROM a WHERE False)
 ----
 select


### PR DESCRIPTION
When we know that the input to an EXISTS has either zero cardinality or
at least one cardinality (and no side-effects) we can eliminate the
input entirely.

Release note: None