### PR TITLE
sql: add feature usage telemetry for CTEs and subqueries

### DIFF
--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -388,6 +388,10 @@ func TestReportUsage(t *testing.T) {
 		if _, err := db.Exec(`SELECT '1.2.3.4'::STRING::INET, '{"a":"b","c":123}'::JSON - 'a', ARRAY (SELECT 1)[1]`); err != nil {
 			t.Fatal(err)
 		}
+		// Try a CTE to check CTE feature reporting.
+		if _, err := db.Exec(`WITH a AS (SELECT 1) SELECT * FROM a`); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	tables, err := ts.collectSchemaInfo(ctx)
@@ -561,6 +565,8 @@ func TestReportUsage(t *testing.T) {
 		"sql.plan.ops.array.cons":                                                   1,
 		"sql.plan.ops.array.flatten":                                                1,
 
+		"sql.plan.cte": 10,
+
 		"unimplemented.#33285.json_object_agg":          10,
 		"unimplemented.pg_catalog.pg_stat_wal_receiver": 10,
 		"unimplemented.syntax.#28751":                   10,
@@ -711,6 +717,7 @@ func TestReportUsage(t *testing.T) {
 		`[true,false,false] SELECT (_, _, __more2__) = (SELECT _, _, _, _ FROM _ LIMIT _)`,
 		"[true,false,false] SELECT _::STRING::INET, _::JSONB - _, ARRAY (SELECT _)[_]",
 		`[true,false,false] UPDATE _ SET _ = _ + _`,
+		"[true,false,false] WITH _ AS (SELECT _) SELECT * FROM _",
 		`[true,false,true] CREATE TABLE _ (_ INT8 PRIMARY KEY, _ INT8, INDEX (_) INTERLEAVE IN PARENT _ (_))`,
 		`[true,false,true] SELECT _ / $1`,
 		`[true,false,true] SELECT _ / _`,
@@ -771,6 +778,7 @@ func TestReportUsage(t *testing.T) {
 			`SET CLUSTER SETTING "server.time_until_store_dead" = _`,
 			`SET CLUSTER SETTING "diagnostics.reporting.send_crash_reports" = _`,
 			`SET application_name = _`,
+			`WITH _ AS (SELECT _) SELECT * FROM _`,
 		},
 		elemName: {
 			`SELECT _ FROM _ WHERE (_ = _) AND (lower(_) = lower(_))`,

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -565,6 +565,9 @@ func TestReportUsage(t *testing.T) {
 		"sql.plan.ops.array.cons":                                                   1,
 		"sql.plan.ops.array.flatten":                                                1,
 
+		// The subquery counter is exercised by `(1, 20, 30, 40) = (SELECT ...)`.
+		"sql.plan.subquery": 1,
+		// The CTE counter is exercised by `WITH a AS (SELECT 1) ...`.
 		"sql.plan.cte": 10,
 
 		"unimplemented.#33285.json_object_agg":          10,

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -17,6 +17,7 @@ package optbuilder
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -25,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/pkg/errors"
 )
 
@@ -484,6 +486,8 @@ func (b *Builder) buildCTE(ctes []*tree.CTE, inScope *scope) (outScope *scope) {
 			expr: cteScope.expr,
 		}
 	}
+
+	telemetry.Inc(sqltelemetry.CteUseCounter)
 
 	return outScope
 }

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -17,10 +17,12 @@ package optbuilder
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
 // subquery represents a subquery expression in an expression tree
@@ -204,6 +206,8 @@ func (b *Builder) buildSubqueryProjection(
 		col := b.synthesizeColumn(outScope, "", texpr.ResolvedType(), texpr, tup)
 		out = b.constructProject(out, []scopeColumn{*col})
 	}
+
+	telemetry.Inc(sqltelemetry.SubqueryUseCounter)
 
 	return out, outScope
 }

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -21,5 +21,9 @@ import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
 var CteUseCounter = telemetry.GetCounterOnce("sql.plan.cte")
 
 // SubqueryUseCounter is to be incremented every time a subquery is
-// planned without error in a query.
+// planned.
 var SubqueryUseCounter = telemetry.GetCounterOnce("sql.plan.subquery")
+
+// CorrelatedSubqueryUseCounter is to be incremented every time a
+// correlated subquery has been processed during planning.
+var CorrelatedSubqueryUseCounter = telemetry.GetCounterOnce("sql.plan.subquery.correlated")

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -19,3 +19,7 @@ import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
 // CteUseCounter is to be incremented every time a CTE (WITH ...)
 // is planned without error in a query.
 var CteUseCounter = telemetry.GetCounterOnce("sql.plan.cte")
+
+// SubqueryUseCounter is to be incremented every time a subquery is
+// planned without error in a query.
+var SubqueryUseCounter = telemetry.GetCounterOnce("sql.plan.subquery")

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -1,0 +1,21 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqltelemetry
+
+import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+
+// CteUseCounter is to be incremented every time a CTE (WITH ...)
+// is planned without error in a query.
+var CteUseCounter = telemetry.GetCounterOnce("sql.plan.cte")

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -17,10 +17,12 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -212,6 +214,8 @@ func (v *subqueryVisitor) extractSubquery(
 	if log.V(2) {
 		log.Infof(v.ctx, "collected subquery: %q -> %d", sub, sub.Idx)
 	}
+
+	telemetry.Inc(sqltelemetry.SubqueryUseCounter)
 
 	// The typing for subqueries is complex, but regular.
 	//

--- a/pkg/sql/with.go
+++ b/pkg/sql/with.go
@@ -17,9 +17,11 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
 // This file contains the implementation of common table expressions. See
@@ -122,6 +124,9 @@ func (p *planner) initWith(ctx context.Context, with *tree.With) (func(p *planne
 		}
 		return popCteNameEnvironment, nil
 	}
+
+	telemetry.Inc(sqltelemetry.CteUseCounter)
+
 	return nil, nil
 }
 


### PR DESCRIPTION
First commit from #35678.

Informs https://github.com/cockroachlabs/registration/issues/203

This adds telemetry for CTEs and subqueries.