### PR TITLE
sql: create a span per sql statement

### DIFF
--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -117,7 +117,9 @@ type StmtBuf struct {
 // buffer.
 type Command interface {
 	fmt.Stringer
-	command()
+	// command returns a string representation of the command type (e.g.
+	// "prepare", "exec stmt").
+	command() string
 }
 
 // ExecStmt is the command for running a query sent through the "simple" pgwire
@@ -138,7 +140,7 @@ type ExecStmt struct {
 }
 
 // command implements the Command interface.
-func (ExecStmt) command() {}
+func (ExecStmt) command() string { return "exec stmt" }
 
 func (e ExecStmt) String() string {
 	// We have the original SQL, but we still use String() because it obfuscates
@@ -160,7 +162,7 @@ type ExecPortal struct {
 }
 
 // command implements the Command interface.
-func (ExecPortal) command() {}
+func (ExecPortal) command() string { return "exec portal" }
 
 func (e ExecPortal) String() string {
 	return fmt.Sprintf("ExecPortal name: %q", e.Name)
@@ -187,7 +189,7 @@ type PrepareStmt struct {
 }
 
 // command implements the Command interface.
-func (PrepareStmt) command() {}
+func (PrepareStmt) command() string { return "prepare" }
 
 func (p PrepareStmt) String() string {
 	// We have the original SQL, but we still use String() because it obfuscates
@@ -205,7 +207,7 @@ type DescribeStmt struct {
 }
 
 // command implements the Command interface.
-func (DescribeStmt) command() {}
+func (DescribeStmt) command() string { return "describe" }
 
 func (d DescribeStmt) String() string {
 	return fmt.Sprintf("Describe: %q", d.Name)
@@ -245,7 +247,7 @@ type BindStmt struct {
 }
 
 // command implements the Command interface.
-func (BindStmt) command() {}
+func (BindStmt) command() string { return "bind" }
 
 func (b BindStmt) String() string {
 	return fmt.Sprintf("BindStmt: %q->%q", b.PreparedStatementName, b.PortalName)
@@ -260,7 +262,7 @@ type DeletePreparedStmt struct {
 }
 
 // command implements the Command interface.
-func (DeletePreparedStmt) command() {}
+func (DeletePreparedStmt) command() string { return "delete" }
 
 func (d DeletePreparedStmt) String() string {
 	return fmt.Sprintf("DeletePreparedStmt: %q", d.Name)
@@ -280,7 +282,7 @@ var _ Command = DeletePreparedStmt{}
 type Sync struct{}
 
 // command implements the Command interface.
-func (Sync) command() {}
+func (Sync) command() string { return "sync" }
 
 func (Sync) String() string {
 	return "Sync"
@@ -293,7 +295,7 @@ var _ Command = Sync{}
 type Flush struct{}
 
 // command implements the Command interface.
-func (Flush) command() {}
+func (Flush) command() string { return "flush" }
 
 func (Flush) String() string {
 	return "Flush"
@@ -313,7 +315,7 @@ type CopyIn struct {
 }
 
 // command implements the Command interface.
-func (CopyIn) command() {}
+func (CopyIn) command() string { return "copy" }
 
 func (CopyIn) String() string {
 	return "CopyIn"
@@ -328,7 +330,7 @@ var _ Command = CopyIn{}
 type DrainRequest struct{}
 
 // command implements the Command interface.
-func (DrainRequest) command() {}
+func (DrainRequest) command() string { return "drain" }
 
 func (DrainRequest) String() string {
 	return "Drain"
@@ -345,7 +347,7 @@ type SendError struct {
 }
 
 // command implements the Command interface.
-func (SendError) command() {}
+func (SendError) command() string { return "send error" }
 
 func (s SendError) String() string {
 	return fmt.Sprintf("SendError: %s", s.Err)

--- a/pkg/sql/logictest/testdata/planner_test/select
+++ b/pkg/sql/logictest/testdata/planner_test/select
@@ -18,21 +18,27 @@ FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%SPAN START%' OR message LIKE '%pos%executing%';
 ----
 0                         === SPAN START: session recording ===                session recording
+1                         === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
 0                         [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  session recording
-1                         === SPAN START: sql txn ===                          sql txn
-1                         [Open pos:?] executing ExecStmt: SELECT 1            sql txn
-2                         === SPAN START: consuming rows ===                   consuming rows
-3                         === SPAN START: flow ===                             flow
-7                         === SPAN START: values ===
+2                         === SPAN START: sql txn ===                          sql txn
+3                         === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
+2                         [Open pos:?] executing ExecStmt: SELECT 1            sql txn
+4                         === SPAN START: consuming rows ===                   consuming rows
+5                         === SPAN START: flow ===                             flow
+13                        === SPAN START: values ===
 cockroach.processorid: 0  values
-1                         [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  sql txn
+6                         === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
+2                         [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  sql txn
+7                         === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
 0                         [NoTxn pos:?] executing ExecStmt: SELECT 2           session recording
-4                         === SPAN START: sql txn ===                          sql txn
-4                         [Open pos:?] executing ExecStmt: SELECT 2            sql txn
-5                         === SPAN START: consuming rows ===                   consuming rows
-6                         === SPAN START: flow ===                             flow
-8                         === SPAN START: values ===
+8                         === SPAN START: sql txn ===                          sql txn
+9                         === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
+8                         [Open pos:?] executing ExecStmt: SELECT 2            sql txn
+10                        === SPAN START: consuming rows ===                   consuming rows
+11                        === SPAN START: flow ===                             flow
+14                        === SPAN START: values ===
 cockroach.processorid: 0  values
+12                        === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
 0                         [NoTxn pos:?] executing ExecStmt: SET TRACING = off  session recording
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/logictest/testdata/planner_test/show_trace
+++ b/pkg/sql/logictest/testdata/planner_test/show_trace
@@ -21,9 +21,9 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow     CPut /Table/2/1/0/"t"/3/1 -> 53
-flow     CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
-sql txn  rows affected: 0
+flow                 CPut /Table/2/1/0/"t"/3/1 -> 53
+flow                 CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
+exec cmd: exec stmt  rows affected: 0
 
 
 # More KV operations.
@@ -41,9 +41,9 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow     CPut /Table/2/1/53/"kv"/3/1 -> 54
-flow     CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-sql txn  rows affected: 0
+flow                 CPut /Table/2/1/53/"kv"/3/1 -> 54
+flow                 CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+exec cmd: exec stmt  rows affected: 0
 
 # We avoid using the full trace output, because that would make the
 # ensuing trace especially chatty, as it traces the index backfill at
@@ -68,8 +68,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow     Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-sql txn  rows affected: 0
+flow                 Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+exec cmd: exec stmt  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -78,10 +78,10 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow     CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
-flow     InitPut /Table/54/2/2/0 -> /BYTES/0x89
-flow     fast path completed
-sql txn  rows affected: 1
+flow                 CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
+flow                 InitPut /Table/54/2/2/0 -> /BYTES/0x89
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 
 statement error duplicate key value
@@ -92,9 +92,9 @@ set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow     CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
-flow     InitPut /Table/54/2/2/0 -> /BYTES/0x89
-sql txn  execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
+flow                 CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
+flow                 InitPut /Table/54/2/2/0 -> /BYTES/0x89
+exec cmd: exec stmt  execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
 
 statement error duplicate key value
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -104,9 +104,9 @@ set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow     CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
-flow     InitPut /Table/54/2/2/0 -> /BYTES/0x8a
-sql txn  execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
+flow                 CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
+flow                 InitPut /Table/54/2/2/0 -> /BYTES/0x8a
+exec cmd: exec stmt  execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 statement ok
 SET tracing = on,kv,results; CREATE TABLE t.kv2 AS TABLE t.kv; SET tracing = off
@@ -122,13 +122,13 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-table reader  Scan /Table/54/{1-2}
-flow          CPut /Table/2/1/53/"kv2"/3/1 -> 55
-flow          CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-table reader  fetched: /kv/primary/1/v -> /2
-flow          CPut /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
-flow          fast path completed
-sql txn       rows affected: 1
+table reader         Scan /Table/54/{1-2}
+flow                 CPut /Table/2/1/53/"kv2"/3/1 -> 55
+flow                 CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+table reader         fetched: /kv/primary/1/v -> /2
+flow                 CPut /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; UPDATE t.kv2 SET v = v + 2; SET tracing = off
@@ -143,11 +143,11 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-table reader  Scan /Table/55/{1-2}
-table reader  fetched: /kv2/primary/...PK.../k/v -> /1/2
-flow          Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
-flow          fast path completed
-sql txn       rows affected: 1
+table reader         Scan /Table/55/{1-2}
+table reader         fetched: /kv2/primary/...PK.../k/v -> /1/2
+flow                 Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off
@@ -156,9 +156,9 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow     DelRange /Table/55/1 - /Table/55/2
-flow     fast path completed
-sql txn  rows affected: 1
+flow                 DelRange /Table/55/1 - /Table/55/2
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv2; SET tracing = off
@@ -175,8 +175,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow     Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... >
-sql txn  rows affected: 0
+flow                 Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... >
+exec cmd: exec stmt  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv; SET tracing = off
@@ -185,12 +185,12 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-table reader  Scan /Table/54/{1-2}
-table reader  fetched: /kv/primary/1/v -> /2
-flow          Del /Table/54/2/2/0
-flow          Del /Table/54/1/1/0
-flow          fast path completed
-sql txn       rows affected: 1
+table reader         Scan /Table/54/{1-2}
+table reader         fetched: /kv/primary/1/v -> /2
+flow                 Del /Table/54/2/2/0
+flow                 Del /Table/54/1/1/0
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP INDEX t.kv@woo CASCADE; SET tracing = off
@@ -209,8 +209,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow     Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-sql txn  rows affected: 0
+flow                 Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+exec cmd: exec stmt  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv; SET tracing = off
@@ -226,8 +226,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow     Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > >
-sql txn  rows affected: 0
+flow                 Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > >
+exec cmd: exec stmt  rows affected: 0
 
 # Check that session tracing does not inhibit the fast path for inserts &
 # friends (the path resulting in 1PC transactions).

--- a/pkg/sql/logictest/testdata/planner_test/upsert
+++ b/pkg/sql/logictest/testdata/planner_test/upsert
@@ -59,11 +59,11 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow     Scan /Table/56/1/2{-/#}
-flow     CPut /Table/56/1/2/0 -> /TUPLE/2:2:Int/3
-flow     InitPut /Table/56/2/3/0 -> /BYTES/0x8a
-flow     fast path completed
-sql txn  rows affected: 1
+flow                 Scan /Table/56/1/2{-/#}
+flow                 CPut /Table/56/1/2/0 -> /TUPLE/2:2:Int/3
+flow                 InitPut /Table/56/2/3/0 -> /BYTES/0x8a
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -72,11 +72,11 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow     Scan /Table/56/1/1{-/#}
-flow     CPut /Table/56/1/1/0 -> /TUPLE/2:2:Int/2
-flow     InitPut /Table/56/2/2/0 -> /BYTES/0x89
-flow     fast path completed
-sql txn  rows affected: 1
+flow                 Scan /Table/56/1/1{-/#}
+flow                 CPut /Table/56/1/1/0 -> /TUPLE/2:2:Int/2
+flow                 InitPut /Table/56/2/2/0 -> /BYTES/0x89
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 statement error duplicate key value
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -86,12 +86,12 @@ set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow     Scan /Table/56/1/2{-/#}
-flow     fetched: /kv/primary/2/v -> /3
-flow     Put /Table/56/1/2/0 -> /TUPLE/2:2:Int/2
-flow     Del /Table/56/2/3/0
-flow     CPut /Table/56/2/2/0 -> /BYTES/0x8a (expecting does not exist)
-sql txn  execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
+flow                 Scan /Table/56/1/2{-/#}
+flow                 fetched: /kv/primary/2/v -> /3
+flow                 Put /Table/56/1/2/0 -> /TUPLE/2:2:Int/2
+flow                 Del /Table/56/2/3/0
+flow                 CPut /Table/56/2/2/0 -> /BYTES/0x8a (expecting does not exist)
+exec cmd: exec stmt  execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 subtest regression_32834
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -17,19 +17,25 @@ SELECT
 FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%SPAN START%' OR message LIKE '%pos%executing%';
 ----
-0  === SPAN START: session recording ===                session recording
-0  [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  session recording
-1  === SPAN START: sql txn ===                          sql txn
-1  [Open pos:?] executing ExecStmt: SELECT 1            sql txn
-2  === SPAN START: consuming rows ===                   consuming rows
-3  === SPAN START: flow ===                             flow
-1  [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  sql txn
-0  [NoTxn pos:?] executing ExecStmt: SELECT 2           session recording
-4  === SPAN START: sql txn ===                          sql txn
-4  [Open pos:?] executing ExecStmt: SELECT 2            sql txn
-5  === SPAN START: consuming rows ===                   consuming rows
-6  === SPAN START: flow ===                             flow
-0  [NoTxn pos:?] executing ExecStmt: SET TRACING = off  session recording
+0   === SPAN START: session recording ===                session recording
+1   === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
+0   [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  session recording
+2   === SPAN START: sql txn ===                          sql txn
+3   === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
+2   [Open pos:?] executing ExecStmt: SELECT 1            sql txn
+4   === SPAN START: consuming rows ===                   consuming rows
+5   === SPAN START: flow ===                             flow
+6   === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
+2   [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  sql txn
+7   === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
+0   [NoTxn pos:?] executing ExecStmt: SELECT 2           session recording
+8   === SPAN START: sql txn ===                          sql txn
+9   === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
+8   [Open pos:?] executing ExecStmt: SELECT 2            sql txn
+10  === SPAN START: consuming rows ===                   consuming rows
+11  === SPAN START: flow ===                             flow
+12  === SPAN START: exec cmd: exec stmt ===              exec cmd: exec stmt
+0   [NoTxn pos:?] executing ExecStmt: SET TRACING = off  session recording
 
 # ------------------------------------------------------------------------------
 # Numeric References Tests.

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -17,9 +17,9 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow     CPut /Table/2/1/0/"t"/3/1 -> 53
-flow     CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
-sql txn  rows affected: 0
+flow                 CPut /Table/2/1/0/"t"/3/1 -> 53
+flow                 CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
+exec cmd: exec stmt  rows affected: 0
 
 
 # More KV operations.
@@ -37,9 +37,9 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow     CPut /Table/2/1/53/"kv"/3/1 -> 54
-flow     CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-sql txn  rows affected: 0
+flow                 CPut /Table/2/1/53/"kv"/3/1 -> 54
+flow                 CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+exec cmd: exec stmt  rows affected: 0
 
 # We avoid using the full trace output, because that would make the
 # ensuing trace especially chatty, as it traces the index backfill at
@@ -64,8 +64,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow     Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-sql txn  rows affected: 0
+flow                 Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+exec cmd: exec stmt  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -74,10 +74,10 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow     CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
-flow     InitPut /Table/54/2/2/0 -> /BYTES/0x89
-flow     fast path completed
-sql txn  rows affected: 1
+flow                 CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
+flow                 InitPut /Table/54/2/2/0 -> /BYTES/0x89
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 
 statement error duplicate key value
@@ -88,9 +88,9 @@ set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow     CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
-flow     InitPut /Table/54/2/2/0 -> /BYTES/0x89
-sql txn  execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
+flow                 CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
+flow                 InitPut /Table/54/2/2/0 -> /BYTES/0x89
+exec cmd: exec stmt  execution failed after 0 rows: duplicate key value (k)=(1) violates unique constraint "primary"
 
 statement error duplicate key value
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -100,9 +100,9 @@ set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow     CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
-flow     InitPut /Table/54/2/2/0 -> /BYTES/0x8a
-sql txn  execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
+flow                 CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
+flow                 InitPut /Table/54/2/2/0 -> /BYTES/0x8a
+exec cmd: exec stmt  execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 statement ok
 SET tracing = on,kv,results; CREATE TABLE t.kv2 AS TABLE t.kv; SET tracing = off
@@ -118,13 +118,13 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-table reader  Scan /Table/54/{1-2}
-flow          CPut /Table/2/1/53/"kv2"/3/1 -> 55
-flow          CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-table reader  fetched: /kv/primary/1/v -> /2
-flow          CPut /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
-flow          fast path completed
-sql txn       rows affected: 1
+table reader         Scan /Table/54/{1-2}
+flow                 CPut /Table/2/1/53/"kv2"/3/1 -> 55
+flow                 CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:1 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+table reader         fetched: /kv/primary/1/v -> /2
+flow                 CPut /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; UPDATE t.kv2 SET v = v + 2; SET tracing = off
@@ -139,11 +139,11 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-table reader  Scan /Table/55/{1-2}
-table reader  fetched: /kv2/primary/...PK.../k/v -> /1/2
-flow          Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
-flow          fast path completed
-sql txn       rows affected: 1
+table reader         Scan /Table/55/{1-2}
+table reader         fetched: /kv2/primary/...PK.../k/v -> /1/2
+flow                 Put /Table/55/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off
@@ -152,9 +152,9 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow     DelRange /Table/55/1 - /Table/55/2
-flow     fast path completed
-sql txn  rows affected: 1
+flow                 DelRange /Table/55/1 - /Table/55/2
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv2; SET tracing = off
@@ -171,8 +171,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow     Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... >
-sql txn  rows affected: 0
+flow                 Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 parent_id:53 version:2 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... >
+exec cmd: exec stmt  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv; SET tracing = off
@@ -181,12 +181,12 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-table reader  Scan /Table/54/{1-2}
-table reader  fetched: /kv/primary/1/v -> /2
-flow          Del /Table/54/2/2/0
-flow          Del /Table/54/1/1/0
-flow          fast path completed
-sql txn       rows affected: 1
+table reader         Scan /Table/54/{1-2}
+table reader         fetched: /kv/primary/1/v -> /2
+flow                 Del /Table/54/2/2/0
+flow                 Del /Table/54/1/1/0
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP INDEX t.kv@woo CASCADE; SET tracing = off
@@ -205,8 +205,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow     Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
-sql txn  rows affected: 0
+flow                 Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:5 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 >
+exec cmd: exec stmt  rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv; SET tracing = off
@@ -222,8 +222,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow     Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > >
-sql txn  rows affected: 0
+flow                 Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 parent_id:53 version:8 modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:64 precision:0 visible_type:BIGINT > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:53 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:... gc_mutations:<index_id:2 drop_time:... job_id:... > >
+exec cmd: exec stmt  rows affected: 0
 
 # Check that session tracing does not inhibit the fast path for inserts &
 # friends (the path resulting in 1PC transactions).

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -226,11 +226,11 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-table reader  Scan /Table/57/1/2{-/#}
-flow          CPut /Table/57/1/2/0 -> /TUPLE/2:2:Int/3
-flow          InitPut /Table/57/2/3/0 -> /BYTES/0x8a
-flow          fast path completed
-sql txn       rows affected: 1
+table reader         Scan /Table/57/1/2{-/#}
+flow                 CPut /Table/57/1/2/0 -> /TUPLE/2:2:Int/3
+flow                 InitPut /Table/57/2/3/0 -> /BYTES/0x8a
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -239,11 +239,11 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-table reader  Scan /Table/57/1/1{-/#}
-flow          CPut /Table/57/1/1/0 -> /TUPLE/2:2:Int/2
-flow          InitPut /Table/57/2/2/0 -> /BYTES/0x89
-flow          fast path completed
-sql txn       rows affected: 1
+table reader         Scan /Table/57/1/1{-/#}
+flow                 CPut /Table/57/1/1/0 -> /TUPLE/2:2:Int/2
+flow                 InitPut /Table/57/2/2/0 -> /BYTES/0x89
+flow                 fast path completed
+exec cmd: exec stmt  rows affected: 1
 
 statement error duplicate key value
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -253,12 +253,12 @@ set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-table reader  Scan /Table/57/1/2{-/#}
-table reader  fetched: /kv/primary/2/v -> /3
-flow          Put /Table/57/1/2/0 -> /TUPLE/2:2:Int/2
-flow          Del /Table/57/2/3/0
-flow          CPut /Table/57/2/2/0 -> /BYTES/0x8a (expecting does not exist)
-sql txn       execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
+table reader         Scan /Table/57/1/2{-/#}
+table reader         fetched: /kv/primary/2/v -> /3
+flow                 Put /Table/57/1/2/0 -> /TUPLE/2:2:Int/2
+flow                 Del /Table/57/2/3/0
+flow                 CPut /Table/57/2/2/0 -> /BYTES/0x8a (expecting does not exist)
+exec cmd: exec stmt  execution failed after 0 rows: duplicate key value (v)=(2) violates unique constraint "woo"
 
 
 subtest regression_32473

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -71,6 +71,7 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
+				"exec cmd: exec stmt",
 				"flow",
 				"session recording",
 				"sql txn",
@@ -125,6 +126,7 @@ func TestTrace(t *testing.T) {
 			expSpans: []string{
 				"session recording",
 				"sql txn",
+				"exec cmd: exec stmt",
 				"flow",
 				"table reader",
 				"consuming rows",
@@ -159,6 +161,7 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
+				"exec cmd: exec stmt",
 				"flow",
 				"session recording",
 				"sql txn",
@@ -191,6 +194,7 @@ func TestTrace(t *testing.T) {
 			expSpans: []string{
 				"session recording",
 				"sql txn",
+				"exec cmd: exec stmt",
 				"flow",
 				"table reader",
 				"consuming rows",


### PR DESCRIPTION
Before this patch, statements did not have their own spans. Instead,
transactions had spans. This dates from a time when the TxnCoordSender
would capture the span of the first write and expect it to live for the
duration of the transaction, but that stopped being the case a while
ago.
This patch makes each statement create its own span.

Release note: None