### PR TITLE
release-19.1: opt: fix panic when creating index constraints for TrueFilter

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -310,3 +310,19 @@ UPDATE t9 SET a = 7 WHERE a = 4
 
 statement error pgcode 23514 failed to satisfy CHECK constraint \(a > b\)
 UPDATE t9 SET a = 2 WHERE a = 5
+
+# Regression test for #36293. Make sure we don't panic with a false check
+# constraint.
+statement ok
+CREATE TABLE t36293 (x bool)
+
+statement ok
+ALTER TABLE t36293
+  ADD COLUMN y INT
+  CHECK (
+    CASE
+    WHEN false
+    THEN x
+    ELSE false
+    END
+  )

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -604,12 +604,17 @@ func (c *indexConstraintCtx) makeSpansForExpr(
 
 	switch t := e.(type) {
 	case *memo.FiltersExpr:
-		if len(*t) == 1 {
+		switch len(*t) {
+		case 0:
+			c.unconstrained(offset, out)
+			return true
+		case 1:
 			return c.makeSpansForExpr(offset, (*t)[0].Condition, out)
+		default:
+			// We don't have enough information to know if the spans are "tight".
+			c.makeSpansForAnd(offset, t, out)
+			return false
 		}
-		// We don't have enough information to know if the spans are "tight".
-		c.makeSpansForAnd(offset, t, out)
-		return false
 
 	case *memo.FiltersItem:
 		// Pass through the call.

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -152,6 +152,9 @@ func TestIndexConstraints(t *testing.T) {
 				}
 				root := f.Memo().RootExpr().(opt.ScalarExpr)
 				filters := memo.FiltersExpr{{Condition: root}}
+				if _, ok := root.(*memo.TrueExpr); ok {
+					filters = memo.TrueFilter
+				}
 
 				var ic idxconstraint.Instance
 				ic.Init(filters, indexCols, notNullCols, invertedIndex, &evalCtx, &f)

--- a/pkg/sql/opt/idxconstraint/testdata/misc
+++ b/pkg/sql/opt/idxconstraint/testdata/misc
@@ -251,3 +251,8 @@ index-constraints vars=(string) index=(@1)
 ----
 [/e'a\x00' - ]
 Remaining filter: length(@1) = 2
+
+index-constraints vars=(bool) index=(@1)
+true
+----
+[ - ]


### PR DESCRIPTION
Backport 1/1 commits from #36343.

/cc @cockroachdb/release

---

Prior to this commit, the index constraints code did not correctly
handle the `TrueFilter` expression, which is an empty `Filters`
expression. It always assumed there was at least one filter, thus
resulting in an index out of range panic when `TrueFilter` was
passed in. This commit adds logic to handle an empty `Filters`
expression correctly.

Fixes #36293

Release note (bug fix): Fixed a panic that occurred when
adding logically false check constraints on a column.
