### PR TITLE
workload: use workload split functionality with tpcc

### DIFF
--- a/pkg/workload/tpcc/generate.go
+++ b/pkg/workload/tpcc/generate.go
@@ -16,6 +16,7 @@
 package tpcc
 
 import (
+	"math"
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
@@ -50,6 +51,15 @@ const (
 	deliveryCount  = 0
 	goodCredit     = "GC"
 	badCredit      = "BC"
+)
+
+// These constants configure how we split the tables when splitting is enabled.
+const (
+	numWarehousesPerRange = 10
+	numItemsPerRange      = 100
+
+	historyRanges                 = 1000
+	numHistoryValsPerRange uint64 = math.MaxUint64 / historyRanges
 )
 
 type generateLocals struct {


### PR DESCRIPTION
Before this PR the tpcc workloads dealt with splitting ranges on their own.
This splitting logic lacked the sophistication built in to the workload package
split implementation which works to mitigate imbalance.

Fixes #25872.

Release note: None