### PR TITLE
opt: turn group collisions into a no-op

### DIFF
--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -408,7 +408,8 @@ func (m *Memo) AddProjectToGroup(e *ProjectExpr, grp RelExpr) *ProjectExpr {
 		m.memEstimate += size
 		m.checkExpr(e)
 	} else if interned.group() != grp.group() {
-		panic(fmt.Sprintf("%s expression cannot be added to multiple groups: %s", e.Op(), interned))
+		// This is a group collision, do nothing.
+		return nil
 	}
 	return interned
 }

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -509,3 +509,176 @@ project
  │         └── a1.id = a3.id [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
  └── projections
       └── const: 1 [type=int]
+
+# Regression test for #35253.
+
+exec-ddl
+CREATE TABLE x (a INT8 PRIMARY KEY)
+----
+TABLE x
+ ├── a int not null
+ └── INDEX primary
+      └── a int not null
+
+memo join-limit=4
+SELECT
+    *
+FROM
+    x AS y
+    JOIN [INSERT INTO x (a) SELECT NULL FROM x RETURNING 1] ON false
+    JOIN x ON true
+    JOIN [UPDATE x SET a = 1 RETURNING 1] ON true
+----
+memo (optimized, ~56KB, required=[presentation: a:1,?column?:5,a:6,?column?:10])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G4) (inner-join G7 G8 G4) (inner-join G9 G10 G4) (inner-join G11 G12 G4) (inner-join G13 G14 G4) (inner-join G15 G16 G4) (inner-join G11 G17 G4) (inner-join G18 G16 G4) (inner-join G6 G5 G4) (inner-join G11 G19 G4) (inner-join G8 G7 G4) (inner-join G10 G9 G4) (inner-join G12 G11 G4) (inner-join G14 G13 G4) (inner-join G11 G20 G4) (inner-join G16 G15 G4) (inner-join G17 G11 G4) (inner-join G16 G18 G4) (inner-join G19 G11 G4) (inner-join G16 G21 G4) (inner-join G16 G22 G4) (inner-join G20 G11 G4) (inner-join G3 G23 G4) (inner-join G24 G16 G4) (inner-join G21 G16 G4) (inner-join G11 G25 G4) (inner-join G3 G26 G4) (inner-join G22 G16 G4) (inner-join G11 G27 G4) (inner-join G3 G28 G4) (inner-join G3 G29 G4) (inner-join G30 G16 G4) (inner-join G23 G3 G4) (inner-join G16 G24 G4) (inner-join G25 G11 G4) (inner-join G26 G3 G4) (inner-join G27 G11 G4) (inner-join G28 G3 G4) (inner-join G29 G3 G4) (inner-join G16 G30 G4)
+ │    └── [presentation: a:1,?column?:5,a:6,?column?:10]
+ │         ├── best: (inner-join G3 G2 G4)
+ │         └── cost: 2112.62
+ ├── G2: (inner-join G5 G7 G4) (inner-join G7 G5 G4) (inner-join G9 G13 G4) (inner-join G11 G15 G4) (inner-join G13 G9 G4) (inner-join G15 G11 G4) (inner-join G11 G18 G4) (inner-join G18 G11 G4)
+ │    └── []
+ │         ├── best: (inner-join G11 G15 G4)
+ │         └── cost: 1040.07
+ ├── G3: (project G31 G32)
+ │    └── []
+ │         ├── best: (project G31 G32)
+ │         └── cost: 1060.04
+ ├── G4: (filters)
+ ├── G5: (inner-join G9 G11 G4) (inner-join G11 G9 G4)
+ │    └── []
+ │         ├── best: (inner-join G9 G11 G4)
+ │         └── cost: 1040.07
+ ├── G6: (inner-join G7 G3 G4) (inner-join G3 G7 G4)
+ │    └── []
+ │         ├── best: (inner-join G7 G3 G4)
+ │         └── cost: 12110.06
+ ├── G7: (scan x)
+ │    └── []
+ │         ├── best: (scan x)
+ │         └── cost: 1020.01
+ ├── G8: (inner-join G5 G3 G4) (inner-join G3 G5 G4) (inner-join G9 G16 G4) (inner-join G11 G14 G4) (inner-join G16 G9 G4) (inner-join G14 G11 G4)
+ │    └── []
+ │         ├── best: (inner-join G3 G5 G4)
+ │         └── cost: 2112.62
+ ├── G9: (values G33 id=v1)
+ │    └── []
+ │         ├── best: (values G33 id=v1)
+ │         └── cost: 0.01
+ ├── G10: (inner-join G13 G3 G4) (inner-join G3 G13 G4) (inner-join G11 G6 G4) (inner-join G7 G16 G4) (inner-join G6 G11 G4) (inner-join G16 G7 G4)
+ │    └── []
+ │         ├── best: (inner-join G3 G13 G4)
+ │         └── cost: 3145.12
+ ├── G11: (project G34 G32)
+ │    └── []
+ │         ├── best: (project G34 G32)
+ │         └── cost: 1040.05
+ ├── G12: (inner-join G15 G3 G4) (inner-join G3 G15 G4)
+ │    └── []
+ │         ├── best: (inner-join G3 G15 G4)
+ │         └── cost: 1072.56
+ ├── G13: (inner-join G11 G7 G4) (inner-join G7 G11 G4)
+ │    └── []
+ │         ├── best: (inner-join G7 G11 G4)
+ │         └── cost: 2072.57
+ ├── G14: (inner-join G9 G3 G4) (inner-join G3 G9 G4)
+ │    └── []
+ │         ├── best: (inner-join G3 G9 G4)
+ │         └── cost: 1072.56
+ ├── G15: (values G33 id=v2)
+ │    └── []
+ │         ├── best: (values G33 id=v2)
+ │         └── cost: 0.01
+ ├── G16: (inner-join G11 G3 G4) (inner-join G3 G11 G4)
+ │    └── []
+ │         ├── best: (inner-join G3 G11 G4)
+ │         └── cost: 2112.60
+ ├── G17: (inner-join G18 G3 G4) (inner-join G3 G18 G4)
+ │    └── []
+ │         ├── best: (inner-join G3 G18 G4)
+ │         └── cost: 1072.56
+ ├── G18: (values G33 id=v3)
+ │    └── []
+ │         ├── best: (values G33 id=v3)
+ │         └── cost: 0.01
+ ├── G19: (inner-join G9 G6 G4) (inner-join G6 G9 G4) (inner-join G3 G24 G4) (inner-join G24 G3 G4)
+ │    └── []
+ │         ├── best: (inner-join G3 G24 G4)
+ │         └── cost: 1072.56
+ ├── G20: (inner-join G7 G14 G4) (inner-join G14 G7 G4) (inner-join G3 G30 G4) (inner-join G30 G3 G4)
+ │    └── []
+ │         ├── best: (inner-join G3 G30 G4)
+ │         └── cost: 1072.56
+ ├── G21: (values G33 id=v6)
+ │    └── []
+ │         ├── best: (values G33 id=v6)
+ │         └── cost: 0.01
+ ├── G22: (values G33 id=v7)
+ │    └── []
+ │         ├── best: (values G33 id=v7)
+ │         └── cost: 0.01
+ ├── G23: (inner-join G24 G11 G4) (inner-join G11 G24 G4)
+ │    └── []
+ │         ├── best: (inner-join G24 G11 G4)
+ │         └── cost: 1040.07
+ ├── G24: (values G33 id=v4)
+ │    └── []
+ │         ├── best: (values G33 id=v4)
+ │         └── cost: 0.01
+ ├── G25: (inner-join G3 G21 G4) (inner-join G21 G3 G4)
+ │    └── []
+ │         ├── best: (inner-join G3 G21 G4)
+ │         └── cost: 1072.56
+ ├── G26: (inner-join G11 G21 G4) (inner-join G21 G11 G4)
+ │    └── []
+ │         ├── best: (inner-join G11 G21 G4)
+ │         └── cost: 1040.07
+ ├── G27: (inner-join G3 G22 G4) (inner-join G22 G3 G4)
+ │    └── []
+ │         ├── best: (inner-join G3 G22 G4)
+ │         └── cost: 1072.56
+ ├── G28: (inner-join G11 G22 G4) (inner-join G22 G11 G4)
+ │    └── []
+ │         ├── best: (inner-join G11 G22 G4)
+ │         └── cost: 1040.07
+ ├── G29: (inner-join G30 G11 G4) (inner-join G11 G30 G4)
+ │    └── []
+ │         ├── best: (inner-join G30 G11 G4)
+ │         └── cost: 1040.07
+ ├── G30: (values G33 id=v5)
+ │    └── []
+ │         ├── best: (values G33 id=v5)
+ │         └── cost: 0.01
+ ├── G31: (update G35 x)
+ │    └── []
+ │         ├── best: (update G35 x)
+ │         └── cost: 1040.03
+ ├── G32: (projections G36)
+ ├── G33: (scalar-list)
+ ├── G34: (select G37 G38)
+ │    └── []
+ │         ├── best: (select G37 G38)
+ │         └── cost: 1040.04
+ ├── G35: (project G39 G32 a)
+ │    └── []
+ │         ├── best: (project G39 G32 a)
+ │         └── cost: 1040.02
+ ├── G36: (const 1)
+ ├── G37: (insert G40 x)
+ │    └── []
+ │         ├── best: (insert G40 x)
+ │         └── cost: 1030.03
+ ├── G38: (filters G41)
+ ├── G39: (scan x)
+ │    └── []
+ │         ├── best: (scan x)
+ │         └── cost: 1020.01
+ ├── G40: (project G42 G43)
+ │    └── []
+ │         ├── best: (project G42 G43)
+ │         └── cost: 1030.02
+ ├── G41: (false)
+ ├── G42: (scan x,cols=())
+ │    └── []
+ │         ├── best: (scan x,cols=())
+ │         └── cost: 1010.01
+ ├── G43: (projections G44)
+ └── G44: (null)


### PR DESCRIPTION
This PR is intended to supercede #35355 after a discussion with @andy-kimball.

From a comment in this commit:

```
The Add...ToGroup functions add a (possibly non-normalized) expression
to a memo group. They operate like this:

Attempt to intern the expression. This will either give back the
original expression, meaning we had not previously interned it, or it
will give back a previously interned version.

If we hadn't ever seen the expression before, then add it to the group
and move on.

If we *had* seen it before, check if it is in the same group as the one
we're attempting to add it to. If it's in the same group, then this is
fine, move along. This happens, for example, if we try to apply
CommuteJoin twice.

If it's in a different group, then we've learned something interesting:
two groups which we previously thought were distinct are actually
equivalent. One approach here would be to merge the two groups into a
single group, since we've proven that they're equivalent. We do
something simpler right now, which is to just bail on trying to add the
new expression, and leave it alone in its old group. This can result in
some expressions not getting fully explored, but we do our best to make
this outcome as much of an edge-case as possible, so hopefully this is
fine in almost every case.
```

Previously we would panic in the event of a group collision. This commit
changes this behaviour to be a no-op.

Release note (bug fix): fixed panics that could occur in some cases
involving joins of the results of mutations.