### PR TITLE
opt: remove checks that various logical properties match within a memo group

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1506,3 +1506,70 @@ right-join (merge)
       └── gt [type=bool, outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ])]
            ├── variable: y [type=int]
            └── variable: v [type=int]
+
+# Regression test #36183.
+opt
+SELECT (SELECT m FROM
+  (SELECT * FROM (SELECT * FROM [INSERT INTO uv VALUES (1, 2) RETURNING *] WHERE false) JOIN (SELECT * FROM uv WHERE false) ON true)
+  JOIN (SELECT * FROM mn WHERE uv.u IN (SELECT n FROM mn)) ON true
+) FROM uv
+----
+project
+ ├── columns: m:17(int)
+ ├── side-effects, mutations
+ ├── prune: (17)
+ ├── left-join-apply
+ │    ├── columns: u:1(int) u:4(int) v:5(int) rowid:6(int) mn.m:13(int)
+ │    ├── side-effects, mutations
+ │    ├── prune: (13)
+ │    ├── reject-nulls: (4-6,13)
+ │    ├── scan uv
+ │    │    ├── columns: u:1(int)
+ │    │    └── prune: (1)
+ │    ├── inner-join
+ │    │    ├── columns: u:4(int) v:5(int!null) rowid:6(int!null) mn.m:13(int!null)
+ │    │    ├── outer: (1)
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── side-effects, mutations
+ │    │    ├── key: (13)
+ │    │    ├── fd: ()-->(4-6)
+ │    │    ├── prune: (13)
+ │    │    ├── select
+ │    │    │    ├── columns: u:4(int) v:5(int!null) rowid:6(int!null)
+ │    │    │    ├── cardinality: [0 - 0]
+ │    │    │    ├── side-effects, mutations
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(4-6)
+ │    │    │    ├── insert uv
+ │    │    │    │    ├── columns: u:4(int) v:5(int!null) rowid:6(int!null)
+ │    │    │    │    ├── insert-mapping:
+ │    │    │    │    │    ├──  column1:7 => u:4
+ │    │    │    │    │    ├──  column2:8 => v:5
+ │    │    │    │    │    └──  column9:9 => rowid:6
+ │    │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    │    ├── side-effects, mutations
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(4-6)
+ │    │    │    │    └── values
+ │    │    │    │         ├── columns: column1:7(int) column2:8(int) column9:9(int)
+ │    │    │    │         ├── cardinality: [1 - 1]
+ │    │    │    │         ├── side-effects
+ │    │    │    │         ├── key: ()
+ │    │    │    │         ├── fd: ()-->(7-9)
+ │    │    │    │         ├── prune: (7-9)
+ │    │    │    │         └── tuple [type=tuple{int, int, int}]
+ │    │    │    │              ├── const: 1 [type=int]
+ │    │    │    │              ├── const: 2 [type=int]
+ │    │    │    │              └── function: unique_rowid [type=int]
+ │    │    │    └── filters
+ │    │    │         └── false [type=bool]
+ │    │    ├── values
+ │    │    │    ├── columns: mn.m:13(int)
+ │    │    │    ├── cardinality: [0 - 0]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(13)
+ │    │    │    └── prune: (13)
+ │    │    └── filters (true)
+ │    └── filters (true)
+ └── projections
+      └── variable: mn.m [type=int, outer=(13)]

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -467,25 +467,14 @@ func (r *Relational) VerifyAgainst(other *Relational) {
 		panic(pgerror.NewAssertionErrorf("output cols mismatch: %s vs %s", log.Safe(r.OutputCols), log.Safe(other.OutputCols)))
 	}
 
-	// NotNullCols, FuncDeps are best effort, so they might differ.
-
 	if r.Cardinality.Max < other.Cardinality.Min ||
 		r.Cardinality.Min > other.Cardinality.Max {
 		panic(pgerror.NewAssertionErrorf("cardinality mismatch: %s vs %s", log.Safe(r.Cardinality), log.Safe(other.Cardinality)))
 	}
 
-	// TODO(radu): these checks might be overzealous - conceivably a
-	// subexpression with outer columns/side-effects/placeholders could be
-	// elided.
-	if !r.OuterCols.Equals(other.OuterCols) {
-		panic(pgerror.NewAssertionErrorf("outer cols mismatch: %s vs %s", log.Safe(r.OuterCols), log.Safe(other.OuterCols)))
-	}
-	if r.CanHaveSideEffects != other.CanHaveSideEffects {
-		panic(pgerror.NewAssertionErrorf("can-have-side-effects mismatch"))
-	}
-	if r.HasPlaceholder != other.HasPlaceholder {
-		panic(pgerror.NewAssertionErrorf("has-placeholder mismatch"))
-	}
+	// NotNullCols, FuncDeps are best effort, so they might differ.
+	// OuterCols, CanHaveSideEffects, and HasPlaceholder might differ if a
+	// subexpression containing them was elided.
 }
 
 // Verify runs consistency checks against the relational properties, in order to


### PR DESCRIPTION
This commit removes checks that verify that the outer columns, side effects,
and placeholders logical properties match between different expressions in
the same memo group. Since subexpressions containing these properties may
be elided (e.g., due to the `SimplifyZeroCardinalityGroup` rule), there is no
guarantee that two logically equivalent expressions will have the same
properties. Removing these checks should eliminate some spurious test
failures.

Closes #36183

Release note: None