### PR TITLE
sql: re-enable automatic statistics by default

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -86,7 +86,7 @@
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statistics to be collected</td></tr>
 <tr><td><code>sql.parallel_scans.enabled</code></td><td>boolean</td><td><code>true</code></td><td>parallelizes scanning different ranges when the maximum result size can be deduced</td></tr>
 <tr><td><code>sql.query_cache.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable the query cache</td></tr>
-<tr><td><code>sql.stats.experimental_automatic_collection.enabled</code></td><td>boolean</td><td><code>false</code></td><td>experimental automatic statistics collection mode</td></tr>
+<tr><td><code>sql.stats.experimental_automatic_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>experimental automatic statistics collection mode</td></tr>
 <tr><td><code>sql.stats.experimental_automatic_collection.fraction_idle</code></td><td>float</td><td><code>0.9</code></td><td>fraction of time that automatic statistics sampler processors are idle</td></tr>
 <tr><td><code>sql.tablecache.lease.refresh_limit</code></td><td>integer</td><td><code>50</code></td><td>maximum number of tables to periodically refresh leases for</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -140,7 +140,7 @@ func registerTPCC(r *registry) {
 		MinVersion: maxVersion("v2.1.0", maybeMinVersionForFixturesImport(cloud)),
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			warehouses := 1400
+			warehouses := 1350
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
 				Duration:   120 * time.Minute,
@@ -165,7 +165,7 @@ func registerTPCC(r *registry) {
 		Tags:       []string{`weekly`},
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			warehouses := 1400
+			warehouses := 1350
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,
 				Duration:   6 * 24 * time.Hour,

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -38,7 +38,7 @@ import (
 var AutomaticStatisticsClusterMode = settings.RegisterBoolSetting(
 	"sql.stats.experimental_automatic_collection.enabled",
 	"experimental automatic statistics collection mode",
-	false,
+	true,
 )
 
 // AutomaticStatisticsIdleTime controls the cluster setting for the fraction


### PR DESCRIPTION
This commit re-enables automatic statistics by default. They may still
be disabled before the 19.1 release, but this will allow the feature to
be more thoroughly tested before the release.

In order to prevent engineers from running into issues during testing
and development, this commit reduces the number of warehouses in the
`tpcc/nodes=3/w=max` and `weekly/tpcc-max` roachtests from 1400 to 1350.
We will reset that number back to 1400 if we disable stats again.
We may also update the number to something in between 1350 and 1400 if
futher testing shows that peformance under auto stats is still reliable
with a higher number.

Release note (sql change): Enabled automatic statistics by default.