### PR TITLE
sql: use cached table descriptors for all system tables not related to leases

### DIFF
--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -834,7 +834,7 @@ func (m *LeaseManager) AcquireFreshestFromStore(ctx context.Context, tableID sql
 		// Acquire a fresh table lease.
 		didAcquire, err := acquireNodeLease(ctx, m, tableID)
 		if m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent != nil {
-			m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent(LeaseAcquireFreshestBlock)
+			m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent(tableID, LeaseAcquireFreshestBlock)
 		}
 		if err != nil {
 			return err
@@ -1140,7 +1140,7 @@ type LeaseStoreTestingKnobs struct {
 	LeaseAcquiredEvent func(table sqlbase.TableDescriptor, err error)
 	// Called before waiting on a results from a DoChan call of acquireNodeLease
 	// in tableState.acquire() and tableState.acquireFreshestFromStore().
-	LeaseAcquireResultBlockEvent func(leaseBlockType LeaseAcquireBlockType)
+	LeaseAcquireResultBlockEvent func(id sqlbase.ID, leaseBlockType LeaseAcquireBlockType)
 	// RemoveOnceDereferenced forces leases to be removed
 	// as soon as they are dereferenced.
 	RemoveOnceDereferenced bool
@@ -1538,7 +1538,7 @@ func (m *LeaseManager) Acquire(
 				return nil, hlc.Timestamp{}, errLease
 			}
 			if m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent != nil {
-				m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent(LeaseAcquireBlock)
+				m.testingKnobs.LeaseStoreTestingKnobs.LeaseAcquireResultBlockEvent(tableID, LeaseAcquireBlock)
 			}
 
 		case errReadOlderTableVersion:

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -671,7 +671,7 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 					LeaseStoreTestingKnobs: LeaseStoreTestingKnobs{
 						RemoveOnceDereferenced: true,
 						LeaseReleasedEvent:     removalTracker.LeaseRemovedNotification,
-						LeaseAcquireResultBlockEvent: func(leaseBlockType LeaseAcquireBlockType) {
+						LeaseAcquireResultBlockEvent: func(_ sqlbase.ID, leaseBlockType LeaseAcquireBlockType) {
 							if leaseBlockType == LeaseAcquireBlock {
 								if count := atomic.LoadInt32(&acquireArrivals); (count < 1 && test.isSecondCallAcquireFreshest) ||
 									(count < 2 && !test.isSecondCallAcquireFreshest) {


### PR DESCRIPTION
This PR addresses a TODO which prevented use of cached table descriptors for
tables other than system.lease and system.descriptor. This use of cached
descriptors is important in large clusters as nodes need to resolve system
tables for jobs and rangelog more than once per second. Without caching this
can lead to a very hot SystemConfigSpan range as described in #35293.

The referenced TODO mentioned that the policy proposed in this PR was not
initially taken because it interfered with tests. I have so far only verified
that the pkg/sql tests have been updated to pass under stress.

Fixes #35293.

Release note: None