### PR TITLE
sql: specify hash or merge join in EXPLAIN

### DIFF
--- a/pkg/sql/logictest/testdata/planner_test/aggregate
+++ b/pkg/sql/logictest/testdata/planner_test/aggregate
@@ -80,7 +80,7 @@ group                ·            ·                                           
  │                   scalar       ·                                             ·                                                             ·
  └── render          ·            ·                                             ("((k, v, w, s) AS k, v, w, s)")                              ·
       │              render 0     ((a.k, a.v, a.w, a.s) AS k, v, w, s)          ·                                                             ·
-      └── join       ·            ·                                             (k, v, w, s, k[omitted], v[omitted], w[omitted], s[omitted])  ·
+      └── hash-join  ·            ·                                             (k, v, w, s, k[omitted], v[omitted], w[omitted], s[omitted])  ·
            │         type         cross                                         ·                                                             ·
            ├── scan  ·            ·                                             (k, v, w, s)                                                  k!=NULL; key(k)
            │         table        kv@primary                                    ·                                                             ·
@@ -103,7 +103,7 @@ group                ·            ·
       │              render 2     a.w
       │              render 3     a.s
       │              render 4     b.k
-      └── join       ·            ·
+      └── hash-join  ·            ·
            │         type         cross
            ├── scan  ·            ·
            │         table        kv@primary
@@ -127,7 +127,7 @@ group                ·            ·
       │              render 3     a.w
       │              render 4     a.s
       │              render 5     b.k
-      └── join       ·            ·
+      └── hash-join  ·            ·
            │         type         cross
            ├── scan  ·            ·
            │         table        kv@primary
@@ -151,7 +151,7 @@ group                ·            ·
       │              render 2     a.w
       │              render 3     a.s
       │              render 4     b.k
-      └── join       ·            ·
+      └── hash-join  ·            ·
            │         type         cross
            ├── scan  ·            ·
            │         table        kv@primary
@@ -174,7 +174,7 @@ group                ·            ·
       │              render 1     a.v
       │              render 2     a.w
       │              render 3     a.s
-      └── join       ·            ·
+      └── hash-join  ·            ·
            │         type         cross
            ├── scan  ·            ·
            │         table        kv@primary
@@ -626,7 +626,7 @@ group                ·            ·
       │              render 2     test.public.kv.w
       │              render 3     test.public.kv.s
       │              render 4     test.public.abc.d
-      └── join       ·            ·
+      └── hash-join  ·            ·
            │         type         inner
            │         pred         test.public.kv.k >= test.public.abc.d
            ├── scan  ·            ·
@@ -738,7 +738,7 @@ render                    ·            ·
            │              render 1     test.public.ab.a
            │              render 2     test.public.ab.b
            │              render 3     test.public.xy.y
-           └── join       ·            ·
+           └── hash-join  ·            ·
                 │         type         cross
                 ├── scan  ·            ·
                 │         table        ab@primary
@@ -853,7 +853,7 @@ group                 ·            ·                        (z, max)          
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT x, max(y) FROM group_ord GROUP BY x) JOIN (SELECT z, min(y) FROM group_ord@foo GROUP BY z) ON x = z
 ----
-join                       ·               ·                        (x, max, z, min)             x=z; x!=NULL
+merge-join                 ·               ·                        (x, max, z, min)             x=z; x!=NULL
  │                         type            inner                    ·                            ·
  │                         equality        (x) = (z)                ·                            ·
  │                         mergeJoinOrder  +"(x=z)"                 ·                            ·

--- a/pkg/sql/logictest/testdata/planner_test/distsql_interleaved_join
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_interleaved_join
@@ -254,20 +254,20 @@ EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
   OR pid1 >= 19 AND pid1 <= 21
   OR pid1 >= 31 AND pid1 <= 33
 ----
-render          ·               ·
- └── join       ·               ·
-      │         type            inner
-      │         equality        (pid1) = (pid1)
-      │         mergeJoinOrder  +"(pid1=pid1)"
-      ├── scan  ·               ·
-      │         table           grandchild2@primary
-      │         spans           /11/#/56/1-/13/#/56/2 /19/#/56/1-/21/#/56/2 /31/#/56/1-/33/#/56/2
-      │         filter          ((pid1 <= 13) OR ((pid1 >= 19) AND (pid1 <= 21))) OR (pid1 >= 31)
-      └── scan  ·               ·
-·               table           parent1@primary
-·               spans           /11-/13/# /19-/21/# /31-/33/#
-·               parallel        ·
-·               filter          ((pid1 <= 13) OR ((pid1 >= 19) AND (pid1 <= 21))) OR (pid1 >= 31)
+render           ·               ·
+ └── merge-join  ·               ·
+      │          type            inner
+      │          equality        (pid1) = (pid1)
+      │          mergeJoinOrder  +"(pid1=pid1)"
+      ├── scan   ·               ·
+      │          table           grandchild2@primary
+      │          spans           /11/#/56/1-/13/#/56/2 /19/#/56/1-/21/#/56/2 /31/#/56/1-/33/#/56/2
+      │          filter          ((pid1 <= 13) OR ((pid1 >= 19) AND (pid1 <= 21))) OR (pid1 >= 31)
+      └── scan   ·               ·
+·                table           parent1@primary
+·                spans           /11-/13/# /19-/21/# /31-/33/#
+·                parallel        ·
+·                filter          ((pid1 <= 13) OR ((pid1 >= 19) AND (pid1 <= 21))) OR (pid1 >= 31)
 
 # Join on multiple interleaved columns with an overarching ancestor (parent1).
 # Note there are 5 nodes because the filter cid2 >= 12 AND cid2 <= 14
@@ -297,17 +297,17 @@ EXPLAIN
     OR child2.cid2 >= 12 AND child2.cid2 <= 14
     OR gcid2 >= 49 AND gcid2 <= 51
 ----
-join       ·               ·
- │         type            inner
- │         equality        (pid1, cid2, cid3) = (pid1, cid2, cid3)
- │         mergeJoinOrder  +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
- ├── scan  ·               ·
- │         table           child2@primary
- │         spans           ALL
- └── scan  ·               ·
-·          table           grandchild2@primary
-·          spans           ALL
-·          filter          (((pid1 >= 5) AND (pid1 <= 7)) OR ((cid2 >= 12) AND (cid2 <= 14))) OR ((gcid2 >= 49) AND (gcid2 <= 51))
+merge-join  ·               ·
+ │          type            inner
+ │          equality        (pid1, cid2, cid3) = (pid1, cid2, cid3)
+ │          mergeJoinOrder  +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
+ ├── scan   ·               ·
+ │          table           child2@primary
+ │          spans           ALL
+ └── scan   ·               ·
+·           table           grandchild2@primary
+·           spans           ALL
+·           filter          (((pid1 >= 5) AND (pid1 <= 7)) OR ((cid2 >= 12) AND (cid2 <= 14))) OR ((gcid2 >= 49) AND (gcid2 <= 51))
 
 # Aggregation over parent and child keys.
 query T
@@ -449,7 +449,7 @@ query TTT
 EXPLAIN SELECT * FROM parent1 JOIN (SELECT * FROM child1 ORDER BY cid1) USING (pid1)
 ----
 render               ·         ·
- └── join            ·         ·
+ └── hash-join       ·         ·
       │              type      inner
       │              equality  (pid1) = (pid1)
       ├── scan       ·         ·

--- a/pkg/sql/logictest/testdata/planner_test/distsql_join
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_join
@@ -39,7 +39,7 @@ EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data) NATURAL JOIN (SELECT a,b
 render               ·               ·                   (a, b)                          a!=NULL; b!=NULL
  │                   render 0        a                   ·                               ·
  │                   render 1        b                   ·                               ·
- └── join            ·               ·                   (a, b, a[omitted], b[omitted])  a=a; b=b; a!=NULL; b!=NULL
+ └── merge-join      ·               ·                   (a, b, a[omitted], b[omitted])  a=a; b=b; a!=NULL; b!=NULL
       │              type            inner               ·                               ·
       │              equality        (a, b) = (a, b)     ·                               ·
       │              mergeJoinOrder  +"(a=a)",+"(b=b)"   ·                               ·
@@ -61,7 +61,7 @@ render               ·               ·                   (a, b)               
 query TTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY c,d)
 ----
-join                 ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL; +a,+b
+merge-join           ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL; +a,+b
  │                   type            inner              ·                               ·
  │                   equality        (a, b) = (c, d)    ·                               ·
  │                   mergeJoinOrder  +"(a=c)",+"(b=d)"  ·                               ·
@@ -90,7 +90,7 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJzEll9ro0wUxu_fTyHn6l06oj
 query TTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY a,b)
 ----
-join                 ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL; +a,+b
+merge-join           ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL; +a,+b
  │                   type            inner              ·                               ·
  │                   equality        (a, b) = (c, d)    ·                               ·
  │                   mergeJoinOrder  +"(a=c)",+"(b=d)"  ·                               ·
@@ -120,7 +120,7 @@ EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,
 ----
 sort                      ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL; +b,+a
  │                        order           +b,+a              ·                               ·
- └── join                 ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL
+ └── merge-join           ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL
       │                   type            inner              ·                               ·
       │                   equality        (a, b) = (c, d)    ·                               ·
       │                   mergeJoinOrder  +"(a=c)",+"(b=d)"  ·                               ·
@@ -169,14 +169,14 @@ EXPLAIN (VERBOSE) (SELECT a,b from data AS data3 NATURAL JOIN ((SELECT a,b FROM 
 render                         ·               ·                                    (a, b)                                                                          a!=NULL; b!=NULL
  │                             render 0        data3.a                              ·                                                                               ·
  │                             render 1        data3.b                              ·                                                                               ·
- └── join                      ·               ·                                    (a, b, c[omitted], d[omitted], a[omitted], b[omitted], c[omitted], d[omitted])  a=c=a=c; b=d=b=d; a!=NULL; b!=NULL
+ └── merge-join                ·               ·                                    (a, b, c[omitted], d[omitted], a[omitted], b[omitted], c[omitted], d[omitted])  a=c=a=c; b=d=b=d; a!=NULL; b!=NULL
       │                        type            inner                                ·                                                                               ·
       │                        equality        (a, b, c, d) = (a, b, c, d)          ·                                                                               ·
       │                        mergeJoinOrder  +"(a=a)",+"(b=b)",+"(c=c)",+"(d=d)"  ·                                                                               ·
       ├── scan                 ·               ·                                    (a, b, c, d)                                                                    a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b,+c,+d
       │                        table           data@primary                         ·                                                                               ·
       │                        spans           ALL                                  ·                                                                               ·
-      └── join                 ·               ·                                    (a, b, c, d)                                                                    a=c; b=d; a!=NULL; b!=NULL; +a,+b
+      └── merge-join           ·               ·                                    (a, b, c, d)                                                                    a=c; b=d; a!=NULL; b!=NULL; +a,+b
            │                   type            inner                                ·                                                                               ·
            │                   equality        (a, b) = (c, d)                      ·                                                                               ·
            │                   mergeJoinOrder  +"(a=c)",+"(b=d)"                    ·                                                                               ·

--- a/pkg/sql/logictest/testdata/planner_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_numtables
@@ -85,21 +85,21 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lU2L2zAQhu_9FWFOu6AQS7
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
 ----
-render          ·               ·                          (x, str)                                 x!=NULL; key(x)
- │              render 0        test.public.numtosquare.x  ·                                        ·
- │              render 1        test.public.numtostr.str   ·                                        ·
- └── join       ·               ·                          (x, xsquared[omitted], y[omitted], str)  x=y; x!=NULL; key(x)
-      │         type            inner                      ·                                        ·
-      │         equality        (x) = (y)                  ·                                        ·
-      │         mergeJoinOrder  +"(x=y)"                   ·                                        ·
-      ├── scan  ·               ·                          (x, xsquared[omitted])                   x!=NULL; key(x); +x
-      │         table           numtosquare@primary        ·                                        ·
-      │         spans           ALL                        ·                                        ·
-      │         filter          (x % 2) = 0                ·                                        ·
-      └── scan  ·               ·                          (y, str)                                 y!=NULL; key(y); +y
-·               table           numtostr@primary           ·                                        ·
-·               spans           ALL                        ·                                        ·
-·               filter          (y % 2) = 0                ·                                        ·
+render           ·               ·                          (x, str)                                 x!=NULL; key(x)
+ │               render 0        test.public.numtosquare.x  ·                                        ·
+ │               render 1        test.public.numtostr.str   ·                                        ·
+ └── merge-join  ·               ·                          (x, xsquared[omitted], y[omitted], str)  x=y; x!=NULL; key(x)
+      │          type            inner                      ·                                        ·
+      │          equality        (x) = (y)                  ·                                        ·
+      │          mergeJoinOrder  +"(x=y)"                   ·                                        ·
+      ├── scan   ·               ·                          (x, xsquared[omitted])                   x!=NULL; key(x); +x
+      │          table           numtosquare@primary        ·                                        ·
+      │          spans           ALL                        ·                                        ·
+      │          filter          (x % 2) = 0                ·                                        ·
+      └── scan   ·               ·                          (y, str)                                 y!=NULL; key(y); +y
+·                table           numtostr@primary           ·                                        ·
+·                spans           ALL                        ·                                        ·
+·                filter          (y % 2) = 0                ·                                        ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0]

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -168,10 +168,10 @@ query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE field != 'size'
 ----
 render                      ·         ·
- └── join                   ·         ·
+ └── hash-join              ·         ·
       │                     type      left outer
       │                     equality  (oid) = (objoid)
-      ├── join              ·         ·
+      ├── hash-join         ·         ·
       │    │                type      inner
       │    │                equality  (relnamespace) = (oid)
       │    ├── filter       ·         ·
@@ -241,7 +241,7 @@ sort                                       ·            ·
            │                               aggregate 7  array_agg(index_name)
            │                               group by     @1-@7
            └── render                      ·            ·
-                └── join                   ·            ·
+                └── hash-join              ·            ·
                      │                     type         left outer
                      │                     equality     (column_name) = (column_name)
                      ├── render            ·            ·
@@ -277,13 +277,13 @@ SELECT * FROM [EXPLAIN SHOW CONSTRAINTS FROM foo] WHERE field != 'size'
 sort                             ·         ·
  │                               order     +table_name,+constraint_name
  └── render                      ·         ·
-      └── join                   ·         ·
+      └── hash-join              ·         ·
            │                     type      inner
            │                     equality  (relnamespace, oid) = (oid, conrelid)
            ├── filter            ·         ·
            │    │                filter    relname = 'foo'
            │    └── values       ·         ·
-           └── join              ·         ·
+           └── hash-join         ·         ·
                 │                type      cross
                 ├── filter       ·         ·
                 │    │           filter    nspname = 'public'

--- a/pkg/sql/logictest/testdata/planner_test/join
+++ b/pkg/sql/logictest/testdata/planner_test/join
@@ -16,7 +16,7 @@ EXPLAIN (VERBOSE) SELECT * FROM onecolumn JOIN twocolumn USING(x)
 render          ·         ·
  │              render 0  test.public.onecolumn.x
  │              render 1  test.public.twocolumn.y
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (x) = (x)
       ├── scan  ·         ·
@@ -36,7 +36,7 @@ render          ·         ·
  │              render 1  a.y
  │              render 2  b.x
  │              render 3  b.y
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (x) = (y)
       ├── scan  ·         ·
@@ -56,7 +56,7 @@ render          ·         ·
  │              render 1  a.y
  │              render 2  b.x
  │              render 3  b.y
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      cross
       ├── scan  ·         ·
       │         table     twocolumn@primary
@@ -75,7 +75,7 @@ render          ·         ·
  │              render 0  a.x
  │              render 1  b.x
  │              render 2  b.y
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (x) = (y)
       ├── scan  ·         ·
@@ -94,7 +94,7 @@ render          ·         ·
  │              render 0  test.public.onecolumn.x
  │              render 1  test.public.twocolumn.x
  │              render 2  test.public.twocolumn.y
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (x) = (y)
       ├── scan  ·         ·
@@ -119,13 +119,13 @@ limit                          ·         ·
       │                        render 3  a.b
       │                        render 4  c.d
       │                        render 5  c.e
-      └── join                 ·         ·
+      └── hash-join            ·         ·
            │                   type      inner
            │                   equality  (b, x) = (d, d)
-           ├── join            ·         ·
+           ├── hash-join       ·         ·
            │    │              type      inner
            │    │              equality  (x) = (b)
-           │    ├── join       ·         ·
+           │    ├── hash-join  ·         ·
            │    │    │         type      cross
            │    │    ├── scan  ·         ·
            │    │    │         table     onecolumn@primary
@@ -147,7 +147,7 @@ EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 render          ·         ·                  (x, y)                                                                        ·
  │              render 0  a.x                ·                                                                             ·
  │              render 1  b.y                ·                                                                             ·
- └── join       ·         ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
+ └── hash-join  ·         ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
       │         type      cross              ·                                                                             ·
       ├── scan  ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                        rowid!=NULL; key(rowid)
       │         table     twocolumn@primary  ·                                                                             ·
@@ -161,7 +161,7 @@ EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
 render          ·         ·                  (y)                                                                                    ·
  │              render 0  b.y                ·                                                                                      ·
- └── join       ·         ·                  (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
+ └── hash-join  ·         ·                  (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
       │         type      inner              ·                                                                                      ·
       │         equality  (x) = (x)          ·                                                                                      ·
       ├── scan  ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
@@ -176,7 +176,7 @@ EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b
 ----
 render          ·         ·                  (y)                                                                                    ·
  │              render 0  b.y                ·                                                                                      ·
- └── join       ·         ·                  (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
+ └── hash-join  ·         ·                  (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
       │         type      inner              ·                                                                                      ·
       │         equality  (x) = (x)          ·                                                                                      ·
       ├── scan  ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
@@ -191,7 +191,7 @@ EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b
 ----
 render          ·         ·                  (x)                                                                                    ·
  │              render 0  a.x                ·                                                                                      ·
- └── join       ·         ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])  ·
+ └── hash-join  ·         ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])  ·
       │         type      inner              ·                                                                                      ·
       │         pred      a.x < b.y          ·                                                                                      ·
       ├── scan  ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
@@ -214,7 +214,7 @@ render                    ·         ·                            (x, two, plus
       │                   render 2  two                          ·                                                      ·
       │                   render 3  NULL                         ·                                                      ·
       │                   render 4  plus1                        ·                                                      ·
-      └── join            ·         ·                            (x, two, x, plus1)                                     ·
+      └── hash-join       ·         ·                            (x, two, x, plus1)                                     ·
            │              type      full outer                   ·                                                      ·
            │              equality  (x) = (x)                    ·                                                      ·
            ├── render     ·         ·                            (x, two)                                               two=CONST
@@ -246,7 +246,7 @@ sort                             ·              ·                  (k, u, w)  
            │                     render 1       u                  ·                             ·
            │                     render 2       NULL               ·                             ·
            │                     render 3       b.w                ·                             ·
-           └── join              ·              ·                  (u, k, k[omitted], w)         ·
+           └── hash-join         ·              ·                  (u, k, k[omitted], w)         ·
                 │                type           inner              ·                             ·
                 │                equality       (k) = (k)          ·                             ·
                 ├── sort         ·              ·                  (u, k)                        +k
@@ -352,39 +352,39 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 1   ·            render 11  con.conname
 1   ·            render 12  pkic.relname
 1   ·            render 13  CASE WHEN con.condeferrable AND con.condeferred THEN 5 WHEN con.condeferrable THEN 6 ELSE 7 END
-2   join         ·          ·
+2   hash-join    ·          ·
 2   ·            type       inner
 2   ·            equality   (oid) = (relnamespace)
-3   join         ·          ·
+3   hash-join    ·          ·
 3   ·            type       inner
 3   ·            equality   (oid, oid) = (attrelid, confrelid)
-4   join         ·          ·
+4   hash-join    ·          ·
 4   ·            type       inner
 4   ·            pred       pka.attnum = con.confkey[pos.n]
-5   join         ·          ·
+5   hash-join    ·          ·
 5   ·            type       inner
 5   ·            equality   (oid) = (relnamespace)
 6   filter       ·          ·
 6   ·            filter     fkn.nspname = 'public'
-6   join         ·          ·
+6   hash-join    ·          ·
 6   ·            type       inner
 6   ·            equality   (oid, oid) = (attrelid, conrelid)
 7   filter       ·          ·
 7   ·            filter     fkc.relname = 'orders'
-7   join         ·          ·
+7   hash-join    ·          ·
 7   ·            type       inner
 7   ·            pred       fka.attnum = con.conkey[pos.n]
-8   join         ·          ·
+8   hash-join    ·          ·
 8   ·            type       inner
 8   ·            equality   (oid) = (objid)
 9   filter       ·          ·
 9   ·            filter     con.contype = 'f'
-9   join         ·          ·
+9   hash-join    ·          ·
 9   ·            type       cross
 10  project set  ·          ·
 10  ·            render 0   generate_series(1, 32)
 11  emptyrow     ·          ·
-10  join         ·          ·
+10  hash-join    ·          ·
 10  ·            type       inner
 10  ·            equality   (refobjid) = (oid)
 11  filter       ·          ·
@@ -406,7 +406,7 @@ query TTT
 EXPLAIN SELECT * FROM pairs, square WHERE pairs.b = square.n
 ----
 render          ·         ·
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (b) = (n)
       ├── scan  ·         ·
@@ -425,7 +425,7 @@ render          ·         ·                                                   
  │              render 1  test.public.pairs.b                                                  ·                                     ·
  │              render 2  test.public.square.n                                                 ·                                     ·
  │              render 3  test.public.square.sq                                                ·                                     ·
- └── join       ·         ·                                                                    (a, b, rowid[hidden,omitted], n, sq)  ·
+ └── hash-join  ·         ·                                                                    (a, b, rowid[hidden,omitted], n, sq)  ·
       │         type      inner                                                                ·                                     ·
       │         pred      (test.public.pairs.a + test.public.pairs.b) = test.public.square.sq  ·                                     ·
       ├── scan  ·         ·                                                                    (a, b, rowid[hidden,omitted])         rowid!=NULL; key(rowid)
@@ -454,7 +454,7 @@ render                    ·         ·                                         
            │              render 2  (test.public.pairs.a * test.public.pairs.b) / 2  ·                                     ·
            │              render 3  test.public.square.n                             ·                                     ·
            │              render 4  test.public.square.sq                            ·                                     ·
-           └── join       ·         ·                                                (a, b, rowid[hidden,omitted], n, sq)  ·
+           └── hash-join  ·         ·                                                (a, b, rowid[hidden,omitted], n, sq)  ·
                 │         type      cross                                            ·                                     ·
                 ├── scan  ·         ·                                                (a, b, rowid[hidden,omitted])         rowid!=NULL; key(rowid)
                 │         table     pairs@primary                                    ·                                     ·
@@ -472,7 +472,7 @@ render          ·         ·                                                   
  │              render 1  test.public.pairs.b                                                  ·                                     ·
  │              render 2  test.public.square.n                                                 ·                                     ·
  │              render 3  test.public.square.sq                                                ·                                     ·
- └── join       ·         ·                                                                    (a, b, rowid[hidden,omitted], n, sq)  ·
+ └── hash-join  ·         ·                                                                    (a, b, rowid[hidden,omitted], n, sq)  ·
       │         type      full outer                                                           ·                                     ·
       │         pred      (test.public.pairs.a + test.public.pairs.b) = test.public.square.sq  ·                                     ·
       ├── scan  ·         ·                                                                    (a, b, rowid[hidden,omitted])         rowid!=NULL; key(rowid)
@@ -492,7 +492,7 @@ render               ·         ·                                              
  │                   render 3  test.public.square.sq                                                ·                                     ·
  └── filter          ·         ·                                                                    (a, b, rowid[hidden,omitted], n, sq)  b!=NULL; sq!=NULL
       │              filter    (test.public.pairs.b % 2) != (test.public.square.sq % 2)             ·                                     ·
-      └── join       ·         ·                                                                    (a, b, rowid[hidden,omitted], n, sq)  ·
+      └── hash-join  ·         ·                                                                    (a, b, rowid[hidden,omitted], n, sq)  ·
            │         type      full outer                                                           ·                                     ·
            │         pred      (test.public.pairs.a + test.public.pairs.b) = test.public.square.sq  ·                                     ·
            ├── scan  ·         ·                                                                    (a, b, rowid[hidden,omitted])         rowid!=NULL; key(rowid)
@@ -519,7 +519,7 @@ render               ·         ·
  │                   render 3  test.public.square.sq
  └── filter          ·         ·
       │              filter    ((test.public.square.n IS NULL) OR (test.public.square.n > 1)) AND ((test.public.square.n IS NULL) OR (test.public.pairs.a < test.public.square.sq))
-      └── join       ·         ·
+      └── hash-join  ·         ·
            │         type      left outer
            │         equality  (b) = (sq)
            │         pred      test.public.pairs.a > 1
@@ -547,7 +547,7 @@ render               ·         ·
  │                   render 3  test.public.square.sq
  └── filter          ·         ·
       │              filter    ((test.public.pairs.a IS NULL) OR (test.public.pairs.a > 2)) AND ((test.public.pairs.a IS NULL) OR (test.public.pairs.a < test.public.square.sq))
-      └── join       ·         ·
+      └── hash-join  ·         ·
            │         type      right outer
            │         equality  (b) = (sq)
            │         pred      test.public.square.n < 6
@@ -573,7 +573,7 @@ render          ·         ·
  │              render 1  test.public.pairs.b
  │              render 2  test.public.square.n
  │              render 3  test.public.square.sq
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (b) = (sq)
       ├── scan  ·         ·
@@ -607,7 +607,7 @@ render                    ·         ·                 (x)                     
       │                   render 6  NULL              ·                                                                                                                                         ·
       │                   render 7  NULL              ·                                                                                                                                         ·
       │                   render 8  NULL              ·                                                                                                                                         ·
-      └── join            ·         ·                 (col1[omitted], x, col2[omitted], y[omitted], rowid[hidden,omitted], col3[omitted], y[omitted], x[omitted], col4[omitted])                ·
+      └── hash-join       ·         ·                 (col1[omitted], x, col2[omitted], y[omitted], rowid[hidden,omitted], col3[omitted], y[omitted], x[omitted], col4[omitted])                ·
            │              type      inner             ·                                                                                                                                         ·
            │              equality  (x, y) = (x, y)   ·                                                                                                                                         ·
            ├── scan       ·         ·                 (col1[omitted], x, col2[omitted], y, rowid[hidden,omitted])                                                                               rowid!=NULL; key(rowid)
@@ -638,69 +638,69 @@ CREATE TABLE pkBAD (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,d))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
 ----
-join       ·               ·                      (a, b, c, d, a, b, c, d)  a=a; b=b; c=c; a!=NULL; b!=NULL; c!=NULL; key(a,b); key(b,c)
- │         type            inner                  ·                         ·
- │         equality        (a, b, c) = (a, b, c)  ·                         ·
- │         mergeJoinOrder  +"(b=b)"               ·                         ·
- ├── scan  ·               ·                      (a, b, c, d)              a!=NULL; b!=NULL; key(a,b); +b
- │         table           pkba@primary           ·                         ·
- │         spans           ALL                    ·                         ·
- └── scan  ·               ·                      (a, b, c, d)              b!=NULL; c!=NULL; key(b,c); +b
-·          table           pkbc@primary           ·                         ·
-·          spans           ALL                    ·                         ·
+merge-join  ·               ·                      (a, b, c, d, a, b, c, d)  a=a; b=b; c=c; a!=NULL; b!=NULL; c!=NULL; key(a,b); key(b,c)
+ │          type            inner                  ·                         ·
+ │          equality        (a, b, c) = (a, b, c)  ·                         ·
+ │          mergeJoinOrder  +"(b=b)"               ·                         ·
+ ├── scan   ·               ·                      (a, b, c, d)              a!=NULL; b!=NULL; key(a,b); +b
+ │          table           pkba@primary           ·                         ·
+ │          spans           ALL                    ·                         ·
+ └── scan   ·               ·                      (a, b, c, d)              b!=NULL; c!=NULL; key(b,c); +b
+·           table           pkbc@primary           ·                         ·
+·           spans           ALL                    ·                         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA NATURAL JOIN pkBAD
 ----
-render          ·               ·                            (a, b, c, d)                                                  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
- │              render 0        test.public.pkba.a           ·                                                             ·
- │              render 1        test.public.pkba.b           ·                                                             ·
- │              render 2        test.public.pkba.c           ·                                                             ·
- │              render 3        test.public.pkba.d           ·                                                             ·
- └── join       ·               ·                            (a, b, c, d, a[omitted], b[omitted], c[omitted], d[omitted])  a=a; b=b; c=c; d=d; a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
-      │         type            inner                        ·                                                             ·
-      │         equality        (a, b, c, d) = (a, b, c, d)  ·                                                             ·
-      │         mergeJoinOrder  +"(b=b)",+"(a=a)",+"(d=d)"   ·                                                             ·
-      ├── scan  ·               ·                            (a, b, c, d)                                                  a!=NULL; b!=NULL; key(a,b); +b,+a
-      │         table           pkba@primary                 ·                                                             ·
-      │         spans           ALL                          ·                                                             ·
-      └── scan  ·               ·                            (a, b, c, d)                                                  a!=NULL; b!=NULL; d!=NULL; key(a,b,d); +b,+a,+d
-·               table           pkbad@primary                ·                                                             ·
-·               spans           ALL                          ·                                                             ·
+render           ·               ·                            (a, b, c, d)                                                  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
+ │               render 0        test.public.pkba.a           ·                                                             ·
+ │               render 1        test.public.pkba.b           ·                                                             ·
+ │               render 2        test.public.pkba.c           ·                                                             ·
+ │               render 3        test.public.pkba.d           ·                                                             ·
+ └── merge-join  ·               ·                            (a, b, c, d, a[omitted], b[omitted], c[omitted], d[omitted])  a=a; b=b; c=c; d=d; a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
+      │          type            inner                        ·                                                             ·
+      │          equality        (a, b, c, d) = (a, b, c, d)  ·                                                             ·
+      │          mergeJoinOrder  +"(b=b)",+"(a=a)",+"(d=d)"   ·                                                             ·
+      ├── scan   ·               ·                            (a, b, c, d)                                                  a!=NULL; b!=NULL; key(a,b); +b,+a
+      │          table           pkba@primary                 ·                                                             ·
+      │          spans           ALL                          ·                                                             ·
+      └── scan   ·               ·                            (a, b, c, d)                                                  a!=NULL; b!=NULL; d!=NULL; key(a,b,d); +b,+a,+d
+·                table           pkbad@primary                ·                                                             ·
+·                spans           ALL                          ·                                                             ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 ----
-render          ·               ·                           (a, b, c, d, d)                                      a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
- │              render 0        l.a                         ·                                                    ·
- │              render 1        l.b                         ·                                                    ·
- │              render 2        l.c                         ·                                                    ·
- │              render 3        l.d                         ·                                                    ·
- │              render 4        r.d                         ·                                                    ·
- └── join       ·               ·                           (a, b, c, d, a[omitted], b[omitted], c[omitted], d)  a=a; b=b; c=c; a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-      │         type            inner                       ·                                                    ·
-      │         equality        (a, b, c) = (a, b, c)       ·                                                    ·
-      │         mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=c)"  ·                                                    ·
-      ├── scan  ·               ·                           (a, b, c, d)                                         a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +b,+a,+c
-      │         table           pkbac@primary               ·                                                    ·
-      │         spans           ALL                         ·                                                    ·
-      └── scan  ·               ·                           (a, b, c, d)                                         a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +b,+a,+c
-·               table           pkbac@primary               ·                                                    ·
-·               spans           ALL                         ·                                                    ·
+render           ·               ·                           (a, b, c, d, d)                                      a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+ │               render 0        l.a                         ·                                                    ·
+ │               render 1        l.b                         ·                                                    ·
+ │               render 2        l.c                         ·                                                    ·
+ │               render 3        l.d                         ·                                                    ·
+ │               render 4        r.d                         ·                                                    ·
+ └── merge-join  ·               ·                           (a, b, c, d, a[omitted], b[omitted], c[omitted], d)  a=a; b=b; c=c; a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+      │          type            inner                       ·                                                    ·
+      │          equality        (a, b, c) = (a, b, c)       ·                                                    ·
+      │          mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=c)"  ·                                                    ·
+      ├── scan   ·               ·                           (a, b, c, d)                                         a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +b,+a,+c
+      │          table           pkbac@primary               ·                                                    ·
+      │          spans           ALL                         ·                                                    ·
+      └── scan   ·               ·                           (a, b, c, d)                                         a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +b,+a,+c
+·                table           pkbac@primary               ·                                                    ·
+·                spans           ALL                         ·                                                    ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
 ----
-join       ·               ·                           (a, b, c, d, a, b, c, d)  a=a; b=b; c=d; a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
- │         type            inner                       ·                         ·
- │         equality        (c, a, b) = (d, a, b)       ·                         ·
- │         mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
- ├── scan  ·               ·                           (a, b, c, d)              a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +b,+a,+c
- │         table           pkbac@primary               ·                         ·
- │         spans           ALL                         ·                         ·
- └── scan  ·               ·                           (a, b, c, d)              a!=NULL; b!=NULL; d!=NULL; key(a,b,d); +b,+a,+d
-·          table           pkbad@primary               ·                         ·
-·          spans           ALL                         ·                         ·
+merge-join  ·               ·                           (a, b, c, d, a, b, c, d)  a=a; b=b; c=d; a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+ │          type            inner                       ·                         ·
+ │          equality        (c, a, b) = (d, a, b)       ·                         ·
+ │          mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
+ ├── scan   ·               ·                           (a, b, c, d)              a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +b,+a,+c
+ │          table           pkbac@primary               ·                         ·
+ │          spans           ALL                         ·                         ·
+ └── scan   ·               ·                           (a, b, c, d)              a!=NULL; b!=NULL; d!=NULL; key(a,b,d); +b,+a,+d
+·           table           pkbad@primary               ·                         ·
+·           spans           ALL                         ·                         ·
 
 # Tests with joins with merged columns of collated string type.
 statement ok
@@ -721,7 +721,7 @@ render               ·         ·                   (s, s, s)                  
       │              render 1  NULL                ·                                       ·
       │              render 2  NULL                ·                                       ·
       │              render 3  test.public.str2.s  ·                                       ·
-      └── join       ·         ·                   (a[omitted], s, a[omitted], s)          ·
+      └── hash-join  ·         ·                   (a[omitted], s, a[omitted], s)          ·
            │         type      inner               ·                                       ·
            │         equality  (s) = (s)           ·                                       ·
            ├── scan  ·         ·                   (a[omitted], s)                         a!=NULL; key(a)
@@ -743,7 +743,7 @@ render               ·         ·                   (s, s, s)                  
       │              render 1  NULL                ·                                       ·
       │              render 2  NULL                ·                                       ·
       │              render 3  test.public.str2.s  ·                                       ·
-      └── join       ·         ·                   (a[omitted], s, a[omitted], s)          ·
+      └── hash-join  ·         ·                   (a[omitted], s, a[omitted], s)          ·
            │         type      left outer          ·                                       ·
            │         equality  (s) = (s)           ·                                       ·
            ├── scan  ·         ·                   (a[omitted], s)                         a!=NULL; key(a)
@@ -766,7 +766,7 @@ render               ·         ·                                              
       │              render 2  test.public.str1.s                              ·                                                  ·
       │              render 3  NULL                                            ·                                                  ·
       │              render 4  test.public.str2.s                              ·                                                  ·
-      └── join       ·         ·                                               (a[omitted], s, a[omitted], s)                     ·
+      └── hash-join  ·         ·                                               (a[omitted], s, a[omitted], s)                     ·
            │         type      right outer                                     ·                                                  ·
            │         equality  (s) = (s)                                       ·                                                  ·
            ├── scan  ·         ·                                               (a[omitted], s)                                    a!=NULL; key(a)
@@ -789,7 +789,7 @@ render               ·         ·                                              
       │              render 2  test.public.str1.s                              ·                                                  ·
       │              render 3  NULL                                            ·                                                  ·
       │              render 4  test.public.str2.s                              ·                                                  ·
-      └── join       ·         ·                                               (a[omitted], s, a[omitted], s)                     ·
+      └── hash-join  ·         ·                                               (a[omitted], s, a[omitted], s)                     ·
            │         type      full outer                                      ·                                                  ·
            │         equality  (s) = (s)                                       ·                                                  ·
            ├── scan  ·         ·                                               (a[omitted], s)                                    a!=NULL; key(a)
@@ -804,25 +804,25 @@ render               ·         ·                                              
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
 ----
-render               ·               ·                                               (a, s)                                                           ·
- │                   render 0        test.public.str2.a                              ·                                                                ·
- │                   render 1        s                                               ·                                                                ·
- └── render          ·               ·                                               (a, s, a[hidden,omitted], s[hidden,omitted], s[hidden,omitted])  ·
-      │              render 0        test.public.str2.a                              ·                                                                ·
-      │              render 1        IFNULL(test.public.str1.s, test.public.str2.s)  ·                                                                ·
-      │              render 2        NULL                                            ·                                                                ·
-      │              render 3        NULL                                            ·                                                                ·
-      │              render 4        NULL                                            ·                                                                ·
-      └── join       ·               ·                                               (a[omitted], s, a, s)                                            ·
-           │         type            right outer                                     ·                                                                ·
-           │         equality        (a, s) = (a, s)                                 ·                                                                ·
-           │         mergeJoinOrder  +"(a=a)"                                        ·                                                                ·
-           ├── scan  ·               ·                                               (a, s)                                                           a!=NULL; key(a); +a
-           │         table           str1@primary                                    ·                                                                ·
-           │         spans           ALL                                             ·                                                                ·
-           └── scan  ·               ·                                               (a, s)                                                           a!=NULL; key(a); +a
-·                    table           str2@primary                                    ·                                                                ·
-·                    spans           ALL                                             ·                                                                ·
+render                ·               ·                                               (a, s)                                                           ·
+ │                    render 0        test.public.str2.a                              ·                                                                ·
+ │                    render 1        s                                               ·                                                                ·
+ └── render           ·               ·                                               (a, s, a[hidden,omitted], s[hidden,omitted], s[hidden,omitted])  ·
+      │               render 0        test.public.str2.a                              ·                                                                ·
+      │               render 1        IFNULL(test.public.str1.s, test.public.str2.s)  ·                                                                ·
+      │               render 2        NULL                                            ·                                                                ·
+      │               render 3        NULL                                            ·                                                                ·
+      │               render 4        NULL                                            ·                                                                ·
+      └── merge-join  ·               ·                                               (a[omitted], s, a, s)                                            ·
+           │          type            right outer                                     ·                                                                ·
+           │          equality        (a, s) = (a, s)                                 ·                                                                ·
+           │          mergeJoinOrder  +"(a=a)"                                        ·                                                                ·
+           ├── scan   ·               ·                                               (a, s)                                                           a!=NULL; key(a); +a
+           │          table           str1@primary                                    ·                                                                ·
+           │          spans           ALL                                             ·                                                                ·
+           └── scan   ·               ·                                               (a, s)                                                           a!=NULL; key(a); +a
+·                     table           str2@primary                                    ·                                                                ·
+·                     spans           ALL                                             ·                                                                ·
 
 
 statement ok
@@ -834,155 +834,155 @@ CREATE TABLE xyv (x INT, y INT, v INT, PRIMARY KEY(x,y,v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 ----
-render          ·               ·                  (x, y, u, v)                          x!=NULL; y!=NULL
- │              render 0        test.public.xyu.x  ·                                     ·
- │              render 1        test.public.xyu.y  ·                                     ·
- │              render 2        test.public.xyu.u  ·                                     ·
- │              render 3        test.public.xyv.v  ·                                     ·
- └── join       ·               ·                  (x, y, u, x[omitted], y[omitted], v)  x=x; y=y; x!=NULL; y!=NULL
-      │         type            inner              ·                                     ·
-      │         equality        (x, y) = (x, y)    ·                                     ·
-      │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
-      ├── scan  ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-      │         table           xyu@primary        ·                                     ·
-      │         spans           /3-                ·                                     ·
-      └── scan  ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-·               table           xyv@primary        ·                                     ·
-·               spans           /3-                ·                                     ·
+render           ·               ·                  (x, y, u, v)                          x!=NULL; y!=NULL
+ │               render 0        test.public.xyu.x  ·                                     ·
+ │               render 1        test.public.xyu.y  ·                                     ·
+ │               render 2        test.public.xyu.u  ·                                     ·
+ │               render 3        test.public.xyv.v  ·                                     ·
+ └── merge-join  ·               ·                  (x, y, u, x[omitted], y[omitted], v)  x=x; y=y; x!=NULL; y!=NULL
+      │          type            inner              ·                                     ·
+      │          equality        (x, y) = (x, y)    ·                                     ·
+      │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
+      ├── scan   ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+      │          table           xyu@primary        ·                                     ·
+      │          spans           /3-                ·                                     ·
+      └── scan   ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·                table           xyv@primary        ·                                     ·
+·                spans           /3-                ·                                     ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-render          ·               ·                  (x, y, u, v)                          ·
- │              render 0        test.public.xyu.x  ·                                     ·
- │              render 1        test.public.xyu.y  ·                                     ·
- │              render 2        test.public.xyu.u  ·                                     ·
- │              render 3        test.public.xyv.v  ·                                     ·
- └── join       ·               ·                  (x, y, u, x[omitted], y[omitted], v)  ·
-      │         type            left outer         ·                                     ·
-      │         equality        (x, y) = (x, y)    ·                                     ·
-      │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
-      ├── scan  ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-      │         table           xyu@primary        ·                                     ·
-      │         spans           /3-                ·                                     ·
-      └── scan  ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-·               table           xyv@primary        ·                                     ·
-·               spans           /3-                ·                                     ·
+render           ·               ·                  (x, y, u, v)                          ·
+ │               render 0        test.public.xyu.x  ·                                     ·
+ │               render 1        test.public.xyu.y  ·                                     ·
+ │               render 2        test.public.xyu.u  ·                                     ·
+ │               render 3        test.public.xyv.v  ·                                     ·
+ └── merge-join  ·               ·                  (x, y, u, x[omitted], y[omitted], v)  ·
+      │          type            left outer         ·                                     ·
+      │          equality        (x, y) = (x, y)    ·                                     ·
+      │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
+      ├── scan   ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+      │          table           xyu@primary        ·                                     ·
+      │          spans           /3-                ·                                     ·
+      └── scan   ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·                table           xyv@primary        ·                                     ·
+·                spans           /3-                ·                                     ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-render               ·               ·                  (x, y, u, v)                                        ·
- │                   render 0        test.public.xyv.x  ·                                                   ·
- │                   render 1        test.public.xyv.y  ·                                                   ·
- │                   render 2        test.public.xyu.u  ·                                                   ·
- │                   render 3        test.public.xyv.v  ·                                                   ·
- └── render          ·               ·                  (x, y, x[hidden,omitted], y[hidden,omitted], u, v)  ·
-      │              render 0        test.public.xyv.x  ·                                                   ·
-      │              render 1        test.public.xyv.y  ·                                                   ·
-      │              render 2        NULL               ·                                                   ·
-      │              render 3        NULL               ·                                                   ·
-      │              render 4        test.public.xyu.u  ·                                                   ·
-      │              render 5        test.public.xyv.v  ·                                                   ·
-      └── join       ·               ·                  (x[omitted], y[omitted], u, x, y, v)                ·
-           │         type            right outer        ·                                                   ·
-           │         equality        (x, y) = (x, y)    ·                                                   ·
-           │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                   ·
-           ├── scan  ·               ·                  (x, y, u)                                           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-           │         table           xyu@primary        ·                                                   ·
-           │         spans           /3-                ·                                                   ·
-           └── scan  ·               ·                  (x, y, v)                                           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-·                    table           xyv@primary        ·                                                   ·
-·                    spans           /3-                ·                                                   ·
+render                ·               ·                  (x, y, u, v)                                        ·
+ │                    render 0        test.public.xyv.x  ·                                                   ·
+ │                    render 1        test.public.xyv.y  ·                                                   ·
+ │                    render 2        test.public.xyu.u  ·                                                   ·
+ │                    render 3        test.public.xyv.v  ·                                                   ·
+ └── render           ·               ·                  (x, y, x[hidden,omitted], y[hidden,omitted], u, v)  ·
+      │               render 0        test.public.xyv.x  ·                                                   ·
+      │               render 1        test.public.xyv.y  ·                                                   ·
+      │               render 2        NULL               ·                                                   ·
+      │               render 3        NULL               ·                                                   ·
+      │               render 4        test.public.xyu.u  ·                                                   ·
+      │               render 5        test.public.xyv.v  ·                                                   ·
+      └── merge-join  ·               ·                  (x[omitted], y[omitted], u, x, y, v)                ·
+           │          type            right outer        ·                                                   ·
+           │          equality        (x, y) = (x, y)    ·                                                   ·
+           │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                   ·
+           ├── scan   ·               ·                  (x, y, u)                                           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+           │          table           xyu@primary        ·                                                   ·
+           │          spans           /3-                ·                                                   ·
+           └── scan   ·               ·                  (x, y, v)                                           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·                     table           xyv@primary        ·                                                   ·
+·                     spans           /3-                ·                                                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-render                    ·               ·                                             (x, y, u, v)                                                                              x!=NULL
- │                        render 0        x                                             ·                                                                                         ·
- │                        render 1        y                                             ·                                                                                         ·
- │                        render 2        test.public.xyu.u                             ·                                                                                         ·
- │                        render 3        test.public.xyv.v                             ·                                                                                         ·
- └── filter               ·               ·                                             (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  x!=NULL
-      │                   filter          x > 2                                         ·                                                                                         ·
-      └── render          ·               ·                                             (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  ·
-           │              render 0        IFNULL(test.public.xyu.x, test.public.xyv.x)  ·                                                                                         ·
-           │              render 1        IFNULL(test.public.xyu.y, test.public.xyv.y)  ·                                                                                         ·
-           │              render 2        NULL                                          ·                                                                                         ·
-           │              render 3        NULL                                          ·                                                                                         ·
-           │              render 4        test.public.xyu.u                             ·                                                                                         ·
-           │              render 5        NULL                                          ·                                                                                         ·
-           │              render 6        NULL                                          ·                                                                                         ·
-           │              render 7        test.public.xyv.v                             ·                                                                                         ·
-           └── join       ·               ·                                             (x, y, u, x, y, v)                                                                        ·
-                │         type            full outer                                    ·                                                                                         ·
-                │         equality        (x, y) = (x, y)                               ·                                                                                         ·
-                │         mergeJoinOrder  +"(x=x)",+"(y=y)"                             ·                                                                                         ·
-                ├── scan  ·               ·                                             (x, y, u)                                                                                 x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-                │         table           xyu@primary                                   ·                                                                                         ·
-                │         spans           ALL                                           ·                                                                                         ·
-                └── scan  ·               ·                                             (x, y, v)                                                                                 x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-·                         table           xyv@primary                                   ·                                                                                         ·
-·                         spans           ALL                                           ·                                                                                         ·
+render                     ·               ·                                             (x, y, u, v)                                                                              x!=NULL
+ │                         render 0        x                                             ·                                                                                         ·
+ │                         render 1        y                                             ·                                                                                         ·
+ │                         render 2        test.public.xyu.u                             ·                                                                                         ·
+ │                         render 3        test.public.xyv.v                             ·                                                                                         ·
+ └── filter                ·               ·                                             (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  x!=NULL
+      │                    filter          x > 2                                         ·                                                                                         ·
+      └── render           ·               ·                                             (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  ·
+           │               render 0        IFNULL(test.public.xyu.x, test.public.xyv.x)  ·                                                                                         ·
+           │               render 1        IFNULL(test.public.xyu.y, test.public.xyv.y)  ·                                                                                         ·
+           │               render 2        NULL                                          ·                                                                                         ·
+           │               render 3        NULL                                          ·                                                                                         ·
+           │               render 4        test.public.xyu.u                             ·                                                                                         ·
+           │               render 5        NULL                                          ·                                                                                         ·
+           │               render 6        NULL                                          ·                                                                                         ·
+           │               render 7        test.public.xyv.v                             ·                                                                                         ·
+           └── merge-join  ·               ·                                             (x, y, u, x, y, v)                                                                        ·
+                │          type            full outer                                    ·                                                                                         ·
+                │          equality        (x, y) = (x, y)                               ·                                                                                         ·
+                │          mergeJoinOrder  +"(x=x)",+"(y=y)"                             ·                                                                                         ·
+                ├── scan   ·               ·                                             (x, y, u)                                                                                 x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+                │          table           xyu@primary                                   ·                                                                                         ·
+                │          spans           ALL                                           ·                                                                                         ·
+                └── scan   ·               ·                                             (x, y, v)                                                                                 x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·                          table           xyv@primary                                   ·                                                                                         ·
+·                          spans           ALL                                           ·                                                                                         ·
 
 # Verify that we transfer constraints between the two sides.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
 ----
-join       ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
- │         type            inner              ·                   ·
- │         equality        (x, y) = (x, y)    ·                   ·
- │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan  ·               ·                  (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
- │         table           xyu@primary        ·                   ·
- │         spans           /1-/1/10           ·                   ·
- └── scan  ·               ·                  (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
-·          table           xyv@primary        ·                   ·
-·          spans           /1-/1/10           ·                   ·
+merge-join  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+ │          type            inner              ·                   ·
+ │          equality        (x, y) = (x, y)    ·                   ·
+ │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+ ├── scan   ·               ·                  (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
+ │          table           xyu@primary        ·                   ·
+ │          spans           /1-/1/10           ·                   ·
+ └── scan   ·               ·                  (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
+·           table           xyv@primary        ·                   ·
+·           spans           /1-/1/10           ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-join       ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
- │         type            inner              ·                   ·
- │         equality        (x, y) = (x, y)    ·                   ·
- │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan  ·               ·                  (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
- │         table           xyu@primary        ·                   ·
- │         spans           /1-/1/10           ·                   ·
- └── scan  ·               ·                  (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
-·          table           xyv@primary        ·                   ·
-·          spans           /1-/1/10           ·                   ·
+merge-join  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+ │          type            inner              ·                   ·
+ │          equality        (x, y) = (x, y)    ·                   ·
+ │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+ ├── scan   ·               ·                  (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
+ │          table           xyu@primary        ·                   ·
+ │          spans           /1-/1/10           ·                   ·
+ └── scan   ·               ·                  (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
+·           table           xyv@primary        ·                   ·
+·           spans           /1-/1/10           ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-join       ·               ·                                                     (x, y, u, x, y, v)  ·
- │         type            left outer                                            ·                   ·
- │         equality        (x, y) = (x, y)                                       ·                   ·
- │         mergeJoinOrder  +"(x=x)",+"(y=y)"                                     ·                   ·
- │         pred            (test.public.xyu.x = 1) AND (test.public.xyu.y < 10)  ·                   ·
- ├── scan  ·               ·                                                     (x, y, u)           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
- │         table           xyu@primary                                           ·                   ·
- │         spans           ALL                                                   ·                   ·
- └── scan  ·               ·                                                     (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
-·          table           xyv@primary                                           ·                   ·
-·          spans           /1-/1/10                                              ·                   ·
+merge-join  ·               ·                                                     (x, y, u, x, y, v)  ·
+ │          type            left outer                                            ·                   ·
+ │          equality        (x, y) = (x, y)                                       ·                   ·
+ │          mergeJoinOrder  +"(x=x)",+"(y=y)"                                     ·                   ·
+ │          pred            (test.public.xyu.x = 1) AND (test.public.xyu.y < 10)  ·                   ·
+ ├── scan   ·               ·                                                     (x, y, u)           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+ │          table           xyu@primary                                           ·                   ·
+ │          spans           ALL                                                   ·                   ·
+ └── scan   ·               ·                                                     (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
+·           table           xyv@primary                                           ·                   ·
+·           spans           /1-/1/10                                              ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-join       ·               ·                                                     (x, y, u, x, y, v)  ·
- │         type            right outer                                           ·                   ·
- │         equality        (x, y) = (x, y)                                       ·                   ·
- │         mergeJoinOrder  +"(x=x)",+"(y=y)"                                     ·                   ·
- │         pred            (test.public.xyv.x = 1) AND (test.public.xyv.y < 10)  ·                   ·
- ├── scan  ·               ·                                                     (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
- │         table           xyu@primary                                           ·                   ·
- │         spans           /1-/1/10                                              ·                   ·
- └── scan  ·               ·                                                     (x, y, v)           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-·          table           xyv@primary                                           ·                   ·
-·          spans           ALL                                                   ·                   ·
+merge-join  ·               ·                                                     (x, y, u, x, y, v)  ·
+ │          type            right outer                                           ·                   ·
+ │          equality        (x, y) = (x, y)                                       ·                   ·
+ │          mergeJoinOrder  +"(x=x)",+"(y=y)"                                     ·                   ·
+ │          pred            (test.public.xyv.x = 1) AND (test.public.xyv.y < 10)  ·                   ·
+ ├── scan   ·               ·                                                     (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
+ │          table           xyu@primary                                           ·                   ·
+ │          spans           /1-/1/10                                              ·                   ·
+ └── scan   ·               ·                                                     (x, y, v)           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·           table           xyv@primary                                           ·                   ·
+·           spans           ALL                                                   ·                   ·
 
 
 # Test OUTER joins that are run in the distSQL merge joiner
@@ -990,127 +990,127 @@ join       ·               ·                                                  
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-render          ·               ·                  (x, y, u, v)                          ·
- │              render 0        xyu.x              ·                                     ·
- │              render 1        xyu.y              ·                                     ·
- │              render 2        xyu.u              ·                                     ·
- │              render 3        xyv.v              ·                                     ·
- └── join       ·               ·                  (x, y, u, x[omitted], y[omitted], v)  ·
-      │         type            left outer         ·                                     ·
-      │         equality        (x, y) = (x, y)    ·                                     ·
-      │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
-      ├── scan  ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-      │         table           xyu@primary        ·                                     ·
-      │         spans           /3-                ·                                     ·
-      └── scan  ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-·               table           xyv@primary        ·                                     ·
-·               spans           /3-                ·                                     ·
+render           ·               ·                  (x, y, u, v)                          ·
+ │               render 0        xyu.x              ·                                     ·
+ │               render 1        xyu.y              ·                                     ·
+ │               render 2        xyu.u              ·                                     ·
+ │               render 3        xyv.v              ·                                     ·
+ └── merge-join  ·               ·                  (x, y, u, x[omitted], y[omitted], v)  ·
+      │          type            left outer         ·                                     ·
+      │          equality        (x, y) = (x, y)    ·                                     ·
+      │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
+      ├── scan   ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+      │          table           xyu@primary        ·                                     ·
+      │          spans           /3-                ·                                     ·
+      └── scan   ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·                table           xyv@primary        ·                                     ·
+·                spans           /3-                ·                                     ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-render               ·               ·                  (x, y, u, v)                                        ·
- │                   render 0        xyv.x              ·                                                   ·
- │                   render 1        xyv.y              ·                                                   ·
- │                   render 2        xyu.u              ·                                                   ·
- │                   render 3        xyv.v              ·                                                   ·
- └── render          ·               ·                  (x, y, x[hidden,omitted], y[hidden,omitted], u, v)  ·
-      │              render 0        xyv.x              ·                                                   ·
-      │              render 1        xyv.y              ·                                                   ·
-      │              render 2        NULL               ·                                                   ·
-      │              render 3        NULL               ·                                                   ·
-      │              render 4        xyu.u              ·                                                   ·
-      │              render 5        xyv.v              ·                                                   ·
-      └── join       ·               ·                  (x[omitted], y[omitted], u, x, y, v)                ·
-           │         type            right outer        ·                                                   ·
-           │         equality        (x, y) = (x, y)    ·                                                   ·
-           │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                   ·
-           ├── scan  ·               ·                  (x, y, u)                                           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-           │         table           xyu@primary        ·                                                   ·
-           │         spans           /3-                ·                                                   ·
-           └── scan  ·               ·                  (x, y, v)                                           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-·                    table           xyv@primary        ·                                                   ·
-·                    spans           /3-                ·                                                   ·
+render                ·               ·                  (x, y, u, v)                                        ·
+ │                    render 0        xyv.x              ·                                                   ·
+ │                    render 1        xyv.y              ·                                                   ·
+ │                    render 2        xyu.u              ·                                                   ·
+ │                    render 3        xyv.v              ·                                                   ·
+ └── render           ·               ·                  (x, y, x[hidden,omitted], y[hidden,omitted], u, v)  ·
+      │               render 0        xyv.x              ·                                                   ·
+      │               render 1        xyv.y              ·                                                   ·
+      │               render 2        NULL               ·                                                   ·
+      │               render 3        NULL               ·                                                   ·
+      │               render 4        xyu.u              ·                                                   ·
+      │               render 5        xyv.v              ·                                                   ·
+      └── merge-join  ·               ·                  (x[omitted], y[omitted], u, x, y, v)                ·
+           │          type            right outer        ·                                                   ·
+           │          equality        (x, y) = (x, y)    ·                                                   ·
+           │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                   ·
+           ├── scan   ·               ·                  (x, y, u)                                           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+           │          table           xyu@primary        ·                                                   ·
+           │          spans           /3-                ·                                                   ·
+           └── scan   ·               ·                  (x, y, v)                                           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·                     table           xyv@primary        ·                                                   ·
+·                     spans           /3-                ·                                                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-render                    ·               ·                     (x, y, u, v)                                                                              x!=NULL
- │                        render 0        x                     ·                                                                                         ·
- │                        render 1        y                     ·                                                                                         ·
- │                        render 2        xyu.u                 ·                                                                                         ·
- │                        render 3        xyv.v                 ·                                                                                         ·
- └── filter               ·               ·                     (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  x!=NULL
-      │                   filter          x > 2                 ·                                                                                         ·
-      └── render          ·               ·                     (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  ·
-           │              render 0        IFNULL(xyu.x, xyv.x)  ·                                                                                         ·
-           │              render 1        IFNULL(xyu.y, xyv.y)  ·                                                                                         ·
-           │              render 2        NULL                  ·                                                                                         ·
-           │              render 3        NULL                  ·                                                                                         ·
-           │              render 4        xyu.u                 ·                                                                                         ·
-           │              render 5        NULL                  ·                                                                                         ·
-           │              render 6        NULL                  ·                                                                                         ·
-           │              render 7        xyv.v                 ·                                                                                         ·
-           └── join       ·               ·                     (x, y, u, x, y, v)                                                                        ·
-                │         type            full outer            ·                                                                                         ·
-                │         equality        (x, y) = (x, y)       ·                                                                                         ·
-                │         mergeJoinOrder  +"(x=x)",+"(y=y)"     ·                                                                                         ·
-                ├── scan  ·               ·                     (x, y, u)                                                                                 x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-                │         table           xyu@primary           ·                                                                                         ·
-                │         spans           ALL                   ·                                                                                         ·
-                └── scan  ·               ·                     (x, y, v)                                                                                 x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-·                         table           xyv@primary           ·                                                                                         ·
-·                         spans           ALL                   ·                                                                                         ·
+render                     ·               ·                     (x, y, u, v)                                                                              x!=NULL
+ │                         render 0        x                     ·                                                                                         ·
+ │                         render 1        y                     ·                                                                                         ·
+ │                         render 2        xyu.u                 ·                                                                                         ·
+ │                         render 3        xyv.v                 ·                                                                                         ·
+ └── filter                ·               ·                     (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  x!=NULL
+      │                    filter          x > 2                 ·                                                                                         ·
+      └── render           ·               ·                     (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  ·
+           │               render 0        IFNULL(xyu.x, xyv.x)  ·                                                                                         ·
+           │               render 1        IFNULL(xyu.y, xyv.y)  ·                                                                                         ·
+           │               render 2        NULL                  ·                                                                                         ·
+           │               render 3        NULL                  ·                                                                                         ·
+           │               render 4        xyu.u                 ·                                                                                         ·
+           │               render 5        NULL                  ·                                                                                         ·
+           │               render 6        NULL                  ·                                                                                         ·
+           │               render 7        xyv.v                 ·                                                                                         ·
+           └── merge-join  ·               ·                     (x, y, u, x, y, v)                                                                        ·
+                │          type            full outer            ·                                                                                         ·
+                │          equality        (x, y) = (x, y)       ·                                                                                         ·
+                │          mergeJoinOrder  +"(x=x)",+"(y=y)"     ·                                                                                         ·
+                ├── scan   ·               ·                     (x, y, u)                                                                                 x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+                │          table           xyu@primary           ·                                                                                         ·
+                │          spans           ALL                   ·                                                                                         ·
+                └── scan   ·               ·                     (x, y, v)                                                                                 x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·                          table           xyv@primary           ·                                                                                         ·
+·                          spans           ALL                   ·                                                                                         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-join       ·               ·                             (x, y, u, x, y, v)  ·
- │         type            left outer                    ·                   ·
- │         equality        (x, y) = (x, y)               ·                   ·
- │         mergeJoinOrder  +"(x=x)",+"(y=y)"             ·                   ·
- │         pred            (xyu.x = 1) AND (xyu.y < 10)  ·                   ·
- ├── scan  ·               ·                             (x, y, u)           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
- │         table           xyu@primary                   ·                   ·
- │         spans           ALL                           ·                   ·
- └── scan  ·               ·                             (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
-·          table           xyv@primary                   ·                   ·
-·          spans           /1-/1/10                      ·                   ·
+merge-join  ·               ·                             (x, y, u, x, y, v)  ·
+ │          type            left outer                    ·                   ·
+ │          equality        (x, y) = (x, y)               ·                   ·
+ │          mergeJoinOrder  +"(x=x)",+"(y=y)"             ·                   ·
+ │          pred            (xyu.x = 1) AND (xyu.y < 10)  ·                   ·
+ ├── scan   ·               ·                             (x, y, u)           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+ │          table           xyu@primary                   ·                   ·
+ │          spans           ALL                           ·                   ·
+ └── scan   ·               ·                             (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
+·           table           xyv@primary                   ·                   ·
+·           spans           /1-/1/10                      ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-join       ·               ·                             (x, y, u, x, y, v)  ·
- │         type            right outer                   ·                   ·
- │         equality        (x, y) = (x, y)               ·                   ·
- │         mergeJoinOrder  +"(x=x)",+"(y=y)"             ·                   ·
- │         pred            (xyv.x = 1) AND (xyv.y < 10)  ·                   ·
- ├── scan  ·               ·                             (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
- │         table           xyu@primary                   ·                   ·
- │         spans           /1-/1/10                      ·                   ·
- └── scan  ·               ·                             (x, y, v)           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-·          table           xyv@primary                   ·                   ·
-·          spans           ALL                           ·                   ·
+merge-join  ·               ·                             (x, y, u, x, y, v)  ·
+ │          type            right outer                   ·                   ·
+ │          equality        (x, y) = (x, y)               ·                   ·
+ │          mergeJoinOrder  +"(x=x)",+"(y=y)"             ·                   ·
+ │          pred            (xyv.x = 1) AND (xyv.y < 10)  ·                   ·
+ ├── scan   ·               ·                             (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
+ │          table           xyu@primary                   ·                   ·
+ │          spans           /1-/1/10                      ·                   ·
+ └── scan   ·               ·                             (x, y, v)           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·           table           xyv@primary                   ·                   ·
+·           spans           ALL                           ·                   ·
 
 # Regression test for #20472: break up tuple inequalities.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2, 3)
 ----
-render          ·               ·                  (x, y, u, v)                          x!=NULL; y!=NULL
- │              render 0        test.public.xyu.x  ·                                     ·
- │              render 1        test.public.xyu.y  ·                                     ·
- │              render 2        test.public.xyu.u  ·                                     ·
- │              render 3        test.public.xyv.v  ·                                     ·
- └── join       ·               ·                  (x, y, u, x[omitted], y[omitted], v)  x=x; y=y; x!=NULL; y!=NULL
-      │         type            inner              ·                                     ·
-      │         equality        (x, y) = (x, y)    ·                                     ·
-      │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
-      ├── scan  ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-      │         table           xyu@primary        ·                                     ·
-      │         spans           /1/2/4-            ·                                     ·
-      └── scan  ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-·               table           xyv@primary        ·                                     ·
-·               spans           /1/2-              ·                                     ·
+render           ·               ·                  (x, y, u, v)                          x!=NULL; y!=NULL
+ │               render 0        test.public.xyu.x  ·                                     ·
+ │               render 1        test.public.xyu.y  ·                                     ·
+ │               render 2        test.public.xyu.u  ·                                     ·
+ │               render 3        test.public.xyv.v  ·                                     ·
+ └── merge-join  ·               ·                  (x, y, u, x[omitted], y[omitted], v)  x=x; y=y; x!=NULL; y!=NULL
+      │          type            inner              ·                                     ·
+      │          equality        (x, y) = (x, y)    ·                                     ·
+      │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
+      ├── scan   ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+      │          table           xyu@primary        ·                                     ·
+      │          spans           /1/2/4-            ·                                     ·
+      └── scan   ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·                table           xyv@primary        ·                                     ·
+·                spans           /1/2-              ·                                     ·
 
 
 # Regression test for #20858.
@@ -1124,65 +1124,65 @@ CREATE TABLE r (a INT PRIMARY KEY)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-render          ·               ·                (a)              ·
- │              render 0        test.public.l.a  ·                ·
- └── join       ·               ·                (a, a[omitted])  ·
-      │         type            left outer       ·                ·
-      │         equality        (a) = (a)        ·                ·
-      │         mergeJoinOrder  +"(a=a)"         ·                ·
-      ├── scan  ·               ·                (a)              a=CONST; key()
-      │         table           l@primary        ·                ·
-      │         spans           /3-/3/#          ·                ·
-      └── scan  ·               ·                (a)              a=CONST; key()
-·               table           r@primary        ·                ·
-·               spans           /3-/3/#          ·                ·
+render           ·               ·                (a)              ·
+ │               render 0        test.public.l.a  ·                ·
+ └── merge-join  ·               ·                (a, a[omitted])  ·
+      │          type            left outer       ·                ·
+      │          equality        (a) = (a)        ·                ·
+      │          mergeJoinOrder  +"(a=a)"         ·                ·
+      ├── scan   ·               ·                (a)              a=CONST; key()
+      │          table           l@primary        ·                ·
+      │          spans           /3-/3/#          ·                ·
+      └── scan   ·               ·                (a)              a=CONST; key()
+·                table           r@primary        ·                ·
+·                spans           /3-/3/#          ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
 ----
-join       ·               ·           (a, a)  ·
- │         type            left outer  ·       ·
- │         equality        (a) = (a)   ·       ·
- │         mergeJoinOrder  +"(a=a)"    ·       ·
- ├── scan  ·               ·           (a)     a=CONST; key()
- │         table           l@primary   ·       ·
- │         spans           /3-/3/#     ·       ·
- └── scan  ·               ·           (a)     a=CONST; key()
-·          table           r@primary   ·       ·
-·          spans           /3-/3/#     ·       ·
+merge-join  ·               ·           (a, a)  ·
+ │          type            left outer  ·       ·
+ │          equality        (a) = (a)   ·       ·
+ │          mergeJoinOrder  +"(a=a)"    ·       ·
+ ├── scan   ·               ·           (a)     a=CONST; key()
+ │          table           l@primary   ·       ·
+ │          spans           /3-/3/#     ·       ·
+ └── scan   ·               ·           (a)     a=CONST; key()
+·           table           r@primary   ·       ·
+·           spans           /3-/3/#     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-render               ·               ·                (a)                     ·
- │                   render 0        test.public.r.a  ·                       ·
- └── render          ·               ·                (a, a[hidden,omitted])  ·
-      │              render 0        test.public.r.a  ·                       ·
-      │              render 1        NULL             ·                       ·
-      └── join       ·               ·                (a[omitted], a)         ·
-           │         type            right outer      ·                       ·
-           │         equality        (a) = (a)        ·                       ·
-           │         mergeJoinOrder  +"(a=a)"         ·                       ·
-           ├── scan  ·               ·                (a)                     a=CONST; key()
-           │         table           l@primary        ·                       ·
-           │         spans           /3-/3/#          ·                       ·
-           └── scan  ·               ·                (a)                     a=CONST; key()
-·                    table           r@primary        ·                       ·
-·                    spans           /3-/3/#          ·                       ·
+render                ·               ·                (a)                     ·
+ │                    render 0        test.public.r.a  ·                       ·
+ └── render           ·               ·                (a, a[hidden,omitted])  ·
+      │               render 0        test.public.r.a  ·                       ·
+      │               render 1        NULL             ·                       ·
+      └── merge-join  ·               ·                (a[omitted], a)         ·
+           │          type            right outer      ·                       ·
+           │          equality        (a) = (a)        ·                       ·
+           │          mergeJoinOrder  +"(a=a)"         ·                       ·
+           ├── scan   ·               ·                (a)                     a=CONST; key()
+           │          table           l@primary        ·                       ·
+           │          spans           /3-/3/#          ·                       ·
+           └── scan   ·               ·                (a)                     a=CONST; key()
+·                     table           r@primary        ·                       ·
+·                     spans           /3-/3/#          ·                       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
 ----
-join       ·               ·            (a, a)  ·
- │         type            right outer  ·       ·
- │         equality        (a) = (a)    ·       ·
- │         mergeJoinOrder  +"(a=a)"     ·       ·
- ├── scan  ·               ·            (a)     a=CONST; key()
- │         table           l@primary    ·       ·
- │         spans           /3-/3/#      ·       ·
- └── scan  ·               ·            (a)     a=CONST; key()
-·          table           r@primary    ·       ·
-·          spans           /3-/3/#      ·       ·
+merge-join  ·               ·            (a, a)  ·
+ │          type            right outer  ·       ·
+ │          equality        (a) = (a)    ·       ·
+ │          mergeJoinOrder  +"(a=a)"     ·       ·
+ ├── scan   ·               ·            (a)     a=CONST; key()
+ │          table           l@primary    ·       ·
+ │          spans           /3-/3/#      ·       ·
+ └── scan   ·               ·            (a)     a=CONST; key()
+·           table           r@primary    ·       ·
+·           spans           /3-/3/#      ·       ·
 
 # Regression tests for #21243
 statement ok
@@ -1207,19 +1207,19 @@ CREATE TABLE abg (
 query TTT
 EXPLAIN SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(1,2) OR ((a,b)=(1,2) AND c < 6) OR ((a,b,c)=(1,2,6) AND d > 8))
 ----
-render          ·               ·
- └── join       ·               ·
-      │         type            inner
-      │         equality        (a, b) = (a, b)
-      │         mergeJoinOrder  +"(a=a)",+"(b=b)"
-      ├── scan  ·               ·
-      │         table           abcdef@primary
-      │         spans           /1/2/6/9-
-      │         filter          (((a, b) > (1, 2)) OR (((a = 1) AND (b = 2)) AND (c < 6))) OR ((((a = 1) AND (b = 2)) AND (c = 6)) AND (d > 8))
-      └── scan  ·               ·
-·               table           abg@primary
-·               spans           /1/2-
-·               filter          (((a, b) > (1, 2)) OR ((a = 1) AND (b = 2))) OR ((a = 1) AND (b = 2))
+render           ·               ·
+ └── merge-join  ·               ·
+      │          type            inner
+      │          equality        (a, b) = (a, b)
+      │          mergeJoinOrder  +"(a=a)",+"(b=b)"
+      ├── scan   ·               ·
+      │          table           abcdef@primary
+      │          spans           /1/2/6/9-
+      │          filter          (((a, b) > (1, 2)) OR (((a = 1) AND (b = 2)) AND (c < 6))) OR ((((a = 1) AND (b = 2)) AND (c = 6)) AND (d > 8))
+      └── scan   ·               ·
+·                table           abg@primary
+·                spans           /1/2-
+·                filter          (((a, b) > (1, 2)) OR ((a = 1) AND (b = 2))) OR ((a = 1) AND (b = 2))
 
 # Regression tests for mixed-type equality columns (#22514).
 statement ok
@@ -1249,7 +1249,7 @@ render          ·         ·
  │              render 1  test.public.foo.b
  │              render 2  test.public.foo.c
  │              render 3  test.public.foo.d
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (a, c) = (a, c)
       │         pred      (test.public.foo.b = test.public.bar.b) AND (test.public.foo.d = test.public.bar.d)
@@ -1285,7 +1285,7 @@ render               ·         ·
       │              render 7  test.public.bar.c
       │              render 8  test.public.bar.d
       │              render 9  NULL
-      └── join       ·         ·
+      └── hash-join  ·         ·
            │         type      inner
            │         pred      test.public.foo.b = test.public.bar.b
            ├── scan  ·         ·
@@ -1308,7 +1308,7 @@ render          ·         ·
  │              render 3  test.public.foo.d
  │              render 4  test.public.bar.c
  │              render 5  test.public.bar.d
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (a) = (a)
       │         pred      test.public.foo.b = test.public.bar.b
@@ -1331,7 +1331,7 @@ render          ·         ·
  │              render 2  test.public.foo.c
  │              render 3  test.public.foo.d
  │              render 4  test.public.bar.d
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (a, c) = (a, c)
       │         pred      test.public.foo.b = test.public.bar.b
@@ -1357,7 +1357,7 @@ render          ·         ·
  │              render 5  test.public.bar.b
  │              render 6  test.public.bar.c
  │              render 7  test.public.bar.d
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         pred      test.public.foo.b = test.public.bar.b
       ├── scan  ·         ·
@@ -1382,7 +1382,7 @@ render          ·         ·
  │              render 5  test.public.bar.b
  │              render 6  test.public.bar.c
  │              render 7  test.public.bar.d
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (a) = (a)
       │         pred      test.public.foo.b = test.public.bar.b
@@ -1407,7 +1407,7 @@ render          ·         ·
  │              render 5  test.public.bar.b
  │              render 6  test.public.bar.c
  │              render 7  test.public.bar.d
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         pred      test.public.foo.b = test.public.bar.b
       ├── scan  ·         ·
@@ -1432,7 +1432,7 @@ render          ·         ·
  │              render 5  test.public.bar.b
  │              render 6  test.public.bar.c
  │              render 7  test.public.bar.d
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (a) = (a)
       │         pred      test.public.foo.b = test.public.bar.b
@@ -1456,7 +1456,7 @@ render          ·         ·
  │              render 3  test.public.foo.d
  │              render 4  test.public.bar.c
  │              render 5  test.public.bar.d
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (a, c) = (a, c)
       │         pred      (test.public.foo.b = test.public.bar.b) AND (test.public.foo.d = test.public.bar.d)

--- a/pkg/sql/logictest/testdata/planner_test/order_by
+++ b/pkg/sql/logictest/testdata/planner_test/order_by
@@ -760,7 +760,7 @@ sort                   ·              ·                 (k)                   
  └── render            ·              ·                 (k, v)                          ·
       │                render 0       test.public.kv.k  ·                               ·
       │                render 1       test.public.kv.v  ·                               ·
-      └── join         ·              ·                 (k, v, a[omitted], b[omitted])  ·
+      └── hash-join    ·              ·                 (k, v, a[omitted], b[omitted])  ·
            │           type           inner             ·                               ·
            │           equality       (k) = (a)         ·                               ·
            ├── scan    ·              ·                 (k, v)                          k!=NULL; key(k)
@@ -773,40 +773,40 @@ sort                   ·              ·                 (k)                   
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-sort                 ·               ·                 (k)                    k!=NULL; key(k)
- │                   order           -v,+k             ·                      ·
- └── render          ·               ·                 (k, v, k)              k=k; k!=NULL; v!=NULL; key(k)
-      │              render 0        a.k               ·                      ·
-      │              render 1        test.public.kv.v  ·                      ·
-      │              render 2        test.public.kv.k  ·                      ·
-      └── join       ·               ·                 (k, v[omitted], k, v)  k=k; v=v; k!=NULL; v!=NULL; key(k)
-           │         type            inner             ·                      ·
-           │         equality        (k, v) = (k, v)   ·                      ·
-           │         mergeJoinOrder  +"(k=k)"          ·                      ·
-           ├── scan  ·               ·                 (k, v)                 k!=NULL; key(k); +k
-           │         table           kv@primary        ·                      ·
-           │         spans           ALL               ·                      ·
-           └── scan  ·               ·                 (k, v)                 k!=NULL; key(k); +k
-·                    table           kv@primary        ·                      ·
-·                    spans           ALL               ·                      ·
+sort                  ·               ·                 (k)                    k!=NULL; key(k)
+ │                    order           -v,+k             ·                      ·
+ └── render           ·               ·                 (k, v, k)              k=k; k!=NULL; v!=NULL; key(k)
+      │               render 0        a.k               ·                      ·
+      │               render 1        test.public.kv.v  ·                      ·
+      │               render 2        test.public.kv.k  ·                      ·
+      └── merge-join  ·               ·                 (k, v[omitted], k, v)  k=k; v=v; k!=NULL; v!=NULL; key(k)
+           │          type            inner             ·                      ·
+           │          equality        (k, v) = (k, v)   ·                      ·
+           │          mergeJoinOrder  +"(k=k)"          ·                      ·
+           ├── scan   ·               ·                 (k, v)                 k!=NULL; key(k); +k
+           │          table           kv@primary        ·                      ·
+           │          spans           ALL               ·                      ·
+           └── scan   ·               ·                 (k, v)                 k!=NULL; key(k); +k
+·                     table           kv@primary        ·                      ·
+·                     spans           ALL               ·                      ·
 
 # The underlying index can be forced manually, of course.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@foo
 ----
-nosort               ·               ·                  (k)                    k!=NULL
- │                   order           -v,+k              ·                      ·
- └── render          ·               ·                  (k, v, k)              k=k; k!=NULL; v!=NULL; -v,+k
-      │              render 0        a.k                ·                      ·
-      │              render 1        test.public.kv.v   ·                      ·
-      │              render 2        test.public.kv.k   ·                      ·
-      └── join       ·               ·                  (k, v[omitted], k, v)  k=k; v=v; k!=NULL; v!=NULL; -v,+k
-           │         type            inner              ·                      ·
-           │         equality        (k, v) = (k, v)    ·                      ·
-           │         mergeJoinOrder  -"(v=v)",+"(k=k)"  ·                      ·
-           ├── scan  ·               ·                  (k, v)                 k!=NULL; weak-key(k,v); -v,+k
-           │         table           kv@foo             ·                      ·
-           │         spans           ALL                ·                      ·
-           └── scan  ·               ·                  (k, v)                 k!=NULL; weak-key(k,v); -v,+k
-·                    table           kv@foo             ·                      ·
-·                    spans           ALL                ·                      ·
+nosort                ·               ·                  (k)                    k!=NULL
+ │                    order           -v,+k              ·                      ·
+ └── render           ·               ·                  (k, v, k)              k=k; k!=NULL; v!=NULL; -v,+k
+      │               render 0        a.k                ·                      ·
+      │               render 1        test.public.kv.v   ·                      ·
+      │               render 2        test.public.kv.k   ·                      ·
+      └── merge-join  ·               ·                  (k, v[omitted], k, v)  k=k; v=v; k!=NULL; v!=NULL; -v,+k
+           │          type            inner              ·                      ·
+           │          equality        (k, v) = (k, v)    ·                      ·
+           │          mergeJoinOrder  -"(v=v)",+"(k=k)"  ·                      ·
+           ├── scan   ·               ·                  (k, v)                 k!=NULL; weak-key(k,v); -v,+k
+           │          table           kv@foo             ·                      ·
+           │          spans           ALL                ·                      ·
+           └── scan   ·               ·                  (k, v)                 k!=NULL; weak-key(k,v); -v,+k
+·                     table           kv@foo             ·                      ·
+·                     spans           ALL                ·                      ·

--- a/pkg/sql/logictest/testdata/planner_test/physical_props
+++ b/pkg/sql/logictest/testdata/planner_test/physical_props
@@ -117,57 +117,57 @@ CREATE TABLE efg (e INT PRIMARY KEY, f INT, g INT)
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=e AND a=1 AND f=g
 ----
-tree       field           description   columns                ordering
-join       ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; a=CONST; key()
- │         type            inner         ·                      ·
- │         equality        (a) = (e)     ·                      ·
- │         mergeJoinOrder  +"(a=e)"      ·                      ·
- ├── scan  ·               ·             (a, b, c, d)           a=CONST; key()
- │         table           abcd@primary  ·                      ·
- │         spans           /1-/1/#       ·                      ·
- └── scan  ·               ·             (e, f, g)              f=g; e=CONST; f!=NULL; g!=NULL; key()
-·          table           efg@primary   ·                      ·
-·          spans           /1-/1/#       ·                      ·
-·          filter          f = g         ·                      ·
+tree        field           description   columns                ordering
+merge-join  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; a=CONST; key()
+ │          type            inner         ·                      ·
+ │          equality        (a) = (e)     ·                      ·
+ │          mergeJoinOrder  +"(a=e)"      ·                      ·
+ ├── scan   ·               ·             (a, b, c, d)           a=CONST; key()
+ │          table           abcd@primary  ·                      ·
+ │          spans           /1-/1/#       ·                      ·
+ └── scan   ·               ·             (e, f, g)              f=g; e=CONST; f!=NULL; g!=NULL; key()
+·           table           efg@primary   ·                      ·
+·           spans           /1-/1/#       ·                      ·
+·           filter          f = g         ·                      ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=e AND b=1 AND f=g
 ----
-tree       field           description   columns                ordering
-join       ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; b=CONST; a!=NULL; key(a)
- │         type            inner         ·                      ·
- │         equality        (a) = (e)     ·                      ·
- │         mergeJoinOrder  +"(a=e)"      ·                      ·
- ├── scan  ·               ·             (a, b, c, d)           b=CONST; a!=NULL; key(a); +a
- │         table           abcd@primary  ·                      ·
- │         spans           ALL           ·                      ·
- │         filter          b = 1         ·                      ·
- └── scan  ·               ·             (e, f, g)              f=g; e!=NULL; f!=NULL; g!=NULL; key(e); +e
-·          table           efg@primary   ·                      ·
-·          spans           ALL           ·                      ·
-·          filter          f = g         ·                      ·
+tree        field           description   columns                ordering
+merge-join  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; b=CONST; a!=NULL; key(a)
+ │          type            inner         ·                      ·
+ │          equality        (a) = (e)     ·                      ·
+ │          mergeJoinOrder  +"(a=e)"      ·                      ·
+ ├── scan   ·               ·             (a, b, c, d)           b=CONST; a!=NULL; key(a); +a
+ │          table           abcd@primary  ·                      ·
+ │          spans           ALL           ·                      ·
+ │          filter          b = 1         ·                      ·
+ └── scan   ·               ·             (e, f, g)              f=g; e!=NULL; f!=NULL; g!=NULL; key(e); +e
+·           table           efg@primary   ·                      ·
+·           spans           ALL           ·                      ·
+·           filter          f = g         ·                      ·
 
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=e
 ----
-tree       field           description   columns                ordering
-join       ·               ·             (a, b, c, d, e, f, g)  a=e; a!=NULL; key(a)
- │         type            inner         ·                      ·
- │         equality        (a) = (e)     ·                      ·
- │         mergeJoinOrder  +"(a=e)"      ·                      ·
- ├── scan  ·               ·             (a, b, c, d)           a!=NULL; key(a); +a
- │         table           abcd@primary  ·                      ·
- │         spans           ALL           ·                      ·
- └── scan  ·               ·             (e, f, g)              e!=NULL; key(e); +e
-·          table           efg@primary   ·                      ·
-·          spans           ALL           ·                      ·
+tree        field           description   columns                ordering
+merge-join  ·               ·             (a, b, c, d, e, f, g)  a=e; a!=NULL; key(a)
+ │          type            inner         ·                      ·
+ │          equality        (a) = (e)     ·                      ·
+ │          mergeJoinOrder  +"(a=e)"      ·                      ·
+ ├── scan   ·               ·             (a, b, c, d)           a!=NULL; key(a); +a
+ │          table           abcd@primary  ·                      ·
+ │          spans           ALL           ·                      ·
+ └── scan   ·               ·             (e, f, g)              e!=NULL; key(e); +e
+·           table           efg@primary   ·                      ·
+·           spans           ALL           ·                      ·
 
 # Verify keys don't get propagated when not appropriate.
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=f
 ----
 tree       field     description   columns                ordering
-join       ·         ·             (a, b, c, d, e, f, g)  ·
+hash-join  ·         ·             (a, b, c, d, e, f, g)  ·
  │         type      inner         ·                      ·
  │         equality  (a) = (f)     ·                      ·
  ├── scan  ·         ·             (a, b, c, d)           a!=NULL; key(a)
@@ -182,7 +182,7 @@ query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN (SELECT * FROM efg WITH ORDINALITY) ON a=e
 ----
 tree             field           description   columns                              ordering
-join             ·               ·             (a, b, c, d, e, f, g, "ordinality")  a=e; a!=NULL; key(a); weak-key("ordinality")
+merge-join       ·               ·             (a, b, c, d, e, f, g, "ordinality")  a=e; a!=NULL; key(a); weak-key("ordinality")
  │               type            inner         ·                                    ·
  │               equality        (a) = (e)     ·                                    ·
  │               mergeJoinOrder  +"(a=e)"      ·                                    ·

--- a/pkg/sql/logictest/testdata/planner_test/select_index
+++ b/pkg/sql/logictest/testdata/planner_test/select_index
@@ -183,7 +183,7 @@ EXPLAIN SELECT * FROM t x JOIN t y USING(b) WHERE x.b < '3'
 ----
 render                     ·               ·
  └── render                ·               ·
-      └── join             ·               ·
+      └── merge-join       ·               ·
            │               type            inner
            │               equality        (b) = (b)
            │               mergeJoinOrder  +"(b=b)"

--- a/pkg/sql/logictest/testdata/planner_test/spool
+++ b/pkg/sql/logictest/testdata/planner_test/spool
@@ -147,7 +147,7 @@ sort                        ·         ·
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t VALUES (2) RETURNING x], t
 ----
-join                        ·         ·
+hash-join                   ·         ·
  │                          type      cross
  ├── spool                  ·         ·
  │    └── run               ·         ·

--- a/pkg/sql/logictest/testdata/planner_test/srfs
+++ b/pkg/sql/logictest/testdata/planner_test/srfs
@@ -11,7 +11,7 @@ project set    ·  ·
 query TTT
 EXPLAIN SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ----
-join                ·     ·
+hash-join           ·     ·
  │                  type  cross
  ├── project set    ·     ·
  │    └── emptyrow  ·     ·
@@ -51,7 +51,7 @@ render               ·         ·                                  (a, b, gener
  └── project set     ·         ·                                  (a, rowid[hidden,omitted], b, rowid[hidden,omitted], generate_series, generate_series)  ·
       │              render 0  generate_series(1, 2)              ·                                                                                       ·
       │              render 1  generate_series(3, 4)              ·                                                                                       ·
-      └── join       ·         ·                                  (a, rowid[hidden,omitted], b, rowid[hidden,omitted])                                    ·
+      └── hash-join  ·         ·                                  (a, rowid[hidden,omitted], b, rowid[hidden,omitted])                                    ·
            │         type      cross                              ·                                                                                       ·
            ├── scan  ·         ·                                  (a, rowid[hidden,omitted])                                                              rowid!=NULL; key(rowid)
            │         table     t@primary                          ·                                                                                       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -198,7 +198,7 @@ group                ·            ·                             (count)       
  │                   scalar       ·                             ·             ·
  └── render          ·            ·                             (column9)     ·
       │              render 0     ((k, v, w, s) AS k, v, w, s)  ·             ·
-      └── join       ·            ·                             (k, v, w, s)  ·
+      └── hash-join  ·            ·                             (k, v, w, s)  ·
            │         type         cross                         ·             ·
            ├── scan  ·            ·                             (k, v, w, s)  ·
            │         table        kv@primary                    ·             ·
@@ -218,7 +218,7 @@ render               ·            ·
       │              aggregate 0  k
       │              aggregate 1  min(k)
       │              group by     @1
-      └── join       ·            ·
+      └── hash-join  ·            ·
            │         type         cross
            ├── scan  ·            ·
            │         table        kv@primary
@@ -238,7 +238,7 @@ render               ·            ·
       │              aggregate 0  k
       │              aggregate 1  min(k)
       │              group by     @1
-      └── join       ·            ·
+      └── hash-join  ·            ·
            │         type         cross
            ├── scan  ·            ·
            │         table        kv@primary
@@ -259,7 +259,7 @@ render               ·            ·
       │              aggregate 0  k
       │              aggregate 1  min(k)
       │              group by     @1
-      └── join       ·            ·
+      └── hash-join  ·            ·
            │         type         cross
            ├── scan  ·            ·
            │         table        kv@primary
@@ -278,7 +278,7 @@ render               ·            ·
  │                   render 0     v
  └── distinct        ·            ·
       │              distinct on  v, w, s
-      └── join       ·            ·
+      └── hash-join  ·            ·
            │         type         cross
            ├── scan  ·            ·
            │         table        kv@primary
@@ -649,7 +649,7 @@ render               ·            ·                                 (sum decim
       │              aggregate 0  k                                 ·                      ·
       │              aggregate 1  sum(d)                            ·                      ·
       │              group by     @1                                ·                      ·
-      └── join       ·            ·                                 (k int, d decimal)     ·
+      └── hash-join  ·            ·                                 (k int, d decimal)     ·
            │         type         inner                             ·                      ·
            │         pred         ((k)[int] >= (d)[decimal])[bool]  ·                      ·
            ├── scan  ·            ·                                 (k int)                ·
@@ -743,7 +743,7 @@ render               ·            ·                                           
       │              aggregate 2  min(y)                                      ·                                         ·
       │              aggregate 3  any_not_null(b)                             ·                                         ·
       │              group by     @1,@3                                       ·                                         ·
-      └── join       ·            ·                                           (a int, b int, x string, y string)        ·
+      └── hash-join  ·            ·                                           (a int, b int, x string, y string)        ·
            │         type         cross                                       ·                                         ·
            ├── scan  ·            ·                                           (a int, b int)                            ·
            │         table        ab@primary                                  ·                                         ·
@@ -985,7 +985,7 @@ group                ·            ·             (count)  ·
  │                   aggregate 0  count_rows()  ·        ·
  │                   scalar       ·             ·        ·
  └── render          ·            ·             ()       ·
-      └── join       ·            ·             (y, v)   ·
+      └── hash-join  ·            ·             (y, v)   ·
            │         type         inner         ·        ·
            │         equality     (y) = (v)     ·        ·
            ├── scan  ·            ·             (y)      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -254,20 +254,20 @@ EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
   OR pid1 >= 19 AND pid1 <= 21
   OR pid1 >= 31 AND pid1 <= 33
 ----
-render          ·               ·
- └── join       ·               ·
-      │         type            inner
-      │         equality        (pid1) = (pid1)
-      │         mergeJoinOrder  +"(pid1=pid1)"
-      ├── scan  ·               ·
-      │         table           grandchild2@primary
-      │         spans           /11/#/56/1-/13/#/56/2 /19/#/56/1-/21/#/56/2 /31/#/56/1-/33/#/56/2
-      │         filter          ((pid1 <= 13) OR ((pid1 >= 19) AND (pid1 <= 21))) OR (pid1 >= 31)
-      └── scan  ·               ·
-·               table           parent1@primary
-·               spans           /11-/13/# /19-/21/# /31-/33/#
-·               parallel        ·
-·               filter          ((pid1 <= 13) OR ((pid1 >= 19) AND (pid1 <= 21))) OR (pid1 >= 31)
+render           ·               ·
+ └── merge-join  ·               ·
+      │          type            inner
+      │          equality        (pid1) = (pid1)
+      │          mergeJoinOrder  +"(pid1=pid1)"
+      ├── scan   ·               ·
+      │          table           grandchild2@primary
+      │          spans           /11/#/56/1-/13/#/56/2 /19/#/56/1-/21/#/56/2 /31/#/56/1-/33/#/56/2
+      │          filter          ((pid1 <= 13) OR ((pid1 >= 19) AND (pid1 <= 21))) OR (pid1 >= 31)
+      └── scan   ·               ·
+·                table           parent1@primary
+·                spans           /11-/13/# /19-/21/# /31-/33/#
+·                parallel        ·
+·                filter          ((pid1 <= 13) OR ((pid1 >= 19) AND (pid1 <= 21))) OR (pid1 >= 31)
 
 # Join on multiple interleaved columns with an overarching ancestor (parent1).
 # Note there are 5 nodes because the filter cid2 >= 12 AND cid2 <= 14
@@ -297,17 +297,17 @@ EXPLAIN
     OR child2.cid2 >= 12 AND child2.cid2 <= 14
     OR gcid2 >= 49 AND gcid2 <= 51
 ----
-join       ·               ·
- │         type            inner
- │         equality        (pid1, cid2, cid3) = (pid1, cid2, cid3)
- │         mergeJoinOrder  +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
- ├── scan  ·               ·
- │         table           child2@primary
- │         spans           ALL
- └── scan  ·               ·
-·          table           grandchild2@primary
-·          spans           ALL
-·          filter          (((pid1 >= 5) AND (pid1 <= 7)) OR ((cid2 >= 12) AND (cid2 <= 14))) OR ((gcid2 >= 49) AND (gcid2 <= 51))
+merge-join  ·               ·
+ │          type            inner
+ │          equality        (pid1, cid2, cid3) = (pid1, cid2, cid3)
+ │          mergeJoinOrder  +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
+ ├── scan   ·               ·
+ │          table           child2@primary
+ │          spans           ALL
+ └── scan   ·               ·
+·           table           grandchild2@primary
+·           spans           ALL
+·           filter          (((pid1 >= 5) AND (pid1 <= 7)) OR ((cid2 >= 12) AND (cid2 <= 14))) OR ((gcid2 >= 49) AND (gcid2 <= 51))
 
 # Aggregation over parent and child keys.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -36,19 +36,19 @@ NULL       /1       {1}       1
 query TTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data) NATURAL JOIN (SELECT a,b FROM data AS data2))
 ----
-render          ·               ·                  (a, b)        ·
- │              render 0        a                  ·             ·
- │              render 1        b                  ·             ·
- └── join       ·               ·                  (a, b, a, b)  ·
-      │         type            inner              ·             ·
-      │         equality        (a, b) = (a, b)    ·             ·
-      │         mergeJoinOrder  +"(a=a)",+"(b=b)"  ·             ·
-      ├── scan  ·               ·                  (a, b)        +a,+b
-      │         table           data@primary       ·             ·
-      │         spans           ALL                ·             ·
-      └── scan  ·               ·                  (a, b)        +a,+b
-·               table           data@primary       ·             ·
-·               spans           ALL                ·             ·
+render           ·               ·                  (a, b)        ·
+ │               render 0        a                  ·             ·
+ │               render 1        b                  ·             ·
+ └── merge-join  ·               ·                  (a, b, a, b)  ·
+      │          type            inner              ·             ·
+      │          equality        (a, b) = (a, b)    ·             ·
+      │          mergeJoinOrder  +"(a=a)",+"(b=b)"  ·             ·
+      ├── scan   ·               ·                  (a, b)        +a,+b
+      │          table           data@primary       ·             ·
+      │          spans           ALL                ·             ·
+      └── scan   ·               ·                  (a, b)        +a,+b
+·                table           data@primary       ·             ·
+·                spans           ALL                ·             ·
 
 # TODO(radu): enable these tests when joins pass through orderings on equality
 # columns.
@@ -116,7 +116,7 @@ EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,
 ----
 sort            ·         ·                (a, b, c, d)  +b,+a
  │              order     +b,+a            ·             ·
- └── join       ·         ·                (a, b, c, d)  ·
+ └── hash-join  ·         ·                (a, b, c, d)  ·
       │         type      inner            ·             ·
       │         equality  (a, b) = (c, d)  ·             ·
       ├── scan  ·         ·                (a, b)        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -84,21 +84,21 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lU2L2zAQhu_9FWFOu6AQS7
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
 ----
-render          ·               ·                    (x, str)     ·
- │              render 0        x                    ·            ·
- │              render 1        str                  ·            ·
- └── join       ·               ·                    (x, y, str)  ·
-      │         type            inner                ·            ·
-      │         equality        (x) = (y)            ·            ·
-      │         mergeJoinOrder  +"(x=y)"             ·            ·
-      ├── scan  ·               ·                    (x)          +x
-      │         table           numtosquare@primary  ·            ·
-      │         spans           ALL                  ·            ·
-      │         filter          (x % 2) = 0          ·            ·
-      └── scan  ·               ·                    (y, str)     +y
-·               table           numtostr@primary     ·            ·
-·               spans           ALL                  ·            ·
-·               filter          (y % 2) = 0          ·            ·
+render           ·               ·                    (x, str)     ·
+ │               render 0        x                    ·            ·
+ │               render 1        str                  ·            ·
+ └── merge-join  ·               ·                    (x, y, str)  ·
+      │          type            inner                ·            ·
+      │          equality        (x) = (y)            ·            ·
+      │          mergeJoinOrder  +"(x=y)"             ·            ·
+      ├── scan   ·               ·                    (x)          +x
+      │          table           numtosquare@primary  ·            ·
+      │          spans           ALL                  ·            ·
+      │          filter          (x % 2) = 0          ·            ·
+      └── scan   ·               ·                    (y, str)     +y
+·                table           numtostr@primary     ·            ·
+·                spans           ALL                  ·            ·
+·                filter          (y % 2) = 0          ·            ·
 
 query T
 SELECT url FROM [EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0]

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -158,10 +158,10 @@ query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE field != 'size'
 ----
 render                      ·         ·
- └── join                   ·         ·
+ └── hash-join              ·         ·
       │                     type      left outer
       │                     equality  (oid) = (objoid)
-      ├── join              ·         ·
+      ├── hash-join         ·         ·
       │    │                type      inner
       │    │                equality  (relnamespace) = (oid)
       │    ├── filter       ·         ·
@@ -231,7 +231,7 @@ sort                                       ·            ·
            │                               aggregate 7  array_agg(index_name)
            │                               group by     @1-@7
            └── render                      ·            ·
-                └── join                   ·            ·
+                └── hash-join              ·            ·
                      │                     type         left outer
                      │                     equality     (column_name) = (column_name)
                      ├── render            ·            ·
@@ -267,13 +267,13 @@ SELECT * FROM [EXPLAIN SHOW CONSTRAINTS FROM foo] WHERE field != 'size'
 sort                             ·         ·
  │                               order     +table_name,+constraint_name
  └── render                      ·         ·
-      └── join                   ·         ·
+      └── hash-join              ·         ·
            │                     type      inner
            │                     equality  (relnamespace, oid) = (oid, conrelid)
            ├── filter            ·         ·
            │    │                filter    relname = 'foo'
            │    └── values       ·         ·
-           └── join              ·         ·
+           └── hash-join         ·         ·
                 │                type      cross
                 ├── filter       ·         ·
                 │    │           filter    nspname = 'public'

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -12,7 +12,7 @@ query TTT
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
 render          ·         ·
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (x) = (x)
       ├── scan  ·         ·
@@ -25,7 +25,7 @@ render          ·         ·
 query TTT
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
-join       ·         ·
+hash-join  ·         ·
  │         type      inner
  │         equality  (x) = (y)
  ├── scan  ·         ·
@@ -38,21 +38,21 @@ join       ·         ·
 query TTT
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
-render          ·         ·
- └── join       ·         ·
-      │         type      cross
-      ├── scan  ·         ·
-      │         table     twocolumn@primary
-      │         spans     ALL
-      └── scan  ·         ·
-·               table     twocolumn@primary
-·               spans     ALL
-·               filter    x = 44
+render          ·       ·
+ └── hash-join  ·       ·
+      │         type    cross
+      ├── scan  ·       ·
+      │         table   twocolumn@primary
+      │         spans   ALL
+      └── scan  ·       ·
+·               table   twocolumn@primary
+·               spans   ALL
+·               filter  x = 44
 
 query TTT
 EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
-join       ·         ·
+hash-join  ·         ·
  │         type      inner
  │         equality  (x) = (y)
  ├── scan  ·         ·
@@ -65,7 +65,7 @@ join       ·         ·
 query TTT
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
-join       ·         ·
+hash-join  ·         ·
  │         type      inner
  │         equality  (x) = (y)
  ├── scan  ·         ·
@@ -87,10 +87,10 @@ LIMIT 1
 render                    ·         ·
  └── limit                ·         ·
       │                   count     1
-      └── join            ·         ·
+      └── hash-join       ·         ·
            │              type      inner
            │              equality  (x) = (x)
-           ├── join       ·         ·
+           ├── hash-join  ·         ·
            │    │         type      inner
            │    │         equality  (x) = (x)
            │    ├── scan  ·         ·
@@ -99,7 +99,7 @@ render                    ·         ·
            │    └── scan  ·         ·
            │              table     onecolumn@primary
            │              spans     ALL
-           └── join       ·         ·
+           └── hash-join  ·         ·
                 │         type      inner
                 │         equality  (x) = (x)
                 ├── scan  ·         ·
@@ -113,7 +113,7 @@ render                    ·         ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
-join       ·      ·                  (x, y)  ·
+hash-join  ·      ·                  (x, y)  ·
  │         type   cross              ·       ·
  ├── scan  ·      ·                  (x)     ·
  │         table  twocolumn@primary  ·       ·
@@ -127,7 +127,7 @@ EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
 render          ·         ·                  (y)        ·
  │              render 0  y                  ·          ·
- └── join       ·         ·                  (x, x, y)  ·
+ └── hash-join  ·         ·                  (x, x, y)  ·
       │         type      inner              ·          ·
       │         equality  (x) = (x)          ·          ·
       ├── scan  ·         ·                  (x)        ·
@@ -142,7 +142,7 @@ EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b
 ----
 render          ·         ·                  (y)        ·
  │              render 0  y                  ·          ·
- └── join       ·         ·                  (x, x, y)  ·
+ └── hash-join  ·         ·                  (x, x, y)  ·
       │         type      inner              ·          ·
       │         equality  (x) = (x)          ·          ·
       ├── scan  ·         ·                  (x)        ·
@@ -157,7 +157,7 @@ EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b
 ----
 render          ·         ·                  (x)     ·
  │              render 0  x                  ·       ·
- └── join       ·         ·                  (x, y)  ·
+ └── hash-join  ·         ·                  (x, y)  ·
       │         type      inner              ·       ·
       │         pred      x < y              ·       ·
       ├── scan  ·         ·                  (x)     ·
@@ -174,7 +174,7 @@ render               ·         ·                  (x, two, plus1)     ·
  │                   render 0  COALESCE(x, x)     ·                   ·
  │                   render 1  two                ·                   ·
  │                   render 2  plus1              ·                   ·
- └── join            ·         ·                  (two, x, plus1, x)  ·
+ └── hash-join       ·         ·                  (two, x, plus1, x)  ·
       │              type      full outer         ·                   ·
       │              equality  (x) = (x)          ·                   ·
       ├── render     ·         ·                  (two, x)            ·
@@ -205,7 +205,7 @@ render                      ·              ·                      (k, u, w)   
            │                render 0       column1                ·                                     ·
            │                render 1       column2                ·                                     ·
            │                render 2       column2                ·                                     ·
-           └── join         ·              ·                      (column1, column2, column1, column2)  ·
+           └── hash-join    ·              ·                      (column1, column2, column1, column2)  ·
                 │           type           inner                  ·                                     ·
                 │           equality       (column2) = (column1)  ·                                     ·
                 ├── values  ·              ·                      (column1, column2)                    ·
@@ -323,18 +323,18 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 2   ·              render 10  conname
 2   ·              render 11  generate_series
 2   ·              render 12  relname
-3   join           ·          ·
+3   hash-join      ·          ·
 3   ·              type       inner
 3   ·              equality   (oid) = (attrelid)
 3   ·              pred       confrelid = oid
-4   join           ·          ·
+4   hash-join      ·          ·
 4   ·              type       inner
 4   ·              equality   (relnamespace) = (oid)
 5   virtual table  ·          ·
 5   ·              source     ·
 5   virtual table  ·          ·
 5   ·              source     ·
-4   join           ·          ·
+4   hash-join      ·          ·
 4   ·              type       inner
 4   ·              equality   (attnum) = (column167)
 5   virtual table  ·          ·
@@ -352,7 +352,7 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 5   ·              render 9   confdeltype
 5   ·              render 10  generate_series
 5   ·              render 11  relname
-6   join           ·          ·
+6   hash-join      ·          ·
 6   ·              type       inner
 6   ·              equality   (conrelid, column166) = (oid, attnum)
 7   render         ·          ·
@@ -367,12 +367,12 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 7   ·              render 8   confkey
 7   ·              render 9   generate_series
 7   ·              render 10  relname
-8   join           ·          ·
+8   hash-join      ·          ·
 8   ·              type       cross
-9   join           ·          ·
+9   hash-join      ·          ·
 9   ·              type       inner
 9   ·              equality   (objid) = (oid)
-10  join           ·          ·
+10  hash-join      ·          ·
 10  ·              type       inner
 10  ·              equality   (refobjid) = (oid)
 11  filter         ·          ·
@@ -390,12 +390,12 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 9   project set    ·          ·
 9   ·              render 0   generate_series(1, 32)
 10  emptyrow       ·          ·
-7   join           ·          ·
+7   hash-join      ·          ·
 7   ·              type       inner
 7   ·              equality   (attrelid) = (oid)
 8   virtual table  ·          ·
 8   ·              source     ·
-8   join           ·          ·
+8   hash-join      ·          ·
 8   ·              type       inner
 8   ·              equality   (relnamespace) = (oid)
 9   filter         ·          ·
@@ -414,16 +414,16 @@ CREATE TABLE cards(id INT PRIMARY KEY, cust INT NOT NULL REFERENCES customers(id
 query TTT
 EXPLAIN SELECT * FROM cards LEFT OUTER JOIN customers ON customers.id = cards.cust
 ----
-join       ·               ·
- │         type            inner
- │         equality        (cust) = (id)
- │         mergeJoinOrder  +"(cust=id)"
- ├── scan  ·               ·
- │         table           cards@cards_auto_index_fk_cust_ref_customers
- │         spans           ALL
- └── scan  ·               ·
-·          table           customers@primary
-·          spans           ALL
+merge-join  ·               ·
+ │          type            inner
+ │          equality        (cust) = (id)
+ │          mergeJoinOrder  +"(cust=id)"
+ ├── scan   ·               ·
+ │          table           cards@cards_auto_index_fk_cust_ref_customers
+ │          spans           ALL
+ └── scan   ·               ·
+·           table           customers@primary
+·           spans           ALL
 
 # Tests for filter propagation through joins.
 
@@ -437,7 +437,7 @@ CREATE TABLE pairs (a INT, b INT)
 query TTT
 EXPLAIN SELECT * FROM pairs, square WHERE pairs.b = square.n
 ----
-join       ·                   ·
+hash-join  ·                   ·
  │         type                inner
  │         equality            (b) = (n)
  │         right cols are key  ·
@@ -457,7 +457,7 @@ render               ·         ·                 (a, b, n, sq)           ·
  │                   render 1  b                 ·                       ·
  │                   render 2  n                 ·                       ·
  │                   render 3  sq                ·                       ·
- └── join            ·         ·                 (column6, a, b, n, sq)  ·
+ └── hash-join       ·         ·                 (column6, a, b, n, sq)  ·
       │              type      inner             ·                       ·
       │              equality  (column6) = (sq)  ·                       ·
       ├── render     ·         ·                 (column6, a, b)         ·
@@ -489,7 +489,7 @@ render                    ·         ·               (a, b, n, sq)       ·
            │              render 2  b               ·                   ·
            │              render 3  n               ·                   ·
            │              render 4  sq              ·                   ·
-           └── join       ·         ·               (a, b, n, sq)       ·
+           └── hash-join  ·         ·               (a, b, n, sq)       ·
                 │         type      cross           ·                   ·
                 ├── scan  ·         ·               (a, b)              ·
                 │         table     pairs@primary   ·                   ·
@@ -507,7 +507,7 @@ render               ·         ·                 (a, b, n, sq)           ·
  │                   render 1  b                 ·                       ·
  │                   render 2  n                 ·                       ·
  │                   render 3  sq                ·                       ·
- └── join            ·         ·                 (column6, a, b, n, sq)  ·
+ └── hash-join       ·         ·                 (column6, a, b, n, sq)  ·
       │              type      full outer        ·                       ·
       │              equality  (column6) = (sq)  ·                       ·
       ├── render     ·         ·                 (column6, a, b)         ·
@@ -531,7 +531,7 @@ render                    ·         ·                    (a, b, n, sq)        
  │                        render 3  sq                   ·                       ·
  └── filter               ·         ·                    (column6, a, b, n, sq)  ·
       │                   filter    (b % 2) != (sq % 2)  ·                       ·
-      └── join            ·         ·                    (column6, a, b, n, sq)  ·
+      └── hash-join       ·         ·                    (column6, a, b, n, sq)  ·
            │              type      full outer           ·                       ·
            │              equality  (column6) = (sq)     ·                       ·
            ├── render     ·         ·                    (column6, a, b)         ·
@@ -557,7 +557,7 @@ SELECT *
 ----
 filter          ·         ·
  │              filter    ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      left outer
       │         equality  (b) = (sq)
       │         pred      a > 1
@@ -585,7 +585,7 @@ render               ·         ·
  │                   render 3  sq
  └── filter          ·         ·
       │              filter    ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
-      └── join       ·         ·
+      └── hash-join  ·         ·
            │         type      left outer
            │         equality  (sq) = (b)
            │         pred      n < 6
@@ -611,7 +611,7 @@ render          ·         ·
  │              render 1  b
  │              render 2  n
  │              render 3  sq
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (sq) = (b)
       ├── scan  ·         ·
@@ -635,7 +635,7 @@ EXPLAIN (VERBOSE) SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 ----
 render          ·         ·                (x)           ·
  │              render 0  x                ·             ·
- └── join       ·         ·                (x, y, y, x)  ·
+ └── hash-join  ·         ·                (x, y, y, x)  ·
       │         type      inner            ·             ·
       │         equality  (x, y) = (x, y)  ·             ·
       ├── scan  ·         ·                (x, y)        ·
@@ -661,7 +661,7 @@ CREATE TABLE pkBAD (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,d))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
 ----
-join       ·                   ·                      (a, b, c, d, a, b, c, d)  ·
+hash-join  ·                   ·                      (a, b, c, d, a, b, c, d)  ·
  │         type                inner                  ·                         ·
  │         equality            (a, b, c) = (a, b, c)  ·                         ·
  │         left cols are key   ·                      ·                         ·
@@ -681,7 +681,7 @@ render          ·                   ·                            (a, b, c, d) 
  │              render 1            b                            ·                         ·
  │              render 2            c                            ·                         ·
  │              render 3            d                            ·                         ·
- └── join       ·                   ·                            (a, b, c, d, a, b, c, d)  ·
+ └── hash-join  ·                   ·                            (a, b, c, d, a, b, c, d)  ·
       │         type                inner                        ·                         ·
       │         equality            (a, b, c, d) = (a, b, c, d)  ·                         ·
       │         left cols are key   ·                            ·                         ·
@@ -696,36 +696,36 @@ render          ·                   ·                            (a, b, c, d) 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 ----
-render          ·               ·                           (a, b, c, d, d)           ·
- │              render 0        a                           ·                         ·
- │              render 1        b                           ·                         ·
- │              render 2        c                           ·                         ·
- │              render 3        d                           ·                         ·
- │              render 4        d                           ·                         ·
- └── join       ·               ·                           (a, b, c, d, a, b, c, d)  ·
-      │         type            inner                       ·                         ·
-      │         equality        (b, a, c) = (b, a, c)       ·                         ·
-      │         mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=c)"  ·                         ·
-      ├── scan  ·               ·                           (a, b, c, d)              +b,+a,+c
-      │         table           pkbac@primary               ·                         ·
-      │         spans           ALL                         ·                         ·
-      └── scan  ·               ·                           (a, b, c, d)              +b,+a,+c
-·               table           pkbac@primary               ·                         ·
-·               spans           ALL                         ·                         ·
+render           ·               ·                           (a, b, c, d, d)           ·
+ │               render 0        a                           ·                         ·
+ │               render 1        b                           ·                         ·
+ │               render 2        c                           ·                         ·
+ │               render 3        d                           ·                         ·
+ │               render 4        d                           ·                         ·
+ └── merge-join  ·               ·                           (a, b, c, d, a, b, c, d)  ·
+      │          type            inner                       ·                         ·
+      │          equality        (b, a, c) = (b, a, c)       ·                         ·
+      │          mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=c)"  ·                         ·
+      ├── scan   ·               ·                           (a, b, c, d)              +b,+a,+c
+      │          table           pkbac@primary               ·                         ·
+      │          spans           ALL                         ·                         ·
+      └── scan   ·               ·                           (a, b, c, d)              +b,+a,+c
+·                table           pkbac@primary               ·                         ·
+·                spans           ALL                         ·                         ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
 ----
-join       ·               ·                           (a, b, c, d, a, b, c, d)  ·
- │         type            inner                       ·                         ·
- │         equality        (b, a, c) = (b, a, d)       ·                         ·
- │         mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
- ├── scan  ·               ·                           (a, b, c, d)              +b,+a,+c
- │         table           pkbac@primary               ·                         ·
- │         spans           ALL                         ·                         ·
- └── scan  ·               ·                           (a, b, c, d)              +b,+a,+d
-·          table           pkbad@primary               ·                         ·
-·          spans           ALL                         ·                         ·
+merge-join  ·               ·                           (a, b, c, d, a, b, c, d)  ·
+ │          type            inner                       ·                         ·
+ │          equality        (b, a, c) = (b, a, d)       ·                         ·
+ │          mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
+ ├── scan   ·               ·                           (a, b, c, d)              +b,+a,+c
+ │          table           pkbac@primary               ·                         ·
+ │          spans           ALL                         ·                         ·
+ └── scan   ·               ·                           (a, b, c, d)              +b,+a,+d
+·           table           pkbad@primary               ·                         ·
+·           spans           ALL                         ·                         ·
 
 # Tests with joins with merged columns of collated string type.
 statement ok
@@ -741,7 +741,7 @@ render          ·         ·             (s, s, s)  ·
  │              render 0  s             ·          ·
  │              render 1  s             ·          ·
  │              render 2  s             ·          ·
- └── join       ·         ·             (s, s)     ·
+ └── hash-join  ·         ·             (s, s)     ·
       │         type      inner         ·          ·
       │         equality  (s) = (s)     ·          ·
       ├── scan  ·         ·             (s)        ·
@@ -758,7 +758,7 @@ render          ·         ·             (s, s, s)  ·
  │              render 0  s             ·          ·
  │              render 1  s             ·          ·
  │              render 2  s             ·          ·
- └── join       ·         ·             (s, s)     ·
+ └── hash-join  ·         ·             (s, s)     ·
       │         type      left outer    ·          ·
       │         equality  (s) = (s)     ·          ·
       ├── scan  ·         ·             (s)        ·
@@ -775,7 +775,7 @@ render          ·         ·               (s, s, s)  ·
  │              render 0  COALESCE(s, s)  ·          ·
  │              render 1  s               ·          ·
  │              render 2  s               ·          ·
- └── join       ·         ·               (s, s)     ·
+ └── hash-join  ·         ·               (s, s)     ·
       │         type      right outer     ·          ·
       │         equality  (s) = (s)       ·          ·
       ├── scan  ·         ·               (s)        ·
@@ -792,7 +792,7 @@ render          ·         ·               (s, s, s)  ·
  │              render 0  COALESCE(s, s)  ·          ·
  │              render 1  s               ·          ·
  │              render 2  s               ·          ·
- └── join       ·         ·               (s, s)     ·
+ └── hash-join  ·         ·               (s, s)     ·
       │         type      full outer      ·          ·
       │         equality  (s) = (s)       ·          ·
       ├── scan  ·         ·               (s)        ·
@@ -810,7 +810,7 @@ EXPLAIN (VERBOSE) SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
 render          ·                   ·                (a, s)        ·
  │              render 0            a                ·             ·
  │              render 1            COALESCE(s, s)   ·             ·
- └── join       ·                   ·                (a, s, a, s)  ·
+ └── hash-join  ·                   ·                (a, s, a, s)  ·
       │         type                right outer      ·             ·
       │         equality            (a, s) = (a, s)  ·             ·
       │         left cols are key   ·                ·             ·
@@ -832,137 +832,137 @@ CREATE TABLE xyv (x INT, y INT, v INT, PRIMARY KEY(x,y,v))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 ----
-render          ·               ·                  (x, y, u, v)        ·
- │              render 0        x                  ·                   ·
- │              render 1        y                  ·                   ·
- │              render 2        u                  ·                   ·
- │              render 3        v                  ·                   ·
- └── join       ·               ·                  (x, y, u, x, y, v)  ·
-      │         type            inner              ·                   ·
-      │         equality        (x, y) = (x, y)    ·                   ·
-      │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
-      ├── scan  ·               ·                  (x, y, u)           +x,+y
-      │         table           xyu@primary        ·                   ·
-      │         spans           /3-                ·                   ·
-      └── scan  ·               ·                  (x, y, v)           +x,+y
-·               table           xyv@primary        ·                   ·
-·               spans           /3-                ·                   ·
+render           ·               ·                  (x, y, u, v)        ·
+ │               render 0        x                  ·                   ·
+ │               render 1        y                  ·                   ·
+ │               render 2        u                  ·                   ·
+ │               render 3        v                  ·                   ·
+ └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+      │          type            inner              ·                   ·
+      │          equality        (x, y) = (x, y)    ·                   ·
+      │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+      ├── scan   ·               ·                  (x, y, u)           +x,+y
+      │          table           xyu@primary        ·                   ·
+      │          spans           /3-                ·                   ·
+      └── scan   ·               ·                  (x, y, v)           +x,+y
+·                table           xyv@primary        ·                   ·
+·                spans           /3-                ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-render          ·               ·                  (x, y, u, v)        ·
- │              render 0        x                  ·                   ·
- │              render 1        y                  ·                   ·
- │              render 2        u                  ·                   ·
- │              render 3        v                  ·                   ·
- └── join       ·               ·                  (x, y, u, x, y, v)  ·
-      │         type            left outer         ·                   ·
-      │         equality        (x, y) = (x, y)    ·                   ·
-      │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
-      ├── scan  ·               ·                  (x, y, u)           +x,+y
-      │         table           xyu@primary        ·                   ·
-      │         spans           /3-                ·                   ·
-      └── scan  ·               ·                  (x, y, v)           +x,+y
-·               table           xyv@primary        ·                   ·
-·               spans           /3-                ·                   ·
+render           ·               ·                  (x, y, u, v)        ·
+ │               render 0        x                  ·                   ·
+ │               render 1        y                  ·                   ·
+ │               render 2        u                  ·                   ·
+ │               render 3        v                  ·                   ·
+ └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+      │          type            left outer         ·                   ·
+      │          equality        (x, y) = (x, y)    ·                   ·
+      │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+      ├── scan   ·               ·                  (x, y, u)           +x,+y
+      │          table           xyu@primary        ·                   ·
+      │          spans           /3-                ·                   ·
+      └── scan   ·               ·                  (x, y, v)           +x,+y
+·                table           xyv@primary        ·                   ·
+·                spans           /3-                ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-render          ·               ·                  (x, y, u, v)        ·
- │              render 0        x                  ·                   ·
- │              render 1        y                  ·                   ·
- │              render 2        u                  ·                   ·
- │              render 3        v                  ·                   ·
- └── join       ·               ·                  (x, y, u, x, y, v)  ·
-      │         type            right outer        ·                   ·
-      │         equality        (x, y) = (x, y)    ·                   ·
-      │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
-      ├── scan  ·               ·                  (x, y, u)           +x,+y
-      │         table           xyu@primary        ·                   ·
-      │         spans           /3-                ·                   ·
-      └── scan  ·               ·                  (x, y, v)           +x,+y
-·               table           xyv@primary        ·                   ·
-·               spans           /3-                ·                   ·
+render           ·               ·                  (x, y, u, v)        ·
+ │               render 0        x                  ·                   ·
+ │               render 1        y                  ·                   ·
+ │               render 2        u                  ·                   ·
+ │               render 3        v                  ·                   ·
+ └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+      │          type            right outer        ·                   ·
+      │          equality        (x, y) = (x, y)    ·                   ·
+      │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+      ├── scan   ·               ·                  (x, y, u)           +x,+y
+      │          table           xyu@primary        ·                   ·
+      │          spans           /3-                ·                   ·
+      └── scan   ·               ·                  (x, y, v)           +x,+y
+·                table           xyv@primary        ·                   ·
+·                spans           /3-                ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-filter               ·               ·                  (x, y, u, v)        ·
- │                   filter          x > 2              ·                   ·
- └── render          ·               ·                  (x, y, u, v)        ·
-      │              render 0        COALESCE(x, x)     ·                   ·
-      │              render 1        COALESCE(y, y)     ·                   ·
-      │              render 2        u                  ·                   ·
-      │              render 3        v                  ·                   ·
-      └── join       ·               ·                  (x, y, u, x, y, v)  ·
-           │         type            full outer         ·                   ·
-           │         equality        (x, y) = (x, y)    ·                   ·
-           │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
-           ├── scan  ·               ·                  (x, y, u)           +x,+y
-           │         table           xyu@primary        ·                   ·
-           │         spans           ALL                ·                   ·
-           └── scan  ·               ·                  (x, y, v)           +x,+y
-·                    table           xyv@primary        ·                   ·
-·                    spans           ALL                ·                   ·
+filter                ·               ·                  (x, y, u, v)        ·
+ │                    filter          x > 2              ·                   ·
+ └── render           ·               ·                  (x, y, u, v)        ·
+      │               render 0        COALESCE(x, x)     ·                   ·
+      │               render 1        COALESCE(y, y)     ·                   ·
+      │               render 2        u                  ·                   ·
+      │               render 3        v                  ·                   ·
+      └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+           │          type            full outer         ·                   ·
+           │          equality        (x, y) = (x, y)    ·                   ·
+           │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+           ├── scan   ·               ·                  (x, y, u)           +x,+y
+           │          table           xyu@primary        ·                   ·
+           │          spans           ALL                ·                   ·
+           └── scan   ·               ·                  (x, y, v)           +x,+y
+·                     table           xyv@primary        ·                   ·
+·                     spans           ALL                ·                   ·
 
 # Verify that we transfer constraints between the two sides.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
 ----
-join       ·               ·                  (x, y, u, x, y, v)  ·
- │         type            inner              ·                   ·
- │         equality        (x, y) = (x, y)    ·                   ·
- │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan  ·               ·                  (x, y, u)           +y
- │         table           xyu@primary        ·                   ·
- │         spans           /1-/1/10           ·                   ·
- └── scan  ·               ·                  (x, y, v)           +y
-·          table           xyv@primary        ·                   ·
-·          spans           /1-/1/10           ·                   ·
+merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+ │          type            inner              ·                   ·
+ │          equality        (x, y) = (x, y)    ·                   ·
+ │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+ ├── scan   ·               ·                  (x, y, u)           +y
+ │          table           xyu@primary        ·                   ·
+ │          spans           /1-/1/10           ·                   ·
+ └── scan   ·               ·                  (x, y, v)           +y
+·           table           xyv@primary        ·                   ·
+·           spans           /1-/1/10           ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-join       ·               ·                  (x, y, u, x, y, v)  ·
- │         type            inner              ·                   ·
- │         equality        (x, y) = (x, y)    ·                   ·
- │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan  ·               ·                  (x, y, u)           +y
- │         table           xyu@primary        ·                   ·
- │         spans           /1-/1/10           ·                   ·
- └── scan  ·               ·                  (x, y, v)           +y
-·          table           xyv@primary        ·                   ·
-·          spans           /1-/1/10           ·                   ·
+merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+ │          type            inner              ·                   ·
+ │          equality        (x, y) = (x, y)    ·                   ·
+ │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+ ├── scan   ·               ·                  (x, y, u)           +y
+ │          table           xyu@primary        ·                   ·
+ │          spans           /1-/1/10           ·                   ·
+ └── scan   ·               ·                  (x, y, v)           +y
+·           table           xyv@primary        ·                   ·
+·           spans           /1-/1/10           ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-join       ·               ·                  (x, y, u, x, y, v)  ·
- │         type            left outer         ·                   ·
- │         equality        (x, y) = (x, y)    ·                   ·
- │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan  ·               ·                  (x, y, u)           +x,+y
- │         table           xyu@primary        ·                   ·
- │         spans           ALL                ·                   ·
- └── scan  ·               ·                  (x, y, v)           +y
-·          table           xyv@primary        ·                   ·
-·          spans           /1-/1/10           ·                   ·
+merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+ │          type            left outer         ·                   ·
+ │          equality        (x, y) = (x, y)    ·                   ·
+ │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+ ├── scan   ·               ·                  (x, y, u)           +x,+y
+ │          table           xyu@primary        ·                   ·
+ │          spans           ALL                ·                   ·
+ └── scan   ·               ·                  (x, y, v)           +y
+·           table           xyv@primary        ·                   ·
+·           spans           /1-/1/10           ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-join       ·               ·                  (x, y, u, x, y, v)  ·
- │         type            right outer        ·                   ·
- │         equality        (x, y) = (x, y)    ·                   ·
- │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan  ·               ·                  (x, y, u)           +y
- │         table           xyu@primary        ·                   ·
- │         spans           /1-/1/10           ·                   ·
- └── scan  ·               ·                  (x, y, v)           +x,+y
-·          table           xyv@primary        ·                   ·
-·          spans           ALL                ·                   ·
+merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+ │          type            right outer        ·                   ·
+ │          equality        (x, y) = (x, y)    ·                   ·
+ │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+ ├── scan   ·               ·                  (x, y, u)           +y
+ │          table           xyu@primary        ·                   ·
+ │          spans           /1-/1/10           ·                   ·
+ └── scan   ·               ·                  (x, y, v)           +x,+y
+·           table           xyv@primary        ·                   ·
+·           spans           ALL                ·                   ·
 
 
 # Test OUTER joins that are run in the distSQL merge joiner
@@ -970,109 +970,109 @@ join       ·               ·                  (x, y, u, x, y, v)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-render          ·               ·                  (x, y, u, v)        ·
- │              render 0        x                  ·                   ·
- │              render 1        y                  ·                   ·
- │              render 2        u                  ·                   ·
- │              render 3        v                  ·                   ·
- └── join       ·               ·                  (x, y, u, x, y, v)  ·
-      │         type            left outer         ·                   ·
-      │         equality        (x, y) = (x, y)    ·                   ·
-      │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
-      ├── scan  ·               ·                  (x, y, u)           +x,+y
-      │         table           xyu@primary        ·                   ·
-      │         spans           /3-                ·                   ·
-      └── scan  ·               ·                  (x, y, v)           +x,+y
-·               table           xyv@primary        ·                   ·
-·               spans           /3-                ·                   ·
+render           ·               ·                  (x, y, u, v)        ·
+ │               render 0        x                  ·                   ·
+ │               render 1        y                  ·                   ·
+ │               render 2        u                  ·                   ·
+ │               render 3        v                  ·                   ·
+ └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+      │          type            left outer         ·                   ·
+      │          equality        (x, y) = (x, y)    ·                   ·
+      │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+      ├── scan   ·               ·                  (x, y, u)           +x,+y
+      │          table           xyu@primary        ·                   ·
+      │          spans           /3-                ·                   ·
+      └── scan   ·               ·                  (x, y, v)           +x,+y
+·                table           xyv@primary        ·                   ·
+·                spans           /3-                ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-render          ·               ·                  (x, y, u, v)        ·
- │              render 0        x                  ·                   ·
- │              render 1        y                  ·                   ·
- │              render 2        u                  ·                   ·
- │              render 3        v                  ·                   ·
- └── join       ·               ·                  (x, y, u, x, y, v)  ·
-      │         type            right outer        ·                   ·
-      │         equality        (x, y) = (x, y)    ·                   ·
-      │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
-      ├── scan  ·               ·                  (x, y, u)           +x,+y
-      │         table           xyu@primary        ·                   ·
-      │         spans           /3-                ·                   ·
-      └── scan  ·               ·                  (x, y, v)           +x,+y
-·               table           xyv@primary        ·                   ·
-·               spans           /3-                ·                   ·
+render           ·               ·                  (x, y, u, v)        ·
+ │               render 0        x                  ·                   ·
+ │               render 1        y                  ·                   ·
+ │               render 2        u                  ·                   ·
+ │               render 3        v                  ·                   ·
+ └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+      │          type            right outer        ·                   ·
+      │          equality        (x, y) = (x, y)    ·                   ·
+      │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+      ├── scan   ·               ·                  (x, y, u)           +x,+y
+      │          table           xyu@primary        ·                   ·
+      │          spans           /3-                ·                   ·
+      └── scan   ·               ·                  (x, y, v)           +x,+y
+·                table           xyv@primary        ·                   ·
+·                spans           /3-                ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-filter               ·               ·                  (x, y, u, v)        ·
- │                   filter          x > 2              ·                   ·
- └── render          ·               ·                  (x, y, u, v)        ·
-      │              render 0        COALESCE(x, x)     ·                   ·
-      │              render 1        COALESCE(y, y)     ·                   ·
-      │              render 2        u                  ·                   ·
-      │              render 3        v                  ·                   ·
-      └── join       ·               ·                  (x, y, u, x, y, v)  ·
-           │         type            full outer         ·                   ·
-           │         equality        (x, y) = (x, y)    ·                   ·
-           │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
-           ├── scan  ·               ·                  (x, y, u)           +x,+y
-           │         table           xyu@primary        ·                   ·
-           │         spans           ALL                ·                   ·
-           └── scan  ·               ·                  (x, y, v)           +x,+y
-·                    table           xyv@primary        ·                   ·
-·                    spans           ALL                ·                   ·
+filter                ·               ·                  (x, y, u, v)        ·
+ │                    filter          x > 2              ·                   ·
+ └── render           ·               ·                  (x, y, u, v)        ·
+      │               render 0        COALESCE(x, x)     ·                   ·
+      │               render 1        COALESCE(y, y)     ·                   ·
+      │               render 2        u                  ·                   ·
+      │               render 3        v                  ·                   ·
+      └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+           │          type            full outer         ·                   ·
+           │          equality        (x, y) = (x, y)    ·                   ·
+           │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+           ├── scan   ·               ·                  (x, y, u)           +x,+y
+           │          table           xyu@primary        ·                   ·
+           │          spans           ALL                ·                   ·
+           └── scan   ·               ·                  (x, y, v)           +x,+y
+·                     table           xyv@primary        ·                   ·
+·                     spans           ALL                ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-join       ·               ·                  (x, y, u, x, y, v)  ·
- │         type            left outer         ·                   ·
- │         equality        (x, y) = (x, y)    ·                   ·
- │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan  ·               ·                  (x, y, u)           +x,+y
- │         table           xyu@primary        ·                   ·
- │         spans           ALL                ·                   ·
- └── scan  ·               ·                  (x, y, v)           +y
-·          table           xyv@primary        ·                   ·
-·          spans           /1-/1/10           ·                   ·
+merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+ │          type            left outer         ·                   ·
+ │          equality        (x, y) = (x, y)    ·                   ·
+ │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+ ├── scan   ·               ·                  (x, y, u)           +x,+y
+ │          table           xyu@primary        ·                   ·
+ │          spans           ALL                ·                   ·
+ └── scan   ·               ·                  (x, y, v)           +y
+·           table           xyv@primary        ·                   ·
+·           spans           /1-/1/10           ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-join       ·               ·                  (x, y, u, x, y, v)  ·
- │         type            right outer        ·                   ·
- │         equality        (x, y) = (x, y)    ·                   ·
- │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan  ·               ·                  (x, y, u)           +y
- │         table           xyu@primary        ·                   ·
- │         spans           /1-/1/10           ·                   ·
- └── scan  ·               ·                  (x, y, v)           +x,+y
-·          table           xyv@primary        ·                   ·
-·          spans           ALL                ·                   ·
+merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+ │          type            right outer        ·                   ·
+ │          equality        (x, y) = (x, y)    ·                   ·
+ │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+ ├── scan   ·               ·                  (x, y, u)           +y
+ │          table           xyu@primary        ·                   ·
+ │          spans           /1-/1/10           ·                   ·
+ └── scan   ·               ·                  (x, y, v)           +x,+y
+·           table           xyv@primary        ·                   ·
+·           spans           ALL                ·                   ·
 
 # Regression test for #20472: break up tuple inequalities.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2, 3)
 ----
-render          ·               ·                  (x, y, u, v)        ·
- │              render 0        x                  ·                   ·
- │              render 1        y                  ·                   ·
- │              render 2        u                  ·                   ·
- │              render 3        v                  ·                   ·
- └── join       ·               ·                  (x, y, u, x, y, v)  ·
-      │         type            inner              ·                   ·
-      │         equality        (x, y) = (x, y)    ·                   ·
-      │         mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
-      ├── scan  ·               ·                  (x, y, u)           +x,+y
-      │         table           xyu@primary        ·                   ·
-      │         spans           /1/2/4-            ·                   ·
-      └── scan  ·               ·                  (x, y, v)           +x,+y
-·               table           xyv@primary        ·                   ·
-·               spans           ALL                ·                   ·
+render           ·               ·                  (x, y, u, v)        ·
+ │               render 0        x                  ·                   ·
+ │               render 1        y                  ·                   ·
+ │               render 2        u                  ·                   ·
+ │               render 3        v                  ·                   ·
+ └── merge-join  ·               ·                  (x, y, u, x, y, v)  ·
+      │          type            inner              ·                   ·
+      │          equality        (x, y) = (x, y)    ·                   ·
+      │          mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+      ├── scan   ·               ·                  (x, y, u)           +x,+y
+      │          table           xyu@primary        ·                   ·
+      │          spans           /1/2/4-            ·                   ·
+      └── scan   ·               ·                  (x, y, v)           +x,+y
+·                table           xyv@primary        ·                   ·
+·                spans           ALL                ·                   ·
 
 
 # Regression test for #20765/27431.
@@ -1088,62 +1088,62 @@ CREATE TABLE r (a INT PRIMARY KEY)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-render          ·               ·           (a)     ·
- │              render 0        a           ·       ·
- └── join       ·               ·           (a, a)  ·
-      │         type            left outer  ·       ·
-      │         equality        (a) = (a)   ·       ·
-      │         mergeJoinOrder  +"(a=a)"    ·       ·
-      ├── scan  ·               ·           (a)     ·
-      │         table           l@primary   ·       ·
-      │         spans           /3-/3/#     ·       ·
-      └── scan  ·               ·           (a)     ·
-·               table           r@primary   ·       ·
-·               spans           /3-/3/#     ·       ·
+render           ·               ·           (a)     ·
+ │               render 0        a           ·       ·
+ └── merge-join  ·               ·           (a, a)  ·
+      │          type            left outer  ·       ·
+      │          equality        (a) = (a)   ·       ·
+      │          mergeJoinOrder  +"(a=a)"    ·       ·
+      ├── scan   ·               ·           (a)     ·
+      │          table           l@primary   ·       ·
+      │          spans           /3-/3/#     ·       ·
+      └── scan   ·               ·           (a)     ·
+·                table           r@primary   ·       ·
+·                spans           /3-/3/#     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
 ----
-join       ·               ·           (a, a)  ·
- │         type            left outer  ·       ·
- │         equality        (a) = (a)   ·       ·
- │         mergeJoinOrder  +"(a=a)"    ·       ·
- ├── scan  ·               ·           (a)     ·
- │         table           l@primary   ·       ·
- │         spans           /3-/3/#     ·       ·
- └── scan  ·               ·           (a)     ·
-·          table           r@primary   ·       ·
-·          spans           /3-/3/#     ·       ·
+merge-join  ·               ·           (a, a)  ·
+ │          type            left outer  ·       ·
+ │          equality        (a) = (a)   ·       ·
+ │          mergeJoinOrder  +"(a=a)"    ·       ·
+ ├── scan   ·               ·           (a)     ·
+ │          table           l@primary   ·       ·
+ │          spans           /3-/3/#     ·       ·
+ └── scan   ·               ·           (a)     ·
+·           table           r@primary   ·       ·
+·           spans           /3-/3/#     ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-render          ·               ·            (a)     ·
- │              render 0        a            ·       ·
- └── join       ·               ·            (a, a)  ·
-      │         type            right outer  ·       ·
-      │         equality        (a) = (a)    ·       ·
-      │         mergeJoinOrder  +"(a=a)"     ·       ·
-      ├── scan  ·               ·            (a)     ·
-      │         table           l@primary    ·       ·
-      │         spans           /3-/3/#      ·       ·
-      └── scan  ·               ·            (a)     ·
-·               table           r@primary    ·       ·
-·               spans           /3-/3/#      ·       ·
+render           ·               ·            (a)     ·
+ │               render 0        a            ·       ·
+ └── merge-join  ·               ·            (a, a)  ·
+      │          type            right outer  ·       ·
+      │          equality        (a) = (a)    ·       ·
+      │          mergeJoinOrder  +"(a=a)"     ·       ·
+      ├── scan   ·               ·            (a)     ·
+      │          table           l@primary    ·       ·
+      │          spans           /3-/3/#      ·       ·
+      └── scan   ·               ·            (a)     ·
+·                table           r@primary    ·       ·
+·                spans           /3-/3/#      ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
 ----
-join       ·               ·            (a, a)  ·
- │         type            right outer  ·       ·
- │         equality        (a) = (a)    ·       ·
- │         mergeJoinOrder  +"(a=a)"     ·       ·
- ├── scan  ·               ·            (a)     ·
- │         table           l@primary    ·       ·
- │         spans           /3-/3/#      ·       ·
- └── scan  ·               ·            (a)     ·
-·          table           r@primary    ·       ·
-·          spans           /3-/3/#      ·       ·
+merge-join  ·               ·            (a, a)  ·
+ │          type            right outer  ·       ·
+ │          equality        (a) = (a)    ·       ·
+ │          mergeJoinOrder  +"(a=a)"     ·       ·
+ ├── scan   ·               ·            (a)     ·
+ │          table           l@primary    ·       ·
+ │          spans           /3-/3/#      ·       ·
+ └── scan   ·               ·            (a)     ·
+·           table           r@primary    ·       ·
+·           spans           /3-/3/#      ·       ·
 
 # Regression tests for #21243
 statement ok
@@ -1168,18 +1168,18 @@ CREATE TABLE abg (
 query TTT
 EXPLAIN SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(1,2) OR ((a,b)=(1,2) AND c < 6) OR ((a,b,c)=(1,2,6) AND d > 8))
 ----
-render          ·               ·
- └── join       ·               ·
-      │         type            inner
-      │         equality        (a, b) = (a, b)
-      │         mergeJoinOrder  +"(a=a)",+"(b=b)"
-      ├── scan  ·               ·
-      │         table           abcdef@primary
-      │         spans           /1/2/6/9-
-      │         filter          (((a, b) > (1, 2)) OR (((a = 1) AND (b = 2)) AND (c < 6))) OR ((((a = 1) AND (b = 2)) AND (c = 6)) AND (d > 8))
-      └── scan  ·               ·
-·               table           abg@primary
-·               spans           ALL
+render           ·               ·
+ └── merge-join  ·               ·
+      │          type            inner
+      │          equality        (a, b) = (a, b)
+      │          mergeJoinOrder  +"(a=a)",+"(b=b)"
+      ├── scan   ·               ·
+      │          table           abcdef@primary
+      │          spans           /1/2/6/9-
+      │          filter          (((a, b) > (1, 2)) OR (((a = 1) AND (b = 2)) AND (c < 6))) OR ((((a = 1) AND (b = 2)) AND (c = 6)) AND (d > 8))
+      └── scan   ·               ·
+·                table           abg@primary
+·                spans           ALL
 
 # Regression tests for mixed-type equality columns (#22514).
 statement ok
@@ -1209,7 +1209,7 @@ render          ·         ·
  │              render 1  b
  │              render 2  c
  │              render 3  d
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (a, c) = (a, c)
       │         pred      (b = b) AND (d = d)
@@ -1234,7 +1234,7 @@ render          ·         ·
  │              render 4  a
  │              render 5  c
  │              render 6  d
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         pred      b = b
       ├── scan  ·         ·
@@ -1257,7 +1257,7 @@ render          ·         ·
  │              render 3  d
  │              render 4  c
  │              render 5  d
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (a) = (a)
       │         pred      b = b
@@ -1280,7 +1280,7 @@ render          ·         ·
  │              render 2  c
  │              render 3  d
  │              render 4  d
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (a, c) = (a, c)
       │         pred      b = b
@@ -1297,7 +1297,7 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.b = bar.b
 ]
 ----
-join       ·      ·
+hash-join  ·      ·
  │         type   inner
  │         pred   b = b
  ├── scan  ·      ·
@@ -1313,7 +1313,7 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
 ]
 ----
-join       ·         ·
+hash-join  ·         ·
  │         type      inner
  │         equality  (a) = (a)
  │         pred      b = b
@@ -1329,7 +1329,7 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.b = bar.b
 ]
 ----
-join       ·      ·
+hash-join  ·      ·
  │         type   inner
  │         pred   b = b
  ├── scan  ·      ·
@@ -1345,7 +1345,7 @@ SELECT tree, field, description FROM [
 EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
 ]
 ----
-join       ·         ·
+hash-join  ·         ·
  │         type      inner
  │         equality  (a) = (a)
  │         pred      b = b
@@ -1361,7 +1361,7 @@ query TTT
 EXPLAIN SELECT * FROM foo JOIN bar USING (a,b) WHERE foo.c = bar.c AND foo.d = bar.d
 ----
 render          ·         ·
- └── join       ·         ·
+ └── hash-join  ·         ·
       │         type      inner
       │         equality  (a, c) = (a, c)
       │         pred      (b = b) AND (d = d)
@@ -1454,7 +1454,7 @@ query TTT
 EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn USING(x)
 ----
 render               ·               ·
- └── join            ·               ·
+ └── merge-join      ·               ·
       │              type            inner
       │              equality        (x) = (x)
       │              mergeJoinOrder  +"(x=x)"
@@ -1474,7 +1474,7 @@ query TTT
 EXPLAIN SELECT * FROM onecolumn NATURAL INNER MERGE JOIN twocolumn
 ----
 render               ·               ·
- └── join            ·               ·
+ └── merge-join      ·               ·
       │              type            inner
       │              equality        (x) = (x)
       │              mergeJoinOrder  +"(x=x)"
@@ -1493,7 +1493,7 @@ render               ·               ·
 query TTT
 EXPLAIN SELECT * FROM onecolumn CROSS MERGE JOIN twocolumn WHERE onecolumn.x = twocolumn.x
 ----
-join            ·               ·
+merge-join      ·               ·
  │              type            inner
  │              equality        (x) = (x)
  │              mergeJoinOrder  +"(x=x)"
@@ -1521,7 +1521,7 @@ EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn ON onecolumn.x > twoc
 query TTT
 EXPLAIN SELECT * FROM cards LEFT OUTER HASH JOIN customers ON customers.id = cards.cust
 ----
-join       ·                   ·
+hash-join  ·                   ·
  │         type                inner
  │         equality            (cust) = (id)
  │         right cols are key  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -41,12 +41,12 @@ render               ·                   ·                (a, b, c, d, b, x, c
  │                   render 5            x                ·                         ·
  │                   render 6            c                ·                         ·
  │                   render 7            y                ·                         ·
- └── join            ·                   ·                (b, x, c, y, a, b, c, d)  ·
+ └── hash-join       ·                   ·                (b, x, c, y, a, b, c, d)  ·
       │              type                inner            ·                         ·
       │              equality            (b, c) = (b, c)  ·                         ·
       │              left cols are key   ·                ·                         ·
       │              right cols are key  ·                ·                         ·
-      ├── join       ·                   ·                (b, x, c, y)              ·
+      ├── hash-join  ·                   ·                (b, x, c, y)              ·
       │    │         type                cross            ·                         ·
       │    ├── scan  ·                   ·                (b, x)                    ·
       │    │         table               bx@primary       ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -205,7 +205,7 @@ distinct                    ·            ·                 (name)             
  │                          distinct on  name              ·                                         ·
  └── render                 ·            ·                 (name)                                    ·
       │                     render 0     name              ·                                         ·
-      └── join              ·            ·                 (title, shelf, title, shelf, name, book)  ·
+      └── hash-join         ·            ·                 (title, shelf, title, shelf, name, book)  ·
            │                type         inner             ·                                         ·
            │                equality     (title) = (book)  ·                                         ·
            ├── lookup-join  ·            ·                 (title, shelf, title, shelf)              ·
@@ -260,7 +260,7 @@ render          ·         ·               (title, edition, shelf, title, editi
  │              render 3  title           ·                                               ·
  │              render 4  edition         ·                                               ·
  │              render 5  shelf           ·                                               ·
- └── join       ·         ·               (title, edition, shelf, title, edition, shelf)  ·
+ └── hash-join  ·         ·               (title, edition, shelf, title, edition, shelf)  ·
       │         type      cross           ·                                               ·
       ├── scan  ·         ·               (title, edition, shelf)                         ·
       │         table     books2@primary  ·                                               ·
@@ -437,7 +437,7 @@ EXPLAIN (VERBOSE) SELECT small.c, large.d FROM small LEFT JOIN large ON small.c 
 render          ·         ·              (c, d)     ·
  │              render 0  c              ·          ·
  │              render 1  d              ·          ·
- └── join       ·         ·              (b, d, c)  ·
+ └── hash-join  ·         ·              (b, d, c)  ·
       │         type      right outer    ·          ·
       │         equality  (b) = (c)      ·          ·
       ├── scan  ·         ·              (b, d)     ·
@@ -578,16 +578,16 @@ render            ·         ·            (d, e, f, a, b, c)  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM def INNER MERGE JOIN abc ON a=f ORDER BY a
 ----
-join       ·               ·            (d, e, f, a, b, c)  +f
- │         type            inner        ·                   ·
- │         equality        (f) = (a)    ·                   ·
- │         mergeJoinOrder  +"(f=a)"     ·                   ·
- ├── scan  ·               ·            (d, e, f)           +f
- │         table           def@primary  ·                   ·
- │         spans           ALL          ·                   ·
- └── scan  ·               ·            (a, b, c)           +a
-·          table           abc@primary  ·                   ·
-·          spans           ALL          ·                   ·
+merge-join  ·               ·            (d, e, f, a, b, c)  +f
+ │          type            inner        ·                   ·
+ │          equality        (f) = (a)    ·                   ·
+ │          mergeJoinOrder  +"(f=a)"     ·                   ·
+ ├── scan   ·               ·            (d, e, f)           +f
+ │          table           def@primary  ·                   ·
+ │          spans           ALL          ·                   ·
+ └── scan   ·               ·            (a, b, c)           +a
+·           table           abc@primary  ·                   ·
+·           spans           ALL          ·                   ·
 
 # Test that we don't get a lookup join if we force a hash join.
 query TTTTT
@@ -595,7 +595,7 @@ EXPLAIN (VERBOSE) SELECT * FROM def INNER HASH JOIN abc ON a=f ORDER BY a
 ----
 sort            ·         ·            (d, e, f, a, b, c)  +f
  │              order     +f           ·                   ·
- └── join       ·         ·            (d, e, f, a, b, c)  ·
+ └── hash-join  ·         ·            (d, e, f, a, b, c)  ·
       │         type      inner        ·                   ·
       │         equality  (f) = (a)    ·                   ·
       ├── scan  ·         ·            (d, e, f)           ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -753,18 +753,18 @@ render                      ·              ·                 (k)              
 query TTTTT
 EXPLAIN (VERBOSE) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-render          ·               ·                  (k)           ·
- │              render 0        k                  ·             ·
- └── join       ·               ·                  (k, v, k, v)  -v,+k
-      │         type            inner              ·             ·
-      │         equality        (v, k) = (v, k)    ·             ·
-      │         mergeJoinOrder  -"(v=v)",+"(k=k)"  ·             ·
-      ├── scan  ·               ·                  (k, v)        -v,+k
-      │         table           kv@foo             ·             ·
-      │         spans           ALL                ·             ·
-      └── scan  ·               ·                  (k, v)        -v,+k
-·               table           kv@foo             ·             ·
-·               spans           ALL                ·             ·
+render           ·               ·                  (k)           ·
+ │               render 0        k                  ·             ·
+ └── merge-join  ·               ·                  (k, v, k, v)  -v,+k
+      │          type            inner              ·             ·
+      │          equality        (v, k) = (v, k)    ·             ·
+      │          mergeJoinOrder  -"(v=v)",+"(k=k)"  ·             ·
+      ├── scan   ·               ·                  (k, v)        -v,+k
+      │          table           kv@foo             ·             ·
+      │          spans           ALL                ·             ·
+      └── scan   ·               ·                  (k, v)        -v,+k
+·                table           kv@foo             ·             ·
+·                spans           ALL                ·             ·
 
 statement ok
 CREATE TABLE xyz (x INT, y INT, z INT, INDEX(z,y))

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -47,16 +47,16 @@ PREPARE change_stats AS SELECT * FROM [EXPLAIN SELECT * FROM ab JOIN cd ON a=c]
 query TTT
 EXECUTE change_stats
 ----
-join       ·               ·
- │         type            inner
- │         equality        (a) = (c)
- │         mergeJoinOrder  +"(a=c)"
- ├── scan  ·               ·
- │         table           ab@primary
- │         spans           ALL
- └── scan  ·               ·
-·          table           cd@primary
-·          spans           ALL
+merge-join  ·               ·
+ │          type            inner
+ │          equality        (a) = (c)
+ │          mergeJoinOrder  +"(a=c)"
+ ├── scan   ·               ·
+ │          table           ab@primary
+ │          spans           ALL
+ └── scan   ·               ·
+·           table           cd@primary
+·           spans           ALL
 
 statement ok
 CREATE STATISTICS s FROM ab

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -191,7 +191,7 @@ render                ·               ·                    (b, a, c, d, a, c, 
  │                    render 4        a                    ·                         ·
  │                    render 5        c                    ·                         ·
  │                    render 6        d                    ·                         ·
- └── join             ·               ·                    (a, b, c, d, a, b, c, d)  ·
+ └── merge-join       ·               ·                    (a, b, c, d, a, b, c, d)  ·
       │               type            inner                ·                         ·
       │               equality        (b) = (b)            ·                         ·
       │               mergeJoinOrder  +"(b=b)"             ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -155,7 +155,7 @@ group                          ·            ·
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x], t
 ----
-join                      ·         ·
+hash-join                 ·         ·
  │                        type      cross
  ├── spool                ·         ·
  │    └── run             ·         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -11,7 +11,7 @@ project set    ·  ·
 query TTT
 EXPLAIN SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ----
-join                ·     ·
+hash-join           ·     ·
  │                  type  cross
  ├── project set    ·     ·
  │    └── emptyrow  ·     ·
@@ -53,9 +53,9 @@ render                        ·         ·                      (a, b, generate
  │                            render 1  b                      ·                                         ·
  │                            render 2  generate_series        ·                                         ·
  │                            render 3  generate_series        ·                                         ·
- └── join                     ·         ·                      (b, generate_series, generate_series, a)  ·
+ └── hash-join                ·         ·                      (b, generate_series, generate_series, a)  ·
       │                       type      cross                  ·                                         ·
-      ├── join                ·         ·                      (b, generate_series, generate_series)     ·
+      ├── hash-join           ·         ·                      (b, generate_series, generate_series)     ·
       │    │                  type      cross                  ·                                         ·
       │    ├── scan           ·         ·                      (b)                                       ·
       │    │                  table     u@primary              ·                                         ·
@@ -94,31 +94,31 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT x, y, z, information_schema._pg_expandarray(ARRAY[x, y, z])
   FROM xy NATURAL JOIN xz WHERE y < z ORDER BY 1, 2, 3
 ----
-render                         ·               ·                                                      (x, y, z, "information_schema._pg_expandarray")  ·
- │                             render 0        x                                                      ·                                                ·
- │                             render 1        y                                                      ·                                                ·
- │                             render 2        z                                                      ·                                                ·
- │                             render 3        "information_schema._pg_expandarray"                   ·                                                ·
- └── sort                      ·               ·                                                      ("information_schema._pg_expandarray", x, y, z)  +x
-      │                        order           +x                                                     ·                                                ·
-      └── render               ·               ·                                                      ("information_schema._pg_expandarray", x, y, z)  ·
-           │                   render 0        ((x, n) AS x, n)                                       ·                                                ·
-           │                   render 1        x                                                      ·                                                ·
-           │                   render 2        y                                                      ·                                                ·
-           │                   render 3        z                                                      ·                                                ·
-           └── project set     ·               ·                                                      (x, y, x, z, x, n)                               ·
-                │              render 0        information_schema._pg_expandarray(ARRAY[@1, @2, @4])  ·                                                ·
-                └── join       ·               ·                                                      (x, y, x, z)                                     ·
-                     │         type            inner                                                  ·                                                ·
-                     │         equality        (x) = (x)                                              ·                                                ·
-                     │         mergeJoinOrder  +"(x=x)"                                               ·                                                ·
-                     │         pred            y < z                                                  ·                                                ·
-                     ├── scan  ·               ·                                                      (x, y)                                           +x
-                     │         table           xy@primary                                             ·                                                ·
-                     │         spans           ALL                                                    ·                                                ·
-                     └── scan  ·               ·                                                      (x, z)                                           +x
-·                              table           xz@primary                                             ·                                                ·
-·                              spans           ALL                                                    ·                                                ·
+render                          ·               ·                                                      (x, y, z, "information_schema._pg_expandarray")  ·
+ │                              render 0        x                                                      ·                                                ·
+ │                              render 1        y                                                      ·                                                ·
+ │                              render 2        z                                                      ·                                                ·
+ │                              render 3        "information_schema._pg_expandarray"                   ·                                                ·
+ └── sort                       ·               ·                                                      ("information_schema._pg_expandarray", x, y, z)  +x
+      │                         order           +x                                                     ·                                                ·
+      └── render                ·               ·                                                      ("information_schema._pg_expandarray", x, y, z)  ·
+           │                    render 0        ((x, n) AS x, n)                                       ·                                                ·
+           │                    render 1        x                                                      ·                                                ·
+           │                    render 2        y                                                      ·                                                ·
+           │                    render 3        z                                                      ·                                                ·
+           └── project set      ·               ·                                                      (x, y, x, z, x, n)                               ·
+                │               render 0        information_schema._pg_expandarray(ARRAY[@1, @2, @4])  ·                                                ·
+                └── merge-join  ·               ·                                                      (x, y, x, z)                                     ·
+                     │          type            inner                                                  ·                                                ·
+                     │          equality        (x) = (x)                                              ·                                                ·
+                     │          mergeJoinOrder  +"(x=x)"                                               ·                                                ·
+                     │          pred            y < z                                                  ·                                                ·
+                     ├── scan   ·               ·                                                      (x, y)                                           +x
+                     │          table           xy@primary                                             ·                                                ·
+                     │          spans           ALL                                                    ·                                                ·
+                     └── scan   ·               ·                                                      (x, z)                                           +x
+·                               table           xz@primary                                             ·                                                ·
+·                               spans           ALL                                                    ·                                                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series(x, z) FROM xz WHERE z < ANY(SELECT generate_series(x, y) FROM xy)
@@ -127,7 +127,7 @@ render                      ·         ·                        (generate_serie
  │                          render 0  generate_series          ·                        ·
  └── project set            ·         ·                        (x, z, generate_series)  ·
       │                     render 0  generate_series(@1, @2)  ·                        ·
-      └── join              ·         ·                        (x, z)                   ·
+      └── hash-join         ·         ·                        (x, z)                   ·
            │                type      semi                     ·                        ·
            │                pred      z < generate_series      ·                        ·
            ├── scan         ·         ·                        (x, z)                   ·
@@ -143,26 +143,26 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_subscripts(ARRAY[0, x, 1, 2]), generate_series(x, y), unnest(ARRAY[0, x, y, z]), y, z
   FROM xy NATURAL LEFT OUTER JOIN xz
 ----
-render               ·               ·                                        (generate_subscripts, generate_series, unnest, y, z)        ·
- │                   render 0        generate_subscripts                      ·                                                           ·
- │                   render 1        generate_series                          ·                                                           ·
- │                   render 2        unnest                                   ·                                                           ·
- │                   render 3        y                                        ·                                                           ·
- │                   render 4        z                                        ·                                                           ·
- └── project set     ·               ·                                        (x, y, x, z, generate_subscripts, generate_series, unnest)  ·
-      │              render 0        generate_subscripts(ARRAY[0, @1, 1, 2])  ·                                                           ·
-      │              render 1        generate_series(@1, @2)                  ·                                                           ·
-      │              render 2        unnest(ARRAY[0, @1, @2, @4])             ·                                                           ·
-      └── join       ·               ·                                        (x, y, x, z)                                                ·
-           │         type            left outer                               ·                                                           ·
-           │         equality        (x) = (x)                                ·                                                           ·
-           │         mergeJoinOrder  +"(x=x)"                                 ·                                                           ·
-           ├── scan  ·               ·                                        (x, y)                                                      +x
-           │         table           xy@primary                               ·                                                           ·
-           │         spans           ALL                                      ·                                                           ·
-           └── scan  ·               ·                                        (x, z)                                                      +x
-·                    table           xz@primary                               ·                                                           ·
-·                    spans           ALL                                      ·                                                           ·
+render                ·               ·                                        (generate_subscripts, generate_series, unnest, y, z)        ·
+ │                    render 0        generate_subscripts                      ·                                                           ·
+ │                    render 1        generate_series                          ·                                                           ·
+ │                    render 2        unnest                                   ·                                                           ·
+ │                    render 3        y                                        ·                                                           ·
+ │                    render 4        z                                        ·                                                           ·
+ └── project set      ·               ·                                        (x, y, x, z, generate_subscripts, generate_series, unnest)  ·
+      │               render 0        generate_subscripts(ARRAY[0, @1, 1, 2])  ·                                                           ·
+      │               render 1        generate_series(@1, @2)                  ·                                                           ·
+      │               render 2        unnest(ARRAY[0, @1, @2, @4])             ·                                                           ·
+      └── merge-join  ·               ·                                        (x, y, x, z)                                                ·
+           │          type            left outer                               ·                                                           ·
+           │          equality        (x) = (x)                                ·                                                           ·
+           │          mergeJoinOrder  +"(x=x)"                                 ·                                                           ·
+           ├── scan   ·               ·                                        (x, y)                                                      +x
+           │          table           xy@primary                               ·                                                           ·
+           │          spans           ALL                                      ·                                                           ·
+           └── scan   ·               ·                                        (x, z)                                                      +x
+·                     table           xz@primary                               ·                                                           ·
+·                     spans           ALL                                      ·                                                           ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT generate_series((SELECT unnest(ARRAY[x, y]) FROM xy), z) FROM xz

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -79,16 +79,16 @@ root                 ·             ·                                          
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM abc WHERE a IN (SELECT a FROM abc)
 ----
-join       ·               ·            (a)  ·
- │         type            semi         ·    ·
- │         equality        (a) = (a)    ·    ·
- │         mergeJoinOrder  +"(a=a)"     ·    ·
- ├── scan  ·               ·            (a)  +a
- │         table           abc@primary  ·    ·
- │         spans           ALL          ·    ·
- └── scan  ·               ·            (a)  +a
-·          table           abc@primary  ·    ·
-·          spans           ALL          ·    ·
+merge-join  ·               ·            (a)  ·
+ │          type            semi         ·    ·
+ │          equality        (a) = (a)    ·    ·
+ │          mergeJoinOrder  +"(a=a)"     ·    ·
+ ├── scan   ·               ·            (a)  +a
+ │          table           abc@primary  ·    ·
+ │          spans           ALL          ·    ·
+ └── scan   ·               ·            (a)  +a
+·           table           abc@primary  ·    ·
+·           spans           ALL          ·    ·
 
 query TTT
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
@@ -156,21 +156,21 @@ CREATE TABLE b (x INT PRIMARY KEY, z INT);
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE a.x=b.x)
 ----
-join       ·               ·          (x, y)  ·
- │         type            semi       ·       ·
- │         equality        (x) = (x)  ·       ·
- │         mergeJoinOrder  +"(x=x)"   ·       ·
- ├── scan  ·               ·          (x, y)  +x
- │         table           a@primary  ·       ·
- │         spans           ALL        ·       ·
- └── scan  ·               ·          (x, z)  +x
-·          table           b@primary  ·       ·
-·          spans           ALL        ·       ·
+merge-join  ·               ·          (x, y)  ·
+ │          type            semi       ·       ·
+ │          equality        (x) = (x)  ·       ·
+ │          mergeJoinOrder  +"(x=x)"   ·       ·
+ ├── scan   ·               ·          (x, y)  +x
+ │          table           a@primary  ·       ·
+ │          spans           ALL        ·       ·
+ └── scan   ·               ·          (x, z)  +x
+·           table           b@primary  ·       ·
+·           spans           ALL        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE b.x-1 = a.x)
 ----
-join            ·                  ·                (x, y)           ·
+hash-join       ·                  ·                (x, y)           ·
  │              type               semi             ·                ·
  │              equality           (x) = (column5)  ·                ·
  │              left cols are key  ·                ·                ·
@@ -188,21 +188,21 @@ join            ·                  ·                (x, y)           ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM b WHERE b.x = a.x)
 ----
-join       ·               ·          (x, y)  ·
- │         type            anti       ·       ·
- │         equality        (x) = (x)  ·       ·
- │         mergeJoinOrder  +"(x=x)"   ·       ·
- ├── scan  ·               ·          (x, y)  +x
- │         table           a@primary  ·       ·
- │         spans           ALL        ·       ·
- └── scan  ·               ·          (x, z)  +x
-·          table           b@primary  ·       ·
-·          spans           ALL        ·       ·
+merge-join  ·               ·          (x, y)  ·
+ │          type            anti       ·       ·
+ │          equality        (x) = (x)  ·       ·
+ │          mergeJoinOrder  +"(x=x)"   ·       ·
+ ├── scan   ·               ·          (x, y)  +x
+ │          table           a@primary  ·       ·
+ │          spans           ALL        ·       ·
+ └── scan   ·               ·          (x, z)  +x
+·           table           b@primary  ·       ·
+·           spans           ALL        ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM b WHERE NOT EXISTS(SELECT * FROM a WHERE x-1 = b.x)
 ----
-join            ·                  ·                (x, z)           ·
+hash-join       ·                  ·                (x, z)           ·
  │              type               anti             ·                ·
  │              equality           (x) = (column5)  ·                ·
  │              left cols are key  ·                ·                ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -146,7 +146,7 @@ count                            ·              ·
                 │                render 6       b
                 │                render 7       c
                 │                render 8       d
-                └── join         ·              ·
+                └── hash-join    ·              ·
                      │           type           left outer
                      ├── values  ·              ·
                      │           size           4 columns, 1 row

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -651,6 +651,12 @@ func nodeName(plan planNode) string {
 		if n.emitAll {
 			return "append"
 		}
+
+	case *joinNode:
+		if len(n.mergeJoinOrdering) > 0 {
+			return "merge-join"
+		}
+		return "hash-join"
 	}
 
 	name, ok := planNodeNames[reflect.TypeOf(plan)]


### PR DESCRIPTION
Replace `join` with `hash-join` or `merge-join` in `EXPLAIN` output.

Fixes #35683.

Release note (sql change): EXPLAIN tree now uses `hash-join` or
`merge-join` instead of `join`.