### PR TITLE
ui: remove monospace font for human-readable job description

### DIFF
--- a/pkg/ui/src/views/jobs/index.styl
+++ b/pkg/ui/src/views/jobs/index.styl
@@ -64,9 +64,10 @@
     overflow hidden
     text-overflow ellipsis
     white-space nowrap
-    font-family Inconsolata-Regular
     max-width 500px
     word-wrap break-word
+    &--sql
+      font-family Inconsolata-Regular
 
   &__status-icon
     display inline-block

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -195,7 +195,13 @@ const jobsTableColumns: ColumnDescriptor<Job>[] = [
   },
   {
     title: "Description",
-    cell: job => <div className="jobs-table__cell--description">{job.description}</div>,
+    cell: job => {
+      // If a [SQL] job.statement exists, it means that job.description
+      // is a human-readable message. Otherwise job.description is a SQL
+      // statement.
+      const additionalStyle = (job.statement ? "" : "--sql");
+      return <div className={`jobs-table__cell--description${additionalStyle}`}>{job.description}</div>;
+    },
     sort: job => job.description,
   },
   {


### PR DESCRIPTION
In #35439, we introduced a user-friendly message (instead of the
exact SQL statement) for automatic table stats.

This commit uses the default font for that message, reserving
the monospace font for just SQL text.

cc @rolandcrosby @piyush-singh

![image](https://user-images.githubusercontent.com/3051672/54228134-e27cd500-44d7-11e9-8272-70da6ca7315c.png)
