### PR TITLE
sql: fix planning of window functions in some cases

### DIFF
--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -814,29 +814,25 @@ func distsqlSetOpJoinType(setOpType tree.UnionType) sqlbase.JoinType {
 	}
 }
 
-func findJoinProcessorNodes(
-	leftRouters, rightRouters []distsqlplan.ProcessorIdx,
-	processors []distsqlplan.Processor,
-	includeRight bool,
+// getNodesOfRouters returns all nodes that routers are put on.
+func getNodesOfRouters(
+	routers []distsqlplan.ProcessorIdx, processors []distsqlplan.Processor,
 ) (nodes []roachpb.NodeID) {
-	// TODO(radu): for now we run a join processor on every node that produces
-	// data for either source. In the future we should be smarter here.
 	seen := make(map[roachpb.NodeID]struct{})
-	for _, pIdx := range leftRouters {
+	for _, pIdx := range routers {
 		n := processors[pIdx].Node
 		if _, ok := seen[n]; !ok {
 			seen[n] = struct{}{}
 			nodes = append(nodes, n)
 		}
 	}
-	if includeRight {
-		for _, pIdx := range rightRouters {
-			n := processors[pIdx].Node
-			if _, ok := seen[n]; !ok {
-				seen[n] = struct{}{}
-				nodes = append(nodes, n)
-			}
-		}
-	}
 	return nodes
+}
+
+func findJoinProcessorNodes(
+	leftRouters, rightRouters []distsqlplan.ProcessorIdx, processors []distsqlplan.Processor,
+) (nodes []roachpb.NodeID) {
+	// TODO(radu): for now we run a join processor on every node that produces
+	// data for either source. In the future we should be smarter here.
+	return getNodesOfRouters(append(leftRouters, rightRouters...), processors)
 }

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -2973,3 +2973,14 @@ SELECT a, json_agg(a) OVER (ORDER BY a) FROM x ORDER BY a
 1 [1]
 2 [1, 2]
 3 [1, 2, 3]
+
+# Test for #35267
+query I
+SELECT
+    row_number() OVER (PARTITION BY s)
+FROM
+    (SELECT sum(a) AS s FROM (SELECT a FROM x UNION ALL SELECT a FROM x) GROUP BY a)
+----
+1
+1
+1


### PR DESCRIPTION
Previously, the incorrect assumption was made that the number of
nodes participating in a stage of a physical plan equals to the
number of processors of the stage which is not true generally
(for example, when UNION ALL is present in the query), and if such
query ran, the cluster panicked. Now, we're fixing the planning code
for such case.

Fixes: #35267.

Release note (bug fix): window functions are now correctly planned
in the query when UNION ALL is present in the subquery.