### PR TITLE
opt: fix error due to attempt to normalize non-const list for IN expression

### DIFF
--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -69,15 +69,16 @@ func (c *CustomFuncs) NeedSortedUniqueList(list memo.ScalarListExpr) bool {
 		return false
 	}
 	ls := listSorter{cf: c, list: list}
+	var needSortedUniqueList bool
 	for i, item := range list {
 		if !opt.IsConstValueOp(item) {
 			return false
 		}
 		if i != 0 && !ls.less(i-1, i) {
-			return true
+			needSortedUniqueList = true
 		}
 	}
-	return false
+	return needSortedUniqueList
 }
 
 // ConstructSortedUniqueList sorts the given list and removes duplicates, and

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -357,6 +357,27 @@ project
  └── projections
       └── s NOT IN ('foo', s || 'foo', 'bar', length(s)::STRING, NULL) [type=bool, outer=(4)]
 
+# Regression test #36031.
+opt expect-not=NormalizeInConst
+SELECT
+    true
+    IN (
+            NULL,
+            NULL,
+            (
+                '201.249.149.90/18':::INET::INET
+                & '97a7:3650:3dd8:d4e9:35fe:6cfb:a714:1c17/61':::INET::INET
+            )::INET
+            << 'e22f:2067:2ed2:7b07:b167:206f:f17b:5b7d/82':::INET::INET
+        )
+----
+values
+ ├── columns: "?column?":1(bool)
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true IN (NULL, NULL, ('201.249.149.90/18' & '97a7:3650:3dd8:d4e9:35fe:6cfb:a714:1c17/61') << 'e22f:2067:2ed2:7b07:b167:206f:f17b:5b7d/82'),) [type=tuple{bool}]
+
 # --------------------------------------------------
 # EliminateExistsProject
 # --------------------------------------------------


### PR DESCRIPTION
If the items in the list of an `IN` expression are all constant, the
optimizer will normalize the list so that duplicates are removed and
items are sorted in increasing order. Prior to this commit, there was an
error in the logic to determine whether the list should be normalized,
and it was possible for lists with non-const items to match the
normalization rule. This commit fixes the logic error.

Fixes #36031

Release note (bug fix): Fixed a planning error that occured with some
IN expressions containing a list of constant and non-constant items.