### PR TITLE
storage: use lease start time to determine follower read safety

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -587,6 +587,24 @@ func (ts *TestServer) LookupRange(key roachpb.Key) (roachpb.RangeDescriptor, err
 	return rs[0], nil
 }
 
+// MergeRanges merges the range containing leftKey with the range to its right.
+func (ts *TestServer) MergeRanges(leftKey roachpb.Key) (roachpb.RangeDescriptor, error) {
+
+	ctx := context.Background()
+	mergeReq := roachpb.AdminMergeRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: leftKey,
+		},
+	}
+	_, pErr := client.SendWrapped(ctx, ts.DB().NonTransactionalSender(), &mergeReq)
+	if pErr != nil {
+		return roachpb.RangeDescriptor{},
+			errors.Errorf(
+				"%q: merge unexpected error: %s", leftKey, pErr)
+	}
+	return ts.LookupRange(leftKey)
+}
+
 // SplitRange splits the range containing splitKey.
 // The right range created by the split starts at the split key and extends to the
 // original range's end key.

--- a/pkg/storage/closed_timestamp_test.go
+++ b/pkg/storage/closed_timestamp_test.go
@@ -16,7 +16,9 @@ package storage_test
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -28,9 +30,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestClosedTimestampCanServe(t *testing.T) {
@@ -44,17 +48,184 @@ func TestClosedTimestampCanServe(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	const numNodes = 3
-
-	tc := serverutils.StartTestCluster(t, numNodes, base.TestClusterArgs{})
+	tc, db0, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t)
 	defer tc.Stopper().Stop(ctx)
 
-	db0 := tc.ServerConn(0)
-	// Every 0.1s=100ms, try close out a timestamp ~300ms in the past.
-	// We don't want to be more aggressive than that since it's also
-	// a limit on how long transactions can run.
-	targetDuration := 300 * time.Millisecond
-	closeFraction := 0.3
+	if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	testutils.SucceedsSoon(t, func() error {
+		return verifyCanReadFromAllRepls(ctx, t, desc, ts, repls, 1)
+	})
+
+	// We just served a follower read. As a sanity check, make sure that we can't write at
+	// that same timestamp.
+	{
+		var baWrite roachpb.BatchRequest
+		r := &roachpb.DeleteRequest{}
+		r.Key = desc.StartKey.AsRawKey()
+		txn := roachpb.MakeTransaction("testwrite", r.Key, roachpb.NormalUserPriority, ts, 100)
+		baWrite.Txn = &txn
+		baWrite.Add(r)
+		baWrite.RangeID = repls[0].RangeID
+		if err := baWrite.SetActiveTimestamp(tc.Server(0).Clock().Now); err != nil {
+			t.Fatal(err)
+		}
+
+		var found bool
+		for _, repl := range repls {
+			resp, pErr := repl.Send(ctx, baWrite)
+			if _, ok := pErr.GoError().(*roachpb.NotLeaseHolderError); ok {
+				continue
+			} else if pErr != nil {
+				t.Fatal(pErr)
+			}
+			found = true
+			if !ts.Less(resp.Txn.Timestamp) || resp.Txn.OrigTimestamp == resp.Txn.Timestamp {
+				t.Fatal("timestamp did not get bumped")
+			}
+			break
+		}
+		if !found {
+			t.Fatal("unable to send to any replica")
+		}
+	}
+}
+
+func TestClosedTimestampCanServeThroughoutLeaseTransfer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	if util.RaceEnabled {
+		// Limiting how long transactions can run does not work
+		// well with race unless we're extremely lenient, which
+		// drives up the test duration.
+		t.Skip("skipping under race")
+	}
+	ctx := context.Background()
+	tc, db0, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t)
+	defer tc.Stopper().Stop(ctx)
+
+	if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
+		t.Fatal(err)
+	}
+	ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	testutils.SucceedsSoon(t, func() error {
+		return verifyCanReadFromAllRepls(ctx, t, desc, ts, repls, 1)
+	})
+
+	// Once we know that we can read safely at this timestamp, want to ensure
+	// that we can always read from this timestamp from all replicas even while
+	// lease transfers are ongoing. The test launches a goroutine to randomly
+	// trigger transfers every
+	const testTime = 500 * time.Millisecond
+	const maxTransferWait = 50 * time.Millisecond
+	deadline := timeutil.Now().Add(testTime)
+	g, gCtx := errgroup.WithContext(ctx)
+	getCurrentLeaseholder := func() (lh roachpb.ReplicationTarget) {
+		testutils.SucceedsSoon(t, func() error {
+			var err error
+			lh, err = tc.FindRangeLeaseHolder(desc, nil)
+			return err
+		})
+		return lh
+	}
+	pickRandomTarget := func(lh roachpb.ReplicationTarget) (t roachpb.ReplicationTarget) {
+		for {
+			if t = tc.Target(rand.Intn(len(repls))); t != lh {
+				return t
+			}
+		}
+	}
+	transferLeasesRandomlyUntilDeadline := func() error {
+		for timeutil.Now().Before(deadline) {
+			lh := getCurrentLeaseholder()
+			target := pickRandomTarget(lh)
+			if err := tc.TransferRangeLease(desc, target); err != nil {
+				return err
+			}
+			time.Sleep(time.Duration(rand.Intn(int(maxTransferWait))))
+		}
+		return nil
+	}
+	g.Go(transferLeasesRandomlyUntilDeadline)
+
+	// Attempt to send read requests to	a replica in a tight loop until deadline
+	// is reached. If an error is seen on any replica then it is returned to the
+	// errgroup.
+	baRead := makeReadBatchRequestForDesc(desc, ts)
+	ensureCanReadFromReplicaUntilDeadline := func(r *storage.Replica) {
+		g.Go(func() error {
+			for timeutil.Now().Before(deadline) {
+				resp, pErr := r.Send(gCtx, baRead)
+				if pErr != nil {
+					return errors.Wrapf(pErr.GoError(), "on %s", r)
+				}
+				rows := resp.Responses[0].GetInner().(*roachpb.ScanResponse).Rows
+				// Should see the write.
+				if len(rows) != 1 {
+					return fmt.Errorf("expected one row, but got %d", len(rows))
+				}
+			}
+			return nil
+		})
+	}
+	for _, r := range repls {
+		ensureCanReadFromReplicaUntilDeadline(r)
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Every 0.1s=100ms, try close out a timestamp ~300ms in the past.
+// We don't want to be more aggressive than that since it's also
+// a limit on how long transactions can run.
+const targetDuration = 300 * time.Millisecond
+const closeFraction = 0.333
+const numNodes = 3
+
+func replsForRange(
+	ctx context.Context,
+	t *testing.T,
+	tc serverutils.TestClusterInterface,
+	desc roachpb.RangeDescriptor,
+) (repls []*storage.Replica) {
+	testutils.SucceedsSoon(t, func() error {
+		repls = nil
+		for i := 0; i < numNodes; i++ {
+			repl, err := tc.Server(i).GetStores().(*storage.Stores).GetReplicaForRangeID(desc.RangeID)
+			if err != nil {
+				return err
+			}
+			if repl != nil {
+				repls = append(repls, repl)
+			}
+		}
+		return nil
+	})
+	return repls
+}
+
+// This gnarly helper function creates a test cluster that is prepared to
+// exercise follower reads. The returned test cluster has follower reads enabled
+// using the above targetDuration and closeFraction. In addition to the newly
+// minted test cluster, this function returns a db handle to node 0, a range
+// descriptor for the range used by the table `cttest.kv` and the replica
+// objects corresponding to the replicas for the range. It is the caller's
+// responsibility to Stop the Stopper on the returned test cluster when done.
+func setupTestClusterForClosedTimestampTesting(
+	ctx context.Context, t *testing.T,
+) (
+	tc serverutils.TestClusterInterface,
+	db0 *gosql.DB,
+	kvTableDesc roachpb.RangeDescriptor,
+	repls []*storage.Replica,
+) {
+
+	tc = serverutils.StartTestCluster(t, numNodes, base.TestClusterArgs{})
+	db0 = tc.ServerConn(0)
 
 	if _, err := db0.Exec(fmt.Sprintf(`
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '%s';
@@ -106,24 +277,8 @@ CREATE TABLE cttest.kv (id INT PRIMARY KEY, value STRING);
 			break
 		}
 	}
-
-	var repls []*storage.Replica
-	testutils.SucceedsSoon(t, func() error {
-		repls = nil
-		for i := 0; i < numNodes; i++ {
-			repl, err := tc.Server(i).GetStores().(*storage.Stores).GetReplicaForRangeID(desc.RangeID)
-			if err != nil {
-				return err
-			}
-			if repl != nil {
-				repls = append(repls, repl)
-			}
-		}
-		return nil
-	})
-
+	repls = replsForRange(ctx, t, tc, desc)
 	require.Equal(t, numReplicas, len(repls))
-
 	// Wait until we see an epoch based lease on our chosen range. This should
 	// happen fairly quickly since we just transferred a lease (as a means to make
 	// it epoch based). If the lease transfer fails, we'll be sitting out the lease
@@ -138,74 +293,54 @@ CREATE TABLE cttest.kv (id INT PRIMARY KEY, value STRING);
 			}
 		}
 	}
+	return tc, db0, desc, repls
+}
 
-	if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
-		t.Fatal(err)
+func verifyCanReadFromAllRepls(
+	ctx context.Context,
+	t *testing.T,
+	desc roachpb.RangeDescriptor,
+	ts hlc.Timestamp,
+	repls []*storage.Replica,
+	expectedRows int,
+) error {
+	t.Helper()
+	baRead := makeReadBatchRequestForDesc(desc, ts)
+	// The read should succeed once enough time (~300ms, but it's difficult to
+	// assert on that) has passed - on all replicas!
+
+	for _, repl := range repls {
+		resp, pErr := repl.Send(ctx, baRead)
+		if pErr != nil {
+			switch tErr := pErr.GetDetail().(type) {
+			case *roachpb.NotLeaseHolderError:
+				log.Infof(ctx, "got not lease holder error, here's the lease: %v  %v %v %v", *tErr.Lease, tErr.Lease.Start.GoTime(), ts.GoTime(), ts.GoTime().Sub(tErr.Lease.Start.GoTime()))
+				return tErr
+			case *roachpb.RangeNotFoundError:
+				// Can happen during upreplication.
+				return tErr
+			default:
+				t.Fatal(errors.Wrapf(pErr.GoError(), "on %s", repl))
+			}
+		}
+		rows := resp.Responses[0].GetInner().(*roachpb.ScanResponse).Rows
+		// Should see the write.
+		if len(rows) != expectedRows {
+			t.Fatalf("expected %d rows, but got %d", expectedRows, len(rows))
+		}
 	}
+	return nil
+}
 
+func makeReadBatchRequestForDesc(
+	desc roachpb.RangeDescriptor, ts hlc.Timestamp,
+) roachpb.BatchRequest {
 	var baRead roachpb.BatchRequest
 	baRead.Header.RangeID = desc.RangeID
 	r := &roachpb.ScanRequest{}
 	r.Key = desc.StartKey.AsRawKey()
 	r.EndKey = desc.EndKey.AsRawKey()
 	baRead.Add(r)
-	baRead.Timestamp = hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
-
-	// The read should succeed once enough time (~300ms, but it's difficult to
-	// assert on that) has passed - on all replicas!
-	testutils.SucceedsSoon(t, func() error {
-		for _, repl := range repls {
-			resp, pErr := repl.Send(ctx, baRead)
-			if pErr != nil {
-				switch tErr := pErr.GetDetail().(type) {
-				case *roachpb.NotLeaseHolderError:
-					return tErr
-				case *roachpb.RangeNotFoundError:
-					// Can happen during upreplication.
-					return tErr
-				default:
-					t.Fatal(errors.Wrapf(pErr.GoError(), "on %s", repl))
-				}
-			}
-			rows := resp.Responses[0].GetInner().(*roachpb.ScanResponse).Rows
-			// Should see the write.
-			if len(rows) != 1 {
-				t.Fatalf("expected one row, but got %d", len(rows))
-			}
-		}
-		return nil
-	})
-
-	// We just served a follower read. As a sanity check, make sure that we can't write at
-	// that same timestamp.
-	{
-		var baWrite roachpb.BatchRequest
-		r := &roachpb.DeleteRequest{}
-		r.Key = desc.StartKey.AsRawKey()
-		txn := roachpb.MakeTransaction("testwrite", r.Key, roachpb.NormalUserPriority, baRead.Timestamp, 100)
-		baWrite.Txn = &txn
-		baWrite.Add(r)
-		baWrite.RangeID = repls[0].RangeID
-		if err := baWrite.SetActiveTimestamp(tc.Server(0).Clock().Now); err != nil {
-			t.Fatal(err)
-		}
-
-		var found bool
-		for _, repl := range repls {
-			resp, pErr := repl.Send(ctx, baWrite)
-			if _, ok := pErr.GoError().(*roachpb.NotLeaseHolderError); ok {
-				continue
-			} else if pErr != nil {
-				t.Fatal(pErr)
-			}
-			found = true
-			if !baRead.Timestamp.Less(resp.Txn.Timestamp) || resp.Txn.OrigTimestamp == resp.Txn.Timestamp {
-				t.Fatal("timestamp did not get bumped")
-			}
-			break
-		}
-		if !found {
-			t.Fatal("unable to send to any replica")
-		}
-	}
+	baRead.Timestamp = ts
+	return baRead
 }

--- a/pkg/storage/closedts/closedts.go
+++ b/pkg/storage/closedts/closedts.go
@@ -137,7 +137,6 @@ type Provider interface {
 	Producer
 	Notifyee
 	Start()
-	CanServe(roachpb.NodeID, hlc.Timestamp, roachpb.RangeID, ctpb.Epoch, ctpb.LAI) bool
 	MaxClosed(roachpb.NodeID, roachpb.RangeID, ctpb.Epoch, ctpb.LAI) hlc.Timestamp
 }
 

--- a/pkg/storage/closedts/container/noop.go
+++ b/pkg/storage/closedts/container/noop.go
@@ -73,11 +73,6 @@ func (noopEverything) Notify(roachpb.NodeID) chan<- ctpb.Entry {
 }
 func (noopEverything) Subscribe(context.Context, chan<- ctpb.Entry) {}
 func (noopEverything) Start()                                       {}
-func (noopEverything) CanServe(
-	roachpb.NodeID, hlc.Timestamp, roachpb.RangeID, ctpb.Epoch, ctpb.LAI,
-) bool {
-	return false
-}
 func (noopEverything) MaxClosed(
 	roachpb.NodeID, roachpb.RangeID, ctpb.Epoch, ctpb.LAI,
 ) hlc.Timestamp {

--- a/pkg/storage/closedts/provider/provider.go
+++ b/pkg/storage/closedts/provider/provider.go
@@ -330,35 +330,12 @@ func (p *Provider) Subscribe(ctx context.Context, ch chan<- ctpb.Entry) {
 	}
 }
 
-// CanServe implements closedts.Provider.
-func (p *Provider) CanServe(
-	nodeID roachpb.NodeID, ts hlc.Timestamp, rangeID roachpb.RangeID, epoch ctpb.Epoch, lai ctpb.LAI,
-) bool {
-	var ok bool
-	p.cfg.Storage.VisitDescending(nodeID, func(entry ctpb.Entry) bool {
-		mlai, found := entry.MLAI[rangeID]
-		ctOK := !entry.ClosedTimestamp.Less(ts)
-
-		ok = found &&
-			ctOK &&
-			entry.Epoch == epoch &&
-			mlai <= lai
-
-		// We're done either if we proved that the read is possible, or if we're
-		// already done looking at closed timestamps large enough to satisfy it.
-		done := ok || !ctOK
-		return done
-	})
-
-	return ok
-}
-
 // MaxClosed implements closedts.Provider.
 func (p *Provider) MaxClosed(
 	nodeID roachpb.NodeID, rangeID roachpb.RangeID, epoch ctpb.Epoch, lai ctpb.LAI,
 ) hlc.Timestamp {
 	var maxTS hlc.Timestamp
-	p.cfg.Storage.VisitDescending(nodeID, func(entry ctpb.Entry) bool {
+	p.cfg.Storage.VisitDescending(nodeID, func(entry ctpb.Entry) (done bool) {
 		if mlai, found := entry.MLAI[rangeID]; found {
 			if entry.Epoch == epoch && mlai <= lai {
 				maxTS = entry.ClosedTimestamp

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -313,6 +313,9 @@ type Replica struct {
 		// we know that the replica has caught up.
 		lastReplicaAdded     roachpb.ReplicaID
 		lastReplicaAddedTime time.Time
+		// initialMaxClosed is the initial maxClosed timestamp for the replica as known
+		// from its left-hand-side upon creation.
+		initialMaxClosed hlc.Timestamp
 
 		// The most recently updated time for each follower of this range. This is updated
 		// every time a Raft message is received from a peer.

--- a/pkg/storage/replica_follower_read.go
+++ b/pkg/storage/replica_follower_read.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/closedts/ctpb"
 	ctstorage "github.com/cockroachdb/cockroach/pkg/storage/closedts/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -45,24 +46,18 @@ func (r *Replica) canServeFollowerRead(
 		FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV) &&
 		lErr.LeaseHolder != nil && lErr.Lease.Type() == roachpb.LeaseEpoch {
 
-		r.mu.RLock()
-		lai := r.mu.state.LeaseAppliedIndex
-		r.mu.RUnlock()
-		canServeFollowerRead = r.store.cfg.ClosedTimestamp.Provider.CanServe(
-			lErr.LeaseHolder.NodeID, ba.Timestamp, r.RangeID, ctpb.Epoch(lErr.Lease.Epoch), ctpb.LAI(lai),
-		)
-
+		canServeFollowerRead = !r.maxClosed(ctx).Less(ba.Timestamp)
 		if !canServeFollowerRead {
-			// We can't actually serve the read. Signal the clients that we want
-			// an update so that future requests can succeed.
+			// We can't actually serve the read based on the closed timestamp.
+			// Signal the clients that we want an update so that future requests can succeed.
 			r.store.cfg.ClosedTimestamp.Clients.Request(lErr.LeaseHolder.NodeID, r.RangeID)
 
 			if false {
 				// NB: this can't go behind V(x) because the log message created by the
 				// storage might be gigantic in real clusters, and we don't want to trip it
 				// using logspy.
-				log.Warningf(ctx, "can't serve follower read for %s at epo %d lai %d, storage is %s",
-					ba.Timestamp, lErr.Lease.Epoch, lai,
+				log.Warningf(ctx, "can't serve follower read for %s at epo %d, storage is %s",
+					ba.Timestamp, lErr.Lease.Epoch,
 					r.store.cfg.ClosedTimestamp.Storage.(*ctstorage.MultiStorage).StringForNodes(lErr.LeaseHolder.NodeID),
 				)
 			}
@@ -80,4 +75,24 @@ func (r *Replica) canServeFollowerRead(
 	// serve reads for that and smaller timestamps forever.
 	log.Event(ctx, "serving via follower read")
 	return nil
+}
+
+// maxClosed returns the maximum closed timestamp for this range.
+// It is computed as the most recent of the known closed timestamp for the
+// current lease holder for this range as tracked by the closed timestamp
+// subsystem and the start time of the current lease. It is safe to use the
+// start time of the current lease because leasePostApply bumps the timestamp
+// cache forward to at least the new lease start time. Using this combination
+// allows the closed timestamp mechanism to be robust to lease transfers.
+func (r *Replica) maxClosed(ctx context.Context) hlc.Timestamp {
+	r.mu.RLock()
+	lai := r.mu.state.LeaseAppliedIndex
+	lease := *r.mu.state.Lease
+	r.mu.RUnlock()
+	maxClosed := r.store.cfg.ClosedTimestamp.Provider.MaxClosed(
+		lease.Replica.NodeID, r.RangeID, ctpb.Epoch(lease.Epoch), ctpb.LAI(lai))
+	if maxClosed.IsEmpty() || maxClosed.Less(lease.Start) {
+		maxClosed = lease.Start
+	}
+	return maxClosed
 }

--- a/pkg/storage/replica_follower_read.go
+++ b/pkg/storage/replica_follower_read.go
@@ -88,11 +88,11 @@ func (r *Replica) maxClosed(ctx context.Context) hlc.Timestamp {
 	r.mu.RLock()
 	lai := r.mu.state.LeaseAppliedIndex
 	lease := *r.mu.state.Lease
+	initialMaxClosed := r.mu.initialMaxClosed
 	r.mu.RUnlock()
 	maxClosed := r.store.cfg.ClosedTimestamp.Provider.MaxClosed(
 		lease.Replica.NodeID, r.RangeID, ctpb.Epoch(lease.Epoch), ctpb.LAI(lai))
-	if maxClosed.IsEmpty() || maxClosed.Less(lease.Start) {
-		maxClosed = lease.Start
-	}
+	maxClosed.Forward(lease.Start)
+	maxClosed.Forward(initialMaxClosed)
 	return maxClosed
 }

--- a/pkg/storage/replica_rangefeed.go
+++ b/pkg/storage/replica_rangefeed.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
-	"github.com/cockroachdb/cockroach/pkg/storage/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/intentresolver"
@@ -414,15 +413,8 @@ func (r *Replica) handleClosedTimestampUpdateRaftMuLocked() {
 		return
 	}
 
-	r.mu.RLock()
-	lai := r.mu.state.LeaseAppliedIndex
-	lease := *r.mu.state.Lease
-	r.mu.RUnlock()
-
 	// Determine what the maximum closed timestamp is for this replica.
-	closedTS := r.store.cfg.ClosedTimestamp.Provider.MaxClosed(
-		lease.Replica.NodeID, r.RangeID, ctpb.Epoch(lease.Epoch), ctpb.LAI(lai),
-	)
+	closedTS := r.maxClosed(context.Background())
 
 	// If the closed timestamp is not empty, inform the Processor.
 	if closedTS.IsEmpty() {

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -143,6 +143,10 @@ type TestServerInterface interface {
 		splitKey roachpb.Key,
 	) (left roachpb.RangeDescriptor, right roachpb.RangeDescriptor, err error)
 
+	// MergeRanges merges the range containing leftKey with the following adjacent
+	// range.
+	MergeRanges(leftKey roachpb.Key) (merged roachpb.RangeDescriptor, err error)
+
 	// ExpectedInitialRangeCount returns the expected number of ranges that should
 	// be on the server after initial (asynchronous) splits have been completed,
 	// assuming no additional information is added outside of the normal bootstrap


### PR DESCRIPTION
This change obviously needs some testing. I'm putting it out to make sure I
understand the issue and proposed solution.

This change attempts to address a situation where a lease transfer may prevent
a follower read. This happens because after the lease transfer we no longer have
any information in the closedts storage regarding the range from the new
leaseholder.

Fixes #35129.
Fixes #32980.

Release note: None