### PR TITLE
storage: remove {Has,Put}BogusSideloadedData

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1417,23 +1417,6 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 	if generated != preemptiveApplied {
 		t.Fatalf("expected %d preemptive snapshots, but found %d", generated, preemptiveApplied)
 	}
-
-	r.PutBogusSideloadedData()
-
-	againR, _, err := mtc.stores[2].GetOrCreateReplica(
-		context.Background(),
-		r.RangeID,
-		0,   // replicaID
-		nil, // fromReplica
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	againR.RaftUnlock()
-
-	if !againR.HasBogusSideloadedData() {
-		t.Fatalf("sideloaded storage changed after fake message to replicaID zero")
-	}
 }
 
 // getRangeMetadata retrieves the current range descriptor for the target


### PR DESCRIPTION
Those were a pain to deal with while looking into Raft log size
computations. They're also ugly, so get rid of them.

One call was simply removed - we can do without this coverage now that
the replicaID does not influence the sideloaded storage location any
more (#35035).

Release note: None