### PR TITLE
workload: run directly on storage engines

### DIFF
--- a/pkg/workload/cli/kv_run.go
+++ b/pkg/workload/cli/kv_run.go
@@ -1,0 +1,171 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/signal"
+
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var kvRunFlags = pflag.NewFlagSet(`kv-run`, pflag.ContinueOnError)
+var usePebble = kvRunFlags.Bool("use-pebble", false, "Use Pebble storage engine.")
+var storeDir = kvRunFlags.String(
+	"store-dir", "",
+	"KV store directory. If not provided, a temporary directory will be used.")
+var dropStore = kvRunFlags.Bool("drop-store", false, "Drop the existing KV database, if it exists")
+
+func init() {
+	AddSubCmd(func(userFacing bool) *cobra.Command {
+		var runCmd = SetCmdDefaults(&cobra.Command{
+			Use:   `kv-run`,
+			Short: `run a workload's operations against a kv storage engine`,
+		})
+
+		// cmdHelper handles common workload command logic, such as error handling and
+		// options validation.
+		cmdHelper := func(
+			gen workload.Generator, fn func(gen workload.Generator) error,
+		) func(*cobra.Command, []string) {
+			return HandleErrs(func(cmd *cobra.Command, args []string) error {
+				if ls := cmd.Flags().Lookup(logflags.LogToStderrName); ls != nil {
+					if !ls.Changed {
+						// Unless the settings were overridden by the user, default to logging
+						// to stderr.
+						_ = ls.Value.Set(log.Severity_INFO.String())
+					}
+				}
+
+				if h, ok := gen.(workload.Hookser); ok {
+					if h.Hooks().Validate != nil {
+						if err := h.Hooks().Validate(); err != nil {
+							return errors.Wrapf(err, "could not validate")
+						}
+					}
+				}
+				return fn(gen)
+			})
+		}
+
+		// runRun makes a storage engine and invokes the main runner
+		runRun := func(gen workload.Generator) error {
+			ctx := context.Background()
+
+			startPProfEndPoint(ctx)
+
+			var dir string
+			var tempdir string
+			if *storeDir == "" {
+				var err error
+				tempdir, err = ioutil.TempDir("", "testing")
+				if err != nil {
+					return err
+				}
+				dir = tempdir
+			} else {
+				dir = *storeDir
+			}
+
+			if *dropStore {
+				for {
+					err := os.RemoveAll(dir)
+					if err == nil {
+						break
+					}
+					if !*tolerateErrors {
+						return err
+					}
+					log.Infof(ctx, "retrying after error during init: %v", err)
+				}
+			}
+
+			r, err := engine.NewRocksDB(
+				engine.RocksDBConfig{
+					Dir: dir,
+				},
+				engine.RocksDBCache{},
+			)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if tempdir != "" {
+					err := os.RemoveAll(tempdir)
+					if err != nil {
+						fmt.Printf("Failed to remove temporary directory: %s: %s\n", tempdir, err.Error())
+					}
+				}
+			}()
+
+			// TODO: this channel is instantiated here because it depends on `exitSignals`
+			// which is in this same package. I think ideally this logic should be in
+			// `KvOpsRun`.
+			done := make(chan os.Signal, 3)
+			signal.Notify(done, exitSignals...)
+
+			opts := workload.KvOpsRunOptions{
+				Duration:       *duration,
+				Histograms:     *histograms,
+				MaxOps:         *maxOps,
+				MaxRate:        *maxRate,
+				Ramp:           *ramp,
+				TolerateErrors: *tolerateErrors,
+			}
+
+			return workload.KvOpsRun(ctx, done, r, gen.(workload.KvOpser), gen.(workload.Hookser), opts)
+		}
+
+		for _, meta := range workload.Registered() {
+			gen := meta.New()
+			if _, ok := gen.(workload.KvOpser); !ok {
+				// If KvOpser is not implemented, this would just fail at runtime,
+				// so omit it.
+				continue
+			}
+
+			var genFlags *pflag.FlagSet
+			if f, ok := gen.(workload.Flagser); ok {
+				genFlags = f.Flags().FlagSet
+			}
+
+			genRunCmd := SetCmdDefaults(&cobra.Command{
+				Use:   meta.Name,
+				Short: meta.Description,
+				Long:  meta.Description + meta.Details,
+				Args:  cobra.ArbitraryArgs,
+			})
+			genRunCmd.Flags().AddFlagSet(kvRunFlags)
+			genRunCmd.Flags().AddFlagSet(sharedFlags)
+			genRunCmd.Flags().AddFlagSet(genFlags)
+			genRunCmd.Run = cmdHelper(gen, runRun)
+			if userFacing && !meta.PublicFacing {
+				genRunCmd.Hidden = true
+			}
+			runCmd.AddCommand(genRunCmd)
+		}
+		return runCmd
+	})
+}

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -43,22 +43,22 @@ import (
 	"golang.org/x/time/rate"
 )
 
+var sharedFlags = pflag.NewFlagSet(`shared`, pflag.ContinueOnError)
 var runFlags = pflag.NewFlagSet(`run`, pflag.ContinueOnError)
-var tolerateErrors = runFlags.Bool("tolerate-errors", false, "Keep running on error")
-var maxRate = runFlags.Float64(
+var tolerateErrors = sharedFlags.Bool("tolerate-errors", false, "Keep running on error")
+var maxRate = sharedFlags.Float64(
 	"max-rate", 0, "Maximum frequency of operations (reads/writes). If 0, no limit.")
-var maxOps = runFlags.Uint64("max-ops", 0, "Maximum number of operations to run")
-var duration = runFlags.Duration("duration", 0, "The duration to run. If 0, run forever.")
+var maxOps = sharedFlags.Uint64("max-ops", 0, "Maximum number of operations to run")
+var duration = sharedFlags.Duration("duration", 0, "The duration to run. If 0, run forever.")
 var doInit = runFlags.Bool("init", false, "Automatically run init")
-var ramp = runFlags.Duration("ramp", 0*time.Second, "The duration over which to ramp up load.")
+var ramp = sharedFlags.Duration("ramp", 0*time.Second, "The duration over which to ramp up load.")
 
 var initFlags = pflag.NewFlagSet(`init`, pflag.ContinueOnError)
 var drop = initFlags.Bool("drop", false, "Drop the existing database, if it exists")
 
-var sharedFlags = pflag.NewFlagSet(`shared`, pflag.ContinueOnError)
-var pprofport = initFlags.Int("pprofport", 33333, "Port for pprof endpoint.")
+var pprofport = sharedFlags.Int("pprofport", 33333, "Port for pprof endpoint.")
 
-var histograms = runFlags.String(
+var histograms = sharedFlags.String(
 	"histograms", "",
 	"File to write per-op incremental and cumulative histogram data.")
 

--- a/pkg/workload/kv_ops_runner.go
+++ b/pkg/workload/kv_ops_runner.go
@@ -1,0 +1,295 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package workload
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/pkg/errors"
+	"golang.org/x/time/rate"
+)
+
+type KvOpsRunOptions struct {
+	Duration       time.Duration
+	Histograms     string
+	MaxOps         uint64
+	MaxRate        float64
+	Ramp           time.Duration
+	TolerateErrors bool
+}
+
+func KvOpsRun(
+	ctx context.Context, done chan os.Signal, eng engine.Engine, opser KvOpser,
+	hookser Hookser, opts KvOpsRunOptions,
+) error {
+	// Number of successful operations
+	var numOps uint64
+
+	var limiter *rate.Limiter
+	if opts.MaxRate > 0 {
+		// Create a limiter using maxRate specified on the command line and
+		// with allowed burst of 1 at the maximum allowed rate.
+		limiter = rate.NewLimiter(rate.Limit(opts.MaxRate), 1)
+	}
+
+	reg := histogram.NewRegistry()
+	var ops QueryLoad
+	for {
+		var err error
+		ops, err = opser.KvOps(eng, reg)
+		if err == nil {
+			break
+		}
+		if !opts.TolerateErrors {
+			return err
+		}
+		log.Infof(ctx, "retrying after error while creating load: %v", err)
+	}
+
+	start := timeutil.Now()
+	errCh := make(chan error)
+	var rampDone chan struct{}
+	if opts.Ramp > 0 {
+		// Create a channel to signal when the ramp period finishes. Will
+		// be reset to nil when consumed by the process loop below.
+		rampDone = make(chan struct{})
+	}
+
+	workersCtx, cancelWorkers := context.WithCancel(ctx)
+	defer cancelWorkers()
+	var wg sync.WaitGroup
+	wg.Add(len(ops.WorkerFns))
+	go func() {
+		// If a ramp period was specified, start all of the workers gradually
+		// with a new context.
+		var rampCtx context.Context
+		if rampDone != nil {
+			var cancel func()
+			rampCtx, cancel = context.WithTimeout(workersCtx, opts.Ramp)
+			defer cancel()
+		}
+
+		for i, workFn := range ops.WorkerFns {
+			go func(i int, workFn func(context.Context) error) {
+				// workerRun is an infinite loop in which the worker continuously attempts to
+				// read / write blocks of random data into a table in cockroach DB. The function
+				// returns only when the provided context is canceled.
+				workerRun := func(
+					ctx context.Context,
+					errCh chan<- error,
+					wg *sync.WaitGroup,
+					limiter *rate.Limiter,
+					workFn func(context.Context) error,
+				) {
+					if wg != nil {
+						defer wg.Done()
+					}
+
+					for {
+						if ctx.Err() != nil {
+							return
+						}
+
+						// Limit how quickly the load generator sends requests based on --max-rate.
+						if limiter != nil {
+							if err := limiter.Wait(ctx); err != nil {
+								if err == ctx.Err() {
+									return
+								}
+								panic(err)
+							}
+						}
+
+						if err := workFn(ctx); err != nil {
+							if errors.Cause(err) == ctx.Err() {
+								return
+							}
+							errCh <- err
+							continue
+						}
+
+						v := atomic.AddUint64(&numOps, 1)
+						if opts.MaxOps > 0 && v >= opts.MaxOps {
+							return
+						}
+					}
+				}
+				// If a ramp period was specified, start all of the workers
+				// gradually with a new context.
+				if rampCtx != nil {
+					rampPerWorker := opts.Ramp / time.Duration(len(ops.WorkerFns))
+					time.Sleep(time.Duration(i) * rampPerWorker)
+					workerRun(rampCtx, errCh, nil /* wg */, limiter, workFn)
+				}
+
+				// Start worker again, this time with the main context.
+				workerRun(workersCtx, errCh, &wg, limiter, workFn)
+			}(i, workFn)
+		}
+
+		if rampCtx != nil {
+			// Wait for the ramp period to finish, then notify the process loop
+			// below to reset timers and histograms.
+			<-rampCtx.Done()
+			close(rampDone)
+		}
+	}()
+
+	var numErr int
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	go func() {
+		wg.Wait()
+		done <- os.Interrupt
+	}()
+
+	if opts.Duration > 0 {
+		go func() {
+			time.Sleep(opts.Duration + opts.Ramp)
+			done <- os.Interrupt
+		}()
+	}
+
+	var jsonEnc *json.Encoder
+	if opts.Histograms != "" {
+		_ = os.MkdirAll(filepath.Dir(opts.Histograms), 0755)
+		jsonF, err := os.Create(opts.Histograms)
+		if err != nil {
+			return err
+		}
+		jsonEnc = json.NewEncoder(jsonF)
+	}
+
+	everySecond := log.Every(time.Second)
+	for i := 0; ; {
+		select {
+		case err := <-errCh:
+			numErr++
+			if opts.TolerateErrors {
+				if everySecond.ShouldLog() {
+					log.Error(ctx, err)
+				}
+				continue
+			}
+			return err
+
+		case <-ticker.C:
+			startElapsed := timeutil.Since(start)
+			reg.Tick(func(t histogram.Tick) {
+				if i%20 == 0 {
+					fmt.Println("_elapsed___errors__ops/sec(inst)___ops/sec(cum)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)")
+				}
+				i++
+				fmt.Printf("%8s %8d %14.1f %14.1f %8.1f %8.1f %8.1f %8.1f %s\n",
+					time.Duration(startElapsed.Seconds()+0.5)*time.Second,
+					numErr,
+					float64(t.Hist.TotalCount())/t.Elapsed.Seconds(),
+					float64(t.Cumulative.TotalCount())/startElapsed.Seconds(),
+					time.Duration(t.Hist.ValueAtQuantile(50)).Seconds()*1000,
+					time.Duration(t.Hist.ValueAtQuantile(95)).Seconds()*1000,
+					time.Duration(t.Hist.ValueAtQuantile(99)).Seconds()*1000,
+					time.Duration(t.Hist.ValueAtQuantile(100)).Seconds()*1000,
+					t.Name,
+				)
+				if jsonEnc != nil && rampDone == nil {
+					_ = jsonEnc.Encode(t.Snapshot())
+				}
+			})
+
+		// Once the load generator is fully ramped up, we reset the histogram
+		// and the start time to throw away the stats for the the ramp up period.
+		case <-rampDone:
+			rampDone = nil
+			start = timeutil.Now()
+			i = 0
+			reg.Tick(func(t histogram.Tick) {
+				t.Cumulative.Reset()
+				t.Hist.Reset()
+			})
+
+		case <-done:
+			cancelWorkers()
+			if ops.Close != nil {
+				ops.Close(ctx)
+			}
+			const totalHeader = "\n_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)"
+			fmt.Println(totalHeader + `__total`)
+			startElapsed := timeutil.Since(start)
+			printTotalHist := func(t histogram.Tick) {
+				if t.Cumulative == nil {
+					return
+				}
+				if t.Cumulative.TotalCount() == 0 {
+					return
+				}
+				fmt.Printf("%7.1fs %8d %14d %14.1f %8.1f %8.1f %8.1f %8.1f %8.1f  %s\n",
+					startElapsed.Seconds(), numErr,
+					t.Cumulative.TotalCount(),
+					float64(t.Cumulative.TotalCount())/startElapsed.Seconds(),
+					time.Duration(t.Cumulative.Mean()).Seconds()*1000,
+					time.Duration(t.Cumulative.ValueAtQuantile(50)).Seconds()*1000,
+					time.Duration(t.Cumulative.ValueAtQuantile(95)).Seconds()*1000,
+					time.Duration(t.Cumulative.ValueAtQuantile(99)).Seconds()*1000,
+					time.Duration(t.Cumulative.ValueAtQuantile(100)).Seconds()*1000,
+					t.Name,
+				)
+			}
+
+			resultTick := histogram.Tick{Name: ops.ResultHist}
+			reg.Tick(func(t histogram.Tick) {
+				printTotalHist(t)
+				if jsonEnc != nil {
+					// Note that we're outputting the delta from the last tick. The
+					// cumulative histogram can be computed by merging all of the
+					// per-tick histograms.
+					_ = jsonEnc.Encode(t.Snapshot())
+				}
+				if ops.ResultHist == `` || ops.ResultHist == t.Name {
+					if resultTick.Cumulative == nil {
+						resultTick.Now = t.Now
+						resultTick.Cumulative = t.Cumulative
+					} else {
+						resultTick.Cumulative.Merge(t.Cumulative)
+					}
+				}
+			})
+
+			fmt.Println(totalHeader + `__result`)
+			printTotalHist(resultTick)
+
+			if hookser != nil {
+				if hookser.Hooks().PostRun != nil {
+					if err := hookser.Hooks().PostRun(startElapsed); err != nil {
+						fmt.Printf("failed post-run hook: %v\n", err)
+					}
+				}
+			}
+			return nil
+		}
+	}
+}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
@@ -82,6 +83,13 @@ type Flagser interface {
 type Opser interface {
 	Generator
 	Ops(urls []string, reg *histogram.Registry) (QueryLoad, error)
+}
+
+// KvOpser returns work functions that synthesize a workload targeting
+// a key-value storage engine directly.
+type KvOpser interface {
+	Generator
+	KvOps(eng engine.Engine, reg *histogram.Registry) (QueryLoad, error)
 }
 
 // Hookser returns any hooks associated with the generator.


### PR DESCRIPTION
This PR forks the `workload run` subcommand to create a `workload kv-run`
that runs the specified workload on RocksDB. The goal is to be able to compare
following three scenarios with a single measurement tool:
    
- RocksDB performance when used via libroach API so it includes CGo overhead. Can be done using `workload kv-run`.
- Pebble performance. Will be done by a future tool in Pebble repo that invokes the function `KvOpsRun` that is introduced in this PR.
- Cockroach performance when SQL queries are derived from basic KV operations. Can be done using the existing `workload kv`.

Release note: None