### PR TITLE
sql*: use pgerror in more places

### DIFF
--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -16,8 +16,8 @@ package sql
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -80,7 +80,8 @@ func (n *alterIndexNode) startExec(params runParams) error {
 			}
 			n.indexDesc.Partitioning = partitioning
 		default:
-			return fmt.Errorf("unsupported alter command: %T", cmd)
+			return pgerror.NewAssertionErrorf(
+				"unsupported alter command: %T", cmd)
 		}
 	}
 

--- a/pkg/sql/alter_user.go
+++ b/pkg/sql/alter_user.go
@@ -18,9 +18,9 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/pkg/errors"
 )
 
 // alterUserSetPasswordNode represents an ALTER USER ... WITH PASSWORD statement.
@@ -70,11 +70,13 @@ func (n *alterUserSetPasswordNode) startExec(params runParams) error {
 
 	// The root user is not allowed a password.
 	if normalizedUsername == security.RootUser {
-		return errors.Errorf("user %s cannot use password authentication", security.RootUser)
+		return pgerror.NewErrorf(pgerror.CodeInvalidPasswordError,
+			"user %s cannot use password authentication", security.RootUser)
 	}
 
 	if len(hashedPassword) > 0 && params.extendedEvalCtx.ExecCfg.RPCContext.Insecure {
-		return errors.New("cluster in insecure mode; user cannot use password authentication")
+		return pgerror.NewError(pgerror.CodeInvalidPasswordError,
+			"cluster in insecure mode; user cannot use password authentication")
 	}
 
 	n.run.rowsAffected, err = params.extendedEvalCtx.ExecCfg.InternalExecutor.Exec(
@@ -89,7 +91,8 @@ func (n *alterUserSetPasswordNode) startExec(params runParams) error {
 		return err
 	}
 	if n.run.rowsAffected == 0 && !n.ifExists {
-		return errors.Errorf("user %s does not exist", normalizedUsername)
+		return pgerror.NewErrorf(pgerror.CodeUndefinedObjectError,
+			"user %s does not exist", normalizedUsername)
 	}
 	return err
 }

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -16,17 +16,18 @@ package sql
 
 import (
 	"context"
-	"errors"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // applyJoinNode implements apply join: the execution component of correlated
@@ -115,9 +116,9 @@ func newApplyJoinNode(
 ) (planNode, error) {
 	switch joinType {
 	case sqlbase.JoinType_RIGHT_OUTER, sqlbase.JoinType_FULL_OUTER:
-		return nil, errors.New("unsupported right outer apply join")
+		return nil, pgerror.NewAssertionErrorf("unsupported right outer apply join: %d", log.Safe(joinType))
 	case sqlbase.JoinType_EXCEPT_ALL, sqlbase.JoinType_INTERSECT_ALL:
-		return nil, errors.New("unsupported apply set op")
+		return nil, pgerror.NewAssertionErrorf("unsupported apply set op: %d", log.Safe(joinType))
 	}
 
 	return &applyJoinNode{

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -16,9 +16,9 @@ package sql
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -66,7 +66,8 @@ func CheckPrivilegeForUser(
 	if descriptor.GetPrivileges().CheckPrivilege(user, privilege) {
 		return nil
 	}
-	return fmt.Errorf("user %s does not have %s privilege on %s %s",
+	return pgerror.NewErrorf(pgerror.CodeInsufficientPrivilegeError,
+		"user %s does not have %s privilege on %s %s",
 		user, privilege, descriptor.TypeName(), descriptor.GetName())
 }
 
@@ -107,7 +108,8 @@ func (p *planner) CheckPrivilege(
 		}
 	}
 
-	return fmt.Errorf("user %s does not have %s privilege on %s %s",
+	return pgerror.NewErrorf(pgerror.CodeInsufficientPrivilegeError,
+		"user %s does not have %s privilege on %s %s",
 		user, privilege, descriptor.TypeName(), descriptor.GetName())
 }
 
@@ -139,7 +141,8 @@ func (p *planner) CheckAnyPrivilege(ctx context.Context, descriptor sqlbase.Desc
 		}
 	}
 
-	return fmt.Errorf("user %s has no privileges on %s %s",
+	return pgerror.NewErrorf(pgerror.CodeInsufficientPrivilegeError,
+		"user %s has no privileges on %s %s",
 		p.SessionData().User, descriptor.TypeName(), descriptor.GetName())
 }
 
@@ -163,7 +166,8 @@ func (p *planner) RequireSuperUser(ctx context.Context, action string) error {
 		return nil
 	}
 
-	return fmt.Errorf("only superusers are allowed to %s", action)
+	return pgerror.NewErrorf(pgerror.CodeInsufficientPrivilegeError,
+		"only superusers are allowed to %s", action)
 }
 
 // MemberOfWithAdminOption looks up all the roles 'member' belongs to (direct and indirect) and

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -165,10 +164,12 @@ func (sc *SchemaChanger) runBackfill(
 					addedChecks = append(addedChecks, &t.Constraint.Check)
 					checksToValidate = append(checksToValidate, *t.Constraint)
 				default:
-					return errors.Errorf("unsupported constraint type: %d", t.Constraint.ConstraintType)
+					return pgerror.NewAssertionErrorf(
+						"unsupported constraint type: %d", log.Safe(t.Constraint.ConstraintType))
 				}
 			default:
-				return errors.Errorf("unsupported mutation: %+v", m)
+				return pgerror.NewAssertionErrorf(
+					"unsupported mutation: %+v", m)
 			}
 
 		case sqlbase.DescriptorMutation_DROP:
@@ -182,12 +183,13 @@ func (sc *SchemaChanger) runBackfill(
 			case *sqlbase.DescriptorMutation_Constraint:
 				// Only possible during a rollback
 				if !m.Rollback {
-					return errors.Errorf(
+					return pgerror.NewAssertionErrorf(
 						"trying to drop constraint through schema changer outside of a rollback: %+v", t)
 				}
 				// no-op
 			default:
-				return errors.Errorf("unsupported mutation: %+v", m)
+				return pgerror.NewAssertionErrorf(
+					"unsupported mutation: %+v", m)
 			}
 		}
 	}
@@ -465,7 +467,8 @@ func getJobIDForMutationWithDescriptor(
 		}
 	}
 
-	return 0, errors.Errorf("job not found for table id %d, mutation %d", tableDesc.ID, mutationID)
+	return 0, pgerror.NewAssertionErrorf(
+		"job not found for table id %d, mutation %d", tableDesc.ID, mutationID)
 }
 
 // nRanges returns the number of ranges that cover a set of spans.
@@ -769,8 +772,9 @@ func (sc *SchemaChanger) validateInvertedIndexes(
 					// JSON columns cannot have unique indexes, so if the expected and
 					// actual counts do not match, it's always a bug rather than a
 					// uniqueness violation.
-					return errors.Errorf("validation of index %s failed: expected %d rows, found %d",
-						idx.Name, expectedCount[i], idxLen)
+					return pgerror.NewAssertionErrorf(
+						"validation of index %s failed: expected %d rows, found %d",
+						idx.Name, log.Safe(expectedCount[i]), log.Safe(idxLen))
 				}
 			case <-ctx.Done():
 				return ctx.Err()
@@ -1002,11 +1006,13 @@ func runSchemaChangesInTxn(
 					tableDesc.Checks = append(tableDesc.Checks, &t.Constraint.Check)
 					checksToValidate = append(checksToValidate, *t.Constraint)
 				default:
-					return errors.Errorf("unsupported constraint type: %d", t.Constraint.ConstraintType)
+					return pgerror.NewAssertionErrorf(
+						"unsupported constraint type: %d", log.Safe(t.Constraint.ConstraintType))
 				}
 
 			default:
-				return errors.Errorf("unsupported mutation: %+v", m)
+				return pgerror.NewAssertionErrorf(
+					"unsupported mutation: %+v", m)
 			}
 
 		case sqlbase.DescriptorMutation_DROP:
@@ -1027,10 +1033,11 @@ func runSchemaChangesInTxn(
 				}
 
 			case *sqlbase.DescriptorMutation_Constraint:
-				return errors.Errorf("constraint validation mutation cannot be in the DROP state within the same transaction: %+v", m)
+				return pgerror.NewAssertionErrorf(
+					"constraint validation mutation cannot be in the DROP state within the same transaction: %+v", m)
 
 			default:
-				return errors.Errorf("unsupported mutation: %+v", m)
+				return pgerror.NewAssertionErrorf("unsupported mutation: %+v", m)
 			}
 
 		}
@@ -1118,7 +1125,7 @@ func columnBackfillInTxn(
 	for k := range fkTables {
 		t := tc.getUncommittedTableByID(k)
 		if (uncommittedTable{}) == t || !t.IsNewTable() {
-			return errors.Errorf(
+			return pgerror.NewAssertionErrorf(
 				"table %s not created in the same transaction as id = %d", tableDesc.Name, k)
 		}
 		otherTableDescs = append(otherTableDescs, t.ImmutableTableDescriptor)

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -22,13 +22,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
 )
 
 // MutationFilter is the type of a simple predicate on a mutation.
@@ -162,7 +162,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 	for id, table := range fkTables {
 		if table.Desc == nil {
 			// We weren't passed all of the tables that we need by the coordinator.
-			return roachpb.Key{}, errors.Errorf("table %v not sent by coordinator", id)
+			return roachpb.Key{}, pgerror.NewAssertionErrorf("table %v not sent by coordinator", id)
 		}
 	}
 	// TODO(dan): Tighten up the bound on the requestedCols parameter to

--- a/pkg/sql/cancel_queries.go
+++ b/pkg/sql/cancel_queries.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
-	"github.com/pkg/errors"
 )
 
 type cancelQueriesNode struct {
@@ -37,10 +36,12 @@ func (p *planner) CancelQueries(ctx context.Context, n *tree.CancelQueries) (pla
 	}
 	cols := planColumns(rows)
 	if len(cols) != 1 {
-		return nil, errors.Errorf("CANCEL QUERIES expects a single column source, got %d columns", len(cols))
+		return nil, pgerror.NewErrorf(pgerror.CodeSyntaxError,
+			"CANCEL QUERIES expects a single column source, got %d columns", len(cols))
 	}
 	if !cols[0].Typ.Equivalent(types.String) {
-		return nil, errors.Errorf("CANCEL QUERIES requires string values, not type %s", cols[0].Typ)
+		return nil, pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError,
+			"CANCEL QUERIES requires string values, not type %s", cols[0].Typ)
 	}
 
 	return &cancelQueriesNode{
@@ -93,7 +94,8 @@ func (n *cancelQueriesNode) Next(params runParams) (bool, error) {
 	}
 
 	if !response.Canceled && !n.ifExists {
-		return false, fmt.Errorf("could not cancel query %s: %s", queryID, response.Error)
+		return false, pgerror.NewErrorf(pgerror.CodeDataExceptionError,
+			"could not cancel query %s: %s", queryID, response.Error)
 	}
 
 	return true, nil

--- a/pkg/sql/cancel_sessions.go
+++ b/pkg/sql/cancel_sessions.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
-	"github.com/pkg/errors"
 )
 
 type cancelSessionsNode struct {
@@ -37,10 +36,12 @@ func (p *planner) CancelSessions(ctx context.Context, n *tree.CancelSessions) (p
 	}
 	cols := planColumns(rows)
 	if len(cols) != 1 {
-		return nil, errors.Errorf("CANCEL SESSIONS expects a single column source, got %d columns", len(cols))
+		return nil, pgerror.NewErrorf(pgerror.CodeSyntaxError,
+			"CANCEL SESSIONS expects a single column source, got %d columns", len(cols))
 	}
 	if !cols[0].Typ.Equivalent(types.String) {
-		return nil, errors.Errorf("CANCEL SESSIONS requires string values, not type %s", cols[0].Typ)
+		return nil, pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError,
+			"CANCEL SESSIONS requires string values, not type %s", cols[0].Typ)
 	}
 
 	return &cancelSessionsNode{
@@ -93,7 +94,8 @@ func (n *cancelSessionsNode) Next(params runParams) (bool, error) {
 	}
 
 	if !response.Canceled && !n.ifExists {
-		return false, fmt.Errorf("could not cancel session %s: %s", sessionID, response.Error)
+		return false, pgerror.NewErrorf(pgerror.CodeDataExceptionError,
+			"could not cancel session %s: %s", sessionID, response.Error)
 	}
 
 	return true, nil

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
 )
 
 func validateCheckExpr(
@@ -57,7 +56,8 @@ func validateCheckExpr(
 		return err
 	}
 	if rows.Len() > 0 {
-		return errors.Errorf("validation of CHECK %q failed on row: %s",
+		return pgerror.NewErrorf(pgerror.CodeCheckViolationError,
+			"validation of CHECK %q failed on row: %s",
 			expr.String(), labeledRowValues(tableDesc.Columns, rows))
 	}
 	return nil

--- a/pkg/sql/colencoding/value_encoding.go
+++ b/pkg/sql/colencoding/value_encoding.go
@@ -16,9 +16,10 @@ package colencoding
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // DecodeTableValueToCol decodes a value encoded by EncodeTableValue, writing
@@ -95,7 +96,8 @@ func decodeUntaggedDatumToCol(
 			vec.Int64()[idx] = i
 		}
 	default:
-		return buf, errors.Errorf("couldn't decode type %s", t)
+		return buf, pgerror.NewAssertionErrorf(
+			"couldn't decode type: %s", log.Safe(t))
 	}
 	return buf, err
 }

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -50,7 +50,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/pkg/errors"
 	"golang.org/x/net/trace"
 )
 
@@ -739,7 +738,8 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 		// We'll cleanup the SQL txn by creating a non-retriable (commit:true) event.
 		// This event is guaranteed to be accepted in every state.
 		ev := eventNonRetriableErr{IsCommit: fsm.FromBool(true)}
-		payload := eventNonRetriableErrPayload{err: fmt.Errorf("connExecutor closing")}
+		payload := eventNonRetriableErrPayload{err: pgerror.NewErrorf(pgerror.CodeAdminShutdownError,
+			"connExecutor closing")}
 		if err := ex.machine.ApplyWithPayload(ctx, ev, payload); err != nil {
 			log.Warningf(ctx, "error while cleaning up connExecutor: %s", err)
 		}
@@ -1393,13 +1393,17 @@ func (ex *connExecutor) updateTxnRewindPosMaybe(
 			nextPos = pos + 1
 		case rewind:
 			if advInfo.rewCap.rewindPos != ex.extraTxnState.txnRewindPos {
-				return errors.Errorf("unexpected rewind position: %d when txn start is: %d",
-					advInfo.rewCap.rewindPos, ex.extraTxnState.txnRewindPos)
+				return pgerror.NewAssertionErrorf(
+					"unexpected rewind position: %d when txn start is: %d",
+					log.Safe(advInfo.rewCap.rewindPos),
+					log.Safe(ex.extraTxnState.txnRewindPos))
 			}
 			// txnRewindPos stays unchanged.
 			return nil
 		default:
-			return errors.Errorf("unexpected advance code when starting a txn: %s", advInfo.code)
+			return pgerror.NewAssertionErrorf(
+				"unexpected advance code when starting a txn: %s",
+				log.Safe(advInfo.code))
 		}
 		ex.setTxnRewindPos(ctx, nextPos)
 	} else {
@@ -1745,7 +1749,8 @@ func (ex *connExecutor) setTransactionModes(
 		}
 	}
 	if modes.Isolation != tree.UnspecifiedIsolation && modes.Isolation != tree.SerializableIsolation {
-		return errors.Errorf("unknown isolation level: %s", modes.Isolation)
+		return pgerror.NewAssertionErrorf(
+			"unknown isolation level: %s", log.Safe(modes.Isolation))
 	}
 	rwMode := modes.ReadWriteMode
 	if modes.AsOf.Expr != nil && (asOfTs == hlc.Timestamp{}) {
@@ -1773,7 +1778,7 @@ func priorityToProto(mode tree.UserPriority) (roachpb.UserPriority, error) {
 	case tree.High:
 		pri = roachpb.MaxUserPriority
 	default:
-		return roachpb.UserPriority(0), errors.Errorf("unknown user priority: %s", mode)
+		return roachpb.UserPriority(0), pgerror.NewAssertionErrorf("unknown user priority: %s", log.Safe(mode))
 	}
 	return pri, nil
 }
@@ -2006,7 +2011,8 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 			return advanceInfo{}, err
 		}
 	default:
-		return advanceInfo{}, errors.Errorf("unexpected event: %v", advInfo.txnEvent)
+		return advanceInfo{}, pgerror.NewAssertionErrorf(
+			"unexpected event: %v", log.Safe(advInfo.txnEvent))
 	}
 
 	return advInfo, nil

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/lib/pq/oid"
-	"github.com/pkg/errors"
 )
 
 func (ex *connExecutor) execPrepare(
@@ -495,7 +494,8 @@ func (ex *connExecutor) execDescribe(
 			res.SetPortalOutput(ctx, portal.Stmt.Columns, portal.OutFormats)
 		}
 	default:
-		return retErr(errors.Errorf("unknown describe type: %s", descCmd.Type))
+		return retErr(pgerror.NewAssertionErrorf(
+			"unknown describe type: %s", log.Safe(descCmd.Type)))
 	}
 	return nil, nil
 }

--- a/pkg/sql/control_jobs.go
+++ b/pkg/sql/control_jobs.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
-	"github.com/pkg/errors"
 )
 
 type controlJobsNode struct {
@@ -43,11 +42,13 @@ func (p *planner) ControlJobs(ctx context.Context, n *tree.ControlJobs) (planNod
 	}
 	cols := planColumns(rows)
 	if len(cols) != 1 {
-		return nil, errors.Errorf("%s JOBS expects a single column source, got %d columns",
+		return nil, pgerror.NewErrorf(pgerror.CodeSyntaxError,
+			"%s JOBS expects a single column source, got %d columns",
 			tree.JobCommandToStatement[n.Command], len(cols))
 	}
 	if !cols[0].Typ.Equivalent(types.Int) {
-		return nil, errors.Errorf("%s JOBS requires int values, not type %s",
+		return nil, pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError,
+			"%s JOBS requires int values, not type %s",
 			tree.JobCommandToStatement[n.Command], cols[0].Typ)
 	}
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -45,7 +45,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/pkg/errors"
 )
 
 const crdbInternalName = "crdb_internal"
@@ -583,7 +582,8 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 
 		sqlStats := p.statsCollector.SQLStats()
 		if sqlStats == nil {
-			return errors.New("cannot access sql statistics from this context")
+			return pgerror.NewAssertionErrorf(
+				"cannot access sql statistics from this context")
 		}
 
 		leaseMgr := p.LeaseMgr()
@@ -1792,7 +1792,8 @@ CREATE TABLE crdb_internal.zones (
 			if entry, ok := namespace[sqlbase.ID(id)]; ok {
 				return uint32(entry.parentID), entry.name, nil
 			}
-			return 0, "", fmt.Errorf("object with ID %d does not exist", id)
+			return 0, "", pgerror.NewAssertionErrorf(
+				"object with ID %d does not exist", log.Safe(id))
 		}
 
 		rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.Query(

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -16,9 +16,9 @@ package sql
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -38,7 +38,8 @@ func (p *planner) CreateDatabase(ctx context.Context, n *tree.CreateDatabase) (p
 	if tmpl := n.Template; tmpl != "" {
 		// See https://www.postgresql.org/docs/current/static/manage-ag-templatedbs.html
 		if !strings.EqualFold(tmpl, "template0") {
-			return nil, fmt.Errorf("unsupported template: %s", tmpl)
+			return nil, pgerror.UnimplementedWithIssueErrorf(10151,
+				"unsupported template: %s", tmpl)
 		}
 	}
 
@@ -47,21 +48,24 @@ func (p *planner) CreateDatabase(ctx context.Context, n *tree.CreateDatabase) (p
 		if !(strings.EqualFold(enc, "UTF8") ||
 			strings.EqualFold(enc, "UTF-8") ||
 			strings.EqualFold(enc, "UNICODE")) {
-			return nil, fmt.Errorf("unsupported encoding: %s", enc)
+			return nil, pgerror.Unimplemented("create.db.encoding",
+				"unsupported encoding: %s", enc)
 		}
 	}
 
 	if col := n.Collate; col != "" {
 		// We only support C and C.UTF-8.
 		if col != "C" && col != "C.UTF-8" {
-			return nil, fmt.Errorf("unsupported collation: %s", col)
+			return nil, pgerror.Unimplemented("create.db.collation",
+				"unsupported collation: %s", col)
 		}
 	}
 
 	if ctype := n.CType; ctype != "" {
 		// We only support C and C.UTF-8.
 		if ctype != "C" && ctype != "C.UTF-8" {
-			return nil, fmt.Errorf("unsupported character classification: %s", ctype)
+			return nil, pgerror.Unimplemented("create.db.classification",
+				"unsupported character classification: %s", ctype)
 		}
 	}
 

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -16,7 +16,6 @@ package sql
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -85,7 +84,8 @@ func (n *createIndexNode) startExec(params runParams) error {
 	_, dropped, err := n.tableDesc.FindIndexByName(string(n.n.Name))
 	if err == nil {
 		if dropped {
-			return fmt.Errorf("index %q being dropped, try again later", string(n.n.Name))
+			return pgerror.NewErrorf(pgerror.CodeObjectNotInPrerequisiteStateError,
+				"index %q being dropped, try again later", string(n.n.Name))
 		}
 		if n.n.IfNotExists {
 			return nil

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -101,7 +101,8 @@ func (*createStatsNode) Values() tree.Datums   { return nil }
 // startJob starts a CreateStats job to plan and execute statistics creation.
 func (n *createStatsNode) startJob(ctx context.Context, resultsCh chan<- tree.Datums) error {
 	if !n.p.ExecCfg().Settings.Version.IsActive(cluster.VersionCreateStats) {
-		return errors.Errorf(`CREATE STATISTICS requires all nodes to be upgraded to %s`,
+		return pgerror.NewErrorf(pgerror.CodeObjectNotInPrerequisiteStateError,
+			`CREATE STATISTICS requires all nodes to be upgraded to %s`,
 			cluster.VersionByKey(cluster.VersionCreateStats),
 		)
 	}
@@ -161,7 +162,8 @@ func (n *createStatsNode) startJob(ctx context.Context, resultsCh chan<- tree.Da
 		columnIDs := make([]sqlbase.ColumnID, len(columns))
 		for i := range columns {
 			if columns[i].Type.SemanticType == sqlbase.ColumnType_JSONB {
-				return errors.New("CREATE STATISTICS is not supported for JSON columns")
+				return pgerror.UnimplementedWithIssueErrorf(35844,
+					"CREATE STATISTICS is not supported for JSON columns")
 			}
 			columnIDs[i] = columns[i].ID
 		}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -489,13 +489,15 @@ func ResolveFK(
 	}
 
 	if len(targetCols) != len(srcCols) {
-		return fmt.Errorf("%d columns must reference exactly %d columns in referenced table (found %d)",
+		return pgerror.NewErrorf(pgerror.CodeSyntaxError,
+			"%d columns must reference exactly %d columns in referenced table (found %d)",
 			len(srcCols), len(srcCols), len(targetCols))
 	}
 
 	for i := range srcCols {
 		if s, t := srcCols[i], targetCols[i]; s.Type.SemanticType != t.Type.SemanticType {
-			return fmt.Errorf("type of %q (%s) does not match foreign key %q.%q (%s)",
+			return pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError,
+				"type of %q (%s) does not match foreign key %q.%q (%s)",
 				s.Name, s.Type.SemanticType, target.Name, t.Name, t.Type.SemanticType)
 		}
 	}

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
 )
 
 //
@@ -184,7 +183,7 @@ func (dc *databaseCache) getCachedDatabaseDescByID(
 
 	database := desc.GetDatabase()
 	if database == nil {
-		return nil, errors.Errorf("[%d] is not a database", id)
+		return nil, pgerror.NewErrorf(pgerror.CodeWrongObjectTypeError, "[%d] is not a database", id)
 	}
 
 	return database, database.Validate()

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -19,11 +19,11 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
 )
 
 // deleteRangeNode implements DELETE on a primary index satisfying certain
@@ -189,7 +189,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 				return err
 			}
 			if !ok {
-				return errors.Errorf("key did not match descriptor")
+				return pgerror.NewAssertionErrorf("key did not match descriptor")
 			}
 			k := i[:len(i)-len(after)]
 			if !bytes.Equal(k, prev) {

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
 )
 
 //
@@ -177,7 +176,8 @@ func getDescriptorByID(
 	case *sqlbase.TableDescriptor:
 		table := desc.GetTable()
 		if table == nil {
-			return errors.Errorf("%q is not a table", desc.String())
+			return pgerror.NewErrorf(pgerror.CodeWrongObjectTypeError,
+				"%q is not a table", desc.String())
 		}
 		table.MaybeFillInDescriptor()
 
@@ -188,7 +188,8 @@ func getDescriptorByID(
 	case *sqlbase.DatabaseDescriptor:
 		database := desc.GetDatabase()
 		if database == nil {
-			return errors.Errorf("%q is not a database", desc.String())
+			return pgerror.NewErrorf(pgerror.CodeWrongObjectTypeError,
+				"%q is not a database", desc.String())
 		}
 
 		if err := database.Validate(); err != nil {
@@ -220,7 +221,7 @@ func GetAllDescriptors(ctx context.Context, txn *client.Txn) ([]sqlbase.Descript
 		case *sqlbase.Descriptor_Database:
 			descs[i] = desc.GetDatabase()
 		default:
-			return nil, errors.Errorf("Descriptor.Union has unexpected type %T", t)
+			return nil, pgerror.NewAssertionErrorf("Descriptor.Union has unexpected type %T", t)
 		}
 	}
 	return descs, nil

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -307,7 +308,7 @@ func (ds *ServerImpl) setupFlow(
 	}
 	nodeID := ds.ServerConfig.NodeID.Get()
 	if nodeID == 0 {
-		return nil, nil, errors.Errorf("setupFlow called before the NodeID was resolved")
+		return nil, nil, pgerror.NewAssertionErrorf("setupFlow called before the NodeID was resolved")
 	}
 
 	const opName = "flow"
@@ -380,8 +381,8 @@ func (ds *ServerImpl) setupFlow(
 		case distsqlpb.BytesEncodeFormat_BASE64:
 			be = sessiondata.BytesEncodeBase64
 		default:
-			return nil, nil, errors.Errorf("unknown byte encode format: %s",
-				req.EvalContext.BytesEncodeFormat.String())
+			return nil, nil, pgerror.NewAssertionErrorf("unknown byte encode format: %s",
+				log.Safe(req.EvalContext.BytesEncodeFormat))
 		}
 		sd := &sessiondata.SessionData{
 			ApplicationName: req.EvalContext.ApplicationName,
@@ -527,7 +528,7 @@ func (ds *ServerImpl) RunSyncFlow(stream distsqlpb.DistSQL_RunSyncFlowServer) er
 		return err
 	}
 	if firstMsg.SetupFlowRequest == nil {
-		return errors.Errorf("first message in RunSyncFlow doesn't contain SetupFlowRequest")
+		return pgerror.NewAssertionErrorf("first message in RunSyncFlow doesn't contain SetupFlowRequest")
 	}
 	req := firstMsg.SetupFlowRequest
 	ctx, f, err := ds.SetupSyncFlow(stream.Context(), &ds.memMonitor, req, mbox)
@@ -582,12 +583,12 @@ func (ds *ServerImpl) flowStreamInt(
 	msg, err := stream.Recv()
 	if err != nil {
 		if err == io.EOF {
-			return errors.Errorf("missing header message")
+			return pgerror.NewAssertionErrorf("missing header message")
 		}
 		return err
 	}
 	if msg.Header == nil {
-		return errors.Errorf("no header in first message")
+		return pgerror.NewAssertionErrorf("no header in first message")
 	}
 	flowID := msg.Header.FlowID
 	streamID := msg.Header.StreamID

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -208,7 +209,8 @@ func newSorter(
 		// LIMIT and OFFSET should each never be greater than math.MaxInt64, the
 		// parser ensures this.
 		if post.Limit > math.MaxInt64 || post.Offset > math.MaxInt64 {
-			return nil, errors.Errorf("error creating sorter: limit %d offset %d too large", post.Limit, post.Offset)
+			return nil, pgerror.NewAssertionErrorf(
+				"error creating sorter: limit %d offset %d too large", log.Safe(post.Limit), log.Safe(post.Offset))
 		}
 		count = post.Limit + post.Offset
 	}

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/sqlmigrations"
@@ -639,7 +640,7 @@ func TestDropIndexWithZoneConfigOSS(t *testing.T) {
 
 	// Verify that dropping the index fails with a "CCL required" error.
 	_, err = sqlDBRaw.Exec(`DROP INDEX t.kv@foo`)
-	if pqErr, ok := err.(*pq.Error); !ok || pqErr.Code != sqlbase.CodeCCLRequired {
+	if pqErr, ok := err.(*pq.Error); !ok || string(pqErr.Code) != pgerror.CodeCCLRequired {
 		t.Fatalf("expected pq error with CCLRequired code, but got %v", err)
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/backup
+++ b/pkg/sql/logictest/testdata/logic_test/backup
@@ -1,7 +1,7 @@
 # LogicTest: local local-opt fakedist fakedist-opt fakedist-metadata
 
-query error unknown statement type
+query error pgcode XXC01 a CCL binary is required to use this statement type
 BACKUP DATABASE foo TO '/bar' INCREMENTAL FROM '/baz'
 
-query error unknown statement type
+query error  pgcode XXC01 a CCL binary is required to use this statement type
 RESTORE DATABASE foo FROM '/bar'

--- a/pkg/sql/logictest/testdata/logic_test/ccl
+++ b/pkg/sql/logictest/testdata/logic_test/ccl
@@ -2,20 +2,20 @@
 
 # CCL-only statements error out trying to handle the parsed statements.
 
-statement error pq: unknown statement type: \*tree\.Backup
+statement error pgcode XXC01 a CCL binary is required to use this statement type: \*tree\.Backup
 BACKUP foo TO "bar"
 
-statement error pq: unknown statement type: \*tree\.Restore
+statement error pgcode XXC01 a CCL binary is required to use this statement type: \*tree\.Restore
 RESTORE foo FROM "bar"
 
-statement error pq: unknown statement type: \*tree\.CreateRole
+statement error pgcode XXC01 a CCL binary is required to use this statement type: \*tree\.CreateRole
 CREATE ROLE foo
 
-statement error pq: unknown statement type: \*tree\.DropRole
+statement error pgcode XXC01 a CCL binary is required to use this statement type: \*tree\.DropRole
 DROP ROLE foo
 
-statement error pq: unknown statement type: \*tree\.GrantRole
+statement error pgcode XXC01 a CCL binary is required to use this statement type: \*tree\.GrantRole
 GRANT foo TO testuser
 
-statement error pq: unknown statement type: \*tree\.RevokeRole
+statement error pgcode XXC01 a CCL binary is required to use this statement type: \*tree\.RevokeRole
 REVOKE foo FROM testuser

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -374,7 +374,7 @@ statement ok
 CREATE TABLE groups (data JSON); INSERT INTO groups VALUES ('{"data": {"domain": "github.com"}}')
 
 # Ensure that trying to create statistics on a JSON column gives an appropriate error.
-statement error pq: CREATE STATISTICS is not supported for JSON columns
+statement error CREATE STATISTICS is not supported for JSON columns
 CREATE STATISTICS s ON data FROM groups
 
 # The json column is not included in the default columns.

--- a/pkg/sql/logictest/testdata/logic_test/partitioning
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning
@@ -1,12 +1,12 @@
 # LogicTest: local local-opt
 
-statement error creating or manipulating partitions requires a CCL binary
+statement error pgcode XXC01 creating or manipulating partitions requires a CCL binary
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (1),
     PARTITION p2 VALUES IN (2)
 )
 
-statement error creating or manipulating partitions requires a CCL binary
+statement error pgcode XXC01 creating or manipulating partitions requires a CCL binary
 CREATE TABLE t (
     a INT PRIMARY KEY, b INT,
     INDEX (b) PARTITION BY LIST (b) (

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -237,7 +237,7 @@ statement ok
 CREATE INDEX bar ON test.kv (quantity)
 
 # bar is invisible
-statement error pgcode XX000 index "bar" not found
+statement error index "bar" not found
 SELECT * FROM test.kv@bar
 
 statement ok
@@ -245,7 +245,7 @@ COMMIT
 
 # bar is still invisible because the error above prevents the
 # transaction from committing.
-statement error pgcode XX000 index "bar" not found
+statement error index "bar" not found
 SELECT * FROM test.kv@bar
 
 subtest create_reference_to_create_outside_txn_17949

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -826,7 +826,7 @@ ALTER TABLE check_table ADD e INT DEFAULT 0
 statement ok
 ALTER TABLE check_table ADD CONSTRAINT e_0 CHECK (e > 0)
 
-statement error pq: validation of CHECK "e > 0" failed on row: k=1, c=NULL, d=1, e=0
+statement error validation of CHECK "e > 0" failed on row: k=1, c=NULL, d=1, e=0
 COMMIT
 
 # Constraint e_0 was not added
@@ -883,7 +883,7 @@ ALTER TABLE check_table ADD CHECK (a >= 0)
 statement ok
 ALTER TABLE check_table ADD CHECK (a < 0)
 
-statement error pq: validation of CHECK \"a < 0\" failed on row: k=0, a=0
+statement error validation of CHECK \"a < 0\" failed on row: k=0, a=0
 COMMIT
 
 query TTTTB
@@ -908,7 +908,7 @@ ALTER TABLE check_table ADD f INT
 statement ok
 ALTER TABLE check_table ADD CONSTRAINT f_0 CHECK (f > 0)
 
-statement error pq: constraint "f_0" in the middle of being added
+statement error constraint "f_0" in the middle of being added
 ALTER TABLE check_table DROP CONSTRAINT f_0
 
 statement ok
@@ -923,7 +923,7 @@ ALTER TABLE check_table ADD g INT
 statement ok
 ALTER TABLE check_table ADD CONSTRAINT g_0 CHECK (g > 0)
 
-statement error pq: referencing constraint "g_0" in the middle of being added
+statement error referencing constraint "g_0" in the middle of being added
 ALTER TABLE check_table DROP COLUMN g
 
 statement ok
@@ -938,7 +938,7 @@ ALTER TABLE check_table ADD h INT
 statement ok
 ALTER TABLE check_table ADD CONSTRAINT h_0 CHECK (h > 0)
 
-statement error pq: constraint "h_0" in the middle of being added
+statement error constraint "h_0" in the middle of being added
 ALTER TABLE check_table VALIDATE CONSTRAINT h_0
 
 statement ok
@@ -961,7 +961,7 @@ ALTER TABLE check_table ADD f INT
 statement ok
 ALTER TABLE check_table ADD CONSTRAINT f_0 CHECK (f > 0)
 
-statement error pq: constraint "f_0" in the middle of being added
+statement error constraint "f_0" in the middle of being added
 ALTER TABLE check_table RENAME CONSTRAINT f_0 to f_1
 
 statement ok
@@ -973,7 +973,7 @@ BEGIN
 statement ok
 ALTER TABLE check_table ADD f INT
 
-statement error pq: constraint "f_0" in the middle of being added
+statement error constraint "f_0" in the middle of being added
 ALTER TABLE check_table ADD CONSTRAINT f_0 CHECK (f > 0),
                         RENAME CONSTRAINT f_0 to f_1
 
@@ -1045,7 +1045,7 @@ statement ok
 INSERT INTO check_table VALUES (0)
 
 # This validates the constraint for existing rows, because it's in the same txn as CREATE TABLE
-statement error pq: validation of CHECK "a > 0" failed on row: a=0
+statement error validation of CHECK "a > 0" failed on row: a=0
 ALTER TABLE check_table ADD CONSTRAINT ck CHECK (a > 0)
 
 statement ok
@@ -1064,7 +1064,7 @@ statement ok
 ALTER TABLE check_table ADD COLUMN b INT DEFAULT 0
 
 # This validates the constraint for existing rows, because it's in the same txn as CREATE TABLE
-statement error pq: validation of CHECK "b > 0" failed on row: a=0, b=0
+statement error validation of CHECK "b > 0" failed on row: a=0, b=0
 ALTER TABLE check_table ADD CONSTRAINT ck CHECK (b > 0)
 
 statement ok
@@ -1080,7 +1080,7 @@ statement ok
 INSERT INTO check_table VALUES (0)
 
 # Test ADD COLUMN and ADD CONSTRAINT in the same ALTER TABLE statement
-statement error pq: validation of CHECK "c > 0" failed on row: a=0, c=0
+statement error validation of CHECK "c > 0" failed on row: a=0, c=0
 ALTER TABLE check_table ADD COLUMN c INT DEFAULT 0, ADD CONSTRAINT ck CHECK (c > 0)
 
 statement ok
@@ -1134,7 +1134,7 @@ ALTER TABLE t ADD CHECK (a < c)
 statement ok
 INSERT INTO t (a) VALUES (11)
 
-statement error pq: validation of CHECK \"a < c\" failed on row: a=11, .* c=10
+statement error validation of CHECK \"a < c\" failed on row: a=11, .* c=10
 COMMIT
 
 # Insert a pre-existing row to test updates
@@ -1153,7 +1153,7 @@ ALTER TABLE t ADD CHECK (a < c)
 statement ok
 UPDATE t SET a = 12 WHERE a < 12
 
-statement error pq: validation of CHECK \"a < c\" failed on row: a=12, .*, c=10
+statement error validation of CHECK \"a < c\" failed on row: a=12, .*, c=10
 COMMIT
 
 statement ok
@@ -1235,7 +1235,7 @@ ALTER TABLE t ADD CHECK (a < c)
 statement ok
 INSERT INTO t (a) VALUES (11)
 
-statement error pq: validation of CHECK \"a < c\" failed on row: a=11, .* c=10
+statement error validation of CHECK \"a < c\" failed on row: a=11, .* c=10
 COMMIT
 
 # Insert a pre-existing row to test updates
@@ -1254,7 +1254,7 @@ ALTER TABLE t ADD CHECK (a < c)
 statement ok
 UPDATE t SET a = 12 WHERE a < 12
 
-statement error pq: validation of CHECK \"a < c\" failed on row: a=12, .*, c=11
+statement error validation of CHECK \"a < c\" failed on row: a=12, .*, c=11
 COMMIT
 
 statement ok

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -1012,7 +1013,17 @@ func writeErr(
 	if ok {
 		code = pgErr.Code
 	} else {
-		code = pgerror.CodeInternalError
+		// The error was not decorated as an pgerror.Error. We don't know
+		// its code, in fact we don't know pretty much anything about it.
+		// We're going to let it flow to the user as a XXUUU error.
+		// We don't use CodeInternalError here (XX000) because internal
+		// errors have gain special status "please tell us about it
+		// ASAP" in CockroachDB.
+		code = pgerror.CodeUncategorizedError
+		// However, we'll keep track of the number of occurrences in
+		// telemetry. Over time, we'll want this count to go down
+		// (i.e. more errors becoming qualified).
+		telemetry.Inc(sqltelemetry.UncategorizedErrorCounter)
 	}
 
 	msgBuilder.putErrFieldMsg(pgwirebase.ServerErrFieldSQLState)

--- a/pkg/sql/pgwire/pgerror/codes.go
+++ b/pkg/sql/pgwire/pgerror/codes.go
@@ -313,4 +313,8 @@ var (
 	// CodeCCLRequired signals that a CCL binary is required to complete this
 	// task.
 	CodeCCLRequired = "XXC01"
+
+	// CodeCCLValidLicenseRequired signals that a valid CCL license is
+	// required to complete this task.
+	CodeCCLValidLicenseRequired = "XXC02"
 )

--- a/pkg/sql/pgwire/pgerror/codes.go
+++ b/pkg/sql/pgwire/pgerror/codes.go
@@ -297,3 +297,20 @@ const (
 	CodeDataCorruptedError  = "XX001"
 	CodeIndexCorruptedError = "XX002"
 )
+
+// The following errors are CockroachDB-specific.
+
+var (
+	// CodeUncategorizedError is used for errors that flow out to a client
+	// when there's no code known yet.
+	CodeUncategorizedError = "XXUUU"
+
+	// CodeRangeUnavailable signals that some data from the cluster cannot be
+	// accessed (e.g. because all replicas awol).
+	// We're using the postgres "Internal Error" error class "XX".
+	CodeRangeUnavailable = "XXC00"
+
+	// CodeCCLRequired signals that a CCL binary is required to complete this
+	// task.
+	CodeCCLRequired = "XXC01"
+)

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -465,7 +465,7 @@ func (b *writeBuffer) writeBinaryDatum(
 		b.putInt32(4)
 		b.putInt32(int32(v.DInt))
 	default:
-		b.setError(errors.Errorf("unsupported type %T", d))
+		b.setError(pgerror.NewAssertionErrorf("unsupported type %T", d))
 	}
 }
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/pkg/errors"
 )
 
 type planMaker interface {
@@ -767,8 +766,11 @@ func (p *planner) newPlan(
 		return p.Values(ctx, n, desiredTypes)
 	case *tree.ValuesClauseWithNames:
 		return p.Values(ctx, n, desiredTypes)
+	case tree.CCLOnlyStatement:
+		return nil, pgerror.NewErrorf(pgerror.CodeCCLRequired,
+			"a CCL binary is required to use this statement type: %T", stmt)
 	default:
-		return nil, errors.Errorf("unknown statement type: %T", stmt)
+		return nil, pgerror.NewAssertionErrorf("unknown statement type: %T", stmt)
 	}
 }
 

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
 )
 
 var queryCacheEnabled = settings.RegisterBoolSetting(
@@ -281,13 +280,13 @@ func (opc *optPlanningCtx) buildReusableMemo(
 	_, isCanned := opc.p.stmt.AST.(*tree.CannedOptPlan)
 	if isCanned {
 		if !p.EvalContext().SessionData.AllowPrepareAsOptPlan {
-			return nil, false, errors.Errorf(
+			return nil, false, pgerror.NewError(pgerror.CodeInsufficientPrivilegeError,
 				"PREPARE AS OPT PLAN is a testing facility that should not be used directly",
 			)
 		}
 
 		if p.SessionData().User != security.RootUser {
-			return nil, false, errors.Errorf(
+			return nil, false, pgerror.NewError(pgerror.CodeInsufficientPrivilegeError,
 				"PREPARE AS OPT PLAN may only be used by root",
 			)
 		}
@@ -311,7 +310,8 @@ func (opc *optPlanningCtx) buildReusableMemo(
 			// We don't support placeholders inside the canned plan. The main reason
 			// is that they would be invisible to the parser (which is reports the
 			// number of placeholders, used to initialize the relevant structures).
-			return nil, false, errors.Errorf("placeholders are not supported with PREPARE AS OPT PLAN")
+			return nil, false, pgerror.NewErrorf(pgerror.CodeSyntaxError,
+				"placeholders are not supported with PREPARE AS OPT PLAN")
 		}
 		// With a canned plan, the memo is already optimized.
 	} else {

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
 )
 
 // collectSpans collects the upper bound set of read and write spans that the
@@ -202,7 +202,7 @@ func indexJoinSpans(params runParams, n *indexJoinNode) (reads, writes roachpb.S
 		return nil, nil, err
 	}
 	if len(indexWrites) > 0 {
-		return nil, nil, errors.Errorf("unexpected index scan span writes: %v", indexWrites)
+		return nil, nil, pgerror.NewAssertionErrorf("unexpected index scan span writes: %v", indexWrites)
 	}
 	// We can not be sure which spans in the table we will read based only on the
 	// initial index span because we will dynamically lookup rows in the table based

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -203,11 +203,11 @@ func isPermanentSchemaChangeError(err error) bool {
 }
 
 var (
-	errExistingSchemaChangeLease  = errors.New("an outstanding schema change lease exists")
-	errExpiredSchemaChangeLease   = errors.New("the schema change lease has expired")
-	errSchemaChangeNotFirstInLine = errors.New("schema change not first in line")
-	errNotHitGCTTLDeadline        = errors.New("not hit gc ttl deadline")
-	errSchemaChangeDuringDrain    = errors.New("a schema change ran during the drain phase, re-increment")
+	errExistingSchemaChangeLease  = pgerror.NewErrorf(pgerror.CodeDataExceptionError, "an outstanding schema change lease exists")
+	errExpiredSchemaChangeLease   = pgerror.NewErrorf(pgerror.CodeDataExceptionError, "the schema change lease has expired")
+	errSchemaChangeNotFirstInLine = pgerror.NewErrorf(pgerror.CodeDataExceptionError, "schema change not first in line")
+	errNotHitGCTTLDeadline        = pgerror.NewErrorf(pgerror.CodeDataExceptionError, "not hit gc ttl deadline")
+	errSchemaChangeDuringDrain    = pgerror.NewErrorf(pgerror.CodeDataExceptionError, "a schema change ran during the drain phase, re-increment")
 )
 
 func shouldLogSchemaChangeError(err error) bool {
@@ -275,11 +275,12 @@ func (sc *SchemaChanger) findTableWithLease(
 		return nil, err
 	}
 	if tableDesc.Lease == nil {
-		return nil, errors.Errorf("no lease present for tableID: %d", sc.tableID)
+		return nil, pgerror.NewAssertionErrorf("no lease present for tableID: %d", log.Safe(sc.tableID))
 	}
 	if *tableDesc.Lease != lease {
 		log.Errorf(ctx, "table: %d has lease: %v, expected: %v", sc.tableID, tableDesc.Lease, lease)
-		return nil, errExpiredSchemaChangeLease
+		return nil, pgerror.NewAssertionErrorWithWrappedErrf(errExpiredSchemaChangeLease,
+			"table: %d has lease: %v, expected: %v", log.Safe(sc.tableID), log.Safe(tableDesc.Lease), log.Safe(lease))
 	}
 	return tableDesc, nil
 }
@@ -597,7 +598,7 @@ func (sc *SchemaChanger) maybeGCMutations(
 		}
 	}
 	if !found {
-		return errors.Errorf("no GC mutation for index %d", sc.dropIndexTimes[0].indexID)
+		return pgerror.NewAssertionErrorf("no GC mutation for index %d", log.Safe(sc.dropIndexTimes[0].indexID))
 	}
 
 	// Check if the deadline for GC'd dropped index expired because
@@ -671,7 +672,7 @@ func (sc *SchemaChanger) updateDropTableJob(
 
 	schemaDetails, ok := job.Details().(jobspb.SchemaChangeDetails)
 	if !ok {
-		return errors.Errorf("unexpected details for job %d", *job.ID())
+		return pgerror.NewAssertionErrorf("unexpected details for job %d: %T", log.Safe(*job.ID()), job.Details())
 	}
 
 	lowestStatus := jobspb.Status_DONE
@@ -696,7 +697,7 @@ func (sc *SchemaChanger) updateDropTableJob(
 	case jobspb.Status_DONE:
 		return job.WithTxn(txn).Succeeded(ctx, onSuccess)
 	default:
-		return errors.Errorf("unexpected dropped table status %d", lowestStatus)
+		return pgerror.NewAssertionErrorf("unexpected dropped table status %d", log.Safe(lowestStatus))
 	}
 
 	if err := job.WithTxn(txn).SetDetails(ctx, schemaDetails); err != nil {
@@ -1149,7 +1150,7 @@ func (sc *SchemaChanger) reverseMutations(ctx context.Context, causingError erro
 			if mutation.Rollback {
 				// Can actually never happen. This prevents a rollback of
 				// an already rolled back mutation.
-				return errors.Errorf("mutation already rolled back: %v", mutation)
+				return pgerror.NewAssertionErrorf("mutation already rolled back: %v", mutation)
 			}
 
 			log.Warningf(ctx, "reverse schema change mutation: %+v", mutation)
@@ -1310,7 +1311,7 @@ func (sc *SchemaChanger) createRollbackJob(
 		}
 	}
 	// Cannot get here.
-	return nil, fmt.Errorf("no job found for table %d mutation %d", sc.tableID, sc.mutationID)
+	return nil, pgerror.NewAssertionErrorf("no job found for table %d mutation %d", log.Safe(sc.tableID), log.Safe(sc.mutationID))
 }
 
 func (sc *SchemaChanger) maybeDropValidatingConstraint(
@@ -1332,7 +1333,7 @@ func (sc *SchemaChanger) maybeDropValidatingConstraint(
 			)
 		}
 	default:
-		return errors.Errorf("unsupported constraint type: %d", constraint.ConstraintType)
+		return pgerror.NewAssertionErrorf("unsupported constraint type: %d", log.Safe(constraint.ConstraintType))
 	}
 	return nil
 }

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -168,6 +168,21 @@ type ObserverStatement interface {
 	observerStatement()
 }
 
+// CCLOnlyStatement is a marker interface for statements that require
+// a CCL binary for successful planning or execution.
+// It is used to enhance error messages when attempting to use these
+// statements in non-CCL binaries.
+type CCLOnlyStatement interface {
+	cclOnlyStatement()
+}
+
+var _ CCLOnlyStatement = &Backup{}
+var _ CCLOnlyStatement = &Restore{}
+var _ CCLOnlyStatement = &CreateRole{}
+var _ CCLOnlyStatement = &DropRole{}
+var _ CCLOnlyStatement = &GrantRole{}
+var _ CCLOnlyStatement = &RevokeRole{}
+
 // StatementType implements the Statement interface.
 func (*AlterIndex) StatementType() StatementType { return DDL }
 
@@ -203,6 +218,8 @@ func (*Backup) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*Backup) StatementTag() string { return "BACKUP" }
+
+func (*Backup) cclOnlyStatement() {}
 
 func (*Backup) hiddenFromShowQueries() {}
 
@@ -330,6 +347,8 @@ func (*CreateRole) StatementType() StatementType { return RowsAffected }
 // StatementTag returns a short string identifying the type of statement.
 func (*CreateRole) StatementTag() string { return "CREATE ROLE" }
 
+func (*CreateRole) cclOnlyStatement() {}
+
 func (*CreateRole) hiddenFromShowQueries() {}
 
 // StatementType implements the Statement interface.
@@ -416,6 +435,8 @@ func (*DropRole) StatementType() StatementType { return RowsAffected }
 // StatementTag returns a short string identifying the type of statement.
 func (*DropRole) StatementTag() string { return "DROP ROLE" }
 
+func (*DropRole) cclOnlyStatement() {}
+
 // StatementType implements the Statement interface.
 func (*Execute) StatementType() StatementType { return Unknown }
 
@@ -447,6 +468,8 @@ func (*GrantRole) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*GrantRole) StatementTag() string { return "GRANT" }
+
+func (*GrantRole) cclOnlyStatement() {}
 
 // StatementType implements the Statement interface.
 func (n *Insert) StatementType() StatementType { return n.Returning.statementType() }
@@ -526,6 +549,8 @@ func (*Restore) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (*Restore) StatementTag() string { return "RESTORE" }
 
+func (*Restore) cclOnlyStatement() {}
+
 func (*Restore) hiddenFromShowQueries() {}
 
 // StatementType implements the Statement interface.
@@ -539,6 +564,8 @@ func (*RevokeRole) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*RevokeRole) StatementTag() string { return "REVOKE" }
+
+func (*RevokeRole) cclOnlyStatement() {}
 
 // StatementType implements the Statement interface.
 func (*RollbackToSavepoint) StatementType() StatementType { return Ack }

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -20,18 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-// Cockroach error extensions:
-const (
-	// CodeRangeUnavailable signals that some data from the cluster cannot be
-	// accessed (e.g. because all replicas awol).
-	// We're using the postgres "Internal Error" error class "XX".
-	CodeRangeUnavailable = "XXC00"
-
-	// CodeCCLRequired signals that a CCL binary is required to complete this
-	// task.
-	CodeCCLRequired = "XXC01"
-)
-
 const (
 	txnAbortedMsg = "current transaction is aborted, commands ignored " +
 		"until end of transaction block"
@@ -92,12 +80,12 @@ func NewUnsupportedSchemaUsageError(name string) error {
 // NewCCLRequiredError creates an error for when a CCL feature is used in an OSS
 // binary.
 func NewCCLRequiredError(err error) error {
-	return pgerror.NewError(CodeCCLRequired, err.Error())
+	return pgerror.Wrapf(err, pgerror.CodeCCLRequired, "")
 }
 
 // IsCCLRequiredError returns whether the error is a CCLRequired error.
 func IsCCLRequiredError(err error) bool {
-	return errHasCode(err, CodeCCLRequired)
+	return errHasCode(err, pgerror.CodeCCLRequired)
 }
 
 // NewUndefinedDatabaseError creates an error that represents a missing database.
@@ -167,7 +155,7 @@ func NewDependentObjectErrorWithHint(msg string, hint string) error {
 func NewRangeUnavailableError(
 	rangeID roachpb.RangeID, origErr error, nodeIDs ...roachpb.NodeID,
 ) error {
-	return pgerror.NewErrorf(CodeRangeUnavailable,
+	return pgerror.NewErrorf(pgerror.CodeRangeUnavailable,
 		"key range id:%d is unavailable; missing nodes: %s. Original error: %v",
 		rangeID, nodeIDs, origErr)
 }

--- a/pkg/sql/sqltelemetry/pgwire.go
+++ b/pkg/sql/sqltelemetry/pgwire.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 )
 
 // CancelRequestCounter is to be incremented every time a pgwire-level
@@ -35,3 +36,7 @@ func UnimplementedClientStatusParameterCounter(key string) telemetry.Counter {
 // client requests the binary encoding for a decimal infinity, which
 // is not well defined in the pg protocol (#32489).
 var BinaryDecimalInfinityCounter = telemetry.GetCounterOnce("pgwire.#32489.binary_decimal_infinity")
+
+// UncategorizedErrorCounter is to be incremented every time an error
+// flows to the client without having been decorated with a pg error.
+var UncategorizedErrorCounter = telemetry.GetCounterOnce("othererror." + pgerror.CodeUncategorizedError)

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -32,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 )
 
 // txnState contains state associated with an ongoing SQL txn; it constitutes
@@ -323,7 +323,7 @@ func (ts *txnState) setReadOnlyMode(mode tree.ReadWriteMode) error {
 		}
 		ts.readOnly = false
 	default:
-		return errors.Errorf("unknown read mode: %s", mode)
+		return pgerror.NewAssertionErrorf("unknown read mode: %s", log.Safe(mode))
 	}
 	return nil
 }


### PR DESCRIPTION
First commit from #35867.

... instead of errors.New, errors.Errorf etc.

(Pursuant to #35847).

Release note: None