### PR TITLE
exec: bugfix to wrapped index/lookup joins

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -346,15 +346,20 @@ func newColOperator(
 				jr  RowSource
 				err error
 			)
+			// The lookup and index joiners need to be passed the post-process specs,
+			// since they inspect them to figure out information about needed columns.
+			// This means that we'll let those processors do any renders or filters,
+			// which isn't ideal. We could improve this.
 			if len(core.JoinReader.LookupColumns) == 0 {
 				jr, err = newIndexJoiner(
-					flowCtx, spec.ProcessorID, core.JoinReader, input, &distsqlpb.PostProcessSpec{}, nil, /* output */
+					flowCtx, spec.ProcessorID, core.JoinReader, input, post, nil, /* output */
 				)
 			} else {
 				jr, err = newJoinReader(
-					flowCtx, spec.ProcessorID, core.JoinReader, input, &distsqlpb.PostProcessSpec{}, nil, /* output */
+					flowCtx, spec.ProcessorID, core.JoinReader, input, post, nil, /* output */
 				)
 			}
+			post = &distsqlpb.PostProcessSpec{}
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -194,5 +194,17 @@ SELECT c.d FROM c@sec JOIN d ON d.b = c.b
 0
 0
 
+# Ensure that lookup joins properly get their postprocessing to select needed
+# columns.
+
+query I
+SELECT c.a FROM c INNER LOOKUP JOIN c@sec AS s ON c.b=s.b
+----
+1
+1
+2
+2
+
+
 statement ok
 RESET optimizer; RESET experimental_vectorize


### PR DESCRIPTION
Wrapped index and lookup joins need to be directly passed their
postprocess specs since they inspect them to figure out information like
needed columns.

Release note: None