### PR TITLE
release-2.1: sql: don't panic in prod on processor double close

### DIFF
--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -891,7 +891,7 @@ func (rb *rowSourceBase) consumerDone() {
 func (rb *rowSourceBase) consumerClosed(name string) {
 	status := ConsumerStatus(atomic.LoadUint32((*uint32)(&rb.consumerStatus)))
 	if status == ConsumerClosed {
-		log.Fatalf(context.Background(), "%s already closed", name)
+		log.ReportOrPanic(context.Background(), nil, "%s already closed", log.Safe(name))
 	}
 	atomic.StoreUint32((*uint32)(&rb.consumerStatus), uint32(ConsumerClosed))
 }

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -488,9 +488,9 @@ func SendCrashReport(
 // Like SendCrashReport, the format string should not contain any sensitive
 // data, and unsafe reportables will be redacted before reporting.
 func ReportOrPanic(
-	ctx context.Context, sv *settings.Values, format string, reportables []interface{},
+	ctx context.Context, sv *settings.Values, format string, reportables ...interface{},
 ) {
-	if !build.IsRelease() || PanicOnAssertions.Get(sv) {
+	if !build.IsRelease() || (sv != nil && PanicOnAssertions.Get(sv)) {
 		panic(fmt.Sprintf(format, reportables...))
 	}
 	Warningf(ctx, format, reportables...)

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -394,11 +394,9 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 	}
 
 	if check && mm.mu.curAllocated != 0 {
-		var reportables []interface{}
 		log.ReportOrPanic(
 			ctx, &mm.settings.SV,
-			fmt.Sprintf("%s: unexpected %d leftover bytes", mm.name, mm.mu.curAllocated),
-			reportables)
+			fmt.Sprintf("%s: unexpected %d leftover bytes", mm.name, mm.mu.curAllocated))
 		mm.releaseBytes(ctx, mm.mu.curAllocated)
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #35125.

/cc @cockroachdb/release

---

Change the unconditional panic in processor double close to a
ReportOrPanic, which won't panic in release builds, but will still
report to Sentry.

Downgrades severity of #32116.

Release note: None
