### PR TITLE
storage: better error when stores are throttled

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -356,7 +356,8 @@ func (r *Replica) HasQuorum() bool {
 // GetStoreList exposes getStoreList for testing only, but with a hardcoded
 // storeFilter of storeFilterNone.
 func (sp *StorePool) GetStoreList(rangeID roachpb.RangeID) (StoreList, int, int) {
-	return sp.getStoreList(rangeID, storeFilterNone)
+	list, available, throttled := sp.getStoreList(rangeID, storeFilterNone)
+	return list, available, len(throttled)
 }
 
 // Stores returns a copy of sl.stores.

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2965,7 +2965,7 @@ type fakeStorePool struct {
 	failedThrottles   int
 }
 
-func (sp *fakeStorePool) throttle(reason throttleReason, toStoreID roachpb.StoreID) {
+func (sp *fakeStorePool) throttle(reason throttleReason, why string, toStoreID roachpb.StoreID) {
 	switch reason {
 	case throttleDeclined:
 		sp.declinedThrottles++


### PR DESCRIPTION
This is an annoying blocker during replication, and has also played a
role in test flakes such as #35307.

Release note: None