### PR TITLE
changefeedccl: add SASL authentication for Kafka

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -67,6 +67,10 @@ const (
 	sinkSchemeBuffer          = ``
 	sinkSchemeExperimentalSQL = `experimental-sql`
 	sinkSchemeKafka           = `kafka`
+	sinkParamSASLEnabled      = `sasl_enabled`
+	sinkParamSASLHandshake    = `sasl_handshake`
+	sinkParamSASLUser         = `sasl_user`
+	sinkParamSASLPassword     = `sasl_password`
 )
 
 var changefeedOptionExpectValues = map[string]sql.KVStringOptValidate{

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1402,6 +1402,42 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?&ca_cert=Zm9v`,
 	)
 
+	// Sanity check kafka sasl parameters.
+	sqlDB.ExpectErr(
+		t, `param sasl_enabled must be a bool`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=maybe`,
+	)
+
+	sqlDB.ExpectErr(
+		t, `param sasl_handshake must be a bool`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true&sasl_handshake=maybe`,
+	)
+
+	sqlDB.ExpectErr(
+		t, `sasl_enabled must be enabled to configure SASL handshake behavior`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_handshake=false`,
+	)
+
+	sqlDB.ExpectErr(
+		t, `sasl_user must be provided when SASL is enabled`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true`,
+	)
+
+	sqlDB.ExpectErr(
+		t, `sasl_password must be provided when SASL is enabled`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true&sasl_user=a`,
+	)
+
+	sqlDB.ExpectErr(
+		t, `sasl_enabled must be enabled if a SASL user is provided`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_user=a`,
+	)
+
+	sqlDB.ExpectErr(
+		t, `sasl_enabled must be enabled if a SASL password is provided`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_password=a`,
+	)
+
 	// The cloudStorageSink is particular about the options it will work with.
 	sqlDB.ExpectErr(
 		t, `this sink is incompatible with format=experimental_avro`,


### PR DESCRIPTION
Adds support for SASL/PLAIN authentication via Kafka URL parameters.
This was already supported by the Sarama library we use for Kafka, so
this change just plumbs the parameters through to Sarama.

I've tested this with and without TLS against a Confluent cluster with
SASL; I have a reproducible script to run these tests in a Roachprod
cluster, but don't know how I'd go about adding such a test to our
automation.

As discussed with Dan, this likely will need to be backported into 19.1.1
at this point, which should be fine as far as customer commitments go. 

Release note (enterprise change): `CHANGEFEED`s now support SASL/PLAIN
authentication when connecting to a Kafka sink.