### PR TITLE
release-2.1: storageccl: tolerate rewriting keys with fewer columns than expected

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1047,11 +1047,19 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 	defer cleanupFn()
 	args := base.TestServerArgs{ExternalIODir: dir}
 
+	_ = sqlDB.Exec(t, `SET CLUSTER SETTING kv.range_merge.queue_enabled = false`)
+
 	// TODO(dan): The INTERLEAVE IN PARENT clause currently doesn't allow the
 	// `db.table` syntax. Fix that and use it here instead of `SET DATABASE`.
 	_ = sqlDB.Exec(t, `SET DATABASE = data`)
-	_ = sqlDB.Exec(t, `CREATE TABLE i0 (a INT, b INT, PRIMARY KEY (a, b)) INTERLEAVE IN PARENT bank (a)`)
-	_ = sqlDB.Exec(t, `CREATE TABLE i0_0 (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) INTERLEAVE IN PARENT i0 (a, b)`)
+
+	// i0 interleaves in parent with a, and has a multi-col PK of its own b, c
+	_ = sqlDB.Exec(t, `CREATE TABLE i0 (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) INTERLEAVE IN PARENT bank (a)`)
+	// Split at at a _strict prefix_ of the cols in i_0's PK
+	_ = sqlDB.Exec(t, `ALTER TABLE i0 SPLIT AT VALUES (1, 1)`)
+
+	// i0_0 interleaves into i0.
+	_ = sqlDB.Exec(t, `CREATE TABLE i0_0 (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b, c, d)) INTERLEAVE IN PARENT i0 (a, b, c)`)
 	_ = sqlDB.Exec(t, `CREATE TABLE i1 (a INT, b CHAR, PRIMARY KEY (a, b)) INTERLEAVE IN PARENT bank (a)`)
 	_ = sqlDB.Exec(t, `CREATE TABLE i2 (a INT, b CHAR, PRIMARY KEY (a, b)) INTERLEAVE IN PARENT bank (a)`)
 
@@ -1059,9 +1067,9 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 	// and 4x in i1.
 	totalRows := numAccounts
 	for i := 0; i < numAccounts; i++ {
-		_ = sqlDB.Exec(t, `INSERT INTO i0 VALUES ($1, 1), ($1, 2)`, i)
+		_ = sqlDB.Exec(t, `INSERT INTO i0 VALUES ($1, 1, 1), ($1, 2, 2)`, i)
 		totalRows += 2
-		_ = sqlDB.Exec(t, `INSERT INTO i0_0 VALUES ($1, 1, 1), ($1, 2, 2), ($1, 3, 3)`, i)
+		_ = sqlDB.Exec(t, `INSERT INTO i0_0 VALUES ($1, 1, 1, 1), ($1, 2, 2, 2), ($1, 3, 3, 3)`, i)
 		totalRows += 3
 		_ = sqlDB.Exec(t, `INSERT INTO i1 VALUES ($1, 'a'), ($1, 'b'), ($1, 'c'), ($1, 'd')`, i)
 		totalRows += 4

--- a/pkg/ccl/storageccl/key_rewriter.go
+++ b/pkg/ccl/storageccl/key_rewriter.go
@@ -176,6 +176,10 @@ func (kr *KeyRewriter) RewriteKey(key []byte) ([]byte, bool, error) {
 			return nil, false, err
 		}
 		k = k[n:]
+		// Check if we ran out of key before getting to an interleave child?
+		if len(k) == 0 {
+			return key, true, nil
+		}
 	}
 	// We might have an interleaved key.
 	k, ok = encoding.DecodeIfInterleavedSentinel(k)


### PR DESCRIPTION
Backport 1/1 commits from #35750.

/cc @cockroachdb/release

---

When rewriting a key, if it belongs to an index in which another is interleaved, once we rewrite past the table/index ID prefix, we previously would assume we had to skip exactly the number of columns indexed before checking if there was an interleave child ID to rewrite.

However, if a span's start or end key does not include all the index columns, this assumption is invalid. It is unclear why we'd have such a span boundary, but if we do, the key rewriter has technically done its job if it rewrites all the IDs in the prefix of a key and then finds the key ends in the middle of the column values. While unexpected, strictly from the point of view of the rewriter, the key's IDs are rewritten and it can return.

Release note (enterprise change): Fix a bug in RESTORE where some unusual range boundaries in interleaved tables caused an error.
