### PR TITLE
sqlsmith: add x IN (SELECT ...)

### DIFF
--- a/pkg/internal/sqlsmith/sqlsmith_test.go
+++ b/pkg/internal/sqlsmith/sqlsmith_test.go
@@ -69,7 +69,7 @@ func TestGenerateParse(t *testing.T) {
 		stmt := smither.Generate()
 		_, err := parser.ParseOne(stmt)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("%v: %v", stmt, err)
 		}
 		if *flagExec {
 			if _, err := sqlDB.Exec(stmt); err != nil {


### PR DESCRIPTION
I added this in an attempt to repro a specific bug. I was unsuccessful,
but figured I should PR this since I already did the work.

This is technically just another instance of a comparison op, it could
probably be refactored to be lumped in with those once there's more
structure around how those are generated.

Release note: None