### PR TITLE
importccl: parallelize CSV-skipping workload IMPORT

### DIFF
--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -444,7 +444,7 @@ func (cp *readImportDataProcessor) doRun(ctx context.Context) error {
 			}
 		}
 		if isWorkload {
-			conv, err = newWorkloadReader(kvCh, singleTable, evalCtx)
+			conv = newWorkloadReader(kvCh, singleTable, cp.flowCtx.NewEvalCtx)
 		} else {
 			conv = newCSVInputReader(kvCh, cp.spec.Format.Csv, singleTable, cp.flowCtx)
 		}

--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -12,35 +12,36 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"runtime"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/pkg/errors"
 )
 
 type workloadReader struct {
-	conv *rowConverter
-	kvCh chan kvBatch
+	newEvalCtx func() *tree.EvalContext
+	table      *sqlbase.TableDescriptor
+	kvCh       chan kvBatch
 }
 
 var _ inputConverter = &workloadReader{}
 
 func newWorkloadReader(
-	kvCh chan kvBatch, table *sqlbase.TableDescriptor, evalCtx *tree.EvalContext,
-) (*workloadReader, error) {
-	conv, err := newRowConverter(table, evalCtx, kvCh)
-	if err != nil {
-		return nil, err
-	}
-	return &workloadReader{kvCh: kvCh, conv: conv}, nil
+	kvCh chan kvBatch, table *sqlbase.TableDescriptor, newEvalCtx func() *tree.EvalContext,
+) *workloadReader {
+	return &workloadReader{newEvalCtx: newEvalCtx, table: table, kvCh: kvCh}
 }
 
 func (w *workloadReader) start(ctx ctxgroup.Group) {
@@ -85,10 +86,12 @@ func (w *workloadReader) readFiles(
 	progressFn func(float32) error,
 	settings *cluster.Settings,
 ) error {
-	var alloc sqlbase.DatumAlloc
 
-	numFiles := float32(len(dataFiles))
-	var filesCompleted int
+	progress := jobs.ProgressUpdateBatcher{
+		Report: func(ctx context.Context, pct float32) error {
+			return progressFn(pct)
+		}}
+
 	for inputIdx, fileName := range dataFiles {
 		file, err := url.Parse(fileName)
 		if err != nil {
@@ -125,36 +128,70 @@ func (w *workloadReader) readFiles(
 			return errors.Wrapf(err, `unknown table %s for generator %s`, conf.Table, meta.Name)
 		}
 
-		// how is this reader, before starting this file.
-		initialProgress := float32(filesCompleted) / numFiles
-		numBatches := conf.BatchEnd - conf.BatchBegin
-		var rows int64
-		lastProgress := rows
-		for b := conf.BatchBegin; b < conf.BatchEnd; b++ {
-			if rows-lastProgress > 10000 {
-				// how far we are on this file
-				fileProgress := float32(b-conf.BatchBegin) / float32(numBatches)
-				progress := initialProgress + fileProgress/numFiles
-				if err := progressFn(progress); err != nil {
+		curBatchAtomic := conf.BatchBegin - 1
+		progressPerBatch := (1.0 / float32(conf.BatchEnd-conf.BatchBegin)) / float32(len(dataFiles))
+		return ctxgroup.GroupWorkers(ctx, runtime.NumCPU(), func(ctx context.Context) error {
+			return w.worker(ctx, t, inputIdx, &progress, progressPerBatch, conf.BatchEnd, &curBatchAtomic)
+		})
+	}
+	if err := progress.Done(ctx); err != nil {
+		log.Warningf(ctx, "failed to update progress: %+v", err)
+	}
+	return nil
+}
+
+// worker can be called concurrently to create multiple workers (that coordinate
+// via curBatchAtomic) to process batches in order. This keeps concurrently
+// running workers ~adjacent batches at any given moment (as opposed to handing
+// large ranges of batches to each worker, e.g. 0-999 to worker 1, 1000-1999 to
+// worker 2, etc). This property is relevant when ordered workload batches
+// produce ordered PK data, since the workers feed into a shared kvCH so then
+// contiguous blocks of PK data will usually be buffered together and thus
+// batched together in the SST builder, minimzing the amount of overlapping SSTs
+// ingested.
+func (w *workloadReader) worker(
+	ctx context.Context,
+	t workload.Table,
+	fileNum int32,
+	progress *jobs.ProgressUpdateBatcher,
+	progressPerBatch float32,
+	batchEnd int64,
+	curBatchAtomic *int64,
+) error {
+	evalCtx := w.newEvalCtx()
+	conv, err := newRowConverter(w.table, evalCtx, w.kvCh)
+	if err != nil {
+		return err
+	}
+	var alloc sqlbase.DatumAlloc
+
+	var pendingProgressBatches int
+	var rowIdx int64
+	for {
+		b := atomic.AddInt64(curBatchAtomic, 1)
+		if b >= batchEnd {
+			break
+		}
+		pendingProgressBatches++
+		for _, values := range t.InitialRows.Batch(int(b)) {
+			rowIdx++
+			for i, value := range values {
+				converted, err := makeDatumFromRaw(&alloc, value, conv.visibleColTypes[i], evalCtx)
+				if err != nil {
 					return err
 				}
-				lastProgress = rows
+				conv.datums[i] = converted
 			}
-			for _, row := range t.InitialRows.Batch(int(b)) {
-				rows++
-				for i, value := range row {
-					converted, err := makeDatumFromRaw(&alloc, value, w.conv.visibleColTypes[i], w.conv.evalCtx)
-					if err != nil {
-						return err
-					}
-					w.conv.datums[i] = converted
-				}
-				if err := w.conv.row(ctx, inputIdx, rows); err != nil {
-					return err
-				}
+			if err := conv.row(ctx, fileNum, rowIdx); err != nil {
+				return err
 			}
 		}
-		filesCompleted++
+		if pendingProgressBatches > 1000 {
+			if err := progress.Add(ctx, progressPerBatch*float32(pendingProgressBatches)); err != nil {
+				log.Warningf(ctx, "failed to update progress: %+v", err)
+			}
+			pendingProgressBatches = 0
+		}
 	}
-	return w.conv.sendBatch(ctx)
+	return conv.sendBatch(ctx)
 }

--- a/pkg/storage/batcheval/cmd_add_sstable.go
+++ b/pkg/storage/batcheval/cmd_add_sstable.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 )
@@ -65,6 +66,9 @@ func EvalAddSSTable(
 		return result.Result{}, errors.Wrap(err, "computing existing stats")
 	}
 	ms.Subtract(existingStats)
+	if existingStats.KeyCount > 0 {
+		log.Infof(ctx, "%s SST covers span containing %d existing keys: [%s, %s)", humanizeutil.IBytes(int64(len(args.Data))), existingStats.KeyCount, args.Key, args.EndKey)
+	}
 
 	// Verify that the keys in the sstable are within the range specified by the
 	// request header, verify the key-value checksums, and compute the new


### PR DESCRIPTION
(only last commit, first two commits are #36042)

Reopening #36060 after accidentally deleting branch and then github said it cannot re-open :/

This spins up multiple workers, each importing every i'th batch, to do
workload IMPORT.

As noted inline, this execution order, as opposed to assinging large
spans of batches to each worker, should mean that adjacent batches are
processed at roughly the same time and thus end up in the same
sort-batch for SST creation, preserving the non-overlapping SSTs when
the workload's batches are ordered and non-overlapping.

Release note: none.