### PR TITLE
sql: join hints

### DIFF
--- a/docs/generated/sql/bnf/joined_table.bnf
+++ b/docs/generated/sql/bnf/joined_table.bnf
@@ -1,7 +1,7 @@
 joined_table ::=
 	'(' joined_table ')'
 	| table_ref 'CROSS' 'JOIN' table_ref
-	| table_ref ( 'FULL' ( 'OUTER' |  ) | 'LEFT' ( 'OUTER' |  ) | 'RIGHT' ( 'OUTER' |  ) | 'INNER' ) 'JOIN' table_ref ( 'USING' '(' ( ( name ) ( ( ',' name ) )* ) ')' | 'ON' a_expr )
+	| table_ref ( 'FULL' ( 'OUTER' |  ) | 'LEFT' ( 'OUTER' |  ) | 'RIGHT' ( 'OUTER' |  ) | 'INNER' ) opt_join_hint 'JOIN' table_ref ( 'USING' '(' ( ( name ) ( ( ',' name ) )* ) ')' | 'ON' a_expr )
 	| table_ref 'JOIN' table_ref ( 'USING' '(' ( ( name ) ( ( ',' name ) )* ) ')' | 'ON' a_expr )
-	| table_ref 'NATURAL' ( 'FULL' ( 'OUTER' |  ) | 'LEFT' ( 'OUTER' |  ) | 'RIGHT' ( 'OUTER' |  ) | 'INNER' ) 'JOIN' table_ref
+	| table_ref 'NATURAL' ( 'FULL' ( 'OUTER' |  ) | 'LEFT' ( 'OUTER' |  ) | 'RIGHT' ( 'OUTER' |  ) | 'INNER' ) opt_join_hint 'JOIN' table_ref
 	| table_ref 'NATURAL' 'JOIN' table_ref

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -622,6 +622,7 @@ unreserved_keyword ::=
 	| 'GLOBAL'
 	| 'GRANTS'
 	| 'GROUPS'
+	| 'HASH'
 	| 'HIGH'
 	| 'HISTOGRAM'
 	| 'HOUR'
@@ -656,10 +657,12 @@ unreserved_keyword ::=
 	| 'LEVEL'
 	| 'LIST'
 	| 'LOCAL'
+	| 'LOOKUP'
 	| 'LOW'
 	| 'MATCH'
 	| 'MATERIALIZED'
 	| 'MAXVALUE'
+	| 'MERGE'
 	| 'MINUTE'
 	| 'MINVALUE'
 	| 'MONTH'
@@ -2019,9 +2022,9 @@ opt_alias_clause ::=
 joined_table ::=
 	'(' joined_table ')'
 	| table_ref 'CROSS' 'JOIN' table_ref
-	| table_ref join_type 'JOIN' table_ref join_qual
+	| table_ref join_type opt_join_hint 'JOIN' table_ref join_qual
 	| table_ref 'JOIN' table_ref join_qual
-	| table_ref 'NATURAL' join_type 'JOIN' table_ref
+	| table_ref 'NATURAL' join_type opt_join_hint 'JOIN' table_ref
 	| table_ref 'NATURAL' 'JOIN' table_ref
 
 alias_clause ::=
@@ -2156,6 +2159,12 @@ join_type ::=
 	| 'LEFT' join_outer
 	| 'RIGHT' join_outer
 	| 'INNER'
+
+opt_join_hint ::=
+	'HASH'
+	| 'MERGE'
+	| 'LOOKUP'
+	| 
 
 join_qual ::=
 	'USING' '(' name_list ')'

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -141,7 +141,7 @@ func (p *planner) getDataSource(
 		if err != nil {
 			return right, err
 		}
-		return p.makeJoin(ctx, sqlbase.JoinTypeFromAstString(t.Join), left, right, t.Cond)
+		return p.makeJoin(ctx, sqlbase.JoinTypeFromAstString(t.JoinType), left, right, t.Cond)
 
 	case *tree.StatementSource:
 		plan, err := p.newPlan(ctx, t.Statement, nil /* desiredTypes */)

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -9,13 +9,9 @@ CREATE TABLE twocolumn (x INT, y INT); INSERT INTO twocolumn(x, y) VALUES (44,51
 ## Simple test cases for inner, left, right, and outer joins
 
 query TTT
-SELECT tree, field, description FROM [
-EXPLAIN (VERBOSE) SELECT * FROM onecolumn JOIN twocolumn USING(x)
-]
+EXPLAIN SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
 render          ·         ·
- │              render 0  x
- │              render 1  y
  └── join       ·         ·
       │         type      inner
       │         equality  (x) = (x)
@@ -27,9 +23,7 @@ render          ·         ·
 ·               spans     ALL
 
 query TTT
-SELECT tree, field, description FROM [
-EXPLAIN (VERBOSE) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
-]
+EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
 join       ·         ·
  │         type      inner
@@ -42,15 +36,9 @@ join       ·         ·
 ·          spans     ALL
 
 query TTT
-SELECT tree, field, description FROM [
-EXPLAIN (VERBOSE) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
-]
+EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
 render          ·         ·
- │              render 0  x
- │              render 1  y
- │              render 2  x
- │              render 3  y
  └── join       ·         ·
       │         type      cross
       ├── scan  ·         ·
@@ -62,9 +50,7 @@ render          ·         ·
 ·               filter    x = 44
 
 query TTT
-SELECT tree, field, description FROM [
-EXPLAIN (VERBOSE) SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
-]
+EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
 join       ·         ·
  │         type      inner
@@ -77,9 +63,7 @@ join       ·         ·
 ·          spans     ALL
 
 query TTT
-SELECT tree, field, description FROM [
-EXPLAIN (VERBOSE) SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
-]
+EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
 join       ·         ·
  │         type      inner
@@ -93,17 +77,14 @@ join       ·         ·
 
 
 query TTT
-SELECT tree, field, description FROM [
-EXPLAIN (VERBOSE) SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
-]
+EXPLAIN SELECT * FROM
+  onecolumn
+  CROSS JOIN twocolumn
+  JOIN onecolumn AS a (b) ON a.b = twocolumn.x
+  JOIN twocolumn AS c (d, e) ON a.b = c.d AND c.d = onecolumn.x
+LIMIT 1
 ----
 render                    ·         ·
- │                        render 0  x
- │                        render 1  x
- │                        render 2  y
- │                        render 3  x
- │                        render 4  x
- │                        render 5  y
  └── limit                ·         ·
       │                   count     1
       └── join            ·         ·
@@ -431,7 +412,7 @@ statement ok
 CREATE TABLE cards(id INT PRIMARY KEY, cust INT NOT NULL REFERENCES customers(id))
 
 query TTT
-EXPLAIN SELECT * FROM cards LEFT OUTER JOIN customers ON customers.id = cards.cust 
+EXPLAIN SELECT * FROM cards LEFT OUTER JOIN customers ON customers.id = cards.cust
 ----
 join       ·               ·
  │         type            inner
@@ -1377,17 +1358,9 @@ join       ·         ·
 
 # Only a and c can be equality columns.
 query TTT
-SELECT tree, field, description FROM [
-EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (a,b) WHERE foo.c = bar.c AND foo.d = bar.d
-]
+EXPLAIN SELECT * FROM foo JOIN bar USING (a,b) WHERE foo.c = bar.c AND foo.d = bar.d
 ----
 render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  c
- │              render 3  d
- │              render 4  c
- │              render 5  d
  └── join       ·         ·
       │         type      inner
       │         equality  (a, c) = (a, c)
@@ -1412,9 +1385,7 @@ CREATE TABLE zigzag (
 
 # No zigzag join should be planned if experimental_enable_zigzag_join is false.
 query TTT
-SELECT tree, field, description FROM [
-EXPLAIN (VERBOSE) SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
-]
+EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ----
 filter           ·       ·
  │               filter  c = 6.0
@@ -1430,9 +1401,7 @@ SET experimental_enable_zigzag_join = true
 
 # Simple zigzag case - fixed columns, output cols from indexes only.
 query TTT
-SELECT tree, field, description FROM [
-EXPLAIN (VERBOSE) SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
-]
+EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ----
 zigzag-join  ·          ·
  │           type       inner
@@ -1447,9 +1416,7 @@ zigzag-join  ·          ·
 
 # Zigzag join nested inside a lookup.
 query TTT
-SELECT tree, field, description FROM [
-EXPLAIN (VERBOSE) SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0
-]
+EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0
 ----
 lookup-join       ·          ·
  │                table      zigzag@primary
@@ -1466,9 +1433,7 @@ lookup-join       ·          ·
 
 # Zigzag join nested inside a lookup, with an on condition on lookup join.
 query TTT
-SELECT tree, field, description FROM [
-EXPLAIN (VERBOSE) SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0 AND d > 4
-]
+EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0 AND d > 4
 ----
 lookup-join       ·          ·
  │                table      zigzag@primary
@@ -1483,3 +1448,47 @@ lookup-join       ·          ·
       └── scan    ·          ·
 ·                 table      zigzag@c_idx
 ·                 fixedvals  1 column
+
+# Test that we can force a merge join.
+query TTT
+EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn USING(x)
+----
+render               ·               ·
+ └── join            ·               ·
+      │              type            inner
+      │              equality        (x) = (x)
+      │              mergeJoinOrder  +"(x=x)"
+      ├── sort       ·               ·
+      │    │         order           +x
+      │    └── scan  ·               ·
+      │              table           onecolumn@primary
+      │              spans           ALL
+      └── sort       ·               ·
+           │         order           +x
+           └── scan  ·               ·
+·                    table           twocolumn@primary
+·                    spans           ALL
+
+statement error LOOKUP can only be used with INNER or LEFT joins
+EXPLAIN SELECT * FROM onecolumn RIGHT LOOKUP JOIN twocolumn USING(x)
+
+statement error could not produce a query plan conforming to the LOOKUP JOIN hint
+EXPLAIN SELECT * FROM onecolumn INNER LOOKUP JOIN twocolumn USING(x)
+
+statement error could not produce a query plan conforming to the MERGE JOIN hint
+EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn ON onecolumn.x > twocolumn.y
+
+# Test that we can force a hash join (instead of merge join).
+query TTT
+EXPLAIN SELECT * FROM cards LEFT OUTER HASH JOIN customers ON customers.id = cards.cust
+----
+join       ·                   ·
+ │         type                inner
+ │         equality            (cust) = (id)
+ │         right cols are key  ·
+ ├── scan  ·                   ·
+ │         table               cards@primary
+ │         spans               ALL
+ └── scan  ·                   ·
+·          table               customers@primary
+·          spans               ALL

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -573,3 +573,34 @@ render            ·         ·            (d, e, f, a, b, c)  ·
       └── scan    ·         ·            (a, b, c)           +a
 ·                 table     abc@primary  ·                   ·
 ·                 spans     ALL          ·                   ·
+
+# Test that we don't get a lookup join if we force a merge join.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM def INNER MERGE JOIN abc ON a=f ORDER BY a
+----
+join       ·               ·            (d, e, f, a, b, c)  +f
+ │         type            inner        ·                   ·
+ │         equality        (f) = (a)    ·                   ·
+ │         mergeJoinOrder  +"(f=a)"     ·                   ·
+ ├── scan  ·               ·            (d, e, f)           +f
+ │         table           def@primary  ·                   ·
+ │         spans           ALL          ·                   ·
+ └── scan  ·               ·            (a, b, c)           +a
+·          table           abc@primary  ·                   ·
+·          spans           ALL          ·                   ·
+
+# Test that we don't get a lookup join if we force a hash join.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM def INNER HASH JOIN abc ON a=f ORDER BY a
+----
+sort            ·         ·            (d, e, f, a, b, c)  +f
+ │              order     +f           ·                   ·
+ └── join       ·         ·            (d, e, f, a, b, c)  ·
+      │         type      inner        ·                   ·
+      │         equality  (f) = (a)    ·                   ·
+      ├── scan  ·         ·            (d, e, f)           ·
+      │         table     def@primary  ·                   ·
+      │         spans     ALL          ·                   ·
+      └── scan  ·         ·            (a, b, c)           ·
+·               table     abc@primary  ·                   ·
+·               spans     ALL          ·                   ·

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -356,6 +356,14 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 	case *CreateTableExpr:
 		tp.Child(t.Syntax.String())
+
+	default:
+		if opt.IsJoinOp(t) {
+			p := t.Private().(*JoinPrivate)
+			if !p.Flags.Empty() {
+				tp.Childf("flags: %s", p.Flags.String())
+			}
+		}
 	}
 
 	if !f.HasFlags(ExprFmtHideMiscProps) {
@@ -832,7 +840,7 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		}
 
 	case *JoinPrivate:
-		// TODO(radu): add code here when we add fields to JoinPrivate.
+		// Nothing to show; flags are shown separately.
 
 	case *ExplainPrivate, *opt.ColSet, *opt.ColList, *SetPrivate, types.T:
 		// Don't show anything, because it's mostly redundant.

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -472,6 +472,12 @@ func (h *hasher) HashScanFlags(val ScanFlags) {
 	h.HashUint64(uint64(val.Index))
 }
 
+func (h *hasher) HashJoinFlags(val JoinFlags) {
+	h.HashBool(val.DisallowHashJoin)
+	h.HashBool(val.DisallowMergeJoin)
+	h.HashBool(val.DisallowLookupJoin)
+}
+
 func (h *hasher) HashExplainOptions(val tree.ExplainOptions) {
 	h.HashColSet(val.Flags)
 	h.HashUint64(uint64(val.Mode))
@@ -730,6 +736,10 @@ func (h *hasher) IsScanLimitEqual(l, r ScanLimit) bool {
 }
 
 func (h *hasher) IsScanFlagsEqual(l, r ScanFlags) bool {
+	return l == r
+}
+
+func (h *hasher) IsJoinFlagsEqual(l, r JoinFlags) bool {
 	return l == r
 }
 

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -229,6 +229,8 @@ define AntiJoin {
 # variants, but excluding IndexJoin, LookupJoin, MergeJoin.
 [Private]
 define JoinPrivate {
+    # Flags modify what type of join we choose.
+    Flags JoinFlags
 }
 
 # IndexJoin represents an inner join between an input expression and a primary

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -3200,3 +3200,43 @@ build
 SELECT * FROM foo JOIN bar ON max(foo.c) < 2
 ----
 error: max(): aggregate functions are not allowed in ON
+
+# Verify join hints get populated.
+build
+SELECT * FROM onecolumn AS a(x) INNER MERGE JOIN onecolumn AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: x:1(int!null) y:3(int!null)
+ └── inner-join
+      ├── columns: x:1(int!null) a.rowid:2(int!null) y:3(int!null) b.rowid:4(int!null)
+      ├── flags: no-lookup-join;no-hash-join
+      ├── scan a
+      │    └── columns: x:1(int) a.rowid:2(int!null)
+      ├── scan b
+      │    └── columns: y:3(int) b.rowid:4(int!null)
+      └── filters
+           └── eq [type=bool]
+                ├── variable: x [type=int]
+                └── variable: y [type=int]
+
+build
+SELECT * FROM onecolumn AS a NATURAL LEFT LOOKUP JOIN onecolumn as b USING(x)
+----
+error (42601): syntax error at or near "using"
+
+build
+SELECT * FROM onecolumn AS a(x) FULL OUTER HASH JOIN onecolumn AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: x:1(int) y:3(int)
+ └── full-join
+      ├── columns: x:1(int) a.rowid:2(int) y:3(int) b.rowid:4(int)
+      ├── flags: no-lookup-join;no-merge-join
+      ├── scan a
+      │    └── columns: x:1(int) a.rowid:2(int!null)
+      ├── scan b
+      │    └── columns: y:3(int) b.rowid:4(int!null)
+      └── filters
+           └── eq [type=bool]
+                ├── variable: x [type=int]
+                └── variable: y [type=int]

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -159,6 +159,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"TupleOrdinal":   {fullName: "memo.TupleOrdinal", passByVal: true},
 		"ScanLimit":      {fullName: "memo.ScanLimit", passByVal: true},
 		"ScanFlags":      {fullName: "memo.ScanFlags", passByVal: true},
+		"JoinFlags":      {fullName: "memo.JoinFlags", passByVal: true},
 		"ExplainOptions": {fullName: "tree.ExplainOptions", passByVal: true},
 		"StatementType":  {fullName: "tree.StatementType", passByVal: true},
 		"ShowTraceType":  {fullName: "tree.ShowTraceType", passByVal: true},

--- a/pkg/sql/opt/optgen/exprgen/testdata/join
+++ b/pkg/sql/opt/optgen/exprgen/testdata/join
@@ -117,3 +117,46 @@ inner-join (merge)
  │         ├── stats: [rows=1000, distinct(5)=100, null(5)=10]
  │         └── cost: 1070.01
  └── filters (true)
+
+expr
+(InnerJoinApply
+  (Sort (Scan [ (Table "abc") (Cols "a,b,c") ]))
+  (Select
+    (Scan [ (Table "def") (Cols "d,e,f") ])
+    [ (Eq (Var "a") (Plus (Var "d") (Var "e"))) ]
+  )
+  [ ]
+  [ ]
+)
+----
+inner-join-apply
+ ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int) t.public.abc.c:3(int) t.public.def.d:5(int) t.public.def.e:6(int) t.public.def.f:7(int)
+ ├── stats: [rows=333333.333]
+ ├── cost: 5611.37451
+ ├── prune: (7)
+ ├── sort
+ │    ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int) t.public.abc.c:3(int)
+ │    ├── stats: [rows=1000]
+ │    ├── cost: 1179.67784
+ │    └── scan t.public.abc
+ │         ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int) t.public.abc.c:3(int)
+ │         ├── stats: [rows=1000]
+ │         └── cost: 1070.01
+ ├── select
+ │    ├── columns: t.public.def.d:5(int) t.public.def.e:6(int) t.public.def.f:7(int)
+ │    ├── outer: (1)
+ │    ├── stats: [rows=333.333333]
+ │    ├── cost: 1080.02
+ │    ├── prune: (7)
+ │    ├── scan t.public.def
+ │    │    ├── columns: t.public.def.d:5(int) t.public.def.e:6(int) t.public.def.f:7(int)
+ │    │    ├── stats: [rows=1000]
+ │    │    ├── cost: 1070.01
+ │    │    └── prune: (5-7)
+ │    └── filters
+ │         └── eq [type=bool, outer=(1,5,6), constraints=(/1: (/NULL - ])]
+ │              ├── variable: t.public.abc.a [type=int]
+ │              └── plus [type=int]
+ │                   ├── variable: t.public.def.d [type=int]
+ │                   └── variable: t.public.def.e [type=int]
+ └── filters (true)

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -2,34 +2,16 @@
 # join.opt contains exploration rules for the Join operator.
 # =============================================================================
 
-# We don't allow any of the logical join -> logical join rules (CommuteJoin,
-# CommuteLeftJoin, CommuteRightJoin, AssociateJoin) to operate on inputs with
-# no columns. This is because zero-column groups can occur multiple times in
-# the same normalized tree, and exploration can cause group collisions:
-#
-# Let A be the 0-column values node with two rows `VALUES (), ()`,
-# and B be the 0-column values node with three rows `VALUES (), (), ()`.
-#
-# Then consider the following query:
-#
-# (A JOIN B) UNION (B JOIN A)
-#
-# During build, we add `A JOIN B` and `B JOIN A` to *separate memo groups*.
-# Then, during exploration, we apply the `CommuteJoin` rule to transform `A
-# JOIN B` to `B JOIN A`. This attempts to get interned into the same group, but
-# the interner finds that `B JOIN A` already exists in a different group, and
-# panics.
-# TODO(justin): find a more long-term solution to this problem.
-
 # CommuteJoin creates a Join with the left and right inputs swapped. This is
 # useful for other rules that convert joins to other operators (like merge
 # join).
+# If any join hints are specified, we keep the order in the query.
 [CommuteJoin, Explore]
 (InnerJoin | FullJoin
-  $left:*
-  $right:*
-  $on:*
-  $private:*
+    $left:*
+    $right:*
+    $on:*
+    $private:* & (NoJoinHints $private)
 )
 =>
 ((OpName) $right $left $on $private)
@@ -37,10 +19,10 @@
 # CommuteLeftJoin creates a Join with the left and right inputs swapped.
 [CommuteLeftJoin, Explore]
 (LeftJoin
-  $left:*
-  $right:*
-  $on:*
-  $private:*
+    $left:*
+    $right:*
+    $on:*
+    $private:* & (NoJoinHints $private)
 )
 =>
 (RightJoin $right $left $on $private)
@@ -48,10 +30,10 @@
 # CommuteRightJoin creates a Join with the left and right inputs swapped.
 [CommuteRightJoin, Explore]
 (RightJoin
-  $left:*
-  $right:*
-  $on:*
-  $private:*
+    $left:*
+    $right:*
+    $on:*
+    $private:* & (NoJoinHints $private)
 )
 =>
 (LeftJoin $right $left $on $private)
@@ -125,16 +107,18 @@
 # to the logically equivalent expression:
 #   A JOIN (B JOIN C ON B.x = C.x) ON A.y = B.y
 #
-# TODO(radu): handle the scan privates.
+# If any of the joins contains a hint, we do not rearrange the joins.
 [AssociateJoin, Explore]
 (InnerJoin
     $left:(InnerJoin
         $innerLeft:*
         $innerRight:*
         $innerOn:*
+        $innerPrivate:* & (NoJoinHints $innerPrivate)
     )
     $right:* & (ShouldReorderJoins $left $right)
     $on:*
+    $private:* & (NoJoinHints $private)
 )
 =>
 (InnerJoin

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -53,6 +53,76 @@ project
       └── filters
            └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
+# Verify that we pick merge join if we force it.
+opt
+SELECT k, x FROM a INNER MERGE JOIN b ON k=x
+----
+inner-join (merge)
+ ├── columns: k:1(int!null) x:5(int!null)
+ ├── left ordering: +1
+ ├── right ordering: +5
+ ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(5)=100, null(5)=0]
+ ├── cost: 2339.35569
+ ├── fd: (1)==(5), (5)==(1)
+ ├── scan a
+ │    ├── columns: k:1(int!null)
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+ │    ├── cost: 1050.01
+ │    ├── key: (1)
+ │    └── ordering: +1
+ ├── sort
+ │    ├── columns: x:5(int)
+ │    ├── stats: [rows=1000, distinct(5)=100, null(5)=10]
+ │    ├── cost: 1259.33569
+ │    ├── ordering: +5
+ │    └── scan b
+ │         ├── columns: x:5(int)
+ │         ├── stats: [rows=1000, distinct(5)=100, null(5)=10]
+ │         └── cost: 1040.01
+ └── filters (true)
+
+# Verify that we pick lookup join if we force it. Note that lookup join is only
+# possible if b is the left table.
+opt
+SELECT k, x FROM b INNER LOOKUP JOIN a ON k=x
+----
+inner-join (lookup a)
+ ├── columns: k:4(int!null) x:1(int!null)
+ ├── key columns: [1] = [4]
+ ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(4)=100, null(4)=0]
+ ├── cost: 6090.02
+ ├── fd: (1)==(4), (4)==(1)
+ ├── scan b
+ │    ├── columns: x:1(int)
+ │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    └── cost: 1040.01
+ └── filters (true)
+
+
+# Verify that if we force lookup join but one isn't possible, the hash join has
+# huge cost (this will result in an error if we try to execbuild the result).
+opt
+SELECT k, x FROM a INNER LOOKUP JOIN b ON k=x
+----
+inner-join
+ ├── columns: k:1(int!null) x:5(int!null)
+ ├── flags: no-merge-join;no-hash-join
+ ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(5)=100, null(5)=0]
+ ├── cost: 1e+100
+ ├── fd: (1)==(5), (5)==(1)
+ ├── scan a
+ │    ├── columns: k:1(int!null)
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+ │    ├── cost: 1050.01
+ │    └── key: (1)
+ ├── scan b
+ │    ├── columns: x:5(int)
+ │    ├── stats: [rows=1000, distinct(5)=100, null(5)=10]
+ │    └── cost: 1040.01
+ └── filters
+      └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+
+
 exec-ddl
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX c_idx (c))
 ----
@@ -77,7 +147,7 @@ ALTER TABLE abc INJECT STATISTICS '[
 ]'
 ----
 
-# Check that we choose the lookup join when it makes sense.
+# Check that we choose the index join when it makes sense.
 opt
 SELECT * FROM abc WHERE c = 1
 ----

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -216,6 +216,28 @@ full-join
  └── filters
       └── a = z [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
 
+# Verify that we don't commute joins if there's a hint.
+memo
+SELECT * FROM abc INNER HASH JOIN xyz ON a=z
+----
+memo (optimized, ~7KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+ ├── G1: (inner-join G2 G3 G4)
+ │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
+ │         ├── best: (inner-join G2 G3 G4)
+ │         └── cost: 2270.03
+ ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
+ │    └── []
+ │         ├── best: (scan abc,cols=(1-3))
+ │         └── cost: 1070.01
+ ├── G3: (scan xyz,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@yz,cols=(5-7))
+ │    └── []
+ │         ├── best: (scan xyz,cols=(5-7))
+ │         └── cost: 1070.01
+ ├── G4: (filters G5)
+ ├── G5: (eq G6 G7)
+ ├── G6: (variable a)
+ └── G7: (variable z)
+
 # --------------------------------------------------
 # CommuteLeftJoin
 # --------------------------------------------------
@@ -262,6 +284,35 @@ right-join
  │    └── fd: ()-->(2)
  └── filters
       └── a = z [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+
+# Verify that we don't commute joins if there's a hint.
+memo
+SELECT * FROM abc LEFT OUTER MERGE JOIN xyz ON a=z
+----
+memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+ ├── G1: (left-join G2 G3 G4) (merge-join G2 G3 G5 left-join,+1,+7)
+ │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
+ │         ├── best: (merge-join G2="[ordering: +1]" G3="[ordering: +7]" G5 left-join,+1,+7)
+ │         └── cost: 2479.36
+ ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
+ │    ├── [ordering: +1]
+ │    │    ├── best: (scan abc@ab,cols=(1-3))
+ │    │    └── cost: 1070.01
+ │    └── []
+ │         ├── best: (scan abc,cols=(1-3))
+ │         └── cost: 1070.01
+ ├── G3: (scan xyz,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@yz,cols=(5-7))
+ │    ├── [ordering: +7]
+ │    │    ├── best: (sort G3)
+ │    │    └── cost: 1289.34
+ │    └── []
+ │         ├── best: (scan xyz,cols=(5-7))
+ │         └── cost: 1070.01
+ ├── G4: (filters G6)
+ ├── G5: (filters)
+ ├── G6: (eq G7 G8)
+ ├── G7: (variable a)
+ └── G8: (variable z)
 
 # --------------------------------------------------
 # CommuteRightJoin
@@ -310,6 +361,29 @@ left-join
  └── filters
       └── a = z [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
 
+# Verify that we don't commute joins if there's a hint.
+memo
+SELECT * FROM abc RIGHT HASH JOIN xyz ON a=z
+----
+memo (optimized, ~7KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+ ├── G1: (right-join G2 G3 G4)
+ │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
+ │         ├── best: (right-join G2 G3 G4)
+ │         └── cost: 2270.03
+ ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
+ │    └── []
+ │         ├── best: (scan abc,cols=(1-3))
+ │         └── cost: 1070.01
+ ├── G3: (scan xyz,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@yz,cols=(5-7))
+ │    └── []
+ │         ├── best: (scan xyz,cols=(5-7))
+ │         └── cost: 1070.01
+ ├── G4: (filters G5)
+ ├── G5: (eq G6 G7)
+ ├── G6: (variable a)
+ └── G7: (variable z)
+
+
 # --------------------------------------------------
 # GenerateMergeJoins
 # --------------------------------------------------
@@ -357,6 +431,28 @@ memo (optimized, ~10KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
  ├── G6: (eq G7 G8)
  ├── G7: (variable a)
  └── G8: (variable x)
+
+# Verify that we don't generate merge joins if there's a hint that says otherwise.
+memo
+SELECT * FROM abc INNER HASH JOIN xyz ON a=x
+----
+memo (optimized, ~7KB, required=[presentation: a:1,b:2,c:3,x:5,y:6,z:7])
+ ├── G1: (inner-join G2 G3 G4)
+ │    └── [presentation: a:1,b:2,c:3,x:5,y:6,z:7]
+ │         ├── best: (inner-join G2 G3 G4)
+ │         └── cost: 2270.03
+ ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
+ │    └── []
+ │         ├── best: (scan abc,cols=(1-3))
+ │         └── cost: 1070.01
+ ├── G3: (scan xyz,cols=(5-7)) (scan xyz@xy,cols=(5-7)) (scan xyz@yz,cols=(5-7))
+ │    └── []
+ │         ├── best: (scan xyz,cols=(5-7))
+ │         └── cost: 1070.01
+ ├── G4: (filters G5)
+ ├── G5: (eq G6 G7)
+ ├── G6: (variable a)
+ └── G7: (variable x)
 
 opt
 SELECT * FROM abc JOIN xyz ON x=a
@@ -1140,6 +1236,28 @@ Source expression:
 No new expressions.
 ----
 ----
+
+# Verify we don't generate lookup joins if there is a hint that says otherwise.
+memo
+SELECT a,b,n,m FROM small INNER HASH JOIN abcd ON a=m
+----
+memo (optimized, ~7KB, required=[presentation: a:4,b:5,n:2,m:1])
+ ├── G1: (inner-join G2 G3 G4)
+ │    └── [presentation: a:4,b:5,n:2,m:1]
+ │         ├── best: (inner-join G2 G3 G4)
+ │         └── cost: 1079.15
+ ├── G2: (scan small,cols=(1,2))
+ │    └── []
+ │         ├── best: (scan small,cols=(1,2))
+ │         └── cost: 10.51
+ ├── G3: (scan abcd,cols=(4,5)) (scan abcd@secondary,cols=(4,5))
+ │    └── []
+ │         ├── best: (scan abcd@secondary,cols=(4,5))
+ │         └── cost: 1050.01
+ ├── G4: (filters G5)
+ ├── G5: (eq G6 G7)
+ ├── G6: (variable a)
+ └── G7: (variable m)
 
 # --------------------------------------------------
 # GenerateLookupJoinsWithFilter

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -355,7 +355,7 @@ memo (optimized, ~11KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,
 memo join-limit=4
 SELECT * FROM bx, cy, dz, abc WHERE a = 1
 ----
-memo (optimized, ~25KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])
+memo (optimized, ~26KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G4) (inner-join G7 G8 G4) (inner-join G9 G10 G4) (inner-join G11 G12 G4) (inner-join G13 G14 G4) (inner-join G15 G16 G4) (inner-join G6 G5 G4) (inner-join G8 G7 G4) (inner-join G10 G9 G4) (inner-join G12 G11 G4) (inner-join G14 G13 G4) (inner-join G16 G15 G4)
  │    └── [presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10]
  │         ├── best: (inner-join G3 G2 G4)

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -920,13 +920,18 @@ func TestParse(t *testing.T) {
 
 		{`SELECT a FROM t1 JOIN t2 ON a = b`},
 		{`SELECT a FROM t1 JOIN t2 USING (a)`},
+		{`SELECT a FROM t1 INNER MERGE JOIN t2 USING (a)`},
 		{`SELECT a FROM t1 LEFT JOIN t2 ON a = b`},
+		{`SELECT a FROM t1 LEFT LOOKUP JOIN t2 ON a = b`},
 		{`SELECT a FROM t1 RIGHT JOIN t2 ON a = b`},
 		{`SELECT a FROM t1 INNER JOIN t2 ON a = b`},
+		{`SELECT a FROM t1 INNER HASH JOIN t2 ON a = b`},
 		{`SELECT a FROM t1 CROSS JOIN t2`},
 		{`SELECT a FROM t1 NATURAL JOIN t2`},
+		{`SELECT a FROM t1 NATURAL INNER MERGE JOIN t2`},
 		{`SELECT a FROM t1 INNER JOIN t2 USING (a)`},
 		{`SELECT a FROM t1 FULL JOIN t2 USING (a)`},
+		{`SELECT a FROM t1 FULL MERGE JOIN t2 USING (a)`},
 		{`SELECT * FROM (t1 WITH ORDINALITY AS o1 CROSS JOIN t2 WITH ORDINALITY AS o2) WITH ORDINALITY AS o3`},
 
 		{`SELECT a FROM t1 AS OF SYSTEM TIME '2016-01-01'`},
@@ -1415,6 +1420,8 @@ func TestParse2(t *testing.T) {
 			`SELECT a FROM t1 LEFT JOIN t2 ON a = b`},
 		{`SELECT a FROM t1 RIGHT OUTER JOIN t2 ON a = b`,
 			`SELECT a FROM t1 RIGHT JOIN t2 ON a = b`},
+		{`SELECT a FROM t1 RIGHT OUTER MERGE JOIN t2 ON a = b`,
+			`SELECT a FROM t1 RIGHT MERGE JOIN t2 ON a = b`},
 		// Some functions are nearly keywords.
 		{`SELECT CURRENT_SCHEMA`,
 			`SELECT current_schema()`},

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -402,20 +402,27 @@ func StripTableParens(expr TableExpr) TableExpr {
 
 // JoinTableExpr represents a TableExpr that's a JOIN operation.
 type JoinTableExpr struct {
-	Join  string
-	Left  TableExpr
-	Right TableExpr
-	Cond  JoinCond
+	JoinType string
+	Left     TableExpr
+	Right    TableExpr
+	Cond     JoinCond
+	Hint     string
 }
 
 // JoinTableExpr.Join
 const (
-	AstJoin      = "JOIN"
-	AstFullJoin  = "FULL JOIN"
-	AstLeftJoin  = "LEFT JOIN"
-	AstRightJoin = "RIGHT JOIN"
-	AstCrossJoin = "CROSS JOIN"
-	AstInnerJoin = "INNER JOIN"
+	AstFull  = "FULL"
+	AstLeft  = "LEFT"
+	AstRight = "RIGHT"
+	AstCross = "CROSS"
+	AstInner = "INNER"
+)
+
+// JoinTableExpr.Hint
+const (
+	AstHash   = "HASH"
+	AstLookup = "LOOKUP"
+	AstMerge  = "MERGE"
 )
 
 // Format implements the NodeFormatter interface.
@@ -426,13 +433,27 @@ func (node *JoinTableExpr) Format(ctx *FmtCtx) {
 		// Natural joins have a different syntax: "<a> NATURAL <join_type> <b>"
 		ctx.FormatNode(node.Cond)
 		ctx.WriteByte(' ')
-		ctx.WriteString(node.Join)
-		ctx.WriteByte(' ')
+		if node.JoinType != "" {
+			ctx.WriteString(node.JoinType)
+			ctx.WriteByte(' ')
+			if node.Hint != "" {
+				ctx.WriteString(node.Hint)
+				ctx.WriteByte(' ')
+			}
+		}
+		ctx.WriteString("JOIN ")
 		ctx.FormatNode(node.Right)
 	} else {
-		// General syntax: "<a> <join_type> <b> <condition>"
-		ctx.WriteString(node.Join)
-		ctx.WriteByte(' ')
+		// General syntax: "<a> <join_type> [<join_hint>] JOIN <b> <condition>"
+		if node.JoinType != "" {
+			ctx.WriteString(node.JoinType)
+			ctx.WriteByte(' ')
+			if node.Hint != "" {
+				ctx.WriteString(node.Hint)
+				ctx.WriteByte(' ')
+			}
+		}
+		ctx.WriteString("JOIN ")
 		ctx.FormatNode(node.Right)
 		if node.Cond != nil {
 			ctx.WriteByte(' ')

--- a/pkg/sql/sqlbase/join_type.go
+++ b/pkg/sql/sqlbase/join_type.go
@@ -37,16 +37,16 @@ const (
 // statement (e.g. "INNER JOIN") and returns the JoinType.
 func JoinTypeFromAstString(joinStr string) JoinType {
 	switch joinStr {
-	case tree.AstJoin, tree.AstInnerJoin, tree.AstCrossJoin:
+	case "", tree.AstInner, tree.AstCross:
 		return InnerJoin
 
-	case tree.AstLeftJoin:
+	case tree.AstLeft:
 		return LeftOuterJoin
 
-	case tree.AstRightJoin:
+	case tree.AstRight:
 		return RightOuterJoin
 
-	case tree.AstFullJoin:
+	case tree.AstFull:
 		return FullOuterJoin
 
 	default:


### PR DESCRIPTION
Adding syntax to force a certain type of join (`HASH`, `MERGE`, or
`LOOKUP`). The syntax is to insert this specifier in-between the join
type (`INNER`, `LEFT`, etc) and the `JOIN` keyword. Note that the hint
cannot be specified with a "bare" `JOIN` (`INNER` must be added in
that case).

This syntax is consistent with the SQL Server syntax (except that they
use `LOOP` instead of `LOOKUP`).

The semantics are as follows:
 - `HASH` forces a hash join; in other words, it disables merge and
   lookup join. A hash join is always possible; even if there are no
   equality columns - we consider the quadratic join a degenerate
   case of the hash join (one bucket).
 - `MERGE` forces a merge join, even if it requires resorting both sides
   of the join.
 - `LOOKUP` forces a lookup join into the right side; the right side
   must be a table with a suitable index. `LOOKUP` can only be used with
   `INNER` and `LEFT` joins.
 - If it is not possible to use the algorithm in the hint, an error is
   returned.
 - When a join hint is specified, the two tables will not be reordered
   by the optimizer.

Release note (sql change): Specific implementations of join can be
forced by inserting `HASH`, `MERGE`, or `LOOKUP` between the type of
join (`INNER | LEFT | RIGHT | FULL`) and the `JOIN` keyword.

CC @awoods187 