### PR TITLE
backport-19.1: increase max sync durations, improve debugging helpers

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2306,12 +2306,16 @@ writing ` + os.DevNull + `
   debug/liveness
   debug/settings
   debug/reports/problemranges
-  debug/gossip/liveness
-  debug/gossip/network
-  debug/gossip/nodes
-  debug/metrics
-  debug/alerts
+  debug/crdb_internal.jobs
+  debug/crdb_internal.schema_changes
   debug/nodes/1/status
+  debug/nodes/1/crdb_internal.gossip_liveness
+  debug/nodes/1/crdb_internal.gossip_network
+  debug/nodes/1/crdb_internal.gossip_nodes
+  debug/nodes/1/crdb_internal.node_metrics
+  debug/nodes/1/crdb_internal.gossip_alerts
+  debug/nodes/1/queries
+  debug/nodes/1/sessions
   debug/nodes/1/details
   debug/nodes/1/gossip
   debug/nodes/1/stacks

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -403,12 +403,15 @@ Decode and print a hexadecimal-encoded key-value pair.
 			bs = append(bs, b)
 		}
 
+		isTS := bytes.HasPrefix(bs[0], keys.TimeseriesPrefix)
 		k, err := engine.DecodeMVCCKey(bs[0])
 		if err != nil {
 			// Older versions of the consistency checker give you diffs with a raw_key that
 			// is already a roachpb.Key, so make a half-assed attempt to support both.
-			fmt.Printf("unable to decode key: %v, assuming it's a roachpb.Key with fake timestamp;\n"+
-				"if the result below looks like garbage, then it likely is:\n\n", err)
+			if !isTS {
+				fmt.Printf("unable to decode key: %v, assuming it's a roachpb.Key with fake timestamp;\n"+
+					"if the result below looks like garbage, then it likely is:\n\n", err)
+			}
 			k = engine.MVCCKey{
 				Key:       bs[0],
 				Timestamp: hlc.Timestamp{WallTime: 987654321},

--- a/pkg/cli/debug/print.go
+++ b/pkg/cli/debug/print.go
@@ -48,6 +48,7 @@ func SprintKeyValue(kv engine.MVCCKeyValue, sizes bool) string {
 		tryMeta,
 		tryTxn,
 		tryRangeIDKey,
+		tryTimeSeries,
 		tryIntent,
 		func(kv engine.MVCCKeyValue) (string, error) {
 			// No better idea, just print raw bytes and hope that folks use `less -S`.
@@ -237,6 +238,22 @@ func tryMeta(kv engine.MVCCKeyValue) (string, error) {
 		return "", err
 	}
 	return descStr(desc), nil
+}
+
+func tryTimeSeries(kv engine.MVCCKeyValue) (string, error) {
+	if len(kv.Value) == 0 || !bytes.HasPrefix(kv.Key.Key, keys.TimeseriesPrefix) {
+		return "", errors.New("empty or not TS")
+	}
+	var meta enginepb.MVCCMetadata
+	if err := protoutil.Unmarshal(kv.Value, &meta); err != nil {
+		return "", err
+	}
+	v := roachpb.Value{RawBytes: meta.RawBytes}
+	var ts roachpb.InternalTimeSeriesData
+	if err := v.GetProto(&ts); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%+v [mergeTS=%s]", &ts, meta.MergeTimestamp), nil
 }
 
 // IsRangeDescriptorKey returns nil if the key decodes as a RangeDescriptor.

--- a/pkg/server/server_engine_health.go
+++ b/pkg/server/server_engine_health.go
@@ -26,7 +26,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-var maxSyncDuration = envutil.EnvOrDefaultDuration("COCKROACH_ENGINE_MAX_SYNC_DURATION", 10*time.Second)
+// maxSyncDuration is very conservatively set high due to known issues such as
+// https://github.com/cockroachdb/cockroach/issues/34860#issuecomment-469262019.
+var maxSyncDuration = envutil.EnvOrDefaultDuration("COCKROACH_ENGINE_MAX_SYNC_DURATION", 120*time.Second)
 
 // startAssertEngineHealth starts a goroutine that periodically verifies that
 // syncing the engines is possible within maxSyncDuration. If not,

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -47,7 +47,9 @@ import (
 	"github.com/petermattis/goid"
 )
 
-var maxSyncDuration = envutil.EnvOrDefaultDuration("COCKROACH_LOG_MAX_SYNC_DURATION", 10*time.Second)
+// maxSyncDuration is set to a conservative value since this is a new mechanism.
+// In practice, even a fraction of that would indicate a problem.
+var maxSyncDuration = envutil.EnvOrDefaultDuration("COCKROACH_LOG_MAX_SYNC_DURATION", 30*time.Second)
 
 const fatalErrorPostamble = `
 


### PR DESCRIPTION
Backport:
  * 1/1 commits from "cli: pretty print timeseries data in decode-value" (#35705)
  * 1/1 commits from "cli: include jobs and more in debug zip" (#35880)
  * 1/1 commits from "server,log: increase the max sync durations" (#35936)

Please see individual PRs for details.

/cc @cockroachdb/release
