### PR TITLE
*: avoid direct uses of pgerror.CodeInternalError

### DIFF
--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1490,11 +1490,12 @@ func (c *cliState) serverSideParse(sql string) (stmts []string, pgErr *pgerror.E
 			return nil, pgerror.NewError(
 				string(pqErr.Code), pqErr.Message).SetHintf("%s", pqErr.Hint).SetDetailf("%s", pqErr.Detail)
 		}
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "%v", err)
+		return nil, pgerror.NewErrorf(pgerror.CodeDataExceptionError,
+			"unexpected error: %v", err)
 	}
 
 	if len(cols) < 2 {
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
+		return nil, pgerror.NewErrorf(pgerror.CodeDataExceptionError,
 			"invalid results for SHOW SYNTAX: %q %q", cols, rows)
 	}
 
@@ -1520,7 +1521,7 @@ func (c *cliState) serverSideParse(sql string) (stmts []string, pgErr *pgerror.E
 	stmts = make([]string, len(rows))
 	for i := range rows {
 		if rows[i][0] != "sql" {
-			return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
+			return nil, pgerror.NewErrorf(pgerror.CodeDataExceptionError,
 				"invalid results for SHOW SYNTAX: %q %q", cols, rows)
 		}
 		stmts[i] = rows[i][1]

--- a/pkg/sql/distsqlpb/data.go
+++ b/pkg/sql/distsqlpb/data.go
@@ -148,8 +148,8 @@ func NewError(err error) *Error {
 		// Anything unrecognized is an "internal error".
 		return &Error{
 			Detail: &Error_PGError{
-				PGError: pgerror.NewError(
-					pgerror.CodeInternalError, err.Error())}}
+				PGError: pgerror.NewAssertionErrorf(
+					"uncaught error: %+v", err)}}
 	}
 }
 

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -179,7 +179,7 @@ func TestOutbox(t *testing.T) {
 	}
 	for i, m := range metas {
 		expectedStr := fmt.Sprintf("meta %d", i)
-		if m.Err.Error() != expectedStr {
+		if !testutils.IsError(m.Err, expectedStr) {
 			t.Fatalf("expected: %q, got: %q", expectedStr, m.Err.Error())
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -15,10 +15,10 @@ INSERT INTO t VALUES (1,1,1)
 statement ok
 CREATE INDEX foo ON t (b)
 
-statement error pq: column b is of type INT and thus is not indexable with an inverted index
+statement error column b is of type INT and thus is not indexable with an inverted index.*\nHINT.*35730
 CREATE INVERTED INDEX foo_inv ON t(b)
 
-statement error pq: column b is of type INT and thus is not indexable with an inverted index
+statement error column b is of type INT and thus is not indexable with an inverted index.*\nHINT.*35730
 CREATE INDEX foo_inv2 ON t USING GIN (b)
 
 statement error pq: inverted indexes can't be unique
@@ -54,7 +54,7 @@ CREATE TABLE d (
   INVERTED INDEX (foo, bar)
 )
 
-statement error column foo is of type INT and thus is not indexable with an inverted index
+statement error column foo is of type INT and thus is not indexable with an inverted index.*\nHINT.*35730
 CREATE TABLE d (
   id INT PRIMARY KEY,
   foo INT,

--- a/pkg/sql/parser/scan_test.go
+++ b/pkg/sql/parser/scan_test.go
@@ -333,7 +333,7 @@ func TestScanError(t *testing.T) {
 		if lval.id != ERROR {
 			t.Errorf("%s: expected ERROR, but found %d", d.sql, lval.id)
 		}
-		if !testutils.IsError(pgerror.NewError(pgerror.CodeInternalError, lval.str), d.err) {
+		if !testutils.IsError(pgerror.NewError("00000", lval.str), d.err) {
 			t.Errorf("%s: expected %s, but found %v", d.sql, d.err, lval.str)
 		}
 	}

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -150,7 +150,7 @@ The Cockroach Labs team appreciates your feedback.
 `
 
 // NewAssertionErrorf creates an internal error.
-func NewAssertionErrorf(format string, args ...interface{}) error {
+func NewAssertionErrorf(format string, args ...interface{}) *Error {
 	err := NewErrorWithDepthf(1, CodeInternalError, "internal error: "+format, args...)
 	err.InternalCommand = captureTrace()
 	err.Detail = err.InternalCommand

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -439,6 +439,36 @@ func TestLint(t *testing.T) {
 		}
 	})
 
+	t.Run("TestInternalErrorCodes", func(t *testing.T) {
+		t.Parallel()
+		cmd, stderr, filter, err := dirCmd(
+			pkgDir,
+			"git",
+			"grep",
+			"-nE",
+			`[^[:alnum:]]pgerror\.NewError.*pgerror\.CodeInternalError`,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			t.Errorf("\n%s <- forbidden; use pgerror.NewAssertionErrorf() instead", s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
 	t.Run("TestTodoStyle", func(t *testing.T) {
 		t.Parallel()
 		// TODO(tamird): enforce presence of name.

--- a/pkg/util/ipaddr/ipaddr.go
+++ b/pkg/util/ipaddr/ipaddr.go
@@ -96,7 +96,8 @@ func (ipAddr *IPAddr) ToBuffer(appendTo []byte) []byte {
 func (ipAddr *IPAddr) FromBuffer(data []byte) ([]byte, error) {
 	ipAddr.Family = IPFamily(data[0])
 	if ipAddr.Family != IPv4family && ipAddr.Family != IPv6family {
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "IPAddr decoding error: bad family, got %d", ipAddr.Family)
+		return nil, pgerror.NewAssertionErrorf(
+			"IPAddr decoding error: unexpected family, got %d", ipAddr.Family)
 	}
 	ipAddr.Mask = data[1]
 
@@ -511,7 +512,7 @@ func (ip Addr) WriteIPv4Bytes(writer io.Writer) error {
 func (ip Addr) WriteIPv6Bytes(writer io.Writer) error {
 	err := binary.Write(writer, binary.BigEndian, ip.Hi)
 	if err != nil {
-		return pgerror.NewErrorf(pgerror.CodeInternalError, "%s", err)
+		return pgerror.NewAssertionErrorf("unable to write to buffer: %v", err)
 	}
 	return binary.Write(writer, binary.BigEndian, ip.Lo)
 }

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -118,7 +118,7 @@ func jsonTypeFromRootBuffer(v []byte) ([]byte, Type, error) {
 			return v[containerHeaderLen+jEntryLen:], StringJSONType, nil
 		}
 	}
-	return nil, 0, pgerror.NewErrorf(pgerror.CodeInternalError, "unknown type %d", typeTag)
+	return nil, 0, pgerror.NewAssertionErrorf("unknown json type %d", typeTag)
 }
 
 func newEncoded(e jEntry, v []byte) (JSON, error) {
@@ -159,7 +159,8 @@ func newEncoded(e jEntry, v []byte) (JSON, error) {
 
 func getUint32At(v []byte, idx int) (uint32, error) {
 	if idx+4 > len(v) {
-		return 0, pgerror.NewError(pgerror.CodeInternalError, "insufficient bytes to decode uint32 int value")
+		return 0, pgerror.NewAssertionErrorf(
+			"insufficient bytes to decode uint32 int value: %+v", v)
 	}
 
 	return uint32(v[idx])<<24 |
@@ -505,7 +506,7 @@ func (j *jsonEncoded) shallowDecode() (JSON, error) {
 		}
 		return result, nil
 	default:
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unknown type %v", j.typ)
+		return nil, pgerror.NewAssertionErrorf("unknown json type: %v", j.typ)
 	}
 }
 


### PR DESCRIPTION
This patch ensures that internal errors / assertion failures are
instantiated with `pgerror.NewAssertionErrorf` (with a linter to also
enforce in the future).

This is in advance of equipping the constructor with a stack trace
collection service.

Release note: None