### PR TITLE
sql: EXECUTE .. DISCARD ROWS

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -209,6 +209,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	if err != nil {
 		return makeErrEvent(err)
 	}
+	var discardRows bool
 
 	switch s := stmt.AST.(type) {
 	case *tree.BeginTransaction:
@@ -343,6 +344,8 @@ func (ex *connExecutor) execStmtInOpenState(
 		stmt.AnonymizedStr = ps.AnonymizedStr
 		res.ResetStmtType(ps.AST)
 
+		discardRows = s.DiscardRows
+
 		// Check again if the statement should be parallelized.
 		parallelize, err = ex.maybeSynchronizeParallelStmts(ctx, stmt)
 		if err != nil {
@@ -405,6 +408,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
 	ex.phaseTimes[plannerStartExecStmt] = timeutil.Now()
 	p.stmt = &stmt
+	p.discardRows = discardRows
 
 	// TODO(andrei): Ideally we'd like to fork off a context for each individual
 	// statement. But the heartbeat loop in TxnCoordSender currently assumes that
@@ -1045,7 +1049,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 			return recv.commErr
 		}
 	}
-
+	recv.discardRows = planner.discardRows
 	// We pass in whether or not we wanted to distribute this plan, which tells
 	// the planner whether or not to plan remote table readers.
 	ex.server.cfg.DistSQLPlanner.PlanAndRun(

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -166,12 +166,20 @@ EXECUTE i(3.3::int)
 ----
 4
 
-query I
+query I colnames
 EXECUTE s
 ----
+a
 1
 2
 3
+
+# DISCARD ROWS drops the results, but does not affect the schema or the
+# internal plan.
+query I colnames
+EXECUTE s DISCARD ROWS
+----
+a
 
 statement
 DEALLOCATE ALL

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -513,8 +513,10 @@ func TestParse(t *testing.T) {
 		{`PREPARE a (STRING, INT8) AS OPT PLAN 'some-string'`},
 
 		{`EXECUTE a`},
+		{`EXECUTE a DISCARD ROWS`},
 		{`EXECUTE a (1)`},
 		{`EXECUTE a (1, 1)`},
+		{`EXECUTE a (1, 1) DISCARD ROWS`},
 		{`EXECUTE a (1 + 1)`},
 
 		{`DEALLOCATE a`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2465,6 +2465,15 @@ execute_stmt:
       Params: $3.exprs(),
     }
   }
+| EXECUTE table_alias_name execute_param_clause DISCARD ROWS
+  {
+    /* SKIP DOC */
+    $$.val = &tree.Execute{
+      Name: tree.Name($2),
+      Params: $3.exprs(),
+      DiscardRows: true,
+    }
+  }
 | EXECUTE error // SHOW HELP: EXECUTE
 
 execute_param_clause:

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -136,6 +136,12 @@ type planner struct {
 	// want to do 1PC transactions have to implement the autoCommitNode interface.
 	autoCommit bool
 
+	// discardRows is set if we want to discard any results rather than sending
+	// them back to the client. Used for testing/benchmarking. Note that the
+	// resulting schema or the plan are not affected.
+	// See EXECUTE .. DISCARD ROWS.
+	discardRows bool
+
 	// cancelChecker is used by planNodes to check for cancellation of the associated
 	// query.
 	cancelChecker *sqlbase.CancelChecker

--- a/pkg/sql/sem/tree/prepare.go
+++ b/pkg/sql/sem/tree/prepare.go
@@ -63,6 +63,9 @@ func (node *CannedOptPlan) Format(ctx *FmtCtx) {
 type Execute struct {
 	Name   Name
 	Params Exprs
+	// DiscardRows is set when we want to throw away all the rows rather than
+	// returning for client (used for testing and benchmarking).
+	DiscardRows bool
 }
 
 // Format implements the NodeFormatter interface.
@@ -73,6 +76,9 @@ func (node *Execute) Format(ctx *FmtCtx) {
 		ctx.WriteString(" (")
 		ctx.FormatNode(&node.Params)
 		ctx.WriteByte(')')
+	}
+	if node.DiscardRows {
+		ctx.WriteString(" DISCARD ROWS")
 	}
 }
 


### PR DESCRIPTION
Add a variant of `EXECUTE` which discards all the result rows. This is
useful for testing and benchmarking, especially in conjunction with
`PREPARE .. AS OPT PLAN ..'.

This is and should stay undocumented.

Release note: None