### PR TITLE
roachtest: reduce size of inverted index test

### DIFF
--- a/pkg/cmd/roachtest/inverted_index.go
+++ b/pkg/cmd/roachtest/inverted_index.go
@@ -46,7 +46,8 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t *test, c *cluster) {
 	cmdInit := fmt.Sprintf("./workload init json {pgurl:1}")
 	c.Run(ctx, workloadNode, cmdInit)
 
-	initialDataDuration := time.Hour
+	// On a 4-node GCE cluster with the standard configuration, this generates ~10 million rows
+	initialDataDuration := time.Minute * 20
 	indexDuration := time.Hour
 	if c.isLocal() {
 		initialDataDuration = time.Minute


### PR DESCRIPTION
The `schemachange/invertedindex` test was running out of memory during the
index backfill for a table with ~30 million rows. Until that is fixed, we'll
run the test on a smaller table with ~10 million rows.

Fixes #35299

Release note: None