### PR TITLE
roachprod: change the location cores are written to

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/support.go
+++ b/pkg/cmd/roachprod/vm/aws/support.go
@@ -99,9 +99,9 @@ root soft core unlimited
 root hard core unlimited
 EOF
 
-mkdir -p /tmp/cores
-chmod a+w /tmp/cores
-CORE_PATTERN="/tmp/cores/core.%e.%p.%h.%t"
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
+CORE_PATTERN="/mnt/data1/cores/core.%e.%p.%h.%t"
 echo "$CORE_PATTERN" > /proc/sys/kernel/core_pattern
 sed -i'~' 's/enabled=1/enabled=0/' /etc/default/apport
 sed -i'~' '/.*kernel\\.core_pattern.*/c\\' /etc/sysctl.conf

--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -99,9 +99,9 @@ root soft core unlimited
 root hard core unlimited
 EOF
 
-mkdir -p /tmp/cores
-chmod a+w /tmp/cores
-CORE_PATTERN="/tmp/cores/core.%e.%p.%h.%t"
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
+CORE_PATTERN="/mnt/data1/cores/core.%e.%p.%h.%t"
 echo "$CORE_PATTERN" > /proc/sys/kernel/core_pattern
 sed -i'~' 's/enabled=1/enabled=0/' /etc/default/apport
 sed -i'~' '/.*kernel\\.core_pattern.*/c\\' /etc/sysctl.conf

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1002,7 +1002,7 @@ func (c *cluster) FetchCores(ctx context.Context) error {
 	// timeout.
 	return contextutil.RunWithTimeout(ctx, "cores", 60*time.Second, func(ctx context.Context) error {
 		path := filepath.Join(c.t.ArtifactsDir(), "cores")
-		return execCmd(ctx, c.l, roachprod, "get", c.name, "/tmp/cores" /* src */, path /* dest */)
+		return execCmd(ctx, c.l, roachprod, "get", c.name, "/mnt/data1/cores" /* src */, path /* dest */)
 	})
 }
 


### PR DESCRIPTION
/tmp is only 10GB in size, while /mnt/data1 is 370GB.

Fixes #35621

Release note: None