### PR TITLE
storage: move a store testing knob

### DIFF
--- a/pkg/kv/txn_correctness_test.go
+++ b/pkg/kv/txn_correctness_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/localtestcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -818,7 +819,9 @@ func (hv *historyVerifier) runCmd(
 func checkConcurrency(name string, txns []string, verify *verifier, t *testing.T) {
 	verifier := newHistoryVerifier(name, txns, verify, t)
 	s := &localtestcluster.LocalTestCluster{
-		DontRetryPushTxnFailures: true,
+		StoreTestingKnobs: &storage.StoreTestingKnobs{
+			DontRetryPushTxnFailures: true,
+		},
 	}
 	s.Start(t, testutils.NewNodeTestBaseContext(), InitFactoryForLocalTestCluster)
 	defer s.Stop()

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -615,11 +615,6 @@ type StoreConfig struct {
 	// maintenance queue to dispatch individual maintenance tasks.
 	TimeSeriesDataStore TimeSeriesDataStore
 
-	// DontRetryPushTxnFailures will propagate a push txn failure immediately
-	// instead of utilizing the txn wait queue to wait for the transaction to
-	// finish or be pushed by a higher priority contender.
-	DontRetryPushTxnFailures bool
-
 	// CoalescedHeartbeatsInterval is the interval for which heartbeat messages
 	// are queued and then sent as a single coalesced heartbeat; it is a
 	// fraction of the RaftTickInterval so that heartbeats don't get delayed by
@@ -2885,7 +2880,7 @@ func (s *Store) Send(
 			// enqueue into the txnWaitQueue in order to await further updates to
 			// the unpushed txn's status. We check ShouldPushImmediately to avoid
 			// retrying non-queueable PushTxnRequests (see #18191).
-			dontRetry := s.cfg.DontRetryPushTxnFailures
+			dontRetry := s.cfg.TestingKnobs.DontRetryPushTxnFailures
 			if !dontRetry && ba.IsSinglePushTxnRequest() {
 				pushReq := ba.Requests[0].GetInner().(*roachpb.PushTxnRequest)
 				dontRetry = txnwait.ShouldPushImmediately(pushReq)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1651,7 +1651,7 @@ func TestStoreResolveWriteIntentRollback(t *testing.T) {
 func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := TestStoreConfig(nil)
-	storeCfg.DontRetryPushTxnFailures = true
+	storeCfg.TestingKnobs.DontRetryPushTxnFailures = true
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, testStoreOpts{createSystemRanges: true}, &storeCfg)

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -174,6 +174,10 @@ type StoreTestingKnobs struct {
 	SystemLogsGCGCDone chan<- struct{}
 	// TxnWait contains knobs for txnwait.Queue instances.
 	TxnWait txnwait.TestingKnobs
+	// DontRetryPushTxnFailures will propagate a push txn failure immediately
+	// instead of utilizing the txn wait queue to wait for the transaction to
+	// finish or be pushed by a higher priority contender.
+	DontRetryPushTxnFailures bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -51,20 +51,19 @@ import (
 // Note that the LocalTestCluster is different from server.TestCluster
 // in that although it uses a distributed sender, there is no RPC traffic.
 type LocalTestCluster struct {
-	Cfg                      storage.StoreConfig
-	Manual                   *hlc.ManualClock
-	Clock                    *hlc.Clock
-	Gossip                   *gossip.Gossip
-	Eng                      engine.Engine
-	Store                    *storage.Store
-	StoreTestingKnobs        *storage.StoreTestingKnobs
-	DBContext                *client.DBContext
-	DB                       *client.DB
-	Stores                   *storage.Stores
-	Stopper                  *stop.Stopper
-	Latency                  time.Duration // sleep for each RPC sent
-	tester                   testing.TB
-	DontRetryPushTxnFailures bool
+	Cfg               storage.StoreConfig
+	Manual            *hlc.ManualClock
+	Clock             *hlc.Clock
+	Gossip            *gossip.Gossip
+	Eng               engine.Engine
+	Store             *storage.Store
+	StoreTestingKnobs *storage.StoreTestingKnobs
+	DBContext         *client.DBContext
+	DB                *client.DB
+	Stores            *storage.Stores
+	Stopper           *stop.Stopper
+	Latency           time.Duration // sleep for each RPC sent
+	tester            testing.TB
 
 	// DisableLivenessHeartbeat, if set, inhibits the heartbeat loop. Some tests
 	// need this because, for example, the heartbeat loop increments some
@@ -143,7 +142,6 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	} else {
 		cfg.TestingKnobs = *ltc.StoreTestingKnobs
 	}
-	cfg.DontRetryPushTxnFailures = ltc.DontRetryPushTxnFailures
 	cfg.AmbientCtx = ambient
 	cfg.DB = ltc.DB
 	cfg.Gossip = ltc.Gossip


### PR DESCRIPTION
... to the TestingKnobs struct where it belongs.

Release note: None