### PR TITLE
importccl: fix bug in progress of direct workload imports

### DIFF
--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -133,7 +133,7 @@ func (w *workloadReader) readFiles(
 		for b := conf.BatchBegin; b < conf.BatchEnd; b++ {
 			if rows-lastProgress > 10000 {
 				// how far we are on this file
-				fileProgress := float32(b) / float32(numBatches)
+				fileProgress := float32(b-conf.BatchBegin) / float32(numBatches)
 				progress := initialProgress + fileProgress/numFiles
 				if err := progressFn(progress); err != nil {
 					return err


### PR DESCRIPTION
I did a pass cleaning up the naming of the loop vars after I’d tested it,
but introduced a bug in determining the i'th batch by including the 
tarting offset in i, resulting in bogus progress i.e. batch 108/10.

Release note: none.