### PR TITLE
storageccl: tolerate rewriting keys with fewer columns than expected

### DIFF
--- a/pkg/ccl/storageccl/key_rewriter.go
+++ b/pkg/ccl/storageccl/key_rewriter.go
@@ -176,6 +176,10 @@ func (kr *KeyRewriter) RewriteKey(key []byte) ([]byte, bool, error) {
 			return nil, false, err
 		}
 		k = k[n:]
+		// Check if we ran out of key before getting to an interleave child?
+		if len(k) == 0 {
+			return key, true, nil
+		}
 	}
 	// We might have an interleaved key.
 	k, ok = encoding.DecodeIfInterleavedSentinel(k)


### PR DESCRIPTION
When rewriting a key, if it belongs to an index in which another is interleaved, once we rewrite past the table/index ID prefix, we previously would assume we had to skip exactly the number of columns indexed before checking if there was an interleave child ID to rewrite.

However, if a span's start or end key does not include all the index columns, this assumption is invalid. It is unclear why we'd have such a span boundary, but if we do, the key rewriter has technically done its job if it rewrites all the IDs in the prefix of a key and then finds the key ends in the middle of the column values. While unexpected, strictly from the point of view of the rewriter, the key's IDs are rewritten and it can return.

Release note (enterprise change): Fix a bug in RESTORE where some unusual range boundaries in interleaved tables caused an error.