### PR TITLE
intentresolver: properly update intent meta and status after PENDING push

### DIFF
--- a/pkg/storage/intentresolver/intent_resolver.go
+++ b/pkg/storage/intentresolver/intent_resolver.go
@@ -708,9 +708,9 @@ func (ir *IntentResolver) CleanupTxnIntentsOnGCAsync(
 				}
 				// Get the pushed txn and update the intents slice.
 				txn = &b.RawResponse().Responses[0].GetInner().(*roachpb.PushTxnResponse).PusheeTxn
-				for _, intent := range intents {
-					intent.Txn = txn.TxnMeta
-					intent.Status = txn.Status
+				for i := range intents {
+					intents[i].Txn = txn.TxnMeta
+					intents[i].Status = txn.Status
 				}
 			}
 			var onCleanupComplete func(error)


### PR DESCRIPTION
This change fixes a bug that was revealed by #35165. After performing
a push on PENDING transactions, `IntentResolver.CleanupTxnIntentsOnGCAsync`
would attempt to update its slice of intents to reflect the new transaction
metadata and status. This update was performed on a copy of the intents,
so it wasn't reflected in the intent slice passed to `cleanupFinishedTxnIntents`.

I believe that the effect of this is that cleaning up a PENDING transaction
would take an extra GC round.

The change to `TestGCQueueTransactionTable` makes the test fail without
the fix.

Release note: None