### PR TITLE
 roachprod: add DNS entries for roachprod hosts

### DIFF
--- a/pkg/cmd/roachprod/cloud/cluster_cloud.go
+++ b/pkg/cmd/roachprod/cloud/cluster_cloud.go
@@ -227,7 +227,7 @@ func CreateCluster(name string, nodes int, opts vm.CreateOpts) error {
 	vmLocations := map[string][]string{}
 	for i, p := 1, 0; i <= nodes; i++ {
 		pName := opts.VMProviders[p]
-		vmName := fmt.Sprintf("%s-%0.4d", name, i)
+		vmName := vm.Name(name, i)
 		vmLocations[pName] = append(vmLocations[pName], vmName)
 
 		p = (p + 1) % providerCount

--- a/pkg/cmd/roachprod/cloud/gc.go
+++ b/pkg/cmd/roachprod/cloud/gc.go
@@ -345,6 +345,7 @@ func GCClusters(cloud *Cloud, dryrun bool) error {
 			if err := DestroyCluster(c); err != nil {
 				postError(client, channel, err)
 			}
+			delete(cloud.Clusters, c.Name)
 		}
 	}
 	return nil

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/exec"
 	"os/user"
@@ -1268,8 +1269,17 @@ var adminurlCmd = &cobra.Command{
 			return err
 		}
 
-		for _, node := range c.ServerNodes() {
+		for i, node := range c.ServerNodes() {
 			host := vm.Name(c.Name, node) + "." + gce.Subdomain
+
+			// verify DNS is working / fallback to IPs if not.
+			if i == 0 && adminurlIPs {
+				if _, err := net.LookupHost(host); err != nil {
+					fmt.Fprintf(os.Stderr, "no valid DNS (yet?). might need to re-run `sync`?")
+					adminurlIPs = true
+				}
+			}
+
 			if adminurlIPs {
 				host = c.VMs[node-1]
 			}

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -445,6 +445,10 @@ directory is removed.
 			if err := cld.DestroyCluster(c); err != nil {
 				return err
 			}
+			delete(cloud.Clusters, c.Name)
+			if err := syncAll(cloud, true /* quiet */); err != nil {
+				return err
+			}
 		} else {
 			if _, ok := install.Clusters[clusterName]; !ok {
 				return fmt.Errorf("cluster %s does not exist", clusterName)
@@ -725,7 +729,13 @@ hourly by a cronjob so it is not necessary to run manually.
 		if err != nil {
 			return err
 		}
-		return cld.GCClusters(cloud, dryrun)
+		if err := cld.GCClusters(cloud, dryrun); err != nil {
+			return err
+		}
+		if !dryrun {
+			return syncAll(cloud, true /*quiet*/)
+		}
+		return nil
 	}),
 }
 

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -85,6 +85,7 @@ var (
 	external       = false
 	adminurlOpen   = false
 	adminurlPath   = ""
+	adminurlIPs    = false
 	useTreeDist    = true
 	encrypt        = false
 	quiet          = false
@@ -702,6 +703,15 @@ func syncAll(cloud *cld.Cloud, quiet bool) error {
 	if err := syncHosts(cloud); err != nil {
 		return err
 	}
+
+	var vms vm.List
+	for _, c := range cloud.Clusters {
+		vms = append(vms, c.VMs...)
+	}
+	if err := gce.SyncDNS(vms); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to update %s DNS: %v", gce.Subdomain, err)
+	}
+
 	err = vm.ProvidersSequential(vm.AllProviderNames(), func(p vm.Provider) error {
 		return p.CleanSSH()
 	})
@@ -1259,7 +1269,10 @@ var adminurlCmd = &cobra.Command{
 		}
 
 		for _, node := range c.ServerNodes() {
-			ip := c.VMs[node-1]
+			host := vm.Name(c.Name, node) + "." + gce.Subdomain
+			if adminurlIPs {
+				host = c.VMs[node-1]
+			}
 			port := install.GetAdminUIPort(c.Impl.NodePort(c, node))
 			scheme := "http"
 			if c.Secure {
@@ -1268,7 +1281,7 @@ var adminurlCmd = &cobra.Command{
 			if !strings.HasPrefix(adminurlPath, "/") {
 				adminurlPath = "/" + adminurlPath
 			}
-			url := fmt.Sprintf("%s://%s:%d%s", scheme, ip, port, adminurlPath)
+			url := fmt.Sprintf("%s://%s:%d%s", scheme, host, port, adminurlPath)
 			if adminurlOpen {
 				if err := exec.Command("python", "-m", "webbrowser", url).Run(); err != nil {
 					return err
@@ -1462,6 +1475,8 @@ func main() {
 		&adminurlOpen, `open`, false, `Open the url in a browser`)
 	adminurlCmd.Flags().StringVar(
 		&adminurlPath, `path`, "/", `Path to add to URL (e.g. to open a same page on each node)`)
+	adminurlCmd.Flags().BoolVar(
+		&adminurlIPs, `ips`, false, `Use Public IPs instead of DNS names in URL`)
 
 	gcCmd.Flags().BoolVarP(
 		&dryrun, "dry-run", "n", dryrun, "dry run (don't perform any actions)")

--- a/pkg/cmd/roachprod/vm/vm.go
+++ b/pkg/cmd/roachprod/vm/vm.go
@@ -56,6 +56,11 @@ type VM struct {
 	Zone        string `json:"zone"`
 }
 
+// Name generates the name for the i'th node in a cluster.
+func Name(cluster string, idx int) string {
+	return fmt.Sprintf("%s-%0.4d", cluster, idx)
+}
+
 // Error values for VM.Error
 var (
 	ErrBadNetwork   = errors.New("could not determine network information")


### PR DESCRIPTION
This adds support for maintaining a Google Cloud DNS zone with entries for hosts in roachprod clusters.
Whenever we re-sync the on-disk cluster listing, if we are configured with default (i.e. cockroach labs) Google Cloud settings, then we also update the google cloud DNS zone.

These aliases can then be used in 'adminurl' to make it easiler to keep track of which nodes you're interacting with while monitoring/debugging.

Release note: none.

Also:

roachprod: sync after gc’ing / destroying clusters
After destroying a cluster (explicitly or via sync), this updates the in-memory clusters to remove it. It then rewrites the on-disk synced cluster listing from that updated in-memory state.