### PR TITLE
backport-19.1: opt,sql: add telemetry for some opt features

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
@@ -1688,6 +1689,7 @@ func (m *sessionDataMutator) SetZigzagJoinEnabled(val bool) {
 }
 
 func (m *sessionDataMutator) SetReorderJoinsLimit(val int) {
+	sqltelemetry.ReportJoinReorderLimit(val)
 	m.data.ReorderJoinsLimit = val
 }
 

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -17,12 +17,14 @@ package optbuilder
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -43,10 +45,12 @@ func (b *Builder) buildJoin(join *tree.JoinTableExpr, inScope *scope) (outScope 
 	switch join.Hint {
 	case "":
 	case tree.AstHash:
+		telemetry.Inc(sqltelemetry.HashJoinHintUseCounter)
 		flags.DisallowMergeJoin = true
 		flags.DisallowLookupJoin = true
 
 	case tree.AstLookup:
+		telemetry.Inc(sqltelemetry.LookupJoinHintUseCounter)
 		flags.DisallowHashJoin = true
 		flags.DisallowMergeJoin = true
 		if joinType != sqlbase.InnerJoin && joinType != sqlbase.LeftOuterJoin {
@@ -56,6 +60,7 @@ func (b *Builder) buildJoin(join *tree.JoinTableExpr, inScope *scope) (outScope 
 		}
 
 	case tree.AstMerge:
+		telemetry.Inc(sqltelemetry.MergeJoinHintUseCounter)
 		flags.DisallowLookupJoin = true
 		flags.DisallowHashJoin = true
 

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -14,7 +14,11 @@
 
 package sqltelemetry
 
-import "github.com/cockroachdb/cockroach/pkg/server/telemetry"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+)
 
 // CteUseCounter is to be incremented every time a CTE (WITH ...)
 // is planned without error in a query.
@@ -27,3 +31,56 @@ var SubqueryUseCounter = telemetry.GetCounterOnce("sql.plan.subquery")
 // CorrelatedSubqueryUseCounter is to be incremented every time a
 // correlated subquery has been processed during planning.
 var CorrelatedSubqueryUseCounter = telemetry.GetCounterOnce("sql.plan.subquery.correlated")
+
+// HashJoinHintUseCounter is to be incremented whenever a query specifies a
+// hash join via a query hint.
+var HashJoinHintUseCounter = telemetry.GetCounterOnce("sql.plan.hints.hash-join")
+
+// MergeJoinHintUseCounter is to be incremented whenever a query specifies a
+// merge join via a query hint.
+var MergeJoinHintUseCounter = telemetry.GetCounterOnce("sql.plan.hints.merge-join")
+
+// LookupJoinHintUseCounter is to be incremented whenever a query specifies a
+// lookup join via a query hint.
+var LookupJoinHintUseCounter = telemetry.GetCounterOnce("sql.plan.hints.lookup-join")
+
+// TurnAutoStatsOnUseCounter is to be incremented whenever automatic stats
+// collection is explicitly enabled.
+var TurnAutoStatsOnUseCounter = telemetry.GetCounterOnce("sql.plan.automatic-stats.enabled")
+
+// TurnAutoStatsOffUseCounter is to be incremented whenever automatic stats
+// collection is explicitly disabled.
+var TurnAutoStatsOffUseCounter = telemetry.GetCounterOnce("sql.plan.automatic-stats.disabled")
+
+// We can't parameterize these telemetry counters, so just make a bunch of
+// buckets for setting the join reorder limit since the range of reasonable
+// values for the join reorder limit is quite small.
+// reorderJoinLimitUseCounters is a list of counters. The entry at position i
+// is the counter for SET reorder_join_limit = i.
+var reorderJoinLimitUseCounters []telemetry.Counter
+
+const reorderJoinsCounters = 12
+
+func init() {
+	reorderJoinLimitUseCounters = make([]telemetry.Counter, reorderJoinsCounters)
+
+	for i := 0; i < reorderJoinsCounters; i++ {
+		reorderJoinLimitUseCounters[i] = telemetry.GetCounterOnce(
+			fmt.Sprintf("sql.plan.reorder-joins.set-limit-%d", i),
+		)
+	}
+}
+
+// ReorderJoinLimitMoreCounter is the counter for the number of times someone
+// set the join reorder limit above reorderJoinsCounters.
+var reorderJoinLimitMoreCounter = telemetry.GetCounterOnce("sql.plan.reorder-joins.set-limit-more")
+
+// ReportJoinReorderLimit is to be called whenever the reorder joins session variable
+// is set.
+func ReportJoinReorderLimit(value int) {
+	if value < reorderJoinsCounters {
+		telemetry.Inc(reorderJoinLimitUseCounters[value])
+	} else {
+		telemetry.Inc(reorderJoinLimitMoreCounter)
+	}
+}

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -34,10 +34,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+// AutoStatsClusterSettingName is the name of the automatic stats collection
+// cluster setting.
+const AutoStatsClusterSettingName = "sql.stats.automatic_collection.enabled"
+
 // AutomaticStatisticsClusterMode controls the cluster setting for enabling
 // automatic table statistics collection.
 var AutomaticStatisticsClusterMode = settings.RegisterBoolSetting(
-	"sql.stats.automatic_collection.enabled",
+	AutoStatsClusterSettingName,
 	"automatic statistics collection mode",
 	true,
 )


### PR DESCRIPTION
Backport 1/1 commits from #36142.

/cc @cockroachdb/release

---

This commit introduces telemetry tracking for:
* join hints (hash, merge, lookup),
* setting of the reorder joins session variable,
* setting of the auto stats cluster setting.

I chose to add a new test for reporting rather than augmenting the
existing one since that tests a bunch of stuff these changes were not
interested in, and there's a lot of tedious changes to be made to it.

cc @knz, wasn't sure how best to approach some of these, your input is appreciated! In particular I suspect there's a better place to track the setting of the cluster setting?

Release note: None
