### PR TITLE
build: reject builds with go 1.12.

### DIFF
--- a/build/go-version-check.sh
+++ b/build/go-version-check.sh
@@ -26,3 +26,9 @@ if (( version_major != required_version_major )) || (( version_minor < minimum_v
   echo "go$required_version_major.$minimum_version_minor+ required (detected go$version)" >&2
   exit 1
 fi
+
+# Pending resolution of #35637
+if [ $version_minor -ge 12 ]; then
+  echo "go 1.12+ is known to produce invalid crdb builds, see https://github.com/cockroachdb/cockroach/issues/35637" >&2
+  exit 1
+fi

--- a/build/teamcity-assert-clean.sh
+++ b/build/teamcity-assert-clean.sh
@@ -10,6 +10,7 @@ if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
   git status >&2 || true
   git diff -a >&2 || true
   echo "Nuking build cruft. Please teach this build to clean up after itself." >&2
-  run docker run --volume="$root:/nuke" --workdir="/nuke" golang:stretch /bin/bash -c "git clean -ffdx ; git submodule foreach --recursive git clean -xffd" >&2
+  # Using golang:1.11.5-stretch instead of golang:stretch because of #35637.
+  run docker run --volume="$root:/nuke" --workdir="/nuke" golang:1.11.5-stretch /bin/bash -c "git clean -ffdx ; git submodule foreach --recursive git clean -xffd" >&2
   exit 1
 fi

--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -26,11 +26,12 @@ tc_start_block "Test archive"
 # NB: This docker container runs as root. Be sure to mount any bind volumes as
 # read-only to avoid creating root-owned directories and files on the host
 # machine.
+# NB: Using golang:1.11.5-stretch instead of golang:stretch because of #35637.
 run docker run \
   --rm \
   --volume="$(cd "$(dirname "$0")" && pwd):/work:ro" \
   --workdir="/work" \
-  golang:stretch ./verify-archive.sh
+  golang:1.11.5-stretch ./verify-archive.sh
 tc_end_block "Test archive"
 
 tc_start_block "Clean up"


### PR DESCRIPTION
Informs #35637

We need this patch because people (eg. brew) are trying to build crdb with 1.12.

Release note (build change): CockroachDB will provisionally refuse to build with
go 1.12, as this is known to produce incorrect code inside CockroachDB.