### PR TITLE
sql: make txn timestamp in test more stable

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3766,9 +3766,16 @@ func TestSchemaChangeRetryError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The timestamp of the transaction is initialized.
 	tx, err := sqlDB.Begin()
 	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The timestamp of the transaction is guaranteed to be fixed after
+	// this statement.
+	if _, err := tx.Exec(`
+		CREATE TABLE t.another (k INT PRIMARY KEY, v INT, pi DECIMAL DEFAULT (DECIMAL '3.14'));
+		`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3780,12 +3787,6 @@ func TestSchemaChangeRetryError(t *testing.T) {
 		t.Fatal(err)
 	}
 	rows.Close()
-
-	if _, err := tx.Exec(`
-		CREATE TABLE t.another (k INT PRIMARY KEY, v INT, pi DECIMAL DEFAULT (DECIMAL '3.14'));
-		`); err != nil {
-		t.Fatal(err)
-	}
 
 	if _, err := tx.Exec(`
 		CREATE UNIQUE INDEX vidx ON t.test (v);


### PR DESCRIPTION
The test was relying on the timestamp being fixed after the
call to BEGIN. This is not the case and occasionally the
timestamp of the txn would get pushed. By moving the CREATE TABLE
the timestamp is guaranteed to get fixed (it is used to write the ModificationTime
into the table descriptor).

fixes #34894 

Release note: None