### PR TITLE
roachtest: Renenable SQLSmith roachtest

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -109,11 +109,10 @@ func registerSQLsmith(r *registry) {
 	r.Add(testSpec{
 		Name:       "sqlsmith",
 		Cluster:    makeClusterSpec(1),
-		MinVersion: "v2.2.0",
+		MinVersion: "v19.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runSQLsmith(ctx, t, c)
 		},
-		Skip:    "https://github.com/cockroachdb/cockroach/issues/32270",
 		Timeout: 20 * time.Minute,
 	})
 }


### PR DESCRIPTION
Note that this is the original roachtest and not the re-written one.  If we find
that this one does not find any different issues, we should remove it entirely.
But there is no harm in enabling it right now.

Release note: None