### PR TITLE
cli/start: make SIGQUIT dump the stacks

### DIFF
--- a/pkg/cli/interactive_tests/test_dump_sig.tcl
+++ b/pkg/cli/interactive_tests/test_dump_sig.tcl
@@ -1,0 +1,35 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+spawn /bin/bash
+
+send "PS1='\\h:''/# '\r"
+eexpect ":/# "
+
+start_test "Check that the server emits a goroutine dump upon receiving signal"
+send "$argv start --insecure --pid-file=server_pid --log-dir=logs --logtostderr\r"
+eexpect "CockroachDB node starting"
+
+system "kill -QUIT `cat server_pid`"
+eexpect "received signal 'quit'"
+eexpect "\nI*stack traces:"
+eexpect "RunAsyncTask"
+eexpect "server drained and shutdown completed"
+# Check that the server eventually terminates.
+eexpect ":/# "
+end_test
+
+start_test "Check that the client also can generate goroutine dumps."
+send "$argv demo --empty\r"
+eexpect root@
+# Dump goroutines in server.
+system "killall -QUIT `basename \$(realpath $argv)`"
+eexpect "SIGQUIT: quit"
+eexpect "RunAsyncTask"
+# Check that the client terminates.
+eexpect ":/# "
+end_test
+
+send "exit\r"
+eexpect eof

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -896,7 +896,8 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 		log.SetSync(true)
 
 		log.Infof(shutdownCtx, "received signal '%s'", sig)
-		if sig == os.Interrupt {
+		switch sig {
+		case os.Interrupt:
 			// Graceful shutdown after an interrupt should cause the process
 			// to terminate with a non-zero exit code; however SIGTERM is
 			// "legitimate" and should be acknowledged with a success exit
@@ -909,6 +910,9 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 			}
 			msgDouble := "Note: a second interrupt will skip graceful shutdown and terminate forcefully"
 			fmt.Fprintln(os.Stdout, msgDouble)
+
+		case quitSignal:
+			log.DumpStacks(shutdownCtx)
 		}
 
 		// Start the draining process in a separate goroutine so that it

--- a/pkg/cli/start_unix.go
+++ b/pkg/cli/start_unix.go
@@ -33,6 +33,9 @@ import (
 // must terminate the process.
 var drainSignals = []os.Signal{unix.SIGINT, unix.SIGTERM, unix.SIGQUIT}
 
+// quitSignal is the signal to recognize to dump Go stacks.
+var quitSignal os.Signal = unix.SIGQUIT
+
 func handleSignalDuringShutdown(sig os.Signal) {
 	// On Unix, a signal that was not handled gracefully by the application
 	// should be reraised so it is visible in the exit code.

--- a/pkg/cli/start_windows.go
+++ b/pkg/cli/start_windows.go
@@ -15,6 +15,9 @@ import "os"
 // drainSignals are the signals that will cause the server to drain and exit.
 var drainSignals = []os.Signal{os.Interrupt}
 
+// quitSignal is the signal to recognize to dump Go stacks.
+var quitSignal os.Signal = -1
+
 func handleSignalDuringShutdown(os.Signal) {
 	// Windows doesn't indicate whether a process exited due to a signal in the
 	// exit code, so we don't need to do anything but exit with a failing code.

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -14,6 +14,7 @@
 package log
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"runtime/debug"
@@ -292,6 +293,13 @@ func (l *loggerT) outputLogEntry(s Severity, file string, line int, msg string) 
 		// function is expecting log.Fatal to return and all is well too.
 	}
 	l.mu.Unlock()
+}
+
+// DumpStacks produces a dump of the stack traces in the logging output.
+func DumpStacks(ctx context.Context) {
+	allStacks := getStacks(true)
+	// TODO(knz): This should really be a "debug" level, not "info".
+	Infof(ctx, "stack traces:\n%s", allStacks)
 }
 
 // printPanicToFile copies the panic details to the log file. This is


### PR DESCRIPTION
Fixes #45875.

What: in the title.

Why: the Go standard behavior is to dump stacks upon SIGQUIT.
This had been disabled since crdb v1.0 but is really useful
to troubleshoot hanging servers.

Release note (cli change): CockroachDB will now dump the stacks of all
goroutines upon receiving SIGQUIT prior to terminating. This feature
is intended for use while troubleshooting misbehaving nodes.