### PR TITLE
roachprod: add --auto and --oneshot flags to monitor

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -98,6 +98,9 @@ var (
 	logsTo         time.Time
 	logsInterval   time.Duration
 
+	monitorAuto    bool
+	monitorOneShot bool
+
 	cachedHostsCluster string
 )
 
@@ -965,10 +968,21 @@ of nodes, outputting a line whenever a change is detected:
 		if err != nil {
 			return err
 		}
-		for i := range c.Monitor() {
-			fmt.Printf("%d: %s\n", i.Index, i.Msg)
+		var lastErr error
+		for msg := range c.Monitor(monitorAuto, monitorOneShot) {
+			if msg.Err != nil {
+				lastErr = errors.Wrapf(err, "%d", msg.Index)
+				fmt.Printf("%d: error: %s\n", msg.Index, msg.Err)
+				continue
+			}
+			if msg.Msg != "" {
+				fmt.Printf("%d: %s\n", msg.Index, msg.Msg)
+			}
+			if strings.Contains(msg.Msg, "dead") {
+				lastErr = errors.Wrapf(errors.New(msg.Msg), "%d", msg.Index)
+			}
 		}
-		return nil
+		return lastErr
 	}),
 }
 
@@ -1553,6 +1567,20 @@ func main() {
 		&logsInterval, "interval", 200*time.Millisecond, "interval to poll logs from host")
 	logsCmd.Flags().StringVar(
 		&logsDir, "logs-dir", "logs", "path to the logs dir, if remote, relative to username's home dir, ignored if local")
+
+	monitorCmd.Flags().BoolVar(
+		&monitorAuto,
+		"auto",
+		false,
+		"Automatically detect the (subset of the given) nodes which to monitor "+
+			"based on the presence of a nontrivial data directory.")
+
+	monitorCmd.Flags().BoolVar(
+		&monitorOneShot,
+		"oneshot",
+		false,
+		"Report the status of all targeted nodes once, then exit. The exit "+
+			"status is nonzero if (and only if) any node was found not running.")
 
 	cachedHostsCmd.Flags().StringVar(&cachedHostsCluster, "cluster", "", "print hosts matching cluster")
 

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -1161,12 +1161,12 @@ func (r *registry) runAsync(
 				if err := c.FetchDebugZip(ctx); err != nil {
 					c.l.Printf("failed to download debug zip: %s", err)
 				}
-			}
-			if err := c.FetchDmesg(ctx); err != nil {
-				c.l.Printf("failed to fetch dmesg: %s", err)
-			}
-			if err := c.FetchCores(ctx); err != nil {
-				c.l.Printf("failed to fetch cores: %s", err)
+				if err := c.FetchDmesg(ctx); err != nil {
+					c.l.Printf("failed to fetch dmesg: %s", err)
+				}
+				if err := c.FetchCores(ctx); err != nil {
+					c.l.Printf("failed to fetch cores: %s", err)
+				}
 			}
 			// NB: fetch the logs even when we have a debug zip because
 			// debug zip can't ever get the logs for down nodes.


### PR DESCRIPTION
roachprod: add --auto and --oneshot flags to monitor

To reliably catch dead nodes in nightly tests it is helpful to add
infrastructure that can detect nodes in an arbitrary cluster without
having to track too precisely what state the test left the cluster in.

The salient observation is that if a node contains a blank data
directory, it was very likely not used as a CockroachDB node by
a test, and does not need to be checked for having crashed.

Add a flag that performs such a check (`--auto`). Also, add a flag
`--oneshot` that monitors the state of the servers just once instead
of polling indefinitely. The intention is that `roachtest` will run

```
roachtest monitor <cluster> --oneshot --auto
```

and fails the test whenever that returns a dead node.

Some examples follows. In them, `tobias-foo` has three nodes and
`roachprod start tobias-foo:1-2` was run, while `tobias-foo:3` was left
unpopulated.

Old behavior is preserved when no flags are given:

```
$ roachprod monitor tobias-foo
3: dead
1: 2973
2: 2933
1: nc exited # I ran roachprod stop tobias-foo:1
1: dead
1: 5089      # I ran roachprod start tobias-foo:1
```

With the `--auto` flag added, `3` is skipped instead of marked dead:

```
$ roachprod monitor tobias-foo --auto
3: skipped
1: 5089
2: 2933
...
```

With only `--oneshot`, the command exits after getting a
status from each node, and returns nonzero because 3 is dead:
```
$ roachprod monitor tobias-foo --oneshot
3: dead
2: 2933
1: 5089
Error:  3: dead
```

The combination `--auto --oneshot` skips 3 and returns a zero
exit status.

```
$ roachprod monitor tobias-foo --oneshot
3: skipped
1: 5089
2: 2933
```

Release note: None
