### PR TITLE
storagebase: add CheckIngestedStats helper, call after all bulk-ingest ops

### DIFF
--- a/pkg/sql/logictest/testdata/planner_test/show_trace
+++ b/pkg/sql/logictest/testdata/planner_test/show_trace
@@ -103,6 +103,7 @@ dist sender send  r6: sending batch 1 Put to (n1,s1):1
 sql txn           rows affected: 0
 dist sender send  r11: sending batch 3 QueryIntent to (n1,s1):1
 dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r20: sending batch 1 ComputeChksum to (n1,s1):1
 
 statement ok
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -99,6 +99,7 @@ dist sender send  r6: sending batch 1 Put to (n1,s1):1
 sql txn           rows affected: 0
 dist sender send  r11: sending batch 3 QueryIntent to (n1,s1):1
 dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r20: sending batch 1 ComputeChksum to (n1,s1):1
 
 statement ok
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off


### PR DESCRIPTION
This helper is intended to be called on the span(s) in which a caller
has been doing bulk-ingestion, to trigger consistency checks on the
range(s) in that span. This might be a good idea on its own but also has
the side effect of fixing up any MVCC stats inaccuracies that might
have been introduced by estimates during ingestion.

It is probably not critical to actually call this: eventually the
consistency queue will call anyway and fixup those stats if needed.
However, if we know we'll call it right away -- specifically before we
mark the operation that was ingesting as completed and turn those ranges
over to real traffic that might expect correct-ish stats -- we might be
able to make coarser, cheaper estimates, for instance during SST
ingestion where the current, accurate stats recomputation is expensive.

See #35231.

Release note: None