### PR TITLE
roachtest: temporarily disable auto stats collection for cdc tests

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -84,6 +84,14 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 		nodes: kafkaNode,
 	}
 
+	// Workaround for #35947. The optimizer currently plans a bad query for TPCC
+	// when it has stats, so disable stats for now.
+	if _, err := db.Exec(
+		`SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled = false`,
+	); err != nil && !strings.Contains(err.Error(), "unknown cluster setting") {
+		t.Fatal(err)
+	}
+
 	var sinkURI string
 	if args.cloudStorageSink {
 		ts := timeutil.Now().Format(`20060102150405`)


### PR DESCRIPTION
Workaround for #35947. The optimizer currently plans a bad query for
TPCC when it has stats, so disable stats for now.

Touches #35327 where local tests saw this happen. Perhaps it's also been the cause of the last two nightly run failures.

Release note: None