### PR TITLE
release-2.1: execbuild: bugfix to group by with input ordering

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -938,28 +938,24 @@ render          ·         ·           (k)     ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
-group           ·            ·              (concat_agg)  ·
- │              aggregate 0  concat_agg(s)  ·             ·
- │              scalar       ·              ·             ·
- └── render     ·            ·              (s)           ·
-      │         render 0     s              ·             ·
-      └── scan  ·            ·              (k, s)        +k
-·               table        kv@primary     ·             ·
-·               spans        ALL            ·             ·
+group      ·            ·              (concat_agg)  ·
+ │         aggregate 0  concat_agg(s)  ·             ·
+ │         scalar       ·              ·             ·
+ └── scan  ·            ·              (k, s)        +k
+·          table        kv@primary     ·             ·
+·          spans        ALL            ·             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT array_agg(k) FROM (SELECT k FROM kv ORDER BY s)
 ----
-group                ·            ·             (array_agg)  ·
- │                   aggregate 0  array_agg(k)  ·            ·
- │                   scalar       ·             ·            ·
- └── render          ·            ·             (k)          ·
-      │              render 0     k             ·            ·
-      └── sort       ·            ·             (k, s)       +s
-           │         order        +s            ·            ·
-           └── scan  ·            ·             (k, s)       ·
-·                    table        kv@primary    ·            ·
-·                    spans        ALL           ·            ·
+group           ·            ·             (array_agg)  ·
+ │              aggregate 0  array_agg(k)  ·            ·
+ │              scalar       ·             ·            ·
+ └── sort       ·            ·             (k, s)       +s
+      │         order        +s            ·            ·
+      └── scan  ·            ·             (k, s)       ·
+·               table        kv@primary    ·            ·
+·               spans        ALL           ·            ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT string_agg(s, ',') FROM (SELECT s FROM kv ORDER BY k)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -104,10 +104,10 @@ scan  ·      ·            (x, y, z)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT z FROM (SELECT y, z FROM xyz WHERE y > 1)
 ----
-distinct        ·            ·        (z)     weak-key(z)
+distinct        ·            ·        (z)     weak-key(z); +z
  │              distinct on  z        ·       ·
  │              order key    z        ·       ·
- └── render     ·            ·        (z)     ·
+ └── render     ·            ·        (z)     +z
       │         render 0     z        ·       ·
       └── scan  ·            ·        (y, z)  +z
 ·               table        xyz@foo  ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -168,13 +168,13 @@ distinct   ·            ·            (pk1, pk2)  weak-key(pk1); +pk1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
-sort                      ·            ·            (a, c)     weak-key(a); +a
- │                        order        +a           ·          ·
- └── distinct             ·            ·            (a, c)     weak-key(a)
-      │                   distinct on  a            ·          ·
-      └── render          ·            ·            (a, c)     ·
-           │              render 0     a            ·          ·
-           │              render 1     c            ·          ·
+render                    ·            ·            (a, c)     ·
+ │                        render 0     a            ·          ·
+ │                        render 1     c            ·          ·
+ └── sort                 ·            ·            (a, b, c)  weak-key(a); +a
+      │                   order        +a           ·          ·
+      └── distinct        ·            ·            (a, b, c)  weak-key(a); -c,+b
+           │              distinct on  a            ·          ·
            └── sort       ·            ·            (a, b, c)  -c,+b
                 │         order        -c,+b        ·          ·
                 └── scan  ·            ·            (a, b, c)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -300,3 +300,75 @@ query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT sum(x) FROM (SELECT a, b::float + c AS x FROM data) WHERE a > x GROUP BY a ORDER BY a]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html#eJzMllGL2kAQx9_7KWSe7rgtl90kGvMUXw4OrBbrPZRWjpxZPMFzZbNCj8PvXpKFGpM6k9RofTTxtzOz_x9DPmCtEjmK32QK4Q_gwEAAAxcYeMDAhxmDjVZzmaZKZ3-xwGPyC0KHwXK92Zrs8YzBXGkJ4QeYpVlJCGEav6zkRMaJ1PcOMEikiZervMxGL99i_R4lsYmBwUSuE6nDTuTeRSIMH4bjwTRgnYjDbMdAbc2-SGrihYSQ71j9Rkbqs9rc-4ctPCxXJq8pOj-3juNKrJxoUm6wWGi5iI3S97w0d5Td7VgnUsskKw0MBqPvz6Px9Hn0NBzeROIWGHx7-nIT8dtSN_sCL--d1zh9LR2ddb_v2D3a8f4cZRspn3NnD8LG8iu1i2Pxylj8z1j5gOOtyaZnyI17_9y_ONK_tUAcJnKsvH9QntcXnZ9VdKIRO2K3NdGJckUj-HWIzlsWvXth0UV908RZTSMasab1WjONKFeMRFyHaaJl03oXNs2tb5p7VtOIRqxpQWumEeWKkbjXYZrbsmnBhU3z6pvmndU0ohFrWr8104hyxUi86zDNa9m0_n_8TPxLaxOZbtQ6lbW-AJ1sOJkspL2MVG31XH7Vap6XsT_HOZc_SGRq7Ftufzyu7auswSLMUVjgsCjDvAi7BzBvBgenwFycRHdPoYWD0y564R4Oe3haRNY-SndxuIvCPRzunSIKDhOi4DAlCkETouA0JUpwiih9fCc4xFIgVgq1UypLpUncBE3kTdBU4BROJE7gVOS8slqaZM7x1cI9IjV8uXCfwCvbpVHoOE2FjtNk6AROhY7jZOj4ZqVCryyZw9QCIjV8y_A-gVf2TKPQcZoKHafJ0AmcCh3HqdAFvmHLoc92n34HAAD__1w5a3Q=
+
+# Ensure that an interesting input ordering that causes an ordered group by
+# forces an ordered synchronizer. We create an index on b even though it's
+# not used to help the optimizer realize that there's an ordering available
+# on b for a constrained scan on the a,b primary index.
+
+statement ok
+CREATE TABLE data2 (a INT, b INT, PRIMARY KEY (a, b), INDEX(b));
+ALTER TABLE data2 SPLIT AT SELECT 1,i FROM generate_series(1, 9) AS g(i);
+ALTER TABLE data2 EXPERIMENTAL_RELOCATE
+  SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i);
+
+# Verify data placement.
+query TTTI colnames
+SELECT start_key, end_key, replicas, lease_holder FROM [SHOW EXPERIMENTAL_RANGES FROM TABLE data2]
+----
+start_key  end_key  replicas  lease_holder
+NULL       /1/1     {2}       2
+/1/1       /1/2     {5}       5
+/1/2       /1/3     {5}       5
+/1/3       /1/4     {5}       5
+/1/4       /1/5     {5}       5
+/1/5       /1/6     {5}       5
+/1/6       /1/7     {5}       5
+/1/7       /1/8     {5}       5
+/1/8       /1/9     {5}       5
+/1/9       NULL     {5}       5
+
+
+query T
+EXPLAIN (opt,verbose) SELECT b, count(*) FROM data2 WHERE a=1 GROUP BY b
+----
+group-by
+ ├── columns: b:2(int!null) count:3(int)
+ ├── grouping columns: b:2(int!null)
+ ├── internal-ordering: +2 opt(1)
+ ├── stats: [rows=9.5617925, distinct(2)=9.5617925]
+ ├── cost: 10.6956179
+ ├── key: (2)
+ ├── fd: (2)-->(3)
+ ├── prune: (3)
+ ├── scan data2
+ │    ├── columns: a:1(int!null) b:2(int!null)
+ │    ├── constraint: /1/2: [/1 - /1]
+ │    ├── stats: [rows=10, distinct(1)=1, distinct(2)=9.5617925]
+ │    ├── cost: 10.4
+ │    ├── key: (2)
+ │    ├── fd: ()-->(1)
+ │    ├── ordering: +2 opt(1)
+ │    ├── prune: (2)
+ │    └── interesting orderings: (+1,+2) (+2,+1)
+ └── aggregations
+      └── count-rows [type=int]
+
+query TTTTT
+EXPLAIN (verbose) SELECT b, count(*) FROM data2 WHERE a=1 GROUP BY b
+----
+group           ·            ·              (b, count)  ·
+ │              aggregate 0  b              ·           ·
+ │              aggregate 1  count_rows()   ·           ·
+ │              group by     @1             ·           ·
+ │              ordered      @1             ·           ·
+ └── render     ·            ·              (b)         +b
+      │         render 0     b              ·           ·
+      └── scan  ·            ·              (a, b)      +b
+·               table        data2@primary  ·           ·
+·               spans        /1-/2          ·           ·
+
+query T
+SELECT url FROM [EXPLAIN (DISTSQL) SELECT b, count(*) FROM data2 WHERE a=1 GROUP BY b];
+----
+https://cockroachdb.github.io/distsqlplan/decode.html#eJzMVN1q2zAUvt9ThHOVMo1YcpyBr1x2FejskTqMMYxRrYNrSC0jybAy8u7DVsE_S9VkC2OX8jnf-f7AP6GWAmP-hBrC70CBAAMCAWQEGiUL1FqqbmQXt-IHhB6Bqm5aYz-byhwQQmhrqQQqFEBAoOHVoZtnx4xAIRVCOKzG8oNsVpvZIgHZmpezGQFteIkQro9kRE1H1CcOp_zhgDvkAtXKm5yHRlVPXD1HghveOUxaEy4iBq_x0kt4b8tSYcmNVCs2pY26RBMbTLjoX7fxtzxO0jze390tI3oDBD4l-zjNd8nX--XNTNFA8vC8eOT68bf7fcQvqtmrqoc7p2qCiL6Hk12NrK3_xNr9_nO-jdNlxObOBtX-RDU7v2N6zY7f4B0F4f9HHbPrdhz8m449d9Y71I2sNZ71h_A6SyhKtBFo2aoCvyhZ9DT2mfS4_oNAbez0o31sazvqBI7B1AlmbjCbg-kY7E_A9DLwxg32nbI9N3jtBAduz8HfeHaD3_C8uchzdnz3KwAA__-t2j90

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -136,12 +136,12 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJyskj1rwzAQhvf-jHdWiT87eO
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c
 ----
-distinct        ·            ·            (a, b)     weak-key(a,b); +a,+b
- │              distinct on  a, b         ·          ·
- │              order key    a, b         ·          ·
- └── render     ·            ·            (a, b)     +a,+b
-      │         render 0     a            ·          ·
-      │         render 1     b            ·          ·
+render          ·            ·            (a, b)     ·
+ │              render 0     a            ·          ·
+ │              render 1     b            ·          ·
+ └── distinct   ·            ·            (a, b, c)  weak-key(a,b); +a,+b,+c
+      │         distinct on  a, b         ·          ·
+      │         order key    a, b         ·          ·
       └── scan  ·            ·            (a, b, c)  +a,+b,+c
 ·               table        abc@primary  ·          ·
 ·               spans        ALL          ·          ·
@@ -149,4 +149,4 @@ distinct        ·            ·            (a, b)     weak-key(a,b); +a,+b
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html#eJy0lM-LqzAQx-_vr3jMtQM10f7y5OFdenldyt4WD9YMRWiNJBF2Kf7vi2axa9lGwezRxO985sOEuUEpBf3PrqQhfgMGCBwQQkCIAGEFKUKlZE5aS9X-YgN78Q5xgFCUVW3a4xQhl4ogvoEpzIUghtfsdKEjZYLUsq0ryGTFpcNUqrhm6iPJTjkgHGoT_00YJhyTENIGQdbmXleb7EwQswans_8V2hRlbpbrIbijtEglSJH4wj5l8qfMO0raUo-cBSZ8gUm4gLRxNciCWR2Ggw7Z9Ilw3xMZYffCG48T4dN9Q9--I-zed-vRN5zuG_n2HWH3vjuPvtF038C37wi791390ob5gXkkXclS04D4rHLQrh0SZ7LrSsta5fSiZN5h7Oehy3UHgrSxt8x-7Et71Tb4PcycYT4Is8cwd5NH0KEzHbnD0Zy-V87w2k1ezyFvnOGtm7ydQ965ZxWMPBP3I3tkp82fzwAAAP__G57AJg==
+https://cockroachdb.github.io/distsqlplan/decode.html#eJy0lE-LszAQh-_vp3iZawM10f7z5GEvvWyXsrfFQ2qGIrRGkgi7FL_7ogG7lm0ixD2a-JtnHibMDSop8JVfUUP6ARQIMCAQA4EECKwgJ1ArWaDWUnW_2MBefEIaESirujHdcU6gkAohvYEpzQUhhXd-uuARuUC17OoKNLy89JhalVeuvjJ-KiBvCcjG3Otow88IKW3JdNZLqU1ZFWa5HoMySrLO56AEKhTpf3vwjMmeMu8oaUs9chYkYwuSxQvIW1eDNJrUIYFDY3ztxqN26fRxsNBxeFiD7WbGcbDpfnGon4c1-G1n9Iun-yWhfh7W4Leb0S-Z7heF-nlYg9_qj9bFL8wj6lpWGkfEZ5WjboegOKPdPVo2qsA3JYseYz8Pfa4_EKiNvaX2Y1_Zq67Bn2HqDLNRmD6GmZvsQcfOdOIOJyF9r5zhtZu8DiFvnOGtm7wNIe_cs4o8z8T9yB7ZefvvOwAA__8Qr7DH

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -161,10 +161,10 @@ query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT b1.title FROM books as b1 JOIN books2 as b2 ON b1.title = b2.title WHERE b1.shelf <> b2.shelf
 ----
 tree                   field        description     columns                       ordering
-distinct               ·            ·               (title)                       weak-key(title)
+distinct               ·            ·               (title)                       weak-key(title); +title
  │                     distinct on  title           ·                             ·
  │                     order key    title           ·                             ·
- └── render            ·            ·               (title)                       ·
+ └── render            ·            ·               (title)                       +title
       │                render 0     title           ·                             ·
       └── lookup-join  ·            ·               (title, shelf, title, shelf)  +title
            │           type         inner           ·                             ·


### PR DESCRIPTION
Backport 1/1 commits from #35221.

/cc @cockroachdb/release

---

Previously, the execbuilder didn't properly preserve the ordering of the
inputs to group by nodes, which could cause the physical planner to fail
to notice a required ordering between stages in a multi stage
aggregation. This could in turn cause incorrect aggregation results.

Fixes #35209.

Release note (bug fix): fix a planning bug that caused incorrect
aggregation results on multi-node aggregations with implicit, partial
orderings on the inputs to the aggregations.
