### PR TITLE
changfeedccl: bound per-changefeed memory buffer capacity

### DIFF
--- a/pkg/ccl/changefeedccl/buffer.go
+++ b/pkg/ccl/changefeedccl/buffer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -81,6 +82,14 @@ func (b *buffer) Get(ctx context.Context) (bufferEntry, error) {
 		return e, nil
 	}
 }
+
+// memBufferDefaultCapacity is the default capacity for a memBuffer for a single
+// changefeed.
+//
+// TODO(dan): It would be better if all changefeeds shared a single capacity
+// that was given by the operater at startup, like we do for RocksDB and SQL.
+var memBufferDefaultCapacity = envutil.EnvOrDefaultBytes(
+	"COCKROACH_CHANGEFEED_BUFFER_CAPACITY", 1<<30) // 1GB
 
 var memBufferColTypes = []sqlbase.ColumnType{
 	{SemanticType: sqlbase.ColumnType_BYTES}, // kv.Key

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -192,7 +192,7 @@ func emitEntries(
 		scratch, valueCopy = scratch.Copy(encodedValue, 0 /* extraCap */)
 
 		if knobs.BeforeEmitRow != nil {
-			if err := knobs.BeforeEmitRow(); err != nil {
+			if err := knobs.BeforeEmitRow(ctx); err != nil {
 				return err
 			}
 		}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -611,7 +611,7 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 
 			// Set up a hook to pause the changfeed on the next emit.
 			var wg sync.WaitGroup
-			waitSinkHook := func() error {
+			waitSinkHook := func(_ context.Context) error {
 				wg.Wait()
 				return nil
 			}
@@ -888,7 +888,7 @@ func TestChangefeedMonitoring(t *testing.T) {
 		knobs := f.Server().(*server.TestServer).Cfg.TestingKnobs.
 			DistSQL.(*distsqlrun.TestingKnobs).
 			Changefeed.(*TestingKnobs)
-		knobs.BeforeEmitRow = func() error {
+		knobs.BeforeEmitRow = func(_ context.Context) error {
 			<-beforeEmitRowCh
 			return nil
 		}
@@ -1128,7 +1128,7 @@ func TestChangefeedDataTTL(t *testing.T) {
 		knobs := f.Server().(*server.TestServer).Cfg.TestingKnobs.
 			DistSQL.(*distsqlrun.TestingKnobs).
 			Changefeed.(*TestingKnobs)
-		knobs.BeforeEmitRow = func() error {
+		knobs.BeforeEmitRow = func(_ context.Context) error {
 			if atomic.LoadInt32(&shouldWait) == 0 {
 				return nil
 			}
@@ -1203,7 +1203,7 @@ func TestChangefeedSchemaTTL(t *testing.T) {
 		knobs := f.Server().(*server.TestServer).Cfg.TestingKnobs.
 			DistSQL.(*distsqlrun.TestingKnobs).
 			Changefeed.(*TestingKnobs)
-		knobs.BeforeEmitRow = func() error {
+		knobs.BeforeEmitRow = func(_ context.Context) error {
 			if atomic.LoadInt32(&shouldWait) == 0 {
 				return nil
 			}
@@ -1712,4 +1712,58 @@ func TestChangefeedTelemetry(t *testing.T) {
 	t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
 	t.Run(`poller`, pollerTest(sinklessTest, testFn))
+}
+
+func TestChangefeedMemBufferCapacity(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		knobs := f.Server().(*server.TestServer).Cfg.TestingKnobs.
+			DistSQL.(*distsqlrun.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+		// The RowContainer used internally by the memBuffer seems to request from
+		// the budget in 10240 chunks. Set this number high enough for one but not
+		// for a second. I'd love to be able to derive this from constants, but I
+		// don't see how to do that without a refactor.
+		knobs.MemBufferCapacity = 20000
+		beforeEmitRowCh := make(chan struct{}, 1)
+		knobs.BeforeEmitRow = func(ctx context.Context) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-beforeEmitRowCh:
+			}
+			return nil
+		}
+		defer close(beforeEmitRowCh)
+
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (0, 'small')`)
+
+		// Force rangefeed, even for the enterprise test.
+		sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.push.enabled = true`)
+		sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+		sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s'`)
+
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo`)
+		defer closeFeed(t, foo)
+
+		// Small amounts of data fit in the buffer.
+		beforeEmitRowCh <- struct{}{}
+		assertPayloads(t, foo, []string{
+			`foo: [0]->{"after": {"a": 0, "b": "small"}}`,
+		})
+
+		// Put enough data in to overflow the buffer and verify that at some point
+		// we get the "memory budget exceeded" error.
+		sqlDB.Exec(t, `INSERT INTO foo SELECT i, 'foofoofoo' FROM generate_series(1, $1) AS g(i)`, 1000)
+		if _, err := foo.Next(); !testutils.IsError(err, `memory budget exceeded`) {
+			t.Fatalf(`expected "memory budget exceeded" error got: %v`, err)
+		}
+	}
+
+	// The mem buffer is only used with RangeFeed.
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
 }

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -8,13 +8,17 @@
 
 package changefeedccl
 
+import "context"
+
 // TestingKnobs are the testing knobs for changefeed.
 type TestingKnobs struct {
 	// BeforeEmitRow is called before every sink emit row operation.
-	BeforeEmitRow func() error
+	BeforeEmitRow func(context.Context) error
 	// AfterSinkFlush is called after a sink flush operation has returned without
 	// error.
 	AfterSinkFlush func() error
+	// MemBufferCapacity, if non-zero, overrides memBufferDefaultCapacity.
+	MemBufferCapacity int64
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Any changefeed that uses RangeFeed has an in-memory buffer that slurps
from the RangeFeed as fast as possible to avoid SLOW_CONSUMER
disconnections. Previously this buffer had an unbounded capacity, which
meant that a slow sink (or an issue like we're seeing in #35114 where
lots of duplicates get emitted), would OOM. Prevent this by setting a
100MB limit.

Ideally all changefeeds would share a single capacity that was given by
the operater at startup, like we do for RocksDB and SQL, but this is a
much bigger change.

Also ideally, this would do something smarter than erroring, like shut
down the RangeFeeds and keep the changefeed running (so it affects the
changefeed.max_behind_nanos which users are expected to monitor), but
this erroring is simplest to start with.

Touches #35114

Release note (bug fix): `CHANGEFEED`s connected to a slow sink now error
instead of using unbounded amounts of memory.