### PR TITLE
sql: check that there are no window functions in window definitions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -2269,6 +2269,9 @@ Tablet      Samsung          200.00   6450.00
 statement error aggregate functions are not allowed in FILTER
 SELECT count(*) FILTER (WHERE count(*) > 5) OVER () FROM products
 
+statement error window functions are not allowed in FILTER
+SELECT count(*) FILTER (WHERE count(*) OVER () > 5) OVER () FROM products
+
 statement error incompatible FILTER expression type: int
 SELECT count(*) FILTER (WHERE 1) OVER () FROM products
 
@@ -2984,3 +2987,21 @@ FROM
 1
 1
 1
+
+# Tests for #32050
+
+statement error window functions are not allowed in window definitions
+SELECT sum(a) OVER (PARTITION BY count(a) OVER ()) FROM x
+
+statement error window functions are not allowed in window definitions
+SELECT sum(a) OVER (ORDER BY count(a) OVER ()) FROM x
+
+statement error more than one row returned by a subquery used as an expression
+SELECT sum(a) OVER (PARTITION BY (SELECT count(*) FROM x GROUP BY a)) FROM x
+
+query I
+SELECT sum(a) OVER (PARTITION BY (SELECT count(*) FROM x GROUP BY a LIMIT 1))::INT FROM x
+----
+6
+6
+6

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -293,6 +293,11 @@ func (p *planner) constructWindowDefinitions(
 
 		// Validate PARTITION BY clause.
 		for _, partition := range windowDef.Partitions {
+			if funcExpr, ok := partition.(*tree.FuncExpr); ok {
+				if funcExpr.IsWindowFunctionApplication() {
+					return pgerror.NewErrorf(pgerror.CodeWindowingError, "window functions are not allowed in window definitions")
+				}
+			}
 			cols, exprs, _, err := p.computeRenderAllowingStars(ctx,
 				tree.SelectExpr{Expr: partition}, types.Any, s.sourceInfo, s.ivarHelper,
 				autoGenerateRenderOutputName)
@@ -306,6 +311,11 @@ func (p *planner) constructWindowDefinitions(
 
 		// Validate ORDER BY clause.
 		for _, orderBy := range windowDef.OrderBy {
+			if funcExpr, ok := orderBy.Expr.(*tree.FuncExpr); ok {
+				if funcExpr.IsWindowFunctionApplication() {
+					return pgerror.NewErrorf(pgerror.CodeWindowingError, "window functions are not allowed in window definitions")
+				}
+			}
 			cols, exprs, _, err := p.computeRenderAllowingStars(ctx,
 				tree.SelectExpr{Expr: orderBy.Expr}, types.Any, s.sourceInfo, s.ivarHelper,
 				autoGenerateRenderOutputName)


### PR DESCRIPTION
Previously, we didn't check whether there are any window functions
within PARTITION BY and ORDER BY parts of OVER clause of a window
function. If there are any, now we error out (similar to PostgreSQL
behavior).

Fixes: #32050.

Release note: None