### PR TITLE
exec: extract spooling phase of sorter into a separate operator

### DIFF
--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -16,7 +16,9 @@ package exec
 
 // Operator is a column vector operator that produces a ColBatch as output.
 type Operator interface {
-	// Init initializes this operator. Will be called once at operator setup time.
+	// Init initializes this operator. Will be called once at operator setup
+	// time. If an operator has an input operator, it's responsible for calling
+	// Init on that input operator as well.
 	Init()
 
 	// Next returns the next ColBatch from this operator. Once the operator is
@@ -34,7 +36,9 @@ type noopOperator struct {
 
 var _ Operator = &noopOperator{}
 
-func (n *noopOperator) Init() {}
+func (n *noopOperator) Init() {
+	n.input.Init()
+}
 
 func (n *noopOperator) Next() ColBatch {
 	return n.input.Next()

--- a/pkg/sql/exec/sort.go
+++ b/pkg/sql/exec/sort.go
@@ -22,10 +22,16 @@ import (
 )
 
 // NewSorter returns a new sort operator, which sorts its input on the columns
-// given in sortColIdxs. The inputTypes must correspond 1-1 with the columns in
-// the input operator.
+// given in orderingCols. The inputTypes must correspond 1-1 with the columns
+// in the input operator.
 func NewSorter(
 	input Operator, inputTypes []types.T, orderingCols []distsqlpb.Ordering_Column,
+) (Operator, error) {
+	return newSorter(newAllSpooler(input, inputTypes), inputTypes, orderingCols)
+}
+
+func newSorter(
+	input spooler, inputTypes []types.T, orderingCols []distsqlpb.Ordering_Column,
 ) (Operator, error) {
 	sorters := make([]colSorter, len(orderingCols))
 	partitioners := make([]partitioner, len(orderingCols)-1)
@@ -60,8 +66,106 @@ func NewSorter(
 	}, nil
 }
 
-type sortOp struct {
+// spooler is a column vector operator that spools the data from its input.
+type spooler interface {
+	// init initializes this spooler and will be called once at the setup time.
+	init()
+	// spool performs the actual spooling.
+	spool()
+	// getValues returns ith ColVec of the already spooled data.
+	getValues(i int) ColVec
+	// getNumTuples returns the number of spooled tuples.
+	getNumTuples() uint64
+	// getPartitionsCol returns a partitions column vector in which every true
+	// value indicates a start of a different partition (i.e. "chunk") within
+	// spooled tuples. It should return nil if all the tuples belong to the same
+	// partition.
+	getPartitionsCol() []bool
+}
+
+// allSpooler is the spooler that spools all tuples from the input. It is used
+// by the general sorter over the whole input.
+type allSpooler struct {
 	input Operator
+
+	// inputTypes contains the types of all of the columns from the input.
+	inputTypes []types.T
+	// values stores all the values from the input after spooling. Each ColVec in
+	// this slice is the entire column from the input.
+	values []ColVec
+	// spooledTuples is the number of tuples spooled.
+	spooledTuples uint64
+	// spooled indicates whether spool() has already been called.
+	spooled bool
+}
+
+func newAllSpooler(input Operator, inputTypes []types.T) spooler {
+	return &allSpooler{
+		input:      input,
+		inputTypes: inputTypes,
+	}
+}
+
+func (p *allSpooler) init() {
+	p.input.Init()
+	p.values = make([]ColVec, len(p.inputTypes))
+	for i := 0; i < len(p.inputTypes); i++ {
+		p.values[i] = newMemColumn(p.inputTypes[i], 0)
+	}
+}
+
+func (p *allSpooler) spool() {
+	if p.spooled {
+		panic("spool() is called for the second time")
+	}
+	p.spooled = true
+	batch := p.input.Next()
+	var nTuples uint64
+	for ; batch.Length() != 0; batch = p.input.Next() {
+		for i := 0; i < len(p.values); i++ {
+			if batch.Selection() == nil {
+				p.values[i].Append(batch.ColVec(i),
+					p.inputTypes[i],
+					nTuples,
+					batch.Length(),
+				)
+			} else {
+				p.values[i].AppendWithSel(batch.ColVec(i),
+					batch.Selection(),
+					batch.Length(),
+					p.inputTypes[i],
+					nTuples,
+				)
+			}
+		}
+		nTuples += uint64(batch.Length())
+	}
+	p.spooledTuples = nTuples
+}
+
+func (p *allSpooler) getValues(i int) ColVec {
+	if !p.spooled {
+		panic("getValues() is called before spool()")
+	}
+	return p.values[i]
+}
+
+func (p *allSpooler) getNumTuples() uint64 {
+	if !p.spooled {
+		panic("getNumTuples() is called before spool()")
+	}
+	return p.spooledTuples
+}
+
+func (p *allSpooler) getPartitionsCol() []bool {
+	if !p.spooled {
+		panic("getPartitionsCol() is called before spool()")
+	}
+	return nil
+}
+
+type sortOp struct {
+	input spooler
 
 	// inputTypes contains the types of all of the columns from input.
 	inputTypes []types.T
@@ -76,21 +180,15 @@ type sortOp struct {
 	isOrderingCol []bool
 	// sorters contains one colSorter per sort column.
 	sorters []colSorter
-	// partitioners contains one partitioner per sort solumn except for the last,
+	// partitioners contains one partitioner per sort column except for the last,
 	// which doesn't need to be partitioned.
 	partitioners []partitioner
 
-	// values stores all the values from the input after spooling. Each ColVec in
-	// this slice is the entire column from the input, since this operator needs
-	// to globally sort its input.
-	values []ColVec
 	// order maintains the order of tuples in the batch, after sorting. The value
 	// at index i in order is the ordinal value of the tuple in the input that
 	// belongs at index i. For example, if the input column to sort was
 	// [c,b,a,d], the order vector after sorting would be [2,1,0,3].
 	order []uint64
-	// spooledTuples is the number of tuples spooled.
-	spooledTuples uint64
 	// emitted is the number of tuples emitted so far.
 	emitted uint64
 	// state is the current state of the sort.
@@ -116,48 +214,51 @@ type colSorter interface {
 }
 
 func (p *sortOp) Init() {
-	p.input.Init()
+	p.input.init()
 	p.output = NewMemBatch(p.inputTypes)
-	p.values = make([]ColVec, len(p.inputTypes))
-	for i := 0; i < len(p.inputTypes); i++ {
-		p.values[i] = newMemColumn(p.inputTypes[i], 0)
-	}
 }
 
 // sortState represents the state of the sort operator.
 type sortState int
 
 const (
-	// sortSpooling is the initial state of the operator, where it must spool all
-	// input data and sort it.
+	// sortSpooling is the initial state of the operator, where it spools its
+	// input.
 	sortSpooling sortState = iota
-	// sortEmitting is the second state of the operator, indicating that each call
-	// to Next will return another chunk of the sorted data.
+	// sortSorting is the second state of the operator, where it actually sorts
+	// all the spooled data.
+	sortSorting
+	// sortEmitting is the third state of the operator, indicating that each call
+	// to Next will return another batch of the sorted data.
 	sortEmitting
 )
 
 func (p *sortOp) Next() ColBatch {
 	switch p.state {
 	case sortSpooling:
-		p.spoolAndSort()
+		p.input.spool()
+		p.state = sortSorting
+		fallthrough
+	case sortSorting:
+		p.sort()
 		p.state = sortEmitting
 		fallthrough
 	case sortEmitting:
 		newEmitted := p.emitted + ColBatchSize
-		if newEmitted > p.spooledTuples {
-			newEmitted = p.spooledTuples
+		if newEmitted > p.input.getNumTuples() {
+			newEmitted = p.input.getNumTuples()
 		}
 		p.output.SetLength(uint16(newEmitted - p.emitted))
 		if p.output.Length() == 0 {
 			return p.output
 		}
 
-		for j := 0; j < len(p.values); j++ {
+		for j := 0; j < len(p.inputTypes); j++ {
 			if p.isOrderingCol[j] {
-				// the vec is already sorted, so just fill it directly.
-				p.output.ColVec(j).Copy(p.values[j], p.emitted, newEmitted, p.inputTypes[j])
+				// The vec is already sorted, so just fill it directly.
+				p.output.ColVec(j).Copy(p.input.getValues(j), p.emitted, newEmitted, p.inputTypes[j])
 			} else {
-				p.output.ColVec(j).CopyWithSelInt64(p.values[j], p.order[p.emitted:], p.output.Length(), p.inputTypes[j])
+				p.output.ColVec(j).CopyWithSelInt64(p.input.getValues(j), p.order[p.emitted:], p.output.Length(), p.inputTypes[j])
 			}
 		}
 		p.emitted = newEmitted
@@ -166,49 +267,32 @@ func (p *sortOp) Next() ColBatch {
 	panic(fmt.Sprintf("invalid sort state %v", p.state))
 }
 
-func (p *sortOp) spoolAndSort() {
-	batch := p.input.Next()
-	var nTuples uint64
-	// First, copy all vecs into values.
-	for ; batch.Length() != 0; batch = p.input.Next() {
-		for i := 0; i < len(p.values); i++ {
-			if batch.Selection() == nil {
-				p.values[i].Append(batch.ColVec(i),
-					p.inputTypes[i],
-					nTuples,
-					batch.Length(),
-				)
-			} else {
-				p.values[i].AppendWithSel(batch.ColVec(i),
-					batch.Selection(),
-					batch.Length(),
-					p.inputTypes[i],
-					nTuples,
-				)
-			}
-		}
-		nTuples += uint64(batch.Length())
-	}
-	p.spooledTuples = nTuples
-
+func (p *sortOp) sort() {
+	spooledTuples := p.input.getNumTuples()
 	// Initialize the order vector to the ordinal positions within the input set.
-	p.order = make([]uint64, nTuples)
+	p.order = make([]uint64, spooledTuples)
 	for i := uint64(0); i < uint64(len(p.order)); i++ {
 		p.order[i] = i
 	}
 
-	workingSpace := make([]uint64, nTuples)
+	workingSpace := make([]uint64, spooledTuples)
 	for i := range p.orderingCols {
-		p.sorters[i].init(p.values[p.orderingCols[i].ColIdx], p.order, workingSpace)
+		p.sorters[i].init(p.input.getValues(int(p.orderingCols[i].ColIdx)), p.order, workingSpace)
 	}
 
-	// Now, sort each column in turn. The first column is doesn't need special
-	// treatment - we just globally sort it.
-
-	p.sorters[0].sort()
-	if len(p.sorters) == 1 {
-		// We're done sorting. Transition to emitting.
-		return
+	// Now, sort each column in turn.
+	sorters := p.sorters
+	partitionsCol := p.input.getPartitionsCol()
+	if partitionsCol == nil {
+		// All spooled tuples belong to the same partition, so the first column
+		// doesn't need special treatment - we just globally sort it.
+		p.sorters[0].sort()
+		if len(p.sorters) == 1 {
+			// We're done sorting. Transition to emitting.
+			return
+		}
+		sorters = sorters[1:]
+		partitionsCol = make([]bool, spooledTuples)
 	}
 
 	// The rest of the columns need p sorts, one per partition in the previous
@@ -233,17 +317,16 @@ func (p *sortOp) spoolAndSort() {
 	// 2 a
 	// 2 b
 
-	outputCol := make([]bool, nTuples)
 	partitions := make([]uint64, 0, 16)
-	for i, sorter := range p.sorters[1:] {
+	for i, sorter := range sorters {
 		// We partition the previous column by running an ordered distinct operation
 		// on it, ORing the results together with each subsequent column. This
 		// produces a distinct vector (a boolean vector that has true in each
 		// position that is different from the last position).
-		p.partitioners[i].partition(p.values[p.orderingCols[i].ColIdx], outputCol, nTuples)
+		p.partitioners[i].partition(p.input.getValues(int(p.orderingCols[i].ColIdx)), partitionsCol, spooledTuples)
 		// Convert the distinct vector into a selection vector - a vector of indices
 		// that were true in the distinct vector.
-		partitions = boolVecToSel64(outputCol, partitions[:0])
+		partitions = boolVecToSel64(partitionsCol, partitions[:0])
 		// Reorder the column we're about to sort, based on the swaps we've seen in
 		// the sort so far.
 		sorter.reorder()

--- a/pkg/sql/exec/sort_test.go
+++ b/pkg/sql/exec/sort_test.go
@@ -182,6 +182,72 @@ func TestSortRandomized(t *testing.T) {
 	})
 }
 
+func TestAllSpooler(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tcs := []struct {
+		tuples tuples
+		typ    []types.T
+	}{
+		{
+			tuples: tuples{{1}, {2}, {3}, {4}, {5}, {6}, {7}},
+			typ:    []types.T{types.Int64},
+		},
+		{
+			tuples: tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
+			typ:    []types.T{types.Int64},
+		},
+		{
+			tuples: tuples{{1, 1}, {3, 2}, {2, 3}, {4, 4}, {5, 5}, {6, 6}, {7, 7}},
+			typ:    []types.T{types.Int64, types.Int64},
+		},
+		{
+			tuples: tuples{{1, 1}, {5, 2}, {3, 3}, {7, 4}, {2, 5}, {6, 6}, {4, 7}},
+			typ:    []types.T{types.Int64, types.Int64},
+		},
+		{
+			tuples: tuples{{1}, {5}, {3}, {3}, {2}, {6}, {4}},
+			typ:    []types.T{types.Int64},
+		},
+		{
+			tuples: tuples{{0, 1, 0}, {1, 2, 0}, {2, 3, 2}, {3, 7, 1}, {4, 2, 2}},
+			typ:    []types.T{types.Int64, types.Int64, types.Int64},
+		},
+		{
+			tuples: tuples{
+				{0, 1, 0},
+				{0, 1, 0},
+				{0, 1, 1},
+				{0, 0, 1},
+				{0, 0, 0},
+			},
+			typ: []types.T{types.Int64, types.Int64, types.Int64},
+		},
+	}
+	for _, tc := range tcs {
+		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
+			allSpooler := newAllSpooler(input[0], tc.typ)
+			allSpooler.init()
+			allSpooler.spool()
+			if len(tc.tuples) != int(allSpooler.getNumTuples()) {
+				t.Fatal(fmt.Sprintf("allSpooler spooled wrong number of tuples: expected %d, but received %d", len(tc.tuples), allSpooler.getNumTuples()))
+			}
+			if allSpooler.getPartitionsCol() != nil {
+				t.Fatal("allSpooler returned non-nil partitionsCol")
+			}
+			for col := 0; col < len(tc.typ); col++ {
+				colVec := allSpooler.getValues(col).Int64()
+				for i := 0; i < int(allSpooler.getNumTuples()); i++ {
+					if colVec[i] != int64(tc.tuples[i][col].(int)) {
+						t.Fatal(fmt.Sprintf("allSpooler returned wrong value in %d column of %d'th tuple : expected %v, but received %v",
+							col, i, tc.tuples[i][col].(int), colVec[i]))
+					}
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkSort(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 
@@ -203,8 +269,8 @@ func BenchmarkSort(b *testing.B) {
 					ordCols[i].Direction = distsqlpb.Ordering_Column_Direction(rng.Int() % 2)
 
 					col := batch.ColVec(i).Int64()
-					for j := 0; i < ColBatchSize; i++ {
-						col[j] = rng.Int63() % int64((j*1024)+1)
+					for j := 0; j < ColBatchSize; j++ {
+						col[j] = rng.Int63() % int64((i*1024)+1)
 					}
 				}
 				b.ResetTimer()
@@ -222,6 +288,39 @@ func BenchmarkSort(b *testing.B) {
 							b.Fail()
 						}
 					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkAllSpooler(b *testing.B) {
+	rng, _ := randutil.NewPseudoRand()
+
+	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
+		for _, nCols := range []int{1, 2, 4} {
+			b.Run(fmt.Sprintf("rows=%d/cols=%d", nBatches*ColBatchSize, nCols), func(b *testing.B) {
+				// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+				// batch) * nCols (number of columns / row).
+				b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols))
+				typs := make([]types.T, nCols)
+				for i := range typs {
+					typs[i] = types.Int64
+				}
+				batch := NewMemBatch(typs)
+				batch.SetLength(ColBatchSize)
+				for i := 0; i < nCols; i++ {
+					col := batch.ColVec(i).Int64()
+					for j := 0; j < ColBatchSize; j++ {
+						col[j] = rng.Int63() % int64((i*1024)+1)
+					}
+				}
+				b.ResetTimer()
+				for n := 0; n < b.N; n++ {
+					source := newFiniteBatchSource(batch, nBatches)
+					allSpooler := newAllSpooler(source, typs)
+					allSpooler.init()
+					allSpooler.spool()
 				}
 			})
 		}


### PR DESCRIPTION
Extracting spooling phase into a separate operator will allow us
to efficiently reuse sorting logic for sort chunks operator. The
benchmarks show no significant changes due to additional function
calls instead of accessing variables directly.

Before (with benchmark bug fixed):
```
BenchmarkSort/rows=2048/cols=1-12         	  100000	     18616 ns/op	 880.06 MB/s
BenchmarkSort/rows=2048/cols=2-12         	   10000	    122138 ns/op	 268.29 MB/s
BenchmarkSort/rows=2048/cols=4-12         	   10000	    210499 ns/op	 311.34 MB/s
BenchmarkSort/rows=16384/cols=1-12        	   10000	    147420 ns/op	 889.10 MB/s
BenchmarkSort/rows=16384/cols=2-12        	    2000	   1008754 ns/op	 259.87 MB/s
BenchmarkSort/rows=16384/cols=4-12        	    1000	   1693625 ns/op	 309.57 MB/s
BenchmarkSort/rows=262144/cols=1-12       	     500	   2361441 ns/op	 888.08 MB/s
BenchmarkSort/rows=262144/cols=2-12       	     100	  13967882 ns/op	 300.28 MB/s
BenchmarkSort/rows=262144/cols=4-12       	      50	  30452824 ns/op	 275.46 MB/s
```
After (with benchmark bug fixed):
```
BenchmarkSort/rows=2048/cols=1-12         	  100000	     18557 ns/op	 882.87 MB/s
BenchmarkSort/rows=2048/cols=2-12         	   10000	    123117 ns/op	 266.15 MB/s
BenchmarkSort/rows=2048/cols=4-12         	   10000	    211704 ns/op	 309.56 MB/s
BenchmarkSort/rows=16384/cols=1-12        	   10000	    149049 ns/op	 879.38 MB/s
BenchmarkSort/rows=16384/cols=2-12        	    2000	   1014123 ns/op	 258.49 MB/s
BenchmarkSort/rows=16384/cols=4-12        	    1000	   1670286 ns/op	 313.89 MB/s
BenchmarkSort/rows=262144/cols=1-12       	     500	   2379547 ns/op	 881.32 MB/s
BenchmarkSort/rows=262144/cols=2-12       	     100	  14311793 ns/op	 293.07 MB/s
BenchmarkSort/rows=262144/cols=4-12       	      50	  29759557 ns/op	 281.88 MB/s
```
And here is the benchmark of allSpooler:
```
BenchmarkAllSpooler/rows=2048/cols=1-12         	  200000	      6366 ns/op	2573.52 MB/s
BenchmarkAllSpooler/rows=2048/cols=2-12         	  100000	     12125 ns/op	2702.37 MB/s
BenchmarkAllSpooler/rows=2048/cols=4-12         	  100000	     23711 ns/op	2763.85 MB/s
BenchmarkAllSpooler/rows=16384/cols=1-12        	   20000	     71757 ns/op	1826.61 MB/s
BenchmarkAllSpooler/rows=16384/cols=2-12        	   10000	    149136 ns/op	1757.74 MB/s
BenchmarkAllSpooler/rows=16384/cols=4-12        	    5000	    319455 ns/op	1641.19 MB/s
BenchmarkAllSpooler/rows=262144/cols=1-12       	    1000	   1407761 ns/op	1489.71 MB/s
BenchmarkAllSpooler/rows=262144/cols=2-12       	     500	   2794163 ns/op	1501.09 MB/s
BenchmarkAllSpooler/rows=262144/cols=4-12       	     300	   5278886 ns/op	1589.09 MB/s
```

Release note: None