### PR TITLE
build: run logic tests in nightly stress

### DIFF
--- a/pkg/cmd/teamcity-trigger/main_test.go
+++ b/pkg/cmd/teamcity-trigger/main_test.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -34,4 +36,44 @@ func TestRunTC(t *testing.T) {
 	if count == 0 {
 		t.Fatal("no builds were created")
 	}
+}
+
+func Example_runTC() {
+	// Shows sample output for two packages, one of which runs with reduced
+	// parallelism.
+	runTC(func(buildID string, opts map[string]string) {
+		pkg := opts["env.PKG"]
+		if !strings.HasSuffix(pkg, "pkg/sql/logictest") && !strings.HasSuffix(pkg, "pkg/storage") {
+			return
+		}
+		var keys []string
+		for k := range opts {
+			if k != "env.PKG" {
+				keys = append(keys, k)
+			}
+		}
+		sort.Strings(keys)
+		fmt.Println(pkg)
+		for _, k := range keys {
+			fmt.Printf("  %-16s %s\n", k+":", opts[k])
+		}
+		fmt.Println()
+	})
+
+	// Output:
+	// github.com/cockroachdb/cockroach/pkg/sql/logictest
+	//   env.GOFLAGS:     -parallel=2
+	//   env.STRESSFLAGS: -p 2
+	//
+	// github.com/cockroachdb/cockroach/pkg/sql/logictest
+	//   env.GOFLAGS:     -race -parallel=1
+	//   env.STRESSFLAGS: -p 1
+	//
+	// github.com/cockroachdb/cockroach/pkg/storage
+	//   env.GOFLAGS:     -parallel=4
+	//   env.STRESSFLAGS: -p 4
+	//
+	// github.com/cockroachdb/cockroach/pkg/storage
+	//   env.GOFLAGS:     -race -parallel=2
+	//   env.STRESSFLAGS: -p 2
 }

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2056,10 +2056,9 @@ var logicTestsConfigFilter = envutil.EnvOrDefaultString("COCKROACH_LOGIC_TESTS_C
 // RunLogicTest is the main entry point for the logic test. The globs parameter
 // specifies the default sets of files to run.
 func RunLogicTest(t *testing.T, globs ...string) {
-	if testutils.NightlyStress() {
-		// See https://github.com/cockroachdb/cockroach/pull/10966.
-		t.Skip()
-	}
+	// Note: there is special code in teamcity-trigger/main.go to run this package
+	// with less concurrency in the nightly stress runs. If you see problems
+	// please make adjustments there.
 
 	if skipLogicTests {
 		t.Skip("COCKROACH_LOGIC_TESTS_SKIP")


### PR DESCRIPTION
We previously skipped it since it had in the past had a tendency to
overload the machine, but this time try instead to run it with lower
parallelism.

It's particularly important to run logic tests under the nightly
stressrace because they aren't run anywhere else in race builds. Note
that race builds also enable additional internal checks in the
optimizer.

Release note: None