### PR TITLE
teamcity: disable musl builds

### DIFF
--- a/pkg/cmd/publish-artifacts/main.go
+++ b/pkg/cmd/publish-artifacts/main.go
@@ -170,7 +170,7 @@ func main() {
 		// of a given triple.
 		{buildType: "darwin", suffix: ".darwin-10.9-amd64"},
 		{buildType: "linux-gnu", suffix: ".linux-2.6.32-gnu-amd64"},
-		{buildType: "linux-musl", suffix: ".linux-2.6.32-musl-amd64"},
+		//{buildType: "linux-musl", suffix: ".linux-2.6.32-musl-amd64"},
 		{buildType: "windows", suffix: ".windows-6.2-amd64.exe"},
 	} {
 		for i, extraArgs := range []struct {

--- a/pkg/cmd/publish-provisional-artifacts/main.go
+++ b/pkg/cmd/publish-provisional-artifacts/main.go
@@ -211,7 +211,7 @@ func run(svc s3I, execFn execRunner, flags runFlags) {
 		// of a given triple.
 		{buildType: "darwin", suffix: ".darwin-10.9-amd64"},
 		{buildType: "linux-gnu", suffix: ".linux-2.6.32-gnu-amd64"},
-		{buildType: "linux-musl", suffix: ".linux-2.6.32-musl-amd64"},
+		//{buildType: "linux-musl", suffix: ".linux-2.6.32-musl-amd64"},
 		{buildType: "windows", suffix: ".windows-6.2-amd64.exe"},
 	} {
 		for i, extraArgs := range []struct {


### PR DESCRIPTION
musl builds are broken now due to GSS. Disable them for now because we
need to move along.

Release note: None