### PR TITLE
opt: fix panic caused by invalid constant folding

### DIFF
--- a/pkg/sql/opt/norm/rules/fold_constants.opt
+++ b/pkg/sql/opt/norm/rules/fold_constants.opt
@@ -65,3 +65,19 @@ $result
 )
 =>
 $result
+
+# FoldCast is similar to FoldUnary, but it involves a cast operation. As with
+# FoldUnary, FoldCast applies as long as the evaluation would not cause an
+# error.
+#
+# This rule is marked as low priority so that the FoldNull rules in scalar.opt
+# can run first.
+[FoldCast, Normalize, LowPriority]
+(Cast
+    $input:*
+    $typ:* &
+        (IsConstValueOrTuple $input) &
+        (Succeeded $result:(FoldCast $input $typ))
+)
+=>
+$result

--- a/pkg/sql/opt/norm/rules/numeric.opt
+++ b/pkg/sql/opt/norm/rules/numeric.opt
@@ -3,28 +3,36 @@
 # =============================================================================
 
 # FoldPlusZero folds $left + 0 for numeric types.
+#
+# Note: It is necessary to cast $left to the column type of the binary
+# operation since the type of $left may not match the column type. For example,
+# 1::int + 0::decimal should result in 1::decimal, not 1::int. The execution
+# engine panics when it expects one type but receives another, so this cast is
+# essential. If $left is already of the correct type, the cast will be removed
+# by the EliminateCast rule. Otherwise, if $left is a constant, the cast will
+# be folded away by the FoldCast rule.
 [FoldPlusZero, Normalize]
-(Plus $left:* (Const 0)) => $left
+(Plus $left:* $right:(Const 0)) => (Cast $left (BinaryColType Plus $left $right))
 
 # FoldZeroPlus folds 0 + $right for numeric types.
 [FoldZeroPlus, Normalize]
-(Plus (Const 0) $right:*) => $right
+(Plus $left:(Const 0) $right:*) => (Cast $right (BinaryColType Plus $left $right))
 
 # FoldMinusZero folds $left - 0 for numeric types.
 [FoldMinusZero, Normalize]
-(Minus $left:* (Const 0)) => $left
+(Minus $left:* $right:(Const 0)) => (Cast $left (BinaryColType Minus $left $right))
 
 # FoldMultOne folds $left * 1 for numeric types.
 [FoldMultOne, Normalize]
-(Mult $left:* (Const 1)) => $left
+(Mult $left:* $right:(Const 1)) => (Cast $left (BinaryColType Mult $left $right))
 
 # FoldOneMult folds 1 * $right for numeric types.
 [FoldOneMult, Normalize]
-(Mult (Const 1) $right:*) => $right
+(Mult $left:(Const 1) $right:*) => (Cast $right (BinaryColType Mult $left $right))
 
 # FoldDivOne folds $left / 1 for numeric types.
 [FoldDivOne, Normalize]
-(Div | FloorDiv $left:* (Const 1)) => $left
+(Div | FloorDiv $left:* $right:(Const 1)) => (Cast $left (BinaryColType (OpName) $left $right))
 
 # InvertMinus rewrites -(a - b) to (b - a) if the operand types allow it.
 [InvertMinus, Normalize]

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -572,3 +572,17 @@ values
  ├── key: ()
  ├── fd: ()-->(1)
  └── (false,) [type=tuple{bool}]
+
+# --------------------------------------------------
+# FoldCast
+# --------------------------------------------------
+
+opt expect=FoldCast
+SELECT 1::int/1
+----
+values
+ ├── columns: "?column?":1(decimal)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (1,) [type=tuple{decimal}]

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -34,6 +34,28 @@ project
       ├── d + d [type=decimal, outer=(4)]
       └── d + d [type=decimal, outer=(4)]
 
+
+# Regression test for #35113.
+opt expect=FoldPlusZero
+SELECT 1::int8 + 0::decimal
+----
+values
+ ├── columns: "?column?":1(decimal)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (1,) [type=tuple{decimal}]
+
+opt expect=FoldZeroPlus
+SELECT 0::decimal + 1::int8
+----
+values
+ ├── columns: "?column?":1(decimal)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (1,) [type=tuple{decimal}]
+
 # --------------------------------------------------
 # FoldMinusZero
 # --------------------------------------------------
@@ -54,6 +76,17 @@ project
       ├── i + i [type=int, outer=(2)]
       ├── f + f [type=float, outer=(3)]
       └── d + d [type=decimal, outer=(4)]
+
+# Regression test for #35113.
+opt expect=FoldMinusZero
+SELECT 0::int8 - 0::decimal
+----
+values
+ ├── columns: "?column?":1(decimal)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (0,) [type=tuple{decimal}]
 
 # --------------------------------------------------
 # FoldMultOne, FoldOneMult
@@ -79,6 +112,27 @@ project
       ├── d + d [type=decimal, outer=(4)]
       └── d + d [type=decimal, outer=(4)]
 
+# Regression test for #35113.
+opt expect=FoldMultOne
+SELECT 2::int8 * 1::decimal
+----
+values
+ ├── columns: "?column?":1(decimal)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (2,) [type=tuple{decimal}]
+
+opt expect=FoldOneMult
+SELECT 1::decimal * 2::int8
+----
+values
+ ├── columns: "?column?":1(decimal)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (2,) [type=tuple{decimal}]
+
 # --------------------------------------------------
 # FoldDivOne
 # --------------------------------------------------
@@ -95,9 +149,30 @@ project
  ├── scan a
  │    └── columns: i:2(int) f:3(float) d:4(decimal)
  └── projections
-      ├── variable: i [type=int, outer=(2)]
+      ├── i::DECIMAL [type=decimal, outer=(2)]
       ├── variable: f [type=float, outer=(3)]
       └── variable: d [type=decimal, outer=(4)]
+
+# Regression test for #35113.
+opt expect=FoldDivOne
+SELECT 1::int8 / 1::decimal
+----
+values
+ ├── columns: "?column?":1(decimal)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (1,) [type=tuple{decimal}]
+
+opt expect=FoldDivOne
+SELECT 1::int8 / 1::int8
+----
+values
+ ├── columns: "?column?":1(decimal)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (1,) [type=tuple{decimal}]
 
 # --------------------------------------------------
 # InvertMinus

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1103,14 +1103,10 @@ values
 opt
 SELECT k FROM a WHERE k = ANY '{1,2,3}'::INT[]
 ----
-select
+scan a
  ├── columns: k:1(int!null)
- ├── key: (1)
- ├── scan a
- │    ├── columns: k:1(int!null)
- │    └── key: (1)
- └── filters
-      └── k = ANY '{1,2,3}'::INT8[] [type=bool, outer=(1)]
+ ├── constraint: /1: [/1 - /3]
+ └── key: (1)
 
 # --------------------------------------------------
 # FoldCollate

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -359,7 +359,7 @@ project
  │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
  │    │    │         │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
  │    │    │         │    │    │    │    │    │    │    └── filters
- │    │    │         │    │    │    │    │    │    │         └── (c.relkind = 'r'::CHAR) OR (c.relkind = 'f'::CHAR) [type=bool, outer=(17)]
+ │    │    │         │    │    │    │    │    │    │         └── (c.relkind = 'r') OR (c.relkind = 'f') [type=bool, outer=(17)]
  │    │    │         │    │    │    │    │    │    ├── scan n@pg_namespace_nspname_index
  │    │    │         │    │    │    │    │    │    │    ├── columns: n.oid:28(oid!null) n.nspname:29(string!null)
  │    │    │         │    │    │    │    │    │    │    ├── constraint: /29: [/'public' - /'public']

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -362,7 +362,7 @@ sort
       │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
       │    │    │         │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
       │    │    │         │    │    │    │    │    │    │    └── filters
-      │    │    │         │    │    │    │    │    │    │         └── (c.relkind = 'r'::CHAR) OR (c.relkind = 'f'::CHAR) [type=bool, outer=(17)]
+      │    │    │         │    │    │    │    │    │    │         └── (c.relkind = 'r') OR (c.relkind = 'f') [type=bool, outer=(17)]
       │    │    │         │    │    │    │    │    │    ├── scan n@pg_namespace_nspname_index
       │    │    │         │    │    │    │    │    │    │    ├── columns: n.oid:28(oid!null) n.nspname:29(string!null)
       │    │    │         │    │    │    │    │    │    │    ├── constraint: /29: [/'public' - /'public']


### PR DESCRIPTION
Prior to this commit, expressions such as `0::int + 0::decimal` were
incorrectly folded to `0::int`. The correct type of this expression is
decimal, and the execution engine panics when it expects one type
but receives another. This commit fixes the problem by casting the
result of several constant-folding rules to the correct output type.

To avoid creating constants with Cast operations, this commit
also adds a new rule to fold Cast operations.

Fixes #35113

Release note (bug fix): Fixed a panic that occurred when evaluating
certain binary expressions containing operands with different types.