### PR TITLE
workload: default --tolerate-errors to true in `run`

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -42,7 +42,7 @@ import (
 )
 
 var runFlags = pflag.NewFlagSet(`run`, pflag.ContinueOnError)
-var tolerateErrors = runFlags.Bool("tolerate-errors", false, "Keep running on error")
+var tolerateErrors = runFlags.Bool("tolerate-errors", true, "Keep running on error")
 var maxRate = runFlags.Float64(
 	"max-rate", 0, "Maximum frequency of operations (reads/writes). If 0, no limit.")
 var maxOps = runFlags.Uint64("max-ops", 0, "Maximum number of operations to run")
@@ -497,6 +497,9 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 				}
 			}
 
+			if numErr > 0 {
+				return errors.Errorf(`encountered %d query errors`, numErr)
+			}
 			return nil
 		}
 	}


### PR DESCRIPTION
We occasionally receive somewhat uninteresting and opaque errors, such
as context deadline exceeded, from queries that a workload runs.
Previously, the default of `--tolerate-errors=false ` would immediately
abort the run. In the context of a roachtest, it would immediately abort
and fail the roachtest.

But for a test that's run once a day, losing a datapoint is a big deal,
and this happened infrequently but still too much. Now, we default
`--tolerate-errors` to true, which keeps running the test. The number of
tolerated errors has always been printed in the run output. It now also
causes the binary to exit with a non-zero exit code.

This means that a roachtest invoking `workload run` with the default
`--tolerate-errors` value will continue past a single error, but be
marked as failed at the end, which is better than the previous behavior
of immediately aborting and losing any chance at adding value. This is a
tradeoff with wasted resources but believed to be better than the
current point on that tradeoff.

The previous behavior is available by explitly setting
`--tolerate-errors` to its old default of false.

Release note (cli change): the --tolerate-errors flag to `cockroach
workload run` now defaults to true