### PR TITLE
release-19.1: pgerror: avoid wrapping special roachpb errors

### DIFF
--- a/pkg/sql/distsqlpb/data.go
+++ b/pkg/sql/distsqlpb/data.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/pkg/errors"
 )
 
 // ConvertToColumnOrdering converts an Ordering type (as defined in data.proto)
@@ -137,6 +138,11 @@ func (e *Error) String() string {
 // recognize certain errors and marshall them accordingly, and everything
 // unrecognized is turned into a PGError with code "internal".
 func NewError(err error) *Error {
+	// Unwrap the error, to attain the cause.
+	// Otherwise, Wrap() may hide the roachpb error
+	// from the cast attempt below.
+	err = errors.Cause(err)
+
 	if pgErr, ok := pgerror.GetPGCause(err); ok {
 		return &Error{Detail: &Error_PGError{PGError: pgErr}}
 	} else if retryErr, ok := err.(*roachpb.UnhandledRetryableError); ok {

--- a/pkg/sql/distsqlpb/data.go
+++ b/pkg/sql/distsqlpb/data.go
@@ -141,6 +141,7 @@ func NewError(err error) *Error {
 	// Unwrap the error, to attain the cause.
 	// Otherwise, Wrap() may hide the roachpb error
 	// from the cast attempt below.
+	origErr := err
 	err = errors.Cause(err)
 
 	if pgErr, ok := pgerror.GetPGCause(err); ok {
@@ -155,7 +156,7 @@ func NewError(err error) *Error {
 		return &Error{
 			Detail: &Error_PGError{
 				PGError: pgerror.NewAssertionErrorf(
-					"uncaught error: %+v", err)}}
+					"uncaught error: %+v", origErr)}}
 	}
 }
 

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -864,14 +864,19 @@ func convertToErrWithPGCode(err error) error {
 	if err == nil {
 		return nil
 	}
-	switch tErr := err.(type) {
+
+	// If the error was wrapped, get to the cause. Otherwise the cast
+	// below will not see what's really happening.
+	wrappedErr := errors.Cause(err)
+
+	switch wrappedErr.(type) {
 	case *roachpb.TransactionRetryWithProtoRefreshError:
 		return sqlbase.NewRetryError(err)
 	case *roachpb.AmbiguousResultError:
 		// TODO(andrei): Once DistSQL starts executing writes, we'll need a
 		// different mechanism to marshal AmbiguousResultErrors from the executing
 		// nodes.
-		return sqlbase.NewStatementCompletionUnknownError(tErr)
+		return sqlbase.NewStatementCompletionUnknownError(err)
 	default:
 		return err
 	}

--- a/pkg/sql/pgwire/pgerror/internal_errors.go
+++ b/pkg/sql/pgwire/pgerror/internal_errors.go
@@ -91,7 +91,13 @@ func NewAssertionErrorWithDepthf(depth int, format string, args ...interface{}) 
 // and turns it into an assertion error. Both details from the original error
 // and the context of the caller are preserved.
 func NewAssertionErrorWithWrappedErrf(err error, format string, args ...interface{}) error {
-	return WrapWithDepthf(1, err, CodeInternalError, format, args...)
+	retErr := WrapWithDepthf(1, err, CodeInternalError, format, args...)
+	pgErr, ok := GetPGCause(retErr)
+	if ok {
+		return pgErr
+	}
+	// The wrap was refused (it's a special error - eg a retry error). Force an assertion error.
+	return NewAssertionErrorWithDepthf(1, "%v", err)
 }
 
 // NewInternalTrackingError instantiates an error

--- a/pkg/sql/pgwire/pgerror/wrap_test.go
+++ b/pkg/sql/pgwire/pgerror/wrap_test.go
@@ -1,0 +1,51 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pgerror_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/pkg/errors"
+)
+
+func TestWrap(t *testing.T) {
+	testData := []struct {
+		err        error
+		expectWrap bool
+	}{
+		{errors.New("woo"), true},
+		{&roachpb.UnhandledRetryableError{}, false},
+		{&roachpb.TransactionRetryWithProtoRefreshError{}, false},
+		{&roachpb.AmbiguousResultError{}, false},
+	}
+
+	for i, test := range testData {
+		werr := pgerror.Wrap(test.err, pgerror.CodeSyntaxError, "woo")
+
+		if !test.expectWrap {
+			oerr := errors.Cause(werr)
+			if oerr != test.err {
+				t.Errorf("%d: original error not preserved; expected %+v, got %+v", i, test.err, oerr)
+			}
+		} else {
+			_, ok := pgerror.GetPGCause(werr)
+			if !ok {
+				t.Errorf("%d: original error not wrapped", i)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #35937.
Backport 1/1 commits from #35944.

/cc @cockroachdb/release

---

Fixes #35883.
Fixes #35943
