### PR TITLE
roachtest: add an ignore list to psycopg

### DIFF
--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -257,11 +257,20 @@ echo "ext {
 		fmt.Fprintf(&bResults, "%d Total Tests Run\n",
 			passExpectedCount+passUnexpectedCount+failExpectedCount+failUnexpectedCount,
 		)
-		fmt.Fprintf(&bResults, "%d tests passed\n", passUnexpectedCount+passExpectedCount)
-		fmt.Fprintf(&bResults, "%d tests failed\n", failUnexpectedCount+failExpectedCount)
-		fmt.Fprintf(&bResults, "%d tests passed unexpectedly\n", passUnexpectedCount)
-		fmt.Fprintf(&bResults, "%d tests failed unexpectedly\n", failUnexpectedCount)
-		fmt.Fprintf(&bResults, "%d tests expected failed, but not run \n", notRunCount)
+
+		p := func(msg string, count int) {
+			testString := "tests"
+			if count == 1 {
+				testString = "test"
+			}
+			fmt.Fprintf(&bResults, "%d %s %s\n", count, testString, msg)
+		}
+		p("passed", passUnexpectedCount+passExpectedCount)
+		p("failed", failUnexpectedCount+failExpectedCount)
+		p("passed unexpectedly", passUnexpectedCount)
+		p("failed unexpectedly", failUnexpectedCount)
+		p("expected failed, but not run", notRunCount)
+
 		fmt.Fprintf(&bResults, "For a full summary look at the hibernate artifacts \n")
 		t.l.Printf("%s\n", bResults.String())
 		t.l.Printf("------------------------\n")

--- a/pkg/cmd/roachtest/psycopg_blacklist.go
+++ b/pkg/cmd/roachtest/psycopg_blacklist.go
@@ -18,23 +18,25 @@ package main
 import "strings"
 
 var psycopgBlacklists = []struct {
-	versionPrefix string
-	name          string
-	list          blacklist
+	versionPrefix  string
+	blacklistname  string
+	blacklist      blacklist
+	ignorelistname string
+	ignorelist     blacklist
 }{
-	{"v2.2", "psycopgBlackList2_2", psycopgBlackList2_2},
+	{"v2.2", "psycopgBlackList2_2", psycopgBlackList2_2, "psycopgIgnoreList2_2", psycopgIgnoreList2_2},
 }
 
-// getPsycopgBlacklistForVersion returns the appropriate psycopg blacklist
-// based on the cockroach version. This check only looks to ensure that the
-// prefix that matches.
-func getPsycopgBlacklistForVersion(version string) (string, blacklist) {
+// getPsycopgBlacklistForVersion returns the appropriate psycopg blacklist and
+// ignorelist based on the cockroach version. This check only looks to ensure
+// that the prefix that matches.
+func getPsycopgBlacklistForVersion(version string) (string, blacklist, string, blacklist) {
 	for _, info := range psycopgBlacklists {
 		if strings.HasPrefix(version, info.versionPrefix) {
-			return info.name, info.list
+			return info.blacklistname, info.blacklist, info.ignorelistname, info.ignorelist
 		}
 	}
-	return "", nil
+	return "", nil, "", nil
 }
 
 // These are lists of known psycopg test errors and failures.
@@ -381,4 +383,8 @@ var psycopgBlackList2_2 = blacklist{
 	"psycopg2.tests.test_types_extras.RangeCasterTestCase.test_schema_range":                                      "26443",
 	"psycopg2.tests.test_with.WithCursorTestCase.test_exception_swallow":                                          "unknown",
 	"psycopg2.tests.test_with.WithCursorTestCase.test_named_with_noop":                                            "unknown",
+}
+
+var psycopgIgnoreList2_2 = blacklist{
+	"psycopg2.tests.test_green.GreenTestCase.test_flush_on_write": "unknown",
 }


### PR DESCRIPTION
There is one flaky test in the psycopg unit tests which adds failures to our
nightlies.  This will now allow for either a pass or fail. It shows up in
the raw test results as a SKIP.

Also cleaned up the output to allow for plural/singular tests/test.

Fixes #35053.

Release note: None