### PR TITLE
opt: restrict use of PREPARE AS OPT PLAN to root

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare_opt_plan
+++ b/pkg/sql/logictest/testdata/logic_test/prepare_opt_plan
@@ -56,3 +56,30 @@ EXECUTE b
 5  five
 1  one
 3  three
+
+# Only root may use PREPARE AS OPT PLAN.
+
+user testuser
+
+statement ok
+SET allow_prepare_as_opt_plan = ON
+
+statement error user testuser does not have SELECT privilege on relation t
+SELECT * FROM t
+
+statement error PREPARE AS OPT PLAN may only be used by root
+PREPARE a AS OPT PLAN '
+(Root
+  (Scan [ (Table "t") (Cols "k") ])
+  (Presentation "k")
+  (NoOrdering)
+)'
+
+# Ensure we error even when the string matches a previously prepared statement.
+statement error PREPARE AS OPT PLAN may only be used by root
+PREPARE b AS OPT PLAN '
+(Root
+  (Scan [ (Table "t") (Cols "k,str") ])
+  (Presentation "k,str")
+  (NoOrdering)
+)'


### PR DESCRIPTION
PREPARE AS OPT PLAN doesn't check permissions, so it could be used by
non-root users to read tables they shouldn't (or possibly panic the
database by creating nonsensical plans).

Also disable plan caching for such plans, because I see little benefit
and potential for information leakage (since canned plans don't track
their deps, they don't get invalidated properly for different users).

Release note: None