### PR TITLE
workload: print time taken to import fixture

### DIFF
--- a/pkg/util/humanizeutil/humanize.go
+++ b/pkg/util/humanizeutil/humanize.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"sync/atomic"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/pflag"
@@ -112,4 +113,15 @@ func (b *BytesValue) String() string {
 // IsSet returns true iff Set has successfully been called.
 func (b *BytesValue) IsSet() bool {
 	return b.isSet
+}
+
+// DataRate formats the passed byte count over duration as "x MiB/s".
+func DataRate(bytes int64, elapsed time.Duration) string {
+	if bytes == 0 {
+		return "0"
+	}
+	if elapsed == 0 {
+		return "inf"
+	}
+	return fmt.Sprintf("%0.2f MiB/s", (float64(bytes)/elapsed.Seconds())/float64(1<<20))
 }


### PR DESCRIPTION
Release note: none.