### PR TITLE
stats: always respect cluster setting for auto stats

### DIFF
--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -224,7 +224,14 @@ func (r *Refresher) Start(
 						}
 
 						for tableID, rowsAffected := range mutationCounts {
+							// Check the cluster setting before each refresh in case it was
+							// disabled recently.
+							if !AutomaticStatisticsClusterMode.Get(st) {
+								break
+							}
+
 							r.maybeRefreshStats(ctx, stopper, tableID, rowsAffected, r.asOfTime)
+
 							select {
 							case <-stopper.ShouldQuiesce():
 								// Don't bother trying to refresh the remaining tables if we


### PR DESCRIPTION
Prior to this commit, it was possible that the automatic statistics
cluster setting was disabled but the system continued to refresh
statistics. This commit adds logic to check the cluster setting
before each refresh to be sure that it's not disabled.

Release note: None