### PR TITLE
release-19.1: opt: fix null count estimation for VALUES

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -1452,11 +1452,12 @@ func (sb *statisticsBuilder) buildSetNode(setNode RelExpr, relProps *props.Relat
 	switch setNode.Op() {
 	case opt.UnionOp, opt.IntersectOp, opt.ExceptOp:
 		// Since UNION, INTERSECT and EXCEPT eliminate duplicate rows, the row
-		// count will equal the distinct count of the set of output columns.
+		// count will equal the distinct count of the set of output columns, plus
+		// any null values.
 		setPrivate := setNode.Private().(*SetPrivate)
 		outputCols := setPrivate.OutCols.ToSet()
 		colStat := sb.colStatSetNodeImpl(outputCols, setNode, relProps)
-		s.RowCount = colStat.DistinctCount
+		s.RowCount = min(colStat.DistinctCount+colStat.NullCount, s.RowCount)
 	}
 
 	sb.finalizeFromCardinality(relProps)
@@ -1558,9 +1559,11 @@ func (sb *statisticsBuilder) colStatValues(
 		hash := uint64(offset64)
 		hasNull := false
 		for i, elem := range row.(*TupleExpr).Elems {
-			if elem.Op() == opt.NullOp {
-				hasNull = true
-			} else if colSet.Contains(int(values.Cols[i])) {
+			if colSet.Contains(int(values.Cols[i])) {
+				if elem.Op() == opt.NullOp {
+					hasNull = true
+					break
+				}
 				// Use the pointer value of the scalar expression, since it's already
 				// been interned. Therefore, two expressions with the same pointer
 				// have the same value.
@@ -1569,11 +1572,10 @@ func (sb *statisticsBuilder) colStatValues(
 				hash *= prime64
 			}
 		}
-		if hash != offset64 {
-			distinct[hash] = struct{}{}
-		}
 		if hasNull {
 			nullCount++
+		} else {
+			distinct[hash] = struct{}{}
 		}
 	}
 

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -274,7 +274,7 @@ memo (optimized, ~4KB, required=[presentation: x:7,y:8])
  ├── G1: (union G2 G3)
  │    └── [presentation: x:7,y:8]
  │         ├── best: (union G2 G3)
- │         └── cost: 2149.84
+ │         └── cost: 2150.04
  ├── G2: (scan a)
  │    └── []
  │         ├── best: (scan a)

--- a/pkg/sql/opt/memo/testdata/stats/set
+++ b/pkg/sql/opt/memo/testdata/stats/set
@@ -712,7 +712,7 @@ union
  ├── columns: x:9(int)
  ├── left columns: b.x:1(int)
  ├── right columns: c.x:5(int)
- ├── stats: [rows=10000, distinct(9)=10000, null(9)=2]
+ ├── stats: [rows=10002, distinct(9)=10000, null(9)=2]
  ├── key: (9)
  ├── project
  │    ├── columns: b.x:1(int)
@@ -738,7 +738,7 @@ intersect
  ├── columns: x:1(int)
  ├── left columns: b.x:1(int)
  ├── right columns: c.x:5(int)
- ├── stats: [rows=5000, distinct(1)=5000, null(1)=1]
+ ├── stats: [rows=5001, distinct(1)=5000, null(1)=1]
  ├── key: (1)
  ├── project
  │    ├── columns: b.x:1(int)
@@ -764,7 +764,7 @@ except
  ├── columns: x:1(int)
  ├── left columns: b.x:1(int)
  ├── right columns: c.x:5(int)
- ├── stats: [rows=5000, distinct(1)=5000, null(1)=1]
+ ├── stats: [rows=5001, distinct(1)=5000, null(1)=1]
  ├── key: (1)
  ├── project
  │    ├── columns: b.x:1(int)
@@ -857,3 +857,40 @@ except-all
            ├── stats: [rows=10000, distinct(5)=5000, null(5)=1000, distinct(7)=10, null(7)=7500, distinct(5,7)=10000, null(5,7)=7750]
            ├── key: (8)
            └── fd: (8)-->(5-7)
+
+# Regression test for #35715.
+opt colstat=(5,2)
+SELECT * FROM
+((VALUES (NULL, true) EXCEPT (VALUES (1, NULL)))) AS t(a, b)
+WHERE a IS NULL and b
+----
+select
+ ├── columns: a:5(int) b:2(bool!null)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(5)=0, null(5)=1, distinct(2,5)=0, null(2,5)=1]
+ ├── key: ()
+ ├── fd: ()-->(2,5)
+ ├── except
+ │    ├── columns: column1:5(int) column2:2(bool)
+ │    ├── left columns: column1:5(int) column2:2(bool)
+ │    ├── right columns: column1:3(int) column2:6(bool)
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(5)=0, null(5)=1, distinct(2,5)=0, null(2,5)=1]
+ │    ├── key: (2,5)
+ │    ├── values
+ │    │    ├── columns: column2:2(bool) column1:5(int)
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(5)=0, null(5)=1, distinct(2,5)=0, null(2,5)=1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(2,5)
+ │    │    └── (true, NULL) [type=tuple{bool, int}]
+ │    └── values
+ │         ├── columns: column1:3(int) column2:6(bool)
+ │         ├── cardinality: [1 - 1]
+ │         ├── stats: [rows=1, distinct(3)=1, null(3)=0, distinct(6)=0, null(6)=1, distinct(3,6)=0, null(3,6)=1]
+ │         ├── key: ()
+ │         ├── fd: ()-->(3,6)
+ │         └── (1, NULL) [type=tuple{int, bool}]
+ └── filters
+      ├── column1 IS NULL [type=bool, outer=(5), constraints=(/5: [/NULL - /NULL]; tight), fd=()-->(5)]
+      └── variable: column2 [type=bool, outer=(2), constraints=(/2: [/true - /true]; tight), fd=()-->(2)]

--- a/pkg/sql/opt/memo/testdata/stats/values
+++ b/pkg/sql/opt/memo/testdata/stats/values
@@ -97,8 +97,30 @@ SELECT * FROM (VALUES (NULL,1), (1,NULL), (NULL,NULL), (1,2))
 values
  ├── columns: column1:1(int) column2:2(int)
  ├── cardinality: [4 - 4]
- ├── stats: [rows=4, distinct(1,2)=2, null(1,2)=3]
+ ├── stats: [rows=4, distinct(1,2)=1, null(1,2)=3]
  ├── (NULL, 1) [type=tuple{int, int}]
  ├── (1, NULL) [type=tuple{int, int}]
  ├── (NULL, NULL) [type=tuple{int, int}]
  └── (1, 2) [type=tuple{int, int}]
+
+# Regression test for #35715.
+norm colstat=1 colstat=2
+SELECT * FROM (VALUES (NULL, 1))
+----
+values
+ ├── columns: column1:1(unknown) column2:2(int)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1, distinct(1)=0, null(1)=1, distinct(2)=1, null(2)=0]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ └── (NULL, 1) [type=tuple{unknown, int}]
+
+norm colstat=1 colstat=2 colstat=(1,2)
+SELECT * FROM (VALUES (NULL, 2), (2, NULL))
+----
+values
+ ├── columns: column1:1(int) column2:2(int)
+ ├── cardinality: [2 - 2]
+ ├── stats: [rows=2, distinct(1)=1, null(1)=1, distinct(2)=1, null(2)=1, distinct(1,2)=0, null(1,2)=2]
+ ├── (NULL, 2) [type=tuple{int, int}]
+ └── (2, NULL) [type=tuple{int, int}]

--- a/pkg/sql/opt/xform/testdata/coster/set
+++ b/pkg/sql/opt/xform/testdata/coster/set
@@ -26,8 +26,8 @@ union
  ├── columns: k:8(int) i:9(int)
  ├── left columns: a.k:1(int) a.i:2(int)
  ├── right columns: x:5(int) z:6(int)
- ├── stats: [rows=1990, distinct(8,9)=1990, null(8,9)=19.92]
- ├── cost: 2149.93
+ ├── stats: [rows=2000, distinct(8,9)=1990, null(8,9)=19.92]
+ ├── cost: 2150.03
  ├── key: (8,9)
  ├── scan a
  │    ├── columns: a.k:1(int!null) a.i:2(int)
@@ -67,8 +67,8 @@ intersect
  ├── columns: k:1(int) i:2(int)
  ├── left columns: k:1(int) i:2(int)
  ├── right columns: x:5(int) z:6(int)
- ├── stats: [rows=990, distinct(1,2)=990, null(1,2)=9.91]
- ├── cost: 2139.93
+ ├── stats: [rows=999.91, distinct(1,2)=990, null(1,2)=9.91]
+ ├── cost: 2140.0291
  ├── key: (1,2)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
@@ -108,8 +108,8 @@ except
  ├── columns: k:1(int) i:2(int)
  ├── left columns: k:1(int) i:2(int)
  ├── right columns: x:5(int) z:6(int)
- ├── stats: [rows=990, distinct(1,2)=990, null(1,2)=9.91]
- ├── cost: 2139.93
+ ├── stats: [rows=999.91, distinct(1,2)=990, null(1,2)=9.91]
+ ├── cost: 2140.0291
  ├── key: (1,2)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)


### PR DESCRIPTION
Backport 1/1 commits from #35955.

/cc @cockroachdb/release

---

Prior to this commit, the `statisticsBuilder` was calculating the
null count for columns in a `VALUES` expression incorrectly. If there
were any null values in a row, the `statisticsBuilder` incremented
the null count for every column, even for the columns that did not
contain a null. This commit fixes the issue by only incrementing
the null count for a column if that column actually contains a null.

Fixes #35715

Release note (bug fix): Fixed an error caused by incorrect calculation
of null counts in VALUES clauses.
