### PR TITLE
roachprod: allow specifying AWS profile and assume role

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/keys.go
+++ b/pkg/cmd/roachprod/vm/aws/keys.go
@@ -28,7 +28,7 @@ import (
 const sshPublicKeyFile = "${HOME}/.ssh/id_rsa.pub"
 
 // sshKeyExists checks to see if there is a an SSH key with the given name in the given region.
-func sshKeyExists(keyName string, region string) (bool, error) {
+func (p *Provider) sshKeyExists(keyName string, region string) (bool, error) {
 	var data struct {
 		KeyPairs []struct {
 			KeyName string
@@ -38,7 +38,7 @@ func sshKeyExists(keyName string, region string) (bool, error) {
 		"ec2", "describe-key-pairs",
 		"--region", region,
 	}
-	err := runJSONCommand(args, &data)
+	err := p.runJSONCommand(args, &data)
 	if err != nil {
 		return false, err
 	}
@@ -52,7 +52,7 @@ func sshKeyExists(keyName string, region string) (bool, error) {
 
 // sshKeyImport takes the user's local, public SSH key and imports it into the ec2 region so that
 // we can create new hosts with it.
-func sshKeyImport(keyName string, region string) error {
+func (p *Provider) sshKeyImport(keyName string, region string) error {
 	keyBytes, err := ioutil.ReadFile(os.ExpandEnv(sshPublicKeyFile))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -71,7 +71,7 @@ func sshKeyImport(keyName string, region string) error {
 		"--key-name", keyName,
 		"--public-key-material", string(keyBytes),
 	}
-	return runJSONCommand(args, &data)
+	return p.runJSONCommand(args, &data)
 }
 
 // sshKeyName computes the name of the ec2 ssh key that we'll store the local user's public key in

--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -186,7 +186,7 @@ func (o *providerOpts) ConfigureClusterFlags(flags *pflag.FlagSet) {
 		project = defaultProject
 	}
 	flags.StringVar(&o.Project, ProviderName+"-project", project,
-		"Project to create cluster in")
+		"Project to manage cluster in")
 }
 
 // Provider TODO(peter): document


### PR DESCRIPTION
Previously, roachprod could only use your default AWS profile, and
required that you were interacting with the account as an IAM user.
With this change, a user can specify a `--aws-profile` flag or set a
`AWS_DEFAULT_PROFILE` environment variable which instructs roachprod
to use that profile instead, and roachprod will also work if a user
is assuming a role into the account.

Release note: None