### PR TITLE
sql: add support for pg_catalog.{current_setting,set_config}

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1810,6 +1810,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			Planner:          p,
 			Sequence:         p,
 			SessionData:      ex.sessionData,
+			SessionAccessor:  p,
 			Settings:         ex.server.cfg.Settings,
 			TestingKnobs:     ex.server.cfg.EvalContextTestingKnobs,
 			ClusterID:        ex.server.cfg.ClusterID(),

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -45,7 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -398,8 +398,6 @@ func (ds *ServerImpl) setupFlow(
 			},
 		}
 
-		evalPlanner := &sqlbase.DummyEvalPlanner{}
-		sequence := &sqlbase.DummySequenceOperators{}
 		evalCtx = &tree.EvalContext{
 			Settings:    ds.ServerConfig.Settings,
 			SessionData: sd,
@@ -411,8 +409,9 @@ func (ds *ServerImpl) setupFlow(
 			// own context.
 			Context:          ctx,
 			Txn:              txn,
-			Planner:          evalPlanner,
-			Sequence:         sequence,
+			Planner:          &sqlbase.DummyEvalPlanner{},
+			SessionAccessor:  &sqlbase.DummySessionAccessor{},
+			Sequence:         &sqlbase.DummySequenceOperators{},
 			InternalExecutor: ie,
 		}
 		evalCtx.SetStmtTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.StmtTimestampNanos))

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1789,3 +1789,54 @@ v_x_y_key   NULL
 
 statement ok
 DROP DATABASE d34862 CASCADE; SET database=test
+
+subtest regression_35108
+
+query T
+SELECT pg_catalog.current_setting('statement_timeout')
+----
+0
+
+query T
+SELECT pg_catalog.current_setting('statement_timeout', false)
+----
+0
+
+# check returns null on unsupported session var.
+query T
+SELECT IFNULL(pg_catalog.current_setting('woo', true), 'OK')
+----
+OK
+
+# check error on nonexistent session var.
+query error unrecognized configuration parameter
+SELECT pg_catalog.current_setting('woo', false)
+
+# check error on unsupported session var.
+query error configuration setting.*not supported
+SELECT pg_catalog.current_setting('vacuum_cost_delay', false)
+
+query T
+SHOW application_name
+----
+·
+
+query T
+SELECT pg_catalog.set_config('application_name', 'woo', false)
+----
+woo
+
+query T
+SHOW application_name
+----
+woo
+
+query error transaction-scoped settings are not supported
+SELECT  pg_catalog.set_config('application_name', 'woo', true)
+
+query error unrecognized configuration parameter
+SELECT  pg_catalog.set_config('woo', 'woo', false)
+
+query error configuration setting.*not supported
+SELECT  pg_catalog.set_config('vacuum_cost_delay', '0', false)
+

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -257,6 +257,7 @@ func newInternalPlanner(
 		ctx, sd, dataMutator, tables, txn, ts, ts, execCfg, &plannerMon,
 	)
 	p.extendedEvalCtx.Planner = p
+	p.extendedEvalCtx.SessionAccessor = p
 	p.extendedEvalCtx.Sequence = p
 	p.extendedEvalCtx.ClusterID = execCfg.ClusterID()
 	p.extendedEvalCtx.NodeID = execCfg.NodeID.Get()

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1875,9 +1875,10 @@ func createSchemaChangeEvalCtx(
 			InternalExecutor: ieFactory(ctx, sd),
 			// TODO(andrei): This is wrong (just like on the main code path on
 			// setupFlow). Each processor should override Ctx with its own context.
-			Context:  ctx,
-			Sequence: &sqlbase.DummySequenceOperators{},
-			Planner:  &sqlbase.DummyEvalPlanner{},
+			Context:         ctx,
+			Sequence:        &sqlbase.DummySequenceOperators{},
+			Planner:         &sqlbase.DummyEvalPlanner{},
+			SessionAccessor: &sqlbase.DummySessionAccessor{},
 		},
 	}
 	// The backfill is going to use the current timestamp for the various

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2397,6 +2397,18 @@ type EvalPlanner interface {
 	EvalSubquery(expr *Subquery) (Datum, error)
 }
 
+// EvalSessionAccessor is a limited interface to access session variables.
+type EvalSessionAccessor interface {
+	// SetConfig sets a session variable to a new value.
+	//
+	// This interface only supports strings as this is sufficient for
+	// pg_catalog.set_config().
+	SetSessionVar(ctx context.Context, settingName, newValue string) error
+
+	// GetSessionVar retrieves the current value of a session variable.
+	GetSessionVar(ctx context.Context, settingName string, missingOk bool) (bool, string, error)
+}
+
 // SessionBoundInternalExecutor is a subset of sqlutil.InternalExecutor used by
 // this sem/tree package which can't even import sqlutil. Executor used through
 // this interface are always "session-bound" - they inherit session variables
@@ -2531,6 +2543,8 @@ type EvalContext struct {
 	InternalExecutor SessionBoundInternalExecutor
 
 	Planner EvalPlanner
+
+	SessionAccessor EvalSessionAccessor
 
 	Sequence SequenceOperators
 

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -47,10 +47,9 @@ func (p *planner) SetVar(ctx context.Context, n *tree.SetVar) (planNode, error) 
 	}
 
 	name := strings.ToLower(n.Name)
-
-	if _, ok := UnsupportedVars[name]; ok {
-		return nil, pgerror.Unimplemented("set."+name,
-			"the configuration setting %q is not supported", name)
+	_, v, err := getSessionVar(name, false /* missingOk */)
+	if err != nil {
+		return nil, err
 	}
 
 	var typedValues []tree.TypedExpr
@@ -79,12 +78,6 @@ func (p *planner) SetVar(ctx context.Context, n *tree.SetVar) (planNode, error) 
 				typedValues[i] = typedValue
 			}
 		}
-	}
-
-	v, ok := varGen[name]
-	if !ok {
-		return nil, pgerror.NewErrorf(pgerror.CodeUndefinedObjectError,
-			"unrecognized configuration parameter %q", name)
 	}
 
 	if v.Set == nil && v.RuntimeSet == nil {

--- a/pkg/sql/sqlbase/evalctx.go
+++ b/pkg/sql/sqlbase/evalctx.go
@@ -107,3 +107,22 @@ func (ep *DummyEvalPlanner) ParseType(sql string) (coltypes.CastTargetType, erro
 func (ep *DummyEvalPlanner) EvalSubquery(expr *tree.Subquery) (tree.Datum, error) {
 	return nil, errEvalPlanner
 }
+
+// DummySessionAccessor implements the tree.EvalSessionAccessor interface by returning errors.
+type DummySessionAccessor struct{}
+
+var _ tree.EvalSessionAccessor = &DummySessionAccessor{}
+
+var errEvalSessionVar = errors.New("cannot backfill expressions that access session variables")
+
+// GetSessionVar is part of the tree.EvalSessionAccessor interface.
+func (ep *DummySessionAccessor) GetSessionVar(
+	_ context.Context, _ string, _ bool,
+) (bool, string, error) {
+	return false, "", errEvalSessionVar
+}
+
+// SetSessionVar is part of the tree.EvalSessionAccessor interface.
+func (ep *DummySessionAccessor) SetSessionVar(_ context.Context, _, _ string) error {
+	return errEvalSessionVar
+}


### PR DESCRIPTION
Fixes #35108. Needed for Flowable compatibility.

Release note (sql change): The SQL built-in functions
`pg_catalog.current_setting()` and `pg_catalog.set_config()` are now
supported for compatibility with PostgreSQL. Note that only
session-scoped configuration changes remain supported (`set_config(_,
_, false)`).