### PR TITLE
ui: fix word-wrapping and tooltip spacing on jobs page

### DIFF
--- a/pkg/ui/src/views/jobs/index.styl
+++ b/pkg/ui/src/views/jobs/index.styl
@@ -66,8 +66,9 @@
     white-space nowrap
     max-width 500px
     word-wrap break-word
-    &--sql
-      font-family Inconsolata-Regular
+
+  &__cell--sql
+    font-family Inconsolata-Regular
 
   &__status-icon
     display inline-block

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -200,7 +200,7 @@ const jobsTableColumns: ColumnDescriptor<Job>[] = [
       // If a [SQL] job.statement exists, it means that job.description
       // is a human-readable message. Otherwise job.description is a SQL
       // statement.
-      const additionalStyle = (job.statement ? "" : "--sql");
+      const additionalStyle = (job.statement ? "" : " jobs-table__cell--sql");
       return <div className={`jobs-table__cell--description${additionalStyle}`}>{job.description}</div>;
     },
     sort: job => job.description,
@@ -244,8 +244,8 @@ interface JobsTableProps {
 const titleTooltip = (
   <span>
     Some jobs can be paused or canceled through SQL. For details, view the docs
-    on the <a href={docsURL.pauseJob} target="_blank"><code>PAUSE JOB</code></a>
-    and <a href={docsURL.cancelJob} target="_blank"><code>CANCEL JOB</code></a>
+    on the <a href={docsURL.pauseJob} target="_blank"><code>PAUSE JOB</code></a>{" "}
+    and <a href={docsURL.cancelJob} target="_blank"><code>CANCEL JOB</code></a>{" "}
     statements.
   </span>
 );


### PR DESCRIPTION
- Fixed spacing for tooltip copy
- Fixed styling bug that was introduced in #35651: Job description
  previously truncated long job descriptions in collapsed view.

Tooltip copy - before:

<img width="300" alt="jobs before" src="https://user-images.githubusercontent.com/3051672/54454081-0be36e00-472f-11e9-8fc2-7e59b4565d51.png">

Tooltip copy - after:

<img width="300" alt="fix tooltip-spacing" src="https://user-images.githubusercontent.com/3051672/54454082-0be36e00-472f-11e9-9683-3b63490fbfe1.png">

Job description - before:

<img width="400" alt="broken text-wrapping" src="https://user-images.githubusercontent.com/3051672/54454213-58c74480-472f-11e9-81fd-7e075510d96f.png">

Job description - after:

<img width="400" alt="fix text-overflow" src="https://user-images.githubusercontent.com/3051672/54455816-16076b80-4733-11e9-94e5-f24312ac6ff1.png">

Release note: None

Fixes: #35604