### PR TITLE
release-19.1: sql: add more check constraint schema change tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -829,6 +829,19 @@ ALTER TABLE check_table ADD CONSTRAINT e_0 CHECK (e > 0)
 statement error pq: validation of CHECK "e > 0" failed on row: k=1, c=NULL, d=1, e=0
 COMMIT
 
+# Test rollbacks after error in expression evaluation
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE check_table ADD e STRING DEFAULT 'a'
+
+statement ok
+ALTER TABLE check_table ADD CONSTRAINT e_0 CHECK (e::INT > 0)
+
+statement error validate check constraint: could not parse "a" as type int
+COMMIT
+
 # Constraint e_0 was not added
 query TTTTB
 SHOW CONSTRAINTS FROM check_table


### PR DESCRIPTION
Backport 1/1 commits from #35815.

/cc @cockroachdb/release

---

Added more tests related to adding check constraints.

Release note: None
