### PR TITLE
exec: implement sort chunks operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -744,7 +744,8 @@ EXECGEN_TARGETS = \
   pkg/sql/exec/rowstovec.eg.go \
   pkg/sql/exec/selection_ops.eg.go \
   pkg/sql/exec/sort.eg.go \
-  pkg/sql/exec/sum_agg.eg.go
+  pkg/sql/exec/sum_agg.eg.go \
+  pkg/sql/exec/tuples_differ.eg.go
 
 OPTGEN_TARGETS = \
 	pkg/sql/opt/memo/expr.og.go \
@@ -1392,6 +1393,7 @@ pkg/sql/exec/mergejoiner.eg.go: pkg/sql/exec/mergejoiner_tmpl.go
 pkg/sql/exec/quicksort.eg.go: pkg/sql/exec/quicksort_tmpl.go
 pkg/sql/exec/sort.eg.go: pkg/sql/exec/sort_tmpl.go
 pkg/sql/exec/sum_agg.eg.go: pkg/sql/exec/sum_agg_tmpl.go
+pkg/sql/exec/tuples_differ.eg.go: pkg/sql/exec/tuples_differ_tmpl.go
 
 $(EXECGEN_TARGETS): bin/execgen
 	@# Remove generated files with the old suffix to avoid conflicts.

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -348,9 +348,16 @@ func newColOperator(
 		if err := checkNumIn(inputs, 1); err != nil {
 			return nil, err
 		}
-		op, err = exec.NewSorter(inputs[0],
-			types.FromColumnTypes(spec.Input[0].ColumnTypes),
-			core.Sorter.OutputOrdering.Columns)
+		if core.Sorter.OrderingMatchLen > 0 {
+			op, err = exec.NewSortChunks(inputs[0],
+				types.FromColumnTypes(spec.Input[0].ColumnTypes),
+				core.Sorter.OutputOrdering.Columns,
+				int(core.Sorter.OrderingMatchLen))
+		} else {
+			op, err = exec.NewSorter(inputs[0],
+				types.FromColumnTypes(spec.Input[0].ColumnTypes),
+				core.Sorter.OutputOrdering.Columns)
+		}
 
 	default:
 		return nil, errors.Errorf("unsupported processor core %s", core)

--- a/pkg/sql/exec/colvec_tmpl.go
+++ b/pkg/sql/exec/colvec_tmpl.go
@@ -293,6 +293,8 @@ func (m *memColumn) ExtendNulls(
 	}
 	if vec.HasNulls() {
 		for i := uint16(0); i < toAppend; i++ {
+			// TODO(yuzefovich): this can be done more efficiently with a bitwise OR:
+			// like m.nulls[i] |= vec.nulls[i].
 			if vec.NullAt(srcStartIdx + i) {
 				m.SetNull64(destStartIdx + uint64(i))
 			}
@@ -310,6 +312,8 @@ func (m *memColumn) ExtendNullsWithSel(
 		m.nulls = append(m.nulls, make([]int64, (toAppend-1)>>6+1)...)
 	}
 	for i := uint16(0); i < toAppend; i++ {
+		// TODO(yuzefovich): this can be done more efficiently with a bitwise OR:
+		// like m.nulls[i] |= vec.nulls[i].
 		if vec.NullAt(sel[srcStartIdx+i]) {
 			m.SetNull64(destStartIdx + uint64(i))
 		}

--- a/pkg/sql/exec/execgen/cmd/execgen/tuples_differ_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/tuples_differ_gen.go
@@ -1,0 +1,54 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func genTuplesDiffer(wr io.Writer) error {
+	d, err := ioutil.ReadFile("pkg/sql/exec/tuples_differ_tmpl.go")
+	if err != nil {
+		return err
+	}
+
+	s := string(d)
+
+	// Replace the template variables.
+	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
+	s = strings.Replace(s, "_TYPES_T", "types.{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TYPE", "{{.LTyp}}", -1)
+	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
+
+	assignNeRe := regexp.MustCompile(`_ASSIGN_NE\((.*),(.*),(.*)\)`)
+	s = assignNeRe.ReplaceAllString(s, "{{.Assign $1 $2 $3}}")
+
+	// Now, generate the op, from the template.
+	tmpl, err := template.New("tuples_differ").Parse(s)
+	if err != nil {
+		return err
+	}
+
+	return tmpl.Execute(wr, comparisonOpToOverloads[tree.NE])
+}
+func init() {
+	registerGenerator(genTuplesDiffer, "tuples_differ.eg.go")
+}

--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -30,6 +30,18 @@ type Operator interface {
 	Next() ColBatch
 }
 
+// resetter is an interface that operators can implement if they can be reset
+// either for reusing (to keep the already allocated memory) or during tests.
+type resetter interface {
+	reset()
+}
+
+// resettableOperator is an Operator that can be reset.
+type resettableOperator interface {
+	Operator
+	resetter
+}
+
 type noopOperator struct {
 	input Operator
 }
@@ -42,4 +54,10 @@ func (n *noopOperator) Init() {
 
 func (n *noopOperator) Next() ColBatch {
 	return n.input.Next()
+}
+
+func (n *noopOperator) reset() {
+	if r, ok := n.input.(resetter); ok {
+		r.reset()
+	}
 }

--- a/pkg/sql/exec/sort.go
+++ b/pkg/sql/exec/sort.go
@@ -32,7 +32,7 @@ func NewSorter(
 
 func newSorter(
 	input spooler, inputTypes []types.T, orderingCols []distsqlpb.Ordering_Column,
-) (Operator, error) {
+) (resettableOperator, error) {
 	sorters := make([]colSorter, len(orderingCols))
 	partitioners := make([]partitioner, len(orderingCols)-1)
 	isOrderingCol := make([]bool, len(inputTypes))
@@ -164,6 +164,13 @@ func (p *allSpooler) getPartitionsCol() []bool {
 	return nil
 }
 
+func (p *allSpooler) reset() {
+	p.spooledTuples = 0
+	if r, ok := p.input.(resetter); ok {
+		r.reset()
+	}
+}
+
 type sortOp struct {
 	input spooler
 
@@ -194,7 +201,8 @@ type sortOp struct {
 	// state is the current state of the sort.
 	state sortState
 
-	output ColBatch
+	workingSpace []uint64
+	output       ColBatch
 }
 
 // colSorter is a single-column sorter, specialized on a particular type.
@@ -267,22 +275,37 @@ func (p *sortOp) Next() ColBatch {
 	panic(fmt.Sprintf("invalid sort state %v", p.state))
 }
 
+// sort sorts the spooled tuples, so it must be called after spool() has been
+// performed.
 func (p *sortOp) sort() {
 	spooledTuples := p.input.getNumTuples()
+	if spooledTuples == 0 {
+		// There is nothing to sort.
+		return
+	}
+	// Allocate p.order and p.workingSpace if it hasn't been allocated yet or the
+	// underlying memory is insufficient.
+	if p.order == nil || uint64(cap(p.order)) < spooledTuples {
+		p.order = make([]uint64, spooledTuples)
+		p.workingSpace = make([]uint64, spooledTuples)
+	}
+	p.order = p.order[:spooledTuples]
+	p.workingSpace = p.workingSpace[:spooledTuples]
+
 	// Initialize the order vector to the ordinal positions within the input set.
-	p.order = make([]uint64, spooledTuples)
 	for i := uint64(0); i < uint64(len(p.order)); i++ {
 		p.order[i] = i
 	}
 
-	workingSpace := make([]uint64, spooledTuples)
 	for i := range p.orderingCols {
-		p.sorters[i].init(p.input.getValues(int(p.orderingCols[i].ColIdx)), p.order, workingSpace)
+		p.sorters[i].init(p.input.getValues(int(p.orderingCols[i].ColIdx)), p.order, p.workingSpace)
 	}
 
 	// Now, sort each column in turn.
 	sorters := p.sorters
 	partitionsCol := p.input.getPartitionsCol()
+	omitNextPartitioning := false
+	offset := 0
 	if partitionsCol == nil {
 		// All spooled tuples belong to the same partition, so the first column
 		// doesn't need special treatment - we just globally sort it.
@@ -293,6 +316,17 @@ func (p *sortOp) sort() {
 		}
 		sorters = sorters[1:]
 		partitionsCol = make([]bool, spooledTuples)
+	} else {
+		// There are at least two partitions already, so the first column needs the
+		// same special treatment as all others. The general sequence is as
+		// follows: global sort -> partition -> sort partitions -> partition ->
+		// -> sort partitions -> partition -> sort partitions -> ..., but in this
+		// case, global sort doesn't make sense and partitioning has already been
+		// done, so we want to skip the first partitioning step and sort partitions
+		// right away. Also, in order to account for not performed global sort, we
+		// introduce an offset of 1 for partitioners.
+		omitNextPartitioning = true
+		offset = 1
 	}
 
 	// The rest of the columns need p sorts, one per partition in the previous
@@ -319,11 +353,15 @@ func (p *sortOp) sort() {
 
 	partitions := make([]uint64, 0, 16)
 	for i, sorter := range sorters {
-		// We partition the previous column by running an ordered distinct operation
-		// on it, ORing the results together with each subsequent column. This
-		// produces a distinct vector (a boolean vector that has true in each
-		// position that is different from the last position).
-		p.partitioners[i].partition(p.input.getValues(int(p.orderingCols[i].ColIdx)), partitionsCol, spooledTuples)
+		if !omitNextPartitioning {
+			// We partition the previous column by running an ordered distinct operation
+			// on it, ORing the results together with each subsequent column. This
+			// produces a distinct vector (a boolean vector that has true in each
+			// position that is different from the last position).
+			p.partitioners[i-offset].partition(p.input.getValues(int(p.orderingCols[i].ColIdx)), partitionsCol, spooledTuples)
+		} else {
+			omitNextPartitioning = false
+		}
 		// Convert the distinct vector into a selection vector - a vector of indices
 		// that were true in the distinct vector.
 		partitions = boolVecToSel64(partitionsCol, partitions[:0])
@@ -334,4 +372,12 @@ func (p *sortOp) sort() {
 		// columns we've seen so far), sort based on the new column.
 		sorter.sortPartitions(partitions)
 	}
+}
+
+func (p *sortOp) reset() {
+	if r, ok := p.input.(resetter); ok {
+		r.reset()
+	}
+	p.emitted = 0
+	p.state = sortSpooling
 }

--- a/pkg/sql/exec/sort_chunks.go
+++ b/pkg/sql/exec/sort_chunks.go
@@ -1,0 +1,404 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+// NewSortChunks returns a new sort chunks operator, which sorts its input on
+// the columns given in orderingCols. The inputTypes must correspond 1-1 with
+// the columns in the input operator. The input tuples must be sorted on first
+// matchLen columns.
+func NewSortChunks(
+	input Operator, inputTypes []types.T, orderingCols []distsqlpb.Ordering_Column, matchLen int,
+) (Operator, error) {
+	if matchLen == len(orderingCols) {
+		// input is already ordered on all orderingCols, so there is nothing more
+		// to sort.
+		return input, nil
+	}
+	chunker, err := newChunker(input, inputTypes, matchLen)
+	if err != nil {
+		return nil, err
+	}
+	sorter, err := newSorter(chunker, inputTypes, orderingCols[matchLen:])
+	if err != nil {
+		return nil, err
+	}
+	return &sortChunksOp{input: chunker, sorter: sorter}, nil
+}
+
+type sortChunksOp struct {
+	input  *chunker
+	sorter resettableOperator
+}
+
+func (c *sortChunksOp) Init() {
+	c.input.init()
+	c.sorter.Init()
+}
+
+func (c *sortChunksOp) Next() ColBatch {
+	for {
+		batch := c.sorter.Next()
+		if batch.Length() == 0 {
+			if c.input.done() {
+				// We're done, so return a zero-length batch.
+				return batch
+			}
+			// We're not yet done - need to process another chunk, so we empty the
+			// chunker's buffer and reset the sorter. Note that we do not want to do
+			// the full reset of the chunker because we're in the middle of
+			// processing of the input to sortChunksOp.
+			c.input.emptyBuffer()
+			c.sorter.reset()
+		} else {
+			return batch
+		}
+	}
+}
+
+// chunkerState represents the state of the chunker spooler.
+type chunkerState int
+
+const (
+	// chunkerReading is the state of the chunker spooler in which it reads a
+	// batch from its input and partitions the batch into chunks. Depending on
+	// current state of the chunker's buffer and number of chunks in the batch,
+	// chunker might stay in chunkerReading state or switch to either of the
+	// emitting states.
+	chunkerReading chunkerState = iota
+	// chunkerEmittingFromBuffer is the state of the chunker spooler in which it
+	// prepares to "emit" tuples that have been buffered. All the tuples belong
+	// to the same chunk ("emit" is in quotes because the chunker does not emit
+	// batches as usual - it, instead, implements spooler interface, and the
+	// batches should be accessed through those methods). The chunker transitions
+	// to chunkerEmittingFromBuffer state and indicates that the tuples need to
+	// be read from the buffer.
+	chunkerEmittingFromBuffer
+	// chunkerEmittingFromBatch is the state of the chunker spooler in which it
+	// prepares to "emit" all chunks that are fully contained within the last
+	// read batch (i.e. all chunks except for the last chunk which might include
+	// tuples from the next batch). The last chunk within the batch is buffered,
+	// the chunker transitions to chunkerReading state and indicates that the
+	// tuples need to be read from s.batch.
+	chunkerEmittingFromBatch
+)
+
+// chunkerReadingState indicates where the spooler needs to read tuples from
+// for emitting.
+type chunkerReadingState int
+
+const (
+	// chunkerReadFromBuffer indicates that the tuples need to be read from the
+	// buffer.
+	chunkerReadFromBuffer = iota
+	// chunkerReadFromBatch indicates that the tuples need to be read from the
+	// last read batch directly. Only tuples that are fully contained within the
+	// last read batch are "emitted".
+	chunkerReadFromBatch
+	// inputDone indicates that the input has been fully consumed and there are
+	// no more tuples to read from the chunker.
+	inputDone
+)
+
+// chunker is a spooler that produces chunks from its input when the tuples
+// are already ordered on the first matchLen columns. The chunks are not
+// emitted in batches as usual when Next()'ed, but, instead, they should be
+// accessed via getValues().
+//
+// Note 1: the chunker assumes that its input produces batches with no
+// selection vector, so it always puts a deselector on top of its input. It
+// does the coalescing itself, so it does not use an extra coalescer.
+// Note 2: the chunker intentionally does not implement resetter interface (if
+// it did, the sorter would reset it, but we don't want that since we're likely
+// in the middle of processing the input). Instead, sortChunksOp will empty the
+// buffer when appropriate.
+type chunker struct {
+	input Operator
+	// inputTypes contains the types of all of the columns from input.
+	inputTypes []types.T
+	// inputDone indicates whether input has been fully consumed.
+	inputDone bool
+	// matchLen indicates the number of first columns on which input is ordered.
+	matchLen int
+
+	// batch is the last read batch from input.
+	batch ColBatch
+	// partitioners contains one partitioner for each of matchLen first already
+	// ordered columns.
+	partitioners []partitioner
+	// partitionCol is a bool slice for partitioners' output to be ORed.
+	partitionCol []bool
+
+	// chunks contains the indices of the first tuples within different chunks
+	// found in the last read batch. Note: the first chunk might be a part of
+	// the chunk that is currently being buffered, and similarly the last chunk
+	// might include tuples from the batches to be read.
+	chunks []uint64
+	// chunksProcessedIdx indicates which chunk within s.chunks should be
+	// processed next.
+	chunksProcessedIdx int
+	// chunksStartIdx indicates the index of the chunk within s.chunks that is
+	// the first one to be emitted from s.batch directly in when reading from
+	// batch.
+	chunksStartIdx int
+
+	// buffered indicates the number of currently buffered tuples.
+	buffered uint64
+	// bufferedColumns is a buffer to store tuples when a chunk is bigger than
+	// ColBatchSize or when the chunk is the last in the last read batch (we
+	// don't know yet where the end of such chunk is).
+	bufferedColumns []ColVec
+
+	readFrom chunkerReadingState
+	output   ColBatch
+	state    chunkerState
+}
+
+func newChunker(input Operator, inputTypes []types.T, matchLen int) (*chunker, error) {
+	var err error
+	partitioners := make([]partitioner, matchLen)
+	for col := 0; col < matchLen; col++ {
+		partitioners[col], err = newPartitioner(inputTypes[col])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &chunker{
+		input:        NewDeselectorOp(input, inputTypes),
+		inputTypes:   inputTypes,
+		matchLen:     matchLen,
+		partitioners: partitioners,
+		state:        chunkerReading,
+	}, nil
+}
+
+func (s *chunker) init() {
+	s.input.Init()
+	s.output = NewMemBatch(s.inputTypes)
+	s.bufferedColumns = make([]ColVec, len(s.inputTypes))
+	for i := 0; i < len(s.inputTypes); i++ {
+		s.bufferedColumns[i] = newMemColumn(s.inputTypes[i], 0)
+	}
+	s.partitionCol = make([]bool, ColBatchSize)
+	s.chunks = make([]uint64, 0, 16)
+}
+
+// done indicates whether the chunker has fully consumed its input.
+func (s *chunker) done() bool {
+	return s.readFrom == inputDone
+}
+
+// prepareNextChunks prepares the chunks for the chunker spooler.
+//
+// Note: it does not return the batches directly; instead, the chunker
+// remembers where the next chunks to be emitted are actually stored. In order
+// to access the chunks, getValues() must be used.
+func (s *chunker) prepareNextChunks() chunkerReadingState {
+	for {
+		switch s.state {
+		case chunkerReading:
+			s.batch = s.input.Next()
+			if s.batch.Length() == 0 {
+				s.inputDone = true
+				if s.buffered > 0 {
+					s.state = chunkerEmittingFromBuffer
+				} else {
+					s.state = chunkerEmittingFromBatch
+				}
+				continue
+			}
+			if s.batch.Selection() != nil {
+				// We assume that the input has been deselected, so the batch should
+				// never have a selection vector set.
+				panic(fmt.Sprintf("unexpected: batch with non-nil selection vector"))
+			}
+
+			// First, run the partitioners on our pre-sorted columns to determine the
+			// boundaries of the chunks (stored in s.chunks) to sort further.
+			copy(s.partitionCol, zeroBoolVec)
+			for i, partitioner := range s.partitioners {
+				partitioner.partition(s.batch.ColVec(i), s.partitionCol, uint64(s.batch.Length()))
+			}
+			s.chunks = boolVecToSel64(s.partitionCol, s.chunks[:0])
+
+			if s.buffered == 0 {
+				// There are no buffered tuples, so a new chunk starts in the current
+				// batch.
+				if len(s.chunks) > 1 {
+					// There is at least one chunk that is fully contained within
+					// s.batch, so we proceed to emitting it.
+					s.state = chunkerEmittingFromBatch
+					continue
+				}
+				// All tuples in s.batch belong to the same chunk. Possibly tuples from
+				// the next batch will also belong to this chunk, so we buffer the full
+				// s.batch.
+				s.buffer(0 /* start */, s.batch.Length())
+				s.state = chunkerReading
+				continue
+			} else {
+				// There are some buffered tuples, so we need to check whether the
+				// first tuple of s.batch belongs to the chunk that is being buffered.
+				differ := false
+				for i := 0; i < s.matchLen; i++ {
+					if err := tuplesDiffer(
+						s.inputTypes[i],
+						s.bufferedColumns[i],
+						0, /*aTupleIdx */
+						s.batch.ColVec(i),
+						0, /* bTupleIdx */
+						&differ,
+					); err != nil {
+						panic(err)
+					}
+				}
+				if differ {
+					// Buffered tuples comprise a full chunk, so we proceed to emitting
+					// it.
+					s.state = chunkerEmittingFromBuffer
+					continue
+				}
+
+				// The first tuple of s.batch belongs to the chunk that is being
+				// buffered.
+				if len(s.chunks) == 1 {
+					// All tuples in s.batch belong to the same chunk that is being
+					// buffered. Possibly tuples from the next batch will also belong to
+					// this chunk, so we buffer the full s.batch.
+					s.buffer(0 /* start */, s.batch.Length())
+					s.state = chunkerReading
+					continue
+				}
+				// First s.chunks[1] tuples belong to the same chunk that is being
+				// buffered, so we buffer them and proceed to emitting all buffered
+				// tuples.
+				s.buffer(0 /* start */, uint16(s.chunks[1]))
+				s.chunksProcessedIdx = 1
+				s.state = chunkerEmittingFromBuffer
+				continue
+			}
+		case chunkerEmittingFromBuffer:
+			s.state = chunkerEmittingFromBatch
+			return chunkerReadFromBuffer
+		case chunkerEmittingFromBatch:
+			if s.chunksProcessedIdx+1 < len(s.chunks) {
+				// There is at least one chunk that is fully contained within s.batch.
+				// We don't know yet whether the tuples from the next batch belong to
+				// the last chunk of the current batch, so we will buffer those and can
+				// only emit "internal" to s.batch chunks. Additionally, if
+				// s.chunksProcessedIdx == 1, then the first chunk was already combined
+				// with the buffered tuples and emitted.
+				s.chunksStartIdx = s.chunksProcessedIdx
+				s.chunksProcessedIdx = len(s.chunks) - 1
+				return chunkerReadFromBatch
+			} else if s.chunksProcessedIdx == len(s.chunks)-1 {
+				// Other tuples might belong to this chunk, so we buffer it.
+				s.buffer(uint16(s.chunks[s.chunksProcessedIdx]), s.batch.Length())
+				// All tuples in s.batch have been processed, so we reset s.chunks and
+				// the corresponding variables.
+				s.chunks = s.chunks[:0]
+				s.chunksProcessedIdx = 0
+				s.state = chunkerReading
+			} else {
+				// All tuples in s.batch have been emitted.
+				if s.inputDone {
+					return inputDone
+				}
+				panic(fmt.Sprintf("unexpected: chunkerEmittingFromBatch state" +
+					"when s.chunks is fully processed and input is not done"))
+			}
+		default:
+			panic(fmt.Sprintf("invalid chunker spooler state %v", s.state))
+		}
+	}
+}
+
+// buffer appends all tuples in range [start,end) from s.batch to already
+// buffered tuples.
+func (s *chunker) buffer(start uint16, end uint16) {
+	for i := 0; i < len(s.bufferedColumns); i++ {
+		s.bufferedColumns[i].AppendSlice(
+			s.batch.ColVec(i),
+			s.inputTypes[i],
+			s.buffered,
+			start,
+			end,
+		)
+	}
+	s.buffered += uint64(end - start)
+}
+
+func (s *chunker) spool() {
+	s.readFrom = s.prepareNextChunks()
+}
+
+func (s *chunker) getValues(i int) ColVec {
+	switch s.readFrom {
+	case chunkerReadFromBuffer:
+		return s.bufferedColumns[i].Slice(s.inputTypes[i], 0 /* start */, s.buffered)
+	case chunkerReadFromBatch:
+		return s.batch.ColVec(i).Slice(s.inputTypes[i], s.chunks[s.chunksStartIdx], s.chunks[len(s.chunks)-1])
+	default:
+		panic(fmt.Sprintf("unexpected chunkerReadingState in getValues: %v", s.state))
+	}
+}
+
+func (s *chunker) getNumTuples() uint64 {
+	switch s.readFrom {
+	case chunkerReadFromBuffer:
+		return s.buffered
+	case chunkerReadFromBatch:
+		return s.chunks[len(s.chunks)-1] - s.chunks[s.chunksStartIdx]
+	case inputDone:
+		return 0
+	default:
+		panic(fmt.Sprintf("unexpected chunkerReadingState in getNumTuples: %v", s.state))
+	}
+}
+
+func (s *chunker) getPartitionsCol() []bool {
+	switch s.readFrom {
+	case chunkerReadFromBuffer:
+		// There is a single chunk in the buffer, so, per spooler's contract, we
+		// return nil.
+		return nil
+	case chunkerReadFromBatch:
+		if s.chunksStartIdx+1 == len(s.chunks)-1 {
+			// There is a single chunk that is fully contained within s.batch, so,
+			// per spooler's contract, we return nil.
+			return nil
+		}
+		copy(s.partitionCol, zeroBoolVec)
+		for i := s.chunksStartIdx; i < len(s.chunks)-1; i++ {
+			// getValues returns a slice starting from s.chunks[s.chunksStartIdx], so
+			// we need to account for that by shifting as well.
+			s.partitionCol[s.chunks[i]-s.chunks[s.chunksStartIdx]] = true
+		}
+		return s.partitionCol
+	default:
+		panic(fmt.Sprintf("unexpected chunkerReadingState in getPartitionsCol: %v", s.state))
+	}
+}
+
+func (s *chunker) emptyBuffer() {
+	// We only need to set s.buffered to 0 to empty the buffer.
+	s.buffered = 0
+}

--- a/pkg/sql/exec/sort_chunks_test.go
+++ b/pkg/sql/exec/sort_chunks_test.go
@@ -1,0 +1,302 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestSortChunks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tcs := []struct {
+		description string
+		tuples      tuples
+		expected    tuples
+		typ         []types.T
+		ordCols     []distsqlpb.Ordering_Column
+		matchLen    int
+	}{
+		{
+			description: `tuples already ordered`,
+			tuples:      tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
+			expected:    tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
+			typ:         []types.T{types.Int64},
+			ordCols:     []distsqlpb.Ordering_Column{{ColIdx: 0}},
+			matchLen:    1,
+		},
+		{
+			description: `three chunks`,
+			tuples:      tuples{{1, 2}, {1, 2}, {1, 3}, {1, 1}, {5, 5}, {6, 6}, {6, 1}},
+			expected:    tuples{{1, 1}, {1, 2}, {1, 2}, {1, 3}, {5, 5}, {6, 1}, {6, 6}},
+			typ:         []types.T{types.Int64, types.Int64},
+			ordCols:     []distsqlpb.Ordering_Column{{ColIdx: 0}, {ColIdx: 1}},
+			matchLen:    1,
+		},
+		{
+			description: `one chunk, matchLen 1, three ordering columns`,
+			tuples: tuples{
+				{0, 1, 2},
+				{0, 2, 0},
+				{0, 1, 0},
+				{0, 1, 1},
+				{0, 2, 1},
+			},
+			expected: tuples{
+				{0, 1, 0},
+				{0, 1, 1},
+				{0, 1, 2},
+				{0, 2, 0},
+				{0, 2, 1},
+			},
+			typ:      []types.T{types.Int64, types.Int64, types.Int64},
+			ordCols:  []distsqlpb.Ordering_Column{{ColIdx: 0}, {ColIdx: 1}, {ColIdx: 2}},
+			matchLen: 1,
+		},
+		{
+			description: `two chunks, matchLen 1, three ordering columns`,
+			tuples: tuples{
+				{0, 1, 2},
+				{0, 2, 0},
+				{0, 1, 0},
+				{1, 2, 1},
+				{1, 1, 1},
+			},
+			expected: tuples{
+				{0, 1, 0},
+				{0, 1, 2},
+				{0, 2, 0},
+				{1, 1, 1},
+				{1, 2, 1},
+			},
+			typ:      []types.T{types.Int64, types.Int64, types.Int64},
+			ordCols:  []distsqlpb.Ordering_Column{{ColIdx: 0}, {ColIdx: 1}, {ColIdx: 2}},
+			matchLen: 1,
+		},
+		{
+			description: `two chunks, matchLen 2, three ordering columns`,
+			tuples: tuples{
+				{0, 1, 2},
+				{0, 1, 0},
+				{0, 1, 1},
+				{0, 2, 1},
+				{0, 2, 0},
+			},
+			expected: tuples{
+				{0, 1, 0},
+				{0, 1, 1},
+				{0, 1, 2},
+				{0, 2, 0},
+				{0, 2, 1},
+			},
+			typ:      []types.T{types.Int64, types.Int64, types.Int64},
+			ordCols:  []distsqlpb.Ordering_Column{{ColIdx: 0}, {ColIdx: 1}, {ColIdx: 2}},
+			matchLen: 2,
+		},
+		{
+			description: `four chunks, matchLen 2, three ordering columns`,
+			tuples: tuples{
+				{0, 1, 2},
+				{0, 1, 0},
+				{0, 2, 0},
+				{1, 1, 1},
+				{1, 2, 1},
+			},
+			expected: tuples{
+				{0, 1, 0},
+				{0, 1, 2},
+				{0, 2, 0},
+				{1, 1, 1},
+				{1, 2, 1},
+			},
+			typ:      []types.T{types.Int64, types.Int64, types.Int64},
+			ordCols:  []distsqlpb.Ordering_Column{{ColIdx: 0}, {ColIdx: 1}, {ColIdx: 2}},
+			matchLen: 2,
+		},
+	}
+	for _, tc := range tcs {
+		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
+			sorter, err := NewSortChunks(input[0], tc.typ, tc.ordCols, tc.matchLen)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cols := make([]int, len(tc.typ))
+			for i := range cols {
+				cols[i] = i
+			}
+			out := newOpTestOutput(sorter, cols, tc.expected)
+
+			if err := out.Verify(); err != nil {
+				t.Fatalf("Test case description: '%s'\n%v", tc.description, err)
+			}
+		})
+	}
+}
+
+func TestSortChunksRandomized(t *testing.T) {
+	rng, _ := randutil.NewPseudoRand()
+	nTups := 8
+	for nCols := 2; nCols < 8; nCols++ {
+		for matchLen := 1; matchLen <= nCols; matchLen++ {
+			// TODO(yuzefovich): randomize types as well.
+			typs := make([]types.T, nCols)
+			ordCols := make([]distsqlpb.Ordering_Column, nCols)
+			for i := range typs {
+				ordCols[i].ColIdx = uint32(i)
+				ordCols[i].Direction = distsqlpb.Ordering_Column_Direction(rng.Int() % 2)
+				typs[i] = types.Int64
+			}
+			tups := make(tuples, nTups)
+			for i := range tups {
+				tups[i] = make(tuple, nCols)
+				for j := range tups[i] {
+					// Small range so we can test partitioning.
+					tups[i][j] = rng.Int63() % 2048
+				}
+			}
+
+			// Sort tups on the first matchLen columns as needed for sort chunks
+			// operator.
+			sortedTups := make(tuples, nTups)
+			copy(sortedTups, tups)
+			sort.Slice(sortedTups, less(sortedTups, ordCols, matchLen))
+
+			// Sort tups on all nCols to get the expected results.
+			expected := make(tuples, nTups)
+			copy(expected, tups)
+			sort.Slice(expected, less(expected, ordCols, nCols))
+
+			runTests(t, []tuples{sortedTups}, func(t *testing.T, input []Operator) {
+				sorter, err := NewSortChunks(input[0], typs, ordCols, matchLen)
+				if err != nil {
+					t.Fatal(err)
+				}
+				cols := make([]int, len(typs))
+				for i := range cols {
+					cols[i] = i
+				}
+				out := newOpTestOutput(sorter, cols, expected)
+
+				if err := out.Verify(); err != nil {
+					t.Fatalf("for input %v:\n%v", sortedTups, err)
+				}
+			})
+		}
+	}
+}
+
+func less(
+	tuples tuples, ordCols []distsqlpb.Ordering_Column, nColsToCompare int,
+) func(i, j int) bool {
+	return func(i, j int) bool {
+		for k := 0; k < nColsToCompare; k++ {
+			col := ordCols[k].ColIdx
+			if tuples[i][col].(int64) < tuples[j][col].(int64) {
+				return ordCols[k].Direction == distsqlpb.Ordering_Column_ASC
+			} else if tuples[i][col].(int64) > tuples[j][col].(int64) {
+				return ordCols[k].Direction == distsqlpb.Ordering_Column_DESC
+			}
+		}
+		return false
+	}
+}
+
+func BenchmarkSortChunks(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+
+	sorterConstructors := []func(Operator, []types.T, []distsqlpb.Ordering_Column, int) (Operator, error){
+		NewSortChunks,
+		func(input Operator, inputTypes []types.T, orderingCols []distsqlpb.Ordering_Column, _ int) (Operator, error) {
+			return NewSorter(input, inputTypes, orderingCols)
+		},
+	}
+	sorterNames := []string{"CHUNKS", "ALL"}
+	for _, nBatches := range []int{1 << 2, 1 << 6} {
+		for _, nCols := range []int{2, 4} {
+			for _, matchLen := range []int{1, 2, 3} {
+				for _, avgChunkSize := range []int{1 << 3, 1 << 7} {
+					for sorterIdx, sorterConstructor := range sorterConstructors {
+						if matchLen >= nCols {
+							continue
+						}
+						b.Run(
+							fmt.Sprintf("%s/rows=%d/cols=%d/matchLen=%d/avgChunkSize=%d",
+								sorterNames[sorterIdx], nBatches*ColBatchSize, nCols, matchLen, avgChunkSize),
+							func(b *testing.B) {
+								// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+								// batch) * nCols (number of columns / row).
+								b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols))
+								typs := make([]types.T, nCols)
+								for i := range typs {
+									typs[i] = types.Int64
+								}
+								batch := NewMemBatch(typs)
+								batch.SetLength(ColBatchSize)
+								ordCols := make([]distsqlpb.Ordering_Column, nCols)
+								for i := range ordCols {
+									ordCols[i].ColIdx = uint32(i)
+									if i < matchLen {
+										ordCols[i].Direction = distsqlpb.Ordering_Column_ASC
+									} else {
+										ordCols[i].Direction = distsqlpb.Ordering_Column_Direction(rng.Int() % 2)
+									}
+
+									col := batch.ColVec(i).Int64()
+									col[0] = 0
+									for j := 1; j < ColBatchSize; j++ {
+										if i < matchLen {
+											col[j] = col[j-1]
+											if rng.Float64() < 1.0/float64(avgChunkSize) {
+												col[j]++
+											}
+										} else {
+											col[j] = rng.Int63() % int64((i*1024)+1)
+										}
+									}
+								}
+								rowsTotal := nBatches * ColBatchSize
+								b.ResetTimer()
+								for n := 0; n < b.N; n++ {
+									source := newFiniteChunksSource(batch, nBatches, matchLen)
+									sorter, err := sorterConstructor(source, typs, ordCols, matchLen)
+									if err != nil {
+										b.Fatal(err)
+									}
+
+									sorter.Init()
+									rowsEmitted := 0
+									for rowsEmitted < rowsTotal {
+										out := sorter.Next()
+										if out.Length() == 0 {
+											b.Fail()
+										}
+										rowsEmitted += int(out.Length())
+									}
+								}
+								b.StopTimer()
+							})
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/sql/exec/sort_test.go
+++ b/pkg/sql/exec/sort_test.go
@@ -135,6 +135,7 @@ func TestSortRandomized(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 	nCols := 2
 	nTups := 8
+	// TODO(yuzefovich): randomize types as well.
 	typs := make([]types.T, nCols)
 	ordCols := make([]distsqlpb.Ordering_Column, nCols)
 	for i := range typs {

--- a/pkg/sql/exec/tuples_differ_tmpl.go
+++ b/pkg/sql/exec/tuples_differ_tmpl.go
@@ -1,0 +1,79 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// {{/*
+// +build execgen_template
+//
+// This file is the execgen template for tuples_differ.eg.go. It's formatted
+// in a special way, so it's both valid Go and a valid text/template input.
+// This permits editing this file with editor support.
+//
+// */}}
+
+package exec
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/pkg/errors"
+)
+
+// {{/*
+
+// Declarations to make the template compile properly.
+
+// Dummy import to pull in "bytes" package.
+var _ bytes.Buffer
+
+// Dummy import to pull in "tree" package.
+var _ tree.Datum
+
+// _GOTYPE is the template Go type variable for this operator. It will be
+// replaced by the Go type equivalent for each type in types.T, for example
+// int64 for types.Int64.
+type _GOTYPE interface{}
+
+// _TYPES_T is the template type variable for types.T. It will be replaced by
+// types.Foo for each type Foo in the types.T type.
+const _TYPES_T = types.Unhandled
+
+// _ASSIGN_NE is the template equality function for assigning the first input
+// to the result of the second input != the third input.
+func _ASSIGN_NE(_, _, _ string) bool {
+	panic("")
+}
+
+// */}}
+
+// tuplesDiffer takes in two ColVecs as well as tuple indices to check whether
+// the tuples differ.
+func tuplesDiffer(
+	t types.T, aColVec ColVec, aTupleIdx int, bColVec ColVec, bTupleIdx int, differ *bool,
+) error {
+	switch t {
+	// {{range .}}
+	case _TYPES_T:
+		aCol := aColVec._TemplateType()
+		bCol := bColVec._TemplateType()
+		var unique bool
+		_ASSIGN_NE("unique", "aCol[aTupleIdx]", "bCol[bTupleIdx]")
+		*differ = *differ || unique
+		return nil
+	// {{end}}
+	default:
+		return errors.Errorf("unsupported tuplesDiffer type %s", t)
+	}
+}

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -636,6 +636,60 @@ func (r *randomLengthBatchSource) Next() ColBatch {
 	return r.internalBatch
 }
 
+// finiteChunksSource is an Operator that returns a batch specified number of
+// times. The first matchLen columns of the batch are incremented every time
+// (except for the first) the batch is returned to emulate source that is
+// already ordered on matchLen columns.
+type finiteChunksSource struct {
+	repeatableBatch *repeatableBatchSource
+
+	usableCount int
+	matchLen    int
+	adjustment  []int64
+}
+
+var _ Operator = &finiteBatchSource{}
+
+func newFiniteChunksSource(batch ColBatch, usableCount int, matchLen int) *finiteChunksSource {
+	return &finiteChunksSource{
+		repeatableBatch: newRepeatableBatchSource(batch),
+		usableCount:     usableCount,
+		matchLen:        matchLen,
+	}
+}
+
+func (f *finiteChunksSource) Init() {
+	f.repeatableBatch.Init()
+	f.adjustment = make([]int64, f.matchLen)
+}
+
+func (f *finiteChunksSource) Next() ColBatch {
+	if f.usableCount > 0 {
+		f.usableCount--
+		batch := f.repeatableBatch.Next()
+		if f.adjustment[0] == 0 {
+			// We need to calculate the difference between the first and the last
+			// tuples in batch in first matchLen columns so that in the following
+			// calls to Next() the batch is adjusted such that tuples in consecutive
+			// batches are ordered on the first matchLen columns.
+			for col := 0; col < f.matchLen; col++ {
+				firstValue := batch.ColVec(col).Int64()[0]
+				lastValue := batch.ColVec(col).Int64()[batch.Length()-1]
+				f.adjustment[col] = lastValue - firstValue
+			}
+		} else {
+			for i := 0; i < f.matchLen; i++ {
+				int64Vec := batch.ColVec(i).Int64()
+				for j := range int64Vec {
+					int64Vec[j] += f.adjustment[i]
+				}
+			}
+		}
+		return batch
+	}
+	return NewMemBatch([]types.T{})
+}
+
 func TestOpTestInputOutput(t *testing.T) {
 	inputs := []tuples{
 		{


### PR DESCRIPTION
Implements sort chunks operator in vectorized engine to be used when
the tuples are already ordered on a prefix of ordering columns. The
"meat" of implementation is a new chunker spooler which produces
chunks of tuples which are then hooked up into a general sorter.
The sorter is reset and reused for every batch of chunks (which can
be a single chunk that spans multiple batches, multiple chunks within
a single batch, or a small chunk that was the last from the input).

Release note: None