### PR TITLE
roachtest: after test, fail (or complain) if any CRDB nodes are dead

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -743,6 +743,9 @@ const progressTodo = "----------------------------------------"
 
 func formatProgress(p float64) string {
 	i := int(math.Ceil(float64(len(progressDone)) * (1 - p)))
+	if i > len(progressDone) {
+		i = len(progressDone)
+	}
 	return fmt.Sprintf("[%s%s] %.0f%%", progressDone[i:], progressTodo[:i], 100*p)
 }
 

--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"text/template"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/config"
@@ -263,40 +264,66 @@ fi
 	}
 }
 
-// NodeMonitorInfo TODO(peter): document
+// NodeMonitorInfo is a message describing a cockroach process' status.
 type NodeMonitorInfo struct {
+	// The index of the node (in a SyncedCluster) at which the message originated.
 	Index int
-	Msg   string
+	// A message about the node. This is either a PID, "dead", "nc exited", or
+	// "skipped".
+	// Anything but a PID or "skipped" is an indication that there is some
+	// problem with the node and that the process is not running.
+	Msg string
+	// Err is an error that may occur when trying to probe the status of the node.
+	// If Err is non-nil, Msg is empty. After an error is returned, the node with
+	// the given index will no longer be probed. Errors typically indicate networking
+	// issues or nodes that have (physically) shut down.
+	Err error
 }
 
-// Monitor TODO(peter): document
-func (c *SyncedCluster) Monitor() chan NodeMonitorInfo {
+// Monitor writes NodeMonitorInfo for the cluster nodes to the returned channel.
+// Infos sent to the channel always have the Index and exactly one of Msg or Err
+// set.
+//
+// If oneShot is true, infos are retrieved only once for each node and the
+// channel is subsequently closed; otherwise the process continues indefinitely
+// (emitting new information as the status of the cockroach process changes).
+//
+// If ignoreEmptyNodes is true, nodes on which no CockroachDB data is found
+// (in {store-dir}) will not be probed and single message, "skipped", will
+// be emitted for them.
+func (c *SyncedCluster) Monitor(ignoreEmptyNodes bool, oneShot bool) chan NodeMonitorInfo {
 	ch := make(chan NodeMonitorInfo)
 	nodes := c.ServerNodes()
+	var wg sync.WaitGroup
 
 	for i := range nodes {
+		wg.Add(2)
 		go func(i int) {
+			defer wg.Done()
 			sess, err := c.newSession(nodes[i])
 			if err != nil {
-				ch <- NodeMonitorInfo{nodes[i], err.Error()}
+				ch <- NodeMonitorInfo{Index: nodes[i], Err: err}
+				wg.Done()
 				return
 			}
 			defer sess.Close()
 
 			p, err := sess.StdoutPipe()
 			if err != nil {
-				ch <- NodeMonitorInfo{nodes[i], err.Error()}
+				ch <- NodeMonitorInfo{Index: nodes[i], Err: err}
+				wg.Done()
 				return
 			}
 
 			go func(p io.Reader) {
+				defer wg.Done()
 				r := bufio.NewReader(p)
 				for {
 					line, _, err := r.ReadLine()
 					if err == io.EOF {
 						return
 					}
-					ch <- NodeMonitorInfo{nodes[i], string(line)}
+					ch <- NodeMonitorInfo{Index: nodes[i], Msg: string(line)}
 				}
 			}(p)
 
@@ -304,10 +331,30 @@ func (c *SyncedCluster) Monitor() chan NodeMonitorInfo {
 			// order to avoid polling with lsof, if we find a live process we use nc
 			// (netcat) to connect to the rpc port which will block until the server
 			// either decides to kill the connection or the process is killed.
-			cmd := fmt.Sprintf(`
+			// In one-shot we don't use nc and return after the first assessment
+			// of the process' health.
+			data := struct {
+				OneShot     bool
+				IgnoreEmpty bool
+				Store       string
+				Port        int
+			}{
+				OneShot:     oneShot,
+				IgnoreEmpty: ignoreEmptyNodes,
+				Store:       Cockroach{}.NodeDir(c, nodes[i]),
+				Port:        Cockroach{}.NodePort(c, nodes[i]),
+			}
+
+			snippet := `
 lastpid=0
+{{ if .IgnoreEmpty}}
+if [ ! -f "{{.Store}}/CURRENT" ]; then
+  echo "skipped"
+  exit 0
+fi
+{{- end}}
 while :; do
-  pid=$(lsof -i :%[1]d -sTCP:LISTEN | awk '!/COMMAND/ {print $2}')
+  pid=$(lsof -i :{{.Port}} -sTCP:LISTEN | awk '!/COMMAND/ {print $2}')
   if [ "${pid}" != "${lastpid}" ]; then
     if [ -n "${lastpid}" -a -z "${pid}" ]; then
       echo dead
@@ -317,21 +364,29 @@ while :; do
       echo ${pid}
     fi
   fi
-
+{{if .OneShot }}
+  exit 0
+{{- end}}
   if [ -n "${lastpid}" ]; then
-    nc localhost %[1]d >/dev/null 2>&1
+    nc localhost {{.Port}} >/dev/null 2>&1
     echo nc exited
   else
     sleep 1
   fi
 done
-`,
-				Cockroach{}.NodePort(c, nodes[i]))
+`
+
+			t := template.Must(template.New("script").Parse(snippet))
+			var buf bytes.Buffer
+			if err := t.Execute(&buf, data); err != nil {
+				ch <- NodeMonitorInfo{Index: nodes[i], Err: err}
+				return
+			}
 
 			// Request a PTY so that the script will receive will receive a SIGPIPE
 			// when the session is closed.
 			if err := sess.RequestPty(); err != nil {
-				ch <- NodeMonitorInfo{nodes[i], err.Error()}
+				ch <- NodeMonitorInfo{Index: nodes[i], Err: err}
 				return
 			}
 			// Give the session a valid stdin pipe so that nc won't exit immediately.
@@ -340,16 +395,20 @@ done
 			// when the roachprod process is killed.
 			inPipe, err := sess.StdinPipe()
 			if err != nil {
-				ch <- NodeMonitorInfo{nodes[i], err.Error()}
+				ch <- NodeMonitorInfo{Index: nodes[i], Err: err}
 				return
 			}
 			defer inPipe.Close()
-			if err := sess.Run(cmd); err != nil {
-				ch <- NodeMonitorInfo{nodes[i], err.Error()}
+			if err := sess.Run(buf.String()); err != nil {
+				ch <- NodeMonitorInfo{Index: nodes[i], Err: err}
 				return
 			}
 		}(i)
 	}
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
 
 	return ch
 }

--- a/pkg/cmd/roachtest/chaos.go
+++ b/pkg/cmd/roachtest/chaos.go
@@ -94,6 +94,8 @@ func (ch *Chaos) Runner(c *cluster, m *monitor) func(context.Context) error {
 
 			select {
 			case <-ch.Stopper:
+				// NB: the roachtest harness checks that at the end of the test,
+				// all nodes that have data also have a running process.
 				l.Printf("restarting %v (chaos is done)\n", target)
 				c.Start(ctx, c.t.(*test), target)
 				return nil

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -116,4 +116,7 @@ func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 		"true true",
 		"false false",
 	})
+
+	// Start node again to satisfy roachtest.
+	c.Start(ctx, t, c.Node(3))
 }

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -430,6 +430,11 @@ SELECT count(replicas)
 	}
 
 	g.checkConnectedAndFunctional(ctx, t, c)
+
+	// Stop our special snowflake process which won't be recognized by the test
+	// harness, and start it again on the regular.
+	c.Stop(ctx, c.Node(1))
+	c.Start(ctx, t, c.Node(1))
 }
 
 func runCheckLocalityIPAddress(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/rapid_restart.go
+++ b/pkg/cmd/roachtest/rapid_restart.go
@@ -111,4 +111,10 @@ func runRapidRestart(ctx context.Context, t *test, c *cluster) {
 
 		t.l.Printf("%d OK\n", j)
 	}
+
+	// Clean up for the test harness. Usually we want to leave nodes running so
+	// that consistency checks can be run, but in this case there's not much
+	// there in the first place anyway.
+	c.Stop(ctx, nodes)
+	c.Wipe(ctx, nodes)
 }

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -792,9 +792,12 @@ func (t *test) printAndFail(skip int, args ...interface{}) {
 }
 
 func (t *test) printfAndFail(skip int, format string, args ...interface{}) {
+	msg := t.decorate(skip+1, fmt.Sprintf(format, args...))
+	t.l.Printf("test failure: " + msg)
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.mu.output = append(t.mu.output, t.decorate(skip+1, fmt.Sprintf(format, args...))...)
+	t.mu.output = append(t.mu.output, msg...)
 	t.mu.failed = true
 	if t.mu.cancel != nil {
 		t.mu.cancel()
@@ -937,6 +940,7 @@ func (r *registry) runAsync(
 	l, err := rootLogger(logPath, teeOpt)
 	FatalIfErr(t, err)
 	t.l = l
+	out := io.MultiWriter(r.out, t.l.file)
 
 	if teamCity {
 		fmt.Printf("##teamcity[testStarted name='%s' flowId='%s']\n", t.Name(), t.Name())
@@ -949,7 +953,7 @@ func (r *registry) runAsync(
 		if len(details) > 0 {
 			detail = fmt.Sprintf(" [%s]", strings.Join(details, ","))
 		}
-		fmt.Fprintf(r.out, "=== RUN   %s%s\n", t.Name(), detail)
+		fmt.Fprintf(out, "=== RUN   %s%s\n", t.Name(), detail)
 	}
 	r.status.Lock()
 	r.status.running[t] = struct{}{}
@@ -1000,7 +1004,7 @@ func (r *registry) runAsync(
 					)
 				}
 
-				fmt.Fprintf(r.out, "--- FAIL: %s (%s)\n%s", t.Name(), dstr, output)
+				fmt.Fprintf(out, "--- FAIL: %s (%s)\n%s", t.Name(), dstr, output)
 				if postIssues && issues.CanPost() && t.spec.Run != nil {
 					authorEmail := getAuthorEmail(failLoc.file, failLoc.line)
 					branch := "<unknown branch>"
@@ -1013,11 +1017,11 @@ func (r *registry) runAsync(
 						"roachtest", t.Name(), "The test failed on "+branch+":\n"+string(output), authorEmail,
 						[]string{"O-roachtest"},
 					); err != nil {
-						fmt.Fprintf(r.out, "failed to post issue: %s\n", err)
+						fmt.Fprintf(out, "failed to post issue: %s\n", err)
 					}
 				}
 			} else if t.spec.Skip == "" {
-				fmt.Fprintf(r.out, "--- PASS: %s (%s)\n", t.Name(), dstr)
+				fmt.Fprintf(out, "--- PASS: %s (%s)\n", t.Name(), dstr)
 				// If `##teamcity[testFailed ...]` is not present before `##teamCity[testFinished ...]`,
 				// TeamCity regards the test as successful.
 			} else {
@@ -1025,9 +1029,9 @@ func (r *registry) runAsync(
 					fmt.Fprintf(r.out, "##teamcity[testIgnored name='%s' message='%s']\n",
 						t.Name(), teamCityEscape(t.spec.Skip))
 				}
-				fmt.Fprintf(r.out, "--- SKIP: %s (%s)\n\t%s\n", t.Name(), dstr, t.spec.Skip)
+				fmt.Fprintf(out, "--- SKIP: %s (%s)\n\t%s\n", t.Name(), dstr, t.spec.Skip)
 				if t.spec.SkipDetails != "" {
-					fmt.Fprintf(r.out, "Details: %s\n", t.spec.SkipDetails)
+					fmt.Fprintf(out, "Details: %s\n", t.spec.SkipDetails)
 				}
 			}
 
@@ -1155,7 +1159,19 @@ func (r *registry) runAsync(
 
 		// No subtests, so this is a leaf test.
 
-		timeout := time.Hour
+		timeout := c.expiration.Add(-10 * time.Minute).Sub(timeutil.Now())
+		if timeout <= 0 {
+			t.spec.Skip = fmt.Sprintf("cluster expired (%s)", timeout)
+			return
+		}
+
+		if t.spec.Timeout > 0 && timeout > t.spec.Timeout {
+			timeout = t.spec.Timeout
+		}
+
+		done := make(chan struct{})
+		defer close(done) // closed only after we've grabbed the debug info below
+
 		defer func() {
 			if t.Failed() {
 				if err := c.FetchDebugZip(ctx); err != nil {
@@ -1176,19 +1192,10 @@ func (r *registry) runAsync(
 				c.l.Printf("failed to download logs: %s", err)
 			}
 		}()
-
-		timeout = c.expiration.Add(-10 * time.Minute).Sub(timeutil.Now())
-		if timeout <= 0 {
-			t.spec.Skip = fmt.Sprintf("cluster expired (%s)", timeout)
-			return
-		}
-
-		if t.spec.Timeout > 0 && timeout > t.spec.Timeout {
-			timeout = t.spec.Timeout
-		}
-
-		done := make(chan struct{})
-		defer close(done)
+		// Detect dead nodes in an inner defer. Note that this will call t.Fatal
+		// when appropriate, which will cause the closure above to enter the
+		// t.Failed() branch.
+		defer c.FailOnDeadNodes(ctx, t)
 
 		runCtx, cancel := context.WithCancel(ctx)
 		t.mu.Lock()

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -1161,12 +1161,12 @@ func (r *registry) runAsync(
 				if err := c.FetchDebugZip(ctx); err != nil {
 					c.l.Printf("failed to download debug zip: %s", err)
 				}
-			}
-			if err := c.FetchDmesg(ctx); err != nil {
-				c.l.Printf("failed to fetch dmesg: %s", err)
-			}
-			if err := c.FetchCores(ctx); err != nil {
-				c.l.Printf("failed to fetch cores: %s", err)
+				if err := c.FetchDmesg(ctx); err != nil {
+					c.l.Printf("failed to fetch dmesg: %s", err)
+				}
+				if err := c.FetchCores(ctx); err != nil {
+					c.l.Printf("failed to fetch cores: %s", err)
+				}
 			}
 			// NB: fetch the logs even when we have a debug zip because
 			// debug zip can't ever get the logs for down nodes.


### PR DESCRIPTION
Do what's in the title. This will help us ensure that no test leaves dead
nodes behind (maybe some tests do that today, perhaps some chaos ones, but
it'll be easy enough to fix). This gives us confidence that when a test
passes, none of the nodes died. Additionally, for tests that fail, it will
always be obvious that a node died because it is now printed as part of the
test output including what gets posted into a Github issue.

Example:

I changed the test below so that it would start nodes 1-3, immediately stop
node 1, and return, resulting in the following test failure:

```
--- FAIL: tpcc/nodes=3/w=max (7.24s)
cluster.go:956,context.go:90,cluster.go:942,test.go:1160,test.go:1219: dead
node detection: 4: skipped
	1: dead
	2: 83220
	3: 83229
	Error:  1: dead
```

Release note: None