### PR TITLE
cli: include jobs and more in debug zip

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2306,12 +2306,16 @@ writing ` + os.DevNull + `
   debug/liveness
   debug/settings
   debug/reports/problemranges
-  debug/gossip/liveness
-  debug/gossip/network
-  debug/gossip/nodes
-  debug/metrics
-  debug/alerts
+  debug/crdb_internal.jobs
+  debug/crdb_internal.schema_changes
   debug/nodes/1/status
+  debug/nodes/1/crdb_internal.gossip_liveness
+  debug/nodes/1/crdb_internal.gossip_network
+  debug/nodes/1/crdb_internal.gossip_nodes
+  debug/nodes/1/crdb_internal.node_metrics
+  debug/nodes/1/crdb_internal.gossip_alerts
+  debug/nodes/1/queries
+  debug/nodes/1/sessions
   debug/nodes/1/details
   debug/nodes/1/gossip
   debug/nodes/1/stacks


### PR DESCRIPTION
Also clean up a bit. We were collecting some information only from
the local node and not from the other nodes.

Release note (general change): `cockroach debug zip` now contains more
information.