### PR TITLE
release-19.1: kv: disallow follower reads for writing transactions

### DIFF
--- a/pkg/ccl/followerreadsccl/followerreads.go
+++ b/pkg/ccl/followerreadsccl/followerreads.go
@@ -93,7 +93,7 @@ func canUseFollowerRead(clusterID uuid.UUID, st *cluster.Settings, ts hlc.Timest
 // canSendToFollower implements the logic for checking whether a batch request
 // may be sent to a follower.
 func canSendToFollower(clusterID uuid.UUID, st *cluster.Settings, ba roachpb.BatchRequest) bool {
-	return ba.IsReadOnly() && ba.Txn != nil &&
+	return ba.IsReadOnly() && ba.Txn != nil && !ba.Txn.IsWriting() &&
 		canUseFollowerRead(clusterID, st, ba.Txn.OrigTimestamp)
 }
 

--- a/pkg/storage/replica_follower_read.go
+++ b/pkg/storage/replica_follower_read.go
@@ -43,8 +43,9 @@ func (r *Replica) canServeFollowerRead(
 ) *roachpb.Error {
 	canServeFollowerRead := false
 	if lErr, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); ok &&
+		lErr.LeaseHolder != nil && lErr.Lease.Type() == roachpb.LeaseEpoch &&
 		FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV) &&
-		lErr.LeaseHolder != nil && lErr.Lease.Type() == roachpb.LeaseEpoch {
+		(ba.Txn == nil || !ba.Txn.IsWriting()) {
 
 		canServeFollowerRead = !r.maxClosed(ctx).Less(ba.Timestamp)
 		if !canServeFollowerRead {


### PR DESCRIPTION
Backport 1/1 commits from #35969.

/cc @cockroachdb/release

---

Fixes #35812.

To avoid missing its own writes, a transaction must not evaluate a read
on a follower who has nit caught up to at least its current provisional
commit timestamp. We were violating this both at the DistSender level and
at the Replica level.

Because the ability to perform follower reads in a writing transaction is
fairly unimportant and has these known issues, this commit disallows
follower reads for writing transactions.

Release note: None
