### PR TITLE
storage: allow backpressuring AddSSTable for splits

### DIFF
--- a/pkg/storage/replica_backpressure.go
+++ b/pkg/storage/replica_backpressure.go
@@ -55,6 +55,7 @@ var backpressurableReqMethods = util.MakeFastIntSet(
 	int(roachpb.Increment),
 	int(roachpb.Delete),
 	int(roachpb.DeleteRange),
+	int(roachpb.AddSSTable),
 )
 
 // backpressurableSpans contains spans of keys where write backpressuring


### PR DESCRIPTION
Nodes appear to getting swamped with AddSSTable requests when they are highly overlapping and thus very expensive.
In particular, splits are getting stuck waiting for the AddSSTable calls since they were not marked as OK to backpressure, e.g. 
```
storage/replica_command.go:246 [n4,split,s4,r202/2:/{Table/53/2/4…-Max}] initiating a split of this range at key /Table/53/2/4/82724/45 [r306] (1.0 GiB above threshold size 64 MiB)
```
h/t to @nvanbenschoten for the suggestion.

Release note (performance improvement): allow oversized ranges to split sooner.