### PR TITLE
roachtest: address various straightforward flakes

### DIFF
--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -391,8 +391,8 @@ tar cvf certs.tar certs
 			"GOTRACEBACK=crash " +
 			"COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=1 " +
 			c.Env + " " + binary + " start " + strings.Join(args, " ") +
-			" >> " + logDir + "/cockroach.stdout 2>> " + logDir + "/cockroach.stderr" +
-			" || (x=$?; cat " + logDir + "/cockroach.stderr; exit $x)"
+			" >> " + logDir + "/cockroach.stdout.log 2>> " + logDir + "/cockroach.stderr.log" +
+			" || (x=$?; cat " + logDir + "/cockroach.stderr.log; exit $x)"
 		if out, err := sess.CombinedOutput(cmd); err != nil {
 			return nil, errors.Wrapf(err, "~ %s\n%s", cmd, out)
 		}

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -81,8 +81,7 @@ func registerDiskFull(r *registry) {
 				c.Run(ctx, c.Node(n), "rm -f {store-dir}/ballast")
 				// Clear any death expectations that did not occur.
 				m.ResetDeaths()
-				c.Start(ctx, t, c.Node(n))
-				return nil
+				return c.StartE(ctx, c.Node(n))
 			})
 			m.Wait()
 		},

--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -28,6 +28,7 @@ func registerDiskFull(r *registry) {
 	r.Add(testSpec{
 		Name:       "disk-full",
 		MinVersion: `v2.1.0`,
+		Skip:       "https://github.com/cockroachdb/cockroach/issues/35328#issuecomment-478540195",
 		Cluster:    makeClusterSpec(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if c.isLocal() {

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -267,6 +267,7 @@ func registerKVQuiescenceDead(r *registry) {
 				)
 			}
 			t.l.Printf("QPS went from %.2f to %2.f with one node down\n", qpsAllUp, qpsOneDown)
+			c.Start(ctx, t, c.Node(nodes)) // satisfy dead node detector
 		},
 	})
 }

--- a/pkg/cmd/roachtest/replicagc.go
+++ b/pkg/cmd/roachtest/replicagc.go
@@ -161,4 +161,7 @@ func runReplicaGCChangedPeers(ctx context.Context, t *test, c *cluster, withRest
 	if n != 0 {
 		t.Fatalf("replica count didn't drop to zero: %d", n)
 	}
+
+	// Restart the remaining nodes to satisfy the dead node detector.
+	c.Start(ctx, t, c.Range(1, 2))
 }

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -50,11 +50,9 @@ func registerLoadSplits(r *registry) {
 		MinVersion: "v2.2.0",
 		Cluster:    makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			// After load based splitting is turned on, from experiments
-			// it's clear that at least 20 splits will happen. We could
-			// change this. Used 20 using pure intuition for a suitable split
-			// count from LBS with this kind of workload.
-			expSplits := 20
+			// This number was determined experimentally. Often, but not always,
+			// more splits will happen.
+			expSplits := 10
 			runLoadSplits(ctx, t, c, splitParams{
 				maxSize:       10 << 30,      // 10 GB
 				concurrency:   64,            // 64 concurrent workers

--- a/pkg/cmd/roachtest/split.go
+++ b/pkg/cmd/roachtest/split.go
@@ -92,7 +92,10 @@ func registerLoadSplits(r *registry) {
 				readPercent:   0,        // 0% reads
 				qpsThreshold:  100,      // 100 queries per second
 				minimumRanges: 1,        // We expect no splits so require only 1 range.
-				maximumRanges: 1,        // We expect no splits so require only 1 range.
+				// We expect no splits so require only 1 range. However, in practice we
+				// sometimes see a split early in, presumably when the sampling gets
+				// lucky.
+				maximumRanges: 2,
 				sequential:    true,
 				waitDuration:  60 * time.Second,
 			})


### PR DESCRIPTION
Most, but not all, are the dead node detector misfiring.
Also skip a few tests.