### PR TITLE
storage: instrument handleRaftReady

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -448,6 +448,18 @@ var (
 		Measurement: "Latency",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	metaRaftHandleReadyLatency = metric.Metadata{
+		Name:        "raft.process.handleready.latency",
+		Help:        "Latency histogram for handling a Raft ready",
+		Measurement: "Latency",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaRaftApplyCommittedLatency = metric.Metadata{
+		Name:        "raft.process.applycommitted.latency",
+		Help:        "Latency histogram for applying all committed Raft commands in a Raft ready",
+		Measurement: "Latency",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 
 	// Raft message metrics.
 	metaRaftRcvdProp = metric.Metadata{
@@ -1007,12 +1019,14 @@ type StoreMetrics struct {
 	RangeRaftLeaderTransfers        *metric.Counter
 
 	// Raft processing metrics.
-	RaftTicks                *metric.Counter
-	RaftWorkingDurationNanos *metric.Counter
-	RaftTickingDurationNanos *metric.Counter
-	RaftCommandsApplied      *metric.Counter
-	RaftLogCommitLatency     *metric.Histogram
-	RaftCommandCommitLatency *metric.Histogram
+	RaftTicks                 *metric.Counter
+	RaftWorkingDurationNanos  *metric.Counter
+	RaftTickingDurationNanos  *metric.Counter
+	RaftCommandsApplied       *metric.Counter
+	RaftLogCommitLatency      *metric.Histogram
+	RaftCommandCommitLatency  *metric.Histogram
+	RaftHandleReadyLatency    *metric.Histogram
+	RaftApplyCommittedLatency *metric.Histogram
 
 	// Raft message metrics.
 	RaftRcvdMsgProp           *metric.Counter
@@ -1202,12 +1216,14 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RangeRaftLeaderTransfers:        metric.NewCounter(metaRangeRaftLeaderTransfers),
 
 		// Raft processing metrics.
-		RaftTicks:                metric.NewCounter(metaRaftTicks),
-		RaftWorkingDurationNanos: metric.NewCounter(metaRaftWorkingDurationNanos),
-		RaftTickingDurationNanos: metric.NewCounter(metaRaftTickingDurationNanos),
-		RaftCommandsApplied:      metric.NewCounter(metaRaftCommandsApplied),
-		RaftLogCommitLatency:     metric.NewLatency(metaRaftLogCommitLatency, histogramWindow),
-		RaftCommandCommitLatency: metric.NewLatency(metaRaftCommandCommitLatency, histogramWindow),
+		RaftTicks:                 metric.NewCounter(metaRaftTicks),
+		RaftWorkingDurationNanos:  metric.NewCounter(metaRaftWorkingDurationNanos),
+		RaftTickingDurationNanos:  metric.NewCounter(metaRaftTickingDurationNanos),
+		RaftCommandsApplied:       metric.NewCounter(metaRaftCommandsApplied),
+		RaftLogCommitLatency:      metric.NewLatency(metaRaftLogCommitLatency, histogramWindow),
+		RaftCommandCommitLatency:  metric.NewLatency(metaRaftCommandCommitLatency, histogramWindow),
+		RaftHandleReadyLatency:    metric.NewLatency(metaRaftHandleReadyLatency, histogramWindow),
+		RaftApplyCommittedLatency: metric.NewLatency(metaRaftApplyCommittedLatency, histogramWindow),
 
 		// Raft message metrics.
 		RaftRcvdMsgProp:           metric.NewCounter(metaRaftRcvdProp),

--- a/pkg/storage/raft.go
+++ b/pkg/storage/raft.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
@@ -184,4 +185,55 @@ func (h *SnapshotRequest_Header) IsPreemptive() bool {
 	// Preemptive snapshots are addressed to replica ID 0. No other requests to
 	// replica ID 0 are allowed.
 	return h.RaftMessageRequest.ToReplica.ReplicaID == 0
+}
+
+// traceEntries records the provided event for all proposals corresponding
+// to the entries contained in ents. The vmodule level for raft must be at
+// least 1.
+func (r *Replica) traceEntries(ents []raftpb.Entry, event string) {
+	if log.V(1) {
+		ids := extractIDs(nil, ents)
+		traceProposals(r, ids, event)
+	}
+}
+
+// traceMessageSends records the provided event for all proposals contained in
+// in entries contained in msgs. The vmodule level for raft must be at
+// least 1.
+func (r *Replica) traceMessageSends(msgs []raftpb.Message, event string) {
+	if log.V(1) {
+		var ids []storagebase.CmdIDKey
+		for _, m := range msgs {
+			ids = extractIDs(ids, m.Entries)
+		}
+		traceProposals(r, ids, event)
+	}
+}
+
+// extractIDs decodes and appends each of the ids corresponding to the entries
+// in ents to ids and returns the result.
+func extractIDs(ids []storagebase.CmdIDKey, ents []raftpb.Entry) []storagebase.CmdIDKey {
+	for _, e := range ents {
+		if e.Type == raftpb.EntryNormal && len(e.Data) > 0 {
+			id, _ := DecodeRaftCommand(e.Data)
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// traceLocalProposals logs a trace event with the provided string for each
+// locally proposed command which corresponds to an id in ids.
+func traceProposals(r *Replica, ids []storagebase.CmdIDKey, event string) {
+	ctxs := make([]context.Context, 0, len(ids))
+	r.mu.RLock()
+	for _, id := range ids {
+		if prop, ok := r.mu.proposals[id]; ok {
+			ctxs = append(ctxs, prop.ctx)
+		}
+	}
+	r.mu.RUnlock()
+	for _, ctx := range ctxs {
+		log.Event(ctx, event)
+	}
 }


### PR DESCRIPTION
This PR comes in two commits. The first adds vmodule-gated tracing of raft message sends as well as an event when the command is committed before any committed commands from this step have been applied. The second adds two histograms to track time spent in handleRaftReady.