### PR TITLE
opt: add parallel test for create stats

### DIFF
--- a/pkg/sql/logictest/testdata/parallel_test/create_stats/create_stats
+++ b/pkg/sql/logictest/testdata/parallel_test/create_stats/create_stats
@@ -1,0 +1,3 @@
+repeat 10
+statement ok
+CREATE STATISTICS s FROM data

--- a/pkg/sql/logictest/testdata/parallel_test/create_stats/setup
+++ b/pkg/sql/logictest/testdata/parallel_test/create_stats/setup
@@ -1,0 +1,9 @@
+statement ok
+CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c), INDEX d_idx (d))
+
+# Generate all combinations of values 1 to 20.
+statement ok
+INSERT INTO data SELECT a, b, c::FLOAT, NULL FROM
+   generate_series(1, 20) AS a(a),
+   generate_series(1, 20) AS b(b),
+   generate_series(1, 20) AS c(c)

--- a/pkg/sql/logictest/testdata/parallel_test/create_stats/test.yaml
+++ b/pkg/sql/logictest/testdata/parallel_test/create_stats/test.yaml
@@ -1,0 +1,20 @@
+# This test runs CREATE STATS many times on the same table from three different
+# hosts.
+
+cluster_size: 3
+
+range_split_size: 32768
+
+run:
+   # First run setup
+   - - file: setup
+
+   # Run create_stats on all nodes in parallel.
+   - - node: 0
+       file: create_stats
+
+     - node: 1
+       file: create_stats
+
+     - node: 2
+       file: create_stats


### PR DESCRIPTION
Adding a test where three nodes run CREATE STATS multiple times (in
parallel) on the same table.

Fixes #34781.

Release note: None