### PR TITLE
release-2.0: storage: don't trip breaker if context is canceled

### DIFF
--- a/pkg/storage/raft_transport.go
+++ b/pkg/storage/raft_transport.go
@@ -464,7 +464,9 @@ func (t *RaftTransport) connectAndProcess(
 		if consecFailures == 0 {
 			log.Warningf(ctx, "raft transport stream to node %d failed: %s", nodeID, err)
 		}
-		breaker.Fail(err)
+		if ctx.Err() == nil {
+			breaker.Fail(err)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR backports the idea behind #35433 to release-2.0.

Release note: None