### PR TITLE
exec: add deselector operator

### DIFF
--- a/pkg/sql/exec/deselector.go
+++ b/pkg/sql/exec/deselector.go
@@ -1,0 +1,60 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import "github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+
+// deselectorOp consumes the input operator, and if resulting batches have a
+// selection vector, it coalesces them (meaning that tuples will be reordered
+// or omitted according to the selection vector). If the batches come with no
+// selection vector, it is a noop.
+type deselectorOp struct {
+	input      Operator
+	inputTypes []types.T
+
+	output ColBatch
+}
+
+var _ Operator = &deselectorOp{}
+
+// NewDeselectorOp creates a new deselector operator on the given input
+// operator with the given column types.
+func NewDeselectorOp(input Operator, colTypes []types.T) Operator {
+	return &deselectorOp{
+		input:      input,
+		inputTypes: colTypes,
+	}
+}
+
+func (p *deselectorOp) Init() {
+	p.input.Init()
+	p.output = NewMemBatch(p.inputTypes)
+}
+
+func (p *deselectorOp) Next() ColBatch {
+	batch := p.input.Next()
+	if batch.Selection() == nil {
+		return batch
+	}
+
+	p.output.SetLength(batch.Length())
+	sel := batch.Selection()
+	for i, t := range p.inputTypes {
+		toCol := p.output.ColVec(i)
+		fromCol := batch.ColVec(i)
+		toCol.CopyWithSelInt16(fromCol, sel, batch.Length(), t)
+	}
+	return p.output
+}

--- a/pkg/sql/exec/deselector_test.go
+++ b/pkg/sql/exec/deselector_test.go
@@ -1,0 +1,117 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+func TestDeselector(t *testing.T) {
+	tcs := []struct {
+		colTypes []types.T
+		tuples   []tuple
+		sel      []uint16
+		expected []tuple
+	}{
+		{
+			colTypes: []types.T{types.Int64},
+			tuples:   tuples{{0}, {1}, {2}},
+			sel:      nil,
+			expected: tuples{{0}, {1}, {2}},
+		},
+		{
+			colTypes: []types.T{types.Int64},
+			tuples:   tuples{{0}, {1}, {2}},
+			sel:      []uint16{},
+			expected: tuples{},
+		},
+		{
+			colTypes: []types.T{types.Int64},
+			tuples:   tuples{{0}, {1}, {2}},
+			sel:      []uint16{1},
+			expected: tuples{{1}},
+		},
+		{
+			colTypes: []types.T{types.Int64},
+			tuples:   tuples{{0}, {1}, {2}},
+			sel:      []uint16{0, 2},
+			expected: tuples{{0}, {2}},
+		},
+		{
+			colTypes: []types.T{types.Int64},
+			tuples:   tuples{{0}, {1}, {2}},
+			sel:      []uint16{0, 1, 2},
+			expected: tuples{{0}, {1}, {2}},
+		},
+	}
+
+	for _, tc := range tcs {
+		runTestsWithFixedSel(t, []tuples{tc.tuples}, tc.sel, func(t *testing.T, input []Operator) {
+			op := NewDeselectorOp(input[0], tc.colTypes)
+			out := newOpTestOutput(op, []int{0}, tc.expected)
+
+			if err := out.Verify(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func BenchmarkDeselector(b *testing.B) {
+	nCols := 1
+	inputTypes := make([]types.T, nCols)
+
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		inputTypes[colIdx] = types.Int64
+	}
+
+	batch := NewMemBatch(inputTypes)
+
+	for colIdx := 0; colIdx < nCols; colIdx++ {
+		col := batch.ColVec(colIdx).Int64()
+		for i := 0; i < ColBatchSize; i++ {
+			col[i] = int64(i)
+		}
+	}
+	for _, probOfOmitting := range []float64{0.1, 0.9} {
+		sel, batchLen := generateSelectionVector(ColBatchSize, probOfOmitting)
+
+		for _, nBatches := range []int{1 << 1, 1 << 2, 1 << 4, 1 << 8} {
+			b.Run(fmt.Sprintf("rows=%d/after selection=%d", nBatches*ColBatchSize, nBatches*int(batchLen)), func(b *testing.B) {
+				// We're measuring the amount of data that is not selected out.
+				b.SetBytes(int64(8 * nBatches * int(batchLen) * nCols))
+				batch.SetSelection(true)
+				copy(batch.Selection(), sel)
+				batch.SetLength(batchLen)
+				input := newRepeatableBatchSource(batch)
+				op := NewDeselectorOp(input, inputTypes)
+				op.Init()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					input.resetBatchesToReturn(nBatches)
+					for b := op.Next(); b.Length() != 0; b = op.Next() {
+					}
+					// We don't need to reset the deselector because it doesn't keep any
+					// state. We do, however, want to keep its already allocated memory
+					// so that this memory allocation doesn't impact the benchmark.
+				}
+				b.StopTimer()
+			})
+		}
+	}
+}

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -58,6 +58,24 @@ func runTests(t *testing.T, tups []tuples, test func(t *testing.T, inputs []Oper
 	}
 }
 
+// runTestsWithFixedSel is a helper that (with a given fixed selection vector)
+// automatically runs your tests with varied batch sizes. Provide a test
+// function that takes a list of input Operators, which will give back the
+// tuples provided in batches.
+func runTestsWithFixedSel(
+	t *testing.T, tups []tuples, sel []uint16, test func(t *testing.T, inputs []Operator),
+) {
+	for _, batchSize := range []uint16{1, 2, 3, 16, 1024} {
+		t.Run(fmt.Sprintf("batchSize=%d/fixedSel", batchSize), func(t *testing.T) {
+			inputSources := make([]Operator, len(tups))
+			for i, tup := range tups {
+				inputSources[i] = newOpFixedSelTestInput(sel, batchSize, tup)
+			}
+			test(t, inputSources)
+		})
+	}
+}
+
 // opTestInput is an Operator that columnarizes test input in the form of tuples
 // of arbitrary Go types. It's meant to be used in Operator unit tests in
 // conjunction with opTestOutput like the following:
@@ -198,6 +216,127 @@ func (s *opTestInput) Next() ColBatch {
 	}
 
 	s.batch.SetLength(batchSize)
+	return s.batch
+}
+
+type opFixedSelTestInput struct {
+	typs []types.T
+
+	batchSize uint16
+	tuples    tuples
+	batch     ColBatch
+	sel       []uint16
+	// idx is the index of the tuple to be emitted next. We need to maintain it
+	// in case the provided selection vector or provided tuples (if sel is nil)
+	// is longer than requested batch size.
+	idx uint16
+}
+
+var _ Operator = &opFixedSelTestInput{}
+
+// newOpFixedSelTestInput returns a new opFixedSelTestInput with the given
+// input tuples and selection vector. The input tuples are translated into
+// types automatically, using simple rules (e.g. integers always become Int64).
+func newOpFixedSelTestInput(sel []uint16, batchSize uint16, tuples tuples) *opFixedSelTestInput {
+	ret := &opFixedSelTestInput{
+		batchSize: batchSize,
+		sel:       sel,
+		tuples:    tuples,
+	}
+	return ret
+}
+
+func (s *opFixedSelTestInput) Init() {
+	if len(s.tuples) == 0 {
+		panic("empty tuple source")
+	}
+
+	typs := make([]types.T, len(s.tuples[0]))
+	for i := range typs {
+		// Default type for test cases is Int64 in case the entire column is null
+		// and the type is indeterminate.
+		typs[i] = types.Int64
+		for _, tup := range s.tuples {
+			if tup[i] != nil {
+				typs[i] = types.FromGoType(tup[i])
+				break
+			}
+		}
+	}
+
+	s.typs = typs
+	s.batch = NewMemBatch(typs)
+	tupleLen := len(s.tuples[0])
+	for _, i := range s.sel {
+		if len(s.tuples[i]) != tupleLen {
+			panic(fmt.Sprintf("mismatched tuple lens: found %+v expected %d vals",
+				s.tuples[i], tupleLen))
+		}
+	}
+
+	if s.sel != nil {
+		s.batch.SetSelection(true)
+		// When non-nil selection vector is given, we convert all tuples into the
+		// Go values at once, and we'll be copying an appropriate chunk of the
+		// selection vector later in Next().
+		for i := range s.typs {
+			vec := s.batch.ColVec(i)
+			vec.UnsetNulls()
+			// Automatically convert the Go values into exec.Type slice elements using
+			// reflection. This is slow, but acceptable for tests.
+			col := reflect.ValueOf(vec.Col())
+			for j := 0; j < len(s.tuples); j++ {
+				if s.tuples[j][i] == nil {
+					vec.SetNull(uint16(j))
+				} else {
+					col.Index(j).Set(
+						reflect.ValueOf(s.tuples[j][i]).Convert(reflect.TypeOf(vec.Col()).Elem()))
+				}
+			}
+		}
+	}
+
+}
+
+func (s *opFixedSelTestInput) Next() ColBatch {
+	var batchSize uint16
+	if s.sel == nil {
+		batchSize = s.batchSize
+		if uint16(len(s.tuples))-s.idx < batchSize {
+			batchSize = uint16(len(s.tuples)) - s.idx
+		}
+		// When nil selection vector is given, we convert only the tuples that fit
+		// into the current batch (keeping the s.idx in mind).
+		for i := range s.typs {
+			vec := s.batch.ColVec(i)
+			vec.UnsetNulls()
+			// Automatically convert the Go values into exec.Type slice elements using
+			// reflection. This is slow, but acceptable for tests.
+			col := reflect.ValueOf(vec.Col())
+			for j := uint16(0); j < batchSize; j++ {
+				if s.tuples[s.idx+j][i] == nil {
+					vec.SetNull(j)
+				} else {
+					col.Index(int(j)).Set(
+						reflect.ValueOf(s.tuples[s.idx+j][i]).Convert(reflect.TypeOf(vec.Col()).Elem()))
+				}
+			}
+		}
+	} else {
+		if s.idx == uint16(len(s.sel)) {
+			s.batch.SetLength(0)
+			return s.batch
+		}
+		batchSize = s.batchSize
+		if uint16(len(s.sel))-s.idx < batchSize {
+			batchSize = uint16(len(s.sel)) - s.idx
+		}
+		// All tuples have already been converted to the Go values, so we only need
+		// to set the right selection vector for s.batch.
+		copy(s.batch.Selection(), s.sel[s.idx:s.idx+batchSize])
+	}
+	s.batch.SetLength(batchSize)
+	s.idx += batchSize
 	return s.batch
 }
 
@@ -349,6 +488,8 @@ func assertTuplesOrderedEqual(expected tuples, actual tuples) error {
 type repeatableBatchSource struct {
 	internalBatch ColBatch
 	batchLen      uint16
+	// sel specifies the desired selection vector for the batch.
+	sel []uint16
 
 	batchesToReturn int
 	batchesReturned int
@@ -356,22 +497,33 @@ type repeatableBatchSource struct {
 
 var _ Operator = &repeatableBatchSource{}
 
-// newRepeatableBatchSource returns a new Operator initialized to return
-// its input batch forever.
+// newRepeatableBatchSource returns a new Operator initialized to return its
+// input batch forever (including the selection vector if batch comes with it).
 func newRepeatableBatchSource(batch ColBatch) *repeatableBatchSource {
-	return &repeatableBatchSource{
+	src := &repeatableBatchSource{
 		internalBatch: batch,
 		batchLen:      batch.Length(),
 	}
+	if batch.Selection() != nil {
+		src.sel = make([]uint16, batch.Length())
+		copy(src.sel, batch.Selection())
+	}
+	return src
 }
 
 func (s *repeatableBatchSource) Next() ColBatch {
-	s.internalBatch.SetSelection(false)
+	s.internalBatch.SetSelection(s.sel != nil)
 	s.batchesReturned++
 	if s.batchesToReturn != 0 && s.batchesReturned > s.batchesToReturn {
 		s.internalBatch.SetLength(0)
 	} else {
 		s.internalBatch.SetLength(s.batchLen)
+	}
+	if s.sel != nil {
+		// Since selection vectors are mutable, to make sure that we return the
+		// batch with the given selection vector, we need to reset
+		// s.internalBatch.Selection() to s.sel on every iteration.
+		copy(s.internalBatch.Selection(), s.sel)
 	}
 	return s.internalBatch
 }
@@ -519,4 +671,78 @@ func TestRepeatableBatchSource(t *testing.T) {
 	if b.Selection() != nil {
 		t.Fatalf("expected repeatableBatchSource to reset selection vector, found %+v", b.Selection())
 	}
+}
+
+func TestRepeatableBatchSourceWithFixedSel(t *testing.T) {
+	batch := NewMemBatch([]types.T{types.Int64})
+	sel, batchLen := generateSelectionVector(10 /* batchSize */, 0 /* probOfOmitting */)
+	batch.SetLength(batchLen)
+	batch.SetSelection(true)
+	copy(batch.Selection(), sel)
+	input := newRepeatableBatchSource(batch)
+	b := input.Next()
+
+	b.SetLength(0)
+	b.SetSelection(false)
+	b = input.Next()
+	if b.Length() != batchLen {
+		t.Fatalf("expected repeatableBatchSource to reset batch length to %d, found %d", batchLen, b.Length())
+	}
+	if b.Selection() == nil {
+		t.Fatalf("expected repeatableBatchSource to reset selection vector, expected %v but found %+v", sel, b.Selection())
+	} else {
+		for i := uint16(0); i < batchLen; i++ {
+			if b.Selection()[i] != sel[i] {
+				t.Fatalf("expected repeatableBatchSource to reset selection vector, expected %v but found %+v", sel, b.Selection())
+			}
+		}
+	}
+
+	newSel, newBatchLen := generateSelectionVector(10 /* batchSize */, 0.2 /* probOfOmitting */)
+	b.SetLength(newBatchLen)
+	b.SetSelection(true)
+	copy(b.Selection(), newSel)
+	b = input.Next()
+	if b.Length() != batchLen {
+		t.Fatalf("expected repeatableBatchSource to reset batch length to %d, found %d", batchLen, b.Length())
+	}
+	if b.Selection() == nil {
+		t.Fatalf("expected repeatableBatchSource to reset selection vector, expected %v but found %+v", sel, b.Selection())
+	} else {
+		for i := uint16(0); i < batchLen; i++ {
+			if b.Selection()[i] != sel[i] {
+				t.Fatalf("expected repeatableBatchSource to reset selection vector, expected %v but found %+v", sel, b.Selection())
+			}
+		}
+	}
+}
+
+// generateSelectionVector creates a selection vector for a given batchSize
+// and returns the selection vector and its length (which will be equal to
+// batchSize if probOfOmitting is 0). probOfOmitting specifies the probability
+// that a row should be omitted from the batch (i.e. whether it should be
+// selected out).
+func generateSelectionVector(batchSize uint16, probOfOmitting float64) ([]uint16, uint16) {
+	if probOfOmitting < 0 || probOfOmitting > 1 {
+		panic(fmt.Sprintf("probability of omitting a row is %f - outside of [0, 1] range", probOfOmitting))
+	}
+	sel := make([]uint16, batchSize)
+	used := make([]bool, batchSize)
+	rng, _ := randutil.NewPseudoRand()
+	for i := uint16(0); i < batchSize; i++ {
+		if rng.Float64() < probOfOmitting {
+			batchSize--
+			i--
+			continue
+		}
+		for {
+			j := uint16(rng.Intn(int(batchSize)))
+			if !used[j] {
+				used[j] = true
+				sel[i] = j
+				break
+			}
+		}
+	}
+	return sel, batchSize
 }


### PR DESCRIPTION
Adds deselector operator that takes in batches and reorders and
omits tuples depending on the selection vector. If a batch comes in
with no selection vector, it is a noop. This operator is pretty cheap
and makes reasoning about other operators (e.g. in sort chunks) a lot
easier, and it could be useful in other places as well.

Benchmarks (with randomly ordered selection vector that omits about 10% of the rows):
```
BenchmarkDeselector/rows=2048/after_selection=1832-12         	 1000000	      1087 ns/op	13479.01 MB/s
BenchmarkDeselector/rows=4096/after_selection=3664-12         	 1000000	      2174 ns/op	13476.79 MB/s
BenchmarkDeselector/rows=16384/after_selection=14656-12       	  200000	      8759 ns/op	13384.91 MB/s
BenchmarkDeselector/rows=262144/after_selection=234496-12     	   10000	    140090 ns/op	13391.12 MB/s
```

Release note: None