### PR TITLE
sql: improve inverted index validation performance

### DIFF
--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -718,6 +718,18 @@ func (j *jsonEncoded) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 	return decoded.encodeInvertedIndexKeys(b)
 }
 
+// numInvertedIndexEntries implements the JSON interface.
+func (j *jsonEncoded) numInvertedIndexEntries() (int, error) {
+	if j.isScalar() || j.containerLen == 0 {
+		return 1, nil
+	}
+	decoded, err := j.decode()
+	if err != nil {
+		return 0, err
+	}
+	return decoded.numInvertedIndexEntries()
+}
+
 func (j *jsonEncoded) allPaths() ([]JSON, error) {
 	decoded, err := j.decode()
 	if err != nil {

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -1302,6 +1302,7 @@ func TestNumInvertedIndexEntries(t *testing.T) {
 		{`[[[]]]`, 1},
 		{`[[{}]]`, 1},
 		{`[{}, []]`, 2},
+		{`[1]`, 1},
 		{`[1, 2]`, 2},
 		{`[1, [1]]`, 2},
 		{`[1, 2, 1, 2]`, 2},
@@ -1920,6 +1921,14 @@ func BenchmarkFetchKey(b *testing.B) {
 				}
 			})
 		})
+	}
+}
+
+func BenchmarkJSONNumInvertedIndexEntries(b *testing.B) {
+	j := jsonTestShorthand(sampleJSON)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = NumInvertedIndexEntries(j)
 	}
 }
 


### PR DESCRIPTION
To compute the expected number of keys in an inverted index, we currently
generate every key and count the number of unique keys, since array elements
can produce duplicate keys. This PR avoids some of these allocations by doing a
simple count for every non-array JSON type. For a 25GB table of random JSON
values generated by the workload, I got a ~15% speedup on the `select
sum(crdb_internal.json_num_index_entries(v)) from json.j` query.

Release note: None