### PR TITLE
exec: Col{Batch,Vec} -> coldata.{Batch,Vec}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -738,7 +738,7 @@ DOCGEN_TARGETS := bin/.docgen_bnfs bin/.docgen_functions
 EXECGEN_TARGETS = \
   pkg/sql/exec/any_not_null_agg.eg.go \
   pkg/sql/exec/avg_agg.eg.go \
-  pkg/sql/exec/colvec.eg.go \
+  pkg/sql/exec/coldata/vec.eg.go \
   pkg/sql/exec/distinct.eg.go \
   pkg/sql/exec/hashjoiner.eg.go \
   pkg/sql/exec/mergejoiner.eg.go \
@@ -1391,7 +1391,7 @@ $(SETTINGS_DOC_PAGE): $(settings-doc-gen)
 
 pkg/sql/exec/any_not_null_agg.eg.go: pkg/sql/exec/any_not_null_agg_tmpl.go
 pkg/sql/exec/avg_agg.eg.go: pkg/sql/exec/avg_agg_tmpl.go
-pkg/sql/exec/colvec.eg.go: pkg/sql/exec/colvec_tmpl.go
+pkg/sql/exec/coldata/vec.eg.go: pkg/sql/exec/coldata/vec_tmpl.go
 pkg/sql/exec/distinct.eg.go: pkg/sql/exec/distinct_tmpl.go
 pkg/sql/exec/hashjoiner.eg.go: pkg/sql/exec/hashjoiner_tmpl.go
 pkg/sql/exec/mergejoiner.eg.go: pkg/sql/exec/mergejoiner_tmpl.go

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/pkg/errors"
@@ -33,7 +33,7 @@ import (
 // for. The input key will also be mutated if matches is false.
 // See the analog in sqlbase/index_encoding.go.
 func DecodeIndexKeyToCols(
-	vecs []exec.ColVec,
+	vecs []coldata.Vec,
 	idx uint16,
 	desc *sqlbase.ImmutableTableDescriptor,
 	index *sqlbase.IndexDescriptor,
@@ -121,7 +121,7 @@ func DecodeIndexKeyToCols(
 // encoding.Ascending.
 // See the analog in sqlbase/index_encoding.go.
 func DecodeKeyValsToCols(
-	vecs []exec.ColVec,
+	vecs []coldata.Vec,
 	idx uint16,
 	indexColIdx []int,
 	types []sqlbase.ColumnType,
@@ -136,7 +136,7 @@ func DecodeKeyValsToCols(
 		var err error
 		i := indexColIdx[j]
 		if i == -1 {
-			// Don't need the col - skip it.
+			// Don't need the coldata - skip it.
 			key, err = skipTableKey(&types[j], key, enc)
 		} else {
 			key, err = decodeTableKeyToCol(vecs[i], idx, &types[j], key, enc)
@@ -149,10 +149,10 @@ func DecodeKeyValsToCols(
 }
 
 // decodeTableKeyToCol decodes a value encoded by EncodeTableKey, writing the result
-// to the idx'th slot of the input exec.ColVec.
+// to the idx'th slot of the input exec.Vec.
 // See the analog, DecodeTableKey, in
 func decodeTableKeyToCol(
-	vec exec.ColVec,
+	vec coldata.Vec,
 	idx uint16,
 	valType *sqlbase.ColumnType,
 	key []byte,
@@ -283,12 +283,12 @@ func skipTableKey(
 }
 
 // UnmarshalColumnValueToCol decodes the value from a roachpb.Value using the
-// type expected by the column, writing into the input ColVec at the given row
+// type expected by the column, writing into the input Vec at the given row
 // idx. An error is returned if the value's type does
 // not match the column's type.
 // See the analog, UnmarshalColumnValue, in sqlbase/column_type_encoding.go
 func UnmarshalColumnValueToCol(
-	vec exec.ColVec, idx uint16, typ sqlbase.ColumnType, value roachpb.Value,
+	vec coldata.Vec, idx uint16, typ sqlbase.ColumnType, value roachpb.Value,
 ) error {
 	if value.RawBytes == nil {
 		vec.SetNull(idx)

--- a/pkg/sql/colencoding/value_encoding.go
+++ b/pkg/sql/colencoding/value_encoding.go
@@ -15,17 +15,17 @@
 package colencoding
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/pkg/errors"
 )
 
 // DecodeTableValueToCol decodes a value encoded by EncodeTableValue, writing
-// the result to the idx'th position of the input exec.ColVec.
+// the result to the idx'th position of the input exec.Vec.
 // See the analog in sqlbase/column_type_encoding.go.
 func DecodeTableValueToCol(
-	vec exec.ColVec,
+	vec coldata.Vec,
 	idx uint16,
 	typ encoding.Type,
 	dataOffset int,
@@ -47,7 +47,7 @@ func DecodeTableValueToCol(
 // decodeUntaggedDatum is used to decode a Datum whose type is known,
 // and which doesn't have a value tag (either due to it having been
 // consumed already or not having one in the first place). It writes the result
-// to the idx'th position of the input exec.ColVec.
+// to the idx'th position of the input exec.Vec.
 //
 // This is used to decode datums encoded using value encoding.
 //
@@ -55,7 +55,7 @@ func DecodeTableValueToCol(
 // the tag directly.
 // See the analog in sqlbase/column_type_encoding.go.
 func decodeUntaggedDatumToCol(
-	vec exec.ColVec, idx uint16, t *sqlbase.ColumnType, buf []byte,
+	vec coldata.Vec, idx uint16, t *sqlbase.ColumnType, buf []byte,
 ) ([]byte, error) {
 	var err error
 	switch t.SemanticType {

--- a/pkg/sql/colencoding/value_encoding_test.go
+++ b/pkg/sql/colencoding/value_encoding_test.go
@@ -18,8 +18,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types/conv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -36,7 +37,7 @@ func TestDecodeTableValueToCol(t *testing.T) {
 	typs := make([]types.T, nCols)
 	for i := 0; i < nCols; i++ {
 		ct := sqlbase.RandColumnType(rng)
-		et := types.FromColumnType(ct)
+		et := conv.FromColumnType(ct)
 		if et == types.Unhandled {
 			i--
 			continue
@@ -52,7 +53,7 @@ func TestDecodeTableValueToCol(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	batch := exec.NewMemBatchWithSize(typs, 1)
+	batch := coldata.NewMemBatchWithSize(typs, 1)
 	for i := 0; i < nCols; i++ {
 		typeOffset, dataOffset, _, typ, err := encoding.DecodeValueTag(buf)
 		fmt.Println(typ)

--- a/pkg/sql/distsqlrun/colbatch_scan.go
+++ b/pkg/sql/distsqlrun/colbatch_scan.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -48,7 +49,7 @@ func (s *colBatchScan) Init() {
 	}
 }
 
-func (s *colBatchScan) Next() exec.ColBatch {
+func (s *colBatchScan) Next() coldata.Batch {
 	bat, err := s.rf.NextBatch(s.ctx)
 	if err != nil {
 		panic(err)

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types/conv"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -130,7 +131,7 @@ func newColOperator(
 				return nil, errors.New("unsorted aggregation not supported")
 			}
 			groupCols.Add(int(col))
-			groupTyps[i] = types.FromColumnType(spec.Input[0].ColumnTypes[col])
+			groupTyps[i] = conv.FromColumnType(spec.Input[0].ColumnTypes[col])
 		}
 		if !orderedCols.SubsetOf(groupCols) {
 			return nil, pgerror.NewAssertionErrorf("ordered cols must be a subset of grouping cols")
@@ -151,7 +152,7 @@ func newColOperator(
 			}
 			aggTyps[i] = make([]types.T, len(agg.ColIdx))
 			for j, colIdx := range agg.ColIdx {
-				aggTyps[i][j] = types.FromColumnType(spec.Input[0].ColumnTypes[colIdx])
+				aggTyps[i][j] = conv.FromColumnType(spec.Input[0].ColumnTypes[colIdx])
 			}
 			aggCols[i] = agg.ColIdx
 			aggFns[i] = agg.Func
@@ -194,7 +195,7 @@ func newColOperator(
 		}
 
 		columnTypes = spec.Input[0].ColumnTypes
-		typs := types.FromColumnTypes(columnTypes)
+		typs := conv.FromColumnTypes(columnTypes)
 		op, err = exec.NewOrderedDistinct(inputs[0], core.Distinct.OrderedColumns, typs)
 
 	case core.HashJoiner != nil:
@@ -206,8 +207,8 @@ func newColOperator(
 			return nil, errors.New("can't plan hash join with on expressions")
 		}
 
-		leftTypes := types.FromColumnTypes(spec.Input[0].ColumnTypes)
-		rightTypes := types.FromColumnTypes(spec.Input[1].ColumnTypes)
+		leftTypes := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
+		rightTypes := conv.FromColumnTypes(spec.Input[1].ColumnTypes)
 
 		nLeftCols := uint32(len(leftTypes))
 		nRightCols := uint32(len(rightTypes))
@@ -260,8 +261,8 @@ func newColOperator(
 			return nil, errors.New("multi column merge join is still unsupported")
 		}
 
-		leftTypes := types.FromColumnTypes(spec.Input[0].ColumnTypes)
-		rightTypes := types.FromColumnTypes(spec.Input[1].ColumnTypes)
+		leftTypes := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
+		rightTypes := conv.FromColumnTypes(spec.Input[1].ColumnTypes)
 
 		nLeftCols := uint32(len(leftTypes))
 		nRightCols := uint32(len(rightTypes))
@@ -350,12 +351,12 @@ func newColOperator(
 		}
 		if core.Sorter.OrderingMatchLen > 0 {
 			op, err = exec.NewSortChunks(inputs[0],
-				types.FromColumnTypes(spec.Input[0].ColumnTypes),
+				conv.FromColumnTypes(spec.Input[0].ColumnTypes),
 				core.Sorter.OutputOrdering.Columns,
 				int(core.Sorter.OrderingMatchLen))
 		} else {
 			op, err = exec.NewSorter(inputs[0],
-				types.FromColumnTypes(spec.Input[0].ColumnTypes),
+				conv.FromColumnTypes(spec.Input[0].ColumnTypes),
 				core.Sorter.OutputOrdering.Columns)
 		}
 

--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -46,8 +47,8 @@ type materializer struct {
 	// curIdx represents the current index into the column batch: the next row the
 	// materializer will emit.
 	curIdx uint16
-	// batch is the current ColBatch the materializer is processing.
-	batch exec.ColBatch
+	// batch is the current Batch the materializer is processing.
+	batch coldata.Batch
 
 	// row is the memory used for the output row.
 	row sqlbase.EncDatumRow

--- a/pkg/sql/exec/any_not_null_agg_tmpl.go
+++ b/pkg/sql/exec/any_not_null_agg_tmpl.go
@@ -25,6 +25,7 @@ package exec
 
 import (
 	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/pkg/errors"
 )
@@ -70,7 +71,7 @@ type anyNotNull_TYPEAgg struct {
 	curIdx int
 }
 
-func (a *anyNotNull_TYPEAgg) Init(groups []bool, vec ColVec) {
+func (a *anyNotNull_TYPEAgg) Init(groups []bool, vec coldata.Vec) {
 	a.groups = groups
 	a.vec = vec._TemplateType()
 	a.Reset()
@@ -90,7 +91,7 @@ func (a *anyNotNull_TYPEAgg) SetOutputIndex(idx int) {
 	}
 }
 
-func (a *anyNotNull_TYPEAgg) Compute(b ColBatch, inputIdxs []uint32) {
+func (a *anyNotNull_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	if a.done {
 		return
 	}

--- a/pkg/sql/exec/avg_agg_tmpl.go
+++ b/pkg/sql/exec/avg_agg_tmpl.go
@@ -25,6 +25,7 @@ package exec
 
 import (
 	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
@@ -80,7 +81,7 @@ type avg_TYPEAgg struct {
 
 var _ aggregateFunc = &avg_TYPEAgg{}
 
-func (a *avg_TYPEAgg) Init(groups []bool, v ColVec) {
+func (a *avg_TYPEAgg) Init(groups []bool, v coldata.Vec) {
 	a.groups = groups
 	a.scratch.vec = v._TemplateType()
 	a.scratch.groupSums = make([]_GOTYPE, len(a.scratch.vec))
@@ -110,7 +111,7 @@ func (a *avg_TYPEAgg) SetOutputIndex(idx int) {
 	}
 }
 
-func (a *avg_TYPEAgg) Compute(b ColBatch, inputIdxs []uint32) {
+func (a *avg_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	if a.done {
 		return
 	}

--- a/pkg/sql/exec/bool_vec_to_sel.go
+++ b/pkg/sql/exec/bool_vec_to_sel.go
@@ -14,6 +14,8 @@
 
 package exec
 
+import "github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+
 // boolVecToSelOp transforms a boolean column into a selection vector by adding
 // an index to the selection for each true value in the boolean column.
 type boolVecToSelOp struct {
@@ -26,9 +28,9 @@ type boolVecToSelOp struct {
 
 var _ Operator = &boolVecToSelOp{}
 
-var zeroBoolVec = make([]bool, ColBatchSize)
+var zeroBoolVec = make([]bool, coldata.BatchSize)
 
-func (p *boolVecToSelOp) Next() ColBatch {
+func (p *boolVecToSelOp) Next() coldata.Batch {
 	// Loop until we have non-zero amount of output to return, or our input's been
 	// exhausted.
 	for {

--- a/pkg/sql/exec/coalescer_test.go
+++ b/pkg/sql/exec/coalescer_test.go
@@ -18,12 +18,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
 
 func TestCoalescer(t *testing.T) {
 	// Large tuple number for coalescing.
-	nRows := ColBatchSize*3 + 7
+	nRows := coldata.BatchSize*3 + 7
 	large := make(tuples, nRows)
 	largeTypes := []types.T{types.Int64}
 
@@ -72,7 +73,7 @@ func TestCoalescer(t *testing.T) {
 
 func BenchmarkCoalescer(b *testing.B) {
 	// The input operator to the coalescer returns a batch of random size from [1,
-	// ColBatchSize) each time.
+	// col.BatchSize) each time.
 	nCols := 4
 	sourceTypes := make([]types.T, nCols)
 
@@ -80,18 +81,18 @@ func BenchmarkCoalescer(b *testing.B) {
 		sourceTypes[colIdx] = types.Int64
 	}
 
-	batch := NewMemBatch(sourceTypes)
+	batch := coldata.NewMemBatch(sourceTypes)
 
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		col := batch.ColVec(colIdx).Int64()
-		for i := 0; i < ColBatchSize; i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			col[i] = int64(i)
 		}
 	}
 
 	for _, nBatches := range []int{1 << 1, 1 << 2, 1 << 4, 1 << 8, 1 << 12, 1 << 16} {
-		b.Run(fmt.Sprintf("rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
-			b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols))
+		b.Run(fmt.Sprintf("rows=%d", nBatches*coldata.BatchSize), func(b *testing.B) {
+			b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				source := newRandomLengthBatchSource(batch)

--- a/pkg/sql/exec/coldata/batch.go
+++ b/pkg/sql/exec/coldata/batch.go
@@ -12,55 +12,55 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package exec
+package coldata
 
 import "github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 
-// ColBatch is the type that columnar operators receive and produce. It
+// Batch is the type that columnar operators receive and produce. It
 // represents a set of column vectors (partial data columns) as well as
 // metadata about a batch, like the selection vector (which rows in the column
 // batch are selected).
-type ColBatch interface {
+type Batch interface {
 	// Length returns the number of values in the columns in the batch.
 	Length() uint16
 	// SetLength sets the number of values in the columns in the batch.
 	SetLength(uint16)
 	// Width returns the number of columns in the batch.
 	Width() int
-	// ColVec returns the ith ColVec in this batch.
-	ColVec(i int) ColVec
+	// Vec returns the ith Vec in this batch.
+	ColVec(i int) Vec
 	// ColVecs returns all of the underlying ColVecs in this batch.
-	ColVecs() []ColVec
+	ColVecs() []Vec
 	// Selection, if not nil, returns the selection vector on this batch: a
 	// densely-packed list of the indices in each column that have not been
 	// filtered out by a previous step.
 	Selection() []uint16
 	// SetSelection sets whether this batch is using its selection vector or not.
 	SetSelection(bool)
-	// AppendCol appends a ColVec with the specified type to this batch.
+	// AppendCol appends a Vec with the specified type to this batch.
 	AppendCol(types.T)
 }
 
-var _ ColBatch = &memBatch{}
+var _ Batch = &memBatch{}
 
-// ColBatchSize is the maximum number of tuples that fit in a column batch.
+// BatchSize is the maximum number of tuples that fit in a column batch.
 // TODO(jordan): tune
-const ColBatchSize = 1024
+const BatchSize = 1024
 
-// NewMemBatch allocates a new in-memory ColBatch.
+// NewMemBatch allocates a new in-memory Batch.
 // TODO(jordan): pool these allocations.
-func NewMemBatch(types []types.T) ColBatch {
-	return NewMemBatchWithSize(types, ColBatchSize)
+func NewMemBatch(types []types.T) Batch {
+	return NewMemBatchWithSize(types, BatchSize)
 }
 
-// NewMemBatchWithSize allocates a new in-memory ColBatch with the given column
+// NewMemBatchWithSize allocates a new in-memory Batch with the given column
 // size. Use for operators that have a precisely-sized output batch.
-func NewMemBatchWithSize(types []types.T, size int) ColBatch {
+func NewMemBatchWithSize(types []types.T, size int) Batch {
 	b := &memBatch{}
-	b.b = make([]ColVec, len(types))
+	b.b = make([]Vec, len(types))
 
 	for i, t := range types {
-		b.b[i] = newMemColumn(t, size)
+		b.b[i] = NewMemColumn(t, size)
 	}
 	b.sel = make([]uint16, size)
 
@@ -71,7 +71,7 @@ type memBatch struct {
 	// length of batch or sel in tuples
 	n uint16
 	// slice of columns in this batch.
-	b      []ColVec
+	b      []Vec
 	useSel bool
 	// if useSel is true, a selection vector from upstream. a selection vector is
 	// a list of selected column indexes in this memBatch's columns.
@@ -86,11 +86,11 @@ func (m *memBatch) Width() int {
 	return len(m.b)
 }
 
-func (m *memBatch) ColVec(i int) ColVec {
+func (m *memBatch) ColVec(i int) Vec {
 	return m.b[i]
 }
 
-func (m *memBatch) ColVecs() []ColVec {
+func (m *memBatch) ColVecs() []Vec {
 	return m.b
 }
 
@@ -110,37 +110,5 @@ func (m *memBatch) SetLength(n uint16) {
 }
 
 func (m *memBatch) AppendCol(t types.T) {
-	m.b = append(m.b, newMemColumn(t, ColBatchSize))
-}
-
-// projectingBatch is a ColBatch that applies a simple projection to another,
-// underlying batch, discarding all columns but the ones in its projection
-// slice, in order.
-type projectingBatch struct {
-	ColBatch
-
-	projection []uint32
-}
-
-func newProjectionBatch(projection []uint32) *projectingBatch {
-	return &projectingBatch{
-		projection: projection,
-	}
-}
-
-func (b *projectingBatch) ColVec(i int) ColVec {
-	return b.ColBatch.ColVec(int(b.projection[i]))
-}
-
-func (b *projectingBatch) ColVecs() []ColVec {
-	panic("projectingBatch doesn't support ColVecs()")
-}
-
-func (b *projectingBatch) Width() int {
-	return len(b.projection)
-}
-
-func (b *projectingBatch) AppendCol(t types.T) {
-	b.ColBatch.AppendCol(t)
-	b.projection = append(b.projection, uint32(b.ColBatch.Width())-1)
+	m.b = append(m.b, NewMemColumn(t, BatchSize))
 }

--- a/pkg/sql/exec/coldata/dep_test.go
+++ b/pkg/sql/exec/coldata/dep_test.go
@@ -1,0 +1,34 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package coldata
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestNoLinkForbidden(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	buildutil.VerifyNoImports(t,
+		"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata", true,
+		[]string{
+			"github.com/cockroachdb/cockroach/pkg/sql/sqlbase",
+			"github.com/cockroachdb/cockroach/pkg/sql/sem/tree",
+		}, nil,
+	)
+}

--- a/pkg/sql/exec/coldata/vec.go
+++ b/pkg/sql/exec/coldata/vec.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package exec
+package coldata
 
 import (
 	"fmt"
@@ -24,9 +24,9 @@ import (
 // column is an interface that represents a raw array of a Go native type.
 type column interface{}
 
-// ColVec is an interface that represents a column vector that's accessible by
+// Vec is an interface that represents a column vector that's accessible by
 // Go native types.
-type ColVec interface {
+type Vec interface {
 	Nulls
 
 	// TODO(jordan): is a bitmap or slice of bools better?
@@ -50,7 +50,7 @@ type ColVec interface {
 	// Decimal returns an apd.Decimal slice.
 	Decimal() []apd.Decimal
 
-	// Col returns the raw, typeless backing storage for this ColVec.
+	// Col returns the raw, typeless backing storage for this Vec.
 	Col() interface{}
 
 	// SetCol sets the member column (in the case of mutable columns).
@@ -60,54 +60,54 @@ type ColVec interface {
 	// Do not call this from normal code - it'll always panic.
 	_TemplateType() []interface{}
 
-	// Append appends fromLength elements of the given ColVec to toLength
-	// elements of this ColVec, assuming that both ColVecs are of type colType.
-	Append(vec ColVec, colType types.T, toLength uint64, fromLength uint16)
+	// Append appends fromLength elements of the given Vec to toLength
+	// elements of this Vec, assuming that both Vecs are of type colType.
+	Append(vec Vec, colType types.T, toLength uint64, fromLength uint16)
 
 	// AppendSlice appends vec[srcStartIdx:srcEndIdx] elements to
-	// this ColVec starting at destStartIdx.
-	AppendSlice(vec ColVec, colType types.T, destStartIdx uint64, srcStartIdx uint16, srcEndIdx uint16)
+	// this Vec starting at destStartIdx.
+	AppendSlice(vec Vec, colType types.T, destStartIdx uint64, srcStartIdx uint16, srcEndIdx uint16)
 
-	// AppendWithSel appends into itself another column vector from a ColBatch with
-	// maximum size of ColBatchSize, filtered by the given selection vector.
-	AppendWithSel(vec ColVec, sel []uint16, batchSize uint16, colType types.T, toLength uint64)
+	// AppendWithSel appends into itself another column vector from a Batch with
+	// maximum size of BatchSize, filtered by the given selection vector.
+	AppendWithSel(vec Vec, sel []uint16, batchSize uint16, colType types.T, toLength uint64)
 
-	// AppendSliceWithSel appends srcEndIdx - srcStartIdx elements to this ColVec starting
+	// AppendSliceWithSel appends srcEndIdx - srcStartIdx elements to this Vec starting
 	// at destStartIdx. These elements come from vec, filtered by the selection
 	// vector sel.
-	AppendSliceWithSel(vec ColVec, colType types.T, destStartIdx uint64, srcStartIdx uint16, srcEndIdx uint16, sel []uint16)
+	AppendSliceWithSel(vec Vec, colType types.T, destStartIdx uint64, srcStartIdx uint16, srcEndIdx uint16, sel []uint16)
 
-	// Copy copies src[srcStartIdx:srcEndIdx] into this ColVec.
-	Copy(src ColVec, srcStartIdx, srcEndIdx uint64, typ types.T)
+	// Copy copies src[srcStartIdx:srcEndIdx] into this Vec.
+	Copy(src Vec, srcStartIdx, srcEndIdx uint64, typ types.T)
 
-	// CopyWithSelInt64 copies vec, filtered by sel, into this ColVec. It replaces
-	// the contents of this ColVec.
-	CopyWithSelInt64(vec ColVec, sel []uint64, nSel uint16, colType types.T)
+	// CopyWithSelInt64 copies vec, filtered by sel, into this Vec. It replaces
+	// the contents of this Vec.
+	CopyWithSelInt64(vec Vec, sel []uint64, nSel uint16, colType types.T)
 
-	// CopyWithSelInt16 copies vec, filtered by sel, into this ColVec. It replaces
-	// the contents of this ColVec.
-	CopyWithSelInt16(vec ColVec, sel []uint16, nSel uint16, colType types.T)
+	// CopyWithSelInt16 copies vec, filtered by sel, into this Vec. It replaces
+	// the contents of this Vec.
+	CopyWithSelInt16(vec Vec, sel []uint16, nSel uint16, colType types.T)
 
 	// CopyWithSelAndNilsInt64 copies vec, filtered by sel, unless nils is set,
-	// into ColVec. It replaces the contents of this ColVec.
-	CopyWithSelAndNilsInt64(vec ColVec, sel []uint64, nSel uint16, nils []bool, colType types.T)
+	// into Vec. It replaces the contents of this Vec.
+	CopyWithSelAndNilsInt64(vec Vec, sel []uint64, nSel uint16, nils []bool, colType types.T)
 
-	// Slice returns a new ColVec representing a slice of the current ColVec from
+	// Slice returns a new Vec representing a slice of the current Vec from
 	// [start, end).
-	Slice(colType types.T, start uint64, end uint64) ColVec
+	Slice(colType types.T, start uint64, end uint64) Vec
 
-	// PrettyValueAt returns a "pretty"value for the idx'th value in this ColVec.
+	// PrettyValueAt returns a "pretty"value for the idx'th value in this Vec.
 	// It uses the reflect package and is not suitable for calling in hot paths.
 	PrettyValueAt(idx uint16, colType types.T) string
 
-	// ExtendNulls extends the null member of a ColVec to accommodate toAppend tuples
+	// ExtendNulls extends the null member of a Vec to accommodate toAppend tuples
 	// and sets the right indexes to null, needed when the length of the underlying column changes.
-	ExtendNulls(vec ColVec, destStartIdx uint64, srcStartIdx uint16, toAppend uint16)
+	ExtendNulls(vec Vec, destStartIdx uint64, srcStartIdx uint16, toAppend uint16)
 
-	// ExtendNullsWithSel extends the null member of a ColVec to accommodate toAppend tuples
+	// ExtendNullsWithSel extends the null member of a Vec to accommodate toAppend tuples
 	// and sets the right indexes to null with the selection vector in mind, needed when the
 	// length of the underlying column changes.
-	ExtendNullsWithSel(vec ColVec, destStartIdx uint64, srcStartIdx uint16, toAppend uint16, sel []uint16)
+	ExtendNullsWithSel(vec Vec, destStartIdx uint64, srcStartIdx uint16, toAppend uint16, sel []uint16)
 }
 
 // Nulls represents a list of potentially nullable values.
@@ -133,15 +133,15 @@ type Nulls interface {
 	SetNulls()
 }
 
-var _ ColVec = &memColumn{}
+var _ Vec = &memColumn{}
 
-// zeroedNulls is a zeroed out slice representing a bitmap of size ColBatchSize.
+// zeroedNulls is a zeroed out slice representing a bitmap of size BatchSize.
 // This is copied to efficiently clear a nulls slice.
-var zeroedNulls [(ColBatchSize-1)>>6 + 1]int64
+var zeroedNulls [(BatchSize-1)>>6 + 1]int64
 
-// filledNulls is a slice representing a bitmap of size ColBatchSize with every
+// filledNulls is a slice representing a bitmap of size BatchSize with every
 // single bit set.
-var filledNulls [(ColBatchSize-1)>>6 + 1]int64
+var filledNulls [(BatchSize-1)>>6 + 1]int64
 
 func init() {
 	// Initializes filledNulls to the desired slice.
@@ -150,7 +150,7 @@ func init() {
 	}
 }
 
-// memColumn is a simple pass-through implementation of ColVec that just casts
+// memColumn is a simple pass-through implementation of Vec that just casts
 // a generic interface{} to the proper type when requested.
 type memColumn struct {
 	col column
@@ -160,8 +160,8 @@ type memColumn struct {
 	hasNulls bool
 }
 
-// newMemColumn returns a new memColumn, initialized with a length.
-func newMemColumn(t types.T, n int) *memColumn {
+// NewMemColumn returns a new memColumn, initialized with a length.
+func NewMemColumn(t types.T, n int) Vec {
 	var nulls []int64
 	if n > 0 {
 		nulls = make([]int64, (n-1)>>6+1)

--- a/pkg/sql/exec/count.go
+++ b/pkg/sql/exec/count.go
@@ -14,7 +14,10 @@
 
 package exec
 
-import "github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
 
 // countOp is an operator that counts the number of input rows it receives,
 // consuming its entire input and outputting a batch with a single integer
@@ -23,7 +26,7 @@ import "github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 type countOp struct {
 	input Operator
 
-	internalBatch ColBatch
+	internalBatch coldata.Batch
 	done          bool
 	count         int64
 }
@@ -33,7 +36,7 @@ func NewCountOp(input Operator) Operator {
 	c := &countOp{
 		input: input,
 	}
-	c.internalBatch = NewMemBatchWithSize([]types.T{types.Int64}, 1)
+	c.internalBatch = coldata.NewMemBatchWithSize([]types.T{types.Int64}, 1)
 	return c
 }
 
@@ -45,7 +48,7 @@ func (c *countOp) Init() {
 	c.done = false
 }
 
-func (c *countOp) Next() ColBatch {
+func (c *countOp) Next() coldata.Batch {
 	if c.done {
 		c.internalBatch.SetLength(0)
 		return c.internalBatch

--- a/pkg/sql/exec/count_agg.go
+++ b/pkg/sql/exec/count_agg.go
@@ -14,6 +14,8 @@
 
 package exec
 
+import "github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+
 func newCountAgg() *countAgg {
 	return &countAgg{}
 }
@@ -26,7 +28,7 @@ type countAgg struct {
 	done   bool
 }
 
-func (a *countAgg) Init(groups []bool, vec ColVec) {
+func (a *countAgg) Init(groups []bool, vec coldata.Vec) {
 	a.groups = groups
 	a.vec = vec.Int64()
 	a.Reset()
@@ -48,7 +50,7 @@ func (a *countAgg) SetOutputIndex(idx int) {
 	}
 }
 
-func (a *countAgg) Compute(b ColBatch, _ []uint32) {
+func (a *countAgg) Compute(b coldata.Batch, _ []uint32) {
 	if a.done {
 		return
 	}

--- a/pkg/sql/exec/dep_test.go
+++ b/pkg/sql/exec/dep_test.go
@@ -1,0 +1,15 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec

--- a/pkg/sql/exec/deselector.go
+++ b/pkg/sql/exec/deselector.go
@@ -14,7 +14,10 @@
 
 package exec
 
-import "github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
 
 // deselectorOp consumes the input operator, and if resulting batches have a
 // selection vector, it coalesces them (meaning that tuples will be reordered
@@ -24,7 +27,7 @@ type deselectorOp struct {
 	input      Operator
 	inputTypes []types.T
 
-	output ColBatch
+	output coldata.Batch
 }
 
 var _ Operator = &deselectorOp{}
@@ -40,10 +43,10 @@ func NewDeselectorOp(input Operator, colTypes []types.T) Operator {
 
 func (p *deselectorOp) Init() {
 	p.input.Init()
-	p.output = NewMemBatch(p.inputTypes)
+	p.output = coldata.NewMemBatch(p.inputTypes)
 }
 
-func (p *deselectorOp) Next() ColBatch {
+func (p *deselectorOp) Next() coldata.Batch {
 	batch := p.input.Next()
 	if batch.Selection() == nil {
 		return batch

--- a/pkg/sql/exec/deselector_test.go
+++ b/pkg/sql/exec/deselector_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
 
@@ -80,19 +81,19 @@ func BenchmarkDeselector(b *testing.B) {
 		inputTypes[colIdx] = types.Int64
 	}
 
-	batch := NewMemBatch(inputTypes)
+	batch := coldata.NewMemBatch(inputTypes)
 
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		col := batch.ColVec(colIdx).Int64()
-		for i := 0; i < ColBatchSize; i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			col[i] = int64(i)
 		}
 	}
 	for _, probOfOmitting := range []float64{0.1, 0.9} {
-		sel, batchLen := generateSelectionVector(ColBatchSize, probOfOmitting)
+		sel, batchLen := generateSelectionVector(coldata.BatchSize, probOfOmitting)
 
 		for _, nBatches := range []int{1 << 1, 1 << 2, 1 << 4, 1 << 8} {
-			b.Run(fmt.Sprintf("rows=%d/after selection=%d", nBatches*ColBatchSize, nBatches*int(batchLen)), func(b *testing.B) {
+			b.Run(fmt.Sprintf("rows=%d/after selection=%d", nBatches*coldata.BatchSize, nBatches*int(batchLen)), func(b *testing.B) {
 				// We're measuring the amount of data that is not selected out.
 				b.SetBytes(int64(8 * nBatches * int(batchLen) * nCols))
 				batch.SetSelection(true)

--- a/pkg/sql/exec/distinct_test.go
+++ b/pkg/sql/exec/distinct_test.go
@@ -17,6 +17,7 @@ package exec
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
@@ -68,13 +69,13 @@ func TestSortedDistinct(t *testing.T) {
 func BenchmarkSortedDistinct(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 
-	batch := NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
+	batch := coldata.NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
 	aCol := batch.ColVec(1).Int64()
 	bCol := batch.ColVec(2).Int64()
 	lastA := int64(0)
 	lastB := int64(0)
-	for i := 0; i < ColBatchSize; i++ {
-		// 1/4 chance of changing each distinct col.
+	for i := 0; i < coldata.BatchSize; i++ {
+		// 1/4 chance of changing each distinct coldata.
 		if rng.Float64() > 0.75 {
 			lastA++
 		}
@@ -84,7 +85,7 @@ func BenchmarkSortedDistinct(b *testing.B) {
 		aCol[i] = lastA
 		bCol[i] = lastB
 	}
-	batch.SetLength(ColBatchSize)
+	batch.SetLength(coldata.BatchSize)
 	source := newRepeatableBatchSource(batch)
 	source.Init()
 
@@ -94,7 +95,7 @@ func BenchmarkSortedDistinct(b *testing.B) {
 	}
 
 	// don't count the artificial zeroOp'd column in the throughput
-	b.SetBytes(int64(8 * ColBatchSize * 3))
+	b.SetBytes(int64(8 * coldata.BatchSize * 3))
 	for i := 0; i < b.N; i++ {
 		distinct.Next()
 	}

--- a/pkg/sql/exec/execgen/cmd/execgen/colvec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/colvec_gen.go
@@ -24,7 +24,7 @@ import (
 )
 
 func genColvec(wr io.Writer) error {
-	d, err := ioutil.ReadFile("pkg/sql/exec/colvec_tmpl.go")
+	d, err := ioutil.ReadFile("pkg/sql/exec/coldata/vec_tmpl.go")
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func genColvec(wr io.Writer) error {
 	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
 
 	// Now, generate the op, from the template.
-	tmpl, err := template.New("colvec_op").Parse(s)
+	tmpl, err := template.New("vec_op").Parse(s)
 	if err != nil {
 		return err
 	}
@@ -45,5 +45,5 @@ func genColvec(wr io.Writer) error {
 	return tmpl.Execute(wr, comparisonOpToOverloads[tree.NE])
 }
 func init() {
-	registerGenerator(genColvec, "colvec.eg.go")
+	registerGenerator(genColvec, "vec.eg.go")
 }

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -28,7 +28,9 @@ import (
 	"bytes"
 
 	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types/conv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/pkg/errors"
@@ -52,22 +54,22 @@ type {{template "opRConstName" .}} struct {
 	outputIdx int
 }
 
-func (p *{{template "opRConstName" .}}) Next() ColBatch {
+func (p *{{template "opRConstName" .}}) Next() coldata.Batch {
 	batch := p.input.Next()
 	if p.outputIdx == batch.Width() {
 		batch.AppendCol(types.{{.RetTyp}})
 	}
-	projCol := batch.ColVec(p.outputIdx).{{.RetTyp}}()[:ColBatchSize]
-	col := batch.ColVec(p.colIdx).{{.LTyp}}()[:ColBatchSize]
+	projCol := batch.ColVec(p.outputIdx).{{.RetTyp}}()[:coldata.BatchSize]
+	coldata := batch.ColVec(p.colIdx).{{.LTyp}}()[:coldata.BatchSize]
 	n := batch.Length()
 	if sel := batch.Selection(); sel != nil {
 		for _, i := range sel {
-			{{(.Assign "projCol[i]" "col[i]" "p.constArg")}}
+			{{(.Assign "projCol[i]" "coldata[i]" "p.constArg")}}
 		}
 	} else {
-		col = col[:n]
-		for i := range col {
-			{{(.Assign "projCol[i]" "col[i]" "p.constArg")}}
+		coldata = coldata[:n]
+		for i := range coldata {
+			{{(.Assign "projCol[i]" "coldata[i]" "p.constArg")}}
 		}
 	}
 	return batch
@@ -86,22 +88,22 @@ type {{template "opLConstName" .}} struct {
 	outputIdx int
 }
 
-func (p *{{template "opLConstName" .}}) Next() ColBatch {
+func (p *{{template "opLConstName" .}}) Next() coldata.Batch {
 	batch := p.input.Next()
 	if p.outputIdx == batch.Width() {
 		batch.AppendCol(types.{{.RetTyp}})
 	}
-	projCol := batch.ColVec(p.outputIdx).{{.RetTyp}}()[:ColBatchSize]
-	col := batch.ColVec(p.colIdx).{{.RTyp}}()[:ColBatchSize]
+	projCol := batch.ColVec(p.outputIdx).{{.RetTyp}}()[:coldata.BatchSize]
+	coldata := batch.ColVec(p.colIdx).{{.RTyp}}()[:coldata.BatchSize]
 	n := batch.Length()
 	if sel := batch.Selection(); sel != nil {
 		for _, i := range sel {
-			{{(.Assign "projCol[i]" "p.constArg" "col[i]")}}
+			{{(.Assign "projCol[i]" "p.constArg" "coldata[i]")}}
 		}
 	} else {
-		col = col[:n]
-		for i := range col {
-			{{(.Assign "projCol[i]" "p.constArg" "col[i]")}}
+		coldata = coldata[:n]
+		for i := range coldata {
+			{{(.Assign "projCol[i]" "p.constArg" "coldata[i]")}}
 		}
 	}
 	return batch
@@ -120,14 +122,14 @@ type {{template "opName" .}} struct {
 	outputIdx int
 }
 
-func (p *{{template "opName" .}}) Next() ColBatch {
+func (p *{{template "opName" .}}) Next() coldata.Batch {
 	batch := p.input.Next()
 	if p.outputIdx == batch.Width() {
 		batch.AppendCol(types.{{.RetTyp}})
 	}
-	projCol := batch.ColVec(p.outputIdx).{{.RetTyp}}()[:ColBatchSize]
-	col1 := batch.ColVec(p.col1Idx).{{.LTyp}}()[:ColBatchSize]
-	col2 := batch.ColVec(p.col2Idx).{{.RTyp}}()[:ColBatchSize]
+	projCol := batch.ColVec(p.outputIdx).{{.RetTyp}}()[:coldata.BatchSize]
+	col1 := batch.ColVec(p.col1Idx).{{.LTyp}}()[:coldata.BatchSize]
+	col2 := batch.ColVec(p.col2Idx).{{.RTyp}}()[:coldata.BatchSize]
 	n := batch.Length()
 	if sel := batch.Selection(); sel != nil {
 		for _, i := range sel {
@@ -162,11 +164,11 @@ func GetProjection{{if $left}}L{{else}}R{{end}}ConstOperator(
 	constArg tree.Datum,
   outputIdx int,
 ) (Operator, error) {
-	c, err := types.GetDatumToPhysicalFn(ct)(constArg)
+	c, err := conv.GetDatumToPhysicalFn(ct)(constArg)
 	if err != nil {
 		return nil, err
 	}
-	switch t := types.FromColumnType(ct); t {
+	switch t := conv.FromColumnType(ct); t {
 	{{range $typ, $overloads := $.TypToOverloads}}
 	case types.{{$typ}}:
 		switch op.(type) {
@@ -222,7 +224,7 @@ func GetProjectionOperator(
 	col2Idx int,
   outputIdx int,
 ) (Operator, error) {
-	switch t := types.FromColumnType(ct); t {
+	switch t := conv.FromColumnType(ct); t {
 	{{range $typ, $overloads := .TypToOverloads}}
 	case types.{{$typ}}:
 		switch op.(type) {

--- a/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/rowstovec_gen.go
@@ -21,6 +21,7 @@ import (
 	"text/template"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types/conv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
@@ -78,7 +79,7 @@ func genRowsToVec(wr io.Writer) error {
 		widths := getWidths(semanticType)
 		for _, width := range widths {
 			ct.Width = width
-			t := types.FromColumnType(ct)
+			t := conv.FromColumnType(ct)
 			if t == types.Unhandled {
 				continue
 			}
@@ -87,7 +88,7 @@ func genRowsToVec(wr io.Writer) error {
 			)
 		}
 		if widths == nil {
-			t := types.FromColumnType(ct)
+			t := conv.FromColumnType(ct)
 			if t == types.Unhandled {
 				continue
 			}

--- a/pkg/sql/exec/limit.go
+++ b/pkg/sql/exec/limit.go
@@ -14,12 +14,14 @@
 
 package exec
 
+import "github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+
 // limitOp is an operator that implements limit, returning only the first n
 // tuples from its input.
 type limitOp struct {
 	input Operator
 
-	internalBatch ColBatch
+	internalBatch coldata.Batch
 	limit         uint64
 
 	// seen is the number of tuples seen so far.
@@ -38,11 +40,11 @@ func NewLimitOp(input Operator, limit uint64) Operator {
 }
 
 func (c *limitOp) Init() {
-	c.internalBatch = NewMemBatch(nil)
+	c.internalBatch = coldata.NewMemBatch(nil)
 	c.input.Init()
 }
 
-func (c *limitOp) Next() ColBatch {
+func (c *limitOp) Next() coldata.Batch {
 	if c.done {
 		c.internalBatch.SetLength(0)
 		return c.internalBatch

--- a/pkg/sql/exec/mergejoiner_test.go
+++ b/pkg/sql/exec/mergejoiner_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
 
@@ -44,7 +45,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{0},
 			expected:        tuples{{1}, {2}, {3}, {4}},
 			expectedOutCols: []int{0},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:     "basic test, no out cols",
@@ -56,7 +57,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{},
 			expected:        tuples{{}, {}, {}, {}},
 			expectedOutCols: []int{},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:     "basic test, L missing",
@@ -68,7 +69,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{0},
 			expected:        tuples{{1}, {3}, {4}},
 			expectedOutCols: []int{0},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:     "basic test, R missing",
@@ -80,7 +81,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{0},
 			expected:        tuples{{1}, {3}, {4}},
 			expectedOutCols: []int{0},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:     "basic test, L duplicate",
@@ -92,7 +93,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{0},
 			expected:        tuples{{1}, {1}, {2}, {3}, {4}},
 			expectedOutCols: []int{0},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:     "basic test, R duplicate",
@@ -104,7 +105,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{0},
 			expected:        tuples{{1}, {1}, {2}, {3}, {4}},
 			expectedOutCols: []int{0},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:     "basic test, L+R duplicates",
@@ -116,7 +117,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{0},
 			expected:        tuples{{1}, {1}, {1}, {1}, {2}, {3}, {4}},
 			expectedOutCols: []int{0},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:     "basic test, L+R duplicate, multiple runs",
@@ -128,10 +129,10 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{0},
 			expected:        tuples{{1}, {1}, {2}, {2}, {2}, {3}, {4}},
 			expectedOutCols: []int{0},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
-			description:     "cross product test, batch size = 1024 (ColBatchSize)",
+			description:     "cross product test, batch size = 1024 (col.BatchSize)",
 			leftTypes:       []types.T{types.Int64},
 			rightTypes:      []types.T{types.Int64},
 			leftTuples:      tuples{{1}, {1}, {1}, {1}},
@@ -140,7 +141,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{0},
 			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
 			expectedOutCols: []int{0},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:     "cross product test, batch size = 4 (small even)",
@@ -188,7 +189,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{0, 1},
 			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
 			expectedOutCols: []int{0, 1, 2, 3},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:     "multi output column test, batch size = 1",
@@ -203,7 +204,7 @@ func TestMergeJoiner(t *testing.T) {
 			outputBatchSize: 1,
 		},
 		{
-			description:     "multi output column test, test output col projection",
+			description:     "multi output column test, test output coldata projection",
 			leftTypes:       []types.T{types.Int64, types.Int64},
 			rightTypes:      []types.T{types.Int64, types.Int64},
 			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
@@ -212,10 +213,10 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{0},
 			expected:        tuples{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
 			expectedOutCols: []int{0, 2},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
-			description:     "multi output column test, test output col projection",
+			description:     "multi output column test, test output coldata projection",
 			leftTypes:       []types.T{types.Int64, types.Int64},
 			rightTypes:      []types.T{types.Int64, types.Int64},
 			leftTuples:      tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
@@ -224,7 +225,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{1},
 			expected:        tuples{{10, 11}, {20, 12}, {30, 13}, {40, 14}},
 			expectedOutCols: []int{1, 3},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:     "multi output column test, L run",
@@ -236,7 +237,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{0, 1},
 			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {2, 21, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
 			expectedOutCols: []int{0, 1, 2, 3},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:     "multi output column test, L run, batch size = 1",
@@ -260,7 +261,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{0, 1},
 			expected:        tuples{{1, 10, 1, 11}, {1, 10, 1, 111}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
 			expectedOutCols: []int{0, 1, 2, 3},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:     "multi output column test, R run, batch size = 1",
@@ -284,7 +285,7 @@ func TestMergeJoiner(t *testing.T) {
 			rightOutCols:    []uint32{1},
 			expected:        tuples{{5, 4}, {2, 4}},
 			expectedOutCols: []int{3, 1},
-			outputBatchSize: ColBatchSize,
+			outputBatchSize: coldata.BatchSize,
 		},
 		{
 			description:  "multi output column test, batch size = 1 and runs (to test saved output), reordered out columns",
@@ -349,14 +350,14 @@ func TestMergeJoiner(t *testing.T) {
 // TestMergeJoinerMultiBatch creates one long input of a 1:1 join, and keeps track of the expected
 // output to make sure the join output is batched correctly.
 func TestMergeJoinerMultiBatch(t *testing.T) {
-	for _, groupSize := range []int{1, 2, ColBatchSize / 4, ColBatchSize / 2} {
+	for _, groupSize := range []int{1, 2, coldata.BatchSize / 4, coldata.BatchSize / 2} {
 		for _, numInputBatches := range []int{1, 2, 16} {
-			for _, outBatchSize := range []uint16{1, 16, ColBatchSize} {
+			for _, outBatchSize := range []uint16{1, 16, coldata.BatchSize} {
 				t.Run(fmt.Sprintf("groupSize=%d/numInputBatches=%d", groupSize, numInputBatches),
 					func(t *testing.T) {
-						nTuples := ColBatchSize * numInputBatches
+						nTuples := coldata.BatchSize * numInputBatches
 						typs := []types.T{types.Int64}
-						cols := []ColVec{newMemColumn(typs[0], nTuples)}
+						cols := []coldata.Vec{coldata.NewMemColumn(typs[0], nTuples)}
 						groups := cols[0].Int64()
 						for i := range groups {
 							groups[i] = int64(i)
@@ -407,13 +408,13 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 // TestMergeJoinerMultiBatchRuns creates one long input of a n:n join, and keeps track of the expected
 // count to make sure the join output is batched correctly.
 func TestMergeJoinerMultiBatchRuns(t *testing.T) {
-	for _, groupSize := range []int{ColBatchSize / 8, ColBatchSize / 4, ColBatchSize / 2} {
+	for _, groupSize := range []int{coldata.BatchSize / 8, coldata.BatchSize / 4, coldata.BatchSize / 2} {
 		for _, numInputBatches := range []int{1, 2, 16} {
 			t.Run(fmt.Sprintf("groupSize=%d/numInputBatches=%d", groupSize, numInputBatches),
 				func(t *testing.T) {
-					nTuples := ColBatchSize * numInputBatches
+					nTuples := coldata.BatchSize * numInputBatches
 					typs := []types.T{types.Int64}
-					cols := []ColVec{newMemColumn(typs[0], nTuples)}
+					cols := []coldata.Vec{coldata.NewMemColumn(typs[0], nTuples)}
 					groups := cols[0].Int64()
 					for i := range groups {
 						groups[i] = int64(i / groupSize)
@@ -453,8 +454,8 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 						i++
 					}
 
-					if count != groupSize*ColBatchSize*numInputBatches {
-						t.Fatalf("Found count %d, expected count %d", count, groupSize*ColBatchSize*numInputBatches)
+					if count != groupSize*coldata.BatchSize*numInputBatches {
+						t.Fatalf("Found count %d, expected count %d", count, groupSize*coldata.BatchSize*numInputBatches)
 					}
 				})
 		}
@@ -464,14 +465,14 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 // TestMergeJoinerLongMultiBatchCount creates one long input of a 1:1 join, and keeps track of the expected
 // count to make sure the join output is batched correctly.
 func TestMergeJoinerLongMultiBatchCount(t *testing.T) {
-	for _, groupSize := range []int{1, 2, ColBatchSize / 4, ColBatchSize / 2} {
+	for _, groupSize := range []int{1, 2, coldata.BatchSize / 4, coldata.BatchSize / 2} {
 		for _, numInputBatches := range []int{1, 2, 16} {
-			for _, outBatchSize := range []uint16{1, 16, ColBatchSize} {
+			for _, outBatchSize := range []uint16{1, 16, coldata.BatchSize} {
 				t.Run(fmt.Sprintf("groupSize=%d/numInputBatches=%d", groupSize, numInputBatches),
 					func(t *testing.T) {
-						nTuples := ColBatchSize * numInputBatches
+						nTuples := coldata.BatchSize * numInputBatches
 						typs := []types.T{types.Int64}
-						cols := []ColVec{newMemColumn(typs[0], nTuples)}
+						cols := []coldata.Vec{coldata.NewMemColumn(typs[0], nTuples)}
 						groups := cols[0].Int64()
 						for i := range groups {
 							groups[i] = int64(i)
@@ -509,13 +510,13 @@ func TestMergeJoinerLongMultiBatchCount(t *testing.T) {
 // TestMergeJoinerMultiBatchCountRuns creates one long input of a n:n join, and keeps track of the expected
 // count to make sure the join output is batched correctly.
 func TestMergeJoinerMultiBatchCountRuns(t *testing.T) {
-	for _, groupSize := range []int{ColBatchSize / 8, ColBatchSize / 4, ColBatchSize / 2} {
+	for _, groupSize := range []int{coldata.BatchSize / 8, coldata.BatchSize / 4, coldata.BatchSize / 2} {
 		for _, numInputBatches := range []int{1, 2, 16} {
 			t.Run(fmt.Sprintf("groupSize=%d/numInputBatches=%d", groupSize, numInputBatches),
 				func(t *testing.T) {
-					nTuples := ColBatchSize * numInputBatches
+					nTuples := coldata.BatchSize * numInputBatches
 					typs := []types.T{types.Int64}
-					cols := []ColVec{newMemColumn(typs[0], nTuples)}
+					cols := []coldata.Vec{coldata.NewMemColumn(typs[0], nTuples)}
 					groups := cols[0].Int64()
 					for i := range groups {
 						groups[i] = int64(i / groupSize)
@@ -541,23 +542,23 @@ func TestMergeJoinerMultiBatchCountRuns(t *testing.T) {
 					for b := a.Next(); b.Length() != 0; b = a.Next() {
 						count += int(b.Length())
 					}
-					if count != groupSize*ColBatchSize*numInputBatches {
-						t.Fatalf("Found count %d, expected count %d", count, groupSize*ColBatchSize*numInputBatches)
+					if count != groupSize*coldata.BatchSize*numInputBatches {
+						t.Fatalf("Found count %d, expected count %d", count, groupSize*coldata.BatchSize*numInputBatches)
 					}
 				})
 		}
 	}
 }
 
-func newBatchOfIntRows(nCols int, batch ColBatch) ColBatch {
+func newBatchOfIntRows(nCols int, batch coldata.Batch) coldata.Batch {
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		col := batch.ColVec(colIdx).Int64()
-		for i := 0; i < ColBatchSize; i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			col[i] = int64(i)
 		}
 	}
 
-	batch.SetLength(ColBatchSize)
+	batch.SetLength(coldata.BatchSize)
 
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		vec := batch.ColVec(colIdx)
@@ -566,15 +567,15 @@ func newBatchOfIntRows(nCols int, batch ColBatch) ColBatch {
 	return batch
 }
 
-func newBatchOfRepeatedIntRows(nCols int, batch ColBatch, numRepeats int) ColBatch {
+func newBatchOfRepeatedIntRows(nCols int, batch coldata.Batch, numRepeats int) coldata.Batch {
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		col := batch.ColVec(colIdx).Int64()
-		for i := 0; i < ColBatchSize; i++ {
+		for i := 0; i < coldata.BatchSize; i++ {
 			col[i] = int64((i + 1) / numRepeats)
 		}
 	}
 
-	batch.SetLength(ColBatchSize)
+	batch.SetLength(coldata.BatchSize)
 
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		vec := batch.ColVec(colIdx)
@@ -591,14 +592,14 @@ func BenchmarkMergeJoiner(b *testing.B) {
 		sourceTypes[colIdx] = types.Int64
 	}
 
-	batch := NewMemBatch(sourceTypes)
+	batch := coldata.NewMemBatch(sourceTypes)
 
 	// 1:1
 	for _, nBatches := range []int{1, 4, 16, 1024} {
-		b.Run(fmt.Sprintf("rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
-			// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+		b.Run(fmt.Sprintf("rows=%d", nBatches*coldata.BatchSize), func(b *testing.B) {
+			// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize (rows /
 			// batch) * nCols (number of columns / row) * 2 (number of sources).
-			b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols * 2))
+			b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols * 2))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				leftSource := newFiniteBatchSource(newBatchOfIntRows(nCols, batch), nBatches)
@@ -633,10 +634,10 @@ func BenchmarkMergeJoiner(b *testing.B) {
 
 	// left repeats
 	for _, nBatches := range []int{1, 4, 16, 1024} {
-		b.Run(fmt.Sprintf("oneSideRepeat-rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
-			// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+		b.Run(fmt.Sprintf("oneSideRepeat-rows=%d", nBatches*coldata.BatchSize), func(b *testing.B) {
+			// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize (rows /
 			// batch) * nCols (number of columns / row) * 2 (number of sources).
-			b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols * 2))
+			b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols * 2))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				leftSource := newFiniteBatchSource(newBatchOfRepeatedIntRows(nCols, batch, nBatches), nBatches)
@@ -671,10 +672,10 @@ func BenchmarkMergeJoiner(b *testing.B) {
 
 	// both repeats
 	for _, nBatches := range []int{1, 4, 16, 1024} {
-		b.Run(fmt.Sprintf("bothSidesRepeat-rows=%d", nBatches*ColBatchSize), func(b *testing.B) {
-			// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+		b.Run(fmt.Sprintf("bothSidesRepeat-rows=%d", nBatches*coldata.BatchSize), func(b *testing.B) {
+			// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize (rows /
 			// batch) * nCols (number of columns / row) * 2 (number of sources).
-			b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols * 2))
+			b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols * 2))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				leftSource := newFiniteBatchSource(newBatchOfRepeatedIntRows(nCols, batch, nBatches), nBatches)

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
 
@@ -47,9 +48,9 @@ var _ apd.Decimal
 
 // {{/*
 func _ADD_SLICE_TO_COLVEC_WITH_SEL(
-	t_dest ColVec,
+	t_dest coldata.Vec,
 	t_destStartIdx int,
-	t_src ColVec,
+	t_src coldata.Vec,
 	t_srcStartIdx int,
 	t_srcEndIdx int,
 	t_sel []uint16,
@@ -77,7 +78,7 @@ func _ADD_SLICE_TO_COLVEC_WITH_SEL(
 
 // {{/*
 func _ADD_SLICE_TO_COLVEC(
-	t_dest ColVec, t_destStartIdx int, t_src ColVec, t_srcStartIdx int, t_srcEndIdx int,
+	t_dest coldata.Vec, t_destStartIdx int, t_src coldata.Vec, t_srcStartIdx int, t_srcEndIdx int,
 ) { // */}}
 	// {{define "addSliceToColVec"}}
 	batchSize := t_srcEndIdx - t_srcStartIdx
@@ -100,9 +101,9 @@ func _ADD_SLICE_TO_COLVEC(
 
 // {{/*
 func _COPY_WITH_SEL(
-	t_dest ColVec,
+	t_dest coldata.Vec,
 	t_destStartIdx int,
-	t_src ColVec,
+	t_src coldata.Vec,
 	t_srcStartIdx int,
 	t_srcEndIdx int,
 	t_sel []uint16,
@@ -142,7 +143,7 @@ func (c *mergeJoinOp) buildLeftGroups(
 	groupsLen int,
 	colOffset int,
 	input *mergeJoinInput,
-	bat ColBatch,
+	bat coldata.Batch,
 	sel []uint16,
 	destStartIdx uint16,
 ) (uint16, int) {
@@ -268,7 +269,7 @@ func (c *mergeJoinOp) buildRightGroups(
 	groupsLen int,
 	colOffset int,
 	input *mergeJoinInput,
-	bat ColBatch,
+	bat coldata.Batch,
 	sel []uint16,
 	destStartIdx uint16,
 ) {

--- a/pkg/sql/exec/offset.go
+++ b/pkg/sql/exec/offset.go
@@ -14,12 +14,14 @@
 
 package exec
 
+import "github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+
 // offsetOp is an operator that implements offset, returning everything
 // after the first n tuples in its input.
 type offsetOp struct {
 	input Operator
 
-	internalBatch ColBatch
+	internalBatch coldata.Batch
 	offset        uint64
 
 	// seen is the number of tuples seen so far.
@@ -36,11 +38,11 @@ func NewOffsetOp(input Operator, offset uint64) Operator {
 }
 
 func (c *offsetOp) Init() {
-	c.internalBatch = NewMemBatch(nil)
+	c.internalBatch = coldata.NewMemBatch(nil)
 	c.input.Init()
 }
 
-func (c *offsetOp) Next() ColBatch {
+func (c *offsetOp) Next() coldata.Batch {
 	for {
 		bat := c.input.Next()
 		length := bat.Length()

--- a/pkg/sql/exec/offset_test.go
+++ b/pkg/sql/exec/offset_test.go
@@ -17,6 +17,7 @@ package exec
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
 
@@ -66,14 +67,14 @@ func TestOffset(t *testing.T) {
 }
 
 func BenchmarkOffset(b *testing.B) {
-	batch := NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
-	batch.SetLength(ColBatchSize)
+	batch := coldata.NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
+	batch.SetLength(coldata.BatchSize)
 	source := newRepeatableBatchSource(batch)
 	source.Init()
 
 	o := NewOffsetOp(source, 1)
 	// Set throughput proportional to size of the selection vector.
-	b.SetBytes(2 * ColBatchSize)
+	b.SetBytes(2 * coldata.BatchSize)
 	for i := 0; i < b.N; i++ {
 		o.(*offsetOp).Reset()
 		o.Next()

--- a/pkg/sql/exec/one_shot.go
+++ b/pkg/sql/exec/one_shot.go
@@ -14,6 +14,8 @@
 
 package exec
 
+import "github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+
 // oneShotOp is an operator that does an arbitrary operation on the first batch
 // that it gets, then deletes itself from the operator tree. This is useful for
 // first-Next initialization that has to happen in an operator.
@@ -22,14 +24,14 @@ type oneShotOp struct {
 
 	outputSourceRef *Operator
 
-	fn func(batch ColBatch)
+	fn func(batch coldata.Batch)
 }
 
 func (o *oneShotOp) Init() {
 	o.input.Init()
 }
 
-func (o *oneShotOp) Next() ColBatch {
+func (o *oneShotOp) Next() coldata.Batch {
 	batch := o.input.Next()
 
 	// Do our one-time work.

--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -14,20 +14,22 @@
 
 package exec
 
-// Operator is a column vector operator that produces a ColBatch as output.
+import "github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+
+// Operator is a column vector operator that produces a Batch as output.
 type Operator interface {
 	// Init initializes this operator. Will be called once at operator setup
 	// time. If an operator has an input operator, it's responsible for calling
 	// Init on that input operator as well.
 	Init()
 
-	// Next returns the next ColBatch from this operator. Once the operator is
-	// finished, it will return a ColBatch with length 0. Subsequent calls to
-	// Next at that point will always return a ColBatch with length 0.
+	// Next returns the next Batch from this operator. Once the operator is
+	// finished, it will return a Batch with length 0. Subsequent calls to
+	// Next at that point will always return a Batch with length 0.
 	//
-	// Calling Next may invalidate the contents of the last ColBatch returned by
+	// Calling Next may invalidate the contents of the last Batch returned by
 	// Next.
-	Next() ColBatch
+	Next() coldata.Batch
 }
 
 // resetter is an interface that operators can implement if they can be reset
@@ -52,7 +54,7 @@ func (n *noopOperator) Init() {
 	n.input.Init()
 }
 
-func (n *noopOperator) Next() ColBatch {
+func (n *noopOperator) Next() coldata.Batch {
 	return n.input.Next()
 }
 

--- a/pkg/sql/exec/projection_ops_test.go
+++ b/pkg/sql/exec/projection_ops_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -59,12 +60,12 @@ func TestProjPlusInt64Int64Op(t *testing.T) {
 func BenchmarkProjPlusInt64Int64ConstOp(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 
-	batch := NewMemBatch([]types.T{types.Int64, types.Int64})
+	batch := coldata.NewMemBatch([]types.T{types.Int64, types.Int64})
 	col := batch.ColVec(0).Int64()
-	for i := int64(0); i < ColBatchSize; i++ {
+	for i := int64(0); i < coldata.BatchSize; i++ {
 		col[i] = rng.Int63()
 	}
-	batch.SetLength(ColBatchSize)
+	batch.SetLength(coldata.BatchSize)
 	source := newRepeatableBatchSource(batch)
 	source.Init()
 
@@ -76,7 +77,7 @@ func BenchmarkProjPlusInt64Int64ConstOp(b *testing.B) {
 	}
 	plusOp.Init()
 
-	b.SetBytes(int64(8 * ColBatchSize))
+	b.SetBytes(int64(8 * coldata.BatchSize))
 	for i := 0; i < b.N; i++ {
 		plusOp.Next()
 	}
@@ -130,14 +131,14 @@ func TestGetProjectionOperator(t *testing.T) {
 func BenchmarkProjPlusInt64Int64Op(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 
-	batch := NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
+	batch := coldata.NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
 	col1 := batch.ColVec(0).Int64()
 	col2 := batch.ColVec(1).Int64()
-	for i := int64(0); i < ColBatchSize; i++ {
+	for i := int64(0); i < coldata.BatchSize; i++ {
 		col1[i] = rng.Int63()
 		col2[i] = rng.Int63()
 	}
-	batch.SetLength(ColBatchSize)
+	batch.SetLength(coldata.BatchSize)
 	source := newRepeatableBatchSource(batch)
 	source.Init()
 
@@ -149,7 +150,7 @@ func BenchmarkProjPlusInt64Int64Op(b *testing.B) {
 	}
 	plusOp.Init()
 
-	b.SetBytes(int64(8 * ColBatchSize * 2))
+	b.SetBytes(int64(8 * coldata.BatchSize * 2))
 	for i := 0; i < b.N; i++ {
 		plusOp.Next()
 	}

--- a/pkg/sql/exec/rowstovec_test.go
+++ b/pkg/sql/exec/rowstovec_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -37,14 +38,14 @@ func TestEncDatumRowsToColVecBool(t *testing.T) {
 			sqlbase.EncDatum{Datum: tree.DBoolFalse},
 		},
 	}
-	vec := newMemColumn(types.Bool, 2)
+	vec := coldata.NewMemColumn(types.Bool, 2)
 	ct := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_BOOL}
 
 	// Test converting column 0.
 	if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, &ct, &alloc); err != nil {
 		t.Fatal(err)
 	}
-	expected := newMemColumn(types.Bool, 2)
+	expected := coldata.NewMemColumn(types.Bool, 2)
 	expected.Bool()[0] = false
 	expected.Bool()[1] = true
 	if !reflect.DeepEqual(vec, expected) {
@@ -67,12 +68,12 @@ func TestEncDatumRowsToColVecInt16(t *testing.T) {
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDInt(17)}},
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDInt(42)}},
 	}
-	vec := newMemColumn(types.Int16, 2)
+	vec := coldata.NewMemColumn(types.Int16, 2)
 	ct := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT, Width: 16}
 	if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, &ct, &alloc); err != nil {
 		t.Fatal(err)
 	}
-	expected := newMemColumn(types.Int16, 2)
+	expected := coldata.NewMemColumn(types.Int16, 2)
 	expected.Int16()[0] = 17
 	expected.Int16()[1] = 42
 	if !reflect.DeepEqual(vec, expected) {
@@ -85,13 +86,13 @@ func TestEncDatumRowsToColVecString(t *testing.T) {
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDString("foo")}},
 		sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: tree.NewDString("bar")}},
 	}
-	vec := newMemColumn(types.Bytes, 2)
+	vec := coldata.NewMemColumn(types.Bytes, 2)
 	for _, width := range []int32{0, 25} {
 		ct := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_STRING, Width: width}
 		if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, &ct, &alloc); err != nil {
 			t.Fatal(err)
 		}
-		expected := newMemColumn(types.Bytes, 2)
+		expected := coldata.NewMemColumn(types.Bytes, 2)
 		expected.Bytes()[0] = []byte("foo")
 		expected.Bytes()[1] = []byte("bar")
 		if !reflect.DeepEqual(vec, expected) {
@@ -103,7 +104,7 @@ func TestEncDatumRowsToColVecString(t *testing.T) {
 func TestEncDatumRowsToColVecDecimal(t *testing.T) {
 	nRows := 3
 	rows := make(sqlbase.EncDatumRows, nRows)
-	expected := newMemColumn(types.Decimal, 3)
+	expected := coldata.NewMemColumn(types.Decimal, 3)
 	for i, s := range []string{"1.0000", "-3.12", "NaN"} {
 		var err error
 		dec, err := tree.ParseDDecimal(s)
@@ -113,7 +114,7 @@ func TestEncDatumRowsToColVecDecimal(t *testing.T) {
 		rows[i] = sqlbase.EncDatumRow{sqlbase.EncDatum{Datum: dec}}
 		expected.Decimal()[i] = dec.Decimal
 	}
-	vec := newMemColumn(types.Decimal, 3)
+	vec := coldata.NewMemColumn(types.Decimal, 3)
 	ct := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_DECIMAL}
 	if err := EncDatumRowsToColVec(rows, vec, 0 /* columnIdx */, &ct, &alloc); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/exec/rowstovec_tmpl.go
+++ b/pkg/sql/exec/rowstovec_tmpl.go
@@ -27,7 +27,8 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/apd"
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types/conv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
@@ -45,12 +46,12 @@ const (
 type _GOTYPE interface{}
 
 func _ROWS_TO_COL_VEC(
-	rows sqlbase.EncDatumRows, vec ColVec, columnIdx int, alloc *sqlbase.DatumAlloc,
+	rows sqlbase.EncDatumRows, vec coldata.Vec, columnIdx int, alloc *sqlbase.DatumAlloc,
 ) error { // */}}
 	// {{define "rowsToColVec"}}
 	nRows := uint16(len(rows))
 	col := vec._TemplateType()
-	datumToPhysicalFn := types.GetDatumToPhysicalFn(*columnType)
+	datumToPhysicalFn := conv.GetDatumToPhysicalFn(*columnType)
 	for i := uint16(0); i < nRows; i++ {
 		if rows[i][columnIdx].Datum == nil {
 			if err := rows[i][columnIdx].EnsureDecoded(columnType, alloc); err != nil {
@@ -79,7 +80,7 @@ func _ROWS_TO_COL_VEC(
 // vector. columnIdx is the 0-based index of the column in the EncDatumRows.
 func EncDatumRowsToColVec(
 	rows sqlbase.EncDatumRows,
-	vec ColVec,
+	vec coldata.Vec,
 	columnIdx int,
 	columnType *sqlbase.ColumnType,
 	alloc *sqlbase.DatumAlloc,

--- a/pkg/sql/exec/selection_ops_test.go
+++ b/pkg/sql/exec/selection_ops_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -97,12 +98,12 @@ func TestGetSelectionOperator(t *testing.T) {
 func BenchmarkSelLTInt64Int64ConstOp(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 
-	batch := NewMemBatch([]types.T{types.Int64})
+	batch := coldata.NewMemBatch([]types.T{types.Int64})
 	col := batch.ColVec(0).Int64()
-	for i := int64(0); i < ColBatchSize; i++ {
+	for i := int64(0); i < coldata.BatchSize; i++ {
 		col[i] = rng.Int63()
 	}
-	batch.SetLength(ColBatchSize)
+	batch.SetLength(coldata.BatchSize)
 	source := newRepeatableBatchSource(batch)
 	source.Init()
 
@@ -113,7 +114,7 @@ func BenchmarkSelLTInt64Int64ConstOp(b *testing.B) {
 	}
 	plusOp.Init()
 
-	b.SetBytes(int64(8 * ColBatchSize))
+	b.SetBytes(int64(8 * coldata.BatchSize))
 	for i := 0; i < b.N; i++ {
 		plusOp.Next()
 	}
@@ -122,14 +123,14 @@ func BenchmarkSelLTInt64Int64ConstOp(b *testing.B) {
 func BenchmarkSelLTInt64Int64Op(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
 
-	batch := NewMemBatch([]types.T{types.Int64, types.Int64})
+	batch := coldata.NewMemBatch([]types.T{types.Int64, types.Int64})
 	col1 := batch.ColVec(0).Int64()
 	col2 := batch.ColVec(1).Int64()
-	for i := int64(0); i < ColBatchSize; i++ {
+	for i := int64(0); i < coldata.BatchSize; i++ {
 		col1[i] = rng.Int63()
 		col2[i] = rng.Int63()
 	}
-	batch.SetLength(ColBatchSize)
+	batch.SetLength(coldata.BatchSize)
 	source := newRepeatableBatchSource(batch)
 	source.Init()
 
@@ -140,7 +141,7 @@ func BenchmarkSelLTInt64Int64Op(b *testing.B) {
 	}
 	plusOp.Init()
 
-	b.SetBytes(int64(8 * ColBatchSize * 2))
+	b.SetBytes(int64(8 * coldata.BatchSize * 2))
 	for i := 0; i < b.N; i++ {
 		plusOp.Next()
 	}

--- a/pkg/sql/exec/sort_chunks_test.go
+++ b/pkg/sql/exec/sort_chunks_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -240,17 +241,17 @@ func BenchmarkSortChunks(b *testing.B) {
 						}
 						b.Run(
 							fmt.Sprintf("%s/rows=%d/cols=%d/matchLen=%d/avgChunkSize=%d",
-								sorterNames[sorterIdx], nBatches*ColBatchSize, nCols, matchLen, avgChunkSize),
+								sorterNames[sorterIdx], nBatches*coldata.BatchSize, nCols, matchLen, avgChunkSize),
 							func(b *testing.B) {
-								// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+								// 8 (bytes / int64) * nBatches (number of batches) * coldata.BatchSize (rows /
 								// batch) * nCols (number of columns / row).
-								b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols))
+								b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols))
 								typs := make([]types.T, nCols)
 								for i := range typs {
 									typs[i] = types.Int64
 								}
-								batch := NewMemBatch(typs)
-								batch.SetLength(ColBatchSize)
+								batch := coldata.NewMemBatch(typs)
+								batch.SetLength(coldata.BatchSize)
 								ordCols := make([]distsqlpb.Ordering_Column, nCols)
 								for i := range ordCols {
 									ordCols[i].ColIdx = uint32(i)
@@ -262,7 +263,7 @@ func BenchmarkSortChunks(b *testing.B) {
 
 									col := batch.ColVec(i).Int64()
 									col[0] = 0
-									for j := 1; j < ColBatchSize; j++ {
+									for j := 1; j < coldata.BatchSize; j++ {
 										if i < matchLen {
 											col[j] = col[j-1]
 											if rng.Float64() < 1.0/float64(avgChunkSize) {
@@ -273,7 +274,7 @@ func BenchmarkSortChunks(b *testing.B) {
 										}
 									}
 								}
-								rowsTotal := nBatches * ColBatchSize
+								rowsTotal := nBatches * coldata.BatchSize
 								b.ResetTimer()
 								for n := 0; n < b.N; n++ {
 									source := newFiniteChunksSource(batch, nBatches, matchLen)

--- a/pkg/sql/exec/sort_test.go
+++ b/pkg/sql/exec/sort_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -254,23 +255,23 @@ func BenchmarkSort(b *testing.B) {
 
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
 		for _, nCols := range []int{1, 2, 4} {
-			b.Run(fmt.Sprintf("rows=%d/cols=%d", nBatches*ColBatchSize, nCols), func(b *testing.B) {
-				// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+			b.Run(fmt.Sprintf("rows=%d/cols=%d", nBatches*coldata.BatchSize, nCols), func(b *testing.B) {
+				// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize (rows /
 				// batch) * nCols (number of columns / row).
-				b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols))
+				b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols))
 				typs := make([]types.T, nCols)
 				for i := range typs {
 					typs[i] = types.Int64
 				}
-				batch := NewMemBatch(typs)
-				batch.SetLength(ColBatchSize)
+				batch := coldata.NewMemBatch(typs)
+				batch.SetLength(coldata.BatchSize)
 				ordCols := make([]distsqlpb.Ordering_Column, nCols)
 				for i := range ordCols {
 					ordCols[i].ColIdx = uint32(i)
 					ordCols[i].Direction = distsqlpb.Ordering_Column_Direction(rng.Int() % 2)
 
 					col := batch.ColVec(i).Int64()
-					for j := 0; j < ColBatchSize; j++ {
+					for j := 0; j < coldata.BatchSize; j++ {
 						col[j] = rng.Int63() % int64((i*1024)+1)
 					}
 				}
@@ -300,19 +301,19 @@ func BenchmarkAllSpooler(b *testing.B) {
 
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
 		for _, nCols := range []int{1, 2, 4} {
-			b.Run(fmt.Sprintf("rows=%d/cols=%d", nBatches*ColBatchSize, nCols), func(b *testing.B) {
-				// 8 (bytes / int64) * nBatches (number of batches) * ColBatchSize (rows /
+			b.Run(fmt.Sprintf("rows=%d/cols=%d", nBatches*coldata.BatchSize, nCols), func(b *testing.B) {
+				// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize (rows /
 				// batch) * nCols (number of columns / row).
-				b.SetBytes(int64(8 * nBatches * ColBatchSize * nCols))
+				b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols))
 				typs := make([]types.T, nCols)
 				for i := range typs {
 					typs[i] = types.Int64
 				}
-				batch := NewMemBatch(typs)
-				batch.SetLength(ColBatchSize)
+				batch := coldata.NewMemBatch(typs)
+				batch.SetLength(coldata.BatchSize)
 				for i := 0; i < nCols; i++ {
 					col := batch.ColVec(i).Int64()
-					for j := 0; j < ColBatchSize; j++ {
+					for j := 0; j < coldata.BatchSize; j++ {
 						col[j] = rng.Int63() % int64((i*1024)+1)
 					}
 				}

--- a/pkg/sql/exec/sort_tmpl.go
+++ b/pkg/sql/exec/sort_tmpl.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
@@ -91,7 +92,7 @@ type sort_TYPE_DIROp struct {
 	workingSpace []uint64
 }
 
-func (s *sort_TYPE_DIROp) init(col ColVec, order []uint64, workingSpace []uint64) {
+func (s *sort_TYPE_DIROp) init(col coldata.Vec, order []uint64, workingSpace []uint64) {
 	s.sortCol = col._TemplateType()
 	s.order = order
 	s.workingSpace = workingSpace

--- a/pkg/sql/exec/sum_agg_tmpl.go
+++ b/pkg/sql/exec/sum_agg_tmpl.go
@@ -25,6 +25,7 @@ package exec
 
 import (
 	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
@@ -75,9 +76,9 @@ var _ aggregateFunc = &sum_TYPEAgg{}
 
 // TODO(asubiotto): Have all these zero batches somewhere else templated
 // separately.
-var zero_TYPEBatch = make([]_GOTYPE, ColBatchSize)
+var zero_TYPEBatch = make([]_GOTYPE, coldata.BatchSize)
 
-func (a *sum_TYPEAgg) Init(groups []bool, v ColVec) {
+func (a *sum_TYPEAgg) Init(groups []bool, v coldata.Vec) {
 	a.groups = groups
 	a.scratch.vec = v._TemplateType()
 	a.Reset()
@@ -99,7 +100,7 @@ func (a *sum_TYPEAgg) SetOutputIndex(idx int) {
 	}
 }
 
-func (a *sum_TYPEAgg) Compute(b ColBatch, inputIdxs []uint32) {
+func (a *sum_TYPEAgg) Compute(b coldata.Batch, inputIdxs []uint32) {
 	if a.done {
 		return
 	}

--- a/pkg/sql/exec/tuples_differ_tmpl.go
+++ b/pkg/sql/exec/tuples_differ_tmpl.go
@@ -26,6 +26,7 @@ package exec
 import (
 	"bytes"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
@@ -61,7 +62,7 @@ func _ASSIGN_NE(_, _, _ string) bool {
 // tuplesDiffer takes in two ColVecs as well as tuple indices to check whether
 // the tuples differ.
 func tuplesDiffer(
-	t types.T, aColVec ColVec, aTupleIdx int, bColVec ColVec, bTupleIdx int, differ *bool,
+	t types.T, aColVec coldata.Vec, aTupleIdx int, bColVec coldata.Vec, bTupleIdx int, differ *bool,
 ) error {
 	switch t {
 	// {{range .}}

--- a/pkg/sql/exec/types/conv/conv.go
+++ b/pkg/sql/exec/types/conv/conv.go
@@ -1,0 +1,177 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package conv
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/pkg/errors"
+)
+
+// FromColumnType returns the T that corresponds to the input ColumnType.
+func FromColumnType(ct sqlbase.ColumnType) types.T {
+	switch ct.SemanticType {
+	case sqlbase.ColumnType_BOOL:
+		return types.Bool
+	case sqlbase.ColumnType_BYTES, sqlbase.ColumnType_STRING, sqlbase.ColumnType_NAME:
+		return types.Bytes
+	case sqlbase.ColumnType_DATE, sqlbase.ColumnType_OID:
+		return types.Int64
+	case sqlbase.ColumnType_DECIMAL:
+		return types.Decimal
+	case sqlbase.ColumnType_INT:
+		switch ct.Width {
+		case 8:
+			return types.Int8
+		case 16:
+			return types.Int16
+		case 32:
+			return types.Int32
+		case 0, 64:
+			return types.Int64
+		}
+		panic(fmt.Sprintf("integer with unknown width %d", ct.Width))
+	case sqlbase.ColumnType_FLOAT:
+		return types.Float64
+	}
+	return types.Unhandled
+}
+
+// FromColumnTypes calls FromColumnType on each element of cts, returning the
+// resulting slice.
+func FromColumnTypes(cts []sqlbase.ColumnType) []types.T {
+	typs := make([]types.T, len(cts))
+	for i := range typs {
+		typs[i] = FromColumnType(cts[i])
+	}
+	return typs
+}
+
+// GetDatumToPhysicalFn returns a function for converting a datum of the given
+// ColumnType to the corresponding Go type.
+func GetDatumToPhysicalFn(ct sqlbase.ColumnType) func(tree.Datum) (interface{}, error) {
+	switch ct.SemanticType {
+	case sqlbase.ColumnType_BOOL:
+		return func(datum tree.Datum) (interface{}, error) {
+			d, ok := datum.(*tree.DBool)
+			if !ok {
+				return nil, errors.Errorf("expected *tree.DBool, found %s", reflect.TypeOf(datum))
+			}
+			return bool(*d), nil
+		}
+	case sqlbase.ColumnType_BYTES:
+		return func(datum tree.Datum) (interface{}, error) {
+			d, ok := datum.(*tree.DBytes)
+			if !ok {
+				return nil, errors.Errorf("expected *tree.DBytes, found %s", reflect.TypeOf(datum))
+			}
+			return encoding.UnsafeConvertStringToBytes(string(*d)), nil
+		}
+	case sqlbase.ColumnType_INT:
+		switch ct.Width {
+		case 8:
+			return func(datum tree.Datum) (interface{}, error) {
+				d, ok := datum.(*tree.DInt)
+				if !ok {
+					return nil, errors.Errorf("expected *tree.DInt, found %s", reflect.TypeOf(datum))
+				}
+				return int8(*d), nil
+			}
+		case 16:
+			return func(datum tree.Datum) (interface{}, error) {
+				d, ok := datum.(*tree.DInt)
+				if !ok {
+					return nil, errors.Errorf("expected *tree.DInt, found %s", reflect.TypeOf(datum))
+				}
+				return int16(*d), nil
+			}
+		case 32:
+			return func(datum tree.Datum) (interface{}, error) {
+				d, ok := datum.(*tree.DInt)
+				if !ok {
+					return nil, errors.Errorf("expected *tree.DInt, found %s", reflect.TypeOf(datum))
+				}
+				return int32(*d), nil
+			}
+		case 0, 64:
+			return func(datum tree.Datum) (interface{}, error) {
+				d, ok := datum.(*tree.DInt)
+				if !ok {
+					return nil, errors.Errorf("expected *tree.DInt, found %s", reflect.TypeOf(datum))
+				}
+				return int64(*d), nil
+			}
+		}
+		panic(fmt.Sprintf("unhandled INT width %d", ct.Width))
+	case sqlbase.ColumnType_DATE:
+		return func(datum tree.Datum) (interface{}, error) {
+			d, ok := datum.(*tree.DDate)
+			if !ok {
+				return nil, errors.Errorf("expected *tree.DDate, found %s", reflect.TypeOf(datum))
+			}
+			return int64(*d), nil
+		}
+	case sqlbase.ColumnType_FLOAT:
+		return func(datum tree.Datum) (interface{}, error) {
+			d, ok := datum.(*tree.DFloat)
+			if !ok {
+				return nil, errors.Errorf("expected *tree.DFloat, found %s", reflect.TypeOf(datum))
+			}
+			return float64(*d), nil
+		}
+	case sqlbase.ColumnType_OID:
+		return func(datum tree.Datum) (interface{}, error) {
+			d, ok := datum.(*tree.DOid)
+			if !ok {
+				return nil, errors.Errorf("expected *tree.DOid, found %s", reflect.TypeOf(datum))
+			}
+			return int64(d.DInt), nil
+		}
+	case sqlbase.ColumnType_STRING:
+		return func(datum tree.Datum) (interface{}, error) {
+			d, ok := datum.(*tree.DString)
+			if !ok {
+				return nil, errors.Errorf("expected *tree.DString, found %s", reflect.TypeOf(datum))
+			}
+			return encoding.UnsafeConvertStringToBytes(string(*d)), nil
+		}
+	case sqlbase.ColumnType_NAME:
+		return func(datum tree.Datum) (interface{}, error) {
+			wrapper, ok := datum.(*tree.DOidWrapper)
+			if !ok {
+				return nil, errors.Errorf("expected *tree.DOidWrapper, found %s", reflect.TypeOf(datum))
+			}
+			d, ok := wrapper.Wrapped.(*tree.DString)
+			if !ok {
+				return nil, errors.Errorf("expected *tree.DString, found %s", reflect.TypeOf(wrapper))
+			}
+			return encoding.UnsafeConvertStringToBytes(string(*d)), nil
+		}
+	case sqlbase.ColumnType_DECIMAL:
+		return func(datum tree.Datum) (interface{}, error) {
+			d, ok := datum.(*tree.DDecimal)
+			if !ok {
+				return nil, errors.Errorf("expected *tree.DDecimal, found %s", reflect.TypeOf(datum))
+			}
+			return d.Decimal, nil
+		}
+	}
+	panic(fmt.Sprintf("unhandled ColumnType %s", ct.String()))
+}

--- a/pkg/sql/exec/types/types.go
+++ b/pkg/sql/exec/types/types.go
@@ -16,13 +16,8 @@ package types
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/cockroachdb/apd"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/pkg/errors"
 )
 
 // T represents an exec physical type - a bytes representation of a particular
@@ -63,45 +58,6 @@ func init() {
 	for i := Bool; i < Unhandled; i++ {
 		AllTypes = append(AllTypes, i)
 	}
-}
-
-// FromColumnType returns the T that corresponds to the input ColumnType.
-func FromColumnType(ct sqlbase.ColumnType) T {
-	switch ct.SemanticType {
-	case sqlbase.ColumnType_BOOL:
-		return Bool
-	case sqlbase.ColumnType_BYTES, sqlbase.ColumnType_STRING, sqlbase.ColumnType_NAME:
-		return Bytes
-	case sqlbase.ColumnType_DATE, sqlbase.ColumnType_OID:
-		return Int64
-	case sqlbase.ColumnType_DECIMAL:
-		return Decimal
-	case sqlbase.ColumnType_INT:
-		switch ct.Width {
-		case 8:
-			return Int8
-		case 16:
-			return Int16
-		case 32:
-			return Int32
-		case 0, 64:
-			return Int64
-		}
-		panic(fmt.Sprintf("integer with unknown width %d", ct.Width))
-	case sqlbase.ColumnType_FLOAT:
-		return Float64
-	}
-	return Unhandled
-}
-
-// FromColumnTypes calls FromColumnType on each element of cts, returning the
-// resulting slice.
-func FromColumnTypes(cts []sqlbase.ColumnType) []T {
-	typs := make([]T, len(cts))
-	for i := range typs {
-		typs[i] = FromColumnType(cts[i])
-	}
-	return typs
 }
 
 // FromGoType returns the type for a Go value, if applicable. Shouldn't be used at
@@ -157,116 +113,4 @@ func (t T) GoTypeName() string {
 	default:
 		panic(fmt.Sprintf("unhandled type %d", t))
 	}
-}
-
-// GetDatumToPhysicalFn returns a function for converting a datum of the given
-// ColumnType to the corresponding Go type.
-func GetDatumToPhysicalFn(ct sqlbase.ColumnType) func(tree.Datum) (interface{}, error) {
-	switch ct.SemanticType {
-	case sqlbase.ColumnType_BOOL:
-		return func(datum tree.Datum) (interface{}, error) {
-			d, ok := datum.(*tree.DBool)
-			if !ok {
-				return nil, errors.Errorf("expected *tree.DBool, found %s", reflect.TypeOf(datum))
-			}
-			return bool(*d), nil
-		}
-	case sqlbase.ColumnType_BYTES:
-		return func(datum tree.Datum) (interface{}, error) {
-			d, ok := datum.(*tree.DBytes)
-			if !ok {
-				return nil, errors.Errorf("expected *tree.DBytes, found %s", reflect.TypeOf(datum))
-			}
-			return encoding.UnsafeConvertStringToBytes(string(*d)), nil
-		}
-	case sqlbase.ColumnType_INT:
-		switch ct.Width {
-		case 8:
-			return func(datum tree.Datum) (interface{}, error) {
-				d, ok := datum.(*tree.DInt)
-				if !ok {
-					return nil, errors.Errorf("expected *tree.DInt, found %s", reflect.TypeOf(datum))
-				}
-				return int8(*d), nil
-			}
-		case 16:
-			return func(datum tree.Datum) (interface{}, error) {
-				d, ok := datum.(*tree.DInt)
-				if !ok {
-					return nil, errors.Errorf("expected *tree.DInt, found %s", reflect.TypeOf(datum))
-				}
-				return int16(*d), nil
-			}
-		case 32:
-			return func(datum tree.Datum) (interface{}, error) {
-				d, ok := datum.(*tree.DInt)
-				if !ok {
-					return nil, errors.Errorf("expected *tree.DInt, found %s", reflect.TypeOf(datum))
-				}
-				return int32(*d), nil
-			}
-		case 0, 64:
-			return func(datum tree.Datum) (interface{}, error) {
-				d, ok := datum.(*tree.DInt)
-				if !ok {
-					return nil, errors.Errorf("expected *tree.DInt, found %s", reflect.TypeOf(datum))
-				}
-				return int64(*d), nil
-			}
-		}
-		panic(fmt.Sprintf("unhandled INT width %d", ct.Width))
-	case sqlbase.ColumnType_DATE:
-		return func(datum tree.Datum) (interface{}, error) {
-			d, ok := datum.(*tree.DDate)
-			if !ok {
-				return nil, errors.Errorf("expected *tree.DDate, found %s", reflect.TypeOf(datum))
-			}
-			return int64(*d), nil
-		}
-	case sqlbase.ColumnType_FLOAT:
-		return func(datum tree.Datum) (interface{}, error) {
-			d, ok := datum.(*tree.DFloat)
-			if !ok {
-				return nil, errors.Errorf("expected *tree.DFloat, found %s", reflect.TypeOf(datum))
-			}
-			return float64(*d), nil
-		}
-	case sqlbase.ColumnType_OID:
-		return func(datum tree.Datum) (interface{}, error) {
-			d, ok := datum.(*tree.DOid)
-			if !ok {
-				return nil, errors.Errorf("expected *tree.DOid, found %s", reflect.TypeOf(datum))
-			}
-			return int64(d.DInt), nil
-		}
-	case sqlbase.ColumnType_STRING:
-		return func(datum tree.Datum) (interface{}, error) {
-			d, ok := datum.(*tree.DString)
-			if !ok {
-				return nil, errors.Errorf("expected *tree.DString, found %s", reflect.TypeOf(datum))
-			}
-			return encoding.UnsafeConvertStringToBytes(string(*d)), nil
-		}
-	case sqlbase.ColumnType_NAME:
-		return func(datum tree.Datum) (interface{}, error) {
-			wrapper, ok := datum.(*tree.DOidWrapper)
-			if !ok {
-				return nil, errors.Errorf("expected *tree.DOidWrapper, found %s", reflect.TypeOf(datum))
-			}
-			d, ok := wrapper.Wrapped.(*tree.DString)
-			if !ok {
-				return nil, errors.Errorf("expected *tree.DString, found %s", reflect.TypeOf(wrapper))
-			}
-			return encoding.UnsafeConvertStringToBytes(string(*d)), nil
-		}
-	case sqlbase.ColumnType_DECIMAL:
-		return func(datum tree.Datum) (interface{}, error) {
-			d, ok := datum.(*tree.DDecimal)
-			if !ok {
-				return nil, errors.Errorf("expected *tree.DDecimal, found %s", reflect.TypeOf(datum))
-			}
-			return d.Decimal, nil
-		}
-	}
-	panic(fmt.Sprintf("unhandled ColumnType %s", ct.String()))
 }


### PR DESCRIPTION
This commit moves ColBatch and ColVec to a new package, coldata, and renames
them Batch and Vec to avoid stuttering.

This enables reuse of the ColBatch and ColVec interfaces and
implementations in other domains, like workload.

Release note: None