### PR TITLE
storage: set tscache low-water mark for local keyspace after merge

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1414,6 +1414,20 @@ func heartbeatArgs(
 	}, roachpb.Header{Txn: txn}
 }
 
+func pushTxnArgs(
+	pusher, pushee *roachpb.Transaction, pushType roachpb.PushTxnType,
+) *roachpb.PushTxnRequest {
+	return &roachpb.PushTxnRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: pushee.Key,
+		},
+		PushTo:    pusher.Timestamp.Next(),
+		PusherTxn: *pusher,
+		PusheeTxn: pushee.TxnMeta,
+		PushType:  pushType,
+	}
+}
+
 func TestSortRangeDescByAge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var replicaDescs []roachpb.ReplicaDescriptor

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
@@ -247,10 +246,7 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease, pe
 		// requests, this is kosher). This means that we don't use the old
 		// lease's expiration but instead use the new lease's start to initialize
 		// the timestamp cache low water.
-		desc := r.Desc()
-		for _, keyRange := range rditer.MakeReplicatedKeyRanges(desc) {
-			r.store.tsCache.SetLowWater(keyRange.Start.Key, keyRange.End.Key, newLease.Start)
-		}
+		setTimestampCacheLowWaterMark(r.store.tsCache, r.Desc(), newLease.Start)
 
 		// Reset the request counts used to make lease placement decisions whenever
 		// starting a new lease.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2317,7 +2317,7 @@ func (s *Store) MergeRange(
 		// timestamps in the timestamp cache. For a full discussion, see the comment
 		// on TestStoreRangeMergeTimestampCacheCausality.
 		_ = s.Clock().Update(freezeStart)
-		s.tsCache.SetLowWater(rightDesc.StartKey.AsRawKey(), rightDesc.EndKey.AsRawKey(), freezeStart)
+		setTimestampCacheLowWaterMark(s.tsCache, &rightDesc, freezeStart)
 	}
 
 	// Update the subsuming range's descriptor.


### PR DESCRIPTION
Fixes #36022.

Before this change, a merge would only bump the timestamp cache for
the global keyspace of the subsumed range to the merge freeze timestamp.
Notably, it forgot to set a new low-water mark for the local keyspace
of the subsumed range. This could lead to all kinds of issues, like
the one we saw in #36022 where a transaction committed after being
considered aborted.

Release note (bug fix): Fix bug with Range merges where the timestamp
cache on the combined leaseholder was not bumped to the merge timestamp
over the subsumed Range's local keyspace.