### PR TITLE
roachprod: fix bug which required setting aws-machine-type-ssd

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -534,8 +534,8 @@ func (p *Provider) runInstance(name string, zone string, opts vm.CreateOpts) err
 		return errors.Errorf("use the --aws-machine-type-ssd flag to set the " +
 			"machine type when --local-ssd=true")
 	} else if !opts.SSDOpts.UseLocalSSD &&
-		p.opts.MachineType != defaultMachineType &&
-		p.opts.SSDMachineType == defaultSSDMachineType {
+		p.opts.MachineType == defaultMachineType &&
+		p.opts.SSDMachineType != defaultSSDMachineType {
 		return errors.Errorf("use the --aws-machine-type flag to set the " +
 			"machine type when --local-ssd=false")
 	}


### PR DESCRIPTION
Before this PR you needed to specify a non-standard aws-machine-type-ssd flag
when trying to create cluster's with non-ssd machines. That's pretty crazy.

Release note: None