### PR TITLE
jobs: some API cleanup

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1094,14 +1094,16 @@ func backupPlanHook(
 }
 
 type backupResumer struct {
+	job      *jobs.Job
 	settings *cluster.Settings
 	res      roachpb.BulkOpSummary
 }
 
+// Resume is part of the jobs.Resumer interface.
 func (b *backupResumer) Resume(
-	ctx context.Context, job *jobs.Job, phs interface{}, resultsCh chan<- tree.Datums,
+	ctx context.Context, phs interface{}, resultsCh chan<- tree.Datums,
 ) error {
-	details := job.Details().(jobspb.BackupDetails)
+	details := b.job.Details().(jobspb.BackupDetails)
 	p := phs.(sql.PlanHookState)
 
 	if len(details.BackupDescriptor) == 0 {
@@ -1135,7 +1137,7 @@ func (b *backupResumer) Resume(
 		// checkpoint, which is more troubling. Sadly, storageccl doesn't provide a
 		// "not found" error that's consistent across all ExportStorage
 		// implementations.
-		log.Warningf(ctx, "unable to load backup checkpoint while resuming job %d: %v", *job.ID(), err)
+		log.Warningf(ctx, "unable to load backup checkpoint while resuming job %d: %v", *b.job.ID(), err)
 	}
 	res, err := backup(
 		ctx,
@@ -1143,7 +1145,7 @@ func (b *backupResumer) Resume(
 		p.ExecCfg().Gossip,
 		p.ExecCfg().Settings,
 		exportStore,
-		job,
+		b.job,
 		&backupDesc,
 		checkpointDesc,
 		resultsCh,
@@ -1152,15 +1154,19 @@ func (b *backupResumer) Resume(
 	return err
 }
 
-func (b *backupResumer) OnFailOrCancel(context.Context, *client.Txn, *jobs.Job) error { return nil }
-func (b *backupResumer) OnSuccess(context.Context, *client.Txn, *jobs.Job) error      { return nil }
+// OnFailOrCancel is part of the jobs.Resumer interface.
+func (b *backupResumer) OnFailOrCancel(context.Context, *client.Txn) error { return nil }
 
+// OnSuccess is part of the jobs.Resumer interface.
+func (b *backupResumer) OnSuccess(context.Context, *client.Txn) error { return nil }
+
+// OnTerminal is part of the jobs.Resumer interface.
 func (b *backupResumer) OnTerminal(
-	ctx context.Context, job *jobs.Job, status jobs.Status, resultsCh chan<- tree.Datums,
+	ctx context.Context, status jobs.Status, resultsCh chan<- tree.Datums,
 ) {
 	// Attempt to delete BACKUP-CHECKPOINT.
 	if err := func() error {
-		details := job.Details().(jobspb.BackupDetails)
+		details := b.job.Details().(jobspb.BackupDetails)
 		conf, err := storageccl.ExportStorageConfFromURI(details.URI)
 		if err != nil {
 			return err
@@ -1181,7 +1187,7 @@ func (b *backupResumer) OnTerminal(
 		// the current coordinator's counts.
 
 		resultsCh <- tree.Datums{
-			tree.NewDInt(tree.DInt(*job.ID())),
+			tree.NewDInt(tree.DInt(*b.job.ID())),
 			tree.NewDString(string(jobs.StatusSucceeded)),
 			tree.NewDFloat(tree.DFloat(1.0)),
 			tree.NewDInt(tree.DInt(b.res.Rows)),
@@ -1246,9 +1252,13 @@ var _ jobs.Resumer = &backupResumer{}
 
 func init() {
 	sql.AddPlanHook(backupPlanHook)
-	jobs.RegisterConstructor(jobspb.TypeBackup, func(settings *cluster.Settings) jobs.Resumer {
-		return &backupResumer{
-			settings: settings,
-		}
-	})
+	jobs.RegisterConstructor(
+		jobspb.TypeBackup,
+		func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
+			return &backupResumer{
+				job:      job,
+				settings: settings,
+			}
+		},
+	)
 }

--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -1192,18 +1192,6 @@ func (b *backupResumer) OnTerminal(
 	}
 }
 
-var _ jobs.Resumer = &backupResumer{}
-
-func backupResumeHook(typ jobspb.Type, settings *cluster.Settings) jobs.Resumer {
-	if typ != jobspb.TypeBackup {
-		return nil
-	}
-
-	return &backupResumer{
-		settings: settings,
-	}
-}
-
 type versionedValues struct {
 	Key    roachpb.Key
 	Values []roachpb.Value
@@ -1254,7 +1242,13 @@ func getAllRevisions(
 	return res, nil
 }
 
+var _ jobs.Resumer = &backupResumer{}
+
 func init() {
 	sql.AddPlanHook(backupPlanHook)
-	jobs.AddResumeHook(backupResumeHook)
+	jobs.RegisterConstructor(jobspb.TypeBackup, func(settings *cluster.Settings) jobs.Resumer {
+		return &backupResumer{
+			settings: settings,
+		}
+	})
 }

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -1432,6 +1432,7 @@ func loadBackupSQLDescs(
 }
 
 type restoreResumer struct {
+	job            *jobs.Job
 	settings       *cluster.Settings
 	res            roachpb.BulkOpSummary
 	databases      []*sqlbase.DatabaseDescriptor
@@ -1439,10 +1440,11 @@ type restoreResumer struct {
 	statsRefresher *stats.Refresher
 }
 
+// Resume is part of the jobs.Resumer interface.
 func (r *restoreResumer) Resume(
-	ctx context.Context, job *jobs.Job, phs interface{}, resultsCh chan<- tree.Datums,
+	ctx context.Context, phs interface{}, resultsCh chan<- tree.Datums,
 ) error {
-	details := job.Details().(jobspb.RestoreDetails)
+	details := r.job.Details().(jobspb.RestoreDetails)
 	p := phs.(sql.PlanHookState)
 
 	backupDescs, sqlDescs, err := loadBackupSQLDescs(ctx, details, r.settings)
@@ -1459,7 +1461,7 @@ func (r *restoreResumer) Resume(
 		sqlDescs,
 		details.TableRewrites,
 		details.OverrideDB,
-		job,
+		r.job,
 		resultsCh,
 	)
 	r.res = res
@@ -1469,12 +1471,12 @@ func (r *restoreResumer) Resume(
 	return err
 }
 
-// OnFailOrCancel removes KV data that has been committed from a restore that
-// has failed or been canceled. It does this by adding the table descriptors
-// in DROP state, which causes the schema change stuff to delete the keys
-// in the background.
-func (r *restoreResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn, job *jobs.Job) error {
-	details := job.Details().(jobspb.RestoreDetails)
+// OnFailOrCancel is part of the jobs.Resumer interface. Removes KV data that
+// has been committed from a restore that has failed or been canceled. It does
+// this by adding the table descriptors in DROP state, which causes the schema
+// change stuff to delete the keys in the background.
+func (r *restoreResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn) error {
+	details := r.job.Details().(jobspb.RestoreDetails)
 
 	// Needed to trigger the schema change manager.
 	if err := txn.SetSystemConfigTrigger(); err != nil {
@@ -1488,13 +1490,14 @@ func (r *restoreResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn, jo
 	return txn.Run(ctx, b)
 }
 
-func (r *restoreResumer) OnSuccess(ctx context.Context, txn *client.Txn, job *jobs.Job) error {
+// OnSuccess is part of the jobs.Resumer interface.
+func (r *restoreResumer) OnSuccess(ctx context.Context, txn *client.Txn) error {
 	log.Event(ctx, "making tables live")
 
 	// Write the new TableDescriptors and flip the namespace entries over to
 	// them. After this call, any queries on a table will be served by the newly
 	// restored data.
-	if err := WriteTableDescs(ctx, txn, r.databases, r.tables, job.Payload().Username, r.settings, nil); err != nil {
+	if err := WriteTableDescs(ctx, txn, r.databases, r.tables, r.job.Payload().Username, r.settings, nil); err != nil {
 		return pgerror.Wrapf(err, pgerror.CodeDataExceptionError,
 			"restoring %d TableDescriptors", len(r.tables))
 	}
@@ -1509,8 +1512,9 @@ func (r *restoreResumer) OnSuccess(ctx context.Context, txn *client.Txn, job *jo
 	return nil
 }
 
+// OnTerminal is part of the jobs.Resumer interface.
 func (r *restoreResumer) OnTerminal(
-	ctx context.Context, job *jobs.Job, status jobs.Status, resultsCh chan<- tree.Datums,
+	ctx context.Context, status jobs.Status, resultsCh chan<- tree.Datums,
 ) {
 	if status == jobs.StatusSucceeded {
 		// TODO(benesch): emit periodic progress updates.
@@ -1519,7 +1523,7 @@ func (r *restoreResumer) OnTerminal(
 		// the current coordinator's counts.
 
 		resultsCh <- tree.Datums{
-			tree.NewDInt(tree.DInt(*job.ID())),
+			tree.NewDInt(tree.DInt(*r.job.ID())),
 			tree.NewDString(string(jobs.StatusSucceeded)),
 			tree.NewDFloat(tree.DFloat(1.0)),
 			tree.NewDInt(tree.DInt(r.res.Rows)),
@@ -1534,9 +1538,13 @@ var _ jobs.Resumer = &restoreResumer{}
 
 func init() {
 	sql.AddPlanHook(restorePlanHook)
-	jobs.RegisterConstructor(jobspb.TypeRestore, func(settings *cluster.Settings) jobs.Resumer {
-		return &restoreResumer{
-			settings: settings,
-		}
-	})
+	jobs.RegisterConstructor(
+		jobspb.TypeRestore,
+		func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
+			return &restoreResumer{
+				job:      job,
+				settings: settings,
+			}
+		},
+	)
 }

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -1532,17 +1532,11 @@ func (r *restoreResumer) OnTerminal(
 
 var _ jobs.Resumer = &restoreResumer{}
 
-func restoreResumeHook(typ jobspb.Type, settings *cluster.Settings) jobs.Resumer {
-	if typ != jobspb.TypeRestore {
-		return nil
-	}
-
-	return &restoreResumer{
-		settings: settings,
-	}
-}
-
 func init() {
 	sql.AddPlanHook(restorePlanHook)
-	jobs.AddResumeHook(restoreResumeHook)
+	jobs.RegisterConstructor(jobspb.TypeRestore, func(settings *cluster.Settings) jobs.Resumer {
+		return &restoreResumer{
+			settings: settings,
+		}
+	})
 }

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -37,7 +37,9 @@ import (
 
 func init() {
 	sql.AddPlanHook(changefeedPlanHook)
-	jobs.AddResumeHook(changefeedResumeHook)
+	jobs.RegisterConstructor(jobspb.TypeChangefeed, func(_ *cluster.Settings) jobs.Resumer {
+		return &changefeedResumer{}
+	})
 }
 
 type envelopeType string
@@ -520,11 +522,4 @@ func (b *changefeedResumer) OnSuccess(context.Context, *client.Txn, *jobs.Job) e
 func (b *changefeedResumer) OnTerminal(
 	context.Context, *jobs.Job, jobs.Status, chan<- tree.Datums,
 ) {
-}
-
-func changefeedResumeHook(typ jobspb.Type, _ *cluster.Settings) jobs.Resumer {
-	if typ != jobspb.TypeChangefeed {
-		return nil
-	}
-	return &changefeedResumer{}
 }

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -37,9 +37,12 @@ import (
 
 func init() {
 	sql.AddPlanHook(changefeedPlanHook)
-	jobs.RegisterConstructor(jobspb.TypeChangefeed, func(_ *cluster.Settings) jobs.Resumer {
-		return &changefeedResumer{}
-	})
+	jobs.RegisterConstructor(
+		jobspb.TypeChangefeed,
+		func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
+			return &changefeedResumer{job: job}
+		},
+	)
 }
 
 type envelopeType string
@@ -415,16 +418,19 @@ func validateChangefeedTable(
 	return nil
 }
 
-type changefeedResumer struct{}
+type changefeedResumer struct {
+	job *jobs.Job
+}
 
+// Resume is part of the jobs.Resumer interface.
 func (b *changefeedResumer) Resume(
-	ctx context.Context, job *jobs.Job, planHookState interface{}, startedCh chan<- tree.Datums,
+	ctx context.Context, planHookState interface{}, startedCh chan<- tree.Datums,
 ) error {
 	phs := planHookState.(sql.PlanHookState)
 	execCfg := phs.ExecCfg()
-	jobID := *job.ID()
-	details := job.Details().(jobspb.ChangefeedDetails)
-	progress := job.Progress()
+	jobID := *b.job.ID()
+	details := b.job.Details().(jobspb.ChangefeedDetails)
+	progress := b.job.Progress()
 
 	// TODO(dan): This is a workaround for not being able to set an initial
 	// progress high-water when creating a job (currently only the progress
@@ -517,9 +523,11 @@ func (b *changefeedResumer) Resume(
 	return errors.Wrap(err, `ran out of retries`)
 }
 
-func (b *changefeedResumer) OnFailOrCancel(context.Context, *client.Txn, *jobs.Job) error { return nil }
-func (b *changefeedResumer) OnSuccess(context.Context, *client.Txn, *jobs.Job) error      { return nil }
-func (b *changefeedResumer) OnTerminal(
-	context.Context, *jobs.Job, jobs.Status, chan<- tree.Datums,
-) {
-}
+// OnFailOrCancel is part of the jobs.Resumer interface.
+func (b *changefeedResumer) OnFailOrCancel(context.Context, *client.Txn) error { return nil }
+
+// OnSuccess is part of the jobs.Resumer interface.
+func (b *changefeedResumer) OnSuccess(context.Context, *client.Txn) error { return nil }
+
+// OnTerminal is part of the jobs.Resumer interface.
+func (b *changefeedResumer) OnTerminal(context.Context, jobs.Status, chan<- tree.Datums) {}

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -1199,17 +1199,11 @@ func (r *importResumer) OnTerminal(
 
 var _ jobs.Resumer = &importResumer{}
 
-func importResumeHook(typ jobspb.Type, settings *cluster.Settings) jobs.Resumer {
-	if typ != jobspb.TypeImport {
-		return nil
-	}
-
-	return &importResumer{
-		settings: settings,
-	}
-}
-
 func init() {
 	sql.AddPlanHook(importPlanHook)
-	jobs.AddResumeHook(importResumeHook)
+	jobs.RegisterConstructor(jobspb.TypeImport, func(settings *cluster.Settings) jobs.Resumer {
+		return &importResumer{
+			settings: settings,
+		}
+	})
 }

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -1021,15 +1021,17 @@ func doDistributedCSVTransform(
 }
 
 type importResumer struct {
+	job            *jobs.Job
 	settings       *cluster.Settings
 	res            roachpb.BulkOpSummary
 	statsRefresher *stats.Refresher
 }
 
+// Resume is part of the jobs.Resumer interface.
 func (r *importResumer) Resume(
-	ctx context.Context, job *jobs.Job, phs interface{}, resultsCh chan<- tree.Datums,
+	ctx context.Context, phs interface{}, resultsCh chan<- tree.Datums,
 ) error {
-	details := job.Details().(jobspb.ImportDetails)
+	details := r.job.Details().(jobspb.ImportDetails)
 	p := phs.(sql.PlanHookState)
 
 	// TODO(dt): consider looking at the legacy fields used in 2.0.
@@ -1081,7 +1083,7 @@ func (r *importResumer) Resume(
 	}
 
 	res, err := doDistributedCSVTransform(
-		ctx, job, files, p, parentID, tables, transform, format, walltime, sstSize, oversample, ingestDirectly,
+		ctx, r.job, files, p, parentID, tables, transform, format, walltime, sstSize, oversample, ingestDirectly,
 	)
 	if err != nil {
 		return err
@@ -1091,12 +1093,12 @@ func (r *importResumer) Resume(
 	return nil
 }
 
-// OnFailOrCancel removes KV data that has been committed from a import that
-// has failed or been canceled. It does this by adding the table descriptors
-// in DROP state, which causes the schema change stuff to delete the keys
-// in the background.
-func (r *importResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn, job *jobs.Job) error {
-	details := job.Details().(jobspb.ImportDetails)
+// OnFailOrCancel is part of the jobs.Resumer interface. Removes data that has
+// been committed from a import that has failed or been canceled. It does this
+// by adding the table descriptors in DROP state, which causes the schema change
+// stuff to delete the keys in the background.
+func (r *importResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn) error {
+	details := r.job.Details().(jobspb.ImportDetails)
 	if details.BackupPath != "" {
 		return nil
 	}
@@ -1121,9 +1123,10 @@ func (r *importResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn, job
 	return txn.Run(ctx, b)
 }
 
-func (r *importResumer) OnSuccess(ctx context.Context, txn *client.Txn, job *jobs.Job) error {
+// OnSuccess is part of the jobs.Resumer interface.
+func (r *importResumer) OnSuccess(ctx context.Context, txn *client.Txn) error {
 	log.Event(ctx, "making tables live")
-	details := job.Details().(jobspb.ImportDetails)
+	details := r.job.Details().(jobspb.ImportDetails)
 
 	if details.BackupPath != "" {
 		return nil
@@ -1148,7 +1151,7 @@ func (r *importResumer) OnSuccess(ctx context.Context, txn *client.Txn, job *job
 	// Write the new TableDescriptors and flip the namespace entries over to
 	// them. After this call, any queries on a table will be served by the newly
 	// imported data.
-	if err := backupccl.WriteTableDescs(ctx, txn, nil, toWrite, job.Payload().Username, r.settings, seqs); err != nil {
+	if err := backupccl.WriteTableDescs(ctx, txn, nil, toWrite, r.job.Payload().Username, r.settings, seqs); err != nil {
 		return pgerror.Wrapf(err, pgerror.CodeDataExceptionError, "creating tables")
 	}
 
@@ -1162,10 +1165,11 @@ func (r *importResumer) OnSuccess(ctx context.Context, txn *client.Txn, job *job
 	return nil
 }
 
+// OnTerminal is part of the jobs.Resumer interface.
 func (r *importResumer) OnTerminal(
-	ctx context.Context, job *jobs.Job, status jobs.Status, resultsCh chan<- tree.Datums,
+	ctx context.Context, status jobs.Status, resultsCh chan<- tree.Datums,
 ) {
-	details := job.Details().(jobspb.ImportDetails)
+	details := r.job.Details().(jobspb.ImportDetails)
 
 	if transform := details.BackupPath; transform != "" {
 		transformStorage, err := storageccl.ExportStorageFromURI(ctx, transform, r.settings)
@@ -1186,7 +1190,7 @@ func (r *importResumer) OnTerminal(
 		telemetry.CountBucketed("import.size-mb", r.res.DataSize/mb)
 
 		resultsCh <- tree.Datums{
-			tree.NewDInt(tree.DInt(*job.ID())),
+			tree.NewDInt(tree.DInt(*r.job.ID())),
 			tree.NewDString(string(jobs.StatusSucceeded)),
 			tree.NewDFloat(tree.DFloat(1.0)),
 			tree.NewDInt(tree.DInt(r.res.Rows)),
@@ -1201,9 +1205,13 @@ var _ jobs.Resumer = &importResumer{}
 
 func init() {
 	sql.AddPlanHook(importPlanHook)
-	jobs.RegisterConstructor(jobspb.TypeImport, func(settings *cluster.Settings) jobs.Resumer {
-		return &importResumer{
-			settings: settings,
-		}
-	})
+	jobs.RegisterConstructor(
+		jobspb.TypeImport,
+		func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
+			return &importResumer{
+				job:      job,
+				settings: settings,
+			}
+		},
+	)
 }

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -32,38 +32,36 @@ func ResetConstructors() func() {
 
 // FakeResumer calls optional callbacks during the job lifecycle.
 type FakeResumer struct {
-	OnResume func(job *Job) error
-	Fail     func(job *Job) error
-	Success  func(job *Job) error
-	Terminal func(job *Job)
+	OnResume func() error
+	Fail     func() error
+	Success  func() error
+	Terminal func()
 }
 
-func (d FakeResumer) Resume(
-	_ context.Context, job *Job, _ interface{}, _ chan<- tree.Datums,
-) error {
+func (d FakeResumer) Resume(_ context.Context, _ interface{}, _ chan<- tree.Datums) error {
 	if d.OnResume != nil {
-		return d.OnResume(job)
+		return d.OnResume()
 	}
 	return nil
 }
 
-func (d FakeResumer) OnFailOrCancel(_ context.Context, _ *client.Txn, job *Job) error {
+func (d FakeResumer) OnFailOrCancel(_ context.Context, _ *client.Txn) error {
 	if d.Fail != nil {
-		return d.Fail(job)
+		return d.Fail()
 	}
 	return nil
 }
 
-func (d FakeResumer) OnSuccess(_ context.Context, _ *client.Txn, job *Job) error {
+func (d FakeResumer) OnSuccess(_ context.Context, _ *client.Txn) error {
 	if d.Success != nil {
-		return d.Success(job)
+		return d.Success()
 	}
 	return nil
 }
 
-func (d FakeResumer) OnTerminal(_ context.Context, job *Job, _ Status, _ chan<- tree.Datums) {
+func (d FakeResumer) OnTerminal(_ context.Context, _ Status, _ chan<- tree.Datums) {
 	if d.Terminal != nil {
-		d.Terminal(job)
+		d.Terminal()
 	}
 }
 

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -18,12 +18,16 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-func ResetResumeHooks() func() {
-	oldResumeHooks := resumeHooks
-	return func() { resumeHooks = oldResumeHooks }
+func ResetConstructors() func() {
+	old := make(map[jobspb.Type]Constructor)
+	for k, v := range constructors {
+		old[k] = v
+	}
+	return func() { constructors = old }
 }
 
 // FakeResumer calls optional callbacks during the job lifecycle.

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -135,7 +135,7 @@ func TestJobsTableProgressFamily(t *testing.T) {
 
 func TestRegistryLifecycle(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer jobs.ResetResumeHooks()()
+	defer jobs.ResetConstructors()()
 
 	defer func(oldInterval time.Duration) {
 		jobs.DefaultAdoptInterval = oldInterval
@@ -240,7 +240,7 @@ func TestRegistryLifecycle(t *testing.T) {
 		},
 	}
 
-	jobs.AddResumeHook(func(typ jobspb.Type, _ *cluster.Settings) jobs.Resumer {
+	jobs.RegisterConstructor(jobspb.TypeImport, func(_ *cluster.Settings) jobs.Resumer {
 		return dummy
 	})
 
@@ -545,7 +545,7 @@ func TestRegistryLifecycle(t *testing.T) {
 
 func TestJobLifecycle(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer jobs.ResetResumeHooks()()
+	defer jobs.ResetConstructors()()
 
 	ctx := context.TODO()
 
@@ -588,12 +588,8 @@ func TestJobLifecycle(t *testing.T) {
 		return nil
 	}}
 
-	jobs.AddResumeHook(func(typ jobspb.Type, _ *cluster.Settings) jobs.Resumer {
-		switch typ {
-		case jobspb.TypeImport:
-			return dummy
-		}
-		return nil
+	jobs.RegisterConstructor(jobspb.TypeImport, func(_ *cluster.Settings) jobs.Resumer {
+		return dummy
 	})
 
 	startLeasedJob := func(t *testing.T, record jobs.Record) (*jobs.Job, expectation) {

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -127,21 +127,23 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 	// receive on it will block until a job is running.
 	resumeCalled := make(chan struct{})
 	var lock syncutil.Mutex
-	jobs.RegisterConstructor(jobspb.TypeBackup, func(_ *cluster.Settings) jobs.Resumer {
+	jobs.RegisterConstructor(jobspb.TypeBackup, func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 		lock.Lock()
 		hookCallCount++
 		lock.Unlock()
-		return jobs.FakeResumer{OnResume: func(job *jobs.Job) error {
-			select {
-			case resumeCalled <- struct{}{}:
-			case <-done:
-			}
-			lock.Lock()
-			resumeCounts[*job.ID()]++
-			lock.Unlock()
-			<-done
-			return nil
-		}}
+		return jobs.FakeResumer{
+			OnResume: func() error {
+				select {
+				case resumeCalled <- struct{}{}:
+				case <-done:
+				}
+				lock.Lock()
+				resumeCounts[*job.ID()]++
+				lock.Unlock()
+				<-done
+				return nil
+			},
+		}
 	})
 
 	for i := 0; i < jobCount; i++ {
@@ -240,11 +242,13 @@ func TestRegistryResumeActiveLease(t *testing.T) {
 
 	resumeCh := make(chan int64)
 	defer jobs.ResetConstructors()()
-	jobs.RegisterConstructor(jobspb.TypeBackup, func(_ *cluster.Settings) jobs.Resumer {
-		return jobs.FakeResumer{OnResume: func(job *jobs.Job) error {
-			resumeCh <- *job.ID()
-			return nil
-		}}
+	jobs.RegisterConstructor(jobspb.TypeBackup, func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
+		return jobs.FakeResumer{
+			OnResume: func() error {
+				resumeCh <- *job.ID()
+				return nil
+			},
+		}
 	})
 
 	ctx := context.Background()

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -308,6 +308,7 @@ func createStatsDefaultColumns(
 // createStatsResumer.Resume so it can be used in createStatsResumer.OnSuccess
 // (if the job is successful).
 type createStatsResumer struct {
+	job     *jobs.Job
 	tableID sqlbase.ID
 	evalCtx *extendedEvalContext
 }
@@ -316,14 +317,14 @@ var _ jobs.Resumer = &createStatsResumer{}
 
 // Resume is part of the jobs.Resumer interface.
 func (r *createStatsResumer) Resume(
-	ctx context.Context, job *jobs.Job, phs interface{}, resultsCh chan<- tree.Datums,
+	ctx context.Context, phs interface{}, resultsCh chan<- tree.Datums,
 ) error {
 	p := phs.(*planner)
-	details := job.Details().(jobspb.CreateStatsDetails)
+	details := r.job.Details().(jobspb.CreateStatsDetails)
 	if details.Name == stats.AutoStatsName {
 		// We want to make sure there is only one automatic CREATE STATISTICS job
 		// running at a time.
-		if err := checkRunningJobs(ctx, job, p); err != nil {
+		if err := checkRunningJobs(ctx, r.job, p); err != nil {
 			return err
 		}
 	}
@@ -350,7 +351,7 @@ func (r *createStatsResumer) Resume(
 		planCtx := dsp.NewPlanningCtx(ctx, r.evalCtx, txn)
 		planCtx.planner = p
 		if err := dsp.planAndRunCreateStats(
-			ctx, r.evalCtx, planCtx, txn, job, NewRowResultWriter(rows),
+			ctx, r.evalCtx, planCtx, txn, r.job, NewRowResultWriter(rows),
 		); err != nil {
 			// Check if this was a context canceled error and restart if it was.
 			if s, ok := status.FromError(errors.Cause(err)); ok {
@@ -366,7 +367,7 @@ func (r *createStatsResumer) Resume(
 			// job progress to coerce out the correct error type. If the update succeeds
 			// then return the original error, otherwise return this error instead so
 			// it can be cleaned up at a higher level.
-			if jobErr := job.FractionProgressed(
+			if jobErr := r.job.FractionProgressed(
 				ctx,
 				func(ctx context.Context, _ jobspb.ProgressDetails) float32 {
 					// The job failed so the progress value here doesn't really matter.
@@ -429,15 +430,13 @@ func checkRunningJobs(ctx context.Context, job *jobs.Job, p *planner) error {
 }
 
 // OnFailOrCancel is part of the jobs.Resumer interface.
-func (r *createStatsResumer) OnFailOrCancel(
-	ctx context.Context, txn *client.Txn, job *jobs.Job,
-) error {
+func (r *createStatsResumer) OnFailOrCancel(ctx context.Context, txn *client.Txn) error {
 	return nil
 }
 
 // OnSuccess is part of the jobs.Resumer interface.
-func (r *createStatsResumer) OnSuccess(ctx context.Context, _ *client.Txn, job *jobs.Job) error {
-	details := job.Details().(jobspb.CreateStatsDetails)
+func (r *createStatsResumer) OnSuccess(ctx context.Context, _ *client.Txn) error {
+	details := r.job.Details().(jobspb.CreateStatsDetails)
 
 	// Invalidate the local cache synchronously; this guarantees that the next
 	// statement in the same session won't use a stale cache (whereas the gossip
@@ -472,13 +471,13 @@ func (r *createStatsResumer) OnSuccess(ctx context.Context, _ *client.Txn, job *
 
 // OnTerminal is part of the jobs.Resumer interface.
 func (r *createStatsResumer) OnTerminal(
-	ctx context.Context, job *jobs.Job, status jobs.Status, resultsCh chan<- tree.Datums,
+	ctx context.Context, status jobs.Status, resultsCh chan<- tree.Datums,
 ) {
 }
 
 func init() {
-	createResumerFn := func(settings *cluster.Settings) jobs.Resumer {
-		return &createStatsResumer{}
+	createResumerFn := func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
+		return &createStatsResumer{job: job}
 	}
 	jobs.RegisterConstructor(jobspb.TypeCreateStats, createResumerFn)
 	jobs.RegisterConstructor(jobspb.TypeAutoCreateStats, createResumerFn)

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -477,10 +477,9 @@ func (r *createStatsResumer) OnTerminal(
 }
 
 func init() {
-	jobs.AddResumeHook(func(typ jobspb.Type, settings *cluster.Settings) jobs.Resumer {
-		if typ != jobspb.TypeCreateStats && typ != jobspb.TypeAutoCreateStats {
-			return nil
-		}
+	createResumerFn := func(settings *cluster.Settings) jobs.Resumer {
 		return &createStatsResumer{}
-	})
+	}
+	jobs.RegisterConstructor(jobspb.TypeCreateStats, createResumerFn)
+	jobs.RegisterConstructor(jobspb.TypeAutoCreateStats, createResumerFn)
 }


### PR DESCRIPTION
#### jobs: clean up the hook interface

The resume hook interface is very awkward: each hook is called and
passed the job type, and only the right hook will work. This is
confusing and unnecessary - we can associate each hook with a specific
job type.

Also renaming "hook" to "constructor" which is more descriptive.

Part of #34418.

Release note: None

#### jobs: clean up the Resumer interface

An instance of Resumer is associated with a specific job. However, the
API looks like that of a singleton "manager" in that every function
gets the job as an argument. This is confusing when trying to
understand these APIs without any prior knowledge.

This change cleans this up by passing the job to the Resumer
constructors instead; implementations can store the job inside each
instance.

Part of #34418.

Release note: None
