### PR TITLE
sql: add profiler labels during CPU profiling

### DIFF
--- a/pkg/server/debug/pprofui/server.go
+++ b/pkg/server/debug/pprofui/server.go
@@ -44,12 +44,29 @@ type Server struct {
 	storage      Storage
 	profileSem   syncutil.Mutex
 	profileTypes map[string]http.HandlerFunc
+	hook         func(profile string, do func())
 }
 
-// NewServer creates a new Server backed by the supplied Storage.
-func NewServer(storage Storage) *Server {
+// NewServer creates a new Server backed by the supplied Storage and optionally
+// a hook which is called when a new profile is created. The closure passed to
+// the hook will carry out the work involved in creating the profile and must
+// be called by the hook. The intention is that hook will be a method such as
+// this:
+//
+// func hook(profile string, do func()) {
+// 	if profile == "profile" {
+// 		something.EnableProfilerLabels()
+// 		defer something.DisableProfilerLabels()
+// 		do()
+// 	}
+// }
+func NewServer(storage Storage, hook func(profile string, do func())) *Server {
+	if hook == nil {
+		hook = func(_ string, do func()) { do() }
+	}
 	s := &Server{
 		storage: storage,
+		hook:    hook,
 	}
 
 	s.profileTypes = map[string]http.HandlerFunc{
@@ -195,7 +212,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		rw := &responseBridge{target: w}
 
-		fetchHandler(rw, req)
+		s.hook(profileName, func() { fetchHandler(rw, req) })
 
 		if rw.statusCode != http.StatusOK && rw.statusCode != 0 {
 			return errors.Errorf("unexpected status: %d", rw.statusCode)

--- a/pkg/server/debug/pprofui/server_test.go
+++ b/pkg/server/debug/pprofui/server_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestServer(t *testing.T) {
 	storage := NewMemStorage(1, 0)
-	s := NewServer(storage)
+	s := NewServer(storage, nil)
 
 	for i := 0; i < 3; i++ {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
 	"github.com/rcrowley/go-metrics/exp"
@@ -118,7 +119,12 @@ func NewServer(st *cluster.Settings) *Server {
 	}
 	mux.HandleFunc("/debug/logspy", spy.handleDebugLogSpy)
 
-	ps := pprofui.NewServer(pprofui.NewMemStorage(1, 0))
+	ps := pprofui.NewServer(pprofui.NewMemStorage(1, 0), func(profile string, do func()) {
+		tBegin := timeutil.Now()
+		log.Infof(context.Background(), "pprofui: recording %s", profile)
+		do()
+		log.Infof(context.Background(), "pprofui: recorded %s in %.2fs", profile, timeutil.Since(tBegin).Seconds())
+	})
 	mux.Handle("/debug/pprof/ui/", http.StripPrefix("/debug/pprof/ui", ps))
 
 	return &Server{

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -125,7 +125,6 @@ func NewServer(st *cluster.Settings) *Server {
 		extra := ""
 		if profile == "profile" {
 			extra = " (enabling profiler labels)"
-			log.Infof(context.Background(), "%s", profile)
 			st.SetCPUProfiling(true)
 			defer st.SetCPUProfiling(false)
 		}

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -121,8 +121,18 @@ func NewServer(st *cluster.Settings) *Server {
 
 	ps := pprofui.NewServer(pprofui.NewMemStorage(1, 0), func(profile string, do func()) {
 		tBegin := timeutil.Now()
-		log.Infof(context.Background(), "pprofui: recording %s", profile)
+
+		extra := ""
+		if profile == "profile" {
+			extra = " (enabling profiler labels)"
+			log.Infof(context.Background(), "%s", profile)
+			st.SetCPUProfiling(true)
+			defer st.SetCPUProfiling(false)
+		}
+		log.Infof(context.Background(), "pprofui: recording %s%s", profile, extra)
+
 		do()
+
 		log.Infof(context.Background(), "pprofui: recorded %s in %.2fs", profile, timeutil.Since(tBegin).Seconds())
 	})
 	mux.Handle("/debug/pprof/ui/", http.StripPrefix("/debug/pprof/ui", ps))

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -71,6 +71,27 @@ type Settings struct {
 	ExternalIODir string
 
 	Initialized bool
+
+	// Set to 1 if a profile is active (if the profile is being grabbed through
+	// the `pprofui` server as opposed to the raw endpoint).
+	cpuProfiling int32 // atomic
+}
+
+// IsCPUProfiling returns true if a pprofui CPU profile is being recorded. This can
+// be used by moving parts across the system to add profiler labels which are
+// too expensive to be enabled at all times.
+func (s *Settings) IsCPUProfiling() bool {
+	return atomic.LoadInt32(&s.cpuProfiling) == 1
+}
+
+// SetCPUProfiling is called from the pprofui to inform the system that a CPU
+// profile is being recorded.
+func (s *Settings) SetCPUProfiling(to bool) {
+	i := int32(0)
+	if to {
+		i = 1
+	}
+	atomic.StoreInt32(&s.cpuProfiling, i)
 }
 
 // NoSettings is used when a func requires a Settings but none is available

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -218,7 +218,7 @@ export default function Debug() {
         <DebugTableRow title="Stopper">
           <DebugTableLink name="Active Tasks" url="/debug/stopper" />
         </DebugTableRow>
-        <DebugTableRow title="Profiling UI">
+        <DebugTableRow title="Profiling UI/pprof">
           <DebugTableLink name="Heap" url="/debug/pprof/ui/heap/" />
           <DebugTableLink name="Profile" url="/debug/pprof/ui/profile/?seconds=5" />
           <DebugTableLink name="Block" url="/debug/pprof/ui/block/" />
@@ -226,14 +226,10 @@ export default function Debug() {
           <DebugTableLink name="Thread Create" url="/debug/pprof/ui/threadcreate/" />
           <DebugTableLink name="Goroutines" url="/debug/pprof/ui/goroutine/" />
         </DebugTableRow>
-        <DebugTableRow title="Profiling Raw">
-          <DebugTableLink name="Heap" url="/debug/pprof/heap?debug=1" />
-          <DebugTableLink name="Profile" url="/debug/pprof/profile?debug=1" />
-          <DebugTableLink name="Block" url="/debug/pprof/block?debug=1" />
-          <DebugTableLink name="Mutex" url="/debug/pprof/mutex?debug=1" />
-          <DebugTableLink name="Thread Create" url="/debug/pprof/threadcreate?debug=1" />
-          <DebugTableLink name="Goroutines" url="/debug/pprof/goroutine?debug=1" />
+        <DebugTableRow title="Goroutines">
           <DebugTableLink name="All Goroutines" url="/debug/pprof/goroutine?debug=2" />
+        </DebugTableRow>
+        <DebugTableRow title="Runtime Trace">
           <DebugTableLink name="Trace" url="/debug/pprof/trace?debug=1" />
         </DebugTableRow>
       </DebugTable>


### PR DESCRIPTION
When pprofui CPU profiling is active, add the statement tag and anonymized
statement string to the goroutine labels.

For example, this is what you can see when running

    ./bin/workload run kv --read-percent 50 --init

```
$ pprof -seconds 10 http://localhost:8080/debug/pprof/ui/profile
[...]
(pprof) tags
stmt.anonymized: Total 7.9s
                 4.0s (50.57%): UPSERT INTO kv(k, v) VALUES ($1, $2)
                 3.9s (49.43%): SELECT k, v FROM kv WHERE k IN ($1,)

 stmt.tag: Total 7.9s
          4.0s (50.57%): INSERT
          3.9s (49.43%): SELECT
```

The dot graphs are similarly annotated, though they require `dot` to be
installed on the machine and thus won't be as useful on the pprofui itself.

Profile tags are not propagated across RPC boundaries. That is, a node may
have high CPU as a result of SQL queries not originating at the node
itself, and no labels will be available.

But perusing this diff, you may notice that any moving part in the system
can sniff whether profiling is active, and can add labels in itself, so in
principle we could add the application name or any other information that
is propagated along with the transaction on the recipient node and track
down problems that way.

We may also be able to add tags based on RangeIDs to identify ranges which
cause high CPU load. The possibilities are endless, and with this infra in
place, it's trivial to quickly iterate on what's useful.

Closes #30930.

Release note (admin ui change): Running nodes can now be CPU profiled in a
way that breaks down CPU usage by query (some restrictions apply).