### PR TITLE
release-19.1: storage: set tscache low-water mark for local keyspace after merge

### DIFF
--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -465,6 +465,21 @@ func mergeCheckingTimestampCaches(t *testing.T, disjointLeaseholders bool) {
 		t.Fatalf("expected read to execute at %v, but executed at %v", readTS, br.Timestamp)
 	}
 
+	// Simulate a txn abort on the RHS from a node with a newer clock. Because
+	// the transaction record for the pushee was not yet written, this will bump
+	// the write timestamp cache to record the abort.
+	pushee := roachpb.MakeTransaction("pushee", rhsKey, roachpb.MinUserPriority, readTS, 0)
+	pusher := roachpb.MakeTransaction("pusher", rhsKey, roachpb.MaxUserPriority, readTS, 0)
+	ba = roachpb.BatchRequest{}
+	ba.Timestamp = readTS
+	ba.RangeID = rhsDesc.RangeID
+	ba.Add(pushTxnArgs(&pusher, &pushee, roachpb.PUSH_ABORT))
+	if br, pErr := rhsStore.Send(ctx, ba); pErr != nil {
+		t.Fatal(pErr)
+	} else if txn := br.Responses[0].GetPushTxn().PusheeTxn; txn.Status != roachpb.ABORTED {
+		t.Fatalf("expected aborted pushee, but got %v", txn)
+	}
+
 	// Merge the RHS back into the LHS.
 	args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
 	if _, pErr := client.SendWrapped(ctx, lhsStore.TestSender(), args); pErr != nil {
@@ -481,6 +496,31 @@ func mergeCheckingTimestampCaches(t *testing.T, disjointLeaseholders bool) {
 		t.Fatal(pErr)
 	} else if !readTS.Less(br.Timestamp) {
 		t.Fatalf("expected write to execute after %v, but executed at %v", readTS, br.Timestamp)
+	}
+
+	// Attempt to create a transaction record for the pushee transaction, which
+	// was aborted before the merge. This should be rejected with a transaction
+	// aborted error. The reason will depend on whether the leaseholders were
+	// disjoint or not because disjoint leaseholders will lead to a loss of
+	// resolution in the timestamp cache. Either way though, the transaction
+	// should not be allowed to create its record.
+	hb, hbH := heartbeatArgs(&pushee, mtc.clock.Now())
+	ba = roachpb.BatchRequest{}
+	ba.Header = hbH
+	ba.RangeID = lhsDesc.RangeID
+	ba.Add(hb)
+	var expReason roachpb.TransactionAbortedReason
+	if disjointLeaseholders {
+		expReason = roachpb.ABORT_REASON_TIMESTAMP_CACHE_REJECTED_POSSIBLE_REPLAY
+	} else {
+		expReason = roachpb.ABORT_REASON_ABORTED_RECORD_FOUND
+	}
+	if _, pErr := lhsStore.Send(ctx, ba); pErr == nil {
+		t.Fatalf("expected TransactionAbortedError(%s) but got %v", expReason, pErr)
+	} else if abortErr, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); !ok {
+		t.Fatalf("expected TransactionAbortedError(%s) but got %v", expReason, pErr)
+	} else if abortErr.Reason != expReason {
+		t.Fatalf("expected TransactionAbortedError(%s) but got %v", expReason, pErr)
 	}
 }
 

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1413,6 +1413,20 @@ func heartbeatArgs(
 	}, roachpb.Header{Txn: txn}
 }
 
+func pushTxnArgs(
+	pusher, pushee *roachpb.Transaction, pushType roachpb.PushTxnType,
+) *roachpb.PushTxnRequest {
+	return &roachpb.PushTxnRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: pushee.Key,
+		},
+		PushTo:    pusher.Timestamp.Next(),
+		PusherTxn: *pusher,
+		PusheeTxn: pushee.TxnMeta,
+		PushType:  pushType,
+	}
+}
+
 func TestSortRangeDescByAge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var replicaDescs []roachpb.ReplicaDescriptor

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
@@ -247,10 +246,7 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease, pe
 		// requests, this is kosher). This means that we don't use the old
 		// lease's expiration but instead use the new lease's start to initialize
 		// the timestamp cache low water.
-		desc := r.Desc()
-		for _, keyRange := range rditer.MakeReplicatedKeyRanges(desc) {
-			r.store.tsCache.SetLowWater(keyRange.Start.Key, keyRange.End.Key, newLease.Start)
-		}
+		setTimestampCacheLowWaterMark(r.store.tsCache, r.Desc(), newLease.Start)
 
 		// Reset the request counts used to make lease placement decisions whenever
 		// starting a new lease.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2305,7 +2305,7 @@ func (s *Store) MergeRange(
 		// timestamps in the timestamp cache. For a full discussion, see the comment
 		// on TestStoreRangeMergeTimestampCacheCausality.
 		_ = s.Clock().Update(freezeStart)
-		s.tsCache.SetLowWater(rightDesc.StartKey.AsRawKey(), rightDesc.EndKey.AsRawKey(), freezeStart)
+		setTimestampCacheLowWaterMark(s.tsCache, &rightDesc, freezeStart)
 	}
 
 	// Update the subsuming range's descriptor.


### PR DESCRIPTION
Backport 1/1 commits from #36318.

/cc @cockroachdb/release

---

Fixes #36022.

Before this change, a merge would only bump the timestamp cache for
the global keyspace of the subsumed range to the merge freeze timestamp.
Notably, it forgot to set a new low-water mark for the local keyspace
of the subsumed range. This could lead to all kinds of issues, like
the one we saw in #36022 where a transaction committed after being
considered aborted.

Release note (bug fix): Fix bug with Range merges where the timestamp
cache on the combined leaseholder was not bumped to the merge timestamp
over the subsumed Range's local keyspace.
