### PR TITLE
Revert "roachpb: clone Txn object in BatchResponse_Header.combine"

### DIFF
--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -17,7 +17,10 @@ package kv
 
 import (
 	"context"
+	"encoding/hex"
+	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -25,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/opentracing/opentracing-go"
@@ -152,6 +156,34 @@ func (gt *grpcTransport) maybeResurrectRetryablesLocked() bool {
 	return len(resurrect) > 0
 }
 
+func withMarshalingDebugging(ctx context.Context, ba roachpb.BatchRequest, f func()) {
+	nPre := ba.Size()
+	defer func() {
+		nPost := ba.Size()
+		if r := recover(); r != nil || nPre != nPost {
+			var buf strings.Builder
+			_, _ = fmt.Fprintf(&buf, "batch size %d -> %d bytes\n", nPre, nPost)
+			func() {
+				defer func() {
+					if rInner := recover(); rInner != nil {
+						_, _ = fmt.Fprintln(&buf, "panic while re-marshaling:", rInner)
+					}
+				}()
+				data, mErr := protoutil.Marshal(&ba)
+				if mErr != nil {
+					_, _ = fmt.Fprintln(&buf, "while re-marshaling:", mErr)
+				} else {
+					_, _ = fmt.Fprintln(&buf, "re-marshaled protobuf:")
+					_, _ = fmt.Fprintln(&buf, hex.Dump(data))
+				}
+			}()
+			_, _ = fmt.Fprintln(&buf, "original panic: ", r)
+			panic(buf.String())
+		}
+	}()
+	f()
+}
+
 // SendNext invokes the specified RPC on the supplied client when the
 // client is ready. On success, the reply is sent on the channel;
 // otherwise an error is sent.
@@ -165,7 +197,11 @@ func (gt *grpcTransport) SendNext(
 	}
 
 	ba.Replica = client.replica
-	reply, err := gt.sendBatch(ctx, client.replica.NodeID, iface, ba)
+	var reply *roachpb.BatchResponse
+
+	withMarshalingDebugging(ctx, ba, func() {
+		reply, err = gt.sendBatch(ctx, client.replica.NodeID, iface, ba)
+	})
 
 	// NotLeaseHolderErrors can be retried.
 	var retryable bool

--- a/pkg/kv/transport_test.go
+++ b/pkg/kv/transport_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )
 
@@ -171,4 +172,31 @@ func (m *mockInternalClient) RangeFeed(
 	ctx context.Context, in *roachpb.RangeFeedRequest, opts ...grpc.CallOption,
 ) (roachpb.Internal_RangeFeedClient, error) {
 	return nil, fmt.Errorf("unsupported RangeFeed call")
+}
+
+func TestWithMarshalingDebugging(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	t.Skip(fmt.Sprintf("Skipped until #34241 is resolved"))
+
+	ctx := context.Background()
+
+	exp := `batch size 23 -> 28 bytes
+re-marshaled protobuf:
+00000000  0a 0a 0a 00 12 06 08 00  10 00 18 00 12 0e 3a 0c  |..............:.|
+00000010  0a 0a 1a 03 66 6f 6f 22  03 62 61 72              |....foo".bar|
+
+original panic:  <nil>
+`
+
+	assert.PanicsWithValue(t, exp, func() {
+		var ba roachpb.BatchRequest
+		ba.Add(&roachpb.ScanRequest{
+			RequestHeader: roachpb.RequestHeader{
+				Key: []byte("foo"),
+			},
+		})
+		withMarshalingDebugging(ctx, ba, func() {
+			ba.Requests[0].GetInner().(*roachpb.ScanRequest).EndKey = roachpb.Key("bar")
+		})
+	})
 }


### PR DESCRIPTION
This reverts the removal of the assertion in commit 05a93a697eb884d3fd04ded8a550eecfe302376a. The actual clone of the Txn object in `BatchResponse_Header.combine` is kept because that was again verified to fix _some_ issue in https://github.com/cockroachdb/cockroach/issues/35803#issuecomment-474091154.

Release note: None