### PR TITLE
server: introduce a new bootstrapping RPC service

### DIFF
--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -69,7 +69,7 @@ func (x ReadConsistencyType) String() string {
 	return proto.EnumName(ReadConsistencyType_name, int32(x))
 }
 func (ReadConsistencyType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{0}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{0}
 }
 
 // ScanFormat is an enumeration of the available response formats for MVCCScan
@@ -97,7 +97,7 @@ func (x ScanFormat) String() string {
 	return proto.EnumName(ScanFormat_name, int32(x))
 }
 func (ScanFormat) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{1}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{1}
 }
 
 // PushTxnType determines what action to take when pushing a transaction.
@@ -128,7 +128,7 @@ func (x PushTxnType) String() string {
 	return proto.EnumName(PushTxnType_name, int32(x))
 }
 func (PushTxnType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{2}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{2}
 }
 
 type ExportStorageProvider int32
@@ -166,7 +166,7 @@ func (x ExportStorageProvider) String() string {
 	return proto.EnumName(ExportStorageProvider_name, int32(x))
 }
 func (ExportStorageProvider) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{3}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{3}
 }
 
 type MVCCFilter int32
@@ -189,7 +189,7 @@ func (x MVCCFilter) String() string {
 	return proto.EnumName(MVCCFilter_name, int32(x))
 }
 func (MVCCFilter) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{4}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{4}
 }
 
 type ResponseHeader_ResumeReason int32
@@ -221,7 +221,7 @@ func (x ResponseHeader_ResumeReason) String() string {
 	return proto.EnumName(ResponseHeader_ResumeReason_name, int32(x))
 }
 func (ResponseHeader_ResumeReason) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{2, 0}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{2, 0}
 }
 
 type QueryIntentRequest_IfMissingBehavior int32
@@ -257,7 +257,7 @@ func (x QueryIntentRequest_IfMissingBehavior) String() string {
 	return proto.EnumName(QueryIntentRequest_IfMissingBehavior_name, int32(x))
 }
 func (QueryIntentRequest_IfMissingBehavior) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{50, 0}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{50, 0}
 }
 
 // RangeInfo describes a range which executed a request. It contains
@@ -273,7 +273,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{0}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{0}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -318,7 +318,7 @@ func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
 func (m *RequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RequestHeader) ProtoMessage()    {}
 func (*RequestHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{1}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{1}
 }
 func (m *RequestHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -378,7 +378,7 @@ func (m *ResponseHeader) Reset()         { *m = ResponseHeader{} }
 func (m *ResponseHeader) String() string { return proto.CompactTextString(m) }
 func (*ResponseHeader) ProtoMessage()    {}
 func (*ResponseHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{2}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{2}
 }
 func (m *ResponseHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -414,7 +414,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{3}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{3}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -454,7 +454,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{4}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{4}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -499,7 +499,7 @@ func (m *PutRequest) Reset()         { *m = PutRequest{} }
 func (m *PutRequest) String() string { return proto.CompactTextString(m) }
 func (*PutRequest) ProtoMessage()    {}
 func (*PutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{5}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{5}
 }
 func (m *PutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -535,7 +535,7 @@ func (m *PutResponse) Reset()         { *m = PutResponse{} }
 func (m *PutResponse) String() string { return proto.CompactTextString(m) }
 func (*PutResponse) ProtoMessage()    {}
 func (*PutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{6}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{6}
 }
 func (m *PutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -591,7 +591,7 @@ func (m *ConditionalPutRequest) Reset()         { *m = ConditionalPutRequest{} }
 func (m *ConditionalPutRequest) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutRequest) ProtoMessage()    {}
 func (*ConditionalPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{7}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{7}
 }
 func (m *ConditionalPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -628,7 +628,7 @@ func (m *ConditionalPutResponse) Reset()         { *m = ConditionalPutResponse{}
 func (m *ConditionalPutResponse) String() string { return proto.CompactTextString(m) }
 func (*ConditionalPutResponse) ProtoMessage()    {}
 func (*ConditionalPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{8}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{8}
 }
 func (m *ConditionalPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -676,7 +676,7 @@ func (m *InitPutRequest) Reset()         { *m = InitPutRequest{} }
 func (m *InitPutRequest) String() string { return proto.CompactTextString(m) }
 func (*InitPutRequest) ProtoMessage()    {}
 func (*InitPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{9}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{9}
 }
 func (m *InitPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -712,7 +712,7 @@ func (m *InitPutResponse) Reset()         { *m = InitPutResponse{} }
 func (m *InitPutResponse) String() string { return proto.CompactTextString(m) }
 func (*InitPutResponse) ProtoMessage()    {}
 func (*InitPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{10}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{10}
 }
 func (m *InitPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -754,7 +754,7 @@ func (m *IncrementRequest) Reset()         { *m = IncrementRequest{} }
 func (m *IncrementRequest) String() string { return proto.CompactTextString(m) }
 func (*IncrementRequest) ProtoMessage()    {}
 func (*IncrementRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{11}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{11}
 }
 func (m *IncrementRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -793,7 +793,7 @@ func (m *IncrementResponse) Reset()         { *m = IncrementResponse{} }
 func (m *IncrementResponse) String() string { return proto.CompactTextString(m) }
 func (*IncrementResponse) ProtoMessage()    {}
 func (*IncrementResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{12}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{12}
 }
 func (m *IncrementResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -829,7 +829,7 @@ func (m *DeleteRequest) Reset()         { *m = DeleteRequest{} }
 func (m *DeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRequest) ProtoMessage()    {}
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{13}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{13}
 }
 func (m *DeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -865,7 +865,7 @@ func (m *DeleteResponse) Reset()         { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()    {}
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{14}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{14}
 }
 func (m *DeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -916,7 +916,7 @@ func (m *DeleteRangeRequest) Reset()         { *m = DeleteRangeRequest{} }
 func (m *DeleteRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeRequest) ProtoMessage()    {}
 func (*DeleteRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{15}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{15}
 }
 func (m *DeleteRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -955,7 +955,7 @@ func (m *DeleteRangeResponse) Reset()         { *m = DeleteRangeResponse{} }
 func (m *DeleteRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeResponse) ProtoMessage()    {}
 func (*DeleteRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{16}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{16}
 }
 func (m *DeleteRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1004,7 +1004,7 @@ func (m *ClearRangeRequest) Reset()         { *m = ClearRangeRequest{} }
 func (m *ClearRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeRequest) ProtoMessage()    {}
 func (*ClearRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{17}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{17}
 }
 func (m *ClearRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1040,7 +1040,7 @@ func (m *ClearRangeResponse) Reset()         { *m = ClearRangeResponse{} }
 func (m *ClearRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ClearRangeResponse) ProtoMessage()    {}
 func (*ClearRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{18}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{18}
 }
 func (m *ClearRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1111,7 +1111,7 @@ func (m *ScanOptions) Reset()         { *m = ScanOptions{} }
 func (m *ScanOptions) String() string { return proto.CompactTextString(m) }
 func (*ScanOptions) ProtoMessage()    {}
 func (*ScanOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{19}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{19}
 }
 func (m *ScanOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1153,7 +1153,7 @@ func (m *ScanRequest) Reset()         { *m = ScanRequest{} }
 func (m *ScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ScanRequest) ProtoMessage()    {}
 func (*ScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{20}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{20}
 }
 func (m *ScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1202,7 +1202,7 @@ func (m *ScanResponse) Reset()         { *m = ScanResponse{} }
 func (m *ScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ScanResponse) ProtoMessage()    {}
 func (*ScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{21}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{21}
 }
 func (m *ScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1244,7 +1244,7 @@ func (m *ReverseScanRequest) Reset()         { *m = ReverseScanRequest{} }
 func (m *ReverseScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanRequest) ProtoMessage()    {}
 func (*ReverseScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{22}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{22}
 }
 func (m *ReverseScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1293,7 +1293,7 @@ func (m *ReverseScanResponse) Reset()         { *m = ReverseScanResponse{} }
 func (m *ReverseScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ReverseScanResponse) ProtoMessage()    {}
 func (*ReverseScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{23}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{23}
 }
 func (m *ReverseScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1334,7 +1334,7 @@ func (m *CheckConsistencyRequest) Reset()         { *m = CheckConsistencyRequest
 func (m *CheckConsistencyRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyRequest) ProtoMessage()    {}
 func (*CheckConsistencyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{24}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{24}
 }
 func (m *CheckConsistencyRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1371,7 +1371,7 @@ func (m *CheckConsistencyResponse) Reset()         { *m = CheckConsistencyRespon
 func (m *CheckConsistencyResponse) String() string { return proto.CompactTextString(m) }
 func (*CheckConsistencyResponse) ProtoMessage()    {}
 func (*CheckConsistencyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{25}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{25}
 }
 func (m *CheckConsistencyResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1421,7 +1421,7 @@ func (m *RecomputeStatsRequest) Reset()         { *m = RecomputeStatsRequest{} }
 func (m *RecomputeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsRequest) ProtoMessage()    {}
 func (*RecomputeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{26}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{26}
 }
 func (m *RecomputeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1459,7 +1459,7 @@ func (m *RecomputeStatsResponse) Reset()         { *m = RecomputeStatsResponse{}
 func (m *RecomputeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RecomputeStatsResponse) ProtoMessage()    {}
 func (*RecomputeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{27}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{27}
 }
 func (m *RecomputeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1495,7 +1495,7 @@ func (m *BeginTransactionRequest) Reset()         { *m = BeginTransactionRequest
 func (m *BeginTransactionRequest) String() string { return proto.CompactTextString(m) }
 func (*BeginTransactionRequest) ProtoMessage()    {}
 func (*BeginTransactionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{28}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{28}
 }
 func (m *BeginTransactionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1531,7 +1531,7 @@ func (m *BeginTransactionResponse) Reset()         { *m = BeginTransactionRespon
 func (m *BeginTransactionResponse) String() string { return proto.CompactTextString(m) }
 func (*BeginTransactionResponse) ProtoMessage()    {}
 func (*BeginTransactionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{29}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{29}
 }
 func (m *BeginTransactionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1605,7 +1605,7 @@ func (m *EndTransactionRequest) Reset()         { *m = EndTransactionRequest{} }
 func (m *EndTransactionRequest) String() string { return proto.CompactTextString(m) }
 func (*EndTransactionRequest) ProtoMessage()    {}
 func (*EndTransactionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{30}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{30}
 }
 func (m *EndTransactionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1651,7 +1651,7 @@ func (m *EndTransactionResponse) Reset()         { *m = EndTransactionResponse{}
 func (m *EndTransactionResponse) String() string { return proto.CompactTextString(m) }
 func (*EndTransactionResponse) ProtoMessage()    {}
 func (*EndTransactionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{31}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{31}
 }
 func (m *EndTransactionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1707,7 +1707,7 @@ func (m *AdminSplitRequest) Reset()         { *m = AdminSplitRequest{} }
 func (m *AdminSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitRequest) ProtoMessage()    {}
 func (*AdminSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{32}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{32}
 }
 func (m *AdminSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1744,7 +1744,7 @@ func (m *AdminSplitResponse) Reset()         { *m = AdminSplitResponse{} }
 func (m *AdminSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminSplitResponse) ProtoMessage()    {}
 func (*AdminSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{33}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{33}
 }
 func (m *AdminSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1788,7 +1788,7 @@ func (m *AdminMergeRequest) Reset()         { *m = AdminMergeRequest{} }
 func (m *AdminMergeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeRequest) ProtoMessage()    {}
 func (*AdminMergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{34}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{34}
 }
 func (m *AdminMergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1825,7 +1825,7 @@ func (m *AdminMergeResponse) Reset()         { *m = AdminMergeResponse{} }
 func (m *AdminMergeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminMergeResponse) ProtoMessage()    {}
 func (*AdminMergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{35}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{35}
 }
 func (m *AdminMergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1865,7 +1865,7 @@ func (m *AdminTransferLeaseRequest) Reset()         { *m = AdminTransferLeaseReq
 func (m *AdminTransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseRequest) ProtoMessage()    {}
 func (*AdminTransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{36}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{36}
 }
 func (m *AdminTransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1900,7 +1900,7 @@ func (m *AdminTransferLeaseResponse) Reset()         { *m = AdminTransferLeaseRe
 func (m *AdminTransferLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminTransferLeaseResponse) ProtoMessage()    {}
 func (*AdminTransferLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{37}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{37}
 }
 func (m *AdminTransferLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1940,7 +1940,7 @@ func (m *AdminChangeReplicasRequest) Reset()         { *m = AdminChangeReplicasR
 func (m *AdminChangeReplicasRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasRequest) ProtoMessage()    {}
 func (*AdminChangeReplicasRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{38}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{38}
 }
 func (m *AdminChangeReplicasRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1975,7 +1975,7 @@ func (m *AdminChangeReplicasResponse) Reset()         { *m = AdminChangeReplicas
 func (m *AdminChangeReplicasResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminChangeReplicasResponse) ProtoMessage()    {}
 func (*AdminChangeReplicasResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{39}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{39}
 }
 func (m *AdminChangeReplicasResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2014,7 +2014,7 @@ func (m *AdminRelocateRangeRequest) Reset()         { *m = AdminRelocateRangeReq
 func (m *AdminRelocateRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeRequest) ProtoMessage()    {}
 func (*AdminRelocateRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{40}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{40}
 }
 func (m *AdminRelocateRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2049,7 +2049,7 @@ func (m *AdminRelocateRangeResponse) Reset()         { *m = AdminRelocateRangeRe
 func (m *AdminRelocateRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminRelocateRangeResponse) ProtoMessage()    {}
 func (*AdminRelocateRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{41}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{41}
 }
 func (m *AdminRelocateRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2090,7 +2090,7 @@ func (m *HeartbeatTxnRequest) Reset()         { *m = HeartbeatTxnRequest{} }
 func (m *HeartbeatTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnRequest) ProtoMessage()    {}
 func (*HeartbeatTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{42}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{42}
 }
 func (m *HeartbeatTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2129,7 +2129,7 @@ func (m *HeartbeatTxnResponse) Reset()         { *m = HeartbeatTxnResponse{} }
 func (m *HeartbeatTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatTxnResponse) ProtoMessage()    {}
 func (*HeartbeatTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{43}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{43}
 }
 func (m *HeartbeatTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2174,7 +2174,7 @@ func (m *GCRequest) Reset()         { *m = GCRequest{} }
 func (m *GCRequest) String() string { return proto.CompactTextString(m) }
 func (*GCRequest) ProtoMessage()    {}
 func (*GCRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{44}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{44}
 }
 func (m *GCRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2210,7 +2210,7 @@ func (m *GCRequest_GCKey) Reset()         { *m = GCRequest_GCKey{} }
 func (m *GCRequest_GCKey) String() string { return proto.CompactTextString(m) }
 func (*GCRequest_GCKey) ProtoMessage()    {}
 func (*GCRequest_GCKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{44, 0}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{44, 0}
 }
 func (m *GCRequest_GCKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2246,7 +2246,7 @@ func (m *GCResponse) Reset()         { *m = GCResponse{} }
 func (m *GCResponse) String() string { return proto.CompactTextString(m) }
 func (*GCResponse) ProtoMessage()    {}
 func (*GCResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{45}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{45}
 }
 func (m *GCResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2330,7 +2330,7 @@ func (m *PushTxnRequest) Reset()         { *m = PushTxnRequest{} }
 func (m *PushTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*PushTxnRequest) ProtoMessage()    {}
 func (*PushTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{46}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{46}
 }
 func (m *PushTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2375,7 +2375,7 @@ func (m *PushTxnResponse) Reset()         { *m = PushTxnResponse{} }
 func (m *PushTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*PushTxnResponse) ProtoMessage()    {}
 func (*PushTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{47}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{47}
 }
 func (m *PushTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2421,7 +2421,7 @@ func (m *QueryTxnRequest) Reset()         { *m = QueryTxnRequest{} }
 func (m *QueryTxnRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnRequest) ProtoMessage()    {}
 func (*QueryTxnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{48}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{48}
 }
 func (m *QueryTxnRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2462,7 +2462,7 @@ func (m *QueryTxnResponse) Reset()         { *m = QueryTxnResponse{} }
 func (m *QueryTxnResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryTxnResponse) ProtoMessage()    {}
 func (*QueryTxnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{49}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{49}
 }
 func (m *QueryTxnResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2524,7 +2524,7 @@ func (m *QueryIntentRequest) Reset()         { *m = QueryIntentRequest{} }
 func (m *QueryIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentRequest) ProtoMessage()    {}
 func (*QueryIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{50}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{50}
 }
 func (m *QueryIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2562,7 +2562,7 @@ func (m *QueryIntentResponse) Reset()         { *m = QueryIntentResponse{} }
 func (m *QueryIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryIntentResponse) ProtoMessage()    {}
 func (*QueryIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{51}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{51}
 }
 func (m *QueryIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2608,7 +2608,7 @@ func (m *ResolveIntentRequest) Reset()         { *m = ResolveIntentRequest{} }
 func (m *ResolveIntentRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRequest) ProtoMessage()    {}
 func (*ResolveIntentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{52}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{52}
 }
 func (m *ResolveIntentRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2645,7 +2645,7 @@ func (m *ResolveIntentResponse) Reset()         { *m = ResolveIntentResponse{} }
 func (m *ResolveIntentResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentResponse) ProtoMessage()    {}
 func (*ResolveIntentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{53}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{53}
 }
 func (m *ResolveIntentResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2695,7 +2695,7 @@ func (m *ResolveIntentRangeRequest) Reset()         { *m = ResolveIntentRangeReq
 func (m *ResolveIntentRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeRequest) ProtoMessage()    {}
 func (*ResolveIntentRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{54}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{54}
 }
 func (m *ResolveIntentRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2732,7 +2732,7 @@ func (m *ResolveIntentRangeResponse) Reset()         { *m = ResolveIntentRangeRe
 func (m *ResolveIntentRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveIntentRangeResponse) ProtoMessage()    {}
 func (*ResolveIntentRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{55}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{55}
 }
 func (m *ResolveIntentRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2771,7 +2771,7 @@ func (m *MergeRequest) Reset()         { *m = MergeRequest{} }
 func (m *MergeRequest) String() string { return proto.CompactTextString(m) }
 func (*MergeRequest) ProtoMessage()    {}
 func (*MergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{56}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{56}
 }
 func (m *MergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2807,7 +2807,7 @@ func (m *MergeResponse) Reset()         { *m = MergeResponse{} }
 func (m *MergeResponse) String() string { return proto.CompactTextString(m) }
 func (*MergeResponse) ProtoMessage()    {}
 func (*MergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{57}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{57}
 }
 func (m *MergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2854,7 +2854,7 @@ func (m *TruncateLogRequest) Reset()         { *m = TruncateLogRequest{} }
 func (m *TruncateLogRequest) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogRequest) ProtoMessage()    {}
 func (*TruncateLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{58}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{58}
 }
 func (m *TruncateLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2890,7 +2890,7 @@ func (m *TruncateLogResponse) Reset()         { *m = TruncateLogResponse{} }
 func (m *TruncateLogResponse) String() string { return proto.CompactTextString(m) }
 func (*TruncateLogResponse) ProtoMessage()    {}
 func (*TruncateLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{59}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{59}
 }
 func (m *TruncateLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2936,7 +2936,7 @@ func (m *RequestLeaseRequest) Reset()         { *m = RequestLeaseRequest{} }
 func (m *RequestLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseRequest) ProtoMessage()    {}
 func (*RequestLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{60}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{60}
 }
 func (m *RequestLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2987,7 +2987,7 @@ func (m *TransferLeaseRequest) Reset()         { *m = TransferLeaseRequest{} }
 func (m *TransferLeaseRequest) String() string { return proto.CompactTextString(m) }
 func (*TransferLeaseRequest) ProtoMessage()    {}
 func (*TransferLeaseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{61}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{61}
 }
 func (m *TransferLeaseRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3026,7 +3026,7 @@ func (m *LeaseInfoRequest) Reset()         { *m = LeaseInfoRequest{} }
 func (m *LeaseInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoRequest) ProtoMessage()    {}
 func (*LeaseInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{62}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{62}
 }
 func (m *LeaseInfoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3065,7 +3065,7 @@ func (m *LeaseInfoResponse) Reset()         { *m = LeaseInfoResponse{} }
 func (m *LeaseInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*LeaseInfoResponse) ProtoMessage()    {}
 func (*LeaseInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{63}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{63}
 }
 func (m *LeaseInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3102,7 +3102,7 @@ func (m *RequestLeaseResponse) Reset()         { *m = RequestLeaseResponse{} }
 func (m *RequestLeaseResponse) String() string { return proto.CompactTextString(m) }
 func (*RequestLeaseResponse) ProtoMessage()    {}
 func (*RequestLeaseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{64}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{64}
 }
 func (m *RequestLeaseResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3147,7 +3147,7 @@ func (m *ComputeChecksumRequest) Reset()         { *m = ComputeChecksumRequest{}
 func (m *ComputeChecksumRequest) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumRequest) ProtoMessage()    {}
 func (*ComputeChecksumRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{65}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{65}
 }
 func (m *ComputeChecksumRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3186,7 +3186,7 @@ func (m *ComputeChecksumResponse) Reset()         { *m = ComputeChecksumResponse
 func (m *ComputeChecksumResponse) String() string { return proto.CompactTextString(m) }
 func (*ComputeChecksumResponse) ProtoMessage()    {}
 func (*ComputeChecksumResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{66}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{66}
 }
 func (m *ComputeChecksumResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3227,7 +3227,7 @@ func (m *ExportStorage) Reset()         { *m = ExportStorage{} }
 func (m *ExportStorage) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage) ProtoMessage()    {}
 func (*ExportStorage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{67}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{67}
 }
 func (m *ExportStorage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3263,7 +3263,7 @@ func (m *ExportStorage_LocalFilePath) Reset()         { *m = ExportStorage_Local
 func (m *ExportStorage_LocalFilePath) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_LocalFilePath) ProtoMessage()    {}
 func (*ExportStorage_LocalFilePath) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{67, 0}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{67, 0}
 }
 func (m *ExportStorage_LocalFilePath) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3298,7 +3298,7 @@ func (m *ExportStorage_Http) Reset()         { *m = ExportStorage_Http{} }
 func (m *ExportStorage_Http) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_Http) ProtoMessage()    {}
 func (*ExportStorage_Http) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{67, 1}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{67, 1}
 }
 func (m *ExportStorage_Http) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3339,7 +3339,7 @@ func (m *ExportStorage_S3) Reset()         { *m = ExportStorage_S3{} }
 func (m *ExportStorage_S3) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_S3) ProtoMessage()    {}
 func (*ExportStorage_S3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{67, 2}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{67, 2}
 }
 func (m *ExportStorage_S3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3380,7 +3380,7 @@ func (m *ExportStorage_GCS) Reset()         { *m = ExportStorage_GCS{} }
 func (m *ExportStorage_GCS) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_GCS) ProtoMessage()    {}
 func (*ExportStorage_GCS) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{67, 3}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{67, 3}
 }
 func (m *ExportStorage_GCS) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3418,7 +3418,7 @@ func (m *ExportStorage_Azure) Reset()         { *m = ExportStorage_Azure{} }
 func (m *ExportStorage_Azure) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_Azure) ProtoMessage()    {}
 func (*ExportStorage_Azure) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{67, 4}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{67, 4}
 }
 func (m *ExportStorage_Azure) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3459,7 +3459,7 @@ func (m *ExportStorage_Workload) Reset()         { *m = ExportStorage_Workload{}
 func (m *ExportStorage_Workload) String() string { return proto.CompactTextString(m) }
 func (*ExportStorage_Workload) ProtoMessage()    {}
 func (*ExportStorage_Workload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{67, 5}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{67, 5}
 }
 func (m *ExportStorage_Workload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3501,7 +3501,7 @@ func (m *WriteBatchRequest) Reset()         { *m = WriteBatchRequest{} }
 func (m *WriteBatchRequest) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchRequest) ProtoMessage()    {}
 func (*WriteBatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{68}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{68}
 }
 func (m *WriteBatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3537,7 +3537,7 @@ func (m *WriteBatchResponse) Reset()         { *m = WriteBatchResponse{} }
 func (m *WriteBatchResponse) String() string { return proto.CompactTextString(m) }
 func (*WriteBatchResponse) ProtoMessage()    {}
 func (*WriteBatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{69}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{69}
 }
 func (m *WriteBatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3584,7 +3584,7 @@ func (m *ExportRequest) Reset()         { *m = ExportRequest{} }
 func (m *ExportRequest) String() string { return proto.CompactTextString(m) }
 func (*ExportRequest) ProtoMessage()    {}
 func (*ExportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{70}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{70}
 }
 func (m *ExportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3622,7 +3622,7 @@ func (m *BulkOpSummary) Reset()         { *m = BulkOpSummary{} }
 func (m *BulkOpSummary) String() string { return proto.CompactTextString(m) }
 func (*BulkOpSummary) ProtoMessage()    {}
 func (*BulkOpSummary) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{71}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{71}
 }
 func (m *BulkOpSummary) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3660,7 +3660,7 @@ func (m *ExportResponse) Reset()         { *m = ExportResponse{} }
 func (m *ExportResponse) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse) ProtoMessage()    {}
 func (*ExportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{72}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{72}
 }
 func (m *ExportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3701,7 +3701,7 @@ func (m *ExportResponse_File) Reset()         { *m = ExportResponse_File{} }
 func (m *ExportResponse_File) String() string { return proto.CompactTextString(m) }
 func (*ExportResponse_File) ProtoMessage()    {}
 func (*ExportResponse_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{72, 0}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{72, 0}
 }
 func (m *ExportResponse_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3753,7 +3753,7 @@ func (m *ImportRequest) Reset()         { *m = ImportRequest{} }
 func (m *ImportRequest) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest) ProtoMessage()    {}
 func (*ImportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{73}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{73}
 }
 func (m *ImportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3790,7 +3790,7 @@ func (m *ImportRequest_File) Reset()         { *m = ImportRequest_File{} }
 func (m *ImportRequest_File) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_File) ProtoMessage()    {}
 func (*ImportRequest_File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{73, 0}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{73, 0}
 }
 func (m *ImportRequest_File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3828,7 +3828,7 @@ func (m *ImportRequest_TableRekey) Reset()         { *m = ImportRequest_TableRek
 func (m *ImportRequest_TableRekey) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest_TableRekey) ProtoMessage()    {}
 func (*ImportRequest_TableRekey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{73, 1}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{73, 1}
 }
 func (m *ImportRequest_TableRekey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3865,7 +3865,7 @@ func (m *ImportResponse) Reset()         { *m = ImportResponse{} }
 func (m *ImportResponse) String() string { return proto.CompactTextString(m) }
 func (*ImportResponse) ProtoMessage()    {}
 func (*ImportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{74}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{74}
 }
 func (m *ImportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3905,7 +3905,7 @@ func (m *AdminScatterRequest) Reset()         { *m = AdminScatterRequest{} }
 func (m *AdminScatterRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterRequest) ProtoMessage()    {}
 func (*AdminScatterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{75}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{75}
 }
 func (m *AdminScatterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3942,7 +3942,7 @@ func (m *AdminScatterResponse) Reset()         { *m = AdminScatterResponse{} }
 func (m *AdminScatterResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse) ProtoMessage()    {}
 func (*AdminScatterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{76}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{76}
 }
 func (m *AdminScatterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3977,7 +3977,7 @@ func (m *AdminScatterResponse_Range) Reset()         { *m = AdminScatterResponse
 func (m *AdminScatterResponse_Range) String() string { return proto.CompactTextString(m) }
 func (*AdminScatterResponse_Range) ProtoMessage()    {}
 func (*AdminScatterResponse_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{76, 0}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{76, 0}
 }
 func (m *AdminScatterResponse_Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4015,7 +4015,7 @@ func (m *AddSSTableRequest) Reset()         { *m = AddSSTableRequest{} }
 func (m *AddSSTableRequest) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableRequest) ProtoMessage()    {}
 func (*AddSSTableRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{77}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{77}
 }
 func (m *AddSSTableRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4051,7 +4051,7 @@ func (m *AddSSTableResponse) Reset()         { *m = AddSSTableResponse{} }
 func (m *AddSSTableResponse) String() string { return proto.CompactTextString(m) }
 func (*AddSSTableResponse) ProtoMessage()    {}
 func (*AddSSTableResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{78}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{78}
 }
 func (m *AddSSTableResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4097,7 +4097,7 @@ func (m *RefreshRequest) Reset()         { *m = RefreshRequest{} }
 func (m *RefreshRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRequest) ProtoMessage()    {}
 func (*RefreshRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{79}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{79}
 }
 func (m *RefreshRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4133,7 +4133,7 @@ func (m *RefreshResponse) Reset()         { *m = RefreshResponse{} }
 func (m *RefreshResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshResponse) ProtoMessage()    {}
 func (*RefreshResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{80}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{80}
 }
 func (m *RefreshResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4175,7 +4175,7 @@ func (m *RefreshRangeRequest) Reset()         { *m = RefreshRangeRequest{} }
 func (m *RefreshRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeRequest) ProtoMessage()    {}
 func (*RefreshRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{81}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{81}
 }
 func (m *RefreshRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4211,7 +4211,7 @@ func (m *RefreshRangeResponse) Reset()         { *m = RefreshRangeResponse{} }
 func (m *RefreshRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RefreshRangeResponse) ProtoMessage()    {}
 func (*RefreshRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{82}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{82}
 }
 func (m *RefreshRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4259,7 +4259,7 @@ func (m *SubsumeRequest) Reset()         { *m = SubsumeRequest{} }
 func (m *SubsumeRequest) String() string { return proto.CompactTextString(m) }
 func (*SubsumeRequest) ProtoMessage()    {}
 func (*SubsumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{83}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{83}
 }
 func (m *SubsumeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4306,7 +4306,7 @@ func (m *SubsumeResponse) Reset()         { *m = SubsumeResponse{} }
 func (m *SubsumeResponse) String() string { return proto.CompactTextString(m) }
 func (*SubsumeResponse) ProtoMessage()    {}
 func (*SubsumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{84}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{84}
 }
 func (m *SubsumeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4343,7 +4343,7 @@ func (m *RangeStatsRequest) Reset()         { *m = RangeStatsRequest{} }
 func (m *RangeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsRequest) ProtoMessage()    {}
 func (*RangeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{85}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{85}
 }
 func (m *RangeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4384,7 +4384,7 @@ func (m *RangeStatsResponse) Reset()         { *m = RangeStatsResponse{} }
 func (m *RangeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeStatsResponse) ProtoMessage()    {}
 func (*RangeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{86}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{86}
 }
 func (m *RangeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4466,7 +4466,7 @@ func (m *RequestUnion) Reset()         { *m = RequestUnion{} }
 func (m *RequestUnion) String() string { return proto.CompactTextString(m) }
 func (*RequestUnion) ProtoMessage()    {}
 func (*RequestUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{87}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{87}
 }
 func (m *RequestUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -5825,7 +5825,7 @@ func (m *ResponseUnion) Reset()         { *m = ResponseUnion{} }
 func (m *ResponseUnion) String() string { return proto.CompactTextString(m) }
 func (*ResponseUnion) ProtoMessage()    {}
 func (*ResponseUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{88}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{88}
 }
 func (m *ResponseUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7174,7 +7174,7 @@ func (m *Header) Reset()         { *m = Header{} }
 func (m *Header) String() string { return proto.CompactTextString(m) }
 func (*Header) ProtoMessage()    {}
 func (*Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{89}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{89}
 }
 func (m *Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7212,7 +7212,7 @@ type BatchRequest struct {
 func (m *BatchRequest) Reset()      { *m = BatchRequest{} }
 func (*BatchRequest) ProtoMessage() {}
 func (*BatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{90}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{90}
 }
 func (m *BatchRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7251,7 +7251,7 @@ type BatchResponse struct {
 func (m *BatchResponse) Reset()      { *m = BatchResponse{} }
 func (*BatchResponse) ProtoMessage() {}
 func (*BatchResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{91}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{91}
 }
 func (m *BatchResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7312,7 +7312,7 @@ func (m *BatchResponse_Header) Reset()         { *m = BatchResponse_Header{} }
 func (m *BatchResponse_Header) String() string { return proto.CompactTextString(m) }
 func (*BatchResponse_Header) ProtoMessage()    {}
 func (*BatchResponse_Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{91, 0}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{91, 0}
 }
 func (m *BatchResponse_Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7350,7 +7350,7 @@ func (m *RangeFeedRequest) Reset()         { *m = RangeFeedRequest{} }
 func (m *RangeFeedRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedRequest) ProtoMessage()    {}
 func (*RangeFeedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{92}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{92}
 }
 func (m *RangeFeedRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7388,7 +7388,7 @@ func (m *RangeFeedValue) Reset()         { *m = RangeFeedValue{} }
 func (m *RangeFeedValue) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedValue) ProtoMessage()    {}
 func (*RangeFeedValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{93}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{93}
 }
 func (m *RangeFeedValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7428,7 +7428,7 @@ func (m *RangeFeedCheckpoint) Reset()         { *m = RangeFeedCheckpoint{} }
 func (m *RangeFeedCheckpoint) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedCheckpoint) ProtoMessage()    {}
 func (*RangeFeedCheckpoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{94}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{94}
 }
 func (m *RangeFeedCheckpoint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7467,7 +7467,7 @@ func (m *RangeFeedError) Reset()         { *m = RangeFeedError{} }
 func (m *RangeFeedError) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedError) ProtoMessage()    {}
 func (*RangeFeedError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{95}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{95}
 }
 func (m *RangeFeedError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -7506,7 +7506,7 @@ func (m *RangeFeedEvent) Reset()         { *m = RangeFeedEvent{} }
 func (m *RangeFeedEvent) String() string { return proto.CompactTextString(m) }
 func (*RangeFeedEvent) ProtoMessage()    {}
 func (*RangeFeedEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_e2607f120b04f650, []int{96}
+	return fileDescriptor_api_df49c07e6f5cafbc, []int{96}
 }
 func (m *RangeFeedEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -33588,9 +33588,9 @@ var (
 	ErrIntOverflowApi   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_e2607f120b04f650) }
+func init() { proto.RegisterFile("roachpb/api.proto", fileDescriptor_api_df49c07e6f5cafbc) }
 
-var fileDescriptor_api_e2607f120b04f650 = []byte{
+var fileDescriptor_api_df49c07e6f5cafbc = []byte{
 	// 6252 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x3d, 0x4b, 0x6c, 0x23, 0xc9,
 	0x75, 0x6a, 0x92, 0x92, 0xc8, 0x47, 0x91, 0x6a, 0x95, 0xe6, 0xc3, 0xd1, 0xcc, 0x8e, 0x34, 0x9c,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -571,7 +571,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// early means that a Bootstrap RPC might erroneously succeed. We should
 	// figure out early if our engines are bootstrapped and, if they are, create a
 	// dummy implementation of the InitServer that rejects all RPCs.
-	s.initServer = newInitServer(s.gossip.Connected, s.stopper.ShouldStop())
+	s.initServer = newInitServer(s, s.gossip.Connected, s.stopper.ShouldStop())
 	serverpb.RegisterInitServer(s.grpc.Server, s.initServer)
 
 	nodeInfo := sql.NodeInfo{

--- a/pkg/server/serverpb/init.pb.go
+++ b/pkg/server/serverpb/init.pb.go
@@ -6,6 +6,10 @@ package serverpb
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
+import roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
+
+import github_com_cockroachdb_cockroach_pkg_util_uuid "github.com/cockroachdb/cockroach/pkg/util/uuid"
+import github_com_cockroachdb_cockroach_pkg_roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
 
 import (
 	context "context"
@@ -34,7 +38,7 @@ func (m *BootstrapRequest) Reset()         { *m = BootstrapRequest{} }
 func (m *BootstrapRequest) String() string { return proto.CompactTextString(m) }
 func (*BootstrapRequest) ProtoMessage()    {}
 func (*BootstrapRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_init_a2f92a9ec99703a0, []int{0}
+	return fileDescriptor_init_ee2f66e3df3374fd, []int{0}
 }
 func (m *BootstrapRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -68,7 +72,7 @@ func (m *BootstrapResponse) Reset()         { *m = BootstrapResponse{} }
 func (m *BootstrapResponse) String() string { return proto.CompactTextString(m) }
 func (*BootstrapResponse) ProtoMessage()    {}
 func (*BootstrapResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_init_a2f92a9ec99703a0, []int{1}
+	return fileDescriptor_init_ee2f66e3df3374fd, []int{1}
 }
 func (m *BootstrapResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -93,9 +97,160 @@ func (m *BootstrapResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_BootstrapResponse proto.InternalMessageInfo
 
+type ClusterInfoRequest struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *ClusterInfoRequest) Reset()         { *m = ClusterInfoRequest{} }
+func (m *ClusterInfoRequest) String() string { return proto.CompactTextString(m) }
+func (*ClusterInfoRequest) ProtoMessage()    {}
+func (*ClusterInfoRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_init_ee2f66e3df3374fd, []int{2}
+}
+func (m *ClusterInfoRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ClusterInfoRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	b = b[:cap(b)]
+	n, err := m.MarshalTo(b)
+	if err != nil {
+		return nil, err
+	}
+	return b[:n], nil
+}
+func (dst *ClusterInfoRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ClusterInfoRequest.Merge(dst, src)
+}
+func (m *ClusterInfoRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *ClusterInfoRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ClusterInfoRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ClusterInfoRequest proto.InternalMessageInfo
+
+type ClusterInfoResponse struct {
+	ClusterID            github_com_cockroachdb_cockroach_pkg_util_uuid.UUID `protobuf:"bytes,1,opt,name=cluster_id,json=clusterId,proto3,customtype=github.com/cockroachdb/cockroach/pkg/util/uuid.UUID" json:"cluster_id"`
+	ActiveVersion        roachpb.Version                                     `protobuf:"bytes,2,opt,name=active_version,json=activeVersion,proto3" json:"active_version"`
+	XXX_NoUnkeyedLiteral struct{}                                            `json:"-"`
+	XXX_sizecache        int32                                               `json:"-"`
+}
+
+func (m *ClusterInfoResponse) Reset()         { *m = ClusterInfoResponse{} }
+func (m *ClusterInfoResponse) String() string { return proto.CompactTextString(m) }
+func (*ClusterInfoResponse) ProtoMessage()    {}
+func (*ClusterInfoResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_init_ee2f66e3df3374fd, []int{3}
+}
+func (m *ClusterInfoResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ClusterInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	b = b[:cap(b)]
+	n, err := m.MarshalTo(b)
+	if err != nil {
+		return nil, err
+	}
+	return b[:n], nil
+}
+func (dst *ClusterInfoResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ClusterInfoResponse.Merge(dst, src)
+}
+func (m *ClusterInfoResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *ClusterInfoResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ClusterInfoResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ClusterInfoResponse proto.InternalMessageInfo
+
+type AllocateNodeIDsRequest struct {
+	// num_stores specifies how many store ids to allocate. If 0, no store ids
+	// will be allocated.
+	NumStores            int32    `protobuf:"varint,1,opt,name=num_stores,json=numStores,proto3" json:"num_stores,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *AllocateNodeIDsRequest) Reset()         { *m = AllocateNodeIDsRequest{} }
+func (m *AllocateNodeIDsRequest) String() string { return proto.CompactTextString(m) }
+func (*AllocateNodeIDsRequest) ProtoMessage()    {}
+func (*AllocateNodeIDsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_init_ee2f66e3df3374fd, []int{4}
+}
+func (m *AllocateNodeIDsRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *AllocateNodeIDsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	b = b[:cap(b)]
+	n, err := m.MarshalTo(b)
+	if err != nil {
+		return nil, err
+	}
+	return b[:n], nil
+}
+func (dst *AllocateNodeIDsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AllocateNodeIDsRequest.Merge(dst, src)
+}
+func (m *AllocateNodeIDsRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *AllocateNodeIDsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_AllocateNodeIDsRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_AllocateNodeIDsRequest proto.InternalMessageInfo
+
+type AllocateNodeIDsResponse struct {
+	// node_id is the newly allocated node id.
+	NodeID github_com_cockroachdb_cockroach_pkg_roachpb.NodeID `protobuf:"varint,1,opt,name=node_id,json=nodeId,proto3,casttype=github.com/cockroachdb/cockroach/pkg/roachpb.NodeID" json:"node_id,omitempty"`
+	// first_store_id is the first (smallest) of the newly allocated store ids.
+	// [fistst_store_id..first_store_id+request.num_stores) are all available to
+	// be used.
+	FirstStoreID         github_com_cockroachdb_cockroach_pkg_roachpb.StoreID `protobuf:"varint,2,opt,name=first_store_id,json=firstStoreId,proto3,casttype=github.com/cockroachdb/cockroach/pkg/roachpb.StoreID" json:"first_store_id,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                                             `json:"-"`
+	XXX_sizecache        int32                                                `json:"-"`
+}
+
+func (m *AllocateNodeIDsResponse) Reset()         { *m = AllocateNodeIDsResponse{} }
+func (m *AllocateNodeIDsResponse) String() string { return proto.CompactTextString(m) }
+func (*AllocateNodeIDsResponse) ProtoMessage()    {}
+func (*AllocateNodeIDsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_init_ee2f66e3df3374fd, []int{5}
+}
+func (m *AllocateNodeIDsResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *AllocateNodeIDsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	b = b[:cap(b)]
+	n, err := m.MarshalTo(b)
+	if err != nil {
+		return nil, err
+	}
+	return b[:n], nil
+}
+func (dst *AllocateNodeIDsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AllocateNodeIDsResponse.Merge(dst, src)
+}
+func (m *AllocateNodeIDsResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *AllocateNodeIDsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_AllocateNodeIDsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_AllocateNodeIDsResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*BootstrapRequest)(nil), "cockroach.server.serverpb.BootstrapRequest")
 	proto.RegisterType((*BootstrapResponse)(nil), "cockroach.server.serverpb.BootstrapResponse")
+	proto.RegisterType((*ClusterInfoRequest)(nil), "cockroach.server.serverpb.ClusterInfoRequest")
+	proto.RegisterType((*ClusterInfoResponse)(nil), "cockroach.server.serverpb.ClusterInfoResponse")
+	proto.RegisterType((*AllocateNodeIDsRequest)(nil), "cockroach.server.serverpb.AllocateNodeIDsRequest")
+	proto.RegisterType((*AllocateNodeIDsResponse)(nil), "cockroach.server.serverpb.AllocateNodeIDsResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -112,6 +267,12 @@ const _ = grpc.SupportPackageIsVersion4
 type InitClient interface {
 	// Bootstrap an uninitialized cluster.
 	Bootstrap(ctx context.Context, in *BootstrapRequest, opts ...grpc.CallOption) (*BootstrapResponse, error)
+	// ClusterInfo returns current cluster information.
+	ClusterInfo(ctx context.Context, in *ClusterInfoRequest, opts ...grpc.CallOption) (*ClusterInfoResponse, error)
+	// AllocateNodeIDs can be used to allocate a node id and multiple store ids.
+	// This can be used by new node joining the cluster to ask another node that's
+	// already part of the cluster to do some work on its behalf.
+	AllocateNodeIDs(ctx context.Context, in *AllocateNodeIDsRequest, opts ...grpc.CallOption) (*AllocateNodeIDsResponse, error)
 }
 
 type initClient struct {
@@ -131,10 +292,34 @@ func (c *initClient) Bootstrap(ctx context.Context, in *BootstrapRequest, opts .
 	return out, nil
 }
 
+func (c *initClient) ClusterInfo(ctx context.Context, in *ClusterInfoRequest, opts ...grpc.CallOption) (*ClusterInfoResponse, error) {
+	out := new(ClusterInfoResponse)
+	err := c.cc.Invoke(ctx, "/cockroach.server.serverpb.Init/ClusterInfo", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *initClient) AllocateNodeIDs(ctx context.Context, in *AllocateNodeIDsRequest, opts ...grpc.CallOption) (*AllocateNodeIDsResponse, error) {
+	out := new(AllocateNodeIDsResponse)
+	err := c.cc.Invoke(ctx, "/cockroach.server.serverpb.Init/AllocateNodeIDs", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // InitServer is the server API for Init service.
 type InitServer interface {
 	// Bootstrap an uninitialized cluster.
 	Bootstrap(context.Context, *BootstrapRequest) (*BootstrapResponse, error)
+	// ClusterInfo returns current cluster information.
+	ClusterInfo(context.Context, *ClusterInfoRequest) (*ClusterInfoResponse, error)
+	// AllocateNodeIDs can be used to allocate a node id and multiple store ids.
+	// This can be used by new node joining the cluster to ask another node that's
+	// already part of the cluster to do some work on its behalf.
+	AllocateNodeIDs(context.Context, *AllocateNodeIDsRequest) (*AllocateNodeIDsResponse, error)
 }
 
 func RegisterInitServer(s *grpc.Server, srv InitServer) {
@@ -159,6 +344,42 @@ func _Init_Bootstrap_Handler(srv interface{}, ctx context.Context, dec func(inte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Init_ClusterInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ClusterInfoRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(InitServer).ClusterInfo(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/cockroach.server.serverpb.Init/ClusterInfo",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(InitServer).ClusterInfo(ctx, req.(*ClusterInfoRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Init_AllocateNodeIDs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AllocateNodeIDsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(InitServer).AllocateNodeIDs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/cockroach.server.serverpb.Init/AllocateNodeIDs",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(InitServer).AllocateNodeIDs(ctx, req.(*AllocateNodeIDsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Init_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cockroach.server.serverpb.Init",
 	HandlerType: (*InitServer)(nil),
@@ -166,6 +387,14 @@ var _Init_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Bootstrap",
 			Handler:    _Init_Bootstrap_Handler,
+		},
+		{
+			MethodName: "ClusterInfo",
+			Handler:    _Init_ClusterInfo_Handler,
+		},
+		{
+			MethodName: "AllocateNodeIDs",
+			Handler:    _Init_AllocateNodeIDs_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -208,6 +437,109 @@ func (m *BootstrapResponse) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *ClusterInfoRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ClusterInfoRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *ClusterInfoResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ClusterInfoResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	dAtA[i] = 0xa
+	i++
+	i = encodeVarintInit(dAtA, i, uint64(m.ClusterID.Size()))
+	n1, err := m.ClusterID.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n1
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintInit(dAtA, i, uint64(m.ActiveVersion.Size()))
+	n2, err := m.ActiveVersion.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n2
+	return i, nil
+}
+
+func (m *AllocateNodeIDsRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *AllocateNodeIDsRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.NumStores != 0 {
+		dAtA[i] = 0x8
+		i++
+		i = encodeVarintInit(dAtA, i, uint64(m.NumStores))
+	}
+	return i, nil
+}
+
+func (m *AllocateNodeIDsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *AllocateNodeIDsResponse) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.NodeID != 0 {
+		dAtA[i] = 0x8
+		i++
+		i = encodeVarintInit(dAtA, i, uint64(m.NodeID))
+	}
+	if m.FirstStoreID != 0 {
+		dAtA[i] = 0x10
+		i++
+		i = encodeVarintInit(dAtA, i, uint64(m.FirstStoreID))
+	}
+	return i, nil
+}
+
 func encodeVarintInit(dAtA []byte, offset int, v uint64) int {
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
@@ -232,6 +564,55 @@ func (m *BootstrapResponse) Size() (n int) {
 	}
 	var l int
 	_ = l
+	return n
+}
+
+func (m *ClusterInfoRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *ClusterInfoResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.ClusterID.Size()
+	n += 1 + l + sovInit(uint64(l))
+	l = m.ActiveVersion.Size()
+	n += 1 + l + sovInit(uint64(l))
+	return n
+}
+
+func (m *AllocateNodeIDsRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.NumStores != 0 {
+		n += 1 + sovInit(uint64(m.NumStores))
+	}
+	return n
+}
+
+func (m *AllocateNodeIDsResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.NodeID != 0 {
+		n += 1 + sovInit(uint64(m.NodeID))
+	}
+	if m.FirstStoreID != 0 {
+		n += 1 + sovInit(uint64(m.FirstStoreID))
+	}
 	return n
 }
 
@@ -327,6 +708,323 @@ func (m *BootstrapResponse) Unmarshal(dAtA []byte) error {
 			return fmt.Errorf("proto: BootstrapResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipInit(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthInit
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ClusterInfoRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowInit
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ClusterInfoRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ClusterInfoRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipInit(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthInit
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ClusterInfoResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowInit
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ClusterInfoResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ClusterInfoResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterID", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowInit
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthInit
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ClusterID.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ActiveVersion", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowInit
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthInit
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ActiveVersion.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipInit(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthInit
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *AllocateNodeIDsRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowInit
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: AllocateNodeIDsRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: AllocateNodeIDsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NumStores", wireType)
+			}
+			m.NumStores = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowInit
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.NumStores |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipInit(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthInit
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *AllocateNodeIDsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowInit
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: AllocateNodeIDsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: AllocateNodeIDsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeID", wireType)
+			}
+			m.NodeID = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowInit
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.NodeID |= (github_com_cockroachdb_cockroach_pkg_roachpb.NodeID(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FirstStoreID", wireType)
+			}
+			m.FirstStoreID = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowInit
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.FirstStoreID |= (github_com_cockroachdb_cockroach_pkg_roachpb.StoreID(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipInit(dAtA[iNdEx:])
@@ -453,19 +1151,39 @@ var (
 	ErrIntOverflowInit   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("server/serverpb/init.proto", fileDescriptor_init_a2f92a9ec99703a0) }
+func init() { proto.RegisterFile("server/serverpb/init.proto", fileDescriptor_init_ee2f66e3df3374fd) }
 
-var fileDescriptor_init_a2f92a9ec99703a0 = []byte{
-	// 164 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2a, 0x4e, 0x2d, 0x2a,
-	0x4b, 0x2d, 0xd2, 0x87, 0x50, 0x05, 0x49, 0xfa, 0x99, 0x79, 0x99, 0x25, 0x7a, 0x05, 0x45, 0xf9,
-	0x25, 0xf9, 0x42, 0x92, 0xc9, 0xf9, 0xc9, 0xd9, 0x45, 0xf9, 0x89, 0xc9, 0x19, 0x7a, 0x10, 0x69,
-	0x3d, 0x98, 0x2a, 0x25, 0x21, 0x2e, 0x01, 0xa7, 0xfc, 0xfc, 0x92, 0xe2, 0x92, 0xa2, 0xc4, 0x82,
-	0xa0, 0xd4, 0xc2, 0xd2, 0xd4, 0xe2, 0x12, 0x25, 0x61, 0x2e, 0x41, 0x24, 0xb1, 0xe2, 0x82, 0xfc,
-	0xbc, 0xe2, 0x54, 0xa3, 0x02, 0x2e, 0x16, 0xcf, 0xbc, 0xcc, 0x12, 0xa1, 0x0c, 0x2e, 0x4e, 0xb8,
-	0xa4, 0x90, 0xb6, 0x1e, 0x4e, 0x93, 0xf5, 0xd0, 0x8d, 0x95, 0xd2, 0x21, 0x4e, 0x31, 0xc4, 0x3e,
-	0x25, 0x06, 0x27, 0xa5, 0x13, 0x0f, 0xe5, 0x18, 0x4e, 0x3c, 0x92, 0x63, 0xbc, 0xf0, 0x48, 0x8e,
-	0xf1, 0xc6, 0x23, 0x39, 0xc6, 0x07, 0x8f, 0xe4, 0x18, 0x27, 0x3c, 0x96, 0x63, 0x88, 0xe2, 0x80,
-	0xe9, 0x4b, 0x62, 0x03, 0x7b, 0xd0, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff, 0x7f, 0x80, 0x65, 0x8d,
-	0xfe, 0x00, 0x00, 0x00,
+var fileDescriptor_init_ee2f66e3df3374fd = []byte{
+	// 490 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x53, 0x4d, 0x6f, 0xd3, 0x40,
+	0x10, 0x8d, 0xab, 0x36, 0x90, 0x69, 0x5a, 0x60, 0x5b, 0x95, 0x62, 0x09, 0xa7, 0xf2, 0xa9, 0x12,
+	0xb0, 0x16, 0x29, 0x12, 0xe7, 0x9a, 0x08, 0xea, 0x0b, 0x07, 0xa3, 0x72, 0xe8, 0x25, 0xf2, 0xc7,
+	0xc6, 0x59, 0x35, 0xd9, 0x35, 0xbb, 0xeb, 0x1c, 0xf8, 0x15, 0xfc, 0x2b, 0x72, 0xe4, 0x88, 0x10,
+	0xb2, 0xc0, 0x88, 0x3f, 0xc1, 0x09, 0xd9, 0x6b, 0x27, 0xa5, 0xa5, 0x55, 0x7a, 0xca, 0xe8, 0xed,
+	0x7b, 0xf3, 0x66, 0x26, 0xcf, 0x60, 0x4a, 0x22, 0x66, 0x44, 0x38, 0xfa, 0x27, 0x0d, 0x1d, 0xca,
+	0xa8, 0xc2, 0xa9, 0xe0, 0x8a, 0xa3, 0x47, 0x11, 0x8f, 0xce, 0x05, 0x0f, 0xa2, 0x31, 0xd6, 0xcf,
+	0xb8, 0x61, 0x99, 0x7b, 0x15, 0x9c, 0x86, 0xce, 0x94, 0xa8, 0x20, 0x0e, 0x54, 0xa0, 0x25, 0xe6,
+	0x6e, 0xc2, 0x13, 0x5e, 0x95, 0x4e, 0x59, 0x69, 0xd4, 0x46, 0x70, 0xdf, 0xe5, 0x5c, 0x49, 0x25,
+	0x82, 0xd4, 0x27, 0x1f, 0x32, 0x22, 0x95, 0xbd, 0x03, 0x0f, 0x2e, 0x60, 0x32, 0xe5, 0x4c, 0x12,
+	0x7b, 0x17, 0xd0, 0xab, 0x49, 0x26, 0x15, 0x11, 0x1e, 0x1b, 0xf1, 0x86, 0xfa, 0xd9, 0x80, 0x9d,
+	0x7f, 0x60, 0xcd, 0x46, 0x09, 0x40, 0xa4, 0xe1, 0x21, 0x8d, 0xf7, 0x8d, 0x03, 0xe3, 0xb0, 0xeb,
+	0x9e, 0xcc, 0xf3, 0x5e, 0xeb, 0x5b, 0xde, 0x3b, 0x4a, 0xa8, 0x1a, 0x67, 0x21, 0x8e, 0xf8, 0xd4,
+	0x59, 0xac, 0x11, 0x87, 0xcb, 0xda, 0x49, 0xcf, 0x13, 0x27, 0x53, 0x74, 0xe2, 0x64, 0x19, 0x8d,
+	0xf1, 0xe9, 0xa9, 0x37, 0x28, 0xf2, 0x5e, 0xa7, 0xf1, 0x19, 0xf8, 0x9d, 0xba, 0xb7, 0x17, 0xa3,
+	0x37, 0xb0, 0x1d, 0x44, 0x8a, 0xce, 0xc8, 0x70, 0x46, 0x84, 0xa4, 0x9c, 0xed, 0xaf, 0x1d, 0x18,
+	0x87, 0x9b, 0x7d, 0x13, 0x2f, 0x2f, 0x54, 0x1f, 0x04, 0xbf, 0xd7, 0x0c, 0x77, 0xbd, 0x1c, 0xc4,
+	0xdf, 0xd2, 0xba, 0x1a, 0xb4, 0x5f, 0xc2, 0xde, 0xf1, 0x64, 0xc2, 0xa3, 0x40, 0x91, 0xb7, 0x3c,
+	0x26, 0xde, 0x40, 0xd6, 0x3b, 0xa2, 0xc7, 0x00, 0x2c, 0x9b, 0x0e, 0xa5, 0xe2, 0x82, 0xc8, 0x6a,
+	0x97, 0x0d, 0xbf, 0xc3, 0xb2, 0xe9, 0xbb, 0x0a, 0xb0, 0x7f, 0x1b, 0xf0, 0xf0, 0x8a, 0xb2, 0x3e,
+	0xc3, 0x19, 0xdc, 0x61, 0x3c, 0x26, 0xcd, 0x0d, 0xb6, 0xdc, 0xe3, 0x22, 0xef, 0xb5, 0x35, 0xeb,
+	0xcf, 0xaa, 0x97, 0x68, 0xc6, 0xd7, 0x32, 0xbf, 0x5d, 0x76, 0xf4, 0x62, 0xc4, 0x60, 0x7b, 0x44,
+	0x85, 0x54, 0x7a, 0xb0, 0xd2, 0xa2, 0xdc, 0x7c, 0xc3, 0x3d, 0x29, 0xf2, 0x5e, 0xf7, 0x75, 0xf9,
+	0x52, 0x0d, 0x58, 0x19, 0xbd, 0xb8, 0x95, 0x51, 0xad, 0xf3, 0xbb, 0xa3, 0x65, 0x97, 0xb8, 0xff,
+	0x7d, 0x0d, 0xd6, 0x3d, 0x46, 0x15, 0x1a, 0x43, 0x67, 0x11, 0x0f, 0xf4, 0x04, 0x5f, 0x9b, 0x44,
+	0x7c, 0x39, 0x58, 0xe6, 0xd3, 0xd5, 0xc8, 0x75, 0xe2, 0x5a, 0x88, 0xc1, 0xe6, 0x85, 0x70, 0xa1,
+	0x67, 0x37, 0xc8, 0xaf, 0x66, 0xd3, 0xc4, 0xab, 0xd2, 0x17, 0x7e, 0x1f, 0xe1, 0xde, 0xa5, 0x7f,
+	0x12, 0x3d, 0xbf, 0xa1, 0xc9, 0xff, 0xf3, 0x62, 0xf6, 0x6f, 0x23, 0x69, 0xbc, 0x5d, 0x7b, 0xfe,
+	0xd3, 0x6a, 0xcd, 0x0b, 0xcb, 0xf8, 0x52, 0x58, 0xc6, 0xd7, 0xc2, 0x32, 0x7e, 0x14, 0x96, 0xf1,
+	0xe9, 0x97, 0xd5, 0x3a, 0xbb, 0xdb, 0xa8, 0xc3, 0x76, 0xf5, 0xcd, 0x1e, 0xfd, 0x0d, 0x00, 0x00,
+	0xff, 0xff, 0xe2, 0x4b, 0xe1, 0xcb, 0x1a, 0x04, 0x00, 0x00,
 }

--- a/pkg/server/serverpb/init.proto
+++ b/pkg/server/serverpb/init.proto
@@ -16,14 +16,46 @@ syntax = "proto3";
 package cockroach.server.serverpb;
 option go_package = "serverpb";
 
+import "roachpb/metadata.proto";
+import "gogoproto/gogo.proto";
+
 message BootstrapRequest {
 }
 
 message BootstrapResponse {
 }
 
+message ClusterInfoRequest {
+}
+
+message ClusterInfoResponse {
+  bytes cluster_id = 1 [(gogoproto.customname) = "ClusterID", (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID", (gogoproto.nullable) = false];
+  roachpb.Version active_version = 2 [(gogoproto.nullable) = false];
+;
+}
+
+message AllocateNodeIDsRequest {
+  // num_stores specifies how many store ids to allocate. If 0, no store ids
+  // will be allocated.
+  int32 num_stores = 1;
+}
+
+message AllocateNodeIDsResponse {
+  // node_id is the newly allocated node id.
+  uint32 node_id = 1 [(gogoproto.customname) = "NodeID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
+  // first_store_id is the first (smallest) of the newly allocated store ids.
+  // [fistst_store_id..first_store_id+request.num_stores) are all available to
+  // be used.
+  int32 first_store_id = 2 [(gogoproto.customname) = "FirstStoreID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID"];
+}
+
 service Init {
   // Bootstrap an uninitialized cluster.
-  rpc Bootstrap(BootstrapRequest) returns (BootstrapResponse) {
-  }
+  rpc Bootstrap(BootstrapRequest) returns (BootstrapResponse) {}
+  // ClusterInfo returns current cluster information.
+  rpc ClusterInfo(ClusterInfoRequest) returns (ClusterInfoResponse) {}
+  // AllocateNodeIDs can be used to allocate a node id and multiple store ids.
+  // This can be used by new node joining the cluster to ask another node that's
+  // already part of the cluster to do some work on its behalf.
+  rpc AllocateNodeIDs(AllocateNodeIDsRequest) returns (AllocateNodeIDsResponse) {}
 }


### PR DESCRIPTION
This patch introduces an RPC service comprised of two methods:
GetClusterInfo - returns the cluster id and version
AllocateNodeIDs - allocates node is and stores ids

The interface is not used at the moment, and I'm not yet sure how it's
going to be used exactly, but I'd like to get it in 19.1 so that 19.2
can use it.
The idea is that I'm pretty unhappy with the current way nodes join an
existing cluster. I'm unhappy that they conservatively start with a
stale cluster version only to find out the real version later, and I'm
unhappy that we have a nodeIDContainer and a clusterIDContainer
everywhwere, helping the node join process where the node needs to "join
the cluster" to some degree before it can allocate its own ids. The idea
of this interface is for a node to delegate this work to one that's
already in the cluster, in the hope that this will support untangle the
join process.

Release note: None