### PR TITLE
storage/tscache: Pick up andy-kimball/arenaskl fix

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -143,11 +143,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:dfe2c5eadcbaf622a726116baf37582aa82fa8d364f05e168b58fbe96551832d"
+  digest = "1:caed868e37c6cda382a217d8ad4f55da579e1a1d046836de57f11a569e383443"
   name = "github.com/andy-kimball/arenaskl"
   packages = ["."]
   pruneopts = "UT"
-  revision = "224761e552afe64db9d93004f8d5d3a686b89771"
+  revision = "6bf06cf57626e536063e9398a57dfe1417ed0799"
 
 [[projects]]
   digest = "1:66b3310cf22cdc96c35ef84ede4f7b9b370971c4025f394c89a2638729653b11"

--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -374,7 +374,7 @@ func (s *intervalSkl) frontPage() *sklPage {
 // pushNewPage prepends a new empty page to the front of the pages list. It
 // accepts an optional arena argument to facilitate re-use.
 func (s *intervalSkl) pushNewPage(maxWallTime int64, arena *arenaskl.Arena) {
-	if arena != nil && arena.Size() == s.pageSize {
+	if arena != nil {
 		// Re-use the provided arena, if possible.
 		arena.Reset()
 	} else {

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -1218,10 +1218,10 @@ func BenchmarkIntervalSklAddAndLookup(b *testing.B) {
 					rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 
 					for n := 0; n < b.N/parallel; n++ {
-						readFrac := rng.Int31()
+						readFrac := rng.Int31n(10)
 						keyNum := rng.Int31n(max)
 
-						if (readFrac % 10) < int32(i) {
+						if readFrac < int32(i) {
 							key := []byte(fmt.Sprintf("%020d", keyNum))
 							s.LookupTimestamp(key)
 						} else {


### PR DESCRIPTION
Fixes #31624.
Fixes #35557.

This commit picks up andy-kimball/arenaskl#4.

I strongly suspect that the uint32 overflow fixed in that PR was the
cause of the two index out of bounds panics. See that commit for more
details.

The PR also fixes a bug in memory recylcling within the tscache. I confirmed
on adriatic that over 900 64MB arenas had been allocated since it was last
wiped.