### PR TITLE
sql: remove unnecessary accesses to system.descriptors

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -173,7 +173,7 @@ func (p *planner) MemberOfWithAdminOption(
 	ctx context.Context, member string,
 ) (map[string]bool, error) {
 	// Lookup table version.
-	objDesc, _, err := p.PhysicalSchemaAccessor().GetObjectDesc(ctx, p.txn, &roleMembersTableName,
+	objDesc, err := p.PhysicalSchemaAccessor().GetObjectDesc(ctx, p.txn, &roleMembersTableName,
 		p.ObjectLookupFlags(true /*required*/, false /*requireMutable*/))
 	if err != nil {
 		return nil, err

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -101,6 +101,24 @@ func getKeysForDatabaseDescriptor(
 	return
 }
 
+// getDatabaseID resolves a database name into a database ID.
+func getDatabaseID(
+	ctx context.Context, txn *client.Txn, name string, required bool,
+) (sqlbase.ID, error) {
+	dbKey := databaseKey{name}
+	gr, err := txn.Get(ctx, dbKey.Key())
+	if err != nil {
+		return 0, err
+	}
+	if !gr.Exists() {
+		if !required {
+			return 0, nil
+		}
+		return 0, sqlbase.NewUndefinedDatabaseError(name)
+	}
+	return sqlbase.ID(gr.ValueInt()), nil
+}
+
 // getDatabaseDescByID looks up the database descriptor given its ID,
 // returning nil if the descriptor is not found. If you want the "not
 // found" condition to return an error, use mustGetDatabaseDescByID() instead.
@@ -132,32 +150,13 @@ func MustGetDatabaseDescByID(
 // getCachedDatabaseDesc looks up the database descriptor from the descriptor cache,
 // given its name. Returns nil and no error if the name is not present in the
 // cache.
-func (dc *databaseCache) getCachedDatabaseDesc(
-	name string, required bool,
-) (*sqlbase.DatabaseDescriptor, error) {
-	if name == sqlbase.SystemDB.Name {
-		return &sqlbase.SystemDB, nil
-	}
-
-	nameKey := databaseKey{name}
-	nameVal := dc.systemConfig.GetValue(nameKey.Key())
-	if nameVal == nil {
-		if !required {
-			return nil, nil
-		}
-		return nil, errors.Errorf("database %q does not exist in system cache", name)
-	}
-
-	id, err := nameVal.GetInt()
-	if err != nil {
+func (dc *databaseCache) getCachedDatabaseDesc(name string) (*sqlbase.DatabaseDescriptor, error) {
+	dbID, err := dc.getCachedDatabaseID(name)
+	if dbID == 0 || err != nil {
 		return nil, err
 	}
 
-	desc, err := dc.getCachedDatabaseDescByID(sqlbase.ID(id))
-	if err == nil && desc == nil {
-		return nil, errors.Errorf("database %q has name entry, but no descriptor in system cache", name)
-	}
-	return desc, err
+	return dc.getCachedDatabaseDescByID(dbID)
 }
 
 // getCachedDatabaseDescByID looks up the database descriptor from the descriptor cache,
@@ -195,11 +194,8 @@ func (dc *databaseCache) getDatabaseDesc(
 	// Lookup the database in the cache first, falling back to the KV store if it
 	// isn't present. The cache might cause the usage of a recently renamed
 	// database, but that's a race that could occur anyways.
-	//
-	// We set required to false here because it's OK if we don't find
-	// the descriptor in the cache; in that case we go to the physical
-	// database below.
-	desc, err := dc.getCachedDatabaseDesc(name, false /*required*/)
+	// The cache lookup may fail.
+	desc, err := dc.getCachedDatabaseDesc(name)
 	if err != nil {
 		return nil, err
 	}
@@ -212,6 +208,9 @@ func (dc *databaseCache) getDatabaseDesc(
 		}); err != nil {
 			return nil, err
 		}
+	}
+	if desc != nil {
+		dc.setID(name, desc.ID)
 	}
 	return desc, err
 }
@@ -238,36 +237,44 @@ func (dc *databaseCache) getDatabaseID(
 	name string,
 	required bool,
 ) (sqlbase.ID, error) {
-	if id := dc.getID(name); id != 0 {
-		return id, nil
+	dbID, err := dc.getCachedDatabaseID(name)
+	if err != nil {
+		return dbID, err
 	}
-
-	desc, err := dc.getDatabaseDesc(ctx, txnRunner, name, required)
-	if err != nil || desc == nil {
-		// desc can be nil if required == false and the database was not found.
-		return 0, err
+	if dbID == sqlbase.InvalidID {
+		if err := txnRunner(ctx, func(ctx context.Context, txn *client.Txn) error {
+			var err error
+			dbID, err = getDatabaseID(ctx, txn, name, required)
+			return err
+		}); err != nil {
+			return sqlbase.InvalidID, err
+		}
 	}
-
-	dc.setID(name, desc.ID)
-	return desc.ID, nil
+	dc.setID(name, dbID)
+	return dbID, nil
 }
 
 // getCachedDatabaseID returns the ID of a database given its name
 // from the cache. This method never goes to the store to resolve
 // the name to id mapping. Returns 0 if the name to id mapping or
 // the database descriptor are not in the cache.
-func (dc *databaseCache) getCachedDatabaseID(ctx context.Context, name string) (sqlbase.ID, error) {
+func (dc *databaseCache) getCachedDatabaseID(name string) (sqlbase.ID, error) {
 	if id := dc.getID(name); id != 0 {
 		return id, nil
 	}
 
-	desc, err := dc.getCachedDatabaseDesc(name, false /*required*/)
-	if err != nil || desc == nil {
-		// desc can be nil if required == false and the database was not found.
-		return 0, err
+	if name == sqlbase.SystemDB.Name {
+		return sqlbase.SystemDB.ID, nil
 	}
 
-	return desc.ID, nil
+	nameKey := databaseKey{name}
+	nameVal := dc.systemConfig.GetValue(nameKey.Key())
+	if nameVal == nil {
+		return 0, nil
+	}
+
+	id, err := nameVal.GetInt()
+	return sqlbase.ID(id), err
 }
 
 // renameDatabase implements the DatabaseDescEditor interface.

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -49,7 +49,7 @@ func GenerateUniqueDescID(ctx context.Context, db *client.DB) (sqlbase.ID, error
 	// Increment unique descriptor counter.
 	newVal, err := client.IncrementValRetryable(ctx, db, keys.DescIDGenerator, 1)
 	if err != nil {
-		return 0, err
+		return sqlbase.InvalidID, err
 	}
 	return sqlbase.ID(newVal - 1), nil
 }
@@ -141,32 +141,21 @@ func (p *planner) createDescriptorWithID(
 	return nil
 }
 
-// getDescriptor looks up the descriptor for `plainKey`, validates it,
-// and unmarshals it into `descriptor`.
-//
-// If `plainKey` doesn't exist, returns false and nil error.
-// In most cases you'll want to use wrappers: `getDatabaseDesc` or
-// `getTableDesc`.
-func getDescriptor(
-	ctx context.Context,
-	txn *client.Txn,
-	plainKey sqlbase.DescriptorKey,
-	descriptor sqlbase.DescriptorProto,
-) (bool, error) {
+// getDescriptorID looks up the ID for plainKey.
+// InvalidID is returned if the name cannot be resolved.
+func getDescriptorID(
+	ctx context.Context, txn *client.Txn, plainKey sqlbase.DescriptorKey,
+) (sqlbase.ID, error) {
 	key := plainKey.Key()
 	log.Eventf(ctx, "looking up descriptor ID for name key %q", key)
 	gr, err := txn.Get(ctx, key)
 	if err != nil {
-		return false, err
+		return sqlbase.InvalidID, err
 	}
 	if !gr.Exists() {
-		return false, nil
+		return sqlbase.InvalidID, nil
 	}
-
-	if err := getDescriptorByID(ctx, txn, sqlbase.ID(gr.ValueInt()), descriptor); err != nil {
-		return false, err
-	}
-	return true, nil
+	return sqlbase.ID(gr.ValueInt()), nil
 }
 
 // getDescriptorByID looks up the descriptor for `id`, validates it,

--- a/pkg/sql/logical_schema_accessors.go
+++ b/pkg/sql/logical_schema_accessors.go
@@ -73,24 +73,24 @@ func (l *LogicalSchemaAccessor) GetObjectNames(
 // GetObjectDesc implements the ObjectAccessor interface.
 func (l *LogicalSchemaAccessor) GetObjectDesc(
 	ctx context.Context, txn *client.Txn, name *ObjectName, flags ObjectLookupFlags,
-) (ObjectDescriptor, *DatabaseDescriptor, error) {
+) (ObjectDescriptor, error) {
 	if scEntry, ok := l.vt.getVirtualSchemaEntry(name.Schema()); ok {
 		tableName := name.Table()
 		if t, ok := scEntry.defs[tableName]; ok {
 			if flags.requireMutable {
-				return sqlbase.NewMutableExistingTableDescriptor(*t.desc), nil, nil
+				return sqlbase.NewMutableExistingTableDescriptor(*t.desc), nil
 			}
-			return sqlbase.NewImmutableTableDescriptor(*t.desc), nil, nil
+			return sqlbase.NewImmutableTableDescriptor(*t.desc), nil
 		}
 		if _, ok := scEntry.allTableNames[tableName]; ok {
-			return nil, nil, pgerror.Unimplemented(name.Schema()+"."+tableName,
+			return nil, pgerror.Unimplemented(name.Schema()+"."+tableName,
 				"virtual schema table not implemented: %s.%s", name.Schema(), tableName)
 		}
 
 		if flags.required {
-			return nil, nil, sqlbase.NewUndefinedRelationError(name)
+			return nil, sqlbase.NewUndefinedRelationError(name)
 		}
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	// Fallthrough.

--- a/pkg/sql/logictest/testdata/planner_test/show_trace
+++ b/pkg/sql/logictest/testdata/planner_test/show_trace
@@ -301,3 +301,29 @@ node_id  store_id  replica_id
 1        1         6
 1        1         7
 1        1         20
+
+subtest system_table_lookup
+
+# We use AOST to bypass the table cache.
+statement ok
+SET tracing = on,kv; SELECT * FROM system.eventlog AS OF SYSTEM TIME '-1us'; SET tracing = off
+
+query TT
+SELECT operation, regexp_replace(regexp_replace(regexp_replace(message, 'job_id:[1-9]\d*', 'job_id:...', 'g'), 'wall_time:\d+', 'wall_time:...'), 'drop_time:\d+', 'drop_time:...', 'g') as message
+  FROM [SHOW KV TRACE FOR SESSION]
+WHERE (message LIKE 'querying next range%' OR message LIKE '%batch%')
+  AND message NOT LIKE '%SystemConfigSpan%'
+  AND message NOT LIKE '%PushTxn%'
+----
+dist sender send  querying next range at /Table/2/1/0/"system"/3/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/1/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/2/1/1/"eventlog"/3/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/12/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/1/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/12/1
+dist sender send  r8: sending batch 1 Scan to (n1,s1):1

--- a/pkg/sql/logictest/testdata/planner_test/show_trace
+++ b/pkg/sql/logictest/testdata/planner_test/show_trace
@@ -317,8 +317,6 @@ WHERE (message LIKE 'querying next range%' OR message LIKE '%batch%')
 ----
 dist sender send  querying next range at /Table/2/1/0/"system"/3/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/1/2/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /Table/2/1/1/"eventlog"/3/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/12/2/1

--- a/pkg/sql/logictest/testdata/planner_test/show_trace
+++ b/pkg/sql/logictest/testdata/planner_test/show_trace
@@ -315,10 +315,6 @@ WHERE (message LIKE 'querying next range%' OR message LIKE '%batch%')
   AND message NOT LIKE '%SystemConfigSpan%'
   AND message NOT LIKE '%PushTxn%'
 ----
-dist sender send  querying next range at /Table/2/1/0/"system"/3/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/1/"eventlog"/3/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/12/2/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/1/2/1

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -297,3 +297,29 @@ node_id  store_id  replica_id
 1        1         6
 1        1         7
 1        1         20
+
+subtest system_table_lookup
+
+# We use AOST to bypass the table cache.
+statement ok
+SET tracing = on,kv; SELECT * FROM system.eventlog AS OF SYSTEM TIME '-1us'; SET tracing = off
+
+query TT
+SELECT operation, regexp_replace(regexp_replace(regexp_replace(message, 'job_id:[1-9]\d*', 'job_id:...', 'g'), 'wall_time:\d+', 'wall_time:...'), 'drop_time:\d+', 'drop_time:...', 'g') as message
+  FROM [SHOW KV TRACE FOR SESSION]
+WHERE (message LIKE 'querying next range%' OR message LIKE '%batch%')
+  AND message NOT LIKE '%SystemConfigSpan%'
+  AND message NOT LIKE '%PushTxn%'
+----
+dist sender send  querying next range at /Table/2/1/0/"system"/3/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/1/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/2/1/1/"eventlog"/3/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/12/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/3/1/1/2/1
+dist sender send  r6: sending batch 1 Get to (n1,s1):1
+dist sender send  querying next range at /Table/12/1
+dist sender send  r8: sending batch 1 Scan to (n1,s1):1

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -313,8 +313,6 @@ WHERE (message LIKE 'querying next range%' OR message LIKE '%batch%')
 ----
 dist sender send  querying next range at /Table/2/1/0/"system"/3/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/3/1/1/2/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /Table/2/1/1/"eventlog"/3/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/12/2/1

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -311,10 +311,6 @@ WHERE (message LIKE 'querying next range%' OR message LIKE '%batch%')
   AND message NOT LIKE '%SystemConfigSpan%'
   AND message NOT LIKE '%PushTxn%'
 ----
-dist sender send  querying next range at /Table/2/1/0/"system"/3/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
-dist sender send  querying next range at /Table/2/1/1/"eventlog"/3/1
-dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/12/2/1
 dist sender send  r6: sending batch 1 Get to (n1,s1):1
 dist sender send  querying next range at /Table/3/1/1/2/1

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -90,7 +90,7 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 	}
 	lookupFlags.required = false
 	for i := range tbNames {
-		objDesc, _, err := phyAccessor.GetObjectDesc(ctx, p.txn, &tbNames[i],
+		objDesc, err := phyAccessor.GetObjectDesc(ctx, p.txn, &tbNames[i],
 			ObjectLookupFlags{CommonLookupFlags: lookupFlags})
 		if err != nil {
 			return err

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -271,7 +271,7 @@ func (p *planner) LookupObject(
 ) (found bool, objMeta tree.NameResolutionResult, err error) {
 	sc := p.LogicalSchemaAccessor()
 	p.tableName = tree.MakeTableNameWithSchema(tree.Name(dbName), tree.Name(scName), tree.Name(tbName))
-	objDesc, _, err := sc.GetObjectDesc(ctx, p.txn, &p.tableName, p.ObjectLookupFlags(false /*required*/, requireMutable))
+	objDesc, err := sc.GetObjectDesc(ctx, p.txn, &p.tableName, p.ObjectLookupFlags(false /*required*/, requireMutable))
 	return objDesc != nil, objDesc, err
 }
 

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -93,13 +93,7 @@ type SchemaAccessor interface {
 	// descriptor and that of its parent database. If the object is not
 	// found and flags.required is true, an error is returned, otherwise
 	// a nil reference is returned.
-	//
-	// The 2nd return value (DatabaseDescriptor) is only returned if the
-	// lookup function otherwise needed to load the database descriptor.
-	// It is not guaranteed to be non-nil even if the first return value
-	// is non-nil.  Callers that need a database descriptor can use that
-	// to avoid an extra roundtrip through a DatabaseAccessor.
-	GetObjectDesc(ctx context.Context, txn *client.Txn, name *ObjectName, flags ObjectLookupFlags) (ObjectDescriptor, *DatabaseDescriptor, error)
+	GetObjectDesc(ctx context.Context, txn *client.Txn, name *ObjectName, flags ObjectLookupFlags) (ObjectDescriptor, error)
 }
 
 // CommonLookupFlags is the common set of flags for the various accessor interfaces.

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -177,7 +177,7 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 
 	for i := range tbNames {
 		tableName := &tbNames[i]
-		objDesc, _, err := p.LogicalSchemaAccessor().GetObjectDesc(ctx, p.txn,
+		objDesc, err := p.LogicalSchemaAccessor().GetObjectDesc(ctx, p.txn,
 			tableName, p.ObjectLookupFlags(true /*required*/, false /*requireMutable*/))
 		if err != nil {
 			return err

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -212,13 +212,13 @@ func (tc *TableCollection) getMutableTableDescriptor(
 		return nil, err
 	}
 
-	if dbID == 0 {
+	if dbID == sqlbase.InvalidID {
 		// Resolve the database from the database cache when the transaction
 		// hasn't modified the database.
 		dbID, err = tc.databaseCache.getDatabaseID(ctx,
 			tc.leaseMgr.execCfg.DB.Txn, tn.Catalog(), flags.required)
-		if err != nil || dbID == 0 {
-			// dbID can still be 0 if required is false and the database is not found.
+		if err != nil || dbID == sqlbase.InvalidID {
+			// dbID can still be invalid if required is false and the database is not found.
 			return nil, err
 		}
 	}
@@ -268,13 +268,13 @@ func (tc *TableCollection) getTableVersion(
 		return nil, err
 	}
 
-	if dbID == 0 {
+	if dbID == sqlbase.InvalidID {
 		// Resolve the database from the database cache when the transaction
 		// hasn't modified the database.
 		dbID, err = tc.databaseCache.getDatabaseID(ctx,
 			tc.leaseMgr.execCfg.DB.Txn, tn.Catalog(), flags.required)
-		if err != nil || dbID == 0 {
-			// dbID can still be 0 if required is false and the database is not found.
+		if err != nil || dbID == sqlbase.InvalidID {
+			// dbID can still be invalid if required is false and the database is not found.
 			return nil, err
 		}
 	}
@@ -473,7 +473,7 @@ func (tc *TableCollection) waitForCacheToDropDatabases(ctx context.Context) {
 			func(dc *databaseCache) bool {
 				// Resolve the database name from the database cache.
 				dbID, err := dc.getCachedDatabaseID(uc.name)
-				if err != nil || dbID == 0 {
+				if err != nil || dbID == sqlbase.InvalidID {
 					// dbID can still be 0 if required is false and
 					// the database is not found. Swallowing error here
 					// because it was felt there was no value in returning
@@ -558,14 +558,14 @@ func (tc *TableCollection) getUncommittedDatabaseID(
 		if requestedDbName == db.name {
 			if db.dropped {
 				if required {
-					return true, 0, sqlbase.NewUndefinedDatabaseError(requestedDbName)
+					return true, sqlbase.InvalidID, sqlbase.NewUndefinedDatabaseError(requestedDbName)
 				}
-				return true, 0, nil
+				return true, sqlbase.InvalidID, nil
 			}
 			return false, db.id, nil
 		}
 	}
-	return false, 0, nil
+	return false, sqlbase.InvalidID, nil
 }
 
 // getUncommittedTable returns a table for the requested tablename

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -195,21 +195,21 @@ type dbCacheSubscriber interface {
 //
 func (tc *TableCollection) getMutableTableDescriptor(
 	ctx context.Context, txn *client.Txn, tn *tree.TableName, flags ObjectLookupFlags,
-) (*sqlbase.MutableTableDescriptor, *sqlbase.DatabaseDescriptor, error) {
+) (*sqlbase.MutableTableDescriptor, error) {
 	if log.V(2) {
 		log.Infof(ctx, "reading mutable descriptor on table '%s'", tn)
 	}
 
 	if tn.SchemaName != tree.PublicSchemaName {
 		if flags.required {
-			return nil, nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(tn))
+			return nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(tn))
 		}
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	refuseFurtherLookup, dbID, err := tc.getUncommittedDatabaseID(tn.Catalog(), flags.required)
 	if refuseFurtherLookup || err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if dbID == 0 {
@@ -219,23 +219,23 @@ func (tc *TableCollection) getMutableTableDescriptor(
 			tc.leaseMgr.execCfg.DB.Txn, tn.Catalog(), flags.required)
 		if err != nil || dbID == 0 {
 			// dbID can still be 0 if required is false and the database is not found.
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
 	if refuseFurtherLookup, table, err := tc.getUncommittedTable(dbID, tn, flags.required); refuseFurtherLookup || err != nil {
-		return nil, nil, err
+		return nil, err
 	} else if mut := table.MutableTableDescriptor; mut != nil {
 		log.VEventf(ctx, 2, "found uncommitted table %d", mut.ID)
-		return mut, nil, nil
+		return mut, nil
 	}
 
 	phyAccessor := UncachedPhysicalAccessor{}
-	obj, db, err := phyAccessor.GetObjectDesc(ctx, txn, tn, flags)
+	obj, err := phyAccessor.GetObjectDesc(ctx, txn, tn, flags)
 	if obj == nil {
-		return nil, db, err
+		return nil, err
 	}
-	return obj.(*sqlbase.MutableTableDescriptor), db, err
+	return obj.(*sqlbase.MutableTableDescriptor), err
 }
 
 // getTableVersion returns a table descriptor with a version suitable for
@@ -251,21 +251,21 @@ func (tc *TableCollection) getMutableTableDescriptor(
 //
 func (tc *TableCollection) getTableVersion(
 	ctx context.Context, txn *client.Txn, tn *tree.TableName, flags ObjectLookupFlags,
-) (*sqlbase.ImmutableTableDescriptor, *sqlbase.DatabaseDescriptor, error) {
+) (*sqlbase.ImmutableTableDescriptor, error) {
 	if log.V(2) {
 		log.Infof(ctx, "planner acquiring lease on table '%s'", tn)
 	}
 
 	if tn.SchemaName != tree.PublicSchemaName {
 		if flags.required {
-			return nil, nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(tn))
+			return nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(tn))
 		}
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	refuseFurtherLookup, dbID, err := tc.getUncommittedDatabaseID(tn.Catalog(), flags.required)
 	if refuseFurtherLookup || err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if dbID == 0 {
@@ -275,7 +275,7 @@ func (tc *TableCollection) getTableVersion(
 			tc.leaseMgr.execCfg.DB.Txn, tn.Catalog(), flags.required)
 		if err != nil || dbID == 0 {
 			// dbID can still be 0 if required is false and the database is not found.
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
@@ -290,7 +290,7 @@ func (tc *TableCollection) getTableVersion(
 		(tn.Catalog() == sqlbase.SystemDB.Name && tn.TableName.String() != sqlbase.RoleMembersTable.Name)
 
 	if refuseFurtherLookup, table, err := tc.getUncommittedTable(dbID, tn, flags.required); refuseFurtherLookup || err != nil {
-		return nil, nil, err
+		return nil, err
 	} else if immut := table.ImmutableTableDescriptor; immut != nil {
 		// If not forcing to resolve using KV, tables being added aren't visible.
 		if immut.Adding() && !avoidCache {
@@ -298,20 +298,20 @@ func (tc *TableCollection) getTableVersion(
 			if !flags.required {
 				err = nil
 			}
-			return nil, nil, err
+			return nil, err
 		}
 
 		log.VEventf(ctx, 2, "found uncommitted table %d", immut.ID)
-		return immut, nil, nil
+		return immut, nil
 	}
 
-	readTableFromStore := func() (*sqlbase.ImmutableTableDescriptor, *sqlbase.DatabaseDescriptor, error) {
+	readTableFromStore := func() (*sqlbase.ImmutableTableDescriptor, error) {
 		phyAccessor := UncachedPhysicalAccessor{}
-		obj, db, err := phyAccessor.GetObjectDesc(ctx, txn, tn, flags)
+		obj, err := phyAccessor.GetObjectDesc(ctx, txn, tn, flags)
 		if obj == nil {
-			return nil, db, err
+			return nil, err
 		}
-		return obj.(*sqlbase.ImmutableTableDescriptor), db, err
+		return obj.(*sqlbase.ImmutableTableDescriptor), err
 	}
 
 	if avoidCache {
@@ -326,7 +326,7 @@ func (tc *TableCollection) getTableVersion(
 		if table.Name == string(tn.TableName) &&
 			table.ParentID == dbID {
 			log.VEventf(ctx, 2, "found table in table collection for table '%s'", tn)
-			return table, nil, nil
+			return table, nil
 		}
 	}
 
@@ -341,7 +341,7 @@ func (tc *TableCollection) getTableVersion(
 		}
 		// Lease acquisition failed with some other error. This we don't
 		// know how to deal with, so propagate the error.
-		return nil, nil, err
+		return nil, err
 	}
 
 	if !origTimestamp.Less(expiration) {
@@ -356,7 +356,7 @@ func (tc *TableCollection) getTableVersion(
 	// so we need to set a deadline on the transaction to prevent it from committing
 	// beyond the table version expiration time.
 	txn.UpdateDeadlineMaybe(ctx, expiration)
-	return table, nil, nil
+	return table, nil
 }
 
 // getTableVersionByID is a by-ID variant of getTableVersion (i.e. uses same cache).
@@ -472,7 +472,7 @@ func (tc *TableCollection) waitForCacheToDropDatabases(ctx context.Context) {
 		tc.dbCacheSubscriber.waitForCacheState(
 			func(dc *databaseCache) bool {
 				// Resolve the database name from the database cache.
-				dbID, err := dc.getCachedDatabaseID(ctx, uc.name)
+				dbID, err := dc.getCachedDatabaseID(uc.name)
 				if err != nil || dbID == 0 {
 					// dbID can still be 0 if required is false and
 					// the database is not found. Swallowing error here


### PR DESCRIPTION
(First commit from #35558.)

The following two patches aim to reduce contention on system.namespace and possibly reduce the overall rate of txn retries on newly minted clusers.

Informs #35549.
Also possibly informs #35293.

### sql: avoid a db descriptor lookup on every table name resolution

Prior to this patch, all _table_ name resolution lookups were also
fetching (and decoding) the database descriptor - incurring an extra
KV get to `system.descriptor` where only the database ID (obtained via
a lookup to `system.namespace`) is sufficient.

This patch simplifies the interface and removes the unnecessary
lookups. This is expected to reduce contention on `system.namespace`.

Before:

```
| querying next range at /Table/2/1/0/"system"/3/1 | look up db ID for system
| r6: sending batch 1 Get to (n1,s1):1             |
| querying next range at /Table/3/1/1/2/1          | look up desc for system
| r6: sending batch 1 Get to (n1,s1):1             |
| querying next range at /Table/2/1/1/"lease"/3/1  | look up table ID for lease
| r6: sending batch 1 Get to (n1,s1):1             |
| querying next range at /Table/3/1/11/2/1         | look up desc for lease
```

After:

```
| querying next range at /Table/2/1/0/"system"/3/1 | look up db ID for system
| r6: sending batch 1 Get to (n1,s1):1             |
| querying next range at /Table/2/1/1/"lease"/3/1  | look up table ID for lease
| r6: sending batch 1 Get to (n1,s1):1             |
| querying next range at /Table/3/1/11/2/1         | look up desc for lease
```

### sql,sqlbase: bypass KV to look up system descriptor IDs

Prior to this patch, both the low-level descriptor lookup functions
and the table cache were using KV operations to look up the IDs for
the system database and system tables. This is unnecessary, since the
name -> ID mapping never thanges for them.

This patch bypasses KV in these cases.

Before:

```
dist sender send  querying next range at /Table/2/1/0/"system"/3/1
dist sender send  r6: sending batch 1 Get to (n1,s1):1
dist sender send  querying next range at /Table/2/1/1/"eventlog"/3/1
dist sender send  r6: sending batch 1 Get to (n1,s1):1
dist sender send  querying next range at /Table/3/1/12/2/1
dist sender send  r6: sending batch 1 Get to (n1,s1):1
dist sender send  querying next range at /Table/3/1/1/2/1
dist sender send  r6: sending batch 1 Get to (n1,s1):1
dist sender send  querying next range at /Table/12/1
dist sender send  r8: sending batch 1 Scan to (n1,s1):1
```

After:

```
dist sender send  querying next range at /Table/3/1/12/2/1
dist sender send  r6: sending batch 1 Get to (n1,s1):1
dist sender send  querying next range at /Table/3/1/1/2/1
dist sender send  r6: sending batch 1 Get to (n1,s1):1
dist sender send  querying next range at /Table/12/1
dist sender send  r8: sending batch 1 Scan to (n1,s1):1
```

