### PR TITLE
sql: Use ColumnDescriptor by-ref rather than by-value

### DIFF
--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -244,8 +244,8 @@ func allocateTableRewrites(
 		}
 
 		// Check that referenced sequences exist.
-		for _, col := range table.Columns {
-			for _, seqID := range col.UsesSequenceIds {
+		for i := range table.Columns {
+			for _, seqID := range table.Columns[i].UsesSequenceIds {
 				if _, ok := tablesByID[seqID]; !ok {
 					if _, ok := opts[restoreOptSkipMissingSequences]; !ok {
 						return nil, errors.Errorf(
@@ -492,8 +492,9 @@ func RewriteTableDescs(
 		}
 
 		// Rewrite sequence references in column descriptors.
-		for idx, col := range table.Columns {
+		for idx := range table.Columns {
 			var newSeqRefs []sqlbase.ID
+			col := &table.Columns[idx]
 			for _, seqID := range col.UsesSequenceIds {
 				if rewrite, ok := tableRewrites[seqID]; ok {
 					newSeqRefs = append(newSeqRefs, rewrite.TableID)
@@ -508,7 +509,6 @@ func RewriteTableDescs(
 				}
 			}
 			col.UsesSequenceIds = newSeqRefs
-			table.Columns[idx] = col
 		}
 
 		// since this is a "new" table in eyes of new cluster, any leftover change

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -353,8 +353,8 @@ func indexToAvroSchema(
 		if !ok {
 			return nil, errors.Errorf(`unknown column id: %d`, colID)
 		}
-		col := tableDesc.Columns[colIdx]
-		field, err := columnDescToAvroSchema(&col)
+		col := &tableDesc.Columns[colIdx]
+		field, err := columnDescToAvroSchema(col)
 		if err != nil {
 			return nil, err
 		}
@@ -384,9 +384,9 @@ func tableToAvroSchema(tableDesc *sqlbase.TableDescriptor) (*avroDataRecord, err
 		fieldIdxByName:   make(map[string]int),
 		colIdxByFieldIdx: make(map[int]int),
 	}
-	for colIdx, col := range tableDesc.Columns {
-		col := col
-		field, err := columnDescToAvroSchema(&col)
+	for colIdx := range tableDesc.Columns {
+		col := &tableDesc.Columns[colIdx]
+		field, err := columnDescToAvroSchema(col)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -110,7 +110,7 @@ func (e *jsonEncoder) EncodeKey(row encodeRow) ([]byte, error) {
 		if !ok {
 			return nil, errors.Errorf(`unknown column id: %d`, colID)
 		}
-		datum, col := row.datums[idx], row.tableDesc.Columns[idx]
+		datum, col := row.datums[idx], &row.tableDesc.Columns[idx]
 		if err := datum.EnsureDecoded(&col.Type, &e.alloc); err != nil {
 			return nil, err
 		}
@@ -139,7 +139,8 @@ func (e *jsonEncoder) EncodeValue(row encodeRow) ([]byte, error) {
 	if !row.deleted {
 		columns := row.tableDesc.Columns
 		after = make(map[string]interface{}, len(columns))
-		for i, col := range columns {
+		for i := range columns {
+			col := &columns[i]
 			datum := row.datums[i]
 			if err := datum.EnsureDecoded(&col.Type, &e.alloc); err != nil {
 				return nil, err

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -89,8 +89,8 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 	// TODO(dan): Allow for decoding a subset of the columns.
 	colIdxMap := make(map[sqlbase.ColumnID]int)
 	var valNeededForCol util.FastIntSet
-	for colIdx, col := range tableDesc.Columns {
-		colIdxMap[col.ID] = colIdx
+	for colIdx := range tableDesc.Columns {
+		colIdxMap[tableDesc.Columns[colIdx].ID] = colIdx
 		valNeededForCol.Add(colIdx)
 	}
 

--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -175,8 +175,8 @@ func Load(
 				Union: &sqlbase.Descriptor_Table{Table: desc.TableDesc()},
 			})
 
-			for _, col := range tableDesc.Columns {
-				if col.IsComputed() {
+			for i := range tableDesc.Columns {
+				if tableDesc.Columns[i].IsComputed() {
 					return backupccl.BackupDescriptor{}, errors.Errorf("computed columns are not allowed")
 				}
 			}
@@ -270,8 +270,8 @@ func insertStmtToKVs(
 		if len(stmt.Columns) != len(cols) {
 			return errors.Errorf("load insert: wrong number of columns: %q", stmt)
 		}
-		for i, col := range tableDesc.Columns {
-			if stmt.Columns[i].String() != col.Name {
+		for i := range tableDesc.Columns {
+			if stmt.Columns[i].String() != tableDesc.Columns[i].Name {
 				return errors.Errorf("load insert: unexpected column order: %q", stmt)
 			}
 		}

--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -256,7 +256,8 @@ func newRowConverter(
 
 	// Check for a hidden column. This should be the unique_rowid PK if present.
 	c.hidden = -1
-	for i, col := range cols {
+	for i := range cols {
+		col := &cols[i]
 		if col.Hidden {
 			if col.DefaultExpr == nil || *col.DefaultExpr != "unique_rowid()" || c.hidden != -1 {
 				return nil, errors.New("unexpected hidden column")

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -176,7 +176,7 @@ func createPartitioningImpl(
 		if err != nil {
 			return partDesc, err
 		}
-		cols = append(cols, col)
+		cols = append(cols, *col)
 		if string(partBy.Fields[i]) != col.Name {
 			n := colOffset + len(partBy.Fields)
 			return partDesc, pgerror.NewErrorf(pgerror.CodeSyntaxError,

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -99,7 +99,8 @@ func (cb *ColumnBackfiller) Init(
 	cb.updateCols = append(cb.added, dropped...)
 	// Populate default or computed values.
 	cb.updateExprs = make([]tree.TypedExpr, len(cb.updateCols))
-	for j, col := range cb.added {
+	for j := range cb.added {
+		col := &cb.added[j]
 		if col.IsComputed() {
 			cb.updateExprs[j] = computedExprs[j]
 		} else if defaultExprs == nil || defaultExprs[j] == nil {
@@ -332,8 +333,9 @@ func (ib *IndexBackfiller) Init(desc *sqlbase.ImmutableTableDescriptor) error {
 		if IndexMutationFilter(m) {
 			idx := m.GetIndex()
 			ib.added = append(ib.added, *idx)
-			for i, col := range cols {
-				if idx.ContainsColumnID(col.ID) {
+			for i := range cols {
+				id := cols[i].ID
+				if idx.ContainsColumnID(id) {
 					valNeededForCol.Add(i)
 				}
 			}
@@ -346,8 +348,8 @@ func (ib *IndexBackfiller) Init(desc *sqlbase.ImmutableTableDescriptor) error {
 	}
 
 	ib.colIdxMap = make(map[sqlbase.ColumnID]int, len(cols))
-	for i, c := range cols {
-		ib.colIdxMap[c.ID] = i
+	for i := range cols {
+		ib.colIdxMap[cols[i].ID] = i
 	}
 
 	tableArgs := row.FetcherTableArgs{

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -122,8 +122,8 @@ func newCopyMachine(
 		return nil, err
 	}
 	c.resultColumns = make(sqlbase.ResultColumns, len(cols))
-	for i, col := range cols {
-		c.resultColumns[i] = sqlbase.ResultColumn{Typ: col.Type.ToDatumType()}
+	for i := range cols {
+		c.resultColumns[i] = sqlbase.ResultColumn{Typ: cols[i].Type.ToDatumType()}
 	}
 	c.rowsMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()
 	c.bufMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1224,7 +1224,8 @@ CREATE TABLE crdb_internal.table_columns (
 			func(db *DatabaseDescriptor, _ string, table *TableDescriptor) error {
 				tableID := tree.NewDInt(tree.DInt(table.ID))
 				tableName := tree.NewDString(table.Name)
-				for _, col := range table.Columns {
+				for i := range table.Columns {
+					col := &table.Columns[i]
 					defStr := tree.DNull
 					if col.DefaultExpr != nil {
 						defStr = tree.NewDString(*col.DefaultExpr)
@@ -1504,7 +1505,8 @@ CREATE TABLE crdb_internal.backward_dependencies (
 				}
 
 				// Record sequence dependencies.
-				for _, col := range table.Columns {
+				for i := range table.Columns {
+					col := &table.Columns[i]
 					for _, sequenceID := range col.UsesSequenceIds {
 						if err := addRow(
 							tableID, tableName,

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -186,7 +186,7 @@ SELECT column_name, character_maximum_length, numeric_precision, numeric_precisi
 	tableDesc = sqlbase.GetTableDescriptor(kvDB, "t", "test")
 	found := false
 	for i := range tableDesc.Columns {
-		col := tableDesc.Columns[i]
+		col := &tableDesc.Columns[i]
 		if col.Name == "k" {
 			// TODO(knz): post-2.2, we're removing the visible types for
 			// integer types so the expectation will be just 0 here.

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -230,7 +230,7 @@ func (n *createViewNode) makeViewTableDesc(
 		if err != nil {
 			return desc, err
 		}
-		desc.AddColumn(*col)
+		desc.AddColumn(col)
 	}
 	// AllocateIDs mutates its receiver. `return desc, desc.AllocateIDs()`
 	// happens to work in gc, but does not work in gccgo.
@@ -269,7 +269,7 @@ func MakeViewTableDesc(
 		if err != nil {
 			return desc, err
 		}
-		desc.AddColumn(*col)
+		desc.AddColumn(col)
 	}
 	// AllocateIDs mutates its receiver. `return desc, desc.AllocateIDs()`
 	// happens to work in gc, but does not work in gccgo.

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -108,11 +108,13 @@ func (mt mutationTest) writeColumnMutation(column string, m sqlbase.DescriptorMu
 	}
 	for i := range mt.tableDesc.Columns {
 		if col.ID == mt.tableDesc.Columns[i].ID {
-			mt.tableDesc.Columns = append(mt.tableDesc.Columns[:i], mt.tableDesc.Columns[i+1:]...)
+			// Use [:i:i] to prevent reuse of existing slice, or outstanding refs
+			// to ColumnDescriptors may unexpectedly change.
+			mt.tableDesc.Columns = append(mt.tableDesc.Columns[:i:i], mt.tableDesc.Columns[i+1:]...)
 			break
 		}
 	}
-	m.Descriptor_ = &sqlbase.DescriptorMutation_Column{Column: &col}
+	m.Descriptor_ = &sqlbase.DescriptorMutation_Column{Column: col}
 	mt.writeMutation(m)
 }
 

--- a/pkg/sql/distsqlrun/scrub_tablereader.go
+++ b/pkg/sql/distsqlrun/scrub_tablereader.go
@@ -190,8 +190,9 @@ func (tr *scrubTableReader) prettyPrimaryKeyValues(
 	row sqlbase.EncDatumRow, table *sqlbase.TableDescriptor,
 ) string {
 	colIdxMap := make(map[sqlbase.ColumnID]int, len(table.Columns))
-	for i, c := range table.Columns {
-		colIdxMap[c.ID] = i
+	for i := range table.Columns {
+		id := table.Columns[i].ID
+		colIdxMap[id] = i
 	}
 	colIDToRowIdxMap := make(map[sqlbase.ColumnID]int, len(table.Columns))
 	for rowIdx, colIdx := range tr.fetcherResultToColIdx {

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -288,8 +288,8 @@ func (p *planner) dropTableImpl(
 	}
 
 	// Remove sequence dependencies.
-	for _, columnDesc := range tableDesc.Columns {
-		if err := removeSequenceDependencies(tableDesc, &columnDesc, params); err != nil {
+	for i := range tableDesc.Columns {
+		if err := removeSequenceDependencies(tableDesc, &tableDesc.Columns[i], params); err != nil {
 			return droppedViews, err
 		}
 	}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -191,8 +191,8 @@ func dIntFnOrNull(fn func() (int32, bool)) tree.Datum {
 
 func validateInformationSchemaTable(table *sqlbase.TableDescriptor) error {
 	// Make sure no tables have boolean columns.
-	for _, col := range table.Columns {
-		if col.Type.SemanticType == sqlbase.ColumnType_BOOL {
+	for i := range table.Columns {
+		if table.Columns[i].Type.SemanticType == sqlbase.ColumnType_BOOL {
 			return errors.Errorf("information_schema tables should never use BOOL columns. "+
 				"See the comment about yesOrNoDatum. Found BOOL column in %s.", table.Name)
 		}
@@ -273,7 +273,8 @@ https://www.postgresql.org/docs/9.5/infoschema-column-privileges.html`,
 			for _, u := range table.Privileges.Users {
 				for _, priv := range columndata {
 					if priv.Mask()&u.Privileges != 0 {
-						for _, cd := range table.Columns {
+						for i := range table.Columns {
+							cd := &table.Columns[i]
 							if err := addRow(
 								tree.DNull,                     // grantor
 								tree.NewDString(u.User),        // grantee
@@ -1461,8 +1462,9 @@ func forEachColumnInIndex(
 	fn func(*sqlbase.ColumnDescriptor) error,
 ) error {
 	colMap := make(map[sqlbase.ColumnID]*sqlbase.ColumnDescriptor, len(table.Columns))
-	for i, column := range table.Columns {
-		colMap[column.ID] = &table.Columns[i]
+	for i := range table.Columns {
+		id := table.Columns[i].ID
+		colMap[id] = &table.Columns[i]
 	}
 	for _, columnID := range index.ColumnIDs {
 		column := colMap[columnID]

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -417,8 +417,9 @@ func (n *insertNode) startExec(params runParams) error {
 		}
 
 		colIDToRetIndex := make(map[sqlbase.ColumnID]int)
-		for i, col := range n.run.ti.tableDesc().Columns {
-			colIDToRetIndex[col.ID] = i
+		cols := n.run.ti.tableDesc().Columns
+		for i := range cols {
+			colIDToRetIndex[cols[i].ID] = i
 		}
 
 		n.run.rowIdxToRetIdx = make([]int, len(n.run.insertCols))
@@ -732,7 +733,7 @@ func (p *planner) processColumns(
 	cols := make([]sqlbase.ColumnDescriptor, len(nameList))
 	colIDSet := make(map[sqlbase.ColumnID]struct{}, len(nameList))
 	for i, colName := range nameList {
-		var col sqlbase.ColumnDescriptor
+		var col *sqlbase.ColumnDescriptor
 		var err error
 		if allowMutations {
 			col, _, err = tableDesc.FindColumnByName(colName)
@@ -748,7 +749,7 @@ func (p *planner) processColumns(
 				"multiple assignments to the same column %q", &nameList[i])
 		}
 		colIDSet[col.ID] = struct{}{}
-		cols[i] = col
+		cols[i] = *col
 	}
 
 	return cols, nil

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -164,8 +164,8 @@ func (b *Builder) constructProjectSet(in memo.RelExpr, srfs []*srf) memo.RelExpr
 	for i, srf := range srfs {
 		zip[i].Func = srf.fn
 		zip[i].Cols = make(opt.ColList, len(srf.cols))
-		for j, col := range srf.cols {
-			zip[i].Cols[j] = col.id
+		for j := range srf.cols {
+			zip[i].Cols[j] = srf.cols[j].id
 		}
 	}
 

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1230,8 +1230,9 @@ func (ef *execFactory) ConstructUpdate(
 	// updateColsIdx inverts the mapping of UpdateCols to FetchCols. See
 	// the explanatory comments in updateRun.
 	updateColsIdx := make(map[sqlbase.ColumnID]int, len(ru.UpdateCols))
-	for i, col := range ru.UpdateCols {
-		updateColsIdx[col.ID] = i
+	for i := range ru.UpdateCols {
+		id := ru.UpdateCols[i].ID
+		updateColsIdx[id] = i
 	}
 
 	upd := updateNodePool.Get().(*updateNode)
@@ -1349,8 +1350,9 @@ func (ef *execFactory) ConstructUpsert(
 	// updateColsIdx inverts the mapping of UpdateCols to FetchCols. See
 	// the explanatory comments in updateRun.
 	updateColsIdx := make(map[sqlbase.ColumnID]int, len(ru.UpdateCols))
-	for i, col := range ru.UpdateCols {
-		updateColsIdx[col.ID] = i
+	for i := range ru.UpdateCols {
+		id := ru.UpdateCols[i].ID
+		updateColsIdx[id] = i
 	}
 
 	// Instantiate the upsert node.

--- a/pkg/sql/opt_index_selection_test.go
+++ b/pkg/sql/opt_index_selection_test.go
@@ -93,7 +93,8 @@ func makeSpans(
 	}
 	var o xform.Optimizer
 	o.Init(p.EvalContext())
-	for _, c := range desc.Columns {
+	for i := range desc.Columns {
+		c := &desc.Columns[i]
 		o.Memo().Metadata().AddColumn(c.Name, c.Type.ToDatumType())
 	}
 	semaCtx := tree.MakeSemaContext()

--- a/pkg/sql/row/cascader.go
+++ b/pkg/sql/row/cascader.go
@@ -120,8 +120,8 @@ func makeUpdateCascader(
 	}
 	var required bool
 	colIDs := make(map[sqlbase.ColumnID]struct{})
-	for _, col := range updateCols {
-		colIDs[col.ID] = struct{}{}
+	for i := range updateCols {
+		colIDs[updateCols[i].ID] = struct{}{}
 	}
 Outer:
 	for _, referencedIndex := range table.AllNonDropIndexes() {

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1105,8 +1105,9 @@ func (rf *Fetcher) NextRowWithErrors(ctx context.Context) (sqlbase.EncDatumRow, 
 func (rf *Fetcher) checkPrimaryIndexDatumEncodings(ctx context.Context) error {
 	table := rf.rowReadyTable
 	scratch := make([]byte, 1024)
-	colIDToColumn := make(map[sqlbase.ColumnID]sqlbase.ColumnDescriptor)
-	for _, col := range table.desc.Columns {
+	colIDToColumn := make(map[sqlbase.ColumnID]*sqlbase.ColumnDescriptor)
+	for i := range table.desc.Columns {
+		col := &table.desc.Columns[i]
 		colIDToColumn[col.ID] = col
 	}
 

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -82,8 +82,9 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 	for _, desc := range []*sqlbase.ImmutableTableDescriptor{parentDesc, childDesc} {
 		colIdxMap := make(map[sqlbase.ColumnID]int)
 		var valNeededForCol util.FastIntSet
-		for colIdx, col := range desc.Columns {
-			colIdxMap[col.ID] = colIdx
+		for colIdx := range desc.Columns {
+			id := desc.Columns[colIdx].ID
+			colIdxMap[id] = colIdx
 			valNeededForCol.Add(colIdx)
 		}
 		args = append(args, row.FetcherTableArgs{

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -1030,8 +1030,8 @@ func (rd *Deleter) DeleteIndexRow(
 // duplicate descriptors in the input.
 func ColIDtoRowIndexFromCols(cols []sqlbase.ColumnDescriptor) map[sqlbase.ColumnID]int {
 	colIDtoRowIndex := make(map[sqlbase.ColumnID]int, len(cols))
-	for i, col := range cols {
-		colIDtoRowIndex[col.ID] = i
+	for i := range cols {
+		colIDtoRowIndex[cols[i].ID] = i
 	}
 	return colIDtoRowIndex
 }

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -351,7 +351,8 @@ func (n *scanNode) initCols() error {
 	}
 
 	if n.colCfg.addUnwantedAsHidden {
-		for _, c := range n.desc.Columns {
+		for i := range n.desc.Columns {
+			c := &n.desc.Columns[i]
 			found := false
 			for _, wc := range n.colCfg.wantedColumns {
 				if sqlbase.ColumnID(wc) == c.ID {
@@ -360,7 +361,7 @@ func (n *scanNode) initCols() error {
 				}
 			}
 			if !found {
-				col := c
+				col := *c
 				col.Hidden = true
 				n.cols = append(n.cols, col)
 			}

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -279,8 +279,9 @@ func getColumns(
 	tableDesc *sqlbase.ImmutableTableDescriptor, indexDesc *sqlbase.IndexDescriptor,
 ) (columns []*sqlbase.ColumnDescriptor, columnNames []string, columnTypes []sqlbase.ColumnType) {
 	colToIdx := make(map[sqlbase.ColumnID]int)
-	for i, col := range tableDesc.Columns {
-		colToIdx[col.ID] = i
+	for i := range tableDesc.Columns {
+		id := tableDesc.Columns[i].ID
+		colToIdx[id] = i
 	}
 
 	// Collect all of the columns we are fetching from the index. This

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -163,7 +163,9 @@ func ShowCreateTable(
 	f.FormatNode(tn)
 	f.WriteString(" (")
 	primaryKeyIsOnVisibleColumn := false
-	for i, col := range desc.VisibleColumns() {
+	visibleCols := desc.VisibleColumns()
+	for i := range visibleCols {
+		col := &visibleCols[i]
 		if i != 0 {
 			f.WriteString(",")
 		}

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -276,8 +276,9 @@ func (desc *TableDescriptor) collectConstraintInfo(
 					"duplicate constraint name: %q", index.Name)
 			}
 			colHiddenMap := make(map[ColumnID]bool, len(desc.Columns))
-			for i, column := range desc.Columns {
-				colHiddenMap[column.ID] = desc.Columns[i].Hidden
+			for i := range desc.Columns {
+				col := &desc.Columns[i]
+				colHiddenMap[col.ID] = col.Hidden
 			}
 			// Don't include constraints against only hidden columns.
 			// This prevents the auto-created rowid primary key index from showing up

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -408,7 +408,8 @@ func TestingMakePrimaryIndexKey(desc *TableDescriptor, vals ...interface{}) (roa
 		}
 		// Check that the value type matches.
 		colID := index.ColumnIDs[i]
-		for _, c := range desc.Columns {
+		for i := range desc.Columns {
+			c := &desc.Columns[i]
 			if c.ID == colID {
 				colTyp, err := DatumTypeToColumnType(datums[i].ResolvedType())
 				if err != nil {

--- a/pkg/sql/table_ref_test.go
+++ b/pkg/sql/table_ref_test.go
@@ -48,7 +48,8 @@ CREATE INDEX bc ON test.t(b, c);
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 	tID := tableDesc.ID
 	var aID, bID, cID sqlbase.ColumnID
-	for _, c := range tableDesc.Columns {
+	for i := range tableDesc.Columns {
+		c := &tableDesc.Columns[i]
 		switch c.Name {
 		case "a":
 			aID = c.ID
@@ -65,7 +66,8 @@ CREATE INDEX bc ON test.t(b, c);
 	tableDesc = sqlbase.GetTableDescriptor(kvDB, "test", "hidden")
 	tIDHidden := tableDesc.ID
 	var rowIDHidden sqlbase.ColumnID
-	for _, c := range tableDesc.Columns {
+	for i := range tableDesc.Columns {
+		c := &tableDesc.Columns[i]
 		switch c.Name {
 		case "rowid":
 			rowIDHidden = c.ID

--- a/pkg/sql/tablewriter_upsert.go
+++ b/pkg/sql/tablewriter_upsert.go
@@ -87,8 +87,9 @@ func (tu *tableUpserterBase) init(txn *client.Txn, evalCtx *tree.EvalContext) er
 		// because even though we might insert values into mutation columns, we
 		// never return them back to the user.
 		tu.colIDToReturnIndex = map[sqlbase.ColumnID]int{}
-		for i, col := range tableDesc.Columns {
-			tu.colIDToReturnIndex[col.ID] = i
+		for i := range tableDesc.Columns {
+			id := tableDesc.Columns[i].ID
+			tu.colIDToReturnIndex[id] = i
 		}
 
 		if len(tu.ri.InsertColIDtoRowIndex) == len(tu.colIDToReturnIndex) {
@@ -319,8 +320,9 @@ func (tu *tableUpserter) init(txn *client.Txn, evalCtx *tree.EvalContext) error 
 	}
 
 	var valNeededForCol util.FastIntSet
-	for i, col := range tu.fetchCols {
-		if _, ok := tu.fetchColIDtoRowIndex[col.ID]; ok {
+	for i := range tu.fetchCols {
+		id := tu.fetchCols[i].ID
+		if _, ok := tu.fetchColIDtoRowIndex[id]; ok {
 			valNeededForCol.Add(i)
 		}
 	}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -422,8 +422,9 @@ func reassignComment(
 		}
 	}
 
-	for _, column := range oldTableDesc.Columns {
-		err = reassignColumnComment(ctx, p, oldTableDesc.ID, newID, column.ID)
+	for i := range oldTableDesc.Columns {
+		id := oldTableDesc.Columns[i].ID
+		err = reassignColumnComment(ctx, p, oldTableDesc.ID, newID, id)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -185,8 +185,9 @@ func (p *planner) Update(
 		// desc.Columns, there's no reason to enter this block if rowsNeeded is
 		// true. Remove this when the TODO above is addressed.
 		var requestedColSet util.FastIntSet
-		for _, col := range requestedCols {
-			requestedColSet.Add(int(col.ID))
+		for i := range requestedCols {
+			id := int(requestedCols[i].ID)
+			requestedColSet.Add(id)
 		}
 		for _, ck := range desc.ActiveChecks() {
 			cols, err := ck.ColumnsUsed(desc.TableDesc())
@@ -376,8 +377,9 @@ func (p *planner) Update(
 	// updateColsIdx inverts the mapping of UpdateCols to FetchCols. See
 	// the explanatory comments in updateRun.
 	updateColsIdx := make(map[sqlbase.ColumnID]int, len(ru.UpdateCols))
-	for i, col := range ru.UpdateCols {
-		updateColsIdx[col.ID] = i
+	for i := range ru.UpdateCols {
+		id := ru.UpdateCols[i].ID
+		updateColsIdx[id] = i
 	}
 
 	un := updateNodePool.Get().(*updateNode)
@@ -631,8 +633,9 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 		// So we need to construct a buffer that groups them together.
 		// iVarContainerForComputedCols does this.
 		copy(u.run.iVarContainerForComputedCols.CurSourceRow, oldValues)
-		for i, col := range u.run.tu.ru.UpdateCols {
-			u.run.iVarContainerForComputedCols.CurSourceRow[u.run.tu.ru.FetchColIDtoRowIndex[col.ID]] = u.run.updateValues[i]
+		for i := range u.run.tu.ru.UpdateCols {
+			id := u.run.tu.ru.UpdateCols[i].ID
+			u.run.iVarContainerForComputedCols.CurSourceRow[u.run.tu.ru.FetchColIDtoRowIndex[id]] = u.run.updateValues[i]
 		}
 
 		// Now (re-)compute the computed columns.

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -228,7 +228,8 @@ func newInvalidVirtualDefEntryError() error {
 // where we can't guarantee it will be Close()d in case of error.
 func (e virtualDefEntry) getPlanInfo() (sqlbase.ResultColumns, virtualTableConstructor) {
 	var columns sqlbase.ResultColumns
-	for _, col := range e.desc.Columns {
+	for i := range e.desc.Columns {
+		col := &e.desc.Columns[i]
 		columns = append(columns, sqlbase.ResultColumn{
 			Name: col.Name,
 			Typ:  col.Type.ToDatumType(),

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -431,11 +431,11 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			var buf bytes.Buffer
 			buf.WriteString(n.run.ti.tableDesc().Name)
 			buf.WriteByte('(')
-			for i, col := range n.run.insertCols {
+			for i := range n.run.insertCols {
 				if i > 0 {
 					buf.WriteString(", ")
 				}
-				buf.WriteString(col.Name)
+				buf.WriteString(n.run.insertCols[i].Name)
 			}
 			buf.WriteByte(')')
 			v.observer.attr(name, "into", buf.String())
@@ -459,11 +459,11 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			var buf bytes.Buffer
 			buf.WriteString(n.run.tw.tableDesc().Name)
 			buf.WriteByte('(')
-			for i, col := range n.run.insertCols {
+			for i := range n.run.insertCols {
 				if i > 0 {
 					buf.WriteString(", ")
 				}
-				buf.WriteString(col.Name)
+				buf.WriteString(n.run.insertCols[i].Name)
 			}
 			buf.WriteByte(')')
 			v.observer.attr(name, "into", buf.String())
@@ -490,11 +490,11 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 			v.observer.attr(name, "table", n.run.tu.tableDesc().Name)
 			if len(n.run.tu.ru.UpdateCols) > 0 {
 				var buf bytes.Buffer
-				for i, col := range n.run.tu.ru.UpdateCols {
+				for i := range n.run.tu.ru.UpdateCols {
 					if i > 0 {
 						buf.WriteString(", ")
 					}
-					buf.WriteString(col.Name)
+					buf.WriteString(n.run.tu.ru.UpdateCols[i].Name)
 				}
 				v.observer.attr(name, "set", buf.String())
 			}

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -867,7 +867,7 @@ func addJobsProgress(ctx context.Context, r runner) error {
 		if _, err := desc.FindActiveColumnByName("progress"); err == nil {
 			return nil
 		}
-		desc.AddColumn(sqlbase.ColumnDescriptor{
+		desc.AddColumn(&sqlbase.ColumnDescriptor{
 			Name:     "progress",
 			Type:     sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_BYTES},
 			Nullable: true,


### PR DESCRIPTION
This commit updates a bunch of places to reference ColumnDescriptor by
pointer instead of by copying its value. ColumnDescriptors are ~200 bytes
large, so the copying expense can add up. In addition, copying by value
can introduce subtle bugs where we take a reference to a field within the
descriptor (e.g. Type field), and then hold onto multiple copies of the
same ColumnDescriptor in memory.

Most of the problem spots are when looping over a slice of
ColumnDescriptors:

  for i, c := tableDesc.Columns {

In that example, each column is copied by-value onto the stack, which
adds overhead that is almost never necessary to accept. In other cases,
ColumnDescriptor is passed by value rather than by reference.

Release note: None