### PR TITLE
release-2.0: rpc: adopt logging in circuitbreaker

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -187,6 +187,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/cenkalti/backoff"
+  packages = ["."]
+  revision = "1e4cf3da559842a91afcb6ea6141451e6c30c618"
+  version = "v2.1.1"
+
+[[projects]]
   name = "github.com/certifi/gocertifi"
   packages = ["."]
   revision = "3fd9e1adb12b72d2f3f82191d49be9b93c69f67c"
@@ -206,6 +212,11 @@
   packages = ["."]
   revision = "b1ce49cb2a474f4416531e7395373eaafaa4fbe2"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/cockroachdb/circuitbreaker"
+  packages = ["."]
+  revision = "a614b14ccf63dd2311d4ff646c30c61b8ed34aa"
 
 [[projects]]
   branch = "master"
@@ -938,12 +949,6 @@
   revision = "1f30fe9094a513ce4c700b9a54458bbb0c96996c"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/rubyist/circuitbreaker"
-  packages = ["."]
-  revision = "2074adba5ddc7d5f7559448a9c3066573521c5bf"
-
-[[projects]]
   name = "github.com/russross/blackfriday"
   packages = ["."]
   revision = "4048872b16cc0fc2c5fd9eacf0ed2c2fedaa0c8c"
@@ -1235,6 +1240,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3f17f79398b9d0ebd6aaaaf0f901bc5b0f8818abe58f95211356691e746ff3ff"
+  inputs-digest = "8cf1fa12e173a7194b9af15d74137b8163c2d7ba9a19b424321bb684467574e2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,11 +61,6 @@ ignored = [
   name = "github.com/montanaflynn/stats"
   branch = "master"
 
-# https://github.com/rubyist/circuitbreaker/commit/af95830
-[[constraint]]
-  name = "github.com/rubyist/circuitbreaker"
-  branch = "master"
-
 # github.com/docker/docker depends on a few functions not included in the
 # latest release: reference.{FamiliarName,ParseNormalizedNamed,TagNameOnly}.
 #
@@ -93,3 +88,7 @@ ignored = [
   [[prune.project]]
     name = "github.com/knz/go-libedit"
     unused-packages = false
+
+[[constraint]]
+  name = "github.com/cockroachdb/circuitbreaker"
+  revision = "a614b14ccf63dd2311d4ff646c30c61b8ed34aa"

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -21,8 +21,8 @@ import (
 	"sync"
 	"time"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/pkg/errors"
-	circuit "github.com/rubyist/circuitbreaker"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -168,7 +168,7 @@ func gossipSucceedsSoon(
 			// If the client wasn't able to connect, restart it.
 			g := gossip[client]
 			g.mu.Lock()
-			client.startLocked(g, disconnected, rpcContext, stopper, rpcContext.NewBreaker())
+			client.startLocked(g, disconnected, rpcContext, stopper, rpcContext.NewBreaker(""))
 			g.mu.Unlock()
 		default:
 		}
@@ -306,7 +306,7 @@ func TestClientNodeID(t *testing.T) {
 		case <-disconnected:
 			// The client hasn't been started or failed to start, loop and try again.
 			local.mu.Lock()
-			c.startLocked(local, disconnected, rpcContext, stopper, rpcContext.NewBreaker())
+			c.startLocked(local, disconnected, rpcContext, stopper, rpcContext.NewBreaker(""))
 			local.mu.Unlock()
 		}
 	}

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -63,9 +63,9 @@ import (
 
 	"google.golang.org/grpc"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
-	circuit "github.com/rubyist/circuitbreaker"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -1345,7 +1345,8 @@ func (g *Gossip) startClientLocked(addr net.Addr) {
 	defer g.clientsMu.Unlock()
 	breaker, ok := g.clientsMu.breakers[addr.String()]
 	if !ok {
-		breaker = g.rpcContext.NewBreaker()
+		name := fmt.Sprintf("gossip %v->%v", g.rpcContext.Addr, addr)
+		breaker = g.rpcContext.NewBreaker(name)
 		g.clientsMu.breakers[addr.String()] = breaker
 	}
 	ctx := g.AnnotateCtx(context.TODO())

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -383,7 +383,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 			localAddr := local.GetNodeAddr()
 			c := newClient(log.AmbientContext{Tracer: tracing.NewTracer()}, localAddr, makeMetrics())
 			peer.mu.Lock()
-			c.startLocked(peer, disconnectedCh, peer.rpcContext, stopper, peer.rpcContext.NewBreaker())
+			c.startLocked(peer, disconnectedCh, peer.rpcContext, stopper, peer.rpcContext.NewBreaker(""))
 			peer.mu.Unlock()
 
 			disconnectedClient := <-disconnectedCh

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -23,10 +23,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
-	"github.com/rubyist/circuitbreaker"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -578,12 +578,13 @@ func (ctx *Context) GRPCDial(target string) *Connection {
 }
 
 // NewBreaker creates a new circuit breaker properly configured for RPC
-// connections.
-func (ctx *Context) NewBreaker() *circuit.Breaker {
+// connections. name is used internally for logging state changes of the
+// returned breaker.
+func (ctx *Context) NewBreaker(name string) *circuit.Breaker {
 	if ctx.BreakerFactory != nil {
 		return ctx.BreakerFactory()
 	}
-	return newBreaker(&ctx.breakerClock)
+	return newBreaker(ctx.masterCtx, name, &ctx.breakerClock)
 }
 
 // ErrNotConnected is returned by ConnHealth when there is no connection to the

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -34,10 +34,10 @@ import (
 	"time"
 
 	"github.com/cenk/backoff"
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/coreos/etcd/raft"
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
-	circuit "github.com/rubyist/circuitbreaker"
 	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cockroach/pkg/base"


### PR DESCRIPTION
Backport 1/1 commits from #33676.

/cc @cockroachdb/release

---

Adopts changes to the circuitbreaker package to enable logging. 

Release note: None
