### PR TITLE
sql: make the datetime logic test more portable

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -795,7 +795,7 @@ SELECT '2015-08-25 05:45:45-01:00'::timestamptz::timestamp
 2015-08-25 02:45:45 +0000 +0000
 
 
-statement error cannot find time zone "foobar": timezone data cannot be found
+statement error cannot find time zone "foobar"
 SET TIME ZONE 'foobar'
 
 statement ok


### PR DESCRIPTION
The suffix in the error message is dependent on the libc in use. Trim
it to assert the expected error.

Release note: None