### PR TITLE
release-19.1: opt: Consider leaseholder preferences when selecting indexes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -111,3 +111,100 @@ EXECUTE p
 scan  ·      ·
 ·     table  t@secondary
 ·     spans  /10-/11
+
+statement ok
+DEALLOCATE p
+
+# ------------------------------------------------------------------------------
+# Put table lease preference in dc2 and secondary index lease preference in dc1
+# so that the gateway matches the secondary index rather the primary index.
+# ------------------------------------------------------------------------------
+
+statement ok
+ALTER TABLE t CONFIGURE ZONE
+USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc2]]'
+
+statement ok
+ALTER INDEX t@secondary CONFIGURE ZONE
+USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
+
+query TTT retry
+EXPLAIN SELECT * FROM t WHERE k=10
+----
+scan  ·      ·
+·     table  t@secondary
+·     spans  /10-/11
+
+# ------------------------------------------------------------------------------
+# Move secondary lease preference to dc3 and put tertiary lease preference in
+# dc1 and ensure that gateway matches tertiary.
+# ------------------------------------------------------------------------------
+
+statement ok
+ALTER INDEX t@secondary CONFIGURE ZONE
+USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc3]]'
+
+statement ok
+ALTER INDEX t@tertiary CONFIGURE ZONE
+USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
+
+query TTT retry
+EXPLAIN SELECT * FROM t WHERE k=10
+----
+scan  ·      ·
+·     table  t@tertiary
+·     spans  /10-/11
+
+# ------------------------------------------------------------------------------
+# Ensure that an index constrained to a region is preferred over an index that
+# merely has a lease preference in that region (since lease preferences can
+# move, whereas constraints are fixed).
+# ------------------------------------------------------------------------------
+
+statement ok
+ALTER TABLE t CONFIGURE ZONE
+USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
+
+statement ok
+ALTER INDEX t@secondary CONFIGURE ZONE
+USING constraints='[+region=test,+dc=dc1]'
+
+statement ok
+ALTER INDEX t@tertiary CONFIGURE ZONE
+USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc1]]'
+
+query TTT retry
+EXPLAIN SELECT * FROM t WHERE k=10
+----
+scan  ·      ·
+·     table  t@secondary
+·     spans  /10-/11
+
+# ------------------------------------------------------------------------------
+# Use PREPARE to make sure that the prepared plan is invalidated when the
+# secondary index's lease preferences change.
+# ------------------------------------------------------------------------------
+
+statement ok
+PREPARE p AS SELECT tree, field, description FROM [EXPLAIN SELECT k, v FROM t WHERE k=10]
+
+query TTT retry
+EXECUTE p
+----
+scan  ·      ·
+·     table  t@secondary
+·     spans  /10-/11
+
+statement ok
+ALTER INDEX t@secondary CONFIGURE ZONE
+USING constraints='[+region=test]', lease_preferences='[[+region=test,+dc=dc2]]'
+
+query TTT retry
+EXECUTE p
+----
+scan  ·      ·
+·     table  t@primary
+·     spans  /10-/10/#
+
+statement ok
+DEALLOCATE p

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -738,6 +738,26 @@ func (z *ZoneConfig) ReplicaConstraints(i int) cat.ReplicaConstraints {
 	return &z.Constraints[i]
 }
 
+// LeasePreferenceCount is part of the cat.Zone interface.
+func (z *ZoneConfig) LeasePreferenceCount() int {
+	return len(z.LeasePreferences)
+}
+
+// LeasePreference is part of the cat.Zone interface.
+func (z *ZoneConfig) LeasePreference(i int) cat.ConstraintSet {
+	return &z.LeasePreferences[i]
+}
+
+// ConstraintCount is part of the cat.LeasePreference interface.
+func (l *LeasePreference) ConstraintCount() int {
+	return len(l.Constraints)
+}
+
+// Constraint is part of the cat.LeasePreference interface.
+func (l *LeasePreference) Constraint(i int) cat.Constraint {
+	return &l.Constraints[i]
+}
+
 // ReplicaCount is part of the cat.ReplicaConstraints interface.
 func (c *Constraints) ReplicaCount() int32 {
 	return c.NumReplicas

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -75,26 +75,26 @@ func TestBuilder(t *testing.T) {
 				memo.ExprFmtHideCost |
 				memo.ExprFmtHideQualifications
 
-			for _, arg := range d.CmdArgs {
-				key, vals := arg.Key, arg.Vals
-				switch key {
-				case "vars":
-					varTypes, err = exprgen.ParseTypes(vals)
-					if err != nil {
-						d.Fatalf(t, "%v", err)
-					}
-
-					iVarHelper = tree.MakeTypesOnlyIndexedVarHelper(varTypes)
-
-				default:
-					if err := tester.Flags.Set(arg); err != nil {
-						d.Fatalf(t, "%s", err)
-					}
-				}
-			}
-
 			switch d.Cmd {
 			case "build-scalar":
+				for _, arg := range d.CmdArgs {
+					key, vals := arg.Key, arg.Vals
+					switch key {
+					case "vars":
+						varTypes, err = exprgen.ParseTypes(vals)
+						if err != nil {
+							d.Fatalf(t, "%v", err)
+						}
+
+						iVarHelper = tree.MakeTypesOnlyIndexedVarHelper(varTypes)
+
+					default:
+						if err := tester.Flags.Set(arg); err != nil {
+							d.Fatalf(t, "%s", err)
+						}
+					}
+				}
+
 				typedExpr, err := testutils.ParseScalarExpr(d.Input, iVarHelper.Container())
 				if err != nil {
 					d.Fatalf(t, "%v", err)

--- a/pkg/sql/opt/xform/testdata/coster/zone
+++ b/pkg/sql/opt/xform/testdata/coster/zone
@@ -47,6 +47,12 @@ TABLE xy
 # --------------------------------------------------
 
 exec-ddl
+ALTER TABLE abc CONFIGURE ZONE USING constraints='[+region=central]'
+----
+ZONE
+ └── constraints: [+region=central]
+
+exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='[+region=east]'
 ----
 ZONE
@@ -58,9 +64,36 @@ ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+region=west]'
 ZONE
  └── constraints: [+region=west]
 
+# With locality in central, use primary index.
+opt format=show-all locality=(region=central)
+SELECT * FROM abc
+----
+scan t.public.abc
+ ├── columns: a:1(int!null) b:2(int) c:3(string)
+ ├── stats: [rows=1000]
+ ├── cost: 1060.01
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── prune: (1-3)
+ └── interesting orderings: (+1) (+2,+3,+1)
+
+# With locality in central, still use bc1 index when the filter is selective.
+opt format=show-all locality=(region=central)
+SELECT * FROM abc WHERE b=10
+----
+scan t.public.abc@bc1
+ ├── columns: a:1(int!null) b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(1)=9.9, null(1)=0, distinct(2)=1, null(2)=0]
+ ├── cost: 11.098
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3), (2,3)~~>(1)
+ ├── prune: (1,3)
+ └── interesting orderings: (+1) (+2,+3,+1)
+
 # With locality in east, use bc1 index.
 opt format=show-all locality=(region=east)
-SELECT b, c FROM abc where b=10
+SELECT b, c FROM abc WHERE b=10
 ----
 scan t.public.abc@bc1
  ├── columns: b:2(int!null) c:3(string)
@@ -74,7 +107,7 @@ scan t.public.abc@bc1
 
 # With locality in west, use bc2 index.
 opt format=show-all locality=(region=west)
-SELECT b, c FROM abc where b=10
+SELECT b, c FROM abc WHERE b=10
 ----
 scan t.public.abc@bc2
  ├── columns: b:2(int!null) c:3(string)
@@ -88,7 +121,7 @@ scan t.public.abc@bc2
 
 # No locality, so use bc1, since it's first.
 opt format=show-all
-SELECT b, c FROM abc where b=10
+SELECT b, c FROM abc WHERE b=10
 ----
 scan t.public.abc@bc1
  ├── columns: b:2(int!null) c:3(string)
@@ -102,7 +135,7 @@ scan t.public.abc@bc1
 
 # Locality doesn't match any constraints, so use bc1, since it's first.
 opt format=show-all locality=(region=central)
-SELECT b, c FROM abc where b=10
+SELECT b, c FROM abc WHERE b=10
 ----
 scan t.public.abc@bc1
  ├── columns: b:2(int!null) c:3(string)
@@ -119,6 +152,12 @@ scan t.public.abc@bc1
 # --------------------------------------------------
 
 exec-ddl
+ALTER TABLE abc CONFIGURE ZONE USING constraints='[+region=us,+dc=central,+rack=1]'
+----
+ZONE
+ └── constraints: [+region=us,+dc=central,+rack=1]
+
+exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='[+region=us,+dc=east,+rack=1]'
 ----
 ZONE
@@ -130,9 +169,36 @@ ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+region=us,+dc=west,+rack
 ZONE
  └── constraints: [+region=us,+dc=west,+rack=1]
 
+# With locality in us + central, use primary index.
+opt format=show-all locality=(region=us,dc=central)
+SELECT * FROM abc
+----
+scan t.public.abc
+ ├── columns: a:1(int!null) b:2(int) c:3(string)
+ ├── stats: [rows=1000]
+ ├── cost: 1060.01
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── prune: (1-3)
+ └── interesting orderings: (+1) (+2,+3,+1)
+
+# With locality in us + central, still use bc1 index if filter is selective.
+opt format=show-all locality=(region=us,dc=central)
+SELECT b, c FROM abc WHERE b=10
+----
+scan t.public.abc@bc1
+ ├── columns: b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
+ ├── cost: 10.6525
+ ├── lax-key: (3)
+ ├── fd: ()-->(2)
+ ├── prune: (3)
+ └── interesting orderings: (+2,+3)
+
 # With locality in us + east, use bc1 index.
 opt format=show-all locality=(region=us,dc=east)
-SELECT b, c FROM abc where b=10
+SELECT b, c FROM abc WHERE b=10
 ----
 scan t.public.abc@bc1
  ├── columns: b:2(int!null) c:3(string)
@@ -146,7 +212,7 @@ scan t.public.abc@bc1
 
 # With locality in us + west, use bc2 index.
 opt format=show-all locality=(region=us,dc=west)
-SELECT b, c FROM abc where b=10
+SELECT b, c FROM abc WHERE b=10
 ----
 scan t.public.abc@bc2
  ├── columns: b:2(int!null) c:3(string)
@@ -160,7 +226,7 @@ scan t.public.abc@bc2
 
 # Ignore "dc=west,rack=1" match if "region" does not match.
 opt format=show-all locality=(region=eu,dc=west,rack=1)
-SELECT b, c FROM abc where b=10
+SELECT b, c FROM abc WHERE b=10
 ----
 scan t.public.abc@bc1
  ├── columns: b:2(int!null) c:3(string)
@@ -193,7 +259,7 @@ ZONE
 # With locality in us, use bc1 index, since only one tier matches in case of
 # both indexes.
 opt format=show-all locality=(region=us)
-SELECT b, c FROM abc where b=10
+SELECT b, c FROM abc WHERE b=10
 ----
 scan t.public.abc@bc1
  ├── columns: b:2(int!null) c:3(string)
@@ -208,7 +274,7 @@ scan t.public.abc@bc1
 # With locality in us + east, use bc2 index (use lowest match count when
 # replicas have different numbers of matches).
 opt format=show-all locality=(region=us,dc=east)
-SELECT b, c FROM abc where b=10
+SELECT b, c FROM abc WHERE b=10
 ----
 scan t.public.abc@bc2
  ├── columns: b:2(int!null) c:3(string)
@@ -238,7 +304,7 @@ ZONE
 
 # With locality in us, use bc1, since it's first in order.
 opt format=show-all locality=(region=us)
-SELECT b, c FROM abc where b=10
+SELECT b, c FROM abc WHERE b=10
 ----
 scan t.public.abc@bc1
  ├── columns: b:2(int!null) c:3(string)
@@ -252,7 +318,7 @@ scan t.public.abc@bc1
 
 # With locality in eu, use bc2, since it's prohibited with bc1.
 opt format=show-all locality=(region=eu)
-SELECT b, c FROM abc where b=10
+SELECT b, c FROM abc WHERE b=10
 ----
 scan t.public.abc@bc2
  ├── columns: b:2(int!null) c:3(string)
@@ -267,7 +333,7 @@ scan t.public.abc@bc2
 # With locality in us + east, use bc2, since it matches both tiers, even though
 # "us" match is after "eu" in list.
 opt format=show-all locality=(region=us,dc=east)
-SELECT b, c FROM abc where b=10
+SELECT b, c FROM abc WHERE b=10
 ----
 scan t.public.abc@bc2
  ├── columns: b:2(int!null) c:3(string)
@@ -377,3 +443,290 @@ inner-join (lookup xy@y1)
       └── eq [type=bool, outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
            ├── variable: t.public.xy.y [type=int]
            └── const: 1 [type=int]
+
+# --------------------------------------------------
+# Lease preferences - single constraint.
+# --------------------------------------------------
+
+exec-ddl
+ALTER TABLE abc CONFIGURE ZONE USING lease_preferences='[[+region=central]]'
+----
+ZONE
+ └── lease preference: [+region=central]
+
+exec-ddl
+ALTER INDEX abc@bc1 CONFIGURE ZONE USING lease_preferences='[[+region=east]]'
+----
+ZONE
+ └── lease preference: [+region=east]
+
+exec-ddl
+ALTER INDEX abc@bc2 CONFIGURE ZONE USING lease_preferences='[[+region=west]]'
+----
+ZONE
+ └── lease preference: [+region=west]
+
+# With locality in us + central, use primary index.
+opt format=show-all locality=(region=central)
+SELECT * FROM abc
+----
+scan t.public.abc
+ ├── columns: a:1(int!null) b:2(int) c:3(string)
+ ├── stats: [rows=1000]
+ ├── cost: 1100.01
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── prune: (1-3)
+ └── interesting orderings: (+1) (+2,+3,+1)
+
+# With locality in us + central, still use bc1 index if filter is selective.
+opt format=show-all locality=(region=central)
+SELECT b, c FROM abc WHERE b=10
+----
+scan t.public.abc@bc1
+ ├── columns: b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
+ ├── cost: 10.9
+ ├── lax-key: (3)
+ ├── fd: ()-->(2)
+ ├── prune: (3)
+ └── interesting orderings: (+2,+3)
+
+# With locality in east, use bc1 index.
+opt format=show-all locality=(region=east)
+SELECT b, c FROM abc WHERE b=10
+----
+scan t.public.abc@bc1
+ ├── columns: b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
+ ├── cost: 10.735
+ ├── lax-key: (3)
+ ├── fd: ()-->(2)
+ ├── prune: (3)
+ └── interesting orderings: (+2,+3)
+
+# With locality in west, use bc2 index.
+opt format=show-all locality=(region=west)
+SELECT b, c FROM abc WHERE b=10
+----
+scan t.public.abc@bc2
+ ├── columns: b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
+ ├── cost: 10.735
+ ├── lax-key: (3)
+ ├── fd: ()-->(2)
+ ├── prune: (3)
+ └── interesting orderings: (+2,+3)
+
+# --------------------------------------------------
+# Lease preferences - multiple constraints.
+# --------------------------------------------------
+
+exec-ddl
+ALTER TABLE abc CONFIGURE ZONE USING lease_preferences='[[+region=us,+dc=central,+rack=1]]'
+----
+ZONE
+ └── lease preference: [+region=us,+dc=central,+rack=1]
+
+exec-ddl
+ALTER INDEX abc@bc1 CONFIGURE ZONE USING lease_preferences='[[+region=us,+dc=east,+rack=1]]'
+----
+ZONE
+ └── lease preference: [+region=us,+dc=east,+rack=1]
+
+exec-ddl
+ALTER INDEX abc@bc2 CONFIGURE ZONE USING lease_preferences='[[+region=us,+dc=west,+rack=1]]'
+----
+ZONE
+ └── lease preference: [+region=us,+dc=west,+rack=1]
+
+# With locality in us + central, use primary index.
+opt format=show-all locality=(region=us,dc=central)
+SELECT * FROM abc
+----
+scan t.public.abc
+ ├── columns: a:1(int!null) b:2(int) c:3(string)
+ ├── stats: [rows=1000]
+ ├── cost: 1100.01
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── prune: (1-3)
+ └── interesting orderings: (+1) (+2,+3,+1)
+
+# With locality in us + central, still use bc1 index if filter is selective.
+opt format=show-all locality=(region=us,dc=central)
+SELECT b, c FROM abc WHERE b=10
+----
+scan t.public.abc@bc1
+ ├── columns: b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
+ ├── cost: 10.8175
+ ├── lax-key: (3)
+ ├── fd: ()-->(2)
+ ├── prune: (3)
+ └── interesting orderings: (+2,+3)
+
+# With locality in us + east, use bc1 index.
+opt format=show-all locality=(region=us,dc=east)
+SELECT b, c FROM abc WHERE b=10
+----
+scan t.public.abc@bc1
+ ├── columns: b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
+ ├── cost: 10.735
+ ├── lax-key: (3)
+ ├── fd: ()-->(2)
+ ├── prune: (3)
+ └── interesting orderings: (+2,+3)
+
+# With locality in us + west, use bc2 index.
+opt format=show-all locality=(region=us,dc=west)
+SELECT b, c FROM abc WHERE b=10
+----
+scan t.public.abc@bc2
+ ├── columns: b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
+ ├── cost: 10.735
+ ├── lax-key: (3)
+ ├── fd: ()-->(2)
+ ├── prune: (3)
+ └── interesting orderings: (+2,+3)
+
+# Ignore "dc=west,rack=1" match if "region" does not match.
+opt format=show-all locality=(region=eu,dc=west,rack=1)
+SELECT b, c FROM abc WHERE b=10
+----
+scan t.public.abc@bc1
+ ├── columns: b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
+ ├── cost: 10.9
+ ├── lax-key: (3)
+ ├── fd: ()-->(2)
+ ├── prune: (3)
+ └── interesting orderings: (+2,+3)
+
+# --------------------------------------------------
+# Zone constraint + leaseholder preference.
+# --------------------------------------------------
+
+exec-ddl
+ALTER TABLE abc CONFIGURE ZONE
+USING constraints='[+region=us]', lease_preferences='[[+region=us,+dc=central]]'
+----
+ZONE
+ ├── constraints: [+region=us]
+ └── lease preference: [+region=us,+dc=central]
+
+exec-ddl
+ALTER INDEX abc@bc1 CONFIGURE ZONE
+USING constraints='[+region=us]', lease_preferences='[[+region=us,+dc=east]]'
+----
+ZONE
+ ├── constraints: [+region=us]
+ └── lease preference: [+region=us,+dc=east]
+
+exec-ddl
+ALTER INDEX abc@bc2 CONFIGURE ZONE
+USING constraints='[+region=us]', lease_preferences='[[+region=us,+dc=west]]'
+----
+ZONE
+ ├── constraints: [+region=us]
+ └── lease preference: [+region=us,+dc=west]
+
+# With locality in us + central, use primary index.
+opt format=show-all locality=(region=us,dc=central)
+SELECT * FROM abc
+----
+scan t.public.abc
+ ├── columns: a:1(int!null) b:2(int) c:3(string)
+ ├── stats: [rows=1000]
+ ├── cost: 1080.01
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── prune: (1-3)
+ └── interesting orderings: (+1) (+2,+3,+1)
+
+# With locality in us + central, still use bc1 index if filter is selective.
+opt format=show-all locality=(region=us,dc=central)
+SELECT b, c FROM abc WHERE b=10
+----
+scan t.public.abc@bc1
+ ├── columns: b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
+ ├── cost: 10.6525
+ ├── lax-key: (3)
+ ├── fd: ()-->(2)
+ ├── prune: (3)
+ └── interesting orderings: (+2,+3)
+
+# With locality in us + east, use bc1 index.
+opt format=show-all locality=(region=us,dc=east)
+SELECT b, c FROM abc WHERE b=10
+----
+scan t.public.abc@bc1
+ ├── columns: b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
+ ├── cost: 10.57
+ ├── lax-key: (3)
+ ├── fd: ()-->(2)
+ ├── prune: (3)
+ └── interesting orderings: (+2,+3)
+
+# With locality in us + west, use bc2 index.
+opt format=show-all locality=(region=us,dc=west)
+SELECT b, c FROM abc WHERE b=10
+----
+scan t.public.abc@bc2
+ ├── columns: b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
+ ├── cost: 10.57
+ ├── lax-key: (3)
+ ├── fd: ()-->(2)
+ ├── prune: (3)
+ └── interesting orderings: (+2,+3)
+
+exec-ddl
+ALTER TABLE abc CONFIGURE ZONE USING constraints='[+region=us]'
+----
+ZONE
+ └── constraints: [+region=us]
+
+exec-ddl
+ALTER INDEX abc@bc1 CONFIGURE ZONE
+USING constraints='[+region=us]', lease_preferences='[[+region=us,+dc=east]]'
+----
+ZONE
+ ├── constraints: [+region=us]
+ └── lease preference: [+region=us,+dc=east]
+
+exec-ddl
+ALTER INDEX abc@bc2 CONFIGURE ZONE
+USING constraints='[+region=us,+dc=east]'
+----
+ZONE
+ └── constraints: [+region=us,+dc=east]
+
+# With locality in the east, prefer the index with the constraints over the
+# index with just the lease preferences.
+opt format=show-all locality=(region=us,dc=east)
+SELECT b, c FROM abc WHERE b=10
+----
+scan t.public.abc@bc2
+ ├── columns: b:2(int!null) c:3(string)
+ ├── constraint: /2/3: [/10 - /10]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
+ ├── cost: 10.405
+ ├── lax-key: (3)
+ ├── fd: ()-->(2)
+ ├── prune: (3)
+ └── interesting orderings: (+2,+3)

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1029,6 +1029,9 @@ func zonesAreEqual(left, right *config.ZoneConfig) bool {
 	if len(left.Subzones) != len(right.Subzones) {
 		return false
 	}
+	if len(left.LeasePreferences) != len(right.LeasePreferences) {
+		return false
+	}
 
 	for i := range left.Subzones {
 		leftSubzone := &left.Subzones[i]
@@ -1053,22 +1056,38 @@ func zonesAreEqual(left, right *config.ZoneConfig) bool {
 		if leftReplCons.NumReplicas != rightReplCons.NumReplicas {
 			return false
 		}
-		if len(leftReplCons.Constraints) != len(rightReplCons.Constraints) {
+		if !constraintsAreEqual(leftReplCons.Constraints, rightReplCons.Constraints) {
 			return false
 		}
+	}
 
-		for j := range leftReplCons.Constraints {
-			leftCons := &leftReplCons.Constraints[j]
-			rightCons := &rightReplCons.Constraints[j]
-			if leftCons.Type != rightCons.Type {
-				return false
-			}
-			if leftCons.Key != rightCons.Key {
-				return false
-			}
-			if leftCons.Value != rightCons.Value {
-				return false
-			}
+	for i := range left.LeasePreferences {
+		leftLeasePrefs := &left.LeasePreferences[i]
+		rightLeasePrefs := &right.LeasePreferences[i]
+		if !constraintsAreEqual(leftLeasePrefs.Constraints, rightLeasePrefs.Constraints) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// constraintsAreEqual compares two sets of constraints for equality.
+func constraintsAreEqual(left, right []config.Constraint) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		leftCons := &left[i]
+		rightCons := &right[i]
+		if leftCons.Type != rightCons.Type {
+			return false
+		}
+		if leftCons.Key != rightCons.Key {
+			return false
+		}
+		if leftCons.Value != rightCons.Value {
+			return false
 		}
 	}
 	return true


### PR DESCRIPTION
Backport 1/1 commits from #36075.

/cc @cockroachdb/release

---

If the cost is otherwise equal, the optimizer will now prefer an index having
a leaseholder preference that best matches the gateway locality. This works
similar to the handling of zone constraints, except that the cost is reduced
to reflect the fact that the leaseholder may move from the preferred location.

Release note (sql change): The optimizer will try to select the index having
a leaseholder preference that is closest.
