### PR TITLE
sql: do not create stats on inverted index columns

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -256,6 +256,10 @@ func createStatsDefaultColumns(
 
 	// Add columns for each secondary index.
 	for i := range desc.Indexes {
+		if desc.Indexes[i].Type == sqlbase.IndexDescriptor_INVERTED {
+			// We don't yet support stats on inverted indexes.
+			continue
+		}
 		idxCol := desc.Indexes[i].ColumnIDs[0]
 		if !requestedCols.Contains(int(idxCol)) {
 			columns = append(

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -388,6 +388,35 @@ FROM [SHOW STATISTICS FOR TABLE groups] ORDER BY statistics_name, column_names::
 statistics_name  column_names
 s                {rowid}
 
+# Regression test for #35764.
+statement ok
+CREATE TABLE users (
+  profile_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  last_updated TIMESTAMP DEFAULT now(),
+  user_profile JSONB,
+  INVERTED INDEX user_details (user_profile)
+)
+
+statement ok
+INSERT INTO users (user_profile) VALUES
+  ('{"first_name": "Lola", "last_name": "Dog", "location": "NYC", "online" : true, "friends" : 547}'),
+  ('{"first_name": "Ernie", "status": "Looking for treats", "location" : "Brooklyn"}'),
+  ('{"first_name": "Carl", "last_name": "Kimball", "location": "NYC", "breed": "Boston Terrier"}'
+)
+
+# Ensure that trying to create statistics with default columns does not fail
+# when there is an inverted index.
+statement ok
+CREATE STATISTICS s FROM users
+
+query TTI colnames
+SELECT statistics_name, column_names, row_count
+FROM [SHOW STATISTICS FOR TABLE users] ORDER BY statistics_name, column_names::STRING
+----
+statistics_name  column_names    row_count
+s                {last_updated}  3
+s                {profile_id}    3
+
 # Arrays are supported.
 statement ok
 CREATE TABLE arr (x INT[])


### PR DESCRIPTION
This commit fixes an issue in which the default columns for
`CREATE STATISTICS` included inverted index columns. Since we
cannot create statistics on JSON columns, running automatic
statistics on a table with an inverted index resulted in the
error "unable to encode table key: *tree.DJSON". This commit
fixes the issue by skipping over inverted indexes when
determining the default columns for `CREATE STATISTICS`.

Fixes #35764

Release note (bug fix): Fixed an error that occurred when
creating statistics on tables with an inverted index.