### PR TITLE
backport-19.1: opt: fix attempting to build EXISTS as multi-row

### DIFF
--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -244,14 +244,14 @@ func (b *Builder) buildScalar(
 		out = b.factory.ConstructColumnAccess(input, memo.TupleOrdinal(t.ColIndex))
 
 	case *tree.ComparisonExpr:
-		if sub, ok := t.Right.(*subquery); ok && sub.wrapInTuple {
+		if sub, ok := t.Right.(*subquery); ok && sub.isMultiRow() {
 			out, _ = b.buildMultiRowSubquery(t, inScope, colRefs)
 			// Perform correctness checks on the outer cols, update colRefs and
 			// b.subquery.outerCols.
 			b.checkSubqueryOuterCols(sub.outerCols, inGroupingContext, inScope, colRefs)
 		} else if b.hasSubOperator(t) {
-			// Cases where the RHS is a subquery and not a scalar (of which only an
-			// array or tuple is legal) were handled above.
+			// Cases where the RHS is a multi-row subquery were handled above, so this
+			// only handles explicit tuples and arrays.
 			out = b.buildAnyScalar(t, inScope, colRefs)
 		} else {
 			left := b.buildScalar(t.TypedLeft(), inScope, nil, nil, colRefs)

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -55,6 +55,11 @@ type subquery struct {
 	outerCols opt.ColSet
 }
 
+// isMultiRow returns whether the subquery can return multiple rows.
+func (s *subquery) isMultiRow() bool {
+	return s.wrapInTuple && !s.Exists
+}
+
 // Walk is part of the tree.Expr interface.
 func (s *subquery) Walk(v tree.Visitor) tree.Expr {
 	return s

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -742,6 +742,24 @@ project
                      └── columns: a:1(int!null) b:2(int) c:3(int)
 
 build
+SELECT true = EXISTS (SELECT 1)
+----
+project
+ ├── columns: "?column?":2(bool)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── eq [type=bool]
+           ├── true [type=bool]
+           └── exists [type=bool]
+                └── project
+                     ├── columns: "?column?":1(int!null)
+                     ├── values
+                     │    └── tuple [type=tuple]
+                     └── projections
+                          └── const: 1 [type=int]
+
+build
 SELECT (SELECT a FROM abc WHERE false)
 ----
 project


### PR DESCRIPTION
Backport 1/1 commits from #36008.

/cc @cockroachdb/release

---

Fixes #35727.

This commit fixes a bug where we would interpret `x = EXISTS(...)` as an
`Any` operation, rather than treating the EXISTS as a scalar.

Release note (bug fix): fixed a panic occurring when comparing a value
to the result of an EXISTS.
