### PR TITLE
sql/logictest: reveal error details if present

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1721,6 +1721,25 @@ func (t *logicTest) verifyError(
 	return true, nil
 }
 
+// formatErr attempts to provide more details if present.
+func formatErr(err error) string {
+	if pqErr, ok := err.(*pq.Error); ok {
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "(%s) %s", pqErr.Code, pqErr.Message)
+		if pqErr.File != "" || pqErr.Line != "" || pqErr.Routine != "" {
+			fmt.Fprintf(&buf, "\n%s:%s: in %s()", pqErr.File, pqErr.Line, pqErr.Routine)
+		}
+		if pqErr.Detail != "" {
+			fmt.Fprintf(&buf, "\nDETAIL: %s", pqErr.Detail)
+		}
+		if pqErr.Code == pgerror.CodeInternalError {
+			fmt.Fprintln(&buf, "\nNOTE: internal errors may have more details in logs. Use -show-logs.")
+		}
+		return buf.String()
+	}
+	return err.Error()
+}
+
 // unexpectedError handles ignoring queries that fail during prepare
 // when -allow-prepare-fail is specified. The argument "sql" is "" to indicate the
 // work is done on behalf of a statement, which always fail upon an
@@ -1734,16 +1753,16 @@ func (t *logicTest) unexpectedError(sql string, pos string, err error) bool {
 		stmt, err := t.db.Prepare(sql)
 		if err != nil {
 			if *showSQL {
-				t.outf("\t-- fails prepare: %s", err)
+				t.outf("\t-- fails prepare: %s", formatErr(err))
 			}
 			t.signalIgnoredError(err, pos, sql)
 			return true
 		}
 		if err := stmt.Close(); err != nil {
-			t.Errorf("%s: %s\nerror when closing prepared statement: %s", sql, pos, err)
+			t.Errorf("%s: %s\nerror when closing prepared statement: %s", sql, pos, formatErr(err))
 		}
 	}
-	t.Errorf("%s: %s\nexpected success, but found\n%s", pos, sql, err)
+	t.Errorf("%s: %s\nexpected success, but found\n%s", pos, sql, formatErr(err))
 	return false
 }
 


### PR DESCRIPTION
Before:

```
testdata/logic_test/assertion_error:4:
expected success, but found
crdb_internal.force_assertion_error(): internal error: woo
```

After (for example, after #35820 is separately applied):

```
testdata/logic_test/assertion_error:4:
expected success, but found
(XX000) crdb_internal.force_assertion_error(): internal error: woo
sql/sem/builtins/builtins.go:2815: in func211()
DETAIL: stack trace:
github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtins.go:2815: in func211()
github.com/cockroachdb/cockroach/pkg/sql/sem/tree/eval.go:3651: in Eval()
github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/expr.go:196: in eval()
github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/processors.go:375: in ProcessRow()
github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/processors.go:778: in ProcessRowHelper()
github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/values.go:126: in Next()
github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/base.go:174: in Run()
github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/processors.go:801: in Run()
github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/flow.go:627: in Run()
github.com/cockroachdb/cockroach/pkg/sql/distsql_running.go:252: in Run()
github.com/cockroachdb/cockroach/pkg/sql/distsql_running.go:839: in PlanAndRun()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor_exec.go:1112: in execWithDistSQLEngine()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor_exec.go:948: in dispatchToExecutionEngine()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor_exec.go:456: in execStmtInOpenState()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor_exec.go:102: in execStmt()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor.go:1178: in run()
github.com/cockroachdb/cockroach/pkg/sql/conn_executor.go:429: in ServeConn()
github.com/cockroachdb/cockroach/pkg/sql/pgwire/conn.go:337: in func4()

NOTE: internal errors may have more details in log. Use -show-logs.
```

Release note: None