### PR TITLE
roachprod: print error when aws username not configured

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -331,6 +331,9 @@ func (p *Provider) FindActiveAccount() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if userInfo.User.UserName == "" {
+		return "", errors.Errorf("username not configured. run 'aws iam get-user'")
+	}
 	cachedActiveAccount = userInfo.User.UserName
 	return cachedActiveAccount, nil
 }


### PR DESCRIPTION
Release note: None