### PR TITLE
roachprod: add public keys for all users to authorized_keys on AWS

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -613,7 +613,7 @@ func (p *Provider) runInstance(name string, zone string, opts vm.CreateOpts) err
 	}
 	filename, err := writeStartupScript(extraMountOpts)
 	if err != nil {
-		return errors.Wrapf(err, "could not write GCE startup script to temp file")
+		return errors.Wrapf(err, "could not write AWS startup script to temp file")
 	}
 	defer func() {
 		_ = os.Remove(filename)

--- a/pkg/cmd/roachprod/vm/aws/support.go
+++ b/pkg/cmd/roachprod/vm/aws/support.go
@@ -37,7 +37,7 @@ import (
 // mounting options. The script cannot take arguments since it is to be invoked
 // by the aws tool which cannot pass args.
 const awsStartupScriptTemplate = `#!/usr/bin/env bash
-# Script for setting up a GCE machine for roachprod use.
+# Script for setting up a AWS machine for roachprod use.
 
 set -x
 sudo apt-get update
@@ -124,7 +124,7 @@ func writeStartupScript(extraMountOpts string) (string, error) {
 
 	args := tmplParams{ExtraMountOpts: extraMountOpts}
 
-	tmpfile, err := ioutil.TempFile("", "gce-startup-script")
+	tmpfile, err := ioutil.TempFile("", "aws-startup-script")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Currently only the creating user has their key installed on AWS vms which is
unfortunate for debugging. On GCE we configure our VMs to have user accounts
for all users in the current project. On AWS we just have a single user named
`ubuntu`. Mostly because it was the simplest approach, this PR detects whether
we're creating an AWS cluster and if so, retreives the list of public keys from
gcloud and installs them into the authorized_keys file for the ubuntu user.

Release note: None