### PR TITLE
roachtest: set job registry leniency on Start

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1191,6 +1191,12 @@ func (c *cluster) StartE(ctx context.Context, opts ...option) error {
 // Start is like StartE() except it takes a test and, on error, calls t.Fatal().
 func (c *cluster) Start(ctx context.Context, t *test, opts ...option) {
 	FatalIfErr(t, c.StartE(ctx, opts...))
+	conn := c.Conn(ctx, 1)
+	if _, err := conn.Exec(`
+		SET CLUSTER SETTING jobs.registry.leniency = '5m'
+	`); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func argExists(args []string, target string) bool {

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -89,7 +89,6 @@ func registerImportTPCH(r *registry) {
 				conn := c.Conn(ctx, 1)
 				if _, err := conn.Exec(`
 					CREATE DATABASE csv;
-					SET CLUSTER SETTING jobs.registry.leniency = '5m';
 				`); err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
This kind of failure has appear multiple times now, so attempt to fix
it in one place. We haven't run SQL on start yet so there may be some
fallout.

See #25782
Fixes #36082

Release note: None