### PR TITLE
distsqlpb,importccl: fix a regression in IMPORT

### DIFF
--- a/pkg/sql/distsqlpb/data.go
+++ b/pkg/sql/distsqlpb/data.go
@@ -141,6 +141,7 @@ func NewError(err error) *Error {
 	// Unwrap the error, to attain the cause.
 	// Otherwise, Wrap() may hide the roachpb error
 	// from the cast attempt below.
+	origErr := err
 	err = errors.Cause(err)
 
 	if pgErr, ok := pgerror.GetPGCause(err); ok {
@@ -155,7 +156,7 @@ func NewError(err error) *Error {
 		return &Error{
 			Detail: &Error_PGError{
 				PGError: pgerror.NewAssertionErrorf(
-					"uncaught error: %+v", err)}}
+					"uncaught error: %+v", origErr)}}
 	}
 }
 


### PR DESCRIPTION
Fixes #35943.

This patch ensures that the full error message (pre-unwrap) is
included for errors that flow out of distsql process towards the
gateway.

This is important because some other internal mechanisms inside
CockroachDB are expecting to see the prefixes introduced by
errors.Wrap to decide other things (a bad idea, but not fixable in the
short term), for example see issue #35942.

Release note: None