### PR TITLE
backport-19.1: opt: don't trim zipped columns when hoisting

### DIFF
--- a/pkg/sql/opt/norm/decorrelate.go
+++ b/pkg/sql/opt/norm/decorrelate.go
@@ -314,8 +314,12 @@ func (c *CustomFuncs) HoistProjectSetSubquery(input memo.RelExpr, zip memo.ZipEx
 		}
 	}
 
+	// The process of hoisting will introduce additional columns, so we introduce
+	// a projection to not include those in the output.
+	outputCols := c.OutputCols(input).Union(zip.OutputCols())
+
 	projectSet := c.f.ConstructProjectSet(hoister.input(), newZip)
-	return c.f.ConstructProject(projectSet, memo.EmptyProjectionsExpr, c.OutputCols(input))
+	return c.f.ConstructProject(projectSet, memo.EmptyProjectionsExpr, outputCols)
 }
 
 // ConstructNonApplyJoin constructs the non-apply join operator that corresponds

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -4228,6 +4228,92 @@ project
  └── projections
       └── ((x, n) AS x, n) [type=tuple{int AS x, int AS n}, outer=(11,12)]
 
+opt expect=HoistProjectSetSubquery
+SELECT a, generate_series(1, (SELECT a)) FROM (VALUES (1)) AS v (a)
+----
+project
+ ├── columns: a:1(int) generate_series:3(int)
+ ├── side-effects
+ ├── fd: ()-->(1)
+ └── project-set
+      ├── columns: column1:1(int) a:2(int) generate_series:3(int)
+      ├── side-effects
+      ├── fd: ()-->(1,2)
+      ├── inner-join-apply
+      │    ├── columns: column1:1(int) a:2(int)
+      │    ├── cardinality: [1 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(1,2)
+      │    ├── values
+      │    │    ├── columns: column1:1(int)
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1)
+      │    │    └── (1,) [type=tuple{int}]
+      │    ├── values
+      │    │    ├── columns: a:2(int)
+      │    │    ├── outer: (1)
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(2)
+      │    │    └── (column1,) [type=tuple{int}]
+      │    └── filters (true)
+      └── zip
+           └── function: generate_series [type=int, outer=(2), side-effects]
+                ├── const: 1 [type=int]
+                └── variable: a [type=int]
+
+opt expect=HoistProjectSetSubquery
+SELECT a, generate_series(1, (SELECT a)), generate_series(1, (SELECT a)) FROM (VALUES (1)) AS v (a)
+----
+project
+ ├── columns: a:1(int) generate_series:3(int) generate_series:5(int)
+ ├── side-effects
+ ├── fd: ()-->(1)
+ └── project-set
+      ├── columns: column1:1(int) a:2(int) generate_series:3(int) a:4(int) generate_series:5(int)
+      ├── side-effects
+      ├── fd: ()-->(1,2,4)
+      ├── inner-join-apply
+      │    ├── columns: column1:1(int) a:2(int) a:4(int)
+      │    ├── cardinality: [1 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(1,2,4)
+      │    ├── inner-join-apply
+      │    │    ├── columns: column1:1(int) a:2(int)
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1,2)
+      │    │    ├── values
+      │    │    │    ├── columns: column1:1(int)
+      │    │    │    ├── cardinality: [1 - 1]
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(1)
+      │    │    │    └── (1,) [type=tuple{int}]
+      │    │    ├── values
+      │    │    │    ├── columns: a:2(int)
+      │    │    │    ├── outer: (1)
+      │    │    │    ├── cardinality: [1 - 1]
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(2)
+      │    │    │    └── (column1,) [type=tuple{int}]
+      │    │    └── filters (true)
+      │    ├── values
+      │    │    ├── columns: a:4(int)
+      │    │    ├── outer: (1)
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(4)
+      │    │    └── (column1,) [type=tuple{int}]
+      │    └── filters (true)
+      └── zip
+           ├── function: generate_series [type=int, outer=(2), side-effects]
+           │    ├── const: 1 [type=int]
+           │    └── variable: a [type=int]
+           └── function: generate_series [type=int, outer=(4), side-effects]
+                ├── const: 1 [type=int]
+                └── variable: a [type=int]
+
 exec-ddl
 CREATE TABLE articles (
   id INT PRIMARY KEY,


### PR DESCRIPTION
Backport 1/1 commits from #36030.

/cc @cockroachdb/release

---

Prior to this commit, this query:
```
SELECT a, generate_series(1, (SELECT a)) FROM (VALUES (1)) AS v (a)
```
would fail with
```
columns required of root must be subset of output columns
```

because when the correlated subquery was being hoisted, we would
introduce a passthrough projection to not include the new columns
introduced by the hoist. This projection was too aggressive though,
since it only allowed through the columns produced by the Input field,
and not any introduced by the zip. This commit fixes this to compute the
project the same way we compute the output columns of a ProjectSet.

Release note (bug fix): Fixed an internal error that could occur when
planning correlated subqueries with SRFs.
