### PR TITLE
stats: quiesce automatic stats refresh task earlier

### DIFF
--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -197,6 +197,13 @@ func (r *Refresher) Start(
 					ctx, "stats.Refresher: maybeRefreshStats", func(ctx context.Context) {
 						for tableID, rowsAffected := range mutationCounts {
 							r.maybeRefreshStats(ctx, stopper, tableID, rowsAffected, r.asOfTime)
+							select {
+							case <-stopper.ShouldQuiesce():
+								// Don't bother trying to refresh the remaining tables if we
+								// are shutting down.
+								return
+							default:
+							}
 						}
 						timer.Reset(refreshInterval)
 					}); err != nil {


### PR DESCRIPTION
Prior to this commit, an async task in the automatic stats Refresher
did a lot of work prior to terminating even if the server had started
to quiesce. `maybeRefreshStats` could be called for every table
in the database, even if `Stop()` was already called. This resulted in
many useless error messages being returned to the user. This commit
fixes the issue by checking `stopper.ShouldQuiesce()` after every
call to `maybeRefreshStats`.

Fixes #34926

Release note: None