### PR TITLE
opt: disable SimplifyZeroCardinalityGroup

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -3,14 +3,16 @@
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE FALSE
 ----
-tree    field  description
-norows  ·      ·
+tree         field  description
+render       ·      ·
+ └── norows  ·      ·
 
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE NULL
 ----
-tree    field  description
-norows  ·      ·
+tree         field  description
+render       ·      ·
+ └── norows  ·      ·
 
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE TRUE

--- a/pkg/sql/opt/memo/testdata/logprops/constraints-null
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints-null
@@ -12,21 +12,19 @@ TABLE t
 opt
 SELECT * FROM t WHERE a = NULL
 ----
-values
+scan t
  ├── columns: a:1(int) b:2(bool) c:3(string)
+ ├── constraint: /4: contradiction
  ├── cardinality: [0 - 0]
- ├── key: ()
- ├── fd: ()-->(1-3)
  └── prune: (1-3)
 
 opt
 SELECT * FROM t WHERE a < NULL
 ----
-values
+scan t
  ├── columns: a:1(int) b:2(bool) c:3(string)
+ ├── constraint: /4: contradiction
  ├── cardinality: [0 - 0]
- ├── key: ()
- ├── fd: ()-->(1-3)
  └── prune: (1-3)
 
 opt

--- a/pkg/sql/opt/memo/testdata/logprops/offset
+++ b/pkg/sql/opt/memo/testdata/logprops/offset
@@ -180,9 +180,29 @@ offset
 opt
 SELECT s, x FROM (SELECT * FROM xyzs LIMIT 100) WHERE s='foo' OFFSET 4294967296
 ----
-values
- ├── columns: s:4(string) x:1(int)
+offset
+ ├── columns: s:4(string!null) x:1(int!null)
  ├── cardinality: [0 - 0]
- ├── key: ()
- ├── fd: ()-->(1,4)
- └── prune: (1,4)
+ ├── key: (1)
+ ├── fd: ()-->(4)
+ ├── prune: (1)
+ ├── interesting orderings: (+1) (-4)
+ ├── select
+ │    ├── columns: x:1(int!null) s:4(string!null)
+ │    ├── cardinality: [0 - 100]
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4)
+ │    ├── prune: (1)
+ │    ├── interesting orderings: (+1) (-4)
+ │    ├── scan xyzs@secondary
+ │    │    ├── columns: x:1(int!null) s:4(string)
+ │    │    ├── limit: 100
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(4)
+ │    │    ├── prune: (1,4)
+ │    │    └── interesting orderings: (+1) (-4)
+ │    └── filters
+ │         └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+ │              ├── variable: s [type=string]
+ │              └── const: 'foo' [type=string]
+ └── const: 4294967296 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/srfs
+++ b/pkg/sql/opt/memo/testdata/logprops/srfs
@@ -20,17 +20,27 @@ TABLE uv
 opt
 SELECT generate_series(0,1) FROM (SELECT * FROM xy LIMIT 0)
 ----
-project-set
+inner-join
  ├── columns: generate_series:3(int)
  ├── cardinality: [0 - 0]
  ├── side-effects
- ├── values
+ ├── project-set
+ │    ├── columns: generate_series:3(int)
+ │    ├── side-effects
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: generate_series [type=int, side-effects]
+ │              ├── const: 0 [type=int]
+ │              └── const: 1 [type=int]
+ ├── limit
  │    ├── cardinality: [0 - 0]
- │    └── key: ()
- └── zip
-      └── function: generate_series [type=int, side-effects]
-           ├── const: 0 [type=int]
-           └── const: 1 [type=int]
+ │    ├── key: ()
+ │    ├── scan xy
+ │    └── const: 0 [type=int]
+ └── filters (true)
 
 opt
 SELECT (SELECT unnest(ARRAY[1,2,y,v]) FROM xy WHERE x = u) FROM uv

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -100,12 +100,34 @@ inner-join
 norm
 SELECT * FROM xysd JOIN uv ON false
 ----
-values
- ├── columns: x:1(int) y:2(int) s:3(string) d:4(decimal) u:5(int) v:6(int)
+inner-join
+ ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) u:5(int) v:6(int!null)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
- ├── key: ()
- └── fd: ()-->(1-6)
+ ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ ├── select
+ │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │    ├── scan xysd
+ │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ │    │    ├── stats: [rows=5000]
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │    └── filters
+ │         └── false [type=bool]
+ ├── select
+ │    ├── columns: u:5(int) v:6(int!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── scan uv
+ │    │    ├── columns: u:5(int) v:6(int!null)
+ │    │    └── stats: [rows=10000]
+ │    └── filters
+ │         └── false [type=bool]
+ └── filters (true)
 
 build colstat=2
 SELECT *, rowid FROM xysd INNER JOIN uv ON x=u

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -69,12 +69,19 @@ scan a
 norm
 SELECT * FROM a WHERE false
 ----
-values
- ├── columns: x:1(int) y:2(int)
+select
+ ├── columns: x:1(int!null) y:2(int)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
- ├── key: ()
- └── fd: ()-->(1,2)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan a
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── stats: [rows=4000]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── filters
+      └── false [type=bool]
 
 # Distinct values calculation with constraints.
 norm

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -244,6 +244,9 @@ func (f *Factory) AssignPlaceholders(from *memo.Memo) (err error) {
 	return nil
 }
 
+// TODO(justin): re-enable this when we have a better solution for #35253.
+const enableSimplifyZeroCardinalityGroup = false
+
 // onConstructRelational is called as a final step by each factory method that
 // constructs a relational expression, so that any custom manual pattern
 // matching/replacement code can be run.
@@ -252,7 +255,7 @@ func (f *Factory) onConstructRelational(rel memo.RelExpr) memo.RelExpr {
 	// SimplifyZeroCardinalityGroup replaces a group with [0 - 0] cardinality
 	// with an empty values expression. It is placed here because it depends on
 	// the logical properties of the group in question.
-	if rel.Op() != opt.ValuesOp {
+	if enableSimplifyZeroCardinalityGroup && rel.Op() != opt.ValuesOp {
 		relational := rel.Relational()
 		if relational.Cardinality.IsZero() && !relational.CanHaveSideEffects {
 			if f.matchedRule == nil || f.matchedRule(opt.SimplifyZeroCardinalityGroup) {

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -225,11 +225,12 @@ project
 opt expect=SimplifyFalseOr
 SELECT * FROM a WHERE false OR false OR false
 ----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+scan a
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── constraint: /1: contradiction
  ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5)
+ ├── key: (1)
+ └── fd: (1)-->(2-5)
 
 # --------------------------------------------------
 # SimplifyAnd + SimplifyOr

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -305,11 +305,12 @@ WHERE
     null::jsonb ?| ARRAY['foo'] OR '{}' ?| null::string[] OR
     null::jsonb ?& ARRAY['foo'] OR '{}' ?& null::string[]
 ----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
+scan a
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) d:6(date)
+ ├── constraint: /1: contradiction
  ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-6)
+ ├── key: (1)
+ └── fd: (1)-->(2-6)
 
 # --------------------------------------------------
 # FoldIsNull

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -267,11 +267,38 @@ right-join
 opt expect=(InlineJoinConstantsLeft,InlineJoinConstantsRight)
 SELECT * FROM (SELECT 1 AS one) INNER JOIN (SELECT 2 AS two) ON one=two
 ----
-values
+inner-join
  ├── columns: one:1(int) two:2(int)
  ├── cardinality: [0 - 0]
  ├── key: ()
- └── fd: ()-->(1,2)
+ ├── fd: ()-->(1,2)
+ ├── select
+ │    ├── columns: one:1(int)
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── values
+ │    │    ├── columns: one:1(int)
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,) [type=tuple{int}]
+ │    └── filters
+ │         └── false [type=bool]
+ ├── select
+ │    ├── columns: two:2(int)
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(2)
+ │    ├── values
+ │    │    ├── columns: two:2(int)
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(2)
+ │    │    └── (2,) [type=tuple{int}]
+ │    └── filters
+ │         └── false [type=bool]
+ └── filters (true)
 
 # Constant column exists in input, but is not referenced.
 opt expect-not=(InlineJoinConstantsLeft,InlineJoinConstantsRight)

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -94,28 +94,42 @@ inner-join
 opt expect=DetectJoinContradiction
 SELECT * FROM a INNER JOIN b ON k IN ()
 ----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+inner-join
+ ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-7)
+ ├── key: (1,6)
+ ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    ├── constraint: /1: contradiction
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── scan b
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── constraint: /6: contradiction
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters (true)
 
 opt expect=DetectJoinContradiction
 SELECT * FROM a LEFT JOIN b ON i=5 AND k IN () AND s='foo'
 ----
 left-join
  ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int) y:7(int)
- ├── key: (1)
- ├── fd: (1)-->(2-7), ()~~>(6,7)
+ ├── key: (1,6)
+ ├── fd: (1)-->(2-5), (6)-->(7)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
- ├── values
- │    ├── columns: x:6(int) y:7(int)
+ ├── scan b
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── constraint: /6: contradiction
  │    ├── cardinality: [0 - 0]
- │    ├── key: ()
- │    └── fd: ()-->(6,7)
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
  └── filters (true)
 
 opt expect=DetectJoinContradiction
@@ -2038,11 +2052,34 @@ inner-join
 norm expect=SimplifyJoinNotNullEquality
 SELECT * FROM a INNER JOIN b ON (a.k=b.x) IS Null
 ----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+inner-join
+ ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-7)
+ ├── key: (1,6)
+ ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── select
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── false [type=bool]
+ ├── select
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    ├── scan b
+ │    │    ├── columns: x:6(int!null) y:7(int)
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── false [type=bool]
+ └── filters (true)
 
 norm expect=SimplifyJoinNotNullEquality
 SELECT * FROM a INNER JOIN b ON (a.k=b.x) IS NOT True

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -76,16 +76,21 @@ opt
 SELECT * FROM (SELECT * FROM a LIMIT 0) LIMIT -1
 ----
 limit
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── cardinality: [0 - 0]
  ├── side-effects
  ├── key: ()
  ├── fd: ()-->(1-5)
- ├── values
- │    ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── limit
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    ├── cardinality: [0 - 0]
  │    ├── key: ()
- │    └── fd: ()-->(1-5)
+ │    ├── fd: ()-->(1-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── const: 0 [type=int]
  └── const: -1 [type=int]
 
 # --------------------------------------------------

--- a/pkg/sql/opt/norm/testdata/rules/max1row
+++ b/pkg/sql/opt/norm/testdata/rules/max1row
@@ -72,11 +72,14 @@ values
  └── tuple [type=tuple{bool}]
       └── gt [type=bool]
            ├── subquery [type=int]
-           │    └── values
+           │    └── limit
            │         ├── columns: i:2(int)
            │         ├── cardinality: [0 - 0]
            │         ├── key: ()
-           │         └── fd: ()-->(2)
+           │         ├── fd: ()-->(2)
+           │         ├── scan a
+           │         │    └── columns: i:2(int)
+           │         └── const: 0 [type=int]
            └── const: 5 [type=int]
 
 # Don't remove the Max1Row operator.

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -402,11 +402,10 @@ select
                 ├── cardinality: [1 - 1]
                 ├── key: ()
                 ├── fd: ()-->(13)
-                ├── values
+                ├── scan a
                 │    ├── columns: s:10(string)
-                │    ├── cardinality: [0 - 0]
-                │    ├── key: ()
-                │    └── fd: ()-->(10)
+                │    ├── constraint: /7: contradiction
+                │    └── cardinality: [0 - 0]
                 └── aggregations
                      └── max [type=string, outer=(10)]
                           └── variable: s [type=string]
@@ -1006,11 +1005,11 @@ project
 opt
 SELECT k FROM e WHERE tz > NULL::TIMESTAMP
 ----
-values
- ├── columns: k:1(int)
+scan e
+ ├── columns: k:1(int!null)
+ ├── constraint: /1: contradiction
  ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1)
+ └── key: (1)
 
 # Working in concert with other norm rules
 opt

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -34,29 +34,44 @@ TABLE uv
 opt expect=SimplifySelectFilters
 SELECT * FROM a WHERE Null
 ----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+scan a
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── constraint: /1: contradiction
  ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5)
+ ├── key: (1)
+ └── fd: (1)-->(2-5)
 
 opt expect=SimplifyJoinFilters
 SELECT * FROM a INNER JOIN xy ON NULL
 ----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+inner-join
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-7)
+ ├── key: (1,6)
+ ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── constraint: /1: contradiction
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── scan xy
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── constraint: /6: contradiction
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters (true)
 
 opt expect=SimplifySelectFilters
 SELECT * FROM a WHERE i=1 AND Null
 ----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+scan a
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── constraint: /1: contradiction
  ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5)
+ ├── key: (1)
+ └── fd: (1)-->(2-5)
 
 opt expect=SimplifySelectFilters
 SELECT * FROM a WHERE k=1 AND (i=2 AND (f=3.5 AND s='foo')) AND true
@@ -133,11 +148,12 @@ select
 opt expect=MergeSelects
 SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
 ----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+scan a
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── constraint: /1: contradiction
  ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5)
+ ├── key: (1)
+ └── fd: (1)-->(2-5)
 
 opt expect=MergeSelects
 SELECT * FROM (SELECT * FROM a WHERE i<5) WHERE s='foo'
@@ -728,11 +744,24 @@ inner-join (merge)
 opt expect=MergeSelectInnerJoin
 SELECT * FROM a INNER JOIN xy ON a.k=xy.x WHERE False
 ----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+inner-join
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-7)
+ ├── key: (1,6)
+ ├── fd: (1)-->(2-5), (6)-->(7)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── constraint: /1: contradiction
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── scan xy
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── constraint: /6: contradiction
+ │    ├── cardinality: [0 - 0]
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters (true)
 
 # Don't merge with LEFT JOIN.
 opt expect-not=MergeSelectInnerJoin
@@ -1176,8 +1205,13 @@ SELECT k FROM
   UNION ALL
   (SELECT k FROM b WHERE i IN ())
 ----
-values
+project
  ├── columns: k:11(int)
  ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(11)
+ ├── scan b
+ │    ├── columns: b.k:1(int!null)
+ │    ├── constraint: /1: contradiction
+ │    ├── cardinality: [0 - 0]
+ │    └── key: (1)
+ └── projections
+      └── variable: b.k [type=int, outer=(1)]

--- a/pkg/sql/opt/norm/testdata/rules/zero_cardinality
+++ b/pkg/sql/opt/norm/testdata/rules/zero_cardinality
@@ -14,82 +14,83 @@ TABLE b
 # SimplifyZeroCardinalityGroup
 # --------------------------------------------------
 
-opt expect=SimplifyZeroCardinalityGroup
-SELECT k FROM b WHERE false
-----
-values
- ├── columns: k:1(int)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1)
-
-opt expect=SimplifyZeroCardinalityGroup
-SELECT * FROM (VALUES (1) OFFSET 1)
-----
-values
- ├── columns: column1:1(int)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1)
-
-opt expect=SimplifyZeroCardinalityGroup
-SELECT * FROM b INNER JOIN b b2 ON False
-----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) k:6(int) i:7(int) f:8(float) s:9(string) j:10(jsonb)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-10)
-
-opt expect=SimplifyZeroCardinalityGroup
-SELECT * FROM b LIMIT 0
-----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5)
-
-opt expect=SimplifyZeroCardinalityGroup
-SELECT * FROM (SELECT * FROM b WHERE i=1) WHERE False
-----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5)
-
-opt expect=SimplifyZeroCardinalityGroup
-SELECT * FROM (SELECT * FROM b WHERE False) WHERE s='foo'
-----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5)
-
-opt expect=SimplifyZeroCardinalityGroup
-SELECT * FROM (SELECT * FROM b WHERE False) WHERE s='foo'
-----
-values
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1-5)
-
-opt
-SELECT * FROM (SELECT CASE WHEN k < 0 THEN 3 / 0 ELSE 3 END FROM b) WHERE false
-----
-project
- ├── columns: case:6(decimal)
- ├── cardinality: [0 - 0]
- ├── side-effects
- ├── key: ()
- ├── fd: ()-->(6)
- ├── values
- │    ├── columns: k:1(int)
- │    ├── cardinality: [0 - 0]
- │    ├── key: ()
- │    └── fd: ()-->(1)
- └── projections
-      └── CASE WHEN k < 0 THEN 3 / 0 ELSE 3 END [type=decimal, outer=(1), side-effects]
+# TODO(justin): re-enable these when we re-enable the rule.
+# opt expect=SimplifyZeroCardinalityGroup
+# SELECT k FROM b WHERE false
+# ----
+# values
+#  ├── columns: k:1(int)
+#  ├── cardinality: [0 - 0]
+#  ├── key: ()
+#  └── fd: ()-->(1)
+# 
+# opt expect=SimplifyZeroCardinalityGroup
+# SELECT * FROM (VALUES (1) OFFSET 1)
+# ----
+# values
+#  ├── columns: column1:1(int)
+#  ├── cardinality: [0 - 0]
+#  ├── key: ()
+#  └── fd: ()-->(1)
+# 
+# opt expect=SimplifyZeroCardinalityGroup
+# SELECT * FROM b INNER JOIN b b2 ON False
+# ----
+# values
+#  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) k:6(int) i:7(int) f:8(float) s:9(string) j:10(jsonb)
+#  ├── cardinality: [0 - 0]
+#  ├── key: ()
+#  └── fd: ()-->(1-10)
+# 
+# opt expect=SimplifyZeroCardinalityGroup
+# SELECT * FROM b LIMIT 0
+# ----
+# values
+#  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+#  ├── cardinality: [0 - 0]
+#  ├── key: ()
+#  └── fd: ()-->(1-5)
+# 
+# opt expect=SimplifyZeroCardinalityGroup
+# SELECT * FROM (SELECT * FROM b WHERE i=1) WHERE False
+# ----
+# values
+#  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+#  ├── cardinality: [0 - 0]
+#  ├── key: ()
+#  └── fd: ()-->(1-5)
+# 
+# opt expect=SimplifyZeroCardinalityGroup
+# SELECT * FROM (SELECT * FROM b WHERE False) WHERE s='foo'
+# ----
+# values
+#  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+#  ├── cardinality: [0 - 0]
+#  ├── key: ()
+#  └── fd: ()-->(1-5)
+# 
+# opt expect=SimplifyZeroCardinalityGroup
+# SELECT * FROM (SELECT * FROM b WHERE False) WHERE s='foo'
+# ----
+# values
+#  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+#  ├── cardinality: [0 - 0]
+#  ├── key: ()
+#  └── fd: ()-->(1-5)
+# 
+# opt
+# SELECT * FROM (SELECT CASE WHEN k < 0 THEN 3 / 0 ELSE 3 END FROM b) WHERE false
+# ----
+# project
+#  ├── columns: case:6(decimal)
+#  ├── cardinality: [0 - 0]
+#  ├── side-effects
+#  ├── key: ()
+#  ├── fd: ()-->(6)
+#  ├── values
+#  │    ├── columns: k:1(int)
+#  │    ├── cardinality: [0 - 0]
+#  │    ├── key: ()
+#  │    └── fd: ()-->(1)
+#  └── projections
+#       └── CASE WHEN k < 0 THEN 3 / 0 ELSE 3 END [type=decimal, outer=(1), side-effects]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -2040,34 +2040,43 @@ project
  │    ├── cardinality: [0 - 0]
  │    ├── side-effects, mutations
  │    ├── fd: ()-->(5-7)
- │    ├── select
+ │    ├── scan x
+ │    │    ├── constraint: /4: contradiction
+ │    │    └── cardinality: [0 - 0]
+ │    ├── inner-join
  │    │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
  │    │    ├── cardinality: [0 - 0]
  │    │    ├── side-effects, mutations
  │    │    ├── fd: ()-->(5-7)
- │    │    ├── insert abc
+ │    │    ├── select
  │    │    │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
- │    │    │    ├── insert-mapping:
- │    │    │    │    ├──  "?column?":13 => abc.a:5
- │    │    │    │    ├──  column14:14 => abc.b:6
- │    │    │    │    ├──  column14:14 => abc.c:7
- │    │    │    │    └──  column15:15 => abc.rowid:8
+ │    │    │    ├── cardinality: [0 - 0]
  │    │    │    ├── side-effects, mutations
  │    │    │    ├── fd: ()-->(5-7)
- │    │    │    └── project
- │    │    │         ├── columns: column14:14(int) column15:15(int) "?column?":13(int!null)
- │    │    │         ├── side-effects
- │    │    │         ├── fd: ()-->(13,14)
- │    │    │         ├── scan abc
- │    │    │         └── projections
- │    │    │              ├── null [type=int]
- │    │    │              ├── unique_rowid() [type=int, side-effects]
- │    │    │              └── const: 1 [type=int]
- │    │    └── filters
- │    │         └── false [type=bool]
- │    ├── values
- │    │    ├── cardinality: [0 - 0]
- │    │    └── key: ()
+ │    │    │    ├── insert abc
+ │    │    │    │    ├── columns: abc.a:5(int!null) abc.b:6(int) abc.c:7(int) abc.rowid:8(int!null)
+ │    │    │    │    ├── insert-mapping:
+ │    │    │    │    │    ├──  "?column?":13 => abc.a:5
+ │    │    │    │    │    ├──  column14:14 => abc.b:6
+ │    │    │    │    │    ├──  column14:14 => abc.c:7
+ │    │    │    │    │    └──  column15:15 => abc.rowid:8
+ │    │    │    │    ├── side-effects, mutations
+ │    │    │    │    ├── fd: ()-->(5-7)
+ │    │    │    │    └── project
+ │    │    │    │         ├── columns: column14:14(int) column15:15(int) "?column?":13(int!null)
+ │    │    │    │         ├── side-effects
+ │    │    │    │         ├── fd: ()-->(13,14)
+ │    │    │    │         ├── scan abc
+ │    │    │    │         └── projections
+ │    │    │    │              ├── null [type=int]
+ │    │    │    │              ├── unique_rowid() [type=int, side-effects]
+ │    │    │    │              └── const: 1 [type=int]
+ │    │    │    └── filters
+ │    │    │         └── false [type=bool]
+ │    │    ├── scan y
+ │    │    │    ├── constraint: /20: contradiction
+ │    │    │    └── cardinality: [0 - 0]
+ │    │    └── filters (true)
  │    └── filters (true)
  └── projections
       └── false [type=bool]

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -509,3 +509,97 @@ project
  │         └── a1.id = a3.id [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  └── projections
       └── const: 1 [type=int]
+
+# Regression test for #35253.
+
+exec-ddl
+CREATE TABLE x (a INT8 PRIMARY KEY)
+----
+TABLE x
+ ├── a int not null
+ └── INDEX primary
+      └── a int not null
+
+opt join-limit=4
+SELECT
+    *
+FROM
+    x AS y
+    JOIN [INSERT INTO x (a) SELECT NULL FROM x RETURNING 1] ON false
+    JOIN x ON true
+    JOIN [UPDATE x SET a = 1 RETURNING 1] ON true
+----
+inner-join
+ ├── columns: a:1(int!null) "?column?":5(int!null) a:6(int!null) "?column?":10(int!null)
+ ├── cardinality: [0 - 0]
+ ├── side-effects, mutations
+ ├── fd: ()-->(5,10)
+ ├── project
+ │    ├── columns: "?column?":10(int!null)
+ │    ├── side-effects, mutations
+ │    ├── fd: ()-->(10)
+ │    ├── update x
+ │    │    ├── columns: x.a:7(int!null)
+ │    │    ├── fetch columns: x.a:8(int)
+ │    │    ├── update-mapping:
+ │    │    │    └──  column9:9 => x.a:7
+ │    │    ├── side-effects, mutations
+ │    │    ├── fd: ()-->(7)
+ │    │    └── project
+ │    │         ├── columns: column9:9(int!null) x.a:8(int!null)
+ │    │         ├── key: (8)
+ │    │         ├── fd: ()-->(9)
+ │    │         ├── scan x
+ │    │         │    ├── columns: x.a:8(int!null)
+ │    │         │    └── key: (8)
+ │    │         └── projections
+ │    │              └── const: 1 [type=int]
+ │    └── projections
+ │         └── const: 1 [type=int]
+ ├── inner-join
+ │    ├── columns: y.a:1(int!null) "?column?":5(int!null) x.a:6(int!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── side-effects, mutations
+ │    ├── fd: ()-->(5)
+ │    ├── scan x
+ │    │    ├── columns: x.a:6(int!null)
+ │    │    └── key: (6)
+ │    ├── inner-join
+ │    │    ├── columns: y.a:1(int!null) "?column?":5(int!null)
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── side-effects, mutations
+ │    │    ├── fd: ()-->(5)
+ │    │    ├── scan y
+ │    │    │    ├── columns: y.a:1(int!null)
+ │    │    │    ├── constraint: /1: contradiction
+ │    │    │    ├── cardinality: [0 - 0]
+ │    │    │    └── key: (1)
+ │    │    ├── project
+ │    │    │    ├── columns: "?column?":5(int!null)
+ │    │    │    ├── cardinality: [0 - 0]
+ │    │    │    ├── side-effects, mutations
+ │    │    │    ├── fd: ()-->(5)
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: x.a:2(int!null)
+ │    │    │    │    ├── cardinality: [0 - 0]
+ │    │    │    │    ├── side-effects, mutations
+ │    │    │    │    ├── fd: ()-->(2)
+ │    │    │    │    ├── insert x
+ │    │    │    │    │    ├── columns: x.a:2(int!null)
+ │    │    │    │    │    ├── insert-mapping:
+ │    │    │    │    │    │    └──  "?column?":4 => x.a:2
+ │    │    │    │    │    ├── side-effects, mutations
+ │    │    │    │    │    ├── fd: ()-->(2)
+ │    │    │    │    │    └── project
+ │    │    │    │    │         ├── columns: "?column?":4(int)
+ │    │    │    │    │         ├── fd: ()-->(4)
+ │    │    │    │    │         ├── scan x
+ │    │    │    │    │         └── projections
+ │    │    │    │    │              └── null [type=int]
+ │    │    │    │    └── filters
+ │    │    │    │         └── false [type=bool]
+ │    │    │    └── projections
+ │    │    │         └── const: 1 [type=int]
+ │    │    └── filters (true)
+ │    └── filters (true)
+ └── filters (true)


### PR DESCRIPTION
At the moment, this rule just causes too many problems to be worth the
trouble. Currently the known problem-case is #35253, which I believe
runs into problems because certain groups only get collapsed into values
clauses as a result of exploration, which messes with the exploration
order. I can't think of a good way to fix this, so for the time being I
think it's safest and most expedient to disable this rule.

Release note (bug fix): fixed panics that could occur in some cases
involving joins of the results of mutations.