### PR TITLE
exec: remove output overflow buffer from vectorized merge joiner

### DIFF
--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -42,6 +42,20 @@ type mjBuilderState struct {
 
 	// outCount keeps record of the current number of rows in the output.
 	outCount uint16
+
+	// Cross product materialization state.
+	left  mjBuilderCrossProductState
+	right mjBuilderCrossProductState
+}
+
+// mjBuilderCrossProductState is used to keep track of builder state within the
+// loops to materialize the cross product. Useful for picking up where we left off.
+type mjBuilderCrossProductState struct {
+	colIdx         int
+	groupsIdx      int
+	curSrcStartIdx int
+	numRepeatsIdx  int
+	finished       bool
 }
 
 // mjProberState contains all the state required to execute in the probing phases.
@@ -114,15 +128,15 @@ type mergeJoinInput struct {
 // It performs a merge on the left and right input sources, based on the equality
 // columns, assuming both inputs are in sorted order.
 
-// The merge join operator uses a "two scan" approach to generate the join.
+// The merge join operator uses a probe and build approach to generate the join.
 // What this means is that instead of going through and expanding the cross product
 // row by row, the operator performs two passes.
 // The first pass generates a list of groups of matching rows based on the equality
 // column. A group is an ADT representing a contiguous set of rows that match on their
 // equality columns. This group is represented as the starting row ordinal, the ending
 // row ordinal, and the number of times this group is expanded/repeated.
-// The second pass is where each of these groups are either expanded or repeated
-// into the output or savedOutput buffer, saving big on the type introspection.
+// The second pass is where the groups and their associated cross products are
+// materialized into the full output.
 
 // TODO(georgeutsin): Add outer joins functionality and templating to support different equality types
 
@@ -130,17 +144,9 @@ type mergeJoinInput struct {
 // right table. These buffers are only used if the group ends with a batch, to make sure
 // that we don't miss any cross product entries while expanding the groups
 // (leftGroups and rightGroups) when a group spans multiple batches.
-
-// There is also a savedOutput buffer in the case that the cross product overflows
-// the output buffer.
 type mergeJoinOp struct {
 	left  mergeJoinInput
 	right mergeJoinInput
-
-	// Output overflow buffer definition for the cross product entries
-	// that don't fit in the current batch.
-	savedOutput       coldata.Batch
-	savedOutputEndIdx int
 
 	// Member to keep track of count overflow, in the case that calculateOutputCount
 	// returns a number that doesn't fit into a uint16.
@@ -186,7 +192,6 @@ func (o *mergeJoinOp) initWithBatchSize(outBatchSize uint16) {
 	copy(outColTypes[len(o.left.sourceTypes):], o.right.sourceTypes)
 
 	o.output = coldata.NewMemBatchWithSize(outColTypes, int(outBatchSize))
-	o.savedOutput = coldata.NewMemBatchWithSize(outColTypes, coldata.BatchSize)
 	o.left.source.Init()
 	o.right.source.Init()
 	o.outputBatchSize = outBatchSize
@@ -196,6 +201,46 @@ func (o *mergeJoinOp) initWithBatchSize(outBatchSize uint16) {
 
 	o.groups = makeGroupsBuffer(coldata.BatchSize)
 	o.proberState.inputDone = false
+	o.resetBuilderCrossProductState()
+}
+
+// Const declarations for the merge joiner cross product (MJCP) zero state.
+const (
+	zeroMJCPcolIdx    = 0
+	zeroMJCPgroupsIdx = 0
+	// The sentinel value for curSrcStartIdx is -1, as this:
+	// a) indicates that a src has not been started
+	// b) panics if the sentinel isn't checked
+	zeroMJCPcurSrcStartIdx = -1
+	zeroMJCPnumRepeatsIdx  = 0
+	// Default the state of the builder to finished.
+	zeroMJCPfinished = true
+)
+
+// Package level struct for easy access to the MJCP zero state.
+var zeroMJBuilderState = mjBuilderCrossProductState{
+	colIdx:         zeroMJCPcolIdx,
+	groupsIdx:      zeroMJCPgroupsIdx,
+	curSrcStartIdx: zeroMJCPcurSrcStartIdx,
+	numRepeatsIdx:  zeroMJCPnumRepeatsIdx,
+	finished:       zeroMJCPfinished,
+}
+
+func (o *mergeJoinOp) resetBuilderCrossProductState() {
+	o.builderState.left.reset()
+	o.builderState.right.reset()
+}
+
+func (s *mjBuilderCrossProductState) reset() {
+	s.setBuilderColumnState(zeroMJBuilderState)
+	s.colIdx = zeroMJCPcolIdx
+	s.finished = zeroMJCPfinished
+}
+
+func (s *mjBuilderCrossProductState) setBuilderColumnState(target mjBuilderCrossProductState) {
+	s.groupsIdx = target.groupsIdx
+	s.curSrcStartIdx = target.curSrcStartIdx
+	s.numRepeatsIdx = target.numRepeatsIdx
 }
 
 // getBatch takes a mergeJoinInput and returns either the next batch (from source),
@@ -223,34 +268,6 @@ func getValForIdx(keys []int64, idx int, sel []uint16) int64 {
 	}
 
 	return keys[idx]
-}
-
-// TODO (georgeutsin): remove saved output buffer and this associated function.
-// buildSavedOutput flushes the savedOutput to output.
-func (o *mergeJoinOp) buildSavedOutput() uint16 {
-	toAppend := o.savedOutputEndIdx
-	offset := len(o.left.sourceTypes)
-	if toAppend > int(o.outputBatchSize) {
-		toAppend = int(o.outputBatchSize)
-	}
-
-	for _, idx := range o.left.outCols {
-		o.output.ColVec(int(idx)).AppendSlice(o.savedOutput.ColVec(int(idx)), o.left.sourceTypes[idx], 0 /* destStartIdx */, 0 /* srcStartIdx */, uint16(toAppend))
-	}
-	for _, idx := range o.right.outCols {
-		o.output.ColVec(offset+int(idx)).AppendSlice(o.savedOutput.ColVec(offset+int(idx)), o.right.sourceTypes[idx], 0 /* destStartIdx */, 0 /* srcStartIdx */, uint16(toAppend))
-	}
-
-	if o.savedOutputEndIdx > toAppend {
-		for _, idx := range o.left.outCols {
-			o.savedOutput.ColVec(int(idx)).Copy(o.savedOutput.ColVec(int(idx)), uint64(toAppend), uint64(o.savedOutputEndIdx), o.left.sourceTypes[idx])
-		}
-		for _, idx := range o.right.outCols {
-			o.savedOutput.ColVec(offset+int(idx)).Copy(o.savedOutput.ColVec(offset+int(idx)), uint64(toAppend), uint64(o.savedOutputEndIdx), o.right.sourceTypes[idx])
-		}
-	}
-	o.savedOutputEndIdx -= toAppend
-	return uint16(toAppend)
 }
 
 // getGroupLengthForValue is a helper function that gets the length of the current group in a batch
@@ -478,10 +495,8 @@ func (o *mergeJoinOp) setBuilderSourceToGroupBuffer() {
 // build creates the cross product, and writes it to the output member.
 func (o *mergeJoinOp) build() {
 	outStartIdx := o.builderState.outCount
-	savedOutCount := 0
-	o.builderState.outCount, savedOutCount = o.buildLeftGroups(o.builderState.lGroups, o.builderState.groupsLen, 0 /* colOffset */, &o.left, o.builderState.lBatch, outStartIdx)
+	o.builderState.outCount = o.buildLeftGroups(o.builderState.lGroups, o.builderState.groupsLen, 0 /* colOffset */, &o.left, o.builderState.lBatch, outStartIdx)
 	o.buildRightGroups(o.builderState.rGroups, o.builderState.groupsLen, len(o.left.sourceTypes), &o.right, o.builderState.rBatch, outStartIdx)
-	o.savedOutputEndIdx += savedOutCount
 }
 
 // initProberState sets the batches, lengths, and current indices to
@@ -515,13 +530,6 @@ func (o *mergeJoinOp) sourceFinished() bool {
 }
 
 func (o *mergeJoinOp) Next() coldata.Batch {
-	// TODO (georgeutsin): remove the saved output buffer
-	if o.savedOutputEndIdx > 0 {
-		count := o.buildSavedOutput()
-		o.output.SetLength(count)
-		return o.output
-	}
-
 	if o.countOverflow > 0 {
 		outCount := o.countOverflow
 		if outCount > (1<<16 - 1) {
@@ -563,11 +571,14 @@ func (o *mergeJoinOp) Next() coldata.Batch {
 		case mjBuild:
 			o.build()
 
-			// TODO (georgeutsin): flesh out this conditional (and builder state) to avoid buffering output.
-			// if builder completed its current source {
-			o.state = mjSetup
-			// }
-			if o.proberState.inputDone || o.builderState.outCount > 0 {
+			if o.builderState.left.finished != o.builderState.right.finished {
+				panic("unexpected builder state, both left and right should finish at the same time")
+			}
+
+			if o.builderState.left.finished && o.builderState.right.finished {
+				o.state = mjSetup
+			}
+			if o.proberState.inputDone || o.builderState.outCount == o.outputBatchSize {
 				o.output.SetLength(o.builderState.outCount)
 				// Reset builder out count.
 				o.builderState.outCount = uint16(0)


### PR DESCRIPTION
Removed the output overflow buffer from the vectorized merge 
joiner. This should (and does) fix the performance issues on n:n 
joins.

By keeping track of all the state at every point while building
the cross product, we can break out and resume at any point along
the way, meaning we don't have to buffer output rows in the case
of large groups on both sides.

Another great benefit is that we don't have to template the batch
slicing methods, which is great for performance.
However, we still need extend/slice batches for when we extend the
left and right groups while probing.

As of now, we still can't figure out how to avoid buffering both
sides of the tables when building a group, although this may
just be a fundamental/unavoidable truth.

Some benchmarks:

```
MergeJoiner/rows=1024-8                     66.3µs ± 0%     69.8µs ± 0%    +5.34%  (p=0.000 n=9+8)
MergeJoiner/rows=4096-8                      253µs ± 0%      268µs ± 1%    +5.82%  (p=0.000 n=8+10)
MergeJoiner/rows=16384-8                     979µs ± 0%     1037µs ± 0%    +5.94%  (p=0.000 n=8+10)
MergeJoiner/rows=1048576-8                  61.2ms ± 1%     66.5ms ± 3%    +8.67%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8       67.8µs ± 0%     71.6µs ± 1%    +5.60%  (p=0.000 n=10+9)
MergeJoiner/oneSideRepeat-rows=4096-8        254µs ± 1%      269µs ± 1%    +5.98%  (p=0.000 n=9+8)
MergeJoiner/oneSideRepeat-rows=16384-8      1.00ms ± 5%     1.05ms ± 0%    +5.26%  (p=0.000 n=10+9)
MergeJoiner/oneSideRepeat-rows=1048576-8    61.5ms ± 1%     65.9ms ± 1%    +7.18%  (p=0.000 n=9+10)
MergeJoiner/bothSidesRepeat-rows=1024-8     70.0µs ± 0%     72.8µs ± 1%    +4.11%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=4096-8     1.35ms ± 2%     0.36ms ± 0%   -73.74%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=16384-8    19.2ms ± 4%      4.0ms ± 3%   -78.94%  (p=0.000 n=9+10)
MergeJoiner/bothSidesRepeat-rows=32768-8    81.1ms ± 7%     16.1ms ± 1%   -80.18%  (p=0.000 n=10+9)

name                                      old speed      new speed       delta
MergeJoiner/rows=1024-8                    989MB/s ± 0%    938MB/s ± 0%    -5.07%  (p=0.000 n=9+8)
MergeJoiner/rows=4096-8                   1.04GB/s ± 0%   0.98GB/s ± 1%    -5.49%  (p=0.000 n=8+10)
MergeJoiner/rows=16384-8                  1.07GB/s ± 0%   1.01GB/s ± 0%    -5.61%  (p=0.000 n=8+10)
MergeJoiner/rows=1048576-8                1.10GB/s ± 1%   1.01GB/s ± 3%    -7.97%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8      966MB/s ± 1%    915MB/s ± 1%    -5.30%  (p=0.000 n=10+9)
MergeJoiner/oneSideRepeat-rows=4096-8     1.03GB/s ± 1%   0.97GB/s ± 1%    -5.64%  (p=0.000 n=9+8)
MergeJoiner/oneSideRepeat-rows=16384-8    1.05GB/s ± 5%   1.00GB/s ± 0%    -5.05%  (p=0.000 n=10+9)
MergeJoiner/oneSideRepeat-rows=1048576-8  1.09GB/s ± 1%   1.02GB/s ± 1%    -6.70%  (p=0.000 n=9+10)
MergeJoiner/bothSidesRepeat-rows=1024-8    937MB/s ± 0%    900MB/s ± 1%    -3.95%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=4096-8    194MB/s ± 2%    737MB/s ± 0%  +280.77%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=16384-8  54.8MB/s ± 4%  260.1MB/s ± 3%  +374.89%  (p=0.000 n=9+10)
MergeJoiner/bothSidesRepeat-rows=32768-8  25.9MB/s ± 7%  130.5MB/s ± 1%  +403.75%  (p=0.000 n=10+9)

name                                      old alloc/op   new alloc/op    delta
MergeJoiner/rows=1024-8                     4.37kB ± 0%     4.36kB ± 0%    -0.09%  (p=0.000 n=10+10)
MergeJoiner/rows=4096-8                     4.61kB ± 0%     4.59kB ± 0%    -0.30%  (p=0.000 n=10+10)
MergeJoiner/rows=16384-8                    5.47kB ± 0%     5.43kB ± 0%    -0.64%  (p=0.000 n=10+10)
MergeJoiner/rows=1048576-8                  85.3kB ± 0%     81.8kB ± 0%    -4.07%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8       4.37kB ± 0%     4.36kB ± 0%    -0.09%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=4096-8       4.61kB ± 0%     4.59kB ± 0%    -0.30%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=16384-8      5.47kB ± 0%     5.43kB ± 0%    -0.64%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1048576-8    85.3kB ± 0%     81.8kB ± 0%    -4.07%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8     4.37kB ± 0%     4.36kB ± 0%    -0.09%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=4096-8      434kB ± 0%        5kB ± 0%   -98.94%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=16384-8    2.90MB ± 0%     0.01MB ± 3%   -99.79%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=32768-8    7.62MB ± 0%     0.01MB ± 0%   -99.89%  (p=0.000 n=10+10)

name                                      old allocs/op  new allocs/op   delta
MergeJoiner/rows=1024-8                       8.00 ± 0%       8.00 ± 0%      ~     (all equal)
MergeJoiner/rows=4096-8                       14.0 ± 0%       14.0 ± 0%      ~     (all equal)
MergeJoiner/rows=16384-8                      38.0 ± 0%       38.0 ± 0%      ~     (all equal)
MergeJoiner/rows=1048576-8                   2.06k ± 0%      2.06k ± 0%    -0.05%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8         8.00 ± 0%       8.00 ± 0%      ~     (all equal)
MergeJoiner/oneSideRepeat-rows=4096-8         14.0 ± 0%       14.0 ± 0%      ~     (all equal)
MergeJoiner/oneSideRepeat-rows=16384-8        38.0 ± 0%       38.0 ± 0%      ~     (all equal)
MergeJoiner/oneSideRepeat-rows=1048576-8     2.06k ± 0%      2.06k ± 0%    -0.05%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8       8.00 ± 0%       8.00 ± 0%      ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=4096-8      5.21k ± 0%      0.01k ± 0%   -99.73%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=16384-8     30.9k ± 0%       0.0k ± 0%   -99.88%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=32768-8     64.3k ± 0%       0.1k ± 0%   -99.89%  (p=0.000 n=10+10)
```

Release note: None