### PR TITLE
release-2.1: build: Upgrade base image for deployment dockerfile

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,10 +1,13 @@
-FROM debian:8.9
+FROM debian:9.8-slim
 
-# Install root CAs so we can make SSL connections to phone home and
-# do backups to GCE/AWS/Azure.
+# For deployment, we need
+# libc6 - dynamically linked by cockroach binary
+# ca-certificates - to authenticate TLS connections for telemetry and
+#                   bulk-io with S3/GCS/Azure
+# tzdata - for time zone functions
 RUN apt-get update && \
 	apt-get -y upgrade && \
-	apt-get install -y ca-certificates  && \
+	apt-get install -y libc6 ca-certificates tzdata && \
 	rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /cockroach


### PR DESCRIPTION
Debian 8.x has unpatched security vulnerabilities in the glibc
package (even though it's supposed to be in its LTS period?), so
upgrade to the current 9.x.

https://security-tracker.debian.org/tracker/source-package/glibc

Release note (build change): Release Docker images are now built on
Debian 9.8.