### PR TITLE
backport-19.1: opt,sql: instrument more opt features

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -28,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -187,6 +189,8 @@ func (n *createStatsNode) startJob(ctx context.Context, resultsCh chan<- tree.Da
 		if err := checkRunningJobs(ctx, nil /* job */, n.p); err != nil {
 			return err
 		}
+	} else {
+		telemetry.Inc(sqltelemetry.CreateStatisticsUseCounter)
 	}
 
 	// Create a job to run statistics creation.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -51,6 +51,7 @@ func (b *Builder) buildDataSource(
 	switch source := texpr.(type) {
 	case *tree.AliasedTableExpr:
 		if source.IndexFlags != nil {
+			telemetry.Inc(sqltelemetry.IndexHintUseCounter)
 			indexFlags = source.IndexFlags
 		}
 

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -44,6 +44,31 @@ var MergeJoinHintUseCounter = telemetry.GetCounterOnce("sql.plan.hints.merge-joi
 // lookup join via a query hint.
 var LookupJoinHintUseCounter = telemetry.GetCounterOnce("sql.plan.hints.lookup-join")
 
+// IndexHintUseCounter is to be incremented whenever a query specifies an index
+// hint.
+var IndexHintUseCounter = telemetry.GetCounterOnce("sql.plan.hints.index")
+
+// ExplainPlanUseCounter is to be incremented whenever vanilla EXPLAIN is run.
+var ExplainPlanUseCounter = telemetry.GetCounterOnce("sql.plan.explain")
+
+// ExplainDistSQLUseCounter is to be incremented whenever EXPLAIN (DISTSQL) is
+// run.
+var ExplainDistSQLUseCounter = telemetry.GetCounterOnce("sql.plan.explain-distsql")
+
+// ExplainAnalyzeUseCounter is to be incremented whenever EXPLAIN ANALYZE is run.
+var ExplainAnalyzeUseCounter = telemetry.GetCounterOnce("sql.plan.explain-analyze")
+
+// ExplainOptUseCounter is to be incremented whenever EXPLAIN (OPT) is run.
+var ExplainOptUseCounter = telemetry.GetCounterOnce("sql.plan.explain-opt")
+
+// ExplainOptVerboseUseCounter is to be incremented whenever
+// EXPLAIN (OPT, VERBOSE) is run.
+var ExplainOptVerboseUseCounter = telemetry.GetCounterOnce("sql.plan.explain-opt-verbose")
+
+// CreateStatisticsUseCounter is to be incremented whenever a non-automatic
+// run of CREATE STATISTICS occurs.
+var CreateStatisticsUseCounter = telemetry.GetCounterOnce("sql.plan.stats.created")
+
 // TurnAutoStatsOnUseCounter is to be incremented whenever automatic stats
 // collection is explicitly enabled.
 var TurnAutoStatsOnUseCounter = telemetry.GetCounterOnce("sql.plan.automatic-stats.enabled")


### PR DESCRIPTION
Backport 1/1 commits from #36299.

/cc @cockroachdb/release

---

Also fix the use of sqlrunner as suggested on the previous PR.

This commit adds telemetry for:
* EXPLAIN {,(opt),(opt, verbose),ANALYZE}
* Explicit uses of CREATE STATISTICS
* Index hints

The issue also requests telemetry on when the optimizer used latency
information to plan, but the optimizer at minimum *consults* such info
whenever it's present, so it's not obvious to me how to define when such
a counter should fire.

Release note: None
