### PR TITLE
kv: disable size check on marshaling to reduce panics

### DIFF
--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -159,8 +159,12 @@ func (gt *grpcTransport) maybeResurrectRetryablesLocked() bool {
 func withMarshalingDebugging(ctx context.Context, ba roachpb.BatchRequest, f func()) {
 	nPre := ba.Size()
 	defer func() {
+		// TODO(ajwerner): re-enable the pre-emptive panic case below when the sizes
+		// do not match. The case is being disabled temporarily to reduce the
+		// rate of panics in the upcoming release. A more holistic fix which
+		// eliminates the shallow copies of transactions is coming soon.
 		nPost := ba.Size()
-		if r := recover(); r != nil || nPre != nPost {
+		if r := recover(); r != nil /* || nPre != nPost */ {
 			var buf strings.Builder
 			_, _ = fmt.Fprintf(&buf, "batch size %d -> %d bytes\n", nPre, nPost)
 			func() {

--- a/pkg/kv/transport_test.go
+++ b/pkg/kv/transport_test.go
@@ -176,6 +176,7 @@ func (m *mockInternalClient) RangeFeed(
 
 func TestWithMarshalingDebugging(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip(fmt.Sprintf("Skipped until #34241 is resolved"))
 
 	ctx := context.Background()
 


### PR DESCRIPTION
This disables a portion of the additional checking added in #35202 because it
increases the rate of panics. This case should be re-enabled with the complete
resolution of #34241.

Release note: None