### PR TITLE
release-2.1: rpc: adopt logging in circuitbreaker

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -250,12 +250,12 @@
   version = "v1.3.1"
 
 [[projects]]
-  digest = "1:4ba637038f22c9065994c0cd734118fc75e0c744f855fd3edbd3b923d1f41d44"
-  name = "github.com/cenk/backoff"
+  digest = "1:166438587ed45ac211dab8a3ecebf4fa0c186d0db63430fb9127bbc2e5fcdc67"
+  name = "github.com/cenkalti/backoff"
   packages = ["."]
   pruneopts = "UT"
-  revision = "61153c768f31ee5f130071d08fc82b85208528de"
-  version = "v1.1.0"
+  revision = "1e4cf3da559842a91afcb6ea6141451e6c30c618"
+  version = "v2.1.1"
 
 [[projects]]
   digest = "1:9ce437e6e6b97d9430e29ac9324e241b3ba77969f14499636e47d4c59fcc236b"
@@ -283,6 +283,14 @@
   pruneopts = "UT"
   revision = "9c2ab8efc9ac66bf4bb79ab6bed4dcd0c709d1b9"
   version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5502cef94063585c627f3bc3ffc80ad7f0f1e0f1b5dccf8aeff9a822526806da"
+  name = "github.com/cockroachdb/circuitbreaker"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a614b14ccf63dd2311d4ff646c30c61b8ed34aa8"
 
 [[projects]]
   branch = "master"
@@ -1227,14 +1235,6 @@
   revision = "1f30fe9094a513ce4c700b9a54458bbb0c96996c"
 
 [[projects]]
-  branch = "master"
-  digest = "1:2704976bbe3459cc3a93c0af2e9e1fc6f0a622db805bbcd1500dfe5977a7ecdf"
-  name = "github.com/rubyist/circuitbreaker"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "2074adba5ddc7d5f7559448a9c3066573521c5bf"
-
-[[projects]]
   digest = "1:9945e4ef330ecb1ca328916effe63b46453c3f39c420c0db97dbdbe832b77662"
   name = "github.com/russross/blackfriday"
   packages = ["."]
@@ -1657,9 +1657,10 @@
     "github.com/backtrace-labs/go-bcd",
     "github.com/benesch/cgosymbolizer",
     "github.com/biogo/store/llrb",
-    "github.com/cenk/backoff",
+    "github.com/cenkalti/backoff",
     "github.com/client9/misspell/cmd/misspell",
     "github.com/cockroachdb/apd",
+    "github.com/cockroachdb/circuitbreaker",
     "github.com/cockroachdb/cmux",
     "github.com/cockroachdb/cockroach-go/crdb",
     "github.com/cockroachdb/crlfmt",
@@ -1712,6 +1713,7 @@
     "github.com/hashicorp/go-version",
     "github.com/jackc/pgx",
     "github.com/jackc/pgx/pgproto3",
+    "github.com/jackc/pgx/pgtype",
     "github.com/jteeuwen/go-bindata/go-bindata",
     "github.com/kisielk/errcheck",
     "github.com/kisielk/gotool",
@@ -1744,7 +1746,6 @@
     "github.com/prometheus/common/expfmt",
     "github.com/rcrowley/go-metrics",
     "github.com/rcrowley/go-metrics/exp",
-    "github.com/rubyist/circuitbreaker",
     "github.com/sasha-s/go-deadlock",
     "github.com/satori/go.uuid",
     "github.com/shirou/gopsutil/cpu",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,9 +57,8 @@ ignored = [
   name = "github.com/montanaflynn/stats"
   branch = "master"
 
-# https://github.com/rubyist/circuitbreaker/commit/af95830
 [[constraint]]
-  name = "github.com/rubyist/circuitbreaker"
+  name = "github.com/cockroachdb/circuitbreaker"
   branch = "master"
 
 [[constraint]]

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -21,8 +21,8 @@ import (
 	"sync"
 	"time"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/pkg/errors"
-	circuit "github.com/rubyist/circuitbreaker"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -169,7 +169,7 @@ func gossipSucceedsSoon(
 			// If the client wasn't able to connect, restart it.
 			g := gossip[client]
 			g.mu.Lock()
-			client.startLocked(g, disconnected, rpcContext, stopper, rpcContext.NewBreaker())
+			client.startLocked(g, disconnected, rpcContext, stopper, rpcContext.NewBreaker(""))
 			g.mu.Unlock()
 		default:
 		}
@@ -307,7 +307,7 @@ func TestClientNodeID(t *testing.T) {
 		case <-disconnected:
 			// The client hasn't been started or failed to start, loop and try again.
 			local.mu.Lock()
-			c.startLocked(local, disconnected, rpcContext, stopper, rpcContext.NewBreaker())
+			c.startLocked(local, disconnected, rpcContext, stopper, rpcContext.NewBreaker(""))
 			local.mu.Unlock()
 		}
 	}

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -65,9 +65,9 @@ import (
 
 	"google.golang.org/grpc"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
-	circuit "github.com/rubyist/circuitbreaker"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -1527,7 +1527,8 @@ func (g *Gossip) startClientLocked(addr net.Addr) {
 	defer g.clientsMu.Unlock()
 	breaker, ok := g.clientsMu.breakers[addr.String()]
 	if !ok {
-		breaker = g.rpcContext.NewBreaker()
+		name := fmt.Sprintf("gossip %v->%v", g.rpcContext.Addr, addr)
+		breaker = g.rpcContext.NewBreaker(name)
 		g.clientsMu.breakers[addr.String()] = breaker
 	}
 	ctx := g.AnnotateCtx(context.TODO())

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -498,7 +498,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 			localAddr := local.GetNodeAddr()
 			c := newClient(log.AmbientContext{Tracer: tracing.NewTracer()}, localAddr, makeMetrics())
 			peer.mu.Lock()
-			c.startLocked(peer, disconnectedCh, peer.rpcContext, stopper, peer.rpcContext.NewBreaker())
+			c.startLocked(peer, disconnectedCh, peer.rpcContext, stopper, peer.rpcContext.NewBreaker(""))
 			peer.mu.Unlock()
 
 			disconnectedClient := <-disconnectedCh

--- a/pkg/rpc/breaker.go
+++ b/pkg/rpc/breaker.go
@@ -15,13 +15,14 @@
 package rpc
 
 import (
+	"context"
 	"time"
 
-	"github.com/cenk/backoff"
-	"github.com/facebookgo/clock"
-	"github.com/rubyist/circuitbreaker"
-
+	"github.com/cenkalti/backoff"
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/facebookgo/clock"
 )
 
 const maxBackoff = time.Second
@@ -90,10 +91,29 @@ func newBackOff(clock backoff.Clock) backoff.BackOff {
 	return b
 }
 
-func newBreaker(clock clock.Clock) *circuit.Breaker {
+func newBreaker(ctx context.Context, name string, clock clock.Clock) *circuit.Breaker {
 	return circuit.NewBreakerWithOptions(&circuit.Options{
+		Name:       name,
 		BackOff:    newBackOff(clock),
 		Clock:      clock,
 		ShouldTrip: circuit.ThresholdTripFunc(1),
+		Logger:     breakerLogger{ctx},
 	})
+}
+
+// breakerLogger implements circuit.Logger to expose logging from the
+// circuitbreaker package. Debugf is logged with a vmodule level of 2 so to see
+// the circuitbreaker debug messages set --vmodule=breaker=2
+type breakerLogger struct {
+	ctx context.Context
+}
+
+func (r breakerLogger) Debugf(format string, v ...interface{}) {
+	if log.V(2) {
+		log.InfofDepth(r.ctx, 1, format, v...)
+	}
+}
+
+func (r breakerLogger) Infof(format string, v ...interface{}) {
+	log.InfofDepth(r.ctx, 1, format, v...)
 }

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -24,10 +24,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
-	"github.com/rubyist/circuitbreaker"
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -682,12 +682,13 @@ func (ctx *Context) GRPCDial(target string) *Connection {
 }
 
 // NewBreaker creates a new circuit breaker properly configured for RPC
-// connections.
-func (ctx *Context) NewBreaker() *circuit.Breaker {
+// connections. name is used internally for logging state changes of the
+// returned breaker.
+func (ctx *Context) NewBreaker(name string) *circuit.Breaker {
 	if ctx.BreakerFactory != nil {
 		return ctx.BreakerFactory()
 	}
-	return newBreaker(&ctx.breakerClock)
+	return newBreaker(ctx.masterCtx, name, &ctx.breakerClock)
 }
 
 // ErrNotHeartbeated is returned by ConnHealth when we have not yet performed

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -99,13 +99,17 @@ func (n *Dialer) Dial(ctx context.Context, nodeID roachpb.NodeID) (_ *grpc.Clien
 	addr, err := n.resolver(nodeID)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to resolve n%d", nodeID)
-		breaker.Fail(err)
+		if ctx.Err() == nil {
+			breaker.Fail(err)
+		}
 		return nil, err
 	}
 	conn, err := n.rpcContext.GRPCDial(addr.String()).Connect(ctx)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to grpc dial n%d at %v", nodeID, addr)
-		breaker.Fail(err)
+		if ctx.Err() == nil {
+			breaker.Fail(err)
+		}
 		return nil, err
 	}
 	breaker.Success()

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -24,9 +24,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cenk/backoff"
+	"github.com/cenkalti/backoff"
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/pkg/errors"
-	circuit "github.com/rubyist/circuitbreaker"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -3654,7 +3654,7 @@ func TestFailedPreemptiveSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const expErr = "snapshot failed: unknown peer 3"
+	const expErr = "snapshot failed: failed to resolve n3: unknown peer 3"
 	if err := rep.ChangeReplicas(
 		context.Background(),
 		roachpb.ADD_REPLICA,

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -33,10 +33,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenk/backoff"
+	"github.com/cenkalti/backoff"
+	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
-	circuit "github.com/rubyist/circuitbreaker"
 	"go.etcd.io/etcd/raft"
 	"google.golang.org/grpc"
 

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/circuitbreaker"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -42,7 +43,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/pkg/errors"
-	"github.com/rubyist/circuitbreaker"
 )
 
 // AddReplica adds the replica to the store's replica map and to the sorted


### PR DESCRIPTION
Backport 1/1 commits from #33676.

/cc @cockroachdb/release

---

Adopts changes to the circuitbreaker package to enable logging. 
Fixes #33657

Release note: None
