### PR TITLE
sql: refactor connExecutor.sessionData initialization

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -694,11 +694,11 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		) sqlutil.InternalExecutor {
 			ie := sql.NewSessionBoundInternalExecutor(
 				ctx,
+				sessionData,
 				s.pgServer.SQLServer,
 				s.sqlMemMetrics,
 				s.st,
 			)
-			ie.CopySessionData(sessionData)
 			return ie
 		}
 

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -105,10 +105,8 @@ func (p *planner) maybeLogStatementInternal(
 	// Instead, make the logger work. This is critical for auditing - we
 	// can't miss any statement.
 
-	s := p.sessionDataMutator
-
 	logV := log.V(2)
-	logExecuteEnabled := logStatementsExecuteEnabled.Get(&s.settings.SV)
+	logExecuteEnabled := logStatementsExecuteEnabled.Get(&p.execCfg.Settings.SV)
 	auditEventsDetected := len(p.curPlan.auditEvents) != 0
 
 	if !logV && !logExecuteEnabled && !auditEventsDetected {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1595,8 +1595,8 @@ type sessionDataMutator struct {
 	data     *sessiondata.SessionData
 	defaults SessionDefaults
 	settings *cluster.Settings
-	// curTxnReadOnly is a value to be mutated through SET transaction_read_only = ...
-	curTxnReadOnly *bool
+	// setCurTxnReadOnly is called when we execute SET transaction_read_only = ...
+	setCurTxnReadOnly func(val bool)
 	// applicationNamedChanged, if set, is called when the "application name"
 	// variable is updated.
 	applicationNameChanged func(newName string)
@@ -1675,7 +1675,7 @@ func (m *sessionDataMutator) SetLocation(loc *time.Location) {
 }
 
 func (m *sessionDataMutator) SetReadOnly(val bool) {
-	*m.curTxnReadOnly = val
+	m.setCurTxnReadOnly(val)
 }
 
 func (m *sessionDataMutator) SetStmtTimeout(timeout time.Duration) {

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -117,14 +117,14 @@ func TestSessionBoundInternalExecutor(t *testing.T) {
 	expDB := "foo"
 	ie := sql.NewSessionBoundInternalExecutor(
 		ctx,
+		&sessiondata.SessionData{
+			Database:      expDB,
+			SequenceState: &sessiondata.SequenceState{},
+		},
 		s.(*server.TestServer).Server.PGServer().SQLServer,
 		sql.MemoryMetrics{},
 		s.ExecutorConfig().(sql.ExecutorConfig).Settings,
 	)
-	ie.CopySessionData(&sessiondata.SessionData{
-		Database:      expDB,
-		SequenceState: &sessiondata.SequenceState{},
-	})
 
 	row, err := ie.QueryRow(ctx, "test", nil /* txn */, "show database")
 	if err != nil {
@@ -178,16 +178,16 @@ func TestInternalExecAppNameInitialization(t *testing.T) {
 
 		ie := sql.NewSessionBoundInternalExecutor(
 			context.TODO(),
+			&sessiondata.SessionData{
+				User:            security.RootUser,
+				Database:        "defaultdb",
+				ApplicationName: "appname_findme",
+				SequenceState:   &sessiondata.SequenceState{},
+			},
 			s.(*server.TestServer).Server.PGServer().SQLServer,
 			sql.MemoryMetrics{},
 			s.ExecutorConfig().(sql.ExecutorConfig).Settings,
 		)
-		ie.CopySessionData(&sessiondata.SessionData{
-			User:            security.RootUser,
-			Database:        "defaultdb",
-			ApplicationName: "appname_findme",
-			SequenceState:   &sessiondata.SequenceState{},
-		})
 		testInternalExecutorAppNameInitialization(
 			t, sem,
 			"appname_findme", // app name in SHOW

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -219,15 +219,14 @@ func newInternalPlanner(
 		leaseMgr:      execCfg.LeaseManager,
 		databaseCache: newDatabaseCache(config.NewSystemConfig()),
 	}
-	txnReadOnly := new(bool)
 	dataMutator := &sessionDataMutator{
 		data: sd,
 		defaults: SessionDefaults(map[string]string{
 			"application_name": "crdb-internal",
 			"database":         "system",
 		}),
-		settings:       execCfg.Settings,
-		curTxnReadOnly: txnReadOnly,
+		settings:          execCfg.Settings,
+		setCurTxnReadOnly: func(bool) {},
 	}
 
 	var ts time.Time
@@ -304,7 +303,7 @@ func internalExtendedEvalCtx(
 		EvalContext: tree.EvalContext{
 			Txn:           txn,
 			SessionData:   sd,
-			TxnReadOnly:   *dataMutator.curTxnReadOnly,
+			TxnReadOnly:   false,
 			TxnImplicit:   true,
 			Settings:      execCfg.Settings,
 			Context:       ctx,

--- a/pkg/sql/sessiondata/sequence_state.go
+++ b/pkg/sql/sessiondata/sequence_state.go
@@ -43,18 +43,6 @@ func NewSequenceState() *SequenceState {
 	return &ss
 }
 
-// copy performs a deep copy of SequenceState.
-func (ss *SequenceState) copy() *SequenceState {
-	cp := NewSequenceState()
-	ss.mu.Lock()
-	defer ss.mu.Unlock()
-	for k, v := range ss.mu.latestValues {
-		cp.mu.latestValues[k] = v
-	}
-	cp.mu.lastSequenceIncremented = ss.mu.lastSequenceIncremented
-	return ss
-}
-
 // NextVal ever called returns true if a sequence has ever been incremented on
 // this session.
 func (ss *SequenceState) nextValEverCalledLocked() bool {

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -154,13 +154,6 @@ func (c *DataConversionConfig) Equals(other *DataConversionConfig) bool {
 	return true
 }
 
-// Copy performs a deep copy of SessionData.
-func (s *SessionData) Copy() SessionData {
-	cp := *s
-	cp.SequenceState = s.SequenceState.copy()
-	return cp
-}
-
 // BytesEncodeFormat controls which format to use for BYTES->STRING
 // conversions.
 type BytesEncodeFormat int


### PR DESCRIPTION
Follow-up to #35217.

This change cleans up the session data semantics around session-bound
internal executors. These executors now have a nil `dataMutator` and
can share the `SessionData` with the "parent" executor.

We now initialize a `connExecutor` with a given `*SessionData,
*sessionDataMutator` pair; it is up to the calling code to create them
from the session args if necessary.

Release note: None