### PR TITLE
logictest: bump stats.DefaultAsOfTime to avoid txn retries

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1025,7 +1025,9 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 	}
 
 	// Update the defaults for automatic statistics to avoid delays in testing.
-	stats.DefaultAsOfTime = time.Microsecond
+	// Avoid making the DefaultAsOfTime too small to avoid interacting with
+	// schema changes and causing transaction retries.
+	stats.DefaultAsOfTime = 10 * time.Millisecond
 	stats.DefaultRefreshInterval = time.Millisecond
 
 	t.cluster = serverutils.StartTestCluster(t.t, cfg.numNodes, params)


### PR DESCRIPTION
Fixes #35549.
Fixes #35484.
Fixes #35757.
Fixes #35766.
Fixes #35769.

Auto-stats collection was running only 1us in the past, allowing it to
interact with schema changes and cause transaction retries.

Release note: None