### PR TITLE
exec: add error handling infrastructure for vectorized engine

### DIFF
--- a/pkg/sql/distsqlrun/vectorized_error_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_error_propagation_test.go
@@ -1,0 +1,157 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlrun
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/pkg/errors"
+)
+
+// TestVectorizedErrorPropagation verifies that materializers successfully
+// handle panics coming from exec package. It sets up the following chain:
+// RowSource -> columnarizer -> exec error emitter -> materializer,
+// and makes sure that a panic doesn't occur yet the error is propagated.
+func TestVectorizedErrorPropagation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+
+	flowCtx := FlowCtx{
+		EvalCtx:  &evalCtx,
+		Settings: cluster.MakeTestingClusterSettings(),
+	}
+
+	nRows, nCols := 1, 1
+	types := sqlbase.OneIntCol
+	input := NewRepeatableRowSource(types, sqlbase.MakeIntRows(nRows, nCols))
+
+	col, err := newColumnarizer(&flowCtx, 0, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vee := exec.NewTestVectorizedErrorEmitter(col)
+	mat, err := newMaterializer(&flowCtx, 1, vee, types, []int{0}, &distsqlpb.PostProcessSpec{}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var meta *ProducerMetadata
+	panicEmitted := false
+	func() {
+		defer func() {
+			if err := recover(); err != nil {
+				panicEmitted = true
+			}
+		}()
+		mat.Start(ctx)
+		_, meta = mat.Next()
+	}()
+	if panicEmitted {
+		t.Fatalf("VectorizedRuntimeError was not caught by the operators.")
+	}
+	if meta == nil || meta.Err == nil {
+		t.Fatalf("VectorizedRuntimeError was not propagated as metadata.")
+	}
+}
+
+// TestNonVectorizedErrorPropagation verifies that materializers do not handle
+// panics coming not from exec package. It sets up the following chain:
+// RowSource -> columnarizer -> distsqlrun error emitter -> materializer,
+// and makes sure that a panic is emitted all the way through the chain.
+func TestNonVectorizedErrorPropagation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+
+	flowCtx := FlowCtx{
+		EvalCtx:  &evalCtx,
+		Settings: cluster.MakeTestingClusterSettings(),
+	}
+
+	nRows, nCols := 1, 1
+	types := sqlbase.OneIntCol
+	input := NewRepeatableRowSource(types, sqlbase.MakeIntRows(nRows, nCols))
+
+	col, err := newColumnarizer(&flowCtx, 0, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nvee := newTestVectorizedErrorEmitter(col)
+	mat, err := newMaterializer(&flowCtx, 1, nvee, types, []int{0}, &distsqlpb.PostProcessSpec{}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	panicEmitted := false
+	func() {
+		defer func() {
+			if err := recover(); err != nil {
+				panicEmitted = true
+			}
+		}()
+		mat.Start(ctx)
+		_, _ = mat.Next()
+	}()
+	if !panicEmitted {
+		t.Fatalf("Not VectorizedRuntimeError was caught by the operators.")
+	}
+}
+
+// testNonVectorizedErrorEmitter is an exec.Operator that panics on every
+// odd-numbered invocation of Next() and returns the next batch from the input
+// on every even-numbered (i.e. it becomes a noop for those iterations). Used
+// for tests only.
+type testNonVectorizedErrorEmitter struct {
+	input     exec.Operator
+	emitBatch bool
+}
+
+var _ exec.Operator = &testNonVectorizedErrorEmitter{}
+
+// newTestVectorizedErrorEmitter creates a new TestVectorizedErrorEmitter.
+func newTestVectorizedErrorEmitter(input exec.Operator) exec.Operator {
+	return &testNonVectorizedErrorEmitter{input: input}
+}
+
+// Init is part of exec.Operator interface.
+func (e *testNonVectorizedErrorEmitter) Init() {
+	e.input.Init()
+}
+
+// Next is part of exec.Operator interface.
+func (e *testNonVectorizedErrorEmitter) Next() coldata.Batch {
+	if !e.emitBatch {
+		e.emitBatch = true
+		panic(errors.New("An error from distsqlrun package"))
+	}
+
+	e.emitBatch = false
+	return e.input.Next()
+}

--- a/pkg/sql/exec/error.go
+++ b/pkg/sql/exec/error.go
@@ -1,0 +1,105 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"bufio"
+	"fmt"
+	"runtime/debug"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/pkg/errors"
+)
+
+const (
+	panicLineSubstring = "runtime/panic.go"
+	execPackagePrefix  = "github.com/cockroachdb/cockroach/pkg/sql/exec"
+)
+
+// CatchVectorizedRuntimeError executes operation, catches a runtime error if
+// it is coming from exec package, and returns it. If an error occurs that is
+// not from exec package, it is not recovered from.
+func CatchVectorizedRuntimeError(operation func()) (retErr error) {
+	defer func() {
+		if err := recover(); err != nil {
+			stackTrace := string(debug.Stack())
+			scanner := bufio.NewScanner(strings.NewReader(stackTrace))
+			panicLineFound := false
+			for scanner.Scan() {
+				if strings.Contains(scanner.Text(), panicLineSubstring) {
+					panicLineFound = true
+					break
+				}
+			}
+			if !panicLineFound {
+				panic(fmt.Sprintf("panic line %q not found in the stack trace\n%s", panicLineSubstring, stackTrace))
+			}
+			if scanner.Scan() {
+				if strings.HasPrefix(strings.TrimSpace(scanner.Text()), execPackagePrefix) {
+					// We only want to catch runtime errors coming from the exec package.
+					if e, ok := err.(error); ok {
+						retErr = e
+					} else {
+						// panic occurred with an object that is not error.
+						retErr = fmt.Errorf(fmt.Sprintf("%v", err))
+					}
+				} else {
+					// Do not recover from the panic not related to the vectorized
+					// engine.
+					panic(err)
+				}
+			} else {
+				panic(fmt.Sprintf("unexpectedly there is no line below the panic line in the stack trace\n%s", stackTrace))
+			}
+		}
+		// No panic happened, so the operation must have been executed
+		// successfully.
+	}()
+	operation()
+	return retErr
+}
+
+// TestVectorizedErrorEmitter is an Operator that panics on every odd-numbered
+// invocation of Next() and returns the next batch from the input on every
+// even-numbered (i.e. it becomes a noop for those iterations). Used for tests
+// only.
+type TestVectorizedErrorEmitter struct {
+	input     Operator
+	emitBatch bool
+}
+
+var _ Operator = &TestVectorizedErrorEmitter{}
+
+// NewTestVectorizedErrorEmitter creates a new TestVectorizedErrorEmitter.
+func NewTestVectorizedErrorEmitter(input Operator) Operator {
+	return &TestVectorizedErrorEmitter{input: input}
+}
+
+// Init is part of Operator interface.
+func (e *TestVectorizedErrorEmitter) Init() {
+	e.input.Init()
+}
+
+// Next is part of Operator interface.
+func (e *TestVectorizedErrorEmitter) Next() coldata.Batch {
+	if !e.emitBatch {
+		e.emitBatch = true
+		panic(errors.New("a panic from exec package"))
+	}
+
+	e.emitBatch = false
+	return e.input.Next()
+}


### PR DESCRIPTION
Adds error handling infrastructure for the vectorized engine. We
plan to use panic and recover mechanism, and materializers will be
responsible for catching all panics and filtering out those that
come from the vectorized engine as well as handling them.

Fixes: #36175.

Release note: None