### PR TITLE
raftentry: truncate entries from old terms when adding to cache

### DIFF
--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -765,7 +765,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 
 	// Update raft log entry cache. We clear any older, uncommitted log entries
 	// and cache the latest ones.
-	r.store.raftEntryCache.Add(r.RangeID, rd.Entries)
+	r.store.raftEntryCache.Add(r.RangeID, rd.Entries, true /* truncate */)
 	r.sendRaftMessages(ctx, otherMsgs)
 	r.traceEntries(rd.CommittedEntries, "committed, before applying any entries")
 	applicationStart := timeutil.Now()

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -178,7 +178,7 @@ func entries(
 	}
 	// Cache the fetched entries, if we may.
 	if canCache {
-		eCache.Add(rangeID, ents)
+		eCache.Add(rangeID, ents, false /* truncate */)
 	}
 
 	// Did the correct number of results come back? If so, we're all good.

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -511,7 +511,7 @@ func TestRaftSSTableSideloadingInline(t *testing.T) {
 			thin: mkEnt(v2, 5, 6, &sstThin), fat: mkEnt(v2, 5, 6, &sstFat),
 			setup: func(ec *raftentry.Cache, ss SideloadStorage) {
 				putOnDisk(ec, ss)
-				ec.Add(rangeID, []raftpb.Entry{mkEnt(v2, 5, 6, &sstFat)})
+				ec.Add(rangeID, []raftpb.Entry{mkEnt(v2, 5, 6, &sstFat)}, true)
 			}, expTrace: "using cache hit",
 		},
 		"v2-fat-without-file": {


### PR DESCRIPTION
Fixes #36353.
Fixes #35424.

See https://github.com/cockroachdb/cockroach/issues/36353#issuecomment-478292863 for the reasoning behind how this could lead to the inconsistency observed in that issue.

This change adds an option to `raftentry.Cache`'s `Add` method to truncate entries from old terms when inserting new entries into the cache. This ensures that old entries at lower terms are purged from the cache and will never be provided to `etcd/raft`. The approach here is analogous to the truncation in [`Replica.append`](https://github.com/cockroachdb/cockroach/blob/a6b3c540b696002b2ed07036a657612995d6d1ab/pkg/storage/replica_raftstorage.go#L621), but for the Raft entry cache instead of for persistent Raft entries.