### PR TITLE
WIP engine: defer compactions while ingesting SSTs

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -421,6 +421,29 @@ DBStatus DBEnableAutoCompaction(DBEngine* db) {
   return ToDBStatus(status);
 }
 
+DBStatus DBOptimizeForBulkIngesting(DBEngine* db) {
+  auto status = db->rep->SetOptions({
+    {"level0_file_num_compaction_trigger", "15"},
+    {"level0_slowdown_writes_trigger", "200"},
+    {"level0_stop_writes_trigger", "400"},
+    {"soft_pending_compaction_bytes_limit", "1000000000000"},
+    {"hard_pending_compaction_bytes_limit", "2000000000000"},
+  });
+  return ToDBStatus(status);
+}
+
+DBStatus DBFinishedBulkIngesting(DBEngine* db) {
+  // TODO(dt): remember the prior settings instead, or at least reuse defaults.
+  auto status = db->rep->SetOptions({
+    {"level0_file_num_compaction_trigger", "2"},
+    {"level0_slowdown_writes_trigger", "20"},
+    {"level0_stop_writes_trigger", "32"},
+    {"soft_pending_compaction_bytes_limit", "68719476736"},
+    {"hard_pending_compaction_bytes_limit", "274877906944"},
+  });
+  return ToDBStatus(status);
+}
+
 DBStatus DBApproximateDiskBytes(DBEngine* db, DBKey start, DBKey end, uint64_t* size) {
   const std::string start_key(EncodeKey(start));
   const std::string end_key(EncodeKey(end));

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -137,6 +137,15 @@ DBStatus DBCompactRange(DBEngine* db, DBSlice start, DBSlice end, bool force_bot
 DBStatus DBDisableAutoCompaction(DBEngine* db);
 DBStatus DBEnableAutoCompaction(DBEngine* db);
 
+// Disable/enable ingestion-optimized compaction settings. Automatic compactions
+// are done at much higher file counts in L0, working on the assumption that the
+// majority of those files are essentially "staged" SSTs for something being
+// bulk-loaded but not yet in use, meaning the extra read-amplification of lots
+// of L0 files is less of an issue, and the extra write amplification of
+// repeated re-compactions before all SSTs are ingested could be.
+DBStatus DBOptimizeForBulkIngesting(DBEngine* db);
+DBStatus DBFinishedBulkIngesting(DBEngine* db);
+
 // Stores the approximate on-disk size of the given key range into the
 // supplied uint64.
 DBStatus DBApproximateDiskBytes(DBEngine* db, DBKey start, DBKey end, uint64_t* size);

--- a/pkg/storage/compactor/compactor.go
+++ b/pkg/storage/compactor/compactor.go
@@ -64,7 +64,7 @@ func NewCompactor(
 }
 
 func (c *Compactor) enabled() bool {
-	return enabled.Get(&c.st.SV)
+	return enabled.Get(&c.st.SV) && !r.eng.IsBulkIngesting()
 }
 
 func (c *Compactor) minInterval() time.Duration {

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -314,6 +314,9 @@ type Engine interface {
 	// that the key range is compacted all the way to the bottommost level of
 	// SSTables, which is necessary to pick up changes to bloom filters.
 	CompactRange(start, end roachpb.Key, forceBottommost bool) error
+	// IsBulkIngesting returns if the engine is currently optimized for doing bulk
+	// ingestion.
+	IsBulkIngesting() bool
 	// OpenFile opens a DBFile with the given filename.
 	OpenFile(filename string) (DBFile, error)
 	// ReadFile reads the content from the file with the given filename int this RocksDB's env.


### PR DESCRIPTION
Immediately before ingesting an SST, we reconfigure RocksDBs compaction settings to allow more files in L0 and avoid the slowdown triggers.
We then wait a minute to revert back to the normal compaction settings on the next sync loop.
On subsequent ingestions, if we've already reconfigured the compaction settings, we simply note the time to extend the revert deadline.

Release note (performance improvement): reduce write amplification during bulk index ingestion.