### PR TITLE
roachtest: fix replicate/wide

### DIFF
--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -380,4 +380,7 @@ FROM crdb_internal.kv_store_status
 	run(`SET CLUSTER SETTING server.time_until_store_dead = '90s'`)
 	setReplication(5)
 	waitForReplication(5)
+
+	// Restart the down nodes to prevent the dead node detector from complaining.
+	c.Start(ctx, t, c.Range(7, 9))
 }


### PR DESCRIPTION
Restart the nodes at the end of the `replica/wide` test in order to
pacify the dead node detector.

Fixes #36265

Release note: None