### PR TITLE
backport-2.1: opt,sql: don't fold "- 0" for JSON

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -477,6 +477,11 @@ SELECT '{"a": 1}'::JSONB - 'b'
 
 # `-` is one of the very few cases that PG errors in a JSON type mismatch with operators.
 query T
+SELECT '[1,2,3]'::JSONB - 0
+----
+[2, 3]
+
+query T
 SELECT '[1,2,3]'::JSONB - 1
 ----
 [1, 3]

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1113,6 +1113,15 @@ func (c *CustomFuncs) ConvertConstArrayToTuple(g memo.GroupID) memo.GroupID {
 //
 // ----------------------------------------------------------------------
 
+// IsAdditive returns true if the type of the expression supports addition and
+// subtraction in the natural way. This differs from "has a +/- Numeric
+// implementation" because JSON has an implementation for "- INT" which doesn't
+// obey x - 0 = x. Additive types include all numeric types as well as
+// timestamps and dates.
+func (c *CustomFuncs) IsAdditive(g memo.GroupID) bool {
+	return types.IsAdditiveType(memo.InferType(memo.MakeNormExprView(c.mem, g)))
+}
+
 // EqualsNumber returns true if the given private numeric value (decimal, float,
 // or integer) is equal to the given integer value.
 func (c *CustomFuncs) EqualsNumber(private memo.PrivateID, value int64) bool {

--- a/pkg/sql/opt/norm/rules/numeric.opt
+++ b/pkg/sql/opt/norm/rules/numeric.opt
@@ -10,9 +10,11 @@
 [FoldZeroPlus, Normalize]
 (Plus (Const 0) $right:*) => $right
 
-# FoldMinusZero folds $left - 0 for numeric types.
+# FoldMinusZero folds $left - 0 for numeric types. This rule requires a check
+# that $left is numeric because JSON - INT is valid and is not a no-op with a
+# zero value.
 [FoldMinusZero, Normalize]
-(Minus $left:* (Const 0)) => $left
+(Minus $left:(IsAdditive $left) (Const 0)) => $left
 
 # FoldMultOne folds $left * 1 for numeric types.
 [FoldMultOne, Normalize]

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -55,6 +55,22 @@ project
       ├── f + f [type=float, outer=(3)]
       └── d + d [type=decimal, outer=(4)]
 
+# Regression test for #35612.
+opt expect-not=FoldMinusZero
+SELECT '[123]'::jsonb - 0
+----
+project
+ ├── columns: "?column?":1(jsonb!null)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── tuple [type=tuple]
+ └── projections
+      └── const: '[]' [type=jsonb]
+
 # --------------------------------------------------
 # FoldMultOne, FoldOneMult
 # --------------------------------------------------

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -140,7 +140,7 @@ func (expr *BinaryExpr) normalize(v *NormalizeVisitor) TypedExpr {
 			break
 		}
 	case Minus:
-		if v.isNumericZero(right) {
+		if types.IsAdditiveType(left.ResolvedType()) && v.isNumericZero(right) {
 			final, v.err = ReType(left, expectedType)
 			break
 		}


### PR DESCRIPTION
Backport 1/1 commits from #35617.

/cc @cockroachdb/release

---

Fixes #35612.

Prior to this commit, we would unconditionally fold x - 0 to x. This was
invalid in the case where x was JSON, since `- 0` in that case means
"delete the 0th entry in the array".

This bug existed in both the HP and CBO.

This fix slightly abuses the existing "types.IsAdditiveType" function to
determine whether or not the identity applies.

Release note (bug fix): Subtracting 0 from a JSON array now correctly
removes its first element.
