### PR TITLE
backport-19.1: opt: fix zigzag joins with IS condition

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -1449,6 +1449,37 @@ lookup-join       ·          ·
 ·                 table      zigzag@c_idx
 ·                 fixedvals  1 column
 
+
+# Regression test for part of #34695.
+statement ok
+CREATE TABLE zigzag2 (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  UNIQUE INDEX a_b_idx(a, b),
+  INDEX c_idx(c)
+)
+
+# Check a value which is equated to NULL.
+
+query TTT
+EXPLAIN SELECT * FROM zigzag2 WHERE a = 1 AND b = 2 AND c IS NULL
+----
+render                 ·          ·
+ └── lookup-join       ·          ·
+      │                table      zigzag2@primary
+      │                type       inner
+      └── zigzag-join  ·          ·
+           │           type       inner
+           │           pred       ((@1 = 1) AND (@2 = 2)) AND (@4 IS NULL)
+           ├── scan    ·          ·
+           │           table      zigzag2@a_b_idx
+           │           fixedvals  2 columns
+           └── scan    ·          ·
+·                      table      zigzag2@c_idx
+·                      fixedvals  1 column
+
 # Test that we can force a merge join.
 query TTT
 EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn USING(x)

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -298,10 +298,10 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			// FixedVals is always going to be a ScalarListExpr, containing tuples,
 			// containing one ScalarListExpr, containing ConstExprs.
 			for i := range t.LeftFixedCols {
-				leftVals[i] = t.FixedVals[0].Child(0).Child(i).(*ConstExpr).Value
+				leftVals[i] = ExtractConstDatum(t.FixedVals[0].Child(0).Child(i))
 			}
 			for i := range t.RightFixedCols {
-				rightVals[i] = t.FixedVals[1].Child(0).Child(i).(*ConstExpr).Value
+				rightVals[i] = ExtractConstDatum(t.FixedVals[1].Child(0).Child(i))
 			}
 			tp.Childf("left fixed columns: %v = %v", t.LeftFixedCols, leftVals)
 			tp.Childf("right fixed columns: %v = %v", t.RightFixedCols, rightVals)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1422,6 +1422,19 @@ inner-join (zigzag pqr@q pqr@r)
       ├── q = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
       └── r = 2 [type=bool, outer=(3), constraints=(/3: [/2 - /2]; tight), fd=()-->(3)]
 
+opt
+SELECT q,r FROM pqr WHERE q = 1 AND r IS NULL
+----
+inner-join (zigzag pqr@q pqr@r)
+ ├── columns: q:2(int!null) r:3(int)
+ ├── eq columns: [1] = [1]
+ ├── left fixed columns: [2] = [1]
+ ├── right fixed columns: [3] = [NULL]
+ ├── fd: ()-->(2,3)
+ └── filters
+      ├── q = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      └── r IS NULL [type=bool, outer=(3), constraints=(/3: [/NULL - /NULL]; tight), fd=()-->(3)]
+
 memo
 SELECT q,r FROM pqr WHERE q = 1 AND r = 2
 ----

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -414,7 +414,7 @@ func TestLint(t *testing.T) {
 			"git",
 			"grep",
 			"-nE",
-			`[^[:alnum:]]panic\(("|[a-z]+Error\{errors\.(New|Errorf)|fmt\.Errorf)`,
+			fmt.Sprintf(`[^[:alnum:]]panic\((%s|"|[a-z]+Error\{errors\.(New|Errorf)|fmt\.Errorf)`, "`"),
 			"--",
 			"sql/opt",
 			":!sql/opt/optgen",


### PR DESCRIPTION
Backport 1/1 commits from #35989.

/cc @cockroachdb/release

---

This commit fixes a problem where the constraint logic could infer that
a column was constant, but our method of determining what that constant
value was was incomplete and so we ended up with incomplete information.
We now correctly infer the value for IS expressions, and also skip over
cases where this happens again so we degrade more gracefully (don't run
a zigzag join, as opposed to panicking).

A more correct fix here would extract the values directly from the
constraints, but I'd like to get this fixed on master to unblock #34695.

Release note: None
