### PR TITLE
stats: convert stats failure into warning

### DIFF
--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -408,7 +408,7 @@ func (r *Refresher) maybeRefreshStats(
 
 		// Log other errors but don't automatically reschedule the refresh, since
 		// that could lead to endless retries.
-		log.Errorf(ctx, "failed to create statistics on table %d: %v", tableID, err)
+		log.Warningf(ctx, "failed to create statistics on table %d: %v", tableID, err)
 		return
 	}
 }


### PR DESCRIPTION
Prior to this commit, failure to successfully create automatic stats
for a table resulted in an error logged to the SQL shell. This commit
converts the error to a warning so that it is not printed in the shell.

Fixes #35668

Release note: None