### PR TITLE
server/debug: expose panicparse's UI at /debug/pprof/goroutineui

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1029,6 +1029,13 @@
   revision = "9f7362b77ad333b26c01c99de52a11bdb650ded2"
 
 [[projects]]
+  digest = "1:2eeeebccad4f052e6037527e86b8114c6bfd184a97f84d4449a5ea6ad202c216"
+  name = "github.com/maruel/panicparse"
+  packages = ["stack"]
+  pruneopts = "UT"
+  revision = "f20d4c4d746f810c9110e21928d4135e1f2a3efa"
+
+[[projects]]
   digest = "1:130d1249f8a867da8115c3de6cddf0ac29ca405117c88aa1541db690384a51c6"
   name = "github.com/marusama/semaphore"
   packages = ["."]
@@ -1786,6 +1793,7 @@
     "github.com/lightstep/lightstep-tracer-go",
     "github.com/linkedin/goavro",
     "github.com/lufia/iostat",
+    "github.com/maruel/panicparse/stack",
     "github.com/marusama/semaphore",
     "github.com/mattn/go-isatty",
     "github.com/mattn/goveralls",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,6 +36,10 @@ ignored = [
   name = "github.com/docker/docker"
   branch = "master"
 
+[[constraint]]
+  name = "github.com/maruel/panicparse"
+  revision = "f20d4c4d746f810c9110e21928d4135e1f2a3efa"
+
 # https://github.com/getsentry/raven-go/pull/139
 [[constraint]]
   name = "github.com/getsentry/raven-go"

--- a/pkg/server/debug/goroutineui/dump.go
+++ b/pkg/server/debug/goroutineui/dump.go
@@ -1,0 +1,100 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package goroutineui
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/maruel/panicparse/stack"
+)
+
+// stacks is a wrapper for runtime.Stack that attempts to recover the data for all goroutines.
+func stacks() []byte {
+	// We don't know how big the traces are, so grow a few times if they don't fit. Start large, though.
+	var trace []byte
+	for n := 1 << 20; /* 1mb */ n <= (1 << 29); /* 512mb */ n *= 2 {
+		trace = make([]byte, n)
+		nbytes := runtime.Stack(trace, true /* all */)
+		if nbytes < len(trace) {
+			return trace[:nbytes]
+		}
+	}
+	return trace
+}
+
+// A Dump wraps a goroutine dump with functionality to output through panicparse.
+type Dump struct {
+	err error
+
+	now     time.Time
+	buckets []*stack.Bucket
+}
+
+// NewDump grabs a goroutine dump and associates it with the supplied time.
+func NewDump(now time.Time) Dump {
+	return NewDumpFromBytes(now, stacks())
+}
+
+// NewDumpFromBytes is like NewDump, but treats the supplied bytes as a goroutine
+// dump.
+func NewDumpFromBytes(now time.Time, b []byte) Dump {
+	c, err := stack.ParseDump(bytes.NewReader(b), ioutil.Discard, true /* guesspaths */)
+	if err != nil {
+		return Dump{err: err}
+	}
+	return Dump{now: now, buckets: stack.Aggregate(c.Goroutines, stack.AnyValue)}
+}
+
+// SortCountDesc rearranges the goroutine buckets such that higher multiplicities
+// appear earlier.
+func (d Dump) SortCountDesc() {
+	sort.Slice(d.buckets, func(i, j int) bool {
+		a, b := d.buckets[i], d.buckets[j]
+		return len(a.IDs) > len(b.IDs)
+	})
+}
+
+// SortWaitDesc rearranges the goroutine buckets such that goroutines that have
+// longer wait times appear earlier.
+func (d Dump) SortWaitDesc() {
+	sort.Slice(d.buckets, func(i, j int) bool {
+		a, b := d.buckets[i], d.buckets[j]
+		return a.SleepMax > b.SleepMax
+	})
+}
+
+// HTML writes the rendered output of panicparse into the supplied Writer.
+func (d Dump) HTML(w io.Writer) error {
+	if d.err != nil {
+		return d.err
+	}
+	return writeToHTML(w, d.buckets, d.now)
+}
+
+// HTMLString is like HTML, but returns a string. If an error occurs, its string
+// representation is returned.
+func (d Dump) HTMLString() string {
+	var w strings.Builder
+	if err := d.HTML(&w); err != nil {
+		return err.Error()
+	}
+	return w.String()
+}

--- a/pkg/server/debug/goroutineui/dump_test.go
+++ b/pkg/server/debug/goroutineui/dump_test.go
@@ -1,0 +1,98 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package goroutineui
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDumpHTML(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	now := time.Time{}
+	dump := NewDumpFromBytes(now, []byte(fixture))
+	dump.SortWaitDesc()  // noop
+	dump.SortCountDesc() // noop
+	act := dump.HTMLString()
+
+	if false {
+		_ = ioutil.WriteFile("test.html", []byte(act), 0644)
+	}
+	assert.Equal(t, exp, act)
+}
+
+// This is the output of debug.PrintStack() on the go playground.
+const fixture = `goroutine 1 [running]:
+runtime/debug.Stack(0x434070, 0xddb11, 0x0, 0x40e0f8)
+	/usr/local/go/src/runtime/debug/stack.go:24 +0xc0
+runtime/debug.PrintStack()
+	/usr/local/go/src/runtime/debug/stack.go:16 +0x20
+main.main()
+	/tmp/sandbox157492124/main.go:6 +0x20`
+
+const exp = `<!DOCTYPE html><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PanicParse</title>
+<link rel="shortcut icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIgAAACACAMAAADnN9ENAAAA5FBMVEVMaXFvTjQhISEhISEhISEhISEhISEhISEhISEhISEhISEhISHRbBTRbBTRbBQhISHRbBTRbBTRbBTRbBQ6OjrRbBTZcBTsehbzfhf1fxfidRVOTk75oiL7uCr90zL3kB3/6zv2hhlHMR5OTk5KSkpKSkpRUVFKSkpKSkpMTExBQUE2NjYpKSlOTk5EREQ8PDw4ODgtLS1RUVFQUFAmJiYkJCQ0NDRLS0tTU1MoKCgyMjJHR0dTU1NdXV0rKytXV1dVVVUvLy9eXl5aWlpcXFxcXFxeXl5fX186OjphYWE/Pz9KSkrdB5CTAAAATHRSTlMAEUZggJjf/6/vcL86e1nP2//vmSC7//////9E/////////2WPpYHp////////////////////z/////8w6P////&#43;p/8f///////&#43;/QBb3BQAACWJJREFUeAHslgWC6yAURUOk1N3d3d29&#43;9/SzzxCStvQEfp9zgZycu8DnvTNN78YJCuqqsry77WQNRum2BX0u7JQiYWJw/l7NBz4AderQkFut8frdn&#43;kFBu2wodeYeHxBwjBkFd6StiFOYiboFCAxf9MRXHc9KGpqurDBpqghzcYuCOCeMp21oKelTBVCQt5kDiisXhCJ5aMQkFu6&#43;lg4tDYr2rikRCPKFgQYlGeiYpN7OHbpMj8OgQ8PAGdWIIlnnwbFKYdtgDAJj&#43;MDgZSX/Zwsx4mbyYR6RbntRZVegQDX7/tI1YexMTNObQ&#43;y992EUWRQJIJQjqTzWRyRjtRiMTqKtWQJCTCD4TMaS6bBzLGxLKRKNer1MELX0wEmYHk8pSMGUmIlMI&#43;LC7uTeEQmhEvnZBC/kqGTolfkmSn72NPbFhoWOHswmczeYYC7YaV4MfBHl&#43;BEYmCSJYVSUM3ukgRM5C7g4edqAqLMBq0m1sRh8oeFl4zzp8swtFApXKlmkIkECD8&#43;mpYEZ8iWZGq1YFKKazg582IDiu8bk7Ob5YaOnVCs9UWu&#43;C99D7LWR5fVeY/YpVOp9Po9rp1g25/AIGIXmhp0yMLgSTIhcYDVYaj0ag1Hk/a0yZ1qVVK6KsmfnMVSbMepBkv32M2nw87rfZioatMxsveirqUBLoxHr1CJpvNZmBQSSB&#43;icd6M9dFpttt21CZ4EHfKKny9Ug4awA/kNRmt993loPBAFSICcbtFpRUeuViFIPFiENpp9NYHg6HexW81Suaiaysscc8gsg6jdTxpFNf6oALUaEmBz2SsMBKEkjeL88Bt8VFWj1fCKvWdDolKmYoYDL5ejcSApNoMsZqBH&#43;0byfbiStNEICbFZt/uIN3WtpASWIUwgOiZWgMyPL7v8&#43;tCuIkBdlwW4WWHS/AdyKzRCEfXy7Iw&#43;PHntlti&#43;k0TZ1FKCJJgteV0wHGhr/1Lvp4/HGQvGdJVVVTZyHFl6TGDEIM3FiUIvnrv53zkXyH4PNzm5mknrhUNo7CUjAeSIbGmNW3Vih/gHGKY1jE53uc1BJYSOF4KCmM6YcqaPmvy/86l88MKPbzcXIKLKSwFJFUPMDtpvPDKT63cZKMJSCRglJE4k7x0hjTaZHAOpzjYBIKCpsThpQLSc4D3GaOdWQ0&#43;CEFEo7HSkpIxjzAraXz4RxbURhJQQtKgYSdYE2mPMBtZYWxjMggIRYLKSiFks0Gw9nExjy16XBnxYBxNHghRSTcE65JEXM4rTl2qIOKkRdnIcWXcDgzXktam8s76zBQzOcZ4q6IsIBCSVVhYTmckpJ2HWBA8XoMMEri1oQnJ89Lx&#43;&#43;3cF6U46hYI8CQ4ks4HBzhYdHK0&#43;TDc5ABxDsCCygi4ZpIJYvF0EIGqzsdffvtskschA4wLGHrcrRoCYfDSnBVe&#43;nc5Yis4zAWRwYHFQwpFxKBuEq6Uyt5untBCs8hjB1DCiVnlfDg5PkCdzUT3TmYDINxezqH46jY7&#43;3FxF0Vd75EVcLZdPPCmEH4cFb202RBfIdT2K4ONo5CyQiSE&#43;T5NJvu8q4z/LE/fBYWwsHY/Xgn45NxGEr8SvyDc4R06zt&#43;W0S7wyGrk1MhdJAhkr2TrEXy09ng/toLL2SfcENkMHRoiYVkrERBnKQKriSynzmqORlAlMObjgyHs&#43;G5kSXp5sGV/NjZQmQyKMQOxnNIpBI1m40sCSoJOjgPux0LKW4XQgkOjpqNBwm9wPYtJFGToeNaJaPjbPS2utRh98bvu/1rLZAMEFWISAjxl0RBNkE//Fb2U4sTBI5bkJ2/JBqCFCHfOH27mBMHKXzI4Rpk/1PI8zmkCpnNx3aXaYh1NICkF5BZwKOkYz&#43;1aBUS&#43;OYmsp9aa8i&#43;wWjUjuDc9BqvyPa9AkSW9b5Tg0yNeWm8ItusmkwuniP6wUrHBSTREFmSpk&#43;R7dZMq4l6sh6uP1kdBLc09WQVyLD5Rc1eCGtAkiPk5pLIZDKuiH7EM40hD4R426oqufmlNwHEOs4hSdN7WmQhqYOoLxslEYd81ejTK5C6MWTtIN6SuHPD4fgSOvxCrnznBZxfQtbPrOTi7kyJdkghNyCpMV&#43;NIP31&#43;4gQVsItubg9yzVerqxyePWKhEHWDiLnhpVQAgoCBh08u7qQuyCv69FSKrmQgLLDm3jHEIdXiJ5MIOTxdZ0B4h0cSvzfnFswzh1SiJ5MACSyn7h89iuhJIMEFCoc49KhJxN2aghxlSiJvJdg1nDMnUMV4k0m9Dmysp/3zErOJKDAwrxahnKcCuFkAp6sjP20qauEwzmTgIJAAYbvuCjEhzT/0htkr/VmyX0VCSnOwoABR0EHBnOlkLw55Ct7HTvImUQoFsN4L1rVS0VVSMh9pD/P4pmTYDgiUW98Y4/BPvRgJGnzG1pk698oiX4HblwK5ZC3rHSE31kf7FJOZxtfQgotEmGIQw1GEvLrdzCaJ6WthJKKElAQGs4Y1x0Bv2uYp9E8Ls8kpIhFEI5Bx5SO44nxIcG/9CL7GF2WM5FgPKDAwlBBBs4LHbqQgN&#43;&#43;yCAeJcMzCSiwiCahAgyM5YZjFvZn4Kd4FJdOgo0VCizEwAAG69AOP5Ow9yOrOB6lw2FZniSWIhbJBAphYE&#43;VI&#43;yNEfMVxyZ/o8SjwMKIAgzUoR1MFfpH4EcTx89HiVBgAeaUqTDoGMKhCgl/0TowcZFbCRcFFFokQJwx4FCM0PesrMTE6QISjwKLRBSWIWOho4VCmBdjTL7IheIsxEioEMYVB9/FByYyxtQLSkiBBaFAFML4mWN235&#43;OesaYzcKnwEIMEVCAcd2x4N9rQtMZGFPkXVJoIQYBAgrFUIOJghkcTtJ1ElBgAcZLSYVmSFK1qUHDqbqk0AIMAwQUYNChF4SDCU/HnZxNlxRY3qBhiPAUOsOC33Z3ZTWgxLOAg8AAhWJI2vhLONeEElqoEYJSKAdP7r15FIlgJBqhHVzUtiTLblBKOlqUVIsAx9LQ0aYkGTZlLCYtO3h2iobjKceG56XFPLwYm7pBKYupsRlE39rOk3GZLn51Owpj89VpmyH/lVCkv0LZYCoDjqXtdPoGqf5lQHlaGNTx0L6BeegZJFnmV1djg6OitqPtRKSYZDrTMyrTOuC/BIJbGRhmXKfLktmkk8QwphfQRkA6jz1zIy&#43;PAbsRbInQi8qgF6C4H9PvfQ2E8NXrR7z9tJvf&#43;Z1/ANt&#43;S&#43;GBXoDpAAAAAElFTkSuQmCC"/>
+<style>
+	body {
+		background: black;
+		color: lightgray;
+	}
+	body, pre {
+		font-family: Menlo, monospace;
+		font-weight: bold;
+	}
+	.FuncStdLibExported {
+		color: #7CFC00;
+	}
+	.FuncStdLib {
+		color: #008000;
+	}
+	.FuncMain {
+		color: #C0C000;
+	}
+	.FuncOtherExported {
+		color: #FF0000;
+	}
+	.FuncOther {
+		color: #A00000;
+	}
+	.RoutineFirst {
+	}
+	.Routine {
+	}
+</style>
+<div id="legend">Generated on 0001-01-01 00:00:00 &#43;0000 UTC.
+</div>
+<div id="content">
+
+	<h1>Running Routine</h1>
+	<span class="Routine">1: <span class="state">running</span>
+	
+	<h2>Stack</h2>
+	
+	- stack.go:24 <span class="FuncStdLibExported">Stack</span>({[{4407408 } {908049 } {0 } {4251896 }] [] false})<br>
+	- stack.go:16 <span class="FuncStdLibExported">PrintStack</span>({[] [] false})<br>
+	- .:0 <span class="FuncMain">main</span>({[] [] false})<br>
+	
+
+</div>
+`

--- a/pkg/server/debug/goroutineui/html.go
+++ b/pkg/server/debug/goroutineui/html.go
@@ -1,0 +1,202 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Copyright 2017 Marc-Antoine Ruel. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// NB: this file's original lives at:
+// https://github.com/maruel/panicparse/blob/master/internal/html.go
+//
+// Please modify this file only when absolutely necessary so that we can
+// pick up updates easily.
+
+package goroutineui
+
+import (
+	"html/template"
+	"io"
+	"time"
+
+	"github.com/maruel/panicparse/stack"
+)
+
+func writeToHTML(w io.Writer, buckets []*stack.Bucket, now time.Time) error {
+	m := template.FuncMap{
+		"funcClass":           funcClass,
+		"notoColorEmoji1F4A3": notoColorEmoji1F4A3,
+	}
+	if len(buckets) > 1 {
+		m["routineClass"] = routineClass
+	} else {
+		m["routineClass"] = func(bucket *stack.Bucket) template.HTML { return "Routine" }
+	}
+	t, err := template.New("htmlTpl").Funcs(m).Parse(htmlTpl)
+	if err != nil {
+		return err
+	}
+	data := struct {
+		Buckets []*stack.Bucket
+		Now     time.Time
+	}{buckets, now.Truncate(time.Second)}
+
+	return t.Execute(w, data)
+}
+
+func funcClass(line *stack.Call) template.HTML {
+	if line.IsStdlib {
+		if line.Func.IsExported() {
+			return "FuncStdLibExported"
+		}
+		return "FuncStdLib"
+	} else if line.IsPkgMain() {
+		return "FuncMain"
+	} else if line.Func.IsExported() {
+		return "FuncOtherExported"
+	}
+	return "FuncOther"
+}
+
+func routineClass(bucket *stack.Bucket) template.HTML {
+	if bucket.First {
+		return "RoutineFirst"
+	}
+	return "Routine"
+}
+
+const htmlTpl = `<!DOCTYPE html>
+{{- define "RenderCall" -}}
+{{.SrcLine}} <span class="{{funcClass .}}">{{.Func.Name}}</span>({{.Args}})
+{{- end -}}
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PanicParse</title>
+<link rel="shortcut icon" type="image/png" href="data:image/png;base64,{{notoColorEmoji1F4A3}}"/>
+<style>
+	body {
+		background: black;
+		color: lightgray;
+	}
+	body, pre {
+		font-family: Menlo, monospace;
+		font-weight: bold;
+	}
+	.FuncStdLibExported {
+		color: #7CFC00;
+	}
+	.FuncStdLib {
+		color: #008000;
+	}
+	.FuncMain {
+		color: #C0C000;
+	}
+	.FuncOtherExported {
+		color: #FF0000;
+	}
+	.FuncOther {
+		color: #A00000;
+	}
+	.RoutineFirst {
+	}
+	.Routine {
+	}
+</style>
+<div id="legend">Generated on {{.Now.String}}.
+</div>
+<div id="content">
+{{range .Buckets}}
+	<h1>{{if .First}}Running {{end}}Routine</h1>
+	<span class="{{routineClass .}}">{{len .IDs}}: <span class="state">{{.State}}</span>
+	{{if .SleepMax -}}
+	  {{- if ne .SleepMin .SleepMax}} <span class="sleep">[{{.SleepMin}}~{{.SleepMax}} minutes]</span>
+		{{- else}} <span class="sleep">[{{.SleepMax}} minutes]</span>
+		{{- end -}}
+	{{- end}}
+	{{if .Locked}} <span class="locked">[locked]</span>
+	{{- end -}}
+	{{- if .CreatedBy.SrcPath}} <span class="created">[Created by {{template "RenderCall" .CreatedBy}}]</span>
+	{{- end -}}
+	<h2>Stack</h2>
+	{{range .Signature.Stack.Calls}}
+	- {{template "RenderCall" .}}<br>
+	{{- end}}
+	{{if .Stack.Elided}}(...)<br>{{end}}
+{{end}}
+</div>
+`
+
+// notoColorEmoji1F4A3 is the bomb emoji U+1F4A3 in Noto Emoji as a PNG.
+//
+// Source: https://www.google.com/get/noto/help/emoji/smileys-people.html
+// License: http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL
+//
+// Created with:
+//   python -c "import base64;a=base64.b64encode(open('emoji_u1f4a3.png','rb').read()); print '\n'.join(a[i:i+70] for i in range(0,len(a),70))"
+func notoColorEmoji1F4A3() template.HTML {
+	return "" +
+		"iVBORw0KGgoAAAANSUhEUgAAAIgAAACACAMAAADnN9ENAAAA5FBMVEVMaXFvTjQhISEhIS" +
+		"EhISEhISEhISEhISEhISEhISEhISEhISHRbBTRbBTRbBQhISHRbBTRbBTRbBTRbBQ6OjrR" +
+		"bBTZcBTsehbzfhf1fxfidRVOTk75oiL7uCr90zL3kB3/6zv2hhlHMR5OTk5KSkpKSkpRUV" +
+		"FKSkpKSkpMTExBQUE2NjYpKSlOTk5EREQ8PDw4ODgtLS1RUVFQUFAmJiYkJCQ0NDRLS0tT" +
+		"U1MoKCgyMjJHR0dTU1NdXV0rKytXV1dVVVUvLy9eXl5aWlpcXFxcXFxeXl5fX186OjphYW" +
+		"E/Pz9KSkrdB5CTAAAATHRSTlMAEUZggJjf/6/vcL86e1nP2//vmSC7//////9E////////" +
+		"/2WPpYHp////////////////////z/////8w6P////+p/8f///////+/QBb3BQAACWJJRE" +
+		"FUeAHslgWC6yAURUOk1N3d3d29+9/SzzxCStvQEfp9zgZycu8DnvTNN78YJCuqqsry77WQ" +
+		"NRum2BX0u7JQiYWJw/l7NBz4AderQkFut8frdn+kFBu2wodeYeHxBwjBkFd6StiFOYiboF" +
+		"CAxf9MRXHc9KGpqurDBpqghzcYuCOCeMp21oKelTBVCQt5kDiisXhCJ5aMQkFu6+lg4tDY" +
+		"r2rikRCPKFgQYlGeiYpN7OHbpMj8OgQ8PAGdWIIlnnwbFKYdtgDAJj+MDgZSX/Zwsx4mby" +
+		"YR6RbntRZVegQDX7/tI1YexMTNObQ+y992EUWRQJIJQjqTzWRyRjtRiMTqKtWQJCTCD4TM" +
+		"aS6bBzLGxLKRKNer1MELX0wEmYHk8pSMGUmIlMI+LC7uTeEQmhEvnZBC/kqGTolfkmSn72" +
+		"NPbFhoWOHswmczeYYC7YaV4MfBHl+BEYmCSJYVSUM3ukgRM5C7g4edqAqLMBq0m1sRh8oe" +
+		"Fl4zzp8swtFApXKlmkIkECD8+mpYEZ8iWZGq1YFKKazg582IDiu8bk7Ob5YaOnVCs9UWu+" +
+		"C99D7LWR5fVeY/YpVOp9Po9rp1g25/AIGIXmhp0yMLgSTIhcYDVYaj0ag1Hk/a0yZ1qVVK" +
+		"6KsmfnMVSbMepBkv32M2nw87rfZioatMxsveirqUBLoxHr1CJpvNZmBQSSB+icd6M9dFpt" +
+		"tt21CZ4EHfKKny9Ug4awA/kNRmt993loPBAFSICcbtFpRUeuViFIPFiENpp9NYHg6HexW8" +
+		"1Suaiaysscc8gsg6jdTxpFNf6oALUaEmBz2SsMBKEkjeL88Bt8VFWj1fCKvWdDolKmYoYD" +
+		"L5ejcSApNoMsZqBH+0byfbiStNEICbFZt/uIN3WtpASWIUwgOiZWgMyPL7v8+tCuIkBdlw" +
+		"W4WWHS/AdyKzRCEfXy7Iw+PHntlti+k0TZ1FKCJJgteV0wHGhr/1Lvp4/HGQvGdJVVVTZy" +
+		"HFl6TGDEIM3FiUIvnrv53zkXyH4PNzm5mknrhUNo7CUjAeSIbGmNW3Vih/gHGKY1jE53uc" +
+		"1BJYSOF4KCmM6YcqaPmvy/86l88MKPbzcXIKLKSwFJFUPMDtpvPDKT63cZKMJSCRglJE4k" +
+		"7x0hjTaZHAOpzjYBIKCpsThpQLSc4D3GaOdWQ0+CEFEo7HSkpIxjzAraXz4RxbURhJQQtK" +
+		"gYSdYE2mPMBtZYWxjMggIRYLKSiFks0Gw9nExjy16XBnxYBxNHghRSTcE65JEXM4rTl2qI" +
+		"OKkRdnIcWXcDgzXktam8s76zBQzOcZ4q6IsIBCSVVhYTmckpJ2HWBA8XoMMEri1oQnJ89L" +
+		"x++3cF6U46hYI8CQ4ks4HBzhYdHK0+TDc5ABxDsCCygi4ZpIJYvF0EIGqzsdffvtskschA" +
+		"4wLGHrcrRoCYfDSnBVe+nc5Yis4zAWRwYHFQwpFxKBuEq6Uyt5untBCs8hjB1DCiVnlfDg" +
+		"5PkCdzUT3TmYDINxezqH46jY7+3FxF0Vd75EVcLZdPPCmEH4cFb202RBfIdT2K4ONo5CyQ" +
+		"iSE+T5NJvu8q4z/LE/fBYWwsHY/Xgn45NxGEr8SvyDc4R06zt+W0S7wyGrk1MhdJAhkr2T" +
+		"rEXy09ng/toLL2SfcENkMHRoiYVkrERBnKQKriSynzmqORlAlMObjgyHs+G5kSXp5sGV/N" +
+		"jZQmQyKMQOxnNIpBI1m40sCSoJOjgPux0LKW4XQgkOjpqNBwm9wPYtJFGToeNaJaPjbPS2" +
+		"utRh98bvu/1rLZAMEFWISAjxl0RBNkE//Fb2U4sTBI5bkJ2/JBqCFCHfOH27mBMHKXzI4R" +
+		"pk/1PI8zmkCpnNx3aXaYh1NICkF5BZwKOkYz+1aBUS+OYmsp9aa8i+wWjUjuDc9BqvyPa9" +
+		"AkSW9b5Tg0yNeWm8ItusmkwuniP6wUrHBSTREFmSpk+R7dZMq4l6sh6uP1kdBLc09WQVyL" +
+		"D5Rc1eCGtAkiPk5pLIZDKuiH7EM40hD4R426oqufmlNwHEOs4hSdN7WmQhqYOoLxslEYd8" +
+		"1ejTK5C6MWTtIN6SuHPD4fgSOvxCrnznBZxfQtbPrOTi7kyJdkghNyCpMV+NIP31+4gQVs" +
+		"Itubg9yzVerqxyePWKhEHWDiLnhpVQAgoCBh08u7qQuyCv69FSKrmQgLLDm3jHEIdXiJ5M" +
+		"IOTxdZ0B4h0cSvzfnFswzh1SiJ5MACSyn7h89iuhJIMEFCoc49KhJxN2aghxlSiJvJdg1n" +
+		"DMnUMV4k0m9Dmysp/3zErOJKDAwrxahnKcCuFkAp6sjP20qauEwzmTgIJAAYbvuCjEhzT/" +
+		"0htkr/VmyX0VCSnOwoABR0EHBnOlkLw55Ct7HTvImUQoFsN4L1rVS0VVSMh9pD/P4pmTYD" +
+		"giUW98Y4/BPvRgJGnzG1pk698oiX4HblwK5ZC3rHSE31kf7FJOZxtfQgotEmGIQw1GEvLr" +
+		"dzCaJ6WthJKKElAQGs4Y1x0Bv2uYp9E8Ls8kpIhFEI5Bx5SO44nxIcG/9CL7GF2WM5FgPK" +
+		"DAwlBBBs4LHbqQgN++yCAeJcMzCSiwiCahAgyM5YZjFvZn4Kd4FJdOgo0VCizEwAAG69AO" +
+		"P5Ow9yOrOB6lw2FZniSWIhbJBAphYE+VI+yNEfMVxyZ/o8SjwMKIAgzUoR1MFfpH4EcTx8" +
+		"9HiVBgAeaUqTDoGMKhCgl/0TowcZFbCRcFFFokQJwx4FCM0PesrMTE6QISjwKLRBSWIWOh" +
+		"o4VCmBdjTL7IheIsxEioEMYVB9/FByYyxtQLSkiBBaFAFML4mWN235+OesaYzcKnwEIMEV" +
+		"CAcd2x4N9rQtMZGFPkXVJoIQYBAgrFUIOJghkcTtJ1ElBgAcZLSYVmSFK1qUHDqbqk0AIM" +
+		"AwQUYNChF4SDCU/HnZxNlxRY3qBhiPAUOsOC33Z3ZTWgxLOAg8AAhWJI2vhLONeEElqoEY" +
+		"JSKAdP7r15FIlgJBqhHVzUtiTLblBKOlqUVIsAx9LQ0aYkGTZlLCYtO3h2iobjKceG56XF" +
+		"PLwYm7pBKYupsRlE39rOk3GZLn51Owpj89VpmyH/lVCkv0LZYCoDjqXtdPoGqf5lQHlaGN" +
+		"Tx0L6BeegZJFnmV1djg6OitqPtRKSYZDrTMyrTOuC/BIJbGRhmXKfLktmkk8QwphfQRkA6" +
+		"jz1zIy+PAbsRbInQi8qgF6C4H9PvfQ2E8NXrR7z9tJvf+Z1/ANt+S+GBXoDpAAAAAElFTk" +
+		"SuQmCC"
+}

--- a/pkg/server/debug/pprofui/server.go
+++ b/pkg/server/debug/pprofui/server.go
@@ -44,12 +44,29 @@ type Server struct {
 	storage      Storage
 	profileSem   syncutil.Mutex
 	profileTypes map[string]http.HandlerFunc
+	hook         func(profile string, do func())
 }
 
-// NewServer creates a new Server backed by the supplied Storage.
-func NewServer(storage Storage) *Server {
+// NewServer creates a new Server backed by the supplied Storage and optionally
+// a hook which is called when a new profile is created. The closure passed to
+// the hook will carry out the work involved in creating the profile and must
+// be called by the hook. The intention is that hook will be a method such as
+// this:
+//
+// func hook(profile string, do func()) {
+// 	if profile == "profile" {
+// 		something.EnableProfilerLabels()
+// 		defer something.DisableProfilerLabels()
+// 		do()
+// 	}
+// }
+func NewServer(storage Storage, hook func(profile string, do func())) *Server {
+	if hook == nil {
+		hook = func(_ string, do func()) { do() }
+	}
 	s := &Server{
 		storage: storage,
+		hook:    hook,
 	}
 
 	s.profileTypes = map[string]http.HandlerFunc{
@@ -195,7 +212,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		rw := &responseBridge{target: w}
 
-		fetchHandler(rw, req)
+		s.hook(profileName, func() { fetchHandler(rw, req) })
 
 		if rw.statusCode != http.StatusOK && rw.statusCode != 0 {
 			return errors.Errorf("unexpected status: %d", rw.statusCode)

--- a/pkg/server/debug/pprofui/server_test.go
+++ b/pkg/server/debug/pprofui/server_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestServer(t *testing.T) {
 	storage := NewMemStorage(1, 0)
-	s := NewServer(storage)
+	s := NewServer(storage, nil)
 
 	for i := 0; i < 3; i++ {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
 	"github.com/rcrowley/go-metrics/exp"
@@ -118,7 +119,12 @@ func NewServer(st *cluster.Settings) *Server {
 	}
 	mux.HandleFunc("/debug/logspy", spy.handleDebugLogSpy)
 
-	ps := pprofui.NewServer(pprofui.NewMemStorage(1, 0))
+	ps := pprofui.NewServer(pprofui.NewMemStorage(1, 0), func(profile string, do func()) {
+		tBegin := timeutil.Now()
+		log.Infof(context.Background(), "pprofui: recording %s", profile)
+		do()
+		log.Infof(context.Background(), "pprofui: recorded %s in %.2fs", profile, timeutil.Since(tBegin).Seconds())
+	})
 	mux.Handle("/debug/pprof/ui/", http.StripPrefix("/debug/pprof/ui", ps))
 
 	return &Server{

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -125,7 +125,6 @@ func NewServer(st *cluster.Settings) *Server {
 		extra := ""
 		if profile == "profile" {
 			extra = " (enabling profiler labels)"
-			log.Infof(context.Background(), "%s", profile)
 			st.SetCPUProfiling(true)
 			defer st.SetCPUProfiling(false)
 		}

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -121,8 +121,18 @@ func NewServer(st *cluster.Settings) *Server {
 
 	ps := pprofui.NewServer(pprofui.NewMemStorage(1, 0), func(profile string, do func()) {
 		tBegin := timeutil.Now()
-		log.Infof(context.Background(), "pprofui: recording %s", profile)
+
+		extra := ""
+		if profile == "profile" {
+			extra = " (enabling profiler labels)"
+			log.Infof(context.Background(), "%s", profile)
+			st.SetCPUProfiling(true)
+			defer st.SetCPUProfiling(false)
+		}
+		log.Infof(context.Background(), "pprofui: recording %s%s", profile, extra)
+
 		do()
+
 		log.Infof(context.Background(), "pprofui: recorded %s in %.2fs", profile, timeutil.Since(tBegin).Seconds())
 	})
 	mux.Handle("/debug/pprof/ui/", http.StripPrefix("/debug/pprof/ui", ps))

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -71,6 +71,27 @@ type Settings struct {
 	ExternalIODir string
 
 	Initialized bool
+
+	// Set to 1 if a profile is active (if the profile is being grabbed through
+	// the `pprofui` server as opposed to the raw endpoint).
+	cpuProfiling int32 // atomic
+}
+
+// IsCPUProfiling returns true if a pprofui CPU profile is being recorded. This can
+// be used by moving parts across the system to add profiler labels which are
+// too expensive to be enabled at all times.
+func (s *Settings) IsCPUProfiling() bool {
+	return atomic.LoadInt32(&s.cpuProfiling) == 1
+}
+
+// SetCPUProfiling is called from the pprofui to inform the system that a CPU
+// profile is being recorded.
+func (s *Settings) SetCPUProfiling(to bool) {
+	i := int32(0)
+	if to {
+		i = 1
+	}
+	atomic.StoreInt32(&s.cpuProfiling, i)
 }
 
 // NoSettings is used when a func requires a Settings but none is available

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -227,7 +227,10 @@ export default function Debug() {
           <DebugTableLink name="Goroutines" url="/debug/pprof/ui/goroutine/" />
         </DebugTableRow>
         <DebugTableRow title="Goroutines">
-          <DebugTableLink name="All Goroutines" url="/debug/pprof/goroutine?debug=2" />
+          <DebugTableLink name="UI" url="/debug/pprof/goroutineui" />
+          <DebugTableLink name="UI (count)" url="/debug/pprof/goroutineui?sort=count" />
+          <DebugTableLink name="UI (wait)" url="/debug/pprof/goroutineui?sort=wait" />
+          <DebugTableLink name="Raw" url="/debug/pprof/goroutine?debug=2" />
         </DebugTableRow>
         <DebugTableRow title="Runtime Trace">
           <DebugTableLink name="Trace" url="/debug/pprof/trace?debug=1" />

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -218,7 +218,7 @@ export default function Debug() {
         <DebugTableRow title="Stopper">
           <DebugTableLink name="Active Tasks" url="/debug/stopper" />
         </DebugTableRow>
-        <DebugTableRow title="Profiling UI">
+        <DebugTableRow title="Profiling UI/pprof">
           <DebugTableLink name="Heap" url="/debug/pprof/ui/heap/" />
           <DebugTableLink name="Profile" url="/debug/pprof/ui/profile/?seconds=5" />
           <DebugTableLink name="Block" url="/debug/pprof/ui/block/" />
@@ -226,14 +226,10 @@ export default function Debug() {
           <DebugTableLink name="Thread Create" url="/debug/pprof/ui/threadcreate/" />
           <DebugTableLink name="Goroutines" url="/debug/pprof/ui/goroutine/" />
         </DebugTableRow>
-        <DebugTableRow title="Profiling Raw">
-          <DebugTableLink name="Heap" url="/debug/pprof/heap?debug=1" />
-          <DebugTableLink name="Profile" url="/debug/pprof/profile?debug=1" />
-          <DebugTableLink name="Block" url="/debug/pprof/block?debug=1" />
-          <DebugTableLink name="Mutex" url="/debug/pprof/mutex?debug=1" />
-          <DebugTableLink name="Thread Create" url="/debug/pprof/threadcreate?debug=1" />
-          <DebugTableLink name="Goroutines" url="/debug/pprof/goroutine?debug=1" />
+        <DebugTableRow title="Goroutines">
           <DebugTableLink name="All Goroutines" url="/debug/pprof/goroutine?debug=2" />
+        </DebugTableRow>
+        <DebugTableRow title="Runtime Trace">
           <DebugTableLink name="Trace" url="/debug/pprof/trace?debug=1" />
         </DebugTableRow>
       </DebugTable>


### PR DESCRIPTION
All but last commit is https://github.com/cockroachdb/cockroach/pull/35147.

----

[panicparse] is a nifty tool that preprocesses goroutine dumps with the
goal of making them more digestible. To do so, it groups "similar" stacks
and tries to highlight system vs user code.

The grouping in particular is helpful since the situations in which we
stare at goroutine dumps are often the same situations in which there are
tons of goroutines all over the place. And even in a happy cluster, our
thread pools show up with high multiplicity and occupy enormous amounts of
terminal real estate.

The UI sets some defaults that are hopefully sane. First, it won't try to
let panicparse rummage through the source files to improve the display of
arguments, as the source files won't be available in prod
(and trying to find them pp will log annoying messages). Second, we operate
at the most lenient similarity where two stack frames are considered
"similar" no matter what the arguments to the method are. This groups most
aggressively which I think is what we want, though if we find out otherwise
it's always easy to download the raw dump and to use panicparse locally.
Or, of course, we can plumb a GET parameter that lets you chose the
similarity strategy.

[panicparse]: https://github.com/maruel/panicparse/

Here's a sample:

![image](https://user-images.githubusercontent.com/5076964/53244768-271d0980-36ac-11e9-9c2c-8bae8a0896ba.png)


Release note (admin ui change): Provide a colorized and aggregate overview over
the active goroutines (at /debug/pprof/goroutineui), useful for internal
debugging.