### PR TITLE
backport-2.1: sql: remove EvalContext.ActiveMemAcc

### DIFF
--- a/pkg/sql/builtin_mem_usage_test.go
+++ b/pkg/sql/builtin_mem_usage_test.go
@@ -17,16 +17,12 @@ package sql
 import (
 	"context"
 	gosql "database/sql"
-	"fmt"
 	"testing"
 
 	"github.com/lib/pq"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -97,71 +93,14 @@ func TestAggregatesMonitorMemory(t *testing.T) {
 	}
 }
 
-func TestBuiltinsAccountForMemory(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	_, repeatFns := builtins.GetBuiltinProperties("repeat")
-	_, concatFns := builtins.GetBuiltinProperties("concat")
-	_, concatwsFns := builtins.GetBuiltinProperties("concat_ws")
-	_, lowerFns := builtins.GetBuiltinProperties("lower")
-
-	testData := []struct {
-		builtin            tree.Overload
-		args               tree.Datums
-		expectedAllocation int64
-	}{
-		{repeatFns[0],
-			tree.Datums{
-				tree.NewDString("abc"),
-				tree.NewDInt(123),
-			},
-			int64(3 * 123)},
-		{concatFns[0],
-			tree.Datums{
-				tree.NewDString("abc"),
-				tree.NewDString("abc"),
-			},
-			int64(3 + 3)},
-		{concatwsFns[0],
-			tree.Datums{
-				tree.NewDString("!"),
-				tree.NewDString("abc"),
-				tree.NewDString("abc"),
-			},
-			int64(3 + 1 + 3)},
-		{lowerFns[0],
-			tree.Datums{
-				tree.NewDString("ABC"),
-			},
-			int64(3)},
-	}
-
-	for _, test := range testData {
-		t.Run("", func(t *testing.T) {
-			evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-			defer evalCtx.Stop(context.Background())
-			defer evalCtx.ActiveMemAcc.Close(context.Background())
-			previouslyAllocated := evalCtx.ActiveMemAcc.Used()
-			_, err := test.builtin.Fn(evalCtx, test.args)
-			if err != nil {
-				t.Fatal(err)
-			}
-			deltaAllocated := evalCtx.ActiveMemAcc.Used() - previouslyAllocated
-			if deltaAllocated != test.expectedAllocation {
-				t.Errorf("Expected to allocate %d, actually allocated %d", test.expectedAllocation, deltaAllocated)
-			}
-		})
-	}
-}
-
 func TestEvaluatedMemoryIsChecked(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// We select the LENGTH here and elsewhere because if we passed the result of
 	// REPEAT up as a result, the memory error would be caught there even if
 	// REPEAT was not doing its accounting.
 	testData := []string{
-		`SELECT length(repeat('abc', 300000))`,
-		`SELECT crdb_internal.no_constant_folding(length(repeat('abc', 300000)))`,
+		`SELECT length(repeat('abc', 70000000))`,
+		`SELECT crdb_internal.no_constant_folding(length(repeat('abc', 70000000)))`,
 	}
 
 	for _, statement := range testData {
@@ -173,45 +112,9 @@ func TestEvaluatedMemoryIsChecked(t *testing.T) {
 
 			if _, err := sqlDB.Exec(
 				statement,
-			); err.(*pq.Error).Code != pgerror.CodeOutOfMemoryError {
+			); err.(*pq.Error).Code != pgerror.CodeProgramLimitExceededError {
 				t.Errorf("Expected \"%s\" to OOM, but it didn't", statement)
 			}
 		})
-	}
-}
-
-func TestMemoryGetsFreedOnEachRow(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	// This test verifies that the memory allocated during the computation of a
-	// row gets freed before moving on to subsequent rows.
-
-	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		SQLMemoryPoolSize: lowMemoryBudget,
-	})
-	defer s.Stopper().Stop(context.Background())
-
-	stringLength := 300000
-	numRows := 100
-
-	// Check that if this string is allocated per-row, we don't OOM.
-	if _, err := sqlDB.Exec(
-		fmt.Sprintf(
-			`SELECT crdb_internal.no_constant_folding(length(repeat('a', %d))) FROM generate_series(1, %d)`,
-			stringLength,
-			numRows,
-		),
-	); err != nil {
-		t.Fatalf("Expected statement to run successfully, but got %s", err)
-	}
-
-	// Ensure that if this memory is all allocated at once, we OOM.
-	if _, err := sqlDB.Exec(
-		fmt.Sprintf(
-			`SELECT crdb_internal.no_constant_folding(length(repeat('a', %d * %d)))`,
-			stringLength,
-			numRows,
-		),
-	); err.(*pq.Error).Code != pgerror.CodeOutOfMemoryError {
-		t.Fatalf("Expected statement to OOM, but it didn't")
 	}
 }

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -185,12 +185,6 @@ func (ex *connExecutor) prepare(
 		ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTimestamp */)
 		p.semaCtx.Placeholders.SetTypeHints(placeholderHints)
 		p.extendedEvalCtx.PrepareOnly = true
-		p.extendedEvalCtx.ActiveMemAcc = &prepared.memAcc
-		// constantMemAcc accounts for all constant folded values that are computed
-		// prior to any rows being computed.
-		constantMemAcc := p.extendedEvalCtx.Mon.MakeBoundAccount()
-		p.extendedEvalCtx.ActiveMemAcc = &constantMemAcc
-		defer constantMemAcc.Close(ctx)
 
 		protoTS, err := p.isAsOf(stmt.AST, ex.server.cfg.Clock.Now() /* max */)
 		if err != nil {

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -615,8 +615,6 @@ func (dsp *DistSQLPlanner) PlanAndRunSubqueries(
 		subqueryMemAccount = subqueryMonitor.MakeBoundAccount()
 		defer subqueryMemAccount.Close(ctx)
 
-		evalCtx.ActiveMemAcc = &subqueryMemAccount
-
 		var subqueryPlanCtx PlanningCtx
 		var distributeSubquery bool
 		if maybeDistribute {

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -308,7 +308,7 @@ func (ds *ServerImpl) setupFlow(
 	}
 	ctx = opentracing.ContextWithSpan(ctx, sp)
 
-	// The monitor and account opened here are closed in Flow.Cleanup().
+	// The monitor opened here are closed in Flow.Cleanup().
 	monitor := mon.MakeMonitor(
 		"flow",
 		mon.MemoryResource,
@@ -319,7 +319,6 @@ func (ds *ServerImpl) setupFlow(
 		ds.Settings,
 	)
 	monitor.Start(ctx, parentMonitor, mon.BoundAccount{})
-	acc := monitor.MakeBoundAccount()
 
 	txn := localState.Txn
 	if txn := req.DeprecatedTxn; txn != nil {
@@ -345,7 +344,6 @@ func (ds *ServerImpl) setupFlow(
 	if localState.EvalContext != nil {
 		evalCtx = localState.EvalContext
 		evalCtx.Mon = &monitor
-		evalCtx.ActiveMemAcc = &acc
 		evalCtx.Txn = txn
 	} else {
 		location, err := timeutil.TimeZoneStringToLocation(req.EvalContext.Location)
@@ -387,13 +385,12 @@ func (ds *ServerImpl) setupFlow(
 		evalPlanner := &dummyEvalPlanner{}
 		sequence := &dummySequenceOperators{}
 		evalCtx = &tree.EvalContext{
-			Settings:     ds.ServerConfig.Settings,
-			SessionData:  sd,
-			ClusterID:    ds.ServerConfig.ClusterID.Get(),
-			NodeID:       nodeID,
-			ReCache:      ds.regexpCache,
-			Mon:          &monitor,
-			ActiveMemAcc: &acc,
+			Settings:    ds.ServerConfig.Settings,
+			SessionData: sd,
+			ClusterID:   ds.ServerConfig.ClusterID.Get(),
+			NodeID:      nodeID,
+			ReCache:     ds.regexpCache,
+			Mon:         &monitor,
 			// TODO(andrei): This is wrong. Each processor should override Ctx with its
 			// own context.
 			Context:          ctx,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -435,11 +435,6 @@ func (dc *databaseCacheHolder) updateSystemConfig(cfg config.SystemConfig) {
 func forEachRow(params runParams, p planNode, f func(tree.Datums) error) error {
 	next, err := p.Next(params)
 	for ; next; next, err = p.Next(params) {
-		// If we're tracking memory, clear the previous row's memory account.
-		if params.extendedEvalCtx.ActiveMemAcc != nil {
-			params.extendedEvalCtx.ActiveMemAcc.Clear(params.ctx)
-		}
-
 		if err := f(p.Values()); err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -262,7 +262,7 @@ SELECT repeat('Pg', -1) || 'empty'
 ----
 empty
 
-statement error pq: repeat\(\): .* memory budget exceeded
+statement error pq: repeat\(\): requested length too large
 SELECT repeat('s', 9223372036854775807)
 
 # Regression for #19035.
@@ -2008,10 +2008,10 @@ SELECT lpad('abc', 5, ''), rpad('abc', 5, '')
 ----
 abc  abc
 
-query error memory budget exceeded
+query error requested length too large
 SELECT lpad('abc', 100000000000000)
 
-query error memory budget exceeded
+query error requested length too large
 SELECT rpad('abc', 100000000000000)
 
 query TT

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -168,10 +168,6 @@ func (p *planNodeToRowSource) Next() (sqlbase.EncDatumRow, *distsqlrun.ProducerM
 			// by Nexting our source until exhaustion.
 			next, err := p.node.Next(p.params)
 			for ; next; next, err = p.node.Next(p.params) {
-				// If we're tracking memory, clear the previous row's memory account.
-				if p.params.extendedEvalCtx.ActiveMemAcc != nil {
-					p.params.extendedEvalCtx.ActiveMemAcc.Clear(p.params.ctx)
-				}
 				count++
 			}
 			if err != nil {

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -150,7 +150,6 @@ func insertNodeWithValuesSpans(
 	// completed, so that the values don't need to be computed again during
 	// plan execution.
 	rowAcc := params.extendedEvalCtx.Mon.MakeBoundAccount()
-	params.extendedEvalCtx.ActiveMemAcc = &rowAcc
 	defer rowAcc.Close(params.ctx)
 
 	defer v.Reset(params.ctx)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -266,13 +266,9 @@ func newInternalPlanner(
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
 	p.extendedEvalCtx.Tables = tables
 
-	acc := plannerMon.MakeBoundAccount()
-	p.extendedEvalCtx.ActiveMemAcc = &acc
-
 	return p, func() {
 		// Note that we capture ctx here. This is only valid as long as we create
 		// the context as explained at the top of the method.
-		acc.Close(ctx)
 		plannerMon.Stop(ctx)
 	}
 }

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -546,7 +546,8 @@ func scrubRunDistSQL(
 	columnTypes []sqlbase.ColumnType,
 ) (*sqlbase.RowContainer, error) {
 	ci := sqlbase.ColTypeInfoFromColTypes(columnTypes)
-	rows := sqlbase.NewRowContainer(*p.extendedEvalCtx.ActiveMemAcc, ci, 0 /* rowCapacity */)
+	acc := p.extendedEvalCtx.Mon.MakeBoundAccount()
+	rows := sqlbase.NewRowContainer(acc, ci, 0 /* rowCapacity */)
 	rowResultWriter := NewRowResultWriter(rows)
 	recv := MakeDistSQLReceiver(
 		ctx,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -66,7 +67,11 @@ var (
 	errChrValueTooSmall = pgerror.NewError(pgerror.CodeInvalidParameterValueError, "input value must be >= 0")
 	errChrValueTooLarge = pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError,
 		"input value must be <= %d (maximum Unicode code point)", utf8.MaxRune)
+	errStringTooLarge = pgerror.NewErrorf(pgerror.CodeProgramLimitExceededError,
+		fmt.Sprintf("requested length too large, exceeds %s", humanizeutil.IBytes(maxAllocatedStringSize)))
 )
+
+const maxAllocatedStringSize = 128 * 1024 * 1024
 
 const errInsufficientArgsFmtString = "unknown signature: %s()"
 
@@ -178,17 +183,11 @@ var builtins = map[string]builtinDefinition{
 
 	"lower": makeBuiltin(tree.FunctionProperties{Category: categoryString},
 		stringOverload1(func(evalCtx *tree.EvalContext, s string) (tree.Datum, error) {
-			if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(s))); err != nil {
-				return nil, err
-			}
 			return tree.NewDString(strings.ToLower(s)), nil
 		}, types.String, "Converts all characters in `val` to their lower-case equivalents.")),
 
 	"upper": makeBuiltin(tree.FunctionProperties{Category: categoryString},
 		stringOverload1(func(evalCtx *tree.EvalContext, s string) (tree.Datum, error) {
-			if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(s))); err != nil {
-				return nil, err
-			}
 			return tree.NewDString(strings.ToUpper(s)), nil
 		}, types.String, "Converts all characters in `val` to their to their upper-case equivalents.")),
 
@@ -203,13 +202,14 @@ var builtins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				var buffer bytes.Buffer
+				length := 0
 				for _, d := range args {
 					if d == tree.DNull {
 						continue
 					}
-					nextLength := len(string(tree.MustBeDString(d)))
-					if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(nextLength)); err != nil {
-						return nil, err
+					length += len(string(tree.MustBeDString(d)))
+					if length > maxAllocatedStringSize {
+						return nil, errStringTooLarge
 					}
 					buffer.WriteString(string(tree.MustBeDString(d)))
 				}
@@ -233,14 +233,14 @@ var builtins = map[string]builtinDefinition{
 				sep := string(tree.MustBeDString(args[0]))
 				var buf bytes.Buffer
 				prefix := ""
+				length := 0
 				for _, d := range args[1:] {
 					if d == tree.DNull {
 						continue
 					}
-					nextLength := len(prefix) + len(string(tree.MustBeDString(d)))
-					if err := evalCtx.ActiveMemAcc.Grow(
-						evalCtx.Ctx(), int64(nextLength)); err != nil {
-						return nil, err
+					length += len(prefix) + len(string(tree.MustBeDString(d)))
+					if length > maxAllocatedStringSize {
+						return nil, errStringTooLarge
 					}
 					// Note: we can't use the range index here because that
 					// would break when the 2nd argument is NULL.
@@ -674,14 +674,11 @@ var builtins = map[string]builtinDefinition{
 					count = 0
 				} else if ln/count != len(s) {
 					// Detect overflow and trigger an error.
-					return nil, pgerror.NewError(
-						pgerror.CodeProgramLimitExceededError, "requested length too large",
-					)
+					return nil, errStringTooLarge
+				} else if ln > maxAllocatedStringSize {
+					return nil, errStringTooLarge
 				}
 
-				if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(ln)); err != nil {
-					return nil, err
-				}
 				return tree.NewDString(strings.Repeat(s, count)), nil
 			},
 			Info: "Concatenates `input` `repeat_counter` number of times.\n\nFor example, " +
@@ -919,10 +916,7 @@ var builtins = map[string]builtinDefinition{
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				length := int(tree.MustBeDInt(args[1]))
-				if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(length)); err != nil {
-					return nil, err
-				}
-				ret, err := lpad(evalCtx, s, length, " ")
+				ret, err := lpad(s, length, " ")
 				if err != nil {
 					return nil, err
 				}
@@ -938,7 +932,7 @@ var builtins = map[string]builtinDefinition{
 				s := string(tree.MustBeDString(args[0]))
 				length := int(tree.MustBeDInt(args[1]))
 				fill := string(tree.MustBeDString(args[2]))
-				ret, err := lpad(evalCtx, s, length, fill)
+				ret, err := lpad(s, length, fill)
 				if err != nil {
 					return nil, err
 				}
@@ -957,7 +951,7 @@ var builtins = map[string]builtinDefinition{
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				length := int(tree.MustBeDInt(args[1]))
-				ret, err := rpad(evalCtx, s, length, " ")
+				ret, err := rpad(s, length, " ")
 				if err != nil {
 					return nil, err
 				}
@@ -973,7 +967,7 @@ var builtins = map[string]builtinDefinition{
 				s := string(tree.MustBeDString(args[0]))
 				length := int(tree.MustBeDInt(args[1]))
 				fill := string(tree.MustBeDString(args[2]))
-				ret, err := rpad(evalCtx, s, length, fill)
+				ret, err := rpad(s, length, fill)
 				if err != nil {
 					return nil, err
 				}
@@ -1022,8 +1016,8 @@ var builtins = map[string]builtinDefinition{
 
 	"reverse": makeBuiltin(defProps(),
 		stringOverload1(func(evalCtx *tree.EvalContext, s string) (tree.Datum, error) {
-			if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(s))); err != nil {
-				return nil, err
+			if len(s) > maxAllocatedStringSize {
+				return nil, errStringTooLarge
 			}
 			runes := []rune(s)
 			for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
@@ -1047,13 +1041,10 @@ var builtins = map[string]builtinDefinition{
 					// Largest result is if there are no replacements.
 					maxResultLen = int64(len(input))
 				}
-				if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), maxResultLen); err != nil {
-					return nil, err
+				if maxResultLen > maxAllocatedStringSize {
+					return nil, errStringTooLarge
 				}
 				result := strings.Replace(input, from, to, -1)
-				if err := evalCtx.ActiveMemAcc.Resize(evalCtx.Ctx(), maxResultLen, int64(len(result))); err != nil {
-					return nil, err
-				}
 				return tree.NewDString(result), nil
 			},
 			types.String,
@@ -1063,9 +1054,6 @@ var builtins = map[string]builtinDefinition{
 	"translate": makeBuiltin(defProps(),
 		stringOverload3("input", "find", "replace",
 			func(evalCtx *tree.EvalContext, s, from, to string) (tree.Datum, error) {
-				if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(s))); err != nil {
-					return nil, err
-				}
 				const deletionRune = utf8.MaxRune + 1
 				translation := make(map[rune]rune, len(from))
 				for _, fromRune := range from {
@@ -1122,9 +1110,6 @@ var builtins = map[string]builtinDefinition{
 				if err != nil {
 					return nil, err
 				}
-				if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(string(tree.MustBeDString(result))))); err != nil {
-					return nil, err
-				}
 				return result, nil
 			},
 			Info: "Replaces matches for the Regular Expression `regex` in `input` with the " +
@@ -1145,9 +1130,6 @@ var builtins = map[string]builtinDefinition{
 				sqlFlags := string(tree.MustBeDString(args[3]))
 				result, err := regexpReplace(evalCtx, s, pattern, to, sqlFlags)
 				if err != nil {
-					return nil, err
-				}
-				if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(string(tree.MustBeDString(result))))); err != nil {
 					return nil, err
 				}
 				return result, nil
@@ -1253,9 +1235,6 @@ CockroachDB supports the following flags:
 
 	"initcap": makeBuiltin(defProps(),
 		stringOverload1(func(evalCtx *tree.EvalContext, s string) (tree.Datum, error) {
-			if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(len(s))); err != nil {
-				return nil, err
-			}
 			return tree.NewDString(strings.Title(strings.ToLower(s))), nil
 		}, types.String, "Capitalizes the first letter of `val`.")),
 
@@ -4310,13 +4289,13 @@ func padMaybeTruncate(s string, length int, fill string) (ok bool, slen int, ret
 	return false, slen, s
 }
 
-func lpad(evalCtx *tree.EvalContext, s string, length int, fill string) (string, error) {
+func lpad(s string, length int, fill string) (string, error) {
+	if length > maxAllocatedStringSize {
+		return "", errStringTooLarge
+	}
 	ok, slen, ret := padMaybeTruncate(s, length, fill)
 	if ok {
 		return ret, nil
-	}
-	if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(length)); err != nil {
-		return "", err
 	}
 	var buf strings.Builder
 	fillRunes := []rune(fill)
@@ -4328,13 +4307,13 @@ func lpad(evalCtx *tree.EvalContext, s string, length int, fill string) (string,
 	return buf.String(), nil
 }
 
-func rpad(evalCtx *tree.EvalContext, s string, length int, fill string) (string, error) {
+func rpad(s string, length int, fill string) (string, error) {
+	if length > maxAllocatedStringSize {
+		return "", errStringTooLarge
+	}
 	ok, slen, ret := padMaybeTruncate(s, length, fill)
 	if ok {
 		return ret, nil
-	}
-	if err := evalCtx.ActiveMemAcc.Grow(evalCtx.Ctx(), int64(length)); err != nil {
-		return "", err
 	}
 	var buf strings.Builder
 	buf.WriteString(s)

--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -192,7 +192,7 @@ func TestEscapeFormatRandom(t *testing.T) {
 
 func TestLPadRPad(t *testing.T) {
 	testCases := []struct {
-		padFn    func(*tree.EvalContext, string, int, string) (string, error)
+		padFn    func(string, int, string) (string, error)
 		str      string
 		length   int
 		fill     string
@@ -228,9 +228,8 @@ func TestLPadRPad(t *testing.T) {
 		{rpad, "Hello", 8, "世界", "Hello世界世"},
 		{rpad, "foo", -1, "世界", ""},
 	}
-	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	for _, tc := range testCases {
-		out, err := tc.padFn(evalCtx, tc.str, tc.length, tc.fill)
+		out, err := tc.padFn(tc.str, tc.length, tc.fill)
 		if err != nil {
 			t.Errorf("Found err %v, expected nil", err)
 		}

--- a/pkg/sql/sem/tree/constant_eval_test.go
+++ b/pkg/sql/sem/tree/constant_eval_test.go
@@ -41,7 +41,6 @@ func TestConstantEvalArrayComparison(t *testing.T) {
 
 	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer ctx.Mon.Stop(context.Background())
-	defer ctx.ActiveMemAcc.Close(context.Background())
 	c := tree.MakeConstantEvalVisitor(ctx)
 	expr, _ = tree.WalkExpr(&c, typedExpr)
 	if err := c.Err(); err != nil {

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2395,11 +2395,6 @@ type EvalContext struct {
 	TestingKnobs EvalContextTestingKnobs
 
 	Mon *mon.BytesMonitor
-
-	// ActiveMemAcc is the account to which values are allocated during
-	// evaluation. It can change over the course of evaluation, such as on a
-	// per-row basis.
-	ActiveMemAcc *mon.BoundAccount
 }
 
 // MakeTestingEvalContext returns an EvalContext that includes a MemoryMonitor.
@@ -2428,8 +2423,6 @@ func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonit
 	monitor.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	ctx.Mon = monitor
 	ctx.Context = context.TODO()
-	acc := monitor.MakeBoundAccount()
-	ctx.ActiveMemAcc = &acc
 	now := timeutil.Now()
 	ctx.SetTxnTimestamp(now)
 	ctx.SetStmtTimestamp(now)

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -1397,10 +1397,7 @@ func TestEval(t *testing.T) {
 		{`ARRAY[(1,'a b'),(2,'c"d')]::string`, `e'{"(1,\\"a b\\")","(2,\\"c\\"\\"d\\")"}'`},
 	}
 	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-	// We have to manually close this account because we're doing the evaluations
-	// ourselves.
-	defer ctx.Mon.Stop(context.Background())
-	defer ctx.ActiveMemAcc.Close(context.Background())
+	defer ctx.Stop(context.Background())
 	for _, d := range testData {
 		t.Run(d.expr, func(t *testing.T) {
 			expr, err := parser.ParseExpr(d.expr)

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -281,7 +281,6 @@ func TestNormalizeExpr(t *testing.T) {
 			rOrig := typedExpr.String()
 			ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer ctx.Mon.Stop(context.Background())
-			defer ctx.ActiveMemAcc.Close(context.Background())
 			r, err := ctx.NormalizeExpr(typedExpr)
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)


### PR DESCRIPTION
Backport 1/1 commits from #34935.

/cc @cockroachdb/release

---

This memory account was used to track allocations performed by builtins
that allocated memory, mainly string manipulation builtins. It was
pretty hard to use this correctly, as the lifetimes of the account were
never particularly clear.

There were a couple of hacks in place to try to clear the memory at the
right times, but they didn't work correctly, leading to crashes that
were hard to diagnose.

Rather than try to make this work perfectly, this commit removes the
memory accounting for these builtins and replaces it with a hard cap on
the size of string allocations - set arbitrarily to 64 MB at this time.

Release note: None
