### PR TITLE
storage: sanity check ChangeReplicas with regards to liveness

### DIFF
--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -323,7 +323,7 @@ func createTestAllocator(
 		storagepb.NodeLivenessStatus_LIVE)
 	a := MakeAllocator(storePool, func(string) (time.Duration, bool) {
 		return 0, true
-	})
+	}, nil)
 	return stopper, g, storePool, a, manual
 }
 
@@ -1238,7 +1238,7 @@ func TestAllocatorTransferLeaseTargetDraining(t *testing.T) {
 		storagepb.NodeLivenessStatus_LIVE)
 	a := MakeAllocator(storePool, func(string) (time.Duration, bool) {
 		return 0, true
-	})
+	}, nil)
 	defer stopper.Stop(context.Background())
 
 	// 3 stores where the lease count for each store is equal to 100x the store
@@ -1632,7 +1632,7 @@ func TestAllocatorShouldTransferLeaseDraining(t *testing.T) {
 		storagepb.NodeLivenessStatus_LIVE)
 	a := MakeAllocator(storePool, func(string) (time.Duration, bool) {
 		return 0, true
-	})
+	}, nil)
 	defer stopper.Stop(context.Background())
 
 	// 4 stores where the lease count for each store is equal to 10x the store
@@ -3765,7 +3765,7 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			a := MakeAllocator(storePool, func(addr string) (time.Duration, bool) {
 				return c.latency[addr], true
-			})
+			}, nil)
 			target := a.TransferLeaseTarget(
 				context.Background(),
 				config.EmptyCompleteZoneConfig(),
@@ -4905,7 +4905,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 		storagepb.NodeLivenessStatus_LIVE)
 	a := MakeAllocator(sp, func(string) (time.Duration, bool) {
 		return 0, true
-	})
+	}, nil)
 
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
@@ -5008,7 +5008,7 @@ func makeDescriptor(storeList []roachpb.StoreID) roachpb.RangeDescriptor {
 func TestAllocatorComputeActionNoStorePool(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	a := MakeAllocator(nil /* storePool */, nil /* rpcContext */)
+	a := MakeAllocator(nil /* storePool */, nil /* rpcContext */, nil /* replicasLivenessFn */)
 	action, priority := a.ComputeAction(context.Background(), &config.ZoneConfig{NumReplicas: proto.Int32(0)}, RangeInfo{})
 	if action != AllocatorNoop {
 		t.Errorf("expected AllocatorNoop, but got %v", action)
@@ -5529,7 +5529,7 @@ func TestAllocatorFullDisks(t *testing.T) {
 	)
 	alloc := MakeAllocator(sp, func(string) (time.Duration, bool) {
 		return 0, false
-	})
+	}, nil)
 
 	var wg sync.WaitGroup
 	g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStorePrefix),
@@ -5669,7 +5669,7 @@ func Example_rebalancing() {
 	)
 	alloc := MakeAllocator(sp, func(string) (time.Duration, bool) {
 		return 0, false
-	})
+	}, nil)
 
 	var wg sync.WaitGroup
 	g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStorePrefix),

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -348,7 +348,7 @@ func (r *Replica) IsRaftGroupInitialized() bool {
 // can achieve quorum.
 func (r *Replica) HasQuorum() bool {
 	desc := r.Desc()
-	liveReplicas, _ := r.store.allocator.storePool.liveAndDeadReplicas(desc.RangeID, desc.Replicas)
+	liveReplicas, _ := r.store.replicasLiveness(desc.Replicas)
 	quorum := computeQuorum(len(desc.Replicas))
 	return len(liveReplicas) >= quorum
 }

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -291,7 +291,7 @@ func (rq *replicateQueue) processOneChange(
 
 	// Avoid taking action if the range has too many dead replicas to make
 	// quorum.
-	liveReplicas, deadReplicas := rq.allocator.storePool.liveAndDeadReplicas(desc.RangeID, desc.Replicas)
+	liveReplicas, deadReplicas := rq.allocator.replicasLivenessFn(desc.Replicas)
 	{
 		quorum := computeQuorum(len(desc.Replicas))
 		if lr := len(liveReplicas); lr < quorum {

--- a/pkg/storage/storagebase/base.go
+++ b/pkg/storage/storagebase/base.go
@@ -105,6 +105,15 @@ type ReplicaApplyFilter func(args ApplyFilterArgs) (int, *roachpb.Error)
 // been processed. This filter is invoked only by the command proposer.
 type ReplicaResponseFilter func(roachpb.BatchRequest, *roachpb.BatchResponse) *roachpb.Error
 
+// ReplicasLivenessFunc divides the provided repls slice into two slices: the
+// first for live replicas, and the second for dead replicas.
+// Replicas for which liveness or deadness cannot be ascertained are excluded
+// from the returned slices. Replicas on decommissioning node/store should be
+// considered live.
+type ReplicasLivenessFunc func(
+	repls []roachpb.ReplicaDescriptor,
+) (live, dead []roachpb.ReplicaDescriptor)
+
 // ContainsKey returns whether this range contains the specified key.
 func ContainsKey(desc roachpb.RangeDescriptor, key roachpb.Key) bool {
 	if bytes.HasPrefix(key, keys.LocalRangeIDPrefix) {

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -152,7 +152,7 @@ const (
 // status returns the current status of the store, including whether
 // any of the replicas for the specified rangeID are corrupted.
 func (sd *storeDetail) status(
-	now time.Time, threshold time.Duration, rangeID roachpb.RangeID, nl NodeLivenessFunc,
+	now time.Time, threshold time.Duration, nl NodeLivenessFunc,
 ) storeStatus {
 	// The store is considered dead if it hasn't been updated via gossip
 	// within the liveness threshold. Note that lastUpdatedTime is set
@@ -272,7 +272,7 @@ func (sp *StorePool) String() string {
 	for _, id := range ids {
 		detail := sp.detailsMu.storeDetails[id]
 		fmt.Fprintf(&buf, "%d", id)
-		status := detail.status(now, timeUntilStoreDead, 0, sp.nodeLivenessFn)
+		status := detail.status(now, timeUntilStoreDead, sp.nodeLivenessFn)
 		if status != storeStatusAvailable {
 			fmt.Fprintf(&buf, " (status=%d)", status)
 		}
@@ -421,7 +421,7 @@ func (sp *StorePool) decommissioningReplicas(
 
 	for _, repl := range repls {
 		detail := sp.getStoreDetailLocked(repl.StoreID)
-		switch detail.status(now, timeUntilStoreDead, rangeID, sp.nodeLivenessFn) {
+		switch detail.status(now, timeUntilStoreDead, sp.nodeLivenessFn) {
 		case storeStatusDecommissioning:
 			decommissioningReplicas = append(decommissioningReplicas, repl)
 		}
@@ -439,10 +439,10 @@ func (sp *StorePool) ClusterNodeCount() int {
 // liveAndDeadReplicas divides the provided repls slice into two slices: the
 // first for live replicas, and the second for dead replicas.
 // Replicas for which liveness or deadness cannot be ascertained are excluded
-// from the returned slices.  Replicas on decommissioning node/store are
-// considered live.
+// from the returned slices. Replicas on decommissioning node/store are
+// considered live. This method is a ReplicasLivenessFunc.
 func (sp *StorePool) liveAndDeadReplicas(
-	rangeID roachpb.RangeID, repls []roachpb.ReplicaDescriptor,
+	repls []roachpb.ReplicaDescriptor,
 ) (liveReplicas, deadReplicas []roachpb.ReplicaDescriptor) {
 	sp.detailsMu.Lock()
 	defer sp.detailsMu.Unlock()
@@ -453,7 +453,7 @@ func (sp *StorePool) liveAndDeadReplicas(
 	for _, repl := range repls {
 		detail := sp.getStoreDetailLocked(repl.StoreID)
 		// Mark replica as dead if store is dead.
-		status := detail.status(now, timeUntilStoreDead, rangeID, sp.nodeLivenessFn)
+		status := detail.status(now, timeUntilStoreDead, sp.nodeLivenessFn)
 		switch status {
 		case storeStatusDead:
 			deadReplicas = append(deadReplicas, repl)
@@ -628,7 +628,7 @@ func (sp *StorePool) getStoreListFromIDsRLocked(
 
 	for _, storeID := range storeIDs {
 		detail := sp.detailsMu.storeDetails[storeID]
-		switch s := detail.status(now, timeUntilStoreDead, rangeID, sp.nodeLivenessFn); s {
+		switch s := detail.status(now, timeUntilStoreDead, sp.nodeLivenessFn); s {
 		case storeStatusThrottled:
 			aliveStoreCount++
 			throttled = append(throttled, detail.throttledBecause)

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -649,7 +649,7 @@ func TestStorePoolFindDeadReplicas(t *testing.T) {
 		mnl.setNodeStatus(roachpb.NodeID(i), storagepb.NodeLivenessStatus_LIVE)
 	}
 
-	liveReplicas, deadReplicas := sp.liveAndDeadReplicas(0, replicas)
+	liveReplicas, deadReplicas := sp.liveAndDeadReplicas(replicas)
 	if len(liveReplicas) != 5 {
 		t.Fatalf("expected five live replicas, found %d (%v)", len(liveReplicas), liveReplicas)
 	}
@@ -660,7 +660,7 @@ func TestStorePoolFindDeadReplicas(t *testing.T) {
 	mnl.setNodeStatus(4, storagepb.NodeLivenessStatus_DEAD)
 	mnl.setNodeStatus(5, storagepb.NodeLivenessStatus_DEAD)
 
-	liveReplicas, deadReplicas = sp.liveAndDeadReplicas(0, replicas)
+	liveReplicas, deadReplicas = sp.liveAndDeadReplicas(replicas)
 	if a, e := liveReplicas, replicas[:3]; !reflect.DeepEqual(a, e) {
 		t.Fatalf("expected live replicas %+v; got %+v", e, a)
 	}
@@ -671,7 +671,7 @@ func TestStorePoolFindDeadReplicas(t *testing.T) {
 	// Mark node 4 as merely unavailable.
 	mnl.setNodeStatus(4, storagepb.NodeLivenessStatus_UNAVAILABLE)
 
-	liveReplicas, deadReplicas = sp.liveAndDeadReplicas(0, replicas)
+	liveReplicas, deadReplicas = sp.liveAndDeadReplicas(replicas)
 	if a, e := liveReplicas, replicas[:3]; !reflect.DeepEqual(a, e) {
 		t.Fatalf("expected live replicas %+v; got %+v", e, a)
 	}
@@ -695,7 +695,7 @@ func TestStorePoolDefaultState(t *testing.T) {
 		storagepb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(context.TODO())
 
-	liveReplicas, deadReplicas := sp.liveAndDeadReplicas(0, []roachpb.ReplicaDescriptor{{StoreID: 1}})
+	liveReplicas, deadReplicas := sp.liveAndDeadReplicas([]roachpb.ReplicaDescriptor{{StoreID: 1}})
 	if len(liveReplicas) != 0 || len(deadReplicas) != 0 {
 		t.Errorf("expected 0 live and 0 dead replicas; got %v and %v", liveReplicas, deadReplicas)
 	}
@@ -886,7 +886,7 @@ func TestStorePoolDecommissioningReplicas(t *testing.T) {
 		mnl.setNodeStatus(roachpb.NodeID(i), storagepb.NodeLivenessStatus_LIVE)
 	}
 
-	liveReplicas, deadReplicas := sp.liveAndDeadReplicas(0, replicas)
+	liveReplicas, deadReplicas := sp.liveAndDeadReplicas(replicas)
 	if len(liveReplicas) != 5 {
 		t.Fatalf("expected five live replicas, found %d (%v)", len(liveReplicas), liveReplicas)
 	}
@@ -898,7 +898,7 @@ func TestStorePoolDecommissioningReplicas(t *testing.T) {
 	// Mark node 5 as dead.
 	mnl.setNodeStatus(5, storagepb.NodeLivenessStatus_DEAD)
 
-	liveReplicas, deadReplicas = sp.liveAndDeadReplicas(0, replicas)
+	liveReplicas, deadReplicas = sp.liveAndDeadReplicas(replicas)
 	// Decommissioning replicas are considered live.
 	if a, e := liveReplicas, replicas[:4]; !reflect.DeepEqual(a, e) {
 		t.Fatalf("expected live replicas %+v; got %+v", e, a)

--- a/pkg/storage/testing_knobs.go
+++ b/pkg/storage/testing_knobs.go
@@ -65,6 +65,11 @@ type StoreTestingKnobs struct {
 	// error returned to the client, or to simulate network failures.
 	TestingResponseFilter storagebase.ReplicaResponseFilter
 
+	// TestingReplicasLiveness uses this function rather than the StoragePool's
+	// implementation of storagebase.ReplicasLivenessFunc to determine the
+	// liveness status of replicas for allocation and merge decisions.
+	TestingReplicasLiveness storagebase.ReplicasLivenessFunc
+
 	// Disables the use of optional one phase commits. Even when enabled, requests
 	// that set the Require1PC flag are permitted to use one phase commits. This
 	// prevents wedging node liveness, which requires one phase commits during


### PR DESCRIPTION
This PR comes in two commits. The first abstracts `StorePool.liveAndDeadNodes` into a func that the `Store` and `Allocator` hold which can be injected via a TestingKnob and the second adds the sanity checks in `Replica.ChangeReplicas`. I'm not particularly attached to `ReplicasLiveness` so suggestions welcomed.

The main idea is that we want some low-level protection against replication changes which increase the risk of unavailability. Adding a dead node seems obviously bad. Removing a live node while the range contains a dead node feels risky. Are there other checks we should have here?

This PR copies some helper testing functions from #36244 which will get rebased away.

Informs #36025.