### PR TITLE
importccl: parallelize CSV-skipping workload IMPORT

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -635,11 +635,7 @@ func backup(
 		allSpans = append(allSpans, spanAndTime{span: s, start: backupDesc.StartTime, end: backupDesc.EndTime})
 	}
 
-	progressLogger := jobs.ProgressLogger{
-		Job:           job,
-		TotalChunks:   len(spans),
-		StartFraction: job.FractionCompleted(),
-	}
+	progressLogger := jobs.NewChunkProgressLogger(job, len(spans), job.FractionCompleted(), jobs.ProgressUpdateOnly)
 
 	// We're already limiting these on the server-side, but sending all the
 	// Export requests at once would fill up distsender/grpc/something and cause

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -586,6 +586,7 @@ func checkInProgressBackupRestore(
 
 func TestBackupRestoreSystemJobsProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer jobs.TestingSetProgressThresholds()()
 
 	checkFraction := func(ctx context.Context, ip inProgressState) error {
 		jobID, err := ip.latestJobID()
@@ -846,7 +847,7 @@ func TestBackupRestoreControlJob(t *testing.T) {
 	t.Skip("#24637")
 
 	// force every call to update
-	jobs.TestingSetProgressThreshold(-1.0)
+	defer jobs.TestingSetProgressThresholds()()
 
 	defer func(oldInterval time.Duration) {
 		jobs.DefaultAdoptInterval = oldInterval

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -1099,11 +1099,8 @@ func restore(
 	}
 	mu.requestsCompleted = make([]bool, len(importSpans))
 
-	progressLogger := jobs.ProgressLogger{
-		Job:           job,
-		TotalChunks:   len(importSpans),
-		StartFraction: job.FractionCompleted(),
-		ProgressedFn: func(progressedCtx context.Context, details jobspb.ProgressDetails) {
+	progressLogger := jobs.NewChunkProgressLogger(job, len(importSpans), job.FractionCompleted(),
+		func(progressedCtx context.Context, details jobspb.ProgressDetails) {
 			switch d := details.(type) {
 			case *jobspb.Progress_Restore:
 				mu.Lock()
@@ -1114,8 +1111,7 @@ func restore(
 			default:
 				log.Errorf(progressedCtx, "job payload had unexpected type %T", d)
 			}
-		},
-	}
+		})
 
 	// We're already limiting these on the server-side, but sending all the
 	// Import requests at once would fill up distsender/grpc/something and cause

--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -444,7 +444,7 @@ func (cp *readImportDataProcessor) doRun(ctx context.Context) error {
 			}
 		}
 		if isWorkload {
-			conv, err = newWorkloadReader(kvCh, singleTable, evalCtx)
+			conv = newWorkloadReader(kvCh, singleTable, cp.flowCtx.NewEvalCtx)
 		} else {
 			conv = newCSVInputReader(kvCh, cp.spec.Format.Csv, singleTable, cp.flowCtx)
 		}

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -248,6 +248,10 @@ func (j *Job) FractionProgressed(ctx context.Context, progressedFn FractionProgr
 				return false, &InvalidStatusError{*j.id, *status, "update progress on", payload.Error}
 			}
 			fractionCompleted := progressedFn(ctx, progress.Details)
+			// allow for slight floating-point rounding inaccuracies
+			if fractionCompleted > 1.0 && fractionCompleted < 1.01 {
+				fractionCompleted = 1.0
+			}
 			if fractionCompleted < 0.0 || fractionCompleted > 1.0 {
 				return false, errors.Errorf(
 					"Job: fractionCompleted %f is outside allowable range [0.0, 1.0] (job %d)",

--- a/pkg/jobs/progress.go
+++ b/pkg/jobs/progress.go
@@ -24,59 +24,78 @@ import (
 // last logged fractionCompleted and the current fractionCompleted is more than
 // progressFractionThreshold.
 var (
-	progressTimeThreshold             = 30 * time.Second
+	progressTimeThreshold             = 15 * time.Second
 	progressFractionThreshold float32 = 0.05
 )
 
-// TestingSetProgressThreshold overrides the progressFractionThreshold.
-func TestingSetProgressThreshold(v float32) func() {
-	old := progressFractionThreshold
-	progressFractionThreshold = v
+// TestingSetProgressThresholds overrides batching limits to update more often.
+func TestingSetProgressThresholds() func() {
+	oldFraction := progressFractionThreshold
+	oldDuration := progressTimeThreshold
+
+	progressFractionThreshold = 0.0001
+	progressTimeThreshold = time.Microsecond
+
 	return func() {
-		progressFractionThreshold = old
+		progressFractionThreshold = oldFraction
+		progressTimeThreshold = oldDuration
 	}
 }
 
-// ProgressLogger is a helper for managing the progress state on a job.
-type ProgressLogger struct {
+// ChunkProgressLogger is a helper for managing the progress state on a job. For
+// a given job, it assumes there are some number of chunks of work to do and
+// tracks the completion progress as chunks are reported as done (via Loop).
+// It then updates the actual job periodically using a ProgressUpdateBatcher.
+type ChunkProgressLogger struct {
 	// These fields must be externally initialized.
-	Job           *Job
-	StartFraction float32
-	TotalChunks   int
-	ProgressedFn  func(context.Context, jobspb.ProgressDetails)
-
-	// The remaining fields are for internal use only.
+	expectedChunks       int
 	completedChunks      int
-	lastReportedAt       time.Time
-	lastReportedFraction float32
+	perChunkContribution float32
+
+	batcher ProgressUpdateBatcher
+}
+
+// ProgressUpdateOnly is for use with NewChunkProgressLogger to just update job
+// progress fraction (ie. when a custom func with side-effects is not needed).
+var ProgressUpdateOnly func(context.Context, jobspb.ProgressDetails)
+
+// NewChunkProgressLogger returns a ChunkProgressLogger.
+func NewChunkProgressLogger(
+	j *Job,
+	expectedChunks int,
+	startFraction float32,
+	progressedFn func(context.Context, jobspb.ProgressDetails),
+) *ChunkProgressLogger {
+	return &ChunkProgressLogger{
+		expectedChunks:       expectedChunks,
+		perChunkContribution: (1.0 - startFraction) * 1.0 / float32(expectedChunks),
+		batcher: ProgressUpdateBatcher{
+			completed: startFraction,
+			reported:  startFraction,
+			Report: func(ctx context.Context, pct float32) error {
+				return j.FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
+					if progressedFn != nil {
+						progressedFn(ctx, details)
+					}
+					return pct
+				})
+			},
+		},
+	}
 }
 
 // chunkFinished marks one chunk of the job as completed. If either the time or
 // fraction threshold has been reached, the progress update will be persisted to
 // system.jobs.
-func (jpl *ProgressLogger) chunkFinished(ctx context.Context) error {
+func (jpl *ChunkProgressLogger) chunkFinished(ctx context.Context) error {
 	jpl.completedChunks++
-	fraction := float32(jpl.completedChunks) / float32(jpl.TotalChunks)
-	fraction = fraction*(1-jpl.StartFraction) + jpl.StartFraction
-	shouldLogProgress := fraction-jpl.lastReportedFraction > progressFractionThreshold ||
-		jpl.lastReportedAt.Add(progressTimeThreshold).Before(timeutil.Now())
-	if !shouldLogProgress {
-		return nil
-	}
-	jpl.lastReportedAt = timeutil.Now()
-	jpl.lastReportedFraction = fraction
-	return jpl.Job.FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
-		if jpl.ProgressedFn != nil {
-			jpl.ProgressedFn(ctx, details)
-		}
-		return fraction
-	})
+	return jpl.batcher.Add(ctx, jpl.perChunkContribution)
 }
 
 // Loop calls chunkFinished for every message received over chunkCh. It exits
 // when chunkCh is closed, when totalChunks messages have been received, or when
 // the context is canceled.
-func (jpl *ProgressLogger) Loop(ctx context.Context, chunkCh <-chan struct{}) error {
+func (jpl *ChunkProgressLogger) Loop(ctx context.Context, chunkCh <-chan struct{}) error {
 	for {
 		select {
 		case _, ok := <-chunkCh:
@@ -86,11 +105,56 @@ func (jpl *ProgressLogger) Loop(ctx context.Context, chunkCh <-chan struct{}) er
 			if err := jpl.chunkFinished(ctx); err != nil {
 				return err
 			}
-			if jpl.completedChunks == jpl.TotalChunks {
-				return nil
+			if jpl.completedChunks == jpl.expectedChunks {
+				return jpl.batcher.Done(ctx)
 			}
 		case <-ctx.Done():
 			return ctx.Err()
 		}
 	}
+}
+
+// ProgressUpdateBatcher is a helper for tracking progress as it is made and
+// calling a progress update function when it has meaningfully advanced (e.g. by
+// more than 5%), while ensuring updates also are not done too often (by default
+// not less than 30s apart).
+type ProgressUpdateBatcher struct {
+	// Report is the function called to record progress
+	Report func(context.Context, float32) error
+
+	// completed is the fraction of a proc's work completed
+	completed float32
+	// reported is the most recently reported value of completed
+	reported float32
+	// lastReported is when we last called report
+	lastReported time.Time
+}
+
+// Add records some additional progress made and checks there has been enough
+// change in the completed progress (and enough time has passed) to report the
+// new progress amount.
+func (p *ProgressUpdateBatcher) Add(ctx context.Context, delta float32) error {
+	p.completed += delta
+
+	shouldReport := p.completed-p.reported > progressFractionThreshold
+	shouldReport = shouldReport && p.lastReported.Add(progressTimeThreshold).Before(timeutil.Now())
+
+	if shouldReport {
+		p.reported = p.completed
+		p.lastReported = timeutil.Now()
+	}
+
+	if shouldReport {
+		return p.Report(ctx, p.completed)
+	}
+	return nil
+}
+
+// Done allows the batcher to report any meaningful unreported progress, without
+// worrying about update frequency now that it is done.
+func (p *ProgressUpdateBatcher) Done(ctx context.Context) error {
+	if p.completed-p.reported > progressFractionThreshold {
+		return p.Report(ctx, p.completed)
+	}
+	return nil
 }

--- a/pkg/storage/batcheval/cmd_add_sstable.go
+++ b/pkg/storage/batcheval/cmd_add_sstable.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 )
@@ -65,6 +66,9 @@ func EvalAddSSTable(
 		return result.Result{}, errors.Wrap(err, "computing existing stats")
 	}
 	ms.Subtract(existingStats)
+	if existingStats.KeyCount > 0 {
+		log.Infof(ctx, "%s SST covers span containing %d existing keys: [%s, %s)", humanizeutil.IBytes(int64(len(args.Data))), existingStats.KeyCount, args.Key, args.EndKey)
+	}
 
 	// Verify that the keys in the sstable are within the range specified by the
 	// request header, verify the key-value checksums, and compute the new


### PR DESCRIPTION
(only last commit, first two commits are #36042)

This spins up multiple workers, each importing every i'th batch, to do
workload IMPORT.

As noted inline, this execution order, as opposed to assinging large
spans of batches to each worker, should mean that adjacent batches are
processed at roughly the same time and thus end up in the same
sort-batch for SST creation, preserving the non-overlapping SSTs when
the workload's batches are ordered and non-overlapping.

Release note: none.