### PR TITLE
sqlsmith: major refactor

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -62,7 +62,7 @@ func (s *scope) getTableExpr() (*tree.AliasedTableExpr, *tableRef, colRefs, bool
 		return nil, nil, nil, false
 	}
 	table := s.schema.tables[rand.Intn(len(s.schema.tables))]
-	alias := tree.Name(s.name("tab"))
+	alias := tree.Name(s.schema.name("tab"))
 	refs := make(colRefs, len(table.Columns))
 	for i, c := range table.Columns {
 		refs[i] = &colRef{
@@ -207,7 +207,7 @@ func (s *scope) makeSelectList(
 			return nil, nil, false
 		}
 		result[i].Expr = next
-		alias := s.name("col")
+		alias := s.schema.name("col")
 		result[i].As = tree.UnrestrictedName(alias)
 		selectRefs[i] = &colRef{
 			typ:  t,
@@ -282,7 +282,7 @@ func (s *scope) makeInsertReturning(
 			return nil, nil, false
 		}
 		returning[i].Expr = e
-		alias := s.name("col")
+		alias := s.schema.name("col")
 		returning[i].As = tree.UnrestrictedName(alias)
 		returningRefs[i] = &colRef{
 			typ: t,

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -234,13 +234,12 @@ func (s *scope) makeExists(refs colRefs) (tree.TypedExpr, bool) {
 		return nil, false
 	}
 
-	return makeTypedExpr(
-		&tree.Subquery{
-			Select: &tree.ParenSelect{Select: selectStmt},
-			Exists: true,
-		},
-		types.Bool,
-	), true
+	subq := &tree.Subquery{
+		Select: &tree.ParenSelect{Select: selectStmt},
+		Exists: true,
+	}
+	subq.SetType(types.Bool)
+	return subq, true
 }
 
 func (s *scope) makeScalarSubquery(typ types.T, refs colRefs) (tree.TypedExpr, bool) {
@@ -250,11 +249,10 @@ func (s *scope) makeScalarSubquery(typ types.T, refs colRefs) (tree.TypedExpr, b
 	}
 	selectStmt.Limit = &tree.Limit{Count: tree.NewDInt(1)}
 
-	return makeTypedExpr(
-		&tree.Subquery{
-			Select: &tree.ParenSelect{Select: selectStmt},
-		},
-		typ,
-	), true
+	subq := &tree.Subquery{
+		Select: &tree.ParenSelect{Select: selectStmt},
+	}
+	subq.SetType(typ)
 
+	return subq, true
 }

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -15,7 +15,6 @@
 package sqlsmith
 
 import (
-	"bytes"
 	"math/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
@@ -102,7 +101,7 @@ func (c *caseExpr) Type() types.T {
 	return c.trueExpr.Type()
 }
 
-func (c *caseExpr) Format(buf *bytes.Buffer) {
+func (c *caseExpr) Format(buf *tree.FmtCtx) {
 	buf.WriteString("case when ")
 	c.condition.Format(buf)
 	buf.WriteString(" then ")
@@ -144,7 +143,7 @@ func (c *coalesceExpr) Type() types.T {
 	return c.firstExpr.Type()
 }
 
-func (c *coalesceExpr) Format(buf *bytes.Buffer) {
+func (c *coalesceExpr) Format(buf *tree.FmtCtx) {
 	buf.WriteString("cast(coalesce(")
 	c.firstExpr.Format(buf)
 	buf.WriteString(", ")
@@ -181,7 +180,7 @@ func (c *constExpr) Type() types.T {
 	return c.typ
 }
 
-func (c *constExpr) Format(buf *bytes.Buffer) {
+func (c *constExpr) Format(buf *tree.FmtCtx) {
 	buf.WriteString(c.expr)
 }
 
@@ -215,7 +214,7 @@ func (c *colRefExpr) Type() types.T {
 	return c.typ
 }
 
-func (c *colRefExpr) Format(buf *bytes.Buffer) {
+func (c *colRefExpr) Format(buf *tree.FmtCtx) {
 	buf.WriteString(c.ref)
 }
 
@@ -248,7 +247,7 @@ func (o *opExpr) Type() types.T {
 	return o.outTyp
 }
 
-func (o *opExpr) Format(buf *bytes.Buffer) {
+func (o *opExpr) Format(buf *tree.FmtCtx) {
 	buf.WriteByte('(')
 	o.left.Format(buf)
 	buf.WriteByte(' ')
@@ -300,7 +299,7 @@ func (f *funcExpr) Type() types.T {
 	return f.outTyp
 }
 
-func (f *funcExpr) Format(buf *bytes.Buffer) {
+func (f *funcExpr) Format(buf *tree.FmtCtx) {
 	buf.WriteString(f.name)
 	buf.WriteByte('(')
 	comma := ""
@@ -346,7 +345,7 @@ type exists struct {
 	subquery relExpr
 }
 
-func (e *exists) Format(buf *bytes.Buffer) {
+func (e *exists) Format(buf *tree.FmtCtx) {
 	buf.WriteString("exists(")
 	e.subquery.Format(buf)
 	buf.WriteString(")")
@@ -373,7 +372,7 @@ type scalarSubq struct {
 	subquery relExpr
 }
 
-func (s *scalarSubq) Format(buf *bytes.Buffer) {
+func (s *scalarSubq) Format(buf *tree.FmtCtx) {
 	buf.WriteString("(")
 	s.subquery.Format(buf)
 	buf.WriteString(")")

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"math/rand"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -221,13 +222,13 @@ func (c *colRefExpr) Format(buf *bytes.Buffer) {
 func (s *scope) makeColRef(typ types.T) (scalarExpr, bool) {
 	ref := s.refs[rand.Intn(len(s.refs))]
 	col := ref.Cols()[rand.Intn(len(ref.Cols()))]
-	if typ != types.Any && col.typ != typ {
+	if typ != types.Any && coltypes.CastTargetToDatumType(col.Type) != typ {
 		return nil, false
 	}
 
 	return &colRefExpr{
-		ref: ref.Name() + "." + col.name,
-		typ: col.typ,
+		ref: ref.Name() + "." + col.Name.String(),
+		typ: coltypes.CastTargetToDatumType(col.Type),
 	}, true
 }
 

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -25,7 +25,7 @@ import (
 
 // makeScalar attempts to construct a scalar expression of the requested type.
 // If it was unsuccessful, it will return false.
-func (s *scope) makeScalar(typ types.T) (scalarExpr, bool) {
+func (s *scope) makeScalar(typ types.T) (tree.TypedExpr, bool) {
 	pickedType := typ
 	if typ == types.Any {
 		pickedType = getRandType()
@@ -33,7 +33,7 @@ func (s *scope) makeScalar(typ types.T) (scalarExpr, bool) {
 	s = s.push()
 
 	for i := 0; i < retryCount; i++ {
-		var result scalarExpr
+		var result tree.TypedExpr
 		var ok bool
 		// TODO(justin): this is how sqlsmith chooses what to do, but it feels
 		// to me like there should be a more clean/principled approach here.
@@ -63,11 +63,11 @@ func (s *scope) makeScalar(typ types.T) (scalarExpr, bool) {
 
 // TODO(justin): sqlsmith separated this out from the general case for
 // some reason - I think there must be a clean way to unify the two.
-func (s *scope) makeBoolExpr() (scalarExpr, bool) {
+func (s *scope) makeBoolExpr() (tree.TypedExpr, bool) {
 	s = s.push()
 
 	for i := 0; i < retryCount; i++ {
-		var result scalarExpr
+		var result tree.TypedExpr
 		var ok bool
 
 		if d6() < 4 {
@@ -87,31 +87,7 @@ func (s *scope) makeBoolExpr() (scalarExpr, bool) {
 	return nil, false
 }
 
-///////
-// CASE
-///////
-
-type caseExpr struct {
-	condition scalarExpr
-	trueExpr  scalarExpr
-	falseExpr scalarExpr
-}
-
-func (c *caseExpr) Type() types.T {
-	return c.trueExpr.Type()
-}
-
-func (c *caseExpr) Format(buf *tree.FmtCtx) {
-	buf.WriteString("case when ")
-	c.condition.Format(buf)
-	buf.WriteString(" then ")
-	c.trueExpr.Format(buf)
-	buf.WriteString(" else ")
-	c.falseExpr.Format(buf)
-	buf.WriteString(" end")
-}
-
-func (s *scope) makeCaseExpr(typ types.T) (scalarExpr, bool) {
+func (s *scope) makeCaseExpr(typ types.T) (*tree.CaseExpr, bool) {
 	condition, ok := s.makeScalar(types.Bool)
 	if !ok {
 		return nil, false
@@ -127,33 +103,19 @@ func (s *scope) makeCaseExpr(typ types.T) (scalarExpr, bool) {
 		return nil, false
 	}
 
-	return &caseExpr{condition, trueExpr, falseExpr}, true
+	expr, err := tree.NewTypedCaseExpr(
+		nil,
+		[]*tree.When{{
+			Cond: condition,
+			Val:  trueExpr,
+		}},
+		falseExpr,
+		typ,
+	)
+	return expr, err == nil
 }
 
-///////////
-// COALESCE
-///////////
-
-type coalesceExpr struct {
-	firstExpr  scalarExpr
-	secondExpr scalarExpr
-}
-
-func (c *coalesceExpr) Type() types.T {
-	return c.firstExpr.Type()
-}
-
-func (c *coalesceExpr) Format(buf *tree.FmtCtx) {
-	buf.WriteString("cast(coalesce(")
-	c.firstExpr.Format(buf)
-	buf.WriteString(", ")
-	c.secondExpr.Format(buf)
-	buf.WriteString(") as ")
-	buf.WriteString(c.firstExpr.Type().SQLName())
-	buf.WriteString(")")
-}
-
-func (s *scope) makeCoalesceExpr(typ types.T) (scalarExpr, bool) {
+func (s *scope) makeCoalesceExpr(typ types.T) (tree.TypedExpr, bool) {
 	firstExpr, ok := s.makeScalar(typ)
 	if !ok {
 		return nil, false
@@ -164,27 +126,16 @@ func (s *scope) makeCoalesceExpr(typ types.T) (scalarExpr, bool) {
 		return nil, false
 	}
 
-	return &coalesceExpr{firstExpr, secondExpr}, true
+	return tree.NewTypedCoalesceExpr(
+		tree.TypedExprs{
+			firstExpr,
+			secondExpr,
+		},
+		typ,
+	), true
 }
 
-////////
-// CONST
-////////
-
-type constExpr struct {
-	typ  types.T
-	expr string
-}
-
-func (c *constExpr) Type() types.T {
-	return c.typ
-}
-
-func (c *constExpr) Format(buf *tree.FmtCtx) {
-	buf.WriteString(c.expr)
-}
-
-func (s *scope) makeConstExpr(typ types.T) scalarExpr {
+func (s *scope) makeConstExpr(typ types.T) tree.TypedExpr {
 	var datum tree.Datum
 	col, err := sqlbase.DatumTypeToColumnType(typ)
 	if err != nil {
@@ -198,66 +149,33 @@ func (s *scope) makeConstExpr(typ types.T) scalarExpr {
 	// TODO(justin): maintain context and see if we're in an INSERT, and maybe use
 	// DEFAULT (which is a legal "value" in such a context).
 
-	return &constExpr{typ, datum.String()}
+	return datum
 }
 
-/////////
-// COLREF
-/////////
-
-type colRefExpr struct {
-	ref string
-	typ types.T
-}
-
-func (c *colRefExpr) Type() types.T {
-	return c.typ
-}
-
-func (c *colRefExpr) Format(buf *tree.FmtCtx) {
-	buf.WriteString(c.ref)
-}
-
-func (s *scope) makeColRef(typ types.T) (scalarExpr, bool) {
+func (s *scope) makeColRef(typ types.T) (tree.TypedExpr, bool) {
 	ref := s.refs[rand.Intn(len(s.refs))]
-	col := ref.Cols()[rand.Intn(len(ref.Cols()))]
-	if typ != types.Any && coltypes.CastTargetToDatumType(col.Type) != typ {
+	// Filter by needed type.
+	cols := make([]*tree.ColumnTableDef, 0, len(ref.Columns))
+	for _, c := range ref.Columns {
+		if typ == types.Any || coltypes.CastTargetToDatumType(c.Type) == typ {
+			cols = append(cols, c)
+		}
+	}
+	if len(cols) == 0 {
 		return nil, false
 	}
+	col := cols[rand.Intn(len(cols))]
 
-	return &colRefExpr{
-		ref: ref.Name() + "." + col.Name.String(),
-		typ: coltypes.CastTargetToDatumType(col.Type),
-	}, true
+	return makeTypedExpr(
+		tree.NewColumnItem(
+			ref.TableName,
+			col.Name,
+		),
+		coltypes.CastTargetToDatumType(col.Type),
+	), true
 }
 
-/////////
-// BIN OP
-/////////
-
-type opExpr struct {
-	outTyp types.T
-
-	left  scalarExpr
-	right scalarExpr
-	op    string
-}
-
-func (o *opExpr) Type() types.T {
-	return o.outTyp
-}
-
-func (o *opExpr) Format(buf *tree.FmtCtx) {
-	buf.WriteByte('(')
-	o.left.Format(buf)
-	buf.WriteByte(' ')
-	buf.WriteString(o.op)
-	buf.WriteByte(' ')
-	o.right.Format(buf)
-	buf.WriteByte(')')
-}
-
-func (s *scope) makeBinOp(typ types.T) (scalarExpr, bool) {
+func (s *scope) makeBinOp(typ types.T) (*tree.BinaryExpr, bool) {
 	if typ == types.Any {
 		typ = getRandType()
 	}
@@ -276,42 +194,15 @@ func (s *scope) makeBinOp(typ types.T) (scalarExpr, bool) {
 		return nil, false
 	}
 
-	return &opExpr{
-		outTyp: typ,
-		left:   left,
-		right:  right,
-		op:     op.name,
-	}, true
+	return tree.NewTypedBinaryExpr(
+		op.op,
+		left,
+		right,
+		typ,
+	), true
 }
 
-//////////
-// FUNC OP
-//////////
-
-type funcExpr struct {
-	outTyp types.T
-
-	name   string
-	inputs []scalarExpr
-}
-
-func (f *funcExpr) Type() types.T {
-	return f.outTyp
-}
-
-func (f *funcExpr) Format(buf *tree.FmtCtx) {
-	buf.WriteString(f.name)
-	buf.WriteByte('(')
-	comma := ""
-	for _, a := range f.inputs {
-		buf.WriteString(comma)
-		a.Format(buf)
-		comma = ", "
-	}
-	buf.WriteByte(')')
-}
-
-func (s *scope) makeFunc(typ types.T) (scalarExpr, bool) {
+func (s *scope) makeFunc(typ types.T) (tree.TypedExpr, bool) {
 	if typ == types.Any {
 		typ = getRandType()
 	}
@@ -321,7 +212,7 @@ func (s *scope) makeFunc(typ types.T) (scalarExpr, bool) {
 	}
 	op := ops[rand.Intn(len(ops))]
 
-	args := make([]scalarExpr, 0)
+	args := make(tree.TypedExprs, 0)
 	for i := range op.inputs {
 		in, ok := s.makeScalar(op.inputs[i])
 		if !ok {
@@ -330,64 +221,49 @@ func (s *scope) makeFunc(typ types.T) (scalarExpr, bool) {
 		args = append(args, in)
 	}
 
-	return &funcExpr{
-		outTyp: typ,
-		name:   op.name,
-		inputs: args,
-	}, true
+	fd, ok := tree.FunDefs[op.name]
+	if !ok {
+		return nil, false
+	}
+	return tree.NewTypedFuncExpr(
+		tree.ResolvableFunctionReference{fd},
+		0, /* aggQualifier */
+		args,
+		nil, /* filter */
+		nil, /* windowDef */
+		typ,
+		nil, /* props */
+		nil, /* overload */
+	), true
 }
 
-/////////
-// EXISTS
-/////////
-
-type exists struct {
-	subquery relExpr
-}
-
-func (e *exists) Format(buf *tree.FmtCtx) {
-	buf.WriteString("exists(")
-	e.subquery.Format(buf)
-	buf.WriteString(")")
-}
-
-func (e *exists) Type() types.T {
-	return types.Bool
-}
-
-func (s *scope) makeExists() (scalarExpr, bool) {
-	outScope, ok := s.makeSelect(nil)
+func (s *scope) makeExists() (tree.TypedExpr, bool) {
+	selectStmt, ok := s.makeSelect(nil)
 	if !ok {
 		return nil, false
 	}
 
-	return &exists{outScope.expr}, true
+	return makeTypedExpr(
+		&tree.Subquery{
+			Select: &tree.ParenSelect{Select: selectStmt},
+			Exists: true,
+		},
+		types.Bool,
+	), true
 }
 
-//////////////////
-// SCALAR SUBQUERY
-//////////////////
-
-type scalarSubq struct {
-	subquery relExpr
-}
-
-func (s *scalarSubq) Format(buf *tree.FmtCtx) {
-	buf.WriteString("(")
-	s.subquery.Format(buf)
-	buf.WriteString(")")
-}
-
-func (s *scalarSubq) Type() types.T {
-	return s.subquery.(*selectExpr).selectList[0].Type()
-}
-
-func (s *scope) makeScalarSubquery(typ types.T) (scalarExpr, bool) {
-	outScope, ok := s.makeSelect([]types.T{typ})
+func (s *scope) makeScalarSubquery(typ types.T) (tree.TypedExpr, bool) {
+	selectStmt, ok := s.makeSelect([]types.T{typ})
 	if !ok {
 		return nil, false
 	}
+	selectStmt.Limit = &tree.Limit{Count: tree.NewDInt(1)}
 
-	outScope.expr.(*selectExpr).limit = "limit 1"
-	return &scalarSubq{outScope.expr}, true
+	return makeTypedExpr(
+		&tree.Subquery{
+			Select: &tree.ParenSelect{Select: selectStmt},
+		},
+		typ,
+	), true
+
 }

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -174,23 +174,23 @@ func (s *scope) makeBinOp(typ types.T, refs colRefs) (*tree.BinaryExpr, bool) {
 	if typ == types.Any {
 		typ = getRandType()
 	}
-	ops := s.schema.GetOperatorsByOutputType(typ)
+	ops := operators[typ.Oid()]
 	if len(ops) == 0 {
 		return nil, false
 	}
 	op := ops[rand.Intn(len(ops))]
 
-	left, ok := s.makeScalar(op.left, refs)
+	left, ok := s.makeScalar(op.LeftType, refs)
 	if !ok {
 		return nil, false
 	}
-	right, ok := s.makeScalar(op.right, refs)
+	right, ok := s.makeScalar(op.RightType, refs)
 	if !ok {
 		return nil, false
 	}
 
 	return tree.NewTypedBinaryExpr(
-		op.op,
+		op.Operator,
 		left,
 		right,
 		typ,

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -87,20 +87,20 @@ func (s *schema) ReloadSchemas(db *gosql.DB) error {
 
 func extractTables(db *gosql.DB) ([]tableRef, error) {
 	rows, err := db.Query(`
-	SELECT
-		table_catalog,
-		table_schema,
-		table_name,
-		column_name,
-		crdb_sql_type,
-		generation_expression != '' AS computed,
-		is_nullable = 'YES' AS nullable
-	FROM
-		information_schema.columns
-	WHERE
-		table_schema = 'public'
-	ORDER BY
-		table_catalog, table_schema, table_name
+SELECT
+	table_catalog,
+	table_schema,
+	table_name,
+	column_name,
+	crdb_sql_type,
+	generation_expression != '' AS computed,
+	is_nullable = 'YES' AS nullable
+FROM
+	information_schema.columns
+WHERE
+	table_schema = 'public'
+ORDER BY
+	table_catalog, table_schema, table_name
 	`)
 	// TODO(justin): have a flag that includes system tables?
 	if err != nil {
@@ -178,6 +178,8 @@ FROM
 	pg_catalog.pg_operator
 WHERE
 	0 NOT IN (oprresult, oprright, oprleft)
+ORDER BY
+	oprname, oprleft, oprright, oprresult
 `)
 	if err != nil {
 		return nil, err
@@ -243,7 +245,7 @@ var binOps = map[string]tree.BinaryOperator{
 func extractFunctions(db *gosql.DB) (map[oid.Oid][]function, error) {
 	rows, err := db.Query(`
 SELECT
-	proname, proargtypes::INT[], prorettype
+	proname, proargtypes::INT8[], prorettype
 FROM
 	pg_catalog.pg_proc
 WHERE
@@ -251,6 +253,8 @@ WHERE
 	AND NOT proiswindow
 	AND NOT proretset
 	AND proname NOT LIKE 'crdb_internal.force_%'
+ORDER BY
+	proname, proargtypes::string, prorettype
 `)
 	if err != nil {
 		return nil, err

--- a/pkg/internal/sqlsmith/scope.go
+++ b/pkg/internal/sqlsmith/scope.go
@@ -15,8 +15,6 @@
 package sqlsmith
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
@@ -39,35 +37,17 @@ func (t colRefs) extend(refs ...*colRef) colRefs {
 }
 
 type scope struct {
-	schema *schema
+	schema *Smither
 
 	// level is how deep we are in the scope tree - it is used as a heuristic
 	// to eventually bottom out recursion (so we don't attempt to construct an
 	// infinitely large join, or something).
 	level int
-
-	// namer is used to generate unique table and column names.
-	namer *namer
 }
 
 func (s *scope) push() *scope {
 	return &scope{
 		level:  s.level + 1,
-		namer:  s.namer,
 		schema: s.schema,
 	}
-}
-
-func (s *scope) name(prefix string) string {
-	return s.namer.name(prefix)
-}
-
-// namer is a helper to generate names with unique prefixes.
-type namer struct {
-	counts map[string]int
-}
-
-func (n *namer) name(prefix string) string {
-	n.counts[prefix] = n.counts[prefix] + 1
-	return fmt.Sprintf("%s_%d", prefix, n.counts[prefix])
 }

--- a/pkg/internal/sqlsmith/scope.go
+++ b/pkg/internal/sqlsmith/scope.go
@@ -17,25 +17,11 @@ package sqlsmith
 import (
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
-
-type writability int
-
-const (
-	notWritable writability = iota
-	writable
-)
-
-type column struct {
-	name        string
-	typ         types.T
-	nullable    bool
-	writability writability
-}
 
 type namedRelation struct {
-	cols []column
+	cols []tree.ColumnTableDef
 	name string
 }
 

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -15,9 +15,10 @@
 package sqlsmith
 
 import (
-	"bytes"
 	gosql "database/sql"
 	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 // sqlsmith-go
@@ -73,8 +74,8 @@ func (s *Smither) Generate() string {
 		if !ok {
 			continue
 		}
-		var buf bytes.Buffer
-		stmt.expr.Format(&buf)
-		return buf.String()
+		ctx := &tree.FmtCtx{}
+		stmt.expr.Format(ctx)
+		return ctx.String()
 	}
 }

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -19,6 +19,7 @@ import (
 	"math/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 // sqlsmith-go
@@ -55,21 +56,26 @@ const retryCount = 20
 
 // Smither is a sqlsmith generator.
 type Smither struct {
-	schema *schema
+	rnd        *rand.Rand
+	lock       syncutil.Mutex
+	tables     []*tableRef
+	nameCounts map[string]int
 }
 
 // NewSmither creates a new Smither.
 func NewSmither(db *gosql.DB, rnd *rand.Rand) (*Smither, error) {
-	schema, err := makeSchema(db, rnd)
-	return &Smither{
-		schema: schema,
-	}, err
+	s := &Smither{
+		rnd:        rnd,
+		nameCounts: map[string]int{},
+	}
+	err := s.ReloadSchemas(db)
+	return s, err
 }
 
 // Generate returns a random SQL string.
 func (s *Smither) Generate() string {
 	for {
-		scope := s.schema.makeScope()
+		scope := s.makeScope()
 		stmt, ok := scope.makeStmt()
 		if !ok {
 			continue

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -74,8 +74,7 @@ func (s *Smither) Generate() string {
 		if !ok {
 			continue
 		}
-		ctx := &tree.FmtCtx{}
-		stmt.expr.Format(ctx)
-		return ctx.String()
+		cfg := tree.DefaultPrettyCfg()
+		return cfg.Pretty(stmt)
 	}
 }

--- a/pkg/internal/sqlsmith/sqlsmith_test.go
+++ b/pkg/internal/sqlsmith/sqlsmith_test.go
@@ -35,8 +35,7 @@ func TestGenerate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i := 0; i < 100; i++ {
-		fmt.Printf("%s;\n\n", smither.Generate())
-		_ = smither.Generate()
+	for i := 0; i < 5; i++ {
+		fmt.Println(smither.Generate())
 	}
 }

--- a/pkg/internal/sqlsmith/sqlsmith_test.go
+++ b/pkg/internal/sqlsmith/sqlsmith_test.go
@@ -1,0 +1,42 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlsmith
+
+import (
+	gosql "database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	_ "github.com/lib/pq"
+)
+
+func TestGenerate(t *testing.T) {
+	t.Skip("used in local dev only")
+
+	db, err := gosql.Open("postgres", "user=root port=26257 sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rnd, _ := randutil.NewPseudoRand()
+	smither, err := NewSmither(db, rnd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 100; i++ {
+		fmt.Printf("%s;\n\n", smither.Generate())
+		_ = smither.Generate()
+	}
+}

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -471,7 +471,7 @@ func TestRandomSyntaxSQLSmith(t *testing.T) {
 			if err := db.exec(ctx, "USE defaultdb"); err != nil {
 				t.Fatalf("couldn't reconnect to db after crasher: %v", c)
 			}
-			fmt.Printf("CRASHER:\n%s\ncaused by: %s\nserver stacktrace:\n%s\n\n", s, c.Error(), c.detail)
+			fmt.Printf("CRASHER:\n%s;\n\ncaused by: %s\nserver stacktrace:\n%s\n\n", s, c.Error(), c.detail)
 			return c
 		}
 		if err == nil {


### PR DESCRIPTION
Refactor sqlsmith to use internal cockroach types for everything. Change reference handling to be more explicit and correct. These should enable us to more easily and correctly add 