### PR TITLE
telemetry: increase the default allocated feature map size

### DIFF
--- a/pkg/server/telemetry/features.go
+++ b/pkg/server/telemetry/features.go
@@ -141,7 +141,7 @@ func init() {
 	counters.m = make(map[string]Counter, approxFeatureCount)
 }
 
-var approxFeatureCount = 100
+var approxFeatureCount = 1500
 
 // counters stores the registry of feature-usage counts.
 // TODO(dt): consider a lock-free map.


### PR DESCRIPTION
With SQL telemetry loaded up the initial feature count is north of
1300. Bump the start size.

Release note: None