### PR TITLE
sql: SET TRANSACTION improvements

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1751,7 +1751,6 @@ func (ex *connExecutor) setTransactionModes(modes tree.TransactionModes) error {
 
 		ts, err := ex.planner.EvalAsOfTimestamp(modes.AsOf)
 		if err != nil {
-			ex.state.mu.Unlock()
 			return err
 		}
 		if rwMode == tree.UnspecifiedReadWriteMode {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -623,7 +623,7 @@ func (s *Server) newConnExecutorWithTxn(
 		ctx,
 		explicitTxn,
 		txn.OrigTimestamp().GoTime(),
-		/* historicalTimestamp */ nil,
+		nil, /* historicalTimestamp */
 		txn.UserPriority(),
 		tree.ReadWrite,
 		txn,

--- a/pkg/sql/logictest/testdata/logic_test/txn_as_of
+++ b/pkg/sql/logictest/testdata/logic_test/txn_as_of
@@ -258,3 +258,18 @@ RELEASE SAVEPOINT cockroach_restart
 
 statement ok
 COMMIT
+
+# Ensure that errors evaluating AOST clauses in BEGIN and SET TRANSACTION do not
+# cause problems.
+
+statement error pq: AS OF SYSTEM TIME: zero timestamp is invalid
+BEGIN AS OF SYSTEM TIME '0'
+
+statement ok
+BEGIN
+
+statement error pq: AS OF SYSTEM TIME: zero timestamp is invalid
+SET TRANSACTION AS OF SYSTEM TIME '0'
+
+statement ok
+ROLLBACK

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -592,7 +592,10 @@ func (p *planner) runWithDistSQL(
 // txnModesSetter is an interface used by SQL execution to influence the current
 // transaction.
 type txnModesSetter interface {
-	setTransactionModes(modes tree.TransactionModes) error
+	// setTransactionModes updates some characteristics of the current
+	// transaction.
+	// asOfTs, if not empty, is the evaluation of modes.AsOf.
+	setTransactionModes(modes tree.TransactionModes, asOfTs hlc.Timestamp) error
 }
 
 // sqlStatsCollector is the interface used by SQL execution, through the


### PR DESCRIPTION
sql: fix wild unlocking

Release note (bug fix): Fix a crash on SET TRANSACTION AS OF SYSTEM TIME
with invalid expressions.


sql: move the evaluation of SET TRANSACTION ... AS OF <expr>  

Before this patch, the way this evaluation worked was that the planner
in charge of running the whole statement was calling back into the
connExecutor, which was evaluating <expr> using connEx.planner. The two
planners were likely the same, but this was ugly. I'm trying to reduce
reliance on ex.planner; instead each statement should know what its
planner is.
This patch moves the evaluation of <expr> before the callback into the
connEx.

Release note: None