### PR TITLE
cli: detect GSS authentication response and recommend `psql`

### DIFF
--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -201,6 +201,13 @@ func MaybeDecorateGRPCError(
 			return errors.Errorf("connection lost.\n\n%v", err)
 		}
 
+		// Does the server require GSSAPI authentication?
+		if strings.Contains(unwrappedErr.Error(), "pq: unknown authentication response: 7") {
+			return fmt.Errorf(
+				"server requires GSSAPI authentication for this user.\n" +
+					"The CockroachDB CLI does not support GSSAPI authentication; use 'psql' instead")
+		}
+
 		// Nothing we can special case, just return what we have.
 		return err
 	}


### PR DESCRIPTION
Detects the "unknown authentication response" that corresponds to GSS
authentication, and suggests that the user use `psql` instead.

Release note: none