### PR TITLE
importccl: use direct datum workload generator by default

### DIFF
--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -36,15 +36,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/pkg/errors"
 )
-
-var useWorkloadFastpath = envutil.EnvOrDefaultBool("COCKROACH_IMPORT_WORKLOAD_FASTER", false)
 
 type readFileFunc func(context.Context, io.Reader, int32, string, progressFn) error
 
@@ -432,13 +429,11 @@ func (cp *readImportDataProcessor) doRun(ctx context.Context) error {
 	var err error
 	switch cp.spec.Format.Format {
 	case roachpb.IOFileFormat_CSV:
-		isWorkload := useWorkloadFastpath
-		if isWorkload {
-			for _, file := range cp.spec.Uri {
-				if conf, err := storageccl.ExportStorageConfFromURI(file); err != nil || conf.Provider != roachpb.ExportStorageProvider_Workload {
-					isWorkload = false
-					break
-				}
+		isWorkload := true
+		for _, file := range cp.spec.Uri {
+			if conf, err := storageccl.ExportStorageConfFromURI(file); err != nil || conf.Provider != roachpb.ExportStorageProvider_Workload {
+				isWorkload = false
+				break
 			}
 		}
 		if isWorkload {


### PR DESCRIPTION
This removes the COCKROACH_IMPORT_WORKLOAD_FASTER flag now that it has been tested for awhile,
and, critically, now that it is actually faster than writing/reading CSVs.

The difference is most pronouced when using distsql sorted IMPORT as it reads twice --
for sampling and then ingest -- but is also measurable in single-pass 'direct' ingest.

All checked passed when running 'fixtures import tpcc --warehouses=1000', and ingest time
using distsql import went from 55m via CSV to 41m using the worklaod reader directly.

Release note: none.