### PR TITLE
pgdate: Improve handling of negative years

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1193,3 +1193,33 @@ query T
 SELECT date_trunc('month', "date") AS date_trunc_month_created_at FROM "topics";
 ----
 2017-12-01 00:00:00 +0000 UTC
+
+
+# Test negative years to ensure they can round-trip through the parser.
+# Also ensure that we don't trigger any of the "convenience" rules.
+subtest regression_35255
+
+query T
+SELECT '-56325279622-12-26'::DATE
+----
+-56325279622-12-26 00:00:00 +0000 +0000
+
+query T
+SELECT '-5632-12-26'::DATE
+----
+-5632-12-26 00:00:00 +0000 +0000
+
+query T
+SELECT '-563-12-26'::DATE
+----
+-0563-12-26 00:00:00 +0000 +0000
+
+query T
+SELECT '-56-12-26'::DATE
+----
+-0056-12-26 00:00:00 +0000 +0000
+
+query T
+SELECT '-5-12-26'::DATE
+----
+-0005-12-26 00:00:00 +0000 +0000

--- a/pkg/util/timeutil/pgdate/parsing.go
+++ b/pkg/util/timeutil/pgdate/parsing.go
@@ -147,7 +147,7 @@ func ParseTimestamp(now time.Time, mode ParseMode, s string) (time.Time, error) 
 
 // badFieldPrefixError constructs a CodeInvalidDatetimeFormatError pgerror.
 func badFieldPrefixError(field field, prefix rune) error {
-	return inputErrorf("unexpected separator '%v' for field %s", prefix, field.Pretty())
+	return inputErrorf("unexpected separator '%s' for field %s", string(prefix), field.Pretty())
 }
 
 // inputErrorf returns a CodeInvalidDatetimeFormatError pgerror.


### PR DESCRIPTION
The current parsing code doesn't handle negative year values and returns an
unhelpful error message. This change allows negative years to be specified, so
that negative-year datums can at least be round-tripped through the parser.

Supports #28099
Fixes #35255

Release note: None