### PR TITLE
sql: fix crash when subzone not configured with GC policy

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -208,3 +208,7 @@ scan  ·      ·
 
 statement ok
 DEALLOCATE p
+
+# test for #36348; place this at the bottom of this file.
+statement ok
+DROP INDEX t@secondary

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1738,7 +1738,8 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 								droppedIdx := &sc.dropIndexTimes[i]
 
 								ttlSeconds := zoneCfg.GC.TTLSeconds
-								if subzone := placeholder.GetSubzone(uint32(droppedIdx.indexID), ""); subzone != nil {
+								if subzone := placeholder.GetSubzone(
+									uint32(droppedIdx.indexID), ""); subzone != nil && subzone.Config.GC != nil {
 									ttlSeconds = subzone.Config.GC.TTLSeconds
 								}
 
@@ -1826,7 +1827,8 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 								ttlSeconds := defTTL
 								if zoneCfg != nil {
 									ttlSeconds = zoneCfg.GC.TTLSeconds
-									if subzone := placeholder.GetSubzone(uint32(m.IndexID), ""); subzone != nil {
+									if subzone := placeholder.GetSubzone(
+										uint32(m.IndexID), ""); subzone != nil && subzone.Config.GC != nil {
 										ttlSeconds = subzone.Config.GC.TTLSeconds
 									}
 								}


### PR DESCRIPTION
fixes #36348

Release note: None