### PR TITLE
distsqlrun: fix deadlock in flow cancellation

### DIFF
--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -702,11 +702,13 @@ func (f *Flow) cancel() {
 	f.flowRegistry.Unlock()
 
 	for _, receiver := range timedOutReceivers {
-		// Stream has yet to be started; send an error to its
-		// receiver and prevent it from being connected.
-		receiver.Push(
-			nil, /* row */
-			&ProducerMetadata{Err: sqlbase.QueryCanceledError})
-		receiver.ProducerDone()
+		go func(receiver RowReceiver) {
+			// Stream has yet to be started; send an error to its
+			// receiver and prevent it from being connected.
+			receiver.Push(
+				nil, /* row */
+				&ProducerMetadata{Err: sqlbase.QueryCanceledError})
+			receiver.ProducerDone()
+		}(receiver)
 	}
 }

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -36,7 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -698,22 +698,15 @@ func (f *Flow) cancel() {
 		return
 	}
 	f.flowRegistry.Lock()
-	defer f.flowRegistry.Unlock()
+	timedOutReceivers := f.flowRegistry.cancelPendingStreamsLocked(f.id)
+	f.flowRegistry.Unlock()
 
-	entry := f.flowRegistry.flows[f.id]
-	for streamID, is := range entry.inboundStreams {
-		// Connected, non-finished inbound streams will get an error
-		// returned in ProcessInboundStream(). Non-connected streams
-		// are handled below.
-		if !is.connected && !is.finished {
-			is.canceled = true
-			// Stream has yet to be started; send an error to its
-			// receiver and prevent it from being connected.
-			is.receiver.Push(
-				nil, /* row */
-				&ProducerMetadata{Err: sqlbase.QueryCanceledError})
-			is.receiver.ProducerDone()
-			f.flowRegistry.finishInboundStreamLocked(f.id, streamID)
-		}
+	for _, receiver := range timedOutReceivers {
+		// Stream has yet to be started; send an error to its
+		// receiver and prevent it from being connected.
+		receiver.Push(
+			nil, /* row */
+			&ProducerMetadata{Err: sqlbase.QueryCanceledError})
+		receiver.ProducerDone()
 	}
 }

--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -210,18 +210,12 @@ func (fr *flowRegistry) RegisterFlow(
 	if len(inboundStreams) > 0 {
 		// Set up a function to time out inbound streams after a while.
 		entry.streamTimer = time.AfterFunc(timeout, func() {
-			var timedOutReceivers []RowReceiver
 			fr.Lock()
-			for streamID, is := range entry.inboundStreams {
-				if !is.connected && !is.canceled {
-					is.canceled = true
-					// We're giving up waiting for this inbound stream. We will push an
-					// error to its consumer after fr.Unlock; the error will propagate and
-					// eventually drain all the processors.
-					timedOutReceivers = append(timedOutReceivers, is.receiver)
-					fr.finishInboundStreamLocked(id, streamID)
-				}
-			}
+			// We're giving up waiting for these inbound streams. We will push an
+			// error to its consumer after fr.Unlock; the error will propagate and
+			// eventually drain all the processors.
+			timedOutReceivers := fr.cancelPendingStreamsLocked(id)
+			fmt.Println("Timed out rec", timedOutReceivers)
 			fr.Unlock()
 			if len(timedOutReceivers) != 0 {
 				// The span in the context might be finished by the time this runs. In
@@ -245,6 +239,31 @@ func (fr *flowRegistry) RegisterFlow(
 		})
 	}
 	return nil
+}
+
+// cancelPendingStreamsLocked cancels all of the streams that haven't been
+// connected yet in this flow, by setting them to finished and ending their
+// wait group. The method returns the list of RowReceivers corresponding to the
+// streams that were canceled. The caller is expected to send those
+// RowReceivers a cancellation message - this method can't do it because sending
+// those messages shouldn't happen under the flow registry's lock.
+func (fr *flowRegistry) cancelPendingStreamsLocked(id distsqlpb.FlowID) []RowReceiver {
+	entry := fr.flows[id]
+	if entry == nil || entry.flow == nil {
+		return nil
+	}
+	pendingReceivers := make([]RowReceiver, 0)
+	for streamID, is := range entry.inboundStreams {
+		// Connected, non-finished inbound streams will get an error
+		// returned in ProcessInboundStream(). Non-connected streams
+		// are handled below.
+		if !is.connected && !is.finished {
+			is.canceled = true
+			pendingReceivers = append(pendingReceivers, is.receiver)
+			fr.finishInboundStreamLocked(id, streamID)
+		}
+	}
+	return pendingReceivers
 }
 
 // UnregisterFlow removes a flow from the registry. Any subsequent

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -558,6 +558,7 @@ func (ds *ServerImpl) RunSyncFlow(stream distsqlpb.DistSQL_RunSyncFlowServer) er
 func (ds *ServerImpl) SetupFlow(
 	ctx context.Context, req *distsqlpb.SetupFlowRequest,
 ) (*distsqlpb.SimpleResponse, error) {
+	log.VEventf(ctx, 1, "received SetupFlow request from n%v for flow %v", req.Flow.Gateway, req.Flow.FlowID)
 	parentSpan := opentracing.SpanFromContext(ctx)
 
 	// Note: the passed context will be canceled when this RPC completes, so we


### PR DESCRIPTION
Fixes #35859.

Previously, if a processor that reads from multiple inputs was waiting
on one input to provide more data, and the other input was full, and
both inputs were connected to inbound streams, it was possible to
deadlock the system during flow cancellation when trying to propagate
the cancellation metadata messages into the flow. The problem was that
the cancellation method wrote metadata messages to each inbound stream
one at a time, so if the first one was full, the canceller would block
and never send a cancellation message to the second stream, which was
the one actually being read from.

Now, the cancellation messages are sent in separate goroutines, ensuring
that the flow will un-stick.

Release note (bug fix): prevent deadlocks when cancelling distributed
queries in some cases.