### PR TITLE
release-19.1: ui: cosmetic upgrade for Logical Plans

### DIFF
--- a/pkg/ui/ccl/src/views/shared/colors.tsx
+++ b/pkg/ui/ccl/src/views/shared/colors.tsx
@@ -1,6 +1,6 @@
 // TODO(vilterp): pull this out into CSS...
 
-export const MAIN_BLUE = "#3A7DE1";
+export const MAIN_BLUE = "#3A7DE1";  // This should match $main-blue-color in palette.styl
 export const BACKGROUND_BLUE = "#B8CCEC";
 export const LIGHT_TEXT_BLUE = "#85A7E3";
 export const DARK_BLUE = "#152849";

--- a/pkg/ui/src/views/statements/planView.spec.tsx
+++ b/pkg/ui/src/views/statements/planView.spec.tsx
@@ -15,7 +15,7 @@
 import { assert } from "chai";
 
 import { cockroach } from "src/js/protos";
-import { FlatPlanNode, flattenTree, planNodeHeaderProps } from "src/views/statements/planView";
+import { FlatPlanNode, FlatPlanNodeAttribute, flattenTree, flattenAttributes } from "src/views/statements/planView";
 import IAttr = cockroach.sql.ExplainTreePlanNode.IAttr;
 import IExplainTreePlanNode = cockroach.sql.IExplainTreePlanNode;
 
@@ -38,6 +38,32 @@ const testAttrs2: IAttr[] = [
   {
     key: "key4",
     value: "value4",
+  },
+];
+
+const testFlatAttrs1: FlatPlanNodeAttribute[] = [
+  {
+    key: "key1",
+    values: ["value1"],
+    warn: false,
+  },
+  {
+    key: "key2",
+    values: ["value2"],
+    warn: false,
+  },
+];
+
+const testFlatAttrs2: FlatPlanNodeAttribute[] = [
+  {
+    key: "key3",
+    values: ["value3"],
+    warn: false,
+  },
+  {
+    key: "key4",
+    values: ["value4"],
+    warn: false,
   },
 ];
 
@@ -68,22 +94,22 @@ const treePlanWithSingleChildPaths: IExplainTreePlanNode = {
 const expectedFlatPlanWithSingleChildPaths: FlatPlanNode[] = [
   {
     name: "root",
-    attrs: null,
+    attrs: [],
     children: [],
   },
   {
     name: "single_grandparent",
-    attrs: testAttrs1,
+    attrs: testFlatAttrs1,
     children: [],
   },
   {
     name: "single_parent",
-    attrs: null,
+    attrs: [],
     children: [],
   },
   {
     name: "single_child",
-    attrs: testAttrs2,
+    attrs: testFlatAttrs2,
     children: [],
   },
 ];
@@ -120,29 +146,29 @@ const treePlanWithChildren1: IExplainTreePlanNode = {
 const expectedFlatPlanWithChildren1: FlatPlanNode[] = [
   {
     name: "root",
-    attrs: testAttrs1,
+    attrs: testFlatAttrs1,
     children: [],
   },
   {
     name: "single_grandparent",
-    attrs: testAttrs1,
+    attrs: testFlatAttrs1,
     children: [
       [
         {
           name: "parent_1",
-          attrs: null,
+          attrs: [],
           children: [],
         },
         {
           name: "single_child",
-          attrs: testAttrs2,
+          attrs: testFlatAttrs2,
           children: [],
         },
       ],
       [
         {
           name: "parent_2",
-          attrs: null,
+          attrs: [],
           children: [],
         },
       ],
@@ -182,29 +208,29 @@ const treePlanWithChildren2: IExplainTreePlanNode = {
 const expectedFlatPlanWithChildren2: FlatPlanNode[] = [
   {
     name: "root",
-    attrs: null,
+    attrs: [],
     children: [],
   },
   {
     name: "single_grandparent",
-    attrs: null,
+    attrs: [],
     children: [],
   },
   {
     name: "single_parent",
-    attrs: null,
+    attrs: [],
     children: [
       [
         {
           name: "child_1",
-          attrs: testAttrs1,
+          attrs: testFlatAttrs1,
           children: [],
         },
       ],
       [
         {
           name: "child_2",
-          attrs: testAttrs2,
+          attrs: testFlatAttrs2,
           children: [],
         },
       ],
@@ -221,7 +247,7 @@ const treePlanWithNoChildren: IExplainTreePlanNode = {
 const expectedFlatPlanWithNoChildren: FlatPlanNode[] = [
   {
     name: "root",
-    attrs: testAttrs1,
+    attrs: testFlatAttrs1,
     children: [],
   },
 ];
@@ -255,120 +281,146 @@ describe("flattenTree", () => {
   });
 });
 
-describe("planNodeHeaderProps", () => {
-  describe("when node is join node", () => {
-    it("prepends join type to title.", () => {
-      const result = planNodeHeaderProps({
-        name: "join",
-        attrs: [
-          {
-            key: "foo",
-            value: "bar",
-          },
-          {
-            key: "type",
-            value: "inner",
-          },
-          {
-            key: "baz",
-            value: "foo-baz",
-          },
-        ],
-        children: [],
-      });
-      assert.deepEqual(
-        result,
+describe("flattenAttributes", () => {
+  describe("when all attributes have different keys", () => {
+    it("creates array with exactly one value for each attribute", () => {
+      const testAttrs: IAttr[] = [
         {
-          title: "inner join",
-          subtitle: null,
+          key: "key1",
+          value: "value1",
+        },
+        {
+          key: "key2",
+          value: "value2",
+        },
+      ];
+      const expectedTestAttrs: FlatPlanNodeAttribute[] = [
+        {
+          key: "key1",
+          values: ["value1"],
           warn: false,
         },
+        {
+          key: "key2",
+          values: ["value2"],
+          warn: false,
+        },
+      ];
+
+      assert.deepEqual(
+        flattenAttributes(testAttrs),
+        expectedTestAttrs,
       );
     });
   });
-  describe("when node is scan node", () => {
-    describe("if not both `spans ALL` and `table` attribute", () => {
-      it("returns default header properties.", () => {
-        const result1 = planNodeHeaderProps({
-          name: "scan",
-          attrs: [
-            {
-              key: "spans",
-              value: "ALL",
-            },
-            {
-              key: "but-not-table-key",
-              value: "table-name@key-type",
-            },
-          ],
-          children: [],
-        });
-        const result2 = planNodeHeaderProps({
-          name: "scan",
-          attrs: [
-            {
-              key: "spans",
-              value: "but-not-ALL-value",
-            },
-            {
-              key: "table",
-              value: "table-name@key-type",
-            },
-          ],
-          children: [],
-        });
-        assert.deepEqual(
-          result1,
-          {
-            title: "scan",
-            subtitle: null,
-            warn: false,
-          },
-        );
-        assert.deepEqual(
-          result2,
-          {
-            title: "scan",
-            subtitle: null,
-            warn: false,
-          },
-        );
+  describe("when there are multiple attributes with same key", () => {
+    it("collects values into one array for same key", () => {
+      const testAttrs: IAttr[] = [
+        {
+          key: "key1",
+          value: "key1-value1",
+        },
+        {
+          key: "key2",
+          value: "key2-value1",
+        },
+        {
+          key: "key1",
+          value: "key1-value2",
+        },
+      ];
+      const expectedTestAttrs: FlatPlanNodeAttribute[] = [
+        {
+          key: "key1",
+          values: ["key1-value1", "key1-value2"],
+          warn: false,
+        },
+        {
+          key: "key2",
+          values: ["key2-value1"],
+          warn: false,
+        },
+      ];
 
-      });
+      assert.deepEqual(
+        flattenAttributes(testAttrs),
+        expectedTestAttrs,
+      );
     });
-    describe("if both `spans ALL` and `table` attribute", () => {
-      it("warns user of table scan.", () => {
-        const result = planNodeHeaderProps({
-          name: "scan",
-          attrs: [
-            {
-              key: "foo",
-              value: "bar",
-            },
-            {
-              key: "spans",
-              value: "ALL",
-            },
-            {
-              key: "baz",
-              value: "foo-baz",
-            },
-            {
-              key: "table",
-              value: "table-name@key-type",
-            },
-          ],
-          children: [],
-        });
-        assert.deepEqual(
-          result,
-          {
-            title: "table scan",
-            subtitle: "table-name",
-            warn: true,
-          },
-        );
-      });
+  });
+  describe("when attribute key/value is `spans ALL`", () => {
+    it("sets warn to true", () => {
+      const testAttrs: IAttr[] = [
+        {
+          key: "foo",
+          value: "bar",
+        },
+        {
+          key: "spans",
+          value: "ALL",
+        },
+      ];
+      const expectedTestAttrs: FlatPlanNodeAttribute[] = [
+        {
+          key: "foo",
+          values: ["bar"],
+          warn: false,
+        },
+        {
+          key: "spans",
+          values: ["ALL"],
+          warn: true,
+        },
+      ];
+
+      assert.deepEqual(
+        flattenAttributes(testAttrs),
+        expectedTestAttrs,
+      );
+    });
+  });
+  describe("when keys are unsorted", () => {
+    it("puts table key first, and sorts remaining keys alphabetically", () => {
+      const testAttrs: IAttr[] = [
+        {
+          key: "zebra",
+          value: "foo",
+        },
+        {
+          key: "table",
+          value: "foo",
+        },
+        {
+          key: "cheetah",
+          value: "foo",
+        },
+        {
+          key: "table",
+          value: "bar",
+        },
+      ];
+      const expectedTestAttrs: FlatPlanNodeAttribute[] = [
+        {
+          key: "table",
+          values: ["foo", "bar"],
+          warn: false,
+        },
+        {
+          key: "cheetah",
+          values: ["foo"],
+          warn: false,
+        },
+        {
+          key: "zebra",
+          values: ["foo"],
+          warn: false,
+        },
+      ];
+
+      assert.deepEqual(
+        flattenAttributes(testAttrs),
+        expectedTestAttrs,
+      );
     });
   });
 });

--- a/pkg/ui/src/views/statements/statements.styl
+++ b/pkg/ui/src/views/statements/statements.styl
@@ -175,6 +175,7 @@ $plan-node-warning-background-color = rgba(209, 135, 55, 0.06)  // light orange
 $plan-node-warning-border-color = rgba(209, 135, 55, 0.3)       // dark orange 2
 $plan-node-details-background-color = #F6F6F6                   // grayish-white
 $plan-node-details-border-color = #ACB8CB                       // dark gray
+$plan-node-attribute-key-color = #5cc123                        // light green
 
 .plan-view-table
   @extend $table-base
@@ -195,18 +196,27 @@ $plan-node-details-border-color = #ACB8CB                       // dark gray
   position relative
   padding-left 6px
 
-  .arrow-icon
-    margin-left 8px
-    polyline
-      fill none
-      stroke $body-color
-      stroke-width 2
+  .plan-view-container
+    height 100%
+    max-height 100%
+    overflow hidden
+
+    .plan-view-container-scroll
+      max-height 400px
+      overflow-y scroll
+
+    .plan-view-container-directions
+      text-align center
+      cursor pointer
+      text-transform uppercase
+      color $main-blue-color
+      font-size smaller
 
   .node-icon
     margin 0 10px 0 12px
 
   .warning-icon
-    margin 0 6px 0 8px
+    margin 0 4px 0 4px
     position relative
     top 3px
     path
@@ -214,58 +224,28 @@ $plan-node-details-border-color = #ACB8CB                       // dark gray
 
   .warn
     position relative
+    left -5px
     color $plan-node-warning-color
     background-color $plan-node-warning-background-color
-
-    .arrow-icon
-      polyline
-        fill none
-        stroke $plan-node-warning-color
-        stroke-width 2
-
-  .arrow
-    font-size smaller
-    display none
-
-  .arrow-expanded
-    font-size smaller
-    display inline
-
-  .hasAttributes
-    &:hover
-      cursor pointer
-
-      .arrow
-        display inline
+    border-radius 2px
+    padding 2px
 
   .nodeDetails
     position relative
     padding 6px 0
     margin 2px 0
     border 1px solid transparent
-    border-radius 3px
-
-    &.expanded
-      border 1px solid $plan-node-details-border-color
-
-    &.expanded
-    &:hover
-      background-color $plan-node-details-background-color
-
-    &.warn
-      &.expanded
-      &:hover
-        position relative
-        background-color $plan-node-warning-background-color
-        border 1px solid $plan-node-warning-border-color
 
   .nodeAttributes
     color $body-color
-    padding 14px 16px
-    margin 6px 10px 4px 15px
-    border 1px solid $plan-node-line-color
+    padding 7px 16px 0px 18px
+    margin-left 16px
+    border-left 1px solid $plan-node-line-color
     background-color white
-    border-radius 2px
+    font-family Inconsolata-Regular, monospace
+
+    .nodeAttributeKey
+      color $plan-node-attribute-key-color
 
   ul
     padding 0

--- a/pkg/ui/styl/base/palette.styl
+++ b/pkg/ui/styl/base/palette.styl
@@ -26,6 +26,7 @@ $tooltip-shadow = rgba(0, 0, 0, .20)
 $table-border-color = #EDEDED
 $button-border-color = #C8CBD4
 $background-color  = #F6F6F6
+$main-blue-color = #3A7DE1  // This should match MAIN_BLUE from colors.tsx
 
 // Alert colors
 $notification-alert-fill-color = #F4D9D9


### PR DESCRIPTION
Backport 1/1 commits from #36062.

/cc @cockroachdb/release

---

This commit has cosmetic updates for Logical Plans, based on customer feedback.

Before:
<img width="400" alt="before" src="https://user-images.githubusercontent.com/3051672/54839778-f8418580-4ca1-11e9-8b21-9c5535a6b288.gif">

After:
<img width="400" alt="after" src="https://user-images.githubusercontent.com/3051672/54855140-91d15d00-4ccb-11e9-933a-fef3e7549e25.gif">

Release note: None
