### PR TITLE
release-19.1: sql: fix crash in type checking code

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -674,7 +674,7 @@ SELECT * FROM x ORDER BY a
 6 12 10
 
 # Verify a bad statement fails.
-statement error could not parse "a" as type int
+statement error unsupported binary operator: <int> \+ <string> \(desired <int>\)
 ALTER TABLE x ADD COLUMN d INT AS (a + 'a') STORED
 
 statement error could not parse "a" as type int

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -104,6 +104,10 @@ EXECUTE a(1, 1, 1)
 query error wrong number of parameters for prepared statement \"a\": expected 2, got 0
 EXECUTE a
 
+# Regression test for #36153.
+statement error unknown signature: array_length\(int, int\)
+PREPARE fail AS SELECT array_length($1, 1)
+
 ## Type hints
 
 statement

--- a/pkg/sql/logictest/testdata/logic_test/suboperators
+++ b/pkg/sql/logictest/testdata/logic_test/suboperators
@@ -367,7 +367,7 @@ SELECT 1 = ANY (1, 2, 3)
 ----
 true
 
-query error could not parse "foo" as type int
+query error unsupported comparison operator: <int> = <string>
 SELECT 1 = ANY (1, 2, 3.3, 'foo')
 
 query B
@@ -415,7 +415,7 @@ SELECT 1::decimal = ANY (((1.0, 1.1)))
 ----
 true
 
-query error could not parse \"hello\" as type int
+query error unsupported comparison operator: <int> = <string>
 SELECT 1 = ANY (1, 'hello', 3)
 
 query B

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -136,10 +136,10 @@ SELECT ts FROM untyped WHERE ts != '2015-09-18 00:00:00'
 
 # Regression tests for #15050
 
-statement error pq: error type checking constant value: could not parse "Not Timestamp" as type timestamp
+statement error unsupported comparison operator: <timestamptz> < <string>
 CREATE TABLE t15050a (c DECIMAL DEFAULT CASE WHEN now() < 'Not Timestamp' THEN 2 ELSE 2 END);
 
-statement error pq: error type checking constant value: could not parse "Not Timestamp" as type timestamp
+statement error unsupported comparison operator: <timestamptz> < <string>
 CREATE TABLE t15050b (c DECIMAL DEFAULT IF(now() < 'Not Timestamp', 2, 2));
 
 # Regression tests for #15632

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -1306,10 +1306,10 @@ SELECT k, lead(k, w) OVER (PARTITION BY v ORDER BY w, k) FROM kv ORDER BY 1
 10  NULL
 11  NULL
 
-query error could not parse "FOO" as type int
+query error unknown signature: lag\(int, int, string\)
 SELECT k, lag(k, 1, 'FOO') OVER () FROM kv ORDER BY 1
 
-query error could not parse "FOO" as type int
+query error unknown signature: lead\(int, int, string\)
 SELECT k, lead(k, 1, 'FOO') OVER () FROM kv ORDER BY 1
 
 query error unknown signature: lag\(int, int, string\)
@@ -1721,7 +1721,7 @@ SELECT k, last_value(v) OVER (PARTITION BY k) FROM kv ORDER BY 1
 10  4
 11  NULL
 
-query error could not parse "FOO" as type int
+query error unknown signature: nth_value\(int, string\)
 SELECT k, nth_value(v, 'FOO') OVER () FROM kv ORDER BY 1
 
 query error argument of nth_value\(\) must be greater than zero


### PR DESCRIPTION
Backport 1/1 commits from #36161.

/cc @cockroachdb/release

---

This change fixes a crash when type checking `array_length($1, 1)`.
The `typeCheckOverloadExprs` function was returning an uninitialized
`TypedExpr` for the first argument. The placeholder argument is
supposed to be filled in by `checkReturn`. In one code path we were
incorrectly assuming that function would always succeed and ignoring
its return flag.

We also clean up the code a bit:
 - we now pass a pointer to the state, given that we modify the slices
   in-place anyway
 - we return the typed expressions from filterAttempt rather than
   relying on the aforementioned slice modification.

Fixes #36153.

Release note (bug fix): Fixed a crash when preparing statements
containing certain expressions (like `array_length` with placeholder
arguments).
