### PR TITLE
sql: enhance/fix the detection of correlated subqueries

### DIFF
--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -249,15 +249,13 @@ func (b *Builder) finishBuildScalar(
 func (b *Builder) finishBuildScalarRef(
 	col *scopeColumn, inScope, outScope *scope, outCol *scopeColumn, colRefs *opt.ColSet,
 ) (out opt.ScalarExpr) {
-	isOuterColumn := inScope == nil || inScope.isOuterColumn(col.id)
-
-	// Remember whether the query was correlated for later.
-	b.IsCorrelated = b.IsCorrelated || isOuterColumn
-
 	// Update the sets of column references and outer columns if needed.
 	if colRefs != nil {
 		colRefs.Add(int(col.id))
 	}
+
+	// Collect the outer columns of the current subquery, if any.
+	isOuterColumn := inScope == nil || inScope.isOuterColumn(col.id)
 	if isOuterColumn && b.subquery != nil {
 		b.subquery.outerCols.Add(int(col.id))
 	}

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -513,6 +513,11 @@ func (b *Builder) checkSubqueryOuterCols(
 		return
 	}
 
+	// Remember whether the query was correlated for the heuristic planner,
+	// to enhance error messages.
+	// TODO(knz): this can go away when the HP disappears.
+	b.IsCorrelated = true
+
 	var inScopeCols opt.ColSet
 	if b.subquery != nil || inGroupingContext {
 		// Only calculate the set of inScope columns if it will be used below.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -909,6 +909,10 @@ const (
 	// planFlagOptUsed is set if the optimizer was used to create the plan.
 	planFlagOptUsed planFlags = (1 << iota)
 
+	// planFlagIsCorrelated is set if the plan contained a correlated subquery.
+	// This is used to enhance the error fallback and for telemetry.
+	planFlagOptIsCorrelated
+
 	// planFlagOptFallback is set if the optimizer was enabled but did not support the
 	// statement.
 	planFlagOptFallback

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -40,6 +40,10 @@ type PreparedStatement struct {
 	// if it is used by the optimizer as a starting point.
 	Memo *memo.Memo
 
+	// IsCorrelated memoizes whether the query contained correlated
+	// subqueries during planning (prior to de-correlation).
+	IsCorrelated bool
+
 	// refCount keeps track of the number of references to this PreparedStatement.
 	// New references are registered through incRef().
 	// Once refCount hits 0 (through calls to decRef()), the following memAcc is

--- a/pkg/sql/querycache/query_cache.go
+++ b/pkg/sql/querycache/query_cache.go
@@ -61,6 +61,9 @@ type CachedData struct {
 	// PrepareMetadata is set for prepare queries. In this case the memo contains
 	// unassigned placeholders. For non-prepared queries, it is nil.
 	PrepareMetadata *sqlbase.PrepareMetadata
+	// IsCorrelated memoizes whether the query contained correlated
+	// subqueries during planning (prior to de-correlation).
+	IsCorrelated bool
 }
 
 func (cd *CachedData) memoryEstimate() int64 {


### PR DESCRIPTION
The fact a subquery is correlated is recorded while building the opt
memo so that, when the CBO fails and falls back, the heuristic planner
can produce a useful error message.

The recording of this correlation bit however was incomplete. This
patch fixes it.

(The astute reader will notice that the bit is recorded even in cases
where the CBO _does_ succeed, in which case it is not going to be
used. This patch is still relevant as it makes all code paths
homogeneous and thus eases the reading of the code overall. This
machinery can be removed entirely when the HP is removed.)

Release note: None