### PR TITLE
sql: show filter inside index-join

### DIFF
--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -678,14 +678,15 @@ CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-render           ·         ·           (x int, y int)                                       x!=NULL; y!=NULL
- │               render 0  (x)[int]    ·                                                    ·
- │               render 1  (y)[int]    ·                                                    ·
- └── index-join  ·         ·           (x int, y int, rowid[hidden,omitted] int)            x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
-      │          table     tt@primary  ·                                                    ·
-      └── scan   ·         ·           (x[omitted] int, y[omitted] int, rowid[hidden] int)  x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
-·                table     tt@a        ·                                                    ·
-·                spans     /!NULL-/10  ·                                                    ·
+render           ·         ·                             (x int, y int)                                       x!=NULL; y!=NULL
+ │               render 0  (x)[int]                      ·                                                    ·
+ │               render 1  (y)[int]                      ·                                                    ·
+ └── index-join  ·         ·                             (x int, y int, rowid[hidden,omitted] int)            x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
+      │          table     tt@primary                    ·                                                    ·
+      │          filter    ((y)[int] > (10)[int])[bool]  ·                                                    ·
+      └── scan   ·         ·                             (x[omitted] int, y[omitted] int, rowid[hidden] int)  x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
+·                table     tt@a                          ·                                                    ·
+·                spans     /!NULL-/10                    ·                                                    ·
 
 query TTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM tt WHERE x < 10 AND y > 10

--- a/pkg/sql/logictest/testdata/planner_test/inverted_index
+++ b/pkg/sql/logictest/testdata/planner_test/inverted_index
@@ -143,38 +143,42 @@ scan  ·       ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
-index-join  ·      ·                                    (a, b)           b=CONST; a!=NULL; key(a)
- │          table  d@primary                            ·                ·
- └── scan   ·      ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
-·           table  d@foo_inv                            ·                ·
-·           spans  /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·                ·
+index-join  ·       ·                                    (a, b)           b=CONST; a!=NULL; key(a)
+ │          table   d@primary                            ·                ·
+ │          filter  b @> '{"a": {"b": "c"}, "f": "g"}'   ·                ·
+ └── scan   ·       ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table   d@foo_inv                            ·                ·
+·           spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
-index-join  ·      ·                                    (a, b)           b=CONST; a!=NULL; key(a)
- │          table  d@primary                            ·                ·
- └── scan   ·      ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
-·           table  d@foo_inv                            ·                ·
-·           spans  /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·                ·
+index-join  ·       ·                                             (a, b)           b=CONST; a!=NULL; key(a)
+ │          table   d@primary                                     ·                ·
+ │          filter  b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·                ·
+ └── scan   ·       ·                                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table   d@foo_inv                                     ·                ·
+·           spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd           ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
-index-join  ·      ·                                                        (a, b)           b=CONST; a!=NULL; key(a)
- │          table  d@primary                                                ·                ·
- └── scan   ·      ·                                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
-·           table  d@foo_inv                                                ·                ·
-·           spans  /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
+index-join  ·       ·                                                        (a, b)           b=CONST; a!=NULL; key(a)
+ │          table   d@primary                                                ·                ·
+ │          filter  b @> '[{"a": {"b": [[2]]}}, "d"]'                        ·                ·
+ └── scan   ·       ·                                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table   d@foo_inv                                                ·                ·
+·           spans   /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
 ----
-index-join  ·      ·                        (a, b)           b=CONST; a!=NULL; key(a)
- │          table  d@primary                ·                ·
- └── scan   ·      ·                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
-·           table  d@foo_inv                ·                ·
-·           spans  /"b"/2-/"b"/2/PrefixEnd  ·                ·
+index-join  ·       ·                         (a, b)           b=CONST; a!=NULL; key(a)
+ │          table   d@primary                 ·                ·
+ │          filter  b @> '{"a": {}, "b": 2}'  ·                ·
+ └── scan   ·       ·                         (a, b[omitted])  b=CONST; a!=NULL; key(a)
+·           table   d@foo_inv                 ·                ·
+·           spans   /"b"/2-/"b"/2/PrefixEnd   ·                ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": {}}'

--- a/pkg/sql/logictest/testdata/planner_test/limit
+++ b/pkg/sql/logictest/testdata/planner_test/limit
@@ -7,14 +7,15 @@ CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX(v))
 query TTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE v > 4 AND w > 30 ORDER BY v LIMIT 2
 ----
-tree             field  description  columns                      ordering
-limit            ·      ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
- │               count  2            ·                            ·
- └── index-join  ·      ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
-      │          table  t@primary    ·                            ·
-      └── scan   ·      ·            (k, v[omitted], w[omitted])  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
-·                table  t@t_v_idx    ·                            ·
-·                spans  /5-          ·                            ·
+tree             field   description  columns                      ordering
+limit            ·       ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+ │               count   2            ·                            ·
+ └── index-join  ·       ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+      │          table   t@primary    ·                            ·
+      │          filter  w > 30       ·                            ·
+      └── scan   ·       ·            (k, v[omitted], w[omitted])  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+·                table   t@t_v_idx    ·                            ·
+·                spans   /5-          ·                            ·
 
 # This kind of query can be used to work around memory usage limits. We need to
 # choose the "hard" limit of 100 over the "soft" limit of 25 (with the hard

--- a/pkg/sql/logictest/testdata/planner_test/select_index
+++ b/pkg/sql/logictest/testdata/planner_test/select_index
@@ -1022,11 +1022,12 @@ index-join  ·      ·
 query TTT
 EXPLAIN SELECT * FROM noncover WHERE c > 0 AND d = 8
 ----
-index-join  ·      ·
- │          table  noncover@primary
- └── scan   ·      ·
-·           table  noncover@c
-·           spans  /1-
+index-join  ·       ·
+ │          table   noncover@primary
+ │          filter  d = 8
+ └── scan   ·       ·
+·           table   noncover@c
+·           spans   /1-
 
 # The following testcases verify that when we have a small limit, we prefer an
 # order-matching index.

--- a/pkg/sql/logictest/testdata/planner_test/select_index_flags
+++ b/pkg/sql/logictest/testdata/planner_test/select_index_flags
@@ -94,12 +94,13 @@ render     ·       ·
 query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
-render           ·      ·
- └── index-join  ·      ·
-      │          table  abcd@primary
-      └── scan   ·      ·
-·                table  abcd@b
-·                spans  ALL
+render           ·       ·
+ └── index-join  ·       ·
+      │          table   abcd@primary
+      │          filter  (c >= 20) AND (c <= 30)
+      └── scan   ·       ·
+·                table   abcd@b
+·                spans   ALL
 
 # No hint, should be using index cd
 query TTT
@@ -124,12 +125,13 @@ render     ·       ·
 query TTT
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----
-render           ·      ·
- └── index-join  ·      ·
-      │          table  abcd@primary
-      └── scan   ·      ·
-·                table  abcd@b
-·                spans  ALL
+render           ·       ·
+ └── index-join  ·       ·
+      │          table   abcd@primary
+      │          filter  (c >= 20) AND (c < 40)
+      └── scan   ·       ·
+·                table   abcd@b
+·                spans   ALL
 
 query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30

--- a/pkg/sql/logictest/testdata/planner_test/tuple
+++ b/pkg/sql/logictest/testdata/planner_test/tuple
@@ -100,16 +100,17 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b))
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3) AND (a, b, c) < (8, 9, 10)
 ----
-render           ·         ·                                          (a, b, c)                          ·
- │               render 0  test.public.abc.a                          ·                                  ·
- │               render 1  test.public.abc.b                          ·                                  ·
- │               render 2  test.public.abc.c                          ·                                  ·
- └── index-join  ·         ·                                          (a, b, c, rowid[hidden,omitted])   rowid!=NULL; weak-key(a,b,rowid)
-      │          table     abc@primary                                ·                                  ·
-      └── scan   ·         ·                                          (a, b, c[omitted], rowid[hidden])  rowid!=NULL; weak-key(a,b,rowid)
-·                table     abc@abc_a_b_idx                            ·                                  ·
-·                spans     /1/2-/8/10                                 ·                                  ·
-·                filter    ((a, b) >= (1, 2)) AND ((a, b) <= (8, 9))  ·                                  ·
+render           ·         ·                                                     (a, b, c)                          ·
+ │               render 0  test.public.abc.a                                     ·                                  ·
+ │               render 1  test.public.abc.b                                     ·                                  ·
+ │               render 2  test.public.abc.c                                     ·                                  ·
+ └── index-join  ·         ·                                                     (a, b, c, rowid[hidden,omitted])   rowid!=NULL; weak-key(a,b,rowid)
+      │          table     abc@primary                                           ·                                  ·
+      │          filter    ((a, b, c) > (1, 2, 3)) AND ((a, b, c) < (8, 9, 10))  ·                                  ·
+      └── scan   ·         ·                                                     (a, b, c[omitted], rowid[hidden])  rowid!=NULL; weak-key(a,b,rowid)
+·                table     abc@abc_a_b_idx                                       ·                                  ·
+·                spans     /1/2-/8/10                                            ·                                  ·
+·                filter    ((a, b) >= (1, 2)) AND ((a, b) <= (8, 9))             ·                                  ·
 
 statement ok
 DROP TABLE abc

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -227,6 +227,7 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 	case *indexJoinNode:
 		if v.observer.attr != nil {
 			v.observer.attr(name, "table", fmt.Sprintf("%s@%s", n.table.desc.Name, n.table.index.Name))
+			v.expr(name, "filter", -1, n.table.filter)
 		}
 		v.visitConcrete(n.index)
 


### PR DESCRIPTION
A recent improvement to EXPLAIN accidentally resulted in hiding any
post-index-join filter. The optimizer doesn't use this (it uses a
separate filterNode), but the heuristic planner does.

Fixes #36170.

Release note (bug fix): fixed a regression in EXPLAIN where it no
longer showed the filter inside an index-join.