### PR TITLE
jobs: don't update the table unnecessarily

### DIFF
--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -60,7 +60,7 @@ const sampleAggregatorProcName = "sample aggregator"
 
 // SampleAggregatorProgressInterval is the frequency at which the
 // SampleAggregator processor will report progress. It is mutable for testing.
-var SampleAggregatorProgressInterval = time.Second
+var SampleAggregatorProgressInterval = 2 * time.Second
 
 func newSampleAggregator(
 	flowCtx *FlowCtx,


### PR DESCRIPTION
Adding code to `FractionProgressed` to avoid writing to the table if
the progress hasn't changed. Note that this function serves the
dual-purpose of checking the job status so this isn't something that
can be done in the caller.

Also increasing the sampler progress reporting interval to two
seconds.

Release note: None