### PR TITLE
release-2.1: storage/engine: fix Go 1.12 build due to missing C.bool type casts

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2113,22 +2113,22 @@ func (r *rocksDBIterator) Valid() (bool, error) {
 
 func (r *rocksDBIterator) Next() {
 	r.checkEngineOpen()
-	r.setState(C.DBIterNext(r.iter, false /* skip_current_key_versions */))
+	r.setState(C.DBIterNext(r.iter, C.bool(false) /* skip_current_key_versions */))
 }
 
 func (r *rocksDBIterator) Prev() {
 	r.checkEngineOpen()
-	r.setState(C.DBIterPrev(r.iter, false /* skip_current_key_versions */))
+	r.setState(C.DBIterPrev(r.iter, C.bool(false) /* skip_current_key_versions */))
 }
 
 func (r *rocksDBIterator) NextKey() {
 	r.checkEngineOpen()
-	r.setState(C.DBIterNext(r.iter, true /* skip_current_key_versions */))
+	r.setState(C.DBIterNext(r.iter, C.bool(true) /* skip_current_key_versions */))
 }
 
 func (r *rocksDBIterator) PrevKey() {
 	r.checkEngineOpen()
-	r.setState(C.DBIterPrev(r.iter, true /* skip_current_key_versions */))
+	r.setState(C.DBIterPrev(r.iter, C.bool(true) /* skip_current_key_versions */))
 }
 
 func (r *rocksDBIterator) Key() MVCCKey {


### PR DESCRIPTION
Backport 1/1 commits from #35195.

Backporting this because the "verify source archive" fails with this error now.

/cc @cockroachdb/release

---

Before this, compiling with Go 1.12 would fail with an error like:
```
cannot use _cgo1 (type bool) as type _Ctype__Bool in argument to _Cfunc_DBIterPrev
```

I haven't looked into what changed to break this yet.

Release note: None
