### PR TITLE
sql/parser: rework the error reporting mechanism

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1381,7 +1381,7 @@ func Example_sql_table() {
 	// sql -e insert into t.t values (e'a\tb\tc\n12\t123123213\t12313', 'tabs')
 	// INSERT 1
 	// sql -e insert into t.t values (e'\xc3\x28', 'non-UTF8 string')
-	// pq: invalid UTF-8 byte sequence
+	// pq: lexical error: invalid UTF-8 byte sequence
 	// DETAIL: source SQL:
 	// insert into t.t values (e'\xc3\x28', 'non-UTF8 string')
 	//                         ^

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -84,10 +84,10 @@ statement ok
 CREATE SEQUENCE high_minvalue_test MINVALUE 5
 
 # Test unimplemented syntax.
-statement error pq: unimplemented at or near "EOF"
+statement error unimplemented at or near "EOF"
 CREATE SEQUENCE err_test AS INT2
 
-statement error pq: unimplemented at or near "EOF"
+statement error unimplemented at or near "EOF"
 CREATE SEQUENCE err_test OWNED BY someuser
 
 # Verify validation of START vs MINVALUE/MAXVALUE.

--- a/pkg/sql/logictest/testdata/logic_test/txn_as_of
+++ b/pkg/sql/logictest/testdata/logic_test/txn_as_of
@@ -122,19 +122,19 @@ COMMIT
 # Verify that setting a TRANSACTION READ WRITE is an error if the transaction
 # has a historical timestamp.
 
-statement error pq: AS OF SYSTEM TIME specified with READ WRITE mode
+statement error AS OF SYSTEM TIME specified with READ WRITE mode
 BEGIN AS OF SYSTEM TIME '-1h'; SET TRANSACTION READ WRITE;
 
 statement ok
 COMMIT
 
-statement error pq: AS OF SYSTEM TIME specified with READ WRITE mode
+statement error AS OF SYSTEM TIME specified with READ WRITE mode
 BEGIN AS OF SYSTEM TIME '-1h', READ WRITE
 
 statement ok
 BEGIN
 
-statement error pq: AS OF SYSTEM TIME specified with READ WRITE mode
+statement error AS OF SYSTEM TIME specified with READ WRITE mode
 SET TRANSACTION AS OF SYSTEM TIME '-1h', READ WRITE
 
 statement ok

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -23,6 +23,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
@@ -75,6 +76,7 @@ func (h *HelpMessage) Format(w io.Writer) {
 func helpWith(sqllex sqlLexer, helpText string) int {
 	scan := sqllex.(*lexer)
 	if helpText == "" {
+		scan.lastError = pgerror.NewError(pgerror.CodeSyntaxError, "")
 		scan.populateHelpMsg("help:\n" + AllHelp)
 		return 1
 	}

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -2101,19 +2101,19 @@ SELECT2 1
 SELECT 1 FROM (t)
                 ^
 HINT: try \h <SOURCE>`},
-		{`SET TIME ZONE INTERVAL 'foobar'`, `could not parse "foobar" as type interval: interval: missing unit at position 0: "foobar" at or near "EOF"
+		{`SET TIME ZONE INTERVAL 'foobar'`, `syntax error: could not parse "foobar" as type interval: interval: missing unit at position 0: "foobar" at or near "EOF"
 SET TIME ZONE INTERVAL 'foobar'
                                ^
 `},
-		{`SELECT INTERVAL 'foo'`, `could not parse "foo" as type interval: interval: missing unit at position 0: "foo" at or near "EOF"
+		{`SELECT INTERVAL 'foo'`, `syntax error: could not parse "foo" as type interval: interval: missing unit at position 0: "foo" at or near "EOF"
 SELECT INTERVAL 'foo'
                      ^
 `},
-		{`SELECT 1 /* hello`, `unterminated comment
+		{`SELECT 1 /* hello`, `lexical error: unterminated comment
 SELECT 1 /* hello
          ^
 `},
-		{`SELECT '1`, `unterminated string
+		{`SELECT '1`, `lexical error: unterminated string
 SELECT '1
        ^
 HINT: try \h SELECT`},
@@ -2132,14 +2132,14 @@ CREATE TABLE test (
 HINT: try \h CREATE TABLE`},
 		{`CREATE TABLE test (
   foo BIT(0)
-)`, `length for type bit must be at least 1 at or near ")"
+)`, `syntax error: length for type bit must be at least 1 at or near ")"
 CREATE TABLE test (
   foo BIT(0)
            ^
 `},
 		{`CREATE TABLE test (
   foo INT8 DEFAULT 1 DEFAULT 2
-)`, `multiple default values specified for column "foo" at or near ")"
+)`, `syntax error: multiple default values specified for column "foo" at or near ")"
 CREATE TABLE test (
   foo INT8 DEFAULT 1 DEFAULT 2
 )
@@ -2147,7 +2147,7 @@ CREATE TABLE test (
 `},
 		{`CREATE TABLE test (
   foo INT8 REFERENCES t1 REFERENCES t2
-)`, `multiple foreign key constraints specified for column "foo" at or near ")"
+)`, `syntax error: multiple foreign key constraints specified for column "foo" at or near ")"
 CREATE TABLE test (
   foo INT8 REFERENCES t1 REFERENCES t2
 )
@@ -2155,7 +2155,7 @@ CREATE TABLE test (
 `},
 		{`CREATE TABLE test (
   foo INT8 FAMILY a FAMILY b
-)`, `multiple column families specified for column "foo" at or near ")"
+)`, `syntax error: multiple column families specified for column "foo" at or near ")"
 CREATE TABLE test (
   foo INT8 FAMILY a FAMILY b
 )
@@ -2167,7 +2167,7 @@ SELECT family FROM test
 HINT: try \h SELECT`},
 		{`CREATE TABLE test (
   foo INT8 NOT NULL NULL
-)`, `conflicting NULL/NOT NULL declarations for column "foo" at or near ")"
+)`, `syntax error: conflicting NULL/NOT NULL declarations for column "foo" at or near ")"
 CREATE TABLE test (
   foo INT8 NOT NULL NULL
 )
@@ -2175,7 +2175,7 @@ CREATE TABLE test (
 `},
 		{`CREATE TABLE test (
   foo INT8 NULL NOT NULL
-)`, `conflicting NULL/NOT NULL declarations for column "foo" at or near ")"
+)`, `syntax error: conflicting NULL/NOT NULL declarations for column "foo" at or near ")"
 CREATE TABLE test (
   foo INT8 NULL NOT NULL
 )
@@ -2213,32 +2213,32 @@ SELECT FROM t
 HINT: try \h SELECT`},
 
 		{"SELECT 1e-\n-1",
-			`invalid floating point literal
+			`lexical error: invalid floating point literal
 SELECT 1e-
        ^
 HINT: try \h SELECT`},
 		{"SELECT foo''",
-			`type does not exist at or near ""
+			`syntax error: type does not exist at or near ""
 SELECT foo''
           ^
 `},
 		{
 			`SELECT 0x FROM t`,
-			`invalid hexadecimal numeric literal
+			`lexical error: invalid hexadecimal numeric literal
 SELECT 0x FROM t
        ^
 HINT: try \h SELECT`,
 		},
 		{
 			`SELECT x'fail' FROM t`,
-			`invalid hexadecimal bytes literal
+			`lexical error: invalid hexadecimal bytes literal
 SELECT x'fail' FROM t
        ^
 HINT: try \h SELECT`,
 		},
 		{
 			`SELECT x'AAB' FROM t`,
-			`invalid hexadecimal bytes literal
+			`lexical error: invalid hexadecimal bytes literal
 SELECT x'AAB' FROM t
        ^
 HINT: try \h SELECT`,
@@ -2266,35 +2266,35 @@ HINT: try \h <SOURCE>`,
 		},
 		{
 			`SELECT a FROM foo@{FORCE_INDEX=bar,FORCE_INDEX=baz}`,
-			`FORCE_INDEX specified multiple times at or near "baz"
+			`syntax error: FORCE_INDEX specified multiple times at or near "baz"
 SELECT a FROM foo@{FORCE_INDEX=bar,FORCE_INDEX=baz}
                                                ^
 `,
 		},
 		{
 			`SELECT a FROM foo@{FORCE_INDEX=bar,NO_INDEX_JOIN}`,
-			`FORCE_INDEX cannot be specified in conjunction with NO_INDEX_JOIN at or near "}"
+			`syntax error: FORCE_INDEX cannot be specified in conjunction with NO_INDEX_JOIN at or near "}"
 SELECT a FROM foo@{FORCE_INDEX=bar,NO_INDEX_JOIN}
                                                 ^
 `,
 		},
 		{
 			`SELECT a FROM foo@{NO_INDEX_JOIN,NO_INDEX_JOIN}`,
-			`NO_INDEX_JOIN specified multiple times at or near "no_index_join"
+			`syntax error: NO_INDEX_JOIN specified multiple times at or near "no_index_join"
 SELECT a FROM foo@{NO_INDEX_JOIN,NO_INDEX_JOIN}
                                  ^
 `,
 		},
 		{
 			`SELECT a FROM foo@{ASC}`,
-			`ASC/DESC must be specified in conjunction with an index at or near "}"
+			`syntax error: ASC/DESC must be specified in conjunction with an index at or near "}"
 SELECT a FROM foo@{ASC}
                       ^
 `,
 		},
 		{
 			`SELECT a FROM foo@{DESC}`,
-			`ASC/DESC must be specified in conjunction with an index at or near "}"
+			`syntax error: ASC/DESC must be specified in conjunction with an index at or near "}"
 SELECT a FROM foo@{DESC}
                        ^
 `,
@@ -2315,14 +2315,14 @@ HINT: try \h ALTER TABLE`,
 		},
 		{
 			`SELECT CAST(1.2+2.3 AS notatype)`,
-			`type does not exist at or near "notatype"
+			`syntax error: type does not exist at or near "notatype"
 SELECT CAST(1.2+2.3 AS notatype)
                        ^
 `,
 		},
 		{
 			`SELECT ANNOTATE_TYPE(1.2+2.3, notatype)`,
-			`type does not exist at or near "notatype"
+			`syntax error: type does not exist at or near "notatype"
 SELECT ANNOTATE_TYPE(1.2+2.3, notatype)
                               ^
 `,
@@ -2385,14 +2385,14 @@ SELECT EXISTS(SELECT 1)[1]
 		},
 		{
 			`SELECT 1 + ANY ARRAY[1, 2, 3]`,
-			`+ ANY <array> is invalid because "+" is not a boolean operator at or near "EOF"
+			`syntax error: + ANY <array> is invalid because "+" is not a boolean operator at or near "EOF"
 SELECT 1 + ANY ARRAY[1, 2, 3]
                              ^
 `,
 		},
 		{
 			`SELECT 'f'::"blah"`,
-			`type does not exist at or near "blah"
+			`syntax error: type does not exist at or near "blah"
 SELECT 'f'::"blah"
             ^
 `,
@@ -2429,63 +2429,63 @@ HINT: try \h RESTORE`,
 		},
 		{
 			`SELECT avg(1) OVER (ROWS UNBOUNDED FOLLOWING) FROM t`,
-			`frame start cannot be UNBOUNDED FOLLOWING at or near "following"
+			`syntax error: frame start cannot be UNBOUNDED FOLLOWING at or near "following"
 SELECT avg(1) OVER (ROWS UNBOUNDED FOLLOWING) FROM t
                                    ^
 `,
 		},
 		{
 			`SELECT avg(1) OVER (ROWS 1 FOLLOWING) FROM t`,
-			`frame starting from following row cannot end with current row at or near "following"
+			`syntax error: frame starting from following row cannot end with current row at or near "following"
 SELECT avg(1) OVER (ROWS 1 FOLLOWING) FROM t
                            ^
 `,
 		},
 		{
 			`SELECT avg(1) OVER (ROWS BETWEEN UNBOUNDED FOLLOWING AND UNBOUNDED FOLLOWING) FROM t`,
-			`frame start cannot be UNBOUNDED FOLLOWING at or near "following"
+			`syntax error: frame start cannot be UNBOUNDED FOLLOWING at or near "following"
 SELECT avg(1) OVER (ROWS BETWEEN UNBOUNDED FOLLOWING AND UNBOUNDED FOLLOWING) FROM t
                                                                    ^
 `,
 		},
 		{
 			`SELECT avg(1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED PRECEDING) FROM t`,
-			`frame end cannot be UNBOUNDED PRECEDING at or near "preceding"
+			`syntax error: frame end cannot be UNBOUNDED PRECEDING at or near "preceding"
 SELECT avg(1) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED PRECEDING) FROM t
                                                                    ^
 `,
 		},
 		{
 			`SELECT avg(1) OVER (ROWS BETWEEN CURRENT ROW AND 1 PRECEDING) FROM t`,
-			`frame starting from current row cannot have preceding rows at or near "preceding"
+			`syntax error: frame starting from current row cannot have preceding rows at or near "preceding"
 SELECT avg(1) OVER (ROWS BETWEEN CURRENT ROW AND 1 PRECEDING) FROM t
                                                    ^
 `,
 		},
 		{
 			`SELECT avg(1) OVER (ROWS BETWEEN 1 FOLLOWING AND 1 PRECEDING) FROM t`,
-			`frame starting from following row cannot have preceding rows at or near "preceding"
+			`syntax error: frame starting from following row cannot have preceding rows at or near "preceding"
 SELECT avg(1) OVER (ROWS BETWEEN 1 FOLLOWING AND 1 PRECEDING) FROM t
                                                    ^
 `,
 		},
 		{
 			`SELECT avg(1) OVER (ROWS BETWEEN 1 FOLLOWING AND CURRENT ROW) FROM t`,
-			`frame starting from following row cannot have preceding rows at or near "row"
+			`syntax error: frame starting from following row cannot have preceding rows at or near "row"
 SELECT avg(1) OVER (ROWS BETWEEN 1 FOLLOWING AND CURRENT ROW) FROM t
                                                          ^
 `,
 		},
 		{
 			`CREATE TABLE foo(a CHAR(0))`,
-			`length for type CHAR must be at least 1 at or near ")"
+			`syntax error: length for type CHAR must be at least 1 at or near ")"
 CREATE TABLE foo(a CHAR(0))
                          ^
 `,
 		},
 		{
 			`e'\xad'::string`,
-			`invalid UTF-8 byte sequence
+			`lexical error: invalid UTF-8 byte sequence
 e'\xad'::string
 ^
 `,
@@ -2499,7 +2499,7 @@ HINT: try \h EXPLAIN`,
 		},
 		{
 			`SELECT $0`,
-			`placeholder index must be between 1 and 65536
+			`lexical error: placeholder index must be between 1 and 65536
 SELECT $0
        ^
 HINT: try \h SELECT`,
@@ -2513,7 +2513,7 @@ HINT: try \h SELECT`,
 		},
 		{
 			`SELECT $123456789`,
-			`placeholder index must be between 1 and 65536
+			`lexical error: placeholder index must be between 1 and 65536
 SELECT $123456789
        ^
 HINT: try \h SELECT`,
@@ -2949,7 +2949,7 @@ func TestUnimplementedSyntax(t *testing.T) {
 				t.Errorf("%s: unknown err type: %T", d.sql, err)
 				return
 			}
-			if !strings.HasPrefix(pgerr.Message, "unimplemented") {
+			if !strings.HasPrefix(pgerr.Message, "syntax error: unimplemented") {
 				t.Errorf("%s: expected unimplemented at start of message, got %q", d.sql, pgerr.Message)
 			}
 			if pgerr.InternalCommand == "" {

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -472,7 +472,7 @@ func TestPGPrepareFail(t *testing.T) {
 		"SELECT $1 > 0 AND NOT $1":                  "pq: placeholder $1 already has type int, cannot assign bool",
 		"CREATE TABLE $1 (id INT)":                  "pq: syntax error at or near \"1\"",
 		"UPDATE d.t SET s = i + $1":                 "pq: unsupported binary operator: <int> + <placeholder{1}> (desired <string>)",
-		"SELECT $0 > 0":                             "pq: placeholder index must be between 1 and 65536",
+		"SELECT $0 > 0":                             "pq: lexical error: placeholder index must be between 1 and 65536",
 		"SELECT $2 > 0":                             "pq: could not determine data type of placeholder $1",
 		"SELECT 3 + CASE (4) WHEN 4 THEN $1 END":    "pq: could not determine data type of placeholder $1",
 		"SELECT ($1 + $1) + current_date()":         "pq: could not determine data type of placeholder $1",


### PR DESCRIPTION
Needed for https://github.com/cockroachlabs/registration/issues/203

Prior to this patch, the parser error handling code was unnecessary
complex, and had two major shortcomings:

- any detailed error object was "flattened" to a simple string when
  converted into a syntax error, resulting in loss of information.
  This was regrettable as any unimplemented error produced
  "underneath" the parser (say, in `coltypes.ArrayOf()`) would
  lose the link to the related issue during that process.

- users would not benefit from the informational and educatinal hint
  available in errors generated by pgerror.Unimplemented().

This patch fixes this.

Release note: None