### PR TITLE
sql,stats: collect stats on non-index columns too

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2817,5 +2817,7 @@ func TestCreateStatsAfterRestore(t *testing.T) {
 	  FROM [SHOW STATISTICS FOR TABLE "data 2".bank]`,
 		[][]string{
 			{"__auto__", "{id}", "1", "1", "0"},
+			{"__auto__", "{balance}", "1", "1", "0"},
+			{"__auto__", "{payload}", "1", "1", "0"},
 		})
 }

--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -85,7 +85,7 @@ func newSampleAggregator(
 		}
 	}
 
-	rankCol := len(spec.SampledColumnIDs)
+	rankCol := len(input.OutputTypes()) - 5
 	s := &sampleAggregator{
 		spec:         spec,
 		input:        input,

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -20,6 +20,8 @@ FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {a}           1000       10              0
+__auto__         {b}           1000       10              0
+__auto__         {c}           1000       10              0
 __auto__         {d}           1000       0               1000
 
 # Disable automatic stats
@@ -37,6 +39,8 @@ FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {a}           1000       10              0
+__auto__         {b}           1000       10              0
+__auto__         {c}           1000       10              0
 __auto__         {d}           1000       0               1000
 
 # Enable automatic stats
@@ -54,6 +58,10 @@ FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
 statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {a}           1000       10              0
 __auto__         {a}           1000       10              0
+__auto__         {b}           1000       10              0
+__auto__         {b}           1000       10              0
+__auto__         {c}           1000       10              0
+__auto__         {c}           1000       10              0
 __auto__         {d}           1000       0               1000
 __auto__         {d}           1000       1               820
 
@@ -71,6 +79,12 @@ statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {a}           1000       10              0
 __auto__         {a}           1000       10              0
 __auto__         {a}           1010       11              0
+__auto__         {b}           1000       10              0
+__auto__         {b}           1000       10              0
+__auto__         {b}           1010       10              0
+__auto__         {c}           1000       10              0
+__auto__         {c}           1000       10              0
+__auto__         {c}           1010       10              0
 __auto__         {d}           1000       0               1000
 __auto__         {d}           1000       1               820
 __auto__         {d}           1010       2               738
@@ -88,6 +102,14 @@ __auto__         {a}           1000       10              0
 __auto__         {a}           1000       10              0
 __auto__         {a}           1010       11              0
 __auto__         {a}           510        11              0
+__auto__         {b}           1000       10              0
+__auto__         {b}           1000       10              0
+__auto__         {b}           1010       10              0
+__auto__         {b}           510        10              0
+__auto__         {c}           1000       10              0
+__auto__         {c}           1000       10              0
+__auto__         {c}           1010       10              0
+__auto__         {c}           510        5               0
 __auto__         {d}           1000       0               1000
 __auto__         {d}           1000       1               820
 __auto__         {d}           1010       2               738
@@ -97,21 +119,35 @@ __auto__         {d}           510        2               328
 statement ok
 CREATE TABLE copy AS SELECT * FROM data
 
-query TTIII colnames,rowsort,retry
-SELECT statistics_name, column_names, row_count, distinct_count, null_count
+# Distinct count for rowid can be flaky, so don't show it. The estimate is
+# almost always 510, but occasionally it is 509...
+query TTII colnames,rowsort,retry
+SELECT statistics_name, column_names, row_count, null_count
 FROM [SHOW STATISTICS FOR TABLE copy] ORDER BY column_names::STRING, created
 ----
-statistics_name  column_names  row_count  distinct_count  null_count
-__auto__         {a}           510        11              0
+statistics_name  column_names  row_count  null_count
+__auto__         {a}           510        0
+__auto__         {b}           510        0
+__auto__         {c}           510        0
+__auto__         {d}           510        328
+__auto__         {rowid}       510        0
 
 # Test fast path delete.
 statement ok
 DELETE FROM copy WHERE true
 
-query TTIII colnames,rowsort,retry
-SELECT statistics_name, column_names, row_count, distinct_count, null_count
+query TTII colnames,rowsort,retry
+SELECT statistics_name, column_names, row_count, null_count
 FROM [SHOW STATISTICS FOR TABLE copy] ORDER BY column_names::STRING, created
 ----
-statistics_name  column_names  row_count  distinct_count  null_count
-__auto__         {a}           510        11              0
-__auto__         {a}           0          0               0
+statistics_name  column_names  row_count  null_count
+__auto__         {a}           510        0
+__auto__         {a}           0          0
+__auto__         {b}           510        0
+__auto__         {b}           0          0
+__auto__         {c}           510        0
+__auto__         {c}           0          0
+__auto__         {d}           510        328
+__auto__         {d}           0          0
+__auto__         {rowid}       510        0
+__auto__         {rowid}       0          0

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -150,6 +150,8 @@ WHERE statistics_name = 's3'
 column_names  row_count  distinct_count  null_count
 {a}           10000      10              0
 {c}           10000      10              0
+{b}           10000      10              0
+{d}           10000      10              0
 
 # Add indexes, including duplicate index on column c.
 statement ok
@@ -166,8 +168,9 @@ WHERE statistics_name = 's4'
 ----
 column_names  row_count  distinct_count  null_count
 {a}           10000      10              0
-{b}           10000      10              0
 {c}           10000      10              0
+{b}           10000      10              0
+{d}           10000      10              0
 
 statement ok
 DROP INDEX data@c_idx; DROP INDEX data@data_c_b_idx
@@ -175,7 +178,8 @@ DROP INDEX data@c_idx; DROP INDEX data@data_c_b_idx
 statement ok
 CREATE STATISTICS s5 FROM [53]
 
-# We should no longer get stats for column c.
+# We should still get stats for column c, but now column c is added later as a
+# non-index column, resulting in a different ordering of the rows.
 query TIII colnames
 SELECT column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data]
@@ -184,9 +188,10 @@ WHERE statistics_name = 's5'
 column_names  row_count  distinct_count  null_count
 {a}           10000      10              0
 {b}           10000      10              0
+{c}           10000      10              0
+{d}           10000      10              0
 
-# A table with a hidden primary key and no other indexes has default
-# column stats collected on the first non-hidden column.
+# Table with a hidden primary key and no other indexes.
 statement ok
 CREATE TABLE simple (x INT, y INT)
 
@@ -198,7 +203,9 @@ SELECT statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE simple]
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
+default_stat1    {rowid}       0          0               0
 default_stat1    {x}           0          0               0
+default_stat1    {y}           0          0               0
 
 # Add one null row.
 statement ok
@@ -211,14 +218,15 @@ CREATE UNIQUE INDEX ON simple (y) STORING (x)
 statement ok
 CREATE STATISTICS default_stat2 FROM simple
 
-# Now stats are only collected on the index column.
+# Now stats are collected on the index column y before column x.
 query TTIII colnames
 SELECT statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE simple]
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-default_stat1    {x}           0          0               0
+default_stat2    {rowid}       1          1               0
 default_stat2    {y}           1          0               1
+default_stat2    {x}           1          0               1
 
 #
 # Test numeric references
@@ -232,8 +240,9 @@ SELECT statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data]
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-s4               {c}           10000      10              0
 s5               {b}           10000      10              0
+s5               {c}           10000      10              0
+s5               {d}           10000      10              0
 s6               {a}           10000      10              0
 
 # Combine default columns and numeric reference.
@@ -248,6 +257,8 @@ WHERE statistics_name = '__auto__'
 column_names  row_count  distinct_count  null_count
 {a}           10000      10              0
 {b}           10000      10              0
+{c}           10000      10              0
+{d}           10000      10              0
 
 #
 # Test delete stats
@@ -267,31 +278,57 @@ CREATE STATISTICS __auto__ FROM [53];
 # Only the last 4-5 automatic stats should remain for each column.
 query TT colnames
 SELECT statistics_name, column_names
-FROM [SHOW STATISTICS FOR TABLE data]
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY statistics_name, column_names::STRING
 ----
 statistics_name  column_names
-s4               {c}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
 __auto__         {b}
-__auto__         {a}
-__auto__         {a}
-__auto__         {a}
-__auto__         {a}
-__auto__         {a}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
 
 statement ok
 CREATE STATISTICS s7 ON a FROM [53]
 
 query TT colnames
 SELECT statistics_name, column_names
-FROM [SHOW STATISTICS FOR TABLE data]
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY statistics_name, column_names::STRING
 ----
 statistics_name  column_names
-s4               {c}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
 __auto__         {b}
-__auto__         {a}
-__auto__         {a}
-__auto__         {a}
-__auto__         {a}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
 s7               {a}
 
 statement ok
@@ -300,15 +337,28 @@ CREATE STATISTICS s8 ON a FROM [53]
 # s7 is deleted but the automatic stats remain.
 query TT colnames
 SELECT statistics_name, column_names
-FROM [SHOW STATISTICS FOR TABLE data]
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY statistics_name, column_names::STRING
 ----
 statistics_name  column_names
-s4               {c}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
 __auto__         {b}
-__auto__         {a}
-__auto__         {a}
-__auto__         {a}
-__auto__         {a}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
 s8               {a}
 
 # Regression test for #33195.
@@ -316,5 +366,5 @@ statement ok
 CREATE TABLE t (x int); INSERT INTO t VALUES (1); ALTER TABLE t DROP COLUMN x
 
 # Ensure that creating stats on a table with no columns does not cause a panic.
-statement error pq: CREATE STATISTICS called on a table with no visible columns
+statement ok
 CREATE STATISTICS s FROM t

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -71,7 +71,7 @@ func TestCreateStatsControlJob(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 	sqlDB.Exec(t, `CREATE DATABASE d`)
-	sqlDB.Exec(t, `CREATE TABLE d.t (x INT)`)
+	sqlDB.Exec(t, `CREATE TABLE d.t (x INT PRIMARY KEY)`)
 	sqlDB.Exec(t, `INSERT INTO d.t SELECT generate_series(1,1000)`)
 
 	t.Run("cancel", func(t *testing.T) {
@@ -397,7 +397,7 @@ func TestCreateStatsAsOfTime(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 	sqlDB.Exec(t, `CREATE DATABASE d`)
-	sqlDB.Exec(t, `CREATE TABLE d.t (x INT)`)
+	sqlDB.Exec(t, `CREATE TABLE d.t (x INT PRIMARY KEY)`)
 
 	var ts1 []uint8
 	sqlDB.QueryRow(t, `

--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -94,7 +94,7 @@ func (sr *SampleReservoir) SampleRow(row sqlbase.EncDatumRow, rank uint64) error
 		return nil
 	}
 	// Replace the max rank if ours is smaller.
-	if rank < sr.samples[0].Rank {
+	if len(sr.samples) > 0 && rank < sr.samples[0].Rank {
 		if err := sr.copyRow(sr.samples[0].Row, row); err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, the default set of columns for automatic statistics only
included columns that were part of an index. This commit adds up to
100 non-index columns to the set of default column statistics.

In addition, this commit disables collection of histograms for statistics
since we are not currently using histograms in the optimizer.

Release note (sql change): Changed the default set of column statistics
created by CREATE STATISTICS to include up to 100 regular table columns
in addition to all indexed columns.

Release note (sql change): Disabled collection of histograms by CREATE
STATISTICS since they are not currently used by the optimizer.