### PR TITLE
opt: set join limit default in opt tests

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -752,25 +752,26 @@ distinct-on
       │    │    ├── key: (1,6,8)
       │    │    ├── fd: ()-->(2)
       │    │    ├── inner-join
-      │    │    │    ├── columns: x:6(int!null) u:8(int!null)
-      │    │    │    ├── key: (6,8)
-      │    │    │    ├── scan xy
-      │    │    │    │    ├── columns: x:6(int!null)
-      │    │    │    │    └── key: (6)
+      │    │    │    ├── columns: k:1(int!null) i:2(int!null) u:8(int!null)
+      │    │    │    ├── key: (1,8)
+      │    │    │    ├── fd: ()-->(2)
       │    │    │    ├── scan uv
       │    │    │    │    ├── columns: u:8(int!null)
       │    │    │    │    └── key: (8)
-      │    │    │    └── filters (true)
-      │    │    ├── select
-      │    │    │    ├── columns: k:1(int!null) i:2(int!null)
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: ()-->(2)
-      │    │    │    ├── scan a
-      │    │    │    │    ├── columns: k:1(int!null) i:2(int)
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: k:1(int!null) i:2(int!null)
       │    │    │    │    ├── key: (1)
-      │    │    │    │    └── fd: (1)-->(2)
-      │    │    │    └── filters
-      │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+      │    │    │    │    ├── fd: ()-->(2)
+      │    │    │    │    ├── scan a
+      │    │    │    │    │    ├── columns: k:1(int!null) i:2(int)
+      │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    └── fd: (1)-->(2)
+      │    │    │    │    └── filters
+      │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+      │    │    │    └── filters (true)
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:6(int!null)
+      │    │    │    └── key: (6)
       │    │    └── filters (true)
       │    └── projections
       │         └── u / 1.1 [type=decimal, outer=(8), side-effects]
@@ -1310,23 +1311,24 @@ group-by
  │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) v:9(int)
  │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: x:6(int!null) v:9(int)
- │    │    │    │    ├── scan xy
- │    │    │    │    │    ├── columns: x:6(int!null)
- │    │    │    │    │    └── key: (6)
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) v:9(int)
+ │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
  │    │    │    │    ├── scan uv
  │    │    │    │    │    └── columns: v:9(int)
- │    │    │    │    └── filters (true)
- │    │    │    ├── select
- │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
- │    │    │    │    ├── key: (1)
- │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
- │    │    │    │    ├── scan a
- │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    ├── select
+ │    │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    └── fd: (1)-->(2-5)
- │    │    │    │    └── filters
- │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+ │    │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    │    │    │    │    ├── scan a
+ │    │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    └── fd: (1)-->(2-5)
+ │    │    │    │    │    └── filters
+ │    │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+ │    │    │    │    └── filters (true)
+ │    │    │    ├── scan xy
+ │    │    │    │    ├── columns: x:6(int!null)
+ │    │    │    │    └── key: (6)
  │    │    │    └── filters (true)
  │    │    └── aggregations
  │    │         ├── count-rows [type=int]
@@ -1376,23 +1378,24 @@ group-by
  │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) v:9(int)
  │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: x:6(int!null) v:9(int)
- │    │    │    │    ├── scan xy
- │    │    │    │    │    ├── columns: x:6(int!null)
- │    │    │    │    │    └── key: (6)
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) v:9(int)
+ │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
  │    │    │    │    ├── scan uv
  │    │    │    │    │    └── columns: v:9(int)
- │    │    │    │    └── filters (true)
- │    │    │    ├── select
- │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
- │    │    │    │    ├── key: (1)
- │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
- │    │    │    │    ├── scan a
- │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    ├── select
+ │    │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    └── fd: (1)-->(2-5)
- │    │    │    │    └── filters
- │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+ │    │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    │    │    │    │    ├── scan a
+ │    │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    └── fd: (1)-->(2-5)
+ │    │    │    │    │    └── filters
+ │    │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+ │    │    │    │    └── filters (true)
+ │    │    │    ├── scan xy
+ │    │    │    │    ├── columns: x:6(int!null)
+ │    │    │    │    └── key: (6)
  │    │    │    └── filters (true)
  │    │    └── aggregations
  │    │         ├── count [type=int, outer=(9)]
@@ -1441,32 +1444,36 @@ project
       │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null) k:5(int!null) i:6(int!null)
       │    │    ├── key: (3)
       │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4,5), (4)==(1,5), (5)-->(6), (5)==(1,4)
-      │    │    ├── inner-join
-      │    │    │    ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int!null)
+      │    │    ├── scan uv
+      │    │    │    ├── columns: u:3(int!null) v:4(int)
       │    │    │    ├── key: (3)
-      │    │    │    ├── fd: (1)-->(2), (3)-->(4), (1)==(4), (4)==(1)
+      │    │    │    └── fd: (3)-->(4)
+      │    │    ├── inner-join (merge)
+      │    │    │    ├── columns: x:1(int!null) y:2(int) k:5(int!null) i:6(int!null)
+      │    │    │    ├── left ordering: +1
+      │    │    │    ├── right ordering: +5
+      │    │    │    ├── key: (5)
+      │    │    │    ├── fd: (1)-->(2), (5)-->(6), (1)==(5), (5)==(1)
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:1(int!null) y:2(int)
       │    │    │    │    ├── key: (1)
-      │    │    │    │    └── fd: (1)-->(2)
-      │    │    │    ├── scan uv
-      │    │    │    │    ├── columns: u:3(int!null) v:4(int)
-      │    │    │    │    ├── key: (3)
-      │    │    │    │    └── fd: (3)-->(4)
-      │    │    │    └── filters
-      │    │    │         └── x = v [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
-      │    │    ├── select
-      │    │    │    ├── columns: k:5(int!null) i:6(int!null)
-      │    │    │    ├── key: (5)
-      │    │    │    ├── fd: (5)-->(6)
-      │    │    │    ├── scan a
-      │    │    │    │    ├── columns: k:5(int!null) i:6(int)
+      │    │    │    │    ├── fd: (1)-->(2)
+      │    │    │    │    └── ordering: +1
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: k:5(int!null) i:6(int!null)
       │    │    │    │    ├── key: (5)
-      │    │    │    │    └── fd: (5)-->(6)
-      │    │    │    └── filters
-      │    │    │         └── i IS NOT NULL [type=bool, outer=(6), constraints=(/6: (/NULL - ]; tight)]
+      │    │    │    │    ├── fd: (5)-->(6)
+      │    │    │    │    ├── ordering: +5
+      │    │    │    │    ├── scan a
+      │    │    │    │    │    ├── columns: k:5(int!null) i:6(int)
+      │    │    │    │    │    ├── key: (5)
+      │    │    │    │    │    ├── fd: (5)-->(6)
+      │    │    │    │    │    └── ordering: +5
+      │    │    │    │    └── filters
+      │    │    │    │         └── i IS NOT NULL [type=bool, outer=(6), constraints=(/6: (/NULL - ]; tight)]
+      │    │    │    └── filters (true)
       │    │    └── filters
-      │    │         └── k = x [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+      │    │         └── x = v [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
       │    └── aggregations
       │         ├── max [type=int, outer=(6)]
       │         │    └── variable: i [type=int]
@@ -1613,27 +1620,27 @@ group-by
  │    │    │    ├── key: (1,6,8)
  │    │    │    ├── fd: ()-->(2), (1)-->(3-5), (8)-->(9)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: x:6(int!null) u:8(int!null) v:9(int)
- │    │    │    │    ├── key: (6,8)
- │    │    │    │    ├── fd: (8)-->(9)
- │    │    │    │    ├── scan xy
- │    │    │    │    │    ├── columns: x:6(int!null)
- │    │    │    │    │    └── key: (6)
+ │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) u:8(int!null) v:9(int)
+ │    │    │    │    ├── key: (1,8)
+ │    │    │    │    ├── fd: ()-->(2), (8)-->(9), (1)-->(3-5)
  │    │    │    │    ├── scan uv
  │    │    │    │    │    ├── columns: u:8(int!null) v:9(int)
  │    │    │    │    │    ├── key: (8)
  │    │    │    │    │    └── fd: (8)-->(9)
- │    │    │    │    └── filters (true)
- │    │    │    ├── select
- │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
- │    │    │    │    ├── key: (1)
- │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
- │    │    │    │    ├── scan a
- │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    ├── select
+ │    │    │    │    │    ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    └── fd: (1)-->(2-5)
- │    │    │    │    └── filters
- │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+ │    │    │    │    │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    │    │    │    │    ├── scan a
+ │    │    │    │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    └── fd: (1)-->(2-5)
+ │    │    │    │    │    └── filters
+ │    │    │    │    │         └── i = 5 [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+ │    │    │    │    └── filters (true)
+ │    │    │    ├── scan xy
+ │    │    │    │    ├── columns: x:6(int!null)
+ │    │    │    │    └── key: (6)
  │    │    │    └── filters (true)
  │    │    └── aggregations
  │    │         ├── first-agg [type=int, outer=(8)]
@@ -2142,31 +2149,31 @@ group-by
  │    │    │    ├── columns: x:1(int!null) y:2(int) k:3(int!null) i:4(int) i:9(int!null) f:10(float!null) column14:14(float!null)
  │    │    │    ├── fd: (1)-->(2), (2)-->(14), (3)-->(4), (10)==(14), (14)==(10)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: k:3(int!null) i:4(int) i:9(int!null) f:10(float)
- │    │    │    │    ├── fd: (3)-->(4)
- │    │    │    │    ├── scan a
- │    │    │    │    │    ├── columns: k:3(int!null) i:4(int)
- │    │    │    │    │    ├── key: (3)
- │    │    │    │    │    └── fd: (3)-->(4)
+ │    │    │    │    ├── columns: x:1(int!null) y:2(int) i:9(int!null) f:10(float!null) column14:14(float!null)
+ │    │    │    │    ├── fd: (1)-->(2), (2)-->(14), (10)==(14), (14)==(10)
+ │    │    │    │    ├── project
+ │    │    │    │    │    ├── columns: column14:14(float) x:1(int!null) y:2(int)
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    ├── fd: (1)-->(2), (2)-->(14)
+ │    │    │    │    │    ├── scan xy
+ │    │    │    │    │    │    ├── columns: x:1(int!null) y:2(int)
+ │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    │    │    └── projections
+ │    │    │    │    │         └── y::FLOAT8 [type=float, outer=(2)]
  │    │    │    │    ├── select
  │    │    │    │    │    ├── columns: i:9(int!null) f:10(float)
  │    │    │    │    │    ├── scan a
  │    │    │    │    │    │    └── columns: i:9(int) f:10(float)
  │    │    │    │    │    └── filters
  │    │    │    │    │         └── i IS NOT NULL [type=bool, outer=(9), constraints=(/9: (/NULL - ]; tight)]
- │    │    │    │    └── filters (true)
- │    │    │    ├── project
- │    │    │    │    ├── columns: column14:14(float) x:1(int!null) y:2(int)
- │    │    │    │    ├── key: (1)
- │    │    │    │    ├── fd: (1)-->(2), (2)-->(14)
- │    │    │    │    ├── scan xy
- │    │    │    │    │    ├── columns: x:1(int!null) y:2(int)
- │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    └── fd: (1)-->(2)
- │    │    │    │    └── projections
- │    │    │    │         └── y::FLOAT8 [type=float, outer=(2)]
- │    │    │    └── filters
- │    │    │         └── column14 = f [type=bool, outer=(10,14), constraints=(/10: (/NULL - ]; /14: (/NULL - ]), fd=(10)==(14), (14)==(10)]
+ │    │    │    │    └── filters
+ │    │    │    │         └── column14 = f [type=bool, outer=(10,14), constraints=(/10: (/NULL - ]; /14: (/NULL - ]), fd=(10)==(14), (14)==(10)]
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:3(int!null) i:4(int)
+ │    │    │    │    ├── key: (3)
+ │    │    │    │    └── fd: (3)-->(4)
+ │    │    │    └── filters (true)
  │    │    └── aggregations
  │    │         ├── max [type=int, outer=(9)]
  │    │         │    └── variable: i [type=int]
@@ -2248,22 +2255,23 @@ project
       │    │    ├── columns: k:1(int!null) i:2(int!null) x:6(int!null) u:8(int!null)
       │    │    ├── key: (1,6)
       │    │    ├── fd: (1)-->(2), (2)==(8), (8)==(2)
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:6(int!null)
+      │    │    │    └── key: (6)
       │    │    ├── inner-join
-      │    │    │    ├── columns: x:6(int!null) u:8(int!null)
-      │    │    │    ├── key: (6,8)
-      │    │    │    ├── scan xy
-      │    │    │    │    ├── columns: x:6(int!null)
-      │    │    │    │    └── key: (6)
+      │    │    │    ├── columns: k:1(int!null) i:2(int!null) u:8(int!null)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2), (2)==(8), (8)==(2)
       │    │    │    ├── scan uv
       │    │    │    │    ├── columns: u:8(int!null)
       │    │    │    │    └── key: (8)
-      │    │    │    └── filters (true)
-      │    │    ├── scan a
-      │    │    │    ├── columns: k:1(int!null) i:2(int)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2)
-      │    │    └── filters
-      │    │         └── u = i [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: k:1(int!null) i:2(int)
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    └── fd: (1)-->(2)
+      │    │    │    └── filters
+      │    │    │         └── u = i [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │    │    └── filters (true)
       │    └── projections
       │         └── COALESCE(u, 10) [type=int, outer=(8)]
       └── filters

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1074,25 +1074,8 @@ project
  │         │    │    │    │    ├── columns: xy.x:6(int!null) u:8(int!null)
  │         │    │    │    │    ├── outer: (4)
  │         │    │    │    │    ├── inner-join
- │         │    │    │    │    │    ├── columns: xy.x:6(int!null) u:8(int!null)
- │         │    │    │    │    │    ├── key: (6,8)
- │         │    │    │    │    │    ├── select
- │         │    │    │    │    │    │    ├── columns: xy.x:6(int!null)
- │         │    │    │    │    │    │    ├── key: (6)
- │         │    │    │    │    │    │    ├── scan xy
- │         │    │    │    │    │    │    │    ├── columns: xy.x:6(int!null)
- │         │    │    │    │    │    │    │    └── key: (6)
- │         │    │    │    │    │    │    └── filters
- │         │    │    │    │    │    │         └── eq [type=bool]
- │         │    │    │    │    │    │              ├── subquery [type=string]
- │         │    │    │    │    │    │              │    └── max1-row
- │         │    │    │    │    │    │              │         ├── columns: s:19(string)
- │         │    │    │    │    │    │              │         ├── cardinality: [0 - 1]
- │         │    │    │    │    │    │              │         ├── key: ()
- │         │    │    │    │    │    │              │         ├── fd: ()-->(19)
- │         │    │    │    │    │    │              │         └── scan a
- │         │    │    │    │    │    │              │              └── columns: s:19(string)
- │         │    │    │    │    │    │              └── const: 'foo' [type=string]
+ │         │    │    │    │    │    ├── columns: u:8(int!null)
+ │         │    │    │    │    │    ├── outer: (4)
  │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: u:8(int!null)
  │         │    │    │    │    │    │    ├── key: (8)
@@ -1110,16 +1093,33 @@ project
  │         │    │    │    │    │    │              │         └── scan a
  │         │    │    │    │    │    │              │              └── columns: s:19(string)
  │         │    │    │    │    │    │              └── const: 'foo' [type=string]
- │         │    │    │    │    │    └── filters (true)
- │         │    │    │    │    ├── limit
- │         │    │    │    │    │    ├── outer: (4)
- │         │    │    │    │    │    ├── cardinality: [0 - 10]
- │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── limit
  │         │    │    │    │    │    │    ├── outer: (4)
- │         │    │    │    │    │    │    ├── scan b
- │         │    │    │    │    │    │    └── filters
- │         │    │    │    │    │    │         └── s >= 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - ]; tight)]
- │         │    │    │    │    │    └── const: 10 [type=int]
+ │         │    │    │    │    │    │    ├── cardinality: [0 - 10]
+ │         │    │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    │    ├── outer: (4)
+ │         │    │    │    │    │    │    │    ├── scan b
+ │         │    │    │    │    │    │    │    └── filters
+ │         │    │    │    │    │    │    │         └── s >= 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - ]; tight)]
+ │         │    │    │    │    │    │    └── const: 10 [type=int]
+ │         │    │    │    │    │    └── filters (true)
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── columns: xy.x:6(int!null)
+ │         │    │    │    │    │    ├── key: (6)
+ │         │    │    │    │    │    ├── scan xy
+ │         │    │    │    │    │    │    ├── columns: xy.x:6(int!null)
+ │         │    │    │    │    │    │    └── key: (6)
+ │         │    │    │    │    │    └── filters
+ │         │    │    │    │    │         └── eq [type=bool]
+ │         │    │    │    │    │              ├── subquery [type=string]
+ │         │    │    │    │    │              │    └── max1-row
+ │         │    │    │    │    │              │         ├── columns: s:19(string)
+ │         │    │    │    │    │              │         ├── cardinality: [0 - 1]
+ │         │    │    │    │    │              │         ├── key: ()
+ │         │    │    │    │    │              │         ├── fd: ()-->(19)
+ │         │    │    │    │    │              │         └── scan a
+ │         │    │    │    │    │              │              └── columns: s:19(string)
+ │         │    │    │    │    │              └── const: 'foo' [type=string]
  │         │    │    │    │    └── filters (true)
  │         │    │    │    └── filters (true)
  │         │    │    └── projections

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -78,39 +78,39 @@ inner-join
  ├── key: (1,7,11)
  ├── fd: ()-->(5,6), (1)-->(2-4), (7)-->(8-10), (11)-->(12)
  ├── inner-join
- │    ├── columns: k:7(int!null) i:8(int) f:9(float) s:10(string) u:11(int!null) v:12(int!null)
+ │    ├── columns: u:5(int!null) v:6(int) k:7(int!null) i:8(int) f:9(float) s:10(string) u:11(int!null) v:12(int!null)
  │    ├── key: (7,11)
- │    ├── fd: (7)-->(8-10), (11)-->(12)
+ │    ├── fd: ()-->(5,6), (7)-->(8-10), (11)-->(12)
  │    ├── scan a
  │    │    ├── columns: k:7(int!null) i:8(int) f:9(float) s:10(string)
  │    │    ├── key: (7)
  │    │    └── fd: (7)-->(8-10)
- │    ├── select
- │    │    ├── columns: u:11(int!null) v:12(int!null)
+ │    ├── inner-join
+ │    │    ├── columns: u:5(int!null) v:6(int) u:11(int!null) v:12(int!null)
  │    │    ├── key: (11)
- │    │    ├── fd: (11)-->(12)
- │    │    ├── scan uv
- │    │    │    ├── columns: u:11(int!null) v:12(int)
+ │    │    ├── fd: ()-->(5,6), (11)-->(12)
+ │    │    ├── select
+ │    │    │    ├── columns: u:11(int!null) v:12(int!null)
  │    │    │    ├── key: (11)
- │    │    │    └── fd: (11)-->(12)
- │    │    └── filters
- │    │         └── v > 2 [type=bool, outer=(12), constraints=(/12: [/3 - ]; tight)]
+ │    │    │    ├── fd: (11)-->(12)
+ │    │    │    ├── scan uv
+ │    │    │    │    ├── columns: u:11(int!null) v:12(int)
+ │    │    │    │    ├── key: (11)
+ │    │    │    │    └── fd: (11)-->(12)
+ │    │    │    └── filters
+ │    │    │         └── v > 2 [type=bool, outer=(12), constraints=(/12: [/3 - ]; tight)]
+ │    │    ├── scan uv
+ │    │    │    ├── columns: u:5(int!null) v:6(int)
+ │    │    │    ├── constraint: /5: [/1 - /1]
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    └── fd: ()-->(5,6)
+ │    │    └── filters (true)
  │    └── filters (true)
- ├── inner-join
- │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) u:5(int!null) v:6(int)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    ├── key: (1)
- │    ├── fd: ()-->(5,6), (1)-->(2-4)
- │    ├── scan a
- │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
- │    │    ├── key: (1)
- │    │    └── fd: (1)-->(2-4)
- │    ├── scan uv
- │    │    ├── columns: u:5(int!null) v:6(int)
- │    │    ├── constraint: /5: [/1 - /1]
- │    │    ├── cardinality: [0 - 1]
- │    │    ├── key: ()
- │    │    └── fd: ()-->(5,6)
- │    └── filters (true)
+ │    └── fd: (1)-->(2-4)
  └── filters (true)
 
 # Left-join operator.

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -150,6 +150,8 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	// Enable zigzag joins for all opt tests. Execbuilder tests exercise
 	// cases where this flag is false.
 	ot.evalCtx.SessionData.ZigzagJoinEnabled = true
+	ot.evalCtx.SessionData.ReorderJoinsLimit = 4
+
 	return ot
 }
 

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -239,36 +239,39 @@ inner-join
  ├── columns: id1_6_0_:1(int!null) id1_4_1_:6(int!null) phone_nu2_6_0_:2(string) person_i4_6_0_:4(int!null) phone_ty3_6_0_:3(string) person_i1_5_0__:12(int!null) addresse2_5_0__:13(string) addresse3_0__:14(string!null) address2_4_1_:7(string) createdo3_4_1_:8(timestamp) name4_4_1_:9(string) nickname5_4_1_:10(string) version6_4_1_:11(int!null) person_i1_5_0__:12(int!null) addresse2_5_0__:13(string) addresse3_0__:14(string!null)
  ├── key: (1,14)
  ├── fd: (1)-->(2-4), (6)-->(7-11), (4)==(6,12), (6)==(4,12), (12,14)-->(13), (12)==(4,6)
- ├── inner-join
- │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int!null) person1_.id:6(int!null) address:7(string) createdon:8(timestamp) name:9(string) nickname:10(string) version:11(int!null)
+ ├── semi-join
+ │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (6)-->(7-11), (4)==(6), (6)==(4)
- │    ├── semi-join
+ │    ├── fd: (1)-->(2-4)
+ │    ├── scan phone0_
  │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-4)
- │    │    ├── scan phone0_
- │    │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int)
- │    │    │    ├── key: (1)
- │    │    │    └── fd: (1)-->(2-4)
- │    │    ├── scan calls3_
- │    │    │    ├── columns: calls3_.id:15(int!null) phone_id:18(int)
- │    │    │    ├── key: (15)
- │    │    │    └── fd: (15)-->(18)
- │    │    └── filters
- │    │         └── phone0_.id = phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+ │    │    └── fd: (1)-->(2-4)
+ │    ├── scan calls3_
+ │    │    ├── columns: calls3_.id:15(int!null) phone_id:18(int)
+ │    │    ├── key: (15)
+ │    │    └── fd: (15)-->(18)
+ │    └── filters
+ │         └── phone0_.id = phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+ ├── inner-join (merge)
+ │    ├── columns: person1_.id:6(int!null) address:7(string) createdon:8(timestamp) name:9(string) nickname:10(string) version:11(int!null) addresses2_.person_id:12(int!null) addresses:13(string) addresses_key:14(string!null)
+ │    ├── left ordering: +6
+ │    ├── right ordering: +12
+ │    ├── key: (12,14)
+ │    ├── fd: (6)-->(7-11), (12,14)-->(13), (6)==(12), (12)==(6)
  │    ├── scan person1_
  │    │    ├── columns: person1_.id:6(int!null) address:7(string) createdon:8(timestamp) name:9(string) nickname:10(string) version:11(int!null)
  │    │    ├── key: (6)
- │    │    └── fd: (6)-->(7-11)
- │    └── filters
- │         └── phone0_.person_id = person1_.id [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
- ├── scan addresses2_
- │    ├── columns: addresses2_.person_id:12(int!null) addresses:13(string) addresses_key:14(string!null)
- │    ├── key: (12,14)
- │    └── fd: (12,14)-->(13)
+ │    │    ├── fd: (6)-->(7-11)
+ │    │    └── ordering: +6
+ │    ├── scan addresses2_
+ │    │    ├── columns: addresses2_.person_id:12(int!null) addresses:13(string) addresses_key:14(string!null)
+ │    │    ├── key: (12,14)
+ │    │    ├── fd: (12,14)-->(13)
+ │    │    └── ordering: +12
+ │    └── filters (true)
  └── filters
-      └── person1_.id = addresses2_.person_id [type=bool, outer=(6,12), constraints=(/6: (/NULL - ]; /12: (/NULL - ]), fd=(6)==(12), (12)==(6)]
+      └── phone0_.person_id = person1_.id [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
 
 opt
 select
@@ -300,33 +303,35 @@ project
  └── inner-join
       ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int!null) person1_.id:6(int!null) addresses2_.person_id:12(int!null)
       ├── fd: (1)-->(2-4), (4)==(6,12), (6)==(4,12), (12)==(4,6)
-      ├── inner-join
-      │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int!null) person1_.id:6(int!null)
+      ├── semi-join
+      │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int)
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-4), (4)==(6), (6)==(4)
-      │    ├── semi-join
+      │    ├── fd: (1)-->(2-4)
+      │    ├── scan phone0_
       │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int)
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-4)
-      │    │    ├── scan phone0_
-      │    │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int)
-      │    │    │    ├── key: (1)
-      │    │    │    └── fd: (1)-->(2-4)
-      │    │    ├── scan calls3_
-      │    │    │    ├── columns: calls3_.id:15(int!null) phone_id:18(int)
-      │    │    │    ├── key: (15)
-      │    │    │    └── fd: (15)-->(18)
-      │    │    └── filters
-      │    │         └── phone0_.id = phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │    │    └── fd: (1)-->(2-4)
+      │    ├── scan calls3_
+      │    │    ├── columns: calls3_.id:15(int!null) phone_id:18(int)
+      │    │    ├── key: (15)
+      │    │    └── fd: (15)-->(18)
+      │    └── filters
+      │         └── phone0_.id = phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      ├── inner-join (merge)
+      │    ├── columns: person1_.id:6(int!null) addresses2_.person_id:12(int!null)
+      │    ├── left ordering: +6
+      │    ├── right ordering: +12
+      │    ├── fd: (6)==(12), (12)==(6)
       │    ├── scan person1_
       │    │    ├── columns: person1_.id:6(int!null)
-      │    │    └── key: (6)
-      │    └── filters
-      │         └── phone0_.person_id = person1_.id [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
-      ├── scan addresses2_
-      │    └── columns: addresses2_.person_id:12(int!null)
+      │    │    ├── key: (6)
+      │    │    └── ordering: +6
+      │    ├── scan addresses2_
+      │    │    ├── columns: addresses2_.person_id:12(int!null)
+      │    │    └── ordering: +12
+      │    └── filters (true)
       └── filters
-           └── person1_.id = addresses2_.person_id [type=bool, outer=(6,12), constraints=(/6: (/NULL - ]; /12: (/NULL - ]), fd=(6)==(12), (12)==(6)]
+           └── phone0_.person_id = person1_.id [type=bool, outer=(4,6), constraints=(/4: (/NULL - ]; /6: (/NULL - ]), fd=(4)==(6), (6)==(4)]
 
 opt
 select
@@ -2692,21 +2697,21 @@ group-by
  │    │    │    ├── columns: this_.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string!null) enrolment_.studentid:6(int!null) enrolment_.coursecode:7(string!null) enrolment_.year:9(int!null) maxstudentenrolment_.coursecode:11(string!null) maxstudentenrolment_.year:13(int!null)
  │    │    │    ├── fd: (1)-->(2-5), (6,7)-->(9), (5)==(11), (11)==(5)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: enrolment_.studentid:6(int!null) enrolment_.coursecode:7(string!null) enrolment_.year:9(int!null) maxstudentenrolment_.coursecode:11(string!null) maxstudentenrolment_.year:13(int!null)
- │    │    │    │    ├── fd: (6,7)-->(9)
- │    │    │    │    ├── scan enrolment_
- │    │    │    │    │    ├── columns: enrolment_.studentid:6(int!null) enrolment_.coursecode:7(string!null) enrolment_.year:9(int!null)
- │    │    │    │    │    ├── key: (6,7)
- │    │    │    │    │    └── fd: (6,7)-->(9)
+ │    │    │    │    ├── columns: this_.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string!null) maxstudentenrolment_.coursecode:11(string!null) maxstudentenrolment_.year:13(int!null)
+ │    │    │    │    ├── fd: (1)-->(2-5), (5)==(11), (11)==(5)
  │    │    │    │    ├── scan maxstudentenrolment_
  │    │    │    │    │    └── columns: maxstudentenrolment_.coursecode:11(string!null) maxstudentenrolment_.year:13(int!null)
- │    │    │    │    └── filters (true)
- │    │    │    ├── scan this_
- │    │    │    │    ├── columns: this_.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string)
- │    │    │    │    ├── key: (1)
- │    │    │    │    └── fd: (1)-->(2-5)
- │    │    │    └── filters
- │    │    │         └── preferredcoursecode = maxstudentenrolment_.coursecode [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
+ │    │    │    │    ├── scan this_
+ │    │    │    │    │    ├── columns: this_.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string)
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2-5)
+ │    │    │    │    └── filters
+ │    │    │    │         └── preferredcoursecode = maxstudentenrolment_.coursecode [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
+ │    │    │    ├── scan enrolment_
+ │    │    │    │    ├── columns: enrolment_.studentid:6(int!null) enrolment_.coursecode:7(string!null) enrolment_.year:9(int!null)
+ │    │    │    │    ├── key: (6,7)
+ │    │    │    │    └── fd: (6,7)-->(9)
+ │    │    │    └── filters (true)
  │    │    └── aggregations
  │    │         ├── max [type=int, outer=(13)]
  │    │         │    └── variable: maxstudentenrolment_.year [type=int]

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -664,14 +664,18 @@ project
       │         │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
       │         │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    ├── fd: ()-->(27), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13)
+      │         │    │    │    │    ├── scan partsupp
+      │         │    │    │    │    │    ├── columns: ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null)
+      │         │    │    │    │    │    ├── key: (17,18)
+      │         │    │    │    │    │    └── fd: (17,18)-->(20)
       │         │    │    │    │    ├── inner-join
-      │         │    │    │    │    │    ├── columns: ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
-      │         │    │    │    │    │    ├── key: (17,18,22)
-      │         │    │    │    │    │    ├── fd: ()-->(27), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24)
-      │         │    │    │    │    │    ├── scan partsupp
-      │         │    │    │    │    │    │    ├── columns: ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null)
-      │         │    │    │    │    │    │    ├── key: (17,18)
-      │         │    │    │    │    │    │    └── fd: (17,18)-->(20)
+      │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    ├── key: (10)
+      │         │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24), (10)-->(11-16), (13)==(22), (22)==(13)
+      │         │    │    │    │    │    ├── scan supplier
+      │         │    │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null)
+      │         │    │    │    │    │    │    ├── key: (10)
+      │         │    │    │    │    │    │    └── fd: (10)-->(11-16)
       │         │    │    │    │    │    ├── inner-join
       │         │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
       │         │    │    │    │    │    │    ├── key: (22)
@@ -692,14 +696,10 @@ project
       │         │    │    │    │    │    │    │         └── r_name = 'EUROPE' [type=bool, outer=(27), constraints=(/27: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(27)]
       │         │    │    │    │    │    │    └── filters
       │         │    │    │    │    │    │         └── n_regionkey = r_regionkey [type=bool, outer=(24,26), constraints=(/24: (/NULL - ]; /26: (/NULL - ]), fd=(24)==(26), (26)==(24)]
-      │         │    │    │    │    │    └── filters (true)
-      │         │    │    │    │    ├── scan supplier
-      │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null)
-      │         │    │    │    │    │    ├── key: (10)
-      │         │    │    │    │    │    └── fd: (10)-->(11-16)
+      │         │    │    │    │    │    └── filters
+      │         │    │    │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(13,22), constraints=(/13: (/NULL - ]; /22: (/NULL - ]), fd=(13)==(22), (22)==(13)]
       │         │    │    │    │    └── filters
-      │         │    │    │    │         ├── s_suppkey = ps_suppkey [type=bool, outer=(10,18), constraints=(/10: (/NULL - ]; /18: (/NULL - ]), fd=(10)==(18), (18)==(10)]
-      │         │    │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(13,22), constraints=(/13: (/NULL - ]; /22: (/NULL - ]), fd=(13)==(22), (22)==(13)]
+      │         │    │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(10,18), constraints=(/10: (/NULL - ]; /18: (/NULL - ]), fd=(10)==(18), (18)==(10)]
       │         │    │    │    ├── select
       │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null)
       │         │    │    │    │    ├── key: (1)
@@ -796,37 +796,35 @@ limit
  │         ├── project
  │         │    ├── columns: column34:34(float) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null)
  │         │    ├── fd: (18)-->(13,16)
- │         │    ├── inner-join
+ │         │    ├── inner-join (lookup lineitem)
  │         │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
+ │         │    │    ├── key columns: [9] = [18]
  │         │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
- │         │    │    ├── inner-join (lookup lineitem)
- │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
- │         │    │    │    ├── key columns: [9] = [18]
- │         │    │    │    ├── fd: (9)-->(10,13,16), (9)==(18), (18)==(9)
- │         │    │    │    ├── select
- │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
+ │         │    │    ├── inner-join (lookup orders)
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
+ │         │    │    │    ├── key columns: [9] = [9]
+ │         │    │    │    ├── key: (9)
+ │         │    │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (1)==(10), (10)==(1)
+ │         │    │    │    ├── inner-join (lookup orders@o_ck)
+ │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null)
+ │         │    │    │    │    ├── key columns: [1] = [10]
  │         │    │    │    │    ├── key: (9)
- │         │    │    │    │    ├── fd: (9)-->(10,13,16)
- │         │    │    │    │    ├── scan orders
- │         │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
- │         │    │    │    │    │    ├── key: (9)
- │         │    │    │    │    │    └── fd: (9)-->(10,13,16)
- │         │    │    │    │    └── filters
- │         │    │    │    │         └── o_orderdate < '1995-03-15' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1995-03-14']; tight)]
+ │         │    │    │    │    ├── fd: ()-->(7), (9)-->(10), (1)==(10), (10)==(1)
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: ()-->(7)
+ │         │    │    │    │    │    ├── scan customer
+ │         │    │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
+ │         │    │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    │    └── fd: (1)-->(7)
+ │         │    │    │    │    │    └── filters
+ │         │    │    │    │    │         └── c_mktsegment = 'BUILDING' [type=bool, outer=(7), constraints=(/7: [/'BUILDING' - /'BUILDING']; tight), fd=()-->(7)]
+ │         │    │    │    │    └── filters (true)
  │         │    │    │    └── filters
- │         │    │    │         └── l_shipdate > '1995-03-15' [type=bool, outer=(28), constraints=(/28: [/'1995-03-16' - ]; tight)]
- │         │    │    ├── select
- │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
- │         │    │    │    ├── key: (1)
- │         │    │    │    ├── fd: ()-->(7)
- │         │    │    │    ├── scan customer
- │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
- │         │    │    │    │    ├── key: (1)
- │         │    │    │    │    └── fd: (1)-->(7)
- │         │    │    │    └── filters
- │         │    │    │         └── c_mktsegment = 'BUILDING' [type=bool, outer=(7), constraints=(/7: [/'BUILDING' - /'BUILDING']; tight), fd=()-->(7)]
+ │         │    │    │         └── o_orderdate < '1995-03-15' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1995-03-14']; tight)]
  │         │    │    └── filters
- │         │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │         │    │         └── l_shipdate > '1995-03-15' [type=bool, outer=(28), constraints=(/28: [/'1995-03-16' - ]; tight)]
  │         │    └── projections
  │         │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(23,24)]
  │         └── aggregations
@@ -1332,31 +1330,35 @@ project
  │    │         │    │    │    │    │    │    │         ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
  │    │         │    │    │    │    │    │    │         ├── key: (50,54)
  │    │         │    │    │    │    │    │    │         ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
- │    │         │    │    │    │    │    │    │         ├── inner-join
- │    │         │    │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    │    │         │    ├── key: (54,58)
- │    │         │    │    │    │    │    │    │         │    ├── fd: ()-->(59), (54)-->(55)
- │    │         │    │    │    │    │    │    │         │    ├── scan n2
- │    │         │    │    │    │    │    │    │         │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null)
- │    │         │    │    │    │    │    │    │         │    │    ├── key: (54)
- │    │         │    │    │    │    │    │    │         │    │    └── fd: (54)-->(55)
+ │    │         │    │    │    │    │    │    │         ├── scan n2
+ │    │         │    │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null)
+ │    │         │    │    │    │    │    │    │         │    ├── key: (54)
+ │    │         │    │    │    │    │    │    │         │    └── fd: (54)-->(55)
+ │    │         │    │    │    │    │    │    │         ├── inner-join (merge)
+ │    │         │    │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    │    │    │    │         │    ├── left ordering: +58
+ │    │         │    │    │    │    │    │    │         │    ├── right ordering: +52
+ │    │         │    │    │    │    │    │    │         │    ├── key: (50)
+ │    │         │    │    │    │    │    │    │         │    ├── fd: ()-->(59), (50)-->(52), (52)==(58), (58)==(52)
  │    │         │    │    │    │    │    │    │         │    ├── select
  │    │         │    │    │    │    │    │    │         │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
  │    │         │    │    │    │    │    │    │         │    │    ├── key: (58)
  │    │         │    │    │    │    │    │    │         │    │    ├── fd: ()-->(59)
+ │    │         │    │    │    │    │    │    │         │    │    ├── ordering: +58 opt(59) [actual: +58]
  │    │         │    │    │    │    │    │    │         │    │    ├── scan region
  │    │         │    │    │    │    │    │    │         │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
  │    │         │    │    │    │    │    │    │         │    │    │    ├── key: (58)
- │    │         │    │    │    │    │    │    │         │    │    │    └── fd: (58)-->(59)
+ │    │         │    │    │    │    │    │    │         │    │    │    ├── fd: (58)-->(59)
+ │    │         │    │    │    │    │    │    │         │    │    │    └── ordering: +58 opt(59) [actual: +58]
  │    │         │    │    │    │    │    │    │         │    │    └── filters
  │    │         │    │    │    │    │    │    │         │    │         └── r_name = 'AMERICA' [type=bool, outer=(59), constraints=(/59: [/'AMERICA' - /'AMERICA']; tight), fd=()-->(59)]
+ │    │         │    │    │    │    │    │    │         │    ├── scan n1@n_rk
+ │    │         │    │    │    │    │    │    │         │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null)
+ │    │         │    │    │    │    │    │    │         │    │    ├── key: (50)
+ │    │         │    │    │    │    │    │    │         │    │    ├── fd: (50)-->(52)
+ │    │         │    │    │    │    │    │    │         │    │    └── ordering: +52
  │    │         │    │    │    │    │    │    │         │    └── filters (true)
- │    │         │    │    │    │    │    │    │         ├── scan n1@n_rk
- │    │         │    │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null)
- │    │         │    │    │    │    │    │    │         │    ├── key: (50)
- │    │         │    │    │    │    │    │    │         │    └── fd: (50)-->(52)
- │    │         │    │    │    │    │    │    │         └── filters
- │    │         │    │    │    │    │    │    │              └── n1.n_regionkey = r_regionkey [type=bool, outer=(52,58), constraints=(/52: (/NULL - ]; /58: (/NULL - ]), fd=(52)==(58), (58)==(52)]
+ │    │         │    │    │    │    │    │    │         └── filters (true)
  │    │         │    │    │    │    │    │    └── filters (true)
  │    │         │    │    │    │    │    ├── index-join orders
  │    │         │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
@@ -1478,34 +1480,31 @@ sort
       │    │    │    ├── inner-join
       │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
       │    │    │    │    ├── fd: (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(34), (34)==(19), (18)==(33), (33)==(18), (17)==(38), (38)==(17)
-      │    │    │    │    ├── inner-join
-      │    │    │    │    │    ├── columns: ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
-      │    │    │    │    │    ├── key: (33,34,38,47)
-      │    │    │    │    │    ├── fd: (33,34)-->(36), (38)-->(42), (47)-->(48)
-      │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    ├── columns: o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
-      │    │    │    │    │    │    ├── key: (38,47)
-      │    │    │    │    │    │    ├── fd: (38)-->(42), (47)-->(48)
-      │    │    │    │    │    │    ├── scan orders@o_od
-      │    │    │    │    │    │    │    ├── columns: o_orderkey:38(int!null) o_orderdate:42(date!null)
-      │    │    │    │    │    │    │    ├── key: (38)
-      │    │    │    │    │    │    │    └── fd: (38)-->(42)
-      │    │    │    │    │    │    ├── scan nation
-      │    │    │    │    │    │    │    ├── columns: n_nationkey:47(int!null) n_name:48(string!null)
-      │    │    │    │    │    │    │    ├── key: (47)
-      │    │    │    │    │    │    │    └── fd: (47)-->(48)
+      │    │    │    │    ├── inner-join (lookup orders)
+      │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null)
+      │    │    │    │    │    ├── key columns: [17] = [38]
+      │    │    │    │    │    ├── fd: (38)-->(42), (33,34)-->(36), (19)==(34), (34)==(19), (18)==(33), (33)==(18), (17)==(38), (38)==(17)
+      │    │    │    │    │    ├── inner-join (lookup lineitem)
+      │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null)
+      │    │    │    │    │    │    ├── key columns: [17 20] = [17 20]
+      │    │    │    │    │    │    ├── fd: (33,34)-->(36), (19)==(34), (34)==(19), (18)==(33), (33)==(18)
+      │    │    │    │    │    │    ├── inner-join (lookup lineitem@l_pk_sk)
+      │    │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_linenumber:20(int!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null)
+      │    │    │    │    │    │    │    ├── key columns: [33 34] = [18 19]
+      │    │    │    │    │    │    │    ├── key: (17,20)
+      │    │    │    │    │    │    │    ├── fd: (33,34)-->(36), (17,20)-->(18,19), (18)==(33), (33)==(18), (19)==(34), (34)==(19)
+      │    │    │    │    │    │    │    ├── scan partsupp
+      │    │    │    │    │    │    │    │    ├── columns: ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null)
+      │    │    │    │    │    │    │    │    ├── key: (33,34)
+      │    │    │    │    │    │    │    │    └── fd: (33,34)-->(36)
+      │    │    │    │    │    │    │    └── filters (true)
       │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    ├── scan partsupp
-      │    │    │    │    │    │    ├── columns: ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null)
-      │    │    │    │    │    │    ├── key: (33,34)
-      │    │    │    │    │    │    └── fd: (33,34)-->(36)
       │    │    │    │    │    └── filters (true)
-      │    │    │    │    ├── scan lineitem
-      │    │    │    │    │    └── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null)
-      │    │    │    │    └── filters
-      │    │    │    │         ├── ps_suppkey = l_suppkey [type=bool, outer=(19,34), constraints=(/19: (/NULL - ]; /34: (/NULL - ]), fd=(19)==(34), (34)==(19)]
-      │    │    │    │         ├── ps_partkey = l_partkey [type=bool, outer=(18,33), constraints=(/18: (/NULL - ]; /33: (/NULL - ]), fd=(18)==(33), (33)==(18)]
-      │    │    │    │         └── o_orderkey = l_orderkey [type=bool, outer=(17,38), constraints=(/17: (/NULL - ]; /38: (/NULL - ]), fd=(17)==(38), (38)==(17)]
+      │    │    │    │    ├── scan nation
+      │    │    │    │    │    ├── columns: n_nationkey:47(int!null) n_name:48(string!null)
+      │    │    │    │    │    ├── key: (47)
+      │    │    │    │    │    └── fd: (47)-->(48)
+      │    │    │    │    └── filters (true)
       │    │    │    ├── scan supplier@s_nk
       │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null)
       │    │    │    │    ├── key: (10)
@@ -1590,31 +1589,33 @@ limit
  │         ├── project
  │         │    ├── columns: column38:38(float) c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) n_name:35(string!null)
  │         │    ├── fd: (1)-->(2,3,5,6,8,35)
- │         │    ├── inner-join (lookup customer)
+ │         │    ├── inner-join
  │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    ├── key columns: [10] = [1]
  │         │    │    ├── fd: ()-->(26), (1)-->(2-6,8), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(34), (34)==(4)
- │         │    │    ├── inner-join (lookup orders)
- │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    │    ├── key columns: [18] = [9]
- │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9)
- │         │    │    │    ├── inner-join
- │         │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    │    │    ├── fd: ()-->(26), (34)-->(35)
- │         │    │    │    │    ├── scan nation
- │         │    │    │    │    │    ├── columns: n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    │    │    │    ├── key: (34)
- │         │    │    │    │    │    └── fd: (34)-->(35)
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
- │         │    │    │    │    │    ├── fd: ()-->(26)
- │         │    │    │    │    │    ├── scan lineitem
- │         │    │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
- │         │    │    │    │    └── filters (true)
- │         │    │    │    └── filters
- │         │    │    │         └── (o_orderdate >= '1993-10-01') AND (o_orderdate < '1994-01-01') [type=bool, outer=(13), constraints=(/13: [/'1993-10-01' - /'1993-12-31']; tight)]
+ │         │    │    ├── scan nation
+ │         │    │    │    ├── columns: n_nationkey:34(int!null) n_name:35(string!null)
+ │         │    │    │    ├── key: (34)
+ │         │    │    │    └── fd: (34)-->(35)
+ │         │    │    ├── inner-join (lookup customer)
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
+ │         │    │    │    ├── key columns: [10] = [1]
+ │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9), (1)-->(2-6,8), (1)==(10), (10)==(1)
+ │         │    │    │    ├── inner-join (lookup lineitem)
+ │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
+ │         │    │    │    │    ├── key columns: [9] = [18]
+ │         │    │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9)
+ │         │    │    │    │    ├── index-join orders
+ │         │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │    │    ├── key: (9)
+ │         │    │    │    │    │    ├── fd: (9)-->(10,13)
+ │         │    │    │    │    │    └── scan orders@o_od
+ │         │    │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │    │         ├── constraint: /13/9: [/'1993-10-01' - /'1993-12-31']
+ │         │    │    │    │    │         ├── key: (9)
+ │         │    │    │    │    │         └── fd: (9)-->(13)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
+ │         │    │    │    └── filters (true)
  │         │    │    └── filters
  │         │    │         └── c_nationkey = n_nationkey [type=bool, outer=(4,34), constraints=(/4: (/NULL - ]; /34: (/NULL - ]), fd=(4)==(34), (34)==(4)]
  │         │    └── projections
@@ -2389,18 +2390,18 @@ limit
  │         ├── inner-join
  │         │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
  │         │    ├── fd: (1)-->(2), (9)-->(10,12,13), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
- │         │    ├── inner-join (merge)
- │         │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
- │         │    │    ├── left ordering: +9
- │         │    │    ├── right ordering: +18
- │         │    │    ├── fd: (9)-->(10,12,13), (9)==(18), (18)==(9)
+ │         │    ├── scan lineitem
+ │         │    │    └── columns: l_orderkey:18(int!null) l_quantity:22(float!null)
+ │         │    ├── inner-join
+ │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
+ │         │    │    ├── key: (9)
+ │         │    │    ├── fd: (9)-->(10,12,13), (1)-->(2), (1)==(10), (10)==(1)
  │         │    │    ├── semi-join (merge)
  │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
  │         │    │    │    ├── left ordering: +9
  │         │    │    │    ├── right ordering: +34
  │         │    │    │    ├── key: (9)
  │         │    │    │    ├── fd: (9)-->(10,12,13)
- │         │    │    │    ├── ordering: +9
  │         │    │    │    ├── scan orders
  │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
  │         │    │    │    │    ├── key: (9)
@@ -2426,16 +2427,14 @@ limit
  │         │    │    │    │    └── filters
  │         │    │    │    │         └── sum > 300.0 [type=bool, outer=(50), constraints=(/50: [/300.00000000000006 - ]; tight)]
  │         │    │    │    └── filters (true)
- │         │    │    ├── scan lineitem
- │         │    │    │    ├── columns: l_orderkey:18(int!null) l_quantity:22(float!null)
- │         │    │    │    └── ordering: +18
- │         │    │    └── filters (true)
- │         │    ├── scan customer
- │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null)
- │         │    │    ├── key: (1)
- │         │    │    └── fd: (1)-->(2)
+ │         │    │    ├── scan customer
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null)
+ │         │    │    │    ├── key: (1)
+ │         │    │    │    └── fd: (1)-->(2)
+ │         │    │    └── filters
+ │         │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
  │         │    └── filters
- │         │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │         │         └── o_orderkey = l_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
  │         └── aggregations
  │              ├── sum [type=float, outer=(22)]
  │              │    └── variable: l_quantity [type=float]
@@ -2731,85 +2730,81 @@ limit
  │         ├── grouping columns: s_name:2(string!null)
  │         ├── key: (2)
  │         ├── fd: (2)-->(69)
- │         ├── inner-join (lookup supplier)
+ │         ├── inner-join
  │         │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
- │         │    ├── key columns: [10] = [1]
  │         │    ├── fd: ()-->(26,34), (1)-->(2,4), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(33), (33)==(4)
- │         │    ├── inner-join (merge)
- │         │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    ├── left ordering: +8
- │         │    │    ├── right ordering: +24
- │         │    │    ├── fd: ()-->(26,34), (8)==(24), (24)==(8)
- │         │    │    ├── semi-join (merge)
- │         │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
- │         │    │    │    ├── left ordering: +8
- │         │    │    │    ├── right ordering: +37
- │         │    │    │    ├── ordering: +8
- │         │    │    │    ├── anti-join (merge)
+ │         │    ├── inner-join (lookup supplier)
+ │         │    │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    ├── key columns: [10] = [1]
+ │         │    │    ├── fd: ()-->(26), (8)==(24), (24)==(8), (1)-->(2,4), (1)==(10), (10)==(1)
+ │         │    │    ├── inner-join (merge)
+ │         │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    │    ├── left ordering: +24
+ │         │    │    │    ├── right ordering: +8
+ │         │    │    │    ├── fd: ()-->(26), (8)==(24), (24)==(8)
+ │         │    │    │    ├── select
+ │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    │    │    ├── key: (24)
+ │         │    │    │    │    ├── fd: ()-->(26)
+ │         │    │    │    │    ├── ordering: +24 opt(26) [actual: +24]
+ │         │    │    │    │    ├── scan orders
+ │         │    │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    │    │    │    ├── key: (24)
+ │         │    │    │    │    │    ├── fd: (24)-->(26)
+ │         │    │    │    │    │    └── ordering: +24 opt(26) [actual: +24]
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── o_orderstatus = 'F' [type=bool, outer=(26), constraints=(/26: [/'F' - /'F']; tight), fd=()-->(26)]
+ │         │    │    │    ├── semi-join (merge)
  │         │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
  │         │    │    │    │    ├── left ordering: +8
- │         │    │    │    │    ├── right ordering: +53
+ │         │    │    │    │    ├── right ordering: +37
  │         │    │    │    │    ├── ordering: +8
- │         │    │    │    │    ├── select
+ │         │    │    │    │    ├── anti-join (merge)
  │         │    │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
+ │         │    │    │    │    │    ├── left ordering: +8
+ │         │    │    │    │    │    ├── right ordering: +53
  │         │    │    │    │    │    ├── ordering: +8
- │         │    │    │    │    │    ├── scan l1
+ │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
- │         │    │    │    │    │    │    └── ordering: +8
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── l1.l_receiptdate > l1.l_commitdate [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(string!null) l3.l_linestatus:62(string!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(string!null) l3.l_shipmode:67(string!null) l3.l_comment:68(string!null)
- │         │    │    │    │    │    ├── key: (53,56)
- │         │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
- │         │    │    │    │    │    ├── ordering: +53
- │         │    │    │    │    │    ├── scan l3
+ │         │    │    │    │    │    │    ├── ordering: +8
+ │         │    │    │    │    │    │    ├── scan l1
+ │         │    │    │    │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
+ │         │    │    │    │    │    │    │    └── ordering: +8
+ │         │    │    │    │    │    │    └── filters
+ │         │    │    │    │    │    │         └── l1.l_receiptdate > l1.l_commitdate [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+ │         │    │    │    │    │    ├── select
  │         │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(string!null) l3.l_linestatus:62(string!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(string!null) l3.l_shipmode:67(string!null) l3.l_comment:68(string!null)
  │         │    │    │    │    │    │    ├── key: (53,56)
  │         │    │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
- │         │    │    │    │    │    │    └── ordering: +53
+ │         │    │    │    │    │    │    ├── ordering: +53
+ │         │    │    │    │    │    │    ├── scan l3
+ │         │    │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(string!null) l3.l_linestatus:62(string!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(string!null) l3.l_shipmode:67(string!null) l3.l_comment:68(string!null)
+ │         │    │    │    │    │    │    │    ├── key: (53,56)
+ │         │    │    │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
+ │         │    │    │    │    │    │    │    └── ordering: +53
+ │         │    │    │    │    │    │    └── filters
+ │         │    │    │    │    │    │         └── l3.l_receiptdate > l3.l_commitdate [type=bool, outer=(64,65), constraints=(/64: (/NULL - ]; /65: (/NULL - ])]
  │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── l3.l_receiptdate > l3.l_commitdate [type=bool, outer=(64,65), constraints=(/64: (/NULL - ]; /65: (/NULL - ])]
+ │         │    │    │    │    │         └── l3.l_suppkey != l1.l_suppkey [type=bool, outer=(10,55), constraints=(/10: (/NULL - ]; /55: (/NULL - ])]
+ │         │    │    │    │    ├── scan l2
+ │         │    │    │    │    │    ├── columns: l2.l_orderkey:37(int!null) l2.l_partkey:38(int!null) l2.l_suppkey:39(int!null) l2.l_linenumber:40(int!null) l2.l_quantity:41(float!null) l2.l_extendedprice:42(float!null) l2.l_discount:43(float!null) l2.l_tax:44(float!null) l2.l_returnflag:45(string!null) l2.l_linestatus:46(string!null) l2.l_shipdate:47(date!null) l2.l_commitdate:48(date!null) l2.l_receiptdate:49(date!null) l2.l_shipinstruct:50(string!null) l2.l_shipmode:51(string!null) l2.l_comment:52(string!null)
+ │         │    │    │    │    │    ├── key: (37,40)
+ │         │    │    │    │    │    ├── fd: (37,40)-->(38,39,41-52)
+ │         │    │    │    │    │    └── ordering: +37
  │         │    │    │    │    └── filters
- │         │    │    │    │         └── l3.l_suppkey != l1.l_suppkey [type=bool, outer=(10,55), constraints=(/10: (/NULL - ]; /55: (/NULL - ])]
- │         │    │    │    ├── scan l2
- │         │    │    │    │    ├── columns: l2.l_orderkey:37(int!null) l2.l_partkey:38(int!null) l2.l_suppkey:39(int!null) l2.l_linenumber:40(int!null) l2.l_quantity:41(float!null) l2.l_extendedprice:42(float!null) l2.l_discount:43(float!null) l2.l_tax:44(float!null) l2.l_returnflag:45(string!null) l2.l_linestatus:46(string!null) l2.l_shipdate:47(date!null) l2.l_commitdate:48(date!null) l2.l_receiptdate:49(date!null) l2.l_shipinstruct:50(string!null) l2.l_shipmode:51(string!null) l2.l_comment:52(string!null)
- │         │    │    │    │    ├── key: (37,40)
- │         │    │    │    │    ├── fd: (37,40)-->(38,39,41-52)
- │         │    │    │    │    └── ordering: +37
- │         │    │    │    └── filters
- │         │    │    │         └── l2.l_suppkey != l1.l_suppkey [type=bool, outer=(10,39), constraints=(/10: (/NULL - ]; /39: (/NULL - ])]
- │         │    │    ├── sort
- │         │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    │    ├── key: (24,33)
- │         │    │    │    ├── fd: ()-->(26,34)
- │         │    │    │    ├── ordering: +24 opt(26,34) [actual: +24]
- │         │    │    │    └── inner-join
- │         │    │    │         ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    │         ├── key: (24,33)
- │         │    │    │         ├── fd: ()-->(26,34)
- │         │    │    │         ├── select
- │         │    │    │         │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
- │         │    │    │         │    ├── key: (24)
- │         │    │    │         │    ├── fd: ()-->(26)
- │         │    │    │         │    ├── scan orders
- │         │    │    │         │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
- │         │    │    │         │    │    ├── key: (24)
- │         │    │    │         │    │    └── fd: (24)-->(26)
- │         │    │    │         │    └── filters
- │         │    │    │         │         └── o_orderstatus = 'F' [type=bool, outer=(26), constraints=(/26: [/'F' - /'F']; tight), fd=()-->(26)]
- │         │    │    │         ├── select
- │         │    │    │         │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    │         │    ├── key: (33)
- │         │    │    │         │    ├── fd: ()-->(34)
- │         │    │    │         │    ├── scan nation
- │         │    │    │         │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    │         │    │    ├── key: (33)
- │         │    │    │         │    │    └── fd: (33)-->(34)
- │         │    │    │         │    └── filters
- │         │    │    │         │         └── n_name = 'SAUDI ARABIA' [type=bool, outer=(34), constraints=(/34: [/'SAUDI ARABIA' - /'SAUDI ARABIA']; tight), fd=()-->(34)]
- │         │    │    │         └── filters (true)
+ │         │    │    │    │         └── l2.l_suppkey != l1.l_suppkey [type=bool, outer=(10,39), constraints=(/10: (/NULL - ]; /39: (/NULL - ])]
+ │         │    │    │    └── filters (true)
  │         │    │    └── filters (true)
+ │         │    ├── select
+ │         │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
+ │         │    │    ├── key: (33)
+ │         │    │    ├── fd: ()-->(34)
+ │         │    │    ├── scan nation
+ │         │    │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
+ │         │    │    │    ├── key: (33)
+ │         │    │    │    └── fd: (33)-->(34)
+ │         │    │    └── filters
+ │         │    │         └── n_name = 'SAUDI ARABIA' [type=bool, outer=(34), constraints=(/34: [/'SAUDI ARABIA' - /'SAUDI ARABIA']; tight), fd=()-->(34)]
  │         │    └── filters
  │         │         └── s_nationkey = n_nationkey [type=bool, outer=(4,33), constraints=(/4: (/NULL - ]; /33: (/NULL - ]), fd=(4)==(33), (33)==(4)]
  │         └── aggregations

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -494,14 +494,18 @@ project
       │         │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
       │         │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    ├── fd: ()-->(27), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13)
+      │         │    │    │    │    ├── scan partsupp
+      │         │    │    │    │    │    ├── columns: ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null)
+      │         │    │    │    │    │    ├── key: (17,18)
+      │         │    │    │    │    │    └── fd: (17,18)-->(20)
       │         │    │    │    │    ├── inner-join
-      │         │    │    │    │    │    ├── columns: ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
-      │         │    │    │    │    │    ├── key: (17,18,22)
-      │         │    │    │    │    │    ├── fd: ()-->(27), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24)
-      │         │    │    │    │    │    ├── scan partsupp
-      │         │    │    │    │    │    │    ├── columns: ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null)
-      │         │    │    │    │    │    │    ├── key: (17,18)
-      │         │    │    │    │    │    │    └── fd: (17,18)-->(20)
+      │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    ├── key: (10)
+      │         │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24), (10)-->(11-16), (13)==(22), (22)==(13)
+      │         │    │    │    │    │    ├── scan supplier
+      │         │    │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null)
+      │         │    │    │    │    │    │    ├── key: (10)
+      │         │    │    │    │    │    │    └── fd: (10)-->(11-16)
       │         │    │    │    │    │    ├── inner-join (lookup nation)
       │         │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
       │         │    │    │    │    │    │    ├── key columns: [22] = [22]
@@ -524,14 +528,10 @@ project
       │         │    │    │    │    │    │    │    │         └── r_name = 'EUROPE' [type=bool, outer=(27), constraints=(/27: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(27)]
       │         │    │    │    │    │    │    │    └── filters (true)
       │         │    │    │    │    │    │    └── filters (true)
-      │         │    │    │    │    │    └── filters (true)
-      │         │    │    │    │    ├── scan supplier
-      │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null)
-      │         │    │    │    │    │    ├── key: (10)
-      │         │    │    │    │    │    └── fd: (10)-->(11-16)
+      │         │    │    │    │    │    └── filters
+      │         │    │    │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(13,22), constraints=(/13: (/NULL - ]; /22: (/NULL - ]), fd=(13)==(22), (22)==(13)]
       │         │    │    │    │    └── filters
-      │         │    │    │    │         ├── s_suppkey = ps_suppkey [type=bool, outer=(10,18), constraints=(/10: (/NULL - ]; /18: (/NULL - ]), fd=(10)==(18), (18)==(10)]
-      │         │    │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(13,22), constraints=(/13: (/NULL - ]; /22: (/NULL - ]), fd=(13)==(22), (22)==(13)]
+      │         │    │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(10,18), constraints=(/10: (/NULL - ]; /18: (/NULL - ]), fd=(10)==(18), (18)==(10)]
       │         │    │    │    ├── select
       │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null)
       │         │    │    │    │    ├── key: (1)
@@ -628,47 +628,35 @@ limit
  │         ├── project
  │         │    ├── columns: column34:34(float) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null)
  │         │    ├── fd: (18)-->(13,16)
- │         │    ├── inner-join
+ │         │    ├── inner-join (lookup lineitem)
  │         │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
+ │         │    │    ├── key columns: [9] = [18]
  │         │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
- │         │    │    ├── inner-join (merge)
- │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
- │         │    │    │    ├── left ordering: +9
- │         │    │    │    ├── right ordering: +18
- │         │    │    │    ├── fd: (9)-->(10,13,16), (9)==(18), (18)==(9)
- │         │    │    │    ├── select
- │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
+ │         │    │    ├── inner-join (lookup orders)
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
+ │         │    │    │    ├── key columns: [9] = [9]
+ │         │    │    │    ├── key: (9)
+ │         │    │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (1)==(10), (10)==(1)
+ │         │    │    │    ├── inner-join (lookup orders@o_ck)
+ │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null)
+ │         │    │    │    │    ├── key columns: [1] = [10]
  │         │    │    │    │    ├── key: (9)
- │         │    │    │    │    ├── fd: (9)-->(10,13,16)
- │         │    │    │    │    ├── ordering: +9
- │         │    │    │    │    ├── scan orders
- │         │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
- │         │    │    │    │    │    ├── key: (9)
- │         │    │    │    │    │    ├── fd: (9)-->(10,13,16)
- │         │    │    │    │    │    └── ordering: +9
- │         │    │    │    │    └── filters
- │         │    │    │    │         └── o_orderdate < '1995-03-15' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1995-03-14']; tight)]
- │         │    │    │    ├── select
- │         │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
- │         │    │    │    │    ├── ordering: +18
- │         │    │    │    │    ├── scan lineitem
- │         │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
- │         │    │    │    │    │    └── ordering: +18
- │         │    │    │    │    └── filters
- │         │    │    │    │         └── l_shipdate > '1995-03-15' [type=bool, outer=(28), constraints=(/28: [/'1995-03-16' - ]; tight)]
- │         │    │    │    └── filters (true)
- │         │    │    ├── select
- │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
- │         │    │    │    ├── key: (1)
- │         │    │    │    ├── fd: ()-->(7)
- │         │    │    │    ├── scan customer
- │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
- │         │    │    │    │    ├── key: (1)
- │         │    │    │    │    └── fd: (1)-->(7)
+ │         │    │    │    │    ├── fd: ()-->(7), (9)-->(10), (1)==(10), (10)==(1)
+ │         │    │    │    │    ├── select
+ │         │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
+ │         │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    ├── fd: ()-->(7)
+ │         │    │    │    │    │    ├── scan customer
+ │         │    │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
+ │         │    │    │    │    │    │    ├── key: (1)
+ │         │    │    │    │    │    │    └── fd: (1)-->(7)
+ │         │    │    │    │    │    └── filters
+ │         │    │    │    │    │         └── c_mktsegment = 'BUILDING' [type=bool, outer=(7), constraints=(/7: [/'BUILDING' - /'BUILDING']; tight), fd=()-->(7)]
+ │         │    │    │    │    └── filters (true)
  │         │    │    │    └── filters
- │         │    │    │         └── c_mktsegment = 'BUILDING' [type=bool, outer=(7), constraints=(/7: [/'BUILDING' - /'BUILDING']; tight), fd=()-->(7)]
+ │         │    │    │         └── o_orderdate < '1995-03-15' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1995-03-14']; tight)]
  │         │    │    └── filters
- │         │    │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │         │    │         └── l_shipdate > '1995-03-15' [type=bool, outer=(28), constraints=(/28: [/'1995-03-16' - ]; tight)]
  │         │    └── projections
  │         │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(23,24)]
  │         └── aggregations
@@ -1000,35 +988,38 @@ group-by
  │         │    │    │    ├── key: (24,41)
  │         │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25)
  │         │    │    │    ├── inner-join
- │         │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
- │         │    │    │    │    ├── key: (33,41)
- │         │    │    │    │    ├── fd: (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36)
- │         │    │    │    │    ├── inner-join
- │         │    │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
- │         │    │    │    │    │    ├── key: (41,45)
- │         │    │    │    │    │    ├── fd: (41)-->(42), (45)-->(46)
- │         │    │    │    │    │    ├── scan n1
- │         │    │    │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null)
- │         │    │    │    │    │    │    ├── key: (41)
- │         │    │    │    │    │    │    └── fd: (41)-->(42)
+ │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    │    │    │    ├── key: (24)
+ │         │    │    │    │    ├── fd: (45)-->(46), (33)-->(36), (36)==(45), (45)==(36), (24)-->(25), (25)==(33), (33)==(25)
+ │         │    │    │    │    ├── inner-join (merge)
+ │         │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    │    │    │    │    ├── left ordering: +45
+ │         │    │    │    │    │    ├── right ordering: +36
+ │         │    │    │    │    │    ├── key: (33)
+ │         │    │    │    │    │    ├── fd: (45)-->(46), (33)-->(36), (36)==(45), (45)==(36)
  │         │    │    │    │    │    ├── scan n2
  │         │    │    │    │    │    │    ├── columns: n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
  │         │    │    │    │    │    │    ├── key: (45)
- │         │    │    │    │    │    │    └── fd: (45)-->(46)
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── ((n1.n_name = 'FRANCE') AND (n2.n_name = 'GERMANY')) OR ((n1.n_name = 'GERMANY') AND (n2.n_name = 'FRANCE')) [type=bool, outer=(42,46)]
- │         │    │    │    │    ├── scan customer@c_nk
- │         │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null)
- │         │    │    │    │    │    ├── key: (33)
- │         │    │    │    │    │    └── fd: (33)-->(36)
+ │         │    │    │    │    │    │    ├── fd: (45)-->(46)
+ │         │    │    │    │    │    │    └── ordering: +45
+ │         │    │    │    │    │    ├── scan customer@c_nk
+ │         │    │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null)
+ │         │    │    │    │    │    │    ├── key: (33)
+ │         │    │    │    │    │    │    ├── fd: (33)-->(36)
+ │         │    │    │    │    │    │    └── ordering: +36
+ │         │    │    │    │    │    └── filters (true)
+ │         │    │    │    │    ├── scan orders@o_ck
+ │         │    │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null)
+ │         │    │    │    │    │    ├── key: (24)
+ │         │    │    │    │    │    └── fd: (24)-->(25)
  │         │    │    │    │    └── filters
- │         │    │    │    │         └── c_nationkey = n2.n_nationkey [type=bool, outer=(36,45), constraints=(/36: (/NULL - ]; /45: (/NULL - ]), fd=(36)==(45), (45)==(36)]
- │         │    │    │    ├── scan orders@o_ck
- │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null)
- │         │    │    │    │    ├── key: (24)
- │         │    │    │    │    └── fd: (24)-->(25)
+ │         │    │    │    │         └── c_custkey = o_custkey [type=bool, outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
+ │         │    │    │    ├── scan n1
+ │         │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null)
+ │         │    │    │    │    ├── key: (41)
+ │         │    │    │    │    └── fd: (41)-->(42)
  │         │    │    │    └── filters
- │         │    │    │         └── c_custkey = o_custkey [type=bool, outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
+ │         │    │    │         └── ((n1.n_name = 'FRANCE') AND (n2.n_name = 'GERMANY')) OR ((n1.n_name = 'GERMANY') AND (n2.n_name = 'FRANCE')) [type=bool, outer=(42,46)]
  │         │    │    ├── index-join lineitem
  │         │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
  │         │    │    │    └── scan lineitem@l_sd
@@ -1145,18 +1136,23 @@ sort
       │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
       │    │    │    │    │    │    │    │    ├── key: (42,54)
       │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45)
+      │    │    │    │    │    │    │    │    ├── scan n2
+      │    │    │    │    │    │    │    │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null)
+      │    │    │    │    │    │    │    │    │    ├── key: (54)
+      │    │    │    │    │    │    │    │    │    └── fd: (54)-->(55)
       │    │    │    │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
-      │    │    │    │    │    │    │    │    │    ├── key: (50,54)
-      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
-      │    │    │    │    │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    │    │    │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
-      │    │    │    │    │    │    │    │    │    │    ├── key: (54,58)
-      │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (54)-->(55)
-      │    │    │    │    │    │    │    │    │    │    ├── scan n2
-      │    │    │    │    │    │    │    │    │    │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null)
-      │    │    │    │    │    │    │    │    │    │    │    ├── key: (54)
-      │    │    │    │    │    │    │    │    │    │    │    └── fd: (54)-->(55)
+      │    │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    │    ├── key: (42)
+      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (52)==(58), (58)==(52), (42)-->(45), (45)==(50), (50)==(45)
+      │    │    │    │    │    │    │    │    │    ├── scan customer@c_nk
+      │    │    │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null)
+      │    │    │    │    │    │    │    │    │    │    ├── key: (42)
+      │    │    │    │    │    │    │    │    │    │    └── fd: (42)-->(45)
+      │    │    │    │    │    │    │    │    │    ├── inner-join (lookup nation@n_rk)
+      │    │    │    │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    │    │    ├── key columns: [58] = [52]
+      │    │    │    │    │    │    │    │    │    │    ├── key: (50)
+      │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (52)==(58), (58)==(52)
       │    │    │    │    │    │    │    │    │    │    ├── select
       │    │    │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
       │    │    │    │    │    │    │    │    │    │    │    ├── key: (58)
@@ -1168,18 +1164,9 @@ sort
       │    │    │    │    │    │    │    │    │    │    │    └── filters
       │    │    │    │    │    │    │    │    │    │    │         └── r_name = 'AMERICA' [type=bool, outer=(59), constraints=(/59: [/'AMERICA' - /'AMERICA']; tight), fd=()-->(59)]
       │    │    │    │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    │    │    │    │    ├── scan n1@n_rk
-      │    │    │    │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null)
-      │    │    │    │    │    │    │    │    │    │    ├── key: (50)
-      │    │    │    │    │    │    │    │    │    │    └── fd: (50)-->(52)
       │    │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │    │         └── n1.n_regionkey = r_regionkey [type=bool, outer=(52,58), constraints=(/52: (/NULL - ]; /58: (/NULL - ]), fd=(52)==(58), (58)==(52)]
-      │    │    │    │    │    │    │    │    ├── scan customer@c_nk
-      │    │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null)
-      │    │    │    │    │    │    │    │    │    ├── key: (42)
-      │    │    │    │    │    │    │    │    │    └── fd: (42)-->(45)
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         └── c_nationkey = n1.n_nationkey [type=bool, outer=(45,50), constraints=(/45: (/NULL - ]; /50: (/NULL - ]), fd=(45)==(50), (50)==(45)]
+      │    │    │    │    │    │    │    │    │         └── c_nationkey = n1.n_nationkey [type=bool, outer=(45,50), constraints=(/45: (/NULL - ]; /50: (/NULL - ]), fd=(45)==(50), (50)==(45)]
+      │    │    │    │    │    │    │    │    └── filters (true)
       │    │    │    │    │    │    │    ├── index-join orders
       │    │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
       │    │    │    │    │    │    │    │    ├── key: (33)
@@ -1292,34 +1279,28 @@ sort
       │    │    │    ├── inner-join
       │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
       │    │    │    │    ├── fd: (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(34), (34)==(19), (18)==(33), (33)==(18), (17)==(38), (38)==(17)
-      │    │    │    │    ├── inner-join
-      │    │    │    │    │    ├── columns: ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
-      │    │    │    │    │    ├── key: (33,34,38,47)
-      │    │    │    │    │    ├── fd: (33,34)-->(36), (38)-->(42), (47)-->(48)
+      │    │    │    │    ├── scan nation
+      │    │    │    │    │    ├── columns: n_nationkey:47(int!null) n_name:48(string!null)
+      │    │    │    │    │    ├── key: (47)
+      │    │    │    │    │    └── fd: (47)-->(48)
+      │    │    │    │    ├── inner-join (lookup orders)
+      │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null)
+      │    │    │    │    │    ├── key columns: [17] = [38]
+      │    │    │    │    │    ├── fd: (38)-->(42), (33,34)-->(36), (19)==(34), (34)==(19), (18)==(33), (33)==(18), (17)==(38), (38)==(17)
       │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    ├── columns: o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
-      │    │    │    │    │    │    ├── key: (38,47)
-      │    │    │    │    │    │    ├── fd: (38)-->(42), (47)-->(48)
-      │    │    │    │    │    │    ├── scan orders@o_od
-      │    │    │    │    │    │    │    ├── columns: o_orderkey:38(int!null) o_orderdate:42(date!null)
-      │    │    │    │    │    │    │    ├── key: (38)
-      │    │    │    │    │    │    │    └── fd: (38)-->(42)
-      │    │    │    │    │    │    ├── scan nation
-      │    │    │    │    │    │    │    ├── columns: n_nationkey:47(int!null) n_name:48(string!null)
-      │    │    │    │    │    │    │    ├── key: (47)
-      │    │    │    │    │    │    │    └── fd: (47)-->(48)
-      │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    ├── scan partsupp
-      │    │    │    │    │    │    ├── columns: ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null)
-      │    │    │    │    │    │    ├── key: (33,34)
-      │    │    │    │    │    │    └── fd: (33,34)-->(36)
+      │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null)
+      │    │    │    │    │    │    ├── fd: (33,34)-->(36), (19)==(34), (34)==(19), (18)==(33), (33)==(18)
+      │    │    │    │    │    │    ├── scan partsupp
+      │    │    │    │    │    │    │    ├── columns: ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null)
+      │    │    │    │    │    │    │    ├── key: (33,34)
+      │    │    │    │    │    │    │    └── fd: (33,34)-->(36)
+      │    │    │    │    │    │    ├── scan lineitem
+      │    │    │    │    │    │    │    └── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null)
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         ├── ps_suppkey = l_suppkey [type=bool, outer=(19,34), constraints=(/19: (/NULL - ]; /34: (/NULL - ]), fd=(19)==(34), (34)==(19)]
+      │    │    │    │    │    │         └── ps_partkey = l_partkey [type=bool, outer=(18,33), constraints=(/18: (/NULL - ]; /33: (/NULL - ]), fd=(18)==(33), (33)==(18)]
       │    │    │    │    │    └── filters (true)
-      │    │    │    │    ├── scan lineitem
-      │    │    │    │    │    └── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null)
-      │    │    │    │    └── filters
-      │    │    │    │         ├── ps_suppkey = l_suppkey [type=bool, outer=(19,34), constraints=(/19: (/NULL - ]; /34: (/NULL - ]), fd=(19)==(34), (34)==(19)]
-      │    │    │    │         ├── ps_partkey = l_partkey [type=bool, outer=(18,33), constraints=(/18: (/NULL - ]; /33: (/NULL - ]), fd=(18)==(33), (33)==(18)]
-      │    │    │    │         └── o_orderkey = l_orderkey [type=bool, outer=(17,38), constraints=(/17: (/NULL - ]; /38: (/NULL - ]), fd=(17)==(38), (38)==(17)]
+      │    │    │    │    └── filters (true)
       │    │    │    ├── scan supplier@s_nk
       │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null)
       │    │    │    │    ├── key: (10)
@@ -1404,45 +1385,31 @@ limit
  │         ├── project
  │         │    ├── columns: column38:38(float) c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) n_name:35(string!null)
  │         │    ├── fd: (1)-->(2,3,5,6,8,35)
- │         │    ├── inner-join
+ │         │    ├── inner-join (lookup nation)
  │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
+ │         │    │    ├── key columns: [4] = [34]
  │         │    │    ├── fd: ()-->(26), (1)-->(2-6,8), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(34), (34)==(4)
- │         │    │    ├── inner-join
- │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9)
- │         │    │    │    ├── inner-join
- │         │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    │    │    ├── fd: ()-->(26), (34)-->(35)
- │         │    │    │    │    ├── scan nation
- │         │    │    │    │    │    ├── columns: n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    │    │    │    ├── key: (34)
- │         │    │    │    │    │    └── fd: (34)-->(35)
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
- │         │    │    │    │    │    ├── fd: ()-->(26)
- │         │    │    │    │    │    ├── scan lineitem
- │         │    │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
- │         │    │    │    │    └── filters (true)
- │         │    │    │    ├── index-join orders
- │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
- │         │    │    │    │    ├── key: (9)
- │         │    │    │    │    ├── fd: (9)-->(10,13)
- │         │    │    │    │    └── scan orders@o_od
- │         │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
- │         │    │    │    │         ├── constraint: /13/9: [/'1993-10-01' - /'1993-12-31']
- │         │    │    │    │         ├── key: (9)
- │         │    │    │    │         └── fd: (9)-->(13)
- │         │    │    │    └── filters
- │         │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
- │         │    │    ├── scan customer
- │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null)
- │         │    │    │    ├── key: (1)
- │         │    │    │    └── fd: (1)-->(2-6,8)
- │         │    │    └── filters
- │         │    │         ├── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
- │         │    │         └── c_nationkey = n_nationkey [type=bool, outer=(4,34), constraints=(/4: (/NULL - ]; /34: (/NULL - ]), fd=(4)==(34), (34)==(4)]
+ │         │    │    ├── inner-join (lookup customer)
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
+ │         │    │    │    ├── key columns: [10] = [1]
+ │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9), (1)-->(2-6,8), (1)==(10), (10)==(1)
+ │         │    │    │    ├── inner-join (lookup lineitem)
+ │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
+ │         │    │    │    │    ├── key columns: [9] = [18]
+ │         │    │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9)
+ │         │    │    │    │    ├── index-join orders
+ │         │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │    │    ├── key: (9)
+ │         │    │    │    │    │    ├── fd: (9)-->(10,13)
+ │         │    │    │    │    │    └── scan orders@o_od
+ │         │    │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │    │         ├── constraint: /13/9: [/'1993-10-01' - /'1993-12-31']
+ │         │    │    │    │    │         ├── key: (9)
+ │         │    │    │    │    │         └── fd: (9)-->(13)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
+ │         │    │    │    └── filters (true)
+ │         │    │    └── filters (true)
  │         │    └── projections
  │         │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(23,24)]
  │         └── aggregations
@@ -2545,84 +2512,74 @@ limit
  │         ├── grouping columns: s_name:2(string!null)
  │         ├── key: (2)
  │         ├── fd: (2)-->(69)
- │         ├── inner-join
+ │         ├── inner-join (lookup nation)
  │         │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
+ │         │    ├── key columns: [4] = [33]
  │         │    ├── fd: ()-->(26,34), (1)-->(2,4), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(33), (33)==(4)
- │         │    ├── scan supplier
- │         │    │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_nationkey:4(int!null)
- │         │    │    ├── key: (1)
- │         │    │    └── fd: (1)-->(2,4)
- │         │    ├── inner-join
- │         │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    ├── fd: ()-->(26,34), (8)==(24), (24)==(8)
- │         │    │    ├── semi-join (merge)
- │         │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
- │         │    │    │    ├── left ordering: +8
- │         │    │    │    ├── right ordering: +37
- │         │    │    │    ├── anti-join (merge)
- │         │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
- │         │    │    │    │    ├── left ordering: +8
- │         │    │    │    │    ├── right ordering: +53
- │         │    │    │    │    ├── ordering: +8
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
- │         │    │    │    │    │    ├── ordering: +8
- │         │    │    │    │    │    ├── scan l1
- │         │    │    │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
- │         │    │    │    │    │    │    └── ordering: +8
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── l1.l_receiptdate > l1.l_commitdate [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(string!null) l3.l_linestatus:62(string!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(string!null) l3.l_shipmode:67(string!null) l3.l_comment:68(string!null)
- │         │    │    │    │    │    ├── key: (53,56)
- │         │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
- │         │    │    │    │    │    ├── ordering: +53
- │         │    │    │    │    │    ├── scan l3
- │         │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(string!null) l3.l_linestatus:62(string!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(string!null) l3.l_shipmode:67(string!null) l3.l_comment:68(string!null)
- │         │    │    │    │    │    │    ├── key: (53,56)
- │         │    │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
- │         │    │    │    │    │    │    └── ordering: +53
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── l3.l_receiptdate > l3.l_commitdate [type=bool, outer=(64,65), constraints=(/64: (/NULL - ]; /65: (/NULL - ])]
- │         │    │    │    │    └── filters
- │         │    │    │    │         └── l3.l_suppkey != l1.l_suppkey [type=bool, outer=(10,55), constraints=(/10: (/NULL - ]; /55: (/NULL - ])]
- │         │    │    │    ├── scan l2
- │         │    │    │    │    ├── columns: l2.l_orderkey:37(int!null) l2.l_partkey:38(int!null) l2.l_suppkey:39(int!null) l2.l_linenumber:40(int!null) l2.l_quantity:41(float!null) l2.l_extendedprice:42(float!null) l2.l_discount:43(float!null) l2.l_tax:44(float!null) l2.l_returnflag:45(string!null) l2.l_linestatus:46(string!null) l2.l_shipdate:47(date!null) l2.l_commitdate:48(date!null) l2.l_receiptdate:49(date!null) l2.l_shipinstruct:50(string!null) l2.l_shipmode:51(string!null) l2.l_comment:52(string!null)
- │         │    │    │    │    ├── key: (37,40)
- │         │    │    │    │    ├── fd: (37,40)-->(38,39,41-52)
- │         │    │    │    │    └── ordering: +37
- │         │    │    │    └── filters
- │         │    │    │         └── l2.l_suppkey != l1.l_suppkey [type=bool, outer=(10,39), constraints=(/10: (/NULL - ]; /39: (/NULL - ])]
- │         │    │    ├── inner-join
- │         │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    │    ├── key: (24,33)
- │         │    │    │    ├── fd: ()-->(26,34)
+ │         │    ├── inner-join (lookup supplier)
+ │         │    │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    ├── key columns: [10] = [1]
+ │         │    │    ├── fd: ()-->(26), (8)==(24), (24)==(8), (1)-->(2,4), (1)==(10), (10)==(1)
+ │         │    │    ├── inner-join (merge)
+ │         │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    │    ├── left ordering: +24
+ │         │    │    │    ├── right ordering: +8
+ │         │    │    │    ├── fd: ()-->(26), (8)==(24), (24)==(8)
  │         │    │    │    ├── select
  │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
  │         │    │    │    │    ├── key: (24)
  │         │    │    │    │    ├── fd: ()-->(26)
+ │         │    │    │    │    ├── ordering: +24 opt(26) [actual: +24]
  │         │    │    │    │    ├── scan orders
  │         │    │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
  │         │    │    │    │    │    ├── key: (24)
- │         │    │    │    │    │    └── fd: (24)-->(26)
+ │         │    │    │    │    │    ├── fd: (24)-->(26)
+ │         │    │    │    │    │    └── ordering: +24 opt(26) [actual: +24]
  │         │    │    │    │    └── filters
  │         │    │    │    │         └── o_orderstatus = 'F' [type=bool, outer=(26), constraints=(/26: [/'F' - /'F']; tight), fd=()-->(26)]
- │         │    │    │    ├── select
- │         │    │    │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    │    │    ├── key: (33)
- │         │    │    │    │    ├── fd: ()-->(34)
- │         │    │    │    │    ├── scan nation
- │         │    │    │    │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
- │         │    │    │    │    │    ├── key: (33)
- │         │    │    │    │    │    └── fd: (33)-->(34)
+ │         │    │    │    ├── semi-join (merge)
+ │         │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
+ │         │    │    │    │    ├── left ordering: +8
+ │         │    │    │    │    ├── right ordering: +37
+ │         │    │    │    │    ├── ordering: +8
+ │         │    │    │    │    ├── anti-join (merge)
+ │         │    │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
+ │         │    │    │    │    │    ├── left ordering: +8
+ │         │    │    │    │    │    ├── right ordering: +53
+ │         │    │    │    │    │    ├── ordering: +8
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
+ │         │    │    │    │    │    │    ├── ordering: +8
+ │         │    │    │    │    │    │    ├── scan l1
+ │         │    │    │    │    │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null)
+ │         │    │    │    │    │    │    │    └── ordering: +8
+ │         │    │    │    │    │    │    └── filters
+ │         │    │    │    │    │    │         └── l1.l_receiptdate > l1.l_commitdate [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(string!null) l3.l_linestatus:62(string!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(string!null) l3.l_shipmode:67(string!null) l3.l_comment:68(string!null)
+ │         │    │    │    │    │    │    ├── key: (53,56)
+ │         │    │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
+ │         │    │    │    │    │    │    ├── ordering: +53
+ │         │    │    │    │    │    │    ├── scan l3
+ │         │    │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(string!null) l3.l_linestatus:62(string!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(string!null) l3.l_shipmode:67(string!null) l3.l_comment:68(string!null)
+ │         │    │    │    │    │    │    │    ├── key: (53,56)
+ │         │    │    │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
+ │         │    │    │    │    │    │    │    └── ordering: +53
+ │         │    │    │    │    │    │    └── filters
+ │         │    │    │    │    │    │         └── l3.l_receiptdate > l3.l_commitdate [type=bool, outer=(64,65), constraints=(/64: (/NULL - ]; /65: (/NULL - ])]
+ │         │    │    │    │    │    └── filters
+ │         │    │    │    │    │         └── l3.l_suppkey != l1.l_suppkey [type=bool, outer=(10,55), constraints=(/10: (/NULL - ]; /55: (/NULL - ])]
+ │         │    │    │    │    ├── scan l2
+ │         │    │    │    │    │    ├── columns: l2.l_orderkey:37(int!null) l2.l_partkey:38(int!null) l2.l_suppkey:39(int!null) l2.l_linenumber:40(int!null) l2.l_quantity:41(float!null) l2.l_extendedprice:42(float!null) l2.l_discount:43(float!null) l2.l_tax:44(float!null) l2.l_returnflag:45(string!null) l2.l_linestatus:46(string!null) l2.l_shipdate:47(date!null) l2.l_commitdate:48(date!null) l2.l_receiptdate:49(date!null) l2.l_shipinstruct:50(string!null) l2.l_shipmode:51(string!null) l2.l_comment:52(string!null)
+ │         │    │    │    │    │    ├── key: (37,40)
+ │         │    │    │    │    │    ├── fd: (37,40)-->(38,39,41-52)
+ │         │    │    │    │    │    └── ordering: +37
  │         │    │    │    │    └── filters
- │         │    │    │    │         └── n_name = 'SAUDI ARABIA' [type=bool, outer=(34), constraints=(/34: [/'SAUDI ARABIA' - /'SAUDI ARABIA']; tight), fd=()-->(34)]
+ │         │    │    │    │         └── l2.l_suppkey != l1.l_suppkey [type=bool, outer=(10,39), constraints=(/10: (/NULL - ]; /39: (/NULL - ])]
  │         │    │    │    └── filters (true)
- │         │    │    └── filters
- │         │    │         └── o_orderkey = l1.l_orderkey [type=bool, outer=(8,24), constraints=(/8: (/NULL - ]; /24: (/NULL - ]), fd=(8)==(24), (24)==(8)]
+ │         │    │    └── filters (true)
  │         │    └── filters
- │         │         ├── s_suppkey = l1.l_suppkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
- │         │         └── s_nationkey = n_nationkey [type=bool, outer=(4,33), constraints=(/4: (/NULL - ]; /33: (/NULL - ]), fd=(4)==(33), (33)==(4)]
+ │         │         └── n_name = 'SAUDI ARABIA' [type=bool, outer=(34), constraints=(/34: [/'SAUDI ARABIA' - /'SAUDI ARABIA']; tight), fd=()-->(34)]
  │         └── aggregations
  │              └── count-rows [type=int]
  └── const: 100 [type=int]

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -310,7 +310,7 @@ inner-join
 # Note the difference in memo size for with and without reorder-joins, for only four tables.
 # TODO(justin): Find a way to reduce this.
 
-memo
+memo join-limit=1
 SELECT * FROM bx, cy, dz, abc WHERE a = 1
 ----
 memo (optimized, ~11KB, required=[presentation: b:1,x:2,c:3,y:4,d:5,z:6,a:7,b:8,c:9,d:10])

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -361,6 +361,7 @@ var varGen = map[string]sessionVar{
 			return strconv.FormatInt(int64(evalCtx.SessionData.ReorderJoinsLimit), 10)
 		},
 		GlobalDefault: func(_ *settings.Values) string {
+			// NOTE: If this is ever changed it must also be changed in the opttester.
 			return "4"
 		},
 	},


### PR DESCRIPTION
This is set by default for clusters but not in opt tests.  I'm not sure
of a good way to share this constant between opt and sql, so just
hardcode it for now.

Release note: None