### PR TITLE
sqlbase: avoid allocations due to ErrNameString, speed up IMPORT by 10%

### DIFF
--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -75,7 +75,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 		case tree.DropRestrict:
 			return nil, pgerror.NewErrorf(pgerror.CodeDependentObjectsStillExistError,
 				"database %q is not empty and RESTRICT was specified",
-				tree.ErrNameString(&dbDesc.Name))
+				tree.ErrNameStringP(&dbDesc.Name))
 		case tree.DropDefault:
 			// The default is CASCADE, however be cautious if CASCADE was
 			// not specified explicitly.

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -640,5 +640,5 @@ func checkDatumTypeFitsColumnType(col cat.Column, typ types.T) {
 	colName := string(col.ColName())
 	panic(builderError{pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError,
 		"value type %s doesn't match type %s of column %q",
-		typ, col.ColTypeStr(), tree.ErrNameString(&colName))})
+		typ, col.ColTypeStr(), tree.ErrNameString(colName))})
 }

--- a/pkg/sql/sem/tree/name_part.go
+++ b/pkg/sql/sem/tree/name_part.go
@@ -50,11 +50,17 @@ func NameString(s string) string {
 	return ((*Name)(&s)).String()
 }
 
-// ErrNameString escapes an identifier stored a string to a SQL
+// ErrNameStringP escapes an identifier stored a string to a SQL
 // identifier suitable for printing in error messages, avoiding a heap
 // allocation.
-func ErrNameString(s *string) string {
+func ErrNameStringP(s *string) string {
 	return ErrString(((*Name)(s)))
+}
+
+// ErrNameString escapes an identifier stored a string to a SQL
+// identifier suitable for printing in error messages.
+func ErrNameString(s string) string {
+	return ErrString(((*Name)(&s)))
 }
 
 // Normalize normalizes to lowercase and Unicode Normalization Form C

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -585,7 +585,7 @@ func (expr *ColumnAccessExpr) TypeCheck(ctx *SemaContext, desired types.T) (Type
 	if expr.ColIndex < 0 {
 		return nil, pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError,
 			"could not identify column %q in %s",
-			ErrNameString(&expr.ColName), resolvedType,
+			ErrNameStringP(&expr.ColName), resolvedType,
 		)
 	}
 
@@ -1216,7 +1216,7 @@ func (expr *Tuple) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, erro
 			for j := 0; j < i; j++ {
 				if expr.Labels[i] == expr.Labels[j] {
 					return nil, pgerror.NewErrorf(pgerror.CodeSyntaxError,
-						"found duplicate tuple label: %q", ErrNameString(&expr.Labels[i]),
+						"found duplicate tuple label: %q", ErrNameStringP(&expr.Labels[i]),
 					)
 				}
 			}

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -691,7 +691,7 @@ func MarshalColumnValue(col ColumnDescriptor, val tree.Datum) (roachpb.Value, er
 			// the mutation planning code.
 			return r, pgerror.NewAssertionErrorf(
 				"locale mismatch %q vs %q for column %q",
-				v.Locale, *col.Type.Locale, tree.ErrNameString(&col.Name))
+				v.Locale, *col.Type.Locale, tree.ErrNameString(col.Name))
 		}
 	case ColumnType_OID:
 		if v, ok := val.(*tree.DOid); ok {
@@ -702,7 +702,7 @@ func MarshalColumnValue(col ColumnDescriptor, val tree.Datum) (roachpb.Value, er
 		return r, pgerror.NewAssertionErrorf("unsupported column type: %s", col.Type.SemanticType)
 	}
 	return r, pgerror.NewAssertionErrorf("mismatched type %q vs %q for column %q",
-		val.ResolvedType(), col.Type.SemanticType, tree.ErrNameString(&col.Name))
+		val.ResolvedType(), col.Type.SemanticType, tree.ErrNameString(col.Name))
 }
 
 // UnmarshalColumnValue is the counterpart to MarshalColumnValues.

--- a/pkg/sql/sqlbase/column_type_properties.go
+++ b/pkg/sql/sqlbase/column_type_properties.go
@@ -673,7 +673,7 @@ func LimitValueWidth(
 		if typ.Width > 0 && utf8.RuneCountInString(sv) > int(typ.Width) {
 			return nil, pgerror.NewErrorf(pgerror.CodeStringDataRightTruncationError,
 				"value too long for type %s (column %q)",
-				typ.SQLString(), tree.ErrNameString(name))
+				typ.SQLString(), tree.ErrNameStringP(name))
 		}
 	case ColumnType_INT:
 		if v, ok := tree.AsDInt(inVal); ok {
@@ -686,7 +686,7 @@ func LimitValueWidth(
 				if (v >= 0 && shifted > 0) || (v < 0 && shifted < -1) {
 					return nil, pgerror.NewErrorf(pgerror.CodeNumericValueOutOfRangeError,
 						"integer out of range for type %s (column %q)",
-						typ.VisibleType, tree.ErrNameString(name))
+						typ.VisibleType, tree.ErrNameStringP(name))
 				}
 			}
 		}
@@ -724,7 +724,7 @@ func LimitValueWidth(
 			err := tree.LimitDecimalWidth(&outDec.Decimal, int(typ.Precision), int(typ.Width))
 			if err != nil {
 				return nil, errors.Wrapf(err, "type %s (column %q)",
-					typ.SQLString(), tree.ErrNameString(name))
+					typ.SQLString(), tree.ErrNameStringP(name))
 			}
 			return &outDec, nil
 		}
@@ -798,13 +798,13 @@ func CheckDatumTypeFitsColumnType(
 		if err := pmap.SetType(p.Idx, colTyp); err != nil {
 			return pgerror.NewErrorf(pgerror.CodeIndeterminateDatatypeError,
 				"cannot infer type for placeholder %s from column %q: %s",
-				p.Idx, tree.ErrNameString(&col.Name), err)
+				p.Idx, tree.ErrNameString(col.Name), err)
 		}
 	} else if !typ.Equivalent(colTyp) {
 		// Not a placeholder; check that the value cast has succeeded.
 		return pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError,
 			"value type %s doesn't match type %s of column %q",
-			typ, col.Type.SQLString(), tree.ErrNameString(&col.Name))
+			typ, col.Type.SQLString(), tree.ErrNameString(col.Name))
 	}
 	return nil
 }

--- a/pkg/sql/sqlbase/computed_exprs.go
+++ b/pkg/sql/sqlbase/computed_exprs.go
@@ -79,7 +79,7 @@ func (*descContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 // CannotWriteToComputedColError constructs a write error for a computed column.
 func CannotWriteToComputedColError(colName string) error {
 	return pgerror.NewErrorf(pgerror.CodeObjectNotInPrerequisiteStateError,
-		"cannot write directly to computed column %q", tree.ErrNameString(&colName))
+		"cannot write directly to computed column %q", tree.ErrNameString(colName))
 }
 
 // ProcessComputedColumns adds columns which are computed to the set of columns

--- a/pkg/sql/views.go
+++ b/pkg/sql/views.go
@@ -51,7 +51,7 @@ type planDependencies map[sqlbase.ID]planDependencyInfo
 func (d planDependencies) String() string {
 	var buf bytes.Buffer
 	for id, deps := range d {
-		fmt.Fprintf(&buf, "%d (%q):", id, tree.ErrNameString(&deps.desc.Name))
+		fmt.Fprintf(&buf, "%d (%q):", id, tree.ErrNameStringP(&deps.desc.Name))
 		for _, dep := range deps.deps {
 			buf.WriteString(" [")
 			if dep.IndexID != 0 {


### PR DESCRIPTION
Informs #34809.

Before this change, `ErrNameString` only accepted a pointer to a string.
This forced the owner of the string to escape. In the following two
cases, this resulted in an entire `ColumnDescriptor` proto to be
allocated on each call:
- `sqlbase.MarshalColumnValue`
- `sqlbase.CheckDatumTypeFitsColumnType`

This showed up on IMPORT benchmarks, where the allocation in `MarshalColumnValue`
was responsible for about a third of heap allocations.

```
name                 old time/op    new time/op    delta
ImportFixtureTPCC-4     6.24s ± 2%     5.68s ±11%   -9.02%  (p=0.000 n=10+10)

name                 old speed      new speed      delta
ImportFixtureTPCC-4  14.2MB/s ± 2%  15.6MB/s ±10%  +10.08%  (p=0.000 n=10+10)

name                 old alloc/op   new alloc/op   delta
ImportFixtureTPCC-4    4.10GB ± 0%    2.77GB ± 0%  -32.34%  (p=0.000 n=10+10)

name                 old allocs/op  new allocs/op  delta
ImportFixtureTPCC-4     39.5M ± 0%     33.2M ± 0%  -16.11%  (p=0.000 n=10+9)
```

It appears that this will also have an effect on `row.Inserter` and
`row.Updater`.

Release note: None