### PR TITLE
release-19.1: followerreads: consider MaxTimestamp and disallow nontransactional reqs

### DIFF
--- a/pkg/ccl/followerreadsccl/followerreads_test.go
+++ b/pkg/ccl/followerreadsccl/followerreads_test.go
@@ -71,6 +71,11 @@ func TestCanSendToFollower(t *testing.T) {
 	if canSendToFollower(uuid.MakeV4(), st, rw) {
 		t.Fatalf("should not be able to send a rw request to a follower")
 	}
+	roNonTxn := roachpb.BatchRequest{Header: oldHeader}
+	roNonTxn.Add(&roachpb.QueryTxnRequest{})
+	if canSendToFollower(uuid.MakeV4(), st, roNonTxn) {
+		t.Fatalf("should not be able to send a non-transactional ro request to a follower")
+	}
 	roNoTxn := roachpb.BatchRequest{}
 	roNoTxn.Add(&roachpb.GetRequest{})
 	if canSendToFollower(uuid.MakeV4(), st, roNoTxn) {

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -911,7 +911,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 			// re-run as part of a transaction for consistency. The
 			// case where we don't need to re-run is if the read
 			// consistency is not required.
-			if ba.Txn == nil && ba.IsPossibleTransaction() && ba.ReadConsistency == roachpb.CONSISTENT {
+			if ba.Txn == nil && ba.IsTransactional() && ba.ReadConsistency == roachpb.CONSISTENT {
 				responseCh <- response{pErr: roachpb.NewError(&roachpb.OpRequiresTxnError{})}
 				return
 			}

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -117,7 +117,6 @@ func (ba *BatchRequest) IsReadOnly() bool {
 // leaseholders of the ranges it addresses.
 func (ba *BatchRequest) RequiresLeaseHolder() bool {
 	return !ba.IsReadOnly() || ba.Header.ReadConsistency.RequiresReadLease()
-
 }
 
 // IsReverse returns true iff the BatchRequest contains a reverse request.
@@ -125,10 +124,16 @@ func (ba *BatchRequest) IsReverse() bool {
 	return ba.hasFlag(isReverse)
 }
 
-// IsPossibleTransaction returns true iff the BatchRequest contains
-// requests that can be part of a transaction.
-func (ba *BatchRequest) IsPossibleTransaction() bool {
+// IsTransactional returns true iff the BatchRequest contains requests that can
+// be part of a transaction.
+func (ba *BatchRequest) IsTransactional() bool {
 	return ba.hasFlag(isTxn)
+}
+
+// IsAllTransactional returns true iff the BatchRequest contains only requests
+// that can be part of a transaction.
+func (ba *BatchRequest) IsAllTransactional() bool {
+	return ba.hasFlagForAll(isTxn)
 }
 
 // IsTransactionWrite returns true iff the BatchRequest contains a txn write.
@@ -278,6 +283,20 @@ func (ba *BatchRequest) hasFlag(flag int) bool {
 		}
 	}
 	return false
+}
+
+// hasFlagForAll returns true iff all of the requests within the batch contains
+// the specified flag.
+func (ba *BatchRequest) hasFlagForAll(flag int) bool {
+	if len(ba.Requests) == 0 {
+		return false
+	}
+	for _, union := range ba.Requests {
+		if (union.GetInner().flags() & flag) == 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // GetArg returns a request of the given type if one is contained in the

--- a/pkg/storage/replica_follower_read.go
+++ b/pkg/storage/replica_follower_read.go
@@ -44,8 +44,9 @@ func (r *Replica) canServeFollowerRead(
 	canServeFollowerRead := false
 	if lErr, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); ok &&
 		lErr.LeaseHolder != nil && lErr.Lease.Type() == roachpb.LeaseEpoch &&
-		FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV) &&
-		(ba.Txn == nil || !ba.Txn.IsWriting()) {
+		ba.IsAllTransactional() && // followerreadsccl.batchCanBeEvaluatedOnFollower
+		(ba.Txn == nil || !ba.Txn.IsWriting()) && // followerreadsccl.txnCanPerformFollowerRead
+		FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV) {
 
 		ts := ba.Timestamp
 		if ba.Txn != nil {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "followerreadsccl,storage: consider MaxClockOffset and MaxTimestamp" (#36247)
  * 1/1 commits from "followerreadsccl,storage: disallow nontransactional read-only reqs" (#36351)

Please see individual PRs for details.

/cc @cockroachdb/release
