### PR TITLE
storage: Downgrade a spammy log message

### DIFF
--- a/pkg/storage/allocator_scorer.go
+++ b/pkg/storage/allocator_scorer.go
@@ -594,7 +594,7 @@ func rebalanceCandidates(
 			// ConvergesOnMean calculations below. This is subtle but important.
 			if nodeHasReplica(store.Node.NodeID, rangeInfo.Desc.Replicas) &&
 				!storeHasReplica(store.StoreID, rangeInfo.Desc.Replicas) {
-				log.Infof(ctx, "nodeHasReplica(n%d, %v)=true", store.Node.NodeID, rangeInfo.Desc.Replicas)
+				log.VEventf(ctx, 2, "nodeHasReplica(n%d, %v)=true", store.Node.NodeID, rangeInfo.Desc.Replicas)
 				continue
 			}
 			constraintsOK, necessary := rebalanceFromConstraintsCheck(


### PR DESCRIPTION
This log message only occurs on clusters with multiple stores per
node, but on those clusters it fires multiple times per second.

Release note: None