### PR TITLE
sql/logictest: reveal error texts better

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1689,7 +1689,7 @@ func (t *logicTest) verifyError(
 		}
 
 		errString := pgerror.FullError(err)
-		newErr := errors.Errorf("%s: %s\nexpected %q, but found %q", pos, sql, expectErr, errString)
+		newErr := errors.Errorf("%s: %s\nexpected:\n%s\n\ngot:\n%s", pos, sql, expectErr, errString)
 		if err != nil && strings.Contains(errString, expectErr) {
 			if t.subtestT != nil {
 				t.subtestT.Logf("The output string contained the input regexp. Perhaps you meant to write:\n"+


### PR DESCRIPTION
Before:

```
--- FAIL: TestLogic/local/assertion_error (0.14s)
    logic.go:2335:

        testdata/logic_test/assertion_error:4:
        expected "waa", but found "pq: internal error:
        crdb_internal.force_assertion_error(): woo\nHINT: You have encountered
        an unexpected error inside CockroachDB.\n\nPlease check
        https://github.com/cockroachdb/cockroach/issues to check\nwhether this
        problem is already tracked. If you cannot find it there,\nplease
        report the error with details at:\n\n
        [...]
        exec.go:456: in
        execStmtInOpenState()\ngithub.com/cockroachdb/cockroach
        /pkg/sql/conn_executor_exec.go:102: in
        execStmt()\ngithub.com/cockroachdb/
        cockroach/pkg/sql/conn_executor.go:1178: in
        run()\ngithub.com/cockroachdb/
        cockroach/pkg/sql/conn_executor.go:429: in
        ServeConn()\ngithub.com/cockroachdb/cockroach/pkg/
        sql/pgwire/conn.go:337: in func4()\n"
```

After:

```
--- FAIL: TestLogic/local/assertion_error (0.15s)
    logic.go:2334:

        testdata/logic_test/assertion_error:4:
        expected:
        waa

        got:
        pq: internal error: crdb_internal.force_assertion_error(): woo
        HINT: You have encountered an unexpected error inside CockroachDB.

        Please check https://github.com/cockroachdb/cockroach/issues to check
        whether this problem is already tracked. If you cannot find it there,
        please report the error with details at: [...]

        DETAIL: stack trace:
        github.com/cockroachdb/cockroach/pkg/sql/sem/tree/eval.go:3664: in Eval()
        github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/expr.go:196: in eval()
        github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/processors.go:375: in ProcessRow()
        github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/processors.go:778: in ProcessRowHelper()
        github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/values.go:126: in Next()
        [...]
```

Release note: None