### PR TITLE
roachprod: add a max-concurrency flag with a default of 32

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -64,14 +64,15 @@ type SyncedCluster struct {
 	Localities []string
 	VPCs       []string
 	// all other fields are populated in newCluster.
-	Nodes       []int
-	Secure      bool
-	Env         string
-	Args        []string
-	Tag         string
-	Impl        ClusterImpl
-	UseTreeDist bool
-	Quiet       bool
+	Nodes          []int
+	Secure         bool
+	Env            string
+	Args           []string
+	Tag            string
+	Impl           ClusterImpl
+	UseTreeDist    bool
+	Quiet          bool
+	MaxConcurrency int // used in Parallel
 	// AuthorizedKeys is used by SetupSSH to add additional authorized keys.
 	AuthorizedKeys []byte
 
@@ -1539,7 +1540,9 @@ func (c *SyncedCluster) Parallel(
 	if concurrency == 0 || concurrency > count {
 		concurrency = count
 	}
-
+	if c.MaxConcurrency > 0 && concurrency > c.MaxConcurrency {
+		concurrency = c.MaxConcurrency
+	}
 	type result struct {
 		index int
 		out   []byte

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -98,6 +98,7 @@ var (
 	logsFrom          time.Time
 	logsTo            time.Time
 	logsInterval      time.Duration
+	maxConcurrency    int
 
 	monitorIgnoreEmptyNodes bool
 	monitorOneShot          bool
@@ -185,6 +186,7 @@ Hint: use "roachprod sync" to update the list of available clusters.
 	}
 	c.UseTreeDist = useTreeDist
 	c.Quiet = quiet || !terminal.IsTerminal(int(os.Stdout.Fd()))
+	c.MaxConcurrency = maxConcurrency
 	return c, nil
 }
 
@@ -1573,7 +1575,9 @@ func main() {
 
 	rootCmd.PersistentFlags().BoolVarP(
 		&quiet, "quiet", "q", false, "disable fancy progress output")
-
+	rootCmd.PersistentFlags().IntVarP(
+		&maxConcurrency, "max-concurrency", "", 32,
+		"maximum number of operations to execute on nodes concurrently, set to zero for infinite")
 	for _, cmd := range []*cobra.Command{createCmd, destroyCmd, extendCmd, logsCmd} {
 		cmd.Flags().StringVarP(&username, "username", "u", os.Getenv("ROACHPROD_USER"),
 			"Username to run under, detect if blank")


### PR DESCRIPTION
This PR adds a --max-concurrency flag to roachprod and defaults its value to 32.
In large clusters doing many concurrent SSH operations can lead to unexpected
behavior where the command fails to communicate with the SSH agent and leads to
the user being prompted for their private key passphrase. Adding a limit
prevents this behavior when interacting with a cluster of 256 nodes.

Release note: None