### PR TITLE
backport-19.1: sql: accommodate no zone config for table/index on schema changer

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1565,6 +1565,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 		if s.testingKnobs.AsyncExecQuickly {
 			delay = 20 * time.Millisecond
 		}
+		defTTL := config.DefaultZoneConfig().GC.TTLSeconds
 
 		execOneSchemaChange := func(schemaChangers map[sqlbase.ID]SchemaChanger) {
 			for tableID, sc := range schemaChangers {
@@ -1624,8 +1625,12 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 					for id, sc := range s.forGC {
 						zoneCfg, placeholder, _, err := ZoneConfigHook(cfg, uint32(id))
 						if err != nil {
-							log.Errorf(ctx, "no zone config for desc: %d", id)
+							log.Errorf(ctx, "zone config for desc: %d, err = %+v", id, err)
 							return
+						}
+						if zoneCfg == nil {
+							// Do nothing, use the old zone config's TTL.
+							continue
 						}
 						if placeholder == nil {
 							placeholder = zoneCfg
@@ -1720,22 +1725,25 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 						if len(table.GCMutations) > 0 {
 							zoneCfg, placeholder, _, err := ZoneConfigHook(cfg, uint32(table.ID))
 							if err != nil {
-								log.Errorf(ctx, "no zone config for desc: %d", table.ID)
+								log.Errorf(ctx, "zone config for desc: %d, err = %+v", table.ID, err)
 								return
 							}
+
 							if placeholder == nil {
 								placeholder = zoneCfg
 							}
 
 							for _, m := range table.GCMutations {
-								ttlSeconds := zoneCfg.GC.TTLSeconds
-								if subzone := placeholder.GetSubzone(uint32(m.IndexID), ""); subzone != nil {
-									ttlSeconds = subzone.Config.GC.TTLSeconds
+								// Initialize TTL without a zone config in case it's not present.
+								ttlSeconds := defTTL
+								if zoneCfg != nil {
+									ttlSeconds = zoneCfg.GC.TTLSeconds
+									if subzone := placeholder.GetSubzone(uint32(m.IndexID), ""); subzone != nil {
+										ttlSeconds = subzone.Config.GC.TTLSeconds
+									}
 								}
+								deadline := m.DropTime + int64(delay) + int64(ttlSeconds)*time.Second.Nanoseconds()
 
-								deadline := m.DropTime +
-									int64(ttlSeconds)*time.Second.Nanoseconds() +
-									int64(delay)
 								dropped := droppedIndex{m.IndexID, m.DropTime, deadline}
 								if minDeadline == 0 || deadline < minDeadline {
 									minDeadline = deadline
@@ -1769,12 +1777,17 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 								schemaChanger.dropTime = table.DropTime
 								zoneCfg, _, _, err := ZoneConfigHook(cfg, uint32(table.ID))
 								if err != nil {
-									log.Errorf(ctx, "no zone config for desc: %d", table.ID)
+									log.Errorf(ctx, "zone config for desc: %d, err: %+v", table.ID, err)
 									return
 								}
-								deadline := table.DropTime +
-									int64(zoneCfg.GC.TTLSeconds)*time.Second.Nanoseconds() +
-									int64(delay)
+
+								// Initialize deadline without a zone config in case it's not present.
+								deadline := table.DropTime + int64(delay)
+								if zoneCfg != nil {
+									deadline += int64(zoneCfg.GC.TTLSeconds) * time.Second.Nanoseconds()
+								} else {
+									deadline += int64(defTTL) * time.Second.Nanoseconds()
+								}
 								if minDeadline == 0 || deadline < minDeadline {
 									minDeadline = deadline
 								}

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -149,7 +149,8 @@ func completeZoneConfig(
 
 // ZoneConfigHook returns the zone config for the object with id using the
 // cached system config. If keySuffix is within a subzone, the subzone's config
-// is returned instead.
+// is returned instead. The bool is set to true when the value returned is
+// cached.
 func ZoneConfigHook(
 	cfg *config.SystemConfig, id uint32,
 ) (*config.ZoneConfig, *config.ZoneConfig, bool, error) {


### PR DESCRIPTION
Backport 1/1 commits from #35991.

/cc @cockroachdb/release

---

The schema changer process runs asynchronously and can
therefore sometimes not see a zone config that has already been
dropped. It should be resilient to such failures.

fixes #35988 

Release note: None
