### PR TITLE
opt: ensure NULLs folded out of a CASE are typed

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -597,6 +597,42 @@ values
  ├── fd: ()-->(1)
  └── ('one',) [type=tuple{string}]
 
+opt expect=SimplifyCaseWhenConstValue
+SELECT CASE 1 WHEN 2 THEN 'one' END
+----
+values
+ ├── columns: case:1(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,) [type=tuple{string}]
+
+opt expect=SimplifyCaseWhenConstValue
+SELECT CASE 1 WHEN 2 THEN 'one' ELSE NULL END
+----
+values
+ ├── columns: case:1(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,) [type=tuple{string}]
+
+# Regression test for #34930.
+norm
+SELECT
+    CASE
+    WHEN true THEN NULL
+    ELSE -0.41697856420581636
+    END
+    - CASE WHEN NULL THEN 1.4034371360919229 ELSE ln(NULL) END
+----
+values
+ ├── columns: "?column?":1(decimal)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,) [type=tuple{decimal}]
+
 # Verify that a true condition does not remove non-constant expressions
 # proceeding it.
 opt expect=SimplifyCaseWhenConstValue


### PR DESCRIPTION
Fixes #34930.

Previously, we could have two well-typed CASE statements that had a
valid binary overload and thus would pass semantic analysis. However,
via SimplifyCaseWhenConstValue, we could fold away the CASEs, leaving us
with only two untyped NULLs (which will not have a valid overload).

The "right" thing to do might be to change the type-checker to have the
NULLs come in through the AST as typed, but this is a bigger change
since the current AST has no notion of a typed null (there's only a
singleton NULL).

Release note (bug fix): fix a panic that could occur via certain
patterns of folding CASE statements containing NULLs.

cc @mjibson 