### PR TITLE
rpc: enable dynamic window resizing

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -65,12 +65,6 @@ const (
 	maximumPingDurationMult = 2
 )
 
-const (
-	defaultWindowSize     = 65535
-	initialWindowSize     = defaultWindowSize * 32 // for an RPC
-	initialConnWindowSize = initialWindowSize * 16 // for a connection
-)
-
 // sourceAddr is the environment-provided local address for outgoing
 // connections.
 var sourceAddr = func() net.Addr {
@@ -161,8 +155,6 @@ func NewServerWithInterceptor(
 		grpc.MaxSendMsgSize(math.MaxInt32),
 		// Adjust the stream and connection window sizes. The gRPC defaults are too
 		// low for high latency connections.
-		grpc.InitialWindowSize(initialWindowSize),
-		grpc.InitialConnWindowSize(initialConnWindowSize),
 		// The default number of concurrent streams/requests on a client connection
 		// is 100, while the server is unlimited. The client setting can only be
 		// controlled by adjusting the server value. Set a very large value for the
@@ -654,9 +646,6 @@ func (ctx *Context) GRPCDialRaw(target string) (*grpc.ClientConn, <-chan struct{
 
 	dialOpts = append(dialOpts, grpc.WithBackoffMaxDelay(maxBackoff))
 	dialOpts = append(dialOpts, grpc.WithKeepaliveParams(clientKeepalive))
-	dialOpts = append(dialOpts,
-		grpc.WithInitialWindowSize(initialWindowSize),
-		grpc.WithInitialConnWindowSize(initialConnWindowSize))
 
 	dialer := onlyOnceDialer{
 		ctx:        ctx.masterCtx,


### PR DESCRIPTION
This commit removes the custom GRPC stream and connection window size
added due to #13687. Since then, GRPC has added dynamic window resizing,
resulting in window resizing depending on the bandwidth-delay product of
a stream (i.e. increase the window if data is flowing). However, GRPC
only enables this behavior if the initial window size is less than or
equal to the default window size.

The reason to have large initial window sizes was to allow for
reasonable throughput on high-latency links. However, the trouble with
having a static window is that some streams can block other streams by
taking up the total window size even though nobody is reading from it on
the other side. Dynamic window sizing improves on both cases. Firstly,
since the initial size is smaller than our current default, any blocked
streams will only occupy 64KB (the default window size) instead of 2MB
(our custom window size).
Secondly, if high throughput is needed (e.g. for a snapshot), we can use
up to 4MB of window space on the connection, resulting in double the
throughput when necessary (experiments shared in this PR).

Closes #14948

Noting this as a bug fix in the release note although this should also
be a performance improvement for snapshots.

Release note (bug fix): Avoid possible query deadlocks

Testing this in various RTT scenarios showed that throughput in high-latency scenarios seems to double, which is expected due to the fact that the maximum window size when using dynamic window resizing is 4MB, twice our current 2MB setting. Here is the graph (DW=F means dynamic window disabled, DW=T means dynamic window enabled)
![image](https://user-images.githubusercontent.com/10560359/53274298-c9e18200-36c4-11e9-92da-6810e0fee8b9.png)

Link to the spreadsheet: https://docs.google.com/spreadsheets/d/1M1SfFE3ltCXln-gN0vGCNhbW6N46XWaX3MqNagkf9Vk/edit#gid=0

Go program used was a modification of gupload to use cockroach's GRPC settings as closely as possible: https://github.com/asubiotto/gupload

Latency added using:
```
roachprod run <cluster> "sudo tc qdisc add dev ens5 root netem delay <n/2>ms"
```

Program run using what I gathered was the maximum snapshot chunk size:
```
./gupload upload --file /dev/zero --address=alfonso-grpc-0001:1313 --chunk-size=262144 [--dwindow]
```

The only concern here might be that the ramp up period slightly affects us in the 120ms case (we are slightly under the static window numbers for the first 2 seconds), although I struggle to see how this will be a problem in practice. This might benefit from checking out on even higher latency links.