### PR TITLE
opt: show hints for merge/lookup join

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -278,6 +278,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 
 	case *LookupJoinExpr:
+		if !t.Flags.Empty() {
+			tp.Childf("flags: %s", t.Flags.String())
+		}
 		idxCols := make(opt.ColList, len(t.KeyCols))
 		idx := md.Table(t.Table).Index(t.Index)
 		for i := range idxCols {
@@ -305,6 +308,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 
 	case *MergeJoinExpr:
+		if !t.Flags.Empty() {
+			tp.Childf("flags: %s", t.Flags.String())
+		}
 		if !f.HasFlags(ExprFmtHideOrderings) {
 			tp.Childf("left ordering: %s", t.LeftEq)
 			tp.Childf("right ordering: %s", t.RightEq)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -303,6 +303,8 @@ define LookupJoinPrivate {
     # join, treating it as if it were another relational input. This makes the
     # lookup join appear more like other join operators.
     lookupProps RelProps
+
+    _ JoinPrivate
 }
 
 # MergeJoin represents a join that is executed using merge-join.
@@ -341,6 +343,8 @@ define MergeJoinPrivate {
     # columns and orderings.
     LeftOrdering  OrderingChoice
     RightOrdering OrderingChoice
+
+    _ JoinPrivate
 }
 
 # ZigzagJoin represents a join that is executed using the zigzag joiner.

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -156,7 +156,12 @@ func (g *exprsGen) genPrivateStruct(define *lang.DefineExpr) {
 			generateComments(g.w, field.Comments, string(field.Name), string(field.Name))
 		}
 
-		fmt.Fprintf(g.w, "  %s %s\n", field.Name, g.md.typeOf(field).name)
+		// If field's name is "_", then use Go embedding syntax.
+		if isEmbeddedField(field) {
+			fmt.Fprintf(g.w, "  %s\n", g.md.typeOf(field).name)
+		} else {
+			fmt.Fprintf(g.w, "  %s %s\n", field.Name, g.md.typeOf(field).name)
+		}
 	}
 	fmt.Fprintf(g.w, "}\n\n")
 }

--- a/pkg/sql/opt/xform/custom_funcs.go
+++ b/pkg/sql/opt/xform/custom_funcs.go
@@ -622,6 +622,7 @@ func (c *CustomFuncs) GenerateMergeJoins(
 		}
 
 		merge := memo.MergeJoinExpr{Left: left, Right: right, On: remainingFilters}
+		merge.JoinPrivate = *joinPrivate
 		merge.JoinType = originalOp
 		merge.LeftEq = make(opt.Ordering, n)
 		merge.RightEq = make(opt.Ordering, n)
@@ -717,6 +718,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 		}
 
 		lookupJoin := memo.LookupJoinExpr{Input: input, On: on}
+		lookupJoin.JoinPrivate = *joinPrivate
 		lookupJoin.JoinType = joinType
 		lookupJoin.Table = scanPrivate.Table
 		lookupJoin.Index = iter.indexOrdinal

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -59,6 +59,7 @@ SELECT k, x FROM a INNER MERGE JOIN b ON k=x
 ----
 inner-join (merge)
  ├── columns: k:1(int!null) x:5(int!null)
+ ├── flags: no-lookup-join;no-hash-join
  ├── left ordering: +1
  ├── right ordering: +5
  ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(5)=100, null(5)=0]
@@ -88,6 +89,7 @@ SELECT k, x FROM b INNER LOOKUP JOIN a ON k=x
 ----
 inner-join (lookup a)
  ├── columns: k:4(int!null) x:1(int!null)
+ ├── flags: no-merge-join;no-hash-join
  ├── key columns: [1] = [4]
  ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(4)=100, null(4)=0]
  ├── cost: 6090.02

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -149,7 +149,7 @@ inner-join (lookup bx)
 memo join-limit=3
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~17KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
+memo (optimized, ~18KB, required=[presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+6) (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8)) (inner-join G6 G7 G8) (inner-join G9 G10 G11) (inner-join G7 G6 G8) (merge-join G6 G7 G5 inner-join,+3,+7) (inner-join G10 G9 G11) (lookup-join G7 G5 cy,keyCols=[7],outCols=(1-8))
  │    └── [presentation: b:1,x:2,c:3,y:4,a:5,b:6,c:7,d:8]
  │         ├── best: (lookup-join G3 G5 bx,keyCols=[6],outCols=(1-8))


### PR DESCRIPTION
Incorporate a copy of the original `JoinPrivate` inside
`Merge/LookupJoinPrivate` and show the original flags.

Fixes #35353.

Release note: None