### PR TITLE
workload: make kv --max-block-bytes an inclusive upper bound

### DIFF
--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -58,7 +58,7 @@ func registerAllocator(r *registry) {
 			// TODO(dan): Ideally, the test would fail if this queryload failed,
 			// but we can't put it in monitor as-is because the test deadlocks.
 			go func() {
-				const cmd = `./workload run kv --tolerate-errors --min-block-bytes=8 --max-block-bytes=128`
+				const cmd = `./workload run kv --tolerate-errors --min-block-bytes=8 --max-block-bytes=127`
 				l, err := t.l.ChildLogger(fmt.Sprintf(`kv-%d`, node))
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -57,7 +57,7 @@ func registerHotSpotSplits(r *registry) {
 			return c.RunL(ctx, quietL, appNode, fmt.Sprintf(
 				"./workload run kv --read-percent=0 --splits=0 --tolerate-errors --concurrency=%d "+
 					"--min-block-bytes=%d --max-block-bytes=%d --duration=%s {pgurl:1-3}",
-				concurrency, blockSize, blockSize+1, duration.String()))
+				concurrency, blockSize, blockSize, duration.String()))
 		})
 
 		m.Go(func() error {

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -59,7 +59,7 @@ func registerKV(r *registry) {
 			var blockSize string
 			if opts.blockSize > 0 {
 				blockSize = fmt.Sprintf(" --min-block-bytes=%d --max-block-bytes=%d",
-					opts.blockSize, opts.blockSize+1)
+					opts.blockSize, opts.blockSize)
 			}
 
 			cmd := fmt.Sprintf(

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -60,7 +60,7 @@ func registerSchemaChangeKV(r *registry) {
 				// TODO(dan): Ideally, the test would fail if this queryload failed,
 				// but we can't put it in monitor as-is because the test deadlocks.
 				go func() {
-					const cmd = `./workload run kv --tolerate-errors --min-block-bytes=8 --max-block-bytes=128 --db=test`
+					const cmd = `./workload run kv --tolerate-errors --min-block-bytes=8 --max-block-bytes=127 --db=test`
 					l, err := t.l.ChildLogger(fmt.Sprintf(`kv-%d`, node))
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -94,7 +94,7 @@ var kvMeta = workload.Meta{
 			`Number of blocks to read/insert in a single SQL statement.`)
 		g.flags.IntVar(&g.minBlockSizeBytes, `min-block-bytes`, 1,
 			`Minimum amount of raw data written with each insertion.`)
-		g.flags.IntVar(&g.maxBlockSizeBytes, `max-block-bytes`, 2,
+		g.flags.IntVar(&g.maxBlockSizeBytes, `max-block-bytes`, 1,
 			`Maximum amount of raw data written with each insertion`)
 		g.flags.Int64Var(&g.cycleLength, `cycle-length`, math.MaxInt64,
 			`Number of keys repeatedly accessed by each writer through upserts.`)
@@ -491,7 +491,7 @@ func (g *zipfGenerator) sequence() int64 {
 }
 
 func randomBlock(config *kv, r *rand.Rand) []byte {
-	blockSize := r.Intn(config.maxBlockSizeBytes-config.minBlockSizeBytes) + config.minBlockSizeBytes
+	blockSize := r.Intn(config.maxBlockSizeBytes-config.minBlockSizeBytes+1) + config.minBlockSizeBytes
 	blockData := make([]byte, blockSize)
 	uniqueSize := int(float64(blockSize) / config.targetCompressionRatio)
 	if uniqueSize < 1 {


### PR DESCRIPTION
The `kv` workload takes arguments `--min-block-bytes` and `--max-block-bytes`
and was generating keys with a length chosen uniformly at random from the
interval that excludes `--max-block-bytes`. Also, since we were using
`Rand.Intn()`, using the same value for both args would cause a panic from
passing in 0. This change makes the upper bound inclusive, which seems to be
the intended behavior.

Release note: None