### PR TITLE
roachtest: extend the schema change test timeout by a bit

### DIFF
--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -305,7 +305,7 @@ func makeIndexAddTpccTest(numNodes, warehouses int, length time.Duration) testSp
 	return testSpec{
 		Name:    fmt.Sprintf("schemachange/index/tpcc/w=%d", warehouses),
 		Cluster: makeClusterSpec(numNodes),
-		Timeout: length * 2,
+		Timeout: length * 3,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{
 				Warehouses: warehouses,


### PR DESCRIPTION
We have #34834 tracking why a schema change is taking more
time. Until that is fixed we'd like to extend this timeout
and run the tests reliably so that we can find other
problems.

related to #35734 #35658 

Release note: None