### PR TITLE
roachtest: Fix blacklist lookups to handle change from v2.2 to v19.1

### DIFF
--- a/pkg/cmd/roachtest/hibernate_blacklist.go
+++ b/pkg/cmd/roachtest/hibernate_blacklist.go
@@ -26,7 +26,8 @@ var hibernateBlacklists = []struct {
 }{
 	{"v2.0", "hibernateBlackList2_0", hibernateBlackList2_0},
 	{"v2.1", "hibernateBlackList2_1", hibernateBlackList2_1},
-	{"v2.2", "hibernateBlackList2_2", hibernateBlackList2_2},
+	{"v2.2", "hibernateBlackList19_1", hibernateBlackList19_1},
+	{"v19.1", "hibernateBlackList19_1", hibernateBlackList19_1},
 }
 
 // getHibernateBlacklistForVersion returns the appropriate hibernate blacklist
@@ -52,7 +53,7 @@ func getHibernateBlacklistForVersion(version string) (string, blacklist) {
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blacklist should be available
 // in the test log.
-var hibernateBlackList2_2 = blacklist{
+var hibernateBlackList19_1 = blacklist{
 	"org.hibernate.id.QuotedIdentifierTest.testDirectIdPropertyAccess":                                                                                                               "24062",
 	"org.hibernate.jpa.test.criteria.QueryBuilderTest.testDateTimeFunctions":                                                                                                         "31708",
 	"org.hibernate.jpa.test.criteria.basic.AggregationResultTest.testSumOfBigDecimals":                                                                                               "5807",

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -258,8 +258,9 @@ func registerPsycopg(r *registry) {
 	}
 
 	r.Add(testSpec{
-		Name:    "psycopg",
-		Cluster: makeClusterSpec(1),
+		Name:       "psycopg",
+		Cluster:    makeClusterSpec(1),
+		MinVersion: "v2.2.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runPsycopg(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/psycopg_blacklist.go
+++ b/pkg/cmd/roachtest/psycopg_blacklist.go
@@ -24,7 +24,8 @@ var psycopgBlacklists = []struct {
 	ignorelistname string
 	ignorelist     blacklist
 }{
-	{"v2.2", "psycopgBlackList2_2", psycopgBlackList2_2, "psycopgIgnoreList2_2", psycopgIgnoreList2_2},
+	{"v2.2", "psycopgBlackList19_1", psycopgBlackList19_1, "psycopgIgnoreList19_1", psycopgIgnoreList19_1},
+	{"v19.1", "psycopgBlackList19_1", psycopgBlackList19_1, "psycopgIgnoreList19_1", psycopgIgnoreList19_1},
 }
 
 // getPsycopgBlacklistForVersion returns the appropriate psycopg blacklist and
@@ -50,7 +51,7 @@ func getPsycopgBlacklistForVersion(version string) (string, blacklist, string, b
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blacklist should be available
 // in the test log.
-var psycopgBlackList2_2 = blacklist{
+var psycopgBlackList19_1 = blacklist{
 	"psycopg2.tests.test_async.AsyncTests.test_async_after_async":                                                 "5807",
 	"psycopg2.tests.test_async.AsyncTests.test_async_callproc":                                                    "5807",
 	"psycopg2.tests.test_async.AsyncTests.test_async_connection_error_message":                                    "5807",
@@ -378,13 +379,12 @@ var psycopgBlackList2_2 = blacklist{
 	"psycopg2.tests.test_types_extras.RangeCasterTestCase.test_cast_timestamp":                                    "unknown",
 	"psycopg2.tests.test_types_extras.RangeCasterTestCase.test_cast_timestamptz":                                  "unknown",
 	"psycopg2.tests.test_types_extras.RangeCasterTestCase.test_range_escaping":                                    "27791",
-	"psycopg2.tests.test_types_extras.RangeCasterTestCase.test_range_not_found":                                   "unknown",
 	"psycopg2.tests.test_types_extras.RangeCasterTestCase.test_register_range_adapter":                            "27791",
 	"psycopg2.tests.test_types_extras.RangeCasterTestCase.test_schema_range":                                      "26443",
 	"psycopg2.tests.test_with.WithCursorTestCase.test_exception_swallow":                                          "unknown",
 	"psycopg2.tests.test_with.WithCursorTestCase.test_named_with_noop":                                            "unknown",
 }
 
-var psycopgIgnoreList2_2 = blacklist{
+var psycopgIgnoreList19_1 = blacklist{
 	"psycopg2.tests.test_green.GreenTestCase.test_flush_on_write": "unknown",
 }


### PR DESCRIPTION
I've been working on this fix as part of #35423 but that's been taking too long
and I don't want the tests to keep failing.  So here is a direct fix that also
updates the blacklist for psycopg as a new test is now passing.

Fixes #35271.
Fixes #35285.

Release note: None