### PR TITLE
sqltelemetry: make SQL telemetry more uniform, w/ linter

### DIFF
--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -267,12 +267,14 @@ func linkArguments(t string) string {
 
 func linkTypeName(s string) string {
 	s = strings.TrimSuffix(s, "{}")
+	s = strings.TrimSuffix(s, "{*}")
 	name := s
 	switch s {
 	case "timestamptz":
 		s = "timestamp"
 	}
 	s = strings.TrimSuffix(s, "[]")
+	s = strings.TrimSuffix(s, "*")
 	switch s {
 	case "int", "decimal", "float", "bool", "date", "timestamp", "interval", "string", "bytes",
 		"inet", "uuid", "collatedstring", "time":

--- a/pkg/server/telemetry/features.go
+++ b/pkg/server/telemetry/features.go
@@ -64,6 +64,18 @@ func Inc(c Counter) {
 	atomic.AddInt32(c, 1)
 }
 
+// GetCounterOnce returns a counter from the global registry,
+// and asserts it didn't exist previously.
+func GetCounterOnce(feature string) Counter {
+	counters.RLock()
+	_, ok := counters.m[feature]
+	counters.RUnlock()
+	if ok {
+		panic("counter already exists: " + feature)
+	}
+	return GetCounter(feature)
+}
+
 // GetCounter returns a counter from the global registry.
 func GetCounter(feature string) Counter {
 	counters.RLock()

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -545,12 +545,12 @@ func TestReportUsage(t *testing.T) {
 
 		// Although the query is executed 10 times, due to plan caching
 		// keyed by the SQL text, the planning only occurs once.
-		"sql.ops.cast.text::inet":  1,
-		"sql.ops.bin.jsonb - text": 1,
-		"sql.builtins.crdb_internal.force_assertion_error(msg: string) -> int": 1,
-		"sql.ops.array.ind":     1,
-		"sql.ops.array.cons":    1,
-		"sql.ops.array.flatten": 1,
+		"sql.plan.ops.cast.string::inet":                                            1,
+		"sql.plan.ops.bin.jsonb - string":                                           1,
+		"sql.plan.builtins.crdb_internal.force_assertion_error(msg: string) -> int": 1,
+		"sql.plan.ops.array.ind":                                                    1,
+		"sql.plan.ops.array.cons":                                                   1,
+		"sql.plan.ops.array.flatten":                                                1,
 
 		"unimplemented.#33285.json_object_agg":          10,
 		"unimplemented.pg_catalog.pg_stat_wal_receiver": 10,

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -275,7 +276,7 @@ func (b *writeBuffer) writeBinaryDatum(
 				// The above encoding is not correct for Infinity, but since that encoding
 				// doesn't exist in postgres, it's unclear what to do. For now use the NaN
 				// encoding and count it to see if anyone even needs this.
-				telemetry.Count("pgwire.#32489.binary_decimal_infinity")
+				telemetry.Inc(sqltelemetry.BinaryDecimalInfinityCounter)
 			}
 
 			return

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/arith"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -1339,7 +1340,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				rval := MustBeDInt(right)
 				if rval < 0 || rval >= 64 {
-					telemetry.Count("sql.large_lshift_argument")
+					telemetry.Inc(sqltelemetry.LargeLShiftArgumentCounter)
 					return nil, pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, "shift argument out of range")
 				}
 				return NewDInt(MustBeDInt(left) << uint(rval)), nil
@@ -1377,7 +1378,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			Fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				rval := MustBeDInt(right)
 				if rval < 0 || rval >= 64 {
-					telemetry.Count("sql.large_rshift_argument")
+					telemetry.Inc(sqltelemetry.LargeRShiftArgumentCounter)
 					return nil, pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, "shift argument out of range")
 				}
 				return NewDInt(MustBeDInt(left) >> uint(rval)), nil

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -14,7 +14,7 @@
 
 package tree
 
-import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+import "github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 
 // FunctionDefinition implements a reference to the (possibly several)
 // overloads for a built-in function.
@@ -126,7 +126,7 @@ func NewFunctionDefinition(
 			props.AmbiguousReturnType = true
 		}
 		// Produce separate telemetry for each overload.
-		def[i].counter = telemetry.GetCounter("sql.builtins." + name + def[i].Signature(false))
+		def[i].counter = sqltelemetry.BuiltinCounter(name, def[i].Signature(false))
 
 		overloads[i] = &def[i]
 	}

--- a/pkg/sql/sem/types/types.go
+++ b/pkg/sql/sem/types/types.go
@@ -193,6 +193,10 @@ type TCollatedString struct {
 
 // String implements the fmt.Stringer interface.
 func (t TCollatedString) String() string {
+	if t.Locale == "" {
+		// Used in telemetry.
+		return "collatedstring{*}"
+	}
 	return fmt.Sprintf("collatedstring{%s}", t.Locale)
 }
 
@@ -445,7 +449,13 @@ func (TPlaceholder) IsAmbiguous() bool { panic("TPlaceholder.IsAmbiguous() is un
 // TArray is the type of a DArray.
 type TArray struct{ Typ T }
 
-func (a TArray) String() string { return a.Typ.String() + "[]" }
+func (a TArray) String() string {
+	if a.Typ == nil {
+		// Used in telemetry.
+		return "*[]"
+	}
+	return a.Typ.String() + "[]"
+}
 
 // Equivalent implements the T interface.
 func (a TArray) Equivalent(other T) bool {

--- a/pkg/sql/sqltelemetry/doc.go
+++ b/pkg/sql/sqltelemetry/doc.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+/*
+Package sqltelemetry contains telemetry counter definitions
+for various SQL features.
+
+Centralizing the counters in a single place achieves three objectives:
+
+- the comments that accompany the counters enable non-technical users
+  to comprehend what is being reported without having to read code.
+
+- the counters are placed side-by-side, grouped by category, so as to
+  enable exploratory discovery of available telemetry.
+
+- the counters are pre-registered and their unicity is asserted,
+  so that no two features end up using the same counter name.
+*/
+package sqltelemetry

--- a/pkg/sql/sqltelemetry/pgwire.go
+++ b/pkg/sql/sqltelemetry/pgwire.go
@@ -1,0 +1,37 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqltelemetry
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+)
+
+// CancelRequestCounter is to be incremented every time a pgwire-level
+// cancel request is received from a client.
+var CancelRequestCounter = telemetry.GetCounterOnce("pgwire.unimplemented.cancel_request")
+
+// UnimplementedClientStatusParameterCounter is to be incremented
+// every time a client attempts to configure a status parameter
+// that's not supported upon session initialization.
+func UnimplementedClientStatusParameterCounter(key string) telemetry.Counter {
+	return telemetry.GetCounter(fmt.Sprintf("unimplemented.pgwire.parameter.%s", key))
+}
+
+// BinaryDecimalInfinityCounter is to be incremented every time a
+// client requests the binary encoding for a decimal infinity, which
+// is not well defined in the pg protocol (#32489).
+var BinaryDecimalInfinityCounter = telemetry.GetCounterOnce("pgwire.#32489.binary_decimal_infinity")

--- a/pkg/sql/sqltelemetry/scalar.go
+++ b/pkg/sql/sqltelemetry/scalar.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqltelemetry
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+)
+
+// BuiltinCounter creates a telemetry counter for a built-in function.
+// This is to be incremented upon type checking of a function application.
+func BuiltinCounter(name, signature string) telemetry.Counter {
+	return telemetry.GetCounterOnce(fmt.Sprintf("sql.plan.builtins.%s%s", name, signature))
+}
+
+// UnaryOpCounter creates a telemetry counter for a scalar unary operator.
+// This is to be incremented upon type checking of this type of scalar operation.
+func UnaryOpCounter(op, typ string) telemetry.Counter {
+	return telemetry.GetCounterOnce(fmt.Sprintf("sql.plan.ops.un.%s %s", op, typ))
+}
+
+// CmpOpCounter creates a telemetry counter for a scalar comparison operator.
+// This is to be incremented upon type checking of this type of scalar operation.
+func CmpOpCounter(op, ltyp, rtyp string) telemetry.Counter {
+	return telemetry.GetCounterOnce(fmt.Sprintf("sql.plan.ops.cmp.%s %s %s", ltyp, op, rtyp))
+}
+
+// BinOpCounter creates a telemetry counter for a scalar binary operator.
+// This is to be incremented upon type checking of this type of scalar operation.
+func BinOpCounter(op, ltyp, rtyp string) telemetry.Counter {
+	return telemetry.GetCounterOnce(fmt.Sprintf("sql.plan.ops.bin.%s %s %s", ltyp, op, rtyp))
+}
+
+// CastOpCounter creates a telemetry counter for a scalar cast operator.
+// This is to be incremented upon type checking of this type of scalar operation.
+func CastOpCounter(ftyp, ttyp string) telemetry.Counter {
+	return telemetry.GetCounterOnce(fmt.Sprintf("sql.plan.ops.cast.%s::%s", ftyp, ttyp))
+}
+
+// ArrayCastCounter is to be incremented when type checking all casts
+// that involve arrays.  This separate telemetry counter is needed
+// because an inter-array cast lands on `sql.plan.ops.cast` telemetry
+// counter for the element type.
+var ArrayCastCounter = telemetry.GetCounterOnce("sql.plan.ops.cast.arrays")
+
+// ArrayConstructorCounter is to be incremented upon type checking
+// of ARRAY[...] expressions/
+var ArrayConstructorCounter = telemetry.GetCounterOnce("sql.plan.ops.array.cons")
+
+// ArrayFlattenCounter is to be incremented upon type checking
+// of ARRAY(...) expressions.
+var ArrayFlattenCounter = telemetry.GetCounterOnce("sql.plan.ops.array.flatten")
+
+// ArraySubscriptCounter is to be incremented upon type checking an
+// array subscript expression x[...].
+var ArraySubscriptCounter = telemetry.GetCounterOnce("sql.plan.ops.array.ind")
+
+// IfErrCounter is to be incremented upon type checking an
+// IFERROR(...) expression or analogous.
+var IfErrCounter = telemetry.GetCounterOnce("sql.plan.ops.iferr")
+
+// LargeLShiftArgumentCounter is to be incremented upon evaluating a scalar
+// expressions a << b when b is larger than 64 or negative.
+var LargeLShiftArgumentCounter = telemetry.GetCounterOnce("sql.large_lshift_argument")
+
+// LargeRShiftArgumentCounter is to be incremented upon evaluating a scalar
+// expressions a >> b when b is larger than 64 or negative.
+var LargeRShiftArgumentCounter = telemetry.GetCounterOnce("sql.large_rshift_argument")

--- a/pkg/sql/sqltelemetry/session.go
+++ b/pkg/sql/sqltelemetry/session.go
@@ -1,0 +1,37 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqltelemetry
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+)
+
+// DefaultIntSize4Counter is to be incremented every time a client
+// change the default_int_size variable to its non-default value 4.
+var DefaultIntSize4Counter = telemetry.GetCounterOnce("sql.default_int_size.4")
+
+// ForceSavepointRestartCounter is to be incremented every time a
+// client customizes the session variable force_savepoint_restart
+// to a non-empty string.
+var ForceSavepointRestartCounter = telemetry.GetCounterOnce("sql.force_savepoint_restart")
+
+// UnimplementedSessionVarValueCounter is to be incremented every time
+// a client attempts to set a compatitibility session var to an
+// unsupported value.
+func UnimplementedSessionVarValueCounter(varName, val string) telemetry.Counter {
+	return telemetry.GetCounter(fmt.Sprintf("unimplemented.sql.session_var.%s.%s", varName, val))
+}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -342,6 +342,71 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	t.Run("TestSQLTelemetryDirectCount", func(t *testing.T) {
+		t.Parallel()
+		cmd, stderr, filter, err := dirCmd(
+			pkgDir,
+			"git",
+			"grep",
+			"-nE",
+			`[^[:alnum:]]telemetry\.Count\(`,
+			"--",
+			"sql",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			t.Errorf("\n%s <- forbidden; use 'sqltelemetry.xxxCounter()' / `telemetry.Inc' instead", s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
+	t.Run("TestSQLTelemetryGetCounter", func(t *testing.T) {
+		t.Parallel()
+		cmd, stderr, filter, err := dirCmd(
+			pkgDir,
+			"git",
+			"grep",
+			"-nE",
+			`[^[:alnum:]]telemetry\.GetCounter`,
+			"--",
+			"sql",
+			":!sql/sqltelemetry",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			t.Errorf("\n%s <- forbidden; use 'sqltelemetry.xxxCounter() instead", s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
 	t.Run("TestTodoStyle", func(t *testing.T) {
 		t.Parallel()
 		// TODO(tamird): enforce presence of name.


### PR DESCRIPTION
This patch groups the telemetry counters for the SQL layer into a
single package `sqltelemetry`. The package aims to document the
telemetry counter in a way that's easily understandable / discoverable
without having to read code.

This also introduces the pattern required by @dt: that telemetry
counter names generated dynamically to be generated in a way that's
regular, subject to later formalization via a new API
`telemetry.GetCounterf()` (so that we can automate the inventorization
of all telemetry counters). This patch ensures that all the dynamic
counter names go to `GetCounter(fmt.Sprintf(...))`, which we'll be
able to re-structure at a later point.

Finally it introduces the prefix `sql.plan`, in anticipation of a
further split between `sql.parse`, `sql.plan`, `sql.exec`.

Release note: None