### PR TITLE
roachtest: add schema change test for constraints

### DIFF
--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -61,6 +61,7 @@ func registerTests(r *registry) {
 	registerRoachmart(r)
 	registerScaleData(r)
 	registerSchemaChangeCancelIndexTPCC1000(r)
+	registerSchemaChangeConstraintTPCC100(r)
 	registerSchemaChangeKV(r)
 	registerSchemaChangeIndexTPCC100(r)
 	registerSchemaChangeIndexTPCC1000(r)


### PR DESCRIPTION
Add a roachtest `schemachange/constraint/tpcc/w=100` for adding check
constraints to a table.

Release note: None