### PR TITLE
ui: add Range Merges to Replication -> Range Operations graph

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -112,6 +112,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph title="Range Operations" sources={storeSources}>
       <Axis label="ranges">
         <Metric name="cr.store.range.splits" title="Splits" nonNegativeRate />
+        <Metric name="cr.store.range.merges" title="Merges" nonNegativeRate />
         <Metric name="cr.store.range.adds" title="Adds" nonNegativeRate />
         <Metric name="cr.store.range.removes" title="Removes" nonNegativeRate />
         <Metric name="cr.store.leases.transfers.success" title="Lease Transfers" nonNegativeRate />


### PR DESCRIPTION
Release note (admin ui change): Range merges will now show up in the Range Operations graph.