### PR TITLE
release-19.1: storage: Added txn wait queue related metrics

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -391,6 +391,7 @@ type Store struct {
 	intentResolver     *intentresolver.IntentResolver
 	raftEntryCache     *raftentry.Cache
 	limiters           batcheval.Limiters
+	txnWaitMetrics     *txnwait.Metrics
 
 	// gossipRangeCountdown and leaseRangeCountdown are countdowns of
 	// changes to range and leaseholder counts, after which the store
@@ -802,6 +803,9 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 
 	s.tsCache = tscache.New(cfg.Clock, cfg.TimestampCachePageSize)
 	s.metrics.registry.AddMetricStruct(s.tsCache.Metrics())
+
+	s.txnWaitMetrics = txnwait.NewMetrics(cfg.HistogramWindowInterval)
+	s.metrics.registry.AddMetricStruct(s.txnWaitMetrics)
 
 	s.compactor = compactor.NewCompactor(
 		s.cfg.Settings,
@@ -4362,6 +4366,12 @@ func (s *Store) setScannerActive(active bool) {
 // GetTxnWaitKnobs is part of txnwait.StoreInterface.
 func (s *Store) GetTxnWaitKnobs() txnwait.TestingKnobs {
 	return s.TestingKnobs().TxnWait
+}
+
+// GetTxnWaitMetrics is called by txnwait.Queue instances to get a reference to
+// the shared metrics instance.
+func (s *Store) GetTxnWaitMetrics() *txnwait.Metrics {
+	return s.txnWaitMetrics
 }
 
 func mustForceScanAndProcess(ctx context.Context, s *Store, q *baseQueue) {

--- a/pkg/storage/txnwait/metrics.go
+++ b/pkg/storage/txnwait/metrics.go
@@ -1,0 +1,106 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package txnwait
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+)
+
+// Metrics contains all the txnqueue related metrics.
+type Metrics struct {
+	PusheeWaiting  *metric.Gauge
+	PusherWaiting  *metric.Gauge
+	QueryWaiting   *metric.Gauge
+	PusherSlow     *metric.Gauge
+	PusherWaitTime *metric.Histogram
+	QueryWaitTime  *metric.Histogram
+	DeadlocksTotal *metric.Counter
+}
+
+// NewMetrics creates a new Metrics instance with all related metric fields.
+func NewMetrics(histogramWindowInterval time.Duration) *Metrics {
+	return &Metrics{
+		PusheeWaiting: metric.NewGauge(
+			metric.Metadata{
+				Name:        "txnwaitqueue.pushee.waiting",
+				Help:        "Number of pushees on the txn wait queue",
+				Measurement: "Waiting Pushees",
+				Unit:        metric.Unit_COUNT,
+			},
+		),
+
+		PusherWaiting: metric.NewGauge(
+			metric.Metadata{
+				Name:        "txnwaitqueue.pusher.waiting",
+				Help:        "Number of pushers on the txn wait queue",
+				Measurement: "Waiting Pushers",
+				Unit:        metric.Unit_COUNT,
+			},
+		),
+
+		QueryWaiting: metric.NewGauge(
+			metric.Metadata{
+				Name:        "txnwaitqueue.query.waiting",
+				Help:        "Number of transaction status queries waiting for an updated transaction record",
+				Measurement: "Waiting Queries",
+				Unit:        metric.Unit_COUNT,
+			},
+		),
+
+		PusherSlow: metric.NewGauge(
+			metric.Metadata{
+				Name:        "txnwaitqueue.pusher.slow",
+				Help:        "The total number of cases where a pusher waited more than the excessive wait threshold",
+				Measurement: "Slow Pushers",
+				Unit:        metric.Unit_COUNT,
+			},
+		),
+
+		PusherWaitTime: metric.NewHistogram(
+			metric.Metadata{
+				Name:        "txnwaitqueue.pusher.wait_time",
+				Help:        "Histogram of durations spent in queue by pushers",
+				Measurement: "Pusher wait time",
+				Unit:        metric.Unit_NANOSECONDS,
+			},
+			histogramWindowInterval,
+			time.Hour.Nanoseconds(),
+			1,
+		),
+
+		QueryWaitTime: metric.NewHistogram(
+			metric.Metadata{
+				Name:        "txnwaitqueue.query.wait_time",
+				Help:        "Histogram of durations spent in queue by queries",
+				Measurement: "Query wait time",
+				Unit:        metric.Unit_NANOSECONDS,
+			},
+			histogramWindowInterval,
+			time.Hour.Nanoseconds(),
+			1,
+		),
+
+		DeadlocksTotal: metric.NewCounter(
+			metric.Metadata{
+				Name:        "txnwaitqueue.deadlocks_total",
+				Help:        "Number of deadlocks detected by the txn wait queue",
+				Measurement: "Deadlocks",
+				Unit:        metric.Unit_COUNT,
+			},
+		),
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #35921.

/cc @cockroachdb/release

---

Resolves https://github.com/cockroachdb/cockroach/issues/31106

The new metrics are:
- current count of pushees, pushers and queries
- the total number of instances where a pusher had to wait more than 1 min on the queue
- histograms for the time spent waiting on the queue for pushers and queries
- total number of deadlocks

Here is a sample chart for the current count of pushees, pushers, queries as well as the total number of cases where a pusher waited more than 1 min
![image](https://user-images.githubusercontent.com/7052693/54570571-3c7c0f80-499c-11e9-938e-e58cda791e17.png)

Here is a sample chart of the cumulative count of the deadlocks expressed as rate
![image](https://user-images.githubusercontent.com/7052693/54570649-895fe600-499c-11e9-9e56-c24a3dad52b6.png)

Here is a sample chart of the pusher wait time breakdown 
![image](https://user-images.githubusercontent.com/7052693/54570704-bb714800-499c-11e9-9a8f-7da56f697997.png)

and a sample chart of the queue wait time breakdown
![image](https://user-images.githubusercontent.com/7052693/54570731-d643bc80-499c-11e9-8fc5-3ed6f39344ea.png)

