### PR TITLE
opt: initialize Memo.safeUpdates

### DIFF
--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -142,6 +142,8 @@ type Memo struct {
 
 	// curID is the highest currently in-use scalar expression ID.
 	curID opt.ScalarID
+
+	// WARNING: if you add more members, add initialization code in Init.
 }
 
 // Init initializes a new empty memo instance, or resets existing state so it
@@ -161,6 +163,9 @@ func (m *Memo) Init(evalCtx *tree.EvalContext) {
 	m.dataConversion = evalCtx.SessionData.DataConversion
 	m.reorderJoinsLimit = evalCtx.SessionData.ReorderJoinsLimit
 	m.zigzagJoinEnabled = evalCtx.SessionData.ZigzagJoinEnabled
+	m.safeUpdates = evalCtx.SessionData.SafeUpdates
+
+	m.curID = 0
 }
 
 // IsEmpty returns true if there are no expressions in the memo.

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -112,6 +112,18 @@ func TestMemoIsStale(t *testing.T) {
 		} else if !isStale {
 			t.Errorf("memo should be stale")
 		}
+
+		// If we did not initialize the Memo's copy of a SessionData setting, the
+		// tests as written still pass if the default value is 0. To detect this, we
+		// create a new memo with the changed setting and verify it's not stale.
+		var o2 xform.Optimizer
+		opttestutils.BuildQuery(t, &o2, catalog, &evalCtx, "SELECT a, b+1 FROM abcview WHERE c='foo'")
+
+		if isStale, err := o2.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
+			t.Fatal(err)
+		} else if isStale {
+			t.Errorf("memo should not be stale")
+		}
 	}
 
 	notStale := func() {


### PR DESCRIPTION
Fixing an omission from `Memo.Init`. The tests weren't catching it
because the default value is 0.

Also fixing the initialization of `curID`, though that omission should
have no visible consequences.

Release note: None