### PR TITLE
sql: ensure sql never uses Clock.PhysicalTime()

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1530,7 +1530,7 @@ func (ex *connExecutor) execCopyIn(
 		txnOpt = copyTxnOpt{
 			txn:           ex.state.mu.txn,
 			txnTimestamp:  ex.state.sqlTimestamp,
-			stmtTimestamp: ex.server.cfg.Clock.PhysicalTime(),
+			stmtTimestamp: ex.server.cfg.Clock.Now().GoTime(),
 		}
 	}
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -372,7 +372,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	// any event unless an an error happens.
 
 	var p *planner
-	stmtTS := ex.server.cfg.Clock.PhysicalTime()
+	stmtTS := ex.server.cfg.Clock.Now().GoTime()
 	// Only run statements asynchronously through the parallelize queue if the
 	// statements are parallelized and we're in a transaction. Parallelized
 	// statements outside of a transaction are run synchronously with mocked
@@ -1184,7 +1184,7 @@ func (ex *connExecutor) execStmtInNoTxnState(
 			makeEventTxnStartPayload(
 				roachpb.NormalUserPriority,
 				mode,
-				ex.server.cfg.Clock.PhysicalTime(),
+				ex.server.cfg.Clock.Now().GoTime(),
 				nil, /* historicalTimestamp */
 				ex.transitionCtx)
 	}

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -158,7 +158,7 @@ func (ex *connExecutor) prepare(
 	txn := client.NewTxn(ctx, ex.server.cfg.DB, ex.server.cfg.NodeID.Get(), client.RootTxn)
 
 	p := &ex.planner
-	ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */)
+	ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.Now().GoTime() /* stmtTS */)
 	p.stmt = &stmt
 	flags, err := ex.populatePrepared(ctx, txn, placeholderHints, p)
 	if err != nil {

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -280,7 +280,7 @@ func (c *copyMachine) preparePlanner(ctx context.Context) func(context.Context, 
 	autoCommit := false
 	if txn == nil {
 		txn = client.NewTxn(ctx, c.p.execCfg.DB, c.p.execCfg.NodeID.Get(), client.RootTxn)
-		txnTs = c.p.execCfg.Clock.PhysicalTime()
+		txnTs = c.p.execCfg.Clock.Now().GoTime()
 		stmtTs = txnTs
 		autoCommit = true
 	}


### PR DESCRIPTION
The physical time is not guaranteed to be monotonic.
Instead use Clock.Now().

CountLease() can be called with a timestamp close to now,
to be used as an AS OF SYSTEM TIME. The query itself is
executed with a statement timestamp drawn from PhysicalTime()
that can move backwards. When comparing the AS OF SYSTEM TIME
with the statement time, the AS OF SYSTEM TIME appears to be
in the future and returns an error. This change fixes this.

fixes #35155

Release note: None