### PR TITLE
release-19.1: sql: fix panic when searching for equivalent renders

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -3005,3 +3005,24 @@ SELECT sum(a) OVER (PARTITION BY (SELECT count(*) FROM x GROUP BY a LIMIT 1))::I
 6
 6
 6
+
+# Regression test for #27293 - make sure comparing two tuple types when
+# generating window functions expressions doesn't panic.
+
+query II
+SELECT
+    min(a) OVER (PARTITION BY (a, a)) AS min,
+    max(a) OVER (PARTITION BY (a, a)) AS max
+FROM
+    (SELECT 1 AS a)
+----
+1 1
+
+query II
+SELECT
+    min(a) OVER (PARTITION BY (())) AS min,
+    max(a) OVER (PARTITION BY (())) AS max
+FROM
+    (SELECT 1 AS a)
+----
+1 1

--- a/pkg/sql/targets.go
+++ b/pkg/sql/targets.go
@@ -126,7 +126,7 @@ func (s *renderNode) addOrReuseRenderStartingFromIdx(
 			// the syntax representation as approximation of equivalence. At this point
 			// the expressions must have undergone name resolution already so that
 			// comparison occurs after replacing column names to IndexedVars.
-			if s.isRenderEquivalent(exprStr, j) && s.render[j].ResolvedType() == col.Typ {
+			if s.isRenderEquivalent(exprStr, j) && s.render[j].ResolvedType().Equivalent(col.Typ) {
 				return j
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #35995.

/cc @cockroachdb/release

---

Previously, certain kinds of window functions could generate a panic
when trying to reuse equivalent renders when those renders were tuples.
This is fixed by comparing the types using the Equivalent method instead
of ==.

Release note (bug fix): fix panics caused by certain window functions
that operate on tuples
