### PR TITLE
stats: add sql-opt-prs as code owner of /pkg/sql/stats

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@
 /pkg/sql/                    @cockroachdb/sql-rest-prs
 
 /pkg/sql/opt/                @cockroachdb/sql-opt-prs
+/pkg/sql/stats/              @cockroachdb/sql-opt-prs
 
 /pkg/sql/parser/             @cockroachdb/sql-language-prs
 


### PR DESCRIPTION
This commit updates `.github/CODEOWNERS` so that members of the
`sql-opt-prs` team will be notified of changes to `/pkg/sql/stats`.

Release note: None