### PR TITLE
storage: support no-op PUSH_TIMESTAMP pushes on STAGING transactions

### DIFF
--- a/pkg/kv/integration_test.go
+++ b/pkg/kv/integration_test.go
@@ -113,7 +113,7 @@ func TestWaiterOnRejectedCommit(t *testing.T) {
 					}
 					return 0, nil
 				},
-				TxnWait: txnwait.TestingKnobs{
+				TxnWaitKnobs: txnwait.TestingKnobs{
 					OnPusherBlocked: func(ctx context.Context, push *roachpb.PushTxnRequest) {
 						// We'll trap a reader entering the wait queue for our txn.
 						v := txnID.Load()

--- a/pkg/storage/batcheval/cmd_resolve_intent.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/pkg/errors"
 )
 
 func init() {
@@ -80,9 +79,6 @@ func ResolveIntent(
 
 	if h.Txn != nil {
 		return result.Result{}, ErrTransactionUnsupported
-	}
-	if args.Status == roachpb.STAGING {
-		return result.Result{}, errors.Errorf("cannot resolve intent with STAGING status")
 	}
 
 	intent := roachpb.Intent{

--- a/pkg/storage/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_range.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
-	"github.com/pkg/errors"
 )
 
 func init() {
@@ -45,9 +44,6 @@ func ResolveIntentRange(
 
 	if h.Txn != nil {
 		return result.Result{}, ErrTransactionUnsupported
-	}
-	if args.Status == roachpb.STAGING {
-		return result.Result{}, errors.Errorf("cannot resolve intent with STAGING status")
 	}
 
 	intent := roachpb.Intent{

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -31,8 +31,10 @@ import (
 // particular point is reached) or to change the behavior by returning
 // an error (which aborts all further processing for the command).
 type StoreTestingKnobs struct {
-	EvalKnobs           storagebase.BatchEvalTestingKnobs
-	IntentResolverKnobs storagebase.IntentResolverTestingKnobs
+	EvalKnobs               storagebase.BatchEvalTestingKnobs
+	IntentResolverKnobs     storagebase.IntentResolverTestingKnobs
+	TxnWaitKnobs            txnwait.TestingKnobs
+	ConsistencyTestingKnobs ConsistencyTestingKnobs
 
 	// TestingRequestFilter is called before evaluating each command on a
 	// replica. The filter is run before the request acquires latches, so
@@ -172,14 +174,14 @@ type StoreTestingKnobs struct {
 	SystemLogsGCPeriod time.Duration
 	// SystemLogsGCGCDone is used to notify when system logs GC is done.
 	SystemLogsGCGCDone chan<- struct{}
-	// TxnWait contains knobs for txnwait.Queue instances.
-	TxnWait txnwait.TestingKnobs
 	// DontRetryPushTxnFailures will propagate a push txn failure immediately
 	// instead of utilizing the txn wait queue to wait for the transaction to
 	// finish or be pushed by a higher priority contender.
 	DontRetryPushTxnFailures bool
-
-	ConsistencyTestingKnobs ConsistencyTestingKnobs
+	// DontRecoverIndeterminateCommits will propagate indeterminate commit
+	// errors from failed txn pushes immediately instead of utilizing the txn
+	// recovery manager to recovery from the indeterminate state.
+	DontRecoverIndeterminateCommits bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Caught while manually testing parallel commits last week.

PR #35763 made it an error to resolve an intent with a STAGING status.
This isn't a crazy thing to do in every circumstance though. The case
where this comes up is a PUSH_TIMESTAMP push on a STAGING transaction
whose timestamp is already sufficiently high. In this case, the pusher
can move the intent up out of its way without modifying the transaction
record or interfering with the parallel commit.

Concretely, this is allowed in pushes that hit this case:
https://github.com/cockroachdb/cockroach/blob/4ab679d978a8f566c1427b372547380ee012292f/pkg/storage/batcheval/cmd_push_txn.go#L197

To test this, the commit extends `TestStoreResolveWriteIntentPushOnRead`
to test scenarios in two different dimensions: PENDING vs. STAGING
transaction records and already pushed txns vs. not already pushed
txns. To test the latter dimensions, the commit had to refine how
far into the future transactions push conflicting intents. Previously,
transactions would push them all the way to hlc.Now() on the pushing
node so that there was no chance that they would be in their uncertainty
window after the push. This was pessimistic. The transaction only needs
to push the conflicting intent up to its observed timestamp for the
pushing node, which may be significantly lower than the current timestamp
on the pushing node. This should increase the number of no-op pushes we
see in the wild.

Release note: None