### PR TITLE
sql: cache planners differently

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -157,8 +157,8 @@ func (ex *connExecutor) prepare(
 	// anything other than getting a timestamp.
 	txn := client.NewTxn(ctx, ex.server.cfg.DB, ex.server.cfg.NodeID.Get(), client.RootTxn)
 
-	p := &ex.planner
-	ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */)
+	p := ex.plannerPool.Checkout(ctx, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */)
+	defer ex.plannerPool.Release(p)
 	p.stmt = &stmt
 	flags, err := ex.populatePrepared(ctx, txn, placeholderHints, p)
 	if err != nil {


### PR DESCRIPTION
Before this patch, a connEx would have one planner used sequentially by
all the statements. Parallel statements would create their own planner.
This patch replaces that statically allocated planner with a pool (of
size 1) that statements checkout and release planners from/to. This is
in anticipation of introducing more parallelism (or rather, pipelining)
with one SQL session through the introduction of portals, which will
mean that multiple statements (and thus, multiple planners) might be
alive at a time.
It also improves the current parallel-queue code, and technically makes
it more efficient since it can now avoid allocating new planners if it
doesn't actually need them. However, the patch introduces the allocation
of one new plan per session (the one that used to be alocated
statically). I have not tried to avoid this.

Release note: None