### PR TITLE
release-19.1: util/log: ensure that non-crashes add a new sentry tag

### DIFF
--- a/pkg/sql/sqltelemetry/report.go
+++ b/pkg/sql/sqltelemetry/report.go
@@ -47,7 +47,7 @@ func RecordError(ctx context.Context, err error, sv *settings.Values) {
 
 		// If there are no details, don't even bother to try.
 		if len(pgErr.SafeDetail) == 0 {
-			log.SendReport(ctx, "<redacted>", nil)
+			log.SendReport(ctx, "<redacted>", log.ReportTypeError, nil)
 			return
 		}
 
@@ -105,9 +105,9 @@ func RecordError(ctx context.Context, err error, sv *settings.Values) {
 
 		// Finally, send the report.
 		if exc != nil {
-			log.SendReport(ctx, headMsg, extras, details, exc)
+			log.SendReport(ctx, headMsg, log.ReportTypeError, extras, details, exc)
 		} else {
-			log.SendReport(ctx, headMsg, extras, details)
+			log.SendReport(ctx, headMsg, log.ReportTypeError, extras, details)
 		}
 	}
 }

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -1800,6 +1800,7 @@ func (r *Replica) processRaftCommand(
 					0, // depth
 					"while acquiring split lock: %s",
 					[]interface{}{err},
+					log.ReportTypeError,
 				)
 			})
 

--- a/pkg/util/errorutil/error.go
+++ b/pkg/util/errorutil/error.go
@@ -64,5 +64,5 @@ func (e UnexpectedWithIssueErr) SafeMessage() string {
 // The format string will be reproduced ad litteram in the report; the arguments
 // will be sanitized.
 func (e UnexpectedWithIssueErr) SendReport(ctx context.Context, sv *settings.Values) {
-	log.SendCrashReport(ctx, sv, 1 /* depth */, "%s", []interface{}{e})
+	log.SendCrashReport(ctx, sv, 1 /* depth */, "%s", []interface{}{e}, log.ReportTypeError)
 }

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -231,7 +231,7 @@ func ReportPanic(ctx context.Context, sv *settings.Values, r interface{}, depth 
 		logging.printPanicToFile(r)
 	}
 
-	SendCrashReport(ctx, sv, depth+1, "", []interface{}{r})
+	SendCrashReport(ctx, sv, depth+1, "", []interface{}{r}, ReportTypePanic)
 
 	// Ensure that the logs are flushed before letting a panic
 	// terminate the server.
@@ -443,6 +443,18 @@ func ReportablesToSafeError(depth int, format string, reportables []interface{})
 	return err
 }
 
+// ReportType is used to differentiate between an actual crash/panic and just
+// reporting an error. This data is useful for stability purposes.
+type ReportType int
+
+const (
+	// ReportTypePanic signifies that this is an actual panic.
+	ReportTypePanic ReportType = iota
+	// ReportTypeError signifies that this is just a report of an error but it
+	// still may include an exception and stack trace.
+	ReportTypeError
+)
+
 // SendCrashReport posts to sentry. The `reportables` is essentially the `args...` in
 // `log.Fatalf(format, args...)` (similarly for `log.Fatal`) or `[]interface{}{arg}` in
 // `panic(arg)`.
@@ -456,15 +468,23 @@ func ReportablesToSafeError(depth int, format string, reportables []interface{})
 // should be at least somewhat helpful in telling us where crashes are coming from. We capture the
 // full stacktrace below, so we only need the short file and line here help uniquely identify the
 // error. Some exceptions, like a runtime.Error, are assumed to be fine as-is.
+//
+// The crashReportType parameter adds a tag to the event that shows if the
+// cluster did indeed crash or not.
 func SendCrashReport(
-	ctx context.Context, sv *settings.Values, depth int, format string, reportables []interface{},
+	ctx context.Context,
+	sv *settings.Values,
+	depth int,
+	format string,
+	reportables []interface{},
+	crashReportType ReportType,
 ) {
 	if !ShouldSendReport(sv) {
 		return
 	}
 	err := ReportablesToSafeError(depth+1, format, reportables)
 	ex := raven.NewException(err, NewStackTrace(depth+1))
-	SendReport(ctx, err.Error(), nil, ex)
+	SendReport(ctx, err.Error(), crashReportType, nil, ex)
 }
 
 // ShouldSendReport returns true iff SendReport() should be called.
@@ -481,9 +501,12 @@ func ShouldSendReport(sv *settings.Values) bool {
 // SendReport uploads a detailed error report to sentry.
 // Note that there can be at most one reportable object of each type in the report.
 // For more messages, use extraDetails.
+// The crashReportType parameter adds a tag to the event that shows if the
+// cluster did indeed crash or not.
 func SendReport(
 	ctx context.Context,
 	errMsg string,
+	crashReportType ReportType,
 	extraDetails map[string]interface{},
 	details ...ReportableObject,
 ) {
@@ -501,6 +524,13 @@ func SendReport(
 	}
 	tags := map[string]string{
 		"uptime": uptimeTag(timeutil.Now()),
+	}
+
+	switch crashReportType {
+	case ReportTypePanic:
+		tags["report_type"] = "panic"
+	case ReportTypeError:
+		tags["report_type"] = "error"
 	}
 
 	for _, f := range tagFns {
@@ -533,7 +563,7 @@ func ReportOrPanic(
 		panic(fmt.Sprintf(format, reportables...))
 	}
 	Warningf(ctx, format, reportables...)
-	SendCrashReport(ctx, sv, 1 /* depth */, format, reportables)
+	SendCrashReport(ctx, sv, 1 /* depth */, format, reportables, ReportTypeError)
 }
 
 const maxTagLen = 500

--- a/pkg/util/log/crash_reporting_packet_test.go
+++ b/pkg/util/log/crash_reporting_packet_test.go
@@ -99,7 +99,7 @@ func TestCrashReportingPacket(t *testing.T) {
 		tagCount int
 		message  string
 	}{
-		{regexp.MustCompile(`^$`), 6, func() string {
+		{regexp.MustCompile(`^$`), 7, func() string {
 			message := prefix
 			// gccgo stack traces are different in the presence of function literals.
 			if runtime.Compiler == "gccgo" {
@@ -110,7 +110,7 @@ func TestCrashReportingPacket(t *testing.T) {
 			message += ": " + panicPre
 			return message
 		}()},
-		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 9, func() string {
+		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 10, func() string {
 			message := prefix
 			// gccgo stack traces are different in the presence of function literals.
 			if runtime.Compiler == "gccgo" {

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -76,7 +76,7 @@ func addStructured(ctx context.Context, s Severity, depth int, format string, ar
 		// We load the ReportingSettings from the a global singleton in this
 		// call path. See the singleton's comment for a rationale.
 		if sv := settings.TODO(); sv != nil {
-			SendCrashReport(ctx, sv, depth+2, format, args)
+			SendCrashReport(ctx, sv, depth+2, format, args, ReportTypePanic)
 		}
 	}
 	// MakeMessage already added the tags when forming msg, we don't want


### PR DESCRIPTION
Backport 1/1 commits from #36302.

/cc @cockroachdb/release

---

In order to distinguish between an actual crash and simply a reported error, a
new tag is added to the sentry report to disambiguate between the two.

Release note: None
