### PR TITLE
roachprod: Revert "roachprod: sync after gc’ing / destroying clusters"

### DIFF
--- a/pkg/cmd/roachprod/cloud/gc.go
+++ b/pkg/cmd/roachprod/cloud/gc.go
@@ -345,7 +345,6 @@ func GCClusters(cloud *Cloud, dryrun bool) error {
 			if err := DestroyCluster(c); err != nil {
 				postError(client, channel, err)
 			}
-			delete(cloud.Clusters, c.Name)
 		}
 	}
 	return nil

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -447,10 +447,6 @@ directory is removed.
 			if err := cld.DestroyCluster(c); err != nil {
 				return err
 			}
-			delete(cloud.Clusters, c.Name)
-			if err := syncAll(cloud, true /* quiet */); err != nil {
-				return err
-			}
 		} else {
 			if _, ok := install.Clusters[clusterName]; !ok {
 				return fmt.Errorf("cluster %s does not exist", clusterName)
@@ -740,13 +736,7 @@ hourly by a cronjob so it is not necessary to run manually.
 		if err != nil {
 			return err
 		}
-		if err := cld.GCClusters(cloud, dryrun); err != nil {
-			return err
-		}
-		if !dryrun {
-			return syncAll(cloud, true /*quiet*/)
-		}
-		return nil
+		return cld.GCClusters(cloud, dryrun)
 	}),
 }
 


### PR DESCRIPTION
This reverts commit 25579972b85fb0a43e113af18e7c1b583d4f782b.

The destroy takes a significant amount of time, meaning the `cloud` list
can be quite stale by the time it is complete.

This sync was only added to clean up DNS entries for destroyed clusters
but those will be removed on next sync anyway so it is not required.

Release note: None