### PR TITLE
sql: equip scalar expressions with telemetry

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1500,6 +1500,10 @@ CREATE TABLE crdb_internal.feature_usage (
 `,
 	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for feature, count := range telemetry.GetFeatureCounts() {
+			if count == 0 {
+				// Skip over empty counters to avoid polluting the output.
+				continue
+			}
 			if err := addRow(
 				tree.NewDString(feature),
 				tree.NewDInt(tree.DInt(int64(count))),

--- a/pkg/sql/sem/tree/datum_invariants_test.go
+++ b/pkg/sql/sem/tree/datum_invariants_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestAllTypesCastableToString(t *testing.T) {
 	for _, typ := range types.AnyNonArray {
-		if !isCastDeepValid(typ, types.String) {
+		if ok, _ := isCastDeepValid(typ, types.String); !ok {
 			t.Errorf("%s is not castable to STRING, all types should be", typ)
 		}
 	}
@@ -30,7 +30,7 @@ func TestAllTypesCastableToString(t *testing.T) {
 
 func TestAllTypesCastableFromString(t *testing.T) {
 	for _, typ := range types.AnyNonArray {
-		if !isCastDeepValid(types.String, typ) {
+		if ok, _ := isCastDeepValid(types.String, typ); !ok {
 			t.Errorf("%s is not castable from STRING, all types should be", typ)
 		}
 	}

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -1478,34 +1479,39 @@ func (node *CastExpr) castType() types.T {
 	return coltypes.CastTargetToDatumType(node.Type)
 }
 
+type castInfo struct {
+	fromT   types.T
+	counter telemetry.Counter
+}
+
 var (
-	bitArrayCastTypes = []types.T{types.Unknown, types.BitArray, types.Int, types.String, types.FamCollatedString}
-	boolCastTypes     = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString}
-	intCastTypes      = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
-		types.Timestamp, types.TimestampTZ, types.Date, types.Interval, types.Oid, types.BitArray}
-	floatCastTypes = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
-		types.Timestamp, types.TimestampTZ, types.Date, types.Interval}
-	decimalCastTypes = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
-		types.Timestamp, types.TimestampTZ, types.Date, types.Interval}
-	stringCastTypes = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
+	bitArrayCastTypes = annotateCast(types.BitArray, []types.T{types.Unknown, types.BitArray, types.Int, types.String, types.FamCollatedString})
+	boolCastTypes     = annotateCast(types.Bool, []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString})
+	intCastTypes      = annotateCast(types.Int, []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
+		types.Timestamp, types.TimestampTZ, types.Date, types.Interval, types.Oid, types.BitArray})
+	floatCastTypes = annotateCast(types.Float, []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
+		types.Timestamp, types.TimestampTZ, types.Date, types.Interval})
+	decimalCastTypes = annotateCast(types.Decimal, []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
+		types.Timestamp, types.TimestampTZ, types.Date, types.Interval})
+	stringCastTypes = annotateCast(types.String, []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
 		types.BitArray,
 		types.FamArray, types.FamTuple,
-		types.Bytes, types.Timestamp, types.TimestampTZ, types.Interval, types.UUID, types.Date, types.Time, types.Oid, types.INet, types.JSON}
-	bytesCastTypes = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Bytes, types.UUID}
-	dateCastTypes  = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Date, types.Timestamp, types.TimestampTZ, types.Int}
-	timeCastTypes  = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Time,
-		types.Timestamp, types.TimestampTZ, types.Interval}
-	timestampCastTypes = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Date, types.Timestamp, types.TimestampTZ, types.Int}
-	intervalCastTypes  = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Int, types.Time, types.Interval, types.Float, types.Decimal}
-	oidCastTypes       = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Int, types.Oid}
-	uuidCastTypes      = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Bytes, types.UUID}
-	inetCastTypes      = []types.T{types.Unknown, types.String, types.FamCollatedString, types.INet}
-	arrayCastTypes     = []types.T{types.Unknown, types.String}
-	jsonCastTypes      = []types.T{types.Unknown, types.String, types.JSON}
+		types.Bytes, types.Timestamp, types.TimestampTZ, types.Interval, types.UUID, types.Date, types.Time, types.Oid, types.INet, types.JSON})
+	bytesCastTypes = annotateCast(types.Bytes, []types.T{types.Unknown, types.String, types.FamCollatedString, types.Bytes, types.UUID})
+	dateCastTypes  = annotateCast(types.Date, []types.T{types.Unknown, types.String, types.FamCollatedString, types.Date, types.Timestamp, types.TimestampTZ, types.Int})
+	timeCastTypes  = annotateCast(types.Time, []types.T{types.Unknown, types.String, types.FamCollatedString, types.Time,
+		types.Timestamp, types.TimestampTZ, types.Interval})
+	timestampCastTypes = annotateCast(types.Timestamp, []types.T{types.Unknown, types.String, types.FamCollatedString, types.Date, types.Timestamp, types.TimestampTZ, types.Int})
+	intervalCastTypes  = annotateCast(types.Interval, []types.T{types.Unknown, types.String, types.FamCollatedString, types.Int, types.Time, types.Interval, types.Float, types.Decimal})
+	oidCastTypes       = annotateCast(types.Oid, []types.T{types.Unknown, types.String, types.FamCollatedString, types.Int, types.Oid})
+	uuidCastTypes      = annotateCast(types.UUID, []types.T{types.Unknown, types.String, types.FamCollatedString, types.Bytes, types.UUID})
+	inetCastTypes      = annotateCast(types.INet, []types.T{types.Unknown, types.String, types.FamCollatedString, types.INet})
+	arrayCastTypes     = annotateCast(types.FamArray, []types.T{types.Unknown, types.String})
+	jsonCastTypes      = annotateCast(types.JSON, []types.T{types.Unknown, types.String, types.JSON})
 )
 
 // validCastTypes returns a set of types that can be cast into the provided type.
-func validCastTypes(t types.T) []types.T {
+func validCastTypes(t types.T) []castInfo {
 	switch types.UnwrapType(t) {
 	case types.BitArray:
 		return bitArrayCastTypes
@@ -1543,7 +1549,7 @@ func validCastTypes(t types.T) []types.T {
 		if t.FamilyEqual(types.FamCollatedString) {
 			return stringCastTypes
 		} else if t.FamilyEqual(types.FamArray) {
-			ret := make([]types.T, len(arrayCastTypes))
+			ret := make([]castInfo, len(arrayCastTypes))
 			copy(ret, arrayCastTypes)
 			return ret
 		}

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -14,6 +14,8 @@
 
 package tree
 
+import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+
 // FunctionDefinition implements a reference to the (possibly several)
 // overloads for a built-in function.
 type FunctionDefinition struct {
@@ -123,6 +125,9 @@ func NewFunctionDefinition(
 			// Builtins with a preferred overload are always ambiguous.
 			props.AmbiguousReturnType = true
 		}
+		// Produce separate telemetry for each overload.
+		def[i].counter = telemetry.GetCounter("sql.builtins." + name + def[i].Signature(false))
+
 		overloads[i] = &def[i]
 	}
 	return &FunctionDefinition{

--- a/pkg/sql/sem/tree/operators.go
+++ b/pkg/sql/sem/tree/operators.go
@@ -1,0 +1,181 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/lib/pq/oid"
+)
+
+// This file implements the generation of unique names for every
+// operator overload.
+//
+// The historical first purpose of generating these names is to be used
+// as telemetry keys, for feature usage reporting.
+
+// Scalar operators will be counter as sql.ops.<kind>.<lhstype> <opname> <rhstype>.
+const unOpCounterNameFmt = "sql.ops.un.%s %s"
+const cmpOpCounterNameFmt = "sql.ops.cmp.%s %s %s"
+const binOpCounterNameFmt = "sql.ops.bin.%s %s %s"
+
+// Cast operators will be counted as sql.ops.cast.<fromtype>::<totype>.
+const castCounterNameFmt = "sql.ops.cast.%s::%s"
+
+// All casts that involve arrays will also be counted towards this
+// feature counter.
+var arrayCastCounter = telemetry.GetCounter("sql.ops.cast.arrays")
+
+// Detailed counter name generation follows.
+//
+// We pre-allocate the counter objects upfront here and later use
+// Inc(), to avoid the hash map lookup in telemetry.Count() upon type
+// checking every scalar operator node.
+
+// The logic that follows is also associated with a related feature in
+// PostgreSQL, which may be implemented by CockroachDB in the future:
+// exposing all the operators as unambiguous, non-overloaded built-in
+// functions.  For example, in PostgreSQL, one can use `SELECT
+// int8um(123)` to apply the int8-specific unary minus operator.
+// This feature can be considered in the future for two reasons:
+//
+// 1. some pg applications may simply require the ability to use the
+//    pg native operator built-ins. If/when this compatibility is
+//    considered, care should be taken to tweak the string maps below
+//    to ensure that the operator names generated here coincide with
+//    those used in the postgres library.
+//
+// 2. since the operator built-in functions are non-overloaded, they
+//    remove the requirement to disambiguate the type of operands
+//    with the ::: (annotate_type) operator. This may be useful
+//    to simplify/accelerate the serialization of scalar expressions
+//    in distsql.
+//
+
+// makeOidName generates a short name for the given type OID.
+func makeOidName(op fmt.Stringer, tOid oid.Oid) (string, bool) {
+	oidName, ok := oid.TypeName[tOid]
+	if !ok {
+		return "", false
+	}
+	name := strings.ToLower(oidName)
+	if strings.HasPrefix(name, "timestamp") {
+		name = "ts" + name[9:]
+	}
+	return name, true
+}
+
+func init() {
+	seen := map[string]struct{}{}
+
+	// Label the unary operators.
+	for op, overloads := range UnaryOps {
+		if int(op) >= len(unaryOpName) || unaryOpName[op] == "" {
+			panic(fmt.Sprintf("missing name for operator %q", op.String()))
+		}
+		opName := unaryOpName[op]
+		for _, impl := range overloads {
+			o := impl.(*UnaryOp)
+			uname, ok := makeOidName(op, o.Typ.Oid())
+			if !ok {
+				continue
+			}
+			name := fmt.Sprintf(unOpCounterNameFmt, opName, uname)
+			if _, ok := seen[name]; ok {
+				panic(fmt.Sprintf("duplicate name: %q", name))
+			}
+			o.counter = telemetry.GetCounter(name)
+		}
+	}
+
+	// Label the comparison operators.
+	for op, overloads := range CmpOps {
+		if int(op) >= len(comparisonOpName) || comparisonOpName[op] == "" {
+			panic(fmt.Sprintf("missing name for operator %q", op.String()))
+		}
+		opName := comparisonOpName[op]
+		for _, impl := range overloads {
+			o := impl.(*CmpOp)
+			lname, lok := makeOidName(op, o.LeftType.Oid())
+			rname, rok := makeOidName(op, o.RightType.Oid())
+			if !lok || !rok {
+				continue
+			}
+			name := fmt.Sprintf(cmpOpCounterNameFmt, lname, opName, rname)
+			if _, ok := seen[name]; ok {
+				panic(fmt.Sprintf("duplicate name: %q", name))
+			}
+			o.counter = telemetry.GetCounter(name)
+		}
+	}
+
+	// Label the binary operators.
+	for op, overloads := range BinOps {
+		if int(op) >= len(binaryOpName) || binaryOpName[op] == "" {
+			panic(fmt.Sprintf("missing name for operator %q", op.String()))
+		}
+		opName := binaryOpName[op]
+		for _, impl := range overloads {
+			o := impl.(*BinOp)
+			lname, lok := makeOidName(op, o.LeftType.Oid())
+			rname, rok := makeOidName(op, o.RightType.Oid())
+			if !lok || !rok {
+				continue
+			}
+			name := fmt.Sprintf(binOpCounterNameFmt, lname, opName, rname)
+			if _, ok := seen[name]; ok {
+				panic(fmt.Sprintf("duplicate name: %q", name))
+			}
+			o.counter = telemetry.GetCounter(name)
+		}
+	}
+}
+
+// annotateCast produces an array of cast types decorated with cast
+// type telemetry counters.
+func annotateCast(toType types.T, fromTypes []types.T) []castInfo {
+	ci := make([]castInfo, len(fromTypes))
+	for i, fromType := range fromTypes {
+		ci[i].fromT = fromType
+	}
+	var rname string
+	if toType.FamilyEqual(types.FamArray) {
+		rname = "array"
+	} else {
+		var rok bool
+		rname, rok = makeOidName(nil, toType.Oid())
+		if !rok {
+			return ci
+		}
+	}
+
+	for i, fromType := range fromTypes {
+		var lname string
+		if fromType.FamilyEqual(types.FamArray) {
+			lname = "array"
+		} else {
+			var lok bool
+			lname, lok = makeOidName(nil, fromType.Oid())
+			if !lok {
+				continue
+			}
+		}
+		ci[i].counter = telemetry.GetCounter(fmt.Sprintf(castCounterNameFmt, lname, rname))
+	}
+	return ci
+}

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/pkg/errors"
@@ -51,6 +52,10 @@ type Overload struct {
 	WindowFunc    func([]types.T, *EvalContext) WindowFunc
 	Fn            func(*EvalContext, Datums) (Datum, error)
 	Generator     GeneratorFactory
+
+	// counter, if non-nil, should be incremented upon successful
+	// type check of expressions using this overload.
+	counter telemetry.Counter
 }
 
 // params implements the overloadImpl interface.


### PR DESCRIPTION
Informs https://github.com/cockroachlabs/registration/issues/203.

This patch introduces telemetry for the following scalar expressions:

- `array[...]`, `array(...)`, `...[...]`

  telemetry: `sql.ops.array.cons`, `sql.ops.array.flatten`,
  `sql.ops.array.ind`

- `IFERROR(...)`

  telemetry: `sql.ops.iferr`

- unary, binary and comparison operators;

  telemetry: `sql.ops.un.<op> <type>`, `sql.ops.bin.<type> <op>
  <type>`, `sql.ops.cmp.<type> <op> <type>`

- casts;

  telemetry: `sql.ops.cast.<type>::<type>`, `sql.ops.cast.arrays`

- built-in function applications.

  telemetry: `sql.builtins.<name><signature>`

For example:

```
> select ('{"a":{"c":"d"},"e":123}'::string::jsonb #- array['a']) - 'e';
> select * from crdb_internal.feature_usage where feature_name like '%json%';
                             feature_name                             | usage_count
+---------------------------------------------------------------------+-------------+
  sql.builtins.json_remove_path.(val: jsonb, path: string[]) -> jsonb |           1
  sql.ops.cast.text::jsonb                                            |           1
  sql.ops.bin.jsonb - text                                            |           1
(3 rows)
```

Release note (sql change): CockroachDB will now report usage frequency
of various SQL scalar operators in telemetry, when telemetry is
enabled, so as to guide future optimizations of query performance.