### PR TITLE
sql,opt: enrich the reported errors, avoid "naked" panics

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -193,7 +193,7 @@ func TestAsOfTime(t *testing.T) {
 	// Subqueries do work of the timestamps are consistent.
 	_, err = db.Query(
 		fmt.Sprintf("SELECT (SELECT a FROM d.t AS OF SYSTEM TIME %s) FROM (SELECT 1) AS OF SYSTEM TIME '1980-01-01'", tsVal1))
-	if !testutils.IsError(err, "pq: cannot specify AS OF SYSTEM TIME with different timestamps") {
+	if !testutils.IsError(err, "cannot specify AS OF SYSTEM TIME with different timestamps") {
 		t.Fatalf("expected inconsistent statements, got: %v", err)
 	}
 	if err := db.QueryRow(

--- a/pkg/sql/coltypes/aliases.go
+++ b/pkg/sql/coltypes/aliases.go
@@ -143,8 +143,9 @@ func NewFloat(prec int64) (*TFloat, error) {
 
 // ArrayOf creates a type alias for an array of the given element type and fixed bounds.
 func ArrayOf(colType T, bounds []int32) (T, error) {
-	if !canBeInArrayColType(colType) {
-		return nil, pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError, "arrays of %s not allowed", colType)
+	if ok, issueNum := canBeInArrayColType(colType); !ok {
+		return nil, pgerror.UnimplementedWithIssueDetailErrorf(issueNum,
+			colType.String(), "arrays of %s not allowed", colType)
 	}
 	return &TArray{ParamType: colType, Bounds: bounds}, nil
 }

--- a/pkg/sql/coltypes/arrays.go
+++ b/pkg/sql/coltypes/arrays.go
@@ -50,12 +50,14 @@ func (node *TArray) Format(buf *bytes.Buffer, f lex.EncodeFlags) {
 
 // canBeInArrayColType returns true if the given T is a valid
 // element type for an array column type.
-func canBeInArrayColType(t T) bool {
+// If the valid return is false, the issue number should
+// be included in the error report to inform the user.
+func canBeInArrayColType(t T) (valid bool, issueNum int) {
 	switch t.(type) {
 	case *TJSON:
-		return false
+		return false, 23468
 	default:
-		return true
+		return true, 0
 	}
 }
 

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -150,7 +150,7 @@ func (p *planner) getDataSource(
 		}
 		cols := planColumns(plan)
 		if len(cols) == 0 {
-			return planDataSource{}, pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError,
+			return planDataSource{}, pgerror.NewErrorf(pgerror.CodeUndefinedColumnError,
 				"statement source \"%v\" does not return any columns", t.Statement)
 		}
 		return planDataSource{

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -749,7 +749,8 @@ func (p *planner) processColumns(
 		}
 
 		if _, ok := colIDSet[col.ID]; ok {
-			return nil, fmt.Errorf("multiple assignments to the same column %q", &nameList[i])
+			return nil, pgerror.NewErrorf(pgerror.CodeSyntaxError,
+				"multiple assignments to the same column %q", &nameList[i])
 		}
 		colIDSet[col.ID] = struct{}{}
 		cols[i] = col

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -86,13 +86,13 @@ SELECT NULL::JSON
 ----
 NULL
 
-statement error arrays of jsonb not allowed
+statement error arrays of jsonb not allowed.*\nHINT:.*23468
 SELECT ARRAY['"hello"'::JSON]
 
-statement error arrays of JSONB not allowed
+statement error arrays of JSONB not allowed.*\nHINT:.*23468
 SELECT '{}'::JSONB[]
 
-statement error arrays of JSONB not allowed
+statement error arrays of JSONB not allowed.*\nHINT:.*23468
 CREATE TABLE x (y JSONB[])
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -185,7 +185,7 @@ SELECT bar FROM foo WHERE bar->'a' = '"b"'::JSON
 ----
 {"a": "b"}
 
-statement error pgcode 0A000 can't order by column type jsonb
+statement error pgcode 0A000 can't order by column type JSONB.*\nHINT.*32706
 SELECT bar FROM foo ORDER BY bar
 
 statement error pgcode 0A000 column k is of type JSONB and thus is not indexable

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -97,7 +97,7 @@ query error pq: unsupported statement: \*tree\.AlterTable
 ALTER TABLE test DROP COLUMN v;
 
 # Don't fall back to heuristic planner in ALWAYS mode.
-query error pq: window functions are not supported
+query error window functions are not supported
 SELECT avg(k) OVER () FROM t ORDER BY 1
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -969,14 +969,6 @@ FROM c ORDER BY c_id
 5  {}
 6  {90}
 
-# We can't decorrelate cases which don't use a scalar type in the
-# ARRAY(...) operator.
-statement error can't execute a correlated ARRAY\(...\) over tuple\{int, string\}
-SELECT
-  c_id,
-  ARRAY(SELECT (o_id, ship) FROM o WHERE o.c_id = c.c_id ORDER BY o_id)
-FROM c ORDER BY c_id
-
 # Regression for issue #24676: missing support for correlated subquery in JSON
 # operator.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery_correlated
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery_correlated
@@ -1,0 +1,23 @@
+# LogicTest: local-opt
+
+# ------------------------------------------------------------------------------
+# Create a simple schema that models customers and orders. Each customer has an
+# id (c_id), and has zero or more orders that are related via a foreign key of
+# the same name. A customer has a billing state and an order has a shipping
+# state, either of which could be NULL. This schema, while simple, is rich
+# enough to provide many interesting correlated subquery variations.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE c (c_id INT PRIMARY KEY, bill TEXT);
+CREATE TABLE o (o_id INT PRIMARY KEY, c_id INT, ship TEXT);
+
+statement ok
+SET optimizer = always
+
+# We can't decorrelate cases which don't use a scalar type in the
+# ARRAY(...) operator.
+statement error can't execute a correlated ARRAY\(...\) over tuple\{int, string\}
+SELECT
+  c_id,
+  ARRAY(SELECT (o_id, ship) FROM o WHERE o.c_id = c.c_id ORDER BY o_id)
+FROM c ORDER BY c_id

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/pkg/errors"
 )
 
 // buildDelete builds a memo group for a DeleteOp expression, which deletes all
@@ -39,7 +38,8 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 	}
 
 	if del.OrderBy != nil && del.Limit == nil {
-		panic(builderError{errors.New("DELETE statement requires LIMIT when ORDER BY is used")})
+		panic(builderError{pgerror.NewErrorf(pgerror.CodeSyntaxError,
+			"DELETE statement requires LIMIT when ORDER BY is used")})
 	}
 
 	if del.With != nil {

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -114,7 +114,7 @@ func (a *aggregateInfo) TypeCheck(ctx *tree.SemaContext, desired types.T) (tree.
 
 // Eval is part of the tree.TypedExpr interface.
 func (a *aggregateInfo) Eval(_ *tree.EvalContext) (tree.Datum, error) {
-	panic("aggregateInfo must be replaced before evaluation")
+	panic(assertionErrorf("aggregateInfo must be replaced before evaluation"))
 }
 
 var _ tree.Expr = &aggregateInfo{}
@@ -145,7 +145,7 @@ func (b *Builder) constructGroupBy(
 			if scalar == nil {
 				// A "pass through" column (i.e. a VariableOp) is not legal as an
 				// aggregation.
-				panic("variable as aggregation")
+				panic(assertionErrorf("variable as aggregation"))
 			}
 			aggs = append(aggs, memo.AggregationsItem{
 				Agg:        scalar,

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/pkg/errors"
 )
 
 // excludedTableName is the name of a special Upsert data source. When a row
@@ -343,7 +342,7 @@ func (mb *mutationBuilder) needExistingRows() bool {
 // list of table columns that are the target of the Insert operation.
 func (mb *mutationBuilder) addTargetNamedColsForInsert(names tree.NameList) {
 	if len(mb.targetColList) != 0 {
-		panic("addTargetNamedColsForInsert cannot be called more than once")
+		panic(assertionErrorf("addTargetNamedColsForInsert cannot be called more than once"))
 	}
 
 	// Add target table columns by the names specified in the Insert statement.
@@ -441,11 +440,11 @@ func (mb *mutationBuilder) checkForeignKeysForInsert() {
 		case 0:
 			// Do nothing.
 		case 1:
-			panic(builderError{errors.Errorf(
+			panic(builderError{pgerror.NewErrorf(pgerror.CodeForeignKeyViolationError,
 				"missing value for column %q in multi-part foreign key", missingCols[0])})
 		default:
 			sort.Strings(missingCols)
-			panic(builderError{errors.Errorf(
+			panic(builderError{pgerror.NewErrorf(pgerror.CodeForeignKeyViolationError,
 				"missing values for columns %q in multi-part foreign key", missingCols)})
 		}
 	}
@@ -463,7 +462,7 @@ func (mb *mutationBuilder) checkForeignKeysForInsert() {
 // columns.
 func (mb *mutationBuilder) addTargetTableColsForInsert(maxCols int) {
 	if len(mb.targetColList) != 0 {
-		panic("addTargetTableColsForInsert cannot be called more than once")
+		panic(assertionErrorf("addTargetTableColsForInsert cannot be called more than once"))
 	}
 
 	// Only consider non-mutation columns, since mutation columns are hidden from
@@ -994,7 +993,7 @@ func (mb *mutationBuilder) ensureUniqueConflictCols(cols tree.NameList) cat.Inde
 			return index
 		}
 	}
-	panic(builderError{errors.New(
+	panic(builderError{pgerror.NewErrorf(pgerror.CodeInvalidColumnReferenceError,
 		"there is no unique or exclusion constraint matching the ON CONFLICT specification")})
 }
 

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -50,7 +50,7 @@ func (b *Builder) buildJoin(join *tree.JoinTableExpr, inScope *scope) (outScope 
 		flags.DisallowHashJoin = true
 		flags.DisallowMergeJoin = true
 		if joinType != sqlbase.InnerJoin && joinType != sqlbase.LeftOuterJoin {
-			panic(builderError{fmt.Errorf(
+			panic(builderError{pgerror.NewErrorf(pgerror.CodeSyntaxError,
 				"%s can only be used with INNER or LEFT joins", tree.AstLookup,
 			)})
 		}

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/pkg/errors"
 )
 
 // mutationBuilder is a helper struct that supports building Insert, Update,
@@ -216,7 +215,8 @@ func (mb *mutationBuilder) addTargetCol(ord int) {
 	// Ensure that the name list does not contain duplicates.
 	colID := mb.tabID.ColumnID(ord)
 	if mb.targetColSet.Contains(int(colID)) {
-		panic(builderError{fmt.Errorf("multiple assignments to the same column %q", tabCol.ColName())})
+		panic(builderError{pgerror.NewErrorf(pgerror.CodeSyntaxError,
+			"multiple assignments to the same column %q", tabCol.ColName())})
 	}
 	mb.targetColSet.Add(int(colID))
 
@@ -597,7 +597,7 @@ func findNotNullIndexCol(index cat.Index) int {
 			return indexCol.Ordinal
 		}
 	}
-	panic("should have found not null column in index")
+	panic(assertionErrorf("should have found not null column in index"))
 }
 
 // resultsNeeded determines whether a statement that might have a RETURNING
@@ -609,7 +609,7 @@ func resultsNeeded(r tree.ReturningClause) bool {
 	case *tree.ReturningNothing, *tree.NoReturningClause:
 		return false
 	default:
-		panic(errors.Errorf("unexpected ReturningClause type: %T", t))
+		panic(assertionErrorf("unexpected ReturningClause type: %T", t))
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -251,7 +251,11 @@ func (b *Builder) analyzeExtraArgument(
 }
 
 func ensureColumnOrderable(e tree.TypedExpr) {
-	if _, ok := e.ResolvedType().(types.TArray); ok || e.ResolvedType() == types.JSON {
-		panic(unimplementedf("can't order by column type %s", e.ResolvedType()))
+	typ := e.ResolvedType()
+	if _, ok := typ.(types.TArray); ok {
+		panic(unimplementedWithIssueDetailf(32707, "", "can't order by column type %s", typ))
+	}
+	if typ == types.JSON {
+		panic(unimplementedWithIssueDetailf(32706, "", "can't order by column type JSONB"))
 	}
 }

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -31,8 +31,8 @@ import (
 )
 
 func checkArrayElementType(t types.T) error {
-	if !types.IsValidArrayElementType(t) {
-		return pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError,
+	if ok, issueNum := types.IsValidArrayElementType(t); !ok {
+		return pgerror.UnimplementedWithIssueDetailErrorf(issueNum, t.String(),
 			"arrays of %s not allowed", t)
 	}
 	return nil
@@ -129,8 +129,8 @@ func (b *Builder) buildScalar(
 			panic(builderError{fmt.Errorf("can't execute a correlated ARRAY(...) over %s", typ)})
 		}
 
-		if !types.IsValidArrayElementType(typ) {
-			panic(builderError{fmt.Errorf("arrays of %s not allowed", typ)})
+		if err := checkArrayElementType(typ); err != nil {
+			panic(builderError{err})
 		}
 
 		// Perform correctness checks on the outer cols, update colRefs and

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -126,7 +126,7 @@ func (b *Builder) buildScalar(
 		// Thus, we reject a query that is correlated and over a type that we can't array_agg.
 		typ := b.factory.Metadata().ColumnMeta(inCol).Type
 		if !s.outerCols.Empty() && !memo.AggregateOverloadExists(opt.ArrayAggOp, typ) {
-			panic(builderError{fmt.Errorf("can't execute a correlated ARRAY(...) over %s", typ)})
+			panic(unimplementedWithIssueDetailf(35710, "", "can't execute a correlated ARRAY(...) over %s", typ))
 		}
 
 		if err := checkArrayElementType(typ); err != nil {
@@ -148,12 +148,12 @@ func (b *Builder) buildScalar(
 		expr := b.buildScalar(t.Expr.(tree.TypedExpr), inScope, nil, nil, colRefs)
 
 		if len(t.Indirection) != 1 {
-			panic(unimplementedWithIssueDetail(32552, "ind", "multidimensional indexing is not supported"))
+			panic(unimplementedWithIssueDetailf(32552, "ind", "multidimensional indexing is not supported"))
 		}
 
 		subscript := t.Indirection[0]
 		if subscript.Slice {
-			panic(unimplementedf("array slicing is not supported"))
+			panic(unimplementedWithIssueDetailf(32551, "", "array slicing is not supported"))
 		}
 
 		out = b.factory.ConstructIndirection(
@@ -384,7 +384,7 @@ func (b *Builder) buildScalar(
 		if b.AllowUnsupportedExpr {
 			out = b.factory.ConstructUnsupportedExpr(scalar)
 		} else {
-			panic(unimplementedf("not yet implemented: scalar expression: %T", scalar))
+			panic(unimplementedWithIssueDetailf(34848, fmt.Sprintf("%T", scalar), "not yet implemented: scalar expression: %T", scalar))
 		}
 	}
 
@@ -432,7 +432,7 @@ func (b *Builder) buildFunction(
 		if inScope.groupby.inAgg {
 			panic(builderError{sqlbase.NewWindowInAggError()})
 		}
-		panic(unimplementedf("window functions are not supported"))
+		panic(unimplementedWithIssueDetailf(34251, "", "window functions are not supported"))
 	}
 
 	def, err := f.Func.Resolve(b.semaCtx.SearchPath)
@@ -441,7 +441,7 @@ func (b *Builder) buildFunction(
 	}
 
 	if isAggregate(def) {
-		panic("aggregate function should have been replaced")
+		panic(assertionErrorf("aggregate function should have been replaced"))
 	}
 
 	args := make(memo.ScalarListExpr, len(f.Exprs))

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -816,7 +816,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 
 	case *tree.FuncExpr:
 		if t.WindowDef != nil {
-			panic(unimplementedf("window functions are not supported"))
+			panic(unimplementedWithIssueDetailf(34251, "", "window functions are not supported"))
 		}
 
 		def, err := t.Func.Resolve(s.builder.semaCtx.SearchPath)
@@ -1143,7 +1143,7 @@ var _ tree.IndexedVarContainer = &scope{}
 
 // IndexedVarEval is part of the IndexedVarContainer interface.
 func (s *scope) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum, error) {
-	panic("unimplemented: scope.IndexedVarEval")
+	panic(assertionErrorf("unimplemented: scope.IndexedVarEval"))
 }
 
 // IndexedVarResolvedType is part of the IndexedVarContainer interface.
@@ -1161,7 +1161,7 @@ func (s *scope) IndexedVarResolvedType(idx int) types.T {
 
 // IndexedVarNodeFormatter is part of the IndexedVarContainer interface.
 func (s *scope) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	panic("unimplemented: scope.IndexedVarNodeFormatter")
+	panic(assertionErrorf("unimplemented: scope.IndexedVarNodeFormatter"))
 }
 
 // newAmbiguousColumnError returns an error with a helpful error message to be

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -56,7 +56,7 @@ func (s *srf) TypeCheck(ctx *tree.SemaContext, desired types.T) (tree.TypedExpr,
 
 // Eval is part of the tree.TypedExpr interface.
 func (s *srf) Eval(_ *tree.EvalContext) (tree.Datum, error) {
-	panic("srf must be replaced before evaluation")
+	panic(assertionErrorf("srf must be replaced before evaluation"))
 }
 
 var _ tree.Expr = &srf{}

--- a/pkg/sql/opt/optbuilder/testdata/create_table
+++ b/pkg/sql/opt/optbuilder/testdata/create_table
@@ -58,7 +58,7 @@ error (42601): CREATE TABLE specifies 2 column names, but data source has 3 colu
 build
 SELECT * FROM [CREATE TABLE ab (a, b) AS SELECT 1, 2]
 ----
-error (0A000): statement source "CREATE TABLE ab (a, b) AS SELECT 1, 2" does not return any columns
+error (42703): statement source "CREATE TABLE ab (a, b) AS SELECT 1, 2" does not return any columns
 
 # Non-existent column.
 build

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -201,7 +201,7 @@ error: no data source matches prefix: "unknown"
 build
 SELECT * FROM [DELETE FROM abcde WHERE a=1]
 ----
-error (0A000): statement source "DELETE FROM abcde WHERE a = 1" does not return any columns
+error (42703): statement source "DELETE FROM abcde WHERE a = 1" does not return any columns
 
 # Non-referenced CTE with mutation.
 build
@@ -219,7 +219,7 @@ error (42P01): no data source matches prefix: abcde
 build
 DELETE FROM abcde WHERE b=1 ORDER BY c
 ----
-error: DELETE statement requires LIMIT when ORDER BY is used
+error (42601): DELETE statement requires LIMIT when ORDER BY is used
 
 # ------------------------------------------------------------------------------
 # Test RETURNING.

--- a/pkg/sql/opt/optbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/optbuilder/testdata/distinct_on
@@ -331,7 +331,7 @@ distinct-on
 build
 SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
 ----
-error (0A000): window functions are not supported
+error (0A000): unimplemented: window functions are not supported
 
 ###########################
 # With ordinal references #

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -528,7 +528,7 @@ error: generate_series(): generator functions are not allowed in RETURNING
 build
 SELECT * FROM [INSERT INTO abcde VALUES (1)]
 ----
-error (0A000): statement source "INSERT INTO abcde VALUES (1)" does not return any columns
+error (42703): statement source "INSERT INTO abcde VALUES (1)" does not return any columns
 
 # Use CTE with multiple variables.
 build
@@ -889,7 +889,7 @@ error (42601): INSERT has more target columns than expressions, 1 expressions fo
 build
 INSERT INTO abcde (a, b, a) VALUES (1, 2, 3)
 ----
-error: multiple assignments to the same column "a"
+error (42601): multiple assignments to the same column "a"
 
 # Undefined column name.
 build

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -396,22 +396,22 @@ error (42P01): no data source matches prefix: a
 build
 SELECT generate_series FROM generate_series(1, 100) ORDER BY ARRAY[generate_series]
 ----
-error (0A000): can't order by column type int[]
+error (0A000): unimplemented: can't order by column type int[]
 
 build
 SELECT ARRAY[generate_series] FROM generate_series(1, 100) ORDER BY ARRAY[generate_series]
 ----
-error (0A000): can't order by column type int[]
+error (0A000): unimplemented: can't order by column type int[]
 
 build
 SELECT ARRAY[generate_series] FROM generate_series(1, 100) ORDER BY 1
 ----
-error (0A000): can't order by column type int[]
+error (0A000): unimplemented: can't order by column type int[]
 
 build
 SELECT ARRAY[generate_series] AS a FROM generate_series(1, 100) ORDER BY a
 ----
-error (0A000): can't order by column type int[]
+error (0A000): unimplemented: can't order by column type int[]
 
 build
 SELECT generate_series, ARRAY[generate_series] FROM generate_series(1, 1) ORDER BY 1
@@ -1092,4 +1092,4 @@ project
 build
 SELECT ARRAY[a] FROM abcd ORDER BY 1
 ----
-error (0A000): can't order by column type int[]
+error (0A000): unimplemented: can't order by column type int[]

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -1117,12 +1117,12 @@ project
 build
 SELECT ARRAY(SELECT (y, 2) FROM u ORDER BY x) FROM v
 ----
-error: can't execute a correlated ARRAY(...) over tuple{int[], int}
+error (0A000): unimplemented: can't execute a correlated ARRAY(...) over tuple{int[], int}
 
 build
 SELECT ARRAY(SELECT y FROM u ORDER BY x) FROM v
 ----
-error: can't execute a correlated ARRAY(...) over int[]
+error (0A000): unimplemented: can't execute a correlated ARRAY(...) over int[]
 
 build-scalar
 ISERROR(1/0)

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -756,12 +756,12 @@ concat [type=oid[]]
 build-scalar
 ARRAY['"foo"'::jsonb]
 ----
-error: arrays of jsonb not allowed
+error: unimplemented: arrays of jsonb not allowed
 
 build-scalar
 ARRAY['"foo"'::json]
 ----
-error: arrays of jsonb not allowed
+error: unimplemented: arrays of jsonb not allowed
 
 opt
 SELECT -((-9223372036854775808):::int)
@@ -907,7 +907,7 @@ project
 build
 SELECT ARRAY(VALUES ('{}'::JSONB))
 ----
-error: arrays of jsonb not allowed
+error (0A000): unimplemented: arrays of jsonb not allowed
 
 build
 SELECT ARRAY(SELECT 1, 2)

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1127,7 +1127,7 @@ select
 build
 SELECT * FROM a AS OF SYSTEM TIME '-1000ns'
 ----
-error: AS OF SYSTEM TIME must be provided on a top-level statement
+error (42601): AS OF SYSTEM TIME must be provided on a top-level statement
 
 build
 SELECT * FROM a AS t(a, b, c)

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -447,7 +447,7 @@ error (42804): value type int doesn't match type STRING of column "x"
 build
 SELECT * FROM [UPDATE abcde SET a=1]
 ----
-error (0A000): statement source "UPDATE abcde SET a = 1" does not return any columns
+error (42703): statement source "UPDATE abcde SET a = 1" does not return any columns
 
 # Non-referenced CTE with mutation.
 build
@@ -465,7 +465,7 @@ error (42P01): no data source matches prefix: abcde
 build
 UPDATE abcde SET b=1 ORDER BY c
 ----
-error: UPDATE statement requires LIMIT when ORDER BY is used
+error (42601): UPDATE statement requires LIMIT when ORDER BY is used
 
 # ------------------------------------------------------------------------------
 # Test RETURNING.
@@ -820,12 +820,12 @@ update abcde
 build
 UPDATE abcde SET (a, b)=(1, 2, 3)
 ----
-error: number of columns (2) does not match number of values (3)
+error (42601): number of columns (2) does not match number of values (3)
 
 build
 UPDATE abcde SET (a, b, a)=(1, 2, 3)
 ----
-error: multiple assignments to the same column "a"
+error (42601): multiple assignments to the same column "a"
 
 build
 UPDATE abcde SET (a, unk)=(1, 2)
@@ -1126,19 +1126,19 @@ project
 build
 UPDATE abcde SET (a, b)=(SELECT y, y+1 AS y1, y+2 AS y2 FROM xyz)
 ----
-error: number of columns (2) does not match number of values (3)
+error (42601): number of columns (2) does not match number of values (3)
 
 # Too few values.
 build
 UPDATE abcde SET (a, b, c)=(SELECT y, y+1 AS y1 FROM xyz)
 ----
-error: number of columns (3) does not match number of values (2)
+error (42601): number of columns (3) does not match number of values (2)
 
 # Try to update same column.
 build
 UPDATE abcde SET (a, b)=(1, 2), (c, b)=(SELECT y, y+1 AS y1 FROM xyz)
 ----
-error: multiple assignments to the same column "b"
+error (42601): multiple assignments to the same column "b"
 
 # Target type does not match subquery result.
 build

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -599,7 +599,7 @@ VALUES (1, 2)
 ON CONFLICT (b) DO
 UPDATE SET a=5
 ----
-error: there is no unique or exclusion constraint matching the ON CONFLICT specification
+error (42P10): there is no unique or exclusion constraint matching the ON CONFLICT specification
 
 # Conflict columns don't match unique index (too many columns).
 build
@@ -608,7 +608,7 @@ VALUES (1, 2)
 ON CONFLICT (a, b) DO
 UPDATE SET a=5
 ----
-error: there is no unique or exclusion constraint matching the ON CONFLICT specification
+error (42P10): there is no unique or exclusion constraint matching the ON CONFLICT specification
 
 # Conflict columns don't match unique index (wrong order).
 build
@@ -617,7 +617,7 @@ VALUES (1, 2)
 ON CONFLICT (c, b) DO
 UPDATE SET a=5
 ----
-error: there is no unique or exclusion constraint matching the ON CONFLICT specification
+error (42P10): there is no unique or exclusion constraint matching the ON CONFLICT specification
 
 # ------------------------------------------------------------------------------
 # Test DO NOTHING.

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -17,14 +17,14 @@ TABLE kv
 build
 SELECT avg(k) OVER (PARTITION BY v) FROM kv ORDER BY 1
 ----
-error (0A000): window functions are not supported
+error (0A000): unimplemented: window functions are not supported
 
 build
 SELECT avg(avg(k) OVER ()) FROM kv ORDER BY 1
 ----
-error (0A000): window functions are not supported
+error (0A000): unimplemented: window functions are not supported
 
 build
 SELECT * FROM kv GROUP BY v, count(w) OVER ()
 ----
-error (0A000): window functions are not supported
+error (0A000): unimplemented: window functions are not supported

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -185,7 +185,7 @@ WITH
     t2 AS (SELECT * FROM t1)
 SELECT * FROM t1 NATURAL JOIN t2
 ----
-error: unsupported multiple use of CTE clause "t1"
+error (0A000): unimplemented: unsupported multiple use of CTE clause "t1"
 
 build
 WITH
@@ -222,7 +222,7 @@ build
 WITH t AS (SELECT a FROM y WHERE a < 3)
   SELECT * FROM t NATURAL JOIN t
 ----
-error: unsupported multiple use of CTE clause "t"
+error (0A000): unimplemented: unsupported multiple use of CTE clause "t"
 
 build
 WITH t(x) AS (SELECT a FROM x)

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
-	"github.com/pkg/errors"
 )
 
 // buildUpdate builds a memo group for an UpdateOp expression. First, an input
@@ -68,7 +67,8 @@ import (
 // become a physical property required of the Update operator).
 func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope) {
 	if upd.OrderBy != nil && upd.Limit == nil {
-		panic(builderError{errors.New("UPDATE statement requires LIMIT when ORDER BY is used")})
+		panic(builderError{pgerror.NewErrorf(pgerror.CodeSyntaxError,
+			"UPDATE statement requires LIMIT when ORDER BY is used")})
 	}
 
 	// UX friendliness safeguard.
@@ -133,7 +133,7 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 // exactly as many columns as are expected by the named SET columns.
 func (mb *mutationBuilder) addTargetColsForUpdate(exprs tree.UpdateExprs) {
 	if len(mb.targetColList) != 0 {
-		panic("addTargetColsForUpdate cannot be called more than once")
+		panic(assertionErrorf("addTargetColsForUpdate cannot be called more than once"))
 	}
 
 	for _, expr := range exprs {
@@ -161,10 +161,12 @@ func (mb *mutationBuilder) addTargetColsForUpdate(exprs tree.UpdateExprs) {
 				n = len(t.Exprs)
 			}
 			if n < 0 {
-				panic(builderError{errors.Errorf("unsupported tuple assignment: %T", expr.Expr)})
+				panic(unimplementedWithIssueDetailf(35713, fmt.Sprintf("%T", expr.Expr),
+					"source for a multiple-column UPDATE item must be a sub-SELECT or ROW() expression; not supported: %T", expr.Expr))
 			}
 			if len(expr.Names) != n {
-				panic(builderError{fmt.Errorf("number of columns (%d) does not match number of values (%d)",
+				panic(builderError{pgerror.NewErrorf(pgerror.CodeSyntaxError,
+					"number of columns (%d) does not match number of values (%d)",
 					len(expr.Names), n)})
 			}
 		}

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -209,7 +209,11 @@ func UnimplementedWithIssueError(issue int, msg string) *Error {
 // This is useful when we need an extra axis of information to drill down into.
 func UnimplementedWithIssueDetailError(issue int, detail, msg string) *Error {
 	err := NewErrorWithDepthf(1, CodeFeatureNotSupportedError, "unimplemented: %s", msg)
-	err.InternalCommand = fmt.Sprintf("#%d.%s", issue, detail)
+	if detail == "" {
+		err.InternalCommand = fmt.Sprintf("#%d", issue)
+	} else {
+		err.InternalCommand = fmt.Sprintf("#%d.%s", issue, detail)
+	}
 	return err.SetHintf("See: https://github.com/cockroachdb/cockroach/issues/%d", issue)
 }
 
@@ -219,7 +223,11 @@ func UnimplementedWithIssueDetailErrorf(
 	issue int, detail, format string, args ...interface{},
 ) error {
 	err := NewErrorWithDepthf(1, CodeFeatureNotSupportedError, "unimplemented: "+format, args...)
-	err.InternalCommand = fmt.Sprintf("#%d.%s", issue, detail)
+	if detail == "" {
+		err.InternalCommand = fmt.Sprintf("#%d", issue)
+	} else {
+		err.InternalCommand = fmt.Sprintf("#%d.%s", issue, detail)
+	}
 	return err.SetHintf("See: https://github.com/cockroachdb/cockroach/issues/%d", issue)
 }
 

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -477,7 +477,8 @@ func (p *planner) getTimestamp(asOf tree.AsOfClause) (hlc.Timestamp, bool, error
 		// would not be set globally for the entire txn.
 		if p.semaCtx.AsOfTimestamp == nil {
 			return hlc.MaxTimestamp, false,
-				fmt.Errorf("AS OF SYSTEM TIME must be provided on a top-level statement")
+				pgerror.NewErrorf(pgerror.CodeSyntaxError,
+					"AS OF SYSTEM TIME must be provided on a top-level statement")
 		}
 
 		// The Executor found an AS OF SYSTEM TIME clause at the top
@@ -490,7 +491,8 @@ func (p *planner) getTimestamp(asOf tree.AsOfClause) (hlc.Timestamp, bool, error
 		}
 		if ts != *p.semaCtx.AsOfTimestamp {
 			return hlc.MaxTimestamp, false,
-				fmt.Errorf("cannot specify AS OF SYSTEM TIME with different timestamps")
+				pgerror.UnimplementedWithIssueError(35712,
+					"cannot specify AS OF SYSTEM TIME with different timestamps")
 		}
 		return ts, true, nil
 	}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3558,7 +3558,7 @@ var jsonArrayLengthImpl = tree.Overload{
 func arrayBuiltin(impl func(types.T) tree.Overload) builtinDefinition {
 	overloads := make([]tree.Overload, 0, len(types.AnyNonArray))
 	for _, typ := range types.AnyNonArray {
-		if types.IsValidArrayElementType(typ) {
+		if ok, _ := types.IsValidArrayElementType(typ); ok {
 			overloads = append(overloads, impl(typ))
 		}
 	}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3885,8 +3885,9 @@ func arrayOfType(typ types.T) (*DArray, error) {
 	if !ok {
 		return nil, pgerror.NewAssertionErrorf("array node type (%v) is not types.TArray", typ)
 	}
-	if !types.IsValidArrayElementType(arrayTyp.Typ) {
-		return nil, pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError, "arrays of %s not allowed", arrayTyp.Typ)
+	if ok, issueNum := types.IsValidArrayElementType(arrayTyp.Typ); !ok {
+		return nil, pgerror.UnimplementedWithIssueDetailErrorf(issueNum, arrayTyp.Typ.String(),
+			"arrays of %s not allowed", arrayTyp.Typ)
 	}
 	return NewDArray(arrayTyp.Typ), nil
 }

--- a/pkg/sql/sem/types/invariants_test.go
+++ b/pkg/sql/sem/types/invariants_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestArraysHaveOids(t *testing.T) {
 	for _, typ := range AnyNonArray {
-		if !IsValidArrayElementType(typ) {
+		if ok, _ := IsValidArrayElementType(typ); !ok {
 			continue
 		}
 

--- a/pkg/sql/sem/types/types.go
+++ b/pkg/sql/sem/types/types.go
@@ -525,12 +525,14 @@ func IsStringType(t T) bool {
 
 // IsValidArrayElementType returns true if the T
 // can be used in TArray.
-func IsValidArrayElementType(t T) bool {
+// If the valid return is false, the issue number should
+// be included in the error report to inform the user.
+func IsValidArrayElementType(t T) (valid bool, issueNum int) {
 	switch t {
 	case JSON:
-		return false
+		return false, 23468
 	default:
-		return true
+		return true, 0
 	}
 }
 

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -227,8 +227,11 @@ func (n *sortNode) Close(ctx context.Context) {
 }
 
 func ensureColumnOrderable(c sqlbase.ResultColumn) error {
-	if _, ok := c.Typ.(types.TArray); ok || c.Typ == types.JSON {
-		return pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError, "can't order by column type %s", c.Typ)
+	if _, ok := c.Typ.(types.TArray); ok {
+		return pgerror.UnimplementedWithIssueErrorf(32707, "can't order by column type %s", c.Typ)
+	}
+	if c.Typ == types.JSON {
+		return pgerror.UnimplementedWithIssueError(32706, "can't order by column type JSONB")
 	}
 	return nil
 }

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -16,6 +16,7 @@ package sql
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -871,8 +872,9 @@ func (p *planner) namesForExprs(
 				n = len(t.D)
 			}
 			if n < 0 {
-				return nil, nil, pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError,
-					"unsupported tuple assignment: %T", expr.Expr)
+				return nil, nil, pgerror.UnimplementedWithIssueDetailErrorf(35713,
+					fmt.Sprintf("%T", expr.Expr),
+					"source for a multiple-column UPDATE item must be a sub-SELECT or ROW() expression; not supported: %T", expr.Expr)
 			}
 			if len(expr.Names) != n {
 				return nil, nil, pgerror.NewErrorf(pgerror.CodeSyntaxError,

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -16,7 +16,6 @@ package sql
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -832,5 +831,6 @@ func upsertExprsAndIndex(
 			return false, onConflict.Exprs, &tableDesc.Indexes[i], nil
 		}
 	}
-	return false, nil, nil, fmt.Errorf("there is no unique or exclusion constraint matching the ON CONFLICT specification")
+	return false, nil, nil, pgerror.NewErrorf(pgerror.CodeInvalidColumnReferenceError,
+		"there is no unique or exclusion constraint matching the ON CONFLICT specification")
 }

--- a/pkg/sql/with.go
+++ b/pkg/sql/with.go
@@ -150,7 +150,7 @@ func (p *planner) getCTEDataSource(tn *tree.TableName) (planDataSource, bool, er
 				// TODO(jordan): figure out how to lift this restriction.
 				// CTE expressions that are used more than once will need to be
 				// pre-evaluated like subqueries, I think.
-				return planDataSource{}, false, pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError,
+				return planDataSource{}, false, pgerror.UnimplementedWithIssueErrorf(21084,
 					"unsupported multiple use of CTE clause %q", tree.ErrString(tn))
 			}
 			cteSource.used = true

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -407,6 +407,38 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	t.Run("TestCBOBuilderPanics", func(t *testing.T) {
+		t.Parallel()
+		cmd, stderr, filter, err := dirCmd(
+			pkgDir,
+			"git",
+			"grep",
+			"-nE",
+			`[^[:alnum:]]panic\(("|[a-z]+Error\{(errors\.(New|Errorf)|fmt\.Errorf))`,
+			"--",
+			"sql/opt/optbuilder",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			t.Errorf("\n%s <- forbidden; use panic(builderError{pgerror.XXX}), panic(assertionErrorf(...)), etc instead", s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
 	t.Run("TestTodoStyle", func(t *testing.T) {
 		t.Parallel()
 		// TODO(tamird): enforce presence of name.


### PR DESCRIPTION
First commit from  #35704.
Informs https://github.com/cockroachlabs/registration/issues/203.

The `optbuilder` package's error handling was deficient in two ways:

- it would fail assertions with a hard panic and cause a node
  shutdown;
- it did not enrich errors with a suitable pg error code in many
  cases, including missing references to issues that track
  unimplemented features.

This patch fixes the former by introducing a new primitive
`assertionErrorf` that creates a pgerror with CodeInternalError (this
is picked up in telemetry automatically).

It fixes the latter by adding the missing error codes.  Where
applicable, errors have been either picked from the HP code, or from
PostgreSQL. In the latter cases the code was also backported to the HP
for consistency.

Additionally, a linter is added to prevent the addition of new
undecorated panics.

Release note: None