### PR TITLE
roachtest: fail test if crdb_internal.check_consistency finds problems

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -956,6 +956,42 @@ func (c *cluster) FailOnDeadNodes(ctx context.Context, t *test) {
 	})
 }
 
+// FailOnReplicaDivergence fails the test if
+// crdb_internal.check_consistency(true, '', '') indicates that any ranges'
+// replicas are inconsistent with each other.
+func (c *cluster) FailOnReplicaDivergence(ctx context.Context, t *test) {
+	if c.nodes < 1 {
+		return // unit tests
+	}
+	// TODO(tbg): n1 isn't necessarily online at this point. Try to sniff out
+	// a node that is.
+	db := c.Conn(ctx, 1)
+	defer db.Close()
+
+	c.l.Printf("running (fast) consistency checks")
+	rows, err := db.QueryContext(ctx, `
+SELECT t.range_id, t.start_key_pretty, t.status, t.detail
+FROM
+crdb_internal.check_consistency(true, '', '') as t
+WHERE t.status NOT IN ('RANGE_CONSISTENT', 'RANGE_INDETERMINATE')`)
+	if err != nil {
+		c.l.Printf("%s", err)
+		return
+	}
+	for rows.Next() {
+		var rangeID int32
+		var prettyKey, status, detail string
+		if err := rows.Scan(&rangeID, &prettyKey, &status, &detail); err != nil {
+			c.l.Printf("%s", err)
+			break
+		}
+		t.Fatalf("r%d (%s) is inconsistent: %s %s", rangeID, prettyKey, status, detail)
+	}
+	if err := rows.Err(); err != nil {
+		c.l.Printf("%s", err)
+	}
+}
+
 // FetchDmesg grabs the dmesg logs if possible. This requires being able to run
 // `sudo dmesg` on the remote nodes.
 func (c *cluster) FetchDmesg(ctx context.Context) error {

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -1192,6 +1192,9 @@ func (r *registry) runAsync(
 				c.l.Printf("failed to download logs: %s", err)
 			}
 		}()
+		// Detect replica divergence (i.e. ranges in which replicas have arrived
+		// at the same log position with different states).
+		defer c.FailOnReplicaDivergence(ctx, t)
 		// Detect dead nodes in an inner defer. Note that this will call t.Fatal
 		// when appropriate, which will cause the closure above to enter the
 		// t.Failed() branch.


### PR DESCRIPTION
This can give us confidence that we'll catch any instances of replica
divergence occurring in roachtest as long as the divergence affects the
MVCCStats keys. This has been the case in all but one reported such issues.

Running the full check is prohibitive and will likely crash the cluster due
to a lack of admission control.

Release note: None