### PR TITLE
release-19.1: pgwire: cancel authentication work when the network connection is closed

### DIFF
--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -28,6 +28,7 @@ type TestingKnobs struct {
 	SQLExecutor         ModuleTestingKnobs
 	SQLLeaseManager     ModuleTestingKnobs
 	SQLSchemaChanger    ModuleTestingKnobs
+	PGWireTestingKnobs  ModuleTestingKnobs
 	SQLMigrationManager ModuleTestingKnobs
 	DistSQL             ModuleTestingKnobs
 	SQLEvalContext      ModuleTestingKnobs

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -66,7 +66,7 @@ func authGSS(
 		}
 
 		for {
-			token, err = c.ReadPasswordBytes()
+			token, err = c.GetPwdData()
 			if err != nil {
 				return err
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -667,6 +667,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if sqlEvalContext := s.cfg.TestingKnobs.SQLEvalContext; sqlEvalContext != nil {
 		execCfg.EvalContextTestingKnobs = *sqlEvalContext.(*tree.EvalContextTestingKnobs)
 	}
+	if pgwireKnobs := s.cfg.TestingKnobs.PGWireTestingKnobs; pgwireKnobs != nil {
+		execCfg.PGWireTestingKnobs = pgwireKnobs.(*sql.PGWireTestingKnobs)
+	}
 
 	s.statsRefresher = stats.MakeRefresher(
 		s.st,
@@ -1707,12 +1710,7 @@ func (s *Server) Start(ctx context.Context) error {
 			connCtx := logtags.AddTag(pgCtx, "client", conn.RemoteAddr().String())
 			setTCPKeepAlive(connCtx, conn)
 
-			// Unless this is a simple disconnect or context timeout, report the error on
-			// this connection's context, so that we know which remote client caused the
-			// error when looking at the logs. Note that we pass a non-cancelable context
-			// in, but the callee eventually wraps the context so that it can get
-			// canceled and it may return the error here.
-			if err := errors.Cause(s.pgServer.ServeConn(connCtx, conn)); err != nil && !netutil.IsClosedConnection(err) && err != context.Canceled && err != context.DeadlineExceeded {
+			if err := s.pgServer.ServeConn(connCtx, conn); err != nil {
 				log.Error(connCtx, err)
 			}
 		}))
@@ -1741,11 +1739,7 @@ func (s *Server) Start(ctx context.Context) error {
 			}
 			netutil.FatalIfUnexpected(httpServer.ServeWith(pgCtx, s.stopper, unixLn, func(conn net.Conn) {
 				connCtx := logtags.AddTag(pgCtx, "client", conn.RemoteAddr().String())
-				if err := s.pgServer.ServeConn(connCtx, conn); err != nil &&
-					!netutil.IsClosedConnection(err) {
-					// Report the error on this connection's context, so that we
-					// know which remote client caused the error when looking at
-					// the logs.
+				if err := s.pgServer.ServeConn(connCtx, conn); err != nil {
 					log.Error(connCtx, err)
 				}
 			}))
@@ -1857,7 +1851,7 @@ func (s *Server) doDrain(
 // On failure, the system may be in a partially drained state and should be
 // recovered by calling Undrain() with the same (or a larger) slice of modes.
 func (s *Server) Drain(ctx context.Context, on []serverpb.DrainMode) ([]serverpb.DrainMode, error) {
-	return s.doDrain(ctx, on, true)
+	return s.doDrain(ctx, on, true /* setTo */)
 }
 
 // Undrain idempotently deactivates the given DrainModes on the Server in the

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -386,9 +386,9 @@ type ConnectionHandler struct {
 	ex *connExecutor
 }
 
-// GetDefaultIntSize implements pgwire.sessionDataProvider and returns
+// GetUnqualifiedIntSize implements pgwire.sessionDataProvider and returns
 // the type that INT should be parsed as.
-func (h ConnectionHandler) GetDefaultIntSize() *coltypes.TInt {
+func (h ConnectionHandler) GetUnqualifiedIntSize() *coltypes.TInt {
 	var size int
 	if h.ex != nil {
 		// The executor will be nil in certain testing situations where
@@ -421,8 +421,11 @@ func (h ConnectionHandler) GetStatusParam(ctx context.Context, varName string) s
 	return defVal
 }
 
-// ServeConn serves a client connection by reading commands from
-// the stmtBuf embedded in the ConnHandler.
+// ServeConn serves a client connection by reading commands from the stmtBuf
+// embedded in the ConnHandler.
+//
+// If not nil, reserved represents memory reserved for the connection. The
+// connExecutor takes ownership of this memory.
 func (s *Server) ServeConn(
 	ctx context.Context, h ConnectionHandler, reserved mon.BoundAccount, cancel context.CancelFunc,
 ) error {
@@ -1060,8 +1063,8 @@ func (ex *connExecutor) Ctx() context.Context {
 //
 // Args:
 // parentMon: The root monitor.
-// reserved: An amount on memory reserved for the connection. The connExecutor
-// 	 takes ownership of this memory.
+// reserved: Memory reserved for the connection. The connExecutor takes
+//   ownership of this memory.
 func (ex *connExecutor) activate(
 	ctx context.Context, parentMon *mon.BytesMonitor, reserved mon.BoundAccount,
 ) {
@@ -1107,6 +1110,9 @@ func (ex *connExecutor) activate(
 // also have an error from the reading side), or some other unexpected failure.
 // Returned errors have not been communicated to the client: it's up to the
 // caller to do that if it wants.
+//
+// If not nil, reserved represents Memory reserved for the connection. The
+// connExecutor takes ownership of this memory.
 //
 // onCancel, if not nil, will be called when the SessionRegistry cancels the
 // session. TODO(andrei): This is hooked up to canceling the pgwire connection's
@@ -1179,8 +1185,8 @@ func (ex *connExecutor) run(
 			ex.phaseTimes[sessionStartParse] = tcmd.ParseStart
 			ex.phaseTimes[sessionEndParse] = tcmd.ParseEnd
 
-			ctx := withStatement(ex.Ctx(), ex.curStmt)
-			ev, payload, err = ex.execStmt(ctx, curStmt, stmtRes, nil /* pinfo */)
+			stmtCtx := withStatement(ex.Ctx(), ex.curStmt)
+			ev, payload, err = ex.execStmt(stmtCtx, curStmt, stmtRes, nil /* pinfo */)
 			if err != nil {
 				return err
 			}
@@ -1238,16 +1244,16 @@ func (ex *connExecutor) run(
 				ExpectedTypes: portal.Stmt.Columns,
 				AnonymizedStr: portal.Stmt.AnonymizedStr,
 			}
-			ctx := withStatement(ex.Ctx(), ex.curStmt)
-			ev, payload, err = ex.execStmt(ctx, curStmt, stmtRes, pinfo)
+			stmtCtx := withStatement(ex.Ctx(), ex.curStmt)
+			ev, payload, err = ex.execStmt(stmtCtx, curStmt, stmtRes, pinfo)
 			if err != nil {
 				return err
 			}
 		case PrepareStmt:
 			ex.curStmt = tcmd.AST
 			res = ex.clientComm.CreatePrepareResult(pos)
-			ctx := withStatement(ex.Ctx(), ex.curStmt)
-			ev, payload = ex.execPrepare(ctx, tcmd)
+			stmtCtx := withStatement(ex.Ctx(), ex.curStmt)
+			ev, payload = ex.execPrepare(stmtCtx, tcmd)
 		case DescribeStmt:
 			descRes := ex.clientComm.CreateDescribeResult(pos)
 			res = descRes

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -378,6 +378,7 @@ type ExecutorConfig struct {
 	QueryCache       *querycache.C
 
 	TestingKnobs              ExecutorTestingKnobs
+	PGWireTestingKnobs        *PGWireTestingKnobs
 	SchemaChangerTestingKnobs *SchemaChangerTestingKnobs
 	DistSQLRunTestingKnobs    *distsqlrun.TestingKnobs
 	EvalContextTestingKnobs   tree.EvalContextTestingKnobs
@@ -444,12 +445,24 @@ type ExecutorTestingKnobs struct {
 	// optimization). This is only called when the Executor is the one doing the
 	// committing.
 	BeforeAutoCommit func(ctx context.Context, stmt string) error
+}
 
-	// CatchPanics causes the connExecutor to recover from panics in its execution
+// PGWireTestingKnobs contains knobs for the pgwire module.
+type PGWireTestingKnobs struct {
+	// CatchPanics causes the pgwire.conn to recover from panics in its execution
 	// thread and return them as errors to the client, closing the connection
 	// afterward.
 	CatchPanics bool
+
+	// AuthHook is used to override the normal authentication handling on new
+	// connections.
+	AuthHook func(context.Context) error
 }
+
+var _ base.ModuleTestingKnobs = &PGWireTestingKnobs{}
+
+// ModuleTestingKnobs implements the base.ModuleTestingKnobs interface.
+func (*PGWireTestingKnobs) ModuleTestingKnobs() {}
 
 // databaseCacheHolder is a thread-safe container for a *databaseCache.
 // It also allows clients to block until the cache is updated to a desired

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime/debug"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -101,6 +103,14 @@ type conn struct {
 	sv *settings.Values
 }
 
+type authOptions struct {
+	skipAuth bool                            // test-only
+	authHook func(ctx context.Context) error // test-only
+	insecure bool
+	auth     *hba.Conf
+	ie       *sql.InternalExecutor
+}
+
 // serveConn creates a conn that will serve the netConn. It returns once the
 // network connection is closed.
 //
@@ -147,11 +157,9 @@ func serveConn(
 	reserved mon.BoundAccount,
 	sqlServer *sql.Server,
 	draining func() bool,
-	ie *sql.InternalExecutor,
+	authOpt authOptions,
 	stopper *stop.Stopper,
-	insecure bool,
-	auth *hba.Conf,
-) error {
+) {
 	sArgs.RemoteAddr = netConn.RemoteAddr()
 
 	if log.V(2) {
@@ -160,15 +168,8 @@ func serveConn(
 
 	c := newConn(netConn, sArgs, metrics, &sqlServer.GetExecutorConfig().Settings.SV)
 
-	if err := c.handleAuthentication(ctx, insecure, ie, auth, sqlServer.GetExecutorConfig()); err != nil {
-		_ = c.conn.Close()
-		reserved.Close(ctx)
-		return err
-	}
-
 	// Do the reading of commands from the network.
-	readingErr := c.serveImpl(ctx, draining, sqlServer, reserved, stopper)
-	return readingErr
+	c.serveImpl(ctx, draining, sqlServer, reserved, authOpt, stopper)
 }
 
 func newConn(
@@ -203,10 +204,12 @@ func (c *conn) GetErr() error {
 }
 
 // serveImpl continuously reads from the network connection and pushes execution
-// instructions into a sql.StmtBuf.
+// instructions into a sql.StmtBuf, from where they'll be processed by a command
+// "processor" goroutine (a connExecutor).
 // The method returns when the pgwire termination message is received, when
 // network communication fails, when the server is draining or when ctx is
-// canceled (which also happens when draining, but not from the get-go).
+// canceled (which also happens when draining (but not from the get-go), and
+// when the processor encounters a fatal error).
 //
 // serveImpl always closes the network connection before returning.
 //
@@ -218,8 +221,9 @@ func (c *conn) serveImpl(
 	draining func() bool,
 	sqlServer *sql.Server,
 	reserved mon.BoundAccount,
+	authOpt authOptions,
 	stopper *stop.Stopper,
-) error {
+) {
 	defer func() { _ = c.conn.Close() }()
 
 	ctx = logtags.AddTag(ctx, "user", c.sessionArgs.User)
@@ -228,123 +232,83 @@ func (c *conn) serveImpl(
 	// for the handshake. After that, all writes are done async, in the
 	// startWriter() goroutine.
 
-	sendStatusParam := func(param, value string) error {
-		c.msgBuilder.initMsg(pgwirebase.ServerMsgParameterStatus)
-		c.msgBuilder.writeTerminatedString(param)
-		c.msgBuilder.writeTerminatedString(value)
-		return c.msgBuilder.finishMsg(c.conn)
-	}
-
-	var connHandler sql.ConnectionHandler
-	if sqlServer != nil {
-		var err error
-		connHandler, err = sqlServer.SetupConn(
-			ctx, c.sessionArgs, &c.stmtBuf, c, c.metrics.SQLMemMetrics)
-		if err != nil {
-			_ /* err */ = writeErr(ctx, &sqlServer.GetExecutorConfig().Settings.SV,
-				err, &c.msgBuilder, c.conn)
-			return err
-		}
-
-		// Send the initial "status parameters" to the client.  This
-		// overlaps partially with session variables. The client wants to
-		// see the values that result of the combination of server-side
-		// defaults with client-provided values.
-		// For details see: https://www.postgresql.org/docs/10/static/libpq-status.html
-		for _, param := range statusReportParams {
-			value := connHandler.GetStatusParam(ctx, param)
-			if err := sendStatusParam(param, value); err != nil {
-				return err
-			}
-		}
-		// The two following status parameters have no equivalent session
-		// variable.
-		if err := sendStatusParam("session_authorization", c.sessionArgs.User); err != nil {
-			return err
-		}
-
-		// TODO(knz): this should retrieve the admin status during
-		// authentication using the roles table, instead of using a
-		// simple/naive username match.
-		isSuperUser := c.sessionArgs.User == security.RootUser
-		superUserVal := "off"
-		if isSuperUser {
-			superUserVal = "on"
-		}
-		if err := sendStatusParam("is_superuser", superUserVal); err != nil {
-			return err
-		}
-	} else {
-		// sqlServer == nil means we are in a local test. In this case
-		// we only need the minimum to make pgx happy.
-		for param, value := range testingStatusReportParams {
-			if err := sendStatusParam(param, value); err != nil {
-				return err
-			}
-		}
-	}
-
-	// An initial readyForQuery message is part of the handshake.
-	c.msgBuilder.initMsg(pgwirebase.ServerMsgReady)
-	c.msgBuilder.writeByte(byte(sql.IdleTxnBlock))
-	if err := c.msgBuilder.finishMsg(c.conn); err != nil {
-		return err
-	}
-
 	ctx, cancelConn := context.WithCancel(ctx)
 	defer cancelConn() // This calms the linter that wants these callbacks to always be called.
-	var ctxCanceled bool
 
-	// Once a session has been set up, the underlying net.Conn is switched to
-	// a conn that exits if the session's context is canceled.
-	c.conn = newReadTimeoutConn(c.conn, func() error {
-		// If the context was closed, it's time to bail. Either a higher-level
-		// server or the command processor have canceled us.
+	var sentDrainSignal bool
+	// The net.Conn is switched to a conn that exits if the ctx is canceled.
+	c.conn = newReadTimeoutConn(c.conn, func(tc *readTimeoutConn) error {
+		// If the context was canceled, it's time to stop reading. Either a
+		// higher-level server or the command processor have canceled us.
 		if ctx.Err() != nil {
-			ctxCanceled = true
 			return ctx.Err()
 		}
 		// If the server is draining, we'll let the processor know by pushing a
 		// DrainRequest. This will make the processor quit whenever it finds a good
 		// time.
-		if draining() {
+		if !sentDrainSignal && draining() {
 			_ /* err */ = c.stmtBuf.Push(ctx, sql.DrainRequest{})
+			sentDrainSignal = true
 		}
 		return nil
 	})
 	c.rd = *bufio.NewReader(c.conn)
 
-	var wg sync.WaitGroup
-	var writerErr error
+	// We'll build an authPipe to communicate with the authentication process.
+	authPipe := newAuthPipe(c)
+	var authenticator authenticator = authPipe
+
+	// procCh is the channel on which we'll receive the termination signal from
+	// the command processor.
+	var procCh <-chan error
+
 	if sqlServer != nil {
-		wg.Add(1)
-		go func() {
-			defer func() {
-				if sqlServer.GetExecutorConfig().TestingKnobs.CatchPanics {
-					if r := recover(); r != nil {
-						// Catch the panic and return it to the client as an error.
-						err := pgerror.NewAssertionErrorf("caught fatal error: %v", r)
-						_ = writeErr(ctx, &sqlServer.GetExecutorConfig().Settings.SV,
-							err, &c.msgBuilder, &c.writerState.buf)
-						_ /* n */, _ /* err */ = c.writerState.buf.WriteTo(c.conn)
-						c.stmtBuf.Close()
-						// Send a ready for query to make sure the client can react.
-						c.bufferReadyForQuery('I')
-					}
-				}
-				wg.Done()
-				cancelConn()
-			}()
-			writerErr = sqlServer.ServeConn(ctx, connHandler, reserved, cancelConn)
-			// TODO(andrei): Should we sometimes transmit the writerErr's to the
-			// client?
-		}()
+		// Spawn the command processing goroutine, which also handles connection
+		// authentication). It will notify us when it's done through procCh, and
+		// we'll also interact with the authentication process through ac.
+		var ac AuthConn = authPipe
+		procCh = c.processCommandsAsync(ctx, authOpt, ac, sqlServer, reserved, cancelConn)
+	} else {
+		// sqlServer == nil means we are in a local test. In this case
+		// we only need the minimum to make pgx happy.
+		var err error
+		for param, value := range testingStatusReportParams {
+			if err := c.sendStatusParam(param, value); err != nil {
+				break
+			}
+		}
+		if err != nil {
+			reserved.Close(ctx)
+			return
+		}
+		var ac AuthConn = authPipe
+		// Simulate auth succeeding.
+		ac.AuthOK(fixedIntSizer{size: coltypes.Int8})
+		dummyCh := make(chan error)
+		close(dummyCh)
+		procCh = dummyCh
+		// An initial readyForQuery message is part of the handshake.
+		c.msgBuilder.initMsg(pgwirebase.ServerMsgReady)
+		c.msgBuilder.writeByte(byte(sql.IdleTxnBlock))
+		if err := c.msgBuilder.finishMsg(c.conn); err != nil {
+			reserved.Close(ctx)
+			return
+		}
 	}
 
 	var err error
 	var terminateSeen bool
 	var doingExtendedQueryMessage bool
 
+	// We need an intSizer, which we're ultimately going to get from the
+	// authenticator once authentication succeeds (because it will actually be a
+	// ConnectionHandler). Until then, we unfortunately still need some intSizer
+	// because we technically might enqueue parsed statements in the statement
+	// buffer even before authentication succeeds (because we need this go routine
+	// to keep reading from the network connection while authentication is in
+	// progress in order to react to the connection closing).
+	var intSizer unqualifiedIntSizer = fixedIntSizer{size: coltypes.Int8}
+	var authDone bool
 Loop:
 	for {
 		var typ pgwirebase.ClientMessageType
@@ -354,11 +318,41 @@ Loop:
 		if err != nil {
 			break Loop
 		}
-		if log.V(2) {
-			log.Infof(ctx, "pgwire: processing %s", typ)
-		}
 		timeReceived := timeutil.Now()
+		log.VEventf(ctx, 2, "pgwire: processing %s", typ)
+
+		if !authDone {
+			if typ == pgwirebase.ClientMsgPassword {
+				var pwd []byte
+				if pwd, err = c.readBuf.GetBytes(n - 4); err != nil {
+					break Loop
+				}
+				// Pass the data to the authenticator. This hopefully causes it to finish
+				// authentication in the background and give us an intSizer when we loop
+				// around.
+				if err = authenticator.sendPwdData(pwd); err != nil {
+					break Loop
+				}
+				continue
+			}
+			// Wait for the auth result.
+			intSizer, err = authenticator.authResult()
+			if err != nil {
+				// The error has already been sent to the client.
+				break Loop
+			} else {
+				authDone = true
+			}
+		}
+
 		switch typ {
+		case pgwirebase.ClientMsgPassword:
+			// This messages are only acceptable during the auth phase, handled above.
+			err = pgwirebase.NewProtocolViolationErrorf("unexpected authentication data")
+			_ /* err */ = writeErr(
+				ctx, &sqlServer.GetExecutorConfig().Settings.SV, err,
+				&c.msgBuilder, &c.writerState.buf)
+			break Loop
 		case pgwirebase.ClientMsgSimpleQuery:
 			if doingExtendedQueryMessage {
 				if err = c.stmtBuf.Push(
@@ -371,7 +365,9 @@ Loop:
 					break
 				}
 			}
-			if err = c.handleSimpleQuery(ctx, &c.readBuf, timeReceived, connHandler); err != nil {
+			if err = c.handleSimpleQuery(
+				ctx, &c.readBuf, timeReceived, intSizer.GetUnqualifiedIntSize(),
+			); err != nil {
 				break
 			}
 			err = c.stmtBuf.Push(ctx, sql.Sync{})
@@ -382,7 +378,7 @@ Loop:
 
 		case pgwirebase.ClientMsgParse:
 			doingExtendedQueryMessage = true
-			err = c.handleParse(ctx, &c.readBuf, connHandler)
+			err = c.handleParse(ctx, &c.readBuf, intSizer.GetUnqualifiedIntSize())
 
 		case pgwirebase.ClientMsgDescribe:
 			doingExtendedQueryMessage = true
@@ -430,37 +426,223 @@ Loop:
 		}
 	}
 
+	// We're done reading data from the client, so make the communication
+	// goroutine stop. Depending on what that goroutine is currently doing (or
+	// blocked on), we cancel and close all the possible channels to make sure we
+	// tickle it in the right way.
+
 	// Signal command processing to stop. It might be the case that the processor
 	// canceled our context and that's how we got here; in that case, this will
 	// be a no-op.
 	c.stmtBuf.Close()
-	cancelConn() // This cancels the processor's context.
-	wg.Wait()
+	// Cancel the processor's context.
+	cancelConn()
+	// In case the authenticator is blocked on waiting for data from the client,
+	// tell it that there's no more data coming. This is a no-op if authentication
+	// was completed already.
+	authenticator.noMorePwdData()
+
+	// Wait for the processor goroutine to finish, if it hasn't already. We're
+	// ignoring the error we get from it, as we have no use for it. It might be a
+	// connection error, or a context cancelation error case this goroutine is the
+	// one that triggered the execution to stop.
+	<-procCh
 
 	if terminateSeen {
-		return nil
+		return
 	}
 	// If we're draining, let the client know by piling on an AdminShutdownError
 	// and flushing the buffer.
-	if ctxCanceled || draining() {
+	if draining() {
+		// TODO(andrei): I think sending this extra error to the client if we also
+		// sent another error for the last query (like a context canceled) is a bad
+		// idead; see #22630. I think we should find a way to return the
+		// AdminShutdown error as the only result of the query.
 		_ /* err */ = writeErr(ctx, &sqlServer.GetExecutorConfig().Settings.SV,
-			newAdminShutdownErr(err), &c.msgBuilder, &c.writerState.buf)
+			newAdminShutdownErr(ErrDrainingExistingConn), &c.msgBuilder, &c.writerState.buf)
 		_ /* n */, _ /* err */ = c.writerState.buf.WriteTo(c.conn)
+	}
+}
 
-		// Swallow whatever error we might have gotten from the writer. If we're
-		// draining, it's probably a canceled context error.
-		return nil
+// unqualifiedIntSizer is used by a conn to get the SQL session's current int size
+// setting.
+//
+// It's a restriction on the ConnectionHandler type.
+type unqualifiedIntSizer interface {
+	// GetUnqualifiedIntSize returns the size that the parser should consider for an
+	// unqualified INT.
+	GetUnqualifiedIntSize() *coltypes.TInt
+}
+
+type fixedIntSizer struct {
+	size *coltypes.TInt
+}
+
+func (f fixedIntSizer) GetUnqualifiedIntSize() *coltypes.TInt {
+	return f.size
+}
+
+// processCommandsAsync spawns a goroutine that authenticates the connection and
+// then processes commands from c.stmtBuf.
+//
+// It returns a channel that will be signaled when this goroutine is done.
+// Whatever error is returned on that channel has already been written to the
+// client connection, if applicable.
+//
+// If authentication fails, this goroutine finishes and, as always, cancelConn
+// is called.
+//
+// Args:
+// ac: An interface used by the authentication process to receive password data
+//   and to ultimately declare the authentication successful.
+// reserved: Reserved memory. This method takes ownership.
+// cancelConn: A function to be called when this goroutine exits. Its goal is to
+//   cancel the connection's context, thus stopping the connection's goroutine.
+//   The returned channel is also closed before this goroutine dies, but the
+//   connection's goroutine is not expected to be reading from that channel
+//   (instead, it's expected to always be monitoring the network connection).
+func (c *conn) processCommandsAsync(
+	ctx context.Context,
+	authOpt authOptions,
+	ac AuthConn,
+	sqlServer *sql.Server,
+	reserved mon.BoundAccount,
+	cancelConn func(),
+) <-chan error {
+	retCh := make(chan error, 1)
+	go func() {
+		var retErr error
+		var connHandler sql.ConnectionHandler
+		var authOK bool
+		defer func() {
+			// Release resources, if we still own them.
+			if reserved != (mon.BoundAccount{}) {
+				reserved.Close(ctx)
+			}
+			// Notify the connection's goroutine that we're terminating. The
+			// connection might know already, as it might have triggered this
+			// goroutine's finish, but it also might be us that we're triggering the
+			// connection's death. This context cancelation serves to interrupt a
+			// network read on the connection's goroutine.
+			cancelConn()
+
+			pgwireKnobs := sqlServer.GetExecutorConfig().PGWireTestingKnobs
+			if pgwireKnobs != nil && pgwireKnobs.CatchPanics {
+				if r := recover(); r != nil {
+					// Catch the panic and return it to the client as an error.
+					pge := pgerror.NewErrorf(pgerror.CodeCrashShutdownError, "caught fatal error: %v", r)
+					pge.Detail = string(debug.Stack())
+					retErr = pge
+					_ = writeErr(
+						ctx, &sqlServer.GetExecutorConfig().Settings.SV, retErr,
+						&c.msgBuilder, &c.writerState.buf)
+					_ /* n */, _ /* err */ = c.writerState.buf.WriteTo(c.conn)
+					c.stmtBuf.Close()
+					// Send a ready for query to make sure the client can react.
+					// TODO(andrei, jordan): Why are we sending this exactly?
+					c.bufferReadyForQuery('I')
+				}
+			}
+			if !authOK {
+				ac.AuthFail(retErr)
+			}
+			// Inform the connection goroutine of success or failure.
+			retCh <- retErr
+		}()
+
+		// Authenticate the connection.
+		if !authOpt.skipAuth {
+			if authOpt.authHook != nil {
+				if retErr = authOpt.authHook(ctx); retErr != nil {
+					return
+				}
+			} else {
+				if retErr = c.handleAuthentication(
+					ctx, ac, authOpt.insecure, authOpt.ie, authOpt.auth,
+					sqlServer.GetExecutorConfig(),
+				); retErr != nil {
+					return
+				}
+			}
+		}
+
+		connHandler, retErr = c.sendInitialConnData(ctx, sqlServer)
+		if retErr != nil {
+			return
+		}
+		ac.AuthOK(connHandler)
+		authOK = true
+
+		// Now actually process commands.
+		retErr = sqlServer.ServeConn(ctx, connHandler, reserved, cancelConn)
+		reserved = mon.BoundAccount{} // we've passed ownership away
+	}()
+	return retCh
+}
+
+func (c *conn) sendStatusParam(param, value string) error {
+	c.msgBuilder.initMsg(pgwirebase.ServerMsgParameterStatus)
+	c.msgBuilder.writeTerminatedString(param)
+	c.msgBuilder.writeTerminatedString(value)
+	return c.msgBuilder.finishMsg(c.conn)
+}
+
+func (c *conn) sendInitialConnData(
+	ctx context.Context, sqlServer *sql.Server,
+) (sql.ConnectionHandler, error) {
+	connHandler, err := sqlServer.SetupConn(
+		ctx, c.sessionArgs, &c.stmtBuf, c, c.metrics.SQLMemMetrics)
+	if err != nil {
+		_ /* err */ = writeErr(
+			ctx, &sqlServer.GetExecutorConfig().Settings.SV, err, &c.msgBuilder, c.conn)
+		return sql.ConnectionHandler{}, err
 	}
-	if writerErr != nil {
-		return writerErr
+
+	// Send the initial "status parameters" to the client.  This
+	// overlaps partially with session variables. The client wants to
+	// see the values that result from the combination of server-side
+	// defaults with client-provided values.
+	// For details see: https://www.postgresql.org/docs/10/static/libpq-status.html
+	for _, param := range statusReportParams {
+		value := connHandler.GetStatusParam(ctx, param)
+		if err := c.sendStatusParam(param, value); err != nil {
+			return sql.ConnectionHandler{}, err
+		}
 	}
-	return nil
+	// The two following status parameters have no equivalent session
+	// variable.
+	if err := c.sendStatusParam("session_authorization", c.sessionArgs.User); err != nil {
+		return sql.ConnectionHandler{}, err
+	}
+
+	// TODO(knz): this should retrieve the admin status during
+	// authentication using the roles table, instead of using a
+	// simple/naive username match.
+	isSuperUser := c.sessionArgs.User == security.RootUser
+	superUserVal := "off"
+	if isSuperUser {
+		superUserVal = "on"
+	}
+	if err := c.sendStatusParam("is_superuser", superUserVal); err != nil {
+		return sql.ConnectionHandler{}, err
+	}
+
+	// An initial readyForQuery message is part of the handshake.
+	c.msgBuilder.initMsg(pgwirebase.ServerMsgReady)
+	c.msgBuilder.writeByte(byte(sql.IdleTxnBlock))
+	if err := c.msgBuilder.finishMsg(c.conn); err != nil {
+		return sql.ConnectionHandler{}, err
+	}
+	return connHandler, nil
 }
 
 // An error is returned iff the statement buffer has been closed. In that case,
 // the connection should be considered toast.
 func (c *conn) handleSimpleQuery(
-	ctx context.Context, buf *pgwirebase.ReadBuffer, timeReceived time.Time, ch sql.ConnectionHandler,
+	ctx context.Context,
+	buf *pgwirebase.ReadBuffer,
+	timeReceived time.Time,
+	unqualifiedIntSize *coltypes.TInt,
 ) error {
 	query, err := buf.GetString()
 	if err != nil {
@@ -470,7 +652,7 @@ func (c *conn) handleSimpleQuery(
 	tracing.AnnotateTrace()
 
 	startParse := timeutil.Now()
-	stmts, err := c.parser.ParseWithInt(query, ch.GetDefaultIntSize())
+	stmts, err := c.parser.ParseWithInt(query, unqualifiedIntSize)
 	if err != nil {
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
 	}
@@ -529,7 +711,7 @@ func (c *conn) handleSimpleQuery(
 // An error is returned iff the statement buffer has been closed. In that case,
 // the connection should be considered toast.
 func (c *conn) handleParse(
-	ctx context.Context, buf *pgwirebase.ReadBuffer, ch sql.ConnectionHandler,
+	ctx context.Context, buf *pgwirebase.ReadBuffer, nakedIntSize *coltypes.TInt,
 ) error {
 	// protocolErr is set if a protocol error has to be sent to the client. A
 	// stanza at the bottom of the function pushes instructions for sending this
@@ -559,7 +741,7 @@ func (c *conn) handleParse(
 	}
 
 	startParse := timeutil.Now()
-	stmts, err := c.parser.ParseWithInt(query, ch.GetDefaultIntSize())
+	stmts, err := c.parser.ParseWithInt(query, nakedIntSize)
 	if err != nil {
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
 	}
@@ -1322,13 +1504,15 @@ func (r *pgwireReader) ReadByte() (byte, error) {
 	return b, err
 }
 
-// handleAuthentication should discuss with the client to arrange
-// authentication and update c.sessionArgs with the authenticated user's
-// name, if different from the one given initially. Note: at this
-// point the sql.Session does not exist yet! If need exists to access the
-// database to look up authentication data, use the internal executor.
+// handleAuthentication checks the connection's user. Errors are sent to the
+// client and also returned.
+//
+// TODO(knz): handleAuthentication should discuss with the client to arrange
+// authentication and update c.sessionArgs with the authenticated user's name,
+// if different from the one given initially.
 func (c *conn) handleAuthentication(
 	ctx context.Context,
+	ac AuthConn,
 	insecure bool,
 	ie *sql.InternalExecutor,
 	auth *hba.Conf,
@@ -1351,7 +1535,7 @@ func (c *conn) handleAuthentication(
 		return sendError(errors.Errorf(security.ErrPasswordUserAuthFailed, c.sessionArgs.User))
 	}
 
-	if tlsConn, ok := c.conn.(*tls.Conn); ok {
+	if tlsConn, ok := c.conn.(*readTimeoutConn).Conn.(*tls.Conn); ok {
 		tlsState := tlsConn.ConnectionState()
 		var methodFn AuthMethod
 		var hbaEntry *hba.Entry
@@ -1409,7 +1593,7 @@ func (c *conn) handleAuthentication(
 			}
 		}
 
-		authenticationHook, err := methodFn(c, tlsState, insecure, hashedPassword, execCfg, hbaEntry)
+		authenticationHook, err := methodFn(ac, tlsState, insecure, hashedPassword, execCfg, hbaEntry)
 		if err != nil {
 			return sendError(err)
 		}
@@ -1459,11 +1643,132 @@ var connAuthConf = settings.RegisterValidatedStringSetting(
 	},
 )
 
-// AuthConn defines exported methods of a conn needed for pgwire authentication.
+// authenticator is the interface used by the connection to pass password data
+// to the authenticator and expect an authentication decision from it.
+type authenticator interface {
+	// sendPwdData is used to push authentication data into the authenticator.
+	// This call is blocking; authenticators are supposed to consume data hastily
+	// once they've requested it.
+	sendPwdData(data []byte) error
+	// noMorePwdData is used to inform the authenticator that the client is not
+	// sending any more authentication data. This method can be called multiple
+	// times.
+	noMorePwdData()
+	// authResult blocks for an authentication decision. This call also informs
+	// the authenticator that no more auth data is coming from the client;
+	// noMorePwdData() is called internally.
+	//
+	// The auth result is either an unqualifiedIntSizer (in case the auth
+	// succeeded) or an auth error.
+	authResult() (unqualifiedIntSizer, error)
+}
+
+// AuthConn is the interface used by the authenticator for interacting with the
+// pgwire connection.
 type AuthConn interface {
+	// SendAuthRequest send a request for authentication information. After
+	// calling this, the authenticator needs to call GetPwdData() quickly, as the
+	// connection's goroutine will be blocked on providing us the requested data.
 	SendAuthRequest(authType int32, data []byte) error
-	ReadPasswordString() (string, error)
-	ReadPasswordBytes() ([]byte, error)
+	// GetPwdData returns authentication info that was previously requested with
+	// SendAuthRequest. The call blocks until such data is available.
+	// An error is returned if the client connection dropped or if the client
+	// didn't respect the protocol. After an error has been returned, GetPwdData()
+	// cannot be called any more.
+	GetPwdData() ([]byte, error)
+	// AuthOK declares that authentication succeeded and provides a
+	// unqualifiedIntSizer, to be returned by authenticator.authResult(). Future
+	// authenticator.sendPwdData() calls fail.
+	AuthOK(unqualifiedIntSizer)
+	// AuthFail declares that authentication has failed and provides an error to
+	// be returned by authenticator.authResult(). Future
+	// authenticator.sendPwdData() calls fail. The error has already been written
+	// to the client connection.
+	AuthFail(err error)
+}
+
+// authPipe is the implementation for the authenticator and AuthConn interfaces.
+// A single authPipe will serve as both an AuthConn and an authenticator; the
+// two represent the two "ends" of the pipe and we'll pass data between them.
+type authPipe struct {
+	c *conn // Only used for writing, not for reading.
+
+	ch chan []byte
+	// writerDone is a channel closed by noMorePwdData().
+	// Nil if noMorePwdData().
+	writerDone chan struct{}
+	readerDone chan authRes
+}
+
+type authRes struct {
+	intSizer unqualifiedIntSizer
+	err      error
+}
+
+func newAuthPipe(c *conn) *authPipe {
+	ap := &authPipe{
+		c:          c,
+		ch:         make(chan []byte),
+		writerDone: make(chan struct{}),
+		readerDone: make(chan authRes, 1),
+	}
+	return ap
+}
+
+var _ authenticator = &authPipe{}
+var _ AuthConn = &authPipe{}
+
+func (p *authPipe) sendPwdData(data []byte) error {
+	select {
+	case p.ch <- data:
+		return nil
+	case <-p.readerDone:
+		return pgwirebase.NewProtocolViolationErrorf("unexpected auth data")
+	}
+}
+
+func (p *authPipe) noMorePwdData() {
+	if p.writerDone == nil {
+		return
+	}
+	// A reader blocked in GetPwdData() gets unblocked with an error.
+	close(p.writerDone)
+	p.writerDone = nil
+}
+
+// GetPwdData is part of the AuthConn interface.
+func (p *authPipe) GetPwdData() ([]byte, error) {
+	select {
+	case data := <-p.ch:
+		return data, nil
+	case <-p.writerDone:
+		return nil, pgwirebase.NewProtocolViolationErrorf("client didn't send required auth data")
+	}
+}
+
+// AuthOK is part of the AuthConn interface.
+func (p *authPipe) AuthOK(intSizer unqualifiedIntSizer) {
+	p.readerDone <- authRes{intSizer: intSizer}
+}
+
+func (p *authPipe) AuthFail(err error) {
+	p.readerDone <- authRes{err: err}
+}
+
+// authResult is part of the authenticator interface.
+func (p *authPipe) authResult() (unqualifiedIntSizer, error) {
+	p.noMorePwdData()
+	res := <-p.readerDone
+	return res.intSizer, res.err
+}
+
+// SendAuthRequest is part of the AuthConn interface.
+func (p *authPipe) SendAuthRequest(authType int32, data []byte) error {
+	c := p.c
+	c.msgBuilder.initMsg(pgwirebase.ServerMsgAuth)
+	c.msgBuilder.putInt32(authType)
+	c.msgBuilder.write(data)
+	return c.msgBuilder.finishMsg(c.conn)
 }
 
 type (
@@ -1487,6 +1792,14 @@ func RegisterAuthMethod(method string, fn AuthMethod, checkEntry CheckHBAEntry) 
 	}
 }
 
+func passwordString(pwdData []byte) (string, error) {
+	// Make a string out of the byte array.
+	if bytes.IndexByte(pwdData, 0) != len(pwdData)-1 {
+		return "", fmt.Errorf("expected 0-terminated byte array")
+	}
+	return string(pwdData[:len(pwdData)-1]), nil
+}
+
 func authPassword(
 	c AuthConn,
 	tlsState tls.ConnectionState,
@@ -1495,10 +1808,14 @@ func authPassword(
 	execCfg *sql.ExecutorConfig,
 	entry *hba.Entry,
 ) (security.UserAuthHook, error) {
-	if err := c.SendAuthRequest(authCleartextPassword, nil); err != nil {
+	if err := c.SendAuthRequest(authCleartextPassword, nil /* data */); err != nil {
 		return nil, err
 	}
-	password, err := c.ReadPasswordString()
+	pwdData, err := c.GetPwdData()
+	if err != nil {
+		return nil, err
+	}
+	password, err := passwordString(pwdData)
 	if err != nil {
 		return nil, err
 	}
@@ -1508,7 +1825,7 @@ func authPassword(
 }
 
 func authCert(
-	c AuthConn,
+	_ AuthConn,
 	tlsState tls.ConnectionState,
 	insecure bool,
 	hashedPassword []byte,
@@ -1548,37 +1865,6 @@ func init() {
 	RegisterAuthMethod("cert-password", authCertPassword, nil)
 }
 
-func (c *conn) SendAuthRequest(authType int32, data []byte) error {
-	c.msgBuilder.initMsg(pgwirebase.ServerMsgAuth)
-	c.msgBuilder.putInt32(authType)
-	c.msgBuilder.write(data)
-	return c.msgBuilder.finishMsg(c.conn)
-}
-
-func (c *conn) ReadPasswordString() (string, error) {
-	typ, n, err := c.readBuf.ReadTypedMsg(&c.rd)
-	c.metrics.BytesInCount.Inc(int64(n))
-	if err != nil {
-		return "", err
-	}
-	if typ != pgwirebase.ClientMsgPassword {
-		return "", errors.Errorf("invalid response to authentication request: %s", typ)
-	}
-	return c.readBuf.GetString()
-}
-
-func (c *conn) ReadPasswordBytes() ([]byte, error) {
-	typ, n, err := c.readBuf.ReadTypedMsg(&c.rd)
-	c.metrics.BytesInCount.Inc(int64(n))
-	if err != nil {
-		return nil, err
-	}
-	if typ != pgwirebase.ClientMsgPassword {
-		return nil, errors.Errorf("invalid response to authentication request: %s", typ)
-	}
-	return c.readBuf.GetBytes(n - 4)
-}
-
 // statusReportParams is a list of session variables that are also
 // reported as server run-time parameters in the pgwire connection
 // initialization.
@@ -1611,10 +1897,13 @@ var testingStatusReportParams = map[string]string{
 // checkExitConds() and aborting the read if an error is returned.
 type readTimeoutConn struct {
 	net.Conn
-	checkExitConds func() error
+	// checkExitConds is called periodically by Read(). If it returns an error,
+	// the Read() returns that error. Future calls to Read() are allowed, in which
+	// case checkExitConds() will be called again.
+	checkExitConds func(*readTimeoutConn) error
 }
 
-func newReadTimeoutConn(c net.Conn, checkExitConds func() error) net.Conn {
+func newReadTimeoutConn(c net.Conn, checkExitConds func(tc *readTimeoutConn) error) net.Conn {
 	// net.Pipe does not support setting deadlines. See
 	// https://github.com/golang/go/blob/go1.7.4/src/net/pipe.go#L57-L67
 	//
@@ -1640,7 +1929,7 @@ func (c *readTimeoutConn) Read(b []byte) (int, error) {
 	// unexpected behavior.
 	defer func() { _ = c.SetReadDeadline(time.Time{}) }()
 	for {
-		if err := c.checkExitConds(); err != nil {
+		if err := c.checkExitConds(c); err != nil {
 			return 0, err
 		}
 		if err := c.SetReadDeadline(timeutil.Now().Add(readTimeout)); err != nil {

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -260,7 +260,7 @@ func TestPGWireDrainClient(t *testing.T) {
 
 	// Ensure server is in draining mode and rejects new connections.
 	testutils.SucceedsSoon(t, func() error {
-		if err := trivialQuery(pgBaseURL); !testutils.IsError(err, pgwire.ErrDraining) {
+		if err := trivialQuery(pgBaseURL); !testutils.IsError(err, pgwire.ErrDrainingNewConn) {
 			return errors.Errorf("unexpected error: %v", err)
 		}
 		return nil
@@ -1893,8 +1893,8 @@ func TestPGWireAuth(t *testing.T) {
 				Host:     net.JoinHostPort(host, port),
 				RawQuery: "sslmode=require",
 			}
-			if err := trivialQuery(unicodeUserPgURL); !testutils.IsError(err, "pq: password authentication failed for user") {
-				t.Fatalf("unexpected error: %v", err)
+			if err := trivialQuery(unicodeUserPgURL); !testutils.IsError(err, "password authentication failed for user") {
+				t.Fatalf("expected \"password authentication failed for user\", got: %v", err)
 			}
 
 			// Supply correct password.
@@ -1927,8 +1927,8 @@ func TestPGWireAuth(t *testing.T) {
 		// Even though the correct password is supplied (empty string), this
 		// should fail because we do not support password authentication for
 		// users with empty passwords.
-		if err := trivialQuery(testUserPgURL); !testutils.IsError(err, "pq: password authentication failed for user") {
-			t.Fatalf("unexpected error: %v", err)
+		if err := trivialQuery(testUserPgURL); !testutils.IsError(err, "password authentication failed for user") {
+			t.Fatalf("expected \"password authentication failed for user\", got: %v", err)
 		}
 	})
 }

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -516,7 +516,7 @@ func testRandomSyntax(
 	// Use a low memory limit to quickly halt runaway functions.
 	params.SQLMemoryPoolSize = 3 * 1024 * 1024 // 3MB
 	// Catch panics and return them as errors.
-	params.Knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
+	params.Knobs.PGWireTestingKnobs = &sql.PGWireTestingKnobs{
 		CatchPanics: true,
 	}
 	s, rawDB, _ := serverutils.StartServer(t, params)


### PR DESCRIPTION
Backport 1/1 commits from #35776.

/cc @cockroachdb/release

---

Before this patch we would not react to a pgwire connection closing
while we were in the process of authenticating the connection's user.
That's bad particularly when authentication is blocked forever because
of data unavailability. Before this patch, goroutines blocked on
authentication would just leak if the client closed the corresponding
connection, leading to OOMs for folks.
Generally, we react to connection cancelation: a dedicated goroutine is
constantly responsible for reading from the network and canceling the
command processor's context if the connection drops. However,
authentication was special in that it happened before the connection
entered this reader/processor-goroutine mode. Authentication did it's
own reading and writing from the net conn.

This patch extends authentication to fit into the 2-goroutine model. The
conn goroutine takes responsibility for reading all the password
information and passing it to an authenticator which runs on the command
processing goroutine. As in all other cases, if the connection is
dropped, the authenticator's ctx will be canceled.
This required abstracting the conn's interaction with the authenticator
through an interface. The authenticator's interactions with the
connection were already abstracted through an interface for GSS API
reasons. That interface is adapted. A "pipe" metaphor is used to model
the interactions between the conn and the authenticator.

Release note: bug fix: memory and goroutines used for authenticating
connections opened while the cluster is unavailable (e.g. network
partition) no longer leak when the client closes said connections.
