### PR TITLE
stats: decrease frequency of automatic stats refreshes

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1029,6 +1029,7 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 	// schema changes and causing transaction retries.
 	stats.DefaultAsOfTime = 10 * time.Millisecond
 	stats.DefaultRefreshInterval = time.Millisecond
+	stats.TargetMinRowsUpdatedBeforeRefresh = 5
 
 	t.cluster = serverutils.StartTestCluster(t.t, cfg.numNodes, params)
 	if cfg.useFakeSpanResolver {

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -28,9 +28,9 @@ __auto__         {d}           1000       0               1000
 statement ok
 SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false
 
-# Update more than 10% of the table.
+# Update more than 20% of the table.
 statement ok
-UPDATE data SET d = 10 WHERE (a = 1 OR a = 2) AND b > 1
+UPDATE data SET d = 10 WHERE (a = 1 OR a = 2 OR a = 3) AND b > 1
 
 # There should be no change to stats.
 query TTIII colnames,rowsort
@@ -47,7 +47,7 @@ __auto__         {d}           1000       0               1000
 statement ok
 SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = true
 
-# Update more than 10% of the table.
+# Update more than 20% of the table.
 statement ok
 UPDATE data SET d = 12 WHERE d = 10
 
@@ -63,13 +63,14 @@ __auto__         {b}           1000       10              0
 __auto__         {c}           1000       10              0
 __auto__         {c}           1000       10              0
 __auto__         {d}           1000       0               1000
-__auto__         {d}           1000       1               820
+__auto__         {d}           1000       1               730
 
-# Upsert more than 10% of the table.
+# Upsert more than 20% of the table.
 statement ok
-UPSERT INTO data SELECT a, b, 1, 1 FROM
+UPSERT INTO data SELECT a, b, c::FLOAT, 1 FROM
 generate_series(1, 11) AS a(a),
-generate_series(1, 10) AS b(b)
+generate_series(1, 10) AS b(b),
+generate_series(1, 5) AS c(c)
 
 query TTIII colnames,rowsort,retry
 SELECT statistics_name, column_names, row_count, distinct_count, null_count
@@ -78,18 +79,18 @@ FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
 statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {a}           1000       10              0
 __auto__         {a}           1000       10              0
-__auto__         {a}           1010       11              0
+__auto__         {a}           1050       11              0
 __auto__         {b}           1000       10              0
 __auto__         {b}           1000       10              0
-__auto__         {b}           1010       10              0
+__auto__         {b}           1050       10              0
 __auto__         {c}           1000       10              0
 __auto__         {c}           1000       10              0
-__auto__         {c}           1010       10              0
+__auto__         {c}           1050       10              0
 __auto__         {d}           1000       0               1000
-__auto__         {d}           1000       1               820
-__auto__         {d}           1010       2               738
+__auto__         {d}           1000       1               730
+__auto__         {d}           1050       2               365
 
-# Delete more than 10% of the table.
+# Delete more than 20% of the table.
 statement ok
 DELETE FROM data WHERE c > 5
 
@@ -100,37 +101,37 @@ FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names::STRING, created
 statistics_name  column_names  row_count  distinct_count  null_count
 __auto__         {a}           1000       10              0
 __auto__         {a}           1000       10              0
-__auto__         {a}           1010       11              0
-__auto__         {a}           510        11              0
+__auto__         {a}           1050       11              0
+__auto__         {a}           550        11              0
 __auto__         {b}           1000       10              0
 __auto__         {b}           1000       10              0
-__auto__         {b}           1010       10              0
-__auto__         {b}           510        10              0
+__auto__         {b}           1050       10              0
+__auto__         {b}           550        10              0
 __auto__         {c}           1000       10              0
 __auto__         {c}           1000       10              0
-__auto__         {c}           1010       10              0
-__auto__         {c}           510        5               0
+__auto__         {c}           1050       10              0
+__auto__         {c}           550        5               0
 __auto__         {d}           1000       0               1000
-__auto__         {d}           1000       1               820
-__auto__         {d}           1010       2               738
-__auto__         {d}           510        2               328
+__auto__         {d}           1000       1               730
+__auto__         {d}           1050       2               365
+__auto__         {d}           550        1               0
 
 # Test CREATE TABLE ... AS
 statement ok
 CREATE TABLE copy AS SELECT * FROM data
 
 # Distinct count for rowid can be flaky, so don't show it. The estimate is
-# almost always 510, but occasionally it is 509...
+# almost always 550, but occasionally it is 549...
 query TTII colnames,rowsort,retry
 SELECT statistics_name, column_names, row_count, null_count
 FROM [SHOW STATISTICS FOR TABLE copy] ORDER BY column_names::STRING, created
 ----
 statistics_name  column_names  row_count  null_count
-__auto__         {a}           510        0
-__auto__         {b}           510        0
-__auto__         {c}           510        0
-__auto__         {d}           510        328
-__auto__         {rowid}       510        0
+__auto__         {a}           550        0
+__auto__         {b}           550        0
+__auto__         {c}           550        0
+__auto__         {d}           550        0
+__auto__         {rowid}       550        0
 
 # Test fast path delete.
 statement ok
@@ -141,13 +142,13 @@ SELECT statistics_name, column_names, row_count, null_count
 FROM [SHOW STATISTICS FOR TABLE copy] ORDER BY column_names::STRING, created
 ----
 statistics_name  column_names  row_count  null_count
-__auto__         {a}           510        0
+__auto__         {a}           550        0
 __auto__         {a}           0          0
-__auto__         {b}           510        0
+__auto__         {b}           550        0
 __auto__         {b}           0          0
-__auto__         {c}           510        0
+__auto__         {c}           550        0
 __auto__         {c}           0          0
-__auto__         {d}           510        328
+__auto__         {d}           550        0
 __auto__         {d}           0          0
-__auto__         {rowid}       510        0
+__auto__         {rowid}       550        0
 __auto__         {rowid}       0          0

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -63,6 +63,11 @@ var DefaultRefreshInterval = time.Minute
 // any effect.
 var DefaultAsOfTime = 30 * time.Second
 
+// TargetMinRowsUpdatedBeforeRefresh indicates the target number of rows that
+// should be updated before a table is refreshed, in addition to the fraction
+// TargetFractionOfRowsUpdatedBeforeRefresh. It is mutable for testing.
+var TargetMinRowsUpdatedBeforeRefresh = 500
+
 // Constants for automatic statistics collection.
 // TODO(rytaft): Should these constants be configurable?
 const (
@@ -73,8 +78,9 @@ const (
 
 	// TargetFractionOfRowsUpdatedBeforeRefresh indicates the target fraction
 	// of rows in a table that should be updated before statistics on that table
-	// are refreshed.
-	TargetFractionOfRowsUpdatedBeforeRefresh = 0.1
+	// are refreshed, in addition to the constant value
+	// TargetMinRowsUpdatedBeforeRefresh.
+	TargetFractionOfRowsUpdatedBeforeRefresh = 0.2
 
 	// defaultAverageTimeBetweenRefreshes is the default time to use as the
 	// "average" time between refreshes when there is no information for a given
@@ -96,7 +102,7 @@ const (
 //
 // The Refresher is designed to schedule a CREATE STATISTICS refresh job after
 // approximately X% of total rows have been updated/inserted/deleted in a given
-// table. Currently, X is hardcoded to be 10%.
+// table. Currently, X is hardcoded to be 20%.
 //
 // The decision to refresh is based on a percentage rather than a fixed number
 // of rows because if a table is huge and rarely updated, we don't want to
@@ -104,10 +110,10 @@ const (
 // updated, we want to update stats more often.
 //
 // To avoid contention on row update counters, we use a statistical approach.
-// For example, suppose we want to refresh stats after 10% of rows are updated
+// For example, suppose we want to refresh stats after 20% of rows are updated
 // and there are currently 1M rows in the table. If a user updates 10 rows,
 // we use random number generation to refresh stats with probability
-// 10/(1M * 0.1) = 0.0001. The general formula is:
+// 10/(1M * 0.2) = 0.00005. The general formula is:
 //
 //                            # rows updated/inserted/deleted
 //    p =  --------------------------------------------------------------------
@@ -115,6 +121,9 @@ const (
 //
 // The existing statistics in the stats cache are used to get the number of
 // rows in the table.
+//
+// In order to prevent small tables from being constantly refreshed, we also
+// require that approximately 500 rows have changed in addition to the 20%.
 //
 // Refresher also implements some heuristic limits designed to corral
 // statistical outliers. If we haven't refreshed stats in 2x the average time
@@ -376,7 +385,8 @@ func (r *Refresher) maybeRefreshStats(
 		mustRefresh = true
 	}
 
-	targetRows := int64(rowCount*TargetFractionOfRowsUpdatedBeforeRefresh) + 1
+	targetRows := int64(rowCount*TargetFractionOfRowsUpdatedBeforeRefresh) +
+		int64(TargetMinRowsUpdatedBeforeRefresh)
 	if !mustRefresh && rowsAffected < math.MaxInt32 && r.randGen.randInt(targetRows) >= rowsAffected {
 		// No refresh is happening this time.
 		return

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -46,6 +46,11 @@ func TestMaybeRefreshStats(t *testing.T) {
 
 	AutomaticStatisticsClusterMode.Override(&evalCtx.Settings.SV, false)
 
+	defer func(oldMin int) {
+		TargetMinRowsUpdatedBeforeRefresh = oldMin
+	}(TargetMinRowsUpdatedBeforeRefresh)
+	TargetMinRowsUpdatedBeforeRefresh = 5
+
 	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
 	sqlRun.Exec(t,
 		`CREATE DATABASE t;


### PR DESCRIPTION
This commit decreases the frequency of automatic statistics refreshes
by increasing the target percentage of stale rows from 10% to 20%.
It also prevents small tables from being refreshed excessively by
requiring that approximately 500 rows in addition to the 20% have been
updated.

Fixes #35795

Release note (performance improvement): Reduced the default frequency
of automatic statistics refreshes.