### PR TITLE
sql: accept+ignore precision 6 on TIME,TIMESTAMP,TIMESTAMPTZ

### DIFF
--- a/pkg/sql/coltypes/timedate.go
+++ b/pkg/sql/coltypes/timedate.go
@@ -16,6 +16,7 @@ package coltypes
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 )
@@ -32,7 +33,14 @@ func (node *TDate) Format(buf *bytes.Buffer, f lex.EncodeFlags) {
 }
 
 // TTime represents a TIME type.
-type TTime struct{}
+type TTime struct {
+	// PrecisionSet indicates whether the Precision type has been set.
+	// Note that this information is only used to round-trip the types
+	// during pretty-printing of an AST. It is not further used
+	// in CockroachDB. (See issue #32565)
+	PrecisionSet bool
+	Precision    int
+}
 
 // TypeName implements the ColTypeFormatter interface.
 func (node *TTime) TypeName() string { return "TIME" }
@@ -40,10 +48,20 @@ func (node *TTime) TypeName() string { return "TIME" }
 // Format implements the ColTypeFormatter interface.
 func (node *TTime) Format(buf *bytes.Buffer, f lex.EncodeFlags) {
 	buf.WriteString(node.TypeName())
+	if node.PrecisionSet {
+		fmt.Fprintf(buf, "(%d)", node.Precision)
+	}
 }
 
 // TTimestamp represents a TIMESTAMP type.
-type TTimestamp struct{}
+type TTimestamp struct {
+	// PrecisionSet indicates whether the Precision type has been set.
+	// Note that this information is only used to round-trip the types
+	// during pretty-printing of an AST. It is not further used
+	// in CockroachDB. (See issue #32098)
+	PrecisionSet bool
+	Precision    int
+}
 
 // TypeName implements the ColTypeFormatter interface.
 func (node *TTimestamp) TypeName() string { return "TIMESTAMP" }
@@ -51,10 +69,20 @@ func (node *TTimestamp) TypeName() string { return "TIMESTAMP" }
 // Format implements the ColTypeFormatter interface.
 func (node *TTimestamp) Format(buf *bytes.Buffer, f lex.EncodeFlags) {
 	buf.WriteString(node.TypeName())
+	if node.PrecisionSet {
+		fmt.Fprintf(buf, "(%d)", node.Precision)
+	}
 }
 
 // TTimestampTZ represents a TIMESTAMP type.
-type TTimestampTZ struct{}
+type TTimestampTZ struct {
+	// PrecisionSet indicates whether the Precision type has been set.
+	// Note that this information is only used to round-trip the types
+	// during pretty-printing of an AST. It is not further used
+	// in CockroachDB. (See issue #32098)
+	PrecisionSet bool
+	Precision    int
+}
 
 // TypeName implements the ColTypeFormatter interface.
 func (node *TTimestampTZ) TypeName() string { return "TIMESTAMPTZ" }
@@ -62,6 +90,9 @@ func (node *TTimestampTZ) TypeName() string { return "TIMESTAMPTZ" }
 // Format implements the ColTypeFormatter interface.
 func (node *TTimestampTZ) Format(buf *bytes.Buffer, f lex.EncodeFlags) {
 	buf.WriteString(node.TypeName())
+	if node.PrecisionSet {
+		fmt.Fprintf(buf, "(%d)", node.Precision)
+	}
 }
 
 // TInterval represents an INTERVAL type

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -685,6 +685,9 @@ func TestParse(t *testing.T) {
 		{`SELECT 'foo'::CHAR(3)`},
 		{`SELECT 'foo'::VARCHAR(3)`},
 		{`SELECT 'foo'::STRING(3)`},
+		{`SELECT 'foo'::TIMESTAMP(6)`},
+		{`SELECT 'foo'::TIMESTAMPTZ(6)`},
+		{`SELECT 'foo'::TIME(6)`},
 
 		{`SELECT '192.168.0.1'::INET`},
 		{`SELECT '192.168.0.1':::INET`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6608,7 +6608,14 @@ const_datetime:
     if $2.bool() { return unimplementedWithIssueDetail(sqllex, 26097, "type") }
     $$.val = coltypes.Time
   }
-| TIME '(' ICONST ')' opt_timezone   { return unimplementedWithIssue(sqllex, 32565) }
+| TIME '(' iconst64 ')' opt_timezone
+  {
+    prec := $3.int64()
+    if prec != 6 {
+         return unimplementedWithIssue(sqllex, 32565)
+    }
+    $$.val = &coltypes.TTime{PrecisionSet: true, Precision: int(prec)}
+  }
 | TIMETZ                             { return unimplementedWithIssueDetail(sqllex, 26097, "type") }
 | TIMETZ '(' ICONST ')'              { return unimplementedWithIssueDetail(sqllex, 26097, "type with precision") }
 | TIMESTAMP opt_timezone
@@ -6619,12 +6626,30 @@ const_datetime:
       $$.val = coltypes.Timestamp
     }
   }
-| TIMESTAMP '(' ICONST ')' opt_timezone { return unimplementedWithIssue(sqllex, 32098) }
+| TIMESTAMP '(' iconst64 ')' opt_timezone
+  {
+    prec := $3.int64()
+    if prec != 6 {
+         return unimplementedWithIssue(sqllex, 32098)
+    }
+    if $5.bool() {
+      $$.val = &coltypes.TTimestampTZ{PrecisionSet: true, Precision: int(prec)}
+    } else {
+      $$.val = &coltypes.TTimestamp{PrecisionSet: true, Precision: int(prec)}
+    }
+  }
 | TIMESTAMPTZ
   {
     $$.val = coltypes.TimestampWithTZ
   }
-| TIMESTAMPTZ '(' ICONST ')'            { return unimplementedWithIssue(sqllex, 32098) }
+| TIMESTAMPTZ '(' iconst64 ')'
+  {
+    prec := $3.int64()
+    if prec != 6 {
+         return unimplementedWithIssue(sqllex, 32098)
+    }
+    $$.val = &coltypes.TTimestampTZ{PrecisionSet: true, Precision: int(prec)}
+  }
 
 opt_timezone:
   WITH_LA TIME ZONE { $$.val = true; }


### PR DESCRIPTION
Informs #32098.
Informs #32565.
This is not the full feature but might unlock Flowable compat. cc @rolandcrosby @awoods187  @drewdeally 

Release note (sql change): CockroachDB now recognizes the syntax
`TIME(6)`, `TIMESTAMP(6)` and `TIMESTAMPTZ(6)` / `TIMESTAMP(6) WITH
TIME ZONE`, for compatibility with PostgreSQL. Only the value 6 is
supported (which is also the default in PostgreSQL). When used for a
table column definition, the precision is not stored and it is not
possible to distinguish types with and without specified precisions in
the introspection metadata.