### PR TITLE
libroach: prevent infinite loop in reverse-scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -603,7 +603,8 @@ $(LIBROACH_DIR)/Makefile: $(C_DEPS_DIR)/libroach-rebuild | bin/.submodules-initi
 	mkdir -p $(LIBROACH_DIR)
 	@# NOTE: If you change the CMake flags below, bump the version in
 	@# $(C_DEPS_DIR)/libroach-rebuild. See above for rationale.
-	cd $(LIBROACH_DIR) && cmake $(xcmake-flags) $(LIBROACH_SRC_DIR) -DCMAKE_BUILD_TYPE=Release \
+	cd $(LIBROACH_DIR) && cmake $(xcmake-flags) $(LIBROACH_SRC_DIR) \
+		-DCMAKE_BUILD_TYPE=$(if $(ENABLE_LIBROACH_ASSERTIONS),Debug,Release) \
 		-DPROTOBUF_LIB=$(LIBPROTOBUF) -DROCKSDB_LIB=$(LIBROCKSDB) \
 		-DJEMALLOC_LIB=$(LIBJEMALLOC) -DSNAPPY_LIB=$(LIBSNAPPY) \
 		-DCRYPTOPP_LIB=$(LIBCRYPTOPP)

--- a/c-deps/libroach/mvcc.h
+++ b/c-deps/libroach/mvcc.h
@@ -545,10 +545,12 @@ template <bool reverse> class mvccScanner {
   bool iterSeekReverse(const rocksdb::Slice& key) {
     clearPeeked();
 
-    // SeekForPrev positions the iterator at the key that is less than
-    // key. NB: the doc comment on SeekForPrev suggests it positions
-    // less than or equal, but this is a lie.
+    // `SeekForPrev` positions the iterator at the last key that is less than or
+    // equal to `key` AND strictly less than `ReadOptions::iterate_upper_bound`.
     iter_rep_->SeekForPrev(key);
+    if (iter_rep_->Valid() && key.compare(iter_rep_->key()) == 0) {
+      iter_rep_->Prev();
+    }
     if (!updateCurrent()) {
       return false;
     }


### PR DESCRIPTION
Fixed and added a test case for infinite loop leading to OOM in reverse-scan
optimization to use `SeekForPrev()` after N `Prev()`s fail to find a new
key. It could happen when that optimization was used on a key that also
had a write intent.

Release note: None
