### PR TITLE
changefeedccl: add telemetry for push/poll at changefeed startup

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlplan"
@@ -71,6 +72,13 @@ func distChangefeedFlow(
 		return err
 	}
 
+	execCfg := phs.ExecCfg()
+	if PushEnabled.Get(&execCfg.Settings.SV) {
+		telemetry.Count(`changefeed.run.push.enabled`)
+	} else {
+		telemetry.Count(`changefeed.run.push.disabled`)
+	}
+
 	spansTS := details.StatementTime
 	var initialHighWater hlc.Timestamp
 	if h := progress.GetHighWater(); h != nil && *h != (hlc.Timestamp{}) {
@@ -80,7 +88,6 @@ func distChangefeedFlow(
 		spansTS = initialHighWater
 	}
 
-	execCfg := phs.ExecCfg()
 	trackedSpans, err := fetchSpansForTargets(ctx, execCfg.DB, details.Targets, spansTS)
 	if err != nil {
 		return err

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1702,11 +1702,19 @@ func TestChangefeedTelemetry(t *testing.T) {
 			expectedSink = `experimental-sql`
 		}
 
+		var expectedPushEnabled string
+		if strings.Contains(t.Name(), `sinkless`) {
+			expectedPushEnabled = `enabled`
+		} else {
+			expectedPushEnabled = `disabled`
+		}
+
 		counts := telemetry.GetAndResetFeatureCounts(false)
 		require.Equal(t, int32(2), counts[`changefeed.create.sink.`+expectedSink])
 		require.Equal(t, int32(2), counts[`changefeed.create.format.json`])
 		require.Equal(t, int32(1), counts[`changefeed.create.num_tables.1`])
 		require.Equal(t, int32(1), counts[`changefeed.create.num_tables.2`])
+		require.Equal(t, int32(2), counts[`changefeed.run.push.`+expectedPushEnabled])
 	}
 
 	t.Run(`sinkless`, sinklessTest(testFn))


### PR DESCRIPTION
This depends on a cluster setting that is consulted once when a
changefeed is created/unpaused, so put it in "changefeed.run" instead of
"changefeed.start".

The relevant features

    changefeed.run.push.enabled
    changefeed.run.push.disabled

Closes #35434

Release note: None