### PR TITLE
opt: Fix panic when CHECK expression depends on delete-only column

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -455,15 +455,32 @@ BEGIN; ALTER TABLE mutation ADD COLUMN z INT AS (x + y) STORED
 query TTTTT
 EXPLAIN (VERBOSE) INSERT INTO mutation(x, y) VALUES (2, 2)
 ----
-count             ·              ·                      ()                           ·
- └── insert       ·              ·                      ()                           ·
-      │           into           mutation(x, y, rowid)  ·                            ·
-      │           strategy       inserter               ·                            ·
-      └── values  ·              ·                      (column1, column2, column7)  ·
-·                 size           3 columns, 1 row       ·                            ·
-·                 row 0, expr 0  2                      ·                            ·
-·                 row 0, expr 1  2                      ·                            ·
-·                 row 0, expr 2  unique_rowid()         ·                            ·
+count             ·              ·                         ()                                    ·
+ └── insert       ·              ·                         ()                                    ·
+      │           into           mutation(x, y, rowid, z)  ·                                     ·
+      │           strategy       inserter                  ·                                     ·
+      └── values  ·              ·                         (column1, column2, column7, column8)  ·
+·                 size           4 columns, 1 row          ·                                     ·
+·                 row 0, expr 0  2                         ·                                     ·
+·                 row 0, expr 1  2                         ·                                     ·
+·                 row 0, expr 2  unique_rowid()            ·                                     ·
+·                 row 0, expr 3  4                         ·                                     ·
 
 statement ok
 ROLLBACK
+
+# This test returns an error with the heuristic planner, but succeeds with the
+# cost-based optimizer. See issue #35193 for more details.
+subtest regression_35193
+
+statement ok
+CREATE TABLE t35193(a INT)
+
+statement ok
+BEGIN; ALTER TABLE t35193 ADD COLUMN b INT; ALTER TABLE t35193 ADD CHECK (a > b)
+
+statement ok
+INSERT INTO t35193 (a) VALUES (1)
+
+statement ok
+COMMIT

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -302,3 +302,19 @@ querying next range at /Table/57/1/1/1/1
 r20: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 fast path completed
 rows affected: 1
+
+# This test returns an error with the heuristic planner, but succeeds with the
+# cost-based optimizer. See issue #35193 for more details.
+subtest regression_35193
+
+statement ok
+CREATE TABLE t35193(a INT)
+
+statement ok
+BEGIN; ALTER TABLE t35193 ADD COLUMN b INT; ALTER TABLE t35193 ADD CHECK (a > b)
+
+statement ok
+UPDATE t35193 SET a=1
+
+statement ok
+COMMIT

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -319,3 +319,19 @@ INSERT INTO t5 VALUES (1, 10, 9) ON CONFLICT (k) DO NOTHING
 
 statement ok
 INSERT INTO t5 VALUES (1, 10, 20) ON CONFLICT (k) DO NOTHING
+
+# This test returns an error with the heuristic planner, but succeeds with the
+# cost-based optimizer. See issue #35193 for more details.
+subtest regression_35193
+
+statement ok
+CREATE TABLE t35193(a INT)
+
+statement ok
+BEGIN; ALTER TABLE t35193 ADD COLUMN b INT; ALTER TABLE t35193 ADD CHECK (a > b)
+
+statement ok
+INSERT INTO t35193 VALUES (1) ON CONFLICT (rowid) DO UPDATE SET a=1
+
+statement ok
+COMMIT

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1990,7 +1990,8 @@ upsert mutation
  │    ├──  column1:6 => a:1
  │    ├──  column2:7 => b:2
  │    ├──  column3:8 => c:3
- │    └──  column9:9 => d:4
+ │    ├──  column9:9 => d:4
+ │    └──  column9:9 => e:5
  ├── update-mapping:
  │    └──  upsert_b:17 => b:2
  ├── cardinality: [0 - 0]

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -324,9 +324,9 @@ func (mb *mutationBuilder) addSynthesizedCols(
 ) {
 	var projectionsScope *scope
 
-	// Skip delete-only mutation columns, since they are ignored by all mutation
-	// operators that synthesize columns.
-	for i, n := 0, mb.tab.WritableColumnCount(); i < n; i++ {
+	// Include mutation columns, because they can be used by other computed
+	// expressions as well as check expressions.
+	for i, n := 0, mb.tab.DeletableColumnCount(); i < n; i++ {
 		// Skip columns that are already specified.
 		if colList[i] != 0 {
 			continue

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -81,6 +81,22 @@ TABLE checks
  ├── CHECK (checks.b < d)
  └── CHECK (a > 0)
 
+exec-ddl
+CREATE TABLE checkmutations (
+    a INT PRIMARY KEY,
+    "b:write-only" INT,
+    "c:delete-only" INT,
+    CHECK (b < c)
+)
+----
+TABLE checkmutations
+ ├── a int not null
+ ├── b int (mutation)
+ ├── c int (mutation)
+ ├── INDEX primary
+ │    └── a int not null
+ └── CHECK (b < c)
+
 # Unknown target table.
 build
 INSERT INTO unknown VALUES (1, 2, 3)
@@ -1185,18 +1201,21 @@ insert mutation
  │    ├──  column1:6 => m:1
  │    ├──  column2:7 => n:2
  │    ├──  column8:8 => o:3
- │    └──  column9:9 => p:4
+ │    ├──  column10:10 => p:4
+ │    └──  column9:9 => q:5
  └── project
-      ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
+      ├── columns: column10:10(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int)
       ├── project
-      │    ├── columns: column8:8(int!null) column1:6(int) column2:7(int)
+      │    ├── columns: column8:8(int!null) column9:9(int) column1:6(int) column2:7(int)
       │    ├── values
       │    │    ├── columns: column1:6(int) column2:7(int)
       │    │    └── tuple [type=tuple{int, int}]
       │    │         ├── const: 1 [type=int]
       │    │         └── const: 2 [type=int]
       │    └── projections
-      │         └── const: 10 [type=int]
+      │         ├── const: 10 [type=int]
+      │         └── cast: INT8 [type=int]
+      │              └── null [type=unknown]
       └── projections
            └── plus [type=int]
                 ├── variable: column8 [type=int]
@@ -1212,18 +1231,21 @@ insert mutation
  │    ├──  column1:6 => m:1
  │    ├──  column2:7 => n:2
  │    ├──  column8:8 => o:3
- │    └──  column9:9 => p:4
+ │    ├──  column10:10 => p:4
+ │    └──  column9:9 => q:5
  └── project
-      ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
+      ├── columns: column10:10(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int)
       ├── project
-      │    ├── columns: column8:8(int!null) column1:6(int) column2:7(int)
+      │    ├── columns: column8:8(int!null) column9:9(int) column1:6(int) column2:7(int)
       │    ├── values
       │    │    ├── columns: column1:6(int) column2:7(int)
       │    │    └── tuple [type=tuple{int, int}]
       │    │         ├── const: 1 [type=int]
       │    │         └── const: 2 [type=int]
       │    └── projections
-      │         └── const: 10 [type=int]
+      │         ├── const: 10 [type=int]
+      │         └── cast: INT8 [type=int]
+      │              └── null [type=unknown]
       └── projections
            └── plus [type=int]
                 ├── variable: column8 [type=int]
@@ -1316,3 +1338,31 @@ insert checks
            └── gt [type=bool]
                 ├── variable: abcde.a [type=int]
                 └── const: 0 [type=int]
+
+# Regression for #35193: Insert into table where check depends on mutation
+# columns.
+build
+INSERT INTO checkmutations (a) VALUES (1)
+----
+insert checkmutations
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  column1:4 => a:1
+ │    ├──  column5:5 => b:2
+ │    └──  column5:5 => c:3
+ ├── check columns: check1:6(bool)
+ └── project
+      ├── columns: check1:6(bool) column1:4(int) column5:5(int)
+      ├── project
+      │    ├── columns: column5:5(int) column1:4(int)
+      │    ├── values
+      │    │    ├── columns: column1:4(int)
+      │    │    └── tuple [type=tuple{int}]
+      │    │         └── const: 1 [type=int]
+      │    └── projections
+      │         └── cast: INT8 [type=int]
+      │              └── null [type=unknown]
+      └── projections
+           └── lt [type=bool]
+                ├── variable: column5 [type=int]
+                └── variable: column5 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -79,6 +79,22 @@ TABLE checks
  ├── CHECK (checks.b < d)
  └── CHECK (a > 0)
 
+exec-ddl
+CREATE TABLE checkmutations (
+    a INT PRIMARY KEY,
+    "b:write-only" INT,
+    "c:delete-only" INT,
+    CHECK (b < c)
+)
+----
+TABLE checkmutations
+ ├── a int not null
+ ├── b int (mutation)
+ ├── c int (mutation)
+ ├── INDEX primary
+ │    └── a int not null
+ └── CHECK (b < c)
+
 # ------------------------------------------------------------------------------
 # Basic tests.
 # ------------------------------------------------------------------------------
@@ -1506,3 +1522,26 @@ update checks
            └── gt [type=bool]
                 ├── variable: abcde.a [type=int]
                 └── const: 0 [type=int]
+
+# Update table where check depends on mutation columns.
+build
+UPDATE checkmutations SET a=1
+----
+update checkmutations
+ ├── columns: <none>
+ ├── fetch columns: a:4(int) b:5(int) c:6(int)
+ ├── update-mapping:
+ │    └──  column7:7 => a:1
+ ├── check columns: check1:8(bool)
+ └── project
+      ├── columns: check1:8(bool) a:4(int!null) b:5(int) c:6(int) column7:7(int!null)
+      ├── project
+      │    ├── columns: column7:7(int!null) a:4(int!null) b:5(int) c:6(int)
+      │    ├── scan checkmutations
+      │    │    └── columns: a:4(int!null) b:5(int) c:6(int)
+      │    └── projections
+      │         └── const: 1 [type=int]
+      └── projections
+           └── lt [type=bool]
+                ├── variable: b [type=int]
+                └── variable: c [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -115,6 +115,22 @@ TABLE checks
  ├── CHECK (checks.b < d)
  └── CHECK (a > 0)
 
+exec-ddl
+CREATE TABLE checkmutations (
+    a INT PRIMARY KEY,
+    "b:write-only" INT,
+    "c:delete-only" INT,
+    CHECK (b < c)
+)
+----
+TABLE checkmutations
+ ├── a int not null
+ ├── b int (mutation)
+ ├── c int (mutation)
+ ├── INDEX primary
+ │    └── a int not null
+ └── CHECK (b < c)
+
 # ------------------------------------------------------------------------------
 # Basic tests.
 # ------------------------------------------------------------------------------
@@ -1078,41 +1094,44 @@ UPDATE SET m=mutation.m+1
 ----
 upsert mutation
  ├── columns: <none>
- ├── canary column: 10
- ├── fetch columns: m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+ ├── canary column: 11
+ ├── fetch columns: m:11(int) n:12(int) o:13(int) p:14(int) q:15(int)
  ├── insert-mapping:
  │    ├──  column1:6 => m:1
  │    ├──  column2:7 => n:2
  │    ├──  column8:8 => o:3
- │    └──  column9:9 => p:4
+ │    ├──  column10:10 => p:4
+ │    └──  column9:9 => q:5
  ├── update-mapping:
- │    ├──  upsert_m:17 => m:1
- │    └──  upsert_p:20 => p:4
+ │    ├──  upsert_m:18 => m:1
+ │    └──  upsert_p:21 => p:4
  └── project
-      ├── columns: upsert_m:17(int) upsert_n:18(int) upsert_o:19(int) upsert_p:20(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      ├── columns: upsert_m:18(int) upsert_n:19(int) upsert_o:20(int) upsert_p:21(int) upsert_q:22(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) column10:10(int) m:11(int) n:12(int) o:13(int) p:14(int) q:15(int)
       ├── project
-      │    ├── columns: column16:16(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
+      │    ├── columns: column17:17(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) column10:10(int) m:11(int) n:12(int) o:13(int) p:14(int) q:15(int) column16:16(int)
       │    ├── project
-      │    │    ├── columns: column15:15(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    ├── columns: column16:16(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) column10:10(int) m:11(int) n:12(int) o:13(int) p:14(int) q:15(int)
       │    │    ├── left-join
-      │    │    │    ├── columns: column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    ├── columns: column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) column10:10(int) m:11(int) n:12(int) o:13(int) p:14(int) q:15(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
+      │    │    │    │    ├── columns: column10:10(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column8:8(int!null) column1:6(int) column2:7(int)
+      │    │    │    │    │    ├── columns: column8:8(int!null) column9:9(int) column1:6(int) column2:7(int)
       │    │    │    │    │    ├── values
       │    │    │    │    │    │    ├── columns: column1:6(int) column2:7(int)
       │    │    │    │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │    │    │    │         ├── const: 1 [type=int]
       │    │    │    │    │    │         └── const: 2 [type=int]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── const: 10 [type=int]
+      │    │    │    │    │         ├── const: 10 [type=int]
+      │    │    │    │    │         └── cast: INT8 [type=int]
+      │    │    │    │    │              └── null [type=unknown]
       │    │    │    │    └── projections
       │    │    │    │         └── plus [type=int]
       │    │    │    │              ├── variable: column8 [type=int]
       │    │    │    │              └── variable: column2 [type=int]
       │    │    │    ├── scan mutation
-      │    │    │    │    └── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    │    └── columns: m:11(int!null) n:12(int) o:13(int) p:14(int) q:15(int)
       │    │    │    └── filters
       │    │    │         └── eq [type=bool]
       │    │    │              ├── variable: column1 [type=int]
@@ -1133,7 +1152,7 @@ upsert mutation
            │    │    │    ├── variable: m [type=int]
            │    │    │    └── null [type=unknown]
            │    │    └── variable: column1 [type=int]
-           │    └── variable: column15 [type=int]
+           │    └── variable: column16 [type=int]
            ├── case [type=int]
            │    ├── true [type=bool]
            │    ├── when [type=int]
@@ -1150,6 +1169,14 @@ upsert mutation
            │    │    │    └── null [type=unknown]
            │    │    └── variable: column8 [type=int]
            │    └── variable: o [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: m [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column10 [type=int]
+           │    └── variable: column17 [type=int]
            └── case [type=int]
                 ├── true [type=bool]
                 ├── when [type=int]
@@ -1157,7 +1184,7 @@ upsert mutation
                 │    │    ├── variable: m [type=int]
                 │    │    └── null [type=unknown]
                 │    └── variable: column9 [type=int]
-                └── variable: column16 [type=int]
+                └── variable: q [type=int]
 
 # ------------------------------------------------------------------------------
 # Test UPSERT.
@@ -1409,39 +1436,42 @@ UPSERT INTO mutation (m, n) VALUES (1, 2)
 ----
 upsert mutation
  ├── columns: <none>
- ├── canary column: 10
- ├── fetch columns: m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+ ├── canary column: 11
+ ├── fetch columns: m:11(int) n:12(int) o:13(int) p:14(int) q:15(int)
  ├── insert-mapping:
  │    ├──  column1:6 => m:1
  │    ├──  column2:7 => n:2
  │    ├──  column8:8 => o:3
- │    └──  column9:9 => p:4
+ │    ├──  column10:10 => p:4
+ │    └──  column9:9 => q:5
  ├── update-mapping:
  │    ├──  column2:7 => n:2
- │    └──  upsert_p:18 => p:4
+ │    └──  upsert_p:19 => p:4
  └── project
-      ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      ├── columns: upsert_m:17(int) upsert_o:18(int) upsert_p:19(int) upsert_q:20(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) column10:10(int) m:11(int) n:12(int) o:13(int) p:14(int) q:15(int)
       ├── project
-      │    ├── columns: column15:15(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    ├── columns: column16:16(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) column10:10(int) m:11(int) n:12(int) o:13(int) p:14(int) q:15(int)
       │    ├── left-join
-      │    │    ├── columns: column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    ├── columns: column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) column10:10(int) m:11(int) n:12(int) o:13(int) p:14(int) q:15(int)
       │    │    ├── project
-      │    │    │    ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
+      │    │    │    ├── columns: column10:10(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column8:8(int!null) column1:6(int) column2:7(int)
+      │    │    │    │    ├── columns: column8:8(int!null) column9:9(int) column1:6(int) column2:7(int)
       │    │    │    │    ├── values
       │    │    │    │    │    ├── columns: column1:6(int) column2:7(int)
       │    │    │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │    │    │         ├── const: 1 [type=int]
       │    │    │    │    │         └── const: 2 [type=int]
       │    │    │    │    └── projections
-      │    │    │    │         └── const: 10 [type=int]
+      │    │    │    │         ├── const: 10 [type=int]
+      │    │    │    │         └── cast: INT8 [type=int]
+      │    │    │    │              └── null [type=unknown]
       │    │    │    └── projections
       │    │    │         └── plus [type=int]
       │    │    │              ├── variable: column8 [type=int]
       │    │    │              └── variable: column2 [type=int]
       │    │    ├── scan mutation
-      │    │    │    └── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    └── columns: m:11(int!null) n:12(int) o:13(int) p:14(int) q:15(int)
       │    │    └── filters
       │    │         └── eq [type=bool]
       │    │              ├── variable: column1 [type=int]
@@ -1467,6 +1497,14 @@ upsert mutation
            │    │    │    └── null [type=unknown]
            │    │    └── variable: column8 [type=int]
            │    └── variable: o [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: m [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column10 [type=int]
+           │    └── variable: column16 [type=int]
            └── case [type=int]
                 ├── true [type=bool]
                 ├── when [type=int]
@@ -1474,7 +1512,7 @@ upsert mutation
                 │    │    ├── variable: m [type=int]
                 │    │    └── null [type=unknown]
                 │    └── variable: column9 [type=int]
-                └── variable: column15 [type=int]
+                └── variable: q [type=int]
 
 # Don't directly update mutation columns. However, computed columns do need to
 # be updated. Use implicit target columns.
@@ -1483,39 +1521,42 @@ UPSERT INTO mutation VALUES (1, 2)
 ----
 upsert mutation
  ├── columns: <none>
- ├── canary column: 10
- ├── fetch columns: m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+ ├── canary column: 11
+ ├── fetch columns: m:11(int) n:12(int) o:13(int) p:14(int) q:15(int)
  ├── insert-mapping:
  │    ├──  column1:6 => m:1
  │    ├──  column2:7 => n:2
  │    ├──  column8:8 => o:3
- │    └──  column9:9 => p:4
+ │    ├──  column10:10 => p:4
+ │    └──  column9:9 => q:5
  ├── update-mapping:
  │    ├──  column2:7 => n:2
- │    └──  upsert_p:18 => p:4
+ │    └──  upsert_p:19 => p:4
  └── project
-      ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      ├── columns: upsert_m:17(int) upsert_o:18(int) upsert_p:19(int) upsert_q:20(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) column10:10(int) m:11(int) n:12(int) o:13(int) p:14(int) q:15(int)
       ├── project
-      │    ├── columns: column15:15(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    ├── columns: column16:16(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) column10:10(int) m:11(int) n:12(int) o:13(int) p:14(int) q:15(int)
       │    ├── left-join
-      │    │    ├── columns: column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    ├── columns: column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) column10:10(int) m:11(int) n:12(int) o:13(int) p:14(int) q:15(int)
       │    │    ├── project
-      │    │    │    ├── columns: column9:9(int) column1:6(int) column2:7(int) column8:8(int!null)
+      │    │    │    ├── columns: column10:10(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column8:8(int!null) column1:6(int) column2:7(int)
+      │    │    │    │    ├── columns: column8:8(int!null) column9:9(int) column1:6(int) column2:7(int)
       │    │    │    │    ├── values
       │    │    │    │    │    ├── columns: column1:6(int) column2:7(int)
       │    │    │    │    │    └── tuple [type=tuple{int, int}]
       │    │    │    │    │         ├── const: 1 [type=int]
       │    │    │    │    │         └── const: 2 [type=int]
       │    │    │    │    └── projections
-      │    │    │    │         └── const: 10 [type=int]
+      │    │    │    │         ├── const: 10 [type=int]
+      │    │    │    │         └── cast: INT8 [type=int]
+      │    │    │    │              └── null [type=unknown]
       │    │    │    └── projections
       │    │    │         └── plus [type=int]
       │    │    │              ├── variable: column8 [type=int]
       │    │    │              └── variable: column2 [type=int]
       │    │    ├── scan mutation
-      │    │    │    └── columns: m:10(int!null) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    │    │    └── columns: m:11(int!null) n:12(int) o:13(int) p:14(int) q:15(int)
       │    │    └── filters
       │    │         └── eq [type=bool]
       │    │              ├── variable: column1 [type=int]
@@ -1541,6 +1582,14 @@ upsert mutation
            │    │    │    └── null [type=unknown]
            │    │    └── variable: column8 [type=int]
            │    └── variable: o [type=int]
+           ├── case [type=int]
+           │    ├── true [type=bool]
+           │    ├── when [type=int]
+           │    │    ├── is [type=bool]
+           │    │    │    ├── variable: m [type=int]
+           │    │    │    └── null [type=unknown]
+           │    │    └── variable: column10 [type=int]
+           │    └── variable: column16 [type=int]
            └── case [type=int]
                 ├── true [type=bool]
                 ├── when [type=int]
@@ -1548,7 +1597,7 @@ upsert mutation
                 │    │    ├── variable: m [type=int]
                 │    │    └── null [type=unknown]
                 │    └── variable: column9 [type=int]
-                └── variable: column15 [type=int]
+                └── variable: q [type=int]
 
 # Use unknown name in upsert column list.
 build
@@ -1897,3 +1946,73 @@ upsert checks
            └── gt [type=bool]
                 ├── variable: abc.a [type=int]
                 └── const: 0 [type=int]
+
+# Upsert into table where check depends on mutation columns.
+build
+INSERT INTO checkmutations (a) VALUES (1) ON CONFLICT (a) DO UPDATE SET a=2
+----
+upsert checkmutations
+ ├── columns: <none>
+ ├── canary column: 6
+ ├── fetch columns: a:6(int) b:7(int) c:8(int)
+ ├── insert-mapping:
+ │    ├──  column1:4 => a:1
+ │    ├──  column5:5 => b:2
+ │    └──  column5:5 => c:3
+ ├── update-mapping:
+ │    └──  upsert_a:10 => a:1
+ ├── check columns: check1:13(bool)
+ └── project
+      ├── columns: check1:13(bool) column1:4(int) column5:5(int) a:6(int) b:7(int) c:8(int) upsert_a:10(int) upsert_b:11(int) upsert_c:12(int)
+      ├── project
+      │    ├── columns: upsert_a:10(int) upsert_b:11(int) upsert_c:12(int) column1:4(int) column5:5(int) a:6(int) b:7(int) c:8(int)
+      │    ├── project
+      │    │    ├── columns: column9:9(int!null) column1:4(int) column5:5(int) a:6(int) b:7(int) c:8(int)
+      │    │    ├── left-join
+      │    │    │    ├── columns: column1:4(int) column5:5(int) a:6(int) b:7(int) c:8(int)
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: column5:5(int) column1:4(int)
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:4(int)
+      │    │    │    │    │    └── tuple [type=tuple{int}]
+      │    │    │    │    │         └── const: 1 [type=int]
+      │    │    │    │    └── projections
+      │    │    │    │         └── cast: INT8 [type=int]
+      │    │    │    │              └── null [type=unknown]
+      │    │    │    ├── scan checkmutations
+      │    │    │    │    └── columns: a:6(int!null) b:7(int) c:8(int)
+      │    │    │    └── filters
+      │    │    │         └── eq [type=bool]
+      │    │    │              ├── variable: column1 [type=int]
+      │    │    │              └── variable: a [type=int]
+      │    │    └── projections
+      │    │         └── const: 2 [type=int]
+      │    └── projections
+      │         ├── case [type=int]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=int]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: a [type=int]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: column1 [type=int]
+      │         │    └── variable: column9 [type=int]
+      │         ├── case [type=int]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=int]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: a [type=int]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: column5 [type=int]
+      │         │    └── variable: b [type=int]
+      │         └── case [type=int]
+      │              ├── true [type=bool]
+      │              ├── when [type=int]
+      │              │    ├── is [type=bool]
+      │              │    │    ├── variable: a [type=int]
+      │              │    │    └── null [type=unknown]
+      │              │    └── variable: column5 [type=int]
+      │              └── variable: c [type=int]
+      └── projections
+           └── lt [type=bool]
+                ├── variable: upsert_b [type=int]
+                └── variable: upsert_c [type=int]


### PR DESCRIPTION
The optimizer was mistakenly assuming that CHECK expressions were not
allowed to reference columns in the "delete-only" mutation state. The
fix is to make delete-only columns part of the input to the INSERT
operator.

Fixes #35193

Release note: None