### PR TITLE
release-19.1: server/status: Add timeseries for IO time

### DIFF
--- a/pkg/server/status/disk_counters.go
+++ b/pkg/server/status/disk_counters.go
@@ -18,6 +18,7 @@ package status
 
 import (
 	"context"
+	"time"
 
 	"github.com/shirou/gopsutil/disk"
 )
@@ -34,8 +35,12 @@ func getDiskCounters(ctx context.Context) ([]diskStats, error) {
 		output[i] = diskStats{
 			readBytes:      int64(counters.ReadBytes),
 			readCount:      int64(counters.ReadCount),
+			readTime:       time.Duration(counters.ReadTime) * time.Millisecond,
 			writeBytes:     int64(counters.WriteBytes),
 			writeCount:     int64(counters.WriteCount),
+			writeTime:      time.Duration(counters.WriteTime) * time.Millisecond,
+			ioTime:         time.Duration(counters.IoTime) * time.Millisecond,
+			weightedIOTime: time.Duration(counters.WeightedIO) * time.Millisecond,
 			iopsInProgress: int64(counters.IopsInProgress),
 		}
 		i++

--- a/pkg/server/status/disk_counters_darwin.go
+++ b/pkg/server/status/disk_counters_darwin.go
@@ -33,8 +33,12 @@ func getDiskCounters(context.Context) ([]diskStats, error) {
 		output[i] = diskStats{
 			readBytes:      counters.BytesRead,
 			readCount:      counters.NumRead,
+			readTime:       counters.TotalReadTime,
 			writeBytes:     counters.BytesWritten,
 			writeCount:     counters.NumWrite,
+			writeTime:      counters.TotalWriteTime,
+			ioTime:         0, // Not reported by this library.
+			weightedIOTime: 0, // Not reported by this library.
 			iopsInProgress: 0, // Not reported by this library. (#27927)
 		}
 	}


### PR DESCRIPTION
Backport 1/1 commits from #35913.

/cc @cockroachdb/release

---

These metrics are either linux-specific or difficult to interpret so
they're not added to dashboards until we figure out what's useful.

Undoes #30488. The disk read and write time metrics aren't the most
useful, but they're what we have and they're better than nothing.

Fixes #34591

Release note: None
