### PR TITLE
heapprofiler: increase frequency of profile collection

### DIFF
--- a/pkg/server/heapprofiler/heapprofiler_test.go
+++ b/pkg/server/heapprofiler/heapprofiler_test.go
@@ -74,21 +74,25 @@ func testHelper(
 
 func TestPercentSystemMemoryHeuristic(t *testing.T) {
 	rssValues := []rssVal{
-		{0, 30}, {20, 40}, // random small values
-		{30, 88},            // should trigger
-		{80, 89},            // should not trigger as less than 60s before last profile
-		{130, 10}, {140, 4}, // random small values
+		{0, 30}, // random small values
+		{20, 40},
+		{30, 88},  // should trigger
+		{50, 94},  // should not trigger as less than 60s before last profile
+		{130, 10}, // random small values
+		{140, 4},
 		{150, 90}, // should trigger
-		{260, 92}, // should not trigger as continues above threshold
+		{210, 94}, // should not trigger as increase is below 5% threshold
 		{290, 30}, // random small value
 		{380, 99}, // should trigger
 		{390, 30}, // random small value
-		{430, 91}, // should not trigger as less than 60s before last profile
+		{400, 91}, // should not trigger as less than 30s before last profile
 		{500, 95}, // should trigger
+		{560, 95}, // should not trigger as increase is below 5% threshold
+		{620, 92}, // should trigger as last profile was 2min ago
 	}
-	expectedScores := []int64{88, 90, 99, 95}
+	expectedScores := []int64{88, 90, 99, 95, 92}
 	prefix := "memprof.fraction_system_memory."
-	expectedPrefixes := []string{prefix, prefix, prefix, prefix}
+	expectedPrefixes := []string{prefix, prefix, prefix, prefix, prefix}
 	hp := &HeapProfiler{
 		stats:      &stats{systemMemory: 100},
 		heuristics: []heuristic{fractionSystemMemoryHeuristic},


### PR DESCRIPTION
Previously, the heap profiler collected heap profiles only when the RSS had
crossed the heap collection memory threshold (by default 85%). This could lead
to very few heap profiles being collected in the case of OOMs. In particular,
if the memory usage on a node increases monotonically, we only collect a single
profile at 85% before the node crashes. With this PR, a profile will now be
collected every 2 minutes whenever RSS is above the threshold, or possibly more
often if we detect an increase of over 5% since the most recent profile
collected. The minimum interval between profiles is also lowered to 30 seconds.
Note that we currently GC profiles stored on disk if there are more than 5.

Part of the motivation for collecting more profiles when the memory is above
the threshold is to be able to take diffs between profiles using pprof, so that
we can see which allocations are causing continued growth.

Release note: None