### PR TITLE
cli/interactive_tests: deflake test_exec_log

### DIFF
--- a/pkg/cli/interactive_tests/test_exec_log.tcl
+++ b/pkg/cli/interactive_tests/test_exec_log.tcl
@@ -42,8 +42,18 @@ eexpect root@
 flush_server_logs
 
 # Now check the items are there in the log file.
-system "grep -q 'hello.*world' $logfile"
-system "grep -q nonexistent $logfile"
+# We need to iterate because flush_server_logs
+# only syncs on flush of cockroach.log, not
+# the exec log.
+system "for i in `seq 1 3`; do
+  grep 'hello.*world' $logfile &&
+  grep nonexistent $logfile &&
+  exit 0;
+  echo still waiting;
+  sleep 1;
+done;
+echo 'server failed to flush exec log?'
+exit 1;"
 system "if grep -q lovely $logfile; then false; fi"
 
 end_test


### PR DESCRIPTION
Fixes #35069.

The test flushes the log files before it tests for existence of some
message in the exec log. However the primitive `flush_server_logs`
only waits for the flush to appear in `cockroach.log`. Since the exec
log is only flushed after that, there is a race condition between the
flush of the exec log and the exit path of `flush_server_logs`,
whereby the remainder of the test could execute "too soon".

This patch makes the test wait longer to find the expected messages in
the exec log.

Release note: None