### PR TITLE
cli: fix `debug zip` nil pointer dereference

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -275,7 +275,7 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 				err = contextutil.RunWithTimeout(baseCtx, "request stacks", timeout,
 					func(ctx context.Context) error {
 						stacks, err := status.Stacks(ctx, &serverpb.StacksRequest{NodeId: id})
-						if err != nil {
+						if err == nil {
 							stacksData = stacks.Data
 						}
 						return err
@@ -291,7 +291,9 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 							NodeId: id,
 							Type:   serverpb.ProfileRequest_HEAP,
 						})
-						heapData = heap.Data
+						if err == nil {
+							heapData = heap.Data
+						}
 						return err
 					})
 				if err := z.createRawOrError(prefix+"/heap", heapData, err); err != nil {

--- a/pkg/cmd/roachtest/debug.go
+++ b/pkg/cmd/roachtest/debug.go
@@ -66,8 +66,17 @@ func registerDebug(r *registry) {
 
 		waitForFullReplication(t, db)
 
-		// Kill first nodes-1 nodes.
-		for i := 1; i < nodes; i++ {
+		// Kill the first node and verify debug zip can be generated with one node
+		// down.
+		c.Stop(ctx, c.Node(1))
+
+		// Run debug zip command against the second node.
+		if err := debugExtractExist(2, "output.zip"); err != nil {
+			t.Fatal(err)
+		}
+
+		// Kill all but the last node.
+		for i := 2; i < nodes; i++ {
 			c.Stop(ctx, c.Node(i))
 		}
 


### PR DESCRIPTION
Fix a nil pointer dereference in `debug zip` when a few nodes are down,
but the cluster is otherwise above quorum. Extended the existing
`debug/nodes=3` roachtest to tickle this problem which was not occurring
previously because that test was checking `debug zip` when all but 1
node was down.

Fixes #35358

Release note (bug fix): Fix a nil pointer dereference in `debug zip`
when one or more nodes in the cluster are down.