### PR TITLE
opt: various small exprgen changes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare_opt_plan
+++ b/pkg/sql/logictest/testdata/logic_test/prepare_opt_plan
@@ -57,6 +57,49 @@ EXECUTE b
 1  one
 3  three
 
+statement ok
+PREPARE e AS OPT PLAN '
+(Root
+  (Explain
+    (Select
+      (Scan [ (Table "t") (Cols "k,str") ])
+      [
+        (Eq
+          (Mod (Var "k") (Const 2))
+          (Const 1)
+        )
+      ]
+    )
+    [
+      (Options "opt,verbose")
+      (ColList [ (NewColumn "text" "string") ])
+      (Props (MinPhysProps))
+    ]
+  )
+  (Presentation "text")
+  (NoOrdering)
+)'
+
+query T
+EXECUTE e
+----
+select
+ ├── columns: k:1 str:2
+ ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
+ ├── cost: 1050.02
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── prune: (2)
+ ├── scan test.public.t
+ │    ├── columns: k:1 str:2
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+ │    ├── cost: 1040.01
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── prune: (1,2)
+ └── filters
+      └── (k % 2) = 1 [outer=(1)]
+
 # Only root may use PREPARE AS OPT PLAN.
 
 user testuser

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -357,6 +357,22 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 	case *CreateTableExpr:
 		tp.Child(t.Syntax.String())
 
+	case *ExplainExpr:
+		// ExplainPlan is the default, don't show it.
+		m := ""
+		if t.Options.Mode != tree.ExplainPlan {
+			m, _ = tree.ExplainModeName(t.Options.Mode)
+		}
+		if t.Options.Flags.Contains(tree.ExplainFlagVerbose) {
+			if m != "" {
+				m += ", "
+			}
+			m += "verbose"
+		}
+		if m != "" {
+			tp.Childf("mode: %s", m)
+		}
+
 	default:
 		if opt.IsJoinOp(t) {
 			p := t.Private().(*JoinPrivate)

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -569,6 +569,7 @@ project
       │    ├── ordering: +5
       │    └── explain
       │         ├── columns: tree:5(string) level:6(int) node_type:7(string) field:8(string) description:9(string) columns:10(string) ordering:11(string)
+      │         ├── mode: verbose
       │         └── scan a
       │              ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
       │              ├── key: (1)

--- a/pkg/sql/opt/optbuilder/testdata/explain
+++ b/pkg/sql/opt/optbuilder/testdata/explain
@@ -36,6 +36,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xy
 ----
 explain
  ├── columns: tree:3(string) field:6(string) description:7(string) columns:8(string) ordering:9(string)  [hidden: level:4(int) node_type:5(string)]
+ ├── mode: verbose
  └── scan xy
       └── columns: x:1(int!null) y:2(int)
 
@@ -45,6 +46,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xy ORDER BY y
 ----
 explain
  ├── columns: tree:3(string) field:6(string) description:7(string) columns:8(string) ordering:9(string)  [hidden: level:4(int) node_type:5(string)]
+ ├── mode: verbose
  └── sort
       ├── columns: x:1(int!null) y:2(int)
       ├── ordering: +2
@@ -56,6 +58,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xy INNER JOIN (VALUES (1, 2), (3, 4)) AS t(u,v) 
 ----
 explain
  ├── columns: tree:5(string) field:8(string) description:9(string) columns:10(string) ordering:11(string)  [hidden: level:6(int) node_type:7(string)]
+ ├── mode: verbose
  └── inner-join
       ├── columns: x:1(int!null) y:2(int) u:3(int!null) v:4(int)
       ├── scan xy
@@ -80,6 +83,7 @@ project
  ├── columns: tree:3(string)
  └── explain
       ├── columns: tree:3(string) level:4(int) node_type:5(string) field:6(string) description:7(string) columns:8(string) ordering:9(string)
+      ├── mode: verbose
       └── scan xy
            └── columns: x:1(int!null) y:2(int)
 
@@ -90,6 +94,7 @@ project
  ├── columns: tree:3(string)
  └── explain
       ├── columns: tree:3(string) level:4(int) node_type:5(string) field:6(string) description:7(string) columns:8(string) ordering:9(string)
+      ├── mode: verbose
       └── sort
            ├── columns: x:1(int!null) x:1(int!null) y:2(int)
            ├── ordering: +2

--- a/pkg/sql/opt/optgen/exprgen/expr_gen.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen.go
@@ -269,6 +269,12 @@ func (eg *exprGen) castToDesiredType(arg interface{}, desiredType reflect.Type) 
 		}
 	}
 
+	if i, ok := arg.(*tree.DInt); ok {
+		if desiredType == reflect.TypeOf(memo.ScanLimit(0)) {
+			return memo.MakeScanLimit(int64(*i), false)
+		}
+	}
+
 	if str, ok := arg.(string); ok {
 		// String to type.
 		if desiredType == reflect.TypeOf((*types.T)(nil)).Elem() {
@@ -297,6 +303,11 @@ func (eg *exprGen) castToDesiredType(arg interface{}, desiredType reflect.Type) 
 		// String to ColSet.
 		if desiredType == reflect.TypeOf(opt.ColSet{}) {
 			return eg.ColSet(str)
+		}
+
+		// String to ExplainOptions.
+		if desiredType == reflect.TypeOf(tree.ExplainOptions{}) {
+			return eg.ExplainOptions(str)
 		}
 	}
 	return nil

--- a/pkg/sql/opt/optgen/exprgen/testdata/explain
+++ b/pkg/sql/opt/optgen/exprgen/testdata/explain
@@ -1,0 +1,124 @@
+exec-ddl
+CREATE TABLE abc (a INT, b INT, c INT, INDEX ab(a, b))
+----
+TABLE abc
+ ├── a int
+ ├── b int
+ ├── c int
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ └── INDEX ab
+      ├── a int
+      ├── b int
+      └── rowid int not null (hidden)
+
+expr
+(Explain
+  (Scan [ (Table "abc") (Cols "a") ])
+  [
+    (Options "opt,verbose")
+    (Props (MinPhysProps))
+  ]
+)
+----
+explain
+ ├── mode: opt, verbose
+ ├── stats: [rows=0]
+ ├── cost: 1050.02
+ └── scan t.public.abc
+      ├── columns: t.public.abc.a:1(int)
+      ├── stats: [rows=1000]
+      ├── cost: 1050.01
+      ├── prune: (1)
+      └── interesting orderings: (+1)
+
+expr
+(Explain
+  (Scan [ (Table "abc") (Cols "a") ])
+  [
+    (Options "verbose")
+    (Props (MinPhysProps))
+  ]
+)
+----
+explain
+ ├── mode: verbose
+ ├── stats: [rows=0]
+ ├── cost: 1050.02
+ └── scan t.public.abc
+      ├── columns: t.public.abc.a:1(int)
+      ├── stats: [rows=1000]
+      ├── cost: 1050.01
+      ├── prune: (1)
+      └── interesting orderings: (+1)
+
+expr
+(Explain
+  (Scan [ (Table "abc") (Cols "a") ])
+  [
+    (Options "opt")
+    (Props (MinPhysProps))
+  ]
+)
+----
+explain
+ ├── mode: opt
+ ├── stats: [rows=0]
+ ├── cost: 1050.02
+ └── scan t.public.abc
+      ├── columns: t.public.abc.a:1(int)
+      ├── stats: [rows=1000]
+      ├── cost: 1050.01
+      ├── prune: (1)
+      └── interesting orderings: (+1)
+
+expr
+(Explain
+  (Sort
+    (Scan [ (Table "abc") (Cols "a,b") ])
+  )
+  [
+    (Options "opt")
+    (Props
+      (MakePhysProps
+        (Presentation "a")
+        (OrderingChoice "+b")
+      )
+    )
+  ]
+)
+----
+explain
+ ├── mode: opt
+ ├── stats: [rows=0]
+ ├── cost: 1279.34569
+ └── sort
+      ├── columns: a:1(int)  [hidden: t.public.abc.b:2(int)]
+      ├── stats: [rows=1000]
+      ├── cost: 1279.33569
+      ├── ordering: +2
+      └── scan t.public.abc
+           ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
+           ├── stats: [rows=1000]
+           └── cost: 1060.01
+
+expr
+(Explain
+  (Scan [ (Table "abc") (Cols "a") ])
+  [
+    (Options "distsql")
+    (Props (MinPhysProps))
+  ]
+)
+----
+explain
+ ├── mode: distsql
+ ├── stats: [rows=0]
+ ├── cost: 1050.02
+ └── scan t.public.abc
+      ├── columns: t.public.abc.a:1(int)
+      ├── stats: [rows=1000]
+      ├── cost: 1050.01
+      ├── prune: (1)
+      └── interesting orderings: (+1)

--- a/pkg/sql/opt/optgen/exprgen/testdata/join
+++ b/pkg/sql/opt/optgen/exprgen/testdata/join
@@ -160,3 +160,33 @@ inner-join-apply
  │                   ├── variable: t.public.def.d [type=int]
  │                   └── variable: t.public.def.e [type=int]
  └── filters (true)
+
+expr
+(IndexJoin
+  (Scan
+    [
+      (Table "abc")
+      (Index "abc@ab")
+      (Cols "a")
+      (HardLimit 10)
+    ]
+  )
+  [
+    (Table (FindTable "abc"))
+    (Cols "c")
+  ]
+)
+----
+index-join abc
+ ├── columns: t.public.abc.c:3(int)
+ ├── cardinality: [0 - 10]
+ ├── stats: [rows=10]
+ ├── cost: 51.02
+ ├── interesting orderings: (+1)
+ └── scan t.public.abc@ab
+      ├── columns: t.public.abc.a:1(int)
+      ├── limit: 10
+      ├── stats: [rows=10]
+      ├── cost: 10.41
+      ├── prune: (1)
+      └── interesting orderings: (+1)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -521,6 +521,7 @@ EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY y
 ----
 explain
  ├── columns: tree:5(string) field:8(string) description:9(string) columns:10(string) ordering:11(string)  [hidden: level:6(int) node_type:7(string)]
+ ├── mode: verbose
  └── sort
       ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
       ├── ordering: +2

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -93,6 +93,16 @@ var explainModeStrings = map[string]ExplainMode{
 	"opt":     ExplainOpt,
 }
 
+// ExplainModeName returns the human-readable name of a given ExplainMode.
+func ExplainModeName(mode ExplainMode) (string, error) {
+	for k, v := range explainModeStrings {
+		if v == mode {
+			return k, nil
+		}
+	}
+	return "", fmt.Errorf("no name for explain mode %v", mode)
+}
+
 // Explain flags.
 const (
 	ExplainFlagVerbose = iota


### PR DESCRIPTION
This commit implements a handful of features I wanted when I was using
exprgen.

* Add FindTable to allow constructing index joins,
* extend the set of valid column name characters (I had a lot named x_1,
  x_2, ...)
* add support for ExplainOptions so we can exprgen an EXPLAIN,
* make it possible to specify a ScanLimit.

Release note: None