### PR TITLE
cli: revert timeout refactoring in `debug synctest`

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -444,6 +444,7 @@ func TestLint(t *testing.T) {
 			":!server/debug/**",
 			":!workload/**",
 			":!*_test.go",
+			":!cli/debug_synctest.go",
 			":!cmd/**",
 		)
 		if err != nil {


### PR DESCRIPTION
447fe7d switched all uses of `WithTimeout()` to `RunWithTimeout()`.
With the latter we cannot distinguish an error caused by the lambda
timing out vs. a timeout error from inside `runSyncer()`.

This test relies on the timeout mechanism to stop the lambda from
running after ten minutes. That case should not be reported as an error.
So we need to revert to `WithTimeout()` within this file.

Command: `git checkout 447fe7d^ -- ./pkg/cli/debug_synctest.go`

Test Plan:
```
./bin/roachtest --user andrewk --cockroach \
	./cockroach-linux-2.6.32-gnu-amd64 --workload ./bin/workload \
	run --debug synctest --roachprod ./bin/roachprod
```

Release note: None