### PR TITLE
release-19.1: sql: produce telemetry for usage of relational operators

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -265,7 +265,9 @@ func (a *applyJoinNode) Next(params runParams) (bool, error) {
 		}
 
 		execFactory := makeExecFactory(params.p)
-		p, err := execbuilder.New(&execFactory, factory.Memo(), newRightSide, params.EvalContext()).Build()
+		eb := execbuilder.New(&execFactory, factory.Memo(), newRightSide, params.EvalContext())
+		eb.DisableTelemetry()
+		p, err := eb.Build()
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -29,6 +29,7 @@ type Builder struct {
 	factory            exec.Factory
 	mem                *memo.Memo
 	e                  opt.Expr
+	disableTelemetry   bool
 	evalCtx            *tree.EvalContext
 	fastIsConstVisitor fastIsConstVisitor
 
@@ -49,6 +50,11 @@ type Builder struct {
 // node tree from the given optimized expression tree.
 func New(factory exec.Factory, mem *memo.Memo, e opt.Expr, evalCtx *tree.EvalContext) *Builder {
 	return &Builder{factory: factory, mem: mem, e: e, evalCtx: evalCtx}
+}
+
+// DisableTelemetry prevents the execbuilder from updating telemetry counters.
+func (b *Builder) DisableTelemetry() {
+	b.disableTelemetry = true
 }
 
 // Build constructs the execution node tree and returns its root node if no

--- a/pkg/sql/opt/exec/execbuilder/testdata/telemetry
+++ b/pkg/sql/opt/exec/execbuilder/testdata/telemetry
@@ -1,0 +1,20 @@
+# LogicTest: local-opt
+
+statement ok
+SELECT EXISTS(SELECT * FROM generate_series(1,2))
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name = 'sql.plan.opt.node.project-set' AND usage_count > 0
+----
+sql.plan.opt.node.project-set
+
+statement ok
+CREATE TABLE t(x INT)
+
+statement ok
+SELECT * FROM t a NATURAL INNER MERGE JOIN t b
+
+query T
+SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name = 'sql.plan.opt.node.merge-join' AND usage_count > 0
+----
+sql.plan.opt.node.merge-join

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -171,7 +171,7 @@ define Project {
 # predicate are filtered. While expressions in the predicate can refer to
 # columns projected by either the left or right inputs, the inputs are not
 # allowed to refer to the other's projected columns.
-[Relational, Join, JoinNonApply]
+[Relational, Join, JoinNonApply, Telemetry]
 define InnerJoin {
     Left  RelExpr
     Right RelExpr
@@ -180,7 +180,7 @@ define InnerJoin {
     _ JoinPrivate
 }
 
-[Relational, Join, JoinNonApply]
+[Relational, Join, JoinNonApply, Telemetry]
 define LeftJoin {
     Left  RelExpr
     Right RelExpr
@@ -189,7 +189,7 @@ define LeftJoin {
    _ JoinPrivate
 }
 
-[Relational, Join, JoinNonApply]
+[Relational, Join, JoinNonApply, Telemetry]
 define RightJoin {
     Left  RelExpr
     Right RelExpr
@@ -198,7 +198,7 @@ define RightJoin {
     _ JoinPrivate
 }
 
-[Relational, Join, JoinNonApply]
+[Relational, Join, JoinNonApply, Telemetry]
 define FullJoin {
     Left  RelExpr
     Right RelExpr
@@ -207,7 +207,7 @@ define FullJoin {
     _ JoinPrivate
 }
 
-[Relational, Join, JoinNonApply]
+[Relational, Join, JoinNonApply, Telemetry]
 define SemiJoin {
     Left  RelExpr
     Right RelExpr
@@ -216,7 +216,7 @@ define SemiJoin {
     _ JoinPrivate
 }
 
-[Relational, Join, JoinNonApply]
+[Relational, Join, JoinNonApply, Telemetry]
 define AntiJoin {
     Left  RelExpr
     Right RelExpr
@@ -260,7 +260,7 @@ define IndexJoinPrivate {
 
 # LookupJoin represents a join between an input expression and an index. The
 # type of join is in the LookupJoinPrivate field.
-[Relational]
+[Relational, Telemetry]
 define LookupJoin {
     Input RelExpr
     On    FiltersExpr
@@ -311,7 +311,7 @@ define LookupJoinPrivate {
 # MergeOn is a scalar which contains the ON condition and merge-join ordering
 # information; see the MergeOn scalar operator.
 # It can be any type of join (identified in the MergeJoinPrivate field).
-[Relational]
+[Relational, Telemetry]
 define MergeJoin {
     Left  RelExpr
     Right RelExpr
@@ -353,7 +353,7 @@ define MergeJoinPrivate {
 # support arbitrary inputs.
 #
 # TODO(itsbilal): Add support for representing multi-way zigzag joins.
-[Relational]
+[Relational, Telemetry]
 define ZigzagJoin {
     On   FiltersExpr
 
@@ -407,7 +407,7 @@ define ZigzagJoinPrivate {
 # InnerJoinApply has the same join semantics as InnerJoin. However, unlike
 # InnerJoin, it allows the right input to refer to columns projected by the
 # left input.
-[Relational, Join, JoinApply]
+[Relational, Join, JoinApply, Telemetry]
 define InnerJoinApply {
     Left  RelExpr
     Right RelExpr
@@ -416,7 +416,7 @@ define InnerJoinApply {
     _ JoinPrivate
 }
 
-[Relational, Join, JoinApply]
+[Relational, Join, JoinApply, Telemetry]
 define LeftJoinApply {
     Left  RelExpr
     Right RelExpr
@@ -425,7 +425,7 @@ define LeftJoinApply {
     _ JoinPrivate
 }
 
-[Relational, Join, JoinApply]
+[Relational, Join, JoinApply, Telemetry]
 define RightJoinApply {
     Left  RelExpr
     Right RelExpr
@@ -434,7 +434,7 @@ define RightJoinApply {
     _ JoinPrivate
 }
 
-[Relational, Join, JoinApply]
+[Relational, Join, JoinApply, Telemetry]
 define FullJoinApply {
     Left  RelExpr
     Right RelExpr
@@ -443,7 +443,7 @@ define FullJoinApply {
     _ JoinPrivate
 }
 
-[Relational, Join, JoinApply]
+[Relational, Join, JoinApply, Telemetry]
 define SemiJoinApply {
     Left  RelExpr
     Right RelExpr
@@ -452,7 +452,7 @@ define SemiJoinApply {
     _ JoinPrivate
 }
 
-[Relational, Join, JoinApply]
+[Relational, Join, JoinApply, Telemetry]
 define AntiJoinApply {
     Left  RelExpr
     Right RelExpr
@@ -479,7 +479,7 @@ define AntiJoinApply {
 # dependent aggregation (like ARRAY_AGG). Grouping columns are inconsequential
 # in this ordering; we currently set all grouping columns as optional in this
 # ordering (but note that this is not required by the operator).
-[Relational, Grouping]
+[Relational, Grouping, Telemetry]
 define GroupBy {
     Input        RelExpr
     Aggregations AggregationsExpr
@@ -523,7 +523,7 @@ define GroupingPrivate {
 # GroupBy and can be used in the same rules (when appropriate). In the
 # ScalarGroupBy case, the grouping column field in GroupingPrivate is always
 # empty.
-[Relational, Grouping]
+[Relational, Grouping, Telemetry]
 define ScalarGroupBy {
     Input        RelExpr
     Aggregations AggregationsExpr
@@ -565,7 +565,7 @@ define ScalarGroupBy {
 # it's polymorphic with GroupBy and can be used in the same rules (when
 # appropriate). In the DistinctOn case, the aggregations can be only FirstAgg or
 # ConstAgg.
-[Relational, Grouping]
+[Relational, Grouping, Telemetry]
 define DistinctOn {
     Input        RelExpr
     Aggregations AggregationsExpr
@@ -827,7 +827,7 @@ define RowNumberPrivate {
 # of R with zip(a,b,c).
 #
 # See the Zip header for more details.
-[Relational]
+[Relational, Telemetry]
 define ProjectSet {
     Input RelExpr
     Zip   ZipExpr

--- a/pkg/sql/opt/telemetry.go
+++ b/pkg/sql/opt/telemetry.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package opt
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+)
+
+// OpTelemetryCounters stores telemetry counters for operators marked with the
+// "Telemetry" tag. All other operators have nil values.
+var OpTelemetryCounters [NumOperators]telemetry.Counter
+
+func init() {
+	for _, op := range TelemetryOperators {
+		OpTelemetryCounters[op] = sqltelemetry.OptNodeCounter(op.String())
+	}
+}

--- a/pkg/sql/sqltelemetry/opt.go
+++ b/pkg/sql/sqltelemetry/opt.go
@@ -1,0 +1,28 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqltelemetry
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+)
+
+// OptNodeCounter should be incremented every time a node of the given
+// type is encountered at the end of the query optimization (i.e. it
+// counts the nodes actually used for physical planning).
+func OptNodeCounter(nodeType string) telemetry.Counter {
+	return telemetry.GetCounterOnce(fmt.Sprintf("sql.plan.opt.node.%s", nodeType))
+}


### PR DESCRIPTION
Backport 1/1 commits from #35679.

/cc @cockroachdb/release

---

This adds telemetry for use of opt nodes at the end of
optimizations (in the exec build phase).

The telemetry counters have the form `sql.plan.opt.node.xxxxx`.

Release note (sql change): CockroachDB will now report uses of the
various relational logical plan operators in telemetry, when telemetry
is enabled, to help guide future optimization efforts.
