### PR TITLE
sql: properly populate attributes in information_schema.views

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1147,11 +1147,11 @@ CREATE TABLE information_schema.views (
     TABLE_NAME                 STRING NOT NULL,
     VIEW_DEFINITION            STRING NOT NULL,
     CHECK_OPTION               STRING,
-    IS_UPDATABLE               STRING,
-    IS_INSERTABLE_INTO         STRING,
-    IS_TRIGGER_UPDATABLE       STRING,
-    IS_TRIGGER_DELETABLE       STRING,
-    IS_TRIGGER_INSERTABLE_INTO STRING
+    IS_UPDATABLE               STRING NOT NULL,
+    IS_INSERTABLE_INTO         STRING NOT NULL,
+    IS_TRIGGER_UPDATABLE       STRING NOT NULL,
+    IS_TRIGGER_DELETABLE       STRING NOT NULL,
+    IS_TRIGGER_INSERTABLE_INTO STRING NOT NULL
 )`,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, dbContext, hideVirtual, /* virtual schemas have no views */
@@ -1173,11 +1173,11 @@ CREATE TABLE information_schema.views (
 					tree.NewDString(table.Name),      // table_name
 					tree.NewDString(table.ViewQuery), // view_definition
 					tree.DNull,                       // check_option
-					tree.DNull,                       // is_updatable
-					tree.DNull,                       // is_insertable_into
-					tree.DNull,                       // is_trigger_updatable
-					tree.DNull,                       // is_trigger_deletable
-					tree.DNull,                       // is_trigger_insertable_into
+					noString,                         // is_updatable
+					noString,                         // is_insertable_into
+					noString,                         // is_trigger_updatable
+					noString,                         // is_trigger_deletable
+					noString,                         // is_trigger_insertable_into
 				)
 			})
 	},

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1640,13 +1640,13 @@ WHERE TABLE_NAME='v_xyz'
 table_catalog  table_schema  table_name  view_definition                    check_option
 other_db       public        v_xyz       SELECT i FROM other_db.public.xyz  NULL
 
-query BBBBB colnames
+query TTTTT colnames
 SELECT IS_UPDATABLE, IS_INSERTABLE_INTO, IS_TRIGGER_UPDATABLE, IS_TRIGGER_DELETABLE, IS_TRIGGER_INSERTABLE_INTO
 FROM other_db.information_schema.views
 WHERE TABLE_NAME='v_xyz'
 ----
 is_updatable  is_insertable_into  is_trigger_updatable  is_trigger_deletable  is_trigger_insertable_into
-NULL          NULL                NULL                  NULL                  NULL
+NO            NO                  NO                    NO                    NO
 
 statement ok
 SET DATABASE = 'test'


### PR DESCRIPTION
The `is_` columns in information_schema.views are yes/no, not
boolean. The logic test was incorrect. Also, the values are known, no
need to populate NULLs for them.

Release note: None