### PR TITLE
scripts: Make DEV_LICENSE optional in gceworker.sh

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -19,7 +19,7 @@ case "${cmd}" in
     gcloud "$@"
     ;;
     create)
-    if [[ "$COCKROACH_DEV_LICENSE" ]]; then
+    if [[ "${COCKROACH_DEV_LICENSE:-}" ]]; then
       echo "Using dev license key from \$COCKROACH_DEV_LICENSE"
     else
       echo -n "Enter your dev license key (if any): "


### PR DESCRIPTION
This would hit an "undefined variable" error (from `set -u`) previously.

Release note: None