### PR TITLE
sql: reduce non-determinism in the show_trace logic tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -137,7 +137,7 @@ statement ok
 ALTER TABLE users RENAME COLUMN species TO species_old,
                   ADD COLUMN species STRING AS (species_old || ' woo') STORED
 
-query T
+query T rowsort
 SELECT species FROM users
 ----
 cat woo

--- a/pkg/sql/logictest/testdata/planner_test/show_trace
+++ b/pkg/sql/logictest/testdata/planner_test/show_trace
@@ -19,19 +19,11 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%intExec=%'
   AND tag NOT LIKE '%scExec%'
   AND tag NOT LIKE '%IndexBackfiller%'
+  AND operation != 'dist sender send'
 ----
-dist sender send  querying next range at /Table/2/1/0/"t"/3/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /System/"desc-idgen"
-dist sender send  r3: sending batch 1 Inc to (n1,s1):1
-flow              CPut /Table/2/1/0/"t"/3/1 -> 53
-flow              CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
-dist sender send  querying next range at /Table/2/1/0/"t"/3/1
-dist sender send  r6: sending batch 2 CPut to (n1,s1):1
-sql txn           rows affected: 0
-dist sender send  querying next range at /Table/2/1/0/"t"/3/1
-dist sender send  r8: sending batch 5 QueryIntent to (n1,s1):1
-dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+flow     CPut /Table/2/1/0/"t"/3/1 -> 53
+flow     CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
+sql txn  rows affected: 0
 
 
 # More KV operations.
@@ -47,29 +39,11 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%intExec=%'
   AND tag NOT LIKE '%scExec%'
   AND tag NOT LIKE '%IndexBackfiller%'
+  AND operation != 'dist sender send'
 ----
-dist sender send  querying next range at /Table/2/1/0/"test"/3/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/52/2/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/0/"t"/3/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /System/"desc-idgen"
-dist sender send  r3: sending batch 1 Inc to (n1,s1):1
-flow              CPut /Table/2/1/53/"kv"/3/1 -> 54
-flow              CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
-dist sender send  r6: sending batch 2 CPut to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-sql txn           rows affected: 0
-dist sender send  querying next range at /Table/2/1/53/"kv"/3/1
-dist sender send  r8: sending batch 5 QueryIntent to (n1,s1):1
-dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+flow     CPut /Table/2/1/53/"kv"/3/1 -> 54
+flow     CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+sql txn  rows affected: 0
 
 # We avoid using the full trace output, because that would make the
 # ensuing trace especially chatty, as it traces the index backfill at
@@ -92,30 +66,22 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%intExec=%'
   AND tag NOT LIKE '%scExec%'
   AND tag NOT LIKE '%IndexBackfiller%'
+  AND operation != 'dist sender send'
 ----
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-flow              Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-dist sender send  r6: sending batch 1 Put to (n1,s1):1
-sql txn           rows affected: 0
-dist sender send  r11: sending batch 3 QueryIntent to (n1,s1):1
-dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+flow     Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+sql txn  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+ WHERE operation != 'dist sender send'
 ----
-flow              CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
-flow              InitPut /Table/54/2/2/0 -> /BYTES/0x89
-dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
-flow              fast path completed
-sql txn           rows affected: 1
+flow     CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
+flow     InitPut /Table/54/2/2/0 -> /BYTES/0x89
+flow     fast path completed
+sql txn  rows affected: 1
 
 
 statement error duplicate key value
@@ -124,14 +90,11 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = 
 query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+ WHERE operation != 'dist sender send'
 ----
-flow              CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
-flow              InitPut /Table/54/2/2/0 -> /BYTES/0x89
-dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
-sql txn           execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
-dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r20: sending batch 1 EndTxn to (n1,s1):1
+flow     CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
+flow     InitPut /Table/54/2/2/0 -> /BYTES/0x89
+sql txn  execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
 
 statement error duplicate key value
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -139,14 +102,11 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = 
 query TT
 set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+ WHERE operation != 'dist sender send'
 ----
-flow              CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
-flow              InitPut /Table/54/2/2/0 -> /BYTES/0x8a
-dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r20: sending batch 1 CPut, 1 EndTxn, 1 InitPut to (n1,s1):1
-sql txn           execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
-dist sender send  querying next range at /Table/54/1/2/0
-dist sender send  r20: sending batch 1 EndTxn to (n1,s1):1
+flow     CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
+flow     InitPut /Table/54/2/2/0 -> /BYTES/0x8a
+sql txn  execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 statement ok
 SET tracing = on,kv,results; CREATE TABLE t.kv2 AS TABLE t.kv; SET tracing = off
@@ -160,37 +120,15 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%intExec=%'
   AND tag NOT LIKE '%scExec%'
   AND tag NOT LIKE '%IndexBackfiller%'
+  AND operation != 'dist sender send'
 ----
-dist sender send  querying next range at /Table/2/1/0/"test"/3/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/52/2/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/0/"t"/3/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-table reader      Scan /Table/54/{1-2}
-dist sender send  querying next range at /Table/54/1
-dist sender send  r20: sending batch 1 Scan to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /System/"desc-idgen"
-dist sender send  r3: sending batch 1 Inc to (n1,s1):1
-flow              CPut /Table/2/1/53/"kv2"/3/1 -> 55
-flow              CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
-dist sender send  r6: sending batch 2 CPut to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/53/2/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-table reader      fetched: /kv/primary/1/v -> /2
-flow              CPut /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
-dist sender send  querying next range at /Table/55/1/...PK.../0
-dist sender send  r20: sending batch 1 CPut to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
-dist sender send  r8: sending batch 5 QueryIntent to (n1,s1):1
-dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
-flow              fast path completed
-sql txn           rows affected: 1
+table reader  Scan /Table/54/{1-2}
+flow          CPut /Table/2/1/53/"kv2"/3/1 -> 55
+flow          CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+table reader  fetched: /kv/primary/1/v -> /2
+flow          CPut /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
+flow          fast path completed
+sql txn       rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; UPDATE t.kv2 SET v = v + 2; SET tracing = off
@@ -203,33 +141,24 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%intExec=%'
   AND tag NOT LIKE '%scExec%'
   AND tag NOT LIKE '%IndexBackfiller%'
+  AND operation != 'dist sender send'
 ----
-dist sender send  querying next range at /Table/2/1/53/"kv2"/3/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/55/2/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r7: sending batch 1 EndTxn, 1 QueryIntent to (n1,s1):1
-table reader      Scan /Table/55/{1-2}
-dist sender send  querying next range at /Table/55/1
-dist sender send  r20: sending batch 1 Scan to (n1,s1):1
-table reader      fetched: /kv2/primary/...PK.../k/v -> /1/2
-flow              Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
-dist sender send  querying next range at /Table/55/1/...PK.../0
-dist sender send  r20: sending batch 1 Put, 1 EndTxn to (n1,s1):1
-flow              fast path completed
-sql txn           rows affected: 1
+table reader  Scan /Table/55/{1-2}
+table reader  fetched: /kv2/primary/...PK.../k/v -> /1/2
+flow          Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
+flow          fast path completed
+sql txn       rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+ WHERE operation != 'dist sender send'
 ----
-flow              DelRange /Table/55/1 - /Table/55/2
-dist sender send  querying next range at /Table/55/1
-dist sender send  r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
-flow              fast path completed
-sql txn           rows affected: 1
+flow     DelRange /Table/55/1 - /Table/55/2
+flow     fast path completed
+sql txn  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv2; SET tracing = off
@@ -244,39 +173,24 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%intExec=%'
   AND tag NOT LIKE '%scExec%'
   AND tag NOT LIKE '%IndexBackfiller%'
+  AND operation != 'dist sender send'
 ----
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-flow              Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... >
-dist sender send  r6: sending batch 1 Put to (n1,s1):1
-sql txn           rows affected: 0
-dist sender send  r11: sending batch 4 QueryIntent to (n1,s1):1
-dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+flow     Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... >
+sql txn  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv; SET tracing = off
 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+ WHERE operation != 'dist sender send'
 ----
-table reader      Scan /Table/54/{1-2}
-dist sender send  querying next range at /Table/54/1
-dist sender send  r20: sending batch 1 Scan to (n1,s1):1
-table reader      fetched: /kv/primary/1/v -> /2
-flow              Del /Table/54/2/2/0
-flow              Del /Table/54/1/1/0
-dist sender send  querying next range at /Table/54/1/1/0
-dist sender send  r20: sending batch 2 Del, 1 EndTxn to (n1,s1):1
-flow              fast path completed
-sql txn           rows affected: 1
+table reader  Scan /Table/54/{1-2}
+table reader  fetched: /kv/primary/1/v -> /2
+flow          Del /Table/54/2/2/0
+flow          Del /Table/54/1/1/0
+flow          fast path completed
+sql txn       rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP INDEX t.kv@woo CASCADE; SET tracing = off
@@ -293,28 +207,10 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%intExec=%'
   AND tag NOT LIKE '%scExec%'
   AND tag NOT LIKE '%IndexBackfiller%'
+  AND operation != 'dist sender send'
 ----
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-flow              Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-dist sender send  r6: sending batch 1 Put to (n1,s1):1
-sql txn           rows affected: 0
-dist sender send  r11: sending batch 3 QueryIntent to (n1,s1):1
-dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+flow     Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+sql txn  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv; SET tracing = off
@@ -328,22 +224,10 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%intExec=%'
   AND tag NOT LIKE '%scExec%'
   AND tag NOT LIKE '%IndexBackfiller%'
+  AND operation != 'dist sender send'
 ----
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-flow              Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > >
-dist sender send  r6: sending batch 1 Put to (n1,s1):1
-sql txn           rows affected: 0
-dist sender send  r11: sending batch 8 QueryIntent to (n1,s1):1
-dist sender send  r6: sending batch 1 EndTxn to (n1,s1):1
+flow     Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > >
+sql txn  rows affected: 0
 
 # Check that session tracing does not inhibit the fast path for inserts &
 # friends (the path resulting in 1PC transactions).


### PR DESCRIPTION
Fixes #33720.
First commit from #35519.

The test is really about asserting the KV operations sent on behalf of
SQL statements. The distsender traffic is really irrelevant. Since
that's where most of the test flakes / non-determinism is coming from,
simply remove it.

Release note: None