### PR TITLE
release-19.1: ui: adjust QPS Summary to match Time Series and Node Map values.

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
@@ -23,7 +23,13 @@ import { NanoToMilli } from "src/util/convert";
 import { EventBox } from "src/views/cluster/containers/events";
 import { Metric } from "src/views/shared/components/metricQuery";
 import {
-  SummaryBar, SummaryLabel, SummaryStat, SummaryStatMessage, SummaryStatBreakdown, SummaryMetricStat,
+  SummaryBar,
+  SummaryLabel,
+  SummaryMetricStat,
+  SummaryStat,
+  SummaryStatBreakdown,
+  SummaryStatMessage,
+  SummaryMetricsAggregator,
 } from "src/views/shared/components/summaryBar";
 
 interface ClusterSummaryProps {
@@ -86,11 +92,17 @@ export default function(props: ClusterSummaryProps) {
                                         usable storage capacity across all nodes.`} />
         </SummaryStat>
         <SummaryStat title="Unavailable ranges" value={props.nodesSummary.nodeSums.unavailableRanges} />
-        <SummaryMetricStat id="qps" title="Queries per second" format={formatOnePlace} >
-          <Metric sources={props.nodeSources} name="cr.node.sql.query.count" title="Queries/Sec" nonNegativeRate />
-        </SummaryMetricStat>
-        <SummaryMetricStat id="p50" title="P50 latency" format={formatNanosAsMillis} >
-          <Metric sources={props.nodeSources} name="cr.node.sql.service.latency-p50" aggregateMax downsampleMax />
+        <SummaryMetricStat
+          id="qps"
+          title="Queries per second"
+          format={formatOnePlace}
+          aggregator={SummaryMetricsAggregator.SUM}
+          summaryStatMessage="Sum of Selects, Updates, Inserts, and Deletes across your entire cluster."
+        >
+          <Metric sources={props.nodeSources} name="cr.node.sql.select.count" title="Queries/Sec" nonNegativeRate />
+          <Metric sources={props.nodeSources} name="cr.node.sql.insert.count" title="Queries/Sec" nonNegativeRate />
+          <Metric sources={props.nodeSources} name="cr.node.sql.update.count" title="Queries/Sec" nonNegativeRate />
+          <Metric sources={props.nodeSources} name="cr.node.sql.delete.count" title="Queries/Sec" nonNegativeRate />
         </SummaryMetricStat>
         <SummaryMetricStat id="p99" title="P99 latency" format={formatNanosAsMillis} >
           <Metric sources={props.nodeSources} name="cr.node.sql.service.latency-p99" aggregateMax downsampleMax />


### PR DESCRIPTION
Backport 1/1 commits from #35693.

/cc @cockroachdb/release

---

In [#283](https://github.com/cockroachlabs/support/issues/283) and #23967,
we note three QPS-related areas in the Admin UI that were causing confusion
for users:

- The SQL Queries Metric, which shows QPS data for
  `SELECT/INSERT/UPDATE/DELETE` SQL queries.
- The Node Map, which shows QPS data for
  `SELECT/INSERT/UPDATE/DELETE` SQL queries.
- The 'Queries per second' in the Summary Bar, which calcuates QPS for all
  SQL queries (`SELECT/INSERT/UPDATE/DELETE`, but also includes DDL statements
  and transaction boundaries).

This commit:
- Updates the 'Queries per second' in the Summary Bar to just
  summarize the query types displayed in SQL Queries Time Series Metric and
  Node Map
- Clarifies which queries are included in Summary Bar with summary stat
  message.
- Removes P50 latency metric, since:
  - latency metrics still include all queries and this change might
    introduce new user questions/confusion.
  - our support team has confirmed that while users care about P99 and P90,
    we actually don't see customers concerned about P50.
  - [Why P50 but not P90] For the P90 & P99 metrics, a push up will most
        likely be from normal SELECT/INSERT/UPDATE/DELETEs. For 50, however,
        if clients are doing a large number of complex transactions or SET
        commands this could really skew the P50 result.

While this doesn't fully address all the concerns raised from #283 and #23967,
this at least provides a short-term fix of making all the numbers consistent.

Time Series vs Summary Bar. Before (discrepancy of 142.9):
<img width="400" alt="adriatic off-by-n" src="https://user-images.githubusercontent.com/3051672/54290723-db120600-4581-11e9-878d-dccd771848fa.png">

Time Series vs Summary Bar. After (sums match up):
<img width="400" alt="adriatic matches" src="https://user-images.githubusercontent.com/3051672/54290716-d6e5e880-4581-11e9-8d04-22a3df639265.png">

Node Map vs Summary Bar. After (sums match up):
<img width="400" alt="adriatic after node-map" src="https://user-images.githubusercontent.com/3051672/54292511-b79c8a80-4584-11e9-9c5b-087e65fa765a.png">

Updated Summary Bar:
<img width="400" alt="updated summary bar" src="https://user-images.githubusercontent.com/3051672/54309359-5b4a6280-45a6-11e9-8fb3-f0850bc3d44e.png">

Release note (admin ui change): 'Queries per second' metric in Summary Bar
adjusted to only summarize the query types displayed in SQL Queries Time
Series Metric and Node Map.
