### PR TITLE
release-19.1: opt: fix cornercase with lookup join child ordering

### DIFF
--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -241,7 +241,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	// Allow testcases to override the flags.
 	for _, a := range d.CmdArgs {
 		if err := ot.Flags.Set(a); err != nil {
-			d.Fatalf(tb, "%s", err)
+			d.Fatalf(tb, "%+v", err)
 		}
 	}
 
@@ -264,7 +264,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 		}
 		s, err := testCatalog.ExecuteDDL(d.Input)
 		if err != nil {
-			d.Fatalf(tb, "%v", err)
+			d.Fatalf(tb, "%+v", err)
 		}
 		return s
 
@@ -297,7 +297,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	case "opt":
 		e, err := ot.Optimize()
 		if err != nil {
-			d.Fatalf(tb, "%v", err)
+			d.Fatalf(tb, "%+v", err)
 		}
 		ot.postProcess(tb, d, e)
 		return memo.FormatExpr(e, ot.Flags.ExprFormat)
@@ -305,35 +305,35 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	case "optsteps":
 		result, err := ot.OptSteps()
 		if err != nil {
-			d.Fatalf(tb, "%v", err)
+			d.Fatalf(tb, "%+v", err)
 		}
 		return result
 
 	case "exploretrace":
 		result, err := ot.ExploreTrace()
 		if err != nil {
-			d.Fatalf(tb, "%v", err)
+			d.Fatalf(tb, "%+v", err)
 		}
 		return result
 
 	case "rulestats":
 		result, err := ot.RuleStats()
 		if err != nil {
-			d.Fatalf(tb, "%v", err)
+			d.Fatalf(tb, "%+v", err)
 		}
 		return result
 
 	case "memo":
 		result, err := ot.Memo()
 		if err != nil {
-			d.Fatalf(tb, "%v", err)
+			d.Fatalf(tb, "%+v", err)
 		}
 		return result
 
 	case "expr":
 		e, err := ot.Expr()
 		if err != nil {
-			d.Fatalf(tb, "%v", err)
+			d.Fatalf(tb, "%+v", err)
 		}
 		ot.postProcess(tb, d, e)
 		return memo.FormatExpr(e, ot.Flags.ExprFormat)
@@ -341,7 +341,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	case "exprnorm":
 		e, err := ot.ExprNorm()
 		if err != nil {
-			d.Fatalf(tb, "%v", err)
+			d.Fatalf(tb, "%+v", err)
 		}
 		ot.postProcess(tb, d, e)
 		return memo.FormatExpr(e, ot.Flags.ExprFormat)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1552,3 +1552,23 @@ sort
            │         └── interesting orderings: (+10) (+6,+7,+10) (+8,+9,+10)
            └── filters
                 └── b = c [type=bool, outer=(2,3), fd=(2)==(3), (3)==(2)]
+
+
+# Regression test for #36219: lookup join with ON condition that imposes an
+# equality on two input columns (which isn't pushed down).
+opt disable=(PushFilterIntoJoinLeftAndRight,PushFilterIntoJoinLeft,PushFilterIntoJoinRight,MapFilterIntoJoinLeft,MapFilterIntoJoinRight)
+SELECT * FROM abc JOIN xyz ON a=x AND x=z ORDER BY z
+----
+inner-join (merge)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) x:4(int!null) y:5(int!null) z:6(int!null)
+ ├── left ordering: +1
+ ├── right ordering: +4
+ ├── ordering: +(1|4|6)
+ ├── scan abc
+ │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ │    └── ordering: +1
+ ├── scan xyz
+ │    ├── columns: x:4(int!null) y:5(int!null) z:6(int!null)
+ │    └── ordering: +4
+ └── filters
+      └── x = z [type=bool]


### PR DESCRIPTION
Backport 2/2 commits from #36240.

/cc @cockroachdb/release

---

#### opt: use +v for errors in opttester

For internal errors `%+v` is now necessary to see the stack trace.

Release note: None

#### opt: fix cornercase with lookup join child ordering

A race-only check uncovered a cornercase with lookup joins where the
ON condition enforces an equality on two input columns (but that
equality is not pushed down). Ideally, this shouldn't happen, but the
AssociateJoin rule doesn't yet map equalities as well as it should.

Regardless, the fix is to trim the equivalent column groups like we do
for Select.

Fixes #36219.

Release note: None

