### PR TITLE
build: fixus for various krb5 fallout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ new engineers.
      - CMake 3.1+
      - Autoconf 2.68+
      - NodeJS 6.x and Yarn 1.7+
+     - Yacc or Bison
 
    Note that at least 4GB of RAM is required to build from source and run tests.
 

--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -25,7 +25,8 @@ sudo apt-get install -y --no-install-recommends \
   g++ \
   git \
   nodejs \
-  yarn
+  yarn \
+  bison
 
 sudo adduser "${USER}" docker
 

--- a/pkg/cmd/publish-artifacts/main.go
+++ b/pkg/cmd/publish-artifacts/main.go
@@ -68,6 +68,7 @@ var libsRe = func() *regexp.Regexp {
 		regexp.QuoteMeta("libdl.so."),
 		regexp.QuoteMeta("libm.so."),
 		regexp.QuoteMeta("libc.so."),
+		regexp.QuoteMeta("libresolv.so."),
 		strings.Replace(regexp.QuoteMeta("ld-linux-ARCH.so."), "ARCH", ".*", -1),
 	}, "|")
 	return regexp.MustCompile(libs)

--- a/pkg/cmd/publish-provisional-artifacts/main.go
+++ b/pkg/cmd/publish-provisional-artifacts/main.go
@@ -73,6 +73,7 @@ var libsRe = func() *regexp.Regexp {
 		regexp.QuoteMeta("libdl.so."),
 		regexp.QuoteMeta("libm.so."),
 		regexp.QuoteMeta("libc.so."),
+		regexp.QuoteMeta("libresolv.so."),
 		strings.Replace(regexp.QuoteMeta("ld-linux-ARCH.so."), "ARCH", ".*", -1),
 	}, "|")
 	return regexp.MustCompile(libs)


### PR DESCRIPTION
- list new yacc requirement in contributing
- add yacc to gceworker.sh
- add libresolv to static link ignoring to fix "Publish Bleeding Edge"

Release note: None