### PR TITLE
opt: add EXPLAIN (opt, env)

### DIFF
--- a/pkg/sql/opt/bench/stub_factory.go
+++ b/pkg/sql/opt/bench/stub_factory.go
@@ -199,6 +199,12 @@ func (f *stubFactory) ConstructPlan(root exec.Node, subqueries []exec.Subquery) 
 	return struct{}{}, nil
 }
 
+func (f *stubFactory) ConstructExplainOpt(
+	plan string, envOpts exec.ExplainEnvData,
+) (exec.Node, error) {
+	return struct{}{}, nil
+}
+
 func (f *stubFactory) ConstructExplain(
 	options *tree.ExplainOptions, stmtType tree.StatementType, plan exec.Plan,
 ) (exec.Node, error) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_env
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_env
@@ -1,0 +1,362 @@
+# LogicTest: local-opt
+
+statement ok
+CREATE TABLE x (
+  a INT PRIMARY KEY,
+  b INT,
+  INDEX (b)
+)
+
+statement ok
+ALTER TABLE x INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 123123,
+    "distinct_count": 100,
+    "histo_buckets": []
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 123123,
+    "distinct_count": 123123,
+    "histo_buckets": []
+  }
+]'
+
+statement ok
+CREATE TABLE y (
+  u INT PRIMARY KEY,
+  v INT REFERENCES x,
+  INDEX (v)
+)
+
+# NOTE: the logic test rewriter formats these terribly, because it thinks it's
+# formatting relational output. If you need to rewrite these try to keep the
+# current formatting.
+
+# Since version might change for reasons unrelated to this test, just ensure
+# there's a line that includes the version (the NOT LIKE %EXPLAIN% is so that
+# we don't just recognize the printing of this query, which also contains the
+# string "Version").
+query B
+SELECT EXISTS(
+    SELECT text FROM
+        [EXPLAIN (opt, env) SELECT * FROM x WHERE b = 3]
+    WHERE text LIKE '%Version%' AND text NOT LIKE '%EXPLAIN%'
+)
+----
+true
+
+statement error ENV only supported with \(OPT\) option
+EXPLAIN (env) SELECT * FROM x WHERE b = 3
+
+query T
+SELECT text FROM [
+EXPLAIN (opt, env) SELECT * FROM x WHERE b = 3
+] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+----
+·
+CREATE TABLE x (
+    a INT8 NOT NULL,
+    b INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (a ASC),
+    INDEX x_b_idx (b ASC),
+    FAMILY "primary" (a, b)
+);
+·
+ALTER TABLE test.public.x INJECT STATISTICS '[
+    {
+        "columns": [
+            "a"
+        ],
+        "created_at": "2018-01-01 01:00:00+00:00",
+        "distinct_count": 100,
+        "histo_col_type": "",
+        "name": "",
+        "null_count": 0,
+        "row_count": 123123
+    },
+    {
+        "columns": [
+            "b"
+        ],
+        "created_at": "2018-01-01 01:00:00+00:00",
+        "distinct_count": 123123,
+        "histo_col_type": "",
+        "name": "",
+        "null_count": 0,
+        "row_count": 123123
+    }
+]';
+·
+SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM x WHERE b = 3] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
+----
+scan x@x_b_idx
+ └── constraint: /2/1: [/3 - /3]
+
+#
+# Multiple Tables.
+#
+
+query T
+SELECT text FROM [
+EXPLAIN (opt, env) SELECT * FROM x, y WHERE b = 3
+] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+----
+·
+CREATE TABLE x (
+    a INT8 NOT NULL,
+    b INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (a ASC),
+    INDEX x_b_idx (b ASC),
+    FAMILY "primary" (a, b)
+);
+·
+ALTER TABLE test.public.x INJECT STATISTICS '[
+    {
+        "columns": [
+            "a"
+        ],
+        "created_at": "2018-01-01 01:00:00+00:00",
+        "distinct_count": 100,
+        "histo_col_type": "",
+        "name": "",
+        "null_count": 0,
+        "row_count": 123123
+    },
+    {
+        "columns": [
+            "b"
+        ],
+        "created_at": "2018-01-01 01:00:00+00:00",
+        "distinct_count": 123123,
+        "histo_col_type": "",
+        "name": "",
+        "null_count": 0,
+        "row_count": 123123
+    }
+]';
+·
+CREATE TABLE y (
+    u INT8 NOT NULL,
+    v INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (u ASC),
+    CONSTRAINT fk_v_ref_x FOREIGN KEY (v) REFERENCES x (a),
+    INDEX y_v_idx (v ASC),
+    FAMILY "primary" (u, v)
+);
+·
+ALTER TABLE test.public.y INJECT STATISTICS '[]';
+·
+SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM x, y WHERE b = 3] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
+----
+inner-join
+ ├── scan y
+ ├── scan x@x_b_idx
+ │    └── constraint: /2/1: [/3 - /3]
+ └── filters (true)
+
+#
+# Same table twice should only show up once.
+#
+
+query T
+SELECT text FROM [
+EXPLAIN (opt, env) SELECT * FROM x one, x two
+] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+----
+·
+CREATE TABLE x (
+    a INT8 NOT NULL,
+    b INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (a ASC),
+    INDEX x_b_idx (b ASC),
+    FAMILY "primary" (a, b)
+);
+·
+ALTER TABLE test.public.x INJECT STATISTICS '[
+    {
+        "columns": [
+            "a"
+        ],
+        "created_at": "2018-01-01 01:00:00+00:00",
+        "distinct_count": 100,
+        "histo_col_type": "",
+        "name": "",
+        "null_count": 0,
+        "row_count": 123123
+    },
+    {
+        "columns": [
+            "b"
+        ],
+        "created_at": "2018-01-01 01:00:00+00:00",
+        "distinct_count": 123123,
+        "histo_col_type": "",
+        "name": "",
+        "null_count": 0,
+        "row_count": 123123
+    }
+]';
+·
+SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM x AS one, x AS two] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
+----
+inner-join
+ ├── scan one
+ ├── scan two
+ └── filters (true)
+
+#
+# Set a relevant session variable to a non-default value and ensure it shows up
+# in the environment dump.
+#
+
+statement ok
+SET experimental_reorder_joins_limit = 100
+
+query T
+SELECT text FROM [
+EXPLAIN (opt, env) SELECT * FROM y WHERE u = 3
+] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+----
+·
+CREATE TABLE y (
+    u INT8 NOT NULL,
+    v INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (u ASC),
+    CONSTRAINT fk_v_ref_x FOREIGN KEY (v) REFERENCES x (a),
+    INDEX y_v_idx (v ASC),
+    FAMILY "primary" (u, v)
+);
+·
+ALTER TABLE test.public.y INJECT STATISTICS '[]';
+·
+SET experimental_reorder_joins_limit = 100;
+·
+SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM y WHERE u = 3] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
+----
+scan y
+ └── constraint: /1: [/3 - /3]
+
+statement ok
+SET experimental_enable_zigzag_join = true
+
+query T
+SELECT text FROM [
+EXPLAIN (opt, env) SELECT * FROM y WHERE u = 3
+] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+----
+·
+CREATE TABLE y (
+    u INT8 NOT NULL,
+    v INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (u ASC),
+    CONSTRAINT fk_v_ref_x FOREIGN KEY (v) REFERENCES x (a),
+    INDEX y_v_idx (v ASC),
+    FAMILY "primary" (u, v)
+);
+·
+ALTER TABLE test.public.y INJECT STATISTICS '[]';
+·
+SET experimental_reorder_joins_limit = 100;
+·
+SET experimental_enable_zigzag_join = on;
+·
+SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM y WHERE u = 3] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
+----
+scan y
+ └── constraint: /1: [/3 - /3]
+
+statement ok
+RESET experimental_reorder_joins_limit
+
+statement ok
+RESET experimental_enable_zigzag_join
+
+#
+# Test sequences.
+#
+
+statement ok
+CREATE SEQUENCE seq
+
+query T
+SELECT text FROM [
+EXPLAIN (opt, env) SELECT * FROM seq
+] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+----
+·
+CREATE SEQUENCE seq MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+·
+SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM seq] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
+----
+sequence-select test.public.seq
+
+#
+# Test views.
+#
+
+statement ok
+CREATE VIEW v AS SELECT a, b, u, v FROM x, y WHERE b = 3
+
+query T
+SELECT text FROM [
+EXPLAIN (opt, env) SELECT * FROM v
+] WHERE text NOT LIKE '%Version%' OR text LIKE '%EXPLAIN%'
+----
+·
+CREATE TABLE x (
+    a INT8 NOT NULL,
+    b INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (a ASC),
+    INDEX x_b_idx (b ASC),
+    FAMILY "primary" (a, b)
+);
+·
+ALTER TABLE test.public.x INJECT STATISTICS '[
+    {
+        "columns": [
+            "a"
+        ],
+        "created_at": "2018-01-01 01:00:00+00:00",
+        "distinct_count": 100,
+        "histo_col_type": "",
+        "name": "",
+        "null_count": 0,
+        "row_count": 123123
+    },
+    {
+        "columns": [
+            "b"
+        ],
+        "created_at": "2018-01-01 01:00:00+00:00",
+        "distinct_count": 123123,
+        "histo_col_type": "",
+        "name": "",
+        "null_count": 0,
+        "row_count": 123123
+    }
+]';
+·
+CREATE TABLE y (
+    u INT8 NOT NULL,
+    v INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (u ASC),
+    CONSTRAINT fk_v_ref_x FOREIGN KEY (v) REFERENCES x (a),
+    INDEX y_v_idx (v ASC),
+    FAMILY "primary" (u, v)
+);
+·
+ALTER TABLE test.public.y INJECT STATISTICS '[]';
+·
+CREATE VIEW v (a, b, u, v) AS SELECT a, b, u, v FROM test.public.x, test.public.y WHERE b = 3;
+·
+SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM v] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
+----
+inner-join
+ ├── scan test.public.y
+ ├── scan test.public.x@x_b_idx
+ │    └── constraint: /2/1: [/3 - /3]
+ └── filters (true)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -265,6 +265,10 @@ type Factory interface {
 	// subqueries.
 	ConstructPlan(root Node, subqueries []Subquery) (Plan, error)
 
+	// ConstructExplain returns a node that implements EXPLAIN (OPT), showing
+	// information about the given plan.
+	ConstructExplainOpt(plan string, envOpts ExplainEnvData) (Node, error)
+
 	// ConstructExplain returns a node that implements EXPLAIN, showing
 	// information about the given plan.
 	ConstructExplain(
@@ -447,4 +451,12 @@ type AggInfo struct {
 	// Filter is the index of the column, if any, which should be used as the
 	// FILTER condition for the aggregate. If there is no filter, Filter is -1.
 	Filter ColumnOrdinal
+}
+
+// ExplainEnvData represents the data that's going to be displayed in EXPLAIN (env).
+type ExplainEnvData struct {
+	ShowEnv   bool
+	Tables    []tree.TableName
+	Sequences []tree.TableName
+	Views     []tree.TableName
 }

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -164,6 +164,9 @@ func (b *Builder) buildView(view cat.View, inScope *scope) (outScope *scope) {
 		}
 
 		b.views[view] = sel
+
+		// Keep track of referenced views for EXPLAIN (opt, env).
+		b.factory.Metadata().AddView(view)
 	}
 
 	// When building the view, we don't want to check for the SELECT privilege

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -17,6 +17,7 @@ package sql
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
@@ -850,6 +851,183 @@ func (ef *execFactory) ConstructPlan(
 	return res, nil
 }
 
+// lineOutputter handles writing strings for EXPLAIN (env). It's a layer of
+// indirection to ensure each line gets its own row and there's exactly one
+// blank line between each output.
+type lineOutputter struct {
+	rows [][]tree.TypedExpr
+}
+
+func (e *lineOutputter) write(s string) {
+	if len(e.rows) > 0 {
+		e.rows = append(e.rows, []tree.TypedExpr{tree.NewDString("")})
+	}
+	ss := strings.Split(strings.Trim(s, "\n"), "\n")
+	for _, line := range ss {
+		e.rows = append(e.rows, []tree.TypedExpr{tree.NewDString(line)})
+	}
+}
+
+// environmentQuery is a helper to run a query to build up the output of
+// showEnv. It expects a query that returns a single string column.
+func (ef *execFactory) environmentQuery(query string) (string, error) {
+	r, err := ef.planner.extendedEvalCtx.InternalExecutor.QueryRow(
+		ef.planner.EvalContext().Context,
+		"EXPLAIN (env)",
+		ef.planner.Txn(),
+		query,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	if len(r) != 1 {
+		return "", pgerror.NewAssertionErrorf(
+			"expected env query %q to return a single column, returned %d",
+			query,
+			len(r),
+		)
+	}
+
+	s, ok := r[0].(*tree.DString)
+	if !ok {
+		return "", pgerror.NewAssertionErrorf(
+			"expected env query %q to return a DString, returned %T",
+			query,
+			r[0],
+		)
+	}
+
+	return string(*s), nil
+}
+
+// showEnv implements EXPLAIN (opt, env). It returns a node which displays
+// the environment a query was run in.
+func (ef *execFactory) showEnv(plan string, envOpts exec.ExplainEnvData) (exec.Node, error) {
+	var out lineOutputter
+
+	// Show the version of Cockroach running.
+	version, err := ef.environmentQuery("SELECT version()")
+	if err != nil {
+		return nil, err
+	}
+	out.write(fmt.Sprintf("Version: %s", version))
+
+	// Show the definition of each referenced catalog object.
+	for _, tn := range envOpts.Sequences {
+		createStatement, err := ef.environmentQuery(
+			fmt.Sprintf("SELECT create_statement FROM [SHOW CREATE SEQUENCE %s]", tn.String()),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		out.write(fmt.Sprintf("%s;", createStatement))
+	}
+
+	// TODO(justin): it might also be relevant in some cases to print the create
+	// statements for tables referenced via FKs in these tables.
+	for _, tn := range envOpts.Tables {
+		createStatement, err := ef.environmentQuery(
+			fmt.Sprintf("SELECT create_statement FROM [SHOW CREATE TABLE %s]", tn.String()),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		out.write(fmt.Sprintf("%s;", createStatement))
+
+		// In addition to the schema, it's important to know what the table
+		// statistics on each table are.
+
+		// NOTE: The histogram buckets take up a ton of vertical space and we
+		// don't use them in planning, so don't include them.
+		// TODO(justin): Revisit this once we use histograms in planning.
+		stats, err := ef.environmentQuery(
+			fmt.Sprintf(
+				`
+SELECT
+	jsonb_pretty(COALESCE(json_agg(stat), '[]'))
+FROM
+	(
+		SELECT
+			json_array_elements(statistics) - 'histo_buckets' AS stat
+		FROM
+			[SHOW STATISTICS USING JSON FOR TABLE %s]
+	)
+`,
+				tn.String(),
+			),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		out.write(
+			fmt.Sprintf(
+				"ALTER TABLE %s INJECT STATISTICS '%s';", tn.String(), stats,
+			),
+		)
+	}
+
+	for _, tn := range envOpts.Views {
+		createStatement, err := ef.environmentQuery(
+			fmt.Sprintf("SELECT create_statement FROM [SHOW CREATE VIEW %s]", tn.String()),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		out.write(fmt.Sprintf("%s;", createStatement))
+	}
+
+	// Show the values of any non-default session variables that can impact
+	// planning decisions.
+	for _, param := range []string{
+		"experimental_reorder_joins_limit",
+		"experimental_enable_zigzag_join",
+	} {
+		value, err := ef.environmentQuery(fmt.Sprintf("SHOW %s", param))
+		if err != nil {
+			return nil, err
+		}
+		defaultVal := varGen[param].GlobalDefault(nil)
+		if value != defaultVal {
+			out.write(fmt.Sprintf("SET %s = %s;", param, value))
+		}
+	}
+
+	// Show the query running. Note that this is the *entire* query, including
+	// the "EXPLAIN (opt, env)" preamble.
+	out.write(fmt.Sprintf("%s;\n----\n%s", ef.planner.stmt.AST.String(), plan))
+
+	return &valuesNode{
+		columns:          sqlbase.ExplainOptColumns,
+		tuples:           out.rows,
+		specifiedInQuery: true,
+	}, nil
+}
+
+// ConstructExplainOpt is part of the exec.Factory interface.
+func (ef *execFactory) ConstructExplainOpt(
+	planText string, envOpts exec.ExplainEnvData,
+) (exec.Node, error) {
+	// If this was an EXPLAIN (opt, env), we need to run a bunch of auxiliary
+	// queries to fetch the environment info.
+	if envOpts.ShowEnv {
+		return ef.showEnv(planText, envOpts)
+	}
+
+	var out lineOutputter
+	out.write(planText)
+
+	return &valuesNode{
+		columns:          sqlbase.ExplainOptColumns,
+		tuples:           out.rows,
+		specifiedInQuery: true,
+	}, nil
+}
+
 // ConstructExplain is part of the exec.Factory interface.
 func (ef *execFactory) ConstructExplain(
 	options *tree.ExplainOptions, stmtType tree.StatementType, plan exec.Plan,
@@ -857,6 +1035,10 @@ func (ef *execFactory) ConstructExplain(
 	p := plan.(*planTop)
 
 	analyzeSet := options.Flags.Contains(tree.ExplainFlagAnalyze)
+
+	if options.Flags.Contains(tree.ExplainFlagEnv) {
+		return nil, errors.New("ENV only supported with (OPT) option")
+	}
 
 	switch options.Mode {
 	case tree.ExplainDistSQL:

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -112,6 +112,7 @@ const (
 	ExplainFlagNoNormalize
 	ExplainFlagNoOptimize
 	ExplainFlagAnalyze
+	ExplainFlagEnv
 )
 
 var explainFlagStrings = map[string]int{
@@ -122,6 +123,7 @@ var explainFlagStrings = map[string]int{
 	"nonormalize": ExplainFlagNoNormalize,
 	"nooptimize":  ExplainFlagNoOptimize,
 	"analyze":     ExplainFlagAnalyze,
+	"env":         ExplainFlagEnv,
 }
 
 // ParseOptions parses the options for an EXPLAIN statement.


### PR DESCRIPTION
This commit adds a new EXPLAIN variant which accepts a query like other
EXPLAIN variants, and also prints:

* The version of Cockroach running,
* any catalog objects referenced by the query,
* any table statistics on any tables,
* any planning-relevant session variables.

The intention is that if a customer is seeing a bad plan, this can
provide all the information we need to reproduce whatever plan they're
seeing.

This changes the way we implement EXPLAIN (opt): previously we would
simply dump everything into a valuesNode in the execbuilder, but this
change changes this to simply build a string in the execbuilder
and then pass that through to the exec factory.

We also pass through the set of catalog objects we want dumped.

Example of running from the CLI:
```
root@:26257/defaultdb> create table x (a int primary key);
CREATE TABLE

Time: 4.774ms

root@:26257/defaultdb> ALTER TABLE x INJECT STATISTICS '[
    {
        "columns": [
            "a"
        ],
        "created_at": "2018-01-01 01:00:00+00:00",
        "distinct_count": 100,
        "histo_col_type": "",
        "name": "",
        "null_count": 0,
        "row_count": 123123
    }
]';

root@:26257/defaultdb> create table y (b int primary key);
CREATE TABLE

Time: 4.985ms

root@:26257/defaultdb> explain (opt, env) select * from x, y where a = b;
                                                               text
+--------------------------------------------------------------------------------------------------------------------------------+
  Version: CockroachDB CCL v2.2.0-alpha.20181217-1907-gba47d3cc7b (x86_64-apple-darwin18.0.0, built 2019/03/15 19:43:11, go1.11)

  CREATE TABLE x (
      a INT8 NOT NULL,
      CONSTRAINT "primary" PRIMARY KEY (a ASC),
      FAMILY "primary" (a)
  );

  ALTER TABLE defaultdb.public.x INJECT STATISTICS '[
      {
          "columns": [
              "a"
          ],
          "created_at": "2018-01-01 01:00:00+00:00",
          "distinct_count": 100,
          "histo_col_type": "",
          "name": "",
          "null_count": 0,
          "row_count": 123123
      }
  ]';

  CREATE TABLE y (
      b INT8 NOT NULL,
      CONSTRAINT "primary" PRIMARY KEY (b ASC),
      FAMILY "primary" (b)
  );

  ALTER TABLE defaultdb.public.y INJECT STATISTICS '[]';

  EXPLAIN (OPT, ENV) SELECT * FROM x, y WHERE a = b;
  ----
  inner-join (merge)
   ├── scan x
   ├── scan y
   └── filters (true)
(36 rows)

Time: 20.757ms
```

Release note (sql change): Added an EXPLAIN (opt, env) option which
provides all relevant information for the planning of a query.