### PR TITLE
opt: Make opt catalog objects immutable

### DIFF
--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -52,6 +52,10 @@ type SchemaName = tree.TableNamePrefix
 
 // Catalog is an interface to a database catalog, exposing only the information
 // needed by the query optimizer.
+//
+// NOTE: Catalog implementations need not be thread-safe. However, the objects
+// returned by the Resolve methods (schemas and data sources) *must* be
+// immutable after construction, and therefore also thread-safe.
 type Catalog interface {
 	// ResolveSchema locates a schema with the given name and returns it along
 	// with the resolved SchemaName (which has all components filled in).
@@ -61,6 +65,9 @@ type Catalog interface {
 	// the input name. Its use is mainly for cosmetic purposes.
 	//
 	// If no such schema exists, then ResolveSchema returns an error.
+	//
+	// NOTE: The returned schema must be immutable after construction, and so can
+	// be safely copied or used across goroutines.
 	ResolveSchema(ctx context.Context, name *SchemaName) (Schema, SchemaName, error)
 
 	// ResolveDataSource locates a data source with the given name and returns it
@@ -75,11 +82,17 @@ type Catalog interface {
 	// "t".
 	//
 	// If no such data source exists, then ResolveDataSource returns an error.
+	//
+	// NOTE: The returned data source must be immutable after construction, and
+	// so can be safely copied or used across goroutines.
 	ResolveDataSource(ctx context.Context, name *DataSourceName) (DataSource, DataSourceName, error)
 
 	// ResolveDataSourceByID is similar to ResolveDataSource, except that it
 	// locates a data source by its StableID. See the comment for StableID for
 	// more details.
+	//
+	// NOTE: The returned data source must be immutable after construction, and
+	// so can be safely copied or used across goroutines.
 	ResolveDataSourceByID(ctx context.Context, id StableID) (DataSource, error)
 
 	// CheckPrivilege verifies that the current user has the given privilege on

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -352,13 +352,11 @@ type optTable struct {
 	// table.
 	name cat.DataSourceName
 
-	// primaryIndex is the inlined wrapper for the table's primary index.
-	primaryIndex optIndex
+	// indexes are the inlined wrappers for the table's primary and secondary
+	// indexes.
+	indexes []optIndex
 
-	// indexes is a cache of index wrappers that's used to satisfy repeated
-	// calls to the Index method for the same index.
-	indexes map[*sqlbase.IndexDescriptor]*optIndex
-
+	// stats are the inlined wrappers for table statistics.
 	stats []optTableStat
 
 	// family is the inlined wrapper for the table's primary family. The primary
@@ -366,9 +364,11 @@ type optTable struct {
 	// were explicitly specified, then the primary family is synthesized.
 	primaryFamily optFamily
 
-	// families is a cache of family wrappers (all except primary family) that's
-	// used to satisfy repeated calls to the Family method for the same family.
-	families map[*sqlbase.ColumnFamilyDescriptor]*optFamily
+	// families are the inlined wrappers for the table's non-primary families,
+	// which are all the families specified by the user after the first. The
+	// primary family is kept separate since the common case is that there's just
+	// one family.
+	families []optFamily
 
 	// colMap is a mapping from unique ColumnID to column ordinal within the
 	// table. This is a common lookup that needs to be fast.
@@ -384,23 +384,32 @@ func newOptTable(
 	stats []*stats.TableStatistic,
 ) *optTable {
 	ot := &optTable{desc: desc, id: id, name: *name}
-	if stats != nil {
-		ot.stats = make([]optTableStat, len(stats))
-		n := 0
-		for i := range stats {
-			// We skip any stats that have columns that don't exist in the table anymore.
-			if ot.stats[n].init(ot, stats[i]) {
-				n++
-			}
-		}
-		ot.stats = ot.stats[:n]
-	}
 
 	// The cat.Table interface requires that table names be fully qualified.
 	ot.name.ExplicitSchema = true
 	ot.name.ExplicitCatalog = true
 
-	ot.primaryIndex.init(ot, &desc.PrimaryIndex)
+	// Create the table's column mapping from sqlbase.ColumnID to column ordinal.
+	ot.colMap = make(map[sqlbase.ColumnID]int, ot.DeletableColumnCount())
+	for i, n := 0, ot.DeletableColumnCount(); i < n; i++ {
+		ot.colMap[sqlbase.ColumnID(ot.Column(i).ColID())] = i
+	}
+
+	if !ot.desc.IsVirtualTable() {
+		// Build the indexes (add 1 to account for lack of primary index in
+		// DeletableIndexes slice).
+		ot.indexes = make([]optIndex, 1+len(ot.desc.DeletableIndexes()))
+
+		for i := range ot.indexes {
+			var idxDesc *sqlbase.IndexDescriptor
+			if i == 0 {
+				idxDesc = &desc.PrimaryIndex
+			} else {
+				idxDesc = &ot.desc.DeletableIndexes()[i-1]
+			}
+			ot.indexes[i].init(ot, idxDesc)
+		}
+	}
 
 	if len(desc.Families) == 0 {
 		// This must be a virtual table, so synthesize a primary family. Only
@@ -413,6 +422,23 @@ func newOptTable(
 		ot.primaryFamily.init(ot, family)
 	} else {
 		ot.primaryFamily.init(ot, &desc.Families[0])
+		ot.families = make([]optFamily, len(desc.Families)-1)
+		for i := range ot.families {
+			ot.families[i].init(ot, &desc.Families[i+1])
+		}
+	}
+
+	// Add stats last, now that other metadata is initialized.
+	if stats != nil {
+		ot.stats = make([]optTableStat, len(stats))
+		n := 0
+		for i := range stats {
+			// We skip any stats that have columns that don't exist in the table anymore.
+			if ot.stats[n].init(ot, stats[i]) {
+				n++
+			}
+		}
+		ot.stats = ot.stats[:n]
 	}
 
 	return ot
@@ -518,24 +544,7 @@ func (ot *optTable) DeletableIndexCount() int {
 
 // Index is part of the cat.Table interface.
 func (ot *optTable) Index(i int) cat.Index {
-	// Primary index is always 0th index.
-	if i == cat.PrimaryIndex {
-		return &ot.primaryIndex
-	}
-
-	// Bias i to account for lack of primary index in DeletableIndexes slice.
-	desc := &ot.desc.DeletableIndexes()[i-1]
-
-	// Check to see if there's already a wrapper for this index descriptor.
-	if ot.indexes == nil {
-		ot.indexes = make(map[*sqlbase.IndexDescriptor]*optIndex, len(ot.desc.Indexes))
-	}
-	wrapper, ok := ot.indexes[desc]
-	if !ok {
-		wrapper = newOptIndex(ot, desc)
-		ot.indexes[desc] = wrapper
-	}
-	return wrapper
+	return &ot.indexes[i]
 }
 
 // StatisticCount is part of the cat.Table interface.
@@ -546,15 +555,6 @@ func (ot *optTable) StatisticCount() int {
 // Statistic is part of the cat.Table interface.
 func (ot *optTable) Statistic(i int) cat.TableStatistic {
 	return &ot.stats[i]
-}
-
-func (ot *optTable) ensureColMap() {
-	if ot.colMap == nil {
-		ot.colMap = make(map[sqlbase.ColumnID]int, ot.DeletableColumnCount())
-		for i, n := 0, ot.DeletableColumnCount(); i < n; i++ {
-			ot.colMap[sqlbase.ColumnID(ot.Column(i).ColID())] = i
-		}
-	}
 }
 
 // CheckCount is part of the cat.Table interface.
@@ -570,34 +570,20 @@ func (ot *optTable) Check(i int) cat.CheckConstraint {
 
 // FamilyCount is part of the cat.Table interface.
 func (ot *optTable) FamilyCount() int {
-	return len(ot.desc.Families)
+	return 1 + len(ot.families)
 }
 
 // Family is part of the cat.Table interface.
 func (ot *optTable) Family(i int) cat.Family {
-	// The default family is always 0th index.
 	if i == 0 {
 		return &ot.primaryFamily
 	}
-	desc := &ot.desc.Families[i]
-
-	// Check to see if there's already a wrapper for this family descriptor, and
-	// if not, create one.
-	if ot.families == nil {
-		ot.families = make(map[*sqlbase.ColumnFamilyDescriptor]*optFamily, len(ot.desc.Families))
-	}
-	wrapper, ok := ot.families[desc]
-	if !ok {
-		wrapper = newOptFamily(ot, desc)
-		ot.families[desc] = wrapper
-	}
-	return wrapper
+	return &ot.families[i-1]
 }
 
 // lookupColumnOrdinal returns the ordinal of the column with the given ID. A
 // cache makes the lookup O(1).
 func (ot *optTable) lookupColumnOrdinal(colID sqlbase.ColumnID) (int, error) {
-	ot.ensureColMap()
 	col, ok := ot.colMap[colID]
 	if ok {
 		return col, nil
@@ -625,12 +611,6 @@ type optIndex struct {
 }
 
 var _ cat.Index = &optIndex{}
-
-func newOptIndex(tab *optTable, desc *sqlbase.IndexDescriptor) *optIndex {
-	oi := &optIndex{}
-	oi.init(tab, desc)
-	return oi
-}
 
 // init can be used instead of newOptIndex when we have a pre-allocated instance
 // (e.g. as part of a bigger struct).
@@ -787,7 +767,6 @@ func (os *optTableStat) init(tab *optTable, stat *stats.TableStatistic) (ok bool
 	os.distinctCount = stat.DistinctCount
 	os.nullCount = stat.NullCount
 	os.columnOrdinals = make([]int, len(stat.ColumnIDs))
-	tab.ensureColMap()
 	for i, c := range stat.ColumnIDs {
 		var ok bool
 		os.columnOrdinals[i], ok = tab.colMap[c]
@@ -852,12 +831,6 @@ type optFamily struct {
 }
 
 var _ cat.Family = &optFamily{}
-
-func newOptFamily(tab *optTable, desc *sqlbase.ColumnFamilyDescriptor) *optFamily {
-	oi := &optFamily{}
-	oi.init(tab, desc)
-	return oi
-}
 
 // init can be used instead of newOptFamily when we have a pre-allocated
 // instance (e.g. as part of a bigger struct).


### PR DESCRIPTION
Update the opt.Catalog interface to require dispensed objects like tables
and indexes, to be immutable after construction. This allows them to be shared
across threads, which is important for the query cache.

Release note: None