### PR TITLE
opt: Fix panic when CASE expressions fold to NULLs

### DIFF
--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1147,28 +1147,15 @@ func (c *CustomFuncs) IsConstValueEqual(const1, const2 opt.ScalarExpr) bool {
 	}
 }
 
-// ensureTyped makes sure that any NULL passing through gets tagged with an
-// appropriate type.
-func (c *CustomFuncs) ensureTyped(d opt.ScalarExpr, typ types.T) opt.ScalarExpr {
-	if d.DataType() == types.Unknown {
-		return c.f.ConstructNull(typ)
-	}
-	return d
-}
-
 // SimplifyWhens removes known unreachable WHEN cases and constructs a new CASE
 // statement. Any known true condition is converted to the ELSE. If only the
 // ELSE remains, its expression is returned. condition must be a ConstValue.
 func (c *CustomFuncs) SimplifyWhens(
 	condition opt.ScalarExpr, whens memo.ScalarListExpr, orElse opt.ScalarExpr,
 ) opt.ScalarExpr {
-	var typ types.T
 	newWhens := make(memo.ScalarListExpr, 0, len(whens))
 	for _, item := range whens {
 		when := item.(*memo.WhenExpr)
-		if typ == nil || typ == types.Unknown {
-			typ = when.Typ
-		}
 		if opt.IsConstValueOp(when.Condition) {
 			if !c.IsConstValueEqual(condition, when.Condition) {
 				// Ignore known unmatching conditions.
@@ -1178,7 +1165,7 @@ func (c *CustomFuncs) SimplifyWhens(
 			// If this is true, we won't ever match anything else, so convert this to
 			// the ELSE (or just return it if there are no earlier items).
 			if len(newWhens) == 0 {
-				return when.Value
+				return c.ensureTyped(when.Value, memo.InferWhensType(whens, orElse))
 			}
 			return c.f.ConstructCase(condition, newWhens, when.Value)
 		}
@@ -1193,10 +1180,19 @@ func (c *CustomFuncs) SimplifyWhens(
 		// a type we observed earlier.
 		// typ will never be nil here because the definition of
 		// SimplifyCaseWhenConstValue ensures that whens is nonempty.
-		return c.ensureTyped(orElse, typ)
+		return c.ensureTyped(orElse, memo.InferWhensType(whens, orElse))
 	}
 
 	return c.f.ConstructCase(condition, newWhens, orElse)
+}
+
+// ensureTyped makes sure that any NULL passing through gets tagged with an
+// appropriate type.
+func (c *CustomFuncs) ensureTyped(d opt.ScalarExpr, typ types.T) opt.ScalarExpr {
+	if d.DataType() == types.Unknown {
+		return c.f.ConstructNull(typ)
+	}
+	return d
 }
 
 // OpsAreSame returns true if the two operators are the same.

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -312,8 +312,8 @@
     $cmp
 )
 
-# FoldCollate converts a Collate expr over an uncollated string into a collated string
-# constant.
+# FoldCollate converts a Collate expr over an uncollated string into a collated
+# string constant.
 [FoldCollate, Normalize]
 (Collate
     $input:(Const)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -618,7 +618,7 @@ values
  └── (NULL,) [type=tuple{string}]
 
 # Regression test for #34930.
-norm
+norm expect=SimplifyCaseWhenConstValue
 SELECT
     CASE
     WHEN true THEN NULL
@@ -632,6 +632,19 @@ values
  ├── key: ()
  ├── fd: ()-->(1)
  └── (NULL,) [type=tuple{decimal}]
+
+# Regression test for #35246.
+norm expect=SimplifyCaseWhenConstValue
+SELECT
+    CASE WHEN true THEN NULL ELSE 'foo' END ||
+    CASE WHEN true THEN NULL ELSE 'bar' END
+----
+values
+ ├── columns: "?column?":1(string)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,) [type=tuple{string}]
 
 # Verify that a true condition does not remove non-constant expressions
 # proceeding it.


### PR DESCRIPTION
The fix for 34930 wasn't quite complete. The static type of the CASE
expression needs to take into account even the types of WHEN and ELSE clauses
that appear *after* a statically true WHEN clause. The fix is to reuse the
exact type inference logic we have in typing.go, and to set the correct
static type when encountering a statically true WHEN clause.

Fixes #35246

Release note: None