### PR TITLE
build: run TestLogic under nightly stress

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2058,7 +2058,9 @@ var logicTestsConfigFilter = envutil.EnvOrDefaultString("COCKROACH_LOGIC_TESTS_C
 func RunLogicTest(t *testing.T, globs ...string) {
 	if testutils.NightlyStress() {
 		// See https://github.com/cockroachdb/cockroach/pull/10966.
-		t.Skip()
+		// There is special code in teamcity-trigger/main.go to run this package
+		// with less concurrency, so if you see problems please make adjustments
+		// there.
 	}
 
 	if skipLogicTests {


### PR DESCRIPTION
We previously skipped it since it had in the past had a tendency to
overload the machine, but this time try instead to run it with lower
parallelism.

The desire to run this test under nightly stressrace is rooted in the
realization that we rarely run its race flavor on any other CI. When
I ran it manually while preparing this PR, I found two data races that
fire 100% of the time (filed separately).

The SQL team should consider a workaround of this type

https://github.com/cockroachdb/cockroach/blob/8be25f0ab712240992b3770792cece25bcf8e2ec/build/teamcity-testrace.sh#L17-L35

so that any change in `pkg/sql/...` triggers `pkg/sql/logictest`.
(cc @jordanlewis)

Release note: None