### PR TITLE
pgerror: avoid wrapping special roachpb errors

### DIFF
--- a/pkg/sql/distsqlpb/data.go
+++ b/pkg/sql/distsqlpb/data.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/pkg/errors"
 )
 
 // ConvertToColumnOrdering converts an Ordering type (as defined in data.proto)
@@ -137,6 +138,11 @@ func (e *Error) String() string {
 // recognize certain errors and marshall them accordingly, and everything
 // unrecognized is turned into a PGError with code "internal".
 func NewError(err error) *Error {
+	// Unwrap the error, to attain the cause.
+	// Otherwise, Wrap() may hide the roachpb error
+	// from the cast attempt below.
+	err = errors.Cause(err)
+
 	if pgErr, ok := pgerror.GetPGCause(err); ok {
 		return &Error{Detail: &Error_PGError{PGError: pgErr}}
 	} else if retryErr, ok := err.(*roachpb.UnhandledRetryableError); ok {

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -864,14 +864,19 @@ func convertToErrWithPGCode(err error) error {
 	if err == nil {
 		return nil
 	}
-	switch tErr := err.(type) {
+
+	// If the error was wrapped, get to the cause. Otherwise the cast
+	// below will not see what's really happening.
+	wrappedErr := errors.Cause(err)
+
+	switch wrappedErr.(type) {
 	case *roachpb.TransactionRetryWithProtoRefreshError:
 		return sqlbase.NewRetryError(err)
 	case *roachpb.AmbiguousResultError:
 		// TODO(andrei): Once DistSQL starts executing writes, we'll need a
 		// different mechanism to marshal AmbiguousResultErrors from the executing
 		// nodes.
-		return sqlbase.NewStatementCompletionUnknownError(tErr)
+		return sqlbase.NewStatementCompletionUnknownError(err)
 	default:
 		return err
 	}

--- a/pkg/sql/pgwire/pgerror/internal_errors.go
+++ b/pkg/sql/pgwire/pgerror/internal_errors.go
@@ -91,7 +91,13 @@ func NewAssertionErrorWithDepthf(depth int, format string, args ...interface{}) 
 // and turns it into an assertion error. Both details from the original error
 // and the context of the caller are preserved.
 func NewAssertionErrorWithWrappedErrf(err error, format string, args ...interface{}) error {
-	return WrapWithDepthf(1, err, CodeInternalError, format, args...)
+	retErr := WrapWithDepthf(1, err, CodeInternalError, format, args...)
+	pgErr, ok := GetPGCause(retErr)
+	if ok {
+		return pgErr
+	}
+	// The wrap was refused (it's a special error - eg a retry error). Force an assertion error.
+	return NewAssertionErrorWithDepthf(1, "%v", err)
 }
 
 // NewInternalTrackingError instantiates an error

--- a/pkg/sql/pgwire/pgerror/wrap_test.go
+++ b/pkg/sql/pgwire/pgerror/wrap_test.go
@@ -1,0 +1,51 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pgerror_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/pkg/errors"
+)
+
+func TestWrap(t *testing.T) {
+	testData := []struct {
+		err        error
+		expectWrap bool
+	}{
+		{errors.New("woo"), true},
+		{&roachpb.UnhandledRetryableError{}, false},
+		{&roachpb.TransactionRetryWithProtoRefreshError{}, false},
+		{&roachpb.AmbiguousResultError{}, false},
+	}
+
+	for i, test := range testData {
+		werr := pgerror.Wrap(test.err, pgerror.CodeSyntaxError, "woo")
+
+		if !test.expectWrap {
+			oerr := errors.Cause(werr)
+			if oerr != test.err {
+				t.Errorf("%d: original error not preserved; expected %+v, got %+v", i, test.err, oerr)
+			}
+		} else {
+			_, ok := pgerror.GetPGCause(werr)
+			if !ok {
+				t.Errorf("%d: original error not wrapped", i)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #35883.

Prior to this patch, the following scenario was possible:

1. some SQL function A() calls client.Txn() to call B() on its behalf
   with a retry loop.
2. client.Txn() calls B()
3. B() runs KV operation, encounters some *roachpb.RetryError
4. B() calls `pgerror.Wrap()` on that retry error, turns it into pg
   error with code 40001
5. B() returns into client.Txn()
6. client.Txn() tests the type of the error expecting to find a
   roachpb error for retries. Because it's a pgerror now, the test
   fails and the retry error is not handled automatically. It flows
   out.
7. A() receives a retry error when it was not expecting any.

The error would incur spurious DDL failures, with the following
example:

```
--- FAIL: TestLogic/fakedist-opt/computed (2.66s)
    logic.go:2346:

        testdata/logic_test/computed:687:
        expected:
        division by zero

        got:
        pq: column "d" being dropped, try again later
```

(This particular test would fail after just a few attempts during a
stress run.)

This patch fixes this scenario by ensuring that retry and ambiguous
result errors flow through `pgerror.Wrapf` without being flattened
into a `pgerror.Error`, and instead remain wrapped as the original
cause via `errors.Wrapf`.

The patch is verified to work by stress testing the logic tests and
verifying that the various error symptoms do not occur any more.

Release note: None