### PR TITLE
changefeedccl: support connecting to kafka with ssl

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -59,9 +59,11 @@ const (
 	optFormatJSON formatType = `json`
 	optFormatAvro formatType = `experimental_avro`
 
-	sinkParamSchemaTopic      = `schema_topic`
-	sinkParamTopicPrefix      = `topic_prefix`
+	sinkParamCACert           = `ca_cert`
 	sinkParamFileSize         = `file_size`
+	sinkParamSchemaTopic      = `schema_topic`
+	sinkParamTLSEnabled       = `tls_enabled`
+	sinkParamTopicPrefix      = `topic_prefix`
 	sinkSchemeBuffer          = ``
 	sinkSchemeExperimentalSQL = `experimental-sql`
 	sinkSchemeKafka           = `kafka`

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1388,6 +1388,20 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?schema_topic=foo`,
 	)
 
+	// Sanity check kafka tls parameters.
+	sqlDB.ExpectErr(
+		t, `param tls_enabled must be a bool`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?tls_enabled=foo`,
+	)
+	sqlDB.ExpectErr(
+		t, `param ca_cert must be base 64 encoded`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?ca_cert=!`,
+	)
+	sqlDB.ExpectErr(
+		t, `ca_cert requires tls_enabled=true`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?&ca_cert=Zm9v`,
+	)
+
 	// The cloudStorageSink is particular about the options it will work with.
 	sqlDB.ExpectErr(
 		t, `this sink is incompatible with format=experimental_avro`,


### PR DESCRIPTION
changefeedccl: support connecting to kafka with ssl

The `kafka` changefeed sink now accepts a `ca_cert` query parameter with
value set to a base 64 encoded ca_cert file:

    kafka://<brokers>?ca_cert=<a bunch of data>

As mentioned in the sarama FAQ (1), users must pass `-keyalg RSA` into
`keytool -genkey` when creating the kafka key store.

(1): https://github.com/Shopify/sarama/wiki/Frequently-Asked-Questions#why-cant-sarama-connect-to-my-kafka-cluster-using-ssl

I manually tested this with a local kafka cluster. Ideally it would be
made into an acceptance roachtest, but sadly I have nowhere near the
time needed to do that plumbing right now.

Closes #30834

Release note (enterprise change): `CHANGEFEED`s now support TLS
connections to Kafka