### PR TITLE
Fix TestReplicaRangefeedRetryErrors

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1086,8 +1086,7 @@ func (n *Node) setupSpanForIncomingRPC(
 func (n *Node) RangeFeed(
 	args *roachpb.RangeFeedRequest, stream roachpb.Internal_RangeFeedServer,
 ) error {
-	ctx := n.storeCfg.AmbientCtx.ResetAndAnnotateCtx(stream.Context())
-	pErr := n.stores.RangeFeed(ctx, args, stream)
+	pErr := n.stores.RangeFeed(args, stream)
 	if pErr != nil {
 		var event roachpb.RangeFeedEvent
 		event.SetValue(&roachpb.RangeFeedError{

--- a/pkg/storage/replica_rangefeed_test.go
+++ b/pkg/storage/replica_rangefeed_test.go
@@ -538,6 +538,9 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 				Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
 			}
 
+			timer := time.AfterFunc(10*time.Second, stream.Cancel)
+			defer timer.Stop()
+
 			pErr := partitionStore.RangeFeed(&req, stream)
 			streamErrC <- pErr
 		}()

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2984,9 +2984,8 @@ func (s *Store) Send(
 // the provided stream and returns with an optional error when the rangefeed is
 // complete.
 func (s *Store) RangeFeed(
-	ctx context.Context, args *roachpb.RangeFeedRequest, stream roachpb.Internal_RangeFeedServer,
+	args *roachpb.RangeFeedRequest, stream roachpb.Internal_RangeFeedServer,
 ) *roachpb.Error {
-	ctx = s.AnnotateCtx(ctx)
 	if err := verifyKeys(args.Span.Key, args.Span.EndKey, true); err != nil {
 		return roachpb.NewError(err)
 	}
@@ -3020,7 +3019,7 @@ func (s *Store) RangeFeed(
 			},
 		})
 	}
-	return repl.RangeFeed(ctx, args, stream, s.limiters.ConcurrentRangefeedIters)
+	return repl.RangeFeed(args, stream, s.limiters.ConcurrentRangefeedIters)
 }
 
 // maybeWaitForPushee potentially diverts the incoming request to

--- a/pkg/storage/stores.go
+++ b/pkg/storage/stores.go
@@ -193,8 +193,9 @@ func (ls *Stores) Send(
 // the provided stream and returns with an optional error when the rangefeed is
 // complete.
 func (ls *Stores) RangeFeed(
-	ctx context.Context, args *roachpb.RangeFeedRequest, stream roachpb.Internal_RangeFeedServer,
+	args *roachpb.RangeFeedRequest, stream roachpb.Internal_RangeFeedServer,
 ) *roachpb.Error {
+	ctx := stream.Context()
 	if args.RangeID == 0 {
 		log.Fatal(ctx, "rangefeed request missing range ID")
 	} else if args.Replica.StoreID == 0 {
@@ -206,7 +207,7 @@ func (ls *Stores) RangeFeed(
 		return roachpb.NewError(err)
 	}
 
-	return store.RangeFeed(ctx, args, stream)
+	return store.RangeFeed(args, stream)
 }
 
 // ReadBootstrapInfo implements the gossip.Storage interface. Read


### PR DESCRIPTION
First commit is #35088.

The Raft handler that was supposed to drop certain MsgApps on the floor
wasn't necessarily doing so due to the async nature of our Raft messaging.
Fix this by not removing the handler, but by replacing it with one that
will filter the desired messages in perpetuity.

Fixes #34978.
(by which I mean: failed within a minute on my gceworker before, now has
been running for at least five).

Release note: None