### PR TITLE
opt: add checks for parallel optPlanningCtx usage

### DIFF
--- a/pkg/util/race_off.go
+++ b/pkg/util/race_off.go
@@ -29,3 +29,21 @@ func EnableRacePreemptionPoints() func() { return func() {} }
 // no-op (and should be optimized out through dead code elimination) if the race
 // build tag was not used.
 func RacePreempt() {}
+
+// NoParallelUse is a struct that can be embedded in other structs. It provides
+// BeginExclusive and EndExclusive functions which trigger panics in race builds
+// if a goroutine calls BeginExclusive before another goroutine calls
+// EndExclusive.
+type NoParallelUse struct {
+}
+
+// Silence unused warnings.
+var _ = NoParallelUse{}
+
+// BeginExclusive marks the beginning of a section where this goroutine is
+// assumed to have exclusive ownership of the object.
+func (*NoParallelUse) BeginExclusive() {}
+
+// EndExclusive marks the end of a section where this goroutine is assumed to
+// have exclusive ownership of the object.
+func (*NoParallelUse) EndExclusive() {}


### PR DESCRIPTION
This commit adds a `util.NoParallelUse` type which provides functions
`Begin()` and `End()` which can be used to mark a critical section. In
race builds, there will be a panic if two goroutines attempt to enter
a critical section at the same time. This type should be useful in
general wherever we want to verify a single-goroutine assumption.

This is used with `optPlanningCtx` which should now panic in race
builds if we attempt to use the same context in parallel.

Release note: None