### PR TITLE
release-2.1: sql: ensure column constraints are validated after SET for UPSERT

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert_local
+++ b/pkg/sql/logictest/testdata/logic_test/upsert_local
@@ -1,0 +1,21 @@
+# LogicTest: local local-parallel-stmts fakedist fakedist-metadata
+
+subtest regression_35040
+# Note: this subtest should be shared with CBO, but the CBO fix is more complex.
+# Splitting in two separate commits (2nd commit puts the test in the right place,
+# but will not be backported to 2.1).
+
+statement ok
+CREATE TABLE test35040(a INT PRIMARY KEY, b INT NOT NULL, c INT2)
+
+statement ok
+INSERT INTO test35040(a,b) VALUES(0,0) ON CONFLICT(a) DO UPDATE SET b = NULL
+
+statement error null value in column "b" violates not-null constraint
+INSERT INTO test35040(a,b) VALUES(0,0) ON CONFLICT(a) DO UPDATE SET b = NULL
+
+statement error integer out of range for type SMALLINT
+INSERT INTO test35040(a,b) VALUES (0,1) ON CONFLICT(a) DO UPDATE SET c = 111111111;
+
+statement ok
+DROP TABLE test35040


### PR DESCRIPTION
Backport 1/1 commits from #35371.

/cc @cockroachdb/release

---

Informs #35040. (Actually fixes it in 2.1.)

Release note (bug fix): CockroachDB now properly applies column width
and nullability constraints on the result of conflict resolution in
UPSERT and INSERT ON CONFLICT.
