### PR TITLE
sql: improve error message while adding column with REFERENCE

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -224,10 +224,15 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 			case *tree.ForeignKeyConstraintTableDef:
 				for _, colName := range d.FromCols {
-					col, _, err := n.tableDesc.FindColumnByName(colName)
+					col, err := n.tableDesc.FindActiveColumnByName(string(colName))
 					if err != nil {
+						if _, dropped, inactiveErr := n.tableDesc.FindColumnByName(colName); inactiveErr == nil && !dropped {
+							return pgerror.UnimplementedWithIssueError(32917,
+								"adding a REFERENCES constraint while the column is being added not supported")
+						}
 						return err
 					}
+
 					if err := col.CheckCanBeFKRef(); err != nil {
 						return err
 					}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -866,3 +866,30 @@ INSERT INTO rides VALUES (567, 'lagos', 'lagos', 10, 100)
 
 statement ok
 ALTER TABLE vehicles DROP COLUMN mycol;
+
+# check that adding a reference on a column still being backfilled fails.
+# fix through #32917
+
+statement ok
+CREATE TABLE t32917 (a INT PRIMARY KEY)
+
+statement ok
+INSERT INTO t32917 VALUES (1), (2), (3)
+
+statement ok
+CREATE TABLE t32917_2 (b INT PRIMARY KEY)
+
+statement ok
+INSERT INTO t32917_2 VALUES (1), (2), (3)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE t32917_2 ADD c INT UNIQUE DEFAULT 4
+
+statement error adding a REFERENCES constraint while the column is being added not supported
+ALTER TABLE t32917_2 ADD CONSTRAINT fk_c_a FOREIGN KEY (c) references t32917 (a)
+
+statement ok
+ROLLBACK

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -2267,7 +2267,7 @@ BEGIN; ALTER TABLE parentid ADD id INT NOT NULL AS (k + 2) STORED; ALTER TABLE c
 statement ok
 ROLLBACK;
 
-statement error column \"id2\" does not exist
+statement error adding a REFERENCES constraint while the column is being added not supported
 BEGIN; ALTER TABLE childid ADD id2 INT UNIQUE NOT NULL DEFAULT 0; ALTER TABLE childid ADD CONSTRAINT fk_id FOREIGN KEY (id2) REFERENCES parentid (k);
 
 statement ok


### PR DESCRIPTION
This will eventually be fixed through #32917

Also added a unittest to check that this fails specifically for
a column needing a backfill.

Release note: None