### PR TITLE
sql: fix missing cleanup 

### DIFF
--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -76,7 +76,7 @@ func (pq *ParallelizeQueue) MustAdd(t *testing.T, plan planNode, exec func() err
 		extendedEvalCtx: &p.extendedEvalCtx,
 	}
 	params.p.curPlan.plan = plan
-	if err := pq.Add(params, exec); err != nil {
+	if err := pq.Add(params, exec, p.curPlan.close /* cleanup */); err != nil {
 		t.Fatalf("ParallelizeQueue.Add failed: %v", err)
 	}
 }

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -314,8 +314,8 @@ type planTop struct {
 // The caller is responsible for populating the placeholders
 // beforehand (currently in semaCtx.Placeholders).
 //
-// After makePlan(), the caller should be careful to also call
-// p.curPlan.Close().
+// If no error is returned, the caller must call p.curPlan.Close() once the plan
+// is no longer needed.
 func (p *planner) makePlan(ctx context.Context) error {
 	// Reinitialize.
 	stmt := p.stmt


### PR DESCRIPTION
execStmtInParallel was not calling the cleanup function on early
returns. This was causing a RETURNING NOTHING to potentially stay in
SHOW QUERIES forever if it encountered a planning error.

The planning errors were also not handled correctly wrt communicating to
the client. The caller of execStmtInParallel was not respecting the
contract by not setting the error on the CommandResult. This one did not
actually translate into a user-visible problem, since we had a
higher-level catch-all in the connEx that made sure that if we got an
error event, we also set an error on the CommandResult.

Release note: None