### PR TITLE
roachtest: clean up the canary tests

### DIFF
--- a/pkg/cmd/roachtest/canary.go
+++ b/pkg/cmd/roachtest/canary.go
@@ -1,0 +1,230 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+)
+
+// This file contains common elements for all 3rd party test suite roachtests.
+// TODO(bram): There are more common elements between all the canary tests,
+// factor more of them into here.
+
+// blacklist is a lists of known test errors and failures.
+type blacklist map[string]string
+
+// blacklistForVersion contains both a blacklist of known test errors and
+// failures but also an optional ignorelist for flaky tests.
+// When the test suite is run, the results are compared to this list.
+// Any passed test that is not on this blacklist is reported as PASS - expected
+// Any passed test that is on this blacklist is reported as PASS - unexpected
+// Any failed test that is on this blacklist is reported as FAIL - expected
+// Any failed test that is not on blackthis list is reported as FAIL - unexpected
+// Any test on this blacklist that is not run is reported as FAIL - not run
+// Ant test in the ignorelist is reported as SKIP if it is run
+type blacklistForVersion struct {
+	versionPrefix  string
+	blacklistname  string
+	blacklist      blacklist
+	ignorelistname string
+	ignorelist     blacklist
+}
+
+type blacklistsForVersion []blacklistForVersion
+
+// getLists returns the appropriate blacklist and ignorelist based on the
+// cockroach version. This check only looks to ensure that the prefix that
+// matches.
+func (b blacklistsForVersion) getLists(version string) (string, blacklist, string, blacklist) {
+	for _, info := range b {
+		if strings.HasPrefix(version, info.versionPrefix) {
+			return info.blacklistname, info.blacklist, info.ignorelistname, info.ignorelist
+		}
+	}
+	return "", nil, "", nil
+}
+
+func fetchCockroachVersion(ctx context.Context, c *cluster, nodeIndex int) (string, error) {
+	db, err := c.ConnE(ctx, nodeIndex)
+	if err != nil {
+		return "", err
+	}
+	defer db.Close()
+	var version string
+	if err := db.QueryRowContext(ctx,
+		`SELECT value FROM crdb_internal.node_build_info where field = 'Version'`,
+	).Scan(&version); err != nil {
+		return "", err
+	}
+	return version, nil
+}
+
+// maybeAddGithubLink will take the issue and if it is just a number, then it
+// will return a full github link.
+func maybeAddGithubLink(issue string) string {
+	if len(issue) == 0 {
+		return ""
+	}
+	issueNum, err := strconv.Atoi(issue)
+	if err != nil {
+		return issue
+	}
+	return fmt.Sprintf("https://github.com/cockroachdb/cockroach/issues/%d", issueNum)
+}
+
+// The following functions are augmented basic cluster functions but there tends
+// to be common networking issues that cause test failures and require putting
+// a retry block around them.
+
+var canaryRetryOptions = retry.Options{
+	InitialBackoff: 10 * time.Second,
+	Multiplier:     2,
+	MaxBackoff:     5 * time.Minute,
+	MaxRetries:     10,
+}
+
+// repeatRunE is the same function as c.RunE but with an automatic retry loop.
+func repeatRunE(
+	ctx context.Context, c *cluster, node nodeListOption, operation string, args ...string,
+) error {
+	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if c.t.Failed() {
+			return fmt.Errorf("test has failed")
+		}
+		attempt++
+		c.l.Printf("attempt %d - %s", attempt, operation)
+		if err := c.RunE(ctx, node, args...); err != nil {
+			c.l.Printf("error - retrying: %s", err)
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("all attempts failed for %s", operation)
+}
+
+// repeatRunWithBuffer is the same function as c.RunWithBuffer but with an
+// automatic retry loop.
+func repeatRunWithBuffer(
+	ctx context.Context, c *cluster, l *logger, node nodeListOption, operation string, args ...string,
+) ([]byte, error) {
+	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if c.t.Failed() {
+			return nil, fmt.Errorf("test has failed")
+		}
+		attempt++
+		c.l.Printf("attempt %d - %s", attempt, operation)
+		result, err := c.RunWithBuffer(ctx, l, node, args...)
+		if err != nil {
+			c.l.Printf("error - retrying: %s", err)
+			continue
+		}
+		return result, err
+	}
+	return nil, fmt.Errorf("all attempts failed for %s", operation)
+}
+
+// repeatGitCloneE is the same function as c.GitCloneE but with an automatic
+// retry loop.
+func repeatGitCloneE(
+	ctx context.Context, c *cluster, src, dest, branch string, node nodeListOption,
+) error {
+	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if c.t.Failed() {
+			return fmt.Errorf("test has failed")
+		}
+		attempt++
+		c.l.Printf("attempt %d - clone %s", attempt, src)
+		if err := c.GitCloneE(ctx, src, dest, branch, node); err != nil {
+			c.l.Printf("error - retrying: %s", err)
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("Could not clone %s", src)
+}
+
+var canaryTagRegex = regexp.MustCompile(`^[^a-zA-Z]*$`)
+
+// repeatGetLatestTag fetches the latest (sorted) tag from a github repo.
+// There is no equivalent function on the cluster as this is really only needed
+// for the canary tests.
+// NB: that this is kind of brittle, as it looks for the latest tag without any
+// letters in it, as alphas, betas and rcs tend to have letters in them. It
+// might make sense to instead pass in a regex specific to the repo instead
+// of using the one here.
+func repeatGetLatestTag(ctx context.Context, c *cluster, user string, repo string) (string, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/tags", user, repo)
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	type Tag struct {
+		Name string
+	}
+	type Tags []Tag
+	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		if c.t.Failed() {
+			return "", fmt.Errorf("test has failed")
+		}
+		attempt++
+
+		c.l.Printf("attempt %d - fetching %s", attempt, url)
+		r, err := httpClient.Get(url)
+		if err != nil {
+			c.l.Printf("error fetching - retrying: %s", err)
+			continue
+		}
+		defer r.Body.Close()
+
+		var tags Tags
+		if err := json.NewDecoder(r.Body).Decode(&tags); err != nil {
+			c.l.Printf("error decoding - retrying: %s", err)
+			continue
+		}
+		if len(tags) == 0 {
+			return "", fmt.Errorf("no tags found at %s", url)
+		}
+
+		var actualTags []string
+		for _, t := range tags {
+			if canaryTagRegex.MatchString(t.Name) {
+				actualTags = append(actualTags, t.Name)
+			}
+		}
+		sort.Strings(actualTags)
+		return actualTags[len(actualTags)-1], nil
+	}
+	return "", fmt.Errorf("could not get tags from %s", url)
+}

--- a/pkg/cmd/roachtest/hibernate_blacklist.go
+++ b/pkg/cmd/roachtest/hibernate_blacklist.go
@@ -15,41 +15,13 @@
 
 package main
 
-import "strings"
-
-type blacklist map[string]string
-
-var hibernateBlacklists = []struct {
-	versionPrefix string
-	name          string
-	list          blacklist
-}{
-	{"v2.0", "hibernateBlackList2_0", hibernateBlackList2_0},
-	{"v2.1", "hibernateBlackList2_1", hibernateBlackList2_1},
-	{"v2.2", "hibernateBlackList19_1", hibernateBlackList19_1},
-	{"v19.1", "hibernateBlackList19_1", hibernateBlackList19_1},
+var hibernateBlacklists = blacklistsForVersion{
+	{"v2.0", "hibernateBlackList2_0", hibernateBlackList2_0, "", nil},
+	{"v2.1", "hibernateBlackList2_1", hibernateBlackList2_1, "", nil},
+	{"v2.2", "hibernateBlackList19_1", hibernateBlackList19_1, "", nil},
+	{"v19.1", "hibernateBlackList19_1", hibernateBlackList19_1, "", nil},
 }
 
-// getHibernateBlacklistForVersion returns the appropriate hibernate blacklist
-// based on the cockroach version. This check only looks to ensure that the
-// prefix from hibernateBlacklists matches.
-func getHibernateBlacklistForVersion(version string) (string, blacklist) {
-	for _, info := range hibernateBlacklists {
-		if strings.HasPrefix(version, info.versionPrefix) {
-			return info.name, info.list
-		}
-	}
-	return "", nil
-}
-
-// These are lists of known hibernate test failures.
-// When the hibernate test suite is run, the results are compared to this list.
-// Any passed test that is not on this list is reported as PASS - expected
-// Any passed test that is on this list is reported as PASS - unexpected
-// Any failed test that is on this list is reported as FAIL - expected
-// Any failed test that is not on this list is reported as FAIL - unexpected
-// Any test on this list that is not run is reported as FAIL - not run
-//
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blacklist should be available
 // in the test log.

--- a/pkg/cmd/roachtest/psycopg_blacklist.go
+++ b/pkg/cmd/roachtest/psycopg_blacklist.go
@@ -15,29 +15,9 @@
 
 package main
 
-import "strings"
-
-var psycopgBlacklists = []struct {
-	versionPrefix  string
-	blacklistname  string
-	blacklist      blacklist
-	ignorelistname string
-	ignorelist     blacklist
-}{
+var psycopgBlacklists = blacklistsForVersion{
 	{"v2.2", "psycopgBlackList19_1", psycopgBlackList19_1, "psycopgIgnoreList19_1", psycopgIgnoreList19_1},
 	{"v19.1", "psycopgBlackList19_1", psycopgBlackList19_1, "psycopgIgnoreList19_1", psycopgIgnoreList19_1},
-}
-
-// getPsycopgBlacklistForVersion returns the appropriate psycopg blacklist and
-// ignorelist based on the cockroach version. This check only looks to ensure
-// that the prefix that matches.
-func getPsycopgBlacklistForVersion(version string) (string, blacklist, string, blacklist) {
-	for _, info := range psycopgBlacklists {
-		if strings.HasPrefix(version, info.versionPrefix) {
-			return info.blacklistname, info.blacklist, info.ignorelistname, info.ignorelist
-		}
-	}
-	return "", nil, "", nil
 }
 
 // These are lists of known psycopg test errors and failures.

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -17,13 +17,7 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"sort"
-	"time"
-
-	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
 // This test runs TypeORM's full test suite against a single cockroach node.
@@ -41,6 +35,7 @@ func registerTypeORM(r *registry) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx, t, c.All())
 
+		t.Status("cloning TypeORM and installing prerequisites")
 		latestTag, err := repeatGetLatestTag(ctx, c, "typeorm", "typeorm")
 		if err != nil {
 			t.Fatal(err)
@@ -50,9 +45,8 @@ func registerTypeORM(r *registry) {
 		}
 		c.l.Printf("Latest TypeORM release is %s.", latestTag)
 
-		t.Status("cloning TypeORM and installing prerequisites")
 		if err := repeatRunE(
-			ctx, c, node, "update apt-get", `sudo apt-get -q update`,
+			ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -68,7 +62,7 @@ func registerTypeORM(r *registry) {
 		}
 
 		if err := repeatRunE(
-			ctx, c, node, "install nodejs and npm", `sudo apt-get -qy install nodejs`,
+			ctx, c, node, "install nodejs and npm", `sudo apt-get -qq install nodejs`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -134,100 +128,9 @@ func registerTypeORM(r *registry) {
 	})
 }
 
-// TODO(bram): Move these functions to either be part of cluster or in a
-// canary helper file. And use them as part of the other canary tests.
-var canaryRetryOptions = retry.Options{
-	InitialBackoff: 10 * time.Second,
-	Multiplier:     2,
-	MaxBackoff:     5 * time.Minute,
-}
-
-func repeatRunE(
-	ctx context.Context, c *cluster, node nodeListOption, operation string, args ...string,
-) error {
-	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		if c.t.Failed() {
-			return fmt.Errorf("test has failed")
-		}
-		attempt++
-		c.l.Printf("attempt %d - %s", attempt, operation)
-		if err := c.RunE(ctx, node, args...); err != nil {
-			c.l.Printf("error - retrying: %s", err)
-			continue
-		}
-		break
-	}
-	return nil
-}
-
-func repeatGitCloneE(
-	ctx context.Context, c *cluster, src, dest, branch string, node nodeListOption,
-) error {
-	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		if c.t.Failed() {
-			return fmt.Errorf("test has failed")
-		}
-		attempt++
-		c.l.Printf("attempt %d - clone %s", attempt, src)
-		if err := c.GitCloneE(ctx, src, dest, branch, node); err != nil {
-			c.l.Printf("error - retrying: %s", err)
-			continue
-		}
-		break
-	}
-	return nil
-}
-
-func repeatGetLatestTag(ctx context.Context, c *cluster, user string, repo string) (string, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/tags", user, repo)
-	httpClient := &http.Client{Timeout: 10 * time.Second}
-	type Tag struct {
-		Name string
-	}
-	type Tags []Tag
-	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
-		if ctx.Err() != nil {
-			return "", ctx.Err()
-		}
-		if c.t.Failed() {
-			return "", fmt.Errorf("test has failed")
-		}
-		attempt++
-
-		c.l.Printf("attempt %d - fetching %s", attempt, url)
-		r, err := httpClient.Get(url)
-		if err != nil {
-			c.l.Printf("error fetching - retrying: %s", err)
-			continue
-		}
-		defer r.Body.Close()
-
-		var tags Tags
-		if err := json.NewDecoder(r.Body).Decode(&tags); err != nil {
-			c.l.Printf("error decoding - retrying: %s", err)
-			continue
-		}
-		if len(tags) == 0 {
-			return "", fmt.Errorf("no tags found at %s", url)
-		}
-
-		actualTags := make([]string, len(tags))
-		for i, t := range tags {
-			actualTags[i] = t.Name
-		}
-		sort.Strings(actualTags)
-		return actualTags[len(actualTags)-1], nil
-	}
-	// This should be unreachable.
-	return "", fmt.Errorf("could not get tags from %s", url)
-}
-
+// This full config is required, but notice that all the non-cockroach databases
+// are set to skip.  Some of the unit tests look for a specific config, like
+// sqlite and will fail if it is not present.
 const typeORMConfigJSON = `
 [
   {


### PR DESCRIPTION
Move all the repeat logic into canary.go and make each step have it's own
repeat loop.
Also DRY up a the blacklist/skiplist logic.

AND ensure that the canary tests all use the latest release instead of a
hardcoded version.  This will give us a head's up if something has gone wrong
with their release.

Fixes #35979.

Release note: None