### PR TITLE
sql: avoid wrapping the special lease expiration error object

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -278,8 +278,7 @@ func (sc *SchemaChanger) findTableWithLease(
 	}
 	if *tableDesc.Lease != lease {
 		log.Errorf(ctx, "table: %d has lease: %v, expected: %v", sc.tableID, tableDesc.Lease, lease)
-		return nil, pgerror.NewAssertionErrorWithWrappedErrf(errExpiredSchemaChangeLease,
-			"table: %d has lease: %v, expected: %v", log.Safe(sc.tableID), log.Safe(tableDesc.Lease), log.Safe(lease))
+		return nil, errExpiredSchemaChangeLease
 	}
 	return tableDesc, nil
 }


### PR DESCRIPTION
Fixes #35734.

Issue #35854 notwithstanding, I misunderstood the logic and considered
a "perfectly normal" case to be an internal error, which was
wrong. This was causing long DDL txns to abort due to lease
expirations, that they would not renew.

Release note: None