### PR TITLE
roachtest: don't stop nodes at end of tpc{c,h}bench

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -730,7 +730,6 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 		return nil
 	})
 	m.Wait()
-	c.Stop(ctx, c.All())
 }
 
 func registerTPCCBench(r *registry) {

--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -91,7 +91,6 @@ func runSQL20Bench(ctx context.Context, t *test, c *cluster, b tpchBenchSpec) {
 		return nil
 	})
 	m.Wait()
-	c.Stop(ctx, c.All())
 }
 
 // loadTPCHBench loads a TPC-H dataset for the specific benchmark spec. The


### PR DESCRIPTION
Fixes #36325.
Touches #36277.
Touches #32135.
Fixes #36022.

Release note: None