### PR TITLE
release-2.1: fix test failure with go1.11

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -57,10 +57,7 @@ import (
 // https://golang.org/cl/38533 and https://golang.org/cl/91115 changed the
 // validation message.
 func wrongArgCountString(want, got int) string {
-	if strings.HasPrefix(runtime.Version(), "go1.10") {
-		return fmt.Sprintf("sql: expected %d arguments, got %d", want, got)
-	}
-	return fmt.Sprintf("sql: statement expects %d inputs; got %d", want, got)
+	return fmt.Sprintf("sql: expected %d arguments, got %d", want, got)
 }
 
 func trivialQuery(pgURL url.URL) error {


### PR DESCRIPTION
The test has some code that handles older versions which is
incorrectly being used for go1.11. We no longer support building with
those older versions so the check can be removed.

Fixes #36184.

Release note: None