### PR TITLE
roachtest: begin the release qualification roachtest whitelist

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -150,6 +150,7 @@ func registerTPCC(r *registry) {
 		// match our expectation for the max tpcc warehouses that previous
 		// releases will support on this hardware.
 		MinVersion: maxVersion("v2.1.0", maybeMinVersionForFixturesImport(cloud)),
+		Tags:       []string{`default`, `release_qualification`},
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			var warehouses int


### PR DESCRIPTION
Starting with `tpcc/nodes=3/w=max` for now so I can get the teamcity
plumbing done. This test verifies that running our claimed max TPCC
warehouses works. The max depends on the hardware configuration:
currently 1450 on a 3-node GCE n1-standard-1 cluster or 2200 on a 3-node
AWS c5d.4xlarge cluster.

Release note: None