### PR TITLE
kv: generate debug output on marshaling panics

### DIFF
--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -17,7 +17,10 @@ package kv
 
 import (
 	"context"
+	"encoding/hex"
+	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -25,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/opentracing/opentracing-go"
@@ -152,6 +156,34 @@ func (gt *grpcTransport) maybeResurrectRetryablesLocked() bool {
 	return len(resurrect) > 0
 }
 
+func withMarshalingDebugging(ctx context.Context, ba roachpb.BatchRequest, f func()) {
+	nPre := ba.Size()
+	defer func() {
+		nPost := ba.Size()
+		if r := recover(); r != nil || nPre != nPost {
+			var buf strings.Builder
+			_, _ = fmt.Fprintf(&buf, "batch size %d -> %d bytes\n", nPre, nPost)
+			func() {
+				defer func() {
+					if rInner := recover(); rInner != nil {
+						_, _ = fmt.Fprintln(&buf, "panic while re-marshaling:", rInner)
+					}
+				}()
+				data, mErr := protoutil.Marshal(&ba)
+				if mErr != nil {
+					_, _ = fmt.Fprintln(&buf, "while re-marshaling:", mErr)
+				} else {
+					_, _ = fmt.Fprintln(&buf, "re-marshaled protobuf:")
+					_, _ = fmt.Fprintln(&buf, hex.Dump(data))
+				}
+			}()
+			_, _ = fmt.Fprintln(&buf, "original panic: ", r)
+			panic(buf.String())
+		}
+	}()
+	f()
+}
+
 // SendNext invokes the specified RPC on the supplied client when the
 // client is ready. On success, the reply is sent on the channel;
 // otherwise an error is sent.
@@ -165,7 +197,11 @@ func (gt *grpcTransport) SendNext(
 	}
 
 	ba.Replica = client.replica
-	reply, err := gt.sendBatch(ctx, client.replica.NodeID, iface, ba)
+	var reply *roachpb.BatchResponse
+
+	withMarshalingDebugging(ctx, ba, func() {
+		reply, err = gt.sendBatch(ctx, client.replica.NodeID, iface, ba)
+	})
 
 	// NotLeaseHolderErrors can be retried.
 	var retryable bool


### PR DESCRIPTION
We're seeing panics from within gogoproto marshaling that indicate that
we're mutating a protobuf while it's being marshaled (thus increasing
the size necessary to marshal it, which is not reflected in the slice
being marshaled into).

Since we haven't managed to figure this out just by thinking hard, it's
time to add some debugging into the mix.

Since this hasn't popped up during our testrace builds, I assume it's
either rare enough or just not tickled in any of the tests (many of
which don't even run under `race` because things get too slow).

My hope is that looking at the bytes we get ouf of this logging we'll
see something that looks out of place and can trace it down.

Touches #34241.

Release note: None