### PR TITLE
util/log: ensure that non-crashes add a new sentry tag

### DIFF
--- a/pkg/sql/sqltelemetry/report.go
+++ b/pkg/sql/sqltelemetry/report.go
@@ -47,7 +47,7 @@ func RecordError(ctx context.Context, err error, sv *settings.Values) {
 
 		// If there are no details, don't even bother to try.
 		if len(pgErr.SafeDetail) == 0 {
-			log.SendReport(ctx, "<redacted>", nil)
+			log.SendReport(ctx, "<redacted>", log.ReportTypeError, nil)
 			return
 		}
 
@@ -105,9 +105,9 @@ func RecordError(ctx context.Context, err error, sv *settings.Values) {
 
 		// Finally, send the report.
 		if exc != nil {
-			log.SendReport(ctx, headMsg, extras, details, exc)
+			log.SendReport(ctx, headMsg, log.ReportTypeError, extras, details, exc)
 		} else {
-			log.SendReport(ctx, headMsg, extras, details)
+			log.SendReport(ctx, headMsg, log.ReportTypeError, extras, details)
 		}
 	}
 }

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -1800,6 +1800,7 @@ func (r *Replica) processRaftCommand(
 					0, // depth
 					"while acquiring split lock: %s",
 					[]interface{}{err},
+					log.ReportTypeError,
 				)
 			})
 

--- a/pkg/util/errorutil/error.go
+++ b/pkg/util/errorutil/error.go
@@ -64,5 +64,5 @@ func (e UnexpectedWithIssueErr) SafeMessage() string {
 // The format string will be reproduced ad litteram in the report; the arguments
 // will be sanitized.
 func (e UnexpectedWithIssueErr) SendReport(ctx context.Context, sv *settings.Values) {
-	log.SendCrashReport(ctx, sv, 1 /* depth */, "%s", []interface{}{e})
+	log.SendCrashReport(ctx, sv, 1 /* depth */, "%s", []interface{}{e}, log.ReportTypeError)
 }

--- a/pkg/util/log/crash_reporting_packet_test.go
+++ b/pkg/util/log/crash_reporting_packet_test.go
@@ -99,7 +99,7 @@ func TestCrashReportingPacket(t *testing.T) {
 		tagCount int
 		message  string
 	}{
-		{regexp.MustCompile(`^$`), 6, func() string {
+		{regexp.MustCompile(`^$`), 7, func() string {
 			message := prefix
 			// gccgo stack traces are different in the presence of function literals.
 			if runtime.Compiler == "gccgo" {
@@ -110,7 +110,7 @@ func TestCrashReportingPacket(t *testing.T) {
 			message += ": " + panicPre
 			return message
 		}()},
-		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 9, func() string {
+		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 10, func() string {
 			message := prefix
 			// gccgo stack traces are different in the presence of function literals.
 			if runtime.Compiler == "gccgo" {

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -76,7 +76,7 @@ func addStructured(ctx context.Context, s Severity, depth int, format string, ar
 		// We load the ReportingSettings from the a global singleton in this
 		// call path. See the singleton's comment for a rationale.
 		if sv := settings.TODO(); sv != nil {
-			SendCrashReport(ctx, sv, depth+2, format, args)
+			SendCrashReport(ctx, sv, depth+2, format, args, ReportTypePanic)
 		}
 	}
 	// MakeMessage already added the tags when forming msg, we don't want


### PR DESCRIPTION
In order to distinguish between an actual crash and simply a reported error, a
new tag is added to the sentry report to disambiguate between the two.

Release note: None