### PR TITLE
sql: fix unnecessary anonymizeStmt in prepare

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -169,7 +169,7 @@ func (a *appStats) getStatsForStmt(
 		// Use the cached anonymized string.
 		key.stmt = stmt.AnonymizedStr
 	} else {
-		key.stmt = anonymizeStmt(stmt)
+		key.stmt = anonymizeStmt(stmt.AST)
 	}
 
 	return a.getStatsForStmtWithKey(key, createIfNonexistent)
@@ -188,8 +188,8 @@ func (a *appStats) getStatsForStmtWithKey(key stmtKey, createIfNonexistent bool)
 	return s
 }
 
-func anonymizeStmt(stmt *Statement) string {
-	return tree.AsStringWithFlags(stmt.AST, tree.FmtHideConstants)
+func anonymizeStmt(ast tree.Statement) string {
+	return tree.AsStringWithFlags(ast, tree.FmtHideConstants)
 }
 
 // sqlStats carries per-application statistics for all applications on

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -142,7 +142,6 @@ func (ex *connExecutor) prepare(
 		return prepared, nil
 	}
 	prepared.Statement = stmt.Statement
-	prepared.AnonymizedStr = anonymizeStmt(&stmt)
 
 	// Point to the prepared state, which can be further populated during query
 	// preparation.
@@ -232,6 +231,7 @@ func (ex *connExecutor) populatePrepared(
 	// Fallback on the heuristic planner if the optimizer was not enabled or used:
 	// create a plan for the statement to figure out the typing, then close the
 	// plan.
+	prepared.AnonymizedStr = anonymizeStmt(stmt.AST)
 	if err := p.prepare(ctx, stmt.AST); err != nil {
 		enhanceErrWithCorrelation(err, isCorrelated)
 		return 0, err

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -39,6 +39,7 @@ var queryCacheEnabled = settings.RegisterBoolSetting(
 // the following stmt.Prepared fields:
 //  - Columns
 //  - Types
+//  - AnonymizedStmt
 //  - Memo (for reuse during exec, if appropriate).
 //
 // On success, the returned flags always have planFlagOptUsed set.
@@ -71,6 +72,7 @@ func (p *planner) prepareUsingOptimizer(
 				if !isStale {
 					opc.log(ctx, "query cache hit (prepare)")
 					opc.flags.Set(planFlagOptCacheHit)
+					stmt.Prepared.AnonymizedStr = pm.AnonymizedStr
 					stmt.Prepared.Columns = pm.Columns
 					stmt.Prepared.Types = pm.Types
 					stmt.Prepared.Memo = cachedData.Memo
@@ -85,6 +87,8 @@ func (p *planner) prepareUsingOptimizer(
 		}
 		opc.flags.Set(planFlagOptCacheMiss)
 	}
+
+	stmt.Prepared.AnonymizedStr = anonymizeStmt(stmt.AST)
 
 	memo, isCorrelated, err := opc.buildReusableMemo(ctx)
 	if err != nil {


### PR DESCRIPTION
We were anonymizing the statement even if we find it in the cache.
This change moves the call until after the cache is consulted, and
populates the value from the cache.

```
name                                               old time/op  new time/op  delta
QueryCache/small/clients-1/prepare-each/cache-off   301µs ± 3%   298µs ± 3%    ~     (p=0.089 n=10+10)
QueryCache/small/clients-1/prepare-each/cache-on    258µs ± 3%   254µs ± 3%  -1.89%   (p=0.013 n=9+10)
```

Release note: None