### PR TITLE
opt: Fix infinite loop between normalization rules

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -590,6 +590,11 @@ func (f *ExprFmtCtx) FormatScalarProps(scalar opt.ScalarExpr) {
 				if scalarProps.CanHaveSideEffects {
 					writeProp("side-effects")
 				}
+				if scalarProps.HasCorrelatedSubquery {
+					writeProp("correlated-subquery")
+				} else if scalarProps.HasSubquery {
+					writeProp("subquery")
+				}
 			}
 
 			if !f.HasFlags(ExprFmtHideConstraints) {

--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -210,7 +210,7 @@ project
  │         └── sum [type=decimal, outer=(9)]
  │              └── variable: x [type=int]
  └── projections
-      └── subquery [type=decimal, outer=(2,10)]
+      └── subquery [type=decimal, outer=(2,10), correlated-subquery]
            └── max1-row
                 ├── columns: sum:11(decimal)
                 ├── outer: (2,10)

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -725,7 +725,7 @@ select
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  └── filters
-      └── exists [type=bool, outer=(1-3)]
+      └── exists [type=bool, outer=(1-3), correlated-subquery]
            └── inner-join
                 ├── columns: x:5(int) y:6(int)
                 ├── outer: (1-3)

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -135,7 +135,7 @@ project
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-4,+3,+1)
  └── projections
-      └── subquery [type=int, outer=(1,2), side-effects]
+      └── subquery [type=int, outer=(1,2), side-effects, correlated-subquery]
            └── max1-row
                 ├── columns: x:8(int)
                 ├── outer: (1,2)

--- a/pkg/sql/opt/memo/testdata/logprops/max1row
+++ b/pkg/sql/opt/memo/testdata/logprops/max1row
@@ -39,7 +39,7 @@ select
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-4,+3,+1)
  └── filters
-      └── eq [type=bool]
+      └── eq [type=bool, subquery]
            ├── subquery [type=string]
            │    └── max1-row
            │         ├── columns: v:7(string)

--- a/pkg/sql/opt/memo/testdata/logprops/offset
+++ b/pkg/sql/opt/memo/testdata/logprops/offset
@@ -105,7 +105,7 @@ project
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-4,+3,+1)
  └── projections
-      └── subquery [type=int, outer=(1,2)]
+      └── subquery [type=int, outer=(1,2), correlated-subquery]
            └── max1-row
                 ├── columns: x:8(int)
                 ├── outer: (1,2)

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -89,7 +89,7 @@ select
  │    ├── prune: (1-4)
  │    └── interesting orderings: (+1) (-3,+4,+1)
  └── filters
-      └── gt [type=bool, outer=(1,2)]
+      └── gt [type=bool, outer=(1,2), correlated-subquery]
            ├── subquery [type=int]
            │    └── max1-row
            │         ├── columns: y:9(int)
@@ -123,7 +123,7 @@ select
            │              │              ├── variable: k [type=int]
            │              │              └── variable: x [type=int]
            │              └── projections
-           │                   └── subquery [type=int, outer=(2)]
+           │                   └── subquery [type=int, outer=(2), correlated-subquery]
            │                        └── max1-row
            │                             ├── columns: y:8(int)
            │                             ├── outer: (2)
@@ -222,7 +222,7 @@ project
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+1)
  └── projections
-      └── subquery [type=int, outer=(1)]
+      └── subquery [type=int, outer=(1), correlated-subquery]
            └── max1-row
                 ├── columns: xysd.y:5(int)
                 ├── outer: (1)
@@ -272,7 +272,7 @@ project
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+1)
  └── projections
-      └── exists [type=bool, outer=(1)]
+      └── exists [type=bool, outer=(1), correlated-subquery]
            └── project
                 ├── columns: exists:12(bool)
                 ├── outer: (1)
@@ -285,7 +285,7 @@ project
                 │    ├── prune: (4-7)
                 │    └── interesting orderings: (+4) (-6,+7,+4)
                 └── projections
-                     └── exists [type=bool, outer=(1)]
+                     └── exists [type=bool, outer=(1), correlated-subquery]
                           └── project
                                ├── columns: y:9(int)
                                ├── outer: (1)

--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -91,7 +91,7 @@ select
  │    ├── prune: (1,2)
  │    └── interesting orderings: (+1)
  └── filters
-      └── exists [type=bool, outer=(1)]
+      └── exists [type=bool, outer=(1), correlated-subquery]
            └── project
                 ├── columns: u:3(int!null) v:4(int!null)
                 ├── outer: (1)
@@ -130,7 +130,7 @@ select
  │    ├── prune: (1,2)
  │    └── interesting orderings: (+1)
  └── filters
-      └── any: eq [type=bool, outer=(1,2)]
+      └── any: eq [type=bool, outer=(1,2), correlated-subquery]
            ├── project
            │    ├── columns: v:4(int!null)
            │    ├── outer: (1)
@@ -153,6 +153,38 @@ select
            │                   ├── variable: u [type=int]
            │                   └── variable: x [type=int]
            └── variable: y [type=int]
+
+# Regression for 36137: need to detect correlation in 2nd Any operator argument.
+build
+SELECT * FROM xy WHERE x=1 OR y IN (SELECT v FROM uv)
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── interesting orderings: (+1)
+ ├── scan xy
+ │    ├── columns: x:1(int!null) y:2(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── prune: (1,2)
+ │    └── interesting orderings: (+1)
+ └── filters
+      └── or [type=bool, outer=(1,2), correlated-subquery]
+           ├── eq [type=bool]
+           │    ├── variable: x [type=int]
+           │    └── const: 1 [type=int]
+           └── any: eq [type=bool]
+                ├── project
+                │    ├── columns: v:4(int!null)
+                │    ├── prune: (4)
+                │    └── scan uv
+                │         ├── columns: u:3(int) v:4(int!null) rowid:5(int!null)
+                │         ├── key: (5)
+                │         ├── fd: (5)-->(3,4)
+                │         ├── prune: (3-5)
+                │         └── interesting orderings: (+5)
+                └── variable: y [type=int]
 
 # Side-effects: test DivOp and impure FuncOp.
 build

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -87,7 +87,7 @@ select
  │    ├── prune: (1,2)
  │    └── interesting orderings: (+1)
  └── filters
-      └── exists [type=bool, outer=(1,2)]
+      └── exists [type=bool, outer=(1,2), correlated-subquery]
            └── select
                 ├── columns: k:3(int!null) u:4(float) v:5(string)
                 ├── outer: (1,2)
@@ -319,7 +319,7 @@ project
       │    ├── prune: (1-5)
       │    └── interesting orderings: (+5)
       └── filters
-           └── gt [type=bool, outer=(2)]
+           └── gt [type=bool, outer=(2), correlated-subquery]
                 ├── subquery [type=int]
                 │    └── max1-row
                 │         ├── columns: count_rows:8(int)

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -123,7 +123,7 @@ select
  │    ├── prune: (1,2)
  │    └── interesting orderings: (+1)
  └── filters
-      └── eq [type=bool, outer=(1,2)]
+      └── eq [type=bool, outer=(1,2), correlated-subquery]
            ├── subquery [type=tuple{int, int}]
            │    └── max1-row
            │         ├── columns: column13:13(tuple{int, int})

--- a/pkg/sql/opt/memo/testdata/logprops/values
+++ b/pkg/sql/opt/memo/testdata/logprops/values
@@ -38,7 +38,7 @@ project
  │    ├── prune: (1,2)
  │    └── interesting orderings: (+1)
  └── projections
-      └── subquery [type=int, outer=(1,2)]
+      └── subquery [type=int, outer=(1,2), correlated-subquery]
            └── max1-row
                 ├── columns: column1:3(int)
                 ├── outer: (1,2)

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -198,7 +198,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  └── filters
-      └── exists [type=bool, outer=(3)]
+      └── exists [type=bool, outer=(3), correlated-subquery]
            └── group-by
                 ├── columns: column8:8(bool)
                 ├── grouping columns: column8:8(bool)

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -579,7 +579,7 @@ Initial expression
    │    ├── key: (1)
    │    └── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
    └── filters
-        └── exists [type=bool, outer=(2)]
+        └── exists [type=bool, outer=(2), correlated-subquery]
              └── select
                   ├── columns: x:6(int!null) y:7(int!null)
                   ├── outer: (2)
@@ -605,7 +605,7 @@ HoistSelectExists
     │    ├── key: (1)
   - │    └── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
   - └── filters
-  -      └── exists [type=bool, outer=(2)]
+  -      └── exists [type=bool, outer=(2), correlated-subquery]
   -           └── select
   -                ├── columns: x:6(int!null) y:7(int!null)
   -                ├── outer: (2)
@@ -772,7 +772,7 @@ Initial expression
    │    ├── key: (1)
    │    └── fd: (1)-->(2)
    └── projections
-        └── any: eq [type=bool, outer=(1)]
+        └── any: eq [type=bool, outer=(1), correlated-subquery]
              ├── project
              │    ├── columns: i:4(int)
              │    ├── outer: (1)
@@ -803,7 +803,7 @@ PruneSelectCols
     │    ├── key: (1)
     │    └── fd: (1)-->(2)
     └── projections
-         └── any: eq [type=bool, outer=(1)]
+         └── any: eq [type=bool, outer=(1), correlated-subquery]
               ├── project
               │    ├── columns: i:4(int)
               │    ├── outer: (1)
@@ -840,7 +840,7 @@ PruneScanCols
   + │    ├── columns: x:1(int!null)
   + │    └── key: (1)
     └── projections
-         └── any: eq [type=bool, outer=(1)]
+         └── any: eq [type=bool, outer=(1), correlated-subquery]
               ├── project
               │    ├── columns: i:4(int)
               │    ├── outer: (1)
@@ -929,7 +929,7 @@ HoistProjectSubquery
   + │    │         └── CASE WHEN bool_or AND (5 IS NOT NULL) THEN true WHEN bool_or IS NULL THEN false END [type=bool, outer=(10)]
   + │    └── filters (true)
     └── projections
-  -      └── any: eq [type=bool, outer=(1)]
+  -      └── any: eq [type=bool, outer=(1), correlated-subquery]
   -           ├── project
   -           │    ├── columns: i:4(int)
   -           │    ├── outer: (1)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -255,7 +255,7 @@ inner-join
  │    │    ├── key: ()
  │    │    └── tuple [type=tuple]
  │    └── zip
- │         └── function: generate_series [type=int, side-effects]
+ │         └── function: generate_series [type=int, side-effects, subquery]
  │              ├── const: 0 [type=int]
  │              └── subquery [type=int]
  │                   └── max1-row
@@ -2733,7 +2733,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── exists [type=bool]
+      └── exists [type=bool, subquery]
            └── scan xy
                 ├── columns: x:6(int!null) y:7(int)
                 ├── limit: 1
@@ -2873,7 +2873,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── not [type=bool]
+      └── not [type=bool, subquery]
            └── exists [type=bool]
                 └── scan xy
                      ├── columns: x:6(int!null) y:7(int)
@@ -2994,7 +2994,7 @@ project
       │    │    │    │    ├── key: ()
       │    │    │    │    └── fd: ()-->(1-5)
       │    │    │    └── filters
-      │    │    │         └── eq [type=bool]
+      │    │    │         └── eq [type=bool, subquery]
       │    │    │              ├── subquery [type=int]
       │    │    │              │    └── scan xy
       │    │    │              │         ├── columns: x:8(int!null)
@@ -3009,7 +3009,7 @@ project
       │    │    │    │    └── columns: y:7(int)
       │    │    │    └── filters
       │    │    │         ├── y = 10 [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
-      │    │    │         └── eq [type=bool]
+      │    │    │         └── eq [type=bool, subquery]
       │    │    │              ├── subquery [type=int]
       │    │    │              │    └── scan xy
       │    │    │              │         ├── columns: x:8(int!null)
@@ -3268,7 +3268,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── is [type=bool, outer=(2)]
+      └── is [type=bool, outer=(2), correlated-subquery]
            ├── any: eq [type=bool]
            │    ├── scan xy
            │    │    └── columns: y:7(int)
@@ -3389,7 +3389,7 @@ project
       │         └── const-agg [type=jsonb, outer=(5)]
       │              └── variable: j [type=jsonb]
       └── filters
-           └── or [type=bool, outer=(11)]
+           └── or [type=bool, outer=(11), subquery]
                 ├── exists [type=bool]
                 │    └── scan xy
                 │         ├── columns: x:6(int!null) y:7(int)
@@ -3468,17 +3468,17 @@ project
  └── projections
       ├── const: 5 [type=int]
       ├── variable: xy.x [type=int, outer=(6)]
-      ├── subquery [type=int]
+      ├── subquery [type=int, subquery]
       │    └── scan xy
       │         ├── columns: xy.y:9(int)
       │         ├── limit: 1
       │         ├── key: ()
       │         └── fd: ()-->(9)
-      ├── any: eq [type=bool]
+      ├── any: eq [type=bool, subquery]
       │    ├── scan xy
       │    │    └── columns: xy.y:11(int)
       │    └── const: 5 [type=int]
-      ├── exists [type=bool]
+      ├── exists [type=bool, subquery]
       │    └── scan xy
       │         ├── columns: xy.x:12(int!null) xy.y:13(int)
       │         ├── limit: 1
@@ -3641,7 +3641,7 @@ project
  ├── scan a
  │    └── columns: i:2(int)
  └── projections
-      └── any: lt [type=bool, outer=(2)]
+      └── any: lt [type=bool, outer=(2), correlated-subquery]
            ├── scan xy
            │    └── columns: y:7(int)
            └── variable: i [type=int]
@@ -4634,7 +4634,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── exists [type=bool]
+      └── exists [type=bool, subquery]
            └── limit
                 ├── columns: y:7(int!null)
                 ├── cardinality: [0 - 1]
@@ -4756,7 +4756,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── not [type=bool]
+      └── not [type=bool, subquery]
            └── exists [type=bool]
                 └── limit
                      ├── columns: y:7(int)

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -470,7 +470,7 @@ project
       │    │         ├── crdb_internal.public.zones.zone_id + 1 [type=int, outer=(1)]
       │    │         └── crdb_internal.public.zones.zone_id + 2 [type=int, outer=(1)]
       │    └── filters
-      │         └── le [type=bool, outer=(6,7), side-effects]
+      │         └── le [type=bool, outer=(6,7), side-effects, correlated-subquery]
       │              ├── case [type=int]
       │              │    ├── true [type=bool]
       │              │    ├── when [type=int]
@@ -591,7 +591,7 @@ project
  │    ├── columns: k:1(int!null)
  │    └── key: (1)
  └── projections
-      ├── exists [type=bool]
+      ├── exists [type=bool, subquery]
       │    └── scan xy
       │         ├── columns: x:7(int!null) y:8(int)
       │         ├── constraint: /7: [/1 - /2]

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -754,7 +754,7 @@ inner-join (merge)
  │    │    ├── fd: (1)-->(2-5)
  │    │    └── ordering: +1
  │    └── filters
- │         └── eq [type=bool, outer=(1,2)]
+ │         └── eq [type=bool, outer=(1,2), subquery]
  │              ├── k * i [type=int]
  │              └── subquery [type=int]
  │                   └── scalar-group-by
@@ -1083,7 +1083,7 @@ project
  │         │    │    │    │    │    │    │    ├── columns: u:8(int!null)
  │         │    │    │    │    │    │    │    └── key: (8)
  │         │    │    │    │    │    │    └── filters
- │         │    │    │    │    │    │         └── eq [type=bool]
+ │         │    │    │    │    │    │         └── eq [type=bool, subquery]
  │         │    │    │    │    │    │              ├── subquery [type=string]
  │         │    │    │    │    │    │              │    └── max1-row
  │         │    │    │    │    │    │              │         ├── columns: s:19(string)
@@ -1110,7 +1110,7 @@ project
  │         │    │    │    │    │    │    ├── columns: xy.x:6(int!null)
  │         │    │    │    │    │    │    └── key: (6)
  │         │    │    │    │    │    └── filters
- │         │    │    │    │    │         └── eq [type=bool]
+ │         │    │    │    │    │         └── eq [type=bool, subquery]
  │         │    │    │    │    │              ├── subquery [type=string]
  │         │    │    │    │    │              │    └── max1-row
  │         │    │    │    │    │              │         ├── columns: s:19(string)
@@ -1131,6 +1131,49 @@ project
  │              └── true_agg IS NOT NULL [type=bool, outer=(14), constraints=(/14: (/NULL - ]; tight)]
  └── projections
       └── const: 1 [type=int]
+
+# Regression for issue 36137. Try to trigger undetectable cycle between the
+# PushFilterIntoJoinLeftAndRight and TryDecorrelateSelect rules.
+opt
+SELECT * FROM a JOIN b ON a.k = b.x
+WHERE (a.k = b.x) OR (a.k IN (SELECT 5 FROM b WHERE x = y));
+----
+inner-join (merge)
+ ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── left ordering: +1
+ ├── right ordering: +6
+ ├── key: (6)
+ ├── fd: (1)-->(2-5), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan a
+ │    ├── columns: k:1(int!null) i:2(int) f:3(float!null) s:4(string) j:5(jsonb)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    └── ordering: +1
+ ├── scan b
+ │    ├── columns: x:6(int!null) y:7(int)
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    └── ordering: +6
+ └── filters
+      └── or [type=bool, outer=(1,6), correlated-subquery]
+           ├── k = x [type=bool]
+           └── any: eq [type=bool]
+                ├── project
+                │    ├── columns: "?column?":10(int!null)
+                │    ├── fd: ()-->(10)
+                │    ├── select
+                │    │    ├── columns: x:8(int!null) y:9(int!null)
+                │    │    ├── key: (8)
+                │    │    ├── fd: (8)==(9), (9)==(8)
+                │    │    ├── scan b
+                │    │    │    ├── columns: x:8(int!null) y:9(int)
+                │    │    │    ├── key: (8)
+                │    │    │    └── fd: (8)-->(9)
+                │    │    └── filters
+                │    │         └── x = y [type=bool, outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
+                │    └── projections
+                │         └── const: 5 [type=int]
+                └── variable: k [type=int]
 
 # --------------------------------------------------
 # PushFilterIntoJoinLeft + PushFilterIntoJoinRight

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -393,7 +393,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── exists [type=bool]
+      └── exists [type=bool, subquery]
            └── scan a
                 ├── columns: k:7(int!null) i:8(int)
                 ├── limit: 1
@@ -417,7 +417,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── exists [type=bool]
+      └── exists [type=bool, subquery]
            └── scalar-group-by
                 ├── columns: max:13(string)
                 ├── cardinality: [1 - 1]
@@ -444,7 +444,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── exists [type=bool]
+      └── exists [type=bool, subquery]
            └── scan a
                 ├── columns: s:10(string)
                 ├── limit: 1
@@ -463,7 +463,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── exists [type=bool]
+      └── exists [type=bool, subquery]
            └── scan a
                 ├── columns: i:8(int) s:10(string)
                 ├── limit: 1
@@ -485,7 +485,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  └── filters
-      └── exists [type=bool]
+      └── exists [type=bool, subquery]
            └── scan a
                 ├── columns: i:8(int) s:10(string)
                 ├── limit: 1
@@ -1339,7 +1339,7 @@ project
  │    │    │    │    └── key: (7)
  │    │    │    └── projections
  │    │    │         ├── true [type=bool]
- │    │    │         └── indirection [type=int]
+ │    │    │         └── indirection [type=int, subquery]
  │    │    │              ├── array-flatten [type=int[]]
  │    │    │              │    └── scan a
  │    │    │              │         ├── columns: k:13(int!null)
@@ -1433,7 +1433,7 @@ project
  ├── fd: ()-->(13)
  ├── scan a
  └── projections
-      └── array-flatten [type=int[]]
+      └── array-flatten [type=int[], subquery]
            └── scan a
                 ├── columns: k:7(int!null)
                 └── key: (7)

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -185,7 +185,7 @@ project
  ├── scan a
  │    └── columns: i:2(int)
  └── projections
-      └── case [type=int, outer=(2), side-effects]
+      └── case [type=int, outer=(2), side-effects, correlated-subquery]
            ├── true [type=bool]
            ├── when [type=int]
            │    ├── i < 0 [type=bool]
@@ -233,7 +233,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── eq [type=bool, outer=(1,2), side-effects, constraints=(/1: (/NULL - ])]
+      └── eq [type=bool, outer=(1,2), side-effects, correlated-subquery, constraints=(/1: (/NULL - ])]
            ├── variable: k [type=int]
            └── case [type=int]
                 ├── true [type=bool]
@@ -278,7 +278,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── eq [type=bool, outer=(1,2), side-effects, constraints=(/1: (/NULL - ])]
+      └── eq [type=bool, outer=(1,2), side-effects, correlated-subquery, constraints=(/1: (/NULL - ])]
            ├── variable: k [type=int]
            └── if-err [type=decimal]
                 ├── 1 / 0 [type=decimal]

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -1724,7 +1724,7 @@ sort
       │         └── sum [type=float, outer=(17)]
       │              └── variable: column17 [type=float]
       └── filters
-           └── gt [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+           └── gt [type=bool, outer=(18), subquery, constraints=(/18: (/NULL - ])]
                 ├── variable: sum [type=float]
                 └── subquery [type=float]
                      └── project
@@ -2086,7 +2086,7 @@ project
       │         │         └── sum [type=float, outer=(24)]
       │         │              └── variable: column24 [type=float]
       │         └── filters
-      │              └── eq [type=bool, outer=(25), constraints=(/25: (/NULL - ])]
+      │              └── eq [type=bool, outer=(25), subquery, constraints=(/25: (/NULL - ])]
       │                   ├── variable: sum [type=float]
       │                   └── subquery [type=float]
       │                        └── scalar-group-by
@@ -2890,7 +2890,7 @@ sort
       │    │    │    │    └── ordering: +1
       │    │    │    └── filters
       │    │    │         ├── substring(c_phone, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(5)]
-      │    │    │         └── gt [type=bool, outer=(6), constraints=(/6: (/NULL - ])]
+      │    │    │         └── gt [type=bool, outer=(6), subquery, constraints=(/6: (/NULL - ])]
       │    │    │              ├── variable: c_acctbal [type=float]
       │    │    │              └── subquery [type=float]
       │    │    │                   └── scalar-group-by

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -1516,7 +1516,7 @@ sort
       │         └── sum [type=float, outer=(17)]
       │              └── variable: column17 [type=float]
       └── filters
-           └── gt [type=bool, outer=(18), constraints=(/18: (/NULL - ])]
+           └── gt [type=bool, outer=(18), subquery, constraints=(/18: (/NULL - ])]
                 ├── variable: sum [type=float]
                 └── subquery [type=float]
                      └── project
@@ -1866,7 +1866,7 @@ sort
            │    │         └── sum [type=float, outer=(24)]
            │    │              └── variable: column24 [type=float]
            │    └── filters
-           │         └── eq [type=bool, outer=(25), constraints=(/25: (/NULL - ])]
+           │         └── eq [type=bool, outer=(25), subquery, constraints=(/25: (/NULL - ])]
            │              ├── variable: sum [type=float]
            │              └── subquery [type=float]
            │                   └── scalar-group-by
@@ -2663,7 +2663,7 @@ sort
       │    │    │    │    └── ordering: +1
       │    │    │    └── filters
       │    │    │         ├── substring(c_phone, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(5)]
-      │    │    │         └── gt [type=bool, outer=(6), constraints=(/6: (/NULL - ])]
+      │    │    │         └── gt [type=bool, outer=(6), subquery, constraints=(/6: (/NULL - ])]
       │    │    │              ├── variable: c_acctbal [type=float]
       │    │    │              └── subquery [type=float]
       │    │    │                   └── scalar-group-by


### PR DESCRIPTION
Two of the normalization rules depend on correct detection of correlated
subqueries, or they will loop. A bug in the logical props builder resulted
in failure to detect a correlated Any operator, which triggered the loop.
The bug was a missing check for correlation in the 2nd argument of Any.

Fixes #36137

Release note: None