### PR TITLE
roachprod: provide an error when no subnets exist in a desired region

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -418,7 +418,10 @@ func (p *Provider) allZones(region string) ([]string, error) {
 			ret = append(ret, zone)
 		}
 	}
-
+	if len(ret) == 0 {
+		return nil, fmt.Errorf("no zones are available in region %v, make sure to "+
+			"include at least one valid subnet", region)
+	}
 	return ret, nil
 }
 


### PR DESCRIPTION
Before this PR roachprod would panic on the following input, now it returns a
hopefully helpful error.

```
roachprod create ajwerner-boom -n 61 --clouds=aws --aws-machine-type-ssd=c5d.xlarge --aws-subnet us-west-2a:subnet-0ffd1c2a34c9231ca,us-west-
2b:subnet-0e6c3c944d64cdcaf,us-west-2c:subnet-0987b45308598f96a
Creating cluster ajwerner-boom with 61 nodes
Unable to create cluster:
in provider: aws: no zones are available in region us-east-2, make sure to  include at least one valid subnet
```

Release note: None