### PR TITLE
sql: pass a ctx explicitly to connEx.recordErr()

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1342,7 +1342,7 @@ func (ex *connExecutor) run(
 				// to call either Close or CloseWithErr.
 				res.CloseWithErr(pe.errorCause())
 			} else {
-				ex.recordError(resErr)
+				ex.recordError(ex.Ctx(), resErr)
 				res.Close(stateToTxnStatusIndicator(ex.machine.CurState()))
 			}
 		} else {
@@ -2054,8 +2054,8 @@ func (ex *connExecutor) initStatementResult(
 // recordError processes an error at the end of query execution.
 // This triggers telemetry and, if the error is an internal error,
 // triggers the emission of a sentry report.
-func (ex *connExecutor) recordError(err error) {
-	sqltelemetry.RecordError(ex.Ctx(), err, &ex.server.cfg.Settings.SV)
+func (ex *connExecutor) recordError(ctx context.Context, err error) {
+	sqltelemetry.RecordError(ctx, err, &ex.server.cfg.Settings.SV)
 }
 
 // newStatsCollector returns an sqlStatsCollector that will record stats in the

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -204,7 +204,7 @@ func (ie *internalExecutorImpl) initConnEx(
 	wg.Add(1)
 	go func() {
 		if err := ex.run(ctx, ie.mon, mon.BoundAccount{} /*reserved*/, nil /* cancel */); err != nil {
-			ex.recordError(err)
+			ex.recordError(ctx, err)
 			errCallback(err)
 		}
 		closeMode := normalClose

--- a/pkg/sql/show_syntax.go
+++ b/pkg/sql/show_syntax.go
@@ -79,12 +79,12 @@ func runShowSyntax(
 	ctx context.Context,
 	stmt string,
 	report func(ctx context.Context, field, msg string) error,
-	reportErr func(err error),
+	reportErr func(ctx context.Context, err error),
 ) error {
 	stmts, err := parser.Parse(stmt)
 	if err != nil {
 		if reportErr != nil {
-			reportErr(err)
+			reportErr(ctx, err)
 		}
 
 		pqErr, ok := pgerror.GetPGCause(err)


### PR DESCRIPTION
It was using ex.Ctx(). Passing context explicitly is always preferred;
ex.Ctx() is supposed to be used in limited circumstances when you don't
know if you're inside a txn or not and the state might change from under
you -  mostly in the ex.run() function; it's not for random utility
functions.

Release note: None