### PR TITLE
sql: make crdb_internal.check_consistency a table generator

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -936,9 +936,9 @@ developers and its definition may change without prior notice.</p>
 <p>Note that uses of this function disable server-side optimizations and
 may increase either contention or retry errors, or both.</p>
 </span></td></tr>
-<tr><td><code>crdb_internal.check_consistency(stats_only: <a href="bool.html">bool</a>, start_key: <a href="bytes.html">bytes</a>, end_key: <a href="bytes.html">bytes</a>) &rarr; tuple{int AS range_id, bytes AS start_key, string AS start_key_pretty, string AS status, string AS detail}[]</code></td><td><span class="funcdesc"><p>Runs a consistency check on ranges touching the specified key range. an empty start or end key is treated as the minimum and maximum possible, respectively. stats_only should only be set to false when targeting a small number of ranges to avoid overloading the cluster. The return value is an array of tuples, with each tuple consisting of the range ID, the status (a roachpb.CheckConsistencyResponse_Status), and verbose detail.</p>
-<p>Example usage:</p>
-<p><code>SELECT (t).* FROM unnest(crdb_internal.check_consistency(true, '\x02', '\x04')) as t;</code></p>
+<tr><td><code>crdb_internal.check_consistency(stats_only: <a href="bool.html">bool</a>, start_key: <a href="bytes.html">bytes</a>, end_key: <a href="bytes.html">bytes</a>) &rarr; tuple{int AS range_id, bytes AS start_key, string AS start_key_pretty, string AS status, string AS detail}</code></td><td><span class="funcdesc"><p>Runs a consistency check on ranges touching the specified key range. an empty start or end key is treated as the minimum and maximum possible, respectively. stats_only should only be set to false when targeting a small number of ranges to avoid overloading the cluster. Each returned row contains the range ID, the status (a roachpb.CheckConsistencyResponse_Status), and verbose detail.</p>
+<p>Example usage:
+SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.cluster_id() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Returns the cluster ID.</p>
 </span></td></tr>

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1834,6 +1834,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			Locality:         ex.server.cfg.Locality,
 			ReCache:          ex.server.reCache,
 			InternalExecutor: ie,
+			DB:               ex.server.cfg.DB,
 		},
 		SessionMutator:  ex.dataMutator,
 		VirtualSchemas:  ex.server.cfg.VirtualSchemas,

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2093,7 +2093,7 @@ statement error start key must be less than end key
 SELECT crdb_internal.check_consistency(true, '\x03', '\x02')
 
 query ITT
-SELECT range_id, status, regexp_replace(detail, '[0-9]+', '', 'g') FROM [ SELECT (t).* FROM unnest(crdb_internal.check_consistency(true, '\x02', '\xffff')) as t WHERE (t).range_id = 1 ]
+SELECT range_id, status, regexp_replace(detail, '[0-9]+', '', 'g') FROM crdb_internal.check_consistency(true, '\x02', '\xffff') WHERE range_id = 1
 ----
 1  RANGE_CONSISTENT  stats: {ContainsEstimates:false LastUpdateNanos: IntentAge: GCBytesAge: LiveBytes: LiveCount: KeyBytes: KeyCount: ValBytes: ValCount: IntentBytes: IntentCount: SysBytes: SysCount: XXX_NoUnkeyedLiteral:{} XXX_sizecache:}
 
@@ -2101,24 +2101,24 @@ SELECT range_id, status, regexp_replace(detail, '[0-9]+', '', 'g') FROM [ SELECT
 # avoid flaking the test when the range count changes, just want to know that
 # we're touching multiple ranges).
 query B
-SELECT count(*) > 5 FROM unnest(crdb_internal.check_consistency(true, '', ''))
+SELECT count(*) > 5 FROM crdb_internal.check_consistency(true, '', '')
 ----
 true
 
 # Query that should touch only a single range.
 query B
-SELECT count(*) = 1 FROM unnest(crdb_internal.check_consistency(true, '\x03', '\x0300'))
+SELECT count(*) = 1 FROM crdb_internal.check_consistency(true, '\x03', '\x0300')
 ----
 true
 
 # Ditto, but implicit start key \x02
 query B
-SELECT count(*) = 1 FROM unnest(crdb_internal.check_consistency(true, '', '\x0200'))
+SELECT count(*) = 1 FROM crdb_internal.check_consistency(true, '', '\x0200')
 ----
 true
 
 # Ditto, but implicit end key.
 query B
-SELECT count(*) = 1 FROM unnest(crdb_internal.check_consistency(true, '\xff', ''))
+SELECT count(*) = 1 FROM crdb_internal.check_consistency(true, '\xff', '')
 ----
 true

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -15,9 +15,14 @@
 package builtins
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -25,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/arith"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/pkg/errors"
 )
 
 // See the comments at the start of generators.go for details about
@@ -175,6 +181,32 @@ var generators = map[string]builtinDefinition{
 	"jsonb_each":                makeBuiltin(genProps(jsonEachGeneratorLabels), jsonEachImpl),
 	"json_each_text":            makeBuiltin(genProps(jsonEachGeneratorLabels), jsonEachTextImpl),
 	"jsonb_each_text":           makeBuiltin(genProps(jsonEachGeneratorLabels), jsonEachTextImpl),
+
+	"crdb_internal.check_consistency": makeBuiltin(
+		tree.FunctionProperties{
+			Impure:       true,
+			Class:        tree.GeneratorClass,
+			Category:     categorySystemInfo,
+			ReturnLabels: []string{"range_id", "start_key", "start_key_pretty", "status", "detail"},
+		},
+		makeGeneratorOverload(
+			tree.ArgTypes{
+				{Name: "stats_only", Typ: types.Bool},
+				{Name: "start_key", Typ: types.Bytes},
+				{Name: "end_key", Typ: types.Bytes},
+			},
+			checkConsistencyGeneratorType,
+			makeCheckConsistencyGenerator,
+			"Runs a consistency check on ranges touching the specified key range. "+
+				"an empty start or end key is treated as the minimum and maximum possible, "+
+				"respectively. stats_only should only be set to false when targeting a "+
+				"small number of ranges to avoid overloading the cluster. Each returned row "+
+				"contains the range ID, the status (a roachpb.CheckConsistencyResponse_Status), "+
+				"and verbose detail.\n\n"+
+				"Example usage:\n"+
+				"SELECT * FROM crdb_internal.check_consistency(true, '\\x02', '\\x04')",
+		),
+	),
 }
 
 func makeGeneratorOverload(
@@ -864,3 +896,106 @@ func (g *jsonEachGenerator) Next() (bool, error) {
 func (g *jsonEachGenerator) Values() tree.Datums {
 	return tree.Datums{g.key, g.value}
 }
+
+type checkConsistencyGenerator struct {
+	ctx      context.Context
+	db       *client.DB
+	from, to roachpb.Key
+	mode     roachpb.ChecksumMode
+	// remainingRows is populated by Start(). Each Next() call peels of the first
+	// row and moves it to curRow.
+	remainingRows []roachpb.CheckConsistencyResponse_Result
+	curRow        roachpb.CheckConsistencyResponse_Result
+}
+
+var _ tree.ValueGenerator = &checkConsistencyGenerator{}
+
+func makeCheckConsistencyGenerator(
+	ctx *tree.EvalContext, args tree.Datums,
+) (tree.ValueGenerator, error) {
+	keyFrom := roachpb.Key(*args[1].(*tree.DBytes))
+	keyTo := roachpb.Key(*args[2].(*tree.DBytes))
+
+	if len(keyFrom) == 0 {
+		keyFrom = keys.LocalMax
+	}
+	if len(keyTo) == 0 {
+		keyTo = roachpb.KeyMax
+	}
+
+	if bytes.Compare(keyFrom, keys.LocalMax) < 0 {
+		return nil, errors.Errorf("start key must be >= %q", []byte(keys.LocalMax))
+	}
+	if bytes.Compare(keyTo, roachpb.KeyMax) > 0 {
+		return nil, errors.Errorf("end key must be < %q", []byte(roachpb.KeyMax))
+	}
+	if bytes.Compare(keyFrom, keyTo) >= 0 {
+		return nil, errors.New("start key must be less than end key")
+	}
+
+	mode := roachpb.ChecksumMode_CHECK_FULL
+	if statsOnly := bool(*args[0].(*tree.DBool)); statsOnly {
+		mode = roachpb.ChecksumMode_CHECK_STATS
+	}
+
+	return &checkConsistencyGenerator{
+		ctx:  ctx.Ctx(),
+		db:   ctx.Txn.DB(),
+		from: keyFrom,
+		to:   keyTo,
+		mode: mode,
+	}, nil
+}
+
+var checkConsistencyGeneratorType = types.TTuple{
+	Labels: []string{"range_id", "start_key", "start_key_pretty", "status", "detail"},
+	Types:  []types.T{types.Int, types.Bytes, types.String, types.String, types.String},
+}
+
+// ResolvedType is part of the tree.ValueGenerator interface.
+func (*checkConsistencyGenerator) ResolvedType() types.T {
+	return checkConsistencyGeneratorType
+}
+
+// Start is part of the tree.ValueGenerator interface.
+func (c *checkConsistencyGenerator) Start() error {
+	var b client.Batch
+	b.AddRawRequest(&roachpb.CheckConsistencyRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key:    c.from,
+			EndKey: c.to,
+		},
+		Mode:     c.mode,
+		WithDiff: true,
+	})
+	if err := c.db.Run(c.ctx, &b); err != nil {
+		return err
+	}
+	resp := b.RawResponse().Responses[0].GetInner().(*roachpb.CheckConsistencyResponse)
+	c.remainingRows = resp.Result
+	return nil
+}
+
+// Next is part of the tree.ValueGenerator interface.
+func (c *checkConsistencyGenerator) Next() (bool, error) {
+	if len(c.remainingRows) == 0 {
+		return false, nil
+	}
+	c.curRow = c.remainingRows[0]
+	c.remainingRows = c.remainingRows[1:]
+	return true, nil
+}
+
+// Values is part of the tree.ValueGenerator interface.
+func (c *checkConsistencyGenerator) Values() tree.Datums {
+	return tree.Datums{
+		tree.NewDInt(tree.DInt(c.curRow.RangeID)),
+		tree.NewDBytes(tree.DBytes(c.curRow.StartKey)),
+		tree.NewDString(roachpb.Key(c.curRow.StartKey).String()),
+		tree.NewDString(c.curRow.Status.String()),
+		tree.NewDString(c.curRow.Detail),
+	}
+}
+
+// Close is part of the tree.ValueGenerator interface.
+func (c *checkConsistencyGenerator) Close() {}

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -940,7 +940,7 @@ func makeCheckConsistencyGenerator(
 
 	return &checkConsistencyGenerator{
 		ctx:  ctx.Ctx(),
-		db:   ctx.Txn.DB(),
+		db:   ctx.DB,
 		from: keyFrom,
 		to:   keyTo,
 		mode: mode,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2563,8 +2563,10 @@ type EvalContext struct {
 
 	Sequence SequenceOperators
 
-	// Ths transaction in which the statement is executing.
+	// The transaction in which the statement is executing.
 	Txn *client.Txn
+	// A handle to the database.
+	DB *client.DB
 
 	ReCache *RegexpCache
 	tmpDec  apd.Decimal


### PR DESCRIPTION
Generate rows instead of an array of tuples. Much easier to use.

Release note: None