### PR TITLE
opt: Fix panic when distinct has extra sort columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -206,6 +206,13 @@ SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
 2 3 2
 5 6 4
 
+# Regression test for #35437: Discard extra ordering columns after performing
+# DISTINCT operation.
+query T
+SELECT (SELECT DISTINCT ON (a) a FROM abc ORDER BY a, b||'foo') || 'bar';
+----
+1bar
+
 #####################
 # With aggregations #
 #####################

--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -1031,3 +1031,66 @@ FROM
     (SELECT a FROM ((SELECT 1 AS a, 1) EXCEPT ALL (SELECT 0, 0)))
 ----
 2
+
+# Regression for issue 35437.
+
+statement ok
+CREATE TABLE users (
+    id INT8 NOT NULL DEFAULT unique_rowid(),
+    name VARCHAR(50),
+    PRIMARY KEY (id)
+);
+INSERT INTO users(id, name) VALUES (1, 'user1');
+INSERT INTO users(id, name) VALUES (2, 'user2');
+INSERT INTO users(id, name) VALUES (3, 'user3');
+
+statement ok
+CREATE TABLE stuff (
+    id INT8 NOT NULL DEFAULT unique_rowid(),
+    date DATE,
+    user_id INT8,
+    PRIMARY KEY (id),
+    FOREIGN KEY (user_id) REFERENCES users (id)
+);
+INSERT INTO stuff(id, date, user_id) VALUES (1, '2007-10-15'::DATE, 1);
+INSERT INTO stuff(id, date, user_id) VALUES (2, '2007-12-15'::DATE, 1);
+INSERT INTO stuff(id, date, user_id) VALUES (3, '2007-11-15'::DATE, 1);
+INSERT INTO stuff(id, date, user_id) VALUES (4, '2008-01-15'::DATE, 2);
+INSERT INTO stuff(id, date, user_id) VALUES (5, '2007-06-15'::DATE, 3);
+INSERT INTO stuff(id, date, user_id) VALUES (6, '2007-03-15'::DATE, 3);
+
+query ITITI
+SELECT
+    users.id AS users_id,
+    users.name AS users_name,
+    stuff_1.id AS stuff_1_id,
+    stuff_1.date AS stuff_1_date,
+    stuff_1.user_id AS stuff_1_user_id
+FROM
+    users
+    LEFT JOIN stuff AS stuff_1
+    ON
+        users.id = stuff_1.user_id
+        AND stuff_1.id
+            = (
+                    SELECT
+                        stuff_2.id
+                    FROM
+                        stuff AS stuff_2
+                    WHERE
+                        stuff_2.user_id = users.id
+                    ORDER BY
+                        stuff_2.date DESC
+                    LIMIT
+                        1
+                )
+ORDER BY
+    users.name;
+----
+1  user1  2  2007-12-15 00:00:00 +0000 +0000  1
+2  user2  4  2008-01-15 00:00:00 +0000 +0000  2
+3  user3  5  2007-06-15 00:00:00 +0000 +0000  3
+
+statement ok
+DROP TABLE stuff;
+DROP TABLE users;

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/pkg/errors"
 )
@@ -240,6 +241,20 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	}
 	if err != nil {
 		return execPlan{}, err
+	}
+
+	// In race builds, assert that the exec plan output columns match the opt
+	// plan output columns.
+	if util.RaceEnabled {
+		optCols := e.Relational().OutputCols
+		var execCols opt.ColSet
+		ep.outputCols.ForEach(func(key, val int) {
+			execCols.Add(key)
+		})
+		if !execCols.Equals(optCols) {
+			return execPlan{}, pgerror.NewAssertionErrorf(
+				"exec columns do not match opt columns: expected %v, got %v", optCols, execCols)
+		}
 	}
 
 	// Wrap the expression in a render expression if presentation requires it.
@@ -863,7 +878,17 @@ func (b *Builder) buildDistinct(distinct *memo.DistinctOnExpr) (execPlan, error)
 	if err != nil {
 		return execPlan{}, err
 	}
-	return execPlan{root: node, outputCols: input.outputCols}, nil
+	ep := execPlan{root: node, outputCols: input.outputCols}
+
+	// buildGroupByInput can add extra sort column(s), so discard those if they
+	// are present by using an additional projection.
+	outCols := distinct.Relational().OutputCols
+	if input.outputCols.Len() == outCols.Len() {
+		return ep, nil
+	}
+	return b.ensureColumns(
+		ep, opt.ColSetToList(outCols), nil /* colNames */, distinct.ProvidedPhysical().Ordering,
+	)
 }
 
 func (b *Builder) buildGroupByInput(groupBy memo.RelExpr) (execPlan, error) {
@@ -1536,15 +1561,13 @@ func (b *Builder) buildDeleteRange(del *memo.DeleteExpr) (execPlan, error) {
 	// canUseDeleteRange has already validated that input is a Scan operator.
 	scan := del.Input.(*memo.ScanExpr)
 	tab := b.mem.Metadata().Table(scan.Table)
-	needed, output := b.getColumns(scan.Cols, scan.Table)
-	res := execPlan{outputCols: output}
+	needed, _ := b.getColumns(scan.Cols, scan.Table)
 
 	root, err := b.factory.ConstructDeleteRange(tab, needed, scan.Constraint)
 	if err != nil {
 		return execPlan{}, err
 	}
-	res.root = root
-	return res, nil
+	return execPlan{root: root}, nil
 }
 
 func (b *Builder) buildCreateTable(ct *memo.CreateTableExpr) (execPlan, error) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -168,7 +168,7 @@ distinct   ·            ·            (pk1, pk2)  weak-key(pk1); +pk1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
-render               ·            ·            (a, c)     ·
+render               ·            ·            (a, c)     +a
  │                   render 0     a            ·          ·
  │                   render 1     c            ·          ·
  └── distinct        ·            ·            (a, b, c)  weak-key(a); +a,-c,+b

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -135,7 +135,7 @@ https://cockroachdb.github.io/distsqlplan/decode.html#eJykk01r4zAQhu_7K8x7lvH3Hn
 query TTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c
 ----
-render          ·            ·            (a, b)     ·
+render          ·            ·            (a, b)     +a,+b
  │              render 0     a            ·          ·
  │              render 1     b            ·          ·
  └── distinct   ·            ·            (a, b, c)  weak-key(a,b); +a,+b,+c


### PR DESCRIPTION
Extra sort columns can get added to the input of a DISTINCT operator. This can
cause a panic when the extra columns(s) are passed through to the  output of the
DISTINCT operator, since they are unexpected. The distinctNode exec operator does
not support projecting a subset of columns.

The fix is to add an explicit renderNode to the output of distinctNode in order to
discard the extra columns.

As part of the fix, I added a new assert that ensures that the exec output columns
match the expected opt output columns. It only runs in race mode. This assert would
have caught this issue with existing tests. It also found another issue, where
the delete range operator was incorrectly projecting columns (it should never have
output columns).

Fixes #35437

Release note: None