### PR TITLE
followerreadsccl,storage: disallow nontransactional read-only reqs

### DIFF
--- a/pkg/ccl/followerreadsccl/followerreads_test.go
+++ b/pkg/ccl/followerreadsccl/followerreads_test.go
@@ -71,6 +71,11 @@ func TestCanSendToFollower(t *testing.T) {
 	if canSendToFollower(uuid.MakeV4(), st, rw) {
 		t.Fatalf("should not be able to send a rw request to a follower")
 	}
+	roNonTxn := roachpb.BatchRequest{Header: oldHeader}
+	roNonTxn.Add(&roachpb.QueryTxnRequest{})
+	if canSendToFollower(uuid.MakeV4(), st, roNonTxn) {
+		t.Fatalf("should not be able to send a non-transactional ro request to a follower")
+	}
 	roNoTxn := roachpb.BatchRequest{}
 	roNoTxn.Add(&roachpb.GetRequest{})
 	if canSendToFollower(uuid.MakeV4(), st, roNoTxn) {

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -911,7 +911,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 			// re-run as part of a transaction for consistency. The
 			// case where we don't need to re-run is if the read
 			// consistency is not required.
-			if ba.Txn == nil && ba.IsPossibleTransaction() && ba.ReadConsistency == roachpb.CONSISTENT {
+			if ba.Txn == nil && ba.IsTransactional() && ba.ReadConsistency == roachpb.CONSISTENT {
 				responseCh <- response{pErr: roachpb.NewError(&roachpb.OpRequiresTxnError{})}
 				return
 			}

--- a/pkg/storage/replica_follower_read.go
+++ b/pkg/storage/replica_follower_read.go
@@ -44,8 +44,9 @@ func (r *Replica) canServeFollowerRead(
 	canServeFollowerRead := false
 	if lErr, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); ok &&
 		lErr.LeaseHolder != nil && lErr.Lease.Type() == roachpb.LeaseEpoch &&
-		FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV) &&
-		(ba.Txn == nil || !ba.Txn.IsWriting()) {
+		ba.IsAllTransactional() && // followerreadsccl.batchCanBeEvaluatedOnFollower
+		(ba.Txn == nil || !ba.Txn.IsWriting()) && // followerreadsccl.txnCanPerformFollowerRead
+		FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV) {
 
 		ts := ba.Timestamp
 		if ba.Txn != nil {


### PR DESCRIPTION
Fixes #36276.

This PR ensures that "non-transactional" read-only requests like
`QueryTxn` requests are never evaluated on a follower. These requests
are not consistent about the timestamp that they assign and they
also occasionally have side-effects that only behave correctly when
evaluated on a leaseholder replica.

Release note: None