### PR TITLE
release-2.1: storage: Sync to disk before returning in WaitForApplication

### DIFF
--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -430,3 +430,18 @@ func Scan(engine Reader, start, end MVCCKey, max int64) ([]MVCCKeyValue, error) 
 	})
 	return kvs, err
 }
+
+// WriteSyncNoop carries out a synchronous no-op write to the engine.
+func WriteSyncNoop(ctx context.Context, eng Engine) error {
+	batch := eng.NewBatch()
+	defer batch.Close()
+
+	if err := batch.LogData(nil); err != nil {
+		return err
+	}
+
+	if err := batch.Commit(true /* sync */); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This prevents on-disk inconsistencies when a node crashes in the
middle of a merge and the lease applied index temporarily regresses.

Fixes #33120

Release note (bug fix): Fixed an on-disk inconsistency that could
result from a crash during a range merge.

@cockroachdb/release 