### PR TITLE
opt[dnm]: tweak cost model

### DIFF
--- a/pkg/sql/opt/xform/testdata/external/activerecord
+++ b/pkg/sql/opt/xform/testdata/external/activerecord
@@ -212,7 +212,7 @@ sort
       │    ├── key: (1,6,23,24,27,34)
       │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (23,24)-->(25), (27)-->(28), (34)-->(61)
       │    ├── inner-join
-      │    │    ├── columns: c.oid:27(oid!null) c.collname:28(string!null) t.oid:34(oid!null) typcollation:61(oid!null)
+      │    │    ├── columns: adrelid:23(oid) adnum:24(int) adbin:25(string) c.oid:27(oid!null) c.collname:28(string!null) t.oid:34(oid!null) typcollation:61(oid!null)
       │    │    ├── key: (27,34)
       │    │    ├── fd: (27)-->(28), (34)-->(61)
       │    │    ├── scan c@pg_collation_name_enc_nsp_index
@@ -225,32 +225,36 @@ sort
       │    │    │    └── fd: (34)-->(61)
       │    │    └── filters
       │    │         └── c.oid != typcollation [type=bool, outer=(27,61), constraints=(/27: (/NULL - ]; /61: (/NULL - ])]
-      │    ├── left-join (lookup pg_attrdef)
+      │    ├── right-join
       │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null) adrelid:23(oid) adnum:24(int) adbin:25(string)
-      │    │    ├── key columns: [22] = [22]
       │    │    ├── key: (1,6,23,24)
       │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (23,24)-->(25)
-      │    │    ├── left-join (lookup pg_attrdef@pg_attrdef_adrelid_adnum_index)
-      │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null) d.oid:22(oid) adrelid:23(oid) adnum:24(int)
-      │    │    │    ├── key columns: [1 6] = [23 24]
-      │    │    │    ├── key: (1,6,22)
-      │    │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18), (22)-->(23,24), (23,24)-->(22)
-      │    │    │    ├── select
-      │    │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
-      │    │    │    │    ├── key: (1,6)
-      │    │    │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18)
-      │    │    │    │    ├── scan a
-      │    │    │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
-      │    │    │    │    │    ├── key: (1,6)
-      │    │    │    │    │    └── fd: (1,6)-->(2,3,9,13,15,18), (1,2)-->(3,6,9,13,15,18)
-      │    │    │    │    └── filters
-      │    │    │    │         ├── attrelid = '"numbers"'::REGCLASS [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
-      │    │    │    │         ├── attnum > 0 [type=bool, outer=(6), constraints=(/6: [/1 - ]; tight)]
-      │    │    │    │         └── NOT attisdropped [type=bool, outer=(15), constraints=(/15: [/false - /false]; tight), fd=()-->(15)]
+      │    │    ├── select
+      │    │    │    ├── columns: adrelid:23(oid!null) adnum:24(int!null) adbin:25(string)
+      │    │    │    ├── key: (23,24)
+      │    │    │    ├── fd: (23,24)-->(25)
+      │    │    │    ├── scan d
+      │    │    │    │    ├── columns: adrelid:23(oid!null) adnum:24(int!null) adbin:25(string)
+      │    │    │    │    ├── key: (23,24)
+      │    │    │    │    └── fd: (23,24)-->(25)
       │    │    │    └── filters
       │    │    │         ├── adrelid = '"numbers"'::REGCLASS [type=bool, outer=(23), constraints=(/23: (/NULL - ])]
       │    │    │         └── adnum > 0 [type=bool, outer=(24), constraints=(/24: [/1 - ]; tight)]
-      │    │    └── filters (true)
+      │    │    ├── select
+      │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
+      │    │    │    ├── key: (1,6)
+      │    │    │    ├── fd: ()-->(15), (1,6)-->(2,3,9,13,18), (1,2)-->(3,6,9,13,18)
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: attrelid:1(oid!null) attname:2(string!null) atttypid:3(oid!null) attnum:6(int!null) atttypmod:9(int!null) attnotnull:13(bool!null) attisdropped:15(bool!null) attcollation:18(oid!null)
+      │    │    │    │    ├── key: (1,6)
+      │    │    │    │    └── fd: (1,6)-->(2,3,9,13,15,18), (1,2)-->(3,6,9,13,15,18)
+      │    │    │    └── filters
+      │    │    │         ├── attrelid = '"numbers"'::REGCLASS [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      │    │    │         ├── attnum > 0 [type=bool, outer=(6), constraints=(/6: [/1 - ]; tight)]
+      │    │    │         └── NOT attisdropped [type=bool, outer=(15), constraints=(/15: [/false - /false]; tight), fd=()-->(15)]
+      │    │    └── filters
+      │    │         ├── attrelid = adrelid [type=bool, outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
+      │    │         └── attnum = adnum [type=bool, outer=(6,24), constraints=(/6: (/NULL - ]; /24: (/NULL - ]), fd=(6)==(24), (24)==(6)]
       │    └── filters
       │         ├── c.oid = attcollation [type=bool, outer=(18,27), constraints=(/18: (/NULL - ]; /27: (/NULL - ]), fd=(18)==(27), (27)==(18)]
       │         └── t.oid = atttypid [type=bool, outer=(3,34), constraints=(/3: (/NULL - ]; /34: (/NULL - ]), fd=(3)==(34), (34)==(3)]

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -53,19 +53,16 @@ TABLE edges
 opt
 select nodes.id,dst from nodes join edges on edges.dst=nodes.id
 ----
-inner-join (merge)
+inner-join
  ├── columns: id:1(int!null) dst:4(int!null)
- ├── left ordering: +1
- ├── right ordering: +4
  ├── fd: (1)==(4), (4)==(1)
  ├── scan nodes
  │    ├── columns: id:1(int!null)
- │    ├── key: (1)
- │    └── ordering: +1
+ │    └── key: (1)
  ├── scan edges@edges_auto_index_fk_dst_ref_nodes
- │    ├── columns: dst:4(int!null)
- │    └── ordering: +4
- └── filters (true)
+ │    └── columns: dst:4(int!null)
+ └── filters
+      └── dst = id [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
 
 # ------------------------------------------------------------------------------
 # Github Issues 16313/16426: Ensure that STORING index is used to filter unread
@@ -140,24 +137,22 @@ project
       ├── key: (1)
       ├── fd: ()-->(9), (1)-->(2,3,5-8,10)
       ├── ordering: +1 opt(9) [actual: +1]
-      ├── index-join article
+      ├── sort
       │    ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) title:5(string) summary:6(string) content:7(string) link:8(string) read:9(bool!null) date:10(timestamptz)
       │    ├── key: (1)
       │    ├── fd: ()-->(9), (1)-->(2,3,5-8,10)
       │    ├── ordering: +1 opt(9) [actual: +1]
       │    └── select
-      │         ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) read:9(bool!null)
+      │         ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) title:5(string) summary:6(string) content:7(string) link:8(string) read:9(bool!null) date:10(timestamptz)
       │         ├── key: (1)
-      │         ├── fd: ()-->(9), (1)-->(2,3)
-      │         ├── ordering: +1 opt(9) [actual: +1]
-      │         ├── scan article@article_idx_read_key
-      │         │    ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) read:9(bool)
-      │         │    ├── constraint: /1: [/1 - ]
+      │         ├── fd: ()-->(9), (1)-->(2,3,5-8,10)
+      │         ├── scan article
+      │         │    ├── columns: id:1(int!null) feed:2(int!null) folder:3(int!null) title:5(string) summary:6(string) content:7(string) link:8(string) read:9(bool) date:10(timestamptz)
       │         │    ├── key: (1)
-      │         │    ├── fd: (1)-->(2,3,9)
-      │         │    └── ordering: +1 opt(9) [actual: +1]
+      │         │    └── fd: (1)-->(2,3,5-10)
       │         └── filters
-      │              └── NOT read [type=bool, outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
+      │              ├── NOT read [type=bool, outer=(9), constraints=(/9: [/false - /false]; tight), fd=()-->(9)]
+      │              └── id > 0 [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
       └── const: 50 [type=int]
 
 # Check that forcing the index works as well.
@@ -389,18 +384,15 @@ group-by
  ├── grouping columns: owner_id:12(uuid)
  ├── key: (12)
  ├── fd: (12)-->(16)
- ├── inner-join (merge)
+ ├── inner-join
  │    ├── columns: vehicle_id:3(uuid!null) v.id:9(uuid!null) owner_id:12(uuid)
- │    ├── left ordering: +3
- │    ├── right ordering: +9
  │    ├── fd: (3)==(9), (9)==(3)
  │    ├── scan r@rides_vehicle_id_idx
- │    │    ├── columns: vehicle_id:3(uuid)
- │    │    └── ordering: +3
+ │    │    └── columns: vehicle_id:3(uuid)
  │    ├── scan v@vehicles_id_idx
- │    │    ├── columns: v.id:9(uuid!null) owner_id:12(uuid)
- │    │    └── ordering: +9
- │    └── filters (true)
+ │    │    └── columns: v.id:9(uuid!null) owner_id:12(uuid)
+ │    └── filters
+ │         └── v.id = vehicle_id [type=bool, outer=(3,9), constraints=(/3: (/NULL - ]; /9: (/NULL - ]), fd=(3)==(9), (9)==(3)]
  └── aggregations
       └── count-rows [type=int]
 
@@ -737,19 +729,16 @@ scalar-group-by
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(28)
- ├── inner-join (merge)
+ ├── inner-join
  │    ├── columns: o_orderkey:1(int!null) l_orderkey:11(int!null)
- │    ├── left ordering: +1
- │    ├── right ordering: +11
  │    ├── fd: (1)==(11), (11)==(1)
  │    ├── scan orders@o_ok
  │    │    ├── columns: o_orderkey:1(int!null)
- │    │    ├── key: (1)
- │    │    └── ordering: +1
+ │    │    └── key: (1)
  │    ├── scan lineitem@l_ok
- │    │    ├── columns: l_orderkey:11(int!null)
- │    │    └── ordering: +11
- │    └── filters (true)
+ │    │    └── columns: l_orderkey:11(int!null)
+ │    └── filters
+ │         └── o_orderkey = l_orderkey [type=bool, outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(11), (11)==(1)]
  └── aggregations
       └── count [type=int, outer=(11)]
            └── variable: l_orderkey [type=int]
@@ -792,34 +781,32 @@ WHERE
 project
  ├── columns: secondary_id:6(string) "?column?":7(jsonb)
  ├── side-effects
- ├── inner-join (lookup idtable)
+ ├── inner-join
  │    ├── columns: primary_id:1(uuid!null) idtable.secondary_id:2(uuid!null) data:3(jsonb!null) json_array_elements:4(jsonb) column5:5(uuid!null)
- │    ├── key columns: [1] = [1]
  │    ├── side-effects
  │    ├── fd: (1)-->(2,3), (4)-->(5), (2)==(5), (5)==(2)
- │    ├── inner-join (lookup idtable@secondary_id)
- │    │    ├── columns: primary_id:1(uuid!null) idtable.secondary_id:2(uuid!null) json_array_elements:4(jsonb) column5:5(uuid!null)
- │    │    ├── key columns: [5] = [2]
+ │    ├── scan idtable
+ │    │    ├── columns: primary_id:1(uuid!null) idtable.secondary_id:2(uuid!null) data:3(jsonb!null)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    ├── project
+ │    │    ├── columns: column5:5(uuid) json_array_elements:4(jsonb)
  │    │    ├── side-effects
- │    │    ├── fd: (4)-->(5), (1)-->(2), (2)==(5), (5)==(2)
- │    │    ├── project
- │    │    │    ├── columns: column5:5(uuid) json_array_elements:4(jsonb)
+ │    │    ├── fd: (4)-->(5)
+ │    │    ├── project-set
+ │    │    │    ├── columns: json_array_elements:4(jsonb)
  │    │    │    ├── side-effects
- │    │    │    ├── fd: (4)-->(5)
- │    │    │    ├── project-set
- │    │    │    │    ├── columns: json_array_elements:4(jsonb)
- │    │    │    │    ├── side-effects
- │    │    │    │    ├── values
- │    │    │    │    │    ├── cardinality: [1 - 1]
- │    │    │    │    │    ├── key: ()
- │    │    │    │    │    └── tuple [type=tuple]
- │    │    │    │    └── zip
- │    │    │    │         └── function: json_array_elements [type=jsonb, side-effects]
- │    │    │    │              └── const: '[{"person_id": "8e5dc104-9f38-4255-9283-fd080be16c57", "product_id": "a739c2d3-edec-413b-88d8-9c31d0414b1e"}, {"person_id": "308686c4-7415-4c2d-92d5-25b39a1c84e2", "product_id": "3f12802d-5b0f-43d7-a0d0-12ac8e88cb18"}]' [type=jsonb]
- │    │    │    └── projections
- │    │    │         └── (json_array_elements->>'secondary_id')::UUID [type=uuid, outer=(4)]
- │    │    └── filters (true)
- │    └── filters (true)
+ │    │    │    ├── values
+ │    │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    └── tuple [type=tuple]
+ │    │    │    └── zip
+ │    │    │         └── function: json_array_elements [type=jsonb, side-effects]
+ │    │    │              └── const: '[{"person_id": "8e5dc104-9f38-4255-9283-fd080be16c57", "product_id": "a739c2d3-edec-413b-88d8-9c31d0414b1e"}, {"person_id": "308686c4-7415-4c2d-92d5-25b39a1c84e2", "product_id": "3f12802d-5b0f-43d7-a0d0-12ac8e88cb18"}]' [type=jsonb]
+ │    │    └── projections
+ │    │         └── (json_array_elements->>'secondary_id')::UUID [type=uuid, outer=(4)]
+ │    └── filters
+ │         └── idtable.secondary_id = column5 [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]
  └── projections
       ├── json_array_elements->>'secondary_id' [type=string, outer=(4)]
       └── data || jsonb_build_object('primary_id', primary_id) [type=jsonb, outer=(1,3)]

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -469,38 +469,33 @@ project
       │    ├── has-placeholder
       │    ├── key: (1,2)
       │    ├── fd: (1,2)-->(3-6,13)
-      │    ├── inner-join (merge)
+      │    ├── inner-join
       │    │    ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int!null) defaultaud0_.revtype:3(int!null) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(string) defaultaud0_.lastname:6(string) defaultaud1_.id:7(int!null) defaultaud1_.rev:8(int!null)
-      │    │    ├── left ordering: +1
-      │    │    ├── right ordering: +7
       │    │    ├── has-placeholder
       │    │    ├── key: (2,7,8)
       │    │    ├── fd: (1,2)-->(3-6), (1)==(7), (7)==(1)
+      │    │    ├── select
+      │    │    │    ├── columns: defaultaud1_.id:7(int!null) defaultaud1_.rev:8(int!null)
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: (7,8)
+      │    │    │    ├── scan defaultaud1_
+      │    │    │    │    ├── columns: defaultaud1_.id:7(int!null) defaultaud1_.rev:8(int!null)
+      │    │    │    │    └── key: (7,8)
+      │    │    │    └── filters
+      │    │    │         └── defaultaud1_.rev <= $1 [type=bool, outer=(8), constraints=(/8: (/NULL - ])]
       │    │    ├── select
       │    │    │    ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int!null) defaultaud0_.revtype:3(int!null) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(string) defaultaud0_.lastname:6(string)
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: (1,2)
       │    │    │    ├── fd: (1,2)-->(3-6)
-      │    │    │    ├── ordering: +1
       │    │    │    ├── scan defaultaud0_
       │    │    │    │    ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int!null) defaultaud0_.revtype:3(int) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(string) defaultaud0_.lastname:6(string)
       │    │    │    │    ├── key: (1,2)
-      │    │    │    │    ├── fd: (1,2)-->(3-6)
-      │    │    │    │    └── ordering: +1
+      │    │    │    │    └── fd: (1,2)-->(3-6)
       │    │    │    └── filters
       │    │    │         └── defaultaud0_.revtype != $2 [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
-      │    │    ├── select
-      │    │    │    ├── columns: defaultaud1_.id:7(int!null) defaultaud1_.rev:8(int!null)
-      │    │    │    ├── has-placeholder
-      │    │    │    ├── key: (7,8)
-      │    │    │    ├── ordering: +7
-      │    │    │    ├── scan defaultaud1_
-      │    │    │    │    ├── columns: defaultaud1_.id:7(int!null) defaultaud1_.rev:8(int!null)
-      │    │    │    │    ├── key: (7,8)
-      │    │    │    │    └── ordering: +7
-      │    │    │    └── filters
-      │    │    │         └── defaultaud1_.rev <= $1 [type=bool, outer=(8), constraints=(/8: (/NULL - ])]
-      │    │    └── filters (true)
+      │    │    └── filters
+      │    │         └── defaultaud0_.id = defaultaud1_.id [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
       │    └── aggregations
       │         ├── max [type=int, outer=(8)]
       │         │    └── variable: defaultaud1_.rev [type=int]
@@ -596,31 +591,27 @@ sort
            │    ├── has-placeholder
            │    ├── key: (1,2)
            │    ├── fd: (1,2)-->(3-8,17)
-           │    ├── inner-join (merge)
+           │    ├── inner-join
            │    │    ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int!null) queryaudit0_.revtype:3(int!null) queryaudit0_.revend:4(int) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(string) queryaudit0_.lastname:7(string) queryaudit0_.address_id:8(int) queryaudit1_.id:9(int!null) queryaudit1_.rev:10(int!null)
-           │    │    ├── left ordering: +1
-           │    │    ├── right ordering: +9
            │    │    ├── has-placeholder
            │    │    ├── key: (2,9,10)
            │    │    ├── fd: (1,2)-->(3-8), (1)==(9), (9)==(1)
+           │    │    ├── scan queryaudit1_
+           │    │    │    ├── columns: queryaudit1_.id:9(int!null) queryaudit1_.rev:10(int!null)
+           │    │    │    └── key: (9,10)
            │    │    ├── select
            │    │    │    ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int!null) queryaudit0_.revtype:3(int!null) queryaudit0_.revend:4(int) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(string) queryaudit0_.lastname:7(string) queryaudit0_.address_id:8(int)
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1,2)
            │    │    │    ├── fd: (1,2)-->(3-8)
-           │    │    │    ├── ordering: +1
            │    │    │    ├── scan queryaudit0_
            │    │    │    │    ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int!null) queryaudit0_.revtype:3(int) queryaudit0_.revend:4(int) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(string) queryaudit0_.lastname:7(string) queryaudit0_.address_id:8(int)
            │    │    │    │    ├── key: (1,2)
-           │    │    │    │    ├── fd: (1,2)-->(3-8)
-           │    │    │    │    └── ordering: +1
+           │    │    │    │    └── fd: (1,2)-->(3-8)
            │    │    │    └── filters
            │    │    │         └── queryaudit0_.revtype != $1 [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
-           │    │    ├── scan queryaudit1_
-           │    │    │    ├── columns: queryaudit1_.id:9(int!null) queryaudit1_.rev:10(int!null)
-           │    │    │    ├── key: (9,10)
-           │    │    │    └── ordering: +9
-           │    │    └── filters (true)
+           │    │    └── filters
+           │    │         └── queryaudit1_.id = queryaudit0_.id [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
            │    └── aggregations
            │         ├── max [type=int, outer=(10)]
            │         │    └── variable: queryaudit1_.rev [type=int]
@@ -1246,29 +1237,23 @@ where
             person0_.id=phones1_.person_id
     )
 ----
-semi-join (merge)
+semi-join
  ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
- ├── left ordering: +1
- ├── right ordering: +10
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person0_
  │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-6)
- │    └── ordering: +1
- ├── sort
+ │    └── fd: (1)-->(2-6)
+ ├── select
  │    ├── columns: person_id:10(int) order_id:11(int!null)
  │    ├── fd: ()-->(11)
- │    ├── ordering: +10 opt(11) [actual: +10]
- │    └── select
- │         ├── columns: person_id:10(int) order_id:11(int!null)
- │         ├── fd: ()-->(11)
- │         ├── scan phones1_
- │         │    └── columns: person_id:10(int) order_id:11(int)
- │         └── filters
- │              └── order_id = 1 [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight), fd=()-->(11)]
- └── filters (true)
+ │    ├── scan phones1_
+ │    │    └── columns: person_id:10(int) order_id:11(int)
+ │    └── filters
+ │         └── order_id = 1 [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight), fd=()-->(11)]
+ └── filters
+      └── person0_.id = person_id [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
 
 opt
 select
@@ -1472,27 +1457,23 @@ where
             person0_.id=addresses1_.Person_id
     )
 ----
-semi-join (merge)
+semi-join
  ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
- ├── left ordering: +1
- ├── right ordering: +7
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person0_
  │    ├── columns: id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-6)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-6)
  ├── select
  │    ├── columns: person_id:7(int!null) addresses:8(string!null)
  │    ├── fd: ()-->(8)
- │    ├── ordering: +7 opt(8) [actual: +7]
  │    ├── scan addresses1_
- │    │    ├── columns: person_id:7(int!null) addresses:8(string)
- │    │    └── ordering: +7 opt(8) [actual: +7]
+ │    │    └── columns: person_id:7(int!null) addresses:8(string)
  │    └── filters
  │         └── addresses = 'Home address' [type=bool, outer=(8), constraints=(/8: [/'Home address' - /'Home address']; tight), fd=()-->(8)]
- └── filters (true)
+ └── filters
+      └── id = person_id [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
 
 opt
 select
@@ -1514,26 +1495,22 @@ where
             person0_.id=addresses1_.Person_id
     )
 ----
-anti-join (merge)
+anti-join
  ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
- ├── left ordering: +1
- ├── right ordering: +7
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person0_
  │    ├── columns: id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-6)
- │    └── ordering: +1
+ │    └── fd: (1)-->(2-6)
  ├── select
  │    ├── columns: person_id:7(int!null) addresses:8(string)
- │    ├── ordering: +7
  │    ├── scan addresses1_
- │    │    ├── columns: person_id:7(int!null) addresses:8(string)
- │    │    └── ordering: +7
+ │    │    └── columns: person_id:7(int!null) addresses:8(string)
  │    └── filters
  │         └── (addresses = 'Home address') IS NOT false [type=bool, outer=(8)]
- └── filters (true)
+ └── filters
+      └── id = person_id [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
 
 exec-ddl
 drop table Phone, phone_call, Person, Phone_repairTimestamps, Person_addresses;
@@ -2223,10 +2200,8 @@ project
  │    │    │    │         └── li.productid = p.productid [type=bool, outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ]), fd=(10)==(12), (12)==(10)]
  │    │    │    └── projections
  │    │    │         └── li.quantity * cost [type=decimal, outer=(11,14)]
- │    │    ├── left-join (merge)
+ │    │    ├── left-join
  │    │    │    ├── columns: order0_.customerid:1(string!null) order0_.ordernumber:2(int!null) orderdate:3(date!null) lineitems1_.customerid:4(string) lineitems1_.ordernumber:5(int) lineitems1_.productid:6(string) lineitems1_.quantity:7(int)
- │    │    │    ├── left ordering: +1,+2
- │    │    │    ├── right ordering: +4,+5
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
  │    │    │    ├── scan order0_
@@ -2240,7 +2215,9 @@ project
  │    │    │    │    ├── constraint: /4/5/6: [/'c111'/0 - /'c111'/0]
  │    │    │    │    ├── key: (6)
  │    │    │    │    └── fd: ()-->(4,5), (6)-->(7)
- │    │    │    └── filters (true)
+ │    │    │    └── filters
+ │    │    │         ├── order0_.customerid = lineitems1_.customerid [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+ │    │    │         └── order0_.ordernumber = lineitems1_.ordernumber [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]
  │    │    └── filters
  │    │         ├── li.customerid = order0_.customerid [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
  │    │         └── li.ordernumber = order0_.ordernumber [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
@@ -2342,23 +2319,20 @@ project
  │    │    │    │    │    │    ├── columns: customer0_.customerid:1(string!null) name:2(string!null) address:3(string!null) orders1_.customerid:4(string) orders1_.ordernumber:5(int) orderdate:6(date) lineitems2_.customerid:7(string) lineitems2_.ordernumber:8(int) lineitems2_.productid:9(string) lineitems2_.quantity:10(int)
  │    │    │    │    │    │    ├── key: (1,4,5,7-9)
  │    │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10)
- │    │    │    │    │    │    ├── left-join (merge)
+ │    │    │    │    │    │    ├── left-join
  │    │    │    │    │    │    │    ├── columns: customer0_.customerid:1(string!null) name:2(string!null) address:3(string!null) orders1_.customerid:4(string) orders1_.ordernumber:5(int) orderdate:6(date)
- │    │    │    │    │    │    │    ├── left ordering: +1
- │    │    │    │    │    │    │    ├── right ordering: +4
  │    │    │    │    │    │    │    ├── key: (1,4,5)
  │    │    │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6)
  │    │    │    │    │    │    │    ├── scan customer0_
  │    │    │    │    │    │    │    │    ├── columns: customer0_.customerid:1(string!null) name:2(string!null) address:3(string!null)
  │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3)
- │    │    │    │    │    │    │    │    └── ordering: +1
+ │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3)
  │    │    │    │    │    │    │    ├── scan orders1_
  │    │    │    │    │    │    │    │    ├── columns: orders1_.customerid:4(string!null) orders1_.ordernumber:5(int!null) orderdate:6(date!null)
  │    │    │    │    │    │    │    │    ├── key: (4,5)
- │    │    │    │    │    │    │    │    ├── fd: (4,5)-->(6)
- │    │    │    │    │    │    │    │    └── ordering: +4
- │    │    │    │    │    │    │    └── filters (true)
+ │    │    │    │    │    │    │    │    └── fd: (4,5)-->(6)
+ │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │    │         └── customer0_.customerid = orders1_.customerid [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
  │    │    │    │    │    │    ├── scan lineitems2_
  │    │    │    │    │    │    │    ├── columns: lineitems2_.customerid:7(string!null) lineitems2_.ordernumber:8(int!null) lineitems2_.productid:9(string!null) lineitems2_.quantity:10(int)
  │    │    │    │    │    │    │    ├── key: (7-9)
@@ -2499,10 +2473,8 @@ project
  │    │    │    │         └── li.productid = p.productid [type=bool, outer=(10,12), constraints=(/10: (/NULL - ]; /12: (/NULL - ]), fd=(10)==(12), (12)==(10)]
  │    │    │    └── projections
  │    │    │         └── li.quantity * cost [type=decimal, outer=(11,14)]
- │    │    ├── left-join (merge)
+ │    │    ├── left-join
  │    │    │    ├── columns: order0_.customerid:1(string!null) order0_.ordernumber:2(int!null) orderdate:3(date!null) lineitems1_.customerid:4(string) lineitems1_.ordernumber:5(int) lineitems1_.productid:6(string) lineitems1_.quantity:7(int)
- │    │    │    ├── left ordering: +1,+2
- │    │    │    ├── right ordering: +4,+5
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
  │    │    │    ├── scan order0_
@@ -2516,7 +2488,9 @@ project
  │    │    │    │    ├── constraint: /4/5/6: [/'c111'/0 - /'c111'/0]
  │    │    │    │    ├── key: (6)
  │    │    │    │    └── fd: ()-->(4,5), (6)-->(7)
- │    │    │    └── filters (true)
+ │    │    │    └── filters
+ │    │    │         ├── order0_.customerid = lineitems1_.customerid [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+ │    │    │         └── order0_.ordernumber = lineitems1_.ordernumber [type=bool, outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ]), fd=(2)==(5), (5)==(2)]
  │    │    └── filters
  │    │         ├── li.customerid = order0_.customerid [type=bool, outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
  │    │         └── li.ordernumber = order0_.ordernumber [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
@@ -2763,22 +2737,19 @@ project
  ├── columns: id1_0_0_:1(int!null) c_name2_0_0_:2(string) formula0_0_:6(int)
  ├── key: (1)
  ├── fd: (1)-->(2), (2)-->(6)
- ├── inner-join (merge)
+ ├── inner-join
  │    ├── columns: this_.id:1(int!null) this_.c_name:2(string) t_name.id:3(int!null)
- │    ├── left ordering: +1
- │    ├── right ordering: +3
  │    ├── key: (3)
  │    ├── fd: (1)-->(2), (1)==(3), (3)==(1)
  │    ├── scan this_
  │    │    ├── columns: this_.id:1(int!null) this_.c_name:2(string)
  │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2)
- │    │    └── ordering: +1
+ │    │    └── fd: (1)-->(2)
  │    ├── scan t_name
  │    │    ├── columns: t_name.id:3(int!null)
- │    │    ├── key: (3)
- │    │    └── ordering: +3
- │    └── filters (true)
+ │    │    └── key: (3)
+ │    └── filters
+ │         └── this_.id = t_name.id [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  └── projections
       └── length(this_.c_name) [type=int, outer=(2)]
 

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -293,18 +293,27 @@ project
  │    │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) fs.oid:121(oid) srvname:122(string) rownum:136(int!null)
  │    │    │    ├── key: (136)
  │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,8,10,13,15,17,20,22,23,26-29,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122)
- │    │    │    └── left-join (lookup pg_foreign_server)
+ │    │    │    └── right-join
  │    │    │         ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) fs.oid:121(oid) srvname:122(string)
- │    │    │         ├── key columns: [119] = [121]
  │    │    │         ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121)
- │    │    │         ├── left-join (lookup pg_foreign_table)
+ │    │    │         ├── scan fs@pg_foreign_server_name_index
+ │    │    │         │    ├── columns: i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) fs.oid:121(oid!null) srvname:122(string!null)
+ │    │    │         │    ├── key: (121)
+ │    │    │         │    └── fd: (121)-->(122), (122)-->(121)
+ │    │    │         ├── right-join
  │    │    │         │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[])
- │    │    │         │    ├── key columns: [1] = [118]
  │    │    │         │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92), (118)-->(119,120)
- │    │    │         │    ├── left-join (lookup pg_class)
+ │    │    │         │    ├── scan ft
+ │    │    │         │    │    ├── columns: i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid!null) ftserver:119(oid!null) ftoptions:120(string[])
+ │    │    │         │    │    ├── key: (118)
+ │    │    │         │    │    └── fd: (118)-->(119,120)
+ │    │    │         │    ├── right-join
  │    │    │         │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string)
- │    │    │         │    │    ├── key columns: [72] = [91]
  │    │    │         │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92)
+ │    │    │         │    │    ├── scan ci@pg_class_relname_nsp_index
+ │    │    │         │    │    │    ├── columns: i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid!null) ci.relname:92(string!null)
+ │    │    │         │    │    │    ├── key: (91)
+ │    │    │         │    │    │    └── fd: (91)-->(92)
  │    │    │         │    │    ├── right-join
  │    │    │         │    │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool)
  │    │    │         │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79)
@@ -373,9 +382,12 @@ project
  │    │    │         │    │    │    │         └── i.inhrelid = c.oid [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ]), fd=(1)==(38), (38)==(1)]
  │    │    │         │    │    │    └── filters
  │    │    │         │    │    │         └── indrelid = c.oid [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ]), fd=(1)==(73), (73)==(1)]
- │    │    │         │    │    └── filters (true)
- │    │    │         │    └── filters (true)
- │    │    │         └── filters (true)
+ │    │    │         │    │    └── filters
+ │    │    │         │    │         └── ci.oid = indexrelid [type=bool, outer=(72,91), constraints=(/72: (/NULL - ]; /91: (/NULL - ]), fd=(72)==(91), (91)==(72)]
+ │    │    │         │    └── filters
+ │    │    │         │         └── ftrelid = c.oid [type=bool, outer=(1,118), constraints=(/1: (/NULL - ]; /118: (/NULL - ]), fd=(1)==(118), (118)==(1)]
+ │    │    │         └── filters
+ │    │    │              └── ftserver = fs.oid [type=bool, outer=(119,121), constraints=(/119: (/NULL - ]; /121: (/NULL - ]), fd=(119)==(121), (121)==(119)]
  │    │    └── filters
  │    │         └── pg_inherits.inhparent = c.oid [type=bool, outer=(1,130), constraints=(/1: (/NULL - ]; /130: (/NULL - ]), fd=(1)==(130), (130)==(1)]
  │    └── aggregations

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -296,18 +296,27 @@ sort
       │    │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) fs.oid:121(oid) srvname:122(string) rownum:136(int!null)
       │    │    │    ├── key: (136)
       │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121), (136)-->(1-3,5,8,10,13,15,17,20,22,23,26-29,32,33,38,39,41-43,68,69,72,73,79,91,92,118-122)
-      │    │    │    └── left-join (lookup pg_foreign_server)
+      │    │    │    └── right-join
       │    │    │         ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) fs.oid:121(oid) srvname:122(string)
-      │    │    │         ├── key columns: [119] = [121]
       │    │    │         ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92), (118)-->(119,120), (121)-->(122), (122)-->(121)
-      │    │    │         ├── left-join (lookup pg_foreign_table)
+      │    │    │         ├── scan fs@pg_foreign_server_name_index
+      │    │    │         │    ├── columns: i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[]) fs.oid:121(oid!null) srvname:122(string!null)
+      │    │    │         │    ├── key: (121)
+      │    │    │         │    └── fd: (121)-->(122), (122)-->(121)
+      │    │    │         ├── right-join
       │    │    │         │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid) ftserver:119(oid) ftoptions:120(string[])
-      │    │    │         │    ├── key columns: [1] = [118]
       │    │    │         │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92), (118)-->(119,120)
-      │    │    │         │    ├── left-join (lookup pg_class)
+      │    │    │         │    ├── scan ft
+      │    │    │         │    │    ├── columns: i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string) ftrelid:118(oid!null) ftserver:119(oid!null) ftoptions:120(string[])
+      │    │    │         │    │    ├── key: (118)
+      │    │    │         │    │    └── fd: (118)-->(119,120)
+      │    │    │         │    ├── right-join
       │    │    │         │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid) ci.relname:92(string)
-      │    │    │         │    │    ├── key columns: [72] = [91]
       │    │    │         │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79), (91)-->(92)
+      │    │    │         │    │    ├── scan ci@pg_class_relname_nsp_index
+      │    │    │         │    │    │    ├── columns: i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool) ci.oid:91(oid!null) ci.relname:92(string!null)
+      │    │    │         │    │    │    ├── key: (91)
+      │    │    │         │    │    │    └── fd: (91)-->(92)
       │    │    │         │    │    ├── right-join
       │    │    │         │    │    │    ├── columns: c.oid:1(oid!null) c.relname:2(string!null) c.relnamespace:3(oid!null) c.relowner:5(oid!null) c.reltablespace:8(oid!null) c.reltuples:10(float!null) c.relhasindex:13(bool!null) c.relpersistence:15(string!null) c.relkind:17(string!null) c.relhasoids:20(bool!null) c.relhasrules:22(bool!null) c.relhastriggers:23(bool!null) c.relacl:26(string[]) c.reloptions:27(string[]) n.oid:28(oid!null) n.nspname:29(string!null) t.oid:32(oid) spcname:33(string) i.inhrelid:38(oid) i.inhparent:39(oid) c2.oid:41(oid) c2.relname:42(string) c2.relnamespace:43(oid) n2.oid:68(oid) n2.nspname:69(string) indexrelid:72(oid) indrelid:73(oid) indisclustered:79(bool)
       │    │    │         │    │    │    ├── fd: ()-->(3,28,29), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(28), (28)==(3), (32)-->(33), (33)-->(32), (41)-->(42,43), (42,43)-->(41), (39)==(41), (41)==(39), (68)~~>(69), (69)~~>(68), (72)-->(73), ()~~>(79)
@@ -376,9 +385,12 @@ sort
       │    │    │         │    │    │    │         └── i.inhrelid = c.oid [type=bool, outer=(1,38), constraints=(/1: (/NULL - ]; /38: (/NULL - ]), fd=(1)==(38), (38)==(1)]
       │    │    │         │    │    │    └── filters
       │    │    │         │    │    │         └── indrelid = c.oid [type=bool, outer=(1,73), constraints=(/1: (/NULL - ]; /73: (/NULL - ]), fd=(1)==(73), (73)==(1)]
-      │    │    │         │    │    └── filters (true)
-      │    │    │         │    └── filters (true)
-      │    │    │         └── filters (true)
+      │    │    │         │    │    └── filters
+      │    │    │         │    │         └── ci.oid = indexrelid [type=bool, outer=(72,91), constraints=(/72: (/NULL - ]; /91: (/NULL - ]), fd=(72)==(91), (91)==(72)]
+      │    │    │         │    └── filters
+      │    │    │         │         └── ftrelid = c.oid [type=bool, outer=(1,118), constraints=(/1: (/NULL - ]; /118: (/NULL - ]), fd=(1)==(118), (118)==(1)]
+      │    │    │         └── filters
+      │    │    │              └── ftserver = fs.oid [type=bool, outer=(119,121), constraints=(/119: (/NULL - ]; /121: (/NULL - ]), fd=(119)==(121), (121)==(119)]
       │    │    └── filters
       │    │         └── pg_inherits.inhparent = c.oid [type=bool, outer=(1,130), constraints=(/1: (/NULL - ]; /130: (/NULL - ]), fd=(1)==(130), (130)==(1)]
       │    └── aggregations

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -272,129 +272,126 @@ from (select flavors.created_at as flavors_created_at,
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 order by anon_1.flavors_id asc
 ----
-project
+sort
  ├── columns: anon_1_flavors_created_at:14(timestamp) anon_1_flavors_updated_at:15(timestamp) anon_1_flavors_id:1(int!null) anon_1_flavors_name:2(string) anon_1_flavors_memory_mb:3(int) anon_1_flavors_vcpus:4(int) anon_1_flavors_root_gb:5(int) anon_1_flavors_ephemeral_gb:6(int) anon_1_flavors_flavorid:7(string) anon_1_flavors_swap:8(int) anon_1_flavors_rxtx_factor:9(float) anon_1_flavors_vcpu_weight:10(int) anon_1_flavors_disabled:11(bool) anon_1_flavors_is_public:12(bool) flavor_extra_specs_1_created_at:29(timestamp) flavor_extra_specs_1_updated_at:30(timestamp) flavor_extra_specs_1_id:25(int) flavor_extra_specs_1_key:26(string) flavor_extra_specs_1_value:27(string) flavor_extra_specs_1_flavor_id:28(int)
  ├── side-effects, has-placeholder
  ├── key: (1,25)
  ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
  ├── ordering: +1
- └── left-join (merge)
-      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
-      ├── left ordering: +1
-      ├── right ordering: +28
+ └── project
+      ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
       ├── side-effects, has-placeholder
       ├── key: (1,25)
-      ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
-      ├── ordering: +1
-      ├── limit
-      │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │    ├── internal-ordering: +1
-      │    ├── side-effects, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    ├── ordering: +1
-      │    ├── offset
-      │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │    │    ├── internal-ordering: +1
-      │    │    ├── has-placeholder
-      │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    ├── ordering: +1
-      │    │    ├── select
-      │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │    │    │    ├── has-placeholder
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    ├── ordering: +1
-      │    │    │    ├── group-by
-      │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
-      │    │    │    │    ├── grouping columns: flavors.id:1(int!null)
-      │    │    │    │    ├── has-placeholder
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    ├── ordering: +1
-      │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
-      │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    ├── right ordering: +17
-      │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
-      │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
-      │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    └── ordering: +1
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── flavorid = $2 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
-      │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── fd: ()-->(22)
-      │    │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
-      │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
-      │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: (17,18)
-      │    │    │    │    │    │    │    ├── ordering: +17
-      │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
-      │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
-      │    │    │    │    │    │    │    │    ├── key: (17,18)
-      │    │    │    │    │    │    │    │    └── ordering: +17
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
-      │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── true [type=bool]
-      │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── const-not-null-agg [type=bool, outer=(22)]
-      │    │    │    │         │    └── variable: true [type=bool]
-      │    │    │    │         ├── const-agg [type=string, outer=(2)]
-      │    │    │    │         │    └── variable: name [type=string]
-      │    │    │    │         ├── const-agg [type=int, outer=(3)]
-      │    │    │    │         │    └── variable: memory_mb [type=int]
-      │    │    │    │         ├── const-agg [type=int, outer=(4)]
-      │    │    │    │         │    └── variable: vcpus [type=int]
-      │    │    │    │         ├── const-agg [type=int, outer=(5)]
-      │    │    │    │         │    └── variable: root_gb [type=int]
-      │    │    │    │         ├── const-agg [type=int, outer=(6)]
-      │    │    │    │         │    └── variable: ephemeral_gb [type=int]
-      │    │    │    │         ├── const-agg [type=string, outer=(7)]
-      │    │    │    │         │    └── variable: flavorid [type=string]
-      │    │    │    │         ├── const-agg [type=int, outer=(8)]
-      │    │    │    │         │    └── variable: swap [type=int]
-      │    │    │    │         ├── const-agg [type=float, outer=(9)]
-      │    │    │    │         │    └── variable: rxtx_factor [type=float]
-      │    │    │    │         ├── const-agg [type=int, outer=(10)]
-      │    │    │    │         │    └── variable: vcpu_weight [type=int]
-      │    │    │    │         ├── const-agg [type=bool, outer=(11)]
-      │    │    │    │         │    └── variable: disabled [type=bool]
-      │    │    │    │         ├── const-agg [type=bool, outer=(12)]
-      │    │    │    │         │    └── variable: is_public [type=bool]
-      │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
-      │    │    │    │         │    └── variable: flavors.created_at [type=timestamp]
-      │    │    │    │         └── const-agg [type=timestamp, outer=(15)]
-      │    │    │    │              └── variable: flavors.updated_at [type=timestamp]
-      │    │    │    └── filters
-      │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
-      │    │    └── placeholder: $3 [type=int]
-      │    └── placeholder: $4 [type=int]
-      ├── sort
-      │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
-      │    ├── key: (25)
-      │    ├── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
-      │    ├── ordering: +28
-      │    └── scan flavor_extra_specs_1
-      │         ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
-      │         ├── key: (25)
-      │         └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
-      └── filters (true)
+      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+      └── right-join
+           ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool) flavor_extra_specs_1.id:25(int) key:26(string) value:27(string) flavor_extra_specs_1.flavor_id:28(int) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+           ├── side-effects, has-placeholder
+           ├── key: (1,25)
+           ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (25)-->(26-30), (26,28)-->(25,27,29,30)
+           ├── scan flavor_extra_specs_1
+           │    ├── columns: flavor_extra_specs_1.id:25(int!null) key:26(string!null) value:27(string) flavor_extra_specs_1.flavor_id:28(int!null) flavor_extra_specs_1.created_at:29(timestamp) flavor_extra_specs_1.updated_at:30(timestamp)
+           │    ├── key: (25)
+           │    └── fd: (25)-->(26-30), (26,28)-->(25,27,29,30)
+           ├── limit
+           │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    ├── internal-ordering: +1
+           │    ├── side-effects, has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── offset
+           │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │    ├── internal-ordering: +1
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── ordering: +1
+           │    │    ├── select
+           │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    ├── ordering: +1
+           │    │    │    ├── group-by
+           │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) true_agg:23(bool)
+           │    │    │    │    ├── grouping columns: flavors.id:1(int!null)
+           │    │    │    │    ├── has-placeholder
+           │    │    │    │    ├── key: (1)
+           │    │    │    │    ├── fd: (1)-->(2-12,14,15,23), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    │    ├── ordering: +1
+           │    │    │    │    ├── left-join (merge)
+           │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp) flavor_projects.flavor_id:17(int) true:22(bool)
+           │    │    │    │    │    ├── left ordering: +1
+           │    │    │    │    │    ├── right ordering: +17
+           │    │    │    │    │    ├── has-placeholder
+           │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), ()~~>(22)
+           │    │    │    │    │    ├── ordering: +1
+           │    │    │    │    │    ├── select
+           │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+           │    │    │    │    │    │    ├── has-placeholder
+           │    │    │    │    │    │    ├── key: (1)
+           │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    │    │    │    ├── ordering: +1
+           │    │    │    │    │    │    ├── scan flavors
+           │    │    │    │    │    │    │    ├── columns: flavors.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) flavors.created_at:14(timestamp) flavors.updated_at:15(timestamp)
+           │    │    │    │    │    │    │    ├── key: (1)
+           │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    │    │    │    │    └── ordering: +1
+           │    │    │    │    │    │    └── filters
+           │    │    │    │    │    │         └── flavorid = $2 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+           │    │    │    │    │    ├── project
+           │    │    │    │    │    │    ├── columns: true:22(bool!null) flavor_projects.flavor_id:17(int!null)
+           │    │    │    │    │    │    ├── has-placeholder
+           │    │    │    │    │    │    ├── fd: ()-->(22)
+           │    │    │    │    │    │    ├── ordering: +17 opt(22) [actual: +17]
+           │    │    │    │    │    │    ├── select
+           │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+           │    │    │    │    │    │    │    ├── has-placeholder
+           │    │    │    │    │    │    │    ├── key: (17,18)
+           │    │    │    │    │    │    │    ├── ordering: +17
+           │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
+           │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:17(int!null) project_id:18(string!null)
+           │    │    │    │    │    │    │    │    ├── key: (17,18)
+           │    │    │    │    │    │    │    │    └── ordering: +17
+           │    │    │    │    │    │    │    └── filters
+           │    │    │    │    │    │    │         └── project_id = $1 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+           │    │    │    │    │    │    └── projections
+           │    │    │    │    │    │         └── true [type=bool]
+           │    │    │    │    │    └── filters (true)
+           │    │    │    │    └── aggregations
+           │    │    │    │         ├── const-not-null-agg [type=bool, outer=(22)]
+           │    │    │    │         │    └── variable: true [type=bool]
+           │    │    │    │         ├── const-agg [type=string, outer=(2)]
+           │    │    │    │         │    └── variable: name [type=string]
+           │    │    │    │         ├── const-agg [type=int, outer=(3)]
+           │    │    │    │         │    └── variable: memory_mb [type=int]
+           │    │    │    │         ├── const-agg [type=int, outer=(4)]
+           │    │    │    │         │    └── variable: vcpus [type=int]
+           │    │    │    │         ├── const-agg [type=int, outer=(5)]
+           │    │    │    │         │    └── variable: root_gb [type=int]
+           │    │    │    │         ├── const-agg [type=int, outer=(6)]
+           │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+           │    │    │    │         ├── const-agg [type=string, outer=(7)]
+           │    │    │    │         │    └── variable: flavorid [type=string]
+           │    │    │    │         ├── const-agg [type=int, outer=(8)]
+           │    │    │    │         │    └── variable: swap [type=int]
+           │    │    │    │         ├── const-agg [type=float, outer=(9)]
+           │    │    │    │         │    └── variable: rxtx_factor [type=float]
+           │    │    │    │         ├── const-agg [type=int, outer=(10)]
+           │    │    │    │         │    └── variable: vcpu_weight [type=int]
+           │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+           │    │    │    │         │    └── variable: disabled [type=bool]
+           │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+           │    │    │    │         │    └── variable: is_public [type=bool]
+           │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+           │    │    │    │         │    └── variable: flavors.created_at [type=timestamp]
+           │    │    │    │         └── const-agg [type=timestamp, outer=(15)]
+           │    │    │    │              └── variable: flavors.updated_at [type=timestamp]
+           │    │    │    └── filters
+           │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,23)]
+           │    │    └── placeholder: $3 [type=int]
+           │    └── placeholder: $4 [type=int]
+           └── filters
+                └── flavor_extra_specs_1.flavor_id = flavors.id [type=bool, outer=(1,28), constraints=(/1: (/NULL - ]; /28: (/NULL - ]), fd=(1)==(28), (28)==(1)]
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -1062,121 +1059,122 @@ project
  ├── side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
- └── left-join (lookup instance_type_extra_specs)
+ └── right-join
       ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
-      ├── key columns: [28] = [28]
       ├── side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
-      ├── left-join (lookup instance_type_extra_specs@secondary)
-      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
-      │    ├── key columns: [1] = [31]
+      ├── select
+      │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool!null) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+      │    ├── has-placeholder
+      │    ├── key: (28)
+      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    ├── scan instance_type_extra_specs_1
+      │    │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+      │    │    ├── key: (28)
+      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      ├── limit
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
       │    ├── side-effects, has-placeholder
-      │    ├── key: (1,28)
-      │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
-      │    ├── limit
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+      │    ├── offset
       │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │    │    ├── side-effects, has-placeholder
+      │    │    ├── has-placeholder
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
-      │    │    ├── offset
+      │    │    ├── select
       │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: (1)
       │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
-      │    │    │    ├── select
+      │    │    │    ├── group-by
       │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │    ├── grouping columns: instance_types.id:1(int!null)
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: (1)
       │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
-      │    │    │    │    ├── group-by
-      │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │    │    │    │    │    ├── grouping columns: instance_types.id:1(int!null)
-      │    │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    ├── left-join
+      │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
       │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
-      │    │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
-      │    │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    │    ├── right ordering: +18
+      │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), ()~~>(25)
+      │    │    │    │    │    ├── index-join instance_types
+      │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
       │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), ()~~>(25)
-      │    │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
+      │    │    │    │    │    │    └── select
+      │    │    │    │    │    │         ├── columns: instance_types.id:1(int!null) name:2(string!null) instance_types.deleted:13(bool!null)
+      │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │         ├── key: (1)
+      │    │    │    │    │    │         ├── fd: (1)-->(2,13), (2,13)-->(1)
+      │    │    │    │    │    │         ├── scan instance_types@secondary
+      │    │    │    │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string!null) instance_types.deleted:13(bool)
+      │    │    │    │    │    │         │    ├── constraint: /2/13: (/NULL - ]
+      │    │    │    │    │    │         │    ├── key: (1)
+      │    │    │    │    │    │         │    └── fd: (1)-->(2,13), (2,13)~~>(1)
+      │    │    │    │    │    │         └── filters
+      │    │    │    │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │    │    │              └── name = $4 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── fd: ()-->(25)
       │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string!null) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
       │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
-      │    │    │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    │    │    ├── scan instance_types
-      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    │    │    │    └── ordering: +1
+      │    │    │    │    │    │    │    ├── key: (18-20)
+      │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+      │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │    │    │    │    │    │    │    │    └── lax-key: (18-20)
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
-      │    │    │    │    │    │    │         └── name = $4 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
-      │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
-      │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── fd: ()-->(25)
-      │    │    │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
-      │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
-      │    │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    │    ├── key: (18-20)
-      │    │    │    │    │    │    │    │    ├── ordering: +18
-      │    │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
-      │    │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
-      │    │    │    │    │    │    │    │    │    ├── lax-key: (18-20)
-      │    │    │    │    │    │    │    │    │    └── ordering: +18
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
-      │    │    │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
-      │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── true [type=bool]
-      │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
-      │    │    │    │    │         │    └── variable: true [type=bool]
-      │    │    │    │    │         ├── const-agg [type=string, outer=(2)]
-      │    │    │    │    │         │    └── variable: name [type=string]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(3)]
-      │    │    │    │    │         │    └── variable: memory_mb [type=int]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(4)]
-      │    │    │    │    │         │    └── variable: vcpus [type=int]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(5)]
-      │    │    │    │    │         │    └── variable: root_gb [type=int]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(6)]
-      │    │    │    │    │         │    └── variable: ephemeral_gb [type=int]
-      │    │    │    │    │         ├── const-agg [type=string, outer=(7)]
-      │    │    │    │    │         │    └── variable: flavorid [type=string]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(8)]
-      │    │    │    │    │         │    └── variable: swap [type=int]
-      │    │    │    │    │         ├── const-agg [type=float, outer=(9)]
-      │    │    │    │    │         │    └── variable: rxtx_factor [type=float]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(10)]
-      │    │    │    │    │         │    └── variable: vcpu_weight [type=int]
-      │    │    │    │    │         ├── const-agg [type=bool, outer=(11)]
-      │    │    │    │    │         │    └── variable: disabled [type=bool]
-      │    │    │    │    │         ├── const-agg [type=bool, outer=(12)]
-      │    │    │    │    │         │    └── variable: is_public [type=bool]
-      │    │    │    │    │         ├── const-agg [type=bool, outer=(13)]
-      │    │    │    │    │         │    └── variable: instance_types.deleted [type=bool]
-      │    │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
-      │    │    │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
-      │    │    │    │    │         ├── const-agg [type=timestamp, outer=(15)]
-      │    │    │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
-      │    │    │    │    │         └── const-agg [type=timestamp, outer=(16)]
-      │    │    │    │    │              └── variable: instance_types.updated_at [type=timestamp]
-      │    │    │    │    └── filters
-      │    │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
-      │    │    │    └── placeholder: $5 [type=int]
-      │    │    └── placeholder: $6 [type=int]
-      │    └── filters
-      │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
-      └── filters (true)
+      │    │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │    │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── true [type=bool]
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
+      │    │    │    │         │    └── variable: true [type=bool]
+      │    │    │    │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │         │    └── variable: name [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │         │    └── variable: memory_mb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │         │    └── variable: vcpus [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │         │    └── variable: root_gb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │         │    └── variable: flavorid [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │         │    └── variable: swap [type=int]
+      │    │    │    │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │         │    └── variable: disabled [type=bool]
+      │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │         │    └── variable: is_public [type=bool]
+      │    │    │    │         ├── const-agg [type=bool, outer=(13)]
+      │    │    │    │         │    └── variable: instance_types.deleted [type=bool]
+      │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
+      │    │    │    │         ├── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
+      │    │    │    │         └── const-agg [type=timestamp, outer=(16)]
+      │    │    │    │              └── variable: instance_types.updated_at [type=timestamp]
+      │    │    │    └── filters
+      │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+      │    │    └── placeholder: $5 [type=int]
+      │    └── placeholder: $6 [type=int]
+      └── filters
+           └── instance_type_extra_specs_1.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -1240,122 +1238,125 @@ project
  ├── side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
- └── left-join (lookup instance_type_extra_specs)
+ └── right-join
       ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
-      ├── key columns: [28] = [28]
       ├── side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
-      ├── left-join (lookup instance_type_extra_specs@secondary)
-      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
-      │    ├── key columns: [1] = [31]
+      ├── select
+      │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool!null) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+      │    ├── has-placeholder
+      │    ├── key: (28)
+      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    ├── scan instance_type_extra_specs_1
+      │    │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+      │    │    ├── key: (28)
+      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      ├── limit
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
       │    ├── side-effects, has-placeholder
-      │    ├── key: (1,28)
-      │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
-      │    ├── limit
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    ├── offset
       │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │    │    ├── side-effects, has-placeholder
+      │    │    ├── has-placeholder
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    ├── offset
+      │    │    ├── select
       │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: (1)
       │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    ├── select
+      │    │    │    ├── group-by
       │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │    ├── grouping columns: instance_types.id:1(int!null)
+      │    │    │    │    ├── internal-ordering: +1
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: (1)
       │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    ├── group-by
-      │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │    │    │    │    │    ├── grouping columns: instance_types.id:1(int!null)
-      │    │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    ├── left-join (merge)
+      │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
+      │    │    │    │    │    ├── left ordering: +1
+      │    │    │    │    │    ├── right ordering: +18
       │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
-      │    │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    │    ├── right ordering: +18
+      │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    ├── select
+      │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
       │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │    │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── scan instance_types
+      │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
       │    │    │    │    │    │    │    ├── key: (1)
       │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    │    │    ├── scan instance_types
-      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    │    │    │    └── ordering: +1
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── instance_types.id = $4 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
-      │    │    │    │    │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
-      │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │    │    │    │    │    │    │    └── ordering: +1
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         ├── instance_types.id = $4 [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      │    │    │    │    │    │         └── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── fd: ()-->(25)
+      │    │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
       │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── fd: ()-->(25)
-      │    │    │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
-      │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
-      │    │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    │    ├── key: (18-20)
-      │    │    │    │    │    │    │    │    ├── ordering: +18
-      │    │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
-      │    │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
-      │    │    │    │    │    │    │    │    │    ├── lax-key: (18-20)
-      │    │    │    │    │    │    │    │    │    └── ordering: +18
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
-      │    │    │    │    │    │    │    │         ├── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
-      │    │    │    │    │    │    │    │         └── instance_type_projects.instance_type_id = $4 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
-      │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── true [type=bool]
-      │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
-      │    │    │    │    │         │    └── variable: true [type=bool]
-      │    │    │    │    │         ├── const-agg [type=string, outer=(2)]
-      │    │    │    │    │         │    └── variable: name [type=string]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(3)]
-      │    │    │    │    │         │    └── variable: memory_mb [type=int]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(4)]
-      │    │    │    │    │         │    └── variable: vcpus [type=int]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(5)]
-      │    │    │    │    │         │    └── variable: root_gb [type=int]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(6)]
-      │    │    │    │    │         │    └── variable: ephemeral_gb [type=int]
-      │    │    │    │    │         ├── const-agg [type=string, outer=(7)]
-      │    │    │    │    │         │    └── variable: flavorid [type=string]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(8)]
-      │    │    │    │    │         │    └── variable: swap [type=int]
-      │    │    │    │    │         ├── const-agg [type=float, outer=(9)]
-      │    │    │    │    │         │    └── variable: rxtx_factor [type=float]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(10)]
-      │    │    │    │    │         │    └── variable: vcpu_weight [type=int]
-      │    │    │    │    │         ├── const-agg [type=bool, outer=(11)]
-      │    │    │    │    │         │    └── variable: disabled [type=bool]
-      │    │    │    │    │         ├── const-agg [type=bool, outer=(12)]
-      │    │    │    │    │         │    └── variable: is_public [type=bool]
-      │    │    │    │    │         ├── const-agg [type=bool, outer=(13)]
-      │    │    │    │    │         │    └── variable: instance_types.deleted [type=bool]
-      │    │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
-      │    │    │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
-      │    │    │    │    │         ├── const-agg [type=timestamp, outer=(15)]
-      │    │    │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
-      │    │    │    │    │         └── const-agg [type=timestamp, outer=(16)]
-      │    │    │    │    │              └── variable: instance_types.updated_at [type=timestamp]
-      │    │    │    │    └── filters
-      │    │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
-      │    │    │    └── placeholder: $5 [type=int]
-      │    │    └── placeholder: $6 [type=int]
-      │    └── filters
-      │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
-      └── filters (true)
+      │    │    │    │    │    │    │    ├── key: (18-20)
+      │    │    │    │    │    │    │    ├── ordering: +18
+      │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+      │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │    │    │    │    │    │    │    │    ├── lax-key: (18-20)
+      │    │    │    │    │    │    │    │    └── ordering: +18
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │    │    │    │    │    │    │         ├── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │    │    │    │    │    │    │         └── instance_type_projects.instance_type_id = $4 [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── true [type=bool]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
+      │    │    │    │         │    └── variable: true [type=bool]
+      │    │    │    │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │         │    └── variable: name [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │         │    └── variable: memory_mb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │         │    └── variable: vcpus [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │         │    └── variable: root_gb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │         │    └── variable: flavorid [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │         │    └── variable: swap [type=int]
+      │    │    │    │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │         │    └── variable: disabled [type=bool]
+      │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │         │    └── variable: is_public [type=bool]
+      │    │    │    │         ├── const-agg [type=bool, outer=(13)]
+      │    │    │    │         │    └── variable: instance_types.deleted [type=bool]
+      │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
+      │    │    │    │         ├── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
+      │    │    │    │         └── const-agg [type=timestamp, outer=(16)]
+      │    │    │    │              └── variable: instance_types.updated_at [type=timestamp]
+      │    │    │    └── filters
+      │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+      │    │    └── placeholder: $5 [type=int]
+      │    └── placeholder: $6 [type=int]
+      └── filters
+           └── instance_type_extra_specs_1.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -2112,121 +2113,122 @@ project
  ├── side-effects, has-placeholder
  ├── key: (1,28)
  ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
- └── left-join (lookup instance_type_extra_specs)
+ └── right-join
       ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
-      ├── key columns: [28] = [28]
       ├── side-effects, has-placeholder
       ├── key: (1,28)
       ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
-      ├── left-join (lookup instance_type_extra_specs@secondary)
-      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool) instance_type_extra_specs_1.id:28(int) key:29(string) instance_type_extra_specs_1.instance_type_id:31(int) instance_type_extra_specs_1.deleted:32(bool)
-      │    ├── key columns: [1] = [31]
+      ├── select
+      │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool!null) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+      │    ├── has-placeholder
+      │    ├── key: (28)
+      │    ├── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    ├── scan instance_type_extra_specs_1
+      │    │    ├── columns: instance_type_extra_specs_1.id:28(int!null) key:29(string) value:30(string) instance_type_extra_specs_1.instance_type_id:31(int!null) instance_type_extra_specs_1.deleted:32(bool) instance_type_extra_specs_1.deleted_at:33(timestamp) instance_type_extra_specs_1.created_at:34(timestamp) instance_type_extra_specs_1.updated_at:35(timestamp)
+      │    │    ├── key: (28)
+      │    │    └── fd: (28)-->(29-35), (29,31,32)~~>(28,30,33-35)
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
+      ├── limit
+      │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
       │    ├── side-effects, has-placeholder
-      │    ├── key: (1,28)
-      │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (28)-->(29,31,32), (29,31,32)~~>(28)
-      │    ├── limit
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    ├── offset
       │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │    │    ├── side-effects, has-placeholder
+      │    │    ├── has-placeholder
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    ├── offset
+      │    │    ├── select
       │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: (1)
       │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    ├── select
+      │    │    │    ├── group-by
       │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
+      │    │    │    │    ├── grouping columns: instance_types.id:1(int!null)
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: (1)
       │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    ├── group-by
-      │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
-      │    │    │    │    │    ├── grouping columns: instance_types.id:1(int!null)
-      │    │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    ├── left-join
+      │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
       │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
-      │    │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    │    ├── right ordering: +18
+      │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
+      │    │    │    │    │    ├── index-join instance_types
+      │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
       │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
-      │    │    │    │    │    │    ├── ordering: +1
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    │    │    └── select
+      │    │    │    │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
+      │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │         ├── key: (1)
+      │    │    │    │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
+      │    │    │    │    │    │         ├── scan instance_types@secondary
+      │    │    │    │    │    │         │    ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool)
+      │    │    │    │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+      │    │    │    │    │    │         │    ├── key: (1)
+      │    │    │    │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+      │    │    │    │    │    │         └── filters
+      │    │    │    │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │    │    │              └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── fd: ()-->(25)
       │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
+      │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
       │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    │    │    ├── scan instance_types
-      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    │    │    │    └── ordering: +1
+      │    │    │    │    │    │    │    ├── key: (18-20)
+      │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
+      │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
+      │    │    │    │    │    │    │    │    └── lax-key: (18-20)
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
-      │    │    │    │    │    │    │         └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
-      │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
-      │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── fd: ()-->(25)
-      │    │    │    │    │    │    │    ├── ordering: +18 opt(25) [actual: +18]
-      │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
-      │    │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    │    ├── key: (18-20)
-      │    │    │    │    │    │    │    │    ├── ordering: +18
-      │    │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
-      │    │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
-      │    │    │    │    │    │    │    │    │    ├── lax-key: (18-20)
-      │    │    │    │    │    │    │    │    │    └── ordering: +18
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
-      │    │    │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
-      │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── true [type=bool]
-      │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
-      │    │    │    │    │         │    └── variable: true [type=bool]
-      │    │    │    │    │         ├── const-agg [type=string, outer=(2)]
-      │    │    │    │    │         │    └── variable: name [type=string]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(3)]
-      │    │    │    │    │         │    └── variable: memory_mb [type=int]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(4)]
-      │    │    │    │    │         │    └── variable: vcpus [type=int]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(5)]
-      │    │    │    │    │         │    └── variable: root_gb [type=int]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(6)]
-      │    │    │    │    │         │    └── variable: ephemeral_gb [type=int]
-      │    │    │    │    │         ├── const-agg [type=string, outer=(7)]
-      │    │    │    │    │         │    └── variable: flavorid [type=string]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(8)]
-      │    │    │    │    │         │    └── variable: swap [type=int]
-      │    │    │    │    │         ├── const-agg [type=float, outer=(9)]
-      │    │    │    │    │         │    └── variable: rxtx_factor [type=float]
-      │    │    │    │    │         ├── const-agg [type=int, outer=(10)]
-      │    │    │    │    │         │    └── variable: vcpu_weight [type=int]
-      │    │    │    │    │         ├── const-agg [type=bool, outer=(11)]
-      │    │    │    │    │         │    └── variable: disabled [type=bool]
-      │    │    │    │    │         ├── const-agg [type=bool, outer=(12)]
-      │    │    │    │    │         │    └── variable: is_public [type=bool]
-      │    │    │    │    │         ├── const-agg [type=bool, outer=(13)]
-      │    │    │    │    │         │    └── variable: instance_types.deleted [type=bool]
-      │    │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
-      │    │    │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
-      │    │    │    │    │         ├── const-agg [type=timestamp, outer=(15)]
-      │    │    │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
-      │    │    │    │    │         └── const-agg [type=timestamp, outer=(16)]
-      │    │    │    │    │              └── variable: instance_types.updated_at [type=timestamp]
-      │    │    │    │    └── filters
-      │    │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
-      │    │    │    └── placeholder: $5 [type=int]
-      │    │    └── placeholder: $6 [type=int]
-      │    └── filters
-      │         └── instance_type_extra_specs_1.deleted = $7 [type=bool, outer=(32), constraints=(/32: (/NULL - ])]
-      └── filters (true)
+      │    │    │    │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
+      │    │    │    │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── true [type=bool]
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── const-not-null-agg [type=bool, outer=(25)]
+      │    │    │    │         │    └── variable: true [type=bool]
+      │    │    │    │         ├── const-agg [type=string, outer=(2)]
+      │    │    │    │         │    └── variable: name [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(3)]
+      │    │    │    │         │    └── variable: memory_mb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(4)]
+      │    │    │    │         │    └── variable: vcpus [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(5)]
+      │    │    │    │         │    └── variable: root_gb [type=int]
+      │    │    │    │         ├── const-agg [type=int, outer=(6)]
+      │    │    │    │         │    └── variable: ephemeral_gb [type=int]
+      │    │    │    │         ├── const-agg [type=string, outer=(7)]
+      │    │    │    │         │    └── variable: flavorid [type=string]
+      │    │    │    │         ├── const-agg [type=int, outer=(8)]
+      │    │    │    │         │    └── variable: swap [type=int]
+      │    │    │    │         ├── const-agg [type=float, outer=(9)]
+      │    │    │    │         │    └── variable: rxtx_factor [type=float]
+      │    │    │    │         ├── const-agg [type=int, outer=(10)]
+      │    │    │    │         │    └── variable: vcpu_weight [type=int]
+      │    │    │    │         ├── const-agg [type=bool, outer=(11)]
+      │    │    │    │         │    └── variable: disabled [type=bool]
+      │    │    │    │         ├── const-agg [type=bool, outer=(12)]
+      │    │    │    │         │    └── variable: is_public [type=bool]
+      │    │    │    │         ├── const-agg [type=bool, outer=(13)]
+      │    │    │    │         │    └── variable: instance_types.deleted [type=bool]
+      │    │    │    │         ├── const-agg [type=timestamp, outer=(14)]
+      │    │    │    │         │    └── variable: instance_types.deleted_at [type=timestamp]
+      │    │    │    │         ├── const-agg [type=timestamp, outer=(15)]
+      │    │    │    │         │    └── variable: instance_types.created_at [type=timestamp]
+      │    │    │    │         └── const-agg [type=timestamp, outer=(16)]
+      │    │    │    │              └── variable: instance_types.updated_at [type=timestamp]
+      │    │    │    └── filters
+      │    │    │         └── (is_public = true) OR (true_agg IS NOT NULL) [type=bool, outer=(12,26)]
+      │    │    └── placeholder: $5 [type=int]
+      │    └── placeholder: $6 [type=int]
+      └── filters
+           └── instance_type_extra_specs_1.instance_type_id = instance_types.id [type=bool, outer=(1,31), constraints=(/1: (/NULL - ]; /31: (/NULL - ]), fd=(1)==(31), (31)==(1)]
 
 opt
 select flavors.created_at as flavors_created_at,
@@ -2466,51 +2468,49 @@ project
       │    │    │    │         ├── group-by
       │    │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
       │    │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
-      │    │    │    │         │    ├── internal-ordering: +1
       │    │    │    │         │    ├── has-placeholder
       │    │    │    │         │    ├── key: (1)
       │    │    │    │         │    ├── fd: (1)-->(2-16,26), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │         │    ├── left-join (merge)
+      │    │    │    │         │    ├── left-join
       │    │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
-      │    │    │    │         │    │    ├── left ordering: +1
-      │    │    │    │         │    │    ├── right ordering: +18
       │    │    │    │         │    │    ├── has-placeholder
       │    │    │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
-      │    │    │    │         │    │    ├── ordering: +1
-      │    │    │    │         │    │    ├── select
+      │    │    │    │         │    │    ├── index-join instance_types
       │    │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
       │    │    │    │         │    │    │    ├── has-placeholder
       │    │    │    │         │    │    │    ├── key: (1)
       │    │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │         │    │    │    ├── ordering: +1
-      │    │    │    │         │    │    │    ├── scan instance_types
-      │    │    │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │    │    │    │         │    │    │    │    ├── key: (1)
-      │    │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │         │    │    │    │    └── ordering: +1
-      │    │    │    │         │    │    │    └── filters
-      │    │    │    │         │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
-      │    │    │    │         │    │    │         └── (flavorid > $4) OR ((flavorid = $5) AND (instance_types.id > $6)) [type=bool, outer=(1,7)]
+      │    │    │    │         │    │    │    └── select
+      │    │    │    │         │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
+      │    │    │    │         │    │    │         ├── has-placeholder
+      │    │    │    │         │    │    │         ├── key: (1)
+      │    │    │    │         │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
+      │    │    │    │         │    │    │         ├── scan instance_types@secondary
+      │    │    │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool)
+      │    │    │    │         │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+      │    │    │    │         │    │    │         │    ├── key: (1)
+      │    │    │    │         │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+      │    │    │    │         │    │    │         └── filters
+      │    │    │    │         │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │         │    │    │              └── (flavorid > $4) OR ((flavorid = $5) AND (instance_types.id > $6)) [type=bool, outer=(1,7)]
       │    │    │    │         │    │    ├── project
       │    │    │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
       │    │    │    │         │    │    │    ├── has-placeholder
       │    │    │    │         │    │    │    ├── fd: ()-->(25)
-      │    │    │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
       │    │    │    │         │    │    │    ├── select
       │    │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
       │    │    │    │         │    │    │    │    ├── has-placeholder
       │    │    │    │         │    │    │    │    ├── key: (18-20)
-      │    │    │    │         │    │    │    │    ├── ordering: +18
       │    │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
       │    │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
-      │    │    │    │         │    │    │    │    │    ├── lax-key: (18-20)
-      │    │    │    │         │    │    │    │    │    └── ordering: +18
+      │    │    │    │         │    │    │    │    │    └── lax-key: (18-20)
       │    │    │    │         │    │    │    │    └── filters
       │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
       │    │    │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
       │    │    │    │         │    │    │    └── projections
       │    │    │    │         │    │    │         └── true [type=bool]
-      │    │    │    │         │    │    └── filters (true)
+      │    │    │    │         │    │    └── filters
+      │    │    │    │         │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
       │    │    │    │         │    └── aggregations
       │    │    │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
       │    │    │    │         │         │    └── variable: true [type=bool]
@@ -3104,51 +3104,49 @@ project
       │    │    │    │         ├── group-by
       │    │    │    │         │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int) vcpus:4(int) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) true_agg:26(bool)
       │    │    │    │         │    ├── grouping columns: instance_types.id:1(int!null)
-      │    │    │    │         │    ├── internal-ordering: +1
       │    │    │    │         │    ├── has-placeholder
       │    │    │    │         │    ├── key: (1)
       │    │    │    │         │    ├── fd: (1)-->(2-16,26), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │         │    ├── left-join (merge)
+      │    │    │    │         │    ├── left-join
       │    │    │    │         │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp) instance_type_projects.instance_type_id:18(int) true:25(bool)
-      │    │    │    │         │    │    ├── left ordering: +1
-      │    │    │    │         │    │    ├── right ordering: +18
       │    │    │    │         │    │    ├── has-placeholder
       │    │    │    │         │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), ()~~>(25)
-      │    │    │    │         │    │    ├── ordering: +1
-      │    │    │    │         │    │    ├── select
+      │    │    │    │         │    │    ├── index-join instance_types
       │    │    │    │         │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string!null) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool!null) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
       │    │    │    │         │    │    │    ├── has-placeholder
       │    │    │    │         │    │    │    ├── key: (1)
       │    │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │         │    │    │    ├── ordering: +1
-      │    │    │    │         │    │    │    ├── scan instance_types
-      │    │    │    │         │    │    │    │    ├── columns: instance_types.id:1(int!null) name:2(string) memory_mb:3(int!null) vcpus:4(int!null) root_gb:5(int) ephemeral_gb:6(int) flavorid:7(string) swap:8(int!null) rxtx_factor:9(float) vcpu_weight:10(int) disabled:11(bool) is_public:12(bool) instance_types.deleted:13(bool) instance_types.deleted_at:14(timestamp) instance_types.created_at:15(timestamp) instance_types.updated_at:16(timestamp)
-      │    │    │    │         │    │    │    │    ├── key: (1)
-      │    │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │         │    │    │    │    └── ordering: +1
-      │    │    │    │         │    │    │    └── filters
-      │    │    │    │         │    │    │         ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
-      │    │    │    │         │    │    │         └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
+      │    │    │    │         │    │    │    └── select
+      │    │    │    │         │    │    │         ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool!null)
+      │    │    │    │         │    │    │         ├── has-placeholder
+      │    │    │    │         │    │    │         ├── key: (1)
+      │    │    │    │         │    │    │         ├── fd: (1)-->(7,13), (7,13)-->(1)
+      │    │    │    │         │    │    │         ├── scan instance_types@secondary
+      │    │    │    │         │    │    │         │    ├── columns: instance_types.id:1(int!null) flavorid:7(string!null) instance_types.deleted:13(bool)
+      │    │    │    │         │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+      │    │    │    │         │    │    │         │    ├── key: (1)
+      │    │    │    │         │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+      │    │    │    │         │    │    │         └── filters
+      │    │    │    │         │    │    │              ├── instance_types.deleted = $1 [type=bool, outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │         │    │    │              └── flavorid = $4 [type=bool, outer=(7), constraints=(/7: (/NULL - ])]
       │    │    │    │         │    │    ├── project
       │    │    │    │         │    │    │    ├── columns: true:25(bool!null) instance_type_projects.instance_type_id:18(int!null)
       │    │    │    │         │    │    │    ├── has-placeholder
       │    │    │    │         │    │    │    ├── fd: ()-->(25)
-      │    │    │    │         │    │    │    ├── ordering: +18 opt(25) [actual: +18]
       │    │    │    │         │    │    │    ├── select
       │    │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string!null) instance_type_projects.deleted:20(bool!null)
       │    │    │    │         │    │    │    │    ├── has-placeholder
       │    │    │    │         │    │    │    │    ├── key: (18-20)
-      │    │    │    │         │    │    │    │    ├── ordering: +18
       │    │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
       │    │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:18(int!null) project_id:19(string) instance_type_projects.deleted:20(bool)
-      │    │    │    │         │    │    │    │    │    ├── lax-key: (18-20)
-      │    │    │    │         │    │    │    │    │    └── ordering: +18
+      │    │    │    │         │    │    │    │    │    └── lax-key: (18-20)
       │    │    │    │         │    │    │    │    └── filters
       │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted = $2 [type=bool, outer=(20), constraints=(/20: (/NULL - ])]
       │    │    │    │         │    │    │    │         └── project_id = $3 [type=bool, outer=(19), constraints=(/19: (/NULL - ])]
       │    │    │    │         │    │    │    └── projections
       │    │    │    │         │    │    │         └── true [type=bool]
-      │    │    │    │         │    │    └── filters (true)
+      │    │    │    │         │    │    └── filters
+      │    │    │    │         │    │         └── instance_type_projects.instance_type_id = instance_types.id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
       │    │    │    │         │    └── aggregations
       │    │    │    │         │         ├── const-not-null-agg [type=bool, outer=(25)]
       │    │    │    │         │         │    └── variable: true [type=bool]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -555,7 +555,7 @@ project
  ├── columns: w_tax:8(decimal)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1]
- ├── cost: 1.14
+ ├── cost: 0.11897
  ├── key: ()
  ├── fd: ()-->(8)
  ├── prune: (8)
@@ -564,7 +564,7 @@ project
       ├── constraint: /1: [/10 - /10]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0]
-      ├── cost: 1.12
+      ├── cost: 0.09897
       ├── key: ()
       ├── fd: ()-->(1,8)
       ├── prune: (1,8)
@@ -579,7 +579,7 @@ project
  ├── columns: c_discount:16(decimal) c_last:6(string) c_credit:14(string)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=3.33333333e-05]
- ├── cost: 0.0200426667
+ ├── cost: 0.0200059123
  ├── key: ()
  ├── fd: ()-->(6,14,16)
  ├── prune: (6,14,16)
@@ -588,7 +588,7 @@ project
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=3.33333333e-05, distinct(1)=3.33333333e-05, null(1)=0, distinct(2)=3.33333333e-05, null(2)=0, distinct(3)=3.33333333e-05, null(3)=0]
-      ├── cost: 0.0100423333
+      ├── cost: 0.010005579
       ├── key: ()
       ├── fd: ()-->(1-3,6,14,16)
       ├── prune: (1-3,6,14,16)
@@ -604,7 +604,7 @@ scan item
  ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
  ├── stats: [rows=12, distinct(1)=12, null(1)=0]
- ├── cost: 13.09
+ ├── cost: 1.44964
  ├── key: (1)
  ├── fd: (1)-->(3-5)
  ├── ordering: +1
@@ -620,7 +620,7 @@ ORDER BY s_i_id
 project
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)  [hidden: s_i_id:1(int!null)]
  ├── stats: [rows=5]
- ├── cost: 6.32
+ ├── cost: 1.06185
  ├── key: (1)
  ├── fd: (1)-->(3,8,14-17)
  ├── ordering: +1
@@ -630,7 +630,7 @@ project
       ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(string) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string)
       ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
       ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(2)=1, null(2)=0]
-      ├── cost: 6.26
+      ├── cost: 1.00185
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
       ├── ordering: +1 opt(2) [actual: +1]
@@ -655,7 +655,7 @@ ORDER BY c_first ASC
 project
  ├── columns: c_id:1(int!null)  [hidden: c_first:4(string)]
  ├── stats: [rows=3.3e-05]
- ├── cost: 0.02003663
+ ├── cost: 0.0200048546
  ├── key: (1)
  ├── fd: (1)-->(4)
  ├── ordering: +4
@@ -664,7 +664,7 @@ project
       ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
       ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
       ├── stats: [rows=3.3e-05, distinct(1)=3.3e-05, null(1)=0, distinct(2)=3.3e-05, null(2)=0, distinct(3)=3.3e-05, null(3)=0, distinct(6)=3.3e-05, null(6)=0]
-      ├── cost: 0.0100363
+      ├── cost: 0.0100045246
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4)
       ├── ordering: +4 opt(2,3,6) [actual: +4]
@@ -689,7 +689,7 @@ project
  ├── columns: c_balance:17(decimal) c_first:4(string) c_middle:5(string) c_last:6(string)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=3.33333333e-05]
- ├── cost: 0.020043
+ ├── cost: 0.0200064837
  ├── key: ()
  ├── fd: ()-->(4-6,17)
  ├── prune: (4-6,17)
@@ -698,7 +698,7 @@ project
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=3.33333333e-05, distinct(1)=3.33333333e-05, null(1)=0, distinct(2)=3.33333333e-05, null(2)=0, distinct(3)=3.33333333e-05, null(3)=0]
-      ├── cost: 0.0100426667
+      ├── cost: 0.0100061503
       ├── key: ()
       ├── fd: ()-->(1-6,17)
       ├── prune: (1-6,17)
@@ -713,7 +713,7 @@ ORDER BY c_first ASC
 project
  ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(string) c_middle:5(string)
  ├── stats: [rows=3.3e-05]
- ├── cost: 0.0301782
+ ├── cost: 0.0300528861
  ├── key: (1)
  ├── fd: (1)-->(4,5,17)
  ├── ordering: +4
@@ -721,7 +721,7 @@ project
  └── index-join customer
       ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_middle:5(string) c_last:6(string!null) c_balance:17(decimal)
       ├── stats: [rows=3.3e-05, distinct(1)=3.3e-05, null(1)=0, distinct(2)=3.3e-05, null(2)=0, distinct(3)=3.3e-05, null(3)=0, distinct(6)=3.3e-05, null(6)=0]
-      ├── cost: 0.02017787
+      ├── cost: 0.0200525561
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
       ├── ordering: +4 opt(2,3,6) [actual: +4]
@@ -730,7 +730,7 @@ project
            ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
            ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
            ├── stats: [rows=3.3e-05, distinct(1)=3.3e-05, null(1)=0, distinct(2)=3.3e-05, null(2)=0, distinct(3)=3.3e-05, null(3)=0, distinct(6)=3.3e-05, null(6)=0]
-           ├── cost: 0.0100363
+           ├── cost: 0.0100045246
            ├── key: (1)
            ├── fd: ()-->(2,3,6), (1)-->(4)
            ├── ordering: +4 opt(2,3,6) [actual: +4]
@@ -748,7 +748,7 @@ project
  ├── columns: o_id:1(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=3.3e-05]
- ├── cost: 0.03017292
+ ├── cost: 0.0300517655
  ├── key: ()
  ├── fd: ()-->(1,5,6)
  ├── prune: (1,5,6)
@@ -756,7 +756,7 @@ project
       ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
       ├── cardinality: [0 - 1]
       ├── stats: [rows=3.3e-05]
-      ├── cost: 0.02017259
+      ├── cost: 0.0200514355
       ├── key: ()
       ├── fd: ()-->(1-6)
       ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
@@ -765,7 +765,7 @@ project
            ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
            ├── limit: 1(rev)
            ├── stats: [rows=3.3e-05, distinct(1)=3.3e-05, null(1)=0, distinct(2)=3.3e-05, null(2)=0, distinct(3)=3.3e-05, null(3)=0, distinct(4)=3.3e-05, null(4)=0]
-           ├── cost: 0.01003564
+           ├── cost: 0.0100039319
            ├── key: ()
            ├── fd: ()-->(1-4)
            ├── prune: (1-4)
@@ -779,14 +779,14 @@ WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
 project
  ├── columns: ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_quantity:8(int) ol_amount:9(decimal) ol_delivery_d:7(timestamp)
  ├── stats: [rows=1e-05]
- ├── cost: 0.0200119
+ ├── cost: 0.0200020263
  ├── prune: (5-9)
  ├── interesting orderings: (+6)
  └── scan order_line
       ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_delivery_d:7(timestamp) ol_quantity:8(int) ol_amount:9(decimal)
       ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
       ├── stats: [rows=1e-05, distinct(1)=1e-05, null(1)=0, distinct(2)=1e-05, null(2)=0, distinct(3)=1e-05, null(3)=0, distinct(5)=1e-05, null(5)=0]
-      ├── cost: 0.0100118
+      ├── cost: 0.0100019263
       ├── fd: ()-->(1-3)
       ├── prune: (1-3,5-9)
       └── interesting orderings: (+3,+2,-1) (+6,+2,+3,+1)
@@ -818,7 +818,7 @@ project
  ├── columns: no_o_id:1(int!null)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1]
- ├── cost: 1.09
+ ├── cost: 0.13119
  ├── key: ()
  ├── fd: ()-->(1)
  ├── prune: (1)
@@ -827,7 +827,7 @@ project
       ├── constraint: /3/2/-1: [/10/100 - /10/100]
       ├── limit: 1(rev)
       ├── stats: [rows=1]
-      ├── cost: 1.07
+      ├── cost: 0.11119
       ├── key: ()
       ├── fd: ()-->(1-3)
       ├── prune: (1-3)
@@ -842,7 +842,7 @@ scalar-group-by
  ├── columns: sum:11(decimal)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 0.0300115
+ ├── cost: 0.0300013407
  ├── key: ()
  ├── fd: ()-->(11)
  ├── prune: (11)
@@ -850,7 +850,7 @@ scalar-group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_amount:9(decimal)
  │    ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
  │    ├── stats: [rows=1e-05, distinct(1)=1e-05, null(1)=0, distinct(2)=1e-05, null(2)=0, distinct(3)=1e-05, null(3)=0]
- │    ├── cost: 0.0100114
+ │    ├── cost: 0.0100012407
  │    ├── fd: ()-->(1-3)
  │    ├── prune: (1-3,9)
  │    └── interesting orderings: (+3,+2,-1)
@@ -875,7 +875,7 @@ project
  ├── columns: d_next_o_id:11(int)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1]
- ├── cost: 1.17
+ ├── cost: 0.13775
  ├── key: ()
  ├── fd: ()-->(11)
  ├── prune: (11)
@@ -884,7 +884,7 @@ project
       ├── constraint: /2/1: [/10/100 - /10/100]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0]
-      ├── cost: 1.15
+      ├── cost: 0.11775
       ├── key: ()
       ├── fd: ()-->(1,2,11)
       ├── prune: (1,2,11)
@@ -904,7 +904,7 @@ scalar-group-by
  ├── columns: count:28(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 1.82111111
+ ├── cost: 0.21823
  ├── key: ()
  ├── fd: ()-->(28)
  ├── prune: (28)
@@ -912,14 +912,14 @@ scalar-group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) s_i_id:11(int!null) s_w_id:12(int!null) s_quantity:13(int!null)
  │    ├── key columns: [3 5] = [12 11]
  │    ├── stats: [rows=1, distinct(1)=0.11109736, null(1)=0, distinct(2)=0.111097416, null(2)=0, distinct(3)=0.111111111, null(3)=0, distinct(5)=0.111111056, null(5)=0, distinct(11)=0.111111056, null(11)=0, distinct(12)=0.111111111, null(12)=0, distinct(13)=1, null(13)=0]
- │    ├── cost: 1.79111111
+ │    ├── cost: 0.18823
  │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    ├── scan order_line
  │    │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null)
  │    │    ├── constraint: /3/2/-1/4: [/10/100/999 - /10/100/980]
  │    │    ├── stats: [rows=0.111111111, distinct(1)=0.111111056, null(1)=0, distinct(2)=0.111111111, null(2)=0, distinct(3)=0.111111111, null(3)=0, distinct(5)=0.111111056, null(5)=0]
- │    │    ├── cost: 0.136666667
+ │    │    ├── cost: 0.0237855556
  │    │    ├── fd: ()-->(2,3)
  │    │    ├── prune: (5)
  │    │    └── interesting orderings: (+3,+2,-1)
@@ -957,7 +957,7 @@ scalar-group-by
  ├── columns: count:22(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 126.526
+ ├── cost: 12.3767
  ├── key: ()
  ├── fd: ()-->(22)
  ├── prune: (22)
@@ -966,13 +966,13 @@ scalar-group-by
  │    ├── left ordering: +1
  │    ├── right ordering: +11
  │    ├── stats: [rows=3.3, distinct(1)=3.3, null(1)=0, distinct(9)=0.966296553, null(9)=0, distinct(11)=3.3, null(11)=0, distinct(21)=2.87528606, null(21)=0]
- │    ├── cost: 126.473
+ │    ├── cost: 12.3237
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)
  │    ├── scan warehouse
  │    │    ├── columns: w_id:1(int!null) w_ytd:9(decimal)
  │    │    ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(9)=1, null(9)=0.1]
- │    │    ├── cost: 11.11
+ │    │    ├── cost: 0.8997
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
  │    │    ├── ordering: +1
@@ -982,7 +982,7 @@ scalar-group-by
  │    │    ├── columns: d_w_id:11(int!null) sum:21(decimal)
  │    │    ├── grouping columns: d_w_id:11(int!null)
  │    │    ├── stats: [rows=10, distinct(11)=10, null(11)=0, distinct(21)=10, null(21)=0]
- │    │    ├── cost: 115.12
+ │    │    ├── cost: 11.181
  │    │    ├── key: (11)
  │    │    ├── fd: (11)-->(21)
  │    │    ├── ordering: +11
@@ -991,7 +991,7 @@ scalar-group-by
  │    │    ├── scan district
  │    │    │    ├── columns: d_w_id:11(int!null) d_ytd:19(decimal)
  │    │    │    ├── stats: [rows=100, distinct(11)=10, null(11)=0]
- │    │    │    ├── cost: 113.01
+ │    │    │    ├── cost: 9.071
  │    │    │    ├── ordering: +11
  │    │    │    ├── prune: (11,19)
  │    │    │    └── interesting orderings: (+11)
@@ -1013,7 +1013,7 @@ ORDER BY d_w_id, d_id
 scan district
  ├── columns: d_next_o_id:11(int)  [hidden: d_id:1(int!null) d_w_id:2(int!null)]
  ├── stats: [rows=100]
- ├── cost: 114.01
+ ├── cost: 10.785
  ├── key: (1,2)
  ├── fd: (1,2)-->(11)
  ├── ordering: +2,+1
@@ -1030,7 +1030,7 @@ group-by
  ├── columns: max:4(int)  [hidden: no_d_id:2(int!null) no_w_id:3(int!null)]
  ├── grouping columns: no_d_id:2(int!null) no_w_id:3(int!null)
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
- ├── cost: 98101.02
+ ├── cost: 11808.12
  ├── key: (2,3)
  ├── fd: (2,3)-->(4)
  ├── ordering: +3,+2
@@ -1039,7 +1039,7 @@ group-by
  ├── scan new_order
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
  │    ├── stats: [rows=90000, distinct(2,3)=100, null(2,3)=0]
- │    ├── cost: 95400.01
+ │    ├── cost: 9107.11
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
@@ -1058,7 +1058,7 @@ group-by
  ├── columns: max:9(int)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
- ├── cost: 330001.02
+ ├── cost: 39604.02
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1067,7 +1067,7 @@ group-by
  ├── scan "order"@order_idx
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=300000, distinct(2,3)=100, null(2,3)=0]
- │    ├── cost: 321000.01
+ │    ├── cost: 30603.01
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
@@ -1090,14 +1090,14 @@ scalar-group-by
  ├── columns: count:8(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 99902.3833
+ ├── cost: 13609.4833
  ├── key: ()
  ├── fd: ()-->(8)
  ├── prune: (8)
  ├── select
  │    ├── columns: no_d_id:2(int!null) no_w_id:3(int!null) max:4(int) min:5(int) count_rows:6(int)
  │    ├── stats: [rows=33.3333333, distinct(2)=33.3333333, null(2)=0, distinct(3)=9.8265847, null(3)=0]
- │    ├── cost: 99902.03
+ │    ├── cost: 13609.13
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(4-6)
  │    ├── interesting orderings: (+3,+2)
@@ -1106,7 +1106,7 @@ scalar-group-by
  │    │    ├── grouping columns: no_d_id:2(int!null) no_w_id:3(int!null)
  │    │    ├── internal-ordering: +3,+2
  │    │    ├── stats: [rows=100, distinct(2)=9000, null(2)=0, distinct(3)=10, null(3)=0, distinct(2,3)=100, null(2,3)=0]
- │    │    ├── cost: 99901.02
+ │    │    ├── cost: 13608.12
  │    │    ├── key: (2,3)
  │    │    ├── fd: (2,3)-->(4-6)
  │    │    ├── prune: (4-6)
@@ -1114,7 +1114,7 @@ scalar-group-by
  │    │    ├── scan new_order
  │    │    │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
  │    │    │    ├── stats: [rows=90000, distinct(2)=9000, null(2)=0, distinct(3)=10, null(3)=0, distinct(2,3)=100, null(2,3)=0]
- │    │    │    ├── cost: 95400.01
+ │    │    │    ├── cost: 9107.11
  │    │    │    ├── key: (1-3)
  │    │    │    ├── ordering: +3,+2
  │    │    │    ├── prune: (1-3)
@@ -1146,7 +1146,7 @@ group-by
  ├── columns: sum:9(decimal)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
- ├── cost: 342001.02
+ ├── cost: 40588.02
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1155,7 +1155,7 @@ group-by
  ├── scan "order"
  │    ├── columns: o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
  │    ├── stats: [rows=300000, distinct(2,3)=100, null(2,3)=0]
- │    ├── cost: 333000.01
+ │    ├── cost: 31587.01
  │    ├── ordering: +3,+2
  │    ├── prune: (2,3,7)
  │    └── interesting orderings: (+3,+2)
@@ -1169,30 +1169,25 @@ FROM order_line
 GROUP BY ol_w_id, ol_d_id
 ORDER BY ol_w_id, ol_d_id
 ----
-sort
+group-by
  ├── columns: count:11(int)  [hidden: ol_d_id:2(int!null) ol_w_id:3(int!null)]
+ ├── grouping columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
- ├── cost: 1110017.08
+ ├── cost: 119791.02
  ├── key: (2,3)
  ├── fd: (2,3)-->(11)
  ├── ordering: +3,+2
  ├── prune: (11)
- └── group-by
-      ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
-      ├── grouping columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
-      ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
-      ├── cost: 1110001.02
-      ├── key: (2,3)
-      ├── fd: (2,3)-->(11)
-      ├── prune: (11)
-      ├── scan order_line@order_line_fk
-      │    ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
-      │    ├── stats: [rows=1000000, distinct(2,3)=100, null(2,3)=0]
-      │    ├── cost: 1070000.01
-      │    ├── prune: (2,3)
-      │    └── interesting orderings: (+3,+2)
-      └── aggregations
-           └── count-rows [type=int]
+ ├── interesting orderings: (+3,+2)
+ ├── scan order_line
+ │    ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
+ │    ├── stats: [rows=1000000, distinct(2,3)=100, null(2,3)=0]
+ │    ├── cost: 89790.01
+ │    ├── ordering: +3,+2
+ │    ├── prune: (2,3)
+ │    └── interesting orderings: (+3,+2)
+ └── aggregations
+      └── count-rows [type=int]
 
 opt format=hide-qual
 (SELECT no_w_id, no_d_id, no_o_id FROM new_order)
@@ -1204,25 +1199,25 @@ except-all
  ├── left columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
  ├── right columns: o_w_id:6(int) o_d_id:5(int) o_id:4(int)
  ├── stats: [rows=90000]
- ├── cost: 424200.248
+ ├── cost: 49652.348
  ├── scan new_order
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
  │    ├── stats: [rows=90000]
- │    ├── cost: 95400.01
+ │    ├── cost: 9107.11
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+3,+2,-1)
  └── project
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
       ├── stats: [rows=9.90033333]
-      ├── cost: 327000.129
+      ├── cost: 38745.129
       ├── key: (4-6)
       ├── prune: (4-6)
       ├── interesting orderings: (+6,+5,-4)
       └── select
            ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            ├── stats: [rows=9.90033333, distinct(4)=9.90033333, null(4)=0, distinct(5)=9.90033333, null(5)=0, distinct(6)=6.3212669, null(6)=0, distinct(9)=1, null(9)=9.90033333]
-           ├── cost: 327000.02
+           ├── cost: 38745.02
            ├── key: (4-6)
            ├── fd: ()-->(9)
            ├── prune: (4-6)
@@ -1230,7 +1225,7 @@ except-all
            ├── scan "order"@order_idx
            │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            │    ├── stats: [rows=300000, distinct(4)=30000, null(4)=0, distinct(5)=30000, null(5)=0, distinct(6)=10, null(6)=0, distinct(9)=30000, null(9)=3000]
-           │    ├── cost: 324000.01
+           │    ├── cost: 35745.01
            │    ├── key: (4-6)
            │    ├── fd: (4-6)-->(9)
            │    ├── prune: (4-6,9)
@@ -1250,18 +1245,18 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── right columns: no_w_id:11(int) no_d_id:10(int) no_o_id:9(int)
  ├── stats: [rows=9.90033333]
- ├── cost: 423300.347
+ ├── cost: 48752.447
  ├── project
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=9.90033333]
- │    ├── cost: 327000.129
+ │    ├── cost: 38745.129
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    └── select
  │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         ├── stats: [rows=9.90033333, distinct(1)=9.90033333, null(1)=0, distinct(2)=9.90033333, null(2)=0, distinct(3)=6.3212669, null(3)=0, distinct(6)=1, null(6)=9.90033333]
- │         ├── cost: 327000.02
+ │         ├── cost: 38745.02
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
@@ -1269,7 +1264,7 @@ except-all
  │         ├── scan "order"@order_idx
  │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         │    ├── stats: [rows=300000, distinct(1)=30000, null(1)=0, distinct(2)=30000, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=30000, null(6)=3000]
- │         │    ├── cost: 324000.01
+ │         │    ├── cost: 35745.01
  │         │    ├── key: (1-3)
  │         │    ├── fd: (1-3)-->(6)
  │         │    ├── prune: (1-3,6)
@@ -1281,7 +1276,7 @@ except-all
  └── scan new_order
       ├── columns: no_o_id:9(int!null) no_d_id:10(int!null) no_w_id:11(int!null)
       ├── stats: [rows=90000]
-      ├── cost: 95400.01
+      ├── cost: 9107.11
       ├── key: (9-11)
       ├── prune: (9-11)
       └── interesting orderings: (+11,+10,-9)
@@ -1305,11 +1300,11 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null) o_ol_cnt:7(int)
  ├── right columns: ol_w_id:11(int) ol_d_id:10(int) ol_o_id:9(int) count_rows:19(int)
  ├── stats: [rows=300000]
- ├── cost: 1474000.04
+ ├── cost: 191659.04
  ├── scan "order"
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
  │    ├── stats: [rows=300000]
- │    ├── cost: 336000.01
+ │    ├── cost: 36729.01
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(7)
  │    ├── prune: (1-3,7)
@@ -1317,16 +1312,18 @@ except-all
  └── group-by
       ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) count_rows:19(int)
       ├── grouping columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
+      ├── internal-ordering: +11,+10,-9
       ├── stats: [rows=100000, distinct(9-11)=100000, null(9-11)=0]
-      ├── cost: 1131000.02
+      ├── cost: 147930.02
       ├── key: (9-11)
       ├── fd: (9-11)-->(19)
       ├── prune: (19)
       ├── interesting orderings: (+11,+10,-9)
-      ├── scan order_line@order_line_fk
+      ├── scan order_line
       │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
       │    ├── stats: [rows=1000000, distinct(9-11)=100000, null(9-11)=0]
-      │    ├── cost: 1080000.01
+      │    ├── cost: 106930.01
+      │    ├── ordering: +11,+10,-9
       │    ├── prune: (9-11)
       │    └── interesting orderings: (+11,+10,-9)
       └── aggregations
@@ -1351,20 +1348,22 @@ except-all
  ├── left columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count_rows:11(int)
  ├── right columns: o_w_id:14(int) o_d_id:13(int) o_id:12(int) o_ol_cnt:18(int)
  ├── stats: [rows=100000]
- ├── cost: 1472000.04
+ ├── cost: 189659.04
  ├── group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
  │    ├── grouping columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
+ │    ├── internal-ordering: +3,+2,-1
  │    ├── stats: [rows=100000, distinct(1-3)=100000, null(1-3)=0]
- │    ├── cost: 1131000.02
+ │    ├── cost: 147930.02
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(11)
  │    ├── prune: (11)
  │    ├── interesting orderings: (+3,+2,-1)
- │    ├── scan order_line@order_line_fk
+ │    ├── scan order_line
  │    │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
  │    │    ├── stats: [rows=1000000, distinct(1-3)=100000, null(1-3)=0]
- │    │    ├── cost: 1080000.01
+ │    │    ├── cost: 106930.01
+ │    │    ├── ordering: +3,+2,-1
  │    │    ├── prune: (1-3)
  │    │    └── interesting orderings: (+3,+2,-1)
  │    └── aggregations
@@ -1372,7 +1371,7 @@ except-all
  └── scan "order"
       ├── columns: o_id:12(int!null) o_d_id:13(int!null) o_w_id:14(int!null) o_ol_cnt:18(int)
       ├── stats: [rows=300000]
-      ├── cost: 336000.01
+      ├── cost: 36729.01
       ├── key: (12-14)
       ├── fd: (12-14)-->(18)
       ├── prune: (12-14,18)
@@ -1399,32 +1398,32 @@ scalar-group-by
  ├── columns: count:19(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 1477001.05
+ ├── cost: 172815.857
  ├── key: ()
  ├── fd: ()-->(19)
  ├── prune: (19)
  ├── select
  │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
  │    ├── stats: [rows=6.54741364]
- │    ├── cost: 1477000.97
+ │    ├── cost: 172815.771
  │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
  │    ├── full-join
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
  │    │    ├── stats: [rows=19.6422409]
- │    │    ├── cost: 1477000.76
+ │    │    ├── cost: 172815.565
  │    │    ├── reject-nulls: (1-3,9-11)
  │    │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
  │    │    ├── project
  │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    │    │    ├── stats: [rows=9.90033333, distinct(1)=9.90033333, null(1)=0, distinct(2)=9.90033333, null(2)=0, distinct(3)=6.3212669, null(3)=0]
- │    │    │    ├── cost: 327000.129
+ │    │    │    ├── cost: 38745.129
  │    │    │    ├── key: (1-3)
  │    │    │    ├── prune: (1-3)
  │    │    │    ├── interesting orderings: (+3,+2,-1)
  │    │    │    └── select
  │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         ├── stats: [rows=9.90033333, distinct(1)=9.90033333, null(1)=0, distinct(2)=9.90033333, null(2)=0, distinct(3)=6.3212669, null(3)=0, distinct(6)=1, null(6)=9.90033333]
- │    │    │         ├── cost: 327000.02
+ │    │    │         ├── cost: 38745.02
  │    │    │         ├── key: (1-3)
  │    │    │         ├── fd: ()-->(6)
  │    │    │         ├── prune: (1-3)
@@ -1432,7 +1431,7 @@ scalar-group-by
  │    │    │         ├── scan "order"@order_idx
  │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         │    ├── stats: [rows=300000, distinct(1)=30000, null(1)=0, distinct(2)=30000, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=30000, null(6)=3000]
- │    │    │         │    ├── cost: 324000.01
+ │    │    │         │    ├── cost: 35745.01
  │    │    │         │    ├── key: (1-3)
  │    │    │         │    ├── fd: (1-3)-->(6)
  │    │    │         │    ├── prune: (1-3,6)
@@ -1444,20 +1443,20 @@ scalar-group-by
  │    │    ├── project
  │    │    │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
  │    │    │    ├── stats: [rows=9.9001, distinct(9)=9.9001, null(9)=0, distinct(10)=9.9001, null(10)=0, distinct(11)=6.32122398, null(11)=0]
- │    │    │    ├── cost: 1150000.13
+ │    │    │    ├── cost: 134070.129
  │    │    │    ├── prune: (9-11)
  │    │    │    ├── interesting orderings: (+11,+10,-9)
  │    │    │    └── select
  │    │    │         ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
  │    │    │         ├── stats: [rows=9.9001, distinct(9)=9.9001, null(9)=0, distinct(10)=9.9001, null(10)=0, distinct(11)=6.32122398, null(11)=0, distinct(15)=1, null(15)=9.9001]
- │    │    │         ├── cost: 1150000.02
+ │    │    │         ├── cost: 134070.02
  │    │    │         ├── fd: ()-->(15)
  │    │    │         ├── prune: (9-11)
  │    │    │         ├── interesting orderings: (+11,+10,-9)
  │    │    │         ├── scan order_line
  │    │    │         │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
  │    │    │         │    ├── stats: [rows=1000000, distinct(9)=100000, null(9)=0, distinct(10)=100000, null(10)=0, distinct(11)=10, null(11)=0, distinct(15)=100000, null(15)=10000]
- │    │    │         │    ├── cost: 1140000.01
+ │    │    │         │    ├── cost: 124070.01
  │    │    │         │    ├── prune: (9-11,15)
  │    │    │         │    └── interesting orderings: (+11,+10,-9)
  │    │    │         └── filters

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -360,7 +360,7 @@ project
  ├── columns: w_tax:8(decimal)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1]
- ├── cost: 1.14
+ ├── cost: 0.11897
  ├── key: ()
  ├── fd: ()-->(8)
  ├── prune: (8)
@@ -369,7 +369,7 @@ project
       ├── constraint: /1: [/10 - /10]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0]
-      ├── cost: 1.12
+      ├── cost: 0.09897
       ├── key: ()
       ├── fd: ()-->(1,8)
       ├── prune: (1,8)
@@ -384,7 +384,7 @@ project
  ├── columns: c_discount:16(decimal) c_last:6(string) c_credit:14(string)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=0.001]
- ├── cost: 0.02128
+ ├── cost: 0.02017737
  ├── key: ()
  ├── fd: ()-->(6,14,16)
  ├── prune: (6,14,16)
@@ -393,7 +393,7 @@ project
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=0.001, distinct(1)=0.001, null(1)=0, distinct(2)=0.001, null(2)=0, distinct(3)=0.001, null(3)=0]
-      ├── cost: 0.01127
+      ├── cost: 0.01016737
       ├── key: ()
       ├── fd: ()-->(1-3,6,14,16)
       ├── prune: (1-3,6,14,16)
@@ -409,7 +409,7 @@ scan item
  ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
  ├── stats: [rows=12, distinct(1)=12, null(1)=0]
- ├── cost: 13.09
+ ├── cost: 1.44964
  ├── key: (1)
  ├── fd: (1)-->(3-5)
  ├── ordering: +1
@@ -425,7 +425,7 @@ ORDER BY s_i_id
 project
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)  [hidden: s_i_id:1(int!null)]
  ├── stats: [rows=0.5]
- ├── cost: 0.65
+ ├── cost: 0.124185
  ├── key: (1)
  ├── fd: (1)-->(3,8,14-17)
  ├── ordering: +1
@@ -435,7 +435,7 @@ project
       ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(string) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string)
       ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
       ├── stats: [rows=0.5, distinct(1)=0.5, null(1)=0, distinct(2)=0.5, null(2)=0]
-      ├── cost: 0.635
+      ├── cost: 0.109185
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
       ├── ordering: +1 opt(2) [actual: +1]
@@ -460,7 +460,7 @@ ORDER BY c_first ASC
 project
  ├── columns: c_id:1(int!null)  [hidden: c_first:4(string)]
  ├── stats: [rows=0.00099]
- ├── cost: 0.0210989
+ ├── cost: 0.0201456389
  ├── key: (1)
  ├── fd: (1)-->(4)
  ├── ordering: +4
@@ -469,7 +469,7 @@ project
       ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
       ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
       ├── stats: [rows=0.00099, distinct(1)=0.00099, null(1)=0, distinct(2)=0.00099, null(2)=0, distinct(3)=0.00099, null(3)=0, distinct(6)=0.00099, null(6)=0]
-      ├── cost: 0.011089
+      ├── cost: 0.0101357389
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4)
       ├── ordering: +4 opt(2,3,6) [actual: +4]
@@ -494,7 +494,7 @@ project
  ├── columns: c_balance:17(decimal) c_first:4(string) c_middle:5(string) c_last:6(string)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=0.001]
- ├── cost: 0.02129
+ ├── cost: 0.02019451
  ├── key: ()
  ├── fd: ()-->(4-6,17)
  ├── prune: (4-6,17)
@@ -503,7 +503,7 @@ project
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=0.001, distinct(1)=0.001, null(1)=0, distinct(2)=0.001, null(2)=0, distinct(3)=0.001, null(3)=0]
-      ├── cost: 0.01128
+      ├── cost: 0.01018451
       ├── key: ()
       ├── fd: ()-->(1-6,17)
       ├── prune: (1-6,17)
@@ -518,7 +518,7 @@ ORDER BY c_first ASC
 project
  ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(string) c_middle:5(string)
  ├── stats: [rows=0.00099]
- ├── cost: 0.035346
+ ├── cost: 0.0315865839
  ├── key: (1)
  ├── fd: (1)-->(4,5,17)
  ├── ordering: +4
@@ -526,7 +526,7 @@ project
  └── index-join customer
       ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_middle:5(string) c_last:6(string!null) c_balance:17(decimal)
       ├── stats: [rows=0.00099, distinct(1)=0.00099, null(1)=0, distinct(2)=0.00099, null(2)=0, distinct(3)=0.00099, null(3)=0, distinct(6)=0.00099, null(6)=0]
-      ├── cost: 0.0253361
+      ├── cost: 0.0215766839
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
       ├── ordering: +4 opt(2,3,6) [actual: +4]
@@ -535,7 +535,7 @@ project
            ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
            ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
            ├── stats: [rows=0.00099, distinct(1)=0.00099, null(1)=0, distinct(2)=0.00099, null(2)=0, distinct(3)=0.00099, null(3)=0, distinct(6)=0.00099, null(6)=0]
-           ├── cost: 0.011089
+           ├── cost: 0.0101357389
            ├── key: (1)
            ├── fd: ()-->(2,3,6), (1)-->(4)
            ├── ordering: +4 opt(2,3,6) [actual: +4]
@@ -553,7 +553,7 @@ project
  ├── columns: o_id:1(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=0.00099]
- ├── cost: 0.0351876
+ ├── cost: 0.0315529635
  ├── key: ()
  ├── fd: ()-->(1,5,6)
  ├── prune: (1,5,6)
@@ -561,7 +561,7 @@ project
       ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
       ├── cardinality: [0 - 1]
       ├── stats: [rows=0.00099]
-      ├── cost: 0.0251777
+      ├── cost: 0.0215430635
       ├── key: ()
       ├── fd: ()-->(1-6)
       ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
@@ -570,7 +570,7 @@ project
            ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
            ├── limit: 1(rev)
            ├── stats: [rows=0.00099, distinct(1)=0.00099, null(1)=0, distinct(2)=0.00099, null(2)=0, distinct(3)=0.00099, null(3)=0, distinct(4)=0.00099, null(4)=0]
-           ├── cost: 0.0110692
+           ├── cost: 0.0101179585
            ├── key: ()
            ├── fd: ()-->(1-4)
            ├── prune: (1-4)
@@ -584,14 +584,14 @@ WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
 project
  ├── columns: ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_quantity:8(int) ol_amount:9(decimal) ol_delivery_d:7(timestamp)
  ├── stats: [rows=0.001]
- ├── cost: 0.02119
+ ├── cost: 0.02020263
  ├── prune: (5-9)
  ├── interesting orderings: (+6)
  └── scan order_line
       ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_delivery_d:7(timestamp) ol_quantity:8(int) ol_amount:9(decimal)
       ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
       ├── stats: [rows=0.001, distinct(1)=0.001, null(1)=0, distinct(2)=0.001, null(2)=0, distinct(3)=0.001, null(3)=0, distinct(5)=0.0009999955, null(5)=0]
-      ├── cost: 0.01118
+      ├── cost: 0.01019263
       ├── fd: ()-->(1-3)
       ├── prune: (1-3,5-9)
       └── interesting orderings: (+3,+2,-1) (+6,+2,+3,+1)
@@ -623,7 +623,7 @@ project
  ├── columns: no_o_id:1(int!null)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=0.1]
- ├── cost: 0.127
+ ├── cost: 0.031119
  ├── key: ()
  ├── fd: ()-->(1)
  ├── prune: (1)
@@ -632,7 +632,7 @@ project
       ├── constraint: /3/2/-1: [/10/100 - /10/100]
       ├── limit: 1(rev)
       ├── stats: [rows=0.1]
-      ├── cost: 0.116
+      ├── cost: 0.020119
       ├── key: ()
       ├── fd: ()-->(1-3)
       ├── prune: (1-3)
@@ -647,7 +647,7 @@ scalar-group-by
  ├── columns: sum:11(decimal)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 0.03115
+ ├── cost: 0.03013407
  ├── key: ()
  ├── fd: ()-->(11)
  ├── prune: (11)
@@ -655,7 +655,7 @@ scalar-group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_amount:9(decimal)
  │    ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
  │    ├── stats: [rows=0.001, distinct(1)=0.001, null(1)=0, distinct(2)=0.001, null(2)=0, distinct(3)=0.001, null(3)=0]
- │    ├── cost: 0.01114
+ │    ├── cost: 0.01012407
  │    ├── fd: ()-->(1-3)
  │    ├── prune: (1-3,9)
  │    └── interesting orderings: (+3,+2,-1)
@@ -680,7 +680,7 @@ project
  ├── columns: d_next_o_id:11(int)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=0.1]
- ├── cost: 0.135
+ ├── cost: 0.031775
  ├── key: ()
  ├── fd: ()-->(11)
  ├── prune: (11)
@@ -689,7 +689,7 @@ project
       ├── constraint: /2/1: [/10/100 - /10/100]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=0.1, distinct(1)=0.1, null(1)=0, distinct(2)=0.1, null(2)=0]
-      ├── cost: 0.124
+      ├── cost: 0.020775
       ├── key: ()
       ├── fd: ()-->(1,2,11)
       ├── prune: (1,2,11)
@@ -709,7 +709,7 @@ scalar-group-by
  ├── columns: count:28(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 0.141477778
+ ├── cost: 0.0571896667
  ├── key: ()
  ├── fd: ()-->(28)
  ├── prune: (28)
@@ -717,14 +717,14 @@ scalar-group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) s_i_id:11(int!null) s_w_id:12(int!null) s_quantity:13(int!null)
  │    ├── key columns: [3 5] = [12 11]
  │    ├── stats: [rows=0.0366666667, distinct(1)=0.0111105556, null(1)=0, distinct(2)=0.0111111111, null(2)=0, distinct(3)=0.0111111111, null(3)=0, distinct(5)=0.0111105556, null(5)=0, distinct(11)=0.0111105556, null(11)=0, distinct(12)=0.0111111111, null(12)=0, distinct(13)=0.0366666667, null(13)=0]
- │    ├── cost: 0.121111111
+ │    ├── cost: 0.036823
  │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    ├── scan order_line
  │    │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null)
  │    │    ├── constraint: /3/2/-1/4: [/10/100/999 - /10/100/980]
  │    │    ├── stats: [rows=0.0111111111, distinct(1)=0.0111105556, null(1)=0, distinct(2)=0.0111111111, null(2)=0, distinct(3)=0.0111111111, null(3)=0, distinct(5)=0.0111105556, null(5)=0]
- │    │    ├── cost: 0.0226666667
+ │    │    ├── cost: 0.0113785556
  │    │    ├── fd: ()-->(2,3)
  │    │    ├── prune: (5)
  │    │    └── interesting orderings: (+3,+2,-1)
@@ -762,32 +762,41 @@ scalar-group-by
  ├── columns: count:22(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 1588.01
+ ├── cost: 212.3
  ├── key: ()
  ├── fd: ()-->(22)
  ├── prune: (22)
- ├── inner-join (lookup warehouse)
+ ├── inner-join (merge)
  │    ├── columns: w_id:1(int!null) w_ytd:9(decimal!null) d_w_id:11(int!null) sum:21(decimal!null)
- │    ├── key columns: [11] = [1]
+ │    ├── left ordering: +1
+ │    ├── right ordering: +11
  │    ├── stats: [rows=33, distinct(1)=33, null(1)=0, distinct(9)=28.3508504, null(9)=0, distinct(11)=33, null(11)=0, distinct(21)=28.3508504, null(21)=0]
- │    ├── cost: 1587.66
+ │    ├── cost: 211.95
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)
- │    ├── interesting orderings: (+11)
+ │    ├── scan warehouse
+ │    │    ├── columns: w_id:1(int!null) w_ytd:9(decimal)
+ │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(9)=100, null(9)=10]
+ │    │    ├── cost: 88.98
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(9)
+ │    │    ├── ordering: +1
+ │    │    ├── prune: (1,9)
+ │    │    └── interesting orderings: (+1)
  │    ├── group-by
  │    │    ├── columns: d_w_id:11(int!null) sum:21(decimal)
  │    │    ├── grouping columns: d_w_id:11(int!null)
- │    │    ├── internal-ordering: +11
  │    │    ├── stats: [rows=100, distinct(11)=100, null(11)=0, distinct(21)=100, null(21)=0]
- │    │    ├── cost: 1151.02
+ │    │    ├── cost: 111.63
  │    │    ├── key: (11)
  │    │    ├── fd: (11)-->(21)
+ │    │    ├── ordering: +11
  │    │    ├── prune: (21)
  │    │    ├── interesting orderings: (+11)
  │    │    ├── scan district
  │    │    │    ├── columns: d_w_id:11(int!null) d_ytd:19(decimal)
  │    │    │    ├── stats: [rows=1000, distinct(11)=100, null(11)=0]
- │    │    │    ├── cost: 1130.01
+ │    │    │    ├── cost: 90.62
  │    │    │    ├── ordering: +11
  │    │    │    ├── prune: (11,19)
  │    │    │    └── interesting orderings: (+11)
@@ -809,7 +818,7 @@ ORDER BY d_w_id, d_id
 scan district
  ├── columns: d_next_o_id:11(int)  [hidden: d_id:1(int!null) d_w_id:2(int!null)]
  ├── stats: [rows=1000]
- ├── cost: 1140.01
+ ├── cost: 107.76
  ├── key: (1,2)
  ├── fd: (1,2)-->(11)
  ├── ordering: +2,+1
@@ -826,7 +835,7 @@ group-by
  ├── columns: max:4(int)  [hidden: no_d_id:2(int!null) no_w_id:3(int!null)]
  ├── grouping columns: no_d_id:2(int!null) no_w_id:3(int!null)
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
- ├── cost: 1100.02
+ ├── cost: 141.21
  ├── key: (2,3)
  ├── fd: (2,3)-->(4)
  ├── ordering: +3,+2
@@ -835,7 +844,7 @@ group-by
  ├── scan new_order
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
  │    ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
- │    ├── cost: 1060.01
+ │    ├── cost: 101.2
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
@@ -854,7 +863,7 @@ group-by
  ├── columns: max:9(int)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
- ├── cost: 1110.02
+ ├── cost: 142.03
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -863,7 +872,7 @@ group-by
  ├── scan "order"@order_idx
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
- │    ├── cost: 1070.01
+ │    ├── cost: 102.02
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
@@ -886,14 +895,14 @@ scalar-group-by
  ├── columns: count:8(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 1133.38333
+ ├── cost: 174.573333
  ├── key: ()
  ├── fd: ()-->(8)
  ├── prune: (8)
  ├── select
  │    ├── columns: no_d_id:2(int!null) no_w_id:3(int!null) max:4(int) min:5(int) count_rows:6(int)
  │    ├── stats: [rows=333.333333, distinct(2)=98.265847, null(2)=0, distinct(3)=98.265847, null(3)=0]
- │    ├── cost: 1130.03
+ │    ├── cost: 171.22
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(4-6)
  │    ├── interesting orderings: (+3,+2)
@@ -902,7 +911,7 @@ scalar-group-by
  │    │    ├── grouping columns: no_d_id:2(int!null) no_w_id:3(int!null)
  │    │    ├── internal-ordering: +3,+2
  │    │    ├── stats: [rows=1000, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0, distinct(2,3)=1000, null(2,3)=0]
- │    │    ├── cost: 1120.02
+ │    │    ├── cost: 161.21
  │    │    ├── key: (2,3)
  │    │    ├── fd: (2,3)-->(4-6)
  │    │    ├── prune: (4-6)
@@ -910,7 +919,7 @@ scalar-group-by
  │    │    ├── scan new_order
  │    │    │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
  │    │    │    ├── stats: [rows=1000, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0, distinct(2,3)=1000, null(2,3)=0]
- │    │    │    ├── cost: 1060.01
+ │    │    │    ├── cost: 101.2
  │    │    │    ├── key: (1-3)
  │    │    │    ├── ordering: +3,+2
  │    │    │    ├── prune: (1-3)
@@ -942,7 +951,7 @@ group-by
  ├── columns: sum:9(decimal)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
- ├── cost: 1150.02
+ ├── cost: 145.31
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -951,7 +960,7 @@ group-by
  ├── scan "order"
  │    ├── columns: o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
  │    ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
- │    ├── cost: 1110.01
+ │    ├── cost: 105.3
  │    ├── ordering: +3,+2
  │    ├── prune: (2,3,7)
  │    └── interesting orderings: (+3,+2)
@@ -969,7 +978,7 @@ group-by
  ├── columns: count:11(int)  [hidden: ol_d_id:2(int!null) ol_w_id:3(int!null)]
  ├── grouping columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
- ├── cost: 1160.02
+ ├── cost: 129.81
  ├── key: (2,3)
  ├── fd: (2,3)-->(11)
  ├── ordering: +3,+2
@@ -978,7 +987,7 @@ group-by
  ├── scan order_line
  │    ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
  │    ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
- │    ├── cost: 1120.01
+ │    ├── cost: 89.8
  │    ├── ordering: +3,+2
  │    ├── prune: (2,3)
  │    └── interesting orderings: (+3,+2)
@@ -995,25 +1004,25 @@ except-all
  ├── left columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
  ├── right columns: o_w_id:6(int) o_d_id:5(int) o_id:4(int)
  ├── stats: [rows=1000]
- ├── cost: 2170.25
+ ├── cost: 250.59
  ├── scan new_order
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
  │    ├── stats: [rows=1000]
- │    ├── cost: 1060.01
+ │    ├── cost: 101.2
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+3,+2,-1)
  └── project
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
       ├── stats: [rows=10]
-      ├── cost: 1090.13
+      ├── cost: 129.28
       ├── key: (4-6)
       ├── prune: (4-6)
       ├── interesting orderings: (+6,+5,-4)
       └── select
            ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            ├── stats: [rows=10, distinct(4)=9.5617925, null(4)=0, distinct(5)=9.5617925, null(5)=0, distinct(6)=9.5617925, null(6)=0, distinct(9)=1, null(9)=10]
-           ├── cost: 1090.02
+           ├── cost: 129.17
            ├── key: (4-6)
            ├── fd: ()-->(9)
            ├── prune: (4-6)
@@ -1021,7 +1030,7 @@ except-all
            ├── scan "order"@order_idx
            │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            │    ├── stats: [rows=1000, distinct(4)=100, null(4)=0, distinct(5)=100, null(5)=0, distinct(6)=100, null(6)=0, distinct(9)=100, null(9)=10]
-           │    ├── cost: 1080.01
+           │    ├── cost: 119.16
            │    ├── key: (4-6)
            │    ├── fd: (4-6)-->(9)
            │    ├── prune: (4-6,9)
@@ -1041,18 +1050,18 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── right columns: no_w_id:11(int) no_d_id:10(int) no_o_id:9(int)
  ├── stats: [rows=10]
- ├── cost: 2160.35
+ ├── cost: 240.69
  ├── project
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=10]
- │    ├── cost: 1090.13
+ │    ├── cost: 129.28
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    └── select
  │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         ├── stats: [rows=10, distinct(1)=9.5617925, null(1)=0, distinct(2)=9.5617925, null(2)=0, distinct(3)=9.5617925, null(3)=0, distinct(6)=1, null(6)=10]
- │         ├── cost: 1090.02
+ │         ├── cost: 129.17
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
@@ -1060,7 +1069,7 @@ except-all
  │         ├── scan "order"@order_idx
  │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         │    ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=100, null(6)=10]
- │         │    ├── cost: 1080.01
+ │         │    ├── cost: 119.16
  │         │    ├── key: (1-3)
  │         │    ├── fd: (1-3)-->(6)
  │         │    ├── prune: (1-3,6)
@@ -1072,7 +1081,7 @@ except-all
  └── scan new_order
       ├── columns: no_o_id:9(int!null) no_d_id:10(int!null) no_w_id:11(int!null)
       ├── stats: [rows=1000]
-      ├── cost: 1060.01
+      ├── cost: 101.2
       ├── key: (9-11)
       ├── prune: (9-11)
       └── interesting orderings: (+11,+10,-9)
@@ -1096,11 +1105,11 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null) o_ol_cnt:7(int)
  ├── right columns: ol_w_id:11(int) ol_d_id:10(int) ol_o_id:9(int) count_rows:19(int)
  ├── stats: [rows=1000]
- ├── cost: 2290.04
+ ├── cost: 309.4
  ├── scan "order"
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
  │    ├── stats: [rows=1000]
- │    ├── cost: 1120.01
+ │    ├── cost: 122.44
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(7)
  │    ├── prune: (1-3,7)
@@ -1108,16 +1117,18 @@ except-all
  └── group-by
       ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) count_rows:19(int)
       ├── grouping columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
+      ├── internal-ordering: +11,+10,-9
       ├── stats: [rows=1000, distinct(9-11)=1000, null(9-11)=0]
-      ├── cost: 1140.02
+      ├── cost: 156.95
       ├── key: (9-11)
       ├── fd: (9-11)-->(19)
       ├── prune: (19)
       ├── interesting orderings: (+11,+10,-9)
-      ├── scan order_line@order_line_fk
+      ├── scan order_line
       │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
       │    ├── stats: [rows=1000, distinct(9-11)=1000, null(9-11)=0]
-      │    ├── cost: 1080.01
+      │    ├── cost: 106.94
+      │    ├── ordering: +11,+10,-9
       │    ├── prune: (9-11)
       │    └── interesting orderings: (+11,+10,-9)
       └── aggregations
@@ -1142,20 +1153,22 @@ except-all
  ├── left columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count_rows:11(int)
  ├── right columns: o_w_id:14(int) o_d_id:13(int) o_id:12(int) o_ol_cnt:18(int)
  ├── stats: [rows=1000]
- ├── cost: 2290.04
+ ├── cost: 309.4
  ├── group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
  │    ├── grouping columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
+ │    ├── internal-ordering: +3,+2,-1
  │    ├── stats: [rows=1000, distinct(1-3)=1000, null(1-3)=0]
- │    ├── cost: 1140.02
+ │    ├── cost: 156.95
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(11)
  │    ├── prune: (11)
  │    ├── interesting orderings: (+3,+2,-1)
- │    ├── scan order_line@order_line_fk
+ │    ├── scan order_line
  │    │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
  │    │    ├── stats: [rows=1000, distinct(1-3)=1000, null(1-3)=0]
- │    │    ├── cost: 1080.01
+ │    │    ├── cost: 106.94
+ │    │    ├── ordering: +3,+2,-1
  │    │    ├── prune: (1-3)
  │    │    └── interesting orderings: (+3,+2,-1)
  │    └── aggregations
@@ -1163,7 +1176,7 @@ except-all
  └── scan "order"
       ├── columns: o_id:12(int!null) o_d_id:13(int!null) o_w_id:14(int!null) o_ol_cnt:18(int)
       ├── stats: [rows=1000]
-      ├── cost: 1120.01
+      ├── cost: 122.44
       ├── key: (12-14)
       ├── fd: (12-14)-->(18)
       ├── prune: (12-14,18)
@@ -1190,32 +1203,32 @@ scalar-group-by
  ├── columns: count:19(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 2241.064
+ ├── cost: 264.085141
  ├── key: ()
  ├── fd: ()-->(19)
  ├── prune: (19)
  ├── select
  │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
  │    ├── stats: [rows=6.62853719]
- │    ├── cost: 2240.97771
+ │    ├── cost: 263.998856
  │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
  │    ├── full-join
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
  │    │    ├── stats: [rows=19.8856116]
- │    │    ├── cost: 2240.76886
+ │    │    ├── cost: 263.79
  │    │    ├── reject-nulls: (1-3,9-11)
  │    │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
  │    │    ├── project
  │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    │    │    ├── stats: [rows=10, distinct(1)=9.5617925, null(1)=0, distinct(2)=9.5617925, null(2)=0, distinct(3)=9.5617925, null(3)=0]
- │    │    │    ├── cost: 1090.13
+ │    │    │    ├── cost: 129.28
  │    │    │    ├── key: (1-3)
  │    │    │    ├── prune: (1-3)
  │    │    │    ├── interesting orderings: (+3,+2,-1)
  │    │    │    └── select
  │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         ├── stats: [rows=10, distinct(1)=9.5617925, null(1)=0, distinct(2)=9.5617925, null(2)=0, distinct(3)=9.5617925, null(3)=0, distinct(6)=1, null(6)=10]
- │    │    │         ├── cost: 1090.02
+ │    │    │         ├── cost: 129.17
  │    │    │         ├── key: (1-3)
  │    │    │         ├── fd: ()-->(6)
  │    │    │         ├── prune: (1-3)
@@ -1223,7 +1236,7 @@ scalar-group-by
  │    │    │         ├── scan "order"@order_idx
  │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         │    ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=100, null(6)=10]
- │    │    │         │    ├── cost: 1080.01
+ │    │    │         │    ├── cost: 119.16
  │    │    │         │    ├── key: (1-3)
  │    │    │         │    ├── fd: (1-3)-->(6)
  │    │    │         │    ├── prune: (1-3,6)
@@ -1235,20 +1248,20 @@ scalar-group-by
  │    │    ├── project
  │    │    │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
  │    │    │    ├── stats: [rows=10, distinct(9)=9.5617925, null(9)=0, distinct(10)=9.5617925, null(10)=0, distinct(11)=9.5617925, null(11)=0]
- │    │    │    ├── cost: 1150.13
+ │    │    │    ├── cost: 134.2
  │    │    │    ├── prune: (9-11)
  │    │    │    ├── interesting orderings: (+11,+10,-9)
  │    │    │    └── select
  │    │    │         ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
  │    │    │         ├── stats: [rows=10, distinct(9)=9.5617925, null(9)=0, distinct(10)=9.5617925, null(10)=0, distinct(11)=9.5617925, null(11)=0, distinct(15)=1, null(15)=10]
- │    │    │         ├── cost: 1150.02
+ │    │    │         ├── cost: 134.09
  │    │    │         ├── fd: ()-->(15)
  │    │    │         ├── prune: (9-11)
  │    │    │         ├── interesting orderings: (+11,+10,-9)
  │    │    │         ├── scan order_line
  │    │    │         │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
  │    │    │         │    ├── stats: [rows=1000, distinct(9)=100, null(9)=0, distinct(10)=100, null(10)=0, distinct(11)=100, null(11)=0, distinct(15)=100, null(15)=10]
- │    │    │         │    ├── cost: 1140.01
+ │    │    │         │    ├── cost: 124.08
  │    │    │         │    ├── prune: (9-11,15)
  │    │    │         │    └── interesting orderings: (+11,+10,-9)
  │    │    │         └── filters

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -618,30 +618,26 @@ project
       │         │    │    │    │    ├── key columns: [41] = [37]
       │         │    │    │    │    ├── key: (34)
       │         │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37)
-      │         │    │    │    │    ├── inner-join (merge)
+      │         │    │    │    │    ├── inner-join
       │         │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
-      │         │    │    │    │    │    ├── left ordering: +43
-      │         │    │    │    │    │    ├── right ordering: +45
       │         │    │    │    │    │    ├── key: (41)
       │         │    │    │    │    │    ├── fd: ()-->(46), (41)-->(43), (43)==(45), (45)==(43)
       │         │    │    │    │    │    ├── scan nation@n_rk
       │         │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null)
       │         │    │    │    │    │    │    ├── key: (41)
-      │         │    │    │    │    │    │    ├── fd: (41)-->(43)
-      │         │    │    │    │    │    │    └── ordering: +43
+      │         │    │    │    │    │    │    └── fd: (41)-->(43)
       │         │    │    │    │    │    ├── select
       │         │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
       │         │    │    │    │    │    │    ├── key: (45)
       │         │    │    │    │    │    │    ├── fd: ()-->(46)
-      │         │    │    │    │    │    │    ├── ordering: +45 opt(46) [actual: +45]
       │         │    │    │    │    │    │    ├── scan region
       │         │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
       │         │    │    │    │    │    │    │    ├── key: (45)
-      │         │    │    │    │    │    │    │    ├── fd: (45)-->(46)
-      │         │    │    │    │    │    │    │    └── ordering: +45 opt(46) [actual: +45]
+      │         │    │    │    │    │    │    │    └── fd: (45)-->(46)
       │         │    │    │    │    │    │    └── filters
       │         │    │    │    │    │    │         └── r_name = 'EUROPE' [type=bool, outer=(46), constraints=(/46: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(46)]
-      │         │    │    │    │    │    └── filters (true)
+      │         │    │    │    │    │    └── filters
+      │         │    │    │    │    │         └── n_regionkey = r_regionkey [type=bool, outer=(43,45), constraints=(/43: (/NULL - ]; /45: (/NULL - ]), fd=(43)==(45), (45)==(43)]
       │         │    │    │    │    └── filters (true)
       │         │    │    │    └── filters
       │         │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ]), fd=(30)==(34), (34)==(30)]
@@ -871,27 +867,34 @@ sort
       ├── grouping columns: o_orderpriority:6(string!null)
       ├── key: (6)
       ├── fd: (6)-->(26)
-      ├── semi-join
+      ├── semi-join (merge)
       │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(string!null)
+      │    ├── left ordering: +1
+      │    ├── right ordering: +10
       │    ├── key: (1)
       │    ├── fd: (1)-->(5,6)
-      │    ├── index-join orders
+      │    ├── select
       │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(string!null)
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(5,6)
-      │    │    └── scan orders@o_od
-      │    │         ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null)
-      │    │         ├── constraint: /5/1: [/'1993-07-01' - /'1993-09-30']
-      │    │         ├── key: (1)
-      │    │         └── fd: (1)-->(5)
+      │    │    ├── ordering: +1
+      │    │    ├── scan orders
+      │    │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(string!null)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(5,6)
+      │    │    │    └── ordering: +1
+      │    │    └── filters
+      │    │         ├── o_orderdate >= '1993-07-01' [type=bool, outer=(5), constraints=(/5: [/'1993-07-01' - ]; tight)]
+      │    │         └── o_orderdate < '1993-10-01' [type=bool, outer=(5), constraints=(/5: (/NULL - /'1993-09-30']; tight)]
       │    ├── select
       │    │    ├── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
+      │    │    ├── ordering: +10
       │    │    ├── scan lineitem
-      │    │    │    └── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
+      │    │    │    ├── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
+      │    │    │    └── ordering: +10
       │    │    └── filters
       │    │         └── l_commitdate < l_receiptdate [type=bool, outer=(21,22), constraints=(/21: (/NULL - ]; /22: (/NULL - ])]
-      │    └── filters
-      │         └── l_orderkey = o_orderkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+      │    └── filters (true)
       └── aggregations
            └── count-rows [type=int]
 
@@ -989,15 +992,17 @@ sort
       │    │    │    │    │    └── filters (true)
       │    │    │    │    └── filters
       │    │    │    │         └── l_suppkey = s_suppkey [type=bool, outer=(20,34), constraints=(/20: (/NULL - ]; /34: (/NULL - ]), fd=(20)==(34), (34)==(20)]
-      │    │    │    ├── index-join orders
+      │    │    │    ├── select
       │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
       │    │    │    │    ├── key: (9)
       │    │    │    │    ├── fd: (9)-->(10,13)
-      │    │    │    │    └── scan orders@o_od
-      │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
-      │    │    │    │         ├── constraint: /13/9: [/'1994-01-01' - /'1994-12-31']
-      │    │    │    │         ├── key: (9)
-      │    │    │    │         └── fd: (9)-->(13)
+      │    │    │    │    ├── scan orders
+      │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
+      │    │    │    │    │    ├── key: (9)
+      │    │    │    │    │    └── fd: (9)-->(10,13)
+      │    │    │    │    └── filters
+      │    │    │    │         ├── o_orderdate >= '1994-01-01' [type=bool, outer=(13), constraints=(/13: [/'1994-01-01' - ]; tight)]
+      │    │    │    │         └── o_orderdate < '1995-01-01' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1994-12-31']; tight)]
       │    │    │    └── filters
       │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
       │    │    ├── scan customer@c_nk
@@ -1048,14 +1053,11 @@ scalar-group-by
  │    ├── columns: column17:17(float)
  │    ├── select
  │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    ├── index-join lineitem
- │    │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    │    └── scan lineitem@l_sd
- │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
- │    │    │         ├── constraint: /11/1/4: [/'1994-01-01' - /'1994-12-31']
- │    │    │         ├── key: (1,4)
- │    │    │         └── fd: (1,4)-->(11)
+ │    │    ├── scan lineitem
+ │    │    │    └── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
  │    │    └── filters
+ │    │         ├── l_shipdate >= '1994-01-01' [type=bool, outer=(11), constraints=(/11: [/'1994-01-01' - ]; tight)]
+ │    │         ├── l_shipdate < '1995-01-01' [type=bool, outer=(11), constraints=(/11: (/NULL - /'1994-12-31']; tight)]
  │    │         ├── l_discount >= 0.05 [type=bool, outer=(7), constraints=(/7: [/0.05 - ]; tight)]
  │    │         ├── l_discount <= 0.07 [type=bool, outer=(7), constraints=(/7: (/NULL - /0.07]; tight)]
  │    │         └── l_quantity < 24.0 [type=bool, outer=(5), constraints=(/5: (/NULL - /23.999999999999996]; tight)]
@@ -1146,46 +1148,35 @@ sort
       │    │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null)
       │    │    │    │    │    ├── key: (24)
       │    │    │    │    │    └── fd: (24)-->(25)
-      │    │    │    │    ├── inner-join (merge)
+      │    │    │    │    ├── inner-join (lookup customer@c_nk)
       │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
-      │    │    │    │    │    ├── left ordering: +36
-      │    │    │    │    │    ├── right ordering: +45
+      │    │    │    │    │    ├── key columns: [45] = [36]
       │    │    │    │    │    ├── key: (33,41)
       │    │    │    │    │    ├── fd: (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36)
-      │    │    │    │    │    ├── scan customer@c_nk
-      │    │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null)
-      │    │    │    │    │    │    ├── key: (33)
-      │    │    │    │    │    │    ├── fd: (33)-->(36)
-      │    │    │    │    │    │    └── ordering: +36
-      │    │    │    │    │    ├── sort
+      │    │    │    │    │    ├── inner-join
       │    │    │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
       │    │    │    │    │    │    ├── key: (41,45)
       │    │    │    │    │    │    ├── fd: (41)-->(42), (45)-->(46)
-      │    │    │    │    │    │    ├── ordering: +45
-      │    │    │    │    │    │    └── inner-join
-      │    │    │    │    │    │         ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
-      │    │    │    │    │    │         ├── key: (41,45)
-      │    │    │    │    │    │         ├── fd: (41)-->(42), (45)-->(46)
-      │    │    │    │    │    │         ├── scan n1
-      │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null)
-      │    │    │    │    │    │         │    ├── key: (41)
-      │    │    │    │    │    │         │    └── fd: (41)-->(42)
-      │    │    │    │    │    │         ├── scan n2
-      │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
-      │    │    │    │    │    │         │    ├── key: (45)
-      │    │    │    │    │    │         │    └── fd: (45)-->(46)
-      │    │    │    │    │    │         └── filters
-      │    │    │    │    │    │              └── ((n1.n_name = 'FRANCE') AND (n2.n_name = 'GERMANY')) OR ((n1.n_name = 'GERMANY') AND (n2.n_name = 'FRANCE')) [type=bool, outer=(42,46)]
+      │    │    │    │    │    │    ├── scan n1
+      │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null)
+      │    │    │    │    │    │    │    ├── key: (41)
+      │    │    │    │    │    │    │    └── fd: (41)-->(42)
+      │    │    │    │    │    │    ├── scan n2
+      │    │    │    │    │    │    │    ├── columns: n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+      │    │    │    │    │    │    │    ├── key: (45)
+      │    │    │    │    │    │    │    └── fd: (45)-->(46)
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── ((n1.n_name = 'FRANCE') AND (n2.n_name = 'GERMANY')) OR ((n1.n_name = 'GERMANY') AND (n2.n_name = 'FRANCE')) [type=bool, outer=(42,46)]
       │    │    │    │    │    └── filters (true)
       │    │    │    │    └── filters
       │    │    │    │         └── c_custkey = o_custkey [type=bool, outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
-      │    │    │    ├── index-join lineitem
+      │    │    │    ├── select
       │    │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
-      │    │    │    │    └── scan lineitem@l_sd
-      │    │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
-      │    │    │    │         ├── constraint: /18/8/11: [/'1995-01-01' - /'1996-12-31']
-      │    │    │    │         ├── key: (8,11)
-      │    │    │    │         └── fd: (8,11)-->(18)
+      │    │    │    │    ├── scan lineitem
+      │    │    │    │    │    └── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+      │    │    │    │    └── filters
+      │    │    │    │         ├── l_shipdate >= '1995-01-01' [type=bool, outer=(18), constraints=(/18: [/'1995-01-01' - ]; tight)]
+      │    │    │    │         └── l_shipdate <= '1996-12-31' [type=bool, outer=(18), constraints=(/18: (/NULL - /'1996-12-31']; tight)]
       │    │    │    └── filters
       │    │    │         └── o_orderkey = l_orderkey [type=bool, outer=(8,24), constraints=(/8: (/NULL - ]; /24: (/NULL - ]), fd=(8)==(24), (24)==(8)]
       │    │    ├── scan supplier@s_nk
@@ -1291,61 +1282,52 @@ project
  │    │         │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
  │    │         │    │    │    │    │    ├── key: (33,54)
  │    │         │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
- │    │         │    │    │    │    │    ├── inner-join (merge)
+ │    │         │    │    │    │    │    ├── inner-join (lookup customer@c_nk)
  │    │         │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    │    ├── left ordering: +45
- │    │         │    │    │    │    │    │    ├── right ordering: +50
+ │    │         │    │    │    │    │    │    ├── key columns: [50] = [45]
  │    │         │    │    │    │    │    │    ├── key: (42,54)
  │    │         │    │    │    │    │    │    ├── fd: ()-->(59), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45)
- │    │         │    │    │    │    │    │    ├── scan customer@c_nk
- │    │         │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null)
- │    │         │    │    │    │    │    │    │    ├── key: (42)
- │    │         │    │    │    │    │    │    │    ├── fd: (42)-->(45)
- │    │         │    │    │    │    │    │    │    └── ordering: +45
- │    │         │    │    │    │    │    │    ├── sort
+ │    │         │    │    │    │    │    │    ├── inner-join
  │    │         │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
  │    │         │    │    │    │    │    │    │    ├── key: (50,54)
  │    │         │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
- │    │         │    │    │    │    │    │    │    ├── ordering: +50 opt(59) [actual: +50]
- │    │         │    │    │    │    │    │    │    └── inner-join
- │    │         │    │    │    │    │    │    │         ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    │    │         ├── key: (50,54)
- │    │         │    │    │    │    │    │    │         ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
- │    │         │    │    │    │    │    │    │         ├── inner-join
- │    │         │    │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    │    │         │    ├── key: (54,58)
- │    │         │    │    │    │    │    │    │         │    ├── fd: ()-->(59), (54)-->(55)
- │    │         │    │    │    │    │    │    │         │    ├── scan n2
- │    │         │    │    │    │    │    │    │         │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null)
- │    │         │    │    │    │    │    │    │         │    │    ├── key: (54)
- │    │         │    │    │    │    │    │    │         │    │    └── fd: (54)-->(55)
- │    │         │    │    │    │    │    │    │         │    ├── select
- │    │         │    │    │    │    │    │    │         │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    │    │         │    │    ├── key: (58)
- │    │         │    │    │    │    │    │    │         │    │    ├── fd: ()-->(59)
- │    │         │    │    │    │    │    │    │         │    │    ├── scan region
- │    │         │    │    │    │    │    │    │         │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
- │    │         │    │    │    │    │    │    │         │    │    │    ├── key: (58)
- │    │         │    │    │    │    │    │    │         │    │    │    └── fd: (58)-->(59)
- │    │         │    │    │    │    │    │    │         │    │    └── filters
- │    │         │    │    │    │    │    │    │         │    │         └── r_name = 'AMERICA' [type=bool, outer=(59), constraints=(/59: [/'AMERICA' - /'AMERICA']; tight), fd=()-->(59)]
- │    │         │    │    │    │    │    │    │         │    └── filters (true)
- │    │         │    │    │    │    │    │    │         ├── scan n1@n_rk
- │    │         │    │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null)
- │    │         │    │    │    │    │    │    │         │    ├── key: (50)
- │    │         │    │    │    │    │    │    │         │    └── fd: (50)-->(52)
- │    │         │    │    │    │    │    │    │         └── filters
- │    │         │    │    │    │    │    │    │              └── n1.n_regionkey = r_regionkey [type=bool, outer=(52,58), constraints=(/52: (/NULL - ]; /58: (/NULL - ]), fd=(52)==(58), (58)==(52)]
+ │    │         │    │    │    │    │    │    │    ├── inner-join
+ │    │         │    │    │    │    │    │    │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    │    │    │    │    │    ├── key: (54,58)
+ │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (54)-->(55)
+ │    │         │    │    │    │    │    │    │    │    ├── scan n2
+ │    │         │    │    │    │    │    │    │    │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null)
+ │    │         │    │    │    │    │    │    │    │    │    ├── key: (54)
+ │    │         │    │    │    │    │    │    │    │    │    └── fd: (54)-->(55)
+ │    │         │    │    │    │    │    │    │    │    ├── select
+ │    │         │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    │    │    │    │    │    │    ├── key: (58)
+ │    │         │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59)
+ │    │         │    │    │    │    │    │    │    │    │    ├── scan region
+ │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (58)
+ │    │         │    │    │    │    │    │    │    │    │    │    └── fd: (58)-->(59)
+ │    │         │    │    │    │    │    │    │    │    │    └── filters
+ │    │         │    │    │    │    │    │    │    │    │         └── r_name = 'AMERICA' [type=bool, outer=(59), constraints=(/59: [/'AMERICA' - /'AMERICA']; tight), fd=()-->(59)]
+ │    │         │    │    │    │    │    │    │    │    └── filters (true)
+ │    │         │    │    │    │    │    │    │    ├── scan n1@n_rk
+ │    │         │    │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null)
+ │    │         │    │    │    │    │    │    │    │    ├── key: (50)
+ │    │         │    │    │    │    │    │    │    │    └── fd: (50)-->(52)
+ │    │         │    │    │    │    │    │    │    └── filters
+ │    │         │    │    │    │    │    │    │         └── n1.n_regionkey = r_regionkey [type=bool, outer=(52,58), constraints=(/52: (/NULL - ]; /58: (/NULL - ]), fd=(52)==(58), (58)==(52)]
  │    │         │    │    │    │    │    │    └── filters (true)
- │    │         │    │    │    │    │    ├── index-join orders
+ │    │         │    │    │    │    │    ├── select
  │    │         │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
  │    │         │    │    │    │    │    │    ├── key: (33)
  │    │         │    │    │    │    │    │    ├── fd: (33)-->(34,37)
- │    │         │    │    │    │    │    │    └── scan orders@o_od
- │    │         │    │    │    │    │    │         ├── columns: o_orderkey:33(int!null) o_orderdate:37(date!null)
- │    │         │    │    │    │    │    │         ├── constraint: /37/33: [/'1995-01-01' - /'1996-12-31']
- │    │         │    │    │    │    │    │         ├── key: (33)
- │    │         │    │    │    │    │    │         └── fd: (33)-->(37)
+ │    │         │    │    │    │    │    │    ├── scan orders
+ │    │         │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
+ │    │         │    │    │    │    │    │    │    ├── key: (33)
+ │    │         │    │    │    │    │    │    │    └── fd: (33)-->(34,37)
+ │    │         │    │    │    │    │    │    └── filters
+ │    │         │    │    │    │    │    │         ├── o_orderdate >= '1995-01-01' [type=bool, outer=(37), constraints=(/37: [/'1995-01-01' - ]; tight)]
+ │    │         │    │    │    │    │    │         └── o_orderdate <= '1996-12-31' [type=bool, outer=(37), constraints=(/37: (/NULL - /'1996-12-31']; tight)]
  │    │         │    │    │    │    │    └── filters
  │    │         │    │    │    │    │         └── o_custkey = c_custkey [type=bool, outer=(34,42), constraints=(/34: (/NULL - ]; /42: (/NULL - ]), fd=(34)==(42), (42)==(34)]
  │    │         │    │    │    │    └── filters
@@ -1571,32 +1553,36 @@ limit
  │         │    ├── fd: (1)-->(2,3,5,6,8,35)
  │         │    ├── inner-join (lookup customer)
  │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    ├── key columns: [10] = [1]
+ │         │    │    ├── key columns: [1] = [1]
  │         │    │    ├── fd: ()-->(26), (1)-->(2-6,8), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(34), (34)==(4)
- │         │    │    ├── inner-join (lookup orders)
- │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    │    ├── key columns: [18] = [9]
- │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9)
- │         │    │    │    ├── inner-join
- │         │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    │    │    ├── fd: ()-->(26), (34)-->(35)
- │         │    │    │    │    ├── scan nation
- │         │    │    │    │    │    ├── columns: n_nationkey:34(int!null) n_name:35(string!null)
- │         │    │    │    │    │    ├── key: (34)
- │         │    │    │    │    │    └── fd: (34)-->(35)
- │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
- │         │    │    │    │    │    ├── fd: ()-->(26)
- │         │    │    │    │    │    ├── scan lineitem
- │         │    │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
- │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
- │         │    │    │    │    └── filters (true)
- │         │    │    │    └── filters
- │         │    │    │         ├── o_orderdate >= '1993-10-01' [type=bool, outer=(13), constraints=(/13: [/'1993-10-01' - ]; tight)]
- │         │    │    │         └── o_orderdate < '1994-01-01' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1993-12-31']; tight)]
- │         │    │    └── filters
- │         │    │         └── c_nationkey = n_nationkey [type=bool, outer=(4,34), constraints=(/4: (/NULL - ]; /34: (/NULL - ]), fd=(4)==(34), (34)==(4)]
+ │         │    │    ├── inner-join (lookup customer@c_nk)
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
+ │         │    │    │    ├── key columns: [34 10] = [4 1]
+ │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9), (1)-->(4), (4)==(34), (34)==(4), (1)==(10), (10)==(1)
+ │         │    │    │    ├── inner-join (lookup orders)
+ │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
+ │         │    │    │    │    ├── key columns: [18] = [9]
+ │         │    │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9)
+ │         │    │    │    │    ├── inner-join
+ │         │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
+ │         │    │    │    │    │    ├── fd: ()-->(26), (34)-->(35)
+ │         │    │    │    │    │    ├── scan nation
+ │         │    │    │    │    │    │    ├── columns: n_nationkey:34(int!null) n_name:35(string!null)
+ │         │    │    │    │    │    │    ├── key: (34)
+ │         │    │    │    │    │    │    └── fd: (34)-->(35)
+ │         │    │    │    │    │    ├── select
+ │         │    │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
+ │         │    │    │    │    │    │    ├── fd: ()-->(26)
+ │         │    │    │    │    │    │    ├── scan lineitem
+ │         │    │    │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
+ │         │    │    │    │    │    │    └── filters
+ │         │    │    │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
+ │         │    │    │    │    │    └── filters (true)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         ├── o_orderdate >= '1993-10-01' [type=bool, outer=(13), constraints=(/13: [/'1993-10-01' - ]; tight)]
+ │         │    │    │    │         └── o_orderdate < '1994-01-01' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1993-12-31']; tight)]
+ │         │    │    │    └── filters (true)
+ │         │    │    └── filters (true)
  │         │    └── projections
  │         │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(23,24)]
  │         └── aggregations
@@ -1812,17 +1798,14 @@ group-by
  │    │    │    ├── ordering: +24
  │    │    │    └── select
  │    │    │         ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
- │    │    │         ├── index-join lineitem
- │    │    │         │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
- │    │    │         │    └── scan lineitem@l_rd
- │    │    │         │         ├── columns: l_orderkey:10(int!null) l_linenumber:13(int!null) l_receiptdate:22(date!null)
- │    │    │         │         ├── constraint: /22/10/13: [/'1994-01-01' - /'1994-12-31']
- │    │    │         │         ├── key: (10,13)
- │    │    │         │         └── fd: (10,13)-->(22)
+ │    │    │         ├── scan lineitem
+ │    │    │         │    └── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
  │    │    │         └── filters
  │    │    │              ├── l_shipmode IN ('MAIL', 'SHIP') [type=bool, outer=(24), constraints=(/24: [/'MAIL' - /'MAIL'] [/'SHIP' - /'SHIP']; tight)]
  │    │    │              ├── l_commitdate < l_receiptdate [type=bool, outer=(21,22), constraints=(/21: (/NULL - ]; /22: (/NULL - ])]
- │    │    │              └── l_shipdate < l_commitdate [type=bool, outer=(20,21), constraints=(/20: (/NULL - ]; /21: (/NULL - ])]
+ │    │    │              ├── l_shipdate < l_commitdate [type=bool, outer=(20,21), constraints=(/20: (/NULL - ]; /21: (/NULL - ])]
+ │    │    │              ├── l_receiptdate >= '1994-01-01' [type=bool, outer=(22), constraints=(/22: [/'1994-01-01' - ]; tight)]
+ │    │    │              └── l_receiptdate < '1995-01-01' [type=bool, outer=(22), constraints=(/22: (/NULL - /'1994-12-31']; tight)]
  │    │    └── filters (true)
  │    └── projections
  │         ├── CASE WHEN (o_orderpriority = '1-URGENT') OR (o_orderpriority = '2-HIGH') THEN 1 ELSE 0 END [type=int, outer=(6)]
@@ -1947,13 +1930,13 @@ project
  │    │    ├── inner-join
  │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(string!null)
  │    │    │    ├── fd: (17)-->(21), (2)==(17), (17)==(2)
- │    │    │    ├── index-join lineitem
+ │    │    │    ├── select
  │    │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    │    │    └── scan lineitem@l_sd
- │    │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
- │    │    │    │         ├── constraint: /11/1/4: [/'1995-09-01' - /'1995-09-30']
- │    │    │    │         ├── key: (1,4)
- │    │    │    │         └── fd: (1,4)-->(11)
+ │    │    │    │    ├── scan lineitem
+ │    │    │    │    │    └── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
+ │    │    │    │    └── filters
+ │    │    │    │         ├── l_shipdate >= '1995-09-01' [type=bool, outer=(11), constraints=(/11: [/'1995-09-01' - ]; tight)]
+ │    │    │    │         └── l_shipdate < '1995-10-01' [type=bool, outer=(11), constraints=(/11: (/NULL - /'1995-09-30']; tight)]
  │    │    │    ├── scan part
  │    │    │    │    ├── columns: p_partkey:17(int!null) p_type:21(string!null)
  │    │    │    │    ├── key: (17)
@@ -2052,13 +2035,13 @@ project
       │         │    ├── fd: (10)-->(25)
       │         │    ├── project
       │         │    │    ├── columns: column24:24(float) l_suppkey:10(int!null)
-      │         │    │    ├── index-join lineitem
+      │         │    │    ├── select
       │         │    │    │    ├── columns: l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
-      │         │    │    │    └── scan lineitem@l_sd
-      │         │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
-      │         │    │    │         ├── constraint: /18/8/11: [/'1996-01-01' - /'1996-03-31']
-      │         │    │    │         ├── key: (8,11)
-      │         │    │    │         └── fd: (8,11)-->(18)
+      │         │    │    │    ├── scan lineitem
+      │         │    │    │    │    └── columns: l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+      │         │    │    │    └── filters
+      │         │    │    │         ├── l_shipdate >= '1996-01-01' [type=bool, outer=(18), constraints=(/18: [/'1996-01-01' - ]; tight)]
+      │         │    │    │         └── l_shipdate < '1996-04-01' [type=bool, outer=(18), constraints=(/18: (/NULL - /'1996-03-31']; tight)]
       │         │    │    └── projections
       │         │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(13,14)]
       │         │    └── aggregations
@@ -2080,13 +2063,13 @@ project
       │                             │    ├── fd: (28)-->(43)
       │                             │    ├── project
       │                             │    │    ├── columns: column42:42(float) l_suppkey:28(int!null)
-      │                             │    │    ├── index-join lineitem
+      │                             │    │    ├── select
       │                             │    │    │    ├── columns: l_suppkey:28(int!null) l_extendedprice:31(float!null) l_discount:32(float!null) l_shipdate:36(date!null)
-      │                             │    │    │    └── scan lineitem@l_sd
-      │                             │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
-      │                             │    │    │         ├── constraint: /36/26/29: [/'1996-01-01' - /'1996-03-31']
-      │                             │    │    │         ├── key: (26,29)
-      │                             │    │    │         └── fd: (26,29)-->(36)
+      │                             │    │    │    ├── scan lineitem
+      │                             │    │    │    │    └── columns: l_suppkey:28(int!null) l_extendedprice:31(float!null) l_discount:32(float!null) l_shipdate:36(date!null)
+      │                             │    │    │    └── filters
+      │                             │    │    │         ├── l_shipdate >= '1996-01-01' [type=bool, outer=(36), constraints=(/36: [/'1996-01-01' - ]; tight)]
+      │                             │    │    │         └── l_shipdate < '1996-04-01' [type=bool, outer=(36), constraints=(/36: (/NULL - /'1996-03-31']; tight)]
       │                             │    │    └── projections
       │                             │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(31,32)]
       │                             │    └── aggregations
@@ -2157,28 +2140,24 @@ sort
       │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
       │    ├── key: (2,6)
       │    ├── fd: (6)-->(9-11), (1)==(6), (6)==(1)
-      │    ├── anti-join (merge)
+      │    ├── anti-join
       │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null)
-      │    │    ├── left ordering: +2
-      │    │    ├── right ordering: +15
       │    │    ├── key: (1,2)
       │    │    ├── scan partsupp@ps_sk
       │    │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null)
-      │    │    │    ├── key: (1,2)
-      │    │    │    └── ordering: +2
+      │    │    │    └── key: (1,2)
       │    │    ├── select
       │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(string!null)
       │    │    │    ├── key: (15)
       │    │    │    ├── fd: (15)-->(21)
-      │    │    │    ├── ordering: +15
       │    │    │    ├── scan supplier
       │    │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(string!null)
       │    │    │    │    ├── key: (15)
-      │    │    │    │    ├── fd: (15)-->(21)
-      │    │    │    │    └── ordering: +15
+      │    │    │    │    └── fd: (15)-->(21)
       │    │    │    └── filters
       │    │    │         └── s_comment LIKE '%Customer%Complaints%' [type=bool, outer=(21), constraints=(/21: (/NULL - ])]
-      │    │    └── filters (true)
+      │    │    └── filters
+      │    │         └── ps_suppkey = s_suppkey [type=bool, outer=(2,15), constraints=(/2: (/NULL - ]; /15: (/NULL - ]), fd=(2)==(15), (15)==(2)]
       │    ├── select
       │    │    ├── columns: p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
       │    │    ├── key: (6)
@@ -2369,34 +2348,29 @@ limit
  │         ├── inner-join
  │         │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
  │         │    ├── fd: (1)-->(2), (9)-->(10,12,13), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
- │         │    ├── inner-join (merge)
+ │         │    ├── inner-join
  │         │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
- │         │    │    ├── left ordering: +9
- │         │    │    ├── right ordering: +18
  │         │    │    ├── fd: (9)-->(10,12,13), (9)==(18), (18)==(9)
- │         │    │    ├── semi-join (merge)
+ │         │    │    ├── scan lineitem
+ │         │    │    │    └── columns: l_orderkey:18(int!null) l_quantity:22(float!null)
+ │         │    │    ├── semi-join
  │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
- │         │    │    │    ├── left ordering: +9
- │         │    │    │    ├── right ordering: +34
  │         │    │    │    ├── key: (9)
  │         │    │    │    ├── fd: (9)-->(10,12,13)
- │         │    │    │    ├── ordering: +9
  │         │    │    │    ├── scan orders
  │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
  │         │    │    │    │    ├── key: (9)
- │         │    │    │    │    ├── fd: (9)-->(10,12,13)
- │         │    │    │    │    └── ordering: +9
+ │         │    │    │    │    └── fd: (9)-->(10,12,13)
  │         │    │    │    ├── select
  │         │    │    │    │    ├── columns: l_orderkey:34(int!null) sum:50(float!null)
  │         │    │    │    │    ├── key: (34)
  │         │    │    │    │    ├── fd: (34)-->(50)
- │         │    │    │    │    ├── ordering: +34
  │         │    │    │    │    ├── group-by
  │         │    │    │    │    │    ├── columns: l_orderkey:34(int!null) sum:50(float)
  │         │    │    │    │    │    ├── grouping columns: l_orderkey:34(int!null)
+ │         │    │    │    │    │    ├── internal-ordering: +34
  │         │    │    │    │    │    ├── key: (34)
  │         │    │    │    │    │    ├── fd: (34)-->(50)
- │         │    │    │    │    │    ├── ordering: +34
  │         │    │    │    │    │    ├── scan lineitem
  │         │    │    │    │    │    │    ├── columns: l_orderkey:34(int!null) l_quantity:38(float!null)
  │         │    │    │    │    │    │    └── ordering: +34
@@ -2405,11 +2379,10 @@ limit
  │         │    │    │    │    │              └── variable: l_quantity [type=float]
  │         │    │    │    │    └── filters
  │         │    │    │    │         └── sum > 300.0 [type=bool, outer=(50), constraints=(/50: [/300.00000000000006 - ]; tight)]
- │         │    │    │    └── filters (true)
- │         │    │    ├── scan lineitem
- │         │    │    │    ├── columns: l_orderkey:18(int!null) l_quantity:22(float!null)
- │         │    │    │    └── ordering: +18
- │         │    │    └── filters (true)
+ │         │    │    │    └── filters
+ │         │    │    │         └── o_orderkey = l_orderkey [type=bool, outer=(9,34), constraints=(/9: (/NULL - ]; /34: (/NULL - ]), fd=(9)==(34), (34)==(9)]
+ │         │    │    └── filters
+ │         │    │         └── o_orderkey = l_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
  │         │    ├── scan customer
  │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null)
  │         │    │    ├── key: (1)
@@ -2598,13 +2571,13 @@ sort
            │    │    │         │    │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null)
            │    │    │         │    │    │    ├── key: (12,13)
            │    │    │         │    │    │    └── fd: (12,13)-->(14)
-           │    │    │         │    │    ├── index-join lineitem
+           │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: l_partkey:27(int!null) l_suppkey:28(int!null) l_quantity:30(float!null) l_shipdate:36(date!null)
-           │    │    │         │    │    │    └── scan lineitem@l_sd
-           │    │    │         │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
-           │    │    │         │    │    │         ├── constraint: /36/26/29: [/'1994-01-01' - /'1994-12-31']
-           │    │    │         │    │    │         ├── key: (26,29)
-           │    │    │         │    │    │         └── fd: (26,29)-->(36)
+           │    │    │         │    │    │    ├── scan lineitem
+           │    │    │         │    │    │    │    └── columns: l_partkey:27(int!null) l_suppkey:28(int!null) l_quantity:30(float!null) l_shipdate:36(date!null)
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         ├── l_shipdate >= '1994-01-01' [type=bool, outer=(36), constraints=(/36: [/'1994-01-01' - ]; tight)]
+           │    │    │         │    │    │         └── l_shipdate < '1995-01-01' [type=bool, outer=(36), constraints=(/36: (/NULL - /'1994-12-31']; tight)]
            │    │    │         │    │    └── filters
            │    │    │         │    │         ├── l_partkey = ps_partkey [type=bool, outer=(12,27), constraints=(/12: (/NULL - ]; /27: (/NULL - ]), fd=(12)==(27), (27)==(12)]
            │    │    │         │    │         └── l_suppkey = ps_suppkey [type=bool, outer=(13,28), constraints=(/13: (/NULL - ]; /28: (/NULL - ]), fd=(13)==(28), (28)==(13)]

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -502,28 +502,26 @@ project
       │         │    │    │    │    │    │    ├── columns: ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null)
       │         │    │    │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    │    │    └── fd: (17,18)-->(20)
-      │         │    │    │    │    │    ├── inner-join (lookup nation)
+      │         │    │    │    │    │    ├── inner-join
       │         │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
-      │         │    │    │    │    │    │    ├── key columns: [22] = [22]
       │         │    │    │    │    │    │    ├── key: (22)
       │         │    │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24)
-      │         │    │    │    │    │    │    ├── inner-join (lookup nation@n_rk)
-      │         │    │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
-      │         │    │    │    │    │    │    │    ├── key columns: [26] = [24]
+      │         │    │    │    │    │    │    ├── scan nation
+      │         │    │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null)
       │         │    │    │    │    │    │    │    ├── key: (22)
-      │         │    │    │    │    │    │    │    ├── fd: ()-->(27), (22)-->(24), (24)==(26), (26)==(24)
-      │         │    │    │    │    │    │    │    ├── select
+      │         │    │    │    │    │    │    │    └── fd: (22)-->(23,24)
+      │         │    │    │    │    │    │    ├── select
+      │         │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    │    │    ├── key: (26)
+      │         │    │    │    │    │    │    │    ├── fd: ()-->(27)
+      │         │    │    │    │    │    │    │    ├── scan region
       │         │    │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(string!null)
       │         │    │    │    │    │    │    │    │    ├── key: (26)
-      │         │    │    │    │    │    │    │    │    ├── fd: ()-->(27)
-      │         │    │    │    │    │    │    │    │    ├── scan region
-      │         │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(string!null)
-      │         │    │    │    │    │    │    │    │    │    ├── key: (26)
-      │         │    │    │    │    │    │    │    │    │    └── fd: (26)-->(27)
-      │         │    │    │    │    │    │    │    │    └── filters
-      │         │    │    │    │    │    │    │    │         └── r_name = 'EUROPE' [type=bool, outer=(27), constraints=(/27: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(27)]
-      │         │    │    │    │    │    │    │    └── filters (true)
-      │         │    │    │    │    │    │    └── filters (true)
+      │         │    │    │    │    │    │    │    │    └── fd: (26)-->(27)
+      │         │    │    │    │    │    │    │    └── filters
+      │         │    │    │    │    │    │    │         └── r_name = 'EUROPE' [type=bool, outer=(27), constraints=(/27: [/'EUROPE' - /'EUROPE']; tight), fd=()-->(27)]
+      │         │    │    │    │    │    │    └── filters
+      │         │    │    │    │    │    │         └── n_regionkey = r_regionkey [type=bool, outer=(24,26), constraints=(/24: (/NULL - ]; /26: (/NULL - ]), fd=(24)==(26), (26)==(24)]
       │         │    │    │    │    │    └── filters (true)
       │         │    │    │    │    ├── scan supplier
       │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null)
@@ -631,32 +629,27 @@ limit
  │         │    ├── inner-join
  │         │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
  │         │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
- │         │    │    ├── inner-join (merge)
+ │         │    │    ├── inner-join
  │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
- │         │    │    │    ├── left ordering: +9
- │         │    │    │    ├── right ordering: +18
  │         │    │    │    ├── fd: (9)-->(10,13,16), (9)==(18), (18)==(9)
  │         │    │    │    ├── select
  │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
  │         │    │    │    │    ├── key: (9)
  │         │    │    │    │    ├── fd: (9)-->(10,13,16)
- │         │    │    │    │    ├── ordering: +9
  │         │    │    │    │    ├── scan orders
  │         │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
  │         │    │    │    │    │    ├── key: (9)
- │         │    │    │    │    │    ├── fd: (9)-->(10,13,16)
- │         │    │    │    │    │    └── ordering: +9
+ │         │    │    │    │    │    └── fd: (9)-->(10,13,16)
  │         │    │    │    │    └── filters
  │         │    │    │    │         └── o_orderdate < '1995-03-15' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1995-03-14']; tight)]
  │         │    │    │    ├── select
  │         │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
- │         │    │    │    │    ├── ordering: +18
  │         │    │    │    │    ├── scan lineitem
- │         │    │    │    │    │    ├── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
- │         │    │    │    │    │    └── ordering: +18
+ │         │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
  │         │    │    │    │    └── filters
  │         │    │    │    │         └── l_shipdate > '1995-03-15' [type=bool, outer=(28), constraints=(/28: [/'1995-03-16' - ]; tight)]
- │         │    │    │    └── filters (true)
+ │         │    │    │    └── filters
+ │         │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
  │         │    │    ├── select
  │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
  │         │    │    │    ├── key: (1)
@@ -724,27 +717,34 @@ sort
       ├── grouping columns: o_orderpriority:6(string!null)
       ├── key: (6)
       ├── fd: (6)-->(26)
-      ├── semi-join
+      ├── semi-join (merge)
       │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(string!null)
+      │    ├── left ordering: +1
+      │    ├── right ordering: +10
       │    ├── key: (1)
       │    ├── fd: (1)-->(5,6)
-      │    ├── index-join orders
+      │    ├── select
       │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(string!null)
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(5,6)
-      │    │    └── scan orders@o_od
-      │    │         ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null)
-      │    │         ├── constraint: /5/1: [/'1993-07-01' - /'1993-09-30']
-      │    │         ├── key: (1)
-      │    │         └── fd: (1)-->(5)
+      │    │    ├── ordering: +1
+      │    │    ├── scan orders
+      │    │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(string!null)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(5,6)
+      │    │    │    └── ordering: +1
+      │    │    └── filters
+      │    │         ├── o_orderdate >= '1993-07-01' [type=bool, outer=(5), constraints=(/5: [/'1993-07-01' - ]; tight)]
+      │    │         └── o_orderdate < '1993-10-01' [type=bool, outer=(5), constraints=(/5: (/NULL - /'1993-09-30']; tight)]
       │    ├── select
       │    │    ├── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
+      │    │    ├── ordering: +10
       │    │    ├── scan lineitem
-      │    │    │    └── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
+      │    │    │    ├── columns: l_orderkey:10(int!null) l_commitdate:21(date!null) l_receiptdate:22(date!null)
+      │    │    │    └── ordering: +10
       │    │    └── filters
       │    │         └── l_commitdate < l_receiptdate [type=bool, outer=(21,22), constraints=(/21: (/NULL - ]; /22: (/NULL - ])]
-      │    └── filters
-      │         └── l_orderkey = o_orderkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+      │    └── filters (true)
       └── aggregations
            └── count-rows [type=int]
 
@@ -822,41 +822,41 @@ sort
       │    │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null)
       │    │    │    │    │    │    ├── key: (34)
       │    │    │    │    │    │    └── fd: (34)-->(37)
-      │    │    │    │    │    ├── inner-join (lookup nation)
+      │    │    │    │    │    ├── inner-join
       │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
-      │    │    │    │    │    │    ├── key columns: [41] = [41]
       │    │    │    │    │    │    ├── key: (41)
       │    │    │    │    │    │    ├── fd: ()-->(46), (41)-->(42,43), (43)==(45), (45)==(43)
-      │    │    │    │    │    │    ├── inner-join (lookup nation@n_rk)
-      │    │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
-      │    │    │    │    │    │    │    ├── key columns: [45] = [43]
+      │    │    │    │    │    │    ├── scan nation
+      │    │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null)
       │    │    │    │    │    │    │    ├── key: (41)
-      │    │    │    │    │    │    │    ├── fd: ()-->(46), (41)-->(43), (43)==(45), (45)==(43)
-      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    └── fd: (41)-->(42,43)
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    │    │    ├── key: (45)
+      │    │    │    │    │    │    │    ├── fd: ()-->(46)
+      │    │    │    │    │    │    │    ├── scan region
       │    │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
       │    │    │    │    │    │    │    │    ├── key: (45)
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(46)
-      │    │    │    │    │    │    │    │    ├── scan region
-      │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
-      │    │    │    │    │    │    │    │    │    ├── key: (45)
-      │    │    │    │    │    │    │    │    │    └── fd: (45)-->(46)
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         └── r_name = 'ASIA' [type=bool, outer=(46), constraints=(/46: [/'ASIA' - /'ASIA']; tight), fd=()-->(46)]
-      │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    │    │    └── fd: (45)-->(46)
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── r_name = 'ASIA' [type=bool, outer=(46), constraints=(/46: [/'ASIA' - /'ASIA']; tight), fd=()-->(46)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── n_regionkey = r_regionkey [type=bool, outer=(43,45), constraints=(/43: (/NULL - ]; /45: (/NULL - ]), fd=(43)==(45), (45)==(43)]
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(37,41), constraints=(/37: (/NULL - ]; /41: (/NULL - ]), fd=(37)==(41), (41)==(37)]
       │    │    │    │    └── filters
       │    │    │    │         └── l_suppkey = s_suppkey [type=bool, outer=(20,34), constraints=(/20: (/NULL - ]; /34: (/NULL - ]), fd=(20)==(34), (34)==(20)]
-      │    │    │    ├── index-join orders
+      │    │    │    ├── select
       │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
       │    │    │    │    ├── key: (9)
       │    │    │    │    ├── fd: (9)-->(10,13)
-      │    │    │    │    └── scan orders@o_od
-      │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
-      │    │    │    │         ├── constraint: /13/9: [/'1994-01-01' - /'1994-12-31']
-      │    │    │    │         ├── key: (9)
-      │    │    │    │         └── fd: (9)-->(13)
+      │    │    │    │    ├── scan orders
+      │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
+      │    │    │    │    │    ├── key: (9)
+      │    │    │    │    │    └── fd: (9)-->(10,13)
+      │    │    │    │    └── filters
+      │    │    │    │         ├── o_orderdate >= '1994-01-01' [type=bool, outer=(13), constraints=(/13: [/'1994-01-01' - ]; tight)]
+      │    │    │    │         └── o_orderdate < '1995-01-01' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1994-12-31']; tight)]
       │    │    │    └── filters
       │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
       │    │    ├── scan customer@c_nk
@@ -907,14 +907,11 @@ scalar-group-by
  │    ├── columns: column17:17(float)
  │    ├── select
  │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    ├── index-join lineitem
- │    │    │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    │    └── scan lineitem@l_sd
- │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
- │    │    │         ├── constraint: /11/1/4: [/'1994-01-01' - /'1994-12-31']
- │    │    │         ├── key: (1,4)
- │    │    │         └── fd: (1,4)-->(11)
+ │    │    ├── scan lineitem
+ │    │    │    └── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
  │    │    └── filters
+ │    │         ├── l_shipdate >= '1994-01-01' [type=bool, outer=(11), constraints=(/11: [/'1994-01-01' - ]; tight)]
+ │    │         ├── l_shipdate < '1995-01-01' [type=bool, outer=(11), constraints=(/11: (/NULL - /'1994-12-31']; tight)]
  │    │         ├── l_discount >= 0.05 [type=bool, outer=(7), constraints=(/7: [/0.05 - ]; tight)]
  │    │         ├── l_discount <= 0.07 [type=bool, outer=(7), constraints=(/7: (/NULL - /0.07]; tight)]
  │    │         └── l_quantity < 24.0 [type=bool, outer=(5), constraints=(/5: (/NULL - /23.999999999999996]; tight)]
@@ -1030,13 +1027,13 @@ group-by
  │         │    │    │    │    └── fd: (24)-->(25)
  │         │    │    │    └── filters
  │         │    │    │         └── c_custkey = o_custkey [type=bool, outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
- │         │    │    ├── index-join lineitem
+ │         │    │    ├── select
  │         │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
- │         │    │    │    └── scan lineitem@l_sd
- │         │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
- │         │    │    │         ├── constraint: /18/8/11: [/'1995-01-01' - /'1996-12-31']
- │         │    │    │         ├── key: (8,11)
- │         │    │    │         └── fd: (8,11)-->(18)
+ │         │    │    │    ├── scan lineitem
+ │         │    │    │    │    └── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+ │         │    │    │    └── filters
+ │         │    │    │         ├── l_shipdate >= '1995-01-01' [type=bool, outer=(18), constraints=(/18: [/'1995-01-01' - ]; tight)]
+ │         │    │    │         └── l_shipdate <= '1996-12-31' [type=bool, outer=(18), constraints=(/18: (/NULL - /'1996-12-31']; tight)]
  │         │    │    └── filters
  │         │    │         └── o_orderkey = l_orderkey [type=bool, outer=(8,24), constraints=(/8: (/NULL - ]; /24: (/NULL - ]), fd=(8)==(24), (24)==(8)]
  │         │    ├── scan supplier@s_nk
@@ -1128,9 +1125,8 @@ sort
       │    │    ├── columns: column63:63(float) o_year:61(int) volume:62(float)
       │    │    ├── project
       │    │    │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(string!null)
-      │    │    │    ├── inner-join (lookup part)
+      │    │    │    ├── inner-join
       │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
-      │    │    │    │    ├── key columns: [18] = [1]
       │    │    │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
       │    │    │    │    ├── inner-join
       │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
@@ -1181,15 +1177,17 @@ sort
       │    │    │    │    │    │    │    │    │    └── fd: (42)-->(45)
       │    │    │    │    │    │    │    │    └── filters
       │    │    │    │    │    │    │    │         └── c_nationkey = n1.n_nationkey [type=bool, outer=(45,50), constraints=(/45: (/NULL - ]; /50: (/NULL - ]), fd=(45)==(50), (50)==(45)]
-      │    │    │    │    │    │    │    ├── index-join orders
+      │    │    │    │    │    │    │    ├── select
       │    │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
       │    │    │    │    │    │    │    │    ├── key: (33)
       │    │    │    │    │    │    │    │    ├── fd: (33)-->(34,37)
-      │    │    │    │    │    │    │    │    └── scan orders@o_od
-      │    │    │    │    │    │    │    │         ├── columns: o_orderkey:33(int!null) o_orderdate:37(date!null)
-      │    │    │    │    │    │    │    │         ├── constraint: /37/33: [/'1995-01-01' - /'1996-12-31']
-      │    │    │    │    │    │    │    │         ├── key: (33)
-      │    │    │    │    │    │    │    │         └── fd: (33)-->(37)
+      │    │    │    │    │    │    │    │    ├── scan orders
+      │    │    │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null)
+      │    │    │    │    │    │    │    │    │    ├── key: (33)
+      │    │    │    │    │    │    │    │    │    └── fd: (33)-->(34,37)
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         ├── o_orderdate >= '1995-01-01' [type=bool, outer=(37), constraints=(/37: [/'1995-01-01' - ]; tight)]
+      │    │    │    │    │    │    │    │         └── o_orderdate <= '1996-12-31' [type=bool, outer=(37), constraints=(/37: (/NULL - /'1996-12-31']; tight)]
       │    │    │    │    │    │    │    └── filters
       │    │    │    │    │    │    │         └── o_custkey = c_custkey [type=bool, outer=(34,42), constraints=(/34: (/NULL - ]; /42: (/NULL - ]), fd=(34)==(42), (42)==(34)]
       │    │    │    │    │    │    ├── scan lineitem
@@ -1203,8 +1201,18 @@ sort
       │    │    │    │    │    └── filters
       │    │    │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
       │    │    │    │    │         └── s_nationkey = n2.n_nationkey [type=bool, outer=(13,54), constraints=(/13: (/NULL - ]; /54: (/NULL - ]), fd=(13)==(54), (54)==(13)]
+      │    │    │    │    ├── select
+      │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null)
+      │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    ├── fd: ()-->(5)
+      │    │    │    │    │    ├── scan part
+      │    │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null)
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    └── fd: (1)-->(5)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── p_type = 'ECONOMY ANODIZED STEEL' [type=bool, outer=(5), constraints=(/5: [/'ECONOMY ANODIZED STEEL' - /'ECONOMY ANODIZED STEEL']; tight), fd=()-->(5)]
       │    │    │    │    └── filters
-      │    │    │    │         └── p_type = 'ECONOMY ANODIZED STEEL' [type=bool, outer=(5), constraints=(/5: [/'ECONOMY ANODIZED STEEL' - /'ECONOMY ANODIZED STEEL']; tight), fd=()-->(5)]
+      │    │    │    │         └── p_partkey = l_partkey [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
       │    │    │    └── projections
       │    │    │         ├── extract('year', o_orderdate) [type=int, outer=(37)]
       │    │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(22,23)]
@@ -1283,10 +1291,19 @@ sort
       ├── fd: (48,51)-->(53)
       ├── project
       │    ├── columns: o_year:51(int) amount:52(float) n_name:48(string!null)
-      │    ├── inner-join (lookup part)
+      │    ├── inner-join
       │    │    ├── columns: p_partkey:1(int!null) p_name:2(string!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
-      │    │    ├── key columns: [18] = [1]
       │    │    ├── fd: (1)-->(2), (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(1,33), (33)==(1,18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13), (1)==(18,33)
+      │    │    ├── select
+      │    │    │    ├── columns: p_partkey:1(int!null) p_name:2(string!null)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2)
+      │    │    │    ├── scan part
+      │    │    │    │    ├── columns: p_partkey:1(int!null) p_name:2(string!null)
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    └── fd: (1)-->(2)
+      │    │    │    └── filters
+      │    │    │         └── p_name LIKE '%green%' [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
       │    │    ├── inner-join
       │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
       │    │    │    ├── fd: (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(33), (33)==(18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13)
@@ -1329,7 +1346,7 @@ sort
       │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
       │    │    │         └── s_nationkey = n_nationkey [type=bool, outer=(13,47), constraints=(/13: (/NULL - ]; /47: (/NULL - ]), fd=(13)==(47), (47)==(13)]
       │    │    └── filters
-      │    │         └── p_name LIKE '%green%' [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+      │    │         └── p_partkey = l_partkey [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
       │    └── projections
       │         ├── extract('year', o_orderdate) [type=int, outer=(42)]
       │         └── (l_extendedprice * (1.0 - l_discount)) - (ps_supplycost * l_quantity) [type=float, outer=(21-23,36)]
@@ -1426,15 +1443,17 @@ limit
  │         │    │    │    │    │    └── filters
  │         │    │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
  │         │    │    │    │    └── filters (true)
- │         │    │    │    ├── index-join orders
+ │         │    │    │    ├── select
  │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
  │         │    │    │    │    ├── key: (9)
  │         │    │    │    │    ├── fd: (9)-->(10,13)
- │         │    │    │    │    └── scan orders@o_od
- │         │    │    │    │         ├── columns: o_orderkey:9(int!null) o_orderdate:13(date!null)
- │         │    │    │    │         ├── constraint: /13/9: [/'1993-10-01' - /'1993-12-31']
- │         │    │    │    │         ├── key: (9)
- │         │    │    │    │         └── fd: (9)-->(13)
+ │         │    │    │    │    ├── scan orders
+ │         │    │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null)
+ │         │    │    │    │    │    ├── key: (9)
+ │         │    │    │    │    │    └── fd: (9)-->(10,13)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         ├── o_orderdate >= '1993-10-01' [type=bool, outer=(13), constraints=(/13: [/'1993-10-01' - ]; tight)]
+ │         │    │    │    │         └── o_orderdate < '1994-01-01' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1993-12-31']; tight)]
  │         │    │    │    └── filters
  │         │    │    │         └── l_orderkey = o_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
  │         │    │    ├── scan customer
@@ -1659,17 +1678,14 @@ group-by
  │    │    │    ├── ordering: +24
  │    │    │    └── select
  │    │    │         ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
- │    │    │         ├── index-join lineitem
- │    │    │         │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
- │    │    │         │    └── scan lineitem@l_rd
- │    │    │         │         ├── columns: l_orderkey:10(int!null) l_linenumber:13(int!null) l_receiptdate:22(date!null)
- │    │    │         │         ├── constraint: /22/10/13: [/'1994-01-01' - /'1994-12-31']
- │    │    │         │         ├── key: (10,13)
- │    │    │         │         └── fd: (10,13)-->(22)
+ │    │    │         ├── scan lineitem
+ │    │    │         │    └── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
  │    │    │         └── filters
  │    │    │              ├── l_shipmode IN ('MAIL', 'SHIP') [type=bool, outer=(24), constraints=(/24: [/'MAIL' - /'MAIL'] [/'SHIP' - /'SHIP']; tight)]
  │    │    │              ├── l_commitdate < l_receiptdate [type=bool, outer=(21,22), constraints=(/21: (/NULL - ]; /22: (/NULL - ])]
- │    │    │              └── l_shipdate < l_commitdate [type=bool, outer=(20,21), constraints=(/20: (/NULL - ]; /21: (/NULL - ])]
+ │    │    │              ├── l_shipdate < l_commitdate [type=bool, outer=(20,21), constraints=(/20: (/NULL - ]; /21: (/NULL - ])]
+ │    │    │              ├── l_receiptdate >= '1994-01-01' [type=bool, outer=(22), constraints=(/22: [/'1994-01-01' - ]; tight)]
+ │    │    │              └── l_receiptdate < '1995-01-01' [type=bool, outer=(22), constraints=(/22: (/NULL - /'1994-12-31']; tight)]
  │    │    └── filters (true)
  │    └── projections
  │         ├── CASE WHEN (o_orderpriority = '1-URGENT') OR (o_orderpriority = '2-HIGH') THEN 1 ELSE 0 END [type=int, outer=(6)]
@@ -1791,18 +1807,22 @@ project
  │    ├── fd: ()-->(27,29)
  │    ├── project
  │    │    ├── columns: column26:26(float) column28:28(float)
- │    │    ├── inner-join (lookup part)
+ │    │    ├── inner-join
  │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(string!null)
- │    │    │    ├── key columns: [2] = [17]
  │    │    │    ├── fd: (17)-->(21), (2)==(17), (17)==(2)
- │    │    │    ├── index-join lineitem
+ │    │    │    ├── scan part
+ │    │    │    │    ├── columns: p_partkey:17(int!null) p_type:21(string!null)
+ │    │    │    │    ├── key: (17)
+ │    │    │    │    └── fd: (17)-->(21)
+ │    │    │    ├── select
  │    │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
- │    │    │    │    └── scan lineitem@l_sd
- │    │    │    │         ├── columns: l_orderkey:1(int!null) l_linenumber:4(int!null) l_shipdate:11(date!null)
- │    │    │    │         ├── constraint: /11/1/4: [/'1995-09-01' - /'1995-09-30']
- │    │    │    │         ├── key: (1,4)
- │    │    │    │         └── fd: (1,4)-->(11)
- │    │    │    └── filters (true)
+ │    │    │    │    ├── scan lineitem
+ │    │    │    │    │    └── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
+ │    │    │    │    └── filters
+ │    │    │    │         ├── l_shipdate >= '1995-09-01' [type=bool, outer=(11), constraints=(/11: [/'1995-09-01' - ]; tight)]
+ │    │    │    │         └── l_shipdate < '1995-10-01' [type=bool, outer=(11), constraints=(/11: (/NULL - /'1995-09-30']; tight)]
+ │    │    │    └── filters
+ │    │    │         └── l_partkey = p_partkey [type=bool, outer=(2,17), constraints=(/2: (/NULL - ]; /17: (/NULL - ]), fd=(2)==(17), (17)==(2)]
  │    │    └── projections
  │    │         ├── CASE WHEN p_type LIKE 'PROMO%' THEN l_extendedprice * (1.0 - l_discount) ELSE 0.0 END [type=float, outer=(6,7,21)]
  │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(6,7)]
@@ -1887,13 +1907,13 @@ sort
            │    │    ├── fd: (10)-->(25)
            │    │    ├── project
            │    │    │    ├── columns: column24:24(float) l_suppkey:10(int!null)
-           │    │    │    ├── index-join lineitem
+           │    │    │    ├── select
            │    │    │    │    ├── columns: l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
-           │    │    │    │    └── scan lineitem@l_sd
-           │    │    │    │         ├── columns: l_orderkey:8(int!null) l_linenumber:11(int!null) l_shipdate:18(date!null)
-           │    │    │    │         ├── constraint: /18/8/11: [/'1996-01-01' - /'1996-03-31']
-           │    │    │    │         ├── key: (8,11)
-           │    │    │    │         └── fd: (8,11)-->(18)
+           │    │    │    │    ├── scan lineitem
+           │    │    │    │    │    └── columns: l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null)
+           │    │    │    │    └── filters
+           │    │    │    │         ├── l_shipdate >= '1996-01-01' [type=bool, outer=(18), constraints=(/18: [/'1996-01-01' - ]; tight)]
+           │    │    │    │         └── l_shipdate < '1996-04-01' [type=bool, outer=(18), constraints=(/18: (/NULL - /'1996-03-31']; tight)]
            │    │    │    └── projections
            │    │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(13,14)]
            │    │    └── aggregations
@@ -1915,13 +1935,13 @@ sort
            │                        │    ├── fd: (28)-->(43)
            │                        │    ├── project
            │                        │    │    ├── columns: column42:42(float) l_suppkey:28(int!null)
-           │                        │    │    ├── index-join lineitem
+           │                        │    │    ├── select
            │                        │    │    │    ├── columns: l_suppkey:28(int!null) l_extendedprice:31(float!null) l_discount:32(float!null) l_shipdate:36(date!null)
-           │                        │    │    │    └── scan lineitem@l_sd
-           │                        │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
-           │                        │    │    │         ├── constraint: /36/26/29: [/'1996-01-01' - /'1996-03-31']
-           │                        │    │    │         ├── key: (26,29)
-           │                        │    │    │         └── fd: (26,29)-->(36)
+           │                        │    │    │    ├── scan lineitem
+           │                        │    │    │    │    └── columns: l_suppkey:28(int!null) l_extendedprice:31(float!null) l_discount:32(float!null) l_shipdate:36(date!null)
+           │                        │    │    │    └── filters
+           │                        │    │    │         ├── l_shipdate >= '1996-01-01' [type=bool, outer=(36), constraints=(/36: [/'1996-01-01' - ]; tight)]
+           │                        │    │    │         └── l_shipdate < '1996-04-01' [type=bool, outer=(36), constraints=(/36: (/NULL - /'1996-03-31']; tight)]
            │                        │    │    └── projections
            │                        │    │         └── l_extendedprice * (1.0 - l_discount) [type=float, outer=(31,32)]
            │                        │    └── aggregations
@@ -1992,28 +2012,24 @@ sort
       │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
       │    ├── key: (2,6)
       │    ├── fd: (6)-->(9-11), (1)==(6), (6)==(1)
-      │    ├── anti-join (merge)
+      │    ├── anti-join
       │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null)
-      │    │    ├── left ordering: +2
-      │    │    ├── right ordering: +15
       │    │    ├── key: (1,2)
       │    │    ├── scan partsupp@ps_sk
       │    │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null)
-      │    │    │    ├── key: (1,2)
-      │    │    │    └── ordering: +2
+      │    │    │    └── key: (1,2)
       │    │    ├── select
       │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(string!null)
       │    │    │    ├── key: (15)
       │    │    │    ├── fd: (15)-->(21)
-      │    │    │    ├── ordering: +15
       │    │    │    ├── scan supplier
       │    │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(string!null)
       │    │    │    │    ├── key: (15)
-      │    │    │    │    ├── fd: (15)-->(21)
-      │    │    │    │    └── ordering: +15
+      │    │    │    │    └── fd: (15)-->(21)
       │    │    │    └── filters
       │    │    │         └── s_comment LIKE '%Customer%Complaints%' [type=bool, outer=(21), constraints=(/21: (/NULL - ])]
-      │    │    └── filters (true)
+      │    │    └── filters
+      │    │         └── ps_suppkey = s_suppkey [type=bool, outer=(2,15), constraints=(/2: (/NULL - ]; /15: (/NULL - ]), fd=(2)==(15), (15)==(2)]
       │    ├── select
       │    │    ├── columns: p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
       │    │    ├── key: (6)
@@ -2208,34 +2224,27 @@ limit
  │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null)
  │         │    │    ├── key: (1)
  │         │    │    └── fd: (1)-->(2)
- │         │    ├── inner-join (merge)
+ │         │    ├── inner-join
  │         │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
- │         │    │    ├── left ordering: +9
- │         │    │    ├── right ordering: +18
  │         │    │    ├── fd: (9)-->(10,12,13), (9)==(18), (18)==(9)
- │         │    │    ├── semi-join (merge)
+ │         │    │    ├── semi-join
  │         │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
- │         │    │    │    ├── left ordering: +9
- │         │    │    │    ├── right ordering: +34
  │         │    │    │    ├── key: (9)
  │         │    │    │    ├── fd: (9)-->(10,12,13)
- │         │    │    │    ├── ordering: +9
  │         │    │    │    ├── scan orders
  │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
  │         │    │    │    │    ├── key: (9)
- │         │    │    │    │    ├── fd: (9)-->(10,12,13)
- │         │    │    │    │    └── ordering: +9
+ │         │    │    │    │    └── fd: (9)-->(10,12,13)
  │         │    │    │    ├── select
  │         │    │    │    │    ├── columns: l_orderkey:34(int!null) sum:50(float!null)
  │         │    │    │    │    ├── key: (34)
  │         │    │    │    │    ├── fd: (34)-->(50)
- │         │    │    │    │    ├── ordering: +34
  │         │    │    │    │    ├── group-by
  │         │    │    │    │    │    ├── columns: l_orderkey:34(int!null) sum:50(float)
  │         │    │    │    │    │    ├── grouping columns: l_orderkey:34(int!null)
+ │         │    │    │    │    │    ├── internal-ordering: +34
  │         │    │    │    │    │    ├── key: (34)
  │         │    │    │    │    │    ├── fd: (34)-->(50)
- │         │    │    │    │    │    ├── ordering: +34
  │         │    │    │    │    │    ├── scan lineitem
  │         │    │    │    │    │    │    ├── columns: l_orderkey:34(int!null) l_quantity:38(float!null)
  │         │    │    │    │    │    │    └── ordering: +34
@@ -2244,11 +2253,12 @@ limit
  │         │    │    │    │    │              └── variable: l_quantity [type=float]
  │         │    │    │    │    └── filters
  │         │    │    │    │         └── sum > 300.0 [type=bool, outer=(50), constraints=(/50: [/300.00000000000006 - ]; tight)]
- │         │    │    │    └── filters (true)
+ │         │    │    │    └── filters
+ │         │    │    │         └── o_orderkey = l_orderkey [type=bool, outer=(9,34), constraints=(/9: (/NULL - ]; /34: (/NULL - ]), fd=(9)==(34), (34)==(9)]
  │         │    │    ├── scan lineitem
- │         │    │    │    ├── columns: l_orderkey:18(int!null) l_quantity:22(float!null)
- │         │    │    │    └── ordering: +18
- │         │    │    └── filters (true)
+ │         │    │    │    └── columns: l_orderkey:18(int!null) l_quantity:22(float!null)
+ │         │    │    └── filters
+ │         │    │         └── o_orderkey = l_orderkey [type=bool, outer=(9,18), constraints=(/9: (/NULL - ]; /18: (/NULL - ]), fd=(9)==(18), (18)==(9)]
  │         │    └── filters
  │         │         └── c_custkey = o_custkey [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
  │         └── aggregations
@@ -2433,13 +2443,13 @@ sort
            │    │    │         │    │    │    ├── columns: ps_partkey:12(int!null) ps_suppkey:13(int!null) ps_availqty:14(int!null)
            │    │    │         │    │    │    ├── key: (12,13)
            │    │    │         │    │    │    └── fd: (12,13)-->(14)
-           │    │    │         │    │    ├── index-join lineitem
+           │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: l_partkey:27(int!null) l_suppkey:28(int!null) l_quantity:30(float!null) l_shipdate:36(date!null)
-           │    │    │         │    │    │    └── scan lineitem@l_sd
-           │    │    │         │    │    │         ├── columns: l_orderkey:26(int!null) l_linenumber:29(int!null) l_shipdate:36(date!null)
-           │    │    │         │    │    │         ├── constraint: /36/26/29: [/'1994-01-01' - /'1994-12-31']
-           │    │    │         │    │    │         ├── key: (26,29)
-           │    │    │         │    │    │         └── fd: (26,29)-->(36)
+           │    │    │         │    │    │    ├── scan lineitem
+           │    │    │         │    │    │    │    └── columns: l_partkey:27(int!null) l_suppkey:28(int!null) l_quantity:30(float!null) l_shipdate:36(date!null)
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         ├── l_shipdate >= '1994-01-01' [type=bool, outer=(36), constraints=(/36: [/'1994-01-01' - ]; tight)]
+           │    │    │         │    │    │         └── l_shipdate < '1995-01-01' [type=bool, outer=(36), constraints=(/36: (/NULL - /'1994-12-31']; tight)]
            │    │    │         │    │    └── filters
            │    │    │         │    │         ├── l_partkey = ps_partkey [type=bool, outer=(12,27), constraints=(/12: (/NULL - ]; /27: (/NULL - ]), fd=(12)==(27), (27)==(12)]
            │    │    │         │    │         └── l_suppkey = ps_suppkey [type=bool, outer=(13,28), constraints=(/13: (/NULL - ]; /28: (/NULL - ]), fd=(13)==(28), (28)==(13)]


### PR DESCRIPTION
tl;dr this work is still really messy and incomplete, and I'm not happy with the presentation, but I needed to get something out the door.

The first commit is the coster changes, the second commit is the changes to external queries.

This PR tweaks the optimizer cost model. It is a bit incomplete:

* I haven't gone through the computations and made them understandable (like factoring out constants)
* Some things remain unchanged, since changing the scans and lookup joins brought a lot of the changes (since many operators largely piggyback off of scans for the bulk of their costing)
* I need to confirm that the cost model that I actually re-implemented in the optimizer was correct by fetching the estimated cost directly, so until then there might be bugs in my translation

This is just to let us take a look through the changed test cases that have changed to see if anything seems egregiously bad.

I can share more detailed data, but the scatterplots for the old/new costers should look roughly like this:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/409075/53590234-537acf00-3b5f-11e9-93fe-dd0c571214cb.png">

I'm a little concerned because it looks like there are some places where we're choosing to sort then merge-join. I need to figure out how to extract the optimizer's estimated costs directly to be able to debug this better, though. Will work on that.

Will post a second PR in the private repo showing the changes to customer queries, I'm having some trouble deciphering some of the changes to them.