### PR TITLE
roachtest: set job registry leniency for tpccbench

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -471,6 +471,13 @@ func loadTPCCBench(
 		return downloadStoreDumps(ctx, c, storeDirsPath, len(roachNodes))
 	}
 
+	// Increase job leniency to prevent restarts due to node liveness.
+	if _, err := db.Exec(`
+		SET CLUSTER SETTING jobs.registry.leniency = '5m';
+	`); err != nil {
+		t.Fatal(err)
+	}
+
 	// Load the corresponding fixture.
 	t.l.Printf("restoring tpcc fixture\n")
 	cmd := tpccFixturesCmd(t, cloud, b.LoadWarehouses, false /* checks */)


### PR DESCRIPTION
See #25782
Fixes #36082

Release note: None