### PR TITLE
sql: Push error telemetry down into pgwire

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1327,7 +1327,6 @@ func (ex *connExecutor) run(
 				ex.sessionEventf(ex.Ctx(), "execution error: %s", pe.errorCause())
 			}
 			if resErr == nil && ok {
-				telemetry.RecordError(pe.errorCause())
 				// Depending on whether the result has the error already or not, we have
 				// to call either Close or CloseWithErr.
 				res.CloseWithErr(pe.errorCause())

--- a/pkg/sql/err_count_test.go
+++ b/pkg/sql/err_count_test.go
@@ -16,6 +16,7 @@ package sql_test
 
 import (
 	"context"
+	gosql "database/sql"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -23,10 +24,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/lib/pq"
 )
 
 func TestErrorCounts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	telemetry.GetAndResetFeatureCounts(false)
 
 	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
@@ -65,6 +69,8 @@ func TestErrorCounts(t *testing.T) {
 func TestUnimplementedCounts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	telemetry.GetAndResetFeatureCounts(false)
+
 	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
@@ -79,5 +85,59 @@ func TestUnimplementedCounts(t *testing.T) {
 
 	if telemetry.GetFeatureCounts()["unimplemented.#9851.INT8->STRING"] == 0 {
 		t.Fatal("expected unimplemented telemetry, got nothing")
+	}
+}
+
+func TestTransactionRetryErrorCounts(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	telemetry.GetAndResetFeatureCounts(false)
+
+	// Transaction retry errors aren't given a pg error code until deep
+	// in pgwire (pgwire.convertToErrWithPGCode). Make sure we're
+	// reporting errors at a level that allows this code to be recorded.
+
+	params, _ := tests.CreateTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+
+	if _, err := db.Exec("CREATE TABLE accounts (id INT8 PRIMARY KEY, balance INT8)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("INSERT INTO accounts VALUES (1, 100)"); err != nil {
+		t.Fatal(err)
+	}
+
+	txn1, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txn2, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, txn := range []*gosql.Tx{txn1, txn2} {
+		rows, err := txn.Query("SELECT * FROM accounts WHERE id = 1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for rows.Next() {
+		}
+		rows.Close()
+	}
+
+	for _, txn := range []*gosql.Tx{txn1, txn2} {
+		if _, err := txn.Exec("UPDATE accounts SET balance = balance - 100 WHERE id = 1"); err != nil {
+			t.Fatal(err)
+		}
+		if err := txn.Commit(); err != nil && err.(*pq.Error).Code != "40001" {
+			t.Fatal(err)
+		}
+	}
+
+	if telemetry.GetFeatureCounts()["errorcodes.40001"] == 0 {
+		t.Fatal("expected error code telemetry, got nothing")
 	}
 }

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -205,6 +206,7 @@ func (ie *internalExecutorImpl) initConnEx(
 	wg.Add(1)
 	go func() {
 		if err := ex.run(ctx, ie.mon, mon.BoundAccount{} /*reserved*/, nil /* cancel */); err != nil {
+			telemetry.RecordError(err)
 			errCallback(err)
 		}
 		closeMode := normalClose

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
@@ -132,7 +131,6 @@ func (r *commandResult) Close(t sql.TransactionStatusIndicator) {
 		r.err = pgerror.UnimplementedWithIssueErrorf(4035,
 			"execute row count limits not supported: %d of %d",
 			r.limit, r.rowsAffected)
-		telemetry.RecordError(r.err)
 		r.conn.bufferErr(r.err)
 	}
 

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -989,6 +990,7 @@ func (c *conn) bufferEmptyQueryResponse() {
 }
 
 func writeErr(err error, msgBuilder *writeBuffer, w io.Writer) error {
+	telemetry.RecordError(err)
 	msgBuilder.initMsg(pgwirebase.ServerMsgErrorResponse)
 
 	msgBuilder.putErrFieldMsg(pgwirebase.ServerErrFieldSeverity)


### PR DESCRIPTION
Previously, errors were reported to telemetry by ConnExecutor and a
few other places, but A) this missed some error paths and B) was too
early to assign the right error codes, which in some cases (for
transaction retries and ambiguous results) doesn't happen until right
before pgwire writes the response.

Also add calls to GetAndResetFeatureCounts to telemetry tests to avoid
false passes from other tests, since telemetry is per-process state.

Release note (bug fix): Improve telemetry for error codes.