### PR TITLE
opt: relax SimplifyZeroCardinalityGroup

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -239,9 +239,6 @@ SELECT * FROM xyzw ORDER BY 1 LIMIT '1'
 query error argument of OFFSET must be type int, not type decimal
 SELECT * FROM xyzw OFFSET 1.5
 
-query error negative value for LIMIT
-SELECT * FROM xyzw LIMIT -100
-
 query error negative value for OFFSET
 SELECT * FROM xyzw OFFSET -100
 

--- a/pkg/sql/opt/memo/testdata/logprops/srfs
+++ b/pkg/sql/opt/memo/testdata/logprops/srfs
@@ -20,17 +20,12 @@ TABLE uv
 opt
 SELECT generate_series(0,1) FROM (SELECT * FROM xy LIMIT 0)
 ----
-project-set
+values
  ├── columns: generate_series:3(int)
  ├── cardinality: [0 - 0]
- ├── side-effects
- ├── values
- │    ├── cardinality: [0 - 0]
- │    └── key: ()
- └── zip
-      └── function: generate_series [type=int, side-effects]
-           ├── const: 0 [type=int]
-           └── const: 1 [type=int]
+ ├── key: ()
+ ├── fd: ()-->(3)
+ └── prune: (3)
 
 opt
 SELECT (SELECT unnest(ARRAY[1,2,y,v]) FROM xy WHERE x = u) FROM uv

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -252,9 +252,9 @@ func (f *Factory) onConstructRelational(rel memo.RelExpr) memo.RelExpr {
 	// SimplifyZeroCardinalityGroup replaces a group with [0 - 0] cardinality
 	// with an empty values expression. It is placed here because it depends on
 	// the logical properties of the group in question.
-	if rel.Op() != opt.ValuesOp {
+	if rel.Op() != opt.ValuesOp && !opt.IsMutationOp(rel) {
 		relational := rel.Relational()
-		if relational.Cardinality.IsZero() && !relational.CanHaveSideEffects {
+		if relational.Cardinality.IsZero() {
 			if f.matchedRule == nil || f.matchedRule(opt.SimplifyZeroCardinalityGroup) {
 				values := f.funcs.ConstructEmptyValues(relational.OutputCols)
 				if f.appliedRule != nil {

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -75,18 +75,11 @@ limit
 opt
 SELECT * FROM (SELECT * FROM a LIMIT 0) LIMIT -1
 ----
-limit
+values
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── cardinality: [0 - 0]
- ├── side-effects
  ├── key: ()
- ├── fd: ()-->(1-5)
- ├── values
- │    ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── cardinality: [0 - 0]
- │    ├── key: ()
- │    └── fd: ()-->(1-5)
- └── const: -1 [type=int]
+ └── fd: ()-->(1-5)
 
 # --------------------------------------------------
 # PushLimitIntoProject
@@ -187,17 +180,11 @@ project
 opt
 SELECT * FROM a LIMIT -1
 ----
-limit
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+values
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── cardinality: [0 - 0]
- ├── side-effects
  ├── key: ()
- ├── fd: ()-->(1-5)
- ├── scan a
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- └── const: -1 [type=int]
+ └── fd: ()-->(1-5)
 
 # --------------------------------------------------
 # PushOffsetIntoProject

--- a/pkg/sql/opt/norm/testdata/rules/zero_cardinality
+++ b/pkg/sql/opt/norm/testdata/rules/zero_cardinality
@@ -80,16 +80,8 @@ values
 opt
 SELECT * FROM (SELECT CASE WHEN k < 0 THEN 3 / 0 ELSE 3 END FROM b) WHERE false
 ----
-project
+values
  ├── columns: case:6(decimal)
  ├── cardinality: [0 - 0]
- ├── side-effects
  ├── key: ()
- ├── fd: ()-->(6)
- ├── values
- │    ├── columns: k:1(int)
- │    ├── cardinality: [0 - 0]
- │    ├── key: ()
- │    └── fd: ()-->(1)
- └── projections
-      └── CASE WHEN k < 0 THEN 3 / 0 ELSE 3 END [type=decimal, outer=(1), side-effects]
+ └── fd: ()-->(6)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1912,47 +1912,11 @@ SELECT
 FROM
     abc AS x JOIN [INSERT INTO abc (a) SELECT 1 FROM abc RETURNING 1] JOIN abc AS y ON true ON false
 ----
-project
- ├── columns: bool:21(bool!null)
+values
+ ├── columns: bool:21(bool)
  ├── cardinality: [0 - 0]
- ├── side-effects, mutations
- ├── fd: ()-->(21)
- ├── inner-join
- │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
- │    ├── cardinality: [0 - 0]
- │    ├── side-effects, mutations
- │    ├── fd: ()-->(5-7)
- │    ├── select
- │    │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
- │    │    ├── cardinality: [0 - 0]
- │    │    ├── side-effects, mutations
- │    │    ├── fd: ()-->(5-7)
- │    │    ├── insert abc
- │    │    │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
- │    │    │    ├── insert-mapping:
- │    │    │    │    ├──  "?column?":13 => abc.a:5
- │    │    │    │    ├──  column14:14 => abc.b:6
- │    │    │    │    ├──  column14:14 => abc.c:7
- │    │    │    │    └──  column15:15 => abc.rowid:8
- │    │    │    ├── side-effects, mutations
- │    │    │    ├── fd: ()-->(5-7)
- │    │    │    └── project
- │    │    │         ├── columns: column14:14(int) column15:15(int) "?column?":13(int!null)
- │    │    │         ├── side-effects
- │    │    │         ├── fd: ()-->(13,14)
- │    │    │         ├── scan abc
- │    │    │         └── projections
- │    │    │              ├── null [type=int]
- │    │    │              ├── unique_rowid() [type=int, side-effects]
- │    │    │              └── const: 1 [type=int]
- │    │    └── filters
- │    │         └── false [type=bool]
- │    ├── values
- │    │    ├── cardinality: [0 - 0]
- │    │    └── key: ()
- │    └── filters (true)
- └── projections
-      └── false [type=bool]
+ ├── key: ()
+ └── fd: ()-->(21)
 
 opt join-limit=3
 SELECT 1 FROM ((VALUES (1), (1)) JOIN ((VALUES (1), (1), (1)) JOIN (VALUES (1), (1), (1), (1)) ON true) ON true)


### PR DESCRIPTION
We used to only trigger SimplifyZeroCardinalityGroup if the group had no
side-effects. This was a little overly restrictive according to the
optimizer's side-effect policy. We can eliminate the group, as long as
it's not a root mutation. I'm not aware of a safe way to detect if an
expression is the root, so it's safest to just disallow the
transformation if the input is a mutation.

Release note: None