### PR TITLE
cli: pretty print timeseries data in decode-value

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -403,12 +403,15 @@ Decode and print a hexadecimal-encoded key-value pair.
 			bs = append(bs, b)
 		}
 
+		isTS := bytes.HasPrefix(bs[0], keys.TimeseriesPrefix)
 		k, err := engine.DecodeMVCCKey(bs[0])
 		if err != nil {
 			// Older versions of the consistency checker give you diffs with a raw_key that
 			// is already a roachpb.Key, so make a half-assed attempt to support both.
-			fmt.Printf("unable to decode key: %v, assuming it's a roachpb.Key with fake timestamp;\n"+
-				"if the result below looks like garbage, then it likely is:\n\n", err)
+			if !isTS {
+				fmt.Printf("unable to decode key: %v, assuming it's a roachpb.Key with fake timestamp;\n"+
+					"if the result below looks like garbage, then it likely is:\n\n", err)
+			}
 			k = engine.MVCCKey{
 				Key:       bs[0],
 				Timestamp: hlc.Timestamp{WallTime: 987654321},

--- a/pkg/cli/debug/print.go
+++ b/pkg/cli/debug/print.go
@@ -48,6 +48,7 @@ func SprintKeyValue(kv engine.MVCCKeyValue, sizes bool) string {
 		tryMeta,
 		tryTxn,
 		tryRangeIDKey,
+		tryTimeSeries,
 		tryIntent,
 		func(kv engine.MVCCKeyValue) (string, error) {
 			// No better idea, just print raw bytes and hope that folks use `less -S`.
@@ -237,6 +238,22 @@ func tryMeta(kv engine.MVCCKeyValue) (string, error) {
 		return "", err
 	}
 	return descStr(desc), nil
+}
+
+func tryTimeSeries(kv engine.MVCCKeyValue) (string, error) {
+	if len(kv.Value) == 0 || !bytes.HasPrefix(kv.Key.Key, keys.TimeseriesPrefix) {
+		return "", errors.New("empty or not TS")
+	}
+	var meta enginepb.MVCCMetadata
+	if err := protoutil.Unmarshal(kv.Value, &meta); err != nil {
+		return "", err
+	}
+	v := roachpb.Value{RawBytes: meta.RawBytes}
+	var ts roachpb.InternalTimeSeriesData
+	if err := v.GetProto(&ts); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%+v [mergeTS=%s]", &ts, meta.MergeTimestamp), nil
 }
 
 // IsRangeDescriptorKey returns nil if the key decodes as a RangeDescriptor.


### PR DESCRIPTION
This will help debug a consistency failure involving timeseries data.

Release note: None