### PR TITLE
Makefile: don't build krb5 on musl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -448,8 +448,8 @@ C_LIBS_COMMON = $(if $(use-stdmalloc),,$(LIBJEMALLOC)) $(LIBPROTOBUF) $(LIBSNAPP
 C_LIBS_OSS = $(C_LIBS_COMMON) $(LIBROACH)
 C_LIBS_CCL = $(C_LIBS_COMMON) $(LIBCRYPTOPP) $(LIBROACHCCL)
 
-# We only include krb5 on linux.
-ifeq "$(findstring linux,$(TARGET_TRIPLE))" "linux"
+# We only include krb5 on linux, non-musl builds.
+ifeq "$(findstring linux-gnu,$(TARGET_TRIPLE))" "linux-gnu"
 C_LIBS_CCL += $(LIBKRB5)
 KRB_CPPFLAGS := -I$(KRB5_DIR)/include
 KRB_DIR := $(KRB5_DIR)/lib


### PR DESCRIPTION
It produces a linking error. It may be fixable, but for now it's not
important, so disable it. In the future if requested by users we can
figure out if/how to fix the musl build.

Release note: None