### PR TITLE
kv: change the DistSender range feed interface pErr-error

### DIFF
--- a/pkg/ccl/changefeedccl/poller.go
+++ b/pkg/ccl/changefeedccl/poller.go
@@ -288,7 +288,7 @@ func (p *poller) rangefeedImpl(ctx context.Context) error {
 			}
 			frontier.Forward(span, lastHighwater)
 			g.GoCtx(func(ctx context.Context) error {
-				return ds.RangeFeed(ctx, req, eventC).GoError()
+				return ds.RangeFeed(ctx, req, eventC)
 			})
 		}
 		g.GoCtx(func(ctx context.Context) error {

--- a/pkg/kv/dist_sender_rangefeed.go
+++ b/pkg/kv/dist_sender_rangefeed.go
@@ -39,18 +39,18 @@ type singleRangeInfo struct {
 // provided channel.
 func (ds *DistSender) RangeFeed(
 	ctx context.Context, args *roachpb.RangeFeedRequest, eventCh chan<- *roachpb.RangeFeedEvent,
-) *roachpb.Error {
+) error {
 	ctx = ds.AnnotateCtx(ctx)
 	ctx, sp := tracing.EnsureChildSpan(ctx, ds.AmbientContext.Tracer, "dist sender")
 	defer sp.Finish()
 
 	startRKey, err := keys.Addr(args.Span.Key)
 	if err != nil {
-		return roachpb.NewError(err)
+		return err
 	}
 	endRKey, err := keys.Addr(args.Span.EndKey)
 	if err != nil {
-		return roachpb.NewError(err)
+		return err
 	}
 	rs := roachpb.RSpan{Key: startRKey, EndKey: endRKey}
 
@@ -77,7 +77,7 @@ func (ds *DistSender) RangeFeed(
 		return ds.divideAndSendRangeFeedToRanges(ctx, args, rs, rangeCh)
 	})
 
-	return roachpb.NewError(g.Wait())
+	return g.Wait()
 }
 
 func (ds *DistSender) divideAndSendRangeFeedToRanges(


### PR DESCRIPTION
There was no reason for it to return pErrs.

Release note: None