### PR TITLE
release-19.1: workload,workloadccl: inject stats for TPC-C workload fixture

### DIFF
--- a/pkg/ccl/workloadccl/cliccl/fixtures.go
+++ b/pkg/ccl/workloadccl/cliccl/fixtures.go
@@ -106,6 +106,9 @@ var fixturesImportFilesPerNode = fixturesImportCmd.PersistentFlags().Int(
 var fixturesRunChecks = fixturesLoadImportShared.Bool(
 	`checks`, true, `Run validity checks on the loaded fixture`)
 
+var fixturesImportInjectStats = fixturesImportCmd.PersistentFlags().Bool(
+	`inject-stats`, true, `Inject pre-calculated statistics if they are available`)
+
 var gcsBucketOverride, gcsPrefixOverride, gcsBillingProjectOverride *string
 
 func init() {
@@ -321,7 +324,10 @@ func fixturesImport(gen workload.Generator, urls []string, dbName string) error 
 	log.Infof(ctx, "starting import of %d tables", len(gen.Tables()))
 	directIngestion := *fixturesImportDirectIngestionTable
 	filesPerNode := *fixturesImportFilesPerNode
-	bytes, err := workloadccl.ImportFixture(ctx, sqlDB, gen, dbName, directIngestion, filesPerNode)
+	injectStats := *fixturesImportInjectStats
+	bytes, err := workloadccl.ImportFixture(
+		ctx, sqlDB, gen, dbName, directIngestion, filesPerNode, injectStats,
+	)
 	if err != nil {
 		return errors.Wrap(err, `importing fixture`)
 	}

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -15,10 +15,12 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -71,6 +73,12 @@ func (g fixtureTestGen) Tables() []workload.Table {
 				return []interface{}{rowIdx, g.val}
 			},
 		),
+		Stats: []workload.JSONStatistic{
+			// Use stats that *don't* match reality, so we can test that these
+			// stats were injected and not calculated by CREATE STATISTICS.
+			workload.MakeStat([]string{"key"}, 100, 100, 0),
+			workload.MakeStat([]string{"value"}, 100, 1, 5),
+		},
 	}}
 }
 
@@ -155,9 +163,18 @@ func TestImportFixture(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
+	defer func(oldRefreshInterval, oldAsOf time.Duration) {
+		stats.DefaultRefreshInterval = oldRefreshInterval
+		stats.DefaultAsOfTime = oldAsOf
+	}(stats.DefaultRefreshInterval, stats.DefaultAsOfTime)
+	stats.DefaultRefreshInterval = time.Millisecond
+	stats.DefaultAsOfTime = 10 * time.Millisecond
+
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=true`)
 
 	gen := makeTestWorkload()
 	flag := fmt.Sprintf(`val=%d`, timeutil.Now().UnixNano())
@@ -167,19 +184,42 @@ func TestImportFixture(t *testing.T) {
 
 	const filesPerNode = 1
 	sqlDB.Exec(t, `CREATE DATABASE distsort`)
-	_, err := ImportFixture(ctx, db, gen, `distsort`, false /* directIngestion */, filesPerNode)
+	_, err := ImportFixture(
+		ctx, db, gen, `distsort`, false /* directIngestion */, filesPerNode, true, /* injectStats */
+	)
 	require.NoError(t, err)
 	sqlDB.CheckQueryResults(t,
 		`SELECT count(*) FROM distsort.fx`, [][]string{{strconv.Itoa(fixtureTestGenRows)}})
 
+	sqlDB.CheckQueryResults(t,
+		`SELECT statistics_name, column_names, row_count, distinct_count, null_count
+           FROM [SHOW STATISTICS FOR TABLE distsort.fx]`,
+		[][]string{
+			{"__auto__", "{key}", "100", "100", "0"},
+			{"__auto__", "{value}", "100", "1", "5"},
+		})
+
 	sqlDB.Exec(t, `CREATE DATABASE direct`)
-	_, err = ImportFixture(ctx, db, gen, `direct`, true /* directIngestion */, filesPerNode)
+	_, err = ImportFixture(
+		ctx, db, gen, `direct`, true /* directIngestion */, filesPerNode, false, /* injectStats */
+	)
 	require.NoError(t, err)
 	sqlDB.CheckQueryResults(t,
 		`SELECT count(*) FROM direct.fx`, [][]string{{strconv.Itoa(fixtureTestGenRows)}})
 
 	fingerprints := sqlDB.QueryStr(t, `SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE distsort.fx`)
 	sqlDB.CheckQueryResults(t, `SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE direct.fx`, fingerprints)
+
+	// Since we did not inject stats, the IMPORT should have triggered
+	// automatic stats collection.
+	sqlDB.CheckQueryResultsRetry(t,
+		`SELECT statistics_name, column_names, row_count, distinct_count, null_count
+           FROM [SHOW STATISTICS FOR TABLE direct.fx]`,
+		[][]string{
+			{"__auto__", "{key}", "10", "10", "0"},
+			{"__auto__", "{value}", "10", "1", "0"},
+		})
+
 }
 
 func BenchmarkImportFixtureTPCC(b *testing.B) {
@@ -198,7 +238,9 @@ func BenchmarkImportFixtureTPCC(b *testing.B) {
 
 		b.StartTimer()
 		const filesPerNode = 1
-		importBytes, err := ImportFixture(ctx, db, gen, `d`, true /* directIngestion */, filesPerNode)
+		importBytes, err := ImportFixture(
+			ctx, db, gen, `d`, true /* directIngestion */, filesPerNode, true, /* injectStats */
+		)
 		require.NoError(b, err)
 		bytes += importBytes
 		b.StopTimer()

--- a/pkg/workload/stats.go
+++ b/pkg/workload/stats.go
@@ -1,0 +1,80 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package workload
+
+import (
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// AutoStatsName is copied from stats.AutoStatsName to avoid pulling
+// in a dependency on sql/stats.
+const AutoStatsName = "__auto__"
+
+// JSONStatistic is copied from stats.JSONStatistic to avoid pulling
+// in a dependency on sql/stats.
+type JSONStatistic struct {
+	Name          string   `json:"name,omitEmpty"`
+	CreatedAt     string   `json:"created_at"`
+	Columns       []string `json:"columns"`
+	RowCount      uint64   `json:"row_count"`
+	DistinctCount uint64   `json:"distinct_count"`
+	NullCount     uint64   `json:"null_count"`
+}
+
+// MakeStat returns a JSONStatistic given the column names, row count, distinct
+// count, and null count.
+func MakeStat(columns []string, rowCount, distinctCount, nullCount uint64) JSONStatistic {
+	return JSONStatistic{
+		Name: AutoStatsName,
+		CreatedAt: tree.AsStringWithFlags(
+			&tree.DTimestamp{Time: timeutil.Now()}, tree.FmtBareStrings,
+		),
+		Columns:       columns,
+		RowCount:      rowCount,
+		DistinctCount: distinctCount,
+		NullCount:     nullCount,
+	}
+}
+
+// DistinctCount returns the expected number of distinct values in a column
+// with rowCount rows, given that the values are chosen from maxDistinctCount
+// possible values using uniform random sampling with replacement.
+func DistinctCount(rowCount, maxDistinctCount uint64) uint64 {
+	n := float64(maxDistinctCount)
+	k := float64(rowCount)
+	// The probability that one specific value (out of the n possible values)
+	// does not appear in any of the k rows is:
+	//
+	//         ⎛ n-1 ⎞ k
+	//     p = ⎜-----⎟
+	//         ⎝  n  ⎠
+	//
+	// Therefore, the probability that a specific value appears at least once is
+	// 1-p. Over all n values, the expected number that appear at least once is
+	// n * (1-p). In other words, the expected distinct count is:
+	//
+	//                             ⎛     ⎛ n-1 ⎞ k ⎞
+	//     E[distinct count] = n * ⎜ 1 - ⎜-----⎟   ⎟
+	//                             ⎝     ⎝  n  ⎠   ⎠
+	//
+	// See https://math.stackexchange.com/questions/72223/finding-expected-
+	//   number-of-distinct-values-selected-from-a-set-of-integers for more info.
+	count := n * (1 - math.Pow((n-1)/n, k))
+	return uint64(int64(math.Round(count)))
+}

--- a/pkg/workload/stats_test.go
+++ b/pkg/workload/stats_test.go
@@ -1,0 +1,56 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package workload
+
+import (
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestDistinctCount(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	test := func(rowCount, maxDistinctCount uint64) {
+		n, count := float64(maxDistinctCount), float64(0)
+		var expected uint64
+		// This calculation should produce the same result as the calculation
+		// in DistinctCount, but it's easier to see how this is correct (it's also
+		// much less efficient). For each row, we select a new value. The
+		// probability that it hasn't been seen before is (n-count)/n, where count
+		// is the total number of values seen so far, and n is the number of
+		// possible values. This probability is also equivalent to the expected
+		// value of the increase in distinct values seen so far, so we calculate
+		// the expected total number of distinct values by summing this probability
+		// over all rows.
+		for i := uint64(0); i < rowCount && expected < maxDistinctCount; i++ {
+			count += (n - count) / n
+			expected = uint64(int64(math.Round(count)))
+		}
+
+		actual := DistinctCount(rowCount, maxDistinctCount)
+		if expected != actual {
+			t.Fatalf("For row count %d and max distinct count %d, expected distinct"+
+				" count %d but found %d", rowCount, maxDistinctCount, expected, actual)
+		}
+	}
+
+	for _, rowCount := range []uint64{0, 1, 10, 100, 1000} {
+		for _, maxDistinctCount := range []uint64{1, 10, 100, 1000} {
+			test(rowCount, maxDistinctCount)
+		}
+	}
+}

--- a/pkg/workload/tpcc/stats_test.go
+++ b/pkg/workload/tpcc/stats_test.go
@@ -1,0 +1,190 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package tpcc
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/workload"
+)
+
+func TestTPCCStats(t *testing.T) {
+	const warehouses = 100
+	gen := FromWarehouses(warehouses).(*tpcc)
+
+	// Note: These are real stats collected from running CREATE STATISTICS on
+	// a database that has been loaded with the initial rows for TPC-C with 100
+	// warehouses. We check that the stats generated for the TPC-C 100 workload
+	// fixture are within 5% of this sample.
+
+	itemStats := `
+    [{"columns": ["i_id"], "distinct_count": 101273, "null_count": 0, "row_count": 100000},
+     {"columns": ["i_im_id"], "distinct_count": 10032, "null_count": 0, "row_count": 100000},
+     {"columns": ["i_name"], "distinct_count": 98749, "null_count": 0, "row_count": 100000},
+     {"columns": ["i_price"], "distinct_count": 9855, "null_count": 0, "row_count": 100000},
+     {"columns": ["i_data"], "distinct_count": 98582, "null_count": 0, "row_count": 100000}]`
+
+	warehouseStats := `
+    [{"columns": ["w_id"], "distinct_count": 100, "null_count": 0, "row_count": 100},
+     {"columns": ["w_name"], "distinct_count": 5, "null_count": 0, "row_count": 100},
+     {"columns": ["w_street_1"], "distinct_count": 11, "null_count": 0, "row_count": 100},
+     {"columns": ["w_street_2"], "distinct_count": 11, "null_count": 0, "row_count": 100},
+     {"columns": ["w_city"], "distinct_count": 11, "null_count": 0, "row_count": 100},
+     {"columns": ["w_state"], "distinct_count": 92, "null_count": 0, "row_count": 100},
+     {"columns": ["w_zip"], "distinct_count": 100, "null_count": 0, "row_count": 100},
+     {"columns": ["w_tax"], "distinct_count": 100, "null_count": 0, "row_count": 100},
+     {"columns": ["w_ytd"], "distinct_count": 1, "null_count": 0, "row_count": 100}]`
+
+	stockStats := `
+    [{"columns": ["s_i_id"], "distinct_count": 101273, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_w_id"], "distinct_count": 100, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_quantity"], "distinct_count": 91, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_dist_01"], "distinct_count": 10147435, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_dist_02"], "distinct_count": 9896785, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_dist_03"], "distinct_count": 9932517, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_dist_04"], "distinct_count": 10048131, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_dist_05"], "distinct_count": 10045535, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_dist_06"], "distinct_count": 9801428, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_dist_07"], "distinct_count": 10074492, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_dist_08"], "distinct_count": 9943047, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_dist_09"], "distinct_count": 10001651, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_dist_10"], "distinct_count": 10097341, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_ytd"], "distinct_count": 1, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_order_cnt"], "distinct_count": 1, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_remote_cnt"], "distinct_count": 1, "null_count": 0, "row_count": 10000000},
+     {"columns": ["s_data"], "distinct_count": 10151633, "null_count": 0, "row_count": 10000000}]`
+
+	districtStats := `
+    [{"columns": ["d_id"], "distinct_count": 10, "null_count": 0, "row_count": 1000},
+     {"columns": ["d_w_id"], "distinct_count": 100, "null_count": 0, "row_count": 1000},
+     {"columns": ["d_name"], "distinct_count": 1000, "null_count": 0, "row_count": 1000},
+     {"columns": ["d_street_1"], "distinct_count": 1000, "null_count": 0, "row_count": 1000},
+     {"columns": ["d_street_2"], "distinct_count": 1000, "null_count": 0, "row_count": 1000},
+     {"columns": ["d_city"], "distinct_count": 1000, "null_count": 0, "row_count": 1000},
+     {"columns": ["d_state"], "distinct_count": 506, "null_count": 0, "row_count": 1000},
+     {"columns": ["d_zip"], "distinct_count": 951, "null_count": 0, "row_count": 1000},
+     {"columns": ["d_tax"], "distinct_count": 780, "null_count": 0, "row_count": 1000},
+     {"columns": ["d_ytd"], "distinct_count": 1, "null_count": 0, "row_count": 1000},
+     {"columns": ["d_next_o_id"], "distinct_count": 1, "null_count": 0, "row_count": 1000}]`
+
+	customerStats := `
+    [{"columns": ["c_id"], "distinct_count": 3000, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_d_id"], "distinct_count": 10, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_w_id"], "distinct_count": 100, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_first"], "distinct_count": 3024712, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_middle"], "distinct_count": 1, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_last"], "distinct_count": 1000, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_street_1"], "distinct_count": 3007563, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_street_2"], "distinct_count": 3000445, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_city"], "distinct_count": 2994387, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_state"], "distinct_count": 676, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_zip"], "distinct_count": 10018, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_phone"], "distinct_count": 2972913, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_since"], "distinct_count": 1, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_credit"], "distinct_count": 2, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_credit_lim"], "distinct_count": 1, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_discount"], "distinct_count": 5000, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_balance"], "distinct_count": 1, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_ytd_payment"], "distinct_count": 1, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_payment_cnt"], "distinct_count": 1, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_delivery_cnt"], "distinct_count": 1, "null_count": 0, "row_count": 3000000},
+     {"columns": ["c_data"], "distinct_count": 2967420, "null_count": 0, "row_count": 3000000}]`
+
+	historyStats := `
+    [{"columns": ["rowid"], "distinct_count": 2985531, "null_count": 0, "row_count": 3000000},
+     {"columns": ["h_c_id"], "distinct_count": 3000, "null_count": 0, "row_count": 3000000},
+     {"columns": ["h_c_d_id"], "distinct_count": 10, "null_count": 0, "row_count": 3000000},
+     {"columns": ["h_c_w_id"], "distinct_count": 100, "null_count": 0, "row_count": 3000000},
+     {"columns": ["h_d_id"], "distinct_count": 10, "null_count": 0, "row_count": 3000000},
+     {"columns": ["h_w_id"], "distinct_count": 100, "null_count": 0, "row_count": 3000000},
+     {"columns": ["h_date"], "distinct_count": 1, "null_count": 0, "row_count": 3000000},
+     {"columns": ["h_amount"], "distinct_count": 1, "null_count": 0, "row_count": 3000000},
+     {"columns": ["h_data"], "distinct_count": 2979454, "null_count": 0, "row_count": 3000000}]`
+
+	orderStats := `
+    [{"columns": ["o_id"], "distinct_count": 3000, "null_count": 0, "row_count": 3000000},
+     {"columns": ["o_d_id"], "distinct_count": 10, "null_count": 0, "row_count": 3000000},
+     {"columns": ["o_w_id"], "distinct_count": 100, "null_count": 0, "row_count": 3000000},
+     {"columns": ["o_c_id"], "distinct_count": 3000, "null_count": 0, "row_count": 3000000},
+     {"columns": ["o_entry_d"], "distinct_count": 1, "null_count": 0, "row_count": 3000000},
+     {"columns": ["o_carrier_id"], "distinct_count": 10, "null_count": 900000, "row_count": 3000000},
+     {"columns": ["o_ol_cnt"], "distinct_count": 11, "null_count": 0, "row_count": 3000000},
+     {"columns": ["o_all_local"], "distinct_count": 1, "null_count": 0, "row_count": 3000000}]`
+
+	newOrderStats := `
+    [{"columns": ["no_o_id"], "distinct_count": 900, "null_count": 0, "row_count": 900000},
+     {"columns": ["no_d_id"], "distinct_count": 10, "null_count": 0, "row_count": 900000},
+     {"columns": ["no_w_id"], "distinct_count": 100, "null_count": 0, "row_count": 900000}]`
+
+	orderLineStats := `
+    [{"columns": ["ol_o_id"], "distinct_count": 3000, "null_count": 0, "row_count": 30005985},
+     {"columns": ["ol_d_id"], "distinct_count": 10, "null_count": 0, "row_count": 30005985},
+     {"columns": ["ol_w_id"], "distinct_count": 100, "null_count": 0, "row_count": 30005985},
+     {"columns": ["ol_number"], "distinct_count": 15, "null_count": 0, "row_count": 30005985},
+     {"columns": ["ol_i_id"], "distinct_count": 101273, "null_count": 0, "row_count": 30005985},
+     {"columns": ["ol_supply_w_id"], "distinct_count": 100, "null_count": 0, "row_count": 30005985},
+     {"columns": ["ol_delivery_d"], "distinct_count": 1, "null_count": 9003667, "row_count": 30005985},
+     {"columns": ["ol_quantity"], "distinct_count": 1, "null_count": 0, "row_count": 30005985},
+     {"columns": ["ol_amount"], "distinct_count": 988202, "null_count": 0, "row_count": 30005985},
+     {"columns": ["ol_dist_info"], "distinct_count": 30179646, "null_count": 0, "row_count": 30005985}]`
+
+	testStats := func(table, expectedStr string, actual []workload.JSONStatistic) {
+		var expected []workload.JSONStatistic
+		if err := json.Unmarshal([]byte(expectedStr), &expected); err != nil {
+			t.Fatal(err)
+		}
+		if len(actual) != len(expected) {
+			t.Fatalf("for table %s, expected %d stats but found %d", table, len(expected), len(actual))
+		}
+		testWithinFivePercent := func(columns []string, a, b uint64) {
+			t.Helper()
+			larger, smaller := float64(a), float64(b)
+			if larger < smaller {
+				larger, smaller = smaller, larger
+			}
+			if (larger-smaller)/smaller > 0.05 {
+				t.Fatalf("for table %s, columns %v, %d and %d are more than 5%% apart",
+					table, columns, a, b)
+			}
+
+		}
+		for i := 0; i < len(actual); i++ {
+			if !reflect.DeepEqual(expected[i].Columns, actual[i].Columns) {
+				t.Fatalf("for table %s, expected columns %v but found %v",
+					table, expected[i].Columns, actual[i].Columns)
+			}
+			testWithinFivePercent(expected[i].Columns, expected[i].RowCount, actual[i].RowCount)
+			testWithinFivePercent(expected[i].Columns, expected[i].DistinctCount, actual[i].DistinctCount)
+			testWithinFivePercent(expected[i].Columns, expected[i].NullCount, actual[i].NullCount)
+			if actual[i].Name != workload.AutoStatsName {
+				t.Fatalf("for table %s, expected name %s but found %s",
+					table, workload.AutoStatsName, actual[i].Name)
+			}
+		}
+	}
+
+	testStats("item", itemStats, gen.tpccItemStats())
+	testStats("warehouse", warehouseStats, gen.tpccWarehouseStats())
+	testStats("stock", stockStats, gen.tpccStockStats())
+	testStats("district", districtStats, gen.tpccDistrictStats())
+	testStats("customer", customerStats, gen.tpccCustomerStats())
+	testStats("history", historyStats, gen.tpccHistoryStats())
+	testStats("order", orderStats, gen.tpccOrderStats())
+	testStats("new_order", newOrderStats, gen.tpccNewOrderStats())
+	testStats("order_line", orderLineStats, gen.tpccOrderLineStats())
+}

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -343,6 +343,7 @@ func (w *tpcc) Tables() []workload.Table {
 				return [][]interface{}{{(i + 1) * numWarehousesPerRange}}
 			},
 		}),
+		Stats: w.tpccWarehouseStats(),
 	}
 	district := workload.Table{
 		Name:   `district`,
@@ -358,6 +359,7 @@ func (w *tpcc) Tables() []workload.Table {
 				return [][]interface{}{{(i + 1) * numWarehousesPerRange, 0}}
 			},
 		}),
+		Stats: w.tpccDistrictStats(),
 	}
 	customer := workload.Table{
 		Name:   `customer`,
@@ -366,6 +368,7 @@ func (w *tpcc) Tables() []workload.Table {
 			numCustomersPerWarehouse*w.warehouses,
 			w.tpccCustomerInitialRow,
 		),
+		Stats: w.tpccCustomerStats(),
 	}
 	history := workload.Table{
 		Name:   `history`,
@@ -383,6 +386,7 @@ func (w *tpcc) Tables() []workload.Table {
 				}
 			},
 		}),
+		Stats: w.tpccHistoryStats(),
 	}
 	order := workload.Table{
 		Name:   `order`,
@@ -391,6 +395,7 @@ func (w *tpcc) Tables() []workload.Table {
 			numOrdersPerWarehouse*w.warehouses,
 			w.tpccOrderInitialRow,
 		),
+		Stats: w.tpccOrderStats(),
 	}
 	newOrder := workload.Table{
 		Name:   `new_order`,
@@ -399,6 +404,7 @@ func (w *tpcc) Tables() []workload.Table {
 			numNewOrdersPerWarehouse*w.warehouses,
 			w.tpccNewOrderInitialRow,
 		),
+		Stats: w.tpccNewOrderStats(),
 	}
 	item := workload.Table{
 		Name:   `item`,
@@ -414,6 +420,7 @@ func (w *tpcc) Tables() []workload.Table {
 				return [][]interface{}{{numItemsPerRange * (i + 1)}}
 			},
 		}),
+		Stats: w.tpccItemStats(),
 	}
 	stock := workload.Table{
 		Name:   `stock`,
@@ -422,6 +429,7 @@ func (w *tpcc) Tables() []workload.Table {
 			numStockPerWarehouse*w.warehouses,
 			w.tpccStockInitialRow,
 		),
+		Stats: w.tpccStockStats(),
 	}
 	orderLine := workload.Table{
 		Name:   `order_line`,
@@ -430,6 +438,7 @@ func (w *tpcc) Tables() []workload.Table {
 			NumBatches: numOrdersPerWarehouse * w.warehouses,
 			Batch:      w.tpccOrderLineInitialRowBatch,
 		},
+		Stats: w.tpccOrderLineStats(),
 	}
 	if w.interleaved {
 		district.Schema += tpccDistrictSchemaInterleave

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -149,6 +149,9 @@ type Table struct {
 	// Splits is the initial splits that will be present in the table after
 	// setup is completed.
 	Splits BatchedTuples
+	// Stats is the pre-calculated set of statistics on this table. They can be
+	// injected using `ALTER TABLE <name> INJECT STATISTICS ...`.
+	Stats []JSONStatistic
 }
 
 // BatchedTuples is a generic generator of tuples (SQL rows, PKs to split at,


### PR DESCRIPTION
Backport 1/1 commits from #35870.

/cc @cockroachdb/release

---

This commit adds logic to pre-calculate stats for any TPC-C workload,
and inject the stats using `ALTER TABLE ... INJECT STATISTICS`. The
benefit of injecting stats is it allows the benchmark to run without the
overhead of performing the initial stats collection. Stats may still
be refreshed throughout the benchmark, but they will not be running
constantly. This is a much closer approximation to how a workload would
be run on a day-to-day basis in production.

Release note (performance improvement): Improved performance of the TPC-C
benchmark by pre-calculating statistics and injecting them during IMPORT.
