### PR TITLE
opt: reuse catalog across queries

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1899,6 +1899,7 @@ func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 	p.preparedStatements = ex.getPrepStmtsAccessor()
 
 	p.queryCacheSession.Init()
+	p.optPlanningCtx.init(p)
 }
 
 func (ex *connExecutor) resetPlanner(

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -166,9 +165,9 @@ type planner struct {
 	// be pool allocated.
 	alloc sqlbase.DatumAlloc
 
-	// optimizer caches an instance of the cost-based optimizer that can be reused
-	// to plan queries (reused in order to reduce allocations).
-	optimizer xform.Optimizer
+	// optPlanningCtx stores the optimizer planning context, which contains
+	// data structures that can be reused between queries (for efficiency).
+	optPlanningCtx optPlanningCtx
 
 	queryCacheSession querycache.Session
 }


### PR DESCRIPTION
This change moves the planning context to the planner and reuses a
single instance of the optCatalog. The optCatalog caches data sources,
keyed by `*ImmutableTableDescriptor`. This saves the creation of new
data sources each time we plan a query, and even when we check a
cached memo for staleness.

Benchmarks (with GOMAXPROCS=1):
```
QueryCache/small/clients-1/simple/cache-off         227µs ± 2%   226µs ± 5%    ~     (p=0.971 n=10+10)
QueryCache/small/clients-1/simple/cache-on          170µs ± 2%   168µs ± 3%    ~      (p=0.133 n=9+10)
QueryCache/small/clients-1/prepare-once/cache-off   182µs ± 2%   178µs ± 1%  -1.90%   (p=0.010 n=10+9)
QueryCache/small/clients-1/prepare-once/cache-on    181µs ± 2%   178µs ± 2%  -1.55%   (p=0.008 n=9+10)
QueryCache/small/clients-1/prepare-each/cache-off   304µs ± 3%   298µs ± 2%  -1.84%  (p=0.002 n=10+10)
QueryCache/small/clients-1/prepare-each/cache-on    264µs ± 4%   258µs ± 4%  -2.47%  (p=0.029 n=10+10)
```

Release note: None