### PR TITLE
sql: add metadata propagation through columnar operators

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -70,6 +70,7 @@ func wrapRowSource(
 			outputToInputColIdx,
 			&distsqlpb.PostProcessSpec{},
 			nil, /* output */
+			nil, /* metadataSourcesQueue */
 		)
 		if err != nil {
 			return nil, err
@@ -100,6 +101,11 @@ func newColOperator(
 	var columnTypes []sqlbase.ColumnType
 
 	switch {
+	case core.Noop != nil:
+		if err := checkNumIn(inputs, 1); err != nil {
+			return nil, err
+		}
+		op = exec.NewNoop(inputs[0])
 	case core.TableReader != nil:
 		if err := checkNumIn(inputs, 0); err != nil {
 			return nil, err
@@ -342,7 +348,8 @@ func newColOperator(
 			)
 			if len(core.JoinReader.LookupColumns) == 0 {
 				jr, err = newIndexJoiner(
-					flowCtx, spec.ProcessorID, core.JoinReader, input, &distsqlpb.PostProcessSpec{}, nil /* output */)
+					flowCtx, spec.ProcessorID, core.JoinReader, input, &distsqlpb.PostProcessSpec{}, nil, /* output */
+				)
 			} else {
 				jr, err = newJoinReader(
 					flowCtx, spec.ProcessorID, core.JoinReader, input, &distsqlpb.PostProcessSpec{}, nil, /* output */
@@ -567,6 +574,7 @@ func (f *Flow) setupVectorized(ctx context.Context) error {
 	}
 
 	inputs := make([]exec.Operator, 0, 2)
+	metadataSourcesQueue := make([]MetadataSource, 0, 1)
 	for len(queue) > 0 {
 		pspec := &f.spec.Processors[queue[0]]
 		queue = queue[1:]
@@ -597,6 +605,9 @@ func (f *Flow) setupVectorized(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		if metaSource, ok := op.(MetadataSource); ok {
+			metadataSourcesQueue = append(metadataSourcesQueue, metaSource)
+		}
 
 		outputStream := output.Streams[0]
 		switch outputStream.Type {
@@ -608,10 +619,20 @@ func (f *Flow) setupVectorized(ctx context.Context) error {
 			for i := range outputToInputColIdx {
 				outputToInputColIdx[i] = i
 			}
-			proc, err := newMaterializer(&f.FlowCtx, pspec.ProcessorID, op, columnTypes, outputToInputColIdx, &distsqlpb.PostProcessSpec{}, f.syncFlowConsumer)
+			proc, err := newMaterializer(
+				&f.FlowCtx,
+				pspec.ProcessorID,
+				op,
+				columnTypes,
+				outputToInputColIdx,
+				&distsqlpb.PostProcessSpec{},
+				f.syncFlowConsumer,
+				metadataSourcesQueue,
+			)
 			if err != nil {
 				return err
 			}
+			metadataSourcesQueue = metadataSourcesQueue[:0]
 			f.processors[0] = proc
 		default:
 			return errors.Errorf("unsupported output stream type %s", outputStream.Type)
@@ -646,6 +667,10 @@ func (f *Flow) setupVectorized(ctx context.Context) error {
 				queue = append(queue, procIdx)
 			}
 		}
+	}
+
+	if len(metadataSourcesQueue) > 0 {
+		panic("Not all metadata sources have been processed.")
 	}
 	return nil
 }

--- a/pkg/sql/distsqlrun/columnar_utils_test.go
+++ b/pkg/sql/distsqlrun/columnar_utils_test.go
@@ -92,7 +92,7 @@ func verifyColOperator(
 	for i := range outputTypes {
 		outputToInputColIdx[i] = i
 	}
-	outColOp, err := newMaterializer(flowCtx, int32(len(inputs))+2, colOp, outputTypes, outputToInputColIdx, &distsqlpb.PostProcessSpec{}, nil)
+	outColOp, err := newMaterializer(flowCtx, int32(len(inputs))+2, colOp, outputTypes, outputToInputColIdx, &distsqlpb.PostProcessSpec{}, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/distsqlrun/materializer_test.go
+++ b/pkg/sql/distsqlrun/materializer_test.go
@@ -50,7 +50,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m, err := newMaterializer(flowCtx, 1, c, types, []int{0, 1}, &distsqlpb.PostProcessSpec{}, nil)
+	m, err := newMaterializer(flowCtx, 1, c, types, []int{0, 1}, &distsqlpb.PostProcessSpec{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestMaterializeTypes(t *testing.T) {
 	for i := range outputToInputColIdx {
 		outputToInputColIdx[i] = i
 	}
-	m, err := newMaterializer(flowCtx, 1, c, types, outputToInputColIdx, &distsqlpb.PostProcessSpec{}, nil)
+	m, err := newMaterializer(flowCtx, 1, c, types, outputToInputColIdx, &distsqlpb.PostProcessSpec{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 
 	b.SetBytes(int64(nRows * nCols * int(unsafe.Sizeof(int64(0)))))
 	for i := 0; i < b.N; i++ {
-		m, err := newMaterializer(flowCtx, 1, c, types, []int{0, 1}, &distsqlpb.PostProcessSpec{}, nil)
+		m, err := newMaterializer(flowCtx, 1, c, types, []int{0, 1}, &distsqlpb.PostProcessSpec{}, nil, nil)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -42,6 +42,18 @@ type Processor interface {
 	Run(context.Context)
 }
 
+// MetadataSource is an interface implemented by processors and columnar
+// operators that can produce metadata.
+type MetadataSource interface {
+	// DrainMeta returns all the metadata produced by the processor or operator.
+	// It will be called exactly once, usually, when the processor or operator
+	// has finished doing its computations.
+	// Implementers can choose what to do on subsequent calls (if such occur).
+	// TODO(yuzefovich): modify the contract to require returning nil on all
+	// calls after the first one.
+	DrainMeta(context.Context) []ProducerMetadata
+}
+
 // ProcOutputHelper is a helper type that performs filtering and projection on
 // the output of a processor.
 type ProcOutputHelper struct {

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -61,6 +61,7 @@ type tableReader struct {
 
 var _ Processor = &tableReader{}
 var _ RowSource = &tableReader{}
+var _ MetadataSource = &tableReader{}
 
 const tableReaderProcName = "table reader"
 
@@ -206,16 +207,7 @@ func initRowFetcher(
 }
 
 func (tr *tableReader) generateTrailingMeta(ctx context.Context) []ProducerMetadata {
-	var trailingMeta []ProducerMetadata
-	if !tr.ignoreMisplannedRanges {
-		ranges := misplannedRanges(tr.Ctx, tr.fetcher.GetRangeInfo(), tr.flowCtx.nodeID)
-		if ranges != nil {
-			trailingMeta = append(trailingMeta, ProducerMetadata{Ranges: ranges})
-		}
-	}
-	if meta := getTxnCoordMeta(ctx, tr.flowCtx.txn); meta != nil {
-		trailingMeta = append(trailingMeta, ProducerMetadata{TxnCoordMeta: meta})
-	}
+	trailingMeta := tr.generateMeta(ctx)
 	tr.InternalClose()
 	return trailingMeta
 }
@@ -324,4 +316,23 @@ func (tr *tableReader) outputStatsToTrace() {
 	if sp := opentracing.SpanFromContext(tr.Ctx); sp != nil {
 		tracing.SetSpanStats(sp, &TableReaderStats{InputStats: is})
 	}
+}
+
+func (tr *tableReader) generateMeta(ctx context.Context) []ProducerMetadata {
+	var trailingMeta []ProducerMetadata
+	if !tr.ignoreMisplannedRanges {
+		ranges := misplannedRanges(ctx, tr.fetcher.GetRangesInfo(), tr.flowCtx.nodeID)
+		if ranges != nil {
+			trailingMeta = append(trailingMeta, ProducerMetadata{Ranges: ranges})
+		}
+	}
+	if meta := getTxnCoordMeta(ctx, tr.flowCtx.txn); meta != nil {
+		trailingMeta = append(trailingMeta, ProducerMetadata{TxnCoordMeta: meta})
+	}
+	return trailingMeta
+}
+
+// DrainMeta is part of the MetadataSource interface.
+func (tr *tableReader) DrainMeta(ctx context.Context) []ProducerMetadata {
+	return tr.generateMeta(ctx)
 }

--- a/pkg/sql/distsqlrun/vectorized_meta_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_meta_propagation_test.go
@@ -1,0 +1,114 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlrun
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+// TestVectorizedMetaPropagation tests whether metadata is correctly propagated
+// alongside columnar operators. It sets up the following "flow":
+// RowSource -> metadataTestSender -> columnarizer -> noopOperator ->
+// -> materializer -> metadataTestReceiver. Metadata propagation is hooked up
+// manually from the columnarizer into the materializer similar to how it is
+// done in setupVectorized.
+func TestVectorizedMetaPropagation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+
+	flowCtx := FlowCtx{
+		EvalCtx:  &evalCtx,
+		Settings: cluster.MakeTestingClusterSettings(),
+	}
+
+	nRows := 10
+	nCols := 1
+	types := sqlbase.OneIntCol
+
+	input := NewRowBuffer(types, sqlbase.MakeIntRows(nRows, nCols), RowBufferArgs{})
+	mtsSpec := distsqlpb.ProcessorCoreUnion{
+		MetadataTestSender: &distsqlpb.MetadataTestSenderSpec{
+			ID: uuid.MakeV4().String(),
+		},
+	}
+	mts, err := newProcessor(ctx, &flowCtx, 0, &mtsSpec, &distsqlpb.PostProcessSpec{}, []RowSource{input}, []RowReceiver{nil}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtsAsRowSource, ok := mts.(RowSource)
+	if !ok {
+		t.Fatal("MetadataTestSender is not a RowSource")
+	}
+
+	col, err := newColumnarizer(&flowCtx, 1, mtsAsRowSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	noop := exec.NewNoop(col)
+	mat, err := newMaterializer(&flowCtx, 2, noop, types, []int{0}, &distsqlpb.PostProcessSpec{}, nil, []MetadataSource{col})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mtrSpec := distsqlpb.ProcessorCoreUnion{
+		MetadataTestReceiver: &distsqlpb.MetadataTestReceiverSpec{
+			SenderIDs: []string{mtsSpec.MetadataTestSender.ID},
+		},
+	}
+	mtr, err := newProcessor(ctx, &flowCtx, 3, &mtrSpec, &distsqlpb.PostProcessSpec{}, []RowSource{RowSource(mat)}, []RowReceiver{nil}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtrAsRowSource, ok := mtr.(RowSource)
+	if !ok {
+		t.Fatal("MetadataTestReceiver is not a RowSource")
+	}
+
+	rowCount, metaCount := 0, 0
+	for {
+		row, meta := mtrAsRowSource.Next()
+		if row == nil && meta == nil {
+			break
+		}
+		if row != nil {
+			rowCount++
+		} else if meta.Err != nil {
+			t.Fatal(meta.Err)
+		} else {
+			metaCount++
+		}
+	}
+	if rowCount != nRows {
+		t.Fatalf("expected %d rows but %d received", nRows, rowCount)
+	}
+	if metaCount != nRows+1 {
+		// metadataTestSender sends a meta after each row plus an additional one to
+		// indicate the last meta.
+		t.Fatalf("expected %d meta but %d received", nRows+1, metaCount)
+	}
+}

--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -50,6 +50,11 @@ type noopOperator struct {
 
 var _ Operator = &noopOperator{}
 
+// NewNoop returns a new noop Operator.
+func NewNoop(input Operator) Operator {
+	return &noopOperator{input: input}
+}
+
 func (n *noopOperator) Init() {
 	n.input.Init()
 }

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -175,7 +175,7 @@ type CFetcher struct {
 	// requests. This has some cost, so it's only enabled by DistSQL when this
 	// info is actually useful for correcting the plan (e.g. not for the PK-side
 	// of an index-join).
-	// If set, GetRangeInfo() can be used to retrieve the accumulated info.
+	// If set, GetRangesInfo() can be used to retrieve the accumulated info.
 	returnRangeInfo bool
 
 	// traceKV indicates whether or not session tracing is enabled. It is set
@@ -1028,4 +1028,10 @@ func (rf *CFetcher) fillNulls() error {
 		rf.machine.colvecs[i].SetNull(rf.machine.rowIdx)
 	}
 	return nil
+}
+
+// GetRangesInfo returns information about the ranges where the rows came from.
+// The RangeInfo's are deduped and not ordered.
+func (rf *CFetcher) GetRangesInfo() []roachpb.RangeInfo {
+	return rf.fetcher.getRangesInfo()
 }

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -197,7 +197,7 @@ type Fetcher struct {
 	// requests. This has some cost, so it's only enabled by DistSQL when this
 	// info is actually useful for correcting the plan (e.g. not for the PK-side
 	// of an index-join).
-	// If set, GetRangeInfo() can be used to retrieve the accumulated info.
+	// If set, GetRangesInfo() can be used to retrieve the accumulated info.
 	returnRangeInfo bool
 
 	// traceKV indicates whether or not session tracing is enabled. It is set
@@ -1295,9 +1295,9 @@ func (rf *Fetcher) PartialKey(nCols int) (roachpb.Key, error) {
 	return rf.kv.Key[:n+rf.currentTable.knownPrefixLength], nil
 }
 
-// GetRangeInfo returns information about the ranges where the rows came from.
+// GetRangesInfo returns information about the ranges where the rows came from.
 // The RangeInfo's are deduped and not ordered.
-func (rf *Fetcher) GetRangeInfo() []roachpb.RangeInfo {
+func (rf *Fetcher) GetRangesInfo() []roachpb.RangeInfo {
 	return rf.kvFetcher.getRangesInfo()
 }
 

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -78,7 +78,7 @@ var _ kvBatchFetcher = &txnKVFetcher{}
 
 func (f *txnKVFetcher) getRangesInfo() []roachpb.RangeInfo {
 	if !f.returnRangeInfo {
-		panic("GetRangeInfo() called on kvBatchFetcher that wasn't configured with returnRangeInfo")
+		panic("GetRangesInfo() called on kvBatchFetcher that wasn't configured with returnRangeInfo")
 	}
 	return f.rangeInfos
 }


### PR DESCRIPTION
Adds infrastructure to support propagation of the metadata from
metadata producers forward by-passing the chain of columnar
operators.

Fixes: #35280.

This is somewhat WIP, and I wanted to get your thoughts whether this is going in the right direction. Probably need to add tests.

Release note: None