### PR TITLE
builder: upgrade to go1.11.6

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -38,9 +38,9 @@ echo '. ~/.bashrc_bootstrap' >> ~/.bashrc
 
 # Install Go.
 trap 'rm -f /tmp/go.tgz' EXIT
-curl https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz > /tmp/go.tgz
+curl https://dl.google.com/go/go1.11.6.linux-amd64.tar.gz > /tmp/go.tgz
 sha256sum -c - <<EOF
-ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25  /tmp/go.tgz
+4e1864282d8d20010d6385a12a1e35641783a380a7c57907bfb46a5499c5eb49  /tmp/go.tgz
 EOF
 sudo tar -C /usr/local -zxf /tmp/go.tgz
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20190308-055513
+version=20190318-200038
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -196,8 +196,8 @@ RUN git clone git://git.sv.gnu.org/sed \
 # releases of Go will no longer be run in CI once it is changed. Consider
 # bumping the minimum allowed version of Go in /build/go-version-chech.sh.
 RUN apt-get install -y --no-install-recommends golang \
- && curl -fsSL https://storage.googleapis.com/golang/go1.11.5.src.tar.gz -o golang.tar.gz \
- && echo 'bc1ef02bb1668835db1390a2e478dcbccb5dd16911691af9d75184bbe5aa943e golang.tar.gz' | sha256sum -c - \
+ && curl -fsSL https://storage.googleapis.com/golang/go1.11.6.src.tar.gz -o golang.tar.gz \
+ && echo 'a96da1425dcbec094736033a8a416316547f8100ab4b72c31d4824d761d3e133 golang.tar.gz' | sha256sum -c - \
  && tar -C /usr/local -xzf golang.tar.gz \
  && rm golang.tar.gz \
  && cd /usr/local/go/src \


### PR DESCRIPTION
Release note (general change): Upgrade the build environment to use
go1.11.6.