### PR TITLE
sql: Fix judgment condition when judging spans overlap.

### DIFF
--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -164,7 +164,7 @@ func makeKVBatchFetcher(
 				// Current span's start key is greater than or equal to the last span's
 				// end key - we're good.
 				continue
-			} else if spans[i].EndKey.Compare(spans[i-1].EndKey) < 0 {
+			} else if spans[i].EndKey.Compare(spans[i-1].Key) < 0 {
 				// Current span's end key is less than or equal to the last span's start
 				// key - also good.
 				continue


### PR DESCRIPTION
Change the judgment condition when judging spans overlap in pkg/sql/row/kv_batch_fetcher.go

Fixes #35046

Release note: None