### PR TITLE
execbuild: bugfix to group by with input ordering

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -749,6 +749,14 @@ func (b *Builder) buildGroupByInput(groupBy memo.RelExpr) (execPlan, error) {
 		neededCols.UnionWith(memo.ExtractAggInputColumns(aggs[i].Agg))
 	}
 
+	// In rare cases, we might need a column only for its ordering, for example:
+	//   SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
+	// In this case we can't project the column away as it is still needed by
+	// distsql to maintain the desired ordering.
+	for _, c := range groupByInput.ProvidedPhysical().Ordering {
+		neededCols.Add(int(c.ID()))
+	}
+
 	if neededCols.Equals(groupByInput.Relational().OutputCols) {
 		// All columns produced by the input are used.
 		return input, nil
@@ -764,14 +772,14 @@ func (b *Builder) buildGroupByInput(groupBy memo.RelExpr) (execPlan, error) {
 		}
 	})
 
-	reqOrdering := input.reqOrdering(groupBy)
+	input.outputCols = newOutputCols
+	reqOrdering := input.reqOrdering(groupByInput)
 	input.root, err = b.factory.ConstructSimpleProject(
 		input.root, cols, nil /* colNames */, reqOrdering,
 	)
 	if err != nil {
 		return execPlan{}, err
 	}
-	input.outputCols = newOutputCols
 	return input, nil
 }
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -945,28 +945,24 @@ render          ·         ·           (k)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
-group           ·            ·              (concat_agg)  ·
- │              aggregate 0  concat_agg(s)  ·             ·
- │              scalar       ·              ·             ·
- └── render     ·            ·              (s)           ·
-      │         render 0     s              ·             ·
-      └── scan  ·            ·              (k, s)        +k
-·               table        kv@primary     ·             ·
-·               spans        ALL            ·             ·
+group      ·            ·              (concat_agg)  ·
+ │         aggregate 0  concat_agg(s)  ·             ·
+ │         scalar       ·              ·             ·
+ └── scan  ·            ·              (k, s)        +k
+·          table        kv@primary     ·             ·
+·          spans        ALL            ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT array_agg(k) FROM (SELECT k FROM kv ORDER BY s)
 ----
-group                ·            ·             (array_agg)  ·
- │                   aggregate 0  array_agg(k)  ·            ·
- │                   scalar       ·             ·            ·
- └── render          ·            ·             (k)          ·
-      │              render 0     k             ·            ·
-      └── sort       ·            ·             (k, s)       +s
-           │         order        +s            ·            ·
-           └── scan  ·            ·             (k, s)       ·
-·                    table        kv@primary    ·            ·
-·                    spans        ALL           ·            ·
+group           ·            ·             (array_agg)  ·
+ │              aggregate 0  array_agg(k)  ·            ·
+ │              scalar       ·             ·            ·
+ └── sort       ·            ·             (k, s)       +s
+      │         order        +s            ·            ·
+      └── scan  ·            ·             (k, s)       ·
+·               table        kv@primary    ·            ·
+·               spans        ALL           ·            ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT string_agg(s, ',') FROM (SELECT s FROM kv ORDER BY k)
@@ -974,8 +970,9 @@ EXPLAIN (VERBOSE) SELECT string_agg(s, ',') FROM (SELECT s FROM kv ORDER BY k)
 group           ·            ·              (string_agg)  ·
  │              aggregate 0  string_agg(s)  ·             ·
  │              scalar       ·              ·             ·
- └── render     ·            ·              (s)           ·
-      │         render 0     s              ·             ·
+ └── render     ·            ·              (k, s)        +k
+      │         render 0     k              ·             ·
+      │         render 1     s              ·             ·
       └── scan  ·            ·              (k, s)        +k
 ·               table        kv@primary     ·             ·
 ·               spans        ALL            ·             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -104,10 +104,10 @@ scan  ·      ·            (x, y, z)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT z FROM (SELECT y, z FROM xyz WHERE y > 1)
 ----
-distinct        ·            ·        (z)     weak-key(z)
+distinct        ·            ·        (z)     weak-key(z); +z
  │              distinct on  z        ·       ·
  │              order key    z        ·       ·
- └── render     ·            ·        (z)     ·
+ └── render     ·            ·        (z)     +z
       │         render 0     z        ·       ·
       └── scan  ·            ·        (y, z)  +z
 ·               table        xyz@foo  ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -168,12 +168,12 @@ distinct   ·            ·            (pk1, pk2)  weak-key(pk1); +pk1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
-distinct             ·            ·            (a, c)     weak-key(a); +a
- │                   distinct on  a            ·          ·
- │                   order key    a            ·          ·
- └── render          ·            ·            (a, c)     +a
-      │              render 0     a            ·          ·
-      │              render 1     c            ·          ·
+render               ·            ·            (a, c)     ·
+ │                   render 0     a            ·          ·
+ │                   render 1     c            ·          ·
+ └── distinct        ·            ·            (a, b, c)  weak-key(a); +a,-c,+b
+      │              distinct on  a            ·          ·
+      │              order key    a            ·          ·
       └── sort       ·            ·            (a, b, c)  +a,-c,+b
            │         order        +a,-c,+b     ·          ·
            └── scan  ·            ·            (a, b, c)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -300,3 +300,75 @@ query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT sum(x) FROM (SELECT a, b::float + c AS x FROM data) WHERE a > x GROUP BY a ORDER BY a]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlk1r20wQx-_PpxBzSsgaaVbym07KJRDIY5c0OZTWBMVaHIOjNas1NIR89yIt1LLVzMi1cH30y08zu__fDHqHXGdqkr6qAuLvgCBAgoAQBEQgoA8zAWuj56ootCn_4oDb7CfEgYBlvt7Y8uuZgLk2CuJ3sEu7UhDDQ_q8UvcqzZTxAxCQKZsuV1WZtVm-puYtyVKbgoCv6zQvYq_no5fmmSc9bV-UKUDAvcozZWIvCa8SGcc3d9Prh5HwEoTZhwC9sdvyhU0XCmL8EO1bnOieXvv93eZulitb1ZTej00QhIoqJw8pd71YGLVIrTY-7t1IUt761GTKqKwsDQKuJ9-eJtOHp8nj3d1FIi_Li3r8_yLBy71utgWe37yXtHjZe3TZ_bbj8NOOt8_RrpH951y5B1HH6jdq14-FjWPh72NVB5xubHl6Qdx49Nf9y0_6dxbI3UQ-K9_fKY_tRwDbjICPPV9WQ4BuCDqYAaZHd_pBZzPAlKvLgucxA9jxDAxOPAOyvYSylYSy54cdS8j06CQcdiYhU66eljwPCWXHEg5PLGHYXsKwlYRhz486lpDp0Uk46kxCplw9rfA8JAw7lnB0Ygmj9hJGrSSMetXb4bHiMX058cadiceUqycUnYd4Ucfijf_ha-gfWrtXxVrnhWr1hhmUh1PZQrnLKPTGzNUXo-dVGfdxWnHVF5kqrPsV3Yfb3P1UNliHkYQlDct9GOtwuAPjYfDoGBjlUfTgGFoGNB2SFx7RcESnxWTdJ-kBDQ9IeEjDw2NEoWFGFBrmRGFoRhSa5kQZHSPKmN4JAbMUmJXC7ZTGUjkkboZm8mZoLnAOZxJncC5ybKyWQzJHerVgxKRGLxfsM3hjuxwUOk1zodM0GzqDc6HTOBs6vVm50BtLZje1EZMavWVwzOCNPXNQ6DTNhU7TbOgMzoVO41zokt6w-6HPPv77FQAA___0jY3c
+
+# Ensure that an interesting input ordering that causes an ordered group by
+# forces an ordered synchronizer. We create an index on b even though it's
+# not used to help the optimizer realize that there's an ordering available
+# on b for a constrained scan on the a,b primary index.
+
+statement ok
+CREATE TABLE data2 (a INT, b INT, PRIMARY KEY (a, b), INDEX(b));
+ALTER TABLE data2 SPLIT AT SELECT 1,i FROM generate_series(1, 9) AS g(i);
+ALTER TABLE data2 EXPERIMENTAL_RELOCATE
+  SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i);
+
+# Verify data placement.
+query TTTI colnames
+SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data2]
+----
+start_key  end_key  replicas  lease_holder
+NULL       /1/1     {2}       2
+/1/1       /1/2     {5}       5
+/1/2       /1/3     {5}       5
+/1/3       /1/4     {5}       5
+/1/4       /1/5     {5}       5
+/1/5       /1/6     {5}       5
+/1/6       /1/7     {5}       5
+/1/7       /1/8     {5}       5
+/1/8       /1/9     {5}       5
+/1/9       NULL     {5}       5
+
+
+query T
+EXPLAIN (opt,verbose) SELECT b, count(*) FROM data2 WHERE a=1 GROUP BY b
+----
+group-by
+ ├── columns: b:2 count:3
+ ├── grouping columns: b:2
+ ├── internal-ordering: +2 opt(1)
+ ├── stats: [rows=9.5617925, distinct(2)=9.5617925, null(2)=0]
+ ├── cost: 10.7156179
+ ├── key: (2)
+ ├── fd: (2)-->(3)
+ ├── prune: (3)
+ ├── scan data2
+ │    ├── columns: a:1 b:2
+ │    ├── constraint: /1/2: [/1 - /1]
+ │    ├── stats: [rows=10, distinct(1)=1, null(1)=0, distinct(2)=9.5617925, null(2)=0]
+ │    ├── cost: 10.41
+ │    ├── key: (2)
+ │    ├── fd: ()-->(1)
+ │    ├── ordering: +2 opt(1) [actual: +2]
+ │    ├── prune: (2)
+ │    └── interesting orderings: (+1,+2) (+2,+1)
+ └── aggregations
+      └── count-rows
+
+query TTTTT
+EXPLAIN (verbose) SELECT b, count(*) FROM data2 WHERE a=1 GROUP BY b
+----
+group           ·            ·              (b, count)  ·
+ │              aggregate 0  b              ·           ·
+ │              aggregate 1  count_rows()   ·           ·
+ │              group by     @1             ·           ·
+ │              ordered      @1             ·           ·
+ └── render     ·            ·              (b)         +b
+      │         render 0     b              ·           ·
+      └── scan  ·            ·              (a, b)      +b
+·               table        data2@primary  ·           ·
+·               spans        /1-/2          ·           ·
+
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT b, count(*) FROM data2 WHERE a=1 GROUP BY b];
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzMlFtr3DAQhd_7K5Z52lAFW9pLQU8OfVpI7bIXSilmUazBMWwsI8nQUPa_F1sBX7pR1m0pfZRnvplz5oB_QKkkxuIJDfBvQIEAAwIrSAlUWmVojNJNyTVu5HfgIYGirGrrPtvCnhA41KXSEjVKICDRiuLU1NNzSiBTGoF3rbG6VVWwHjUSULV9GZsSMFbkCHx5Jr3VtLf6wuC9eDjhFoVEHYSD8VDp4kno50gKKxqHu0qUhs8CehvQoLGd1JbPIgavCaFThNzlucZcWKUDNtQRtbvcpfisfd3FX49xsj_Gh_v7eURvgMDH5BDvj9vky25-M1LULXl4nj0K8_jL_PbmL6rZq6q7OZdyg4i-h4vh9awtf8fa7vDpuIn384iNnXWqFwPV7PrQ6ZWhN7GzyaG_IaR3mcV_FDr7u6Gv_k3oof_WWzSVKg1e9Q8JG0soc3QnMKrWGX7WKmvXuGfScu0Hica66gf32JSu1Ajsw9QLMz_MxjDtw4sBTKfBaz-88MoO_fDSC6_8nld_4tkPv-F5Pclzen73MwAA__-UYket

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -135,12 +135,12 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJykk01r4zAQhu_7K8x7lvH3Hn
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c
 ----
-distinct        ·            ·            (a, b)     weak-key(a,b); +a,+b
- │              distinct on  a, b         ·          ·
- │              order key    a, b         ·          ·
- └── render     ·            ·            (a, b)     +a,+b
-      │         render 0     a            ·          ·
-      │         render 1     b            ·          ·
+render          ·            ·            (a, b)     ·
+ │              render 0     a            ·          ·
+ │              render 1     b            ·          ·
+ └── distinct   ·            ·            (a, b, c)  weak-key(a,b); +a,+b,+c
+      │         distinct on  a, b         ·          ·
+      │         order key    a, b         ·          ·
       └── scan  ·            ·            (a, b, c)  +a,+b,+c
 ·               table        abc@primary  ·          ·
 ·               spans        ALL          ·          ·
@@ -148,4 +148,4 @@ distinct        ·            ·            (a, b)     weak-key(a,b); +a,+b
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJy0lEFvmzAYhu_7Fei7xhHYJmnKicMulap26rbTwsHFnzqkFCPbkTZF-e8TeCKBLcYL2cWSgdfPq-dDPkCtJD6JdzSQfQMKBBgQ4EAgBQIrKAg0WpVojNLtJy7wIH9AlhCo6mZv28cFgVJphOwAtrI7hAy-iNcdvqCQqOP2XIlWVLsO0-jqXeifuXgtgcDnRtQmi-Knr4-Pp2UZb4FuoV_ZFoDA895mUU5JzkjOoTgSUHt76mCseEPI6JGE9_xYGVvVpY3Xw5IdpUVqiRrlb-xFJrvIPKGUO2rMWZCcLUjOF1AcfQVpMqshHzSk4dNjIdP7Y1rL882sAU5U7f3c3XCALFwP_xc97FyP2_BuTa_WM1G117O5oR4ericN0zNysTzfxFtYXa1nomqv5_6GetJwPUmAnuXoboxELSMaKfsd9ZVWJhr2Vlb_6VL8C_MFTaNqgwPipZOT9qZE-YbuhjVqr0v8pFXZYdz2uct1DyQa695St3mo3au24HmYesNsEKbjMPOTJ9Dcm0794XRO75U3vPaT13PId97wxk_ezCHf-2eVTPwm_p9szC6OH34FAAD__6vp-Bs=
+https://cockroachdb.github.io/distsqlplan/decode.html#eJy0lMFvmzAUxu_7K9C7xhHYkDTlxGGXSlUzddtpcHDxU4eUYmQbaVPF_z6BJQJsMa6SXSw9w-fv8-9Z7x1qKfCJv6GG9AdQIMCAQAwEEiCwg4JAo2SJWkvV_2IFD-IXpBGBqm5a028XBEqpENJ3MJU5IaTwjb-c8Bm5QBX25wo0vDoNNo2q3rj6nfGXEgh8bXit0yB8-v74eF62YQ40h3FlOUDREZCtOXtqw18RUtoR_1yfK22qujThfh4qoyTr735UAhWKNLAblzzZRc-zlbRHLX02JGMbksUbKDpXQBp5JSRwbM1a3HgWl_q3jvm07q9WbafFh7q3Em2Ec3fD7jF_HPFHcLApDlvEw5p441iJNuI43BBH7I8j8cOxuPt2WoQ57LxxrEQbcdzfEEfijyPywLFdDLqA1yKggTQ_UXlSWEk0Utj9pwn3D89n1I2sNc4cL50c9WMPxSvacallq0r8omQ52NjyOOiGDYHa2K_UFg-1_dQHnIqpU8xmYroUM7fzinXsVCducXJN7p1TvHc7769xvnOKD27nwzXO9-5eRSvPxP3Ilt5F9-lPAAAA__-Unui8

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -171,10 +171,10 @@ query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT b1.title FROM books as b1 JOIN books2 as b2 ON b1.title = b2.title WHERE b1.shelf <> b2.shelf
 ----
 tree                   field        description     columns                       ordering
-distinct               ·            ·               (title)                       weak-key(title)
+distinct               ·            ·               (title)                       weak-key(title); +title
  │                     distinct on  title           ·                             ·
  │                     order key    title           ·                             ·
- └── render            ·            ·               (title)                       ·
+ └── render            ·            ·               (title)                       +title
       │                render 0     title           ·                             ·
       └── lookup-join  ·            ·               (title, shelf, title, shelf)  +title
            │           table        books2@primary  ·                             ·


### PR DESCRIPTION
Previously, the execbuilder didn't properly preserve the ordering of the
inputs to group by nodes, which could cause the physical planner to fail
to notice a required ordering between stages in a multi stage
aggregation. This could in turn cause incorrect aggregation results.

Fixes #35209.

Release note (bug fix): fix a planning bug that caused incorrect
aggregation results on multi-node aggregations with implicit, partial
orderings on the inputs to the aggregations.