### PR TITLE
sql: fix pgwire parsing certain binary encodings of numeric values an order of magnitude off

### DIFF
--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -192,6 +193,45 @@ func TestEncodings(t *testing.T) {
 					})
 				}
 			})
+		})
+	}
+}
+
+// TestExoticNumericEncodings goes through specific, legal pgwire encodings
+// that Postgres itself would usually choose to not produce, which therefore
+// would not be covered by TestEncodings. Of course, being valid encodings
+// they'd still be accepted and correctly parsed by Postgres.
+func TestExoticNumericEncodings(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		Value    *apd.Decimal
+		Encoding []byte
+	}{
+		{apd.New(0, 0), []byte{0, 0, 0, 0, 0, 0, 0, 0}},
+		{apd.New(0, 0), []byte{0, 1, 0, 0, 0, 0, 0, 0, 0, 0}},
+		{apd.New(10000, 0), []byte{0, 2, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0}},
+		{apd.New(10001, 0), []byte{0, 2, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1}},
+		{apd.New(1000000, 0), []byte{0, 2, 0, 1, 0, 0, 0, 0, 0, 100, 0, 0}},
+		{apd.New(1000001, 0), []byte{0, 2, 0, 1, 0, 0, 0, 0, 0, 100, 0, 1}},
+		{apd.New(100000000, 0), []byte{0, 1, 0, 2, 0, 0, 0, 0, 0, 1}},
+		{apd.New(100000000, 0), []byte{0, 2, 0, 2, 0, 0, 0, 0, 0, 1, 0, 0}},
+		{apd.New(100000000, 0), []byte{0, 3, 0, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0}},
+		{apd.New(100000001, 0), []byte{0, 3, 0, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1}},
+	}
+
+	evalCtx := tree.MakeTestingEvalContext(nil)
+	for i, c := range testCases {
+		t.Run(fmt.Sprintf("%d_%s", i, c.Value), func(t *testing.T) {
+			d, err := pgwirebase.DecodeOidDatum(nil, oid.T_numeric, pgwirebase.FormatBinary, c.Encoding)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expected := &tree.DDecimal{Decimal: *c.Value}
+			if d.Compare(&evalCtx, expected) != 0 {
+				t.Fatalf("%v != %v", d, expected)
+			}
 		})
 	}
 }

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -456,7 +456,9 @@ func DecodeOidDatum(
 						alloc.i16 /= 10
 					}
 				}
-				decDigits = strconv.AppendUint(decDigits, uint64(alloc.i16), 10)
+				if alloc.i16 > 0 {
+					decDigits = strconv.AppendUint(decDigits, uint64(alloc.i16), 10)
+				}
 				decString := string(decDigits)
 				if _, ok := alloc.dd.Coeff.SetString(decString, 10); !ok {
 					return nil, errors.Errorf("could not parse string %q as decimal", decString)


### PR DESCRIPTION
Some numeric values can be encoded in multiple ways on the wire. For example, 1000000 may be encoded as:

    {
      Ndigits: 1,
      Weight: 1,
      Sign: 0,
      Dscale: 0,
      digits: []byte{0, 100}
    }

This specific case works and is tested by `TestEncodings`. However, an alternate encoding for the same value exists:

    {
      Ndigits: 2,
      Weight: 1,
      Sign: 0,
      Dscale: 0,
      digits: []byte{0, 100, 0, 0}
    }

This encoding results in Cockroach producing a value that's an order of magnitude larger than intended (10000000). Importantly, this is the encoding used by Diesel in the Rust world.

The issue was found in `DecodeOidDatum`, where `nextDigit()` takes care of appending the right number of zeroes to the value, up to 4 total per `i16` group. Since `nextDigit()` can complete a zero value entirely by itself, `strconv.AppendUint` is correctly skipped if the value of the group is 0, as that would add a fifth digit. However, the last group of digits is handled separately from the rest. That code was missing special handling for the 0 value, resulting in 5 zero digits being produced for the final group. The issue was remedied by introducing the same check done for the other digit groups.

Test cases for failing examples were added in the form of `TestExoticNumericEncodings`. Unfortunately there did not seem to be a way to merge these with `TestEncodings` as its test cases are generated programmatically, thus limiting the possible values to the ones chosen by Postgres, which were already fine.