### PR TITLE
build: add roachprod-stress{race} to go-targets-ccl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -764,6 +764,7 @@ go-targets-ccl := \
 	bench benchshort \
 	check test testshort testslow testrace testraceslow testbuild \
 	stress stressrace \
+	roachprod-stress roachprod-stressrace \
 	generate \
 	lint lintshort
 


### PR DESCRIPTION
Without this, running `make roachprod-stress` on a fresh checkout
would fail to build dependencies like protobufs and generated parser
files. The invocation would then fail with an error like:
```
Makefile:1356: recipe for target 'pkg/sql/lex/keywords.go' failed
Makefile:903: recipe for target 'roachprod-stress' failed
```

Release note: None