### PR TITLE
opt: add a range operator to fix selectivity estimation of range predicates

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -211,6 +211,9 @@ func (b *Builder) buildBoolean(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree
 	case opt.FiltersItemOp:
 		return b.buildScalar(ctx, scalar.Child(0).(opt.ScalarExpr))
 
+	case opt.RangeOp:
+		return b.buildScalar(ctx, scalar.Child(0).(opt.ScalarExpr))
+
 	default:
 		panic(pgerror.NewAssertionErrorf("invalid op %s", log.Safe(scalar.Op())))
 	}

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -480,23 +480,13 @@ values  ·              ·                  (column1 int, column2 int, column3 i
 ·       row 1, expr 1  (5)[int]           ·                                        ·
 ·       row 1, expr 2  (6)[int]           ·                                        ·
 
-# TODO(rytaft): range operator needed to detect contradiction
 query TTTTT
 EXPLAIN (TYPES) SELECT 2*count(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND count(k)>1
 ----
-render               ·            ·                                                                          (z int, v int)     ·
- │                   render 0     ((agg0)[int] * (2)[int])[int]                                              ·                  ·
- │                   render 1     (v)[int]                                                                   ·                  ·
- └── filter          ·            ·                                                                          (v int, agg0 int)  ·
-      │              filter       ((agg0)[int] > (1)[int])[bool]                                             ·                  ·
-      └── group      ·            ·                                                                          (v int, agg0 int)  ·
-           │         aggregate 0  v                                                                          ·                  ·
-           │         aggregate 1  count(k)                                                                   ·                  ·
-           │         group by     @2                                                                         ·                  ·
-           └── scan  ·            ·                                                                          (k int, v int)     ·
-·                    table        t@primary                                                                  ·                  ·
-·                    spans        ALL                                                                        ·                  ·
-·                    filter       ((((v)[int] > (123)[int])[bool]) AND (((v)[int] < (2)[int])[bool]))[bool]  ·                  ·
+render       ·         ·         (z int, v int)  ·
+ │           render 0  (z)[int]  ·               ·
+ │           render 1  (v)[int]  ·               ·
+ └── norows  ·         ·         (v int, z int)  ·
 
 query TTTTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -606,22 +606,17 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ]
 ----
-render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  n
- │              render 3  sq
- └── hash-join  ·         ·
-      │         type      inner
-      │         equality  (sq) = (b)
-      ├── scan  ·         ·
-      │         table     square@primary
-      │         spans     /2-/5/#
-      │         parallel  ·
-      └── scan  ·         ·
-·               table     pairs@primary
-·               spans     ALL
-·               filter    ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
+hash-join  ·         ·
+ │         type      inner
+ │         equality  (b) = (sq)
+ ├── scan  ·         ·
+ │         table     pairs@primary
+ │         spans     ALL
+ │         filter    ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
+ └── scan  ·         ·
+·          table     square@primary
+·          spans     /2-/5/#
+·          parallel  ·
 
 
 statement ok

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -272,5 +272,13 @@ func checkFilters(filters FiltersExpr) {
 		if opt.IsListItemOp(item.Condition) {
 			panic(pgerror.NewAssertionErrorf("filters list item cannot contain another list item"))
 		}
+		if item.Condition.Op() == opt.RangeOp {
+			if !item.scalar.TightConstraints {
+				panic(pgerror.NewAssertionErrorf("Range operator should always have tight constraints"))
+			}
+			if item.scalar.OuterCols.Len() != 1 {
+				panic(pgerror.NewAssertionErrorf("Range operator should have exactly one outer col"))
+			}
+		}
 	}
 }

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -436,6 +436,9 @@ func (cb *constraintsBuilder) buildConstraints(e opt.ScalarExpr) (_ *constraint.
 		cl = cl.Intersect(cb.evalCtx, cr)
 		tightl = tightl && tightr
 		return cl, (tightl || cl == contradiction)
+
+	case *RangeExpr:
+		return cb.buildConstraints(t.And)
 	}
 
 	if e.ChildCount() < 2 {

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -45,12 +45,14 @@ select
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      ├── gt [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
-      │    ├── variable: x [type=int]
-      │    └── const: 0 [type=int]
-      └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /1]; tight)]
-           ├── variable: x [type=int]
-           └── const: 2 [type=int]
+      └── range [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+           └── and [type=bool]
+                ├── gt [type=bool]
+                │    ├── variable: x [type=int]
+                │    └── const: 0 [type=int]
+                └── lt [type=bool]
+                     ├── variable: x [type=int]
+                     └── const: 2 [type=int]
 
 opt
 SELECT * FROM a WHERE x >= 1
@@ -119,12 +121,14 @@ select
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
-      │    ├── variable: x [type=int]
-      │    └── const: 1 [type=int]
-      └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /4]; tight)]
-           ├── variable: x [type=int]
-           └── const: 5 [type=int]
+      └── range [type=bool, outer=(1), constraints=(/1: [/2 - /4]; tight)]
+           └── and [type=bool]
+                ├── gt [type=bool]
+                │    ├── variable: x [type=int]
+                │    └── const: 1 [type=int]
+                └── lt [type=bool]
+                     ├── variable: x [type=int]
+                     └── const: 5 [type=int]
 
 opt
 SELECT * FROM a WHERE x = 1 AND y = 5
@@ -152,18 +156,22 @@ select
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
-      │    ├── variable: x [type=int]
-      │    └── const: 1 [type=int]
-      ├── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /4]; tight)]
-      │    ├── variable: x [type=int]
-      │    └── const: 5 [type=int]
-      ├── ge [type=bool, outer=(2), constraints=(/2: [/7 - ]; tight)]
-      │    ├── variable: y [type=int]
-      │    └── const: 7 [type=int]
-      └── le [type=bool, outer=(2), constraints=(/2: (/NULL - /9]; tight)]
-           ├── variable: y [type=int]
-           └── const: 9 [type=int]
+      ├── range [type=bool, outer=(1), constraints=(/1: [/2 - /4]; tight)]
+      │    └── and [type=bool]
+      │         ├── gt [type=bool]
+      │         │    ├── variable: x [type=int]
+      │         │    └── const: 1 [type=int]
+      │         └── lt [type=bool]
+      │              ├── variable: x [type=int]
+      │              └── const: 5 [type=int]
+      └── range [type=bool, outer=(2), constraints=(/2: [/7 - /9]; tight)]
+           └── and [type=bool]
+                ├── ge [type=bool]
+                │    ├── variable: y [type=int]
+                │    └── const: 7 [type=int]
+                └── le [type=bool]
+                     ├── variable: y [type=int]
+                     └── const: 9 [type=int]
 
 # Verify the resulting constraints are not tight.
 opt
@@ -175,12 +183,14 @@ select
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
-      │    ├── variable: x [type=int]
-      │    └── const: 1 [type=int]
-      ├── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /4]; tight)]
-      │    ├── variable: x [type=int]
-      │    └── const: 5 [type=int]
+      ├── range [type=bool, outer=(1), constraints=(/1: [/2 - /4]; tight)]
+      │    └── and [type=bool]
+      │         ├── gt [type=bool]
+      │         │    ├── variable: x [type=int]
+      │         │    └── const: 1 [type=int]
+      │         └── lt [type=bool]
+      │              ├── variable: x [type=int]
+      │              └── const: 5 [type=int]
       └── eq [type=bool, outer=(1,2)]
            ├── plus [type=int]
            │    ├── variable: x [type=int]
@@ -262,12 +272,14 @@ select
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+1)
  └── filters
-      ├── le [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo']; tight)]
-      │    ├── variable: v [type=string]
-      │    └── const: 'foo' [type=string]
-      └── ge [type=bool, outer=(3), constraints=(/3: [/'bar' - ]; tight)]
-           ├── variable: v [type=string]
-           └── const: 'bar' [type=string]
+      └── range [type=bool, outer=(3), constraints=(/3: [/'bar' - /'foo']; tight)]
+           └── and [type=bool]
+                ├── le [type=bool]
+                │    ├── variable: v [type=string]
+                │    └── const: 'foo' [type=string]
+                └── ge [type=bool]
+                     ├── variable: v [type=string]
+                     └── const: 'bar' [type=string]
 
 # Test IN.
 opt
@@ -318,17 +330,19 @@ select
  │    ├── columns: x:1(int) y:2(int)
  │    └── prune: (1,2)
  └── filters
-      ├── in [type=bool, outer=(1), constraints=(/1: [/1 - /1] [/3 - /3] [/5 - /5] [/7 - /7] [/9 - /9]; tight)]
-      │    ├── variable: x [type=int]
-      │    └── tuple [type=tuple{int, int, int, int, int}]
-      │         ├── const: 1 [type=int]
-      │         ├── const: 3 [type=int]
-      │         ├── const: 5 [type=int]
-      │         ├── const: 7 [type=int]
-      │         └── const: 9 [type=int]
-      └── gt [type=bool, outer=(1), constraints=(/1: [/7 - ]; tight)]
-           ├── variable: x [type=int]
-           └── const: 6 [type=int]
+      └── range [type=bool, outer=(1), constraints=(/1: [/7 - /7] [/9 - /9]; tight)]
+           └── and [type=bool]
+                ├── in [type=bool]
+                │    ├── variable: x [type=int]
+                │    └── tuple [type=tuple{int, int, int, int, int}]
+                │         ├── const: 1 [type=int]
+                │         ├── const: 3 [type=int]
+                │         ├── const: 5 [type=int]
+                │         ├── const: 7 [type=int]
+                │         └── const: 9 [type=int]
+                └── gt [type=bool]
+                     ├── variable: x [type=int]
+                     └── const: 6 [type=int]
 
 # Test IN in combination with a condition on another column.
 opt

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -143,20 +143,12 @@ TABLE t
  ├── FAMILY family2 (c)
  └── FAMILY family3 (d)
 
-# Test case where one of the explorations causes construction of a scan with a
-# contradiction.
-# TODO(rytaft): Range operator
 opt
 SELECT 1 FROM t WHERE a > 1 AND a < 2
 ----
-project
- ├── columns: "?column?":5(int!null)
+values
+ ├── columns: "?column?":5(int)
+ ├── cardinality: [0 - 0]
+ ├── key: ()
  ├── fd: ()-->(5)
- ├── prune: (5)
- ├── scan t@a_desc
- │    ├── columns: a:1(int!null)
- │    ├── constraint: /-1/2: contradiction
- │    ├── prune: (1)
- │    └── interesting orderings: (+1) (-1)
- └── projections
-      └── const: 1 [type=int]
+ └── prune: (5)

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -393,11 +393,11 @@ SELECT * FROM xysd JOIN uv ON x=u AND y+v=5 AND y > 0 AND y < 300
 ----
 inner-join
  ├── columns: x:1(int!null) y:2(int!null) s:3(string) d:4(decimal!null) u:5(int!null) v:6(int!null)
- ├── stats: [rows=3333.33333, distinct(1)=500, null(1)=0, distinct(2)=308.233808, null(2)=0, distinct(4)=346.00432, null(4)=0, distinct(5)=500, null(5)=0, distinct(6)=100, null(6)=0]
+ ├── stats: [rows=3333.33333, distinct(1)=500, null(1)=0, distinct(2)=298.995696, null(2)=0, distinct(4)=499.363351, null(4)=0, distinct(5)=500, null(5)=0, distinct(6)=100, null(6)=0]
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (1)==(5), (5)==(1)
  ├── select
  │    ├── columns: x:1(int!null) y:2(int!null) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0, distinct(2)=308.239988, null(2)=0, distinct(4)=346.026926, null(4)=0]
+ │    ├── stats: [rows=3737.5, distinct(1)=3737.5, null(1)=0, distinct(2)=299, null(2)=0, distinct(4)=499.999473, null(4)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── scan xysd
@@ -406,8 +406,7 @@ inner-join
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    └── filters
- │         ├── y > 0 [type=bool, outer=(2), constraints=(/2: [/1 - ]; tight)]
- │         └── y < 300 [type=bool, outer=(2), constraints=(/2: (/NULL - /299]; tight)]
+ │         └── (y > 0) AND (y < 300) [type=bool, outer=(2), constraints=(/2: [/1 - /299]; tight)]
  ├── scan uv
  │    ├── columns: u:5(int) v:6(int!null)
  │    └── stats: [rows=10000, distinct(5)=500, null(5)=0, distinct(6)=100, null(6)=0]

--- a/pkg/sql/opt/memo/testdata/stats/ordinality
+++ b/pkg/sql/opt/memo/testdata/stats/ordinality
@@ -29,7 +29,7 @@ SELECT * FROM (SELECT * FROM a WITH ORDINALITY) WHERE ordinality > 0 AND ordinal
 ----
 select
  ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
- ├── stats: [rows=444.444444, distinct(1)=444.444444, null(1)=0, distinct(3)=444.444444, null(3)=0]
+ ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(3)=10, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(2,3), (3)-->(1,2)
  ├── row-number
@@ -43,15 +43,14 @@ select
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters
-      ├── ordinality > 0 [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]
-      └── ordinality <= 10 [type=bool, outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+      └── (ordinality > 0) AND (ordinality <= 10) [type=bool, outer=(3), constraints=(/3: [/1 - /10]; tight)]
 
 norm
 SELECT * FROM (SELECT * FROM a WITH ORDINALITY) WHERE y > 0 AND y <= 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int!null) ordinality:3(int!null)
- ├── stats: [rows=444.444444, distinct(1)=444.444444, null(1)=0, distinct(2)=276.821541, null(2)=0, distinct(3)=444.444444, null(3)=0]
+ ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0]
  ├── key: (1)
  ├── fd: (1)-->(2,3), (3)-->(1,2)
  ├── row-number
@@ -65,8 +64,7 @@ select
  │         ├── key: (1)
  │         └── fd: (1)-->(2)
  └── filters
-      ├── y > 0 [type=bool, outer=(2), constraints=(/2: [/1 - ]; tight)]
-      └── y <= 10 [type=bool, outer=(2), constraints=(/2: (/NULL - /10]; tight)]
+      └── (y > 0) AND (y <= 10) [type=bool, outer=(2), constraints=(/2: [/1 - /10]; tight)]
 
 norm
 SELECT 1 x FROM a WITH ORDINALITY
@@ -89,11 +87,11 @@ SELECT x FROM (SELECT * FROM a WITH ORDINALITY) WHERE ordinality > 0 AND ordinal
 ----
 project
  ├── columns: x:1(int!null)
- ├── stats: [rows=444.444444]
+ ├── stats: [rows=10]
  ├── key: (1)
  └── select
       ├── columns: x:1(int!null) ordinality:3(int!null)
-      ├── stats: [rows=444.444444, distinct(1)=444.444444, null(1)=0, distinct(3)=444.444444, null(3)=0]
+      ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(3)=10, null(3)=0]
       ├── key: (1)
       ├── fd: (1)-->(3), (3)-->(1)
       ├── row-number
@@ -106,8 +104,7 @@ project
       │         ├── stats: [rows=4000, distinct(1)=5000, null(1)=0]
       │         └── key: (1)
       └── filters
-           ├── ordinality > 0 [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]
-           └── ordinality <= 10 [type=bool, outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+           └── (ordinality > 0) AND (ordinality <= 10) [type=bool, outer=(3), constraints=(/3: [/1 - /10]; tight)]
 
 
 norm

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -103,7 +103,7 @@ SELECT s, x FROM a WHERE x > 0 AND x <= 100
 scan a
  ├── columns: s:3(string) x:1(int!null)
  ├── constraint: /1: [/1 - /100]
- ├── stats: [rows=333.333333, distinct(1)=323.895037, null(1)=0]
+ ├── stats: [rows=150, distinct(1)=100, null(1)=0]
  ├── key: (1)
  └── fd: (1)-->(3)
 
@@ -126,13 +126,13 @@ group-by
  ├── columns: count:6(int) y:2(int) x:1(int!null)
  ├── grouping columns: x:1(int!null)
  ├── internal-ordering: +1
- ├── stats: [rows=323.895037, distinct(1)=323.895037, null(1)=0]
+ ├── stats: [rows=100, distinct(1)=100, null(1)=0]
  ├── key: (1)
  ├── fd: (1)-->(2,6)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int)
  │    ├── constraint: /1: [/1 - /100]
- │    ├── stats: [rows=333.333333, distinct(1)=323.895037, null(1)=0]
+ │    ├── stats: [rows=150, distinct(1)=100, null(1)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── ordering: +1

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -82,11 +82,11 @@ SELECT * FROM b WHERE x = 1 AND z = 2 AND rowid >= 5 AND rowid <= 8
 ----
 project
  ├── columns: x:1(int!null) z:2(int!null)
- ├── stats: [rows=0.00222222222]
+ ├── stats: [rows=8e-06]
  ├── fd: ()-->(1,2)
  └── select
       ├── columns: x:1(int!null) z:2(int!null) rowid:3(int!null)
-      ├── stats: [rows=0.00222222222, distinct(1)=0.00222222222, null(1)=0, distinct(2)=0.00222222222, null(2)=0, distinct(3)=0.00222222222, null(3)=0]
+      ├── stats: [rows=8e-06, distinct(1)=8e-06, null(1)=0, distinct(2)=8e-06, null(2)=0, distinct(3)=8e-06, null(3)=0]
       ├── key: (3)
       ├── fd: ()-->(1,2)
       ├── scan b
@@ -95,10 +95,9 @@ project
       │    ├── key: (3)
       │    └── fd: (3)-->(1,2)
       └── filters
+           ├── (rowid >= 5) AND (rowid <= 8) [type=bool, outer=(3), constraints=(/3: [/5 - /8]; tight)]
            ├── x = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
-           ├── z = 2 [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
-           ├── rowid >= 5 [type=bool, outer=(3), constraints=(/3: [/5 - ]; tight)]
-           └── rowid <= 8 [type=bool, outer=(3), constraints=(/3: (/NULL - /8]; tight)]
+           └── z = 2 [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
 
 # Can't determine stats from filter.
 norm
@@ -158,22 +157,21 @@ SELECT sum(x) FROM b WHERE x > 1000 AND x <= 2000 GROUP BY z
 ----
 project
  ├── columns: sum:4(decimal)
- ├── stats: [rows=99.9992331]
+ ├── stats: [rows=100]
  └── group-by
       ├── columns: z:2(int!null) sum:4(decimal)
       ├── grouping columns: z:2(int!null)
-      ├── stats: [rows=99.9992331, distinct(2)=99.9992331, null(2)=0]
+      ├── stats: [rows=100, distinct(2)=100, null(2)=0]
       ├── key: (2)
       ├── fd: (2)-->(4)
       ├── select
       │    ├── columns: x:1(int!null) z:2(int!null)
-      │    ├── stats: [rows=1111.11111, distinct(1)=1049.38272, null(1)=0, distinct(2)=99.9992331, null(2)=0]
+      │    ├── stats: [rows=2000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=0]
       │    ├── scan b
       │    │    ├── columns: x:1(int) z:2(int!null)
       │    │    └── stats: [rows=10000, distinct(1)=5000, null(1)=0, distinct(2)=100, null(2)=0]
       │    └── filters
-      │         ├── x > 1000 [type=bool, outer=(1), constraints=(/1: [/1001 - ]; tight)]
-      │         └── x <= 2000 [type=bool, outer=(1), constraints=(/1: (/NULL - /2000]; tight)]
+      │         └── (x > 1000) AND (x <= 2000) [type=bool, outer=(1), constraints=(/1: [/1001 - /2000]; tight)]
       └── aggregations
            └── sum [type=decimal, outer=(1)]
                 └── variable: x [type=int]
@@ -225,6 +223,9 @@ TABLE tab0
  └── INDEX primary
       └── pk int not null
 
+# Note: it's not clear that this still tests the above issue, but I have left
+# it here anyway as an interesting test case. I've added another query below
+# to regression-test the divide-by-zero issue.
 opt
 SELECT pk FROM tab0 WHERE
   col0 = 1 AND
@@ -232,37 +233,54 @@ SELECT pk FROM tab0 WHERE
   (col0 = 1 OR col0 IN (SELECT col3 FROM tab0)) AND
   (col0 = 1 OR col0 IN (SELECT col3 FROM tab0))
 ----
+values
+ ├── columns: pk:1(int)
+ ├── cardinality: [0 - 0]
+ ├── stats: [rows=0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+exec-ddl
+ALTER TABLE tab0 INJECT STATISTICS '[
+{
+  "columns": ["col0"],
+  "created_at": "2018-01-01 1:00:00.00000+00:00",
+  "row_count": 100,
+  "distinct_count": 0,
+  "null_count": 100
+},
+{
+  "columns": ["col3"],
+  "created_at": "2018-01-01 1:00:00.00000+00:00",
+  "row_count": 100,
+  "distinct_count": 10
+}
+]'
+----
+
+opt
+SELECT count(*) FROM (SELECT * FROM tab0 WHERE col3 = 10) GROUP BY col0
+----
 project
- ├── columns: pk:1(int!null)
- ├── stats: [rows=1.1]
- ├── key: (1)
- └── select
-      ├── columns: pk:1(int!null) col0:2(int!null)
-      ├── stats: [rows=1.1, distinct(1)=1.1, null(1)=0, distinct(2)=1, null(2)=0]
-      ├── key: (1)
-      ├── fd: ()-->(2)
-      ├── scan tab0
-      │    ├── columns: pk:1(int!null) col0:2(int)
-      │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10]
-      │    ├── key: (1)
-      │    └── fd: (1)-->(2)
-      └── filters
-           ├── col0 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
-           ├── col0 = 2 [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
-           ├── or [type=bool, outer=(2)]
-           │    ├── col0 = 1 [type=bool]
-           │    └── any: eq [type=bool]
-           │         ├── scan tab0
-           │         │    ├── columns: col3:12(int)
-           │         │    └── stats: [rows=1000]
-           │         └── variable: col0 [type=int]
-           └── or [type=bool, outer=(2)]
-                ├── col0 = 1 [type=bool]
-                └── any: eq [type=bool]
-                     ├── scan tab0
-                     │    ├── columns: col3:19(int)
-                     │    └── stats: [rows=1000]
-                     └── variable: col0 [type=int]
+ ├── columns: count:8(int)
+ ├── stats: [rows=0]
+ └── group-by
+      ├── columns: col0:2(int) count_rows:8(int)
+      ├── grouping columns: col0:2(int)
+      ├── stats: [rows=0, distinct(2)=0, null(2)=0]
+      ├── key: (2)
+      ├── fd: (2)-->(8)
+      ├── select
+      │    ├── columns: col0:2(int) col3:5(int!null)
+      │    ├── stats: [rows=10, distinct(2)=0, null(2)=10, distinct(5)=1, null(5)=0]
+      │    ├── fd: ()-->(5)
+      │    ├── scan tab0
+      │    │    ├── columns: col0:2(int) col3:5(int)
+      │    │    └── stats: [rows=100, distinct(2)=0, null(2)=100, distinct(5)=10, null(5)=0]
+      │    └── filters
+      │         └── col3 = 10 [type=bool, outer=(5), constraints=(/5: [/10 - /10]; tight), fd=()-->(5)]
+      └── aggregations
+           └── count-rows [type=int]
 
 
 exec-ddl
@@ -370,7 +388,7 @@ SELECT * FROM district WHERE d_id > 1 AND d_id < 10 AND d_w_id=10 AND d_name='bo
 ----
 select
  ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_name:3(string!null)
- ├── stats: [rows=0.0111111111, distinct(1)=0.0111055572, null(1)=0, distinct(2)=0.0111111111, null(2)=0, distinct(3)=0.0111111111, null(3)=0]
+ ├── stats: [rows=0.08, distinct(1)=0.08, null(1)=0, distinct(2)=0.08, null(2)=0, distinct(3)=0.08, null(3)=0]
  ├── key: (1)
  ├── fd: ()-->(2,3)
  ├── scan district
@@ -379,8 +397,7 @@ select
  │    ├── key: (1,2)
  │    └── fd: (1,2)-->(3)
  └── filters
-      ├── d_id > 1 [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
-      ├── d_id < 10 [type=bool, outer=(1), constraints=(/1: (/NULL - /9]; tight)]
+      ├── (d_id > 1) AND (d_id < 10) [type=bool, outer=(1), constraints=(/1: [/2 - /9]; tight)]
       ├── d_w_id = 10 [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
       └── d_name = 'bobs_burgers' [type=bool, outer=(3), constraints=(/3: [/'bobs_burgers' - /'bobs_burgers']; tight), fd=()-->(3)]
 
@@ -540,15 +557,14 @@ SELECT * FROM order_history WHERE item_id = order_id AND item_id < 5 AND item_id
 ----
 select
  ├── columns: order_id:1(int!null) item_id:2(int!null) customer_id:3(int) year:4(int)
- ├── stats: [rows=1.1, distinct(1)=1.1, null(1)=0, distinct(2)=1.1, null(2)=0]
+ ├── stats: [rows=0.99, distinct(1)=0.99, null(1)=0, distinct(2)=0.99, null(2)=0]
  ├── fd: (1)==(2), (2)==(1)
  ├── scan order_history
  │    ├── columns: order_id:1(int) item_id:2(int) customer_id:3(int) year:4(int)
  │    └── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10]
  └── filters
-      ├── item_id = order_id [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
-      ├── item_id < 5 [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
-      └── item_id > 0 [type=bool, outer=(2), constraints=(/2: [/1 - ]; tight)]
+      ├── (item_id < 5) AND (item_id > 0) [type=bool, outer=(2), constraints=(/2: [/1 - /4]; tight)]
+      └── item_id = order_id [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
 
 # Test equality condition with another condition on a different attribute.
 norm
@@ -556,15 +572,14 @@ SELECT * FROM order_history WHERE item_id = order_id AND customer_id < 5 AND cus
 ----
 select
  ├── columns: order_id:1(int!null) item_id:2(int!null) customer_id:3(int!null) year:4(int)
- ├── stats: [rows=1.1, distinct(1)=1.1, null(1)=0, distinct(2)=1.1, null(2)=0, distinct(3)=1.1, null(3)=0]
+ ├── stats: [rows=0.99, distinct(1)=0.99, null(1)=0, distinct(2)=0.99, null(2)=0, distinct(3)=0.99, null(3)=0]
  ├── fd: (1)==(2), (2)==(1)
  ├── scan order_history
  │    ├── columns: order_id:1(int) item_id:2(int) customer_id:3(int) year:4(int)
  │    └── stats: [rows=1000, distinct(1)=100, null(1)=10, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10]
  └── filters
-      ├── item_id = order_id [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
-      ├── customer_id < 5 [type=bool, outer=(3), constraints=(/3: (/NULL - /4]; tight)]
-      └── customer_id > 0 [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]
+      ├── (customer_id < 5) AND (customer_id > 0) [type=bool, outer=(3), constraints=(/3: [/1 - /4]; tight)]
+      └── item_id = order_id [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
 
 # Test equality condition with another filter condition without a constraint.
 norm
@@ -601,7 +616,7 @@ SELECT * FROM c WHERE x >= 0 AND x < 100
 ----
 select
  ├── columns: x:1(int!null) z:2(int!null)
- ├── stats: [rows=110, distinct(1)=110, null(1)=0, distinct(2)=69.2053852, null(2)=0]
+ ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=65.5215193, null(2)=0]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── scan c
@@ -610,8 +625,7 @@ select
  │    ├── lax-key: (1,2)
  │    └── fd: (1)~~>(2)
  └── filters
-      ├── x >= 0 [type=bool, outer=(1), constraints=(/1: [/0 - ]; tight)]
-      └── x < 100 [type=bool, outer=(1), constraints=(/1: (/NULL - /99]; tight)]
+      └── (x >= 0) AND (x < 100) [type=bool, outer=(1), constraints=(/1: [/0 - /99]; tight)]
 
 exec-ddl
 CREATE TABLE uvw (u INT, v INT, w INT)
@@ -1080,11 +1094,11 @@ SELECT * FROM b WHERE x = 1 AND z = 2 AND rowid >= 5 AND rowid <= 8
 ----
 project
  ├── columns: x:1(int!null) z:2(int!null)
- ├── stats: [rows=0.00177777778]
+ ├── stats: [rows=6.4e-06]
  ├── fd: ()-->(1,2)
  └── select
       ├── columns: x:1(int!null) z:2(int!null) rowid:3(int!null)
-      ├── stats: [rows=0.00177777778, distinct(1)=0.00177777778, null(1)=0, distinct(2)=0.00177777778, null(2)=0, distinct(3)=0.00177777778, null(3)=0]
+      ├── stats: [rows=6.4e-06, distinct(1)=6.4e-06, null(1)=0, distinct(2)=6.4e-06, null(2)=0, distinct(3)=6.4e-06, null(3)=0]
       ├── key: (3)
       ├── fd: ()-->(1,2)
       ├── scan b
@@ -1093,10 +1107,9 @@ project
       │    ├── key: (3)
       │    └── fd: (3)-->(1,2)
       └── filters
+           ├── (rowid >= 5) AND (rowid <= 8) [type=bool, outer=(3), constraints=(/3: [/5 - /8]; tight)]
            ├── x = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
-           ├── z = 2 [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
-           ├── rowid >= 5 [type=bool, outer=(3), constraints=(/3: [/5 - ]; tight)]
-           └── rowid <= 8 [type=bool, outer=(3), constraints=(/3: (/NULL - /8]; tight)]
+           └── z = 2 [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
 
 # Can't determine stats from filter.
 norm
@@ -1140,7 +1153,7 @@ SELECT * FROM c WHERE x >= 0 AND x < 100
 ----
 select
  ├── columns: x:1(int!null) z:2(int!null)
- ├── stats: [rows=555.555556, distinct(1)=555.555556, null(1)=0, distinct(2)=555.555556, null(2)=0]
+ ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0]
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── scan c
@@ -1149,8 +1162,7 @@ select
  │    ├── lax-key: (1,2)
  │    └── fd: (1)~~>(2)
  └── filters
-      ├── x >= 0 [type=bool, outer=(1), constraints=(/1: [/0 - ]; tight)]
-      └── x < 100 [type=bool, outer=(1), constraints=(/1: (/NULL - /99]; tight)]
+      └── (x >= 0) AND (x < 100) [type=bool, outer=(1), constraints=(/1: [/0 - /99]; tight)]
 
 # Bump up null counts
 exec-ddl

--- a/pkg/sql/opt/norm/rules/bool.opt
+++ b/pkg/sql/opt/norm/rules/bool.opt
@@ -105,6 +105,15 @@ $right
 =>
 $left
 
+# SimplifyRange simplifies a Range operator for which the input is no longer an
+# And expression, likely due to simplification of the And operator itself.
+[SimplifyRange, Normalize]
+(Range
+    $input:^(And)
+)
+=>
+$input
+
 # FoldNullAndOr replaces the operator with null if both operands are null.
 [FoldNullAndOr, Normalize]
 (And | Or (Null) (Null))

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -23,6 +23,30 @@
     (SimplifyFilters $filters)
 )
 
+# ConsolidateSelectFilters consolidates filters that constrain a single
+# variable. For example, filters x >= 5 and x <= 10 would be combined into a
+# single Range operation.
+#
+# The benefit of consolidating these filters is it allows a single constraint
+# to be generated for the variable instead of multiple. In the example above,
+# we can generate the single constraint [/5 - /10] instead of the two
+# constraints [/5 - ] and [ - /10]. The single constraint allows us to better
+# estimate the selectivity of the predicate when calculating statistics for
+# the Select expression.
+#
+# This rule is low priority so other rules in this file such as
+# RemoveNotNullCondition can run first.
+[ConsolidateSelectFilters, Normalize, LowPriority]
+(Select
+    $input:*
+    $filters:* & (CanConsolidateFilters $filters)
+)
+=>
+(Select
+    $input
+    (ConsolidateFilters $filters)
+)
+
 # DetectSelectContradiction replaces a Select with an empty Values if it detects
 # a contradiction in the filter.
 [DetectSelectContradiction, Normalize]

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -246,6 +246,20 @@ project
       └── (k = 1) AND (k = 2) [type=bool, outer=(1)]
 
 # --------------------------------------------------
+# SimplifyRange
+# --------------------------------------------------
+
+opt expect=SimplifyRange
+SELECT * FROM a WHERE k = 1 AND k = 2-1
+----
+scan a
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── constraint: /1: [/1 - /1]
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
+# --------------------------------------------------
 # FoldNullAndOr
 # --------------------------------------------------
 opt expect=FoldNullAndOr
@@ -322,12 +336,11 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      ├── i != 1 [type=bool, outer=(2), constraints=(/2: (/NULL - /0] [/2 - ]; tight)]
+      ├── (i != 1) AND (i > 1) [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
       ├── f = i [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
       ├── i <= k [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
       ├── i < f [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
-      ├── f >= 1.0 [type=bool, outer=(3), constraints=(/3: [/1.0 - ]; tight)]
-      └── i > 1 [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
+      └── f >= 1.0 [type=bool, outer=(3), constraints=(/3: [/1.0 - ]; tight)]
 
 # IN and IS comparisons.
 opt expect=NegateComparison
@@ -344,9 +357,8 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
+      ├── (f IN (3.0, 4.0)) AND (f IS NOT NULL) [type=bool, outer=(3), constraints=(/3: [/3.0 - /3.0] [/4.0 - /4.0]; tight)]
       ├── i NOT IN (1, 2) [type=bool, outer=(2)]
-      ├── f IN (3.0, 4.0) [type=bool, outer=(3), constraints=(/3: [/3.0 - /3.0] [/4.0 - /4.0]; tight)]
-      ├── f IS NOT NULL [type=bool, outer=(3), constraints=(/3: (/NULL - ]; tight)]
       └── s IS NULL [type=bool, outer=(4), constraints=(/4: [/NULL - /NULL]; tight), fd=()-->(4)]
 
 # Like comparisons.
@@ -502,10 +514,9 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
+      ├── (i <= 10) AND (i >= 5) [type=bool, outer=(2), constraints=(/2: [/5 - /10]; tight)]
       ├── k < i [type=bool, outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ])]
       ├── i >= f [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ])]
-      ├── i <= 10 [type=bool, outer=(2), constraints=(/2: (/NULL - /10]; tight)]
-      ├── i >= 5 [type=bool, outer=(2), constraints=(/2: [/5 - ]; tight)]
       └── f <= 1.0 [type=bool, outer=(3), constraints=(/3: (/NULL - /1.0]; tight)]
 
 # --------------------------------------------------

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -28,6 +28,38 @@ TABLE uv
  └── INDEX primary
       └── u int not null
 
+exec-ddl
+CREATE TABLE c (a BOOL, b BOOL, c BOOL, d BOOL, e BOOL)
+----
+TABLE c
+ ├── a bool
+ ├── b bool
+ ├── c bool
+ ├── d bool
+ ├── e bool
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE TABLE e
+(
+    k INT PRIMARY KEY,
+    i INT,
+    t TIMESTAMP,
+    tz TIMESTAMPTZ,
+    d DATE
+)
+----
+TABLE e
+ ├── k int not null
+ ├── i int
+ ├── t timestamp
+ ├── tz timestamptz
+ ├── d date
+ └── INDEX primary
+      └── k int not null
+
 # --------------------------------------------------
 # SimplifyFilters
 # --------------------------------------------------
@@ -100,6 +132,150 @@ inner-join (lookup xy)
       └── i = y [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 
 # --------------------------------------------------
+# ConsolidateSelectFilters
+# --------------------------------------------------
+
+opt expect=ConsolidateSelectFilters
+SELECT * FROM a WHERE i >= 5 AND i < 10 AND i IN (0, 2, 4, 6, 8, 10, 12)
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── ((i >= 5) AND (i < 10)) AND (i IN (0, 2, 4, 6, 8, 10, 12)) [type=bool, outer=(2), constraints=(/2: [/6 - /6] [/8 - /8]; tight)]
+
+opt expect-not=ConsolidateSelectFilters
+SELECT * FROM a WHERE k >= 5 AND i < 10
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── constraint: /1: [/5 - ]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── i < 10 [type=bool, outer=(2), constraints=(/2: (/NULL - /9]; tight)]
+
+opt expect=ConsolidateSelectFilters
+SELECT * FROM c WHERE a AND a=true AND b AND b=c
+----
+select
+ ├── columns: a:1(bool!null) b:2(bool!null) c:3(bool!null) d:4(bool) e:5(bool)
+ ├── fd: ()-->(1-3), (2)==(3), (3)==(2)
+ ├── scan c
+ │    └── columns: a:1(bool) b:2(bool) c:3(bool) d:4(bool) e:5(bool)
+ └── filters
+      ├── a AND (a = true) [type=bool, outer=(1), constraints=(/1: [/true - /true]; tight), fd=()-->(1)]
+      ├── variable: b [type=bool, outer=(2), constraints=(/2: [/true - /true]; tight), fd=()-->(2)]
+      └── b = c [type=bool, outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
+
+opt expect=ConsolidateSelectFilters
+SELECT * FROM a WHERE i IS NOT NULL AND i = 3
+AND f > 5 AND f < 15 AND s >= 'bar' AND s <= 'foo'
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) f:3(float!null) s:4(string!null) j:5(jsonb)
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      ├── (i IS NOT NULL) AND (i = 3) [type=bool, outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+      ├── (f > 5.0) AND (f < 15.0) [type=bool, outer=(3), constraints=(/3: [/5.000000000000001 - /14.999999999999998]; tight)]
+      └── (s >= 'bar') AND (s <= 'foo') [type=bool, outer=(4), constraints=(/4: [/'bar' - /'foo']; tight)]
+
+opt expect=ConsolidateSelectFilters
+SELECT * FROM a WHERE i IS NULL AND i IS DISTINCT FROM 5
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── (i IS NULL) AND (i IS DISTINCT FROM 5) [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL]; tight), fd=()-->(2)]
+
+opt expect=ConsolidateSelectFilters
+SELECT * FROM a WHERE s LIKE 'a%' AND s SIMILAR TO 'a_' AND s = 'aa'
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string!null) j:5(jsonb)
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      ├── (s LIKE 'a%') AND (s = 'aa') [type=bool, outer=(4), constraints=(/4: [/'aa' - /'aa']; tight), fd=()-->(4)]
+      └── s SIMILAR TO 'a_' [type=bool, outer=(4), constraints=(/4: [/'a' - /'b'))]
+
+# One of the constraints is not tight, so it should not be consolidated.
+opt expect-not=ConsolidateSelectFilters
+SELECT k FROM e WHERE d > '2018-07-01' AND d < '2018-07-01'::DATE + '1w1s'::INTERVAL
+----
+project
+ ├── columns: k:1(int!null)
+ ├── key: (1)
+ └── select
+      ├── columns: k:1(int!null) d:5(date!null)
+      ├── key: (1)
+      ├── fd: (1)-->(5)
+      ├── scan e
+      │    ├── columns: k:1(int!null) d:5(date)
+      │    ├── key: (1)
+      │    └── fd: (1)-->(5)
+      └── filters
+           ├── d > '2018-07-01' [type=bool, outer=(5), constraints=(/5: [/'2018-07-02' - ]; tight)]
+           └── d < '2018-07-08 00:00:01+00:00' [type=bool, outer=(5), constraints=(/5: (/NULL - ])]
+
+# Ranges can be merged with other filters to create new ranges.
+norm expect=ConsolidateSelectFilters
+SELECT * FROM (SELECT * FROM a WHERE k = 5) AS a, e WHERE a.k = e.k AND a.k > 1 AND e.k < 10
+----
+inner-join
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) k:6(int!null) i:7(int) t:8(timestamp) tz:9(timestamptz) d:10(date)
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-10)
+ ├── select
+ │    ├── columns: a.k:1(int!null) a.i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-5)
+ │    ├── scan a
+ │    │    ├── columns: a.k:1(int!null) a.i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── ((a.k = 5) AND (a.k > 1)) AND (a.k < 10) [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ ├── select
+ │    ├── columns: e.k:6(int!null) e.i:7(int) t:8(timestamp) tz:9(timestamptz) d:10(date)
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7-10)
+ │    ├── scan e
+ │    │    ├── columns: e.k:6(int!null) e.i:7(int) t:8(timestamp) tz:9(timestamptz) d:10(date)
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7-10)
+ │    └── filters
+ │         └── (e.k > 1) AND (e.k < 10) [type=bool, outer=(6), constraints=(/6: [/2 - /9]; tight)]
+ └── filters
+      └── a.k = e.k [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+
+# --------------------------------------------------
 # EliminateSelect
 # --------------------------------------------------
 opt expect=EliminateSelect
@@ -166,8 +342,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      ├── i > 1 [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
-      ├── i < 10 [type=bool, outer=(2), constraints=(/2: (/NULL - /9]; tight)]
+      ├── (i > 1) AND (i < 10) [type=bool, outer=(2), constraints=(/2: [/2 - /9]; tight)]
       └── (s = 'foo') OR (k = 5) [type=bool, outer=(1,4)]
 
 # --------------------------------------------------
@@ -1057,8 +1232,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  └── filters
-      ├── i < 100 [type=bool, outer=(2), constraints=(/2: (/NULL - /99]; tight)]
-      └── i IS NOT NULL [type=bool, outer=(2), constraints=(/2: (/NULL - ]; tight)]
+      └── (i < 100) AND (i IS NOT NULL) [type=bool, outer=(2), constraints=(/2: (/NULL - /99]; tight)]
 
 opt expect=RemoveNotNullCondition
 SELECT k,s FROM b WHERE k IS NOT NULL AND s IS NOT NULL

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -308,6 +308,19 @@ define Or {
     Right ScalarExpr
 }
 
+# Range contains an And expression that constrains a single variable to a
+# range. For example, the And expression might be x > 5 AND x < 10. The
+# children of the And expression can be arbitrary expressions (including nested
+# And expressions), but they must all constrain the same variable, and the
+# constraints must be tight.
+#
+# Currently, Range expressions are only created by the ConsolidateSelectFilters
+# normalization rule.
+[Scalar, Boolean]
+define Range {
+    And ScalarExpr
+}
+
 # Not is the boolean negation operator that evaluates to true if its input
 # evaluates to false.
 [Scalar, Boolean]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -29,9 +29,66 @@ exec-ddl
 ALTER TABLE warehouse INJECT STATISTICS '[
   {
     "columns": ["w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10,
-    "distinct_count": 10
+    "distinct_count": 100,
+    "null_count": 0, 
+    "row_count": 100, 
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["w_name"],
+    "distinct_count": 5,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["w_street_1"],
+    "distinct_count": 11,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["w_street_2"],
+    "distinct_count": 11,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["w_city"],
+    "distinct_count": 11,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["w_state"],
+    "distinct_count": 92,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["w_zip"],
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["w_tax"],
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["w_ytd"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 100,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   }
 ]'
 ----
@@ -74,10 +131,81 @@ TABLE district
 exec-ddl
 ALTER TABLE district INJECT STATISTICS '[
   {
+    "columns": ["d_id"],
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
     "columns": ["d_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 100,
-    "distinct_count": 10
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["d_name"],
+    "distinct_count": 1000,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["d_street_1"],
+    "distinct_count": 1000,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["d_street_2"],
+    "distinct_count": 1000,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["d_city"],
+    "distinct_count": 1000,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["d_state"],
+    "distinct_count": 506,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["d_zip"],
+    "distinct_count": 951,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["d_tax"],
+    "distinct_count": 780,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["d_ytd"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["d_next_o_id"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 1000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   }
 ]'
 ----
@@ -148,28 +276,151 @@ TABLE customer
 exec-ddl
 ALTER TABLE customer INJECT STATISTICS '[
   {
+    "columns": ["c_id"],
+    "distinct_count": 3000,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_d_id"],
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
     "columns": ["c_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 10
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["c_w_id", "c_d_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 100
+    "columns": ["c_first"],
+    "distinct_count": 3024712,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["c_w_id", "c_d_id", "c_last"],
-    "created_at": "2018-01-01 1:30:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 100000
+    "columns": ["c_middle"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["c_w_id", "c_d_id", "c_last", "c_first"],
-    "created_at": "2018-01-01 1:30:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 300000
+    "columns": ["c_last"],
+    "distinct_count": 1000,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_street_1"],
+    "distinct_count": 3007563,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_street_2"],
+    "distinct_count": 3000445,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_city"],
+    "distinct_count": 2994387,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_state"],
+    "distinct_count": 676,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_zip"],
+    "distinct_count": 10018,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_phone"],
+    "distinct_count": 2972913,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_since"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_credit"],
+    "distinct_count": 2,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_credit_lim"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_discount"],
+    "distinct_count": 5000,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_balance"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_ytd_payment"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_payment_cnt"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_delivery_cnt"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["c_data"],
+    "distinct_count": 2967420,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   }
 ]'
 ----
@@ -219,22 +470,67 @@ TABLE history
 exec-ddl
 ALTER TABLE history INJECT STATISTICS '[
   {
+    "columns": ["rowid"],
+    "distinct_count": 2985531,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["h_c_id"],
+    "distinct_count": 3000,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["h_c_d_id"],
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["h_c_w_id"],
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["h_d_id"],
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
     "columns": ["h_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 30000000,
-    "distinct_count": 10
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["h_w_id", "h_d_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 30000000,
-    "distinct_count": 100
+    "columns": ["h_date"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["h_w_id", "h_d_id", "h_c_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 30000000,
-    "distinct_count": 30000000
+    "columns": ["h_amount"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["h_data"],
+    "distinct_count": 2979454,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   }
 ]'
 ----
@@ -284,28 +580,60 @@ TABLE order
 exec-ddl
 ALTER TABLE "order" INJECT STATISTICS '[
   {
+    "columns": ["o_id"],
+    "distinct_count": 3000,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["o_d_id"],
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
     "columns": ["o_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 10
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["o_w_id", "o_d_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 100
+    "columns": ["o_c_id"],
+    "distinct_count": 3000,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["o_w_id", "o_d_id", "o_carrier_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 1000
+    "columns": ["o_entry_d"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["o_w_id", "o_d_id", "o_c_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 300000,
-    "distinct_count": 300000
+    "columns": ["o_carrier_id"],
+    "distinct_count": 10,
+    "null_count": 900000,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["o_ol_cnt"],
+    "distinct_count": 11,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["o_all_local"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 3000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   }
 ]'
 ----
@@ -330,17 +658,26 @@ TABLE new_order
 
 exec-ddl
 ALTER TABLE new_order INJECT STATISTICS '[
-  {
-    "columns": ["no_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 90000,
-    "distinct_count": 10
+    {
+    "columns": ["no_o_id"],
+    "distinct_count": 900,
+    "null_count": 0,
+    "row_count": 900000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["no_w_id", "no_d_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 90000,
-    "distinct_count": 100
+    "columns": ["no_d_id"],
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 900000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["no_w_id"],
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 900000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   }
 ]'
 ----
@@ -369,9 +706,38 @@ exec-ddl
 ALTER TABLE item INJECT STATISTICS '[
   {
     "columns": ["i_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "distinct_count": 101273,
+    "null_count": 0,
     "row_count": 100000,
-    "distinct_count": 100000
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["i_im_id"],
+    "distinct_count": 10032,
+    "null_count": 0,
+    "row_count": 100000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["i_name"],
+    "distinct_count": 98749,
+    "null_count": 0,
+    "row_count": 100000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["i_price"],
+    "distinct_count": 9855,
+    "null_count": 0,
+    "row_count": 100000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["i_data"],
+    "distinct_count": 98582,
+    "null_count": 0,
+    "row_count": 100000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   }
 ]'
 ----
@@ -432,16 +798,123 @@ TABLE stock
 exec-ddl
 ALTER TABLE stock INJECT STATISTICS '[
   {
-    "columns": ["s_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 10
+    "columns": ["s_i_id"],
+    "distinct_count": 101273,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["s_i_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 100000
+    "columns": ["s_w_id"],
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_quantity"],
+    "distinct_count": 91,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_dist_01"],
+    "distinct_count": 10147435,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_dist_02"],
+    "distinct_count": 9896785,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_dist_03"],
+    "distinct_count": 9932517,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_dist_04"],
+    "distinct_count": 10048131,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_dist_05"],
+    "distinct_count": 10045535,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_dist_06"],
+    "distinct_count": 9801428,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_dist_07"],
+    "distinct_count": 10074492,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_dist_08"],
+    "distinct_count": 9943047,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_dist_09"],
+    "distinct_count": 10001651,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_dist_10"],
+    "distinct_count": 10097341,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_ytd"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_order_cnt"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_remote_cnt"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["s_data"],
+    "distinct_count": 10151633,
+    "null_count": 0,
+    "row_count": 10000000,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   }
 ]'
 ----
@@ -493,46 +966,74 @@ TABLE order_line
 exec-ddl
 ALTER TABLE order_line INJECT STATISTICS '[
   {
+    "columns": ["ol_o_id"],
+    "distinct_count": 3000,
+    "null_count": 0,
+    "row_count": 30005985,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["ol_d_id"],
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 30005985,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
     "columns": ["ol_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 10
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 30005985,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["ol_w_id", "ol_d_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 100
+    "columns": ["ol_number"],
+    "distinct_count": 15,
+    "null_count": 0,
+    "row_count": 30005985,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["ol_w_id", "ol_d_id", "ol_o_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 100000
+    "columns": ["ol_i_id"],
+    "distinct_count": 101273,
+    "null_count": 0,
+    "row_count": 30005985,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
     "columns": ["ol_supply_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 10
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 30005985,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["ol_supply_w_id", "ol_d_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 100
+    "columns": ["ol_delivery_d"],
+    "distinct_count": 1,
+    "null_count": 9003667,
+    "row_count": 30005985,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["ol_supply_w_id", "ol_d_id", "ol_w_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-    "distinct_count": 1000
+    "columns": ["ol_quantity"],
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 30005985,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   },
   {
-    "columns": ["ol_supply_w_id", "ol_d_id", "ol_w_id", "ol_o_id"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 1000000,
-        "distinct_count": 100000
+    "columns": ["ol_amount"],
+    "distinct_count": 988202,
+    "null_count": 0,
+    "row_count": 30005985,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
+  },
+  {
+    "columns": ["ol_dist_info"],
+    "distinct_count": 30179646,
+    "null_count": 0,
+    "row_count": 30005985,
+    "created_at": "2018-01-01 1:00:00.00000+00:00"
   }
 ]'
 ----
@@ -578,8 +1079,8 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 project
  ├── columns: c_discount:16(decimal) c_last:6(string) c_credit:14(string)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=3.33333333e-05]
- ├── cost: 0.0200426667
+ ├── stats: [rows=1]
+ ├── cost: 1.3
  ├── key: ()
  ├── fd: ()-->(6,14,16)
  ├── prune: (6,14,16)
@@ -587,8 +1088,8 @@ project
       ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_last:6(string) c_credit:14(string) c_discount:16(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=3.33333333e-05, distinct(1)=3.33333333e-05, null(1)=0, distinct(2)=3.33333333e-05, null(2)=0, distinct(3)=3.33333333e-05, null(3)=0]
-      ├── cost: 0.0100423333
+      ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
+      ├── cost: 1.28
       ├── key: ()
       ├── fd: ()-->(1-3,6,14,16)
       ├── prune: (1-3,6,14,16)
@@ -603,8 +1104,8 @@ ORDER BY i_id
 scan item
  ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
- ├── stats: [rows=12, distinct(1)=12, null(1)=0]
- ├── cost: 13.09
+ ├── stats: [rows=11.8491602, distinct(1)=11.8491602, null(1)=0]
+ ├── cost: 12.9255846
  ├── key: (1)
  ├── fd: (1)-->(3-5)
  ├── ordering: +1
@@ -619,8 +1120,8 @@ ORDER BY s_i_id
 ----
 project
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)  [hidden: s_i_id:1(int!null)]
- ├── stats: [rows=5]
- ├── cost: 6.32
+ ├── stats: [rows=4.93715008]
+ ├── cost: 6.2408091
  ├── key: (1)
  ├── fd: (1)-->(3,8,14-17)
  ├── ordering: +1
@@ -629,8 +1130,8 @@ project
  └── scan stock
       ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(string) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string)
       ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
-      ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(2)=1, null(2)=0]
-      ├── cost: 6.26
+      ├── stats: [rows=4.93715008, distinct(1)=4.93715008, null(1)=0, distinct(2)=1, null(2)=0]
+      ├── cost: 6.1814376
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
       ├── ordering: +1 opt(2) [actual: +1]
@@ -654,8 +1155,8 @@ ORDER BY c_first ASC
 ----
 project
  ├── columns: c_id:1(int!null)  [hidden: c_first:4(string)]
- ├── stats: [rows=3.3e-05]
- ├── cost: 0.02003663
+ ├── stats: [rows=3]
+ ├── cost: 3.35
  ├── key: (1)
  ├── fd: (1)-->(4)
  ├── ordering: +4
@@ -663,8 +1164,8 @@ project
  └── scan customer@customer_idx
       ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
       ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
-      ├── stats: [rows=3.3e-05, distinct(1)=3.3e-05, null(1)=0, distinct(2)=3.3e-05, null(2)=0, distinct(3)=3.3e-05, null(3)=0, distinct(6)=3.3e-05, null(6)=0]
-      ├── cost: 0.0100363
+      ├── stats: [rows=3, distinct(1)=2.998502, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0]
+      ├── cost: 3.31
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4)
       ├── ordering: +4 opt(2,3,6) [actual: +4]
@@ -688,8 +1189,8 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 project
  ├── columns: c_balance:17(decimal) c_first:4(string) c_middle:5(string) c_last:6(string)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=3.33333333e-05]
- ├── cost: 0.020043
+ ├── stats: [rows=1]
+ ├── cost: 1.31
  ├── key: ()
  ├── fd: ()-->(4-6,17)
  ├── prune: (4-6,17)
@@ -697,8 +1198,8 @@ project
       ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_middle:5(string) c_last:6(string) c_balance:17(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=3.33333333e-05, distinct(1)=3.33333333e-05, null(1)=0, distinct(2)=3.33333333e-05, null(2)=0, distinct(3)=3.33333333e-05, null(3)=0]
-      ├── cost: 0.0100426667
+      ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
+      ├── cost: 1.29
       ├── key: ()
       ├── fd: ()-->(1-6,17)
       ├── prune: (1-6,17)
@@ -712,16 +1213,16 @@ ORDER BY c_first ASC
 ----
 project
  ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(string) c_middle:5(string)
- ├── stats: [rows=3.3e-05]
- ├── cost: 0.0301782
+ ├── stats: [rows=3]
+ ├── cost: 16.23
  ├── key: (1)
  ├── fd: (1)-->(4,5,17)
  ├── ordering: +4
  ├── prune: (1,4,5,17)
  └── index-join customer
       ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_middle:5(string) c_last:6(string!null) c_balance:17(decimal)
-      ├── stats: [rows=3.3e-05, distinct(1)=3.3e-05, null(1)=0, distinct(2)=3.3e-05, null(2)=0, distinct(3)=3.3e-05, null(3)=0, distinct(6)=3.3e-05, null(6)=0]
-      ├── cost: 0.02017787
+      ├── stats: [rows=3, distinct(1)=2.998502, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0]
+      ├── cost: 16.19
       ├── key: (1)
       ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
       ├── ordering: +4 opt(2,3,6) [actual: +4]
@@ -729,8 +1230,8 @@ project
       └── scan customer@customer_idx
            ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
            ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
-           ├── stats: [rows=3.3e-05, distinct(1)=3.3e-05, null(1)=0, distinct(2)=3.3e-05, null(2)=0, distinct(3)=3.3e-05, null(3)=0, distinct(6)=3.3e-05, null(6)=0]
-           ├── cost: 0.0100363
+           ├── stats: [rows=3, distinct(1)=2.998502, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0]
+           ├── cost: 3.31
            ├── key: (1)
            ├── fd: ()-->(2,3,6), (1)-->(4)
            ├── ordering: +4 opt(2,3,6) [actual: +4]
@@ -747,16 +1248,16 @@ LIMIT 1
 project
  ├── columns: o_id:1(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=3.3e-05]
- ├── cost: 0.03017292
+ ├── stats: [rows=1]
+ ├── cost: 5.27
  ├── key: ()
  ├── fd: ()-->(1,5,6)
  ├── prune: (1,5,6)
  └── index-join order
       ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=3.3e-05]
-      ├── cost: 0.02017259
+      ├── stats: [rows=1]
+      ├── cost: 5.25
       ├── key: ()
       ├── fd: ()-->(1-6)
       ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
@@ -764,8 +1265,8 @@ project
            ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
            ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
            ├── limit: 1(rev)
-           ├── stats: [rows=3.3e-05, distinct(1)=3.3e-05, null(1)=0, distinct(2)=3.3e-05, null(2)=0, distinct(3)=3.3e-05, null(3)=0, distinct(4)=3.3e-05, null(4)=0]
-           ├── cost: 0.01003564
+           ├── stats: [rows=1, distinct(1)=0.999833519, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0]
+           ├── cost: 1.09
            ├── key: ()
            ├── fd: ()-->(1-4)
            ├── prune: (1-4)
@@ -778,15 +1279,15 @@ WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
 ----
 project
  ├── columns: ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_quantity:8(int) ol_amount:9(decimal) ol_delivery_d:7(timestamp)
- ├── stats: [rows=1e-05]
- ├── cost: 0.0200119
+ ├── stats: [rows=10.001995]
+ ├── cost: 11.9223741
  ├── prune: (5-9)
  ├── interesting orderings: (+6)
  └── scan order_line
       ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_delivery_d:7(timestamp) ol_quantity:8(int) ol_amount:9(decimal)
       ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
-      ├── stats: [rows=1e-05, distinct(1)=1e-05, null(1)=0, distinct(2)=1e-05, null(2)=0, distinct(3)=1e-05, null(3)=0, distinct(5)=1e-05, null(5)=0]
-      ├── cost: 0.0100118
+      ├── stats: [rows=10.001995, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=10.0015028, null(5)=0]
+      ├── cost: 11.8123541
       ├── fd: ()-->(1-3)
       ├── prune: (1-3,5-9)
       └── interesting orderings: (+3,+2,-1) (+6,+2,+3,+1)
@@ -842,15 +1343,15 @@ scalar-group-by
  ├── columns: sum:11(decimal)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 0.0300115
+ ├── cost: 11.5322943
  ├── key: ()
  ├── fd: ()-->(11)
  ├── prune: (11)
  ├── scan order_line
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_amount:9(decimal)
  │    ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
- │    ├── stats: [rows=1e-05, distinct(1)=1e-05, null(1)=0, distinct(2)=1e-05, null(2)=0, distinct(3)=1e-05, null(3)=0]
- │    ├── cost: 0.0100114
+ │    ├── stats: [rows=10.001995, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
+ │    ├── cost: 11.4122743
  │    ├── fd: ()-->(1-3)
  │    ├── prune: (1-3,9)
  │    └── interesting orderings: (+3,+2,-1)
@@ -904,22 +1405,22 @@ scalar-group-by
  ├── columns: count:28(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 2.84111111
+ ├── cost: 1551.03048
  ├── key: ()
  ├── fd: ()-->(28)
  ├── prune: (28)
  ├── inner-join (lookup stock)
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) s_i_id:11(int!null) s_w_id:12(int!null) s_quantity:13(int!null)
  │    ├── key columns: [3 5] = [12 11]
- │    ├── stats: [rows=1, distinct(1)=0.11109736, null(1)=0, distinct(2)=0.111097416, null(2)=0, distinct(3)=0.111111111, null(3)=0, distinct(5)=0.111111056, null(5)=0, distinct(11)=0.111111056, null(11)=0, distinct(12)=0.111111111, null(12)=0, distinct(13)=1, null(13)=0]
- │    ├── cost: 2.81111111
+ │    ├── stats: [rows=234.432912, distinct(1)=19.9998377, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=199.843131, null(5)=0, distinct(11)=199.843131, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=84.0785286, null(13)=0]
+ │    ├── cost: 1548.66615
  │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    ├── scan order_line
  │    │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null)
  │    │    ├── constraint: /3/2/-1/4: [/10/100/999 - /10/100/980]
- │    │    ├── stats: [rows=0.111111111, distinct(1)=0.111111056, null(1)=0, distinct(2)=0.111111111, null(2)=0, distinct(3)=0.111111111, null(3)=0, distinct(5)=0.111111056, null(5)=0]
- │    │    ├── cost: 0.136666667
+ │    │    ├── stats: [rows=200.0399, distinct(1)=20, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=199.843131, null(5)=0]
+ │    │    ├── cost: 228.055486
  │    │    ├── fd: ()-->(2,3)
  │    │    ├── prune: (5)
  │    │    └── interesting orderings: (+3,+2,-1)
@@ -957,7 +1458,7 @@ scalar-group-by
  ├── columns: count:22(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 126.526
+ ├── cost: 1264.72667
  ├── key: ()
  ├── fd: ()-->(22)
  ├── prune: (22)
@@ -965,13 +1466,1648 @@ scalar-group-by
  │    ├── columns: w_id:1(int!null) w_ytd:9(decimal!null) d_w_id:11(int!null) sum:21(decimal!null)
  │    ├── left ordering: +1
  │    ├── right ordering: +11
- │    ├── stats: [rows=3.3, distinct(1)=3.3, null(1)=0, distinct(9)=0.966296553, null(9)=0, distinct(11)=3.3, null(11)=0, distinct(21)=2.87528606, null(21)=0]
- │    ├── cost: 126.473
+ │    ├── stats: [rows=33.3333333, distinct(1)=33.3333333, null(1)=0, distinct(9)=1, null(9)=0, distinct(11)=33.3333333, null(11)=0, distinct(21)=28.3867538, null(21)=0]
+ │    ├── cost: 1264.37333
  │    ├── key: (11)
  │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)
  │    ├── scan warehouse
  │    │    ├── columns: w_id:1(int!null) w_ytd:9(decimal)
- │    │    ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(9)=1, null(9)=0.1]
+ │    │    ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(9)=1, null(9)=0]
+ │    │    ├── cost: 111.01
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(9)
+ │    │    ├── ordering: +1
+ │    │    ├── prune: (1,9)
+ │    │    └── interesting orderings: (+1)
+ │    ├── group-by
+ │    │    ├── columns: d_w_id:11(int!null) sum:21(decimal)
+ │    │    ├── grouping columns: d_w_id:11(int!null)
+ │    │    ├── stats: [rows=100, distinct(11)=100, null(11)=0, distinct(21)=100, null(21)=0]
+ │    │    ├── cost: 1151.02
+ │    │    ├── key: (11)
+ │    │    ├── fd: (11)-->(21)
+ │    │    ├── ordering: +11
+ │    │    ├── prune: (21)
+ │    │    ├── interesting orderings: (+11)
+ │    │    ├── scan district
+ │    │    │    ├── columns: d_w_id:11(int!null) d_ytd:19(decimal)
+ │    │    │    ├── stats: [rows=1000, distinct(11)=100, null(11)=0]
+ │    │    │    ├── cost: 1130.01
+ │    │    │    ├── ordering: +11
+ │    │    │    ├── prune: (11,19)
+ │    │    │    └── interesting orderings: (+11)
+ │    │    └── aggregations
+ │    │         └── sum [type=decimal, outer=(19)]
+ │    │              └── variable: d_ytd [type=decimal]
+ │    └── filters
+ │         └── ne [type=bool, outer=(9,21), constraints=(/9: (/NULL - ]; /21: (/NULL - ])]
+ │              ├── variable: w_ytd [type=decimal]
+ │              └── variable: sum [type=decimal]
+ └── aggregations
+      └── count-rows [type=int]
+
+opt format=hide-qual
+SELECT d_next_o_id
+FROM district
+ORDER BY d_w_id, d_id
+----
+scan district
+ ├── columns: d_next_o_id:11(int)  [hidden: d_id:1(int!null) d_w_id:2(int!null)]
+ ├── stats: [rows=1000]
+ ├── cost: 1140.01
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(11)
+ ├── ordering: +2,+1
+ ├── prune: (1,2,11)
+ └── interesting orderings: (+2,+1)
+
+opt format=hide-qual
+SELECT max(no_o_id)
+FROM new_order
+GROUP BY no_d_id, no_w_id
+ORDER BY no_w_id, no_d_id
+----
+group-by
+ ├── columns: max:4(int)  [hidden: no_d_id:2(int!null) no_w_id:3(int!null)]
+ ├── grouping columns: no_d_id:2(int!null) no_w_id:3(int!null)
+ ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
+ ├── cost: 981010.02
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(4)
+ ├── ordering: +3,+2
+ ├── prune: (4)
+ ├── interesting orderings: (+3,+2)
+ ├── scan new_order
+ │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
+ │    ├── stats: [rows=900000, distinct(2,3)=1000, null(2,3)=0]
+ │    ├── cost: 954000.01
+ │    ├── key: (1-3)
+ │    ├── ordering: +3,+2
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+3,+2,-1)
+ └── aggregations
+      └── max [type=int, outer=(1)]
+           └── variable: no_o_id [type=int]
+
+opt format=hide-qual
+SELECT max(o_id)
+FROM "order"
+GROUP BY o_d_id, o_w_id
+ORDER BY o_w_id, o_d_id
+----
+group-by
+ ├── columns: max:9(int)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
+ ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
+ ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
+ ├── cost: 3300010.02
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(9)
+ ├── ordering: +3,+2
+ ├── prune: (9)
+ ├── interesting orderings: (+3,+2)
+ ├── scan "order"@order_idx
+ │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
+ │    ├── stats: [rows=3000000, distinct(2,3)=1000, null(2,3)=0]
+ │    ├── cost: 3210000.01
+ │    ├── key: (1-3)
+ │    ├── ordering: +3,+2
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+3,+2,-1)
+ └── aggregations
+      └── max [type=int, outer=(1)]
+           └── variable: o_id [type=int]
+
+opt format=hide-qual
+SELECT count(*)
+FROM
+(
+    SELECT max(no_o_id) - min(no_o_id) - count(*) AS nod
+    FROM new_order
+    GROUP BY no_w_id, no_d_id
+)
+WHERE nod != -1
+----
+scalar-group-by
+ ├── columns: count:8(int)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 999023.383
+ ├── key: ()
+ ├── fd: ()-->(8)
+ ├── prune: (8)
+ ├── select
+ │    ├── columns: no_d_id:2(int!null) no_w_id:3(int!null) max:4(int) min:5(int) count_rows:6(int)
+ │    ├── stats: [rows=333.333333, distinct(2)=10, null(2)=0, distinct(3)=98.265847, null(3)=0]
+ │    ├── cost: 999020.03
+ │    ├── key: (2,3)
+ │    ├── fd: (2,3)-->(4-6)
+ │    ├── interesting orderings: (+3,+2)
+ │    ├── group-by
+ │    │    ├── columns: no_d_id:2(int!null) no_w_id:3(int!null) max:4(int) min:5(int) count_rows:6(int)
+ │    │    ├── grouping columns: no_d_id:2(int!null) no_w_id:3(int!null)
+ │    │    ├── internal-ordering: +3,+2
+ │    │    ├── stats: [rows=1000, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(2,3)=1000, null(2,3)=0]
+ │    │    ├── cost: 999010.02
+ │    │    ├── key: (2,3)
+ │    │    ├── fd: (2,3)-->(4-6)
+ │    │    ├── prune: (4-6)
+ │    │    ├── interesting orderings: (+3,+2)
+ │    │    ├── scan new_order
+ │    │    │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
+ │    │    │    ├── stats: [rows=900000, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(2,3)=1000, null(2,3)=0]
+ │    │    │    ├── cost: 954000.01
+ │    │    │    ├── key: (1-3)
+ │    │    │    ├── ordering: +3,+2
+ │    │    │    ├── prune: (1-3)
+ │    │    │    └── interesting orderings: (+3,+2,-1)
+ │    │    └── aggregations
+ │    │         ├── max [type=int, outer=(1)]
+ │    │         │    └── variable: no_o_id [type=int]
+ │    │         ├── min [type=int, outer=(1)]
+ │    │         │    └── variable: no_o_id [type=int]
+ │    │         └── count-rows [type=int]
+ │    └── filters
+ │         └── ne [type=bool, outer=(4-6)]
+ │              ├── minus [type=int]
+ │              │    ├── minus [type=int]
+ │              │    │    ├── variable: max [type=int]
+ │              │    │    └── variable: min [type=int]
+ │              │    └── variable: count_rows [type=int]
+ │              └── const: -1 [type=int]
+ └── aggregations
+      └── count-rows [type=int]
+
+opt format=hide-qual
+SELECT sum(o_ol_cnt)
+FROM "order"
+GROUP BY o_w_id, o_d_id
+ORDER BY o_w_id, o_d_id
+----
+group-by
+ ├── columns: sum:9(decimal)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
+ ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
+ ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
+ ├── cost: 3420010.02
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(9)
+ ├── ordering: +3,+2
+ ├── prune: (9)
+ ├── interesting orderings: (+3,+2)
+ ├── scan "order"
+ │    ├── columns: o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
+ │    ├── stats: [rows=3000000, distinct(2,3)=1000, null(2,3)=0]
+ │    ├── cost: 3330000.01
+ │    ├── ordering: +3,+2
+ │    ├── prune: (2,3,7)
+ │    └── interesting orderings: (+3,+2)
+ └── aggregations
+      └── sum [type=decimal, outer=(7)]
+           └── variable: o_ol_cnt [type=int]
+
+opt format=hide-qual
+SELECT count(*)
+FROM order_line
+GROUP BY ol_w_id, ol_d_id
+ORDER BY ol_w_id, ol_d_id
+----
+sort
+ ├── columns: count:11(int)  [hidden: ol_d_id:2(int!null) ol_w_id:3(int!null)]
+ ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
+ ├── cost: 33306883.7
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(11)
+ ├── ordering: +3,+2
+ ├── prune: (11)
+ └── group-by
+      ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
+      ├── grouping columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
+      ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
+      ├── cost: 33306653.4
+      ├── key: (2,3)
+      ├── fd: (2,3)-->(11)
+      ├── prune: (11)
+      ├── scan order_line@order_line_fk
+      │    ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
+      │    ├── stats: [rows=30005985, distinct(2,3)=1000, null(2,3)=0]
+      │    ├── cost: 32106404
+      │    ├── prune: (2,3)
+      │    └── interesting orderings: (+3,+2)
+      └── aggregations
+           └── count-rows [type=int]
+
+opt format=hide-qual
+(SELECT no_w_id, no_d_id, no_o_id FROM new_order)
+EXCEPT ALL
+(SELECT o_w_id, o_d_id, o_id FROM "order" WHERE o_carrier_id IS NULL)
+----
+except-all
+ ├── columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
+ ├── left columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
+ ├── right columns: o_w_id:6(int) o_d_id:5(int) o_id:4(int)
+ ├── stats: [rows=900000]
+ ├── cost: 4246800.05
+ ├── scan new_order
+ │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
+ │    ├── stats: [rows=900000]
+ │    ├── cost: 954000.01
+ │    ├── key: (1-3)
+ │    ├── prune: (1-3)
+ │    └── interesting orderings: (+3,+2,-1)
+ └── project
+      ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
+      ├── stats: [rows=240000]
+      ├── cost: 3272400.03
+      ├── key: (4-6)
+      ├── prune: (4-6)
+      ├── interesting orderings: (+6,+5,-4)
+      └── select
+           ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
+           ├── stats: [rows=240000, distinct(4)=3000, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=100, null(6)=0, distinct(9)=1, null(9)=240000]
+           ├── cost: 3270000.02
+           ├── key: (4-6)
+           ├── fd: ()-->(9)
+           ├── prune: (4-6)
+           ├── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
+           ├── scan "order"@order_idx
+           │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
+           │    ├── stats: [rows=3000000, distinct(4)=3000, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=100, null(6)=0, distinct(9)=10, null(9)=900000]
+           │    ├── cost: 3240000.01
+           │    ├── key: (4-6)
+           │    ├── fd: (4-6)-->(9)
+           │    ├── prune: (4-6,9)
+           │    └── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
+           └── filters
+                └── is [type=bool, outer=(9), constraints=(/9: [/NULL - /NULL]; tight), fd=()-->(9)]
+                     ├── variable: o_carrier_id [type=int]
+                     └── null [type=unknown]
+
+opt format=hide-qual
+(SELECT o_w_id, o_d_id, o_id FROM "order" WHERE o_carrier_id IS NULL)
+EXCEPT ALL
+(SELECT no_w_id, no_d_id, no_o_id FROM new_order)
+----
+except-all
+ ├── columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
+ ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
+ ├── right columns: no_w_id:11(int) no_d_id:10(int) no_o_id:9(int)
+ ├── stats: [rows=240000]
+ ├── cost: 4240200.05
+ ├── project
+ │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
+ │    ├── stats: [rows=240000]
+ │    ├── cost: 3272400.03
+ │    ├── key: (1-3)
+ │    ├── prune: (1-3)
+ │    ├── interesting orderings: (+3,+2,-1)
+ │    └── select
+ │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
+ │         ├── stats: [rows=240000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=1, null(6)=240000]
+ │         ├── cost: 3270000.02
+ │         ├── key: (1-3)
+ │         ├── fd: ()-->(6)
+ │         ├── prune: (1-3)
+ │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
+ │         ├── scan "order"@order_idx
+ │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
+ │         │    ├── stats: [rows=3000000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=10, null(6)=900000]
+ │         │    ├── cost: 3240000.01
+ │         │    ├── key: (1-3)
+ │         │    ├── fd: (1-3)-->(6)
+ │         │    ├── prune: (1-3,6)
+ │         │    └── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
+ │         └── filters
+ │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
+ │                   ├── variable: o_carrier_id [type=int]
+ │                   └── null [type=unknown]
+ └── scan new_order
+      ├── columns: no_o_id:9(int!null) no_d_id:10(int!null) no_w_id:11(int!null)
+      ├── stats: [rows=900000]
+      ├── cost: 954000.01
+      ├── key: (9-11)
+      ├── prune: (9-11)
+      └── interesting orderings: (+11,+10,-9)
+
+opt format=hide-qual
+(
+    SELECT o_w_id, o_d_id, o_id, o_ol_cnt
+    FROM "order"
+    ORDER BY o_w_id, o_d_id, o_id DESC
+)
+EXCEPT ALL
+(
+    SELECT ol_w_id, ol_d_id, ol_o_id, count(*)
+    FROM order_line
+    GROUP BY (ol_w_id, ol_d_id, ol_o_id)
+    ORDER BY ol_w_id, ol_d_id, ol_o_id DESC
+)
+----
+except-all
+ ├── columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null) o_ol_cnt:7(int)
+ ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null) o_ol_cnt:7(int)
+ ├── right columns: ol_w_id:11(int) ol_d_id:10(int) ol_o_id:9(int) count_rows:19(int)
+ ├── stats: [rows=3000000]
+ ├── cost: 37386763.1
+ ├── scan "order"
+ │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
+ │    ├── stats: [rows=3000000]
+ │    ├── cost: 3360000.01
+ │    ├── key: (1-3)
+ │    ├── fd: (1-3)-->(7)
+ │    ├── prune: (1-3,7)
+ │    └── interesting orderings: (+3,+2,-1)
+ └── group-by
+      ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) count_rows:19(int)
+      ├── grouping columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
+      ├── stats: [rows=3000000, distinct(9-11)=3000000, null(9-11)=0]
+      ├── cost: 33936763.1
+      ├── key: (9-11)
+      ├── fd: (9-11)-->(19)
+      ├── prune: (19)
+      ├── interesting orderings: (+11,+10,-9)
+      ├── scan order_line@order_line_fk
+      │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
+      │    ├── stats: [rows=30005985, distinct(9-11)=3000000, null(9-11)=0]
+      │    ├── cost: 32406463.8
+      │    ├── prune: (9-11)
+      │    └── interesting orderings: (+11,+10,-9)
+      └── aggregations
+           └── count-rows [type=int]
+
+opt format=hide-qual
+(
+    SELECT ol_w_id, ol_d_id, ol_o_id, count(*)
+    FROM order_line
+    GROUP BY (ol_w_id, ol_d_id, ol_o_id)
+    ORDER BY ol_w_id, ol_d_id, ol_o_id DESC
+)
+EXCEPT ALL
+(
+    SELECT o_w_id, o_d_id, o_id, o_ol_cnt
+    FROM "order"
+    ORDER BY o_w_id, o_d_id, o_id DESC
+)
+----
+except-all
+ ├── columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count:11(int)
+ ├── left columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count_rows:11(int)
+ ├── right columns: o_w_id:14(int) o_d_id:13(int) o_id:12(int) o_ol_cnt:18(int)
+ ├── stats: [rows=3000000]
+ ├── cost: 37386763.1
+ ├── group-by
+ │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
+ │    ├── grouping columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
+ │    ├── stats: [rows=3000000, distinct(1-3)=3000000, null(1-3)=0]
+ │    ├── cost: 33936763.1
+ │    ├── key: (1-3)
+ │    ├── fd: (1-3)-->(11)
+ │    ├── prune: (11)
+ │    ├── interesting orderings: (+3,+2,-1)
+ │    ├── scan order_line@order_line_fk
+ │    │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
+ │    │    ├── stats: [rows=30005985, distinct(1-3)=3000000, null(1-3)=0]
+ │    │    ├── cost: 32406463.8
+ │    │    ├── prune: (1-3)
+ │    │    └── interesting orderings: (+3,+2,-1)
+ │    └── aggregations
+ │         └── count-rows [type=int]
+ └── scan "order"
+      ├── columns: o_id:12(int!null) o_d_id:13(int!null) o_w_id:14(int!null) o_ol_cnt:18(int)
+      ├── stats: [rows=3000000]
+      ├── cost: 3360000.01
+      ├── key: (12-14)
+      ├── fd: (12-14)-->(18)
+      ├── prune: (12-14,18)
+      └── interesting orderings: (+14,+13,-12)
+
+opt format=hide-qual
+SELECT count(*)
+FROM
+(
+    SELECT o_w_id, o_d_id, o_id
+    FROM "order"
+    WHERE o_carrier_id IS NULL
+)
+FULL OUTER JOIN
+(
+    SELECT ol_w_id, ol_d_id, ol_o_id
+    FROM order_line
+    WHERE ol_delivery_d IS NULL
+)
+ON (ol_w_id = o_w_id AND ol_d_id = o_d_id AND ol_o_id = o_id)
+WHERE ol_o_id IS NULL OR o_id IS NULL
+----
+scalar-group-by
+ ├── columns: count:19(int)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 39158757.2
+ ├── key: ()
+ ├── fd: ()-->(19)
+ ├── prune: (19)
+ ├── select
+ │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
+ │    ├── stats: [rows=10001995]
+ │    ├── cost: 39058737.2
+ │    ├── interesting orderings: (+11,+10,-9) (+3,+2,-1)
+ │    ├── full-join
+ │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
+ │    │    ├── stats: [rows=30005985]
+ │    │    ├── cost: 38758677.3
+ │    │    ├── reject-nulls: (1-3,9-11)
+ │    │    ├── interesting orderings: (+11,+10,-9) (+3,+2,-1)
+ │    │    ├── project
+ │    │    │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
+ │    │    │    ├── stats: [rows=30005985, distinct(9)=3000, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=100, null(11)=0]
+ │    │    │    ├── cost: 34806942.6
+ │    │    │    ├── prune: (9-11)
+ │    │    │    ├── interesting orderings: (+11,+10,-9)
+ │    │    │    └── select
+ │    │    │         ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
+ │    │    │         ├── stats: [rows=30005985, distinct(9)=3000, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=100, null(11)=0, distinct(15)=1, null(15)=9003667]
+ │    │    │         ├── cost: 34506882.8
+ │    │    │         ├── fd: ()-->(15)
+ │    │    │         ├── prune: (9-11)
+ │    │    │         ├── interesting orderings: (+11,+10,-9)
+ │    │    │         ├── scan order_line
+ │    │    │         │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
+ │    │    │         │    ├── stats: [rows=30005985, distinct(9)=3000, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=100, null(11)=0, distinct(15)=1, null(15)=9003667]
+ │    │    │         │    ├── cost: 34206822.9
+ │    │    │         │    ├── prune: (9-11,15)
+ │    │    │         │    └── interesting orderings: (+11,+10,-9)
+ │    │    │         └── filters
+ │    │    │              └── is [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight), fd=()-->(15)]
+ │    │    │                   ├── variable: ol_delivery_d [type=timestamp]
+ │    │    │                   └── null [type=unknown]
+ │    │    ├── project
+ │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
+ │    │    │    ├── stats: [rows=240000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0]
+ │    │    │    ├── cost: 3272400.03
+ │    │    │    ├── key: (1-3)
+ │    │    │    ├── prune: (1-3)
+ │    │    │    ├── interesting orderings: (+3,+2,-1)
+ │    │    │    └── select
+ │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
+ │    │    │         ├── stats: [rows=240000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=1, null(6)=240000]
+ │    │    │         ├── cost: 3270000.02
+ │    │    │         ├── key: (1-3)
+ │    │    │         ├── fd: ()-->(6)
+ │    │    │         ├── prune: (1-3)
+ │    │    │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
+ │    │    │         ├── scan "order"@order_idx
+ │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
+ │    │    │         │    ├── stats: [rows=3000000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=10, null(6)=900000]
+ │    │    │         │    ├── cost: 3240000.01
+ │    │    │         │    ├── key: (1-3)
+ │    │    │         │    ├── fd: (1-3)-->(6)
+ │    │    │         │    ├── prune: (1-3,6)
+ │    │    │         │    └── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
+ │    │    │         └── filters
+ │    │    │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
+ │    │    │                   ├── variable: o_carrier_id [type=int]
+ │    │    │                   └── null [type=unknown]
+ │    │    └── filters
+ │    │         ├── eq [type=bool, outer=(3,11), constraints=(/3: (/NULL - ]; /11: (/NULL - ]), fd=(3)==(11), (11)==(3)]
+ │    │         │    ├── variable: ol_w_id [type=int]
+ │    │         │    └── variable: o_w_id [type=int]
+ │    │         ├── eq [type=bool, outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
+ │    │         │    ├── variable: ol_d_id [type=int]
+ │    │         │    └── variable: o_d_id [type=int]
+ │    │         └── eq [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │    │              ├── variable: ol_o_id [type=int]
+ │    │              └── variable: o_id [type=int]
+ │    └── filters
+ │         └── or [type=bool, outer=(1,9)]
+ │              ├── is [type=bool]
+ │              │    ├── variable: ol_o_id [type=int]
+ │              │    └── null [type=unknown]
+ │              └── is [type=bool]
+ │                   ├── variable: o_id [type=int]
+ │                   └── null [type=unknown]
+ └── aggregations
+      └── count-rows [type=int]
+
+# Regression test for #35947. Re-run the test with stats from a cluster with 10
+# warehouses where the workload has been running for several weeks.
+
+exec-ddl
+ALTER TABLE warehouse INJECT STATISTICS '[
+  {
+    "columns": ["w_street_1"],
+    "created_at": "2019-03-19 17:58:55.09398+00:00",
+    "distinct_count": 5,
+    "null_count": 0,
+    "row_count": 10
+  },
+  {
+    "columns": ["w_name"],
+    "created_at": "2019-03-19 17:58:55.09398+00:00",
+    "distinct_count": 5,
+    "null_count": 0,
+    "row_count": 10
+  },
+  {
+    "columns": ["w_id"],
+    "created_at": "2019-03-19 17:58:55.09398+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 10
+  },
+  {
+    "columns": ["w_street_2"],
+    "created_at": "2019-03-19 17:58:55.09398+00:00",
+    "distinct_count": 6,
+    "null_count": 0,
+    "row_count": 10
+  },
+  {
+    "columns": ["w_city"],
+    "created_at": "2019-03-19 17:58:55.09398+00:00",
+    "distinct_count": 6,
+    "null_count": 0,
+    "row_count": 10
+  },
+  {
+    "columns": ["w_state"],
+    "created_at": "2019-03-19 17:58:55.09398+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 10
+  },
+  {
+    "columns": ["w_zip"],
+    "created_at": "2019-03-19 17:58:55.09398+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 10
+  },
+  {
+    "columns": ["w_tax"],
+    "created_at": "2019-03-19 17:58:55.09398+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 10
+  },
+  {
+    "columns": ["w_ytd"],
+    "created_at": "2019-03-19 17:58:55.09398+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 10
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE district INJECT STATISTICS '[
+  {
+    "columns": ["d_street_1"],
+    "created_at": "2019-03-19 17:58:17.665378+00:00",
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 100
+  },
+  {
+    "columns": ["d_id"],
+    "created_at": "2019-03-19 17:58:17.665378+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 100
+  },
+  {
+    "columns": ["d_name"],
+    "created_at": "2019-03-19 17:58:17.665378+00:00",
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 100
+  },
+  {
+    "columns": ["d_w_id"],
+    "created_at": "2019-03-19 17:58:17.665378+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 100
+  },
+  {
+    "columns": ["d_street_2"],
+    "created_at": "2019-03-19 17:58:17.665378+00:00",
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 100
+  },
+  {
+    "columns": ["d_city"],
+    "created_at": "2019-03-19 17:58:17.665378+00:00",
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 100
+  },
+  {
+    "columns": ["d_state"],
+    "created_at": "2019-03-19 17:58:17.665378+00:00",
+    "distinct_count": 95,
+    "null_count": 0,
+    "row_count": 100
+  },
+  {
+    "columns": ["d_zip"],
+    "created_at": "2019-03-19 17:58:17.665378+00:00",
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 100
+  },
+  {
+    "columns": ["d_tax"],
+    "created_at": "2019-03-19 17:58:17.665378+00:00",
+    "distinct_count": 97,
+    "null_count": 0,
+    "row_count": 100
+  },
+  {
+    "columns": ["d_ytd"],
+    "created_at": "2019-03-19 17:58:17.665378+00:00",
+    "distinct_count": 100,
+    "null_count": 0,
+    "row_count": 100
+  },
+  {
+    "columns": ["d_next_o_id"],
+    "created_at": "2019-03-19 17:58:17.665378+00:00",
+    "distinct_count": 99,
+    "null_count": 0,
+    "row_count": 100
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE customer INJECT STATISTICS '[
+  {
+    "columns": ["c_city"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 298858,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_id"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 3000,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_d_id"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_first"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 300249,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_middle"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_last"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 1000,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_street_1"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 297424,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_street_2"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 300347,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_w_id"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_state"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 676,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_zip"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 10018,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_phone"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 299040,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_since"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_credit"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 2,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_credit_lim"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 1,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_discount"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 5000,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_balance"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 299825,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_ytd_payment"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 296467,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_payment_cnt"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 1452,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_delivery_cnt"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 1456,
+    "null_count": 0,
+    "row_count": 300000
+  },
+  {
+    "columns": ["c_data"],
+    "created_at": "2019-03-19 17:58:48.698906+00:00",
+    "distinct_count": 298234,
+    "null_count": 0,
+    "row_count": 300000
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE history INJECT STATISTICS '[
+  {
+    "columns": ["rowid"],
+    "created_at": "2019-03-19 18:21:11.200688+00:00",
+    "distinct_count": 40498941,
+    "null_count": 0,
+    "row_count": 40286242},
+  {
+    "columns": ["h_w_id"],
+    "created_at": "2019-03-19 18:21:11.200688+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 40286242},
+  {
+    "columns": ["h_c_w_id"],
+    "created_at": "2019-03-19 18:21:11.200688+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 40286242},
+  {
+    "columns": ["h_c_id"],
+    "created_at": "2019-03-19 18:21:11.200688+00:00",
+    "distinct_count": 3000,
+    "null_count": 0,
+    "row_count": 40286242},
+  {
+    "columns": ["h_c_d_id"],
+    "created_at": "2019-03-19 18:21:11.200688+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 40286242},
+  {
+    "columns": ["h_d_id"],
+    "created_at": "2019-03-19 18:21:11.200688+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 40286242},
+  {
+    "columns": ["h_date"],
+    "created_at": "2019-03-19 18:21:11.200688+00:00",
+    "distinct_count": 1707299,
+    "null_count": 0,
+    "row_count": 40286242},
+  {
+    "columns": ["h_amount"],
+    "created_at": "2019-03-19 18:21:11.200688+00:00",
+    "distinct_count": 489649,
+    "null_count": 0,
+    "row_count": 40286242},
+  {
+    "columns": ["h_data"],
+    "created_at": "2019-03-19 18:21:11.200688+00:00",
+    "distinct_count": 299903,
+    "null_count": 0,
+    "row_count": 40286242}
+]'
+----
+
+exec-ddl
+ALTER TABLE "order" INJECT STATISTICS '[
+  {
+    "columns": ["o_w_id"],
+    "created_at": "2019-03-19 17:58:12.008755+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 65604710
+  },
+  {
+    "columns": ["o_id"],
+    "created_at": "2019-03-19 17:58:12.008755+00:00",
+    "distinct_count": 659249,
+    "null_count": 0,
+    "row_count": 65604710
+  },
+  {
+    "columns": ["o_d_id"],
+    "created_at": "2019-03-19 17:58:12.008755+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 65604710
+  },
+  {
+    "columns": ["o_c_id"],
+    "created_at": "2019-03-19 17:58:12.008755+00:00",
+    "distinct_count": 3000,
+    "null_count": 0,
+    "row_count": 65604710
+  },
+  {
+    "columns": ["o_entry_d"],
+    "created_at": "2019-03-19 17:58:12.008755+00:00",
+    "distinct_count": 2845896,
+    "null_count": 0,
+    "row_count": 65604710
+  },
+  {
+    "columns": ["o_carrier_id"],
+    "created_at": "2019-03-19 17:58:12.008755+00:00",
+    "distinct_count": 10,
+    "null_count": 11322,
+    "row_count": 65604710
+  },
+  {
+    "columns": ["o_ol_cnt"],
+    "created_at": "2019-03-19 17:58:12.008755+00:00",
+    "distinct_count": 11,
+    "null_count": 0,
+    "row_count": 65604710
+  },
+  {
+    "columns": ["o_all_local"],
+    "created_at": "2019-03-19 17:58:12.008755+00:00",
+    "distinct_count": 2,
+    "null_count": 0,
+    "row_count": 65604710
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE new_order INJECT STATISTICS '[
+  {
+    "columns": ["no_w_id"],
+    "created_at": "2019-03-19 18:12:13.614374+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 11322},
+  {
+    "columns": ["no_o_id"],
+    "created_at": "2019-03-19 18:12:13.614374+00:00",
+    "distinct_count": 3473,
+    "null_count": 0,
+    "row_count": 11322},
+  {
+    "columns": ["no_d_id"],
+    "created_at": "2019-03-19 18:12:13.614374+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 11322}
+]'
+----
+
+exec-ddl
+ALTER TABLE item INJECT STATISTICS '[
+  {
+    "columns": ["i_id"],
+    "created_at": "2019-03-19 17:58:54.856266+00:00",
+    "distinct_count": 101273,
+    "null_count": 0,
+    "row_count": 100000
+  },
+  {
+    "columns": ["i_im_id"],
+    "created_at": "2019-03-19 17:58:54.856266+00:00",
+    "distinct_count": 10034,
+    "null_count": 0,
+    "row_count": 100000
+  },
+  {
+    "columns": ["i_name"],
+    "created_at": "2019-03-19 17:58:54.856266+00:00",
+    "distinct_count": 99350,
+    "null_count": 0,
+    "row_count": 100000
+  },
+  {
+    "columns": ["i_price"],
+    "created_at": "2019-03-19 17:58:54.856266+00:00",
+    "distinct_count": 9857,
+    "null_count": 0,
+    "row_count": 100000
+  },
+  {
+    "columns": ["i_data"],
+    "created_at": "2019-03-19 17:58:54.856266+00:00",
+    "distinct_count": 100852,
+    "null_count": 0,
+    "row_count": 100000
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE stock INJECT STATISTICS '[
+  {
+    "columns": ["s_dist_02"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 986857,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_i_id"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 101273,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_quantity"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 91,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_dist_01"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 989838,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_w_id"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_dist_03"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 1008181,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_dist_04"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 1012198,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_dist_05"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 986878,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_dist_06"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 996501,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_dist_07"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 1002457,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_dist_08"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 1007497,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_dist_09"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 995973,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_dist_10"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 1002525,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_ytd"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 29896,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_order_cnt"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 7810,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_remote_cnt"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 189,
+    "null_count": 0,
+    "row_count": 1000000
+  },
+  {
+    "columns": ["s_data"],
+    "created_at": "2019-03-19 14:58:34.961378+00:00",
+    "distinct_count": 1012256,
+    "null_count": 0,
+    "row_count": 1000000
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE order_line INJECT STATISTICS '[
+  {
+    "columns": ["ol_supply_w_id"],
+    "created_at": "2019-03-19 07:20:59.138579+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 646903924
+  },
+  {
+    "columns": ["ol_w_id"],
+    "created_at": "2019-03-19 07:20:59.138579+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 646903924
+  },
+  {
+    "columns": ["ol_o_id"],
+    "created_at": "2019-03-19 07:20:59.138579+00:00",
+    "distinct_count": 651111,
+    "null_count": 0,
+    "row_count": 646903924
+  },
+  {
+    "columns": ["ol_d_id"],
+    "created_at": "2019-03-19 07:20:59.138579+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 646903924
+  },
+  {
+    "columns": ["ol_number"],
+    "created_at": "2019-03-19 07:20:59.138579+00:00",
+    "distinct_count": 15,
+    "null_count": 0,
+    "row_count": 646903924
+  },
+  {
+    "columns": ["ol_i_id"],
+    "created_at": "2019-03-19 07:20:59.138579+00:00",
+    "distinct_count": 101273,
+    "null_count": 0,
+    "row_count": 646903924
+  },
+  {
+    "columns": ["ol_delivery_d"],
+    "created_at": "2019-03-19 07:20:59.138579+00:00",
+    "distinct_count": 2351500,
+    "null_count": 106092,
+    "row_count": 646903924
+  },
+  {
+    "columns": ["ol_quantity"],
+    "created_at": "2019-03-19 07:20:59.138579+00:00",
+    "distinct_count": 10,
+    "null_count": 0,
+    "row_count": 646903924
+  },
+  {
+    "columns": ["ol_amount"],
+    "created_at": "2019-03-19 07:20:59.138579+00:00",
+    "distinct_count": 609193,
+    "null_count": 0,
+    "row_count": 646903924
+  },
+  {
+    "columns": ["ol_dist_info"],
+    "created_at": "2019-03-19 07:20:59.138579+00:00",
+    "distinct_count": 13030568,
+    "null_count": 0,
+    "row_count": 646903924
+  }
+]'
+----
+
+# --------------------------------------------------
+# 2.4 The New Order Transaction
+#
+# The New-Order business transaction consists of entering a complete order
+# through a single database transaction. It represents a mid-weight, read-write
+# transaction with a high frequency of execution and stringent response time
+# requirements to satisfy on-line users. This transaction is the backbone of
+# the workload. It is designed to place a variable load on the system to
+# reflect on-line database activity as typically found in production
+# environments.
+# --------------------------------------------------
+opt format=hide-qual
+SELECT w_tax FROM warehouse WHERE w_id = 10
+----
+project
+ ├── columns: w_tax:8(decimal)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 1.14
+ ├── key: ()
+ ├── fd: ()-->(8)
+ ├── prune: (8)
+ └── scan warehouse
+      ├── columns: w_id:1(int!null) w_tax:8(decimal)
+      ├── constraint: /1: [/10 - /10]
+      ├── cardinality: [0 - 1]
+      ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+      ├── cost: 1.12
+      ├── key: ()
+      ├── fd: ()-->(1,8)
+      ├── prune: (1,8)
+      └── interesting orderings: (+1)
+
+opt format=hide-qual
+SELECT c_discount, c_last, c_credit
+FROM customer
+WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
+----
+project
+ ├── columns: c_discount:16(decimal) c_last:6(string) c_credit:14(string)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 1.3
+ ├── key: ()
+ ├── fd: ()-->(6,14,16)
+ ├── prune: (6,14,16)
+ └── scan customer
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_last:6(string) c_credit:14(string) c_discount:16(decimal)
+      ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
+      ├── cardinality: [0 - 1]
+      ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
+      ├── cost: 1.28
+      ├── key: ()
+      ├── fd: ()-->(1-3,6,14,16)
+      ├── prune: (1-3,6,14,16)
+      └── interesting orderings: (+3,+2,+1) (+3,+2,+6)
+
+opt format=hide-qual
+SELECT i_price, i_name, i_data
+FROM item
+WHERE i_id IN (125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300)
+ORDER BY i_id
+----
+scan item
+ ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)  [hidden: i_id:1(int!null)]
+ ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
+ ├── stats: [rows=11.8491602, distinct(1)=11.8491602, null(1)=0]
+ ├── cost: 12.9255846
+ ├── key: (1)
+ ├── fd: (1)-->(3-5)
+ ├── ordering: +1
+ ├── prune: (3-5)
+ └── interesting orderings: (+1)
+
+opt format=hide-qual
+SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_05
+FROM stock
+WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
+ORDER BY s_i_id
+----
+project
+ ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)  [hidden: s_i_id:1(int!null)]
+ ├── stats: [rows=4.93715008]
+ ├── cost: 6.2408091
+ ├── key: (1)
+ ├── fd: (1)-->(3,8,14-17)
+ ├── ordering: +1
+ ├── prune: (1,3,8,14-17)
+ ├── interesting orderings: (+1)
+ └── scan stock
+      ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(string) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string)
+      ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
+      ├── stats: [rows=4.93715008, distinct(1)=4.93715008, null(1)=0, distinct(2)=1, null(2)=0]
+      ├── cost: 6.1814376
+      ├── key: (1)
+      ├── fd: ()-->(2), (1)-->(3,8,14-17)
+      ├── ordering: +1 opt(2) [actual: +1]
+      ├── prune: (1-3,8,14-17)
+      └── interesting orderings: (+2,+1) (+1,+2)
+
+# --------------------------------------------------
+# 2.5 The Payment Transaction
+#
+# The Payment business transaction updates the customer's balance and reflects
+# the payment on the district and warehouse sales statistics. It represents a
+# light-weight, read-write transaction with a high frequency of execution and
+# stringent response time requirements to satisfy on-line users. In addition,
+# this transaction includes non-primary key access to the CUSTOMER table.
+# --------------------------------------------------
+opt format=hide-qual
+SELECT c_id
+FROM customer
+WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
+ORDER BY c_first ASC
+----
+project
+ ├── columns: c_id:1(int!null)  [hidden: c_first:4(string)]
+ ├── stats: [rows=3]
+ ├── cost: 3.35
+ ├── key: (1)
+ ├── fd: (1)-->(4)
+ ├── ordering: +4
+ ├── prune: (1,4)
+ └── scan customer@customer_idx
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
+      ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
+      ├── stats: [rows=3, distinct(1)=2.99851548, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0]
+      ├── cost: 3.31
+      ├── key: (1)
+      ├── fd: ()-->(2,3,6), (1)-->(4)
+      ├── ordering: +4 opt(2,3,6) [actual: +4]
+      ├── prune: (1-4,6)
+      └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
+
+# --------------------------------------------------
+# 2.6 The Order Status Transaction
+#
+# The Order-Status business transaction queries the status of a customer's last
+# order. It represents a mid-weight read-only database transaction with a low
+# frequency of execution and response time requirement to satisfy on-line
+# users. In addition, this table includes non-primary key access to the
+# CUSTOMER table.
+# --------------------------------------------------
+opt format=hide-qual
+SELECT c_balance, c_first, c_middle, c_last
+FROM customer
+WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
+----
+project
+ ├── columns: c_balance:17(decimal) c_first:4(string) c_middle:5(string) c_last:6(string)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 1.31
+ ├── key: ()
+ ├── fd: ()-->(4-6,17)
+ ├── prune: (4-6,17)
+ └── scan customer
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_middle:5(string) c_last:6(string) c_balance:17(decimal)
+      ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
+      ├── cardinality: [0 - 1]
+      ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
+      ├── cost: 1.29
+      ├── key: ()
+      ├── fd: ()-->(1-6,17)
+      ├── prune: (1-6,17)
+      └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
+
+opt format=hide-qual
+SELECT c_id, c_balance, c_first, c_middle
+FROM customer
+WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
+ORDER BY c_first ASC
+----
+project
+ ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(string) c_middle:5(string)
+ ├── stats: [rows=3]
+ ├── cost: 16.23
+ ├── key: (1)
+ ├── fd: (1)-->(4,5,17)
+ ├── ordering: +4
+ ├── prune: (1,4,5,17)
+ └── index-join customer
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_middle:5(string) c_last:6(string!null) c_balance:17(decimal)
+      ├── stats: [rows=3, distinct(1)=2.99851548, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0]
+      ├── cost: 16.19
+      ├── key: (1)
+      ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
+      ├── ordering: +4 opt(2,3,6) [actual: +4]
+      ├── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
+      └── scan customer@customer_idx
+           ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
+           ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
+           ├── stats: [rows=3, distinct(1)=2.99851548, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0]
+           ├── cost: 3.31
+           ├── key: (1)
+           ├── fd: ()-->(2,3,6), (1)-->(4)
+           ├── ordering: +4 opt(2,3,6) [actual: +4]
+           ├── prune: (1-4,6)
+           └── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
+
+opt format=hide-qual
+SELECT o_id, o_entry_d, o_carrier_id
+FROM "order"
+WHERE o_w_id = 10 AND o_d_id = 100 AND o_c_id = 50
+ORDER BY o_id DESC
+LIMIT 1
+----
+project
+ ├── columns: o_id:1(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 5.27
+ ├── key: ()
+ ├── fd: ()-->(1,5,6)
+ ├── prune: (1,5,6)
+ └── index-join order
+      ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null) o_entry_d:5(timestamp) o_carrier_id:6(int)
+      ├── cardinality: [0 - 1]
+      ├── stats: [rows=1]
+      ├── cost: 5.25
+      ├── key: ()
+      ├── fd: ()-->(1-6)
+      ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
+      └── scan "order"@secondary,rev
+           ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
+           ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
+           ├── limit: 1(rev)
+           ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0]
+           ├── cost: 1.09
+           ├── key: ()
+           ├── fd: ()-->(1-4)
+           ├── prune: (1-4)
+           └── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
+
+opt format=hide-qual
+SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
+FROM order_line
+WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
+----
+project
+ ├── columns: ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_quantity:8(int) ol_amount:9(decimal) ol_delivery_d:7(timestamp)
+ ├── stats: [rows=9.93538619]
+ ├── cost: 11.8431096
+ ├── prune: (5-9)
+ ├── interesting orderings: (+6)
+ └── scan order_line
+      ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_delivery_d:7(timestamp) ol_quantity:8(int) ol_amount:9(decimal)
+      ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
+      ├── stats: [rows=9.93538619, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=9.93489892, null(5)=0]
+      ├── cost: 11.7337557
+      ├── fd: ()-->(1-3)
+      ├── prune: (1-3,5-9)
+      └── interesting orderings: (+3,+2,-1) (+6,+2,+3,+1)
+
+# --------------------------------------------------
+# 2.7 The Delivery Transaction
+#
+# The Delivery business transaction consists of processing a batch of 10 new
+# (not yet delivered) orders. Each order is processed (delivered) in full
+# within the scope of a read-write database transaction. The number of orders
+# delivered as a group (or batched) within the same database transaction is
+# implementation specific. The business transaction, comprised of one or more
+# (up to 10) database transactions, has a low frequency of execution and must
+# complete within a relaxed response time requirement.
+#
+# The Delivery transaction is intended to be executed in deferred mode through
+# a queuing mechanism, rather than interactively, with terminal response
+# indicating transaction completion. The result of the deferred execution is
+# recorded into a result file.
+# --------------------------------------------------
+opt format=hide-qual
+SELECT no_o_id
+FROM new_order
+WHERE no_w_id = 10 AND no_d_id = 100
+ORDER BY no_o_id ASC
+LIMIT 1
+----
+project
+ ├── columns: no_o_id:1(int!null)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 1.09
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── prune: (1)
+ └── scan new_order,rev
+      ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
+      ├── constraint: /3/2/-1: [/10/100 - /10/100]
+      ├── limit: 1(rev)
+      ├── stats: [rows=1]
+      ├── cost: 1.07
+      ├── key: ()
+      ├── fd: ()-->(1-3)
+      ├── prune: (1-3)
+      └── interesting orderings: (+3,+2,-1)
+
+opt format=hide-qual
+SELECT sum(ol_amount)
+FROM order_line
+WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
+----
+scalar-group-by
+ ├── columns: sum:11(decimal)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 11.4556941
+ ├── key: ()
+ ├── fd: ()-->(11)
+ ├── prune: (11)
+ ├── scan order_line
+ │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_amount:9(decimal)
+ │    ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
+ │    ├── stats: [rows=9.93538619, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
+ │    ├── cost: 11.3363403
+ │    ├── fd: ()-->(1-3)
+ │    ├── prune: (1-3,9)
+ │    └── interesting orderings: (+3,+2,-1)
+ └── aggregations
+      └── sum [type=decimal, outer=(9)]
+           └── variable: ol_amount [type=decimal]
+
+# --------------------------------------------------
+# 2.8 The Stock-Level Transaction
+#
+# The Stock-Level business transaction determines the number of recently sold
+# items that have a stock level below a specified threshold. It represents a
+# heavy read-only database transaction with a low frequency of execution, a
+# relaxed response time requirement, and relaxed consistency requirements.
+# --------------------------------------------------
+opt format=hide-qual
+SELECT d_next_o_id
+FROM district
+WHERE d_w_id = 10 AND d_id = 100
+----
+project
+ ├── columns: d_next_o_id:11(int)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 1.17
+ ├── key: ()
+ ├── fd: ()-->(11)
+ ├── prune: (11)
+ └── scan district
+      ├── columns: d_id:1(int!null) d_w_id:2(int!null) d_next_o_id:11(int)
+      ├── constraint: /2/1: [/10/100 - /10/100]
+      ├── cardinality: [0 - 1]
+      ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0]
+      ├── cost: 1.15
+      ├── key: ()
+      ├── fd: ()-->(1,2,11)
+      ├── prune: (1,2,11)
+      └── interesting orderings: (+2,+1)
+
+opt format=hide-qual
+SELECT count(DISTINCT s_i_id)
+FROM order_line
+JOIN stock
+ON s_i_id=ol_i_id AND s_w_id=ol_w_id
+WHERE ol_w_id = 10
+    AND ol_d_id = 100
+    AND ol_o_id BETWEEN 1000 - 20 AND 1000 - 1
+    AND s_quantity < 15
+----
+scalar-group-by
+ ├── columns: count:28(int)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 1534.07466
+ ├── key: ()
+ ├── fd: ()-->(28)
+ ├── prune: (28)
+ ├── inner-join (lookup stock)
+ │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) s_i_id:11(int!null) s_w_id:12(int!null) s_quantity:13(int!null)
+ │    ├── key columns: [3 5] = [12 11]
+ │    ├── stats: [rows=229.899982, distinct(1)=19.9997964, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=198.51294, null(5)=0, distinct(11)=198.51294, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=83.7250115, null(13)=0]
+ │    ├── cost: 1531.75566
+ │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
+ │    ├── interesting orderings: (+3,+2,-1)
+ │    ├── scan order_line
+ │    │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null)
+ │    │    ├── constraint: /3/2/-1/4: [/10/100/999 - /10/100/980]
+ │    │    ├── stats: [rows=198.707724, distinct(1)=20, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(5)=198.51294, null(5)=0]
+ │    │    ├── cost: 226.536805
+ │    │    ├── fd: ()-->(2,3)
+ │    │    ├── prune: (5)
+ │    │    └── interesting orderings: (+3,+2,-1)
+ │    └── filters
+ │         ├── eq [type=bool, outer=(12), constraints=(/12: [/10 - /10]; tight), fd=()-->(12)]
+ │         │    ├── variable: s_w_id [type=int]
+ │         │    └── const: 10 [type=int]
+ │         └── lt [type=bool, outer=(13), constraints=(/13: (/NULL - /14]; tight)]
+ │              ├── variable: s_quantity [type=int]
+ │              └── const: 15 [type=int]
+ └── aggregations
+      └── count [type=int, outer=(11)]
+           └── agg-distinct [type=int]
+                └── variable: s_i_id [type=int]
+
+# --------------------------------------------------
+# Consistency Queries
+#
+# These queries run after TPCC in order to check database consistency.
+# They are not part of the benchmark itself.
+# --------------------------------------------------
+opt format=hide-qual
+SELECT count(*)
+FROM warehouse
+FULL OUTER JOIN
+(
+    SELECT d_w_id, sum(d_ytd) as sum_d_ytd
+    FROM district
+    GROUP BY d_w_id
+)
+ON (w_id = d_w_id)
+WHERE w_ytd != sum_d_ytd
+----
+scalar-group-by
+ ├── columns: count:22(int)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 126.526667
+ ├── key: ()
+ ├── fd: ()-->(22)
+ ├── prune: (22)
+ ├── inner-join (merge)
+ │    ├── columns: w_id:1(int!null) w_ytd:9(decimal!null) d_w_id:11(int!null) sum:21(decimal!null)
+ │    ├── left ordering: +1
+ │    ├── right ordering: +11
+ │    ├── stats: [rows=3.33333333, distinct(1)=3.33333333, null(1)=0, distinct(9)=2.87528606, null(9)=0, distinct(11)=3.33333333, null(11)=0, distinct(21)=2.87528606, null(21)=0]
+ │    ├── cost: 126.473333
+ │    ├── key: (11)
+ │    ├── fd: (1)-->(9), (11)-->(21), (1)==(11), (11)==(1)
+ │    ├── scan warehouse
+ │    │    ├── columns: w_id:1(int!null) w_ytd:9(decimal)
+ │    │    ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(9)=10, null(9)=0]
  │    │    ├── cost: 11.11
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(9)
@@ -1030,7 +3166,7 @@ group-by
  ├── columns: max:4(int)  [hidden: no_d_id:2(int!null) no_w_id:3(int!null)]
  ├── grouping columns: no_d_id:2(int!null) no_w_id:3(int!null)
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
- ├── cost: 98101.02
+ ├── cost: 12342
  ├── key: (2,3)
  ├── fd: (2,3)-->(4)
  ├── ordering: +3,+2
@@ -1038,8 +3174,8 @@ group-by
  ├── interesting orderings: (+3,+2)
  ├── scan new_order
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
- │    ├── stats: [rows=90000, distinct(2,3)=100, null(2,3)=0]
- │    ├── cost: 95400.01
+ │    ├── stats: [rows=11322, distinct(2,3)=100, null(2,3)=0]
+ │    ├── cost: 12001.33
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
@@ -1058,7 +3194,7 @@ group-by
  ├── columns: max:9(int)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
- ├── cost: 330001.02
+ ├── cost: 72165182
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1066,8 +3202,8 @@ group-by
  ├── interesting orderings: (+3,+2)
  ├── scan "order"@order_idx
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
- │    ├── stats: [rows=300000, distinct(2,3)=100, null(2,3)=0]
- │    ├── cost: 321000.01
+ │    ├── stats: [rows=65604710, distinct(2,3)=100, null(2,3)=0]
+ │    ├── cost: 70197039.7
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
@@ -1090,14 +3226,14 @@ scalar-group-by
  ├── columns: count:8(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 99902.3833
+ ├── cost: 12569.8033
  ├── key: ()
  ├── fd: ()-->(8)
  ├── prune: (8)
  ├── select
  │    ├── columns: no_d_id:2(int!null) no_w_id:3(int!null) max:4(int) min:5(int) count_rows:6(int)
- │    ├── stats: [rows=33.3333333, distinct(2)=33.3333333, null(2)=0, distinct(3)=9.8265847, null(3)=0]
- │    ├── cost: 99902.03
+ │    ├── stats: [rows=33.3333333, distinct(2)=9.8265847, null(2)=0, distinct(3)=9.8265847, null(3)=0]
+ │    ├── cost: 12569.45
  │    ├── key: (2,3)
  │    ├── fd: (2,3)-->(4-6)
  │    ├── interesting orderings: (+3,+2)
@@ -1105,16 +3241,16 @@ scalar-group-by
  │    │    ├── columns: no_d_id:2(int!null) no_w_id:3(int!null) max:4(int) min:5(int) count_rows:6(int)
  │    │    ├── grouping columns: no_d_id:2(int!null) no_w_id:3(int!null)
  │    │    ├── internal-ordering: +3,+2
- │    │    ├── stats: [rows=100, distinct(2)=9000, null(2)=0, distinct(3)=10, null(3)=0, distinct(2,3)=100, null(2,3)=0]
- │    │    ├── cost: 99901.02
+ │    │    ├── stats: [rows=100, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(2,3)=100, null(2,3)=0]
+ │    │    ├── cost: 12568.44
  │    │    ├── key: (2,3)
  │    │    ├── fd: (2,3)-->(4-6)
  │    │    ├── prune: (4-6)
  │    │    ├── interesting orderings: (+3,+2)
  │    │    ├── scan new_order
  │    │    │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
- │    │    │    ├── stats: [rows=90000, distinct(2)=9000, null(2)=0, distinct(3)=10, null(3)=0, distinct(2,3)=100, null(2,3)=0]
- │    │    │    ├── cost: 95400.01
+ │    │    │    ├── stats: [rows=11322, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(2,3)=100, null(2,3)=0]
+ │    │    │    ├── cost: 12001.33
  │    │    │    ├── key: (1-3)
  │    │    │    ├── ordering: +3,+2
  │    │    │    ├── prune: (1-3)
@@ -1146,7 +3282,7 @@ group-by
  ├── columns: sum:9(decimal)  [hidden: o_d_id:2(int!null) o_w_id:3(int!null)]
  ├── grouping columns: o_d_id:2(int!null) o_w_id:3(int!null)
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
- ├── cost: 342001.02
+ ├── cost: 74789370.4
  ├── key: (2,3)
  ├── fd: (2,3)-->(9)
  ├── ordering: +3,+2
@@ -1154,8 +3290,8 @@ group-by
  ├── interesting orderings: (+3,+2)
  ├── scan "order"
  │    ├── columns: o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
- │    ├── stats: [rows=300000, distinct(2,3)=100, null(2,3)=0]
- │    ├── cost: 333000.01
+ │    ├── stats: [rows=65604710, distinct(2,3)=100, null(2,3)=0]
+ │    ├── cost: 72821228.1
  │    ├── ordering: +3,+2
  │    ├── prune: (2,3,7)
  │    └── interesting orderings: (+3,+2)
@@ -1172,7 +3308,7 @@ ORDER BY ol_w_id, ol_d_id
 sort
  ├── columns: count:11(int)  [hidden: ol_d_id:2(int!null) ol_w_id:3(int!null)]
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
- ├── cost: 1110017.08
+ ├── cost: 718063373
  ├── key: (2,3)
  ├── fd: (2,3)-->(11)
  ├── ordering: +3,+2
@@ -1181,14 +3317,14 @@ sort
       ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
       ├── grouping columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
       ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
-      ├── cost: 1110001.02
+      ├── cost: 718063357
       ├── key: (2,3)
       ├── fd: (2,3)-->(11)
       ├── prune: (11)
       ├── scan order_line@order_line_fk
       │    ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
-      │    ├── stats: [rows=1000000, distinct(2,3)=100, null(2,3)=0]
-      │    ├── cost: 1070000.01
+      │    ├── stats: [rows=646903924, distinct(2,3)=100, null(2,3)=0]
+      │    ├── cost: 692187199
       │    ├── prune: (2,3)
       │    └── interesting orderings: (+3,+2)
       └── aggregations
@@ -1203,34 +3339,34 @@ except-all
  ├── columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
  ├── left columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
  ├── right columns: o_w_id:6(int) o_d_id:5(int) o_id:4(int)
- ├── stats: [rows=90000]
- ├── cost: 424200.248
+ ├── stats: [rows=11322]
+ ├── cost: 71652571.1
  ├── scan new_order
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
- │    ├── stats: [rows=90000]
- │    ├── cost: 95400.01
+ │    ├── stats: [rows=11322]
+ │    ├── cost: 12001.33
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+3,+2,-1)
  └── project
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
-      ├── stats: [rows=9.90033333]
-      ├── cost: 327000.129
+      ├── stats: [rows=6560471]
+      ├── cost: 71574738.6
       ├── key: (4-6)
       ├── prune: (4-6)
       ├── interesting orderings: (+6,+5,-4)
       └── select
            ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
-           ├── stats: [rows=9.90033333, distinct(4)=9.90033333, null(4)=0, distinct(5)=9.90033333, null(5)=0, distinct(6)=6.3212669, null(6)=0, distinct(9)=1, null(9)=9.90033333]
-           ├── cost: 327000.02
+           ├── stats: [rows=6560471, distinct(4)=659230.57, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=10, null(6)=0, distinct(9)=1, null(9)=11322]
+           ├── cost: 71509133.9
            ├── key: (4-6)
            ├── fd: ()-->(9)
            ├── prune: (4-6)
            ├── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
            ├── scan "order"@order_idx
            │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
-           │    ├── stats: [rows=300000, distinct(4)=30000, null(4)=0, distinct(5)=30000, null(5)=0, distinct(6)=10, null(6)=0, distinct(9)=30000, null(9)=3000]
-           │    ├── cost: 324000.01
+           │    ├── stats: [rows=65604710, distinct(4)=659249, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=10, null(6)=0, distinct(9)=10, null(9)=11322]
+           │    ├── cost: 70853086.8
            │    ├── key: (4-6)
            │    ├── fd: (4-6)-->(9)
            │    ├── prune: (4-6,9)
@@ -1249,27 +3385,27 @@ except-all
  ├── columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── right columns: no_w_id:11(int) no_d_id:10(int) no_o_id:9(int)
- ├── stats: [rows=9.90033333]
- ├── cost: 423300.347
+ ├── stats: [rows=6560471]
+ ├── cost: 71718062.6
  ├── project
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
- │    ├── stats: [rows=9.90033333]
- │    ├── cost: 327000.129
+ │    ├── stats: [rows=6560471]
+ │    ├── cost: 71574738.6
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    └── select
  │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
- │         ├── stats: [rows=9.90033333, distinct(1)=9.90033333, null(1)=0, distinct(2)=9.90033333, null(2)=0, distinct(3)=6.3212669, null(3)=0, distinct(6)=1, null(6)=9.90033333]
- │         ├── cost: 327000.02
+ │         ├── stats: [rows=6560471, distinct(1)=659230.57, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=11322]
+ │         ├── cost: 71509133.9
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
  │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
  │         ├── scan "order"@order_idx
  │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
- │         │    ├── stats: [rows=300000, distinct(1)=30000, null(1)=0, distinct(2)=30000, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=30000, null(6)=3000]
- │         │    ├── cost: 324000.01
+ │         │    ├── stats: [rows=65604710, distinct(1)=659249, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=10, null(6)=11322]
+ │         │    ├── cost: 70853086.8
  │         │    ├── key: (1-3)
  │         │    ├── fd: (1-3)-->(6)
  │         │    ├── prune: (1-3,6)
@@ -1280,8 +3416,8 @@ except-all
  │                   └── null [type=unknown]
  └── scan new_order
       ├── columns: no_o_id:9(int!null) no_d_id:10(int!null) no_w_id:11(int!null)
-      ├── stats: [rows=90000]
-      ├── cost: 95400.01
+      ├── stats: [rows=11322]
+      ├── cost: 12001.33
       ├── key: (9-11)
       ├── prune: (9-11)
       └── interesting orderings: (+11,+10,-9)
@@ -1304,12 +3440,12 @@ except-all
  ├── columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null) o_ol_cnt:7(int)
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null) o_ol_cnt:7(int)
  ├── right columns: ol_w_id:11(int) ol_d_id:10(int) ol_o_id:9(int) count_rows:19(int)
- ├── stats: [rows=300000]
- ├── cost: 1474000.04
+ ├── stats: [rows=65604710]
+ ├── cost: 807093026
  ├── scan "order"
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
- │    ├── stats: [rows=300000]
- │    ├── cost: 336000.01
+ │    ├── stats: [rows=65604710]
+ │    ├── cost: 73477275.2
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(7)
  │    ├── prune: (1-3,7)
@@ -1317,16 +3453,16 @@ except-all
  └── group-by
       ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) count_rows:19(int)
       ├── grouping columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
-      ├── stats: [rows=100000, distinct(9-11)=100000, null(9-11)=0]
-      ├── cost: 1131000.02
+      ├── stats: [rows=65111100, distinct(9-11)=65111100, null(9-11)=0]
+      ├── cost: 731652545
       ├── key: (9-11)
       ├── fd: (9-11)-->(19)
       ├── prune: (19)
       ├── interesting orderings: (+11,+10,-9)
       ├── scan order_line@order_line_fk
       │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
-      │    ├── stats: [rows=1000000, distinct(9-11)=100000, null(9-11)=0]
-      │    ├── cost: 1080000.01
+      │    ├── stats: [rows=646903924, distinct(9-11)=65111100, null(9-11)=0]
+      │    ├── cost: 698656238
       │    ├── prune: (9-11)
       │    └── interesting orderings: (+11,+10,-9)
       └── aggregations
@@ -1350,29 +3486,29 @@ except-all
  ├── columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count:11(int)
  ├── left columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count_rows:11(int)
  ├── right columns: o_w_id:14(int) o_d_id:13(int) o_id:12(int) o_ol_cnt:18(int)
- ├── stats: [rows=100000]
- ├── cost: 1472000.04
+ ├── stats: [rows=65111100]
+ ├── cost: 807088089
  ├── group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
  │    ├── grouping columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
- │    ├── stats: [rows=100000, distinct(1-3)=100000, null(1-3)=0]
- │    ├── cost: 1131000.02
+ │    ├── stats: [rows=65111100, distinct(1-3)=65111100, null(1-3)=0]
+ │    ├── cost: 731652545
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(11)
  │    ├── prune: (11)
  │    ├── interesting orderings: (+3,+2,-1)
  │    ├── scan order_line@order_line_fk
  │    │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
- │    │    ├── stats: [rows=1000000, distinct(1-3)=100000, null(1-3)=0]
- │    │    ├── cost: 1080000.01
+ │    │    ├── stats: [rows=646903924, distinct(1-3)=65111100, null(1-3)=0]
+ │    │    ├── cost: 698656238
  │    │    ├── prune: (1-3)
  │    │    └── interesting orderings: (+3,+2,-1)
  │    └── aggregations
  │         └── count-rows [type=int]
  └── scan "order"
       ├── columns: o_id:12(int!null) o_d_id:13(int!null) o_w_id:14(int!null) o_ol_cnt:18(int)
-      ├── stats: [rows=300000]
-      ├── cost: 336000.01
+      ├── stats: [rows=65604710]
+      ├── cost: 73477275.2
       ├── key: (12-14)
       ├── fd: (12-14)-->(18)
       ├── prune: (12-14,18)
@@ -1399,40 +3535,40 @@ scalar-group-by
  ├── columns: count:19(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 1477001.05
+ ├── cost: 815749348
  ├── key: ()
  ├── fd: ()-->(19)
  ├── prune: (19)
  ├── select
  │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
- │    ├── stats: [rows=6.54741364]
- │    ├── cost: 1477000.97
+ │    ├── stats: [rows=2186906.23]
+ │    ├── cost: 815727479
  │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
  │    ├── full-join
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
- │    │    ├── stats: [rows=19.6422409]
- │    │    ├── cost: 1477000.76
+ │    │    ├── stats: [rows=6560718.68]
+ │    │    ├── cost: 815661872
  │    │    ├── reject-nulls: (1-3,9-11)
  │    │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
  │    │    ├── project
  │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
- │    │    │    ├── stats: [rows=9.90033333, distinct(1)=9.90033333, null(1)=0, distinct(2)=9.90033333, null(2)=0, distinct(3)=6.3212669, null(3)=0]
- │    │    │    ├── cost: 327000.129
+ │    │    │    ├── stats: [rows=6560471, distinct(1)=659230.57, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
+ │    │    │    ├── cost: 71574738.6
  │    │    │    ├── key: (1-3)
  │    │    │    ├── prune: (1-3)
  │    │    │    ├── interesting orderings: (+3,+2,-1)
  │    │    │    └── select
  │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
- │    │    │         ├── stats: [rows=9.90033333, distinct(1)=9.90033333, null(1)=0, distinct(2)=9.90033333, null(2)=0, distinct(3)=6.3212669, null(3)=0, distinct(6)=1, null(6)=9.90033333]
- │    │    │         ├── cost: 327000.02
+ │    │    │         ├── stats: [rows=6560471, distinct(1)=659230.57, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=11322]
+ │    │    │         ├── cost: 71509133.9
  │    │    │         ├── key: (1-3)
  │    │    │         ├── fd: ()-->(6)
  │    │    │         ├── prune: (1-3)
  │    │    │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
  │    │    │         ├── scan "order"@order_idx
  │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
- │    │    │         │    ├── stats: [rows=300000, distinct(1)=30000, null(1)=0, distinct(2)=30000, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=30000, null(6)=3000]
- │    │    │         │    ├── cost: 324000.01
+ │    │    │         │    ├── stats: [rows=65604710, distinct(1)=659249, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=10, null(6)=11322]
+ │    │    │         │    ├── cost: 70853086.8
  │    │    │         │    ├── key: (1-3)
  │    │    │         │    ├── fd: (1-3)-->(6)
  │    │    │         │    ├── prune: (1-3,6)
@@ -1443,21 +3579,21 @@ scalar-group-by
  │    │    │                   └── null [type=unknown]
  │    │    ├── project
  │    │    │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
- │    │    │    ├── stats: [rows=9.9001, distinct(9)=9.9001, null(9)=0, distinct(10)=9.9001, null(10)=0, distinct(11)=6.32122398, null(11)=0]
- │    │    │    ├── cost: 1150000.13
+ │    │    │    ├── stats: [rows=275.057668, distinct(9)=275.044618, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0]
+ │    │    │    ├── cost: 743939515
  │    │    │    ├── prune: (9-11)
  │    │    │    ├── interesting orderings: (+11,+10,-9)
  │    │    │    └── select
  │    │    │         ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
- │    │    │         ├── stats: [rows=9.9001, distinct(9)=9.9001, null(9)=0, distinct(10)=9.9001, null(10)=0, distinct(11)=6.32122398, null(11)=0, distinct(15)=1, null(15)=9.9001]
- │    │    │         ├── cost: 1150000.02
+ │    │    │         ├── stats: [rows=275.057668, distinct(9)=275.044618, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0, distinct(15)=1, null(15)=275.057668]
+ │    │    │         ├── cost: 743939513
  │    │    │         ├── fd: ()-->(15)
  │    │    │         ├── prune: (9-11)
  │    │    │         ├── interesting orderings: (+11,+10,-9)
  │    │    │         ├── scan order_line
  │    │    │         │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
- │    │    │         │    ├── stats: [rows=1000000, distinct(9)=100000, null(9)=0, distinct(10)=100000, null(10)=0, distinct(11)=10, null(11)=0, distinct(15)=100000, null(15)=10000]
- │    │    │         │    ├── cost: 1140000.01
+ │    │    │         │    ├── stats: [rows=646903924, distinct(9)=651111, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0, distinct(15)=2351500, null(15)=106092]
+ │    │    │         │    ├── cost: 737470473
  │    │    │         │    ├── prune: (9-11,15)
  │    │    │         │    └── interesting orderings: (+11,+10,-9)
  │    │    │         └── filters

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -709,22 +709,22 @@ scalar-group-by
  ├── columns: count:28(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 0.178877778
+ ├── cost: 0.28998
  ├── key: ()
  ├── fd: ()-->(28)
  ├── prune: (28)
  ├── inner-join (lookup stock)
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) s_i_id:11(int!null) s_w_id:12(int!null) s_quantity:13(int!null)
  │    ├── key columns: [3 5] = [12 11]
- │    ├── stats: [rows=0.0366666667, distinct(1)=0.0111105556, null(1)=0, distinct(2)=0.0111111111, null(2)=0, distinct(3)=0.0111111111, null(3)=0, distinct(5)=0.0111105556, null(5)=0, distinct(11)=0.0111105556, null(11)=0, distinct(12)=0.0111111111, null(12)=0, distinct(13)=0.0366666667, null(13)=0]
- │    ├── cost: 0.158511111
+ │    ├── stats: [rows=0.066, distinct(1)=0.02, null(1)=0, distinct(2)=0.02, null(2)=0, distinct(3)=0.02, null(3)=0, distinct(5)=0.0199982001, null(5)=0, distinct(11)=0.0199982001, null(11)=0, distinct(12)=0.02, null(12)=0, distinct(13)=0.066, null(13)=0]
+ │    ├── cost: 0.26932
  │    ├── fd: ()-->(2,3,12), (11)-->(13), (5)==(11), (11)==(5), (3)==(12), (12)==(3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    ├── scan order_line
  │    │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null)
  │    │    ├── constraint: /3/2/-1/4: [/10/100/999 - /10/100/980]
- │    │    ├── stats: [rows=0.0111111111, distinct(1)=0.0111105556, null(1)=0, distinct(2)=0.0111111111, null(2)=0, distinct(3)=0.0111111111, null(3)=0, distinct(5)=0.0111105556, null(5)=0]
- │    │    ├── cost: 0.0226666667
+ │    │    ├── stats: [rows=0.02, distinct(1)=0.02, null(1)=0, distinct(2)=0.02, null(2)=0, distinct(3)=0.02, null(3)=0, distinct(5)=0.0199982001, null(5)=0]
+ │    │    ├── cost: 0.0328
  │    │    ├── fd: ()-->(2,3)
  │    │    ├── prune: (5)
  │    │    └── interesting orderings: (+3,+2,-1)

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -1078,8 +1078,7 @@ scalar-group-by
  │    │    │         ├── key: (1,4)
  │    │    │         └── fd: (1,4)-->(11)
  │    │    └── filters
- │    │         ├── l_discount >= 0.05 [type=bool, outer=(7), constraints=(/7: [/0.05 - ]; tight)]
- │    │         ├── l_discount <= 0.07 [type=bool, outer=(7), constraints=(/7: (/NULL - /0.07]; tight)]
+ │    │         ├── (l_discount >= 0.05) AND (l_discount <= 0.07) [type=bool, outer=(7), constraints=(/7: [/0.05 - /0.07]; tight)]
  │    │         └── l_quantity < 24.0 [type=bool, outer=(5), constraints=(/5: (/NULL - /23.999999999999996]; tight)]
  │    └── projections
  │         └── l_extendedprice * l_discount [type=float, outer=(6,7)]
@@ -1615,8 +1614,7 @@ limit
  │         │    │    │    │    │         └── l_returnflag = 'R' [type=bool, outer=(26), constraints=(/26: [/'R' - /'R']; tight), fd=()-->(26)]
  │         │    │    │    │    └── filters (true)
  │         │    │    │    └── filters
- │         │    │    │         ├── o_orderdate >= '1993-10-01' [type=bool, outer=(13), constraints=(/13: [/'1993-10-01' - ]; tight)]
- │         │    │    │         └── o_orderdate < '1994-01-01' [type=bool, outer=(13), constraints=(/13: (/NULL - /'1993-12-31']; tight)]
+ │         │    │    │         └── (o_orderdate >= '1993-10-01') AND (o_orderdate < '1994-01-01') [type=bool, outer=(13), constraints=(/13: [/'1993-10-01' - /'1993-12-31']; tight)]
  │         │    │    └── filters
  │         │    │         └── c_nationkey = n_nationkey [type=bool, outer=(4,34), constraints=(/4: (/NULL - ]; /34: (/NULL - ]), fd=(4)==(34), (34)==(4)]
  │         │    └── projections

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -915,8 +915,7 @@ scalar-group-by
  │    │    │         ├── key: (1,4)
  │    │    │         └── fd: (1,4)-->(11)
  │    │    └── filters
- │    │         ├── l_discount >= 0.05 [type=bool, outer=(7), constraints=(/7: [/0.05 - ]; tight)]
- │    │         ├── l_discount <= 0.07 [type=bool, outer=(7), constraints=(/7: (/NULL - /0.07]; tight)]
+ │    │         ├── (l_discount >= 0.05) AND (l_discount <= 0.07) [type=bool, outer=(7), constraints=(/7: [/0.05 - /0.07]; tight)]
  │    │         └── l_quantity < 24.0 [type=bool, outer=(5), constraints=(/5: (/NULL - /23.999999999999996]; tight)]
  │    └── projections
  │         └── l_extendedprice * l_discount [type=float, outer=(6,7)]

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -260,8 +260,7 @@ explain
       │         │         ├── key: (1)
       │         │         └── fd: (1)-->(2)
       │         └── filters
-      │              ├── a >= 20 [type=bool, outer=(1), constraints=(/1: [/20 - ]; tight)]
-      │              └── a <= 30 [type=bool, outer=(1), constraints=(/1: (/NULL - /30]; tight)]
+      │              └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
       └── const: 5 [type=int]
 
 optsteps
@@ -340,8 +339,45 @@ SimplifySelectFilters
   +           │              └── a <= 30 [type=bool, outer=(1), constraints=(/1: (/NULL - /30]; tight)]
               └── const: 5 [type=int]
 ================================================================================
+ConsolidateSelectFilters
+  Cost: 10000000000000000159028911097599180468360808563945281389781327557747838772170381060813469985856815104.00
+================================================================================
+   explain
+    ├── columns: tree:5(string) field:6(string) description:7(string)
+    └── sort
+         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+         ├── cardinality: [0 - 5]
+         ├── key: (1)
+         ├── fd: (1)-->(2-4), (2-4)~~>(1)
+         ├── ordering: -2
+         └── limit
+              ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+              ├── internal-ordering: -2
+              ├── cardinality: [0 - 5]
+              ├── key: (1)
+              ├── fd: (1)-->(2-4), (2-4)~~>(1)
+              ├── sort
+              │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+              │    ├── key: (1)
+              │    ├── fd: (1)-->(2-4), (2-4)~~>(1)
+              │    ├── ordering: -2
+              │    └── select
+              │         ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+              │         ├── key: (1)
+              │         ├── fd: (1)-->(2-4), (2-4)~~>(1)
+              │         ├── scan abcd
+              │         │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
+              │         │    ├── flags: force-index=b
+              │         │    ├── key: (1)
+              │         │    └── fd: (1)-->(2-4), (2-4)~~>(1)
+              │         └── filters
+  -           │              ├── a >= 20 [type=bool, outer=(1), constraints=(/1: [/20 - ]; tight)]
+  -           │              └── a <= 30 [type=bool, outer=(1), constraints=(/1: (/NULL - /30]; tight)]
+  +           │              └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
+              └── const: 5 [type=int]
+================================================================================
 GenerateIndexScans
-  Cost: 5157.43
+  Cost: 5141.09
 ================================================================================
    explain
     ├── columns: tree:5(string) field:6(string) description:7(string)
@@ -374,8 +410,7 @@ GenerateIndexScans
   -           │         │    ├── key: (1)
   -           │         │    └── fd: (1)-->(2-4), (2-4)~~>(1)
   -           │         └── filters
-  -           │              ├── a >= 20 [type=bool, outer=(1), constraints=(/1: [/20 - ]; tight)]
-  -           │              └── a <= 30 [type=bool, outer=(1), constraints=(/1: (/NULL - /30]; tight)]
+  -           │              └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
   -           └── const: 5 [type=int]
   +      ├── sort
   +      │    ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
@@ -396,8 +431,7 @@ GenerateIndexScans
   +      │         │         ├── key: (1)
   +      │         │         └── fd: (1)-->(2)
   +      │         └── filters
-  +      │              ├── a >= 20 [type=bool, outer=(1), constraints=(/1: [/20 - ]; tight)]
-  +      │              └── a <= 30 [type=bool, outer=(1), constraints=(/1: (/NULL - /30]; tight)]
+  +      │              └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
   +      └── const: 5 [type=int]
 --------------------------------------------------------------------------------
 GenerateZigzagJoins (no changes)
@@ -407,7 +441,7 @@ GenerateConstrainedScans (no changes)
 --------------------------------------------------------------------------------
 ================================================================================
 Final best expression
-  Cost: 5157.43
+  Cost: 5141.09
 ================================================================================
   explain
    ├── columns: tree:5(string) field:6(string) description:7(string)
@@ -437,6 +471,5 @@ Final best expression
         │         │         ├── key: (1)
         │         │         └── fd: (1)-->(2)
         │         └── filters
-        │              ├── a >= 20 [type=bool, outer=(1), constraints=(/1: [/20 - ]; tight)]
-        │              └── a <= 30 [type=bool, outer=(1), constraints=(/1: (/NULL - /30]; tight)]
+        │              └── (a >= 20) AND (a <= 30) [type=bool, outer=(1), constraints=(/1: [/20 - /30]; tight)]
         └── const: 5 [type=int]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -333,16 +333,18 @@ memo (optimized, ~3KB, required=[presentation: k:1,u:2,v:3,j:4])
  │    └── []
  │         ├── best: (scan b)
  │         └── cost: 1080.01
- ├── G3: (filters G5 G6)
+ ├── G3: (filters G5)
  ├── G4: (scan b@v,cols=(1,3),constrained)
  │    └── []
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.41
- ├── G5: (ge G7 G8)
- ├── G6: (le G7 G9)
- ├── G7: (variable v)
- ├── G8: (const 1)
- └── G9: (const 10)
+ ├── G5: (range G6)
+ ├── G6: (and G7 G8)
+ ├── G7: (ge G9 G10)
+ ├── G8: (le G9 G11)
+ ├── G9: (variable v)
+ ├── G10: (const 1)
+ └── G11: (const 10)
 
 # Don't choose lookup join if it's not beneficial.
 opt
@@ -390,29 +392,31 @@ memo (optimized, ~5KB, required=[presentation: k:1,u:2,v:3,j:4])
  │    └── []
  │         ├── best: (scan b)
  │         └── cost: 1080.01
- ├── G3: (filters G7 G8 G9)
+ ├── G3: (filters G7 G8)
  ├── G4: (scan b,constrained)
  │    └── []
  │         ├── best: (scan b,constrained)
  │         └── cost: 360.01
- ├── G5: (filters G7 G8)
- ├── G6: (select G10 G11)
+ ├── G5: (filters G7)
+ ├── G6: (select G9 G10)
  │    └── []
- │         ├── best: (select G10 G11)
+ │         ├── best: (select G9 G10)
  │         └── cost: 10.52
- ├── G7: (ge G12 G13)
- ├── G8: (le G12 G14)
- ├── G9: (gt G15 G16)
- ├── G10: (scan b@v,cols=(1,3),constrained)
+ ├── G7: (range G11)
+ ├── G8: (gt G12 G13)
+ ├── G9: (scan b@v,cols=(1,3),constrained)
  │    └── []
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.41
- ├── G11: (filters G9)
- ├── G12: (variable v)
- ├── G13: (const 1)
- ├── G14: (const 10)
- ├── G15: (variable k)
- └── G16: (const 5)
+ ├── G10: (filters G8)
+ ├── G11: (and G14 G15)
+ ├── G12: (variable k)
+ ├── G13: (const 5)
+ ├── G14: (ge G16 G17)
+ ├── G15: (le G16 G18)
+ ├── G16: (variable v)
+ ├── G17: (const 1)
+ └── G18: (const 10)
 
 # Ensure the rule doesn't match at all when the first column of the index is
 # not in the filter (i.e. the @v index is not matched by ConstrainScans).
@@ -482,25 +486,27 @@ memo (optimized, ~4KB, required=[presentation: k:1,u:2,v:3,j:4])
  │    └── []
  │         ├── best: (scan b)
  │         └── cost: 1080.01
- ├── G3: (filters G6 G7 G8)
- ├── G4: (index-join G9 b,cols=(1-4))
+ ├── G3: (filters G6 G7)
+ ├── G4: (index-join G8 b,cols=(1-4))
  │    └── []
- │         ├── best: (index-join G9 b,cols=(1-4))
+ │         ├── best: (index-join G8 b,cols=(1-4))
  │         └── cost: 51.32
- ├── G5: (filters G8)
- ├── G6: (ge G10 G11)
- ├── G7: (le G10 G12)
- ├── G8: (eq G13 G11)
- ├── G9: (scan b@v,cols=(1,3),constrained)
+ ├── G5: (filters G7)
+ ├── G6: (range G9)
+ ├── G7: (eq G10 G11)
+ ├── G8: (scan b@v,cols=(1,3),constrained)
  │    └── []
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.41
- ├── G10: (variable v)
+ ├── G9: (and G12 G13)
+ ├── G10: (plus G14 G15)
  ├── G11: (const 1)
- ├── G12: (const 10)
- ├── G13: (plus G14 G15)
+ ├── G12: (ge G16 G11)
+ ├── G13: (le G16 G17)
  ├── G14: (variable k)
- └── G15: (variable u)
+ ├── G15: (variable u)
+ ├── G16: (variable v)
+ └── G17: (const 10)
 
 opt
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
@@ -539,37 +545,39 @@ memo (optimized, ~7KB, required=[presentation: k:1,u:2,v:3,j:4])
  │    └── []
  │         ├── best: (scan b)
  │         └── cost: 1080.01
- ├── G3: (filters G8 G9 G10 G11)
+ ├── G3: (filters G8 G9 G10)
  ├── G4: (scan b,constrained)
  │    └── []
  │         ├── best: (scan b,constrained)
  │         └── cost: 360.01
- ├── G5: (filters G8 G9 G10)
- ├── G6: (index-join G12 b,cols=(1-4))
+ ├── G5: (filters G8 G9)
+ ├── G6: (index-join G11 b,cols=(1-4))
  │    └── []
- │         ├── best: (index-join G12 b,cols=(1-4))
+ │         ├── best: (index-join G11 b,cols=(1-4))
  │         └── cost: 24.16
- ├── G7: (filters G10)
- ├── G8: (ge G13 G14)
- ├── G9: (le G13 G15)
- ├── G10: (eq G16 G14)
- ├── G11: (gt G17 G18)
- ├── G12: (select G19 G20)
+ ├── G7: (filters G9)
+ ├── G8: (range G12)
+ ├── G9: (eq G13 G14)
+ ├── G10: (gt G15 G16)
+ ├── G11: (select G17 G18)
  │    └── []
- │         ├── best: (select G19 G20)
+ │         ├── best: (select G17 G18)
  │         └── cost: 10.52
- ├── G13: (variable v)
+ ├── G12: (and G19 G20)
+ ├── G13: (plus G15 G21)
  ├── G14: (const 1)
- ├── G15: (const 10)
- ├── G16: (plus G17 G21)
- ├── G17: (variable k)
- ├── G18: (const 5)
- ├── G19: (scan b@v,cols=(1,3),constrained)
+ ├── G15: (variable k)
+ ├── G16: (const 5)
+ ├── G17: (scan b@v,cols=(1,3),constrained)
  │    └── []
  │         ├── best: (scan b@v,cols=(1,3),constrained)
  │         └── cost: 10.41
- ├── G20: (filters G11)
- └── G21: (variable u)
+ ├── G18: (filters G10)
+ ├── G19: (ge G22 G14)
+ ├── G20: (le G22 G23)
+ ├── G21: (variable u)
+ ├── G22: (variable v)
+ └── G23: (const 10)
 
 # Constraint + index-join.
 opt


### PR DESCRIPTION
This commit adds a new scalar operator called `Range`. `Range` contains a single
input, which is an `And` expression that constrains a single variable to a
range. For example, the `And` expression might be `x >= 6 AND x <= 10`.

This commit also adds a new normalization rule called `ConsolidateSelectFilters`,
which consolidates filters that constrain a single variable, and puts them
into a `Range` operation. For example, filters `x >= 6` and `x <= 10` would be
consolidated into a single `Range` operation.

The benefit of consolidating these filters is it allows a single constraint
to be generated for the variable instead of multiple. In the example above,
we can generate the single constraint `[/6 - /10]` instead of the two
constraints `[/6 - ]` and `[ - /10]`. The single constraint allows us to better
estimate the selectivity of the predicate when calculating statistics for
a `Select` expression.

For example, suppose that `x` initially has 1000000 distinct values. Once
we apply the predicate `x >= 6 AND x <= 10`, it has at most 5 distinct values.
Assuming a uniform data distribution, the selectivity of this predicate is
`5/1000000`, or `0.000005`. Prior to this commit, we were significantly
overestimating the selectivity as `1/9`, or `0.111111`.

Fixes #35947

Release note (performance improvement): Improved the selectivity estimation
of range predicates during query optimization.