### PR TITLE
docs: renderNode can not do filtering, it should be filterNode

### DIFF
--- a/docs/tech-notes/life_of_a_query.md
+++ b/docs/tech-notes/life_of_a_query.md
@@ -269,7 +269,7 @@ root@:26257> EXPLAIN(EXPRS,NOEXPAND,NOOPTIMIZE,METADATA) SELECT * FROM customers
 ```
 
 You can see data being produced by a `scanNode`, being filtered by a
-`renderNode` (presented as "render"), and then sorted by a `sortNode`
+`filterNode` (presented as "filter"), and then sorted by a `sortNode`
 (presented as "nosort", because we have turned off order analysis with
 NOEXPAND and the sort node doesn't know yet whether sorting is
 needed), wrapped in a `selectTopNode` (presented as "select").


### PR DESCRIPTION
    The description here is not accurate, `renderNode` can not do filtering, it should be `filterNode`.
    This modification has no effect on the system.

Release note: None