### PR TITLE
sql: automatically disable result buffering for sinkless changefeeds

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -792,23 +792,23 @@ func VerifyUsableExportTarget(
 // backupPlanHook implements PlanHookFn.
 func backupPlanHook(
 	_ context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, error) {
+) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, bool, error) {
 	backupStmt, ok := stmt.(*tree.Backup)
 	if !ok {
-		return nil, nil, nil, nil
+		return nil, nil, nil, false, nil
 	}
 
 	toFn, err := p.TypeAsString(backupStmt.To, "BACKUP")
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, false, err
 	}
 	incrementalFromFn, err := p.TypeAsStringArray(backupStmt.IncrementalFrom, "BACKUP")
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, false, err
 	}
 	optsFn, err := p.TypeAsStringOpts(backupStmt.Options, backupOptionExpectValues)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, false, err
 	}
 
 	header := sqlbase.ResultColumns{
@@ -1082,7 +1082,7 @@ func backupPlanHook(
 		}
 		return <-errCh
 	}
-	return fn, header, nil, nil
+	return fn, header, nil, false, nil
 }
 
 type backupResumer struct {

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -1236,20 +1236,20 @@ var RestoreHeader = sqlbase.ResultColumns{
 // restorePlanHook implements sql.PlanHookFn.
 func restorePlanHook(
 	_ context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, error) {
+) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, bool, error) {
 	restoreStmt, ok := stmt.(*tree.Restore)
 	if !ok {
-		return nil, nil, nil, nil
+		return nil, nil, nil, false, nil
 	}
 
 	fromFn, err := p.TypeAsStringArray(restoreStmt.From, "RESTORE")
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, false, err
 	}
 
 	optsFn, err := p.TypeAsStringOpts(restoreStmt.Options, restoreOptionExpectValues)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, false, err
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
@@ -1306,7 +1306,7 @@ func restorePlanHook(
 		}
 		return doRestorePlan(ctx, restoreStmt, p, from, endTime, opts, resultsCh)
 	}
-	return fn, RestoreHeader, nil, nil
+	return fn, RestoreHeader, nil, false, nil
 }
 
 func doRestorePlan(

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -26,25 +26,25 @@ import (
 // showBackupPlanHook implements PlanHookFn.
 func showBackupPlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, error) {
+) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, bool, error) {
 	backup, ok := stmt.(*tree.ShowBackup)
 	if !ok {
-		return nil, nil, nil, nil
+		return nil, nil, nil, false, nil
 	}
 
 	if err := utilccl.CheckEnterpriseEnabled(
 		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "SHOW BACKUP",
 	); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, false, err
 	}
 
 	if err := p.RequireSuperUser(ctx, "SHOW BACKUP"); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, false, err
 	}
 
 	toFn, err := p.TypeAsString(backup.Path, "SHOW BACKUP")
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, false, err
 	}
 
 	var shower backupShower
@@ -81,7 +81,7 @@ func showBackupPlanHook(
 		return nil
 	}
 
-	return fn, shower.header, nil, nil
+	return fn, shower.header, nil, false, nil
 }
 
 type backupShower struct {

--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -84,9 +84,7 @@ func MakeSinklessFeedFactory(s serverutils.TestServerInterface, sink url.URL) Te
 // Feed implements the TestFeedFactory interface
 func (f *sinklessFeedFactory) Feed(create string, args ...interface{}) (TestFeed, error) {
 	sink := f.sink
-	q := sink.Query()
-	q.Add(`results_buffer_size`, `1`)
-	sink.RawQuery = q.Encode()
+	sink.RawQuery = sink.Query().Encode()
 	sink.Path = `d`
 	// Use pgx directly instead of database/sql so we can close the conn
 	// (instead of returning it to the pool).

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -866,6 +866,12 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	// defer is a catch-all in case some other return path is taken.
 	defer planner.curPlan.close(ctx)
 
+	// Certain statements want their results to go to the client
+	// directly. Configure this here.
+	if planner.curPlan.avoidBuffering {
+		res.DisableBuffering()
+	}
+
 	// Ensure that the plan is collected just before closing.
 	if sampleLogicalPlans.Get(&ex.appStats.st.SV) {
 		planner.curPlan.maybeSavePlan = func(ctx context.Context) *roachpb.ExplainTreePlanNode {

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -706,6 +706,12 @@ type RestrictedCommandResult interface {
 	// RowsAffected returns either the number of times AddRow was called, or the
 	// sum of all n passed into IncrementRowsAffected.
 	RowsAffected() int
+
+	// DisableBuffering can be called during execution to ensure that
+	// the results accumulated so far, and all subsequent rows added
+	// to this CommandResult, will be flushed immediately to the client.
+	// This is currently used for sinkless changefeeds.
+	DisableBuffering()
 }
 
 // DescribeResult represents the result of a Describe command (for either
@@ -872,6 +878,10 @@ func (r *bufferedCommandResult) AddRow(ctx context.Context, row tree.Datums) err
 	copy(rowCopy, row)
 	r.rows = append(r.rows, rowCopy)
 	return nil
+}
+
+func (r *bufferedCommandResult) DisableBuffering() {
+	panic("cannot disable buffering here")
 }
 
 // SetError is part of the RestrictedCommandResult interface.

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -36,7 +36,7 @@ import (
 // plan execution.
 type planHookFn func(
 	context.Context, tree.Statement, PlanHookState,
-) (fn PlanHookRowFn, header sqlbase.ResultColumns, subplans []planNode, err error)
+) (fn PlanHookRowFn, header sqlbase.ResultColumns, subplans []planNode, avoidBuffering bool, err error)
 
 // PlanHookRowFn describes the row-production for hook-created plans. The
 // channel argument is used to return results to the plan's runner. It's

--- a/pkg/sql/tests/planhook.go
+++ b/pkg/sql/tests/planhook.go
@@ -29,10 +29,10 @@ import (
 func init() {
 	testingPlanHook := func(
 		ctx context.Context, stmt tree.Statement, state sql.PlanHookState,
-	) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, error) {
+	) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, bool, error) {
 		show, ok := stmt.(*tree.ShowVar)
 		if !ok || show.Name != "planhook" {
-			return nil, nil, nil, nil
+			return nil, nil, nil, false, nil
 		}
 		header := sqlbase.ResultColumns{
 			{Name: "value", Typ: types.String},
@@ -41,7 +41,7 @@ func init() {
 		return func(_ context.Context, subPlans []sql.PlanNode, resultsCh chan<- tree.Datums) error {
 			resultsCh <- tree.Datums{tree.NewDString(show.Name)}
 			return nil
-		}, header, []sql.PlanNode{}, nil
+		}, header, []sql.PlanNode{}, false, nil
 	}
 	sql.AddPlanHook(testingPlanHook)
 }


### PR DESCRIPTION
Discussed on #34423.

This is limited in scope, but it will do in 19.1 where the feature is experimental anyway. In 19.2, bulk i/o will come into the CBO, and we can build a more robust solution there.
