### PR TITLE
storageccl: leave params in workload URIs

### DIFF
--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -191,6 +191,9 @@ func SanitizeExportStorageURI(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if uri.Scheme == "experimental-workload" {
+		return path, nil
+	}
 	// All current export storage providers store credentials in the query string,
 	// if they store it in the URI at all.
 	uri.RawQuery = ""


### PR DESCRIPTION
workload URIs do not contain anything sensitive and including them in the job make it easier see what it was actually doing.

Release note: none.