### PR TITLE
workload,workloadccl: improve `cockroach workload` logging

### DIFF
--- a/pkg/ccl/workloadccl/cliccl/fixtures.go
+++ b/pkg/ccl/workloadccl/cliccl/fixtures.go
@@ -288,9 +288,13 @@ func fixturesLoad(gen workload.Generator, urls []string, dbName string) error {
 	if err != nil {
 		return errors.Wrap(err, `finding fixture`)
 	}
-	if err := workloadccl.RestoreFixture(ctx, sqlDB, fixture, dbName); err != nil {
+
+	log.Infof(ctx, "starting load of %d tables", len(gen.Tables()))
+	bytes, err := workloadccl.RestoreFixture(ctx, sqlDB, fixture, dbName)
+	if err != nil {
 		return errors.Wrap(err, `restoring fixture`)
 	}
+	log.Infof(ctx, "loaded %s bytes in %d tables", humanizeutil.IBytes(bytes), len(gen.Tables()))
 
 	if hooks, ok := gen.(workload.Hookser); *fixturesRunChecks && ok {
 		if consistencyCheckFn := hooks.Hooks().CheckConsistency; consistencyCheckFn != nil {
@@ -314,6 +318,7 @@ func fixturesImport(gen workload.Generator, urls []string, dbName string) error 
 		return err
 	}
 
+	log.Infof(ctx, "starting import of %d tables", len(gen.Tables()))
 	directIngestion := *fixturesImportDirectIngestionTable
 	filesPerNode := *fixturesImportFilesPerNode
 	bytes, err := workloadccl.ImportFixture(ctx, sqlDB, gen, dbName, directIngestion, filesPerNode)

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -144,7 +144,7 @@ func TestFixture(t *testing.T) {
 	}
 
 	sqlDB.Exec(t, `CREATE DATABASE test`)
-	if err := RestoreFixture(ctx, db, fixture, `test`); err != nil {
+	if _, err := RestoreFixture(ctx, db, fixture, `test`); err != nil {
 		t.Fatalf(`%+v`, err)
 	}
 	sqlDB.CheckQueryResults(t,

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/pkg/errors"
@@ -142,6 +143,14 @@ func CmdHelper(
 	const crdbDefaultURL = `postgres://root@localhost:26257?sslmode=disable`
 
 	return HandleErrs(func(cmd *cobra.Command, args []string) error {
+		if ls := cmd.Flags().Lookup(logflags.LogToStderrName); ls != nil {
+			if !ls.Changed {
+				// Unless the settings were overridden by the user, default to logging
+				// to stderr.
+				_ = ls.Value.Set(log.Severity_INFO.String())
+			}
+		}
+
 		if h, ok := gen.(workload.Hookser); ok {
 			if h.Hooks().Validate != nil {
 				if err := h.Hooks().Validate(); err != nil {


### PR DESCRIPTION
Default --logtostderr to INFO when run as part of the cockroach binary,
so our logging shows up in the console.

Also match up the output between `fixtures import` and `fixtures load`.

Release note: None