### PR TITLE
opt: only plan zigzag joins against lax key cols

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -1469,19 +1469,13 @@ CREATE TABLE zigzag2 (
 query TTT
 EXPLAIN SELECT * FROM zigzag2 WHERE a = 1 AND b = 2 AND c IS NULL
 ----
-render                 ·          ·
- └── lookup-join       ·          ·
-      │                table      zigzag2@primary
-      │                type       inner
-      └── zigzag-join  ·          ·
-           │           type       inner
-           │           pred       ((@1 = 1) AND (@2 = 2)) AND (@4 IS NULL)
-           ├── scan    ·          ·
-           │           table      zigzag2@a_b_idx
-           │           fixedvals  2 columns
-           └── scan    ·          ·
-·                      table      zigzag2@c_idx
-·                      fixedvals  1 column
+filter           ·       ·
+ │               filter  c IS NULL
+ └── index-join  ·       ·
+      │          table   zigzag2@primary
+      └── scan   ·       ·
+·                table   zigzag2@a_b_idx
+·                spans   /1/2-/1/3
 
 # Test that we can force a merge join.
 query TTT

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -119,6 +119,28 @@ TABLE pqr
       ├── s string
       └── p int not null
 
+exec-ddl
+CREATE TABLE zz (
+    a INT8 PRIMARY KEY,
+    b INT8 NULL,
+    c INT8 NULL,
+    INDEX idx_b (b ASC),
+    CONSTRAINT idx_c UNIQUE (c)
+)
+----
+TABLE zz
+ ├── a int not null
+ ├── b int
+ ├── c int
+ ├── INDEX primary
+ │    └── a int not null
+ ├── INDEX idx_b
+ │    ├── b int
+ │    └── a int not null
+ └── INDEX idx_c
+      ├── c int
+      └── a int not null (storing)
+
 # --------------------------------------------------
 # CommuteJoin
 # --------------------------------------------------
@@ -1681,6 +1703,35 @@ inner-join (zigzag pqr@q pqr@s)
       ├── q = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
       ├── r = 1 [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
       └── s = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+# Don't generate a zigzag which has the PK as its equality columns against
+# nullable unique indexes where the primary key is not part of the indexed
+# columns.
+
+# Regression test for #36051: prior to fixing this, we would try to use the PK
+# as the equality column here, but it's not actually part of the key so we
+# can't zigzag on it.
+opt
+SELECT * FROM zz WHERE b IS NULL AND c = 2
+----
+select
+ ├── columns: a:1(int!null) b:2(int) c:3(int!null)
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ ├── index-join zz
+ │    ├── columns: a:1(int!null) b:2(int) c:3(int)
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-3)
+ │    └── scan zz@idx_c
+ │         ├── columns: a:1(int!null) c:3(int!null)
+ │         ├── constraint: /3: [/2 - /2]
+ │         ├── cardinality: [0 - 1]
+ │         ├── key: ()
+ │         └── fd: ()-->(1,3)
+ └── filters
+      └── b IS NULL [type=bool, outer=(2), constraints=(/2: [/NULL - /NULL]; tight), fd=()-->(2)]
 
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -219,30 +219,32 @@ project
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
- └── inner-join (zigzag a@u a@v)
+ └── select
       ├── columns: k:1(int!null) u:2(int!null) v:3(int!null)
-      ├── eq columns: [1] = [1]
-      ├── left fixed columns: [2] = [1]
-      ├── right fixed columns: [3] = [5]
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1-3)
+      ├── scan a@v
+      │    ├── columns: k:1(int!null) u:2(int) v:3(int!null)
+      │    ├── constraint: /3: [/5 - /5]
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    └── fd: ()-->(1-3)
       └── filters
-           ├── u = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
-           └── v = 5 [type=bool, outer=(3), constraints=(/3: [/5 - /5]; tight), fd=()-->(3)]
+           └── u = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
 
 memo
 SELECT k FROM a WHERE u = 1 AND v = 5
 ----
-memo (optimized, ~8KB, required=[presentation: k:1])
+memo (optimized, ~6KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
- │         └── cost: 0.04
- ├── G2: (select G4 G5) (zigzag-join G5 a@u a@v) (select G6 G7) (select G8 G9)
+ │         └── cost: 1.10
+ ├── G2: (select G4 G5) (select G6 G7) (select G8 G9)
  │    └── []
- │         ├── best: (zigzag-join G5 a@u a@v)
- │         └── cost: 0.03
+ │         ├── best: (select G8 G9)
+ │         └── cost: 1.09
  ├── G3: (projections)
  ├── G4: (scan a) (scan a@u) (scan a@v)
  │    └── []


### PR DESCRIPTION
Fixes #36051.

The zigzag joiner today only supports zigzagging across a prefix of the
key columns of an index. Previously, we would check the entire column
set of the index, which would cause problems when we tried to zigzag on
columns which weren't guaranteed to be present in the key part of the
index.

Release note (bug fix): fixed a panic when planning zigzag joins against
unique indexes.