### PR TITLE
exec: fix hash functions not using selection index

### DIFF
--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -145,9 +145,9 @@ func _REHASH_BODY(buckets []uint64, keys []interface{}, nKeys uint64, _SEL_STRIN
 	// {{define "rehashBody"}}
 	for i := uint64(0); i < nKeys; i++ {
 		v := keys[_SEL_IND]
-		p := uintptr(buckets[i])
+		p := uintptr(buckets[_SEL_IND])
 		_ASSIGN_HASH(p, v)
-		buckets[i] = uint64(p)
+		buckets[_SEL_IND] = uint64(p)
 	}
 	// {{end}}
 


### PR DESCRIPTION
This would break hashing with a selection vector as we'd be rehashing
the wrong indices.

Release note: None