### PR TITLE
release-19.1: sql,stats: delete CREATE STATS jobs that fail due to another job running

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -200,7 +201,7 @@ func (n *createStatsNode) startJob(ctx context.Context, resultsCh chan<- tree.Da
 		description = statement
 		statement = ""
 	}
-	_, errCh, err := n.p.ExecCfg().JobRegistry.StartJob(ctx, resultsCh, jobs.Record{
+	job, errCh, err := n.p.ExecCfg().JobRegistry.StartJob(ctx, resultsCh, jobs.Record{
 		Description: description,
 		Statement:   statement,
 		Username:    n.p.User(),
@@ -217,7 +218,20 @@ func (n *createStatsNode) startJob(ctx context.Context, resultsCh chan<- tree.Da
 	if err != nil {
 		return err
 	}
-	return <-errCh
+
+	if err = <-errCh; err != nil {
+		pgerr, ok := errors.Cause(err).(*pgerror.Error)
+		if ok && pgerr.Code == pgerror.CodeLockNotAvailableError {
+			// Delete the job so users don't see it and get confused by the error.
+			const stmt = `DELETE FROM system.jobs WHERE id = $1`
+			if _ /* cols */, delErr := n.p.ExecCfg().InternalExecutor.Exec(
+				ctx, "delete-job", nil /* txn */, stmt, *job.ID(),
+			); delErr != nil {
+				log.Warningf(ctx, "failed to delete job: %v", delErr)
+			}
+		}
+	}
+	return err
 }
 
 // maxNonIndexCols is the maximum number of non-index columns that we will use


### PR DESCRIPTION
Backport 1/1 commits from #36232.

/cc @cockroachdb/release

---

If two CREATE STATS jobs start at almost exactly the same time, it's possible
that both jobs will be created successfully, but then the one with the later
creation timestamp will fail immediately once it detects the other job that
started earlier. In this case, the failed job shows up in the jobs table with
the error "another CREATE STATISTICS job is already running". Although this is
perfectly fine from the point of view of the system, it's an implementation
detail that could be confusing to users who see the failed job in the Admin UI
or SHOW AUTOMATIC JOBS. For this reason, this commit adds logic to delete the
failed job from the jobs table as soon as it completes.

Release note: None
