### PR TITLE
roachpb: prevent data race on Transaction

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -100,8 +100,7 @@ func registerKV(r *registry) {
 		// Configs with large nodes.
 		{nodes: 3, cpus: 96, readPercent: 0},
 		{nodes: 3, cpus: 96, readPercent: 95},
-		// Skipped: https://github.com/cockroachdb/cockroach/issues/34241.
-		// {nodes: 4, cpus: 96, readPercent: 50, batchSize: 64},
+		{nodes: 4, cpus: 96, readPercent: 50, batchSize: 64},
 
 		// Configs with encryption.
 		{nodes: 1, cpus: 8, readPercent: 0, encryption: true},

--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -385,7 +385,6 @@ func TestSetPriority(t *testing.T) {
 				}
 
 				br := &roachpb.BatchResponse{}
-				br.Txn = &roachpb.Transaction{}
 				br.Txn.Update(ba.Txn) // copy
 				return br, nil
 			}), clock)

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -967,7 +967,9 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 			// Update the transaction from the response. Note that this wouldn't happen
 			// on the asynchronous path, but if we have newer information it's good to
 			// use it.
-			ba.UpdateTxn(resp.reply.Txn)
+			if !lastRange {
+				ba.UpdateTxn(resp.reply.Txn)
+			}
 
 			mightStopEarly := ba.MaxSpanRequestKeys > 0 || stopAtRangeBoundary
 			// Check whether we've received enough responses to exit query loop.

--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -17,10 +17,7 @@ package kv
 
 import (
 	"context"
-	"encoding/hex"
-	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -28,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/opentracing/opentracing-go"
@@ -156,38 +152,6 @@ func (gt *grpcTransport) maybeResurrectRetryablesLocked() bool {
 	return len(resurrect) > 0
 }
 
-func withMarshalingDebugging(ctx context.Context, ba roachpb.BatchRequest, f func()) {
-	nPre := ba.Size()
-	defer func() {
-		// TODO(ajwerner): re-enable the pre-emptive panic case below when the sizes
-		// do not match. The case is being disabled temporarily to reduce the
-		// rate of panics in the upcoming release. A more holistic fix which
-		// eliminates the shallow copies of transactions is coming soon.
-		nPost := ba.Size()
-		if r := recover(); r != nil /* || nPre != nPost */ {
-			var buf strings.Builder
-			_, _ = fmt.Fprintf(&buf, "batch size %d -> %d bytes\n", nPre, nPost)
-			func() {
-				defer func() {
-					if rInner := recover(); rInner != nil {
-						_, _ = fmt.Fprintln(&buf, "panic while re-marshaling:", rInner)
-					}
-				}()
-				data, mErr := protoutil.Marshal(&ba)
-				if mErr != nil {
-					_, _ = fmt.Fprintln(&buf, "while re-marshaling:", mErr)
-				} else {
-					_, _ = fmt.Fprintln(&buf, "re-marshaled protobuf:")
-					_, _ = fmt.Fprintln(&buf, hex.Dump(data))
-				}
-			}()
-			_, _ = fmt.Fprintln(&buf, "original panic: ", r)
-			panic(buf.String())
-		}
-	}()
-	f()
-}
-
 // SendNext invokes the specified RPC on the supplied client when the
 // client is ready. On success, the reply is sent on the channel;
 // otherwise an error is sent.
@@ -201,11 +165,7 @@ func (gt *grpcTransport) SendNext(
 	}
 
 	ba.Replica = client.replica
-	var reply *roachpb.BatchResponse
-
-	withMarshalingDebugging(ctx, ba, func() {
-		reply, err = gt.sendBatch(ctx, client.replica.NodeID, iface, ba)
-	})
+	reply, err := gt.sendBatch(ctx, client.replica.NodeID, iface, ba)
 
 	// NotLeaseHolderErrors can be retried.
 	var retryable bool

--- a/pkg/kv/transport_test.go
+++ b/pkg/kv/transport_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )
 
@@ -172,31 +171,4 @@ func (m *mockInternalClient) RangeFeed(
 	ctx context.Context, in *roachpb.RangeFeedRequest, opts ...grpc.CallOption,
 ) (roachpb.Internal_RangeFeedClient, error) {
 	return nil, fmt.Errorf("unsupported RangeFeed call")
-}
-
-func TestWithMarshalingDebugging(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	t.Skip(fmt.Sprintf("Skipped until #34241 is resolved"))
-
-	ctx := context.Background()
-
-	exp := `batch size 23 -> 28 bytes
-re-marshaled protobuf:
-00000000  0a 0a 0a 00 12 06 08 00  10 00 18 00 12 0e 3a 0c  |..............:.|
-00000010  0a 0a 1a 03 66 6f 6f 22  03 62 61 72              |....foo".bar|
-
-original panic:  <nil>
-`
-
-	assert.PanicsWithValue(t, exp, func() {
-		var ba roachpb.BatchRequest
-		ba.Add(&roachpb.ScanRequest{
-			RequestHeader: roachpb.RequestHeader{
-				Key: []byte("foo"),
-			},
-		})
-		withMarshalingDebugging(ctx, ba, func() {
-			ba.Requests[0].GetInner().(*roachpb.ScanRequest).EndKey = roachpb.Key("bar")
-		})
-	})
 }

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -905,8 +905,7 @@ func (tc *TxnCoordSender) UpdateStateOnRemoteRetryableErr(
 	// handleRetryableErrLocked().
 	if err.Transaction.ID == txnID {
 		// This is where we get a new epoch.
-		cp := err.Transaction.Clone()
-		tc.mu.txn.Update(&cp)
+		tc.mu.txn.Update(&err.Transaction)
 	}
 	return roachpb.NewError(err)
 }
@@ -1036,8 +1035,7 @@ func (tc *TxnCoordSender) updateStateLocked(
 			tc.mu.storedErr = pErr
 
 			// Cleanup.
-			cp := pErr.GetTxn().Clone()
-			tc.mu.txn.Update(&cp)
+			tc.mu.txn.Update(pErr.GetTxn())
 			tc.cleanupTxnLocked(ctx)
 			return pErr
 		}
@@ -1056,8 +1054,7 @@ func (tc *TxnCoordSender) updateStateLocked(
 		// handleRetryableErrLocked().
 		if err.Transaction.ID == ba.Txn.ID {
 			// This is where we get a new epoch.
-			cp := err.Transaction.Clone()
-			tc.mu.txn.Update(&cp)
+			tc.mu.txn.Update(&err.Transaction)
 		}
 		return roachpb.NewError(err)
 	}
@@ -1069,8 +1066,7 @@ func (tc *TxnCoordSender) updateStateLocked(
 			PrevError: pErr.String(),
 		})
 		// Cleanup.
-		cp := errTxn.Clone()
-		tc.mu.txn.Update(&cp)
+		tc.mu.txn.Update(errTxn)
 		tc.cleanupTxnLocked(ctx)
 	}
 	return pErr

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -383,10 +383,13 @@ func (h *BatchResponse_Header) combine(o BatchResponse_Header) error {
 		)
 	}
 	h.Timestamp.Forward(o.Timestamp)
-	if h.Txn == nil {
-		h.Txn = o.Txn
-	} else {
-		h.Txn.Update(o.Txn)
+	if txn := o.Txn; txn != nil {
+		if h.Txn == nil {
+			txnClone := txn.Clone()
+			h.Txn = &txnClone
+		} else {
+			h.Txn.Update(txn)
+		}
 	}
 	h.Now.Forward(o.Now)
 	h.CollectedSpans = append(h.CollectedSpans, o.CollectedSpans...)

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -424,7 +424,6 @@ func (br *BatchResponse) Combine(otherBatch *BatchResponse, positions []int) err
 			return errors.Errorf("can not combine %T and %T", valLeft, valRight)
 		}
 	}
-	br.Txn.Update(otherBatch.Txn)
 	return nil
 }
 

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -72,17 +72,17 @@ func (ba *BatchRequest) SetActiveTimestamp(nowFn func() hlc.Timestamp) error {
 // UpdateTxn updates the batch transaction from the supplied one in
 // a copy-on-write fashion, i.e. without mutating an existing
 // Transaction struct.
-func (ba *BatchRequest) UpdateTxn(otherTxn *Transaction) {
-	if otherTxn == nil {
+func (ba *BatchRequest) UpdateTxn(o *Transaction) {
+	if o == nil {
 		return
 	}
-	otherTxn.AssertInitialized(context.TODO())
+	o.AssertInitialized(context.TODO())
 	if ba.Txn == nil {
-		ba.Txn = otherTxn
+		ba.Txn = o
 		return
 	}
 	clonedTxn := ba.Txn.Clone()
-	clonedTxn.Update(otherTxn)
+	clonedTxn.Update(o)
 	ba.Txn = &clonedTxn
 }
 

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -171,9 +171,9 @@ func (e *Error) GetTxn() *Transaction {
 	return e.UnexposedTxn
 }
 
-// UpdateTxn updates the txn.
+// UpdateTxn updates the error transaction.
 func (e *Error) UpdateTxn(o *Transaction) {
-	if e == nil {
+	if o == nil {
 		return
 	}
 	if e.UnexposedTxn == nil {

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -151,7 +151,6 @@ func (e *Error) GoError() error {
 
 // SetTxn sets the txn and resets the error message. txn is cloned before being
 // stored in the Error.
-// TODO(kaneda): Unexpose this method and make callers use NewErrorWithTxn.
 func (e *Error) SetTxn(txn *Transaction) {
 	e.UnexposedTxn = txn
 	if txn != nil {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2795,18 +2795,13 @@ func (s *Store) Send(
 			// this node.
 			if pErr != nil {
 				pErr.OriginNode = ba.Replica.NodeID
-				if txn := pErr.GetTxn(); txn != nil {
-					// Clone the txn, as we'll modify it.
-					pErr.SetTxn(txn)
-				} else {
+				if txn := pErr.GetTxn(); txn == nil {
 					pErr.SetTxn(ba.Txn)
 				}
-				pErr.GetTxn().UpdateObservedTimestamp(ba.Replica.NodeID, now)
 			} else {
 				if br.Txn == nil {
 					br.Txn = ba.Txn
 				}
-				br.Txn.UpdateObservedTimestamp(ba.Replica.NodeID, now)
 				// Update our clock with the outgoing response txn timestamp
 				// (if timestamp has been forwarded).
 				if ba.Timestamp.Less(br.Txn.Timestamp) {

--- a/pkg/testutils/storageutils/mocking.go
+++ b/pkg/testutils/storageutils/mocking.go
@@ -58,11 +58,7 @@ func WrapFilterForReplayProtection(
 func shallowCloneErrorWithTxn(pErr *roachpb.Error) *roachpb.Error {
 	if pErr != nil {
 		pErrCopy := *pErr
-		txn := pErrCopy.GetTxn()
-		if txn != nil {
-			txnClone := txn.Clone()
-			pErrCopy.SetTxn(&txnClone)
-		}
+		pErrCopy.SetTxn(pErrCopy.GetTxn())
 		return &pErrCopy
 	}
 


### PR DESCRIPTION
Fixes #34241.

This PR starts off with a series of small cleanups related to ownership of `roachpb.Transaction` objects and the use of deep and shallow clones. This makes up the first 5 commits.

Next, the 6th commit removes redundant calls to `Transaction.UpdateObservedTimestamp`, reducing it down to have just a single caller that is easy to reason about.

The 7th commit is what actually fixes the referenced issue. It adds in the proto clone that was missing from `BatchResponse_Header.combine` and allowing a `BatchRequest` to reference the same `Transaction` object as a `BatchResponse`. I confirmed a number of times that this stops the assertion from firing, so the commit also re-enables the skipped roachtest and removes the assertion.

~The final two commits are the two that we might consider waiting on and not including in this release, but they're also the most exciting. By making `Transaction.ObservedTimestamps` immutable (which it almost already was), we can prohibit all interior mutability of references within `Transaction`, give it value semantics, and eliminate the distinction between "shallow" and "deep" object cloning. This reduces the cost of a clone to a single straightforward allocation and makes working with the object easier to think about.~

EDIT: these two were removed from this PR.

Past this point, I think the only other change we might want to make here is making a clone of `ba.Txn` in `internalClientAdapter` and then declare that the `Batch` handler goroutine has exclusive ownership over its `ba.Txn`. This would allow us to avoid a few conservative clones that would no longer be necessary, like [here](https://github.com/cockroachdb/cockroach/blob/57e825a7940495b67e0cc7213a5fabc24e12be0e/pkg/storage/store.go#L2827) and [here](https://github.com/cockroachdb/cockroach/blob/57e825a7940495b67e0cc7213a5fabc24e12be0e/pkg/storage/replica.go#L1309). I did not make this change here.