### PR TITLE
workload,roachtest: add library for tpcc results and adopt in roachtest

### DIFF
--- a/pkg/ccl/workloadccl/roachmartccl/roachmart.go
+++ b/pkg/ccl/workloadccl/roachmartccl/roachmart.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/spf13/pflag"
 )
 
@@ -199,9 +200,7 @@ func (m *roachmart) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (m *roachmart) Ops(
-	urls []string, reg *workload.HistogramRegistry,
-) (workload.QueryLoad, error) {
+func (m *roachmart) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(m, m.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1046,6 +1046,22 @@ func (c *cluster) Put(ctx context.Context, src, dest string, opts ...option) {
 	}
 }
 
+// Get gets files from remote hosts.
+func (c *cluster) Get(ctx context.Context, src, dest string, opts ...option) {
+	if c.t.Failed() {
+		// If the test has failed, don't try to limp along.
+		return
+	}
+	if atomic.LoadInt32(&interrupted) == 1 {
+		c.t.Fatal("interrupted")
+	}
+	c.status(fmt.Sprintf("getting %v", src))
+	err := execCmd(ctx, c.l, roachprod, "get", c.makeNodes(opts...), src, dest)
+	if err != nil {
+		c.t.Fatal(err)
+	}
+}
+
 // Put a string into the specified file on the remote(s).
 func (c *cluster) PutString(
 	ctx context.Context, content, dest string, mode os.FileMode, opts ...option,

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"golang.org/x/exp/rand"
@@ -145,7 +146,7 @@ func (b *bank) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (b *bank) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+func (b *bank) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(b, b.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/bulkingest/bulkingest.go
+++ b/pkg/workload/bulkingest/bulkingest.go
@@ -59,6 +59,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
@@ -159,9 +160,7 @@ func (w *bulkingest) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *bulkingest) Ops(
-	urls []string, reg *workload.HistogramRegistry,
-) (workload.QueryLoad, error) {
+func (w *bulkingest) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/histogram/histogram.go
+++ b/pkg/workload/histogram/histogram.go
@@ -12,10 +12,13 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package workload
+package histogram
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -97,10 +100,10 @@ func (w *NamedHistogram) tick(fn func(h *hdrhistogram.Histogram)) {
 	fn(h)
 }
 
-// HistogramRegistry is a thread-safe enclosure for a (possibly large) number of
+// Registry is a thread-safe enclosure for a (possibly large) number of
 // named histograms. It allows for "tick"ing them periodically to reset the
 // counts and also supports aggregations.
-type HistogramRegistry struct {
+type Registry struct {
 	mu struct {
 		syncutil.Mutex
 		registered map[string][]*NamedHistogram
@@ -111,9 +114,9 @@ type HistogramRegistry struct {
 	prevTick   map[string]time.Time
 }
 
-// NewHistogramRegistry returns an initialized HistogramRegistry.
-func NewHistogramRegistry() *HistogramRegistry {
-	r := &HistogramRegistry{
+// NewRegistry returns an initialized Registry.
+func NewRegistry() *Registry {
+	r := &Registry{
 		start:      timeutil.Now(),
 		cumulative: make(map[string]*hdrhistogram.Histogram),
 		prevTick:   make(map[string]time.Time),
@@ -124,7 +127,7 @@ func NewHistogramRegistry() *HistogramRegistry {
 
 // GetHandle returns a thread-local handle for creating and registering
 // NamedHistograms.
-func (w *HistogramRegistry) GetHandle() *Histograms {
+func (w *Registry) GetHandle() *Histograms {
 	hists := &Histograms{reg: w}
 	hists.mu.hists = make(map[string]*NamedHistogram)
 	return hists
@@ -132,7 +135,7 @@ func (w *HistogramRegistry) GetHandle() *Histograms {
 
 // Tick aggregates all registered histograms, grouped by name. It is expected to
 // be called periodically from one goroutine.
-func (w *HistogramRegistry) Tick(fn func(HistogramTick)) {
+func (w *Registry) Tick(fn func(Tick)) {
 	merged := make(map[string]*hdrhistogram.Histogram)
 	var names []string
 	var wg sync.WaitGroup
@@ -172,7 +175,7 @@ func (w *HistogramRegistry) Tick(fn func(HistogramTick)) {
 			prevTick = w.start
 		}
 		w.prevTick[name] = now
-		fn(HistogramTick{
+		fn(Tick{
 			Name:       name,
 			Hist:       mergedHist,
 			Cumulative: w.cumulative[name],
@@ -187,7 +190,7 @@ func (w *HistogramRegistry) Tick(fn func(HistogramTick)) {
 // Histograms is a thread-local handle for creating and registering
 // NamedHistograms.
 type Histograms struct {
-	reg *HistogramRegistry
+	reg *Registry
 	mu  struct {
 		syncutil.RWMutex
 		hists map[string]*NamedHistogram
@@ -223,9 +226,9 @@ func (w *Histograms) Get(name string) *NamedHistogram {
 	return hist
 }
 
-// HistogramTick is an aggregation of ticking all histograms in a
-// HistogramRegistry with a given name.
-type HistogramTick struct {
+// Tick is an aggregation of ticking all histograms in a
+// Registry with a given name.
+type Tick struct {
 	// Name is the name given to the histograms represented by this tick.
 	Name string
 	// Hist is the merged result of the represented histograms for this tick.
@@ -243,7 +246,7 @@ type HistogramTick struct {
 }
 
 // Snapshot creates a SnapshotTick from the receiver.
-func (t HistogramTick) Snapshot() SnapshotTick {
+func (t Tick) Snapshot() SnapshotTick {
 	return SnapshotTick{
 		Name:    t.Name,
 		Elapsed: t.Elapsed,
@@ -252,7 +255,7 @@ func (t HistogramTick) Snapshot() SnapshotTick {
 	}
 }
 
-// SnapshotTick parallels HistogramTick but replace the histogram with a
+// SnapshotTick parallels Tick but replace the histogram with a
 // snapshot that is suitable for serialization. Additionally, it only contains
 // the per-tick histogram, not the cumulative histogram. (The cumulative
 // histogram can be computed by aggregating all of the per-tick histograms).
@@ -261,4 +264,24 @@ type SnapshotTick struct {
 	Hist    *hdrhistogram.Snapshot
 	Elapsed time.Duration
 	Now     time.Time
+}
+
+// DecodeSnapshots decodes a file with SnapshotTicks into a series.
+func DecodeSnapshots(snapshotsPath string) (map[string][]SnapshotTick, error) {
+	f, err := os.Open(snapshotsPath)
+	if err != nil {
+		return nil, err
+	}
+	dec := json.NewDecoder(f)
+	ret := make(map[string][]SnapshotTick)
+	for {
+		var tick SnapshotTick
+		if err := dec.Decode(&tick); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		ret[tick.Name] = append(ret[tick.Name], tick)
+	}
+	return ret, nil
 }

--- a/pkg/workload/histogram/histogram.go
+++ b/pkg/workload/histogram/histogram.go
@@ -226,6 +226,14 @@ func (w *Histograms) Get(name string) *NamedHistogram {
 	return hist
 }
 
+// Copy makes a new histogram which is a copy of h.
+func Copy(h *hdrhistogram.Histogram) *hdrhistogram.Histogram {
+	dup := hdrhistogram.New(h.LowestTrackableValue(), h.HighestTrackableValue(),
+		int(h.SignificantFigures()))
+	dup.Merge(h)
+	return dup
+}
+
 // Tick is an aggregation of ticking all histograms in a
 // Registry with a given name.
 type Tick struct {

--- a/pkg/workload/histogram/histogram.go
+++ b/pkg/workload/histogram/histogram.go
@@ -275,11 +275,12 @@ type SnapshotTick struct {
 }
 
 // DecodeSnapshots decodes a file with SnapshotTicks into a series.
-func DecodeSnapshots(snapshotsPath string) (map[string][]SnapshotTick, error) {
-	f, err := os.Open(snapshotsPath)
+func DecodeSnapshots(path string) (map[string][]SnapshotTick, error) {
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = f.Close() }()
 	dec := json.NewDecoder(f)
 	ret := make(map[string][]SnapshotTick)
 	for {

--- a/pkg/workload/indexes/indexes.go
+++ b/pkg/workload/indexes/indexes.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
@@ -129,7 +130,7 @@ func (w *indexes) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *indexes) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+func (w *indexes) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	ctx := context.Background()
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
@@ -160,7 +161,7 @@ func (w *indexes) Ops(urls []string, reg *workload.HistogramRegistry) (workload.
 
 type indexesOp struct {
 	config *indexes
-	hists  *workload.Histograms
+	hists  *histogram.Histograms
 	rand   *rand.Rand
 	sr     workload.SQLRunner
 	stmt   workload.StmtHandle

--- a/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
+++ b/pkg/workload/interleavedpartitioned/interleavedpartitioned.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
@@ -431,7 +432,7 @@ func (w *interleavedPartitioned) Tables() []workload.Table {
 
 // Ops implements the Opser interface.
 func (w *interleavedPartitioned) Ops(
-	urls []string, reg *workload.HistogramRegistry,
+	urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, ``, urls)
 	if err != nil {
@@ -542,7 +543,7 @@ func (w *interleavedPartitioned) Ops(
 }
 
 func (w *interleavedPartitioned) deleteFunc(
-	ctx context.Context, hists *workload.Histograms, rng *rand.Rand,
+	ctx context.Context, hists *histogram.Histograms, rng *rand.Rand,
 ) error {
 	start := timeutil.Now()
 	var statement *gosql.Stmt
@@ -563,7 +564,7 @@ func (w *interleavedPartitioned) deleteFunc(
 }
 
 func (w *interleavedPartitioned) insertFunc(
-	ctx context.Context, db *gosql.DB, hists *workload.Histograms, rng *rand.Rand, workerID int,
+	ctx context.Context, db *gosql.DB, hists *histogram.Histograms, rng *rand.Rand, workerID int,
 ) error {
 	start := timeutil.Now()
 	// Execute the transaction.
@@ -658,7 +659,7 @@ func (w *interleavedPartitioned) insertFunc(
 func (w *interleavedPartitioned) fetchSessionID(
 	ctx context.Context,
 	rng *rand.Rand,
-	hists *workload.Histograms,
+	hists *histogram.Histograms,
 	locality string,
 	localPercent int,
 ) (string, error) {
@@ -684,7 +685,7 @@ func (w *interleavedPartitioned) fetchSessionID(
 }
 
 func (w *interleavedPartitioned) retrieveFunc(
-	ctx context.Context, hists *workload.Histograms, rng *rand.Rand,
+	ctx context.Context, hists *histogram.Histograms, rng *rand.Rand,
 ) error {
 	sessionID, err := w.fetchSessionID(ctx, rng, hists, w.locality, w.retrieveLocalPercent)
 	if err != nil {
@@ -710,7 +711,7 @@ func (w *interleavedPartitioned) retrieveFunc(
 }
 
 func (w *interleavedPartitioned) updateFunc(
-	ctx context.Context, hists *workload.Histograms, rng *rand.Rand,
+	ctx context.Context, hists *histogram.Histograms, rng *rand.Rand,
 ) error {
 	sessionID, err := w.fetchSessionID(ctx, rng, hists, w.locality, w.updateLocalPercent)
 	if err != nil {

--- a/pkg/workload/jsonload/json.go
+++ b/pkg/workload/jsonload/json.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
@@ -130,7 +131,7 @@ func (w *jsonLoad) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *jsonLoad) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+func (w *jsonLoad) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
@@ -203,7 +204,7 @@ func (w *jsonLoad) Ops(urls []string, reg *workload.HistogramRegistry) (workload
 
 type jsonOp struct {
 	config    *jsonLoad
-	hists     *workload.Histograms
+	hists     *histogram.Histograms
 	db        *gosql.DB
 	readStmt  *gosql.Stmt
 	writeStmt *gosql.Stmt

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
@@ -176,7 +177,7 @@ func (w *kv) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *kv) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+func (w *kv) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	writeSeq := 0
 	if w.writeSeq != "" {
 		first := w.writeSeq[0]
@@ -272,7 +273,7 @@ func (w *kv) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Query
 
 type kvOp struct {
 	config          *kv
-	hists           *workload.Histograms
+	hists           *histogram.Histograms
 	sr              workload.SQLRunner
 	readStmt        workload.StmtHandle
 	writeStmt       workload.StmtHandle

--- a/pkg/workload/ledger/ledger.go
+++ b/pkg/workload/ledger/ledger.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
@@ -44,7 +45,7 @@ type ledger struct {
 	txs  []tx
 	deck []int // contains indexes into the txs slice
 
-	reg      *workload.HistogramRegistry
+	reg      *histogram.Registry
 	rngPool  *sync.Pool
 	hashPool *sync.Pool
 }
@@ -182,7 +183,7 @@ func (w *ledger) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *ledger) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+func (w *ledger) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/ledger/worker.go
+++ b/pkg/workload/ledger/worker.go
@@ -23,13 +23,13 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 )
 
 type worker struct {
 	config *ledger
-	hists  *workload.Histograms
+	hists  *histogram.Histograms
 	db     *gosql.DB
 
 	rng      *rand.Rand

--- a/pkg/workload/querybench/query_bench.go
+++ b/pkg/workload/querybench/query_bench.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
@@ -93,9 +94,7 @@ func (*queryBench) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (g *queryBench) Ops(
-	urls []string, reg *workload.HistogramRegistry,
-) (workload.QueryLoad, error) {
+func (g *queryBench) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
@@ -170,7 +169,7 @@ type namedStmt struct {
 }
 
 type queryBenchWorker struct {
-	hists *workload.Histograms
+	hists *histogram.Histograms
 	db    *gosql.DB
 	stmts []namedStmt
 

--- a/pkg/workload/queue/queue.go
+++ b/pkg/workload/queue/queue.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/spf13/pflag"
 )
 
@@ -73,7 +74,7 @@ func (w *queue) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *queue) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+func (w *queue) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
@@ -131,7 +132,7 @@ func (w *queue) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Qu
 type queueOp struct {
 	workerID   int
 	config     *queue
-	hists      *workload.Histograms
+	hists      *histogram.Histograms
 	db         *gosql.DB
 	insertStmt *gosql.Stmt
 	deleteStmt *gosql.Stmt

--- a/pkg/workload/rand/rand.go
+++ b/pkg/workload/rand/rand.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/lib/pq"
 	"github.com/lib/pq/oid"
 	"github.com/pkg/errors"
@@ -116,7 +117,7 @@ type col struct {
 }
 
 // Ops implements the Opser interface.
-func (w *random) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+func (w *random) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
@@ -297,7 +298,7 @@ AND    i.indisprimary`, relid)
 
 type randOp struct {
 	config    *random
-	hists     *workload.Histograms
+	hists     *histogram.Histograms
 	db        *gosql.DB
 	cols      []col
 	rng       *rand.Rand

--- a/pkg/workload/sqlsmith/sqlsmith.go
+++ b/pkg/workload/sqlsmith/sqlsmith.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/spf13/pflag"
 )
 
@@ -79,7 +80,7 @@ func (g *sqlSmith) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (g *sqlSmith) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+func (g *sqlSmith) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/tpcc/result.go
+++ b/pkg/workload/tpcc/result.go
@@ -73,9 +73,8 @@ type Result struct {
 	Elapsed time.Duration
 
 	// WarehouseFactor is the maximal number of newOrder transactions per second
-	// per Warehouse. If zero it defaults to DefaultWarehouseFactor which is set
-	// via the spec's value. The value is used to compute the efficiency of the
-	// run.
+	// per Warehouse. If zero it defaults to DeckWarehouseFactor which is derived
+	// from this workload. The value is used to compute the efficiency of the run.
 	WarehouseFactor float64
 }
 
@@ -162,7 +161,7 @@ func NewResultWithSnapshots(
 // TpmC returns a tpmC value with a warehouse factor of 12.86.
 // TpmC will panic if r does not contain a "newOrder" histogram in Cumulative.
 func (r *Result) TpmC() float64 {
-	return float64(r.Cumulative["newOrder"].TotalCount()) / (r.Elapsed.Seconds() * 60)
+	return float64(r.Cumulative["newOrder"].TotalCount()) / (r.Elapsed.Seconds() / 60)
 }
 
 // Efficiency returns the efficiency of a TPC-C run.

--- a/pkg/workload/tpcc/result.go
+++ b/pkg/workload/tpcc/result.go
@@ -1,0 +1,217 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package tpcc
+
+import (
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/codahale/hdrhistogram"
+	"github.com/pkg/errors"
+)
+
+// SpecWarehouseFactor is the default maximum per-warehouse newOrder
+// throughput per second used to compute the maximum throughput value for a
+// given warehouse count. This value is provided in the TPC-C spec.
+const SpecWarehouseFactor = 12.86
+
+// DeckWarehouseFactor is the warehouse factor to be used with the workload deck
+// implemented in this package. This value differs from the spec's provided
+// value as the deck mechanism used by workload differs from the default
+// workload but is an acceptable alternative. This is the default value.
+//
+// The 12.605 is computed from the operation mix and the number of secs
+// it takes to cycle through a deck:
+//
+//   10*(18+12) + 10*(3+12) + 1*(2+10) + 1*(2+5) + 1*(2+5) = 476
+//
+// 10 workers per warehouse times 10 newOrder ops per deck results in:
+//
+//   (10*10)/(476/60) = 12.605...
+//
+const DeckWarehouseFactor = 12.605
+
+// PassingEfficiency is a percentage of the theoretical maximum tpmC required
+// to pass TPC-C.
+const PassingEfficiency = 85.0
+
+// These values represent the maximum allowable 90th-%ile latency for the
+// given queries as specified in section 5.2.5.7 of the TPC-C spec.
+var passing90ThPercentile = map[string]time.Duration{
+	"newOrder":    5 * time.Second,
+	"payment":     5 * time.Second,
+	"orderStatus": 5 * time.Second,
+	"delivery":    5 * time.Second,
+	"stockLevel":  20 * time.Second,
+}
+
+// Result represents the outcome of a TPCC run.
+type Result struct {
+
+	// ActiveWarehouses is the number of warehouses used in the TPC-C run.
+	ActiveWarehouses int
+
+	// Cumulative maps from query name to the cumulative response time
+	// histogram for the TPC-C run.
+	Cumulative map[string]*hdrhistogram.Histogram
+
+	// Elapsed is the amount of time captured by the Cumulative.
+	Elapsed time.Duration
+
+	// WarehouseFactor is the maximal number of newOrder transactions per second
+	// per Warehouse. If zero it defaults to DefaultWarehouseFactor which is set
+	// via the spec's value. The value is used to compute the efficiency of the
+	// run.
+	WarehouseFactor float64
+}
+
+// MergeResults returns a result value constructed by merging the arguments.
+// It should only be used if the number of ActiveWarehouses matches and will
+// panic if they differ. Elapsed is computed as the max of all elapsed values
+// and makes the assumption that the distibutions roughly overlap in time.
+// This should be used when merging from multiple load generators during the
+// same test run.
+func MergeResults(results ...*Result) *Result {
+	if len(results) == 0 {
+		return nil
+	}
+	base := &Result{
+		ActiveWarehouses: results[0].ActiveWarehouses,
+		Cumulative: make(map[string]*hdrhistogram.Histogram,
+			len(results[0].Cumulative)),
+		WarehouseFactor: results[0].WarehouseFactor,
+	}
+	for _, r := range results {
+		if r.Elapsed > base.Elapsed {
+			base.Elapsed = r.Elapsed
+		}
+		if r.ActiveWarehouses != base.ActiveWarehouses {
+			panic(errors.Errorf("cannot merge histograms with different "+
+				"ActiveWarehouses values: got both %v and %v",
+				r.ActiveWarehouses, base.ActiveWarehouses))
+		}
+		for q, h := range r.Cumulative {
+			if cur, exists := base.Cumulative[q]; exists {
+				cur.Merge(h)
+			} else {
+				base.Cumulative[q] = histogram.Copy(h)
+			}
+		}
+	}
+	return base
+}
+
+// NewResult constructs a new Result.
+func NewResult(
+	activeWarehouses int,
+	warehouseFactor float64,
+	elapsed time.Duration,
+	cumulative map[string]*hdrhistogram.Histogram,
+) *Result {
+	return &Result{
+		ActiveWarehouses: activeWarehouses,
+		WarehouseFactor:  warehouseFactor,
+		Elapsed:          elapsed,
+		Cumulative:       cumulative,
+	}
+}
+
+// NewResultWithSnapshots creates a new result from a deserialized set of
+// histogram snapshots.
+func NewResultWithSnapshots(
+	activeWarehouses int, warehouseFactor float64, snapshots map[string][]histogram.SnapshotTick,
+) *Result {
+	var start time.Time
+	var end time.Time
+	ret := make(map[string]*hdrhistogram.Histogram, len(snapshots))
+	for n, snaps := range snapshots {
+		var cur *hdrhistogram.Histogram
+		for _, s := range snaps {
+			h := hdrhistogram.Import(s.Hist)
+			if cur == nil {
+				cur = h
+			} else {
+				cur.Merge(h)
+			}
+			if start.IsZero() || s.Now.Before(start) {
+				start = s.Now
+			}
+			if sEnd := s.Now.Add(s.Elapsed); end.IsZero() || sEnd.After(end) {
+				end = sEnd
+			}
+		}
+		ret[n] = cur
+	}
+	return NewResult(activeWarehouses, warehouseFactor, end.Sub(start), ret)
+}
+
+// TpmC returns a tpmC value with a warehouse factor of 12.86.
+// TpmC will panic if r does not contain a "newOrder" histogram in Cumulative.
+func (r *Result) TpmC() float64 {
+	return float64(r.Cumulative["newOrder"].TotalCount()) / (r.Elapsed.Seconds() * 60)
+}
+
+// Efficiency returns the efficiency of a TPC-C run.
+// It relies on the WarehouseFactor which defaults to DeckWarehouseFactor.
+func (r *Result) Efficiency() float64 {
+	tpmC := r.TpmC()
+	warehouseFactor := r.WarehouseFactor
+	if warehouseFactor == 0 {
+		warehouseFactor = DeckWarehouseFactor
+	}
+	return (100 * tpmC) / (warehouseFactor * float64(r.ActiveWarehouses))
+}
+
+// FailureError returns nil if the Result is passing or an error describing
+// the failure if the result is failing.
+func (r *Result) FailureError() error {
+	if _, newOrderExists := r.Cumulative["newOrder"]; !newOrderExists {
+		return errors.Errorf("no newOrder data exists")
+	}
+
+	// Collect all failing criteria errors into errs so that the returned error
+	// contains information about all of the failures.
+	var errs []error
+	if eff := r.Efficiency(); eff < PassingEfficiency {
+		errs = append(errs, errors.Errorf("efficiency value of %v is below "+
+			"passing threshold of %v", eff, PassingEfficiency))
+	}
+	for query, max90th := range passing90ThPercentile {
+		h, exists := r.Cumulative[query]
+		if !exists {
+			return errors.Errorf("no %v data exists", query)
+		}
+		if v := time.Duration(h.ValueAtQuantile(.9)); v > max90th {
+			errs = append(errs, errors.Errorf("90th percentile latency for %v at %v "+
+				"exceeds passing threshold of %v", query, v, max90th))
+		}
+	}
+	switch len(errs) {
+	case 0:
+		return nil
+	case 1:
+		return errs[0]
+	default:
+		return errors.New("failed with multiple errors: " +
+			strings.Join(func() (s []string) {
+				for _, e := range errs {
+					s = append(s, e.Error())
+				}
+				return s
+			}(), ", "))
+	}
+}

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -268,7 +268,7 @@ func (w *tpcc) Hooks() workload.Hooks {
 					fmt.Printf("%7.1fs %10.1f %5.1f%% %8.1f %8.1f %8.1f %8.1f %8.1f %8.1f\n",
 						startElapsed.Seconds(),
 						tpmC,
-						100*tpmC/(12.86*float64(w.activeWarehouses)),
+						100*tpmC/(SpecWarehouseFactor*float64(w.activeWarehouses)),
 						time.Duration(t.Cumulative.Mean()).Seconds()*1000,
 						time.Duration(t.Cumulative.ValueAtQuantile(50)).Seconds()*1000,
 						time.Duration(t.Cumulative.ValueAtQuantile(90)).Seconds()*1000,

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/jackc/pgx"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -58,7 +59,7 @@ type tpcc struct {
 
 	auditor *auditor
 
-	reg *workload.HistogramRegistry
+	reg *histogram.Registry
 
 	split   bool
 	scatter bool
@@ -261,7 +262,7 @@ func (w *tpcc) Hooks() workload.Hooks {
 			fmt.Println(totalHeader)
 
 			const newOrderName = `newOrder`
-			w.reg.Tick(func(t workload.HistogramTick) {
+			w.reg.Tick(func(t histogram.Tick) {
 				if newOrderName == t.Name {
 					tpmC := float64(t.Cumulative.TotalCount()) / startElapsed.Seconds() * 60
 					fmt.Printf("%7.1fs %10.1f %5.1f%% %8.1f %8.1f %8.1f %8.1f %8.1f %8.1f\n",
@@ -447,7 +448,7 @@ func (w *tpcc) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *tpcc) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+func (w *tpcc) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.dbOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/tpcc/worker.go
+++ b/pkg/workload/tpcc/worker.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/rand"
 )
@@ -130,7 +131,7 @@ type worker struct {
 	config *tpcc
 	// txs maps 1-to-1 with config.txInfos.
 	txs       []tpccTx
-	hists     *workload.Histograms
+	hists     *histogram.Histograms
 	warehouse int
 
 	deckPerm []int
@@ -141,7 +142,7 @@ func newWorker(
 	ctx context.Context,
 	config *tpcc,
 	mcp *workload.MultiConnPool,
-	hists *workload.Histograms,
+	hists *histogram.Histograms,
 	warehouse int,
 ) (*worker, error) {
 	w := &worker{

--- a/pkg/workload/tpch/tpch.go
+++ b/pkg/workload/tpch/tpch.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
@@ -148,7 +149,7 @@ func (w *tpch) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *tpch) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+func (w *tpch) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
@@ -175,7 +176,7 @@ func (w *tpch) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Que
 
 type worker struct {
 	config *tpch
-	hists  *workload.Histograms
+	hists  *histogram.Histograms
 	db     *gosql.DB
 	ops    int
 }

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
@@ -80,7 +81,7 @@ type Flagser interface {
 // to have been created and initialized before running these.
 type Opser interface {
 	Generator
-	Ops(urls []string, reg *HistogramRegistry) (QueryLoad, error)
+	Ops(urls []string, reg *histogram.Registry) (QueryLoad, error)
 }
 
 // Hookser returns any hooks associated with the generator.

--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
@@ -206,7 +207,7 @@ func (g *ycsb) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (g *ycsb) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+func (g *ycsb) Ops(urls []string, reg *histogram.Registry) (workload.QueryLoad, error) {
 	sqlDatabase, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
@@ -308,7 +309,7 @@ type randGenerator interface {
 
 type ycsbWorker struct {
 	config               *ycsb
-	hists                *workload.Histograms
+	hists                *histogram.Histograms
 	db                   *gosql.DB
 	readStmt, insertStmt *gosql.Stmt
 


### PR DESCRIPTION
This PR comes in 3 commits. The first moves some histogram related objects out of workload into a subpackage. The next commit adds a tpcc.Results struct which can compute and verify requirements from data about the run. The last commit adopts this new object in roachtest's tpccbench. Note that this still does not impact roachperf.  