### PR TITLE
sql: properly mark sequences as `bigint` in information_schema.sequences

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -857,7 +857,7 @@ CREATE TABLE information_schema.sequences (
 					tree.NewDString(db.GetName()),    // catalog
 					tree.NewDString(scName),          // schema
 					tree.NewDString(table.GetName()), // name
-					tree.NewDString("integer"),       // type
+					tree.NewDString("bigint"),        // type
 					tree.NewDInt(64),                 // numeric precision
 					tree.NewDInt(2),                  // numeric precision radix
 					tree.NewDInt(0),                  // numeric scale

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1697,8 +1697,8 @@ query TTTTIIITTTTT colnames
 SELECT * FROM information_schema.sequences
 ----
 sequence_catalog  sequence_schema  sequence_name  data_type  numeric_precision  numeric_precision_radix  numeric_scale  start_value  minimum_value  maximum_value        increment  cycle_option
-test              public           test_seq       integer    64                 2                        0              1            1              9223372036854775807  1          NO
-test              public           test_seq_2     integer    64                 2                        0              15           5              1000                 -1         NO
+test              public           test_seq       bigint     64                 2                        0              1            1              9223372036854775807  1          NO
+test              public           test_seq_2     bigint     64                 2                        0              15           5              1000                 -1         NO
 
 statement ok
 CREATE DATABASE other_db


### PR DESCRIPTION
Release note (bug fix): CockroachDB now properly reports `bigint`
in information_schema.sequences.type, for compatibility with PostgreSQL.