### PR TITLE
release-19.1: opt: Round decimal values before check constraints

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -958,6 +958,10 @@ may increase either contention or retry errors, or both.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.pretty_key(raw_key: <a href="bytes.html">bytes</a>, skip_fields: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
+<tr><td><code>crdb_internal.round_decimal_values(val: <a href="decimal.html">decimal</a>, scale: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>This function is used internally to round decimal values during mutations.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.round_decimal_values(val: <a href="decimal.html">decimal</a>[], scale: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a>[]</code></td><td><span class="funcdesc"><p>This function is used internally to round decimal array values during mutations.</p>
+</span></td></tr>
 <tr><td><code>crdb_internal.set_vmodule(vmodule_string: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Set the equivalent of the <code>--vmodule</code> flag on the gateway node processing this request; it affords control over the logging verbosity of different files. Example syntax: <code>crdb_internal.set_vmodule('recordio=2,file=1,gfs*=3')</code>. Reset with: <code>crdb_internal.set_vmodule('')</code>. Raising the verbosity can severely affect performance.</p>
 </span></td></tr>
 <tr><td><code>current_database() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current database.</p>

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -686,3 +686,22 @@ INSERT INTO t35611 (a) VALUES (1)
 
 statement ok
 COMMIT
+
+# ------------------------------------------------------------------------------
+# Regression for #35364.
+# ------------------------------------------------------------------------------
+subtest regression_35364
+
+statement ok
+CREATE TABLE t35364(x DECIMAL(1,0) CHECK (x = 0))
+
+statement ok
+INSERT INTO t35364(x) VALUES (0.1)
+
+query T
+SELECT x FROM t35364
+----
+0
+
+statement ok
+DROP TABLE t35364

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -527,3 +527,22 @@ query II
 SELECT * FROM t32054
 ----
 NULL  NULL
+
+# ------------------------------------------------------------------------------
+# Regression for #35364.
+# ------------------------------------------------------------------------------
+subtest regression_35364
+
+statement ok
+CREATE TABLE t35364(x DECIMAL(1,0) CHECK (x >= 1))
+
+statement ok
+INSERT INTO t35364 VALUES (1)
+
+statement ok
+UPDATE t35364 SET x=0.5
+
+query T
+SELECT x FROM t35364
+----
+1

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -868,3 +868,69 @@ INSERT INTO test35040(a,b) VALUES (0,1) ON CONFLICT(a) DO UPDATE SET c = 1111111
 
 statement ok
 DROP TABLE test35040
+
+# ------------------------------------------------------------------------------
+# Regression for #35364.
+# ------------------------------------------------------------------------------
+subtest regression_35364
+
+statement ok
+CREATE TABLE t35364(x INT PRIMARY KEY, y DECIMAL(10,1) CHECK(y >= 8.0), UNIQUE INDEX (y))
+
+statement ok
+INSERT INTO t35364(x, y) VALUES (1, 10.2)
+
+# 10.18 should be mapped to 10.2 before the left outer join so that the conflict
+# can be detected, and 7.95 should be mapped to 8.0 so that check constraint
+# will pass.
+statement ok
+INSERT INTO t35364(x, y) VALUES (2, 10.18) ON CONFLICT (y) DO UPDATE SET y=7.95
+
+query IT
+SELECT * FROM t35364
+----
+1  8.0
+
+statement ok
+DROP TABLE t35364
+
+# Check UPSERT syntax.
+statement ok
+CREATE TABLE t35364(
+    x DECIMAL(10,0) CHECK (x >= 0) PRIMARY KEY,
+    y DECIMAL(10,0) CHECK (y >= 0)
+)
+
+statement ok
+UPSERT INTO t35364 (x) VALUES (-0.1)
+
+query TT
+SELECT * FROM t35364
+----
+-0  NULL
+
+statement ok
+UPSERT INTO t35364 (x, y) VALUES (-0.2, -0.3)
+
+query TT
+SELECT * FROM t35364
+----
+-0  -0
+
+statement ok
+UPSERT INTO t35364 (x, y) VALUES (1.5, 2.5)
+
+query TT rowsort
+SELECT * FROM t35364
+----
+-0  -0
+2   3
+
+statement ok
+INSERT INTO t35364 (x) VALUES (1.5) ON CONFLICT (x) DO UPDATE SET x=2.5, y=3.5
+
+query TT rowsort
+SELECT * FROM t35364
+----
+-0  -0
+3   4

--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -35,6 +35,26 @@ type Column interface {
 	// DatumType returns the data type of the column.
 	DatumType() types.T
 
+	// ColTypePrecision returns the precision of the column's SQL data type. This
+	// is only defined for the Decimal data type and represents the max number of
+	// decimal digits in the decimal (including fractional digits). If precision
+	// is 0, then the decimal has no max precision.
+	ColTypePrecision() int
+
+	// ColTypeWidth returns the width of the column's SQL data type. This has
+	// different meanings depending on the data type:
+	//
+	//   Decimal  : scale
+	//   Int      : # bits (16, 32, 64, etc)
+	//   Bit Array: # bits
+	//   String   : rune count
+	//
+	// TODO(andyk): It'd be better to expose the attributes of the column type
+	// using a different type or interface. However, currently that's hard to do,
+	// since using sqlbase.ColumnType creates an import cycle, and there's no good
+	// way to create a coltypes.T from sqlbase.ColumnType.
+	ColTypeWidth() int
+
 	// ColTypeStr returns the SQL data type of the column, as a string. Note that
 	// this is sometimes different than DatumType().String(), since datum types
 	// are a subset of column types.

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -494,3 +494,21 @@ render                    ·         ·                    (z)                  
                 └── scan  ·         ·                    (a, b, c)                 +c
 ·                         table     abc@abc_c_idx        ·                         ·
 ·                         spans     ALL                  ·                         ·
+
+# ------------------------------------------------------------------------------
+# Regression for #35364. This tests behavior that is different between the CBO
+# and the HP. The CBO will (deliberately) round any input columns *before*
+# evaluating any computed columns, as well as rounding the output.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE t35364(
+    x DECIMAL(10,0) CHECK(round(x) = x) PRIMARY KEY,
+    y DECIMAL(10,0) DEFAULT (1.5),
+    z DECIMAL(10,0) AS (x+y+2.5) STORED CHECK(z >= 7)
+)
+
+query TTT
+INSERT INTO t35364 (x) VALUES (1.5) RETURNING *
+----
+2  2  7

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -322,3 +322,26 @@ render                    ·         ·              (a)                       +
                 └── scan  ·         ·              (a, b, c, rowid[hidden])  +c
 ·                         table     abc@abc_c_idx  ·                         ·
 ·                         spans     ALL            ·                         ·
+
+# ------------------------------------------------------------------------------
+# Regression for #35364. This tests behavior that is different between the CBO
+# and the HP. The CBO will (deliberately) round any input columns *before*
+# evaluating any computed columns, as well as rounding the output.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE t35364(
+    x DECIMAL(10,0) CHECK(round(x) = x) PRIMARY KEY,
+    y DECIMAL(10,0) DEFAULT (1.5),
+    z DECIMAL(10,0) AS (x+y+2.5) STORED CHECK(z >= 7)
+)
+
+query TTT
+INSERT INTO t35364 (x) VALUES (1.5) RETURNING *
+----
+2  2  7
+
+query TTT
+UPDATE t35364 SET x=2.5 RETURNING *
+----
+3  2  8

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -342,3 +342,34 @@ render                         ·         ·                    (z)             
                      └── scan  ·         ·                    (a, b, c)                    +c
 ·                              table     abc@abc_c_idx        ·                            ·
 ·                              spans     ALL                  ·                            ·
+
+# ------------------------------------------------------------------------------
+# Regression for #35364. This tests behavior that is different between the CBO
+# and the HP. The CBO will (deliberately) round any input columns *before*
+# evaluating any computed columns, as well as rounding the output.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE t35364(
+    x DECIMAL(10,0) CHECK(round(x) = x) PRIMARY KEY,
+    y DECIMAL(10,0) DEFAULT (1.5),
+    z DECIMAL(10,0) AS (x+y+2.5) STORED CHECK(z >= 7)
+)
+
+query TTT
+UPSERT INTO t35364 (x) VALUES (1.5) RETURNING *
+----
+2  2  7
+
+query TTT
+UPSERT INTO t35364 (x, y) VALUES (1.5, 2.5) RETURNING *
+----
+2  3  8
+
+query TTT
+INSERT INTO t35364 (x) VALUES (1.5) ON CONFLICT (x) DO UPDATE SET x=2.5 RETURNING *
+----
+3  3  9
+
+statement error pq: failed to satisfy CHECK constraint \(z >= 7\)
+UPSERT INTO t35364 (x) VALUES (0)

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -78,11 +78,11 @@ project
       │    └──  upsert_rowid:20 => rowid:4
       ├── side-effects, mutations
       └── project
-           ├── columns: upsert_a:17(int) upsert_b:18(int) upsert_c:19(int) upsert_rowid:20(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+           ├── columns: upsert_a:17(int) upsert_b:18(int) upsert_c:19(int) upsert_rowid:20(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null) column15:15(int) column16:16(int)
            ├── side-effects
            ├── key: (5,13)
-           ├── fd: ()-->(6,9), (5)-->(8), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (5,13)-->(17-19), (8,13)-->(20)
-           ├── prune: (5,6,8-13,17-20)
+           ├── fd: ()-->(6,9,14), (5)-->(8), (13)-->(10-12), (10)-->(11-13), (11,12)~~>(10,13), (12)-->(15), (15)-->(16), (5,13)-->(17), (13,15)-->(18), (13,16)-->(19), (8,13)-->(20)
+           ├── prune: (5,6,8-20)
            ├── interesting orderings: (+5) (+6) (+13) (+10) (+11,+12,+13)
            ├── project
            │    ├── columns: column16:16(int) x:5(int!null) y:6(int!null) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null) column15:15(int)
@@ -400,11 +400,11 @@ project
  │    ├── cardinality: [2 - ]
  │    ├── side-effects, mutations
  │    └── project
- │         ├── columns: upsert_b:14(int) upsert_c:15(int) upsert_rowid:16(int) column1:5(int) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+ │         ├── columns: upsert_b:14(int) upsert_c:15(int) upsert_rowid:16(int) column1:5(int) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int)
  │         ├── cardinality: [2 - ]
  │         ├── side-effects
- │         ├── fd: ()-->(6,8), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12), (10,12)-->(14), (7,12)-->(16)
- │         ├── prune: (5-12,14-16)
+ │         ├── fd: ()-->(6,8), (12)-->(9-11), (9)-->(10-12), (10,11)~~>(9,12), (10)-->(13), (10,12)-->(14), (12,13)-->(15), (7,12)-->(16)
+ │         ├── prune: (5-16)
  │         ├── interesting orderings: (+12) (+9) (+10,+11,+12)
  │         ├── project
  │         │    ├── columns: column13:13(int) column1:5(int) column6:6(int!null) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -79,9 +79,9 @@ select
  │    ├── side-effects, mutations
  │    ├── stats: [rows=200, distinct(1)=181.351171, null(1)=0, distinct(2)=200, null(2)=0]
  │    └── project
- │         ├── columns: upsert_x:13(string) upsert_y:14(int) upsert_z:15(float) a:4(int!null) b:5(string!null) column8:8(float) x:9(string) y:10(int) z:11(float)
+ │         ├── columns: upsert_x:13(string) upsert_y:14(int) upsert_z:15(float) a:4(int!null) b:5(string!null) column8:8(float) x:9(string) y:10(int) z:11(float) column12:12(int!null)
  │         ├── stats: [rows=200, distinct(13)=181.351171, null(13)=0, distinct(14)=200, null(14)=0]
- │         ├── fd: ()-->(5,8), (9)-->(10,11), (9)-->(13), (4,9)-->(14)
+ │         ├── fd: ()-->(5,8,12), (9)-->(10,11), (9)-->(13), (4,9)-->(14)
  │         ├── project
  │         │    ├── columns: column12:12(int!null) a:4(int!null) b:5(string!null) column8:8(float) x:9(string) y:10(int) z:11(float)
  │         │    ├── stats: [rows=200, distinct(5,9)=181.351171, null(5,9)=0, distinct(4,9,12)=200, null(4,9,12)=0]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1845,9 +1845,9 @@ upsert a
       └── projections
            └── CASE WHEN k IS NULL THEN column7 ELSE i + 1 END [type=int, outer=(7,9,10)]
 
-# No pruning when RETURNING clause is present.
-# TODO(andyk): Need to prune output columns.
-opt expect-not=(PruneMutationFetchCols,PruneMutationInputCols)
+# Prune update columns replaced by upsert columns.
+# TODO(andyk): Need to also prune output columns.
+opt expect=PruneMutationInputCols expect-not=PruneMutationFetchCols
 INSERT INTO a (k, s) VALUES (1, 'foo') ON CONFLICT (k) DO UPDATE SET i=a.i+1 RETURNING *
 ----
 upsert a

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -223,11 +223,19 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 		mb.buildInputForInsert(inScope, nil /* rows */)
 	}
 
-	// Add default and computed columns that were not explicitly specified by
-	// name or implicitly targeted by input columns. This includes any columns
-	// undergoing write mutations, as they must always have a default or computed
-	// value.
-	mb.addDefaultAndComputedColsForInsert()
+	// Add default columns that were not explicitly specified by name or
+	// implicitly targeted by input columns. This includes columns undergoing
+	// write mutations, if they have a default value.
+	mb.addDefaultColsForInsert()
+
+	// Possibly round DECIMAL-related columns containing insertion values. Do
+	// this before evaluating computed expressions, since those may depend on
+	// the inserted columns.
+	mb.roundDecimalValues(mb.insertOrds, false /* roundComputedCols */)
+
+	// Add any computed columns. This includes columns undergoing write mutations,
+	// if they have a computed value.
+	mb.addComputedColsForInsert()
 
 	var returning tree.ReturningExprs
 	if resultsNeeded(ins.Returning) {
@@ -283,10 +291,6 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 
 		// Build each of the SET expressions.
 		mb.addUpdateCols(ins.OnConflict.Exprs)
-
-		// Add additional columns for computed expressions that may depend on any
-		// updated columns.
-		mb.addComputedColsForUpdate()
 
 		// Build the final upsert statement, including any returned expressions.
 		mb.buildUpsert(returning)
@@ -565,27 +569,31 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 	}
 }
 
-// addDefaultAndComputedColsForInsert wraps an Insert input expression with
-// Project operator(s) containing any default (or nullable) and computed columns
-// that are not yet part of the target column list. This includes mutation
-// columns, since they must always have default or computed values.
-//
-// After this call, the input expression will provide values for every one of
-// the target table columns, whether it was explicitly specified or implicitly
-// added.
-func (mb *mutationBuilder) addDefaultAndComputedColsForInsert() {
-	// Add any missing default and nullable columns.
+// addDefaultColsForInsert wraps an Insert input expression with a Project
+// operator containing any default (or nullable) columns that are not yet part
+// of the target column list. This includes mutation columns, since they must
+// always have default or computed values.
+func (mb *mutationBuilder) addDefaultColsForInsert() {
 	mb.addSynthesizedCols(
 		mb.insertOrds,
 		func(tabCol cat.Column) bool { return !tabCol.IsComputed() },
 	)
+}
 
-	// Add any missing computed columns. This must be done after adding default
-	// columns above, because computed columns can depend on default columns.
+// addComputedColsForInsert wraps an Insert input expression with a Project
+// operator containing computed columns that are not yet part of the target
+// column list. This includes mutation columns, since they must always have
+// default or computed values. This must be done after calling
+// addDefaultColsForInsert, because computed columns can depend on default
+// columns.
+func (mb *mutationBuilder) addComputedColsForInsert() {
 	mb.addSynthesizedCols(
 		mb.insertOrds,
 		func(tabCol cat.Column) bool { return tabCol.IsComputed() },
 	)
+
+	// Possibly round DECIMAL-related computed columns.
+	mb.roundDecimalValues(mb.insertOrds, true /* roundComputedCols */)
 }
 
 // buildInsert constructs an Insert operator, possibly wrapped by a Project

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -326,12 +326,18 @@ func (mb *mutationBuilder) needExistingRows() bool {
 		keyOrds.Add(primary.Column(i).Ordinal)
 	}
 
-	for i, colID := range mb.insertColList {
+	for i, n := 0, mb.tab.DeletableColumnCount(); i < n; i++ {
 		if keyOrds.Contains(i) {
-			// Don't consider key columns.
+			// #1: Don't consider key columns.
 			continue
 		}
-		if colID == 0 || colID != mb.updateColList[i] {
+		insertColID := mb.insertColID(i)
+		if insertColID == 0 {
+			// #2: Non-key column does not have insert value specified.
+			return true
+		}
+		if insertColID != mb.scopeOrdToColID(mb.updateOrds[i]) {
+			// #3: Update value is not same as corresponding insert value.
 			return true
 		}
 	}
@@ -486,8 +492,6 @@ func (mb *mutationBuilder) addTargetTableColsForInsert(maxCols int) {
 // buildInputForInsert constructs the memo group for the input expression and
 // constructs a new output scope containing that expression's output columns.
 func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.Select) {
-	mb.insertColList = make(opt.ColList, mb.tab.DeletableColumnCount())
-
 	// Handle DEFAULT VALUES case by creating a single empty row as input.
 	if inputRows == nil {
 		mb.outScope = inScope.push()
@@ -542,7 +546,7 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 	// Loop over input columns and:
 	//   1. Type check each column
 	//   2. Assign name to each column
-	//   3. Add id of each column to the insertColList
+	//   3. Add scope column ordinal to the insertOrds list.
 	for i := range mb.outScope.cols {
 		inCol := &mb.outScope.cols[i]
 		ord := mb.tabID.ColumnOrdinal(mb.targetColList[i])
@@ -555,9 +559,9 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 		inCol.table = *mb.tab.Name()
 		inCol.name = tree.Name(mb.md.ColumnMeta(mb.targetColList[i]).Alias)
 
-		// Map the ordinal position of each table column to the id of the input
-		// column which will be inserted into that position.
-		mb.insertColList[ord] = inCol.id
+		// Record the ordinal position of the scope column that contains the
+		// value to be inserted into the corresponding target table column.
+		mb.insertOrds[ord] = scopeOrdinal(i)
 	}
 }
 
@@ -572,14 +576,14 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 func (mb *mutationBuilder) addDefaultAndComputedColsForInsert() {
 	// Add any missing default and nullable columns.
 	mb.addSynthesizedCols(
-		mb.insertColList,
+		mb.insertOrds,
 		func(tabCol cat.Column) bool { return !tabCol.IsComputed() },
 	)
 
 	// Add any missing computed columns. This must be done after adding default
 	// columns above, because computed columns can depend on default columns.
 	mb.addSynthesizedCols(
-		mb.insertColList,
+		mb.insertOrds,
 		func(tabCol cat.Column) bool { return tabCol.IsComputed() },
 	)
 }
@@ -659,7 +663,7 @@ func (mb *mutationBuilder) buildInputForDoNothing(inScope *scope, onConflict *tr
 			scanColID := scanScope.cols[indexCol.Ordinal].id
 
 			condition := mb.b.factory.ConstructEq(
-				mb.b.factory.ConstructVariable(mb.insertColList[indexCol.Ordinal]),
+				mb.b.factory.ConstructVariable(mb.insertColID(indexCol.Ordinal)),
 				mb.b.factory.ConstructVariable(scanColID),
 			)
 			on = append(on, memo.FiltersItem{Condition: condition})
@@ -731,10 +735,10 @@ func (mb *mutationBuilder) buildInputForUpsert(
 	canaryScopeCol := &fetchScope.cols[findNotNullIndexCol(mb.tab.Index(cat.PrimaryIndex))]
 	mb.canaryColID = canaryScopeCol.id
 
-	// Set list of columns that will be fetched by the input expression.
-	mb.fetchColList = make(opt.ColList, mb.tab.DeletableColumnCount())
+	// Set fetchOrds to point to the scope columns created for the fetch values.
 	for i := range fetchScope.cols {
-		mb.fetchColList[i] = fetchScope.cols[i].id
+		// Fetch columns come after insert columns.
+		mb.fetchOrds[i] = scopeOrdinal(len(mb.outScope.cols) + i)
 	}
 
 	// Add the fetch columns to the current scope. It's OK to modify the current
@@ -753,7 +757,7 @@ func (mb *mutationBuilder) buildInputForUpsert(
 			fetchCol := &fetchScope.cols[i]
 			if fetchCol.name == name {
 				condition := mb.b.factory.ConstructEq(
-					mb.b.factory.ConstructVariable(mb.insertColList[i]),
+					mb.b.factory.ConstructVariable(mb.insertColID(i)),
 					mb.b.factory.ConstructVariable(fetchCol.id),
 				)
 				on = append(on, memo.FiltersItem{Condition: condition})
@@ -813,27 +817,26 @@ func (mb *mutationBuilder) buildInputForUpsert(
 // The UPSERT statement will update the value of column "b" from 2 => 2.0, but
 // will not modify column "a".
 func (mb *mutationBuilder) setUpsertCols(insertCols tree.NameList) {
-	mb.updateColList = make(opt.ColList, len(mb.insertColList))
 	if len(insertCols) != 0 {
 		for _, name := range insertCols {
 			// Table column must exist, since existence of insertCols has already
 			// been checked previously.
 			ord := cat.FindTableColumnByName(mb.tab, name)
-			mb.updateColList[ord] = mb.insertColList[ord]
+			mb.updateOrds[ord] = mb.insertOrds[ord]
 		}
 	} else {
-		copy(mb.updateColList, mb.insertColList)
+		copy(mb.updateOrds, mb.insertOrds)
 	}
 
 	// Never update mutation columns.
 	for i, n := mb.tab.ColumnCount(), mb.tab.DeletableColumnCount(); i < n; i++ {
-		mb.updateColList[i] = 0
+		mb.updateOrds[i] = -1
 	}
 
 	// Never update primary key columns.
 	conflictIndex := mb.tab.Index(cat.PrimaryIndex)
 	for i, n := 0, conflictIndex.KeyColumnCount(); i < n; i++ {
-		mb.updateColList[conflictIndex.Column(i).Ordinal] = 0
+		mb.updateOrds[conflictIndex.Column(i).Ordinal] = -1
 	}
 }
 
@@ -873,92 +876,60 @@ func (mb *mutationBuilder) buildUpsert(returning tree.ReturningExprs) {
 // on the final result values.
 func (mb *mutationBuilder) projectUpsertColumns() {
 	projectionsScope := mb.outScope.replace()
-	projectionsScope.cols = make([]scopeColumn, 0, len(mb.outScope.cols))
+	projectionsScope.appendColumnsFromScope(mb.outScope)
 
-	addAnonymousColumn := func(id opt.ColumnID) *scopeColumn {
-		projectionsScope.cols = append(projectionsScope.cols, scopeColumn{
-			typ: mb.md.ColumnMeta(id).Type,
-			id:  id,
-		})
-		return &projectionsScope.cols[len(projectionsScope.cols)-1]
-	}
-
-	// Pass through all fetch and insert columns. The fetch columns always include
-	// the canary column.
-	passthrough := mb.fetchColList.ToSet()
-	passthrough.UnionWith(mb.insertColList.ToSet())
-	for i := range mb.outScope.cols {
-		col := &mb.outScope.cols[i]
-		if passthrough.Contains(int(col.id)) {
-			// Don't copy the column's name, since fetch and insert columns can no
-			// longer be referenced by expressions, such as any check constraints.
-			addAnonymousColumn(col.id)
-		}
-	}
-
-	// Project a column for each target table column that needs to be either
-	// inserted or updated. This can include mutation columns.
-	mb.upsertColList = make(opt.ColList, mb.tab.DeletableColumnCount())
+	// Add a new column for each target table column that needs to be upserted.
+	// This can include mutation columns.
 	for i, n := 0, mb.tab.DeletableColumnCount(); i < n; i++ {
-		insertColID := mb.insertColList[i]
-		updateColID := mb.updateColList[i]
-		if updateColID == 0 && mb.fetchColList != nil {
-			updateColID = mb.fetchColList[i]
+		insertScopeOrd := mb.insertOrds[i]
+		updateScopeOrd := mb.updateOrds[i]
+		if updateScopeOrd == -1 {
+			updateScopeOrd = mb.fetchOrds[i]
 		}
 
-		var scopeCol *scopeColumn
-		switch {
-		case insertColID == 0 && updateColID == 0:
-			// Neither insert nor update required for this column, so skip.
+		// Skip columns that will only be inserted or only updated.
+		if insertScopeOrd == -1 || updateScopeOrd == -1 {
 			continue
-
-		case insertColID == 0:
-			// No insert is required, so just pass through update column.
-			scopeCol = addAnonymousColumn(updateColID)
-
-		case updateColID == 0:
-			// No update is required, so just pass through insert column.
-			scopeCol = addAnonymousColumn(insertColID)
-
-		case insertColID == updateColID:
-			// Same column is used for both insert and update, so just pass through
-			// one of the columns.
-			scopeCol = addAnonymousColumn(insertColID)
-
-		default:
-			// Generate CASE that toggles between insert and update column.
-			caseExpr := mb.b.factory.ConstructCase(
-				memo.TrueSingleton,
-				memo.ScalarListExpr{
-					mb.b.factory.ConstructWhen(
-						mb.b.factory.ConstructIs(
-							mb.b.factory.ConstructVariable(mb.canaryColID),
-							memo.NullSingleton,
-						),
-						mb.b.factory.ConstructVariable(insertColID),
-					),
-				},
-				mb.b.factory.ConstructVariable(updateColID),
-			)
-
-			alias := fmt.Sprintf("upsert_%s", mb.tab.Column(i).ColName())
-			typ := mb.md.ColumnMeta(insertColID).Type
-			scopeCol = mb.b.synthesizeColumn(projectionsScope, alias, typ, nil /* expr */, caseExpr)
 		}
+
+		// Skip columns where the insert value and update value are the same.
+		if mb.scopeOrdToColID(insertScopeOrd) == mb.scopeOrdToColID(updateScopeOrd) {
+			continue
+		}
+
+		// Generate CASE that toggles between insert and update column.
+		caseExpr := mb.b.factory.ConstructCase(
+			memo.TrueSingleton,
+			memo.ScalarListExpr{
+				mb.b.factory.ConstructWhen(
+					mb.b.factory.ConstructIs(
+						mb.b.factory.ConstructVariable(mb.canaryColID),
+						memo.NullSingleton,
+					),
+					mb.b.factory.ConstructVariable(mb.outScope.cols[insertScopeOrd].id),
+				),
+			},
+			mb.b.factory.ConstructVariable(mb.outScope.cols[updateScopeOrd].id),
+		)
+
+		alias := fmt.Sprintf("upsert_%s", mb.tab.Column(i).ColName())
+		typ := mb.outScope.cols[insertScopeOrd].typ
+		scopeCol := mb.b.synthesizeColumn(projectionsScope, alias, typ, nil /* expr */, caseExpr)
+		scopeColOrd := scopeOrdinal(len(projectionsScope.cols) - 1)
 
 		// Assign name to synthesized column. Check constraint columns may refer
 		// to columns in the table by name.
 		scopeCol.table = *mb.tab.Name()
 		scopeCol.name = mb.tab.Column(i).ColName()
 
-		// Update the ids for the update columns that are involved in the Upsert.
-		// The new column ids will be used by the Upsert operator in place of the
-		// original column ids. Also set the upsertColList, as those columns can
-		// be used by RETURNING columns.
-		if mb.updateColList[i] != 0 {
-			mb.updateColList[i] = scopeCol.id
+		// Update the scope ordinals for the update columns that are involved in
+		// the Upsert. The new columns will be used by the Upsert operator in place
+		// of the original columns. Also set the scope ordinals for the upsert
+		// columns, as those columns can be used by RETURNING columns.
+		if mb.updateOrds[i] != -1 {
+			mb.updateOrds[i] = scopeColOrd
 		}
-		mb.upsertColList[i] = scopeCol.id
+		mb.upsertOrds[i] = scopeColOrd
 	}
 
 	mb.b.constructProjectForScope(mb.outScope, projectionsScope)

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // mutationBuilder is a helper struct that supports building Insert, Update,
@@ -47,6 +48,19 @@ type mutationBuilder struct {
 	// resolved table name if no alias was specified.
 	alias tree.TableName
 
+	// outScope contains the current set of columns that are in scope, as well as
+	// the output expression as it is incrementally built. Once the final mutation
+	// expression is completed, it will be contained in outScope.expr. Columns,
+	// when present, are arranged in this order:
+	//
+	//   +--------+-------+--------+--------+-------+
+	//   | Insert | Fetch | Update | Upsert | Check |
+	//   +--------+-------+--------+--------+-------+
+	//
+	// Each column is identified by its ordinal position in outScope, and those
+	// ordinals are stored in the corresponding ScopeOrds fields (see below).
+	outScope *scope
+
 	// targetColList is an ordered list of IDs of the table columns into which
 	// values will be inserted, or which will be updated with new values. It is
 	// incrementally built as the mutation operator is built.
@@ -55,46 +69,44 @@ type mutationBuilder struct {
 	// targetColSet contains the same column IDs as targetColList, but as a set.
 	targetColSet opt.ColSet
 
-	// insertColList is an ordered list of IDs of input columns which provide
-	// values to be inserted. Its length is always equal to the number of columns
-	// in the target table, including mutation columns. Table columns which will
-	// not have values inserted are set to zero (e.g. delete-only mutation
-	// columns). insertColList is empty if this is not an Insert operator.
-	insertColList opt.ColList
+	// insertOrds lists the outScope columns providing values to insert. Its
+	// length is always equal to the number of columns in the target table,
+	// including mutation columns. Table columns which will not have values
+	// inserted are set to -1 (e.g. delete-only mutation columns). insertOrds
+	// is empty if this is not an Insert/Upsert operator.
+	insertOrds []scopeOrdinal
 
-	// fetchColList is an ordered list of IDs of input columns which are fetched
-	// from a target table in order to provide existing values that will form
+	// fetchOrds lists the outScope columns storing values which are fetched
+	// from the target table in order to provide existing values that will form
 	// lookup and update values. Its length is always equal to the number of
 	// columns in the target table, including mutation columns. Table columns
-	// which do not need to be fetched are set to zero. fetchColList is empty if
-	// this is an Insert operator with no ON CONFLICT clause.
-	fetchColList opt.ColList
+	// which do not need to be fetched are set to -1. fetchOrds is empty if
+	// this is an Insert operator.
+	fetchOrds []scopeOrdinal
 
-	// updateColList is an ordered list of IDs of input columns which contain new
-	// updated values for columns in a target table. Its length is always equal
-	// to the number of columns in the target table, including mutation columns.
-	// Table columns which do not need to be updated are set to zero.
-	// updateColList is empty if this is an Insert operator with no ON CONFLICT
-	// clause.
-	updateColList opt.ColList
+	// updateOrds lists the outScope columns providing update values. Its length
+	// is always equal to the number of columns in the target table, including
+	// mutation columns. Table columns which do not need to be updated are set
+	// to -1.
+	updateOrds []scopeOrdinal
 
-	// upsertColList is an ordered list of IDs of input columns which choose
-	// between an insert or update column using a CASE expression:
+	// upsertOrds lists the outScope columns that choose between an insert or
+	// update column using a CASE expression:
 	//
 	//   CASE WHEN canary_col IS NULL THEN ins_col ELSE upd_col END
 	//
 	// These columns are used to compute constraints and to return result rows.
-	// The length of upsertColList is always equal to the number of columns in
+	// The length of upsertOrds is always equal to the number of columns in
 	// the target table, including mutation columns. Table columns which do not
-	// need to be updated are set to zero. upsertColList is empty if this is not
+	// need to be updated are set to -1. upsertOrds is empty if this is not
 	// an Upsert operator.
-	upsertColList opt.ColList
+	upsertOrds []scopeOrdinal
 
-	// checkColList is an ordered list of IDs of input columns which contain the
-	// boolean results of evaluating check constraint expressions defined on the
-	// target table. Its length is always equal to the number of check constraints
-	// on the table (see opt.Table.CheckCount).
-	checkColList opt.ColList
+	// checkOrds lists the outScope columns storing the boolean results of
+	// evaluating check constraint expressions defined on the target table. Its
+	// length is always equal to the number of check constraints on the table
+	// (see opt.Table.CheckCount).
+	checkOrds []scopeOrdinal
 
 	// canaryColID is the ID of the column that is used to decide whether to
 	// insert or update each row. If the canary column's value is null, then it's
@@ -109,11 +121,6 @@ type mutationBuilder struct {
 	// parsedExprs is a cached set of parsed default and computed expressions
 	// from the table schema. These are parsed once and cached for reuse.
 	parsedExprs []tree.Expr
-
-	// outScope contains the current set of columns that are in scope, as well as
-	// the output expression as it is incrementally built. Once the final Insert
-	// expression is completed, it will be contained in outScope.expr.
-	outScope *scope
 }
 
 func (mb *mutationBuilder) init(b *Builder, op opt.Operator, tab cat.Table, alias tree.TableName) {
@@ -124,8 +131,36 @@ func (mb *mutationBuilder) init(b *Builder, op opt.Operator, tab cat.Table, alia
 	mb.alias = alias
 	mb.targetColList = make(opt.ColList, 0, tab.DeletableColumnCount())
 
+	// Allocate segmented array of scope column ordinals.
+	n := tab.DeletableColumnCount()
+	scopeOrds := make([]scopeOrdinal, n*4+tab.CheckCount())
+	for i := range scopeOrds {
+		scopeOrds[i] = -1
+	}
+	mb.insertOrds = scopeOrds[:n]
+	mb.fetchOrds = scopeOrds[n : n*2]
+	mb.updateOrds = scopeOrds[n*2 : n*3]
+	mb.upsertOrds = scopeOrds[n*3 : n*4]
+	mb.checkOrds = scopeOrds[n*4:]
+
 	// Add the table and its columns (including mutation columns) to metadata.
 	mb.tabID = mb.md.AddTableWithAlias(tab, &mb.alias)
+}
+
+// scopeOrdToColID returns the ID of the given scope column. If no scope column
+// is defined, scopeOrdToColID returns 0.
+func (mb *mutationBuilder) scopeOrdToColID(ord scopeOrdinal) opt.ColumnID {
+	if ord == -1 {
+		return 0
+	}
+	return mb.outScope.cols[ord].id
+}
+
+// insertColID is a convenience method that returns the ID of the input column
+// that provides the insertion value for the given table column (specified by
+// ordinal position in the table).
+func (mb *mutationBuilder) insertColID(tabOrd int) opt.ColumnID {
+	return mb.scopeOrdToColID(mb.insertOrds[tabOrd])
 }
 
 // buildInputForUpdateOrDelete constructs a Select expression from the fields in
@@ -176,9 +211,8 @@ func (mb *mutationBuilder) buildInputForUpdateOrDelete(
 	mb.outScope = projectionsScope
 
 	// Set list of columns that will be fetched by the input expression.
-	mb.fetchColList = make(opt.ColList, mb.tab.DeletableColumnCount())
 	for i := range mb.outScope.cols {
-		mb.fetchColList[i] = mb.outScope.cols[i].id
+		mb.fetchOrds[i] = scopeOrdinal(i)
 	}
 }
 
@@ -320,7 +354,7 @@ func (mb *mutationBuilder) replaceDefaultExprs(inRows *tree.Select) (outRows *tr
 // columns are synthesized for any missing columns, as long as the addCol
 // callback function returns true for that column.
 func (mb *mutationBuilder) addSynthesizedCols(
-	colList opt.ColList, addCol func(tabCol cat.Column) bool,
+	scopeOrds []scopeOrdinal, addCol func(tabCol cat.Column) bool,
 ) {
 	var projectionsScope *scope
 
@@ -328,7 +362,7 @@ func (mb *mutationBuilder) addSynthesizedCols(
 	// operators that synthesize columns.
 	for i, n := 0, mb.tab.WritableColumnCount(); i < n; i++ {
 		// Skip columns that are already specified.
-		if colList[i] != 0 {
+		if scopeOrds[i] != -1 {
 			continue
 		}
 
@@ -355,8 +389,8 @@ func (mb *mutationBuilder) addSynthesizedCols(
 		scopeCol.table = *mb.tab.Name()
 		scopeCol.name = tabCol.ColName()
 
-		// Store id of newly synthesized column in corresponding list slot.
-		colList[i] = scopeCol.id
+		// Remember ordinal position of the new scope column.
+		scopeOrds[i] = scopeOrdinal(len(projectionsScope.cols) - 1)
 
 		// Add corresponding target column.
 		mb.targetColList = append(mb.targetColList, tabColID)
@@ -378,7 +412,6 @@ func (mb *mutationBuilder) addCheckConstraintCols() {
 		// to the correct columns.
 		mb.disambiguateColumns()
 
-		mb.checkColList = make(opt.ColList, mb.tab.CheckCount())
 		projectionsScope := mb.outScope.replace()
 		projectionsScope.appendColumnsFromScope(mb.outScope)
 
@@ -392,7 +425,7 @@ func (mb *mutationBuilder) addCheckConstraintCols() {
 			texpr := mb.outScope.resolveAndRequireType(expr, types.Bool)
 			scopeCol := mb.b.addColumn(projectionsScope, alias, texpr)
 			mb.b.buildScalar(texpr, mb.outScope, projectionsScope, scopeCol, nil)
-			mb.checkColList[i] = scopeCol.id
+			mb.checkOrds[i] = scopeOrdinal(len(projectionsScope.cols) - 1)
 		}
 
 		mb.b.constructProjectForScope(mb.outScope, projectionsScope)
@@ -404,26 +437,23 @@ func (mb *mutationBuilder) addCheckConstraintCols() {
 // has each table column name, and that name refers to the column with the final
 // value that the mutation applies.
 func (mb *mutationBuilder) disambiguateColumns() {
+	// Determine the set of scope columns that will have their names preserved.
+	var preserve util.FastIntSet
 	for i, n := 0, mb.tab.DeletableColumnCount(); i < n; i++ {
-		colName := mb.tab.Column(i).ColName()
-		colID := mb.mapToInputColID(i)
-		if colID == 0 {
-			// Column not involved in the statement, so skip it (e.g. a delete-only
-			// column in an Insert statement).
-			continue
+		scopeOrd := mb.mapToReturnScopeOrd(i)
+		if scopeOrd != -1 {
+			preserve.Add(int(scopeOrd))
 		}
-		for i := range mb.outScope.cols {
-			col := &mb.outScope.cols[i]
-			if col.name == colName {
-				if col.id == colID {
-					// Use table name, not alias name, since computed column
-					// expressions will not reference aliases.
-					col.table = *mb.tab.Name()
-				} else {
-					// Clear name so that it will never match.
-					col.clearName()
-				}
-			}
+	}
+
+	// Clear names of all non-preserved columns. Set the fully qualified table
+	// name of preserved columns, since computed column expressions will reference
+	// table names, not alias names.
+	for i := range mb.outScope.cols {
+		if preserve.Contains(i) {
+			mb.outScope.cols[i].table = *mb.tab.Name()
+		} else {
+			mb.outScope.cols[i].clearName()
 		}
 	}
 }
@@ -431,35 +461,51 @@ func (mb *mutationBuilder) disambiguateColumns() {
 // makeMutationPrivate builds a MutationPrivate struct containing the table and
 // column metadata needed for the mutation operator.
 func (mb *mutationBuilder) makeMutationPrivate(needResults bool) *memo.MutationPrivate {
+	// Helper function to create a column list in the MutationPrivate.
+	makeColList := func(scopeOrds []scopeOrdinal) opt.ColList {
+		var colList opt.ColList
+		for i := range scopeOrds {
+			if scopeOrds[i] != -1 {
+				if colList == nil {
+					colList = make(opt.ColList, len(scopeOrds))
+				}
+				colList[i] = mb.scopeOrdToColID(scopeOrds[i])
+			}
+		}
+		return colList
+	}
+
 	private := &memo.MutationPrivate{
 		Table:      mb.tabID,
-		InsertCols: mb.insertColList,
-		FetchCols:  mb.fetchColList,
-		UpdateCols: mb.updateColList,
+		InsertCols: makeColList(mb.insertOrds),
+		FetchCols:  makeColList(mb.fetchOrds),
+		UpdateCols: makeColList(mb.updateOrds),
 		CanaryCol:  mb.canaryColID,
-		CheckCols:  mb.checkColList,
+		CheckCols:  makeColList(mb.checkOrds),
 	}
 
 	if needResults {
 		// Only non-mutation columns are output columns. ReturnCols needs to have
 		// DeletableColumnCount entries, but only the first ColumnCount entries
-		// can be non-zero.
+		// can be defined (i.e. >= 0).
 		private.ReturnCols = make(opt.ColList, mb.tab.DeletableColumnCount())
 		for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
-			private.ReturnCols[i] = mb.mapToInputColID(i)
-			if private.ReturnCols[i] == 0 {
-				panic(fmt.Sprintf("column %d is not available in the mutation input", i))
+			scopeOrd := mb.mapToReturnScopeOrd(i)
+			if scopeOrd == -1 {
+				panic(pgerror.NewAssertionErrorf("column %d is not available in the mutation input", i))
 			}
+			private.ReturnCols[i] = mb.outScope.cols[scopeOrd].id
 		}
 	}
 
 	return private
 }
 
-// mapToInputColID returns the ID of the input column that provides the final
-// value for the column at the given ordinal position in the table. This value
-// might mutate the column, or it might be returned by the mutation statement,
-// or it might not be used at all. Columns take priority in this order:
+// mapToReturnScopeOrd returns the ordinal of the scope column that provides the
+// final value for the column at the given ordinal position in the table. This
+// value might mutate the column, or it might be returned by the mutation
+// statement, or it might not be used at all. Columns take priority in this
+// order:
 //
 //   upsert, update, fetch, insert
 //
@@ -469,26 +515,26 @@ func (mb *mutationBuilder) makeMutationPrivate(needResults bool) *memo.MutationP
 // of fetch and insert columns doesn't matter, since they're only used together
 // in the upsert case where an upsert column would be available.
 //
-// If the column is never referenced by the statement, then mapToInputColID
+// If the column is never referenced by the statement, then mapToReturnScopeOrd
 // returns 0. This would be the case for delete-only columns in an Insert
 // statement, because they're neither fetched nor mutated.
-func (mb *mutationBuilder) mapToInputColID(ord int) opt.ColumnID {
+func (mb *mutationBuilder) mapToReturnScopeOrd(tabOrd int) scopeOrdinal {
 	switch {
-	case mb.upsertColList != nil && mb.upsertColList[ord] != 0:
-		return mb.upsertColList[ord]
+	case mb.upsertOrds[tabOrd] != -1:
+		return mb.upsertOrds[tabOrd]
 
-	case mb.updateColList != nil && mb.updateColList[ord] != 0:
-		return mb.updateColList[ord]
+	case mb.updateOrds[tabOrd] != -1:
+		return mb.updateOrds[tabOrd]
 
-	case mb.fetchColList != nil && mb.fetchColList[ord] != 0:
-		return mb.fetchColList[ord]
+	case mb.fetchOrds[tabOrd] != -1:
+		return mb.fetchOrds[tabOrd]
 
-	case mb.insertColList != nil && mb.insertColList[ord] != 0:
-		return mb.insertColList[ord]
+	case mb.insertOrds[tabOrd] != -1:
+		return mb.insertOrds[tabOrd]
 
 	default:
 		// Column is never referenced by the statement.
-		return 0
+		return -1
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -30,6 +30,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
+// scopeOrdinal identifies an ordinal position with a list of scope columns.
+type scopeOrdinal int
+
 // scope is used for the build process and maintains the variables that have
 // been bound within the current scope as columnProps. Variables bound in the
 // parent scope are also visible in this scope.

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -83,6 +83,24 @@ TABLE checks
  ├── CHECK (checks.b < d)
  └── CHECK (a > 0)
 
+exec-ddl
+CREATE TABLE decimals (
+    a DECIMAL(10,0) PRIMARY KEY CHECK (round(a) = a),
+    b DECIMAL(5,1)[] CHECK (b[0] > 1),
+    c DECIMAL(10,1) DEFAULT (1.23),
+    d DECIMAL(10,1) AS (a+c) STORED
+)
+----
+TABLE decimals
+ ├── a decimal not null
+ ├── b decimal[]
+ ├── c decimal
+ ├── d decimal
+ ├── INDEX primary
+ │    └── a decimal not null
+ ├── CHECK (round(a) = a)
+ └── CHECK (b[0] > 1)
+
 # Unknown target table.
 build
 INSERT INTO unknown VALUES (1, 2, 3)
@@ -1264,7 +1282,7 @@ INSERT INTO mutation (m, n, p) VALUES (1, 2, 3)
 error (42703): column "p" does not exist
 
 # ------------------------------------------------------------------------------
-# Test check constraints
+# Test check constraints.
 # ------------------------------------------------------------------------------
 
 # Insert constants.
@@ -1332,3 +1350,48 @@ insert checks
            └── gt [type=bool]
                 ├── variable: abcde.a [type=int]
                 └── const: 0 [type=int]
+
+# ------------------------------------------------------------------------------
+# Test decimal column rounding.
+# ------------------------------------------------------------------------------
+
+opt
+INSERT INTO decimals (a, b) VALUES (1.1, ARRAY[0.95, NULL, 15])
+----
+insert decimals
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├──  a:8 => decimals.a:1
+ │    ├──  b:9 => decimals.b:2
+ │    ├──  c:10 => decimals.c:3
+ │    └──  d:12 => decimals.d:4
+ ├── check columns: check1:13(bool) check2:14(bool)
+ └── project
+      ├── columns: check1:13(bool) check2:14(bool) d:12(decimal) a:8(decimal) b:9(decimal[]) c:10(decimal)
+      ├── values
+      │    ├── columns: a:8(decimal) b:9(decimal[]) c:10(decimal)
+      │    └── tuple [type=tuple{decimal, decimal[], decimal}]
+      │         ├── function: crdb_internal.round_decimal_values [type=decimal]
+      │         │    ├── const: 1.1 [type=decimal]
+      │         │    └── const: 0 [type=int]
+      │         ├── function: crdb_internal.round_decimal_values [type=decimal[]]
+      │         │    ├── const: ARRAY[0.95,NULL,15] [type=decimal[]]
+      │         │    └── const: 1 [type=int]
+      │         └── function: crdb_internal.round_decimal_values [type=decimal]
+      │              ├── const: 1.23 [type=decimal]
+      │              └── const: 1 [type=int]
+      └── projections
+           ├── eq [type=bool]
+           │    ├── variable: a [type=decimal]
+           │    └── function: round [type=decimal]
+           │         └── variable: a [type=decimal]
+           ├── gt [type=bool]
+           │    ├── indirection [type=decimal]
+           │    │    ├── variable: b [type=decimal[]]
+           │    │    └── const: 0 [type=int]
+           │    └── const: 1 [type=decimal]
+           └── function: crdb_internal.round_decimal_values [type=decimal]
+                ├── plus [type=decimal]
+                │    ├── variable: a [type=decimal]
+                │    └── variable: c [type=decimal]
+                └── const: 1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -83,6 +83,24 @@ TABLE checks
  ├── CHECK (checks.b < d)
  └── CHECK (a > 0)
 
+exec-ddl
+CREATE TABLE decimals (
+    a DECIMAL(10,0) PRIMARY KEY CHECK (round(a) = a),
+    b DECIMAL(5,1)[] CHECK (b[0] > 1),
+    c DECIMAL(10,1) DEFAULT (1.23),
+    d DECIMAL(10,1) AS (a+c) STORED
+)
+----
+TABLE decimals
+ ├── a decimal not null
+ ├── b decimal[]
+ ├── c decimal
+ ├── d decimal
+ ├── INDEX primary
+ │    └── a decimal not null
+ ├── CHECK (round(a) = a)
+ └── CHECK (b[0] > 1)
+
 # ------------------------------------------------------------------------------
 # Basic tests.
 # ------------------------------------------------------------------------------
@@ -1538,3 +1556,49 @@ update checks
            └── gt [type=bool]
                 ├── variable: abcde.a [type=int]
                 └── const: 0 [type=int]
+
+# ------------------------------------------------------------------------------
+# Test decimal column truncation.
+# ------------------------------------------------------------------------------
+
+opt
+UPDATE decimals SET a=1.1, b=ARRAY[0.95, NULL, 15]
+----
+update decimals
+ ├── columns: <none>
+ ├── fetch columns: decimals.a:5(decimal) decimals.b:6(decimal[]) c:7(decimal) decimals.d:8(decimal)
+ ├── update-mapping:
+ │    ├──  a:11 => decimals.a:1
+ │    ├──  b:12 => decimals.b:2
+ │    └──  d:15 => decimals.d:4
+ ├── check columns: check1:16(bool) check2:17(bool)
+ └── project
+      ├── columns: check1:16(bool) check2:17(bool) d:15(decimal) decimals.a:5(decimal!null) decimals.b:6(decimal[]) c:7(decimal) decimals.d:8(decimal) a:11(decimal) b:12(decimal[])
+      ├── project
+      │    ├── columns: a:11(decimal) b:12(decimal[]) decimals.a:5(decimal!null) decimals.b:6(decimal[]) c:7(decimal) decimals.d:8(decimal)
+      │    ├── scan decimals
+      │    │    └── columns: decimals.a:5(decimal!null) decimals.b:6(decimal[]) c:7(decimal) decimals.d:8(decimal)
+      │    └── projections
+      │         ├── function: crdb_internal.round_decimal_values [type=decimal]
+      │         │    ├── const: 1.1 [type=decimal]
+      │         │    └── const: 0 [type=int]
+      │         └── function: crdb_internal.round_decimal_values [type=decimal[]]
+      │              ├── const: ARRAY[0.95,NULL,15] [type=decimal[]]
+      │              └── const: 1 [type=int]
+      └── projections
+           ├── eq [type=bool]
+           │    ├── variable: a [type=decimal]
+           │    └── function: round [type=decimal]
+           │         └── variable: a [type=decimal]
+           ├── gt [type=bool]
+           │    ├── indirection [type=decimal]
+           │    │    ├── variable: b [type=decimal[]]
+           │    │    └── const: 0 [type=int]
+           │    └── const: 1 [type=decimal]
+           └── function: crdb_internal.round_decimal_values [type=decimal]
+                ├── function: crdb_internal.round_decimal_values [type=decimal]
+                │    ├── plus [type=decimal]
+                │    │    ├── variable: a [type=decimal]
+                │    │    └── variable: c [type=decimal]
+                │    └── const: 1 [type=int]
+                └── const: 1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -117,6 +117,24 @@ TABLE checks
  ├── CHECK (checks.b < d)
  └── CHECK (a > 0)
 
+exec-ddl
+CREATE TABLE decimals (
+    a DECIMAL(10,0) PRIMARY KEY CHECK (round(a) = a),
+    b DECIMAL(5,1)[] CHECK (b[0] > 1),
+    c DECIMAL(10,1) DEFAULT (1.23),
+    d DECIMAL(10,1) AS (a+c) STORED
+)
+----
+TABLE decimals
+ ├── a decimal not null
+ ├── b decimal[]
+ ├── c decimal
+ ├── d decimal
+ ├── INDEX primary
+ │    └── a decimal not null
+ ├── CHECK (round(a) = a)
+ └── CHECK (b[0] > 1)
+
 # ------------------------------------------------------------------------------
 # Basic tests.
 # ------------------------------------------------------------------------------
@@ -1580,7 +1598,7 @@ UPSERT INTO xyz (x, unknown) VALUES (1)
 error (42703): column "unknown" does not exist
 
 # ------------------------------------------------------------------------------
-# Test check constraints
+# Test check constraints.
 # ------------------------------------------------------------------------------
 
 # INSERT..ON CONFLICT
@@ -1920,3 +1938,257 @@ upsert checks
            └── gt [type=bool]
                 ├── variable: abc.a [type=int]
                 └── const: 0 [type=int]
+
+# ------------------------------------------------------------------------------
+# Test decimal column truncation.
+# ------------------------------------------------------------------------------
+
+# Fast UPSERT case.
+opt
+UPSERT INTO decimals (a, b) VALUES (1.1, ARRAY[0.95])
+----
+upsert decimals
+ ├── columns: <none>
+ ├── canary column: 13
+ ├── fetch columns: decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
+ ├── insert-mapping:
+ │    ├──  a:8 => decimals.a:1
+ │    ├──  b:9 => decimals.b:2
+ │    ├──  c:10 => decimals.c:3
+ │    └──  d:12 => decimals.d:4
+ ├── update-mapping:
+ │    ├──  b:9 => decimals.b:2
+ │    └──  upsert_d:21 => decimals.d:4
+ ├── check columns: check1:22(bool) check2:23(bool)
+ └── project
+      ├── columns: check1:22(bool) check2:23(bool) a:8(decimal) b:9(decimal[]) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal) upsert_d:21(decimal)
+      ├── project
+      │    ├── columns: upsert_a:19(decimal) upsert_d:21(decimal) a:8(decimal) b:9(decimal[]) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
+      │    ├── left-join (lookup decimals)
+      │    │    ├── columns: a:8(decimal) b:9(decimal[]) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
+      │    │    ├── key columns: [8] = [13]
+      │    │    ├── project
+      │    │    │    ├── columns: d:12(decimal) a:8(decimal) b:9(decimal[]) c:10(decimal)
+      │    │    │    ├── values
+      │    │    │    │    ├── columns: a:8(decimal) b:9(decimal[]) c:10(decimal)
+      │    │    │    │    └── tuple [type=tuple{decimal, decimal[], decimal}]
+      │    │    │    │         ├── function: crdb_internal.round_decimal_values [type=decimal]
+      │    │    │    │         │    ├── const: 1.1 [type=decimal]
+      │    │    │    │         │    └── const: 0 [type=int]
+      │    │    │    │         ├── function: crdb_internal.round_decimal_values [type=decimal[]]
+      │    │    │    │         │    ├── const: ARRAY[0.95] [type=decimal[]]
+      │    │    │    │         │    └── const: 1 [type=int]
+      │    │    │    │         └── function: crdb_internal.round_decimal_values [type=decimal]
+      │    │    │    │              ├── const: 1.23 [type=decimal]
+      │    │    │    │              └── const: 1 [type=int]
+      │    │    │    └── projections
+      │    │    │         └── function: crdb_internal.round_decimal_values [type=decimal]
+      │    │    │              ├── plus [type=decimal]
+      │    │    │              │    ├── variable: a [type=decimal]
+      │    │    │              │    └── variable: c [type=decimal]
+      │    │    │              └── const: 1 [type=int]
+      │    │    └── filters (true)
+      │    └── projections
+      │         ├── case [type=decimal]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=decimal]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: decimals.a [type=decimal]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: a [type=decimal]
+      │         │    └── variable: decimals.a [type=decimal]
+      │         └── case [type=decimal]
+      │              ├── true [type=bool]
+      │              ├── when [type=decimal]
+      │              │    ├── is [type=bool]
+      │              │    │    ├── variable: decimals.a [type=decimal]
+      │              │    │    └── null [type=unknown]
+      │              │    └── variable: d [type=decimal]
+      │              └── function: crdb_internal.round_decimal_values [type=decimal]
+      │                   ├── plus [type=decimal]
+      │                   │    ├── variable: decimals.a [type=decimal]
+      │                   │    └── variable: decimals.c [type=decimal]
+      │                   └── const: 1 [type=int]
+      └── projections
+           ├── eq [type=bool]
+           │    ├── variable: upsert_a [type=decimal]
+           │    └── function: round [type=decimal]
+           │         └── variable: upsert_a [type=decimal]
+           └── gt [type=bool]
+                ├── indirection [type=decimal]
+                │    ├── variable: b [type=decimal[]]
+                │    └── const: 0 [type=int]
+                └── const: 1 [type=decimal]
+
+# Regular UPSERT case.
+opt
+UPSERT INTO decimals (a) VALUES (1.1)
+----
+upsert decimals
+ ├── columns: <none>
+ ├── canary column: 13
+ ├── fetch columns: decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
+ ├── insert-mapping:
+ │    ├──  a:8 => decimals.a:1
+ │    ├──  b:9 => decimals.b:2
+ │    ├──  c:10 => decimals.c:3
+ │    └──  d:12 => decimals.d:4
+ ├── update-mapping:
+ │    └──  upsert_d:22 => decimals.d:4
+ ├── check columns: check1:23(bool) check2:24(bool)
+ └── project
+      ├── columns: check1:23(bool) check2:24(bool) a:8(decimal) b:9(decimal[]) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal) upsert_d:22(decimal)
+      ├── project
+      │    ├── columns: upsert_a:19(decimal) upsert_b:20(decimal[]) upsert_d:22(decimal) a:8(decimal) b:9(decimal[]) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
+      │    ├── left-join (lookup decimals)
+      │    │    ├── columns: a:8(decimal) b:9(decimal[]) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
+      │    │    ├── key columns: [8] = [13]
+      │    │    ├── project
+      │    │    │    ├── columns: d:12(decimal) a:8(decimal) b:9(decimal[]) c:10(decimal)
+      │    │    │    ├── values
+      │    │    │    │    ├── columns: a:8(decimal) b:9(decimal[]) c:10(decimal)
+      │    │    │    │    └── tuple [type=tuple{decimal, decimal[], decimal}]
+      │    │    │    │         ├── function: crdb_internal.round_decimal_values [type=decimal]
+      │    │    │    │         │    ├── const: 1.1 [type=decimal]
+      │    │    │    │         │    └── const: 0 [type=int]
+      │    │    │    │         ├── function: crdb_internal.round_decimal_values [type=decimal[]]
+      │    │    │    │         │    ├── null [type=decimal[]]
+      │    │    │    │         │    └── const: 1 [type=int]
+      │    │    │    │         └── function: crdb_internal.round_decimal_values [type=decimal]
+      │    │    │    │              ├── const: 1.23 [type=decimal]
+      │    │    │    │              └── const: 1 [type=int]
+      │    │    │    └── projections
+      │    │    │         └── function: crdb_internal.round_decimal_values [type=decimal]
+      │    │    │              ├── plus [type=decimal]
+      │    │    │              │    ├── variable: a [type=decimal]
+      │    │    │              │    └── variable: c [type=decimal]
+      │    │    │              └── const: 1 [type=int]
+      │    │    └── filters (true)
+      │    └── projections
+      │         ├── case [type=decimal]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=decimal]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: decimals.a [type=decimal]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: a [type=decimal]
+      │         │    └── variable: decimals.a [type=decimal]
+      │         ├── case [type=decimal[]]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=decimal[]]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: decimals.a [type=decimal]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: b [type=decimal[]]
+      │         │    └── variable: decimals.b [type=decimal[]]
+      │         └── case [type=decimal]
+      │              ├── true [type=bool]
+      │              ├── when [type=decimal]
+      │              │    ├── is [type=bool]
+      │              │    │    ├── variable: decimals.a [type=decimal]
+      │              │    │    └── null [type=unknown]
+      │              │    └── variable: d [type=decimal]
+      │              └── function: crdb_internal.round_decimal_values [type=decimal]
+      │                   ├── plus [type=decimal]
+      │                   │    ├── variable: decimals.a [type=decimal]
+      │                   │    └── variable: decimals.c [type=decimal]
+      │                   └── const: 1 [type=int]
+      └── projections
+           ├── eq [type=bool]
+           │    ├── variable: upsert_a [type=decimal]
+           │    └── function: round [type=decimal]
+           │         └── variable: upsert_a [type=decimal]
+           └── gt [type=bool]
+                ├── indirection [type=decimal]
+                │    ├── variable: upsert_b [type=decimal[]]
+                │    └── const: 0 [type=int]
+                └── const: 1 [type=decimal]
+
+# INSERT...ON CONFLICT case.
+opt
+INSERT INTO decimals (a, b) VALUES (1.1, ARRAY[0.95])
+ON CONFLICT (a)
+DO UPDATE SET b=ARRAY[0.99]
+----
+upsert decimals
+ ├── columns: <none>
+ ├── canary column: 13
+ ├── fetch columns: decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
+ ├── insert-mapping:
+ │    ├──  a:8 => decimals.a:1
+ │    ├──  b:9 => decimals.b:2
+ │    ├──  c:10 => decimals.c:3
+ │    └──  d:12 => decimals.d:4
+ ├── update-mapping:
+ │    ├──  upsert_b:22 => decimals.b:2
+ │    └──  upsert_d:24 => decimals.d:4
+ ├── check columns: check1:25(bool) check2:26(bool)
+ └── project
+      ├── columns: check1:25(bool) check2:26(bool) a:8(decimal) b:9(decimal[]) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal) upsert_b:22(decimal[]) upsert_d:24(decimal)
+      ├── project
+      │    ├── columns: upsert_a:21(decimal) upsert_b:22(decimal[]) upsert_d:24(decimal) a:8(decimal) b:9(decimal[]) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
+      │    ├── left-join (lookup decimals)
+      │    │    ├── columns: a:8(decimal) b:9(decimal[]) c:10(decimal) d:12(decimal) decimals.a:13(decimal) decimals.b:14(decimal[]) decimals.c:15(decimal) decimals.d:16(decimal)
+      │    │    ├── key columns: [8] = [13]
+      │    │    ├── project
+      │    │    │    ├── columns: d:12(decimal) a:8(decimal) b:9(decimal[]) c:10(decimal)
+      │    │    │    ├── values
+      │    │    │    │    ├── columns: a:8(decimal) b:9(decimal[]) c:10(decimal)
+      │    │    │    │    └── tuple [type=tuple{decimal, decimal[], decimal}]
+      │    │    │    │         ├── function: crdb_internal.round_decimal_values [type=decimal]
+      │    │    │    │         │    ├── const: 1.1 [type=decimal]
+      │    │    │    │         │    └── const: 0 [type=int]
+      │    │    │    │         ├── function: crdb_internal.round_decimal_values [type=decimal[]]
+      │    │    │    │         │    ├── const: ARRAY[0.95] [type=decimal[]]
+      │    │    │    │         │    └── const: 1 [type=int]
+      │    │    │    │         └── function: crdb_internal.round_decimal_values [type=decimal]
+      │    │    │    │              ├── const: 1.23 [type=decimal]
+      │    │    │    │              └── const: 1 [type=int]
+      │    │    │    └── projections
+      │    │    │         └── function: crdb_internal.round_decimal_values [type=decimal]
+      │    │    │              ├── plus [type=decimal]
+      │    │    │              │    ├── variable: a [type=decimal]
+      │    │    │              │    └── variable: c [type=decimal]
+      │    │    │              └── const: 1 [type=int]
+      │    │    └── filters (true)
+      │    └── projections
+      │         ├── case [type=decimal]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=decimal]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: decimals.a [type=decimal]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: a [type=decimal]
+      │         │    └── variable: decimals.a [type=decimal]
+      │         ├── case [type=decimal[]]
+      │         │    ├── true [type=bool]
+      │         │    ├── when [type=decimal[]]
+      │         │    │    ├── is [type=bool]
+      │         │    │    │    ├── variable: decimals.a [type=decimal]
+      │         │    │    │    └── null [type=unknown]
+      │         │    │    └── variable: b [type=decimal[]]
+      │         │    └── function: crdb_internal.round_decimal_values [type=decimal[]]
+      │         │         ├── const: ARRAY[0.99] [type=decimal[]]
+      │         │         └── const: 1 [type=int]
+      │         └── case [type=decimal]
+      │              ├── true [type=bool]
+      │              ├── when [type=decimal]
+      │              │    ├── is [type=bool]
+      │              │    │    ├── variable: decimals.a [type=decimal]
+      │              │    │    └── null [type=unknown]
+      │              │    └── variable: d [type=decimal]
+      │              └── function: crdb_internal.round_decimal_values [type=decimal]
+      │                   ├── plus [type=decimal]
+      │                   │    ├── variable: decimals.a [type=decimal]
+      │                   │    └── variable: decimals.c [type=decimal]
+      │                   └── const: 1 [type=int]
+      └── projections
+           ├── eq [type=bool]
+           │    ├── variable: upsert_a [type=decimal]
+           │    └── function: round [type=decimal]
+           │         └── variable: upsert_a [type=decimal]
+           └── gt [type=bool]
+                ├── indirection [type=decimal]
+                │    ├── variable: upsert_b [type=decimal[]]
+                │    └── const: 0 [type=int]
+                └── const: 1 [type=decimal]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -141,7 +141,7 @@ upsert abc
  │    ├──  upsert_a:16 => a:1
  │    └──  upsert_c:18 => c:3
  └── project
-      ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_rowid:19(int) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+      ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_rowid:19(int) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null) column15:15(int)
       ├── project
       │    ├── columns: column15:15(int) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null)
       │    ├── project
@@ -238,7 +238,7 @@ project
       │    ├──  upsert_c:19 => c:3
       │    └──  upsert_rowid:20 => rowid:4
       └── project
-           ├── columns: upsert_a:17(int) upsert_b:18(int) upsert_c:19(int) upsert_rowid:20(int) x:5(int!null) y:6(int) z:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+           ├── columns: upsert_a:17(int) upsert_b:18(int) upsert_c:19(int) upsert_rowid:20(int) x:5(int!null) y:6(int) z:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null) column14:14(int!null) column15:15(int!null) column16:16(int)
            ├── project
            │    ├── columns: column16:16(int) x:5(int!null) y:6(int) z:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null) column14:14(int!null) column15:15(int!null)
            │    ├── project
@@ -325,7 +325,7 @@ upsert abc
  │    ├──  upsert_b:17 => b:2
  │    └──  upsert_c:18 => c:3
  └── project
-      ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_rowid:19(int) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int)
+      ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_rowid:19(int) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null) column15:15(int)
       ├── project
       │    ├── columns: column15:15(int) x:5(int!null) y:6(int) column8:8(int) column9:9(int) a:10(int) b:11(int) c:12(int) rowid:13(int) column14:14(int!null)
       │    ├── project
@@ -431,7 +431,7 @@ sort
            │    ├──  upsert_c:17 => c:3
            │    └──  upsert_rowid:18 => rowid:4
            └── project
-                ├── columns: upsert_a:15(int) upsert_b:16(int) upsert_c:17(int) upsert_rowid:18(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+                ├── columns: upsert_a:15(int) upsert_b:16(int) upsert_c:17(int) upsert_rowid:18(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null) column14:14(int)
                 ├── project
                 │    ├── columns: column14:14(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int!null)
                 │    ├── project
@@ -522,7 +522,7 @@ upsert tab
  │    ├──  upsert_a:15 => a:1
  │    └──  upsert_c:17 => c:3
  └── project
-      ├── columns: upsert_a:15(int) upsert_b:16(int) upsert_c:17(int) upsert_rowid:18(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+      ├── columns: upsert_a:15(int) upsert_b:16(int) upsert_c:17(int) upsert_rowid:18(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int)
       ├── project
       │    ├── columns: column14:14(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int)
       │    ├── project
@@ -773,7 +773,7 @@ project
  │    │    ├──  upsert_y:14 => y:2
  │    │    └──  upsert_z:15 => z:3
  │    └── project
- │         ├── columns: upsert_x:13(int) upsert_y:14(int) upsert_z:15(int) column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
+ │         ├── columns: upsert_x:13(int) upsert_y:14(int) upsert_z:15(int) column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int) column10:10(int) column11:11(int) column12:12(int)
  │         ├── project
  │         │    ├── columns: column10:10(int) column11:11(int) column12:12(int) column1:4(int) column2:5(int) column3:6(int) x:7(int) y:8(int) z:9(int)
  │         │    ├── select
@@ -894,7 +894,7 @@ upsert abc
  │    ├──  upsert_b:19 => b:2
  │    └──  upsert_c:20 => c:3
  └── project
-      ├── columns: upsert_a:18(int) upsert_b:19(int) upsert_c:20(int) upsert_rowid:21(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+      ├── columns: upsert_a:18(int) upsert_b:19(int) upsert_c:20(int) upsert_rowid:21(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int) column17:17(int)
       ├── project
       │    ├── columns: column17:17(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) x:13(int) "?column?":16(int)
       │    ├── left-join-apply
@@ -998,7 +998,7 @@ upsert abc
  │    ├──  upsert_b:17 => b:2
  │    └──  upsert_c:18 => c:3
  └── project
-      ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_rowid:19(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int)
+      ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_rowid:19(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int!null) column15:15(int)
       ├── project
       │    ├── columns: column15:15(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) rowid:12(int) column13:13(int) column14:14(int!null)
       │    ├── project
@@ -1092,9 +1092,9 @@ upsert mutation
  │    └──  upsert_p:20 => p:4
  ├── check columns: check1:21(bool)
  └── project
-      ├── columns: check1:21(bool) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) upsert_m:17(int) upsert_n:18(int) upsert_o:19(int) upsert_p:20(int)
+      ├── columns: check1:21(bool) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) column16:16(int) upsert_m:17(int) upsert_n:18(int) upsert_o:19(int) upsert_p:20(int)
       ├── project
-      │    ├── columns: upsert_m:17(int) upsert_n:18(int) upsert_o:19(int) upsert_p:20(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    ├── columns: upsert_m:17(int) upsert_n:18(int) upsert_o:19(int) upsert_p:20(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) column16:16(int)
       │    ├── project
       │    │    ├── columns: column16:16(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
       │    │    ├── project
@@ -1430,9 +1430,9 @@ upsert mutation
  │    └──  upsert_p:18 => p:4
  ├── check columns: check1:19(bool)
  └── project
-      ├── columns: check1:19(bool) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) upsert_m:16(int) upsert_o:17(int) upsert_p:18(int)
+      ├── columns: check1:19(bool) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) upsert_m:16(int) upsert_o:17(int) upsert_p:18(int)
       ├── project
-      │    ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
       │    ├── project
       │    │    ├── columns: column15:15(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       │    │    ├── left-join
@@ -1511,9 +1511,9 @@ upsert mutation
  │    └──  upsert_p:18 => p:4
  ├── check columns: check1:19(bool)
  └── project
-      ├── columns: check1:19(bool) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) upsert_m:16(int) upsert_o:17(int) upsert_p:18(int)
+      ├── columns: check1:19(bool) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int) upsert_m:16(int) upsert_o:17(int) upsert_p:18(int)
       ├── project
-      │    ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
+      │    ├── columns: upsert_m:16(int) upsert_o:17(int) upsert_p:18(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int) column15:15(int)
       │    ├── project
       │    │    ├── columns: column15:15(int) column1:6(int) column2:7(int) column8:8(int!null) column9:9(int) m:10(int) n:11(int) o:12(int) p:13(int) q:14(int)
       │    │    ├── left-join
@@ -1602,9 +1602,9 @@ upsert checks
  │    └──  upsert_d:19 => d:4
  ├── check columns: check1:20(bool) check2:21(bool)
  └── project
-      ├── columns: check1:20(bool) check2:21(bool) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_d:19(int)
+      ├── columns: check1:20(bool) check2:21(bool) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int!null) column14:14(int!null) column15:15(int) upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_d:19(int)
       ├── project
-      │    ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_d:19(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
+      │    ├── columns: upsert_a:16(int) upsert_b:17(int) upsert_c:18(int) upsert_d:19(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int!null) column14:14(int!null) column15:15(int)
       │    ├── project
       │    │    ├── columns: column15:15(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int!null) column14:14(int!null)
       │    │    ├── project
@@ -1753,9 +1753,9 @@ upsert checks
  │    └──  upsert_d:16 => d:4
  ├── check columns: check1:17(bool) check2:18(bool)
  └── project
-      ├── columns: check1:17(bool) check2:18(bool) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) upsert_a:14(int) upsert_c:15(int) upsert_d:16(int)
+      ├── columns: check1:17(bool) check2:18(bool) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int) upsert_a:14(int) upsert_c:15(int) upsert_d:16(int)
       ├── project
-      │    ├── columns: upsert_a:14(int) upsert_c:15(int) upsert_d:16(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
+      │    ├── columns: upsert_a:14(int) upsert_c:15(int) upsert_d:16(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int) column13:13(int)
       │    ├── project
       │    │    ├── columns: column13:13(int) column1:5(int) column2:6(int) column7:7(int) column8:8(int) a:9(int) b:10(int) c:11(int) d:12(int)
       │    │    ├── left-join
@@ -1840,9 +1840,9 @@ upsert checks
  │    └──  upsert_d:22 => d:4
  ├── check columns: check1:23(bool) check2:24(bool)
  └── project
-      ├── columns: check1:23(bool) check2:24(bool) abc.a:5(int!null) abc.b:6(int) column9:9(int) column10:10(int) checks.a:11(int) checks.b:12(int) checks.c:13(int) d:14(int) upsert_b:20(int) upsert_c:21(int) upsert_d:22(int)
+      ├── columns: check1:23(bool) check2:24(bool) abc.a:5(int!null) abc.b:6(int) column9:9(int) column10:10(int) checks.a:11(int) checks.b:12(int) checks.c:13(int) d:14(int) column18:18(int) column19:19(int) upsert_b:20(int) upsert_c:21(int) upsert_d:22(int)
       ├── project
-      │    ├── columns: upsert_b:20(int) upsert_c:21(int) upsert_d:22(int) abc.a:5(int!null) abc.b:6(int) column9:9(int) column10:10(int) checks.a:11(int) checks.b:12(int) checks.c:13(int) d:14(int)
+      │    ├── columns: upsert_b:20(int) upsert_c:21(int) upsert_d:22(int) abc.a:5(int!null) abc.b:6(int) column9:9(int) column10:10(int) checks.a:11(int) checks.b:12(int) checks.c:13(int) d:14(int) column18:18(int) column19:19(int)
       │    ├── project
       │    │    ├── columns: column19:19(int) abc.a:5(int!null) abc.b:6(int) column9:9(int) column10:10(int) checks.a:11(int) checks.b:12(int) checks.c:13(int) d:14(int) column18:18(int)
       │    │    ├── project

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -192,8 +192,6 @@ func (mb *mutationBuilder) addTargetColsForUpdate(exprs tree.UpdateExprs) {
 // input. A final Project operator is built if any single-column or tuple SET
 // expressions are present.
 func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
-	mb.updateColList = make(opt.ColList, mb.tab.DeletableColumnCount())
-
 	// SET expressions should reject aggregates, generators, etc.
 	scalarProps := &mb.b.semaCtx.Properties
 	defer scalarProps.Restore(*scalarProps)
@@ -207,13 +205,13 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 	projectionsScope := mb.outScope.replace()
 	projectionsScope.appendColumnsFromScope(mb.outScope)
 
-	checkCol := func(sourceCol *scopeColumn, targetColID opt.ColumnID) {
+	checkCol := func(sourceCol *scopeColumn, scopeOrd scopeOrdinal, targetColID opt.ColumnID) {
 		// Type check the input expression against the corresponding table column.
 		ord := mb.tabID.ColumnOrdinal(targetColID)
 		checkDatumTypeFitsColumnType(mb.tab.Column(ord), sourceCol.typ)
 
-		// Add new column ID to the list of columns to update.
-		mb.updateColList[ord] = sourceCol.id
+		// Add ordinal of new column scope to the list of columns to update.
+		mb.updateOrds[ord] = scopeOrd
 
 		// Rename the column to match the target column being updated.
 		sourceCol.name = mb.tab.Column(ord).ColName()
@@ -229,9 +227,10 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 		desiredType := mb.md.ColumnMeta(targetColID).Type
 		texpr := inScope.resolveType(expr, desiredType)
 		scopeCol := mb.b.addColumn(projectionsScope, "" /* alias */, texpr)
+		scopeColOrd := scopeOrdinal(len(projectionsScope.cols) - 1)
 		mb.b.buildScalar(texpr, inScope, projectionsScope, scopeCol, nil)
 
-		checkCol(scopeCol, targetColID)
+		checkCol(scopeCol, scopeColOrd, targetColID)
 	}
 
 	n := 0
@@ -246,7 +245,8 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 
 				// Type check and rename columns.
 				for i := range subqueryScope.cols {
-					checkCol(&subqueryScope.cols[i], mb.targetColList[n])
+					scopeColOrd := scopeOrdinal(len(projectionsScope.cols) + i)
+					checkCol(&subqueryScope.cols[i], scopeColOrd, mb.targetColList[n])
 					n++
 				}
 
@@ -302,7 +302,7 @@ func (mb *mutationBuilder) addComputedColsForUpdate() {
 	mb.disambiguateColumns()
 
 	mb.addSynthesizedCols(
-		mb.updateColList,
+		mb.updateOrds,
 		func(tabCol cat.Column) bool { return tabCol.IsComputed() },
 	)
 }

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -302,6 +303,16 @@ func (tt *Table) addColumn(def *tree.ColumnTableDef) {
 		Name:     string(def.Name),
 		Type:     typ,
 		Nullable: nullable,
+	}
+
+	var err error
+	col.ColType, err = sqlbase.DatumTypeToColumnType(typ)
+	if err != nil {
+		panic(err)
+	}
+	col.ColType, err = sqlbase.PopulateTypeAttrs(col.ColType, def.Type)
+	if err != nil {
+		panic(err)
 	}
 
 	// Look for name suffixes indicating this is a mutation column.

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -20,13 +20,13 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
-	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
@@ -694,6 +694,7 @@ type Column struct {
 	Nullable     bool
 	Name         string
 	Type         types.T
+	ColType      sqlbase.ColumnType
 	DefaultExpr  *string
 	ComputedExpr *string
 }
@@ -720,13 +721,19 @@ func (tc *Column) DatumType() types.T {
 	return tc.Type
 }
 
+// ColTypePrecision is part of the cat.Column interface.
+func (tc *Column) ColTypePrecision() int {
+	return int(tc.ColType.Precision)
+}
+
+// ColTypeWidth is part of the cat.Column interface.
+func (tc *Column) ColTypeWidth() int {
+	return int(tc.ColType.Width)
+}
+
 // ColTypeStr is part of the cat.Column interface.
 func (tc *Column) ColTypeStr() string {
-	t, err := coltypes.DatumTypeToColumnType(tc.Type)
-	if err != nil {
-		panic(err)
-	}
-	return t.String()
+	return tc.ColType.SQLString()
 }
 
 // IsHidden is part of the cat.Column interface.

--- a/pkg/sql/sem/tree/testdata/eval/func
+++ b/pkg/sql/sem/tree/testdata/eval/func
@@ -15,3 +15,97 @@ eval
 UPPER('hello')
 ----
 'HELLO'
+
+# Scale < -Exponent.
+eval
+crdb_internal.round_decimal_values(1.23:::decimal, 1)
+----
+1.2
+
+# Scale = -Exponent.
+eval
+crdb_internal.round_decimal_values(1.23:::decimal, 2)
+----
+1.23
+
+# Scale > -Exponent.
+eval
+crdb_internal.round_decimal_values(1.23:::decimal, 3)
+----
+1.23
+
+# Scale=0 with whole number.
+eval
+crdb_internal.round_decimal_values(123:::decimal, 0)
+----
+123
+
+# Scale=0 with fractional number.
+eval
+crdb_internal.round_decimal_values(0.123:::decimal, 0)
+----
+0
+
+# Special-value cases.
+eval
+crdb_internal.round_decimal_values('NaN'::decimal, 0)
+----
+NaN
+
+eval
+crdb_internal.round_decimal_values('-inf'::decimal, 0)
+----
+-Infinity
+
+eval
+crdb_internal.round_decimal_values('inf'::decimal, 0)
+----
+Infinity
+
+# NULL value.
+eval
+crdb_internal.round_decimal_values(null, 0)
+----
+NULL
+
+# NULL decimal value.
+eval
+crdb_internal.round_decimal_values(null::decimal, 0)
+----
+NULL
+
+# Round 10th fractional digit.
+eval
+crdb_internal.round_decimal_values(1000000000000000.0000000005::decimal, 9)
+----
+1000000000000000.000000001
+
+# Truncate extra zeros.
+eval
+crdb_internal.round_decimal_values(1000000000000000.0000000000::decimal, 3)
+----
+1000000000000000.000
+
+# Round with 1 digit coefficient and large negative exponent.
+eval
+crdb_internal.round_decimal_values(0.0000000005::decimal, 9)
+----
+1E-9
+
+# Decimal in array.
+eval
+crdb_internal.round_decimal_values(ARRAY[1.25::decimal], 1)
+----
+ARRAY[1.3]
+
+# Multiple array values need to be rounded + NULL values.
+eval
+crdb_internal.round_decimal_values(ARRAY[NULL, 1.25::decimal, NULL, 1.23::decimal], 1)
+----
+ARRAY[NULL,1.3,NULL,1.2]
+
+# None of the array values need to be rounded.
+eval
+crdb_internal.round_decimal_values(ARRAY[1.2::decimal, 5::decimal, NULL], 1)
+----
+ARRAY[1.2,5,NULL]

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2804,6 +2804,16 @@ func (desc *ColumnDescriptor) DatumType() types.T {
 	return desc.Type.ToDatumType()
 }
 
+// ColTypePrecision is part of the cat.Column interface.
+func (desc *ColumnDescriptor) ColTypePrecision() int {
+	return int(desc.Type.Precision)
+}
+
+// ColTypeWidth is part of the cat.Column interface.
+func (desc *ColumnDescriptor) ColTypeWidth() int {
+	return int(desc.Type.Width)
+}
+
 // ColTypeStr is part of the cat.Column interface.
 func (desc *ColumnDescriptor) ColTypeStr() string {
 	return desc.Type.SQLString()


### PR DESCRIPTION
Backport 2/2 commits from #36066.

/cc @cockroachdb/release

---

opt: Round decimal values before check constraints

The PG spec requires the following DECIMAL type behavior:

  If the scale of a value to be stored is greater than the declared scale
  of the column, the system will round the value to the specified number
  of fractional digits.

This is currently happening at the very end of the mutation operator, after
any check constraints. This commit moves the rounding to occur before check
constraints. Rounding must be performed on inserted and updated values before
computed columns are evaluated as well, since computed columns should run on
the final values to be inserted/updated.

Fixes #35364

Release note (sql change): Computed columns are now evaluated after rounding
any decimal values in input columns. Previously, computed columns used input
values before rounding.
