### PR TITLE
stats: invalidate local cache synchronously

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -290,6 +290,7 @@ func createStatsDefaultColumns(
 // createStatsResumer.Resume so it can be used in createStatsResumer.OnSuccess
 // (if the job is successful).
 type createStatsResumer struct {
+	tableID sqlbase.ID
 	evalCtx *extendedEvalContext
 }
 
@@ -309,6 +310,7 @@ func (r *createStatsResumer) Resume(
 		}
 	}
 
+	r.tableID = details.Table.ID
 	r.evalCtx = p.ExtendedEvalContext()
 
 	ci := sqlbase.ColTypeInfoFromColTypes([]sqlbase.ColumnType{})
@@ -419,10 +421,16 @@ func (r *createStatsResumer) OnFailOrCancel(
 func (r *createStatsResumer) OnSuccess(ctx context.Context, _ *client.Txn, job *jobs.Job) error {
 	details := job.Details().(jobspb.CreateStatsDetails)
 
+	// Invalidate the local cache synchronously; this guarantees that the next
+	// statement in the same session won't use a stale cache (whereas the gossip
+	// update is handled asynchronously).
+	r.evalCtx.ExecCfg.TableStatsCache.InvalidateTableStats(ctx, r.tableID)
+
+	// Record this statistics creation in the event log.
 	if !createStatsPostEvents.Get(&r.evalCtx.Settings.SV) {
 		return nil
 	}
-	// Record this statistics creation in the event log.
+
 	// TODO(rytaft): This creates a new transaction for the CREATE STATISTICS
 	// event. It must be different from the CREATE STATISTICS transaction,
 	// because that transaction must be read-only. In the future we may want

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -4,33 +4,28 @@
 # statistics if distsql mode is OFF.
 
 statement ok
-CREATE TABLE a (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
-
-# Create a new table to avoid depending on the asynchronous stat cache
-# invalidation.
-statement ok
-CREATE TABLE b (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
-INSERT INTO b VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 4), (2, 5), (2, 6), (2, 7)
+CREATE TABLE uv (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
+INSERT INTO uv VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 4), (2, 5), (2, 6), (2, 7)
 
 statement ok
-CREATE STATISTICS u ON u FROM b;
-CREATE STATISTICS v ON v FROM b
+CREATE STATISTICS u ON u FROM uv;
+CREATE STATISTICS v ON v FROM uv
 
 statement ok
 set experimental_enable_zigzag_join = false
 
 # Verify we scan index v which has the more selective constraint.
 query TTTTT
-EXPLAIN (VERBOSE) SELECT * FROM b WHERE u = 1 AND v = 1
+EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-scan  ·       ·          (u, v)  ·
-·     table   b@b_v_idx  ·       ·
-·     spans   /1-/2      ·       ·
-·     filter  u = 1      ·       ·
+scan  ·       ·            (u, v)  ·
+·     table   uv@uv_v_idx  ·       ·
+·     spans   /1-/2        ·       ·
+·     filter  u = 1        ·       ·
 
 # Verify that injecting different statistics changes the plan.
 statement ok
-ALTER TABLE b INJECT STATISTICS '[
+ALTER TABLE uv INJECT STATISTICS '[
   {
     "columns": ["u"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
@@ -46,17 +41,17 @@ ALTER TABLE b INJECT STATISTICS '[
 ]'
 
 query TTTTT
-EXPLAIN (VERBOSE) SELECT * FROM b WHERE u = 1 AND v = 1
+EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-scan  ·       ·          (u, v)  ·
-·     table   b@b_u_idx  ·       ·
-·     spans   /1-/2      ·       ·
-·     filter  v = 1      ·       ·
+scan  ·       ·            (u, v)  ·
+·     table   uv@uv_u_idx  ·       ·
+·     spans   /1-/2        ·       ·
+·     filter  v = 1        ·       ·
 
 # Verify that injecting different statistics with null counts
 # changes the plan.
 statement ok
-ALTER TABLE b INJECT STATISTICS '[
+ALTER TABLE uv INJECT STATISTICS '[
   {
     "columns": ["u"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
@@ -74,15 +69,15 @@ ALTER TABLE b INJECT STATISTICS '[
 ]'
 
 query TTTTT
-EXPLAIN (VERBOSE) SELECT * FROM b WHERE u = 1 AND v = 1
+EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-scan  ·       ·          (u, v)  ·
-·     table   b@b_u_idx  ·       ·
-·     spans   /1-/2      ·       ·
-·     filter  v = 1      ·       ·
+scan  ·       ·            (u, v)  ·
+·     table   uv@uv_u_idx  ·       ·
+·     spans   /1-/2        ·       ·
+·     filter  v = 1        ·       ·
 
 statement ok
-ALTER TABLE b INJECT STATISTICS '[
+ALTER TABLE uv INJECT STATISTICS '[
   {
     "columns": ["u"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
@@ -100,9 +95,9 @@ ALTER TABLE b INJECT STATISTICS '[
 ]'
 
 query TTTTT
-EXPLAIN (VERBOSE) SELECT * FROM b WHERE u = 1 AND v = 1
+EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-scan  ·       ·          (u, v)  ·
-·     table   b@b_v_idx  ·       ·
-·     spans   /1-/2      ·       ·
-·     filter  u = 1      ·       ·
+scan  ·       ·            (u, v)  ·
+·     table   uv@uv_v_idx  ·       ·
+·     spans   /1-/2        ·       ·
+·     filter  u = 1        ·       ·


### PR DESCRIPTION
A couple of tests rely on the new stats being in effect once CREATE
STATISTICS completes. This is usually the case, but not reliably so
(the invalidation mechanism is asynchronous).

This commit adds a call to invalidate the local cache synchronously
(similar to INJECT STATISTICS).

We also clean up the code that triggers invalidation via gossip to do
it once for the entire table, not once per statistic.

Finally, the stats test is cleaned up (it contained a so-called
workaround for this problem that made no sense).

Fixes #36087.
Fixes #36218.

Release note: None