### PR TITLE
roachprod: default to sequential=true

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1538,7 +1538,7 @@ func main() {
 		switch cmd {
 		case startCmd, testCmd:
 			cmd.Flags().BoolVar(
-				&install.StartOpts.Sequential, "sequential", false,
+				&install.StartOpts.Sequential, "sequential", true,
 				"start nodes sequentially so node IDs match hostnames")
 			cmd.Flags().StringArrayVarP(
 				&nodeArgs, "args", "a", nil, "node arguments")

--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -257,7 +257,7 @@ func runWideReplication(ctx context.Context, t *test, c *cluster) {
 		t.Fatalf("9-node cluster required")
 	}
 
-	args := startArgs("--sequential", "--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
+	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, t, c.All(), args)
 

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -24,7 +24,7 @@ import (
 
 func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 	c.Put(ctx, cockroach, "./cockroach")
-	c.Start(ctx, t, c.Range(1, 3), startArgs("--sequential"))
+	c.Start(ctx, t, c.Range(1, 3))
 
 	db := c.Conn(ctx, 1)
 	defer db.Close()

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -269,7 +269,7 @@ func execCLI(
 }
 
 func runDecommissionAcceptance(ctx context.Context, t *test, c *cluster) {
-	args := startArgs("--sequential", "--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
+	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Start(ctx, t, args)
 

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -38,7 +38,7 @@ import (
 func registerGossip(r *registry) {
 	runGossipChaos := func(ctx context.Context, t *test, c *cluster) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Start(ctx, t, c.All(), startArgs("--sequential"))
+		c.Start(ctx, t, c.All())
 
 		gossipNetwork := func(node int) string {
 			const query = `

--- a/pkg/cmd/roachtest/rebalance_load.go
+++ b/pkg/cmd/roachtest/rebalance_load.go
@@ -55,7 +55,7 @@ func registerRebalanceLoad(r *registry) {
 		appNode := c.Node(c.nodes)
 
 		c.Put(ctx, cockroach, "./cockroach", roachNodes)
-		args := startArgs("--sequential",
+		args := startArgs(
 			"--args=--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")
 		c.Start(ctx, t, roachNodes, args)
 

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -44,7 +44,7 @@ func runReplicaGCChangedPeers(ctx context.Context, t *test, c *cluster, withRest
 		t.Fatal("test needs to be run with 6 nodes")
 	}
 
-	args := startArgs("--sequential", "--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
+	args := startArgs("--env=COCKROACH_SCAN_MAX_IDLE_TIME=5ms")
 	c.Put(ctx, cockroach, "./cockroach")
 	c.Put(ctx, workload, "./workload", c.Node(1))
 	c.Start(ctx, t, args, c.Range(1, 3))

--- a/pkg/cmd/roachtest/store_gen.go
+++ b/pkg/cmd/roachtest/store_gen.go
@@ -65,7 +65,7 @@ func registerStoreGen(r *registry, args []string) {
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Put(ctx, workload, "./workload")
-			c.Start(ctx, t, startArgs("--sequential"))
+			c.Start(ctx, t)
 
 			{
 				m := newMonitor(ctx, c)


### PR DESCRIPTION
We spend lots of time and mental context keeping the node-index-to-ID
mapping around during debugging sessions, both POC testing, manual
experiments, and roachtest (including acceptance). It's not worth the
engineering time. Default to starting nodes sequentially.

Release note: None