### PR TITLE
roachprod: add a setup-ssh command

### DIFF
--- a/pkg/cmd/roachprod/cloud/cluster_cloud.go
+++ b/pkg/cmd/roachprod/cloud/cluster_cloud.go
@@ -150,6 +150,16 @@ func (c *Cluster) IsLocal() bool {
 	return c.Name == config.Local
 }
 
+// HasProvider returns true if there is a vm in VMs with the given provider.
+func (c *Cluster) HasProvider(provider string) bool {
+	for i := range c.VMs {
+		if c.VMs[i].Provider == provider {
+			return true
+		}
+	}
+	return false
+}
+
 func namesFromVM(v vm.VM) (string, string, error) {
 	if v.IsLocal() {
 		return config.Local, config.Local, nil


### PR DESCRIPTION
This PR refactors cluster creation to separate ssh set up from the rest
of cluster creation. It then makes this setup process idempotent and lastly
it exposes this step as an independent command.

Having setup-ssh as a separate command can be useful to recover from cases
where SSH setup might have failed or to update keys after new users were added
or if roachprod was updated to have new behavior.