### PR TITLE
opt: Fix test flake in zone test

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -8,7 +8,8 @@ statement ok
 CREATE TABLE t (
     k INT PRIMARY KEY,
     v STRING,
-    INDEX secondary (k) STORING (v)
+    INDEX secondary (k) STORING (v),
+    INDEX tertiary (k) STORING (v)
 );
 
 # ------------------------------------------------------------------------------
@@ -21,6 +22,42 @@ ALTER TABLE t CONFIGURE ZONE USING constraints='[+region=test,+dc=dc2]'
 
 statement ok
 ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]'
+
+query TTT retry
+EXPLAIN SELECT * FROM t WHERE k=10
+----
+scan  ·      ·
+·     table  t@secondary
+·     spans  /10-/11
+
+# ------------------------------------------------------------------------------
+# Move secondary to dc3 and put tertiary in dc1 and ensure that gateway matches
+# tertiary instead of secondary. Regression for #35546.
+# ------------------------------------------------------------------------------
+
+statement ok
+ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc3]'
+
+statement ok
+ALTER INDEX t@tertiary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]'
+
+query TTT retry
+EXPLAIN SELECT * FROM t WHERE k=10
+----
+scan  ·      ·
+·     table  t@tertiary
+·     spans  /10-/11
+
+# ------------------------------------------------------------------------------
+# Swap secondary and tertiary localities and ensure invalidation occurs.
+# Regression for #35546.
+# ------------------------------------------------------------------------------
+
+statement ok
+ALTER INDEX t@secondary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc1]'
+
+statement ok
+ALTER INDEX t@tertiary CONFIGURE ZONE USING constraints='[+region=test,+dc=dc3]'
 
 query TTT retry
 EXPLAIN SELECT * FROM t WHERE k=10

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1026,6 +1026,27 @@ func zonesAreEqual(left, right *config.ZoneConfig) bool {
 	if len(left.Constraints) != len(right.Constraints) {
 		return false
 	}
+	if len(left.Subzones) != len(right.Subzones) {
+		return false
+	}
+
+	for i := range left.Subzones {
+		leftSubzone := &left.Subzones[i]
+		rightSubzone := &right.Subzones[i]
+
+		// Skip subzones that only apply to one partition of an index, since
+		// they're also skipped in newOptTable.
+		if len(leftSubzone.PartitionName) != 0 && len(rightSubzone.PartitionName) != 0 {
+			continue
+		}
+
+		if leftSubzone.IndexID != rightSubzone.IndexID {
+			return false
+		}
+
+		return zonesAreEqual(&leftSubzone.Config, &rightSubzone.Config)
+	}
+
 	for i := range left.Constraints {
 		leftReplCons := &left.Constraints[i]
 		rightReplCons := &right.Constraints[i]

--- a/pkg/sql/opt_catalog_test.go
+++ b/pkg/sql/opt_catalog_test.go
@@ -1,0 +1,101 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// Note that zonesAreEqual only tests equality on fields used by the optimizer.
+func TestZonesAreEqual(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	zone1 := &config.ZoneConfig{}
+	require.Equal(t, zone1, zone1)
+
+	zone2 := &config.ZoneConfig{}
+	require.Equal(t, zone1, zone2)
+
+	constraints1 := []config.Constraints{
+		{NumReplicas: 0, Constraints: []config.Constraint{
+			{Type: config.Constraint_REQUIRED, Key: "k1", Value: "v1"},
+		}},
+	}
+	zone3 := &config.ZoneConfig{Constraints: constraints1}
+	zone4 := &config.ZoneConfig{Constraints: constraints1}
+	require.Equal(t, zone3, zone4)
+
+	zone5 := &config.ZoneConfig{Constraints: []config.Constraints{
+		{NumReplicas: 3, Constraints: []config.Constraint{
+			{Type: config.Constraint_REQUIRED, Key: "k1", Value: "v1"},
+		}},
+	}}
+	require.NotEqual(t, zone4, zone5)
+
+	constraints2 := []config.Constraints{
+		{NumReplicas: 3, Constraints: []config.Constraint{
+			{Type: config.Constraint_REQUIRED, Key: "k1", Value: "v1"},
+		}},
+		{NumReplicas: 1, Constraints: []config.Constraint{
+			{Type: config.Constraint_REQUIRED, Key: "k2", Value: "v2"},
+		}},
+	}
+	zone6 := &config.ZoneConfig{Constraints: constraints2}
+	require.NotEqual(t, zone5, zone6)
+
+	zone7 := &config.ZoneConfig{Constraints: []config.Constraints{
+		{NumReplicas: 3, Constraints: []config.Constraint{
+			{Type: config.Constraint_REQUIRED, Key: "k1", Value: "v1"},
+		}},
+		{NumReplicas: 1, Constraints: []config.Constraint{
+			{Type: config.Constraint_REQUIRED, Key: "k3", Value: "v3"},
+		}},
+	}}
+	require.NotEqual(t, zone6, zone7)
+
+	zone8 := &config.ZoneConfig{Constraints: []config.Constraints{
+		{NumReplicas: 3, Constraints: []config.Constraint{
+			{Type: config.Constraint_REQUIRED, Key: "k1", Value: "v1"},
+		}},
+		{NumReplicas: 1, Constraints: []config.Constraint{
+			{Type: config.Constraint_PROHIBITED, Key: "k2", Value: "v2"},
+		}},
+	}}
+	require.NotEqual(t, zone6, zone8)
+
+	subzones1 := []config.Subzone{{IndexID: 0, Config: *zone3}}
+	zone9 := &config.ZoneConfig{Constraints: constraints1, Subzones: subzones1}
+	require.NotEqual(t, zone3, zone9)
+
+	zone10 := &config.ZoneConfig{Constraints: constraints1, Subzones: []config.Subzone{
+		{IndexID: 1, Config: *zone3},
+	}}
+	require.NotEqual(t, zone9, zone10)
+
+	zone11 := &config.ZoneConfig{Constraints: constraints1, Subzones: []config.Subzone{
+		{IndexID: 1, PartitionName: "p1", Config: *zone3},
+	}}
+	require.NotEqual(t, zone10, zone11)
+
+	zone12 := &config.ZoneConfig{Constraints: constraints1, Subzones: []config.Subzone{
+		{IndexID: 1, Config: *zone3},
+		{IndexID: 2, PartitionName: "p1", Config: *zone3},
+	}}
+	require.NotEqual(t, zone10, zone12)
+}


### PR DESCRIPTION
The zone invalidation code is not correctly invalidating in cases where the new
zone has different subzones than the old. The fixed code adds those checks, as
well as regression tests that more reliably repro and regress the issue.

Fixes #35546

Release note: None