### PR TITLE
sql: don't reinitialize the entire planner and evalcontext every time

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -692,14 +692,14 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		func(
 			ctx context.Context, sessionData *sessiondata.SessionData,
 		) sqlutil.InternalExecutor {
-			ie := sql.MakeSessionBoundInternalExecutor(
+			ie := sql.NewSessionBoundInternalExecutor(
 				ctx,
-				sessionData,
 				s.pgServer.SQLServer,
 				s.sqlMemMetrics,
 				s.st,
 			)
-			return &ie
+			ie.CopySessionData(sessionData)
+			return ie
 		}
 
 	for _, m := range s.pgServer.Metrics() {

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -159,7 +159,7 @@ func (ex *connExecutor) prepare(
 	txn := client.NewTxn(ctx, ex.server.cfg.DB, ex.server.cfg.NodeID.Get(), client.RootTxn)
 
 	p := &ex.planner
-	ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTimestamp */)
+	ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */)
 	p.stmt = &stmt
 	flags, err := ex.populatePrepared(ctx, txn, placeholderHints, p)
 	if err != nil {

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -667,7 +667,7 @@ func (dsp *DistSQLPlanner) PlanAndRunSubqueries(
 			planIdx,
 			subqueryPlan,
 			planner,
-			evalCtxFactory,
+			evalCtxFactory(),
 			subqueryPlans,
 			recv,
 			maybeDistribute,
@@ -685,13 +685,11 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	planIdx int,
 	subqueryPlan subquery,
 	planner *planner,
-	evalCtxFactory func() *extendedEvalContext,
+	evalCtx *extendedEvalContext,
 	subqueryPlans []subquery,
 	recv *DistSQLReceiver,
 	maybeDistribute bool,
 ) error {
-	evalCtx := evalCtxFactory()
-
 	subqueryMonitor := mon.MakeMonitor(
 		"subquery",
 		mon.MemoryResource,

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -115,16 +115,16 @@ func TestSessionBoundInternalExecutor(t *testing.T) {
 	}
 
 	expDB := "foo"
-	ie := sql.MakeSessionBoundInternalExecutor(
+	ie := sql.NewSessionBoundInternalExecutor(
 		ctx,
-		&sessiondata.SessionData{
-			Database:      expDB,
-			SequenceState: &sessiondata.SequenceState{},
-		},
 		s.(*server.TestServer).Server.PGServer().SQLServer,
 		sql.MemoryMetrics{},
 		s.ExecutorConfig().(sql.ExecutorConfig).Settings,
 	)
+	ie.CopySessionData(&sessiondata.SessionData{
+		Database:      expDB,
+		SequenceState: &sessiondata.SequenceState{},
+	})
 
 	row, err := ie.QueryRow(ctx, "test", nil /* txn */, "show database")
 	if err != nil {
@@ -176,22 +176,24 @@ func TestInternalExecAppNameInitialization(t *testing.T) {
 		s, _, _ := serverutils.StartServer(t, params)
 		defer s.Stopper().Stop(context.TODO())
 
-		ie := sql.MakeSessionBoundInternalExecutor(
+		ie := sql.NewSessionBoundInternalExecutor(
 			context.TODO(),
-			&sessiondata.SessionData{
-				User:            security.RootUser,
-				Database:        "defaultdb",
-				ApplicationName: "appname_findme",
-				SequenceState:   &sessiondata.SequenceState{},
-			},
 			s.(*server.TestServer).Server.PGServer().SQLServer,
 			sql.MemoryMetrics{},
 			s.ExecutorConfig().(sql.ExecutorConfig).Settings,
 		)
-		testInternalExecutorAppNameInitialization(t, sem,
+		ie.CopySessionData(&sessiondata.SessionData{
+			User:            security.RootUser,
+			Database:        "defaultdb",
+			ApplicationName: "appname_findme",
+			SequenceState:   &sessiondata.SequenceState{},
+		})
+		testInternalExecutorAppNameInitialization(
+			t, sem,
 			"appname_findme", // app name in SHOW
 			sql.DelegatedAppNamePrefix+"appname_findme", // app name in stats
-			&ie)
+			ie,
+		)
 	})
 }
 


### PR DESCRIPTION
#### opt: improve query cache benchmark

Extending BenchmarkQueryCache to support multiple issuing methods.

Release note: None

#### sql: don't reinitialize the entire planner and evalcontext every time

A nontrivial time is spent doing `resetPlanner` because it populates a
ton of fields. Most of these fields can be set once. This change
splits the function into an `initPlanner` to be called once and a
`resetPlanner` to be called before every query.

This also fixes a bug where the query cache session info was being
reset on every query, defeating the mechanism to tone down the caching
when the hit rate is low.

Finally, this sets us up for a follow-up change which will reuse the
opt catalog (and its cached objects) across queries.

```
name                                               old time/op  new time/op  delta
QueryCache/small/clients-1/simple/cache-off         361µs ± 2%   362µs ± 2%    ~     (p=0.478 n=11+11)
QueryCache/small/clients-1/simple/cache-on          285µs ± 3%   285µs ± 2%    ~     (p=0.843 n=12+12)
QueryCache/small/clients-1/prepare-once/cache-off   306µs ± 4%   301µs ± 2%  -1.72%  (p=0.033 n=12+12)
QueryCache/small/clients-1/prepare-once/cache-on    306µs ± 4%   302µs ± 2%    ~     (p=0.266 n=12+12)
QueryCache/small/clients-1/prepare-each/cache-off   502µs ± 3%   502µs ± 3%    ~     (p=0.833 n=11+12)
QueryCache/small/clients-1/prepare-each/cache-on    446µs ± 4%   434µs ± 2%  -2.60%  (p=0.006 n=12+12)
QueryCache/large/clients-1/simple/cache-off         373µs ± 3%   375µs ± 3%    ~     (p=0.525 n=12+11)
QueryCache/large/clients-1/simple/cache-on          407µs ± 3%   408µs ± 5%    ~     (p=0.755 n=12+12)
QueryCache/large/clients-1/prepare-once/cache-off   313µs ± 2%   307µs ± 1%  -1.94%  (p=0.000 n=11+12)
QueryCache/large/clients-1/prepare-once/cache-on    313µs ± 2%   306µs ± 1%  -2.30%  (p=0.000 n=11+12)
QueryCache/large/clients-1/prepare-each/cache-off   514µs ± 3%   509µs ± 4%    ~     (p=0.219 n=12+12)
QueryCache/large/clients-1/prepare-each/cache-on    454µs ± 2%   440µs ± 2%  -2.96%  (p=0.000 n=11+12)
```

Release note: None
