### PR TITLE
storage: delay application of preemptive snapshots

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -407,8 +407,14 @@ var (
 	}
 	metaRangeSnapshotsPreemptiveApplied = metric.Metadata{
 		Name:        "range.snapshots.preemptive-applied",
-		Help:        "Number of applied pre-emptive snapshots",
+		Help:        "Number of applied (delayed or undelayed) pre-emptive snapshots",
 		Measurement: "Snapshots",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRangeSnapshotsPreemptiveDelayedBytes = metric.Metadata{
+		Name:        "range.snapshots.preemptive-delayed-bytes",
+		Help:        "Bytes held in-memory in delayed preemptive snapshots",
+		Measurement: "Memory",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaRangeRaftLeaderTransfers = metric.Metadata{
@@ -1040,14 +1046,15 @@ type StoreMetrics struct {
 	// accordingly.
 
 	// Range event metrics.
-	RangeSplits                     *metric.Counter
-	RangeMerges                     *metric.Counter
-	RangeAdds                       *metric.Counter
-	RangeRemoves                    *metric.Counter
-	RangeSnapshotsGenerated         *metric.Counter
-	RangeSnapshotsNormalApplied     *metric.Counter
-	RangeSnapshotsPreemptiveApplied *metric.Counter
-	RangeRaftLeaderTransfers        *metric.Counter
+	RangeSplits                          *metric.Counter
+	RangeMerges                          *metric.Counter
+	RangeAdds                            *metric.Counter
+	RangeRemoves                         *metric.Counter
+	RangeSnapshotsGenerated              *metric.Counter
+	RangeSnapshotsNormalApplied          *metric.Counter
+	RangeSnapshotsPreemptiveApplied      *metric.Counter
+	RangeSnapshotsPreemptiveDelayedBytes *metric.Gauge
+	RangeRaftLeaderTransfers             *metric.Counter
 
 	// Raft processing metrics.
 	RaftTicks                 *metric.Counter
@@ -1249,14 +1256,15 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RdbNumSSTables:              metric.NewGauge(metaRdbNumSSTables),
 
 		// Range event metrics.
-		RangeSplits:                     metric.NewCounter(metaRangeSplits),
-		RangeMerges:                     metric.NewCounter(metaRangeMerges),
-		RangeAdds:                       metric.NewCounter(metaRangeAdds),
-		RangeRemoves:                    metric.NewCounter(metaRangeRemoves),
-		RangeSnapshotsGenerated:         metric.NewCounter(metaRangeSnapshotsGenerated),
-		RangeSnapshotsNormalApplied:     metric.NewCounter(metaRangeSnapshotsNormalApplied),
-		RangeSnapshotsPreemptiveApplied: metric.NewCounter(metaRangeSnapshotsPreemptiveApplied),
-		RangeRaftLeaderTransfers:        metric.NewCounter(metaRangeRaftLeaderTransfers),
+		RangeSplits:                          metric.NewCounter(metaRangeSplits),
+		RangeMerges:                          metric.NewCounter(metaRangeMerges),
+		RangeAdds:                            metric.NewCounter(metaRangeAdds),
+		RangeRemoves:                         metric.NewCounter(metaRangeRemoves),
+		RangeSnapshotsGenerated:              metric.NewCounter(metaRangeSnapshotsGenerated),
+		RangeSnapshotsNormalApplied:          metric.NewCounter(metaRangeSnapshotsNormalApplied),
+		RangeSnapshotsPreemptiveApplied:      metric.NewCounter(metaRangeSnapshotsPreemptiveApplied),
+		RangeSnapshotsPreemptiveDelayedBytes: metric.NewGauge(metaRangeSnapshotsPreemptiveDelayedBytes),
+		RangeRaftLeaderTransfers:             metric.NewCounter(metaRangeRaftLeaderTransfers),
 
 		// Raft processing metrics.
 		RaftTicks:                 metric.NewCounter(metaRaftTicks),

--- a/pkg/storage/raft.go
+++ b/pkg/storage/raft.go
@@ -179,14 +179,6 @@ func raftEntryFormatter(data []byte) string {
 	return fmt.Sprintf("[%x] [%d]", commandID, len(data))
 }
 
-// IsPreemptive returns whether this is a preemptive snapshot or a Raft
-// snapshot.
-func (h *SnapshotRequest_Header) IsPreemptive() bool {
-	// Preemptive snapshots are addressed to replica ID 0. No other requests to
-	// replica ID 0 are allowed.
-	return h.RaftMessageRequest.ToReplica.ReplicaID == 0
-}
-
 // traceEntries records the provided event for all proposals corresponding
 // to the entries contained in ents. The vmodule level for raft must be at
 // least 1.

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -934,9 +934,12 @@ func (r *Replica) sendSnapshot(
 			FromReplica: fromRepDesc,
 			ToReplica:   repDesc,
 			Message: raftpb.Message{
-				Type:     raftpb.MsgSnap,
-				To:       uint64(repDesc.ReplicaID),
-				From:     uint64(fromRepDesc.ReplicaID),
+				Type: raftpb.MsgSnap,
+				To:   uint64(repDesc.ReplicaID),
+				From: uint64(fromRepDesc.ReplicaID),
+				// TODO(tbg): is it kosher to pick a random Term from a RaftStatus
+				// and to stick that in a message? Should this term match that of
+				// the HardState in the snapshot from which the data was taken?
 				Term:     status.Term,
 				Snapshot: snap.RaftSnap,
 			},

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -501,6 +501,11 @@ type IncomingSnapshot struct {
 	snapType                       string
 }
 
+// IsPreemptive returns whether this is a delayed or undelayed preemptive snapshot.
+func (is *IncomingSnapshot) IsPreemptive() bool {
+	return is.snapType != snapTypeRaft
+}
+
 // snapshot creates an OutgoingSnapshot containing a rocksdb snapshot for the
 // given range. Note that snapshot() is called without Replica.raftMu held.
 func snapshot(
@@ -667,8 +672,9 @@ func (r *Replica) updateRangeInfo(desc *roachpb.RangeDescriptor) error {
 }
 
 const (
-	snapTypeRaft       = "Raft"
-	snapTypePreemptive = "preemptive"
+	snapTypeRaft                   = "Raft"
+	snapTypePreemptive             = "preemptive"
+	snapTypeLocalDelayedPreemptive = "delayed preemptive"
 )
 
 func clearRangeData(
@@ -767,10 +773,18 @@ func (r *Replica) applySnapshot(
 	snapType := inSnap.snapType
 	defer func() {
 		if err == nil {
-			if snapType == snapTypeRaft {
+			switch snapType {
+			case snapTypeRaft:
 				r.store.metrics.RangeSnapshotsNormalApplied.Inc(1)
-			} else {
+			case snapTypePreemptive:
+				log.Fatalf(ctx, "unexpectedly asked to apply an undelayed preemptive snapshot")
+			case snapTypeLocalDelayedPreemptive:
+				// We treat application of a delayed preemptive snapshot as an
+				// application of a preemptive snapshot as far as stats are
+				// concerned.
 				r.store.metrics.RangeSnapshotsPreemptiveApplied.Inc(1)
+			default:
+				log.Fatalf(ctx, "unknown snapshot type %s", snapType)
 			}
 		}
 	}()

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -30,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/pkg/errors"
@@ -38,10 +38,6 @@ import (
 )
 
 const (
-	// preemptiveSnapshotRaftGroupID is a bogus ID for which a Raft group is
-	// temporarily created during the application of a preemptive snapshot.
-	preemptiveSnapshotRaftGroupID = math.MaxUint64
-
 	// Messages that provide detail about why a preemptive snapshot was rejected.
 	snapshotStoreTooFullMsg = "store almost out of disk space"
 	snapshotApplySemBusyMsg = "store busy applying snapshots"
@@ -51,6 +47,89 @@ const (
 	// canApplySnapshotLocked and is exposed here so testing can rely on it.
 	IntersectingSnapshotMsg = "snapshot intersects existing range"
 )
+
+type delayedPreemptiveSnap struct {
+	Header           SnapshotRequest_Header
+	IncomingSnapshot IncomingSnapshot
+	// Received is the time at which the snapshot was fully received.
+	Received time.Time
+}
+
+type delayedPreemptiveSnaps struct {
+	mu syncutil.Mutex
+	m  map[roachpb.RangeID]delayedPreemptiveSnap // init on first use
+
+	// When zero, sane defaults are used.
+	maxSize int
+	maxAge  time.Duration
+}
+
+func (dps *delayedPreemptiveSnaps) insert(rangeID roachpb.RangeID, snap delayedPreemptiveSnap) {
+	dps.mu.Lock()
+	defer dps.mu.Unlock()
+	if dps.m == nil {
+		dps.m = map[roachpb.RangeID]delayedPreemptiveSnap{}
+	}
+	dps.m[rangeID] = snap
+}
+
+func (dps *delayedPreemptiveSnaps) getAndRemove(
+	rangeID roachpb.RangeID,
+) (_ delayedPreemptiveSnap, found bool) {
+	dps.mu.Lock()
+	defer dps.mu.Unlock()
+	snap, ok := dps.m[rangeID]
+	if ok {
+		delete(dps.m, rangeID)
+	}
+	return snap, ok
+}
+
+func (dps *delayedPreemptiveSnaps) gc(now time.Time) (bytesDeleted int, numDeleted int) {
+	dps.mu.Lock()
+	defer dps.mu.Unlock()
+
+	maxAge := 20 * time.Second
+	if dps.maxAge != 0 {
+		maxAge = dps.maxAge
+	}
+
+	maxSize := 128 * (1 << 20) // 128MB
+	if dps.maxSize > 0 {
+		maxSize = dps.maxSize
+	}
+
+	var totalSize int
+	for rangeID, snap := range dps.m {
+		var size int
+		for _, b := range snap.IncomingSnapshot.Batches {
+			size += len(b)
+		}
+		totalSize += size
+		// Delete snapshots that we see once more than maxSize memory is
+		// allocated. Also delete all snapshots that have been sitting around
+		// for 20 seconds or more.
+		if totalSize > maxSize || now.Sub(snap.Received) > maxAge {
+			numDeleted++
+			bytesDeleted += size
+			delete(dps.m, rangeID)
+		}
+	}
+	return bytesDeleted, numDeleted
+}
+
+func (dps *delayedPreemptiveSnaps) bytes() int {
+	dps.mu.Lock()
+	defer dps.mu.Unlock()
+
+	var totalSize int
+	for _, snap := range dps.m {
+		for _, b := range snap.IncomingSnapshot.Batches {
+			totalSize += len(b)
+		}
+	}
+	return totalSize
+}
 
 // incomingSnapshotStream is the minimal interface on a GRPC stream required
 // to receive a snapshot over the network.
@@ -408,16 +487,8 @@ func (s *Store) reserveSnapshot(
 // The authoritative bool determines whether the check is carried out with the
 // intention of actually applying the snapshot (in which case an existing replica
 // must exist and have its raftMu locked) or as a preliminary check.
-func (s *Store) canApplySnapshot(
-	ctx context.Context, snapHeader *SnapshotRequest_Header, authoritative bool,
-) (*ReplicaPlaceholder, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.canApplySnapshotLocked(ctx, snapHeader, authoritative)
-}
-
 func (s *Store) canApplySnapshotLocked(
-	ctx context.Context, snapHeader *SnapshotRequest_Header, authoritative bool,
+	ctx context.Context, preemptive bool, snapHeader *SnapshotRequest_Header, authoritative bool,
 ) (*ReplicaPlaceholder, error) {
 	desc := *snapHeader.State.Desc
 
@@ -457,7 +528,7 @@ func (s *Store) canApplySnapshotLocked(
 		existingRepl.mu.RUnlock()
 
 		if existingIsInitialized {
-			if !snapHeader.IsPreemptive() {
+			if !preemptive {
 				// Regular Raft snapshots can't be refused at this point,
 				// even if they widen the existing replica. See the comments
 				// in Replica.maybeAcquireSnapshotMergeLock for how this is
@@ -502,7 +573,7 @@ func (s *Store) canApplySnapshotLocked(
 			// sure enough that this couldn't happen by accident to GC the
 			// replica ourselves - the replica GC queue will perform the proper
 			// check).
-		} else if snapHeader.IsPreemptive() {
+		} else if preemptive {
 			// Morally, the existing replica now has a nonzero replica ID
 			// because we already know that it is not initialized (i.e. has no
 			// data). Interestingly, the case in which it has a zero replica ID
@@ -618,15 +689,27 @@ func (s *Store) receiveSnapshot(
 	}
 	defer cleanup()
 
+	// At this stage, we detect preemptive snapshots by the fact that they are
+	// addressed to replicaID zero. Note that this won't be true when the snapshot
+	// is applied as a delayed preemptive snapshot: at that point it will have a
+	// replicaID (but we'll instead use IncomingSnapshot.IsPreemptive()).
+	preemptive := header.RaftMessageRequest.ToReplica.ReplicaID == 0
+
 	// Check to see if the snapshot can be applied but don't attempt to add
 	// a placeholder here, because we're not holding the replica's raftMu.
 	// We'll perform this check again later after receiving the rest of the
 	// snapshot data - this is purely an optimization to prevent downloading
 	// a snapshot that we know we won't be able to apply.
-	if _, err := s.canApplySnapshot(ctx, header, false /* authoritative */); err != nil {
-		return sendSnapshotError(stream,
-			errors.Wrapf(err, "%s,r%d: cannot apply snapshot", s, header.State.Desc.RangeID),
-		)
+	{
+		s.mu.Lock()
+		_, err := s.canApplySnapshotLocked(ctx, preemptive, header, false /* authoritative */)
+		s.mu.Unlock()
+
+		if err != nil {
+			return sendSnapshotError(stream,
+				errors.Wrapf(err, "%s,r%d: cannot apply snapshot", s, header.State.Desc.RangeID),
+			)
+		}
 	}
 
 	// Determine which snapshot strategy the sender is using to send this
@@ -656,8 +739,22 @@ func (s *Store) receiveSnapshot(
 	if err != nil {
 		return err
 	}
-	if err := s.processRaftSnapshotRequest(ctx, header, inSnap); err != nil {
-		return sendSnapshotError(stream, errors.Wrap(err.GoError(), "failed to apply snapshot"))
+
+	if preemptive {
+		now := timeutil.Now()
+		// Store the preemptive snapshot. It will be applied as a Raft snapshot
+		// right when the replica is created (with a replicaID).
+		var snap delayedPreemptiveSnap
+		snap.Header = *header
+		snap.IncomingSnapshot = inSnap
+		snap.Received = now
+
+		s.delayedPreemptiveSnaps.gc(now)
+		s.delayedPreemptiveSnaps.insert(header.State.Desc.RangeID, snap)
+	} else {
+		if err := s.processRaftSnapshotRequest(ctx, header, inSnap); err != nil {
+			return sendSnapshotError(stream, errors.Wrap(err.GoError(), "failed to apply snapshot"))
+		}
 	}
 
 	return stream.Send(&SnapshotResponse{Status: SnapshotResponse_APPLIED})

--- a/pkg/storage/store_snapshot_test.go
+++ b/pkg/storage/store_snapshot_test.go
@@ -135,13 +135,16 @@ func TestSnapshotPreemptiveOnUninitializedReplica(t *testing.T) {
 
 	header := &SnapshotRequest_Header{}
 	header.State.Desc = &desc
+	inSnap := IncomingSnapshot{snapType: snapTypeLocalDelayedPreemptive}
 
-	if !header.IsPreemptive() {
+	if !inSnap.IsPreemptive() {
 		t.Fatal("mock snapshot isn't preemptive")
 	}
 
-	if _, err := store.canApplySnapshot(
-		ctx, header, true, /* authoritative */
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if _, err := store.canApplySnapshotLocked(
+		ctx, inSnap.IsPreemptive(), header, true, /* authoritative */
 	); !testutils.IsError(err, "intersects existing range") {
 		t.Fatal(err)
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2798,6 +2798,7 @@ func TestStoreRangePlaceholders(t *testing.T) {
 // Test that we remove snapshot placeholders on error conditions.
 func TestStoreRemovePlaceholderOnError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
 	tc := testContext{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
@@ -2835,7 +2836,7 @@ func TestStoreRemovePlaceholderOnError(t *testing.T) {
 			ToReplica: roachpb.ReplicaDescriptor{
 				NodeID:    1,
 				StoreID:   1,
-				ReplicaID: 0,
+				ReplicaID: 17, // Raft snapshot
 			},
 			FromReplica: roachpb.ReplicaDescriptor{
 				NodeID:    2,
@@ -2850,7 +2851,7 @@ func TestStoreRemovePlaceholderOnError(t *testing.T) {
 			},
 		},
 	}
-	const expected = "preemptive snapshot from term 0 received"
+	const expected = "snapshot from term 0 received"
 	if err := s.processRaftSnapshotRequest(ctx, snapHeader,
 		IncomingSnapshot{
 			SnapUUID: uuid.MakeV4(),
@@ -2931,6 +2932,7 @@ func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 			},
 			Message: raftpb.Message{
 				Type: raftpb.MsgSnap,
+				Term: 1,
 				Snapshot: raftpb.Snapshot{
 					Data: data,
 					Metadata: raftpb.SnapshotMetadata{

--- a/pkg/storage/txnwait/txnqueue.go
+++ b/pkg/storage/txnwait/txnqueue.go
@@ -643,7 +643,7 @@ func (q *Queue) MaybeWaitForQuery(
 
 	q.mu.Lock()
 	// If the txn wait queue is not enabled or if the request is not
-	// contained within the replica, do nothing. The request can fall
+	// contained within the replica, do nothing. The request can fallp
 	// outside of the replica after a split or merge. Note that the
 	// ContainsKey check is done under the txn wait queue's lock to
 	// ensure that it's not cleared before an incorrect insertion happens.


### PR DESCRIPTION
Currently, in-memory Replica objects can end up having a replicaID zero.
Roughly speaking, this is always the case when a Replica's range
descriptor does not contain the Replica's store, though sometimes we do
have a replicaID taken from incoming Raft messages (which then won't
survive across a restart).

We end up in this unnatural state mostly due to preemptive snapshots,
which are a snapshot of the Range state before adding a certain replica,
sent to the store that will house that replica once the configuration
change to add it has completed. The range descriptor in the snapshot
cannot yet assign the Replica a proper replicaID because none has been
allocated yet (and this allocation has to be done in the replica change
transaction, which hasn't started yet).

Even when the configuration change completes and the leader starts
"catching up" the preemptive snapshot and informs it of the replicaID,
it will take a few moments until the Replica catches up to the log entry
that actually updates the descriptor. If the node reboots before that
log entry is durably applied, the replicaID will "restart" at zero until
the leader contacts the Replica again.

This suggests that preemptive snapshots introduce fundamental complexity
which we'd like to avoid - as long as we use preemptive snapshots there
will not be sanity in this department.

This PR introduces a mechanism which delays the application of
preemptive snapshots so that we apply them only when the first request
*after* the completed configuration change comes in (at which point a
replicaID is present).

Superficially, this seems to solve the above problem (since the Replica
will only be instantiated the moment a replicaID is known), though it
doesn't do so across restarts.

However, if we synchronously persisted (not done in this PR) the
replicaID from incoming Raft messages whenever it changed, it seems that
we should always be able to assign a replicaID when creating a Replica,
even when dealing with descriptors that don't contain the replica itself
(since there would've been a Raft message with a replicaID at some
point, and we persist that). This roughly corresponds to persisting
`Replica.lastToReplica`.

We ultimately want to switch to learner replicas instead of preemptive
snapshots. Learner replicas have the advantage that they are always
represented in the replica descriptor, and so the snapshot that
initializes them will be a proper Raft snapshot containing a descriptor
containing the learner Replica itself. However, it's clear that we need
to continue supporting preemptive snapshots in 19.2 due to the need to
support mixed 19.1/19.2 clusters.

This PR in conjunction with persisting the replicaID (and auxiliary
work, for example on the split lock which currently also creates a
replica with replicaID zero and which we know [has bugs]) should allow
us to remove replicaID zero from the code base without waiting out the
19.1 release cycle.

[has bugs]: #21146

Release note: None