### PR TITLE
release-2.0: storage: don't require consensus for no-op requests

### DIFF
--- a/pkg/storage/batcheval/result/result.go
+++ b/pkg/storage/batcheval/result/result.go
@@ -31,13 +31,6 @@ import (
 // the proposing node may die before the local results are processed,
 // so any side effects here are only best-effort.
 type LocalResult struct {
-	// The error resulting from the proposal. Most failing proposals will
-	// fail-fast, i.e. will return an error to the client above Raft. However,
-	// some proposals need to commit data even on error, and in that case we
-	// treat the proposal like a successful one, except that the error stored
-	// here will be sent to the client when the associated batch commits. In
-	// the common case, this field is nil.
-	Err   *roachpb.Error
 	Reply *roachpb.BatchResponse
 
 	// Intents stores any intents encountered but not conflicted with.

--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -114,6 +114,11 @@ func (b *RocksDBBatchBuilder) Len() int {
 	return len(b.repr)
 }
 
+// Empty returns whether the under construction repr is empty.
+func (b *RocksDBBatchBuilder) Empty() bool {
+	return len(b.repr) <= headerSize
+}
+
 // getRepr constructs the batch representation and returns it.
 func (b *RocksDBBatchBuilder) getRepr() []byte {
 	b.maybeInit()

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -292,6 +292,8 @@ type Batch interface {
 	// situations where we know all of the batched operations are for distinct
 	// keys.
 	Distinct() ReadWriter
+	// Empty returns whether the batch is empty or not.
+	Empty() bool
 	// Repr returns the underlying representation of the batch and can be used to
 	// reconstitute the batch on a remote node using Writer.ApplyBatchRepr().
 	Repr() []byte

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1809,6 +1809,10 @@ func (r *rocksDBBatch) commitInternal(sync bool) error {
 	return nil
 }
 
+func (r *rocksDBBatch) Empty() bool {
+	return r.flushes == 0 && r.builder.Empty()
+}
+
 func (r *rocksDBBatch) Repr() []byte {
 	if r.flushes == 0 {
 		// We've never flushed to C++. Return the mutations only.

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2912,6 +2912,8 @@ func (r *Replica) evaluateProposal(
 	defer batch.Close()
 
 	if pErr != nil {
+		pErr = r.maybeSetCorrupt(ctx, pErr)
+
 		// Restore the original txn's Writing bool if the error specifies
 		// a transaction.
 		if txn := pErr.GetTxn(); txn != nil {
@@ -2930,11 +2932,10 @@ func (r *Replica) evaluateProposal(
 		res.Local = result.LocalResult{
 			Intents:            &intents,
 			EndTxns:            &endTxns,
-			Err:                r.maybeSetCorrupt(ctx, pErr),
 			LeaseMetricsResult: res.Local.LeaseMetricsResult,
 		}
 		res.Replicated.Reset()
-		return &res, res.Local.Err
+		return &res, pErr
 	}
 
 	// Set the local reply, which is held only on the proposing replica and is
@@ -4935,10 +4936,6 @@ func (r *Replica) processRaftCommand(
 				// for instance due to its log position) or the Replica is now
 				// corrupted.
 				response.Err = pErr
-			} else if proposal.Local.Err != nil {
-				// Everything went as expected, but this proposal should return
-				// an error to the client.
-				response.Err = proposal.Local.Err
 			} else if proposal.Local.Reply != nil {
 				response.Reply = proposal.Local.Reply
 			} else {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5234,9 +5234,6 @@ func (r *Replica) evaluateProposalInner(
 		}
 		result.Local.Reply = br
 		result.Local.Err = pErr
-		if batch == nil {
-			return result
-		}
 	}
 
 	if result.Local.Err != nil && ba.IsWrite() {
@@ -5368,20 +5365,20 @@ func (r *Replica) evaluateWriteBatch(
 			return batch, ms, br, res, nil
 		}
 
-		batch.Close()
 		ms = enginepb.MVCCStats{}
 
 		// Handle the case of a required one phase commit transaction.
 		if etArg.Require1PC {
 			if pErr != nil {
-				return nil, ms, nil, result.Result{}, pErr
+				return batch, ms, nil, result.Result{}, pErr
 			} else if ba.Timestamp != br.Timestamp {
 				err := roachpb.NewTransactionRetryError(roachpb.RETRY_REASON_UNKNOWN)
-				return nil, ms, nil, result.Result{}, roachpb.NewError(err)
+				return batch, ms, nil, result.Result{}, roachpb.NewError(err)
 			}
 			log.Fatal(ctx, "unreachable")
 		}
 
+		batch.Close()
 		log.VEventf(ctx, 2, "1PC execution failed, reverting to regular execution for batch")
 	}
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5212,10 +5212,6 @@ func (r *Replica) applyRaftCommand(
 func (r *Replica) evaluateProposalInner(
 	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest, spans *spanset.SpanSet,
 ) result.Result {
-	// Keep track of original txn Writing state to sanitize txn
-	// reported with any error except TransactionRetryError.
-	wasWriting := ba.Txn != nil && ba.Txn.Writing
-
 	// Evaluate the commands. If this returns without an error, the batch should
 	// be committed.
 	var result result.Result
@@ -5252,7 +5248,7 @@ func (r *Replica) evaluateProposalInner(
 				log.Fatalf(ctx, "error had a txn but batch is non-transactional. Err txn: %s", txn)
 			}
 			if txn.ID == ba.Txn.ID {
-				txn.Writing = wasWriting
+				txn.Writing = ba.Txn.Writing
 			}
 		}
 		return result

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5214,28 +5214,14 @@ func (r *Replica) evaluateProposalInner(
 ) result.Result {
 	// Evaluate the commands. If this returns without an error, the batch should
 	// be committed.
-	var result result.Result
-	var batch engine.Batch
-	{
-		// TODO(tschottdorf): absorb all returned values in `pd` below this point
-		// in the call stack as well.
-		var pErr *roachpb.Error
-		var ms enginepb.MVCCStats
-		var br *roachpb.BatchResponse
-		batch, ms, br, result, pErr = r.evaluateWriteBatch(ctx, idKey, ba, spans)
-		if r.store.cfg.Settings.Version.IsActive(cluster.VersionMVCCNetworkStats) {
-			result.Replicated.Delta = ms.ToNetworkStats()
-		} else {
-			result.Replicated.DeprecatedDelta = &ms
-		}
-		result.Local.Reply = br
-		result.Local.Err = pErr
-	}
-
-	if result.Local.Err != nil && ba.IsWrite() {
+	// TODO(tschottdorf): absorb all returned values in `res` below this point
+	// in the call stack as well.
+	batch, ms, br, res, pErr := r.evaluateWriteBatch(ctx, idKey, ba, spans)
+	if pErr != nil {
 		// TODO(tschottdorf): make `nil` acceptable. Corresponds to
 		// roachpb.Response{With->Or}Error.
-		result.Local.Reply = &roachpb.BatchResponse{}
+		res.Local.Reply = &roachpb.BatchResponse{}
+		res.Local.Err = pErr
 		// Reset the batch to clear out partial execution. Don't set
 		// a WriteBatch to signal to the caller that we fail-fast this
 		// proposal.
@@ -5243,7 +5229,7 @@ func (r *Replica) evaluateProposalInner(
 		batch = nil
 		// Restore the original txn's Writing bool if the error specifies a
 		// transaction.
-		if txn := result.Local.Err.GetTxn(); txn != nil {
+		if txn := res.Local.Err.GetTxn(); txn != nil {
 			if ba.Txn == nil {
 				log.Fatalf(ctx, "error had a txn but batch is non-transactional. Err txn: %s", txn)
 			}
@@ -5251,17 +5237,23 @@ func (r *Replica) evaluateProposalInner(
 				txn.Writing = ba.Txn.Writing
 			}
 		}
-		return result
+		return res
 	}
 
-	result.WriteBatch = &storagebase.WriteBatch{
+	res.Local.Reply = br
+	if r.store.cfg.Settings.Version.IsActive(cluster.VersionMVCCNetworkStats) {
+		res.Replicated.Delta = ms.ToNetworkStats()
+	} else {
+		res.Replicated.DeprecatedDelta = &ms
+	}
+	res.WriteBatch = &storagebase.WriteBatch{
 		Data: batch.Repr(),
 	}
 	// Note: reusing the proposer's batch when applying the command on the
 	// proposer was explored as an optimization but resulted in no performance
 	// benefit.
 	batch.Close()
-	return result
+	return res
 }
 
 // checkIfTxnAborted checks the txn AbortSpan for the given

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2892,13 +2892,6 @@ func (r *Replica) requestToProposal(
 // while still handling LocalEvalResult.
 //
 // Replica.mu must not be held.
-//
-// TODO(tschottdorf): the setting of WriteTooOld does not work. With
-// proposer-evaluated KV, TestStoreResolveWriteIntentPushOnRead fails in the
-// SNAPSHOT case since the transactional write in that test *always* catches
-// a WriteTooOldError. With proposer-evaluated KV disabled the same happens,
-// but the resulting WriteTooOld flag on the transaction is lost, letting the
-// test pass erroneously.
 func (r *Replica) evaluateProposal(
 	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest, spans *spanset.SpanSet,
 ) (*result.Result, *roachpb.Error) {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2847,7 +2847,8 @@ func (r *Replica) tryExecuteWriteBatch(
 
 // requestToProposal converts a BatchRequest into a ProposalData, by
 // evaluating it. The returned ProposalData is partially valid even
-// on a non-nil *roachpb.Error.
+// on a non-nil *roachpb.Error and should be proposed through Raft
+// if ProposalData.command is non-nil.
 func (r *Replica) requestToProposal(
 	ctx context.Context,
 	idKey storagebase.CmdIDKey,
@@ -2855,29 +2856,30 @@ func (r *Replica) requestToProposal(
 	endCmds *endCmds,
 	spans *spanset.SpanSet,
 ) (*ProposalData, *roachpb.Error) {
+	res, needConsensus, pErr := r.evaluateProposal(ctx, idKey, ba, spans)
+
+	// Fill out the results even if pErr != nil; we'll return the error below.
 	proposal := &ProposalData{
 		ctx:     ctx,
 		idKey:   idKey,
 		endCmds: endCmds,
 		doneCh:  make(chan proposalResult, 1),
+		Local:   &res.Local,
 		Request: &ba,
 	}
-	var pErr *roachpb.Error
-	var result *result.Result
-	result, pErr = r.evaluateProposal(ctx, idKey, ba, spans)
 
-	// Fill out the results even if pErr != nil; we'll return the error below.
-	proposal.Local = &result.Local
-	proposal.command = storagebase.RaftCommand{
-		ReplicatedEvalResult: result.Replicated,
-		WriteBatch:           result.WriteBatch,
+	if needConsensus {
+		proposal.command = &storagebase.RaftCommand{
+			ReplicatedEvalResult: res.Replicated,
+			WriteBatch:           res.WriteBatch,
+		}
+		if r.store.TestingKnobs().EvalKnobs.TestingEvalFilter != nil {
+			// For backwards compatibility, tests that use TestingEvalFilter
+			// need the original request to be preserved. See #10493
+			proposal.command.TestingBatchRequest = &ba
+		}
 	}
 
-	if r.store.TestingKnobs().EvalKnobs.TestingEvalFilter != nil {
-		// For backwards compatibility, tests that use TestingEvalFilter
-		// need the original request to be preserved. See #10493
-		proposal.command.TestingBatchRequest = &ba
-	}
 	return proposal, pErr
 }
 
@@ -2887,16 +2889,18 @@ func (r *Replica) requestToProposal(
 // return value is ready to be inserted into Replica's proposal map
 // and subsequently passed to submitProposalLocked.
 //
-// If an *Error is returned, the proposal should fail fast, i.e. be
-// sent directly back to the client without going through Raft, but
-// while still handling LocalEvalResult.
+// The method also returns a flag indicating if the request needs to
+// be proposed through Raft and replicated. This flag will be false
+// either if the request was a no-op or if it hit an error. In this
+// case, the result can be sent directly back to the client without
+// going through Raft, but while still handling LocalEvalResult.
 //
 // Replica.mu must not be held.
 func (r *Replica) evaluateProposal(
 	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest, spans *spanset.SpanSet,
-) (*result.Result, *roachpb.Error) {
+) (*result.Result, bool, *roachpb.Error) {
 	if ba.Timestamp == (hlc.Timestamp{}) {
-		return nil, roachpb.NewErrorf("can't propose Raft command with zero timestamp")
+		return nil, false, roachpb.NewErrorf("can't propose Raft command with zero timestamp")
 	}
 
 	// Evaluate the commands. If this returns without an error, the batch should
@@ -2935,43 +2939,60 @@ func (r *Replica) evaluateProposal(
 			LeaseMetricsResult: res.Local.LeaseMetricsResult,
 		}
 		res.Replicated.Reset()
-		return &res, pErr
+		return &res, false /* needConsensus */, pErr
 	}
 
 	// Set the local reply, which is held only on the proposing replica and is
-	// returned to the client after the proposal completes.
+	// returned to the client after the proposal completes, or immediately if
+	// replication is not necessary.
 	res.Local.Reply = br
 
-	// Set the proposal's WriteBatch, which is the serialized representation of
-	// the proposals effect on RocksDB.
-	res.WriteBatch = &storagebase.WriteBatch{
-		Data: batch.Repr(),
-	}
+	// needConsensus determines if the result needs to be replicated and
+	// proposed through Raft. This is necessary if at least one of the
+	// following conditions is true:
+	// 1. the request created a non-empty write batch.
+	// 2. the request had an impact on the MVCCStats. NB: this is possible
+	//    even with an empty write batch when stats are recomputed.
+	// 3. the request has replicated side-effects.
+	// 4. the cluster is in "clockless" mode, in which case consensus is
+	//    used to enforce a linearization of all reads and writes.
+	needConsensus := !batch.Empty() ||
+		ms != (enginepb.MVCCStats{}) ||
+		!res.Replicated.Equal(storagebase.ReplicatedEvalResult{}) ||
+		r.store.Clock().MaxOffset() == timeutil.ClocklessMaxOffset
 
-	// Set the proposal's replicated result, which contains metadata and
-	// side-effects that are to be replicated to all replicas.
-	res.Replicated.IsLeaseRequest = ba.IsLeaseRequest()
-	res.Replicated.Timestamp = ba.Timestamp
-	if r.store.cfg.Settings.Version.IsActive(cluster.VersionMVCCNetworkStats) {
-		res.Replicated.Delta = ms.ToNetworkStats()
-	} else {
-		res.Replicated.DeprecatedDelta = &ms
-	}
-	// If the cluster version is and always will be VersionNoRaftProposalKeys or
-	// greater, we don't need to send the key range through Raft. This decision
-	// is based on the minimum supported version and not the active version
-	// because Raft entries need to be usable even across allowable version
-	// downgrades.
-	if !r.ClusterSettings().Version.IsMinSupported(cluster.VersionNoRaftProposalKeys) {
-		rSpan, err := keys.Range(ba)
-		if err != nil {
-			return nil, roachpb.NewError(err)
+	if needConsensus {
+		// Set the proposal's WriteBatch, which is the serialized representation of
+		// the proposals effect on RocksDB.
+		res.WriteBatch = &storagebase.WriteBatch{
+			Data: batch.Repr(),
 		}
-		res.Replicated.DeprecatedStartKey = rSpan.Key
-		res.Replicated.DeprecatedEndKey = rSpan.EndKey
+
+		// Set the proposal's replicated result, which contains metadata and
+		// side-effects that are to be replicated to all replicas.
+		res.Replicated.IsLeaseRequest = ba.IsLeaseRequest()
+		res.Replicated.Timestamp = ba.Timestamp
+		if r.store.cfg.Settings.Version.IsActive(cluster.VersionMVCCNetworkStats) {
+			res.Replicated.Delta = ms.ToNetworkStats()
+		} else {
+			res.Replicated.DeprecatedDelta = &ms
+		}
+		// If the cluster version is and always will be VersionNoRaftProposalKeys or
+		// greater, we don't need to send the key range through Raft. This decision
+		// is based on the minimum supported version and not the active version
+		// because Raft entries need to be usable even across allowable version
+		// downgrades.
+		if !r.ClusterSettings().Version.IsMinSupported(cluster.VersionNoRaftProposalKeys) {
+			rSpan, err := keys.Range(ba)
+			if err != nil {
+				return &res, false /* needConsensus */, roachpb.NewError(err)
+			}
+			res.Replicated.DeprecatedStartKey = rSpan.Key
+			res.Replicated.DeprecatedEndKey = rSpan.EndKey
+		}
 	}
 
-	return &res, nil
+	return &res, needConsensus, nil
 }
 
 // insertProposalLocked assigns a MaxLeaseIndex to a proposal and adds
@@ -3028,7 +3049,7 @@ func makeIDKey() storagebase.CmdIDKey {
 // propose prepares the necessary pending command struct and initializes a
 // client command ID if one hasn't been. A verified lease is supplied
 // as a parameter if the command requires a lease; nil otherwise. It
-// then proposes the command to Raft and returns
+// then proposes the command to Raft if necessary and returns
 // - a channel which receives a response or error upon application
 // - a closure used to attempt to abandon the command. When called, it tries to
 //   remove the pending command from the internal commands map. This is
@@ -3080,25 +3101,26 @@ func (r *Replica) propose(
 	idKey := makeIDKey()
 	proposal, pErr := r.requestToProposal(ctx, idKey, ba, endCmds, spans)
 	log.Event(proposal.ctx, "evaluated request")
-	// An error here corresponds to a failfast-proposal: The command resulted
-	// in an error and did not need to commit a batch (the common error case).
-	if pErr != nil {
-		if proposal.Local == nil {
-			return nil, nil, noop, roachpb.NewError(errors.Errorf(
-				"requestToProposal returned error %s without eval results", pErr))
-		}
+
+	// There are two cases where request evaluation does not lead to a Raft
+	// proposal:
+	// 1. proposal.command == nil indicates that the evaluation was a no-op
+	//    and that no Raft command needs to be proposed.
+	// 2. pErr != nil corresponds to a failed proposal - the command resulted
+	//    in an error.
+	if proposal.command == nil {
 		intents := proposal.Local.DetachIntents()
-		endTxns := proposal.Local.DetachEndTxns(true /* alwaysOnly */)
-		if proposal.Local != nil {
-			r.handleLocalEvalResult(ctx, *proposal.Local)
+		endTxns := proposal.Local.DetachEndTxns(pErr != nil /* alwaysOnly */)
+		r.handleLocalEvalResult(ctx, *proposal.Local)
+
+		pr := proposalResult{
+			Reply:   proposal.Local.Reply,
+			Err:     pErr,
+			Intents: intents,
+			EndTxns: endTxns,
 		}
-		if endCmds != nil {
-			endCmds.done(nil, pErr, proposalNoRetry)
-		}
-		ch := make(chan proposalResult, 1)
-		ch <- proposalResult{Err: pErr, Intents: intents, EndTxns: endTxns}
-		close(ch)
-		return ch, func() bool { return false }, noop, nil
+		proposal.finishRaftApplication(pr)
+		return proposal.doneCh, func() bool { return false }, noop, nil
 	}
 
 	// TODO(irfansharif): This int cast indicates that if someone configures a
@@ -3164,7 +3186,7 @@ func (r *Replica) propose(
 	if filter := r.store.TestingKnobs().TestingProposalFilter; filter != nil {
 		filterArgs := storagebase.ProposalFilterArgs{
 			Ctx:   ctx,
-			Cmd:   proposal.command,
+			Cmd:   *proposal.command,
 			CmdID: idKey,
 			Req:   ba,
 		}
@@ -3222,7 +3244,7 @@ func (r *Replica) isSoloReplicaRLocked() bool {
 }
 
 func defaultSubmitProposalLocked(r *Replica, p *ProposalData) error {
-	data, err := protoutil.Marshal(&p.command)
+	data, err := protoutil.Marshal(p.command)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2889,45 +2889,80 @@ func (r *Replica) requestToProposal(
 //
 // If an *Error is returned, the proposal should fail fast, i.e. be
 // sent directly back to the client without going through Raft, but
-// while still handling LocalEvalResult. Note that even if this method
-// returns a nil error, the command could still return an error to the
-// client, but only after going through raft (e.g. to lay down
-// intents).
+// while still handling LocalEvalResult.
 //
 // Replica.mu must not be held.
+//
+// TODO(tschottdorf): the setting of WriteTooOld does not work. With
+// proposer-evaluated KV, TestStoreResolveWriteIntentPushOnRead fails in the
+// SNAPSHOT case since the transactional write in that test *always* catches
+// a WriteTooOldError. With proposer-evaluated KV disabled the same happens,
+// but the resulting WriteTooOld flag on the transaction is lost, letting the
+// test pass erroneously.
 func (r *Replica) evaluateProposal(
 	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest, spans *spanset.SpanSet,
 ) (*result.Result, *roachpb.Error) {
-	// Note that we don't hold any locks at this point. This is important
-	// since evaluating a proposal is expensive (at least under proposer-
-	// evaluated KV).
-	var res result.Result
-
 	if ba.Timestamp == (hlc.Timestamp{}) {
 		return nil, roachpb.NewErrorf("can't propose Raft command with zero timestamp")
 	}
 
-	res = r.evaluateProposalInner(ctx, idKey, ba, spans)
+	// Evaluate the commands. If this returns without an error, the batch should
+	// be committed. Note that we don't hold any locks at this point. This is
+	// important since evaluating a proposal is expensive.
+	// TODO(tschottdorf): absorb all returned values in `res` below this point
+	// in the call stack as well.
+	batch, ms, br, res, pErr := r.evaluateWriteBatch(ctx, idKey, ba, spans)
 
-	if res.Local.Err != nil {
-		// Failed proposals (whether they're failfast or not) can't have any
-		// Result except what's whitelisted here.
+	// Note: reusing the proposer's batch when applying the command on the
+	// proposer was explored as an optimization but resulted in no performance
+	// benefit.
+	defer batch.Close()
+
+	if pErr != nil {
+		// Restore the original txn's Writing bool if the error specifies
+		// a transaction.
+		if txn := pErr.GetTxn(); txn != nil {
+			if ba.Txn == nil {
+				log.Fatalf(ctx, "error had a txn but batch is non-transactional. Err txn: %s", txn)
+			}
+			if txn.ID == ba.Txn.ID {
+				txn.Writing = ba.Txn.Writing
+			}
+		}
+
+		// Failed proposals can't have any Result except for what's
+		// whitelisted here.
 		intents := res.Local.DetachIntents()
 		endTxns := res.Local.DetachEndTxns(true /* alwaysOnly */)
 		res.Local = result.LocalResult{
 			Intents:            &intents,
 			EndTxns:            &endTxns,
-			Err:                r.maybeSetCorrupt(ctx, res.Local.Err),
+			Err:                r.maybeSetCorrupt(ctx, pErr),
 			LeaseMetricsResult: res.Local.LeaseMetricsResult,
 		}
-		if res.WriteBatch == nil {
-			res.Replicated.Reset()
-		}
+		res.Replicated.Reset()
+		return &res, res.Local.Err
 	}
 
+	// Set the local reply, which is held only on the proposing replica and is
+	// returned to the client after the proposal completes.
+	res.Local.Reply = br
+
+	// Set the proposal's WriteBatch, which is the serialized representation of
+	// the proposals effect on RocksDB.
+	res.WriteBatch = &storagebase.WriteBatch{
+		Data: batch.Repr(),
+	}
+
+	// Set the proposal's replicated result, which contains metadata and
+	// side-effects that are to be replicated to all replicas.
 	res.Replicated.IsLeaseRequest = ba.IsLeaseRequest()
 	res.Replicated.Timestamp = ba.Timestamp
-
+	if r.store.cfg.Settings.Version.IsActive(cluster.VersionMVCCNetworkStats) {
+		res.Replicated.Delta = ms.ToNetworkStats()
+	} else {
+		res.Replicated.DeprecatedDelta = &ms
+	}
 	// If the cluster version is and always will be VersionNoRaftProposalKeys or
 	// greater, we don't need to send the key range through Raft. This decision
 	// is based on the minimum supported version and not the active version
@@ -2942,15 +2977,6 @@ func (r *Replica) evaluateProposal(
 		res.Replicated.DeprecatedEndKey = rSpan.EndKey
 	}
 
-	if res.WriteBatch == nil {
-		if res.Local.Err == nil {
-			log.Fatalf(ctx, "proposal must fail fast with an error: %+v", ba)
-		}
-		return &res, res.Local.Err
-	}
-
-	// If there is an error, it will be returned to the client when the
-	// proposal (and thus WriteBatch) applies.
 	return &res, nil
 }
 
@@ -5192,68 +5218,6 @@ func (r *Replica) applyRaftCommand(
 	elapsed := timeutil.Since(start)
 	r.store.metrics.RaftCommandCommitLatency.RecordValue(elapsed.Nanoseconds())
 	return deltaStats, nil
-}
-
-// evaluateProposalInner executes the command in a batch engine and returns
-// the batch containing the results. If the return value contains a non-nil
-// WriteBatch, the caller should go ahead with the proposal (eventually
-// committing the data contained in the batch), even when the Err field is set
-// (which is then the result sent to the client).
-//
-// TODO(tschottdorf): the setting of WriteTooOld does not work. With
-// proposer-evaluated KV, TestStoreResolveWriteIntentPushOnRead fails in the
-// SNAPSHOT case since the transactional write in that test *always* catches
-// a WriteTooOldError. With proposer-evaluated KV disabled the same happens,
-// but the resulting WriteTooOld flag on the transaction is lost, letting the
-// test pass erroneously.
-//
-// TODO(bdarnell): merge evaluateProposal and evaluateProposalInner. There
-// is no longer a clear distinction between them.
-func (r *Replica) evaluateProposalInner(
-	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest, spans *spanset.SpanSet,
-) result.Result {
-	// Evaluate the commands. If this returns without an error, the batch should
-	// be committed.
-	// TODO(tschottdorf): absorb all returned values in `res` below this point
-	// in the call stack as well.
-	batch, ms, br, res, pErr := r.evaluateWriteBatch(ctx, idKey, ba, spans)
-	if pErr != nil {
-		// TODO(tschottdorf): make `nil` acceptable. Corresponds to
-		// roachpb.Response{With->Or}Error.
-		res.Local.Reply = &roachpb.BatchResponse{}
-		res.Local.Err = pErr
-		// Reset the batch to clear out partial execution. Don't set
-		// a WriteBatch to signal to the caller that we fail-fast this
-		// proposal.
-		batch.Close()
-		batch = nil
-		// Restore the original txn's Writing bool if the error specifies a
-		// transaction.
-		if txn := res.Local.Err.GetTxn(); txn != nil {
-			if ba.Txn == nil {
-				log.Fatalf(ctx, "error had a txn but batch is non-transactional. Err txn: %s", txn)
-			}
-			if txn.ID == ba.Txn.ID {
-				txn.Writing = ba.Txn.Writing
-			}
-		}
-		return res
-	}
-
-	res.Local.Reply = br
-	if r.store.cfg.Settings.Version.IsActive(cluster.VersionMVCCNetworkStats) {
-		res.Replicated.Delta = ms.ToNetworkStats()
-	} else {
-		res.Replicated.DeprecatedDelta = &ms
-	}
-	res.WriteBatch = &storagebase.WriteBatch{
-		Data: batch.Repr(),
-	}
-	// Note: reusing the proposer's batch when applying the command on the
-	// proposer was explored as an optimization but resulted in no performance
-	// benefit.
-	batch.Close()
-	return res
 }
 
 // checkIfTxnAborted checks the txn AbortSpan for the given

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -62,7 +62,7 @@ type ProposalData struct {
 
 	// command is serialized and proposed to raft. In the event of
 	// reproposals its MaxLeaseIndex field is mutated.
-	command storagebase.RaftCommand
+	command *storagebase.RaftCommand
 
 	// endCmds.finish is called after command execution to update the timestamp cache &
 	// command queue.

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -713,18 +713,10 @@ func (r *Replica) handleReplicatedEvalResult(
 }
 
 func (r *Replica) handleLocalEvalResult(ctx context.Context, lResult result.LocalResult) {
-	// Enqueue failed push transactions on the txnWaitQueue.
-	if !r.store.cfg.DontRetryPushTxnFailures {
-		if tpErr, ok := lResult.Err.GetDetail().(*roachpb.TransactionPushError); ok {
-			r.txnWaitQueue.Enqueue(&tpErr.PusheeTxn)
-		}
-	}
-
 	// Fields for which no action is taken in this method are zeroed so that
 	// they don't trigger an assertion at the end of the method (which checks
 	// that all fields were handled).
 	{
-		lResult.Err = nil
 		lResult.Reply = nil
 	}
 

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -72,7 +72,7 @@ func (r *Replica) maybeSideloadEntriesRaftMuLocked(
 		defer r.mu.Unlock()
 		cmd, ok := r.mu.localProposals[cmdID]
 		if ok {
-			return cmd.command, true
+			return *cmd.command, true
 		}
 		return storagebase.RaftCommand{}, false
 	}

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -329,6 +329,10 @@ func (s spanSetBatch) Distinct() engine.ReadWriter {
 	return makeSpanSetReadWriter(s.b.Distinct(), s.spans)
 }
 
+func (s spanSetBatch) Empty() bool {
+	return s.b.Empty()
+}
+
 func (s spanSetBatch) Repr() []byte {
 	return s.b.Repr()
 }


### PR DESCRIPTION
Backport:
  * 6/6 commits from "storage: merge replica.evaluateProposal and replica.evaluateProposalInner" (#24250)
  * 1/3 commits from "storage: don't require consensus for no-op requests" (#24345)

Please see individual PRs for details.

Created by running:
```
backport 24250 24345 -r 2.0 -c f21fbffef515e980e94f94b0cf8e06b62fedbed1 -c 2a31faf3ef46a12b2552ac938bbf37381e6578f1 -c 4b068af12b1ce234de685e83956cfba3023abce9 -c 3c9deb6e0f098000772e18ac626079fdace1e454 -c 2165a742659aef9a528587b12f3241327b64b2d7 -c 4b265d06fcf6571f3d84e97002a4a27d2b9b5b41 -c 6fcb3db983c55bd5799a880038c222911d2e1dbf
```

The backport was clean.

/cc @cockroachdb/release
