### PR TITLE
sql: don't double call ConsumerClosed in wrapped local plans

### DIFF
--- a/pkg/sql/row_source_to_plan_node.go
+++ b/pkg/sql/row_source_to_plan_node.go
@@ -124,6 +124,7 @@ func (r *rowSourceToPlanNode) Values() tree.Datums {
 func (r *rowSourceToPlanNode) Close(ctx context.Context) {
 	if r.source != nil {
 		r.source.ConsumerClosed()
+		r.source = nil
 	}
 	if r.originalPlanNode != nil {
 		r.originalPlanNode.Close(ctx)


### PR DESCRIPTION
Previously, if someone double-closed a planNode tree containing a
wrapped distsql plan, that might double close a RowChannel, which is
illegal. Add a protection against that.

Release note: None