### PR TITLE
release-19.1: stats: invalidate local cache synchronously

### DIFF
--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -269,7 +269,7 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 	// internal executor instead of doing this weird thing where it uses the
 	// internal executor to execute one statement at a time inside a db.Txn()
 	// closure.
-	return s.flowCtx.ClientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+	if err := s.flowCtx.ClientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		for _, si := range s.sketches {
 			var histogram *stats.HistogramData
 			if si.spec.GenerateHistogram && len(s.sr.Get()) != 0 {
@@ -309,7 +309,6 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 			// Insert the new stat.
 			if err := stats.InsertNewStat(
 				ctx,
-				s.flowCtx.Gossip,
 				s.flowCtx.executor,
 				txn,
 				s.tableID,
@@ -325,7 +324,12 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 		}
 
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	// Gossip invalidation of the stat caches for this table.
+	return stats.GossipTableStatAdded(s.flowCtx.Gossip, s.tableID)
 }
 
 // generateHistogram returns a histogram (on a given column) from a set of

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -4,30 +4,25 @@
 # statistics if distsql mode is OFF.
 
 statement ok
-CREATE TABLE a (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
-
-# Create a new table to avoid depending on the asynchronous stat cache
-# invalidation.
-statement ok
-CREATE TABLE b (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
-INSERT INTO b VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 4), (2, 5), (2, 6), (2, 7)
+CREATE TABLE uv (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
+INSERT INTO uv VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 4), (2, 5), (2, 6), (2, 7)
 
 statement ok
-CREATE STATISTICS u ON u FROM b;
-CREATE STATISTICS v ON v FROM b
+CREATE STATISTICS u ON u FROM uv;
+CREATE STATISTICS v ON v FROM uv
 
 # Verify we scan index v which has the more selective constraint.
 query TTTTT
-EXPLAIN (VERBOSE) SELECT * FROM b WHERE u = 1 AND v = 1
+EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-scan  ·       ·          (u, v)  ·
-·     table   b@b_v_idx  ·       ·
-·     spans   /1-/2      ·       ·
-·     filter  u = 1      ·       ·
+scan  ·       ·            (u, v)  ·
+·     table   uv@uv_v_idx  ·       ·
+·     spans   /1-/2        ·       ·
+·     filter  u = 1        ·       ·
 
 # Verify that injecting different statistics changes the plan.
 statement ok
-ALTER TABLE b INJECT STATISTICS '[
+ALTER TABLE uv INJECT STATISTICS '[
   {
     "columns": ["u"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
@@ -43,17 +38,17 @@ ALTER TABLE b INJECT STATISTICS '[
 ]'
 
 query TTTTT
-EXPLAIN (VERBOSE) SELECT * FROM b WHERE u = 1 AND v = 1
+EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-scan  ·       ·          (u, v)  ·
-·     table   b@b_u_idx  ·       ·
-·     spans   /1-/2      ·       ·
-·     filter  v = 1      ·       ·
+scan  ·       ·            (u, v)  ·
+·     table   uv@uv_u_idx  ·       ·
+·     spans   /1-/2        ·       ·
+·     filter  v = 1        ·       ·
 
 # Verify that injecting different statistics with null counts
 # changes the plan.
 statement ok
-ALTER TABLE b INJECT STATISTICS '[
+ALTER TABLE uv INJECT STATISTICS '[
   {
     "columns": ["u"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
@@ -71,15 +66,15 @@ ALTER TABLE b INJECT STATISTICS '[
 ]'
 
 query TTTTT
-EXPLAIN (VERBOSE) SELECT * FROM b WHERE u = 1 AND v = 1
+EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-scan  ·       ·          (u, v)  ·
-·     table   b@b_u_idx  ·       ·
-·     spans   /1-/2      ·       ·
-·     filter  v = 1      ·       ·
+scan  ·       ·            (u, v)  ·
+·     table   uv@uv_u_idx  ·       ·
+·     spans   /1-/2        ·       ·
+·     filter  v = 1        ·       ·
 
 statement ok
-ALTER TABLE b INJECT STATISTICS '[
+ALTER TABLE uv INJECT STATISTICS '[
   {
     "columns": ["u"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
@@ -97,9 +92,9 @@ ALTER TABLE b INJECT STATISTICS '[
 ]'
 
 query TTTTT
-EXPLAIN (VERBOSE) SELECT * FROM b WHERE u = 1 AND v = 1
+EXPLAIN (VERBOSE) SELECT * FROM uv WHERE u = 1 AND v = 1
 ----
-scan  ·       ·          (u, v)  ·
-·     table   b@b_v_idx  ·       ·
-·     spans   /1-/2      ·       ·
-·     filter  u = 1      ·       ·
+scan  ·       ·            (u, v)  ·
+·     table   uv@uv_v_idx  ·       ·
+·     spans   /1-/2        ·       ·
+·     filter  u = 1        ·       ·


### PR DESCRIPTION
Backport 1/1 commits from #36245.

/cc @cockroachdb/release

---

A couple of tests rely on the new stats being in effect once CREATE
STATISTICS completes. This is usually the case, but not reliably so
(the invalidation mechanism is asynchronous).

This commit adds a call to invalidate the local cache synchronously
(similar to INJECT STATISTICS).

We also clean up the code that triggers invalidation via gossip to do
it once for the entire table, not once per statistic.

Finally, the stats test is cleaned up (it contained a so-called
workaround for this problem that made no sense).

Fixes #36087.
Fixes #36218.

Release note: None
