### PR TITLE
sqlsmith: lock on name fetching

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -40,8 +40,11 @@ func (s *Smither) makeScope() *scope {
 }
 
 func (s *Smither) name(prefix string) string {
+	s.lock.Lock()
 	s.nameCounts[prefix]++
-	return fmt.Sprintf("%s_%d", prefix, s.nameCounts[prefix])
+	count := s.nameCounts[prefix]
+	s.lock.Unlock()
+	return fmt.Sprintf("%s_%d", prefix, count)
 }
 
 // ReloadSchemas loads tables from the database. Not safe to use concurrently


### PR DESCRIPTION
Fixes a race when multiple go routines are calling Generate concurrently.

Release note: None