### PR TITLE
tscache: reduce unit test logging output

### DIFF
--- a/pkg/storage/tscache/cache_test.go
+++ b/pkg/storage/tscache/cache_test.go
@@ -560,7 +560,8 @@ func TestTimestampCacheImplsIdentical(t *testing.T) {
 					rounds /= 2
 				}
 				for j := 0; j < rounds; j++ {
-					t.Logf("goroutine %d at iter %d", i, j)
+					// This is a lot of log output so only un-comment to debug.
+					// t.Logf("goroutine %d at iter %d", i, j)
 
 					// Wait for all goroutines to synchronize.
 					select {
@@ -582,7 +583,8 @@ func TestTimestampCacheImplsIdentical(t *testing.T) {
 
 					newVal := cacheValue{ts: ts, txnID: txnID}
 					for _, tc := range caches {
-						t.Logf("adding (%T) [%s,%s) = %s", tc, string(from), string(to), newVal)
+						// This is a lot of log output so only un-comment to debug.
+						// t.Logf("adding (%T) [%s,%s) = %s", tc, string(from), string(to), newVal)
 						tc.Add(from, to, ts, txnID, true /* readCache */)
 					}
 


### PR DESCRIPTION
On a regular CI run, these two logging lines were generating 21MB of output.

```
$ grep -o "cache_test.go:\d*:" Unit_Tests_test_57528.log | sort | uniq -c
64000 cache_test.go:563:
128000 cache_test.go:585:

$ grep "cache_test.go:\d*:" Unit_Tests_test_57528.log | wc -c
 21969350
```

Release note: None