### PR TITLE
tree: teach ALTER TABLE to pretty print

### DIFF
--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -146,7 +146,8 @@ func (p *PrettyCfg) Doc(f NodeFormatter) pretty.Doc {
 
 func (p *PrettyCfg) docAsString(f NodeFormatter) pretty.Doc {
 	const prettyFlags = FmtShowPasswords | FmtParsable
-	return pretty.Text(AsStringWithFlags(f, prettyFlags))
+	txt := AsStringWithFlags(f, prettyFlags)
+	return pretty.Text(strings.TrimSpace(txt))
 }
 
 func (p *PrettyCfg) nestUnder(a, b pretty.Doc) pretty.Doc {
@@ -1621,5 +1622,38 @@ func (node *CoalesceExpr) doc(p *PrettyCfg) pretty.Doc {
 		node.Name, "(",
 		p.Doc(&node.Exprs),
 		")", "",
+	)
+}
+
+func (node *AlterTable) doc(p *PrettyCfg) pretty.Doc {
+	title := "ALTER TABLE"
+	if node.IfExists {
+		title += " IF EXISTS"
+	}
+	return p.nestUnder(
+		pretty.Concat(
+			prettyKeywordWithText("", title, " "),
+			p.Doc(&node.Table),
+		),
+		p.Doc(&node.Cmds),
+	)
+}
+
+func (node *AlterTableCmds) doc(p *PrettyCfg) pretty.Doc {
+	cmds := make([]pretty.Doc, len(*node))
+	for i, c := range *node {
+		cmds[i] = p.Doc(c)
+	}
+	return pretty.Join(",", cmds...)
+}
+
+func (node *AlterTableAddColumn) doc(p *PrettyCfg) pretty.Doc {
+	title := "ADD COLUMN"
+	if node.IfNotExists {
+		title += " IF NOT EXISTS"
+	}
+	return p.nestUnder(
+		pretty.Keyword(title),
+		p.Doc(node.ColumnDef),
 	)
 }


### PR DESCRIPTION
AlterTable has many kinds of commands. Only one is added here since
it benefits the most from pretty printing. The others are fine as is,
except they print themselves with a space at the front. We can safely
trim all spaces for nodes that don't support pretty printing because
either it's the root node (and thus shouldn't have trailing whitespace)
or its parent node can pretty print itself, and so the whitespace isn't
needed for token separation.

Release note: None