### PR TITLE
mon: don't panic in prod if no bytes to release

### DIFF
--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -625,8 +625,10 @@ func (mm *BytesMonitor) releaseBytes(ctx context.Context, sz int64) {
 	mm.mu.Lock()
 	defer mm.mu.Unlock()
 	if mm.mu.curAllocated < sz {
-		panic(fmt.Sprintf("%s: no bytes to release, current %d, free %d",
-			mm.name, mm.mu.curAllocated, sz))
+		sz = mm.mu.curAllocated
+		log.ReportOrPanic(ctx, &mm.settings.SV,
+			"%s: no bytes to release, current %d, free %d",
+			mm.name, mm.mu.curAllocated, sz)
 	}
 	mm.mu.curAllocated -= sz
 	if mm.curBytesCount != nil {


### PR DESCRIPTION
Previously, we'd unconditionally panic the server if a memory monitor
was asked to release more bytes than it had allocated. This can happen
when there's a bug in memory accounting, but doesn't indicate an
actual memory leak.

This commit changes the panic to be a ReportOrPanic, which will panic in
test environments and send a report to sentry in production
environments. The memory monitor then resets itself to 0 allocated
bytes.

Closes #35278.

Release note (bug fix): prevent production server crashes on certain
assertion errors