### PR TITLE
server: remove testing traces of an old env var

### DIFF
--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -494,7 +494,6 @@ func (l *DockerCluster) startNode(ctx context.Context, node *testNode) {
 		"--log-dir="+dockerLogDir)
 	env := []string{
 		"COCKROACH_SCAN_MAX_IDLE_TIME=200ms",
-		"COCKROACH_CONSISTENCY_CHECK_PANIC_ON_FAILURE=true",
 		"COCKROACH_SKIP_UPDATE_CHECK=1",
 		"COCKROACH_CRASH_REPORTS=",
 	}

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -105,9 +105,6 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		if err := os.Unsetenv("COCKROACH_CONSISTENCY_CHECK_INTERVAL"); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.Unsetenv("COCKROACH_CONSISTENCY_CHECK_PANIC_ON_FAILURE"); err != nil {
-			t.Fatal(err)
-		}
 		envutil.ClearEnvCache()
 	}
 	defer resetEnvVar()


### PR DESCRIPTION
The env var was removed years ago.

Release note: None