### PR TITLE
roachtest: skip cdc/bank

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -485,6 +485,7 @@ func registerCDC(r *registry) {
 	// without potentially leaking secrets.
 	r.Add(testSpec{
 		Name:       "cdc/bank",
+		Skip:       `#35614`,
 		MinVersion: "v2.1.0",
 		Cluster:    makeClusterSpec(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {


### PR DESCRIPTION
cdc/bank is included in the acceptance roachtests run on every PR to
validate changefeeds end-to-end with a real kafka. The runtime recently
jumped from 1-3m (with a few outliers at 5 or 6m) to regularly be above
30-45m. This will get in the way of regular development, so skipping
until I can investigate what's going on.

Touches #35614

Release note: None