### PR TITLE
exec: add multi column equality to vectorized mergejoiner

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -265,11 +265,6 @@ func newColOperator(
 				"can't plan merge join with on expressions")
 		}
 
-		if len(core.MergeJoiner.LeftOrdering.Columns) > 1 || len(core.MergeJoiner.RightOrdering.Columns) > 1 {
-			return nil, pgerror.NewErrorf(pgerror.CodeDataExceptionError,
-				"multi column merge join is still unsupported")
-		}
-
 		leftTypes := conv.FromColumnTypes(spec.Input[0].ColumnTypes)
 		rightTypes := conv.FromColumnTypes(spec.Input[1].ColumnTypes)
 

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -19,15 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
 
-// side is an enum that allows for switching between the left and right
-// input sources, useful for abstraction.
-type side int
-
-const (
-	left  side = 0
-	right side = 1
-)
-
 // group is an ADT representing a run, and numRepeats is used when
 // expanding each run into a cross product in the build phase.
 // Note that a run becomes a group when it is finished and the number
@@ -93,7 +84,7 @@ type mergeJoinOp struct {
 	savedOutput       coldata.Batch
 	savedOutputEndIdx int
 
-	// Member to keep track of count overflow, in the case that getExpectedOutCount
+	// Member to keep track of count overflow, in the case that calculateOutputCount
 	// returns a number that doesn't fit into a uint16.
 	countOverflow uint64
 
@@ -108,11 +99,9 @@ type mergeJoinOp struct {
 	lRunEndIdx int
 	rRun       coldata.Batch
 	rRunEndIdx int
-	matchVal   int64
 
 	// Local buffer for the "working" repeated groups.
-	leftGroups  []group
-	rightGroups []group
+	groups groupsBuffer
 }
 
 // NewMergeJoinOp returns a new merge join operator with the given spec.
@@ -151,26 +140,23 @@ func (c *mergeJoinOp) initWithBatchSize(outBatchSize uint16) {
 	c.lRun = coldata.NewMemBatchWithSize(c.left.sourceTypes, coldata.BatchSize)
 	c.rRun = coldata.NewMemBatchWithSize(c.right.sourceTypes, coldata.BatchSize)
 
-	c.leftGroups = make([]group, coldata.BatchSize)
-	c.rightGroups = make([]group, coldata.BatchSize)
+	c.groups = newGroupsBuffer(coldata.BatchSize)
 }
 
-// getBatch takes a side as input and returns either the next batch (from source),
+// getBatch takes a mergeJoinInput and returns either the next batch (from source),
 // or the saved batch from state (if it exists).
-func (c *mergeJoinOp) getBatch(s side) (coldata.Batch, []uint16) {
+func (c *mergeJoinOp) getBatch(input *mergeJoinInput) (coldata.Batch, []uint16) {
 	batch := c.savedLeftBatch
-	source := c.left.source
 
-	if s == right {
+	if input == &c.right {
 		batch = c.savedRightBatch
-		source = c.right.source
 	}
 
 	if batch != nil {
 		return batch, batch.Selection()
 	}
 
-	n := source.Next()
+	n := input.source.Next()
 	return n, n.Selection()
 }
 
@@ -253,21 +239,84 @@ func getRunLengthForValue(
 	return runLength, false
 }
 
-// getExpectedOutCount is a helper function to generate the right length of output,
-// if there are no output columns. ex: in the case of a COUNT().
-func (c *mergeJoinOp) getExpectedOutCount(groups []group, groupsLen int) uint16 {
+// calculateOutputCount is a helper function only exercised in the case that there are no output
+// columns, ie the SQL statement was a SELECT COUNT. It uses the groups and the current output
+// count to determine what the new output count is.
+// SIDE EFFECT: if there is overflow in the output count, the overflow amount is added to
+// countOverflow.
+func (c *mergeJoinOp) calculateOutputCount(
+	groups []group, groupsLen int, curOutputCount uint16,
+) uint16 {
 	count := uint64(0)
 	for i := 0; i < groupsLen; i++ {
 		count += uint64((groups[i].rowEndIdx - groups[i].rowStartIdx) * groups[i].numRepeats)
 	}
 
 	// Add count to overflow if it is larger than a uint16.
-	if count > (1<<16 - 1) {
-		c.countOverflow = count - (1<<16 - 1)
+	if count+uint64(curOutputCount) > (1<<16 - 1) {
+		c.countOverflow += count + uint64(curOutputCount) - (1<<16 - 1)
 		count = 1<<16 - 1
+	} else {
+		count = count + uint64(curOutputCount)
 	}
 
 	return uint16(count)
+}
+
+// completeRun extends the run in state given the source input.
+// To do this, we first check that the next batch is still the same run by checking all equality
+// columns except for the last minor equality column. Then we complete the run by Next'ing input
+// until the run is over.
+// SIDE EFFECT: extends the run in state corresponding to the source.
+func (c *mergeJoinOp) completeRun(
+	source *mergeJoinInput, bat coldata.Batch, rowIdx int,
+) (idx int, batch coldata.Batch, length int, sel []uint16) {
+	isRunComplete := false
+	length = int(bat.Length())
+	sel = bat.Selection()
+	eqColIdx := len(source.eqCols) - 1
+	keys := bat.ColVec(int(source.eqCols[eqColIdx])).Int64()
+	savedRun := c.lRun
+	savedRunIdx := &c.lRunEndIdx
+	if source == &c.right {
+		savedRun = c.rRun
+		savedRunIdx = &c.rRunEndIdx
+	}
+
+	// Check all equality columns before the last equality column to make sure we're in the same run.
+	for i := 0; i < len(source.eqCols)-1; i++ {
+		colIdx := source.eqCols[i]
+		prevVal := getValForIdx(savedRun.ColVec(int(colIdx)).Int64(), *savedRunIdx-1, nil)
+		curVal := getValForIdx(bat.ColVec(int(colIdx)).Int64(), rowIdx, sel)
+		if prevVal != curVal {
+			return rowIdx, bat, length, sel
+		}
+	}
+
+	// Continue the saved run based on the last equality column.
+	eqVal := getValForIdx(savedRun.ColVec(eqColIdx).Int64(), *savedRunIdx-1, nil)
+	for !isRunComplete {
+		// Find the length of the run.
+		runLength, complete := getRunLengthForValue(rowIdx, length, keys, sel, eqVal)
+		isRunComplete = complete
+
+		// Save the run to state.
+		c.saveRunToState(rowIdx, runLength, bat, sel, source, savedRun, savedRunIdx)
+		rowIdx += runLength
+
+		// Get the next batch if we hit the end.
+		if rowIdx == length {
+			rowIdx, bat, sel = nextBatch(source)
+			length = int(bat.Length())
+			if length == 0 {
+				// The run is complete if there are no more batches left.
+				break
+			}
+			keys = bat.ColVec(int(source.eqCols[eqColIdx])).Int64()
+		}
+	}
+
+	return rowIdx, bat, length, sel
 }
 
 // saveRunToState puts each column of the batch in a run into state, to be able to build
@@ -284,12 +333,12 @@ func (c *mergeJoinOp) saveRunToState(
 ) {
 	endIdx := idx + runLength
 	if sel != nil {
-		for _, cIdx := range src.outCols {
-			destBatch.ColVec(int(cIdx)).AppendSliceWithSel(bat.ColVec(int(cIdx)), src.sourceTypes[cIdx], uint64(*destStartIdx), uint16(idx), uint16(endIdx), sel)
+		for cIdx, cType := range src.sourceTypes {
+			destBatch.ColVec(cIdx).AppendSliceWithSel(bat.ColVec(cIdx), cType, uint64(*destStartIdx), uint16(idx), uint16(endIdx), sel)
 		}
 	} else {
-		for _, cIdx := range src.outCols {
-			destBatch.ColVec(int(cIdx)).AppendSlice(bat.ColVec(int(cIdx)), src.sourceTypes[cIdx], uint64(*destStartIdx), uint16(idx), uint16(endIdx))
+		for cIdx, cType := range src.sourceTypes {
+			destBatch.ColVec(cIdx).AppendSlice(bat.ColVec(cIdx), cType, uint64(*destStartIdx), uint16(idx), uint16(endIdx))
 		}
 	}
 
@@ -298,18 +347,18 @@ func (c *mergeJoinOp) saveRunToState(
 
 // buildSavedRuns expands the left and right runs in state into their cross product, dumping it
 // into the output buffer (and savedOutput overflow buffer if necessary).
-func (c *mergeJoinOp) buildSavedRuns() uint16 {
+func (c *mergeJoinOp) buildSavedRuns(outCount uint16) uint16 {
 	leftGroups := []group{{0, c.lRunEndIdx, c.rRunEndIdx}}
 	rightGroups := []group{{0, c.rRunEndIdx, c.lRunEndIdx}}
 
-	outCount, savedOutCount := c.buildLeftGroups(leftGroups, 1, 0, &c.left, c.lRun, nil, 0)
-	c.buildRightGroups(rightGroups, 1, len(c.left.sourceTypes), &c.right, c.rRun, nil, 0)
+	rowOutCount, savedOutCount := c.buildLeftGroups(leftGroups, 1, 0, &c.left, c.lRun, nil, outCount)
+	c.buildRightGroups(rightGroups, 1, len(c.left.sourceTypes), &c.right, c.rRun, nil, outCount)
 
 	c.savedOutputEndIdx += savedOutCount
 	c.lRunEndIdx = 0
 	c.rRunEndIdx = 0
 
-	return outCount
+	return rowOutCount
 }
 
 func (c *mergeJoinOp) Next() coldata.Batch {
@@ -329,12 +378,12 @@ func (c *mergeJoinOp) Next() coldata.Batch {
 		return c.output
 	}
 
-	lBat, lSel := c.getBatch(left)
-	rBat, rSel := c.getBatch(right)
-	eqColIdx := 0
+	lBat, lSel := c.getBatch(&c.left)
+	rBat, rSel := c.getBatch(&c.right)
 	lIdx, rIdx := c.savedLeftIdx, c.savedRightIdx
 
 	for {
+		eqColIdx := 0
 		outCount := uint16(0)
 
 		lLength := int(lBat.Length())
@@ -344,121 +393,96 @@ func (c *mergeJoinOp) Next() coldata.Batch {
 		// The (lLength == 0 || rLength == 0) clause is specifically for inner joins.
 		// TODO (georgeutsin): update this logic to be able to support joins other than INNER.
 		if lLength == 0 || rLength == 0 {
-			outCount = c.buildSavedRuns()
+			outCount = c.buildSavedRuns(outCount)
 			c.output.SetLength(outCount)
 			return c.output
 		}
-
-		lKeys := lBat.ColVec(int(c.left.eqCols[eqColIdx])).Int64()
-		rKeys := rBat.ColVec(int(c.right.eqCols[eqColIdx])).Int64()
 
 		// Phase 0: finish previous run if it exists (mini probe and build).
 		if c.lRunEndIdx > 0 || c.rRunEndIdx > 0 {
-			isLRunComplete := false
-			for !isLRunComplete {
-				// Find the length of the run.
-				runLength, complete := getRunLengthForValue(lIdx, lLength, lKeys, lSel, c.matchVal)
-				isLRunComplete = complete
+			lIdx, lBat, lLength, lSel = c.completeRun(&c.left, lBat, lIdx)
+			rIdx, rBat, rLength, rSel = c.completeRun(&c.right, rBat, rIdx)
 
-				// Save the run to state.
-				c.saveRunToState(lIdx, runLength, lBat, lSel, &c.left, c.lRun, &c.lRunEndIdx)
-				lIdx += runLength
-
-				// Get the next batch if we hit the end.
-				if lIdx == lLength {
-					lIdx, lBat, lSel = nextBatch(&c.left)
-					lLength = int(lBat.Length())
-					if lLength == 0 {
-						// The run is complete if there are no more batches left.
-						break
-					}
-					lKeys = lBat.ColVec(int(c.left.eqCols[eqColIdx])).Int64()
-				}
-			}
-
-			isRRunComplete := false
-			for !isRRunComplete {
-				// Find the length of the run.
-				runLength, complete := getRunLengthForValue(rIdx, rLength, rKeys, rSel, c.matchVal)
-				isRRunComplete = complete
-
-				// Save the run to state.
-				c.saveRunToState(rIdx, runLength, rBat, rSel, &c.right, c.rRun, &c.rRunEndIdx)
-				rIdx += runLength
-
-				// Get the next batch if we hit the end.
-				if rIdx == rLength {
-					rIdx, rBat, rSel = nextBatch(&c.right)
-					rLength = int(rBat.Length())
-					if rLength == 0 {
-						// The run is complete if there are no more batches left.
-						break
-					}
-					rKeys = rBat.ColVec(int(c.right.eqCols[eqColIdx])).Int64()
-				}
-			}
-
-			outCount = c.buildSavedRuns()
-			c.saveBatchesToState(lIdx, lBat, rIdx, rBat)
-			c.output.SetLength(outCount)
-			return c.output
+			outCount = c.buildSavedRuns(outCount)
 		}
 
 		// Phase 1: probe.
-		leftGroupsLen := 0
-		rightGroupsLen := 0
-		for lIdx < lLength && rIdx < rLength {
-			lVal := getValForIdx(lKeys, lIdx, lSel)
-			rVal := getValForIdx(rKeys, rIdx, rSel)
+		// In this phase, we generate the groups slices that are used in the build phase.
+		// We do this by first assuming that every row in both batches contributes to the
+		// cross product. Then, with every equality column, we filter out the rows that
+		// don't contribute to the cross product (ie they don't have a matching row on
+		// the other side in the case of an inner join), and set the correct cardinality.
+		// Note that in this phase, we do this for every group, except the last group in
+		// the batch. The last group in the batch is still considered a "run", since we
+		// don't know if it is complete yet or not, so we handle it in the next iteration.
 
-			if lVal == rVal { // match
-				// Find the length of the runs on each side.
-				lRunLength, _ := getRunLengthForValue(lIdx, lLength, lKeys, lSel, lVal)
-				rRunLength, _ := getRunLengthForValue(rIdx, rLength, rKeys, rSel, rVal)
+		c.groups.reset(lIdx, lLength, rIdx, rLength)
+	EqLoop:
+		for eqColIdx = 0; eqColIdx < len(c.left.eqCols); eqColIdx++ {
+			lKeys := lBat.ColVec(int(c.left.eqCols[eqColIdx])).Int64()
+			rKeys := rBat.ColVec(int(c.right.eqCols[eqColIdx])).Int64()
+			// Iterate over all the groups in the column.
+			var lGroup, rGroup group
+			for c.groups.nextGroupInCol(&lGroup, &rGroup) {
+				curLIdx := lGroup.rowStartIdx
+				curRIdx := rGroup.rowStartIdx
+				curLLength := lGroup.rowEndIdx
+				curRLength := rGroup.rowEndIdx
+				// Expand or filter each group based on the current equality column
+				for curLIdx < curLLength && curRIdx < curRLength {
+					lVal := getValForIdx(lKeys, curLIdx, lSel)
+					rVal := getValForIdx(rKeys, curRIdx, rSel)
 
-				// Either run ends with a batch. Save state and have it handled in the next iteration.
-				if lRunLength+lIdx >= lLength || rRunLength+rIdx >= rLength {
-					c.saveRunToState(lIdx, lRunLength, lBat, lSel, &c.left, c.lRun, &c.lRunEndIdx)
-					lIdx += lRunLength
-					c.saveRunToState(rIdx, rRunLength, rBat, rSel, &c.right, c.rRun, &c.rRunEndIdx)
-					rIdx += rRunLength
+					if lVal == rVal { // match
+						// Find the length of the runs on each side.
+						lRunLength, lComplete := getRunLengthForValue(curLIdx, curLLength, lKeys, lSel, lVal)
+						rRunLength, rComplete := getRunLengthForValue(curRIdx, curRLength, rKeys, rSel, rVal)
 
-					c.matchVal = lVal
-					break
+						// Last equality column and either run is incomplete. Save state and have it handled in the next iteration.
+						if eqColIdx == len(c.left.eqCols)-1 && (!lComplete || !rComplete) {
+							c.saveRunToState(curLIdx, lRunLength, lBat, lSel, &c.left, c.lRun, &c.lRunEndIdx)
+							lIdx = lRunLength + curLIdx
+							c.saveRunToState(curRIdx, rRunLength, rBat, rSel, &c.right, c.rRun, &c.rRunEndIdx)
+							rIdx = rRunLength + curRIdx
+
+							c.groups.finishedCol()
+							break EqLoop
+						}
+
+						// Neither run ends with the batch so convert the runs to groups and increment the indices.
+						c.groups.addGroupsToNextCol(curLIdx, lRunLength, curRIdx, rRunLength)
+						curLIdx += lRunLength
+						curRIdx += rRunLength
+					} else { // mismatch
+						if lVal < rVal {
+							curLIdx++
+						} else {
+							curRIdx++
+						}
+					}
 				}
+				// Both lIdx and rIdx should point to the last elements processed in their respective batches.
+				lIdx = curLIdx
+				rIdx = curRIdx
 
-				// Neither run ends with the batch so convert the runs to groups and increment the indices.
-				c.leftGroups[leftGroupsLen] = group{lIdx, lIdx + lRunLength, rRunLength}
-				leftGroupsLen++
-				lIdx += lRunLength
-
-				c.rightGroups[rightGroupsLen] = group{rIdx, rIdx + rRunLength, lRunLength}
-				rightGroupsLen++
-				rIdx += rRunLength
-			} else { // mismatch
-				if lVal < rVal {
-					lIdx++
-				} else {
-					rIdx++
-				}
 			}
+			// Look at the groups associated with the next equality column by moving the circular buffer pointer up.
+			c.groups.finishedCol()
 		}
 
 		// Phase 2: build.
-		rowOutCount, savedOutCount := c.buildLeftGroups(c.leftGroups, leftGroupsLen, 0 /* colOffset */, &c.left, lBat, lSel, outCount)
-		c.buildRightGroups(c.rightGroups, rightGroupsLen, len(c.left.sourceTypes), &c.right, rBat, rSel, outCount)
+		bufferLen := c.groups.getBufferLen()
+		rowOutCount, savedOutCount := c.buildLeftGroups(c.groups.getLGroups(), bufferLen, 0 /* colOffset */, &c.left, lBat, lSel, outCount)
+		c.buildRightGroups(c.groups.getRGroups(), bufferLen, len(c.left.sourceTypes), &c.right, rBat, rSel, outCount)
 		c.savedOutputEndIdx += savedOutCount
-		outCount += rowOutCount
+		outCount = rowOutCount
 
-		// Avoid empty output batches.
-		if outCount == 0 {
-			// But only do this check when we've reached the end of one of the input batches (with no matches).
-			if lIdx == lLength {
-				lIdx, lBat, lSel = nextBatch(&c.left)
-			}
-			if rIdx == rLength {
-				rIdx, rBat, rSel = nextBatch(&c.right)
-			}
+		// Get the next batch if we're done with the current batch.
+		if lIdx == lLength {
+			lIdx, lBat, lSel = nextBatch(&c.left)
+		}
+		if rIdx == rLength {
+			rIdx, rBat, rSel = nextBatch(&c.right)
 		}
 
 		c.saveBatchesToState(lIdx, lBat, rIdx, rBat)

--- a/pkg/sql/exec/mergejoiner_groups_buffer.go
+++ b/pkg/sql/exec/mergejoiner_groups_buffer.go
@@ -1,0 +1,106 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+type groupsBuffer struct {
+	bufferStartIdx     int
+	bufferEndIdx       int
+	bufferCap          int
+	bufferEndIdxForCol int
+
+	leftGroups        []group
+	rightGroups       []group
+	leftReturnGroups  []group
+	rightReturnGroups []group
+}
+
+func newGroupsBuffer(bufferCap int) groupsBuffer {
+	b := groupsBuffer{
+		bufferCap:         bufferCap,
+		leftGroups:        make([]group, bufferCap),
+		rightGroups:       make([]group, bufferCap),
+		leftReturnGroups:  make([]group, bufferCap),
+		rightReturnGroups: make([]group, bufferCap),
+	}
+	return b
+}
+
+func (b *groupsBuffer) reset(lIdx int, lLength int, rIdx int, rLength int) {
+	b.bufferStartIdx = 0
+	b.bufferEndIdx = 1
+	b.bufferEndIdxForCol = 1
+
+	b.leftGroups[0] = group{lIdx, lLength, 1}
+	b.rightGroups[0] = group{rIdx, rLength, 1}
+}
+
+func (b *groupsBuffer) nextGroupInCol(lGroup *group, rGroup *group) bool {
+	if b.bufferStartIdx >= b.bufferEndIdxForCol {
+		return false
+	}
+	idx := b.bufferStartIdx % b.bufferCap
+	b.bufferStartIdx++
+
+	if b.bufferStartIdx >= b.bufferCap {
+		b.bufferStartIdx -= b.bufferCap
+	}
+
+	*lGroup = b.leftGroups[idx]
+	*rGroup = b.rightGroups[idx]
+	return true
+}
+
+func (b *groupsBuffer) addGroupsToNextCol(
+	curLIdx int, lRunLength int, curRIdx int, rRunLength int,
+) {
+	b.leftGroups[b.bufferEndIdx] = group{curLIdx, curLIdx + lRunLength, rRunLength}
+	b.rightGroups[b.bufferEndIdx] = group{curRIdx, curRIdx + rRunLength, lRunLength}
+	b.bufferEndIdx++
+
+	if b.bufferEndIdx >= b.bufferCap {
+		b.bufferEndIdx -= b.bufferCap
+	}
+}
+
+func (b *groupsBuffer) finishedCol() {
+	b.bufferStartIdx = b.bufferEndIdxForCol
+	b.bufferEndIdxForCol = b.bufferEndIdx
+}
+
+func (b *groupsBuffer) getLGroups() []group {
+	return b.getGroups(b.leftGroups, b.leftReturnGroups)
+}
+
+func (b *groupsBuffer) getRGroups() []group {
+	return b.getGroups(b.rightGroups, b.rightReturnGroups)
+}
+
+func (b *groupsBuffer) getGroups(groups []group, returnGroups []group) []group {
+	startIdx := b.bufferStartIdx % b.bufferCap
+	endIdx := b.bufferEndIdx % b.bufferCap
+
+	if endIdx < startIdx {
+		copy(returnGroups, groups[startIdx:b.bufferCap])
+		start := b.bufferCap - startIdx
+		copy(returnGroups[start:], groups[:endIdx])
+		return returnGroups
+	}
+
+	return groups[startIdx:endIdx]
+}
+
+func (b *groupsBuffer) getBufferLen() int {
+	return b.bufferEndIdx - b.bufferStartIdx
+}

--- a/pkg/sql/exec/mergejoiner_groups_buffer.go
+++ b/pkg/sql/exec/mergejoiner_groups_buffer.go
@@ -14,30 +14,32 @@
 
 package exec
 
-type groupsBuffer struct {
+// circularGroupsBuffer is a struct design to store the groups slice
+// for a given column. We know that there is a maximum number of possible
+// groups per batch, so we can cap the buffer and make it circular.
+type circularGroupsBuffer struct {
 	bufferStartIdx     int
 	bufferEndIdx       int
 	bufferCap          int
 	bufferEndIdxForCol int
 
-	leftGroups        []group
-	rightGroups       []group
-	leftReturnGroups  []group
-	rightReturnGroups []group
+	leftGroups  []group
+	rightGroups []group
 }
 
-func newGroupsBuffer(bufferCap int) groupsBuffer {
-	b := groupsBuffer{
-		bufferCap:         bufferCap,
-		leftGroups:        make([]group, bufferCap),
-		rightGroups:       make([]group, bufferCap),
-		leftReturnGroups:  make([]group, bufferCap),
-		rightReturnGroups: make([]group, bufferCap),
+func makeGroupsBuffer(bufferCap int) circularGroupsBuffer {
+	return circularGroupsBuffer{
+		bufferCap: bufferCap,
+		// Allocate twice the amount of space needed so that no additional
+		// allocations are needed to make the resulting slice contiguous.
+		leftGroups:  make([]group, bufferCap*2),
+		rightGroups: make([]group, bufferCap*2),
 	}
-	return b
 }
 
-func (b *groupsBuffer) reset(lIdx int, lLength int, rIdx int, rLength int) {
+// reset sets the circular buffer state to groups that produce the maximal
+// cross product, ie one maximal group on each side.
+func (b *circularGroupsBuffer) reset(lIdx int, lLength int, rIdx int, rLength int) {
 	b.bufferStartIdx = 0
 	b.bufferEndIdx = 1
 	b.bufferEndIdxForCol = 1
@@ -46,11 +48,14 @@ func (b *groupsBuffer) reset(lIdx int, lLength int, rIdx int, rLength int) {
 	b.rightGroups[0] = group{rIdx, rLength, 1}
 }
 
-func (b *groupsBuffer) nextGroupInCol(lGroup *group, rGroup *group) bool {
-	if b.bufferStartIdx >= b.bufferEndIdxForCol {
+// nextGroupInCol returns whether or not there exists a next group in the current
+// column, and sets the parameters to be the left and right groups corresponding
+// to the next values in the buffer.
+func (b *circularGroupsBuffer) nextGroupInCol(lGroup *group, rGroup *group) bool {
+	if b.bufferStartIdx == b.bufferEndIdxForCol {
 		return false
 	}
-	idx := b.bufferStartIdx % b.bufferCap
+	idx := b.bufferStartIdx
 	b.bufferStartIdx++
 
 	if b.bufferStartIdx >= b.bufferCap {
@@ -62,45 +67,54 @@ func (b *groupsBuffer) nextGroupInCol(lGroup *group, rGroup *group) bool {
 	return true
 }
 
-func (b *groupsBuffer) addGroupsToNextCol(
+// addGroupsToNextCol appends a left and right group to the buffer. In an iteration
+// of a column, these values are either processed in the next equality column, or
+// used to build the cross product.
+func (b *circularGroupsBuffer) addGroupsToNextCol(
 	curLIdx int, lRunLength int, curRIdx int, rRunLength int,
 ) {
 	b.leftGroups[b.bufferEndIdx] = group{curLIdx, curLIdx + lRunLength, rRunLength}
 	b.rightGroups[b.bufferEndIdx] = group{curRIdx, curRIdx + rRunLength, lRunLength}
 	b.bufferEndIdx++
 
+	// Modulus on every step is more expensive than this check.
 	if b.bufferEndIdx >= b.bufferCap {
 		b.bufferEndIdx -= b.bufferCap
 	}
 }
 
-func (b *groupsBuffer) finishedCol() {
+// finishedCol is used to notify the circular buffer to update the indices representing
+// the "window" of available values for the next column.
+func (b *circularGroupsBuffer) finishedCol() {
 	b.bufferStartIdx = b.bufferEndIdxForCol
 	b.bufferEndIdxForCol = b.bufferEndIdx
 }
 
-func (b *groupsBuffer) getLGroups() []group {
-	return b.getGroups(b.leftGroups, b.leftReturnGroups)
+// getLGroups wraps getGroups for the groups on the left side.
+func (b *circularGroupsBuffer) getLGroups() []group {
+	return b.getGroups(b.leftGroups)
 }
 
-func (b *groupsBuffer) getRGroups() []group {
-	return b.getGroups(b.rightGroups, b.rightReturnGroups)
+// getRGroups wraps getGroups for the groups on the right side.
+func (b *circularGroupsBuffer) getRGroups() []group {
+	return b.getGroups(b.rightGroups)
 }
 
-func (b *groupsBuffer) getGroups(groups []group, returnGroups []group) []group {
-	startIdx := b.bufferStartIdx % b.bufferCap
-	endIdx := b.bufferEndIdx % b.bufferCap
+// getGroups returns a []group that is contiguous, which is a useful simplification
+// for the build phase.
+func (b *circularGroupsBuffer) getGroups(groups []group) []group {
+	startIdx := b.bufferStartIdx
+	endIdx := b.bufferEndIdx
 
 	if endIdx < startIdx {
-		copy(returnGroups, groups[startIdx:b.bufferCap])
-		start := b.bufferCap - startIdx
-		copy(returnGroups[start:], groups[:endIdx])
-		return returnGroups
+		copy(groups[b.bufferCap:], groups[:endIdx])
+		endIdx += b.bufferCap
 	}
 
 	return groups[startIdx:endIdx]
 }
 
-func (b *groupsBuffer) getBufferLen() int {
+// getBufferLen returns the length of the buffer, ie the length of the "window".
+func (b *circularGroupsBuffer) getBufferLen() int {
 	return (b.bufferEndIdx - b.bufferStartIdx + b.bufferCap) % b.bufferCap
 }

--- a/pkg/sql/exec/mergejoiner_groups_buffer.go
+++ b/pkg/sql/exec/mergejoiner_groups_buffer.go
@@ -102,5 +102,5 @@ func (b *groupsBuffer) getGroups(groups []group, returnGroups []group) []group {
 }
 
 func (b *groupsBuffer) getBufferLen() int {
-	return b.bufferEndIdx - b.bufferStartIdx
+	return (b.bufferEndIdx - b.bufferStartIdx + b.bufferCap) % b.bufferCap
 }

--- a/pkg/sql/exec/mergejoiner_test.go
+++ b/pkg/sql/exec/mergejoiner_test.go
@@ -28,9 +28,11 @@ func TestMergeJoiner(t *testing.T) {
 		leftTuples      []tuple
 		leftTypes       []types.T
 		leftOutCols     []uint32
+		leftEqCols      []uint32
 		rightTuples     []tuple
 		rightTypes      []types.T
 		rightOutCols    []uint32
+		rightEqCols     []uint32
 		expected        []tuple
 		expectedOutCols []int
 		outputBatchSize uint16
@@ -43,6 +45,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1}, {2}, {3}, {4}},
 			leftOutCols:     []uint32{0},
 			rightOutCols:    []uint32{0},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1}, {2}, {3}, {4}},
 			expectedOutCols: []int{0},
 			outputBatchSize: coldata.BatchSize,
@@ -55,6 +59,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1}, {2}, {3}, {4}},
 			leftOutCols:     []uint32{},
 			rightOutCols:    []uint32{},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{}, {}, {}, {}},
 			expectedOutCols: []int{},
 			outputBatchSize: coldata.BatchSize,
@@ -67,6 +73,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1}, {2}, {3}, {4}},
 			leftOutCols:     []uint32{0},
 			rightOutCols:    []uint32{0},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1}, {3}, {4}},
 			expectedOutCols: []int{0},
 			outputBatchSize: coldata.BatchSize,
@@ -79,6 +87,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1}, {3}, {4}},
 			leftOutCols:     []uint32{0},
 			rightOutCols:    []uint32{0},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1}, {3}, {4}},
 			expectedOutCols: []int{0},
 			outputBatchSize: coldata.BatchSize,
@@ -91,6 +101,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1}, {2}, {3}, {4}},
 			leftOutCols:     []uint32{0},
 			rightOutCols:    []uint32{0},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1}, {1}, {2}, {3}, {4}},
 			expectedOutCols: []int{0},
 			outputBatchSize: coldata.BatchSize,
@@ -103,6 +115,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1}, {1}, {2}, {3}, {4}},
 			leftOutCols:     []uint32{0},
 			rightOutCols:    []uint32{0},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1}, {1}, {2}, {3}, {4}},
 			expectedOutCols: []int{0},
 			outputBatchSize: coldata.BatchSize,
@@ -115,6 +129,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1}, {1}, {2}, {3}, {4}},
 			leftOutCols:     []uint32{0},
 			rightOutCols:    []uint32{0},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1}, {1}, {1}, {1}, {2}, {3}, {4}},
 			expectedOutCols: []int{0},
 			outputBatchSize: coldata.BatchSize,
@@ -127,6 +143,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1}, {1}, {2}, {3}, {4}},
 			leftOutCols:     []uint32{0},
 			rightOutCols:    []uint32{0},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1}, {1}, {2}, {2}, {2}, {3}, {4}},
 			expectedOutCols: []int{0},
 			outputBatchSize: coldata.BatchSize,
@@ -139,6 +157,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1}, {1}, {1}, {1}},
 			leftOutCols:     []uint32{0},
 			rightOutCols:    []uint32{0},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
 			expectedOutCols: []int{0},
 			outputBatchSize: coldata.BatchSize,
@@ -151,6 +171,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1}, {1}, {1}, {1}},
 			leftOutCols:     []uint32{0},
 			rightOutCols:    []uint32{0},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
 			expectedOutCols: []int{0},
 			outputBatchSize: 4,
@@ -163,6 +185,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1}, {1}, {1}, {1}},
 			leftOutCols:     []uint32{0},
 			rightOutCols:    []uint32{0},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
 			expectedOutCols: []int{0},
 			outputBatchSize: 3,
@@ -175,6 +199,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1}, {1}, {1}, {1}},
 			leftOutCols:     []uint32{0},
 			rightOutCols:    []uint32{0},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
 			expectedOutCols: []int{0},
 			outputBatchSize: 1,
@@ -187,6 +213,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
 			leftOutCols:     []uint32{0, 1},
 			rightOutCols:    []uint32{0, 1},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
 			expectedOutCols: []int{0, 1, 2, 3},
 			outputBatchSize: coldata.BatchSize,
@@ -199,6 +227,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
 			leftOutCols:     []uint32{0, 1},
 			rightOutCols:    []uint32{0, 1},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
 			expectedOutCols: []int{0, 1, 2, 3},
 			outputBatchSize: 1,
@@ -211,6 +241,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
 			leftOutCols:     []uint32{0},
 			rightOutCols:    []uint32{0},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
 			expectedOutCols: []int{0, 2},
 			outputBatchSize: coldata.BatchSize,
@@ -223,6 +255,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
 			leftOutCols:     []uint32{1},
 			rightOutCols:    []uint32{1},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{10, 11}, {20, 12}, {30, 13}, {40, 14}},
 			expectedOutCols: []int{1, 3},
 			outputBatchSize: coldata.BatchSize,
@@ -235,6 +269,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
 			leftOutCols:     []uint32{0, 1},
 			rightOutCols:    []uint32{0, 1},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {2, 21, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
 			expectedOutCols: []int{0, 1, 2, 3},
 			outputBatchSize: coldata.BatchSize,
@@ -247,6 +283,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1, 11}, {2, 12}, {3, 13}, {4, 14}},
 			leftOutCols:     []uint32{0, 1},
 			rightOutCols:    []uint32{0, 1},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1, 10, 1, 11}, {2, 20, 2, 12}, {2, 21, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
 			expectedOutCols: []int{0, 1, 2, 3},
 			outputBatchSize: 1,
@@ -259,6 +297,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1, 11}, {1, 111}, {2, 12}, {3, 13}, {4, 14}},
 			leftOutCols:     []uint32{0, 1},
 			rightOutCols:    []uint32{0, 1},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1, 10, 1, 11}, {1, 10, 1, 111}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
 			expectedOutCols: []int{0, 1, 2, 3},
 			outputBatchSize: coldata.BatchSize,
@@ -271,6 +311,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{1, 11}, {1, 111}, {2, 12}, {3, 13}, {4, 14}},
 			leftOutCols:     []uint32{0, 1},
 			rightOutCols:    []uint32{0, 1},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{1, 10, 1, 11}, {1, 10, 1, 111}, {2, 20, 2, 12}, {3, 30, 3, 13}, {4, 40, 4, 14}},
 			expectedOutCols: []int{0, 1, 2, 3},
 			outputBatchSize: 1,
@@ -283,6 +325,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:     tuples{{0, 5}, {1, 3}, {3, 2}, {4, 6}},
 			leftOutCols:     []uint32{1},
 			rightOutCols:    []uint32{1},
+			leftEqCols:      []uint32{0},
+			rightEqCols:     []uint32{0},
 			expected:        tuples{{5, 4}, {2, 4}},
 			expectedOutCols: []int{3, 1},
 			outputBatchSize: coldata.BatchSize,
@@ -295,6 +339,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:  tuples{{1, 11}, {1, 11}, {2, 12}, {3, 13}, {4, 14}},
 			leftOutCols:  []uint32{1, 0},
 			rightOutCols: []uint32{1, 0},
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
 			expected: tuples{
 				{10, 1, 11, 1},
 				{10, 1, 11, 1},
@@ -317,6 +363,8 @@ func TestMergeJoiner(t *testing.T) {
 			rightTuples:  tuples{{1, 11}, {1, 11}, {2, 12}, {3, 13}, {4, 14}},
 			leftOutCols:  []uint32{1, 0},
 			rightOutCols: []uint32{1},
+			leftEqCols:   []uint32{0},
+			rightEqCols:  []uint32{0},
 			expected: tuples{
 				{10, 1, 11},
 				{10, 1, 11},
@@ -331,11 +379,105 @@ func TestMergeJoiner(t *testing.T) {
 			expectedOutCols: []int{1, 0, 3},
 			outputBatchSize: 1,
 		},
+		{
+			description:  "multi column equality basic test",
+			leftTypes:    []types.T{types.Int64, types.Int64},
+			rightTypes:   []types.T{types.Int64, types.Int64},
+			leftTuples:   tuples{{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:  tuples{{1, 10}, {2, 20}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{0, 1},
+			leftEqCols:   []uint32{0, 1},
+			rightEqCols:  []uint32{0, 1},
+			expected: tuples{
+				{1, 10, 1, 10},
+				{2, 20, 2, 20},
+			},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: coldata.BatchSize,
+		},
+		{
+			description:  "multi column equality runs",
+			leftTypes:    []types.T{types.Int64, types.Int64},
+			rightTypes:   []types.T{types.Int64, types.Int64},
+			leftTuples:   tuples{{1, 10}, {1, 10}, {1, 10}, {2, 20}, {3, 30}, {4, 40}},
+			rightTuples:  tuples{{1, 10}, {1, 10}, {2, 20}, {3, 13}, {4, 14}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{0, 1},
+			leftEqCols:   []uint32{0, 1},
+			rightEqCols:  []uint32{0, 1},
+			expected: tuples{
+				{1, 10, 1, 10},
+				{1, 10, 1, 10},
+				{1, 10, 1, 10},
+				{1, 10, 1, 10},
+				{1, 10, 1, 10},
+				{1, 10, 1, 10},
+				{2, 20, 2, 20},
+			},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: coldata.BatchSize,
+		},
+		{
+			description:  "multi column non-consecutive equality cols",
+			leftTypes:    []types.T{types.Int64, types.Int64, types.Int64},
+			rightTypes:   []types.T{types.Int64, types.Int64, types.Int64},
+			leftTuples:   tuples{{1, 123, 1}, {1, 234, 10}},
+			rightTuples:  tuples{{1, 1, 345}, {1, 10, 456}},
+			leftOutCols:  []uint32{0, 2, 1},
+			rightOutCols: []uint32{0, 2, 1},
+			leftEqCols:   []uint32{0, 2},
+			rightEqCols:  []uint32{0, 1},
+			expected: tuples{
+				{1, 123, 1, 1, 1, 345},
+				{1, 234, 10, 1, 10, 456},
+			},
+			expectedOutCols: []int{0, 1, 2, 3, 4, 5},
+			outputBatchSize: coldata.BatchSize,
+		},
+		{
+			description:  "multi column equality: new batch ends run",
+			leftTypes:    []types.T{types.Int64, types.Int64},
+			rightTypes:   []types.T{types.Int64, types.Int64},
+			leftTuples:   tuples{{1, 1}, {1, 1}, {3, 3}, {4, 3}},
+			rightTuples:  tuples{{1, 1}, {1, 2}, {3, 3}, {3, 3}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{0, 1},
+			leftEqCols:   []uint32{0, 1},
+			rightEqCols:  []uint32{0, 1},
+			expected: tuples{
+				{1, 1, 1, 1},
+				{1, 1, 1, 1},
+				{3, 3, 3, 3},
+				{3, 3, 3, 3},
+			},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: coldata.BatchSize,
+		},
+		{
+			description:  "multi column equality: reordered eq columns",
+			leftTypes:    []types.T{types.Int64, types.Int64},
+			rightTypes:   []types.T{types.Int64, types.Int64},
+			leftTuples:   tuples{{1, 1}, {1, 1}, {3, 3}, {4, 3}},
+			rightTuples:  tuples{{1, 1}, {1, 2}, {3, 3}, {3, 3}},
+			leftOutCols:  []uint32{0, 1},
+			rightOutCols: []uint32{0, 1},
+			leftEqCols:   []uint32{0, 1},
+			rightEqCols:  []uint32{1, 0},
+			expected: tuples{
+				{1, 1, 1, 1},
+				{1, 1, 1, 1},
+				{3, 3, 3, 3},
+				{3, 3, 3, 3},
+			},
+			expectedOutCols: []int{0, 1, 2, 3},
+			outputBatchSize: coldata.BatchSize,
+		},
 	}
 
 	for _, tc := range tcs {
 		runTests(t, []tuples{tc.leftTuples, tc.rightTuples}, func(t *testing.T, input []Operator) {
-			s := NewMergeJoinOp(input[0], input[1], tc.leftOutCols, tc.rightOutCols, tc.leftTypes, tc.rightTypes, []uint32{0}, []uint32{0})
+			s := NewMergeJoinOp(input[0], input[1], tc.leftOutCols, tc.rightOutCols, tc.leftTypes, tc.rightTypes, tc.leftEqCols, tc.rightEqCols)
 
 			out := newOpTestOutput(s, tc.expectedOutCols, tc.expected)
 			s.(*mergeJoinOp).initWithBatchSize(tc.outputBatchSize)
@@ -413,11 +555,11 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 			t.Run(fmt.Sprintf("groupSize=%d/numInputBatches=%d", groupSize, numInputBatches),
 				func(t *testing.T) {
 					nTuples := coldata.BatchSize * numInputBatches
-					typs := []types.T{types.Int64}
-					cols := []coldata.Vec{coldata.NewMemColumn(typs[0], nTuples)}
-					groups := cols[0].Int64()
-					for i := range groups {
-						groups[i] = int64(i / groupSize)
+					typs := []types.T{types.Int64, types.Int64}
+					cols := []coldata.Vec{coldata.NewMemColumn(typs[0], nTuples), coldata.NewMemColumn(typs[1], nTuples)}
+					for i := range cols[0].Int64() {
+						cols[0].Int64()[i] = int64(i / groupSize)
+						cols[1].Int64()[i] = int64(i / groupSize)
 					}
 
 					leftSource := newChunkingBatchSource(typs, cols, uint64(nTuples))
@@ -430,8 +572,8 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 						[]uint32{0},
 						typs,
 						typs,
-						[]uint32{0},
-						[]uint32{0},
+						[]uint32{0, 1},
+						[]uint32{0, 1},
 					)
 
 					a.(*mergeJoinOp).Init()
@@ -624,88 +766,85 @@ func BenchmarkMergeJoiner(b *testing.B) {
 				s.Init()
 
 				b.StartTimer()
-				for i := 0; i < nBatches; i++ {
-					s.Next()
+				for b := s.Next(); b.Length() != 0; b = s.Next() {
 				}
 				b.StopTimer()
 			}
 		})
 	}
-
-	// left repeats
-	for _, nBatches := range []int{1, 4, 16, 1024} {
-		b.Run(fmt.Sprintf("oneSideRepeat-rows=%d", nBatches*coldata.BatchSize), func(b *testing.B) {
-			// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize (rows /
-			// batch) * nCols (number of columns / row) * 2 (number of sources).
-			b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols * 2))
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				leftSource := newFiniteBatchSource(newBatchOfRepeatedIntRows(nCols, batch, nBatches), nBatches)
-				rightSource := newFiniteBatchSource(newBatchOfIntRows(nCols, batch), nBatches)
-
-				s := mergeJoinOp{
-					left: mergeJoinInput{
-						eqCols:      []uint32{0},
-						outCols:     []uint32{0, 1},
-						sourceTypes: sourceTypes,
-						source:      leftSource,
-					},
-
-					right: mergeJoinInput{
-						eqCols:      []uint32{0},
-						outCols:     []uint32{2, 3},
-						sourceTypes: sourceTypes,
-						source:      rightSource,
-					},
-				}
-
-				s.Init()
-
-				b.StartTimer()
-				for i := 0; i < nBatches; i++ {
-					s.Next()
-				}
-				b.StopTimer()
-			}
-		})
-	}
-
-	// both repeats
-	for _, nBatches := range []int{1, 4, 16, 1024} {
-		b.Run(fmt.Sprintf("bothSidesRepeat-rows=%d", nBatches*coldata.BatchSize), func(b *testing.B) {
-			// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize (rows /
-			// batch) * nCols (number of columns / row) * 2 (number of sources).
-			b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols * 2))
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				leftSource := newFiniteBatchSource(newBatchOfRepeatedIntRows(nCols, batch, nBatches), nBatches)
-				rightSource := newFiniteBatchSource(newBatchOfRepeatedIntRows(nCols, batch, nBatches), nBatches)
-
-				s := mergeJoinOp{
-					left: mergeJoinInput{
-						eqCols:      []uint32{0},
-						outCols:     []uint32{0, 1},
-						sourceTypes: sourceTypes,
-						source:      leftSource,
-					},
-
-					right: mergeJoinInput{
-						eqCols:      []uint32{0},
-						outCols:     []uint32{2, 3},
-						sourceTypes: sourceTypes,
-						source:      rightSource,
-					},
-				}
-
-				s.Init()
-
-				b.StartTimer()
-				for i := 0; i < nBatches; i++ {
-					s.Next()
-				}
-				b.StopTimer()
-			}
-		})
-	}
+	//
+	//// left repeats
+	//for _, nBatches := range []int{1, 4, 16, 1024} {
+	//	b.Run(fmt.Sprintf("oneSideRepeat-rows=%d", nBatches*coldata.BatchSize), func(b *testing.B) {
+	//		// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize (rows /
+	//		// batch) * nCols (number of columns / row) * 2 (number of sources).
+	//		b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols * 2))
+	//		b.ResetTimer()
+	//		for i := 0; i < b.N; i++ {
+	//			leftSource := newFiniteBatchSource(newBatchOfRepeatedIntRows(nCols, batch, nBatches), nBatches)
+	//			rightSource := newFiniteBatchSource(newBatchOfIntRows(nCols, batch), nBatches)
+	//
+	//			s := mergeJoinOp{
+	//				left: mergeJoinInput{
+	//					eqCols:      []uint32{0},
+	//					outCols:     []uint32{0, 1},
+	//					sourceTypes: sourceTypes,
+	//					source:      leftSource,
+	//				},
+	//
+	//				right: mergeJoinInput{
+	//					eqCols:      []uint32{0},
+	//					outCols:     []uint32{2, 3},
+	//					sourceTypes: sourceTypes,
+	//					source:      rightSource,
+	//				},
+	//			}
+	//
+	//			s.Init()
+	//
+	//			b.StartTimer()
+	//			for b := s.Next(); b.Length() != 0; b = s.Next() {
+	//			}
+	//			b.StopTimer()
+	//		}
+	//	})
+	//}
+	//
+	//// both repeats
+	//for _, nBatches := range []int{1, 4, 16, 32} {
+	//	b.Run(fmt.Sprintf("bothSidesRepeat-rows=%d", nBatches*coldata.BatchSize), func(b *testing.B) {
+	//		// 8 (bytes / int64) * nBatches (number of batches) * col.BatchSize (rows /
+	//		// batch) * nCols (number of columns / row) * 2 (number of sources).
+	//		b.SetBytes(int64(8 * nBatches * coldata.BatchSize * nCols * 2))
+	//		b.ResetTimer()
+	//		for i := 0; i < b.N; i++ {
+	//			leftSource := newFiniteBatchSource(newBatchOfRepeatedIntRows(nCols, batch, nBatches), nBatches)
+	//			rightSource := newFiniteBatchSource(newBatchOfRepeatedIntRows(nCols, batch, nBatches), nBatches)
+	//
+	//			s := mergeJoinOp{
+	//				left: mergeJoinInput{
+	//					eqCols:      []uint32{0},
+	//					outCols:     []uint32{0, 1},
+	//					sourceTypes: sourceTypes,
+	//					source:      leftSource,
+	//				},
+	//
+	//				right: mergeJoinInput{
+	//					eqCols:      []uint32{0},
+	//					outCols:     []uint32{2, 3},
+	//					sourceTypes: sourceTypes,
+	//					source:      rightSource,
+	//				},
+	//			}
+	//
+	//			s.Init()
+	//
+	//			b.StartTimer()
+	//			for b := s.Next(); b.Length() != 0; b = s.Next() {
+	//			}
+	//			b.StopTimer()
+	//		}
+	//	})
+	//}
 
 }

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -146,14 +146,13 @@ func (c *mergeJoinOp) buildLeftGroups(
 	bat coldata.Batch,
 	sel []uint16,
 	destStartIdx uint16,
-) (uint16, int) {
-	savedOutCount := 0
-	outCount := uint16(0)
+) (outStartIdx uint16, savedOutCount int) {
+	savedOutCount = 0
+	outStartIdx = destStartIdx
 	// Loop over every column.
 	for _, colIdx := range input.outCols {
 		savedOutCount = 0
-		outCount = 0
-		outStartIdx := int(destStartIdx)
+		outStartIdx = destStartIdx
 		out := c.output.ColVec(int(colIdx))
 		savedOut := c.savedOutput.ColVec(int(colIdx))
 		src := bat.ColVec(int(colIdx))
@@ -175,11 +174,11 @@ func (c *mergeJoinOp) buildLeftGroups(
 						for k := 0; k < leftGroup.numRepeats; k++ {
 							srcStartIdx := curSrcStartIdx
 							srcEndIdx := curSrcStartIdx + 1
-							if outStartIdx < int(c.outputBatchSize) {
+							if outStartIdx < c.outputBatchSize {
 
 								// TODO (georgeutsin): update template language to automatically generate template function function parameter definitions from expressions passed in.
 								t_dest := out
-								t_destStartIdx := outStartIdx
+								t_destStartIdx := int(outStartIdx)
 								t_src := src
 								t_srcStartIdx := srcStartIdx
 								t_srcEndIdx := srcEndIdx
@@ -187,7 +186,6 @@ func (c *mergeJoinOp) buildLeftGroups(
 								_COPY_WITH_SEL(t_dest, t_destStartIdx, t_src, t_srcStartIdx, t_srcEndIdx, t_sel)
 
 								outStartIdx++
-								outCount++
 							} else {
 								t_dest := savedOut
 								t_destStartIdx := c.savedOutputEndIdx + savedOutCount
@@ -212,12 +210,11 @@ func (c *mergeJoinOp) buildLeftGroups(
 						for k := 0; k < leftGroup.numRepeats; k++ {
 							srcStartIdx := curSrcStartIdx
 							srcEndIdx := curSrcStartIdx + 1
-							if outStartIdx < int(c.outputBatchSize) {
+							if outStartIdx < c.outputBatchSize {
 
 								copy(outCol[outStartIdx:], srcCol[srcStartIdx:srcEndIdx])
 
 								outStartIdx++
-								outCount++
 							} else {
 								t_dest := savedOut
 								t_destStartIdx := c.savedOutputEndIdx + savedOutCount
@@ -239,10 +236,10 @@ func (c *mergeJoinOp) buildLeftGroups(
 	}
 
 	if len(input.outCols) == 0 {
-		outCount = c.getExpectedOutCount(leftGroups, groupsLen)
+		outStartIdx = c.calculateOutputCount(leftGroups, groupsLen, outStartIdx)
 	}
 
-	return outCount, savedOutCount
+	return outStartIdx, savedOutCount
 }
 
 // buildRightGroups takes a []group and repeats each group numRepeats times.

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -137,6 +137,8 @@ func _COPY_WITH_SEL(
 //  1  |  b
 // Note: this is different from buildRightGroups in that each row of group is repeated
 // numRepeats times, instead of a simple copy of the group as a whole.
+// buildLeftGroups returns the first available index of the output buffer as outStartIdx
+// and the number of elements that were saved into state as savedOutCount.
 // SIDE EFFECTS: writes into c.output (and c.savedOutput if applicable).
 func (c *mergeJoinOp) buildLeftGroups(
 	leftGroups []group,


### PR DESCRIPTION
Added the ability to join on multiple columns in the vectorized
merge joiner. This was done by inverting the previous method of
generating groups; instead of assuming no matches and discovering
matches group by group, if we assume that everything is a match
and filter out the rows that don't match in the join, we can use
multiple columns in this approach.

This PR also includes some work on output shaping, to ensure that
we still have decently shaped outputs, even when a batch ends on
a small run. Also fixed the benchmarks in this PR.

Updated benchmarks for the mergejoiner:

```
BenchmarkMergeJoiner/rows=1024-8         	   20000	     67231 ns/op	 974.77 MB/s
BenchmarkMergeJoiner/rows=4096-8         	    5000	    257487 ns/op	1018.08 MB/s
BenchmarkMergeJoiner/rows=16384-8        	    2000	    995437 ns/op	1053.38 MB/s
BenchmarkMergeJoiner/rows=1048576-8      	      20	  62822638 ns/op	1068.23 MB/s
BenchmarkMergeJoiner/oneSideRepeat-rows=1024-8         	   20000	     67343 ns/op	 973.16 MB/s
BenchmarkMergeJoiner/oneSideRepeat-rows=4096-8         	    5000	    256988 ns/op	1020.06 MB/s
BenchmarkMergeJoiner/oneSideRepeat-rows=16384-8        	    2000	    997690 ns/op	1051.00 MB/s
BenchmarkMergeJoiner/oneSideRepeat-rows=1048576-8      	      20	  62184741 ns/op	1079.19 MB/s
BenchmarkMergeJoiner/bothSidesRepeat-rows=1024-8       	   20000	     68672 ns/op	 954.32 MB/s
BenchmarkMergeJoiner/bothSidesRepeat-rows=4096-8       	    1000	   1336630 ns/op	 196.12 MB/s
BenchmarkMergeJoiner/bothSidesRepeat-rows=16384-8      	     100	  18478767 ns/op	  56.74 MB/s
BenchmarkMergeJoiner/bothSidesRepeat-rows=32768-8      	      20	  80351272 ns/op	  26.10 MB/s
```

Note that the performance degradation in the 'bothSidesRepeat'
is actually due to incorrect benchmarking in the first place.
Regardless, this is still an area of investigation.

Release note: None