### PR TITLE
roachtest: fix cluster name validation

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -791,8 +791,8 @@ func (c *cluster) setTest(t testI) {
 	}
 }
 
-// validateCluster takes a cluster and checks that the reality corresponds to
-// the cluster's spec. It's intended to be used with clusters created by
+// validate takes a cluster and checks that the reality corresponds to the
+// cluster's spec. It's intended to be used with clusters created by
 // attachToExistingCluster(); otherwise, clusters create with newCluster() are
 // know to be up to spec.
 func (c *cluster) validate(ctx context.Context, nodes clusterSpec, l *logger) error {

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -302,10 +302,9 @@ func (r *registry) verifyValidClusterName(testName string) error {
 	// construct both a TeamCity cluster name and a TeamCity node name and
 	// validate both.
 
-	// The name of a cluster is constructed as "[cluster ID][test name]"
-	// In TeamCity runs, the cluster ID is currently a prefix with 6 digits, but
-	// we use 7 here for a bit of breathing room.
-	teamcityClusterName := makeGCEClusterName("teamcity-1234567-" + testName)
+	// The name of a cluster is constructed as
+	// <cluster ID>-<timestamp>-<test name>.
+	teamcityClusterName := makeGCEClusterName("teamcity-1234567890-" + testName)
 	if !gceNameRE.MatchString(teamcityClusterName) {
 		return fmt.Errorf(
 			"test name '%s' results in invalid cluster name"+


### PR DESCRIPTION
We have some protection against large test names generating invalid
cluster names. However, the validation logic was stale; it was asuming a
6-digit unique id, but in fact we use a 10-digit timestamp.

Release note: None