### PR TITLE
requestbatcher: fix bug when deadline for two batches is exactly equal

### DIFF
--- a/pkg/internal/client/requestbatcher/batcher.go
+++ b/pkg/internal/client/requestbatcher/batcher.go
@@ -132,6 +132,9 @@ type Config struct {
 	// Note that values	less than or equal to zero will result in the use of
 	// DefaultInFlightBackpressureLimit.
 	InFlightBackpressureLimit int
+
+	// NowFunc is used to determine the current time. It defaults to timeutil.Now.
+	NowFunc func() time.Time
 }
 
 const (
@@ -198,6 +201,9 @@ func validateConfig(cfg *Config) {
 	}
 	if cfg.InFlightBackpressureLimit <= 0 {
 		cfg.InFlightBackpressureLimit = DefaultInFlightBackpressureLimit
+	}
+	if cfg.NowFunc == nil {
+		cfg.NowFunc = timeutil.Now
 	}
 }
 
@@ -329,7 +335,7 @@ func (b *RequestBatcher) run(ctx context.Context) {
 			}
 		}
 		handleRequest = func(req *request) {
-			now := timeutil.Now()
+			now := b.cfg.NowFunc()
 			ba, existsInQueue := b.batches.get(req.rangeID)
 			if !existsInQueue {
 				ba = b.pool.newBatch(now)
@@ -350,7 +356,7 @@ func (b *RequestBatcher) run(ctx context.Context) {
 			if next := b.batches.peekFront(); next != nil {
 				nextDeadline = next.deadline
 			}
-			if !deadline.Equal(nextDeadline) {
+			if !deadline.Equal(nextDeadline) || timer.Read {
 				deadline = nextDeadline
 				if !deadline.IsZero() {
 					timer.Reset(time.Until(deadline))
@@ -360,7 +366,6 @@ func (b *RequestBatcher) run(ctx context.Context) {
 					timer.Stop()
 					timer = timeutil.NewTimer()
 				}
-				deadline = nextDeadline
 			}
 		}
 	)
@@ -545,7 +550,11 @@ func (q *batchQueue) Swap(i, j int) {
 }
 
 func (q *batchQueue) Less(i, j int) bool {
-	return q.batches[i].deadline.Before(q.batches[j].deadline)
+	idl, jdl := q.batches[i].deadline, q.batches[j].deadline
+	if before := idl.Before(jdl); before || !idl.Equal(jdl) {
+		return before
+	}
+	return q.batches[i].rangeID() < q.batches[j].rangeID()
 }
 
 func (q *batchQueue) Push(v interface{}) {


### PR DESCRIPTION
The bug presented itself as a cluster which seemed to have stalled nodes. Upon
further investigation it became clear that the stalled nodes were all
attempting to communicate with a single node which was massively blocked
resolving intents. After some reproduction I discovered that the batcher
had a timer with a Read value that was true. The logic indicated that this
would happen if two consecutive batches had exactly the same deadline.

At first this seemed unlikely but it seems to resolve the issue. Previously
the scenario had a tendency to reproduce itself in my setup within 30 minutes
and did so four times for me this evening and a number of times for Andy. I
have been running 2 for the last 45 minutes without a reproduction. Maybe this
scenario is more possible than I had envisioned because of the way go's
monotonic clock works? I'm not really sure. I was surprised that this could be
the bug but the unit test clearly highlights that such an occurrence would be
problematic.

Fixes #35104.

Release note: None