### PR TITLE
pgwire: add counter metric to track number of incoming connections

### DIFF
--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -82,6 +82,12 @@ var (
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
 	}
+	MetaNewConns = metric.Metadata{
+		Name:        "sql.new_conns",
+		Help:        "Counter of the number of sql connections created",
+		Measurement: "Connections",
+		Unit:        metric.Unit_COUNT,
+	}
 	MetaBytesIn = metric.Metadata{
 		Name:        "sql.bytesin",
 		Help:        "Number of sql bytes received",
@@ -158,6 +164,7 @@ type ServerMetrics struct {
 	BytesInCount   *metric.Counter
 	BytesOutCount  *metric.Counter
 	Conns          *metric.Gauge
+	NewConns       *metric.Counter
 	ConnMemMetrics sql.MemoryMetrics
 	SQLMemMetrics  sql.MemoryMetrics
 }
@@ -169,6 +176,7 @@ func makeServerMetrics(
 		BytesInCount:   metric.NewCounter(MetaBytesIn),
 		BytesOutCount:  metric.NewCounter(MetaBytesOut),
 		Conns:          metric.NewGauge(MetaConns),
+		NewConns:       metric.NewCounter(MetaNewConns),
 		ConnMemMetrics: sql.MakeMemMetrics("conns", histogramWindow),
 		SQLMemMetrics:  sqlMemMetrics,
 	}
@@ -421,6 +429,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 	// DrainClient() waits for that number to drop to zero,
 	// so we don't want it to oscillate unnecessarily.
 	if !draining {
+		s.metrics.NewConns.Inc(1)
 		s.metrics.Conns.Inc(1)
 		defer s.metrics.Conns.Dec(1)
 	}


### PR DESCRIPTION
When clusters experience problems they can sometimes receive floods of new sql
connections. We currently don't have visibility in to the rate of new
connections. This metric can help understand whether traffic for things like
internal-get-hashed-pwd is due to faulty logic in that component or to
legitimate load due to an increase in connections.

Release note: None