### PR TITLE
sql: permit subqueries within RHS of applyjoin

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -149,3 +149,45 @@ EXECUTE e
 3  three  3  three  3  three
 4  four   4  four   4  four
 5  five   5  five   5  five
+
+# Test subqueries within an apply join.
+
+statement ok
+PREPARE f AS OPT PLAN '
+(Root
+  (InnerJoinApply
+    (Scan [(Table "t") (Cols "k,str") ])
+    (Select
+      (Scan [(Table "u") (Cols "l,str2") ])
+      [ (Eq (Plus (Var "k")
+                  (Subquery (Values [(Tuple [(Const 1)] "tuple{int}") ]
+                                    [(Cols [(NewColumn "z" "int")] )])
+                            []))
+            (Var "l") )]
+     )
+    []
+    []
+  )
+  (Presentation "k,str,l,str2")
+  (NoOrdering)
+)'
+
+query ITIT rowsort
+EXECUTE f
+----
+1  one    2  two
+2  two    3  three
+3  three  4  four
+4  four   5  five
+
+# Another test of subqueries within an apply join.
+
+query I
+SELECT
+	(SELECT * FROM (VALUES ((SELECT x FROM (VALUES (1)) AS s (x)) + y)))
+FROM
+	(VALUES (1), (2), (3)) AS t (y)
+----
+2
+3
+4

--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -928,13 +928,11 @@ ON c.c_id=o.c_id AND EXISTS(SELECT * FROM o WHERE o.c_id=c.c_id AND ship IS NULL
 4  70
 4  80
 
-query II rowsort
+query error more than one row returned by a subquery
 SELECT c.c_id, o.o_id
 FROM c
 INNER JOIN o
 ON c.c_id=o.c_id AND o.ship = (SELECT o.ship FROM o WHERE o.c_id=c.c_id);
-----
-6  90
 
 statement error AS OF SYSTEM TIME must be provided on a top-level statement
 SELECT (SELECT c_id FROM o AS OF SYSTEM TIME '-1us')

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -557,8 +557,12 @@ func (b *Builder) buildSubquery(
 func (b *Builder) addSubquery(
 	mode exec.SubqueryMode, typ types.T, root exec.Node, originalExpr *tree.Subquery,
 ) *tree.Subquery {
+	var originalSelect tree.SelectStatement
+	if originalExpr != nil {
+		originalSelect = originalExpr.Select
+	}
 	exprNode := &tree.Subquery{
-		Select: originalExpr.Select,
+		Select: originalSelect,
 		Exists: mode == exec.SubqueryExists,
 	}
 	exprNode.SetType(typ)


### PR DESCRIPTION
Previously, the code assumed that subqueries would have already been
promoted to top-level subqueries and run exactly once by the
re-optimization phase of apply join. However, that promotion happens in
execbuild, not in the optimizer, and therefore won't have already
happened by the time that we go to execbuild the re-optimized RHS in
apply join.

For now, the solution is to re-run the subqueries in the RHS every time
the RHS is run. This is suboptimal because subqueries need only be run
once per query regardless of their position within the apply join tree.
However, setting this up currently is difficult at the moment and would
have required a more invasive change.

When WITH support is available, the optimizer will promote subqueries
into WITH clauses up front, at which point we will be able to safely
remove the requirement that apply join rerun subqueries on the RHS.

Closes #35594.

Release note: None