### PR TITLE
workload: allow columnar data generation (alloc -73%, MB/s +60%)

### DIFF
--- a/pkg/ccl/backupccl/bench_test.go
+++ b/pkg/ccl/backupccl/bench_test.go
@@ -29,7 +29,7 @@ func bankBuf(numAccounts int) *bytes.Buffer {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "CREATE TABLE %s %s;\n", bankData.Name, bankData.Schema)
 	for rowIdx := 0; rowIdx < bankData.InitialRows.NumBatches; rowIdx++ {
-		for _, row := range bankData.InitialRows.Batch(rowIdx) {
+		for _, row := range bankData.InitialRows.BatchRows(rowIdx) {
 			rowBatch := strings.Join(workload.StringTuple(row), `,`)
 			fmt.Fprintf(&buf, "INSERT INTO %s VALUES (%s);\n", bankData.Name, rowBatch)
 		}

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -278,7 +278,7 @@ func loadWorkloadBatches(sqlDB *gosql.DB, table workload.Table) ([]time.Time, in
 		params = params[:0]
 		insertStmtBuf.Reset()
 		insertStmtBuf.WriteString(`INSERT INTO "` + table.Name + `" VALUES `)
-		for _, row := range table.InitialRows.Batch(batchIdx) {
+		for _, row := range table.InitialRows.BatchRows(batchIdx) {
 			if len(params) != 0 {
 				insertStmtBuf.WriteString(`,`)
 			}

--- a/pkg/ccl/importccl/load_test.go
+++ b/pkg/ccl/importccl/load_test.go
@@ -30,7 +30,7 @@ func bankBuf(numAccounts int) *bytes.Buffer {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "CREATE TABLE %s %s;\n", bankData.Name, bankData.Schema)
 	for rowIdx := 0; rowIdx < bankData.InitialRows.NumBatches; rowIdx++ {
-		for _, row := range bankData.InitialRows.Batch(rowIdx) {
+		for _, row := range bankData.InitialRows.BatchRows(rowIdx) {
 			rowTuple := strings.Join(workload.StringTuple(row), `,`)
 			fmt.Fprintf(&buf, "INSERT INTO %s VALUES (%s);\n", bankData.Name, rowTuple)
 		}
@@ -79,8 +79,8 @@ func TestImportOutOfOrder(t *testing.T) {
 		t.Fatal(err)
 	}
 	bankData := bank.FromRows(2).Tables()[0]
-	row1 := workload.StringTuple(bankData.InitialRows.Batch(0)[0])
-	row2 := workload.StringTuple(bankData.InitialRows.Batch(1)[0])
+	row1 := workload.StringTuple(bankData.InitialRows.BatchRows(0)[0])
+	row2 := workload.StringTuple(bankData.InitialRows.BatchRows(1)[0])
 
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "CREATE TABLE %s %s;\n", bankData.Name, bankData.Schema)

--- a/pkg/ccl/utilccl/sampledataccl/bankdata.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata.go
@@ -53,7 +53,7 @@ func toBackup(t testing.TB, data workload.Table, dir string, chunkBytes int64) (
 	var stmts bytes.Buffer
 	fmt.Fprintf(&stmts, "CREATE TABLE %s %s;\n", data.Name, data.Schema)
 	for rowIdx := 0; rowIdx < data.InitialRows.NumBatches; rowIdx++ {
-		for _, row := range data.InitialRows.Batch(rowIdx) {
+		for _, row := range data.InitialRows.BatchRows(rowIdx) {
 			rowBatch := strings.Join(workload.StringTuple(row), `,`)
 			fmt.Fprintf(&stmts, "INSERT INTO %s VALUES (%s);\n", data.Name, rowBatch)
 		}

--- a/pkg/ccl/workloadccl/bench_test.go
+++ b/pkg/ccl/workloadccl/bench_test.go
@@ -27,7 +27,7 @@ func benchmarkImportFixture(b *testing.B, gen workload.Generator) {
 	var bytes int64
 	b.StopTimer()
 	for i := 0; i < b.N; i++ {
-		s, db, _ := serverutils.StartServer(b, base.TestServerArgs{})
+		s, db, _ := serverutils.StartServer(b, base.TestServerArgs{UseDatabase: `d`})
 		sqlDB := sqlutils.MakeSQLRunner(db)
 		sqlDB.Exec(b, `CREATE DATABASE d`)
 

--- a/pkg/ccl/workloadccl/cliccl/fixtures.go
+++ b/pkg/ccl/workloadccl/cliccl/fixtures.go
@@ -296,12 +296,15 @@ func fixturesLoad(gen workload.Generator, urls []string, dbName string) error {
 		return errors.Wrap(err, `finding fixture`)
 	}
 
+	start := timeutil.Now()
 	log.Infof(ctx, "starting load of %d tables", len(gen.Tables()))
 	bytes, err := workloadccl.RestoreFixture(ctx, sqlDB, fixture, dbName)
 	if err != nil {
 		return errors.Wrap(err, `restoring fixture`)
 	}
-	log.Infof(ctx, "loaded %s bytes in %d tables", humanizeutil.IBytes(bytes), len(gen.Tables()))
+	elapsed := timeutil.Since(start)
+	log.Infof(ctx, "loaded %s in %d tables (took %s, %s)",
+		humanizeutil.IBytes(bytes), len(gen.Tables()), elapsed, humanizeutil.DataRate(bytes, elapsed))
 
 	if hooks, ok := gen.(workload.Hookser); *fixturesRunChecks && ok {
 		if consistencyCheckFn := hooks.Hooks().CheckConsistency; consistencyCheckFn != nil {
@@ -338,7 +341,7 @@ func fixturesImport(gen workload.Generator, urls []string, dbName string) error 
 		return errors.Wrap(err, `importing fixture`)
 	}
 	elapsed := timeutil.Since(start)
-	log.Infof(ctx, "imported %s bytes in %d tables (took %s, %s)",
+	log.Infof(ctx, "imported %s in %d tables (took %s, %s)",
 		humanizeutil.IBytes(bytes), len(gen.Tables()), elapsed, humanizeutil.DataRate(bytes, elapsed))
 
 	if hooks, ok := gen.(workload.Hookser); *fixturesRunChecks && ok {

--- a/pkg/ccl/workloadccl/format/sstable.go
+++ b/pkg/ccl/workloadccl/format/sstable.go
@@ -72,9 +72,8 @@ func ToSSTable(t workload.Table, tableID sqlbase.ID, ts time.Time) ([]byte, erro
 	g.GoCtx(func(ctx context.Context) error {
 		defer close(kvCh)
 		evalCtx := &tree.EvalContext{SessionData: &sessiondata.SessionData{}}
-		var alloc sqlbase.DatumAlloc
 		finishedBatchFn := func() {}
-		return wc.Worker(ctx, evalCtx, &alloc, finishedBatchFn)
+		return wc.Worker(ctx, evalCtx, finishedBatchFn)
 	})
 	g.GoCtx(func(ctx context.Context) error {
 		for kvBatch := range kvCh {

--- a/pkg/ccl/workloadccl/roachmartccl/roachmart.go
+++ b/pkg/ccl/workloadccl/roachmartccl/roachmart.go
@@ -185,7 +185,7 @@ func (m *roachmart) Tables() []workload.Table {
 		InitialRows: workload.Tuples(
 			m.orders,
 			func(rowIdx int) []interface{} {
-				user := users.InitialRows.Batch(rowIdx % m.users)[0]
+				user := users.InitialRows.BatchRows(rowIdx % m.users)[0]
 				zone, email := user[0], user[1]
 				return []interface{}{
 					zone,                         // user_zone
@@ -227,7 +227,7 @@ func (m *roachmart) Ops(urls []string, reg *histogram.Registry) (workload.QueryL
 			// our locality requirements.
 			var zone, email interface{}
 			for i := rng.Int(); ; i++ {
-				user := usersTable.InitialRows.Batch(i % m.users)[0]
+				user := usersTable.InitialRows.BatchRows(i % m.users)[0]
 				zone, email = user[0], user[1]
 				userLocal := zone == m.localZone
 				if userLocal == wantLocal {

--- a/pkg/cli/examples.go
+++ b/pkg/cli/examples.go
@@ -62,7 +62,7 @@ func runGenExamplesCmd(gen workload.Generator) {
 		fmt.Fprintf(w, "DROP TABLE IF EXISTS \"%s\";\n", table.Name)
 		fmt.Fprintf(w, "CREATE TABLE \"%s\" %s;\n", table.Name, table.Schema)
 		for rowIdx := 0; rowIdx < table.InitialRows.NumBatches; rowIdx++ {
-			for _, row := range table.InitialRows.Batch(rowIdx) {
+			for _, row := range table.InitialRows.BatchRows(rowIdx) {
 				rowTuple := strings.Join(workload.StringTuple(row), `,`)
 				fmt.Fprintf(w, "INSERT INTO \"%s\" VALUES (%s);\n", table.Name, rowTuple)
 			}

--- a/pkg/sql/exec/coldata/vec.go
+++ b/pkg/sql/exec/coldata/vec.go
@@ -27,6 +27,9 @@ type column interface{}
 // Vec is an interface that represents a column vector that's accessible by
 // Go native types.
 type Vec interface {
+	// Type returns the type of data stored in this Vec.
+	Type() types.T
+
 	// TODO(jordan): is a bitmap or slice of bools better?
 	// Bool returns a bool list.
 	Bool() []bool
@@ -110,6 +113,7 @@ var _ Vec = &memColumn{}
 // memColumn is a simple pass-through implementation of Vec that just casts
 // a generic interface{} to the proper type when requested.
 type memColumn struct {
+	t     types.T
 	col   column
 	nulls Nulls
 }
@@ -120,26 +124,30 @@ func NewMemColumn(t types.T, n int) Vec {
 
 	switch t {
 	case types.Bool:
-		return &memColumn{col: make([]bool, n), nulls: nulls}
+		return &memColumn{t: t, col: make([]bool, n), nulls: nulls}
 	case types.Bytes:
-		return &memColumn{col: make([][]byte, n), nulls: nulls}
+		return &memColumn{t: t, col: make([][]byte, n), nulls: nulls}
 	case types.Int8:
-		return &memColumn{col: make([]int8, n), nulls: nulls}
+		return &memColumn{t: t, col: make([]int8, n), nulls: nulls}
 	case types.Int16:
-		return &memColumn{col: make([]int16, n), nulls: nulls}
+		return &memColumn{t: t, col: make([]int16, n), nulls: nulls}
 	case types.Int32:
-		return &memColumn{col: make([]int32, n), nulls: nulls}
+		return &memColumn{t: t, col: make([]int32, n), nulls: nulls}
 	case types.Int64:
-		return &memColumn{col: make([]int64, n), nulls: nulls}
+		return &memColumn{t: t, col: make([]int64, n), nulls: nulls}
 	case types.Float32:
-		return &memColumn{col: make([]float32, n), nulls: nulls}
+		return &memColumn{t: t, col: make([]float32, n), nulls: nulls}
 	case types.Float64:
-		return &memColumn{col: make([]float64, n), nulls: nulls}
+		return &memColumn{t: t, col: make([]float64, n), nulls: nulls}
 	case types.Decimal:
-		return &memColumn{col: make([]apd.Decimal, n), nulls: nulls}
+		return &memColumn{t: t, col: make([]apd.Decimal, n), nulls: nulls}
 	default:
 		panic(fmt.Sprintf("unhandled type %s", t))
 	}
+}
+
+func (m *memColumn) Type() types.T {
+	return m.t
 }
 
 func (m *memColumn) SetCol(col interface{}) {

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -549,7 +549,7 @@ type finiteBatchSource struct {
 
 var _ Operator = &finiteBatchSource{}
 
-var emptyBatch = coldata.NewMemBatch([]types.T{})
+var emptyBatch = coldata.NewMemBatchWithSize([]types.T{}, 0)
 
 // newFiniteBatchSource returns a new Operator initialized to return its input
 // batch a specified number of times.

--- a/pkg/workload/bank/bank_test.go
+++ b/pkg/workload/bank/bank_test.go
@@ -69,22 +69,3 @@ func TestBank(t *testing.T) {
 		})
 	}
 }
-
-func BenchmarkInitBank(b *testing.B) {
-	gen := FromRows(1000)
-	var bytes int64
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		for _, table := range gen.Tables() {
-			for rowIdx := 0; rowIdx < table.InitialRows.NumBatches; rowIdx++ {
-				for _, row := range table.InitialRows.Batch(rowIdx) {
-					for _, datum := range row {
-						bytes += workload.ApproxDatumSize(datum)
-					}
-				}
-			}
-		}
-	}
-	b.StopTimer()
-	b.SetBytes(bytes / int64(b.N))
-}

--- a/pkg/workload/bench_test.go
+++ b/pkg/workload/bench_test.go
@@ -15,12 +15,33 @@
 package workload_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpcc"
 )
+
+func columnByteSize(col coldata.Vec) int64 {
+	switch col.Type() {
+	case types.Int64:
+		return int64(len(col.Int64()) * 8)
+	case types.Float64:
+		return int64(len(col.Float64()) * 8)
+	case types.Bytes:
+		var bytes int64
+		for _, b := range col.Bytes() {
+			bytes += int64(len(b))
+		}
+		return bytes
+	default:
+		panic(fmt.Sprintf(`unhandled type %s`, col.Type().GoTypeName()))
+	}
+}
 
 func benchmarkInitialData(b *testing.B, gen workload.Generator) {
 	tables := gen.Tables()
@@ -28,12 +49,16 @@ func benchmarkInitialData(b *testing.B, gen workload.Generator) {
 	var bytes int64
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		// Share the Batch and ByteAllocator across tables but not across benchmark
+		// iterations.
+		cb := coldata.NewMemBatch(nil)
+		var a bufalloc.ByteAllocator
 		for _, table := range tables {
 			for rowIdx := 0; rowIdx < table.InitialRows.NumBatches; rowIdx++ {
-				for _, row := range table.InitialRows.Batch(rowIdx) {
-					for _, datum := range row {
-						bytes += workload.ApproxDatumSize(datum)
-					}
+				a = a[:0]
+				table.InitialRows.FillBatch(rowIdx, cb, &a)
+				for _, col := range cb.ColVecs() {
+					bytes += columnByteSize(col)
 				}
 			}
 		}

--- a/pkg/workload/csv.go
+++ b/pkg/workload/csv.go
@@ -22,7 +22,11 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding/csv"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -39,6 +43,9 @@ const (
 func WriteCSVRows(
 	ctx context.Context, w io.Writer, table Table, rowStart, rowEnd int, sizeBytesLimit int64,
 ) (rowBatchIdx int, err error) {
+	cb := coldata.NewMemBatchWithSize(nil, 0)
+	var a bufalloc.ByteAllocator
+
 	bytesWrittenW := &bytesWrittenWriter{w: w}
 	csvW := csv.NewWriter(bytesWrittenW)
 	var rowStrings []string
@@ -52,14 +59,16 @@ func WriteCSVRows(
 			return 0, ctx.Err()
 		default:
 		}
-		for _, row := range table.InitialRows.Batch(rowBatchIdx) {
-			if cap(rowStrings) < len(row) {
-				rowStrings = make([]string, len(row))
-			} else {
-				rowStrings = rowStrings[:len(row)]
-			}
-			for i, datum := range row {
-				rowStrings[i] = datumToCSVString(datum)
+		a = a[:0]
+		table.InitialRows.FillBatch(rowBatchIdx, cb, &a)
+		if numCols := cb.Width(); cap(rowStrings) < numCols {
+			rowStrings = make([]string, numCols)
+		} else {
+			rowStrings = rowStrings[:numCols]
+		}
+		for rowIdx, numRows := 0, int(cb.Length()); rowIdx < numRows; rowIdx++ {
+			for colIdx, col := range cb.ColVecs() {
+				rowStrings[colIdx] = colDatumToCSVString(col, rowIdx)
 			}
 			if err := csvW.Write(rowStrings); err != nil {
 				return 0, err
@@ -74,13 +83,21 @@ type csvRowsReader struct {
 	t                    Table
 	batchStart, batchEnd int
 
-	buf        bytes.Buffer
-	csvW       *csv.Writer
-	batchIdx   int
+	buf  bytes.Buffer
+	csvW *csv.Writer
+
+	batchIdx int
+	cb       coldata.Batch
+	a        bufalloc.ByteAllocator
+
 	stringsBuf []string
 }
 
 func (r *csvRowsReader) Read(p []byte) (n int, err error) {
+	if r.cb == nil {
+		r.cb = coldata.NewMemBatchWithSize(nil, 0)
+	}
+
 	for {
 		if r.buf.Len() > 0 {
 			return r.buf.Read(p)
@@ -89,16 +106,17 @@ func (r *csvRowsReader) Read(p []byte) (n int, err error) {
 		if r.batchIdx == r.batchEnd {
 			return 0, io.EOF
 		}
-		batch := r.t.InitialRows.Batch(r.batchIdx)
+		r.a = r.a[:0]
+		r.t.InitialRows.FillBatch(r.batchIdx, r.cb, &r.a)
 		r.batchIdx++
-		for _, row := range batch {
-			if cap(r.stringsBuf) < len(row) {
-				r.stringsBuf = make([]string, len(row))
-			} else {
-				r.stringsBuf = r.stringsBuf[:len(row)]
-			}
-			for i, datum := range row {
-				r.stringsBuf[i] = datumToCSVString(datum)
+		if numCols := r.cb.Width(); cap(r.stringsBuf) < numCols {
+			r.stringsBuf = make([]string, numCols)
+		} else {
+			r.stringsBuf = r.stringsBuf[:numCols]
+		}
+		for rowIdx, numRows := 0, int(r.cb.Length()); rowIdx < numRows; rowIdx++ {
+			for colIdx, col := range r.cb.ColVecs() {
+				r.stringsBuf[colIdx] = colDatumToCSVString(col, rowIdx)
 			}
 			if err := r.csvW.Write(r.stringsBuf); err != nil {
 				return 0, err
@@ -120,22 +138,22 @@ func NewCSVRowsReader(t Table, batchStart, batchEnd int) io.Reader {
 	return r
 }
 
-func datumToCSVString(datum interface{}) string {
-	if datum == nil {
+func colDatumToCSVString(col coldata.Vec, rowIdx int) string {
+	if col.Nulls().NullAt64(uint64(rowIdx)) {
 		return `NULL`
 	}
-	switch t := datum.(type) {
-	case int:
-		return strconv.Itoa(t)
-	case int64:
-		return fmt.Sprint(t)
-	case float64:
-		return strconv.FormatFloat(t, 'f', -1, 64)
-	case string:
-		return t
-	default:
-		panic(fmt.Sprintf("unsupported type %T: %v", datum, datum))
+	switch col.Type() {
+	case types.Bool:
+		return strconv.FormatBool(col.Bool()[rowIdx])
+	case types.Int64:
+		return strconv.FormatInt(col.Int64()[rowIdx], 10)
+	case types.Float64:
+		return strconv.FormatFloat(col.Float64()[rowIdx], 'f', -1, 64)
+	case types.Bytes:
+		bytes := col.Bytes()[rowIdx]
+		return *(*string)(unsafe.Pointer(&bytes))
 	}
+	panic(fmt.Sprintf(`unhandled type %s`, col.Type().GoTypeName()))
 }
 
 // HandleCSV configures a Generator with url params and outputs the data for a
@@ -174,7 +192,7 @@ func HandleCSV(w http.ResponseWriter, req *http.Request, prefix string, meta Met
 	if table == nil {
 		return errors.Errorf(`could not find table %s in generator %s`, tableName, meta.Name)
 	}
-	if table.InitialRows.Batch == nil {
+	if table.InitialRows.FillBatch == nil {
 		return errors.Errorf(`csv-server is not supported for workload %s`, meta.Name)
 	}
 

--- a/pkg/workload/examples/startrek.go
+++ b/pkg/workload/examples/startrek.go
@@ -14,7 +14,10 @@
 
 package examples
 
-import "github.com/cockroachdb/cockroach/pkg/workload"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+)
 
 const (
 	episodesSchema = `(id INT PRIMARY KEY, season INT, num INT, title TEXT, stardate DECIMAL)`
@@ -47,20 +50,30 @@ func (startrek) Tables() []workload.Table {
 		{
 			Name:   `episodes`,
 			Schema: episodesSchema,
-			InitialRows: workload.Tuples(
+			InitialRows: workload.TypedTuples(
 				len(startrekEpisodes),
+				episodesColTypes,
 				func(rowIdx int) []interface{} { return startrekEpisodes[rowIdx] },
 			),
 		},
 		{
 			Name:   `quotes`,
 			Schema: quotesSchema,
-			InitialRows: workload.Tuples(
+			InitialRows: workload.TypedTuples(
 				len(startrekQuotes),
+				quotesColTypes,
 				func(rowIdx int) []interface{} { return startrekQuotes[rowIdx] },
 			),
 		},
 	}
+}
+
+var episodesColTypes = []types.T{
+	types.Int64,
+	types.Int64,
+	types.Int64,
+	types.Bytes,
+	types.Float64,
 }
 
 // The data that follows was derived from the 'startrek' fortune cookie file.
@@ -145,6 +158,14 @@ var startrekEpisodes = [...][]interface{}{
 	{78, 3, 23, `All Our Yesterdays`, 5943.7},
 	{79, 3, 24, `Turnabout Intruder`, 5928.5},
 }
+
+var quotesColTypes = []types.T{
+	types.Bytes,
+	types.Bytes,
+	types.Float64,
+	types.Int64,
+}
+
 var startrekQuotes = [...][]interface{}{
 	{`"... freedom ... is a worship word..." "It is our worship word too."`, `Cloud William and Kirk`, nil, 52},
 	{`"Beauty is transitory." "Beauty survives."`, `Spock and Kirk`, nil, 72},

--- a/pkg/workload/ledger/generate.go
+++ b/pkg/workload/ledger/generate.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"strconv"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -35,6 +36,19 @@ const (
 	txnTypeReference = 400
 	cashMoneyType    = "C"
 )
+
+var ledgerCustomerColTypes = []types.T{
+	types.Int64,
+	types.Bytes,
+	types.Bytes,
+	types.Bytes,
+	types.Bool,
+	types.Bool,
+	types.Bytes,
+	types.Int64,
+	types.Int64,
+	types.Int64,
+}
 
 func (w *ledger) ledgerCustomerInitialRow(rowIdx int) []interface{} {
 	rng := w.rngPool.Get().(*rand.Rand)
@@ -59,6 +73,18 @@ func (w *ledger) ledgerCustomerSplitRow(splitIdx int) []interface{} {
 	return []interface{}{
 		(splitIdx + 1) * (w.customers / w.splits),
 	}
+}
+
+var ledgerTransactionColTypes = []types.T{
+	types.Bytes,
+	types.Bytes,
+	types.Bytes,
+	types.Int64,
+	types.Bytes,
+	types.Bytes,
+	types.Bytes,
+	types.Bytes,
+	types.Bytes,
 }
 
 func (w *ledger) ledgerTransactionInitialRow(rowIdx int) []interface{} {

--- a/pkg/workload/ledger/ledger.go
+++ b/pkg/workload/ledger/ledger.go
@@ -130,8 +130,9 @@ func (w *ledger) Tables() []workload.Table {
 	customer := workload.Table{
 		Name:   `customer`,
 		Schema: ledgerCustomerSchema,
-		InitialRows: workload.Tuples(
+		InitialRows: workload.TypedTuples(
 			w.customers,
+			ledgerCustomerColTypes,
 			w.ledgerCustomerInitialRow,
 		),
 		Splits: workload.Tuples(
@@ -142,8 +143,9 @@ func (w *ledger) Tables() []workload.Table {
 	transaction := workload.Table{
 		Name:   `transaction`,
 		Schema: ledgerTransactionSchema,
-		InitialRows: workload.Tuples(
+		InitialRows: workload.TypedTuples(
 			numTxnsPerCustomer*w.customers,
+			ledgerTransactionColTypes,
 			w.ledgerTransactionInitialRow,
 		),
 		Splits: workload.Tuples(

--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -141,9 +141,9 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 
 	d := newOrderData{
 		wID:    wID,
-		dID:    randInt(rng, 1, 10),
+		dID:    int(randInt(rng, 1, 10)),
 		cID:    randCustomerID(rng),
-		oOlCnt: randInt(rng, 5, 15),
+		oOlCnt: int(randInt(rng, 5, 15)),
 	}
 	d.items = make([]orderItem, d.oOlCnt)
 

--- a/pkg/workload/tpcc/order_status.go
+++ b/pkg/workload/tpcc/order_status.go
@@ -136,7 +136,7 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 	// 2.6.1.2: The customer is randomly selected 60% of the time by last name
 	// and 40% by number.
 	if rng.Intn(100) < 60 {
-		d.cLast = randCLast(rng)
+		d.cLast = string(randCLast(rng))
 		atomic.AddUint64(&o.config.auditor.orderStatusByLastName, 1)
 	} else {
 		d.cID = randCustomerID(rng)

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -190,7 +190,7 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 	// 2.5.1.2: The customer is randomly selected 60% of the time by last name
 	// and 40% by number.
 	if rng.Intn(100) < 60 {
-		d.cLast = randCLast(rng)
+		d.cLast = string(randCLast(rng))
 		atomic.AddUint64(&p.config.auditor.paymentsByLastName, 1)
 	} else {
 		d.cID = randCustomerID(rng)

--- a/pkg/workload/tpcc/stock_level.go
+++ b/pkg/workload/tpcc/stock_level.go
@@ -100,7 +100,7 @@ func (s *stockLevel) run(ctx context.Context, wID int) (interface{}, error) {
 	// 2.8.1.2: The threshold of minimum quantity in stock is selected at random
 	// within [10..20].
 	d := stockLevelData{
-		threshold: randInt(rng, 10, 20),
+		threshold: int(randInt(rng, 10, 20)),
 		dID:       rng.Intn(10) + 1,
 	}
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -27,10 +27,15 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
@@ -163,23 +168,138 @@ type BatchedTuples struct {
 	// NumTotal is the total number of tuples in all batches. Not all generators
 	// will know this, it's set to 0 when unknown.
 	NumTotal int
-	// Batch is a function to deterministically compute a batch of tuples given
-	// its index.
-	Batch func(int) [][]interface{}
+	// FillBatch is a function to deterministically compute a columnar-batch of
+	// tuples given its index.
+	//
+	// To save allocations, the Vecs in the passed Batch are reused when possible,
+	// so the results of this call are invalidated the next time the same Batch is
+	// passed to FillBatch. Ditto the ByteAllocator, which can be reset in between
+	// calls. If a caller needs the Batch and its contents to be long lived,
+	// simply pass a new Batch to each call and don't reset the ByteAllocator.
+	FillBatch func(int, coldata.Batch, *bufalloc.ByteAllocator)
 }
 
-// Tuples returns a BatchedTuples where each batch has size 1.
+// Tuples is like TypedTuples except that it tries to guess the type of each
+// datum. However, if the function ever returns nil for one of the datums, you
+// need to use TypedTuples instead and specify the types.
 func Tuples(count int, fn func(int) []interface{}) BatchedTuples {
+	return TypedTuples(count, nil /* colTypes */, fn)
+}
+
+// TypedTuples returns a BatchedTuples where each batch has size 1. It's
+// intended to be easier to use than directly specifying a BatchedTuples, but
+// the tradeoff is some bit of performance. If colTypes is nil, an attempt is
+// made to infer them.
+func TypedTuples(count int, colTypes []types.T, fn func(int) []interface{}) BatchedTuples {
+	// The FillBatch we create has to be concurrency safe, so we can't let it do
+	// the one-time initialization of colTypes without this protection.
+	var colTypesOnce sync.Once
+
 	t := BatchedTuples{
 		NumBatches: count,
 		NumTotal:   count,
 	}
 	if fn != nil {
-		t.Batch = func(batchIdx int) [][]interface{} {
-			return [][]interface{}{fn(batchIdx)}
+		t.FillBatch = func(batchIdx int, cb coldata.Batch, _ *bufalloc.ByteAllocator) {
+			row := fn(batchIdx)
+
+			colTypesOnce.Do(func() {
+				if colTypes == nil {
+					colTypes = make([]types.T, len(row))
+					for i, datum := range row {
+						if datum == nil {
+							panic(fmt.Sprintf(
+								`can't determine type of nil column; call TypedTuples directly: %v`, row))
+						} else {
+							switch datum.(type) {
+							case time.Time:
+								colTypes[i] = types.Bytes
+							default:
+								colTypes[i] = types.FromGoType(datum)
+							}
+						}
+					}
+				}
+			})
+
+			cb.Reset(colTypes, 1)
+			for colIdx, col := range cb.ColVecs() {
+				switch d := row[colIdx].(type) {
+				case nil:
+					col.Nulls().SetNull(0)
+				case bool:
+					col.Bool()[0] = d
+				case int:
+					col.Int64()[0] = int64(d)
+				case float64:
+					col.Float64()[0] = d
+				case string:
+					col.Bytes()[0] = []byte(d)
+				case []byte:
+					col.Bytes()[0] = d
+				case time.Time:
+					col.Bytes()[0] = []byte(d.Round(time.Microsecond).UTC().Format(tree.TimestampOutputFormat))
+				default:
+					panic(fmt.Sprintf(`unhandled datum type %T`, d))
+				}
+			}
 		}
 	}
 	return t
+}
+
+// BatchRows is a function to deterministically compute a row-batch of tuples
+// given its index. BatchRows doesn't attempt any reuse and so is allocation
+// heavy. In performance-critical code, FillBatch should be used directly,
+// instead.
+func (b BatchedTuples) BatchRows(batchIdx int) [][]interface{} {
+	cb := coldata.NewMemBatchWithSize(nil, 0)
+	var a bufalloc.ByteAllocator
+	b.FillBatch(batchIdx, cb, &a)
+	return ColBatchToRows(cb)
+}
+
+// ColBatchToRows materializes the columnar data in a coldata.Batch into rows.
+func ColBatchToRows(cb coldata.Batch) [][]interface{} {
+	numRows, numCols := int(cb.Length()), cb.Width()
+	// Allocate all the []interface{} row slices in one go.
+	datums := make([]interface{}, numRows*numCols)
+	for colIdx, col := range cb.ColVecs() {
+		nulls := col.Nulls()
+		switch col.Type() {
+		case types.Bool:
+			for rowIdx, datum := range col.Bool() {
+				if !nulls.NullAt64(uint64(rowIdx)) {
+					datums[rowIdx*numCols+colIdx] = datum
+				}
+			}
+		case types.Int64:
+			for rowIdx, datum := range col.Int64() {
+				if !nulls.NullAt64(uint64(rowIdx)) {
+					datums[rowIdx*numCols+colIdx] = datum
+				}
+			}
+		case types.Float64:
+			for rowIdx, datum := range col.Float64() {
+				if !nulls.NullAt64(uint64(rowIdx)) {
+					datums[rowIdx*numCols+colIdx] = datum
+				}
+			}
+		case types.Bytes:
+			for rowIdx, datum := range col.Bytes() {
+				if !nulls.NullAt64(uint64(rowIdx)) {
+					datums[rowIdx*numCols+colIdx] = datum
+				}
+			}
+		default:
+			panic(fmt.Sprintf(`unhandled type %s`, col.Type().GoTypeName()))
+		}
+	}
+	rows := make([][]interface{}, numRows)
+	for rowIdx := 0; rowIdx < numRows; rowIdx++ {
+		rows[rowIdx] = datums[rowIdx*numCols : (rowIdx+1)*numCols]
+	}
+	return rows
 }
 
 // QueryLoad represents some SQL query workload performable on a database
@@ -277,6 +397,8 @@ func ApproxDatumSize(x interface{}) int64 {
 		// used to batch things by size and table of all `0`s should not get
 		// infinite size batches.
 		return int64(bits.Len(uint(t))+8) / 8
+	case int64:
+		return int64(bits.Len64(uint64(t))+8) / 8
 	case uint64:
 		return int64(bits.Len64(t)+8) / 8
 	case float64:
@@ -333,7 +455,7 @@ func Setup(
 	for _, table := range tables {
 		if table.InitialRows.NumBatches == 0 {
 			continue
-		} else if table.InitialRows.Batch == nil {
+		} else if table.InitialRows.FillBatch == nil {
 			return 0, errors.Errorf(
 				`initial data is not supported for workload %s`, gen.Meta().Name)
 		}
@@ -365,8 +487,8 @@ func Setup(
 				}
 				_ = flush()
 
-				for rowBatchIdx := startIdx; rowBatchIdx < endIdx; rowBatchIdx++ {
-					for _, row := range table.InitialRows.Batch(rowBatchIdx) {
+				for batchIdx := startIdx; batchIdx < endIdx; batchIdx++ {
+					for _, row := range table.InitialRows.BatchRows(batchIdx) {
 						if len(params) != 0 {
 							insertStmtBuf.WriteString(`,`)
 						}
@@ -427,7 +549,7 @@ func Split(ctx context.Context, db *gosql.DB, table Table, concurrency int) erro
 	}
 	splitPoints := make([][]interface{}, 0, table.Splits.NumBatches)
 	for splitIdx := 0; splitIdx < table.Splits.NumBatches; splitIdx++ {
-		splitPoints = append(splitPoints, table.Splits.Batch(splitIdx)...)
+		splitPoints = append(splitPoints, table.Splits.BatchRows(splitIdx)...)
 	}
 	sort.Sort(sliceSliceInterface(splitPoints))
 
@@ -525,6 +647,8 @@ func StringTuple(datums []interface{}) []string {
 		switch x := datum.(type) {
 		case int:
 			s[i] = strconv.Itoa(x)
+		case int64:
+			s[i] = strconv.FormatInt(x, 10)
 		case uint64:
 			s[i] = strconv.FormatUint(x, 10)
 		case string:
@@ -554,6 +678,13 @@ func (s sliceSliceInterface) Less(i, j int) bool {
 		switch x := s[i][offset].(type) {
 		case int:
 			if y := s[j][offset].(int); x < y {
+				return true
+			} else if x > y {
+				return false
+			}
+			continue
+		case int64:
+			if y := s[j][offset].(int64); x < y {
 				return true
 			} else if x > y {
 				return false


### PR DESCRIPTION
A workload.Generator previously could specifiy its initial table data
using one of two methods. One outputs a single row as `[]interface{}`
and the other is a batch of `[][]interface{}`. This commit switches the
latter to be a columar batch, allowing selected performance-critical
workload generators (tpcc, bank) to generate initial table data with
dramatically reduced allocations.

The single row option still exists and will continue to be used by most
workload.Generators, as it's much simpler. An adaptor from the columnar
batch to the old row oriented `[][]interface{}` batch is included for
ease of use in non-performance sensitive consumers of initial table
data. IMPORT, on the other hand, is switched to using the columnar
batches directly.

Some of the savings here is reusing batches, but the majority comes from
`[]interface{}` requiring that everything assinged to it be on the heap,
while something like `[]int` doesn't. We also get some amount of speedup
in initial table data consumers from fewer type switches.

This could also be accomplished without being columnar, but doing the
minimum non-columnar thing to get the same results will require
reinventing most of the work that the columnar does. Plus it will almost
certainly be convenient for columnar exec benchmarking to have a common
format.

Benchmark results:

    name                               old time/op    new time/op    delta
    InitialData/tpcc/warehouses=1-8       552ms ± 1%     454ms ± 0%  -17.81%  (p=0.008 n=5+5)
    InitialData/bank/rows=1000-8          461µs ± 0%     332µs ± 1%  -28.10%  (p=0.008 n=5+5)
    WriteCSVRows-8                       15.0µs ± 1%    16.8µs ± 1%  +12.44%  (p=0.008 n=5+5)
    CSVRowsReader-8                      17.8µs ± 1%    19.3µs ± 1%   +8.41%  (p=0.008 n=5+5)

    name                               old speed      new speed      delta
    InitialData/tpcc/warehouses=1-8     128MB/s ± 1%   209MB/s ± 0%  +63.22%  (p=0.008 n=5+5)
    InitialData/bank/rows=1000-8        223MB/s ± 0%   350MB/s ± 1%  +56.83%  (p=0.008 n=5+5)
    WriteCSVRows-8                      118MB/s ± 2%   107MB/s ± 3%   -9.43%  (p=0.008 n=5+5)
    CSVRowsReader-8                     101MB/s ± 4%    92MB/s ± 5%   -8.31%  (p=0.016 n=5+5)

    name                               old alloc/op   new alloc/op   delta
    InitialData/tpcc/warehouses=1-8       246MB ± 0%      75MB ± 0%  -69.61%  (p=0.008 n=5+5)
    InitialData/bank/rows=1000-8          232kB ± 0%      19kB ± 0%  -91.75%  (p=0.008 n=5+5)
    WriteCSVRows-8                       5.60kB ± 0%    5.70kB ± 0%   +1.71%  (p=0.016 n=4+5)
    CSVRowsReader-8                      7.35kB ± 1%    7.39kB ± 0%     ~     (p=0.667 n=5+4)

    name                               old allocs/op  new allocs/op  delta
    InitialData/tpcc/warehouses=1-8       5.60M ± 0%     1.48M ± 0%  -73.56%  (p=0.008 n=5+5)
    InitialData/bank/rows=1000-8          6.00k ± 0%     1.02k ± 0%  -83.01%  (p=0.008 n=5+5)
    WriteCSVRows-8                         48.0 ± 0%      50.0 ± 0%   +4.17%  (p=0.008 n=5+5)
    CSVRowsReader-8                        54.0 ± 0%      55.0 ± 0%   +1.85%  (p=0.008 n=5+5)

We could probably speed the CSV stuff back up with some followup work,
but (a) the overall `fixtures import` benchmark is still faster and (b)
we're about to switch to dt's import magic that skips the CSV roundtrip.

Current `fixtures import`

    name                               old time/op    new time/op    delta
    ImportFixture/tpcc/warehouses=1-8     3.35s ± 2%     3.29s ± 3%     ~     (p=0.310 n=5+5)

    name                               old speed      new speed      delta
    ImportFixture/tpcc/warehouses=1-8  26.4MB/s ± 2%  26.9MB/s ± 3%     ~     (p=0.310 n=5+5)

    name                               old alloc/op   new alloc/op   delta
    ImportFixture/tpcc/warehouses=1-8    3.09GB ± 0%    2.92GB ± 0%   -5.60%  (p=0.008 n=5+5)

    name                               old allocs/op  new allocs/op  delta
    ImportFixture/tpcc/warehouses=1-8     32.1M ± 0%     28.0M ± 0%  -12.86%  (p=0.008 n=5+5)

Magic `fixtures import` that skips CSV roundtrip:

    name                               old time/op    new time/op    delta
    ImportFixture/tpcc/warehouses=1-8     2.88s ± 3%     2.86s ± 4%     ~     (p=0.548 n=5+5)

    name                               old speed      new speed      delta
    ImportFixture/tpcc/warehouses=1-8  30.7MB/s ± 3%  30.9MB/s ± 4%     ~     (p=0.548 n=5+5)

    name                               old alloc/op   new alloc/op   delta
    ImportFixture/tpcc/warehouses=1-8    2.87GB ± 0%    2.73GB ± 0%   -4.97%  (p=0.008 n=5+5)

    name                               old allocs/op  new allocs/op  delta
    ImportFixture/tpcc/warehouses=1-8     26.1M ± 0%     21.5M ± 0%  -17.75%  (p=0.008 n=5+5)

Touches #34809

Release note: None