### PR TITLE
stats,opt: finalize automatic stats cluster settings and join reorder limit setting

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -97,8 +97,10 @@
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statistics to be collected</td></tr>
 <tr><td><code>sql.parallel_scans.enabled</code></td><td>boolean</td><td><code>true</code></td><td>parallelizes scanning different ranges when the maximum result size can be deduced</td></tr>
 <tr><td><code>sql.query_cache.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable the query cache</td></tr>
-<tr><td><code>sql.stats.experimental_automatic_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>experimental automatic statistics collection mode</td></tr>
-<tr><td><code>sql.stats.experimental_automatic_collection.max_fraction_idle</code></td><td>float</td><td><code>0.9</code></td><td>maximum fraction of time that automatic statistics sampler processors are idle</td></tr>
+<tr><td><code>sql.stats.automatic_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>automatic statistics collection mode</td></tr>
+<tr><td><code>sql.stats.automatic_collection.fraction_stale_rows</code></td><td>float</td><td><code>0.2</code></td><td>target fraction of stale rows per table that will trigger a statistics refresh</td></tr>
+<tr><td><code>sql.stats.automatic_collection.max_fraction_idle</code></td><td>float</td><td><code>0.9</code></td><td>maximum fraction of time that automatic statistics sampler processors are idle</td></tr>
+<tr><td><code>sql.stats.automatic_collection.min_stale_rows</code></td><td>integer</td><td><code>500</code></td><td>target minimum number of stale rows per table that will trigger a statistics refresh</td></tr>
 <tr><td><code>sql.stats.post_events.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, an event is shown for every CREATE STATISTICS job</td></tr>
 <tr><td><code>sql.tablecache.lease.refresh_limit</code></td><td>integer</td><td><code>50</code></td><td>maximum number of tables to periodically refresh leases for</td></tr>
 <tr><td><code>sql.trace.log_statement_execute</code></td><td>boolean</td><td><code>false</code></td><td>set to true to enable logging of executed statements</td></tr>

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2812,7 +2812,7 @@ func TestCreateStatsAfterRestore(t *testing.T) {
 	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
 	defer cleanupFn()
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=true`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=true`)
 
 	sqlDB.Exec(t, `BACKUP DATABASE data TO $1 WITH revision_history`, localFoo)
 	sqlDB.Exec(t, `CREATE DATABASE "data 2"`)

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -2447,7 +2447,7 @@ func TestCreateStatsAfterImport(t *testing.T) {
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=true`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=true`)
 
 	sqlDB.Exec(t, "IMPORT PGDUMP ($1)", "nodelocal:///cockroachdump/dump.sql")
 

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -535,7 +535,7 @@ func importFixtureTable(
 func disableAutoStats(ctx context.Context, sqlDB *gosql.DB) func() {
 	var autoStatsEnabled bool
 	err := sqlDB.QueryRow(
-		`SHOW CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled`,
+		`SHOW CLUSTER SETTING sql.stats.automatic_collection.enabled`,
 	).Scan(&autoStatsEnabled)
 	if err != nil {
 		log.Warningf(ctx, "error retrieving automatic stats cluster setting: %v", err)
@@ -544,7 +544,7 @@ func disableAutoStats(ctx context.Context, sqlDB *gosql.DB) func() {
 
 	if autoStatsEnabled {
 		_, err = sqlDB.Exec(
-			`SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=false`,
+			`SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false`,
 		)
 		if err != nil {
 			log.Warningf(ctx, "error disabling automatic stats: %v", err)
@@ -552,7 +552,7 @@ func disableAutoStats(ctx context.Context, sqlDB *gosql.DB) func() {
 		}
 		return func() {
 			_, err := sqlDB.Exec(
-				`SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=true`,
+				`SET CLUSTER SETTING sql.stats.automatic_collection.enabled=true`,
 			)
 			if err != nil {
 				log.Warningf(ctx, "error enabling automatic stats: %v", err)

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -174,7 +174,7 @@ func TestImportFixture(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=true`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=true`)
 
 	gen := makeTestWorkload()
 	flag := fmt.Sprintf(`val=%d`, timeutil.Now().UnixNano())

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -87,7 +87,7 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 	// Workaround for #35947. The optimizer currently plans a bad query for TPCC
 	// when it has stats, so disable stats for now.
 	if _, err := db.Exec(
-		`SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false`,
+		`SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`,
 	); err != nil && !strings.Contains(err.Error(), "unknown cluster setting") {
 		t.Fatal(err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -669,6 +669,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	s.statsRefresher = stats.MakeRefresher(
+		s.st,
 		internalExecutor,
 		execCfg.TableStatsCache,
 		stats.DefaultAsOfTime,
@@ -1611,7 +1612,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Start the background thread for periodically refreshing table statistics.
 	if err := s.statsRefresher.Start(
-		ctx, &s.st.SV, s.stopper, stats.DefaultRefreshInterval,
+		ctx, s.stopper, stats.DefaultRefreshInterval,
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -142,11 +142,12 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 
 	var rowsExpected uint64
 	if len(tableStats) > 0 {
+		overhead := sqlstats.AutomaticStatisticsFractionStaleRows.Get(&dsp.st.SV)
 		// Convert to a signed integer first to make the linter happy.
 		rowsExpected = uint64(int64(
 			// The total expected number of rows is the same number that was measured
 			// most recently, plus some overhead for possible insertions.
-			float64(tableStats[0].RowCount) * (1 + sqlstats.TargetFractionOfRowsUpdatedBeforeRefresh),
+			float64(tableStats[0].RowCount) * (1 + overhead),
 		))
 	}
 

--- a/pkg/sql/distsqlpb/processors.pb.go
+++ b/pkg/sql/distsqlpb/processors.pb.go
@@ -67,7 +67,7 @@ func (x *ScanVisibility) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (ScanVisibility) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{0}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{0}
 }
 
 type SketchType int32
@@ -103,7 +103,7 @@ func (x *SketchType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (SketchType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{1}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{1}
 }
 
 // These mirror the aggregate functions supported by sql/parser. See
@@ -199,7 +199,7 @@ func (x *AggregatorSpec_Func) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Func) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{17, 0}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{17, 0}
 }
 
 type AggregatorSpec_Type int32
@@ -245,7 +245,7 @@ func (x *AggregatorSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (AggregatorSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{17, 1}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{17, 1}
 }
 
 type BackfillerSpec_Type int32
@@ -284,7 +284,7 @@ func (x *BackfillerSpec_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (BackfillerSpec_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{18, 0}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{18, 0}
 }
 
 type WindowerSpec_WindowFunc int32
@@ -348,7 +348,7 @@ func (x *WindowerSpec_WindowFunc) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_WindowFunc) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{29, 0}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{29, 0}
 }
 
 // Mode indicates which mode of framing is used.
@@ -392,7 +392,7 @@ func (x *WindowerSpec_Frame_Mode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_Mode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{29, 1, 0}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{29, 1, 0}
 }
 
 // BoundType indicates which type of boundary is used.
@@ -439,7 +439,7 @@ func (x *WindowerSpec_Frame_BoundType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (WindowerSpec_Frame_BoundType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{29, 1, 1}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{29, 1, 1}
 }
 
 // Each processor has the following components:
@@ -488,7 +488,7 @@ func (m *ProcessorSpec) Reset()         { *m = ProcessorSpec{} }
 func (m *ProcessorSpec) String() string { return proto.CompactTextString(m) }
 func (*ProcessorSpec) ProtoMessage()    {}
 func (*ProcessorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{0}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{0}
 }
 func (m *ProcessorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -549,7 +549,7 @@ func (m *PostProcessSpec) Reset()         { *m = PostProcessSpec{} }
 func (m *PostProcessSpec) String() string { return proto.CompactTextString(m) }
 func (*PostProcessSpec) ProtoMessage()    {}
 func (*PostProcessSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{1}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{1}
 }
 func (m *PostProcessSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -607,7 +607,7 @@ func (m *ProcessorCoreUnion) Reset()         { *m = ProcessorCoreUnion{} }
 func (m *ProcessorCoreUnion) String() string { return proto.CompactTextString(m) }
 func (*ProcessorCoreUnion) ProtoMessage()    {}
 func (*ProcessorCoreUnion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{2}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{2}
 }
 func (m *ProcessorCoreUnion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -644,7 +644,7 @@ func (m *NoopCoreSpec) Reset()         { *m = NoopCoreSpec{} }
 func (m *NoopCoreSpec) String() string { return proto.CompactTextString(m) }
 func (*NoopCoreSpec) ProtoMessage()    {}
 func (*NoopCoreSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{3}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{3}
 }
 func (m *NoopCoreSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -679,7 +679,7 @@ func (m *MetadataTestSenderSpec) Reset()         { *m = MetadataTestSenderSpec{}
 func (m *MetadataTestSenderSpec) String() string { return proto.CompactTextString(m) }
 func (*MetadataTestSenderSpec) ProtoMessage()    {}
 func (*MetadataTestSenderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{4}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{4}
 }
 func (m *MetadataTestSenderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -714,7 +714,7 @@ func (m *MetadataTestReceiverSpec) Reset()         { *m = MetadataTestReceiverSp
 func (m *MetadataTestReceiverSpec) String() string { return proto.CompactTextString(m) }
 func (*MetadataTestReceiverSpec) ProtoMessage()    {}
 func (*MetadataTestReceiverSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{5}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{5}
 }
 func (m *MetadataTestReceiverSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -758,7 +758,7 @@ func (m *ValuesCoreSpec) Reset()         { *m = ValuesCoreSpec{} }
 func (m *ValuesCoreSpec) String() string { return proto.CompactTextString(m) }
 func (*ValuesCoreSpec) ProtoMessage()    {}
 func (*ValuesCoreSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{6}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{6}
 }
 func (m *ValuesCoreSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -796,7 +796,7 @@ func (m *TableReaderSpan) Reset()         { *m = TableReaderSpan{} }
 func (m *TableReaderSpan) String() string { return proto.CompactTextString(m) }
 func (*TableReaderSpan) ProtoMessage()    {}
 func (*TableReaderSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{7}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{7}
 }
 func (m *TableReaderSpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -866,7 +866,7 @@ func (m *TableReaderSpec) Reset()         { *m = TableReaderSpec{} }
 func (m *TableReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*TableReaderSpec) ProtoMessage()    {}
 func (*TableReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{8}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{8}
 }
 func (m *TableReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -951,7 +951,7 @@ func (m *JoinReaderSpec) Reset()         { *m = JoinReaderSpec{} }
 func (m *JoinReaderSpec) String() string { return proto.CompactTextString(m) }
 func (*JoinReaderSpec) ProtoMessage()    {}
 func (*JoinReaderSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{9}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{9}
 }
 func (m *JoinReaderSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -997,7 +997,7 @@ func (m *SorterSpec) Reset()         { *m = SorterSpec{} }
 func (m *SorterSpec) String() string { return proto.CompactTextString(m) }
 func (*SorterSpec) ProtoMessage()    {}
 func (*SorterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{10}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{10}
 }
 func (m *SorterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1043,7 +1043,7 @@ func (m *DistinctSpec) Reset()         { *m = DistinctSpec{} }
 func (m *DistinctSpec) String() string { return proto.CompactTextString(m) }
 func (*DistinctSpec) ProtoMessage()    {}
 func (*DistinctSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{11}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{11}
 }
 func (m *DistinctSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1101,7 +1101,7 @@ func (m *ZigzagJoinerSpec) Reset()         { *m = ZigzagJoinerSpec{} }
 func (m *ZigzagJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*ZigzagJoinerSpec) ProtoMessage()    {}
 func (*ZigzagJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{12}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{12}
 }
 func (m *ZigzagJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1145,7 +1145,7 @@ func (m *LocalPlanNodeSpec) Reset()         { *m = LocalPlanNodeSpec{} }
 func (m *LocalPlanNodeSpec) String() string { return proto.CompactTextString(m) }
 func (*LocalPlanNodeSpec) ProtoMessage()    {}
 func (*LocalPlanNodeSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{13}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{13}
 }
 func (m *LocalPlanNodeSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1180,7 +1180,7 @@ func (m *Columns) Reset()         { *m = Columns{} }
 func (m *Columns) String() string { return proto.CompactTextString(m) }
 func (*Columns) ProtoMessage()    {}
 func (*Columns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{14}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{14}
 }
 func (m *Columns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1250,7 +1250,7 @@ func (m *MergeJoinerSpec) Reset()         { *m = MergeJoinerSpec{} }
 func (m *MergeJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*MergeJoinerSpec) ProtoMessage()    {}
 func (*MergeJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{15}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{15}
 }
 func (m *MergeJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1339,7 +1339,7 @@ func (m *HashJoinerSpec) Reset()         { *m = HashJoinerSpec{} }
 func (m *HashJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*HashJoinerSpec) ProtoMessage()    {}
 func (*HashJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{16}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{16}
 }
 func (m *HashJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1387,7 +1387,7 @@ func (m *AggregatorSpec) Reset()         { *m = AggregatorSpec{} }
 func (m *AggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec) ProtoMessage()    {}
 func (*AggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{17}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{17}
 }
 func (m *AggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1440,7 +1440,7 @@ func (m *AggregatorSpec_Aggregation) Reset()         { *m = AggregatorSpec_Aggre
 func (m *AggregatorSpec_Aggregation) String() string { return proto.CompactTextString(m) }
 func (*AggregatorSpec_Aggregation) ProtoMessage()    {}
 func (*AggregatorSpec_Aggregation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{17, 0}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{17, 0}
 }
 func (m *AggregatorSpec_Aggregation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1500,7 +1500,7 @@ func (m *BackfillerSpec) Reset()         { *m = BackfillerSpec{} }
 func (m *BackfillerSpec) String() string { return proto.CompactTextString(m) }
 func (*BackfillerSpec) ProtoMessage()    {}
 func (*BackfillerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{18}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{18}
 }
 func (m *BackfillerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1540,7 +1540,7 @@ func (m *FlowSpec) Reset()         { *m = FlowSpec{} }
 func (m *FlowSpec) String() string { return proto.CompactTextString(m) }
 func (*FlowSpec) ProtoMessage()    {}
 func (*FlowSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{19}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{19}
 }
 func (m *FlowSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1582,7 +1582,7 @@ func (m *JobProgress) Reset()         { *m = JobProgress{} }
 func (m *JobProgress) String() string { return proto.CompactTextString(m) }
 func (*JobProgress) ProtoMessage()    {}
 func (*JobProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{20}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{20}
 }
 func (m *JobProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1642,7 +1642,7 @@ func (m *ReadImportDataSpec) Reset()         { *m = ReadImportDataSpec{} }
 func (m *ReadImportDataSpec) String() string { return proto.CompactTextString(m) }
 func (*ReadImportDataSpec) ProtoMessage()    {}
 func (*ReadImportDataSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{21}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{21}
 }
 func (m *ReadImportDataSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1689,7 +1689,7 @@ func (m *SSTWriterSpec) Reset()         { *m = SSTWriterSpec{} }
 func (m *SSTWriterSpec) String() string { return proto.CompactTextString(m) }
 func (*SSTWriterSpec) ProtoMessage()    {}
 func (*SSTWriterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{22}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{22}
 }
 func (m *SSTWriterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1727,7 +1727,7 @@ func (m *SSTWriterSpec_SpanName) Reset()         { *m = SSTWriterSpec_SpanName{}
 func (m *SSTWriterSpec_SpanName) String() string { return proto.CompactTextString(m) }
 func (*SSTWriterSpec_SpanName) ProtoMessage()    {}
 func (*SSTWriterSpec_SpanName) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{22, 0}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{22, 0}
 }
 func (m *SSTWriterSpec_SpanName) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1771,7 +1771,7 @@ func (m *CSVWriterSpec) Reset()         { *m = CSVWriterSpec{} }
 func (m *CSVWriterSpec) String() string { return proto.CompactTextString(m) }
 func (*CSVWriterSpec) ProtoMessage()    {}
 func (*CSVWriterSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{23}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{23}
 }
 func (m *CSVWriterSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1818,7 +1818,7 @@ func (m *SketchSpec) Reset()         { *m = SketchSpec{} }
 func (m *SketchSpec) String() string { return proto.CompactTextString(m) }
 func (*SketchSpec) ProtoMessage()    {}
 func (*SketchSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{24}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{24}
 }
 func (m *SketchSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1884,7 +1884,7 @@ type SamplerSpec struct {
 	//
 	// Currently, this field is set only for automatic statistics based on the
 	// value of the cluster setting
-	// sql.stats.experimental_automatic_collection.max_fraction_idle.
+	// sql.stats.automatic_collection.max_fraction_idle.
 	MaxFractionIdle      float64  `protobuf:"fixed64,3,opt,name=max_fraction_idle,json=maxFractionIdle" json:"max_fraction_idle"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -1894,7 +1894,7 @@ func (m *SamplerSpec) Reset()         { *m = SamplerSpec{} }
 func (m *SamplerSpec) String() string { return proto.CompactTextString(m) }
 func (*SamplerSpec) ProtoMessage()    {}
 func (*SamplerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{25}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{25}
 }
 func (m *SamplerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1957,7 +1957,7 @@ func (m *SampleAggregatorSpec) Reset()         { *m = SampleAggregatorSpec{} }
 func (m *SampleAggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*SampleAggregatorSpec) ProtoMessage()    {}
 func (*SampleAggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{26}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{26}
 }
 func (m *SampleAggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2022,7 +2022,7 @@ func (m *InterleavedReaderJoinerSpec) Reset()         { *m = InterleavedReaderJo
 func (m *InterleavedReaderJoinerSpec) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{27}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{27}
 }
 func (m *InterleavedReaderJoinerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2080,7 +2080,7 @@ func (m *InterleavedReaderJoinerSpec_Table) Reset()         { *m = InterleavedRe
 func (m *InterleavedReaderJoinerSpec_Table) String() string { return proto.CompactTextString(m) }
 func (*InterleavedReaderJoinerSpec_Table) ProtoMessage()    {}
 func (*InterleavedReaderJoinerSpec_Table) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{27, 0}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{27, 0}
 }
 func (m *InterleavedReaderJoinerSpec_Table) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2122,7 +2122,7 @@ func (m *ProjectSetSpec) Reset()         { *m = ProjectSetSpec{} }
 func (m *ProjectSetSpec) String() string { return proto.CompactTextString(m) }
 func (*ProjectSetSpec) ProtoMessage()    {}
 func (*ProjectSetSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{28}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{28}
 }
 func (m *ProjectSetSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2166,7 +2166,7 @@ func (m *WindowerSpec) Reset()         { *m = WindowerSpec{} }
 func (m *WindowerSpec) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec) ProtoMessage()    {}
 func (*WindowerSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{29}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{29}
 }
 func (m *WindowerSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2204,7 +2204,7 @@ func (m *WindowerSpec_Func) Reset()         { *m = WindowerSpec_Func{} }
 func (m *WindowerSpec_Func) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Func) ProtoMessage()    {}
 func (*WindowerSpec_Func) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{29, 0}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{29, 0}
 }
 func (m *WindowerSpec_Func) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2241,7 +2241,7 @@ func (m *WindowerSpec_Frame) Reset()         { *m = WindowerSpec_Frame{} }
 func (m *WindowerSpec_Frame) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame) ProtoMessage()    {}
 func (*WindowerSpec_Frame) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{29, 1}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{29, 1}
 }
 func (m *WindowerSpec_Frame) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2283,7 +2283,7 @@ func (m *WindowerSpec_Frame_Bound) Reset()         { *m = WindowerSpec_Frame_Bou
 func (m *WindowerSpec_Frame_Bound) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bound) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bound) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{29, 1, 0}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{29, 1, 0}
 }
 func (m *WindowerSpec_Frame_Bound) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2321,7 +2321,7 @@ func (m *WindowerSpec_Frame_Bounds) Reset()         { *m = WindowerSpec_Frame_Bo
 func (m *WindowerSpec_Frame_Bounds) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_Frame_Bounds) ProtoMessage()    {}
 func (*WindowerSpec_Frame_Bounds) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{29, 1, 1}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{29, 1, 1}
 }
 func (m *WindowerSpec_Frame_Bounds) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2371,7 +2371,7 @@ func (m *WindowerSpec_WindowFn) Reset()         { *m = WindowerSpec_WindowFn{} }
 func (m *WindowerSpec_WindowFn) String() string { return proto.CompactTextString(m) }
 func (*WindowerSpec_WindowFn) ProtoMessage()    {}
 func (*WindowerSpec_WindowFn) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{29, 2}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{29, 2}
 }
 func (m *WindowerSpec_WindowFn) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2410,7 +2410,7 @@ func (m *ChangeAggregatorSpec) Reset()         { *m = ChangeAggregatorSpec{} }
 func (m *ChangeAggregatorSpec) String() string { return proto.CompactTextString(m) }
 func (*ChangeAggregatorSpec) ProtoMessage()    {}
 func (*ChangeAggregatorSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{30}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{30}
 }
 func (m *ChangeAggregatorSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2446,7 +2446,7 @@ func (m *ChangeAggregatorSpec_Watch) Reset()         { *m = ChangeAggregatorSpec
 func (m *ChangeAggregatorSpec_Watch) String() string { return proto.CompactTextString(m) }
 func (*ChangeAggregatorSpec_Watch) ProtoMessage()    {}
 func (*ChangeAggregatorSpec_Watch) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{30, 0}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{30, 0}
 }
 func (m *ChangeAggregatorSpec_Watch) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2491,7 +2491,7 @@ func (m *ChangeFrontierSpec) Reset()         { *m = ChangeFrontierSpec{} }
 func (m *ChangeFrontierSpec) String() string { return proto.CompactTextString(m) }
 func (*ChangeFrontierSpec) ProtoMessage()    {}
 func (*ChangeFrontierSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_processors_b792cab98a5e2997, []int{31}
+	return fileDescriptor_processors_a3aa49cacbc6cfe8, []int{31}
 }
 func (m *ChangeFrontierSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -13393,10 +13393,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("sql/distsqlpb/processors.proto", fileDescriptor_processors_b792cab98a5e2997)
+	proto.RegisterFile("sql/distsqlpb/processors.proto", fileDescriptor_processors_a3aa49cacbc6cfe8)
 }
 
-var fileDescriptor_processors_b792cab98a5e2997 = []byte{
+var fileDescriptor_processors_a3aa49cacbc6cfe8 = []byte{
 	// 4130 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x7a, 0x3d, 0x70, 0x1b, 0x49,
 	0x76, 0xbf, 0xf0, 0x0d, 0x3c, 0x7c, 0x70, 0xd4, 0xa2, 0x56, 0x58, 0xee, 0xfe, 0x45, 0x09, 0xbb,

--- a/pkg/sql/distsqlpb/processors.proto
+++ b/pkg/sql/distsqlpb/processors.proto
@@ -774,7 +774,7 @@ message SamplerSpec {
   //
   // Currently, this field is set only for automatic statistics based on the
   // value of the cluster setting
-  // sql.stats.experimental_automatic_collection.max_fraction_idle.
+  // sql.stats.automatic_collection.max_fraction_idle.
   optional double max_fraction_idle = 3 [(gogoproto.nullable) = false];
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -233,7 +233,7 @@ subtest regression_33361
 
 # Disable automatic stats to avoid flakiness (sometimes causes retry errors).
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 
 statement ok
 CREATE TABLE t33361(x INT PRIMARY KEY, y INT UNIQUE, z INT); INSERT INTO t33361 VALUES (1, 2, 3)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -5,7 +5,7 @@ CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c), INDE
 
 # Enable automatic stats
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = true
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = true
 
 # Generate all combinations of values 1 to 10.
 statement ok
@@ -26,7 +26,7 @@ __auto__         {d}           1000       0               1000
 
 # Disable automatic stats
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 
 # Update more than 20% of the table.
 statement ok
@@ -45,7 +45,7 @@ __auto__         {d}           1000       0               1000
 
 # Enable automatic stats
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = true
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = true
 
 # Update more than 20% of the table.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2,7 +2,7 @@
 
 # Disable automatic stats.
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d), INDEX c_idx (c, d))

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -363,12 +363,13 @@ SELECT "targetID", "reportingID", "info"
 FROM system.eventlog
 WHERE "eventType" = 'set_cluster_setting'
 AND info NOT LIKE '%version%' AND info NOT LIKE '%sql.defaults.distsql%' AND info NOT LIKE '%cluster.secret%'
-AND info NOT LIKE '%sql.stats.experimental_automatic_collection.enabled%'
+AND info NOT LIKE '%sql.stats.automatic_collection.enabled%'
 ORDER BY "timestamp"
 ----
 0  1  {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"root"}
 0  1  {"SettingName":"trace.debug.enable","Value":"false","User":"root"}
 0  1  {"SettingName":"kv.range_merge.queue_enabled","Value":"false","User":"root"}
+0  1  {"SettingName":"sql.stats.automatic_collection.min_stale_rows","Value":"5","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"false","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"DEFAULT","User":"root"}
 0  1  {"SettingName":"cluster.organization","Value":"'some string'","User":"root"}

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -2,7 +2,7 @@
 
 # Disable automatic stats to avoid flakiness.
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 
 statement ok
 CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE)

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1433,7 +1433,6 @@ default_transaction_read_only        off           NULL      NULL        NULL   
 distsql                              off           NULL      NULL        NULL        string
 experimental_enable_zigzag_join      on            NULL      NULL        NULL        string
 experimental_force_split_at          off           NULL      NULL        NULL        string
-experimental_reorder_joins_limit     4             NULL      NULL        NULL        string
 experimental_serial_normalization    rowid         NULL      NULL        NULL        string
 experimental_vectorize               off           NULL      NULL        NULL        string
 extra_float_digits                   0             NULL      NULL        NULL        string
@@ -1444,6 +1443,7 @@ intervalstyle                        postgres      NULL      NULL        NULL   
 lock_timeout                         0             NULL      NULL        NULL        string
 max_index_keys                       32            NULL      NULL        NULL        string
 node_id                              1             NULL      NULL        NULL        string
+reorder_joins_limit                  4             NULL      NULL        NULL        string
 results_buffer_size                  16384         NULL      NULL        NULL        string
 row_security                         off           NULL      NULL        NULL        string
 search_path                          public        NULL      NULL        NULL        string
@@ -1483,7 +1483,6 @@ default_transaction_read_only        off           NULL  user     NULL      off 
 distsql                              off           NULL  user     NULL      off           off
 experimental_enable_zigzag_join      on            NULL  user     NULL      on            on
 experimental_force_split_at          off           NULL  user     NULL      off           off
-experimental_reorder_joins_limit     4             NULL  user     NULL      4             4
 experimental_serial_normalization    rowid         NULL  user     NULL      rowid         rowid
 experimental_vectorize               off           NULL  user     NULL      off           off
 extra_float_digits                   0             NULL  user     NULL      0             2
@@ -1494,6 +1493,7 @@ intervalstyle                        postgres      NULL  user     NULL      post
 lock_timeout                         0             NULL  user     NULL      0             0
 max_index_keys                       32            NULL  user     NULL      32            32
 node_id                              1             NULL  user     NULL      1             1
+reorder_joins_limit                  4             NULL  user     NULL      4             4
 results_buffer_size                  16384         NULL  user     NULL      16384         16384
 row_security                         off           NULL  user     NULL      off           off
 search_path                          public        NULL  user     NULL      public        public
@@ -1529,7 +1529,6 @@ default_transaction_read_only        NULL    NULL     NULL     NULL        NULL
 distsql                              NULL    NULL     NULL     NULL        NULL
 experimental_enable_zigzag_join      NULL    NULL     NULL     NULL        NULL
 experimental_force_split_at          NULL    NULL     NULL     NULL        NULL
-experimental_reorder_joins_limit     NULL    NULL     NULL     NULL        NULL
 experimental_serial_normalization    NULL    NULL     NULL     NULL        NULL
 experimental_vectorize               NULL    NULL     NULL     NULL        NULL
 extra_float_digits                   NULL    NULL     NULL     NULL        NULL
@@ -1541,6 +1540,7 @@ lock_timeout                         NULL    NULL     NULL     NULL        NULL
 max_index_keys                       NULL    NULL     NULL     NULL        NULL
 node_id                              NULL    NULL     NULL     NULL        NULL
 optimizer                            NULL    NULL     NULL     NULL        NULL
+reorder_joins_limit                  NULL    NULL     NULL     NULL        NULL
 results_buffer_size                  NULL    NULL     NULL     NULL        NULL
 row_security                         NULL    NULL     NULL     NULL        NULL
 search_path                          NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -2,7 +2,7 @@
 
 # Disable automatic stats to avoid flakiness.
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 
 # Test default table-level permissions.
 # Default user is root.

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -2,7 +2,7 @@
 
 # Disable automatic stats to avoid flakiness (sometimes causes retry errors).
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 
 subtest create_and_add_fk_in_same_txn
 

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -38,7 +38,6 @@ default_transaction_read_only        off
 distsql                              off
 experimental_enable_zigzag_join      on
 experimental_force_split_at          off
-experimental_reorder_joins_limit     4
 experimental_serial_normalization    rowid
 experimental_vectorize               off
 extra_float_digits                   0
@@ -49,6 +48,7 @@ intervalstyle                        postgres
 lock_timeout                         0
 max_index_keys                       32
 node_id                              1
+reorder_joins_limit                  4
 results_buffer_size                  16384
 row_security                         off
 search_path                          public

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -442,12 +442,13 @@ query T
 SELECT name
 FROM system.settings
 WHERE name != 'sql.defaults.distsql'
-AND name != 'sql.stats.experimental_automatic_collection.enabled'
+AND name != 'sql.stats.automatic_collection.enabled'
 ORDER BY name
 ----
 cluster.secret
 diagnostics.reporting.enabled
 kv.range_merge.queue_enabled
+sql.stats.automatic_collection.min_stale_rows
 trace.debug.enable
 version
 
@@ -458,13 +459,14 @@ query TT
 SELECT name, value
 FROM system.settings
 WHERE name NOT IN ('version', 'sql.defaults.distsql', 'cluster.secret',
-  'sql.stats.experimental_automatic_collection.enabled')
+  'sql.stats.automatic_collection.enabled')
 ORDER BY name
 ----
-diagnostics.reporting.enabled  true
-kv.range_merge.queue_enabled   false
-somesetting                    somevalue
-trace.debug.enable             false
+diagnostics.reporting.enabled                  true
+kv.range_merge.queue_enabled                   false
+somesetting                                    somevalue
+sql.stats.automatic_collection.min_stale_rows  5
+trace.debug.enable                             false
 
 user testuser
 

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -2,7 +2,7 @@
 
 # Disable automatic stats.
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 
 statement ok
 CREATE TABLE a (a INT, b INT, PRIMARY KEY (a, b))

--- a/pkg/sql/logictest/testdata/planner_test/show_trace
+++ b/pkg/sql/logictest/testdata/planner_test/show_trace
@@ -2,7 +2,7 @@
 
 # Disable automatic stats.
 statement ok
-SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
 
 # Check SHOW KV TRACE FOR SESSION.
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_env
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_env
@@ -214,7 +214,7 @@ inner-join
 #
 
 statement ok
-SET experimental_reorder_joins_limit = 100
+SET reorder_joins_limit = 100
 
 query T
 SELECT text FROM [
@@ -233,7 +233,7 @@ CREATE TABLE y (
 ·
 ALTER TABLE test.public.y INJECT STATISTICS '[]';
 ·
-SET experimental_reorder_joins_limit = 100;
+SET reorder_joins_limit = 100;
 ·
 SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM y WHERE u = 3] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
 ----
@@ -260,7 +260,7 @@ CREATE TABLE y (
 ·
 ALTER TABLE test.public.y INJECT STATISTICS '[]';
 ·
-SET experimental_reorder_joins_limit = 100;
+SET reorder_joins_limit = 100;
 ·
 SET experimental_enable_zigzag_join = off;
 ·
@@ -270,7 +270,7 @@ scan y
  └── constraint: /1: [/3 - /3]
 
 statement ok
-RESET experimental_reorder_joins_limit
+RESET reorder_joins_limit
 
 statement ok
 RESET experimental_enable_zigzag_join

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -27,7 +27,7 @@ CREATE TABLE abc (
 )
 
 statement ok
-SET experimental_reorder_joins_limit = 0
+SET reorder_joins_limit = 0
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
@@ -59,7 +59,7 @@ render               ·                   ·                (a, b, c, d, b, x, c
 ·                    spans               /1-/1/#          ·                         ·
 
 statement ok
-SET experimental_reorder_joins_limit = 3
+SET reorder_joins_limit = 3
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc, bx, cy WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -984,7 +984,7 @@ FROM
 	// Show the values of any non-default session variables that can impact
 	// planning decisions.
 	for _, param := range []string{
-		"experimental_reorder_joins_limit",
+		"reorder_joins_limit",
 		"experimental_enable_zigzag_join",
 	} {
 		value, err := ef.environmentQuery(fmt.Sprintf("SHOW %s", param))

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -4235,7 +4235,7 @@ func TestCreateStatsAfterSchemaChange(t *testing.T) {
 		CREATE DATABASE t;
 		CREATE TABLE t.test (k INT PRIMARY KEY, v CHAR, w CHAR);`)
 
-	sqlRun.Exec(t, `SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=true`)
+	sqlRun.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=true`)
 
 	// Add an index.
 	sqlRun.Exec(t, `CREATE INDEX foo ON t.test (w)`)

--- a/pkg/sql/stats/automatic_stats_manual_test.go
+++ b/pkg/sql/stats/automatic_stats_manual_test.go
@@ -65,7 +65,7 @@ func TestAdaptiveThrottling(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	r := sqlutils.MakeSQLRunner(sqlDB)
-	r.Exec(t, "SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false")
+	r.Exec(t, "SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false")
 	r.Exec(t, "CREATE TABLE xyz (x INT, y INT, z INT)")
 
 	// log prints the message to stdout and to the test log.

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -41,15 +41,12 @@ func TestMaybeRefreshStats(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.NewTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 
-	AutomaticStatisticsClusterMode.Override(&evalCtx.Settings.SV, false)
-
-	defer func(oldMin int) {
-		TargetMinRowsUpdatedBeforeRefresh = oldMin
-	}(TargetMinRowsUpdatedBeforeRefresh)
-	TargetMinRowsUpdatedBeforeRefresh = 5
+	AutomaticStatisticsClusterMode.Override(&st.SV, false)
+	AutomaticStatisticsMinStaleRows.Override(&st.SV, 5)
 
 	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
 	sqlRun.Exec(t,
@@ -61,7 +58,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	descA := sqlbase.GetTableDescriptor(s.DB(), "t", "a")
 	cache := NewTableStatisticsCache(10 /* cacheSize */, s.Gossip(), kvDB, executor)
-	refresher := MakeRefresher(executor, cache, time.Microsecond /* asOfTime */)
+	refresher := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
 	// There should not be any stats yet.
 	if err := checkStatsCount(ctx, cache, descA.ID, 0 /* expected */); err != nil {
@@ -116,10 +113,11 @@ func TestAverageRefreshTime(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.NewTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 
-	AutomaticStatisticsClusterMode.Override(&evalCtx.Settings.SV, false)
+	AutomaticStatisticsClusterMode.Override(&st.SV, false)
 
 	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
 	sqlRun.Exec(t,
@@ -130,7 +128,7 @@ func TestAverageRefreshTime(t *testing.T) {
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	tableID := sqlbase.GetTableDescriptor(s.DB(), "t", "a").ID
 	cache := NewTableStatisticsCache(10 /* cacheSize */, s.Gossip(), kvDB, executor)
-	refresher := MakeRefresher(executor, cache, time.Microsecond /* asOfTime */)
+	refresher := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
 	checkAverageRefreshTime := func(expected time.Duration) error {
 		cache.InvalidateTableStats(ctx, tableID)
@@ -346,12 +344,12 @@ func TestAutoStatsReadOnlyTables(t *testing.T) {
 
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	cache := NewTableStatisticsCache(10 /* cacheSize */, s.Gossip(), kvDB, executor)
-	refresher := MakeRefresher(executor, cache, time.Microsecond /* asOfTime */)
+	refresher := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
 	AutomaticStatisticsClusterMode.Override(&st.SV, true)
 
 	if err := refresher.Start(
-		ctx, &st.SV, s.Stopper(), time.Millisecond, /* refreshInterval */
+		ctx, s.Stopper(), time.Millisecond, /* refreshInterval */
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -371,12 +369,13 @@ func TestNoRetryOnFailure(t *testing.T) {
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.NewTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 
 	executor := s.InternalExecutor().(sqlutil.InternalExecutor)
 	cache := NewTableStatisticsCache(10 /* cacheSize */, s.Gossip(), kvDB, executor)
-	r := MakeRefresher(executor, cache, time.Microsecond /* asOfTime */)
+	r := MakeRefresher(st, executor, cache, time.Microsecond /* asOfTime */)
 
 	// Try to refresh stats on a table that doesn't exist.
 	r.maybeRefreshStats(

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -436,7 +436,7 @@ func TestCreateStatsProgress(t *testing.T) {
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`)
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE d.t (i INT8 PRIMARY KEY)`)
 	sqlDB.Exec(t, `INSERT INTO d.t SELECT generate_series(1,1000)`)

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -343,12 +343,16 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
-	`experimental_reorder_joins_limit`: {
-		GetStringVal: makeIntGetStringValFn(`experimental_reorder_joins_limit`),
+	`reorder_joins_limit`: {
+		GetStringVal: makeIntGetStringValFn(`reorder_joins_limit`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			b, err := strconv.ParseInt(s, 10, 64)
 			if err != nil {
 				return err
+			}
+			if b < 0 {
+				return pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError,
+					"cannot set reorder_joins_limit to a negative value: %d", b)
 			}
 			m.SetReorderJoinsLimit(int(b))
 			return nil


### PR DESCRIPTION
This PR removes "experimental" from the two existing cluster
settings for automatic stats. It also adds two new cluster settings,
`sql.stats.automatic_collection.fraction_stale_rows` and
`sql.stats.automatic_collection.min_stale_rows`, which control
the target number of rows in a table that should be stale before
statistics on that table are refreshed.

This PR also removes "experimental" from the `experimental_reorder_joins_limit`
session setting. It also adds validation to ensure users cannot set it to
a negative value.

Closes #35544
Fixes #35348

