### PR TITLE
sql*: distinguish the XX "important" pg errors

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/sqlmigrations"
@@ -639,7 +640,7 @@ func TestDropIndexWithZoneConfigOSS(t *testing.T) {
 
 	// Verify that dropping the index fails with a "CCL required" error.
 	_, err = sqlDBRaw.Exec(`DROP INDEX t.kv@foo`)
-	if pqErr, ok := err.(*pq.Error); !ok || pqErr.Code != sqlbase.CodeCCLRequired {
+	if pqErr, ok := err.(*pq.Error); !ok || string(pqErr.Code) != pgerror.CodeCCLRequired {
 		t.Fatalf("expected pq error with CCLRequired code, but got %v", err)
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/partitioning
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning
@@ -1,12 +1,12 @@
 # LogicTest: local local-opt
 
-statement error creating or manipulating partitions requires a CCL binary
+statement error pgcode XXC01 creating or manipulating partitions requires a CCL binary
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (1),
     PARTITION p2 VALUES IN (2)
 )
 
-statement error creating or manipulating partitions requires a CCL binary
+statement error pgcode XXC01 creating or manipulating partitions requires a CCL binary
 CREATE TABLE t (
     a INT PRIMARY KEY, b INT,
     INDEX (b) PARTITION BY LIST (b) (

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -237,7 +237,7 @@ statement ok
 CREATE INDEX bar ON test.kv (quantity)
 
 # bar is invisible
-statement error pgcode XX000 index "bar" not found
+statement error index "bar" not found
 SELECT * FROM test.kv@bar
 
 statement ok
@@ -245,7 +245,7 @@ COMMIT
 
 # bar is still invisible because the error above prevents the
 # transaction from committing.
-statement error pgcode XX000 index "bar" not found
+statement error index "bar" not found
 SELECT * FROM test.kv@bar
 
 subtest create_reference_to_create_outside_txn_17949

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -1012,7 +1013,17 @@ func writeErr(
 	if ok {
 		code = pgErr.Code
 	} else {
-		code = pgerror.CodeInternalError
+		// The error was not decorated as an pgerror.Error. We don't know
+		// its code, in fact we don't know pretty much anything about it.
+		// We're going to let it flow to the user as a XXUUU error.
+		// We don't use CodeInternalError here (XX000) because internal
+		// errors have gain special status "please tell us about it
+		// ASAP" in CockroachDB.
+		code = pgerror.CodeUncategorizedError
+		// However, we'll keep track of the number of occurrences in
+		// telemetry. Over time, we'll want this count to go down
+		// (i.e. more errors becoming qualified).
+		telemetry.Inc(sqltelemetry.UncategorizedErrorCounter)
 	}
 
 	msgBuilder.putErrFieldMsg(pgwirebase.ServerErrFieldSQLState)

--- a/pkg/sql/pgwire/pgerror/codes.go
+++ b/pkg/sql/pgwire/pgerror/codes.go
@@ -297,3 +297,20 @@ const (
 	CodeDataCorruptedError  = "XX001"
 	CodeIndexCorruptedError = "XX002"
 )
+
+// The following errors are CockroachDB-specific.
+
+var (
+	// CodeUncategorizedError is used for errors that flow out to a client
+	// when there's no code known yet.
+	CodeUncategorizedError = "XXUUU"
+
+	// CodeRangeUnavailable signals that some data from the cluster cannot be
+	// accessed (e.g. because all replicas awol).
+	// We're using the postgres "Internal Error" error class "XX".
+	CodeRangeUnavailable = "XXC00"
+
+	// CodeCCLRequired signals that a CCL binary is required to complete this
+	// task.
+	CodeCCLRequired = "XXC01"
+)

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -20,18 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-// Cockroach error extensions:
-const (
-	// CodeRangeUnavailable signals that some data from the cluster cannot be
-	// accessed (e.g. because all replicas awol).
-	// We're using the postgres "Internal Error" error class "XX".
-	CodeRangeUnavailable = "XXC00"
-
-	// CodeCCLRequired signals that a CCL binary is required to complete this
-	// task.
-	CodeCCLRequired = "XXC01"
-)
-
 const (
 	txnAbortedMsg = "current transaction is aborted, commands ignored " +
 		"until end of transaction block"
@@ -92,12 +80,12 @@ func NewUnsupportedSchemaUsageError(name string) error {
 // NewCCLRequiredError creates an error for when a CCL feature is used in an OSS
 // binary.
 func NewCCLRequiredError(err error) error {
-	return pgerror.NewError(CodeCCLRequired, err.Error())
+	return pgerror.Wrapf(err, pgerror.CodeCCLRequired, "")
 }
 
 // IsCCLRequiredError returns whether the error is a CCLRequired error.
 func IsCCLRequiredError(err error) bool {
-	return errHasCode(err, CodeCCLRequired)
+	return errHasCode(err, pgerror.CodeCCLRequired)
 }
 
 // NewUndefinedDatabaseError creates an error that represents a missing database.
@@ -167,7 +155,7 @@ func NewDependentObjectErrorWithHint(msg string, hint string) error {
 func NewRangeUnavailableError(
 	rangeID roachpb.RangeID, origErr error, nodeIDs ...roachpb.NodeID,
 ) error {
-	return pgerror.NewErrorf(CodeRangeUnavailable,
+	return pgerror.NewErrorf(pgerror.CodeRangeUnavailable,
 		"key range id:%d is unavailable; missing nodes: %s. Original error: %v",
 		rangeID, nodeIDs, origErr)
 }

--- a/pkg/sql/sqltelemetry/pgwire.go
+++ b/pkg/sql/sqltelemetry/pgwire.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 )
 
 // CancelRequestCounter is to be incremented every time a pgwire-level
@@ -35,3 +36,7 @@ func UnimplementedClientStatusParameterCounter(key string) telemetry.Counter {
 // client requests the binary encoding for a decimal infinity, which
 // is not well defined in the pg protocol (#32489).
 var BinaryDecimalInfinityCounter = telemetry.GetCounterOnce("pgwire.#32489.binary_decimal_infinity")
+
+// UncategorizedErrorCounter is to be incremented every time an error
+// flows to the client without having been decorated with a pg error.
+var UncategorizedErrorCounter = telemetry.GetCounterOnce("othererror." + pgerror.CodeUncategorizedError)


### PR DESCRIPTION
Prior to this patch, we were transforming any non-pgerror.Error error
into pg code XX000 ("internal error") when sending it back to the
client.

This is problematic for two reasons:

- the recent changes to make internal errors reportable to telemetry go
  hand-in-hand with a general recommendation to user to inform us
  when they encounter an internal error or code "XX000".

  We do not want *as much* users to inform us when they encounter
  innocuous errors that happen to miss a pg code.

- we want a linter in logic tests to assert that *expected* errors
  that come up during tests are not wrapped in-between the point they
  were generated to the point they are sent to the client by an
  internal error code (as such can happen when an error is encountered
  on a path where no error was expected). In those cases, the expected
  error message will be present (enclosed) in the internal error, and
  thus match the logic test expected error string, although it's not
  really the error that was expected any more.

  To properly identify these internal errors we'd like to rely on the
  error code for internal errors. This can work if all unqualified
  errors default to the same code.

This patch fixes the situation by introducing the new code
XXUUU ("unknown error") for all unqualified errors, and adding the
aforementioned logic test error check.

Release note (sql change): regular SQL errors that indicate erroneous
SQL and for which CockroachDB does not yet populate a well-defined
PostgreSQL error code will now be reported with code XXUUU instead of
code XX000.