### PR TITLE
Makefile: bump the test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ TESTCONFIG :=
 SUBTESTS :=
 
 ## Test timeout to use for regular tests.
-TESTTIMEOUT := 8m
+TESTTIMEOUT := 12m
 
 ## Test timeout to use for race tests.
 RACETIMEOUT := 25m


### PR DESCRIPTION
The test suite has progressively become slower and we're now running
into the 8m limits, causing lots of test flakes.

This new default will bring us forward, but really a more durable
solution would be to profile the tests and divide the work among more
CI tasks running in parallel.

Release note: None