### PR TITLE
opt: turn on zigzag joins by default

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1431,7 +1431,7 @@ default_int_size                     8             NULL      NULL        NULL   
 default_transaction_isolation        serializable  NULL      NULL        NULL        string
 default_transaction_read_only        off           NULL      NULL        NULL        string
 distsql                              off           NULL      NULL        NULL        string
-experimental_enable_zigzag_join      off           NULL      NULL        NULL        string
+experimental_enable_zigzag_join      on            NULL      NULL        NULL        string
 experimental_force_split_at          off           NULL      NULL        NULL        string
 experimental_reorder_joins_limit     4             NULL      NULL        NULL        string
 experimental_serial_normalization    rowid         NULL      NULL        NULL        string
@@ -1481,7 +1481,7 @@ default_int_size                     8             NULL  user     NULL      8   
 default_transaction_isolation        serializable  NULL  user     NULL      default       default
 default_transaction_read_only        off           NULL  user     NULL      off           off
 distsql                              off           NULL  user     NULL      off           off
-experimental_enable_zigzag_join      off           NULL  user     NULL      off           off
+experimental_enable_zigzag_join      on            NULL  user     NULL      on            on
 experimental_force_split_at          off           NULL  user     NULL      off           off
 experimental_reorder_joins_limit     4             NULL  user     NULL      4             4
 experimental_serial_normalization    rowid         NULL  user     NULL      rowid         rowid

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -36,7 +36,7 @@ default_int_size                     8
 default_transaction_isolation        serializable
 default_transaction_read_only        off
 distsql                              off
-experimental_enable_zigzag_join      off
+experimental_enable_zigzag_join      on
 experimental_force_split_at          off
 experimental_reorder_joins_limit     4
 experimental_serial_normalization    rowid

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_env
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_env
@@ -241,7 +241,7 @@ scan y
  └── constraint: /1: [/3 - /3]
 
 statement ok
-SET experimental_enable_zigzag_join = true
+SET experimental_enable_zigzag_join = false
 
 query T
 SELECT text FROM [
@@ -262,7 +262,7 @@ ALTER TABLE test.public.y INJECT STATISTICS '[]';
 ·
 SET experimental_reorder_joins_limit = 100;
 ·
-SET experimental_enable_zigzag_join = on;
+SET experimental_enable_zigzag_join = off;
 ·
 SELECT text FROM [EXPLAIN (OPT, ENV) SELECT * FROM y WHERE u = 3] WHERE (text NOT LIKE '%Version%') OR (text LIKE '%EXPLAIN%');
 ----

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -137,41 +137,55 @@ scan  ·       ·
 ·     spans   ALL
 ·     filter  b @> '{"a": {}}'
 
-## Multi-path contains queries. Should create zigzag joins with the respective
-## session flag enabled.
+# Multi-path contains queries. Should create zigzag joins.
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
-filter           ·       ·                                    (a, b)  ·
- │               filter  b @> '{"a": {"b": "c"}, "f": "g"}'   ·       ·
- └── index-join  ·       ·                                    (a, b)  ·
-      │          table   d@primary                            ·       ·
-      └── scan   ·       ·                                    (a)     ·
-·                table   d@foo_inv                            ·       ·
-·                spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·       ·
+lookup-join       ·          ·                                    (a, b)  ·
+ │                table      d@primary                            ·       ·
+ │                type       inner                                ·       ·
+ │                pred       @2 @> '{"a": {"b": "c"}, "f": "g"}'  ·       ·
+ └── zigzag-join  ·          ·                                    (a)     ·
+      │           type       inner                                ·       ·
+      ├── scan    ·          ·                                    (a)     ·
+      │           table      d@foo_inv                            ·       ·
+      │           fixedvals  1 column                             ·       ·
+      └── scan    ·          ·                                    ()      ·
+·                 table      d@foo_inv                            ·       ·
+·                 fixedvals  1 column                             ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
-filter           ·       ·                                             (a, b)  ·
- │               filter  b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
- └── index-join  ·       ·                                             (a, b)  ·
-      │          table   d@primary                                     ·       ·
-      └── scan   ·       ·                                             (a)     ·
-·                table   d@foo_inv                                     ·       ·
-·                spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd           ·       ·
+lookup-join       ·          ·                                              (a, b)  ·
+ │                table      d@primary                                      ·       ·
+ │                type       inner                                          ·       ·
+ │                pred       @2 @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·       ·
+ └── zigzag-join  ·          ·                                              (a)     ·
+      │           type       inner                                          ·       ·
+      ├── scan    ·          ·                                              (a)     ·
+      │           table      d@foo_inv                                      ·       ·
+      │           fixedvals  1 column                                       ·       ·
+      └── scan    ·          ·                                              ()      ·
+·                 table      d@foo_inv                                      ·       ·
+·                 fixedvals  1 column                                       ·       ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
-filter           ·       ·                                                        (a, b)  ·
- │               filter  b @> '[{"a": {"b": [[2]]}}, "d"]'                        ·       ·
- └── index-join  ·       ·                                                        (a, b)  ·
-      │          table   d@primary                                                ·       ·
-      └── scan   ·       ·                                                        (a)     ·
-·                table   d@foo_inv                                                ·       ·
-·                spans   /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·       ·
+lookup-join       ·          ·                                   (a, b)  ·
+ │                table      d@primary                           ·       ·
+ │                type       inner                               ·       ·
+ │                pred       @2 @> '[{"a": {"b": [[2]]}}, "d"]'  ·       ·
+ └── zigzag-join  ·          ·                                   (a)     ·
+      │           type       inner                               ·       ·
+      ├── scan    ·          ·                                   (a)     ·
+      │           table      d@foo_inv                           ·       ·
+      │           fixedvals  1 column                            ·       ·
+      └── scan    ·          ·                                   ()      ·
+·                 table      d@foo_inv                           ·       ·
+·                 fixedvals  1 column                            ·       ·
 
 statement ok
 SET experimental_enable_zigzag_join = true

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -1384,6 +1384,9 @@ CREATE TABLE zigzag (
 )
 
 # No zigzag join should be planned if experimental_enable_zigzag_join is false.
+statement ok
+SET experimental_enable_zigzag_join = false
+
 query TTT
 EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ----

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -16,6 +16,9 @@ statement ok
 CREATE STATISTICS u ON u FROM b;
 CREATE STATISTICS v ON v FROM b
 
+statement ok
+set experimental_enable_zigzag_join = false
+
 # Verify we scan index v which has the more selective constraint.
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM b WHERE u = 1 AND v = 1

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -339,7 +339,7 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext) string {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData.ZigzagJoinEnabled)
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 
 	// CockroachDB extension.
@@ -750,6 +750,7 @@ func displayPgBool(val bool) func(_ *settings.Values) string {
 	return func(_ *settings.Values) string { return strVal }
 }
 
+var globalTrue = displayPgBool(true)
 var globalFalse = displayPgBool(false)
 
 func makeCompatBoolVar(varName string, displayValue, anyValAllowed bool) sessionVar {


### PR DESCRIPTION
Release note (sql change): Zigzag joins will now be planned by the
optimizer in certain cases. They were previously available via the
`experimental_enable_zigzag_join` session variable and can still be
disabled by setting that value to "false".