### PR TITLE
sql: add regression tests for memory accounting bug

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -746,3 +746,19 @@ CREATE TABLE x (
 
 query error value type decimal doesn't match type INT8 of column "a"
 INSERT INTO x VALUES(1.4)
+
+# Regression test for #34901: verify that builtins can be used in computed
+# column expressions without a "memory budget exceeded" error while backfilling
+statement ok
+CREATE TABLE t34901 (x STRING)
+
+statement ok
+INSERT INTO t34901 VALUES ('a')
+
+statement ok
+ALTER TABLE t34901 ADD COLUMN y STRING AS (concat(x, 'b')) STORED
+
+query TT
+SELECT * FROM t34901
+----
+a  ab

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -117,3 +117,19 @@ column_name  data_type  is_nullable  column_default  generation_expression  indi
 a            INT8       false        NULL            ·                      {primary}  false
 b            TIMESTAMP  true         NULL            ·                      {}         false
 c            INT8       true         NULL            ·                      {}         false
+
+# Regression test for #34901: verify that builtins can be used in default value
+# expressions without a "memory budget exceeded" error while backfilling
+statement ok
+CREATE TABLE t34901 (x STRING)
+
+statement ok
+INSERT INTO t34901 VALUES ('a')
+
+statement ok
+ALTER TABLE t34901 ADD COLUMN y STRING DEFAULT (concat('b', 'c'))
+
+query TT
+SELECT * FROM t34901
+----
+a  bc


### PR DESCRIPTION
Add regression tests for a bug where backfilling a computed column or a column
with a default value using a builtin function would cause a `memory budget
exceeded` error (#34901). This was fixed by #34935.

Release note: None