### PR TITLE
sql: Fix judgment condition when judging spans overlap.

### DIFF
--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -164,7 +164,7 @@ func makeKVBatchFetcher(
 				// Current span's start key is greater than or equal to the last span's
 				// end key - we're good.
 				continue
-			} else if spans[i].EndKey.Compare(spans[i-1].EndKey) < 0 {
+			} else if spans[i].EndKey.Compare(spans[i-1].Key) < 0 {
 				// Current span's end key is less than or equal to the last span's start
 				// key - also good.
 				continue


### PR DESCRIPTION
The code is to verify the spans do not contain consecutive overlapping spans.
However there is a little mistake in judgement condition:
(We can also find out this mismatch through its comments)

```
if spans[i].Key.Compare(spans[i-1].EndKey) >= 0 {
	// Current span's start key is greater than or equal to the last span's
	// end key - we're good.
	continue
} else if spans[i].EndKey.Compare(spans[i-1].EndKey) < 0 {
	// Current span's end key is less than or equal to the last span's start
	// key - also good.
	continue
}
```

Consider the following case:
there are two spans which contain consecutive overlapping spans: {"C","F"},{"A","E"}.
In this case,the original code can not handle correctly.

Fixes: #35046

Release note (bug fix): Fix the judgment condition so that it can correctly judge the consecutive overlapping spans.