### PR TITLE
exec: add templating to vectorized merge join 

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -282,18 +282,10 @@ func newColOperator(
 		rightEqCols := make([]uint32, 0, nRightCols)
 
 		for _, oCol := range core.MergeJoiner.LeftOrdering.Columns {
-			if leftTypes[oCol.ColIdx] != types.Int64 {
-				return nil, pgerror.NewErrorf(pgerror.CodeDataExceptionError,
-					"merge join equality is only supported on Int64")
-			}
 			leftEqCols = append(leftEqCols, oCol.ColIdx)
 		}
 
 		for _, oCol := range core.MergeJoiner.RightOrdering.Columns {
-			if rightTypes[oCol.ColIdx] != types.Int64 {
-				return nil, pgerror.NewErrorf(pgerror.CodeDataExceptionError,
-					"merge join equality is only supported on Int64")
-			}
 			rightEqCols = append(rightEqCols, oCol.ColIdx)
 		}
 
@@ -318,7 +310,7 @@ func newColOperator(
 			}
 		}
 
-		op = exec.NewMergeJoinOp(
+		op, err = exec.NewMergeJoinOp(
 			inputs[0],
 			inputs[1],
 			leftOutCols,

--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -125,14 +125,17 @@ func newColOperator(
 		for _, col := range aggSpec.OrderedGroupCols {
 			orderedCols.Add(int(col))
 		}
-		groupTyps := make([]types.T, len(aggSpec.GroupCols))
-		for i, col := range aggSpec.GroupCols {
+		for _, col := range aggSpec.GroupCols {
 			if !orderedCols.Contains(int(col)) {
 				return nil, pgerror.NewErrorf(pgerror.CodeDataExceptionError,
 					"unsorted aggregation not supported")
 			}
 			groupCols.Add(int(col))
-			groupTyps[i] = conv.FromColumnType(spec.Input[0].ColumnTypes[col])
+		}
+
+		groupTyps := make([]types.T, len(spec.Input[0].ColumnTypes))
+		for i := range spec.Input[0].ColumnTypes {
+			groupTyps[i] = conv.FromColumnType(spec.Input[0].ColumnTypes[i])
 		}
 		if !orderedCols.SubsetOf(groupCols) {
 			return nil, pgerror.NewAssertionErrorf("ordered cols must be a subset of grouping cols")

--- a/pkg/sql/exec/distinct_test.go
+++ b/pkg/sql/exec/distinct_test.go
@@ -49,6 +49,25 @@ func TestSortedDistinct(t *testing.T) {
 				{2.0, 3, "40", 4},
 			},
 		},
+		{
+			distinctCols: []uint32{1, 0, 2},
+			colTypes:     []types.T{types.Float64, types.Int64, types.Bytes},
+			numCols:      4,
+			tuples: tuples{
+				{1.0, 2, "30", 4},
+				{1.0, 2, "30", 5},
+				{2.0, 2, "30", 4},
+				{2.0, 3, "30", 4},
+				{2.0, 3, "40", 4},
+				{2.0, 3, "40", 4},
+			},
+			expected: tuples{
+				{1.0, 2, "30", 4},
+				{2.0, 2, "30", 4},
+				{2.0, 3, "30", 4},
+				{2.0, 3, "40", 4},
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -89,7 +108,7 @@ func BenchmarkSortedDistinct(b *testing.B) {
 	source := newRepeatableBatchSource(batch)
 	source.Init()
 
-	distinct, err := NewOrderedDistinct(source, []uint32{1, 2}, []types.T{types.Int64, types.Int64})
+	distinct, err := NewOrderedDistinct(source, []uint32{1, 2}, []types.T{types.Int64, types.Int64, types.Int64})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/exec/distinct_tmpl.go
+++ b/pkg/sql/exec/distinct_tmpl.go
@@ -161,6 +161,10 @@ func (p *sortedDistinct_TYPEOp) Init() {
 	p.input.Init()
 }
 
+func (p *sortedDistinct_TYPEOp) reset() {
+	p.foundFirstRow = false
+}
+
 func (p *sortedDistinct_TYPEOp) Next() coldata.Batch {
 	batch := p.input.Next()
 	if batch.Length() == 0 {

--- a/pkg/sql/exec/distinct_tmpl.go
+++ b/pkg/sql/exec/distinct_tmpl.go
@@ -42,7 +42,7 @@ func orderedDistinctColsToOperators(
 	distinctCol := make([]bool, coldata.BatchSize)
 	var err error
 	for i := range distinctCols {
-		input, err = newSingleOrderedDistinct(input, int(distinctCols[i]), distinctCol, typs[i])
+		input, err = newSingleOrderedDistinct(input, int(distinctCols[i]), distinctCol, typs[distinctCols[i]])
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/sql/exec/execgen/cmd/execgen/mergejoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/mergejoiner_gen.go
@@ -23,6 +23,26 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+// mjOverload contains the overloads for both equality and less than comparisons.
+type mjOverload struct {
+	// The embedded overload has the shared type information for both of the
+	// overloads, so that you can reference that information inside of . without
+	// needing to pick Eq or Lt.
+	overload
+	Eq *overload
+	Lt *overload
+}
+
+// selPermutation contains information about which permutation of selection vector
+// state the template is materializing.
+type selPermutation struct {
+	IsLSel bool
+	IsRSel bool
+
+	LSelString string
+	RSelString string
+}
+
 func genMergeJoinOps(wr io.Writer) error {
 	d, err := ioutil.ReadFile("pkg/sql/exec/mergejoiner_tmpl.go")
 	if err != nil {
@@ -35,24 +55,80 @@ func genMergeJoinOps(wr io.Writer) error {
 	s = strings.Replace(s, "_GOTYPE", "{{.LTyp.GoTypeName}}", -1)
 	s = strings.Replace(s, "_TYPES_T", "types.{{.LTyp}}", -1)
 	s = strings.Replace(s, "_TemplateType", "{{.LTyp}}", -1)
-
-	addSliceWithSel := makeFunctionRegex("_ADD_SLICE_TO_COLVEC_WITH_SEL", 6)
-	s = addSliceWithSel.ReplaceAllString(s, `{{template "addSliceToColVecWithSel" . }}`)
-
-	addSlice := makeFunctionRegex("_ADD_SLICE_TO_COLVEC", 5)
-	s = addSlice.ReplaceAllString(s, `{{template "addSliceToColVec" . }}`)
+	s = strings.Replace(s, "_L_SEL_IND", "{{$sel.LSelString}}", -1)
+	s = strings.Replace(s, "_R_SEL_IND", "{{$sel.RSelString}}", -1)
+	s = strings.Replace(s, "_IS_L_SEL", "{{$sel.IsLSel}}", -1)
+	s = strings.Replace(s, "_IS_R_SEL", "{{$sel.IsRSel}}", -1)
 
 	copyWithSel := makeFunctionRegex("_COPY_WITH_SEL", 5)
 	s = copyWithSel.ReplaceAllString(s, `{{template "copyWithSel" . }}`)
 
+	probeBody := makeFunctionRegex("_PROBE_BODY", 2)
+	s = probeBody.ReplaceAllString(s, `{{template "probeBody" buildDict "Global" . "LSelInd" $1 "RSelInd" $2}}`)
+
+	assignEqRe := makeFunctionRegex("_ASSIGN_EQ", 3)
+	s = assignEqRe.ReplaceAllString(s, `{{.Eq.Assign $1 $2 $3}}`)
+
+	assignLtRe := makeFunctionRegex("_ASSIGN_LT", 3)
+	s = assignLtRe.ReplaceAllString(s, `{{.Lt.Assign $1 $2 $3}}`)
+
 	// Now, generate the op, from the template.
-	tmpl, err := template.New("mergejoin_op").Parse(s)
+	tmpl, err := template.New("mergejoin_op").Funcs(template.FuncMap{"buildDict": buildDict}).Parse(s)
 	if err != nil {
 		return err
 	}
 
-	return tmpl.Execute(wr, comparisonOpToOverloads[tree.EQ])
+	allOverloads := intersectOverloads(comparisonOpToOverloads[tree.EQ], comparisonOpToOverloads[tree.LT])
+
+	// Create an mjOverload for each overload, combining the two overloads so that
+	// the template code can access both the LT method and the EQ method in the
+	// same range loop.
+	mjOverloads := make([]mjOverload, len(allOverloads[0]))
+	for i := range allOverloads[0] {
+		mjOverloads[i] = mjOverload{
+			overload: *allOverloads[0][i],
+			Eq:       allOverloads[0][i],
+			Lt:       allOverloads[1][i],
+		}
+	}
+
+	// Create each permutation of selection vector state.
+	selPermutations := []selPermutation{
+		{
+			IsLSel:     true,
+			IsRSel:     true,
+			LSelString: "lSel[curLIdx]",
+			RSelString: "rSel[curRIdx]",
+		},
+		{
+			IsLSel:     true,
+			IsRSel:     false,
+			LSelString: "lSel[curLIdx]",
+			RSelString: "curRIdx",
+		},
+		{
+			IsLSel:     false,
+			IsRSel:     true,
+			LSelString: "curLIdx",
+			RSelString: "rSel[curRIdx]",
+		},
+		{
+			IsLSel:     false,
+			IsRSel:     false,
+			LSelString: "curLIdx",
+			RSelString: "curRIdx",
+		},
+	}
+
+	return tmpl.Execute(wr, struct {
+		MJOverloads     interface{}
+		SelPermutations interface{}
+	}{
+		MJOverloads:     mjOverloads,
+		SelPermutations: selPermutations,
+	})
 }
+
 func init() {
 	registerGenerator(genMergeJoinOps, "mergejoiner.eg.go")
 }

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -85,10 +85,10 @@ type mjProberState struct {
 type mjState int
 
 const (
-	// mjSetup is the entry state of the merge joiner where all the batches and indices
+	// mjEntry is the entry state of the merge joiner where all the batches and indices
 	// are properly set, regardless if Next was called the first time or the 1000th time.
 	// This state also routes into the correct state based on the prober state after setup.
-	mjSetup mjState = iota
+	mjEntry mjState = iota
 
 	// mjSourceFinished is the state in which one of the input sources has no more available
 	// batches, thus signaling that the joiner should begin wrapping up execution by outputting
@@ -120,8 +120,26 @@ type mergeJoinInput struct {
 	// the merge joiner.
 	sourceTypes []types.T
 
+	// The distincter is used in the finishGroup phase, and is used only to determine
+	// where the current group ends, in the case that the group ended with a batch.
+	distincterInput feedOperator
+	distincter      Operator
+	distinctOutput  []bool
+
 	// source specifies the input operator to the merge join.
 	source Operator
+}
+
+// feedOperator is used to feed the distincter with input by manually setting the
+// next batch.
+type feedOperator struct {
+	bat coldata.Batch
+}
+
+func (feedOperator) Init() {}
+
+func (o *feedOperator) Next() coldata.Batch {
+	return o.bat
 }
 
 // mergeJoinOp is an operator that implements sort-merge join.
@@ -174,12 +192,26 @@ func NewMergeJoinOp(
 	rightTypes []types.T,
 	leftEqCols []uint32,
 	rightEqCols []uint32,
-) Operator {
+) (Operator, error) {
 	c := &mergeJoinOp{
 		left:  mergeJoinInput{source: left, outCols: leftOutCols, sourceTypes: leftTypes, eqCols: leftEqCols},
 		right: mergeJoinInput{source: right, outCols: rightOutCols, sourceTypes: rightTypes, eqCols: rightEqCols},
 	}
-	return c
+
+	var err error
+	c.left.distincterInput = feedOperator{}
+	c.left.distincter, c.left.distinctOutput, err = orderedDistinctColsToOperators(
+		&c.left.distincterInput, leftEqCols, leftTypes)
+	if err != nil {
+		return nil, err
+	}
+	c.right.distincterInput = feedOperator{}
+	c.right.distincter, c.right.distinctOutput, err = orderedDistinctColsToOperators(
+		&c.right.distincterInput, rightEqCols, rightTypes)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
 func (o *mergeJoinOp) Init() {
@@ -263,37 +295,6 @@ func (o *mergeJoinOp) getBatch(input *mergeJoinInput) coldata.Batch {
 	return n
 }
 
-// getValForIdx returns the value for comparison given a slice and an index.
-// TODO(georgeutsin): template this to work for all types.
-func getValForIdx(keys []int64, idx int, sel []uint16) int64 {
-	if sel != nil {
-		return keys[sel[idx]]
-	}
-
-	return keys[idx]
-}
-
-// getGroupLengthForValue is a helper function that gets the length of the current group in a batch
-// starting at idx, given the comparison value. Also returns a boolean indicating whether the group
-// is known to be complete.
-func getGroupLengthForValue(
-	idx int, length int, keys []int64, sel []uint16, compVal int64,
-) (int, bool) {
-	if length == 0 {
-		return 0, true
-	}
-
-	groupLength := 0
-	for idx < length {
-		if getValForIdx(keys, idx, sel) != compVal {
-			return groupLength, true
-		}
-		groupLength++
-		idx++
-	}
-	return groupLength, false
-}
-
 // calculateOutputCount is a helper function only exercised in the case that there are no output
 // columns, ie the SQL statement was a SELECT COUNT. It uses the groups and the current output
 // count to determine what the new output count is.
@@ -326,12 +327,8 @@ func (o *mergeJoinOp) calculateOutputCount(
 func (o *mergeJoinOp) completeGroup(
 	input *mergeJoinInput, bat coldata.Batch, rowIdx int,
 ) (idx int, batch coldata.Batch, length int) {
-	isGroupComplete := false
 	length = int(bat.Length())
 	sel := bat.Selection()
-	// The equality column idx is the last equality column.
-	eqColIdx := int(input.eqCols[len(input.eqCols)-1])
-	keys := bat.ColVec(eqColIdx).Int64()
 	savedGroup := o.proberState.lGroup
 	savedGroupIdx := &o.proberState.lGroupEndIdx
 	if input == &o.right {
@@ -339,37 +336,54 @@ func (o *mergeJoinOp) completeGroup(
 		savedGroupIdx = &o.proberState.rGroupEndIdx
 	}
 
-	// Check all equality columns before the last equality column to make sure we're in the same group.
-	for i := 0; i < len(input.eqCols)-1; i++ {
-		colIdx := input.eqCols[i]
-		prevVal := getValForIdx(savedGroup.ColVec(int(colIdx)).Int64(), *savedGroupIdx-1, nil)
-		curVal := getValForIdx(bat.ColVec(int(colIdx)).Int64(), rowIdx, sel)
-		if prevVal != curVal {
-			return rowIdx, bat, length
-		}
+	if o.isGroupFinished(input, savedGroup, *savedGroupIdx, bat, rowIdx, sel) {
+		return rowIdx, bat, length
 	}
 
-	// Continue the group based on the last equality column.
-	eqVal := getValForIdx(savedGroup.ColVec(eqColIdx).Int64(), *savedGroupIdx-1, nil)
+	isGroupComplete := false
+	input.distincter.(resetter).reset()
+	// Ignore the first row of the distincter in the first pass, since we already
+	// know that we are in the same group and thus the row is not distinct,
+	// regardless of what the distincter outputs.
+	loopStartIndex := 1
 	for !isGroupComplete {
-		// Find the length of the group.
-		groupLength, complete := getGroupLengthForValue(rowIdx, length, keys, sel, eqVal)
-		isGroupComplete = complete
+		input.distincterInput.bat = bat
+		input.distincter.Next()
+
+		var groupLength int
+		if sel != nil {
+			for groupLength = loopStartIndex; groupLength < length; groupLength++ {
+				if input.distinctOutput[sel[groupLength]] {
+					// We found the beginning of a new group!
+					isGroupComplete = true
+					break
+				}
+			}
+		} else {
+			for groupLength = loopStartIndex; groupLength < length; groupLength++ {
+				if input.distinctOutput[groupLength] {
+					// We found the beginning of a new group!
+					isGroupComplete = true
+					break
+				}
+			}
+		}
+
+		// Zero out the distinct output for the next pass.
+		copy(input.distinctOutput, zeroBoolVec)
+		loopStartIndex = 0
 
 		// Save the group to state.
 		o.saveGroupToState(rowIdx, groupLength, bat, sel, input, savedGroup, savedGroupIdx)
 		rowIdx += groupLength
 
-		// Get the next batch if we hit the end.
-		if rowIdx == length {
+		if !isGroupComplete {
 			rowIdx, bat = 0, input.source.Next()
-			sel = bat.Selection()
 			length = int(bat.Length())
 			if length == 0 {
 				// The group is complete if there are no more batches left.
 				break
 			}
-			keys = bat.ColVec(eqColIdx).Int64()
 		}
 	}
 
@@ -402,6 +416,16 @@ func (o *mergeJoinOp) saveGroupToState(
 	*destStartIdx += groupLength
 }
 
+// setBuilderSourceToBatch sets the builder state to use groups from the circular
+// group buffer, and the batches from input.
+func (o *mergeJoinOp) setBuilderSourceToBatch() {
+	o.builderState.lGroups = o.groups.getLGroups()
+	o.builderState.rGroups = o.groups.getRGroups()
+	o.builderState.groupsLen = o.groups.getBufferLen()
+	o.builderState.lBatch = o.proberState.lBatch
+	o.builderState.rBatch = o.proberState.rBatch
+}
+
 // probe is where we generate the groups slices that are used in the build phase.
 // We do this by first assuming that every row in both batches contributes to the
 // cross product. Then, with every equality column, we filter out the rows that
@@ -413,67 +437,19 @@ func (o *mergeJoinOp) probe() {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
-EqLoop:
-	for eqColIdx := 0; eqColIdx < len(o.left.eqCols); eqColIdx++ {
-		lKeys := o.proberState.lBatch.ColVec(int(o.left.eqCols[eqColIdx])).Int64()
-		rKeys := o.proberState.rBatch.ColVec(int(o.right.eqCols[eqColIdx])).Int64()
-		// Iterate over all the groups in the column.
-		var lGroup, rGroup group
-		for o.groups.nextGroupInCol(&lGroup, &rGroup) {
-			curLIdx := lGroup.rowStartIdx
-			curRIdx := rGroup.rowStartIdx
-			curLLength := lGroup.rowEndIdx
-			curRLength := rGroup.rowEndIdx
-			// Expand or filter each group based on the current equality column.
-			for curLIdx < curLLength && curRIdx < curRLength {
-				lVal := getValForIdx(lKeys, curLIdx, lSel)
-				rVal := getValForIdx(rKeys, curRIdx, rSel)
-
-				if lVal == rVal { // match
-					// Find the length of the groups on each side.
-					lGroupLength, lComplete := getGroupLengthForValue(curLIdx, curLLength, lKeys, lSel, lVal)
-					rGroupLength, rComplete := getGroupLengthForValue(curRIdx, curRLength, rKeys, rSel, rVal)
-
-					// Last equality column and either group is incomplete. Save state and have it handled in the next iteration.
-					if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-						o.saveGroupToState(curLIdx, lGroupLength, o.proberState.lBatch, lSel, &o.left, o.proberState.lGroup, &o.proberState.lGroupEndIdx)
-						o.proberState.lIdx = lGroupLength + curLIdx
-						o.saveGroupToState(curRIdx, rGroupLength, o.proberState.rBatch, rSel, &o.right, o.proberState.rGroup, &o.proberState.rGroupEndIdx)
-						o.proberState.rIdx = rGroupLength + curRIdx
-
-						o.groups.finishedCol()
-						break EqLoop
-					}
-
-					// Neither group ends with the batch so add the group to the circular buffer and increment the indices.
-					o.groups.addGroupsToNextCol(curLIdx, lGroupLength, curRIdx, rGroupLength)
-					curLIdx += lGroupLength
-					curRIdx += rGroupLength
-				} else { // mismatch
-					if lVal < rVal {
-						curLIdx++
-					} else {
-						curRIdx++
-					}
-				}
-			}
-			// Both o.proberState.lIdx and o.proberState.rIdx should point to the last elements processed in their respective batches.
-			o.proberState.lIdx = curLIdx
-			o.proberState.rIdx = curRIdx
+	if lSel != nil {
+		if rSel != nil {
+			o.probeBodyLSeltrueRSeltrue()
+		} else {
+			o.probeBodyLSeltrueRSelfalse()
 		}
-		// Look at the groups associated with the next equality column by moving the circular buffer pointer up.
-		o.groups.finishedCol()
+	} else {
+		if rSel != nil {
+			o.probeBodyLSelfalseRSeltrue()
+		} else {
+			o.probeBodyLSelfalseRSelfalse()
+		}
 	}
-}
-
-// setBuilderSourceToBatch sets the builder state to use groups from the circular
-// group buffer, and the batches from input.
-func (o *mergeJoinOp) setBuilderSourceToBatch() {
-	o.builderState.lGroups = o.groups.getLGroups()
-	o.builderState.rGroups = o.groups.getRGroups()
-	o.builderState.groupsLen = o.groups.getBufferLen()
-	o.builderState.lBatch = o.proberState.lBatch
-	o.builderState.rBatch = o.proberState.rBatch
 }
 
 // finishProbe completes the groups on both sides of the input.
@@ -550,16 +526,16 @@ func (o *mergeJoinOp) Next() coldata.Batch {
 
 	for {
 		switch o.state {
-		case mjSetup:
+		case mjEntry:
 			o.initProberState()
-
-			if o.sourceFinished() {
-				o.state = mjSourceFinished
-				break
-			}
 
 			if o.groupNeedsToBeFinished() {
 				o.state = mjFinishGroup
+				break
+			}
+
+			if o.sourceFinished() {
+				o.state = mjSourceFinished
 				break
 			}
 
@@ -584,7 +560,7 @@ func (o *mergeJoinOp) Next() coldata.Batch {
 			}
 
 			if o.builderState.left.finished && o.builderState.right.finished {
-				o.state = mjSetup
+				o.state = mjEntry
 			}
 			if o.proberState.inputDone || o.builderState.outCount == o.outputBatchSize {
 				o.output.SetLength(o.builderState.outCount)


### PR DESCRIPTION
The second last step in the vectorized merge join operator is the
introduction of templating so that the equality type isn't limited
to just int64s.

With this change, there are also performance boosts as the
selection vector switching is now moved outside the tight loop.

Further, we noticed a bug in the previous completeGroups
implementation, so we killed two birds with one stone by both
templating and fixing that edge case with the use of the distinct
operator.

Special thanks to @jordanlewis who is really a coauthor of this
PR.

And as usual, some benchmarks:

```
name                                      old time/op    new time/op    delta
MergeJoiner/rows=1024-8                     44.9µs ± 1%    35.3µs ± 0%  -21.43%  (p=0.000 n=10+10)
MergeJoiner/rows=4096-8                      171µs ± 0%     133µs ± 0%  -22.15%  (p=0.000 n=10+10)
MergeJoiner/rows=16384-8                     656µs ± 1%     508µs ± 1%  -22.60%  (p=0.000 n=10+10)
MergeJoiner/rows=1048576-8                  40.3ms ± 1%    30.8ms ± 1%  -23.43%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8       45.4µs ± 0%    35.4µs ± 0%  -22.19%  (p=0.000 n=10+9)
MergeJoiner/oneSideRepeat-rows=4096-8        171µs ± 0%     133µs ± 0%  -22.16%  (p=0.000 n=10+8)
MergeJoiner/oneSideRepeat-rows=16384-8       655µs ± 0%     508µs ± 0%  -22.54%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1048576-8    40.3ms ± 1%    31.0ms ± 1%  -23.12%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=1024-8     48.3µs ± 1%    37.6µs ± 1%  -22.25%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=4096-8      186µs ± 1%     174µs ± 0%   -6.05%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=16384-8    1.41ms ± 0%    1.39ms ± 1%   -1.59%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=32768-8    4.93ms ± 1%    5.28ms ± 1%   +7.17%  (p=0.000 n=9+10)

name                                      old speed      new speed      delta
MergeJoiner/rows=1024-8                   1.46GB/s ± 1%  1.86GB/s ± 0%  +27.28%  (p=0.000 n=10+10)
MergeJoiner/rows=4096-8                   1.53GB/s ± 0%  1.97GB/s ± 0%  +28.46%  (p=0.000 n=10+10)
MergeJoiner/rows=16384-8                  1.60GB/s ± 1%  2.06GB/s ± 1%  +29.20%  (p=0.000 n=10+10)
MergeJoiner/rows=1048576-8                1.67GB/s ± 1%  2.18GB/s ± 1%  +30.60%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8     1.44GB/s ± 0%  1.85GB/s ± 0%  +28.52%  (p=0.000 n=10+9)
MergeJoiner/oneSideRepeat-rows=4096-8     1.54GB/s ± 0%  1.97GB/s ± 0%  +28.47%  (p=0.000 n=10+8)
MergeJoiner/oneSideRepeat-rows=16384-8    1.60GB/s ± 0%  2.07GB/s ± 0%  +29.10%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1048576-8  1.67GB/s ± 1%  2.17GB/s ± 1%  +30.07%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=1024-8   1.36GB/s ± 1%  1.74GB/s ± 1%  +28.62%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=4096-8   1.41GB/s ± 1%  1.50GB/s ± 0%   +6.43%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=16384-8   743MB/s ± 0%   755MB/s ± 1%   +1.62%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=32768-8   426MB/s ± 1%   397MB/s ± 1%   -6.69%  (p=0.000 n=9+10)

name                                      old alloc/op   new alloc/op   delta
MergeJoiner/rows=1024-8                     4.23kB ± 0%    4.23kB ± 0%   -0.07%  (p=0.000 n=10+10)
MergeJoiner/rows=4096-8                     4.25kB ± 0%    4.25kB ± 0%     ~     (all equal)
MergeJoiner/rows=16384-8                    4.34kB ± 0%    4.30kB ± 0%   -0.92%  (p=0.000 n=10+10)
MergeJoiner/rows=1048576-8                  12.2kB ± 0%     9.0kB ± 0%  -26.16%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8       4.23kB ± 0%    4.23kB ± 0%   -0.07%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=4096-8       4.25kB ± 0%    4.25kB ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=16384-8      4.34kB ± 0%    4.30kB ± 0%   -0.92%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1048576-8    12.2kB ± 0%     9.0kB ± 0%  -26.16%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8     4.23kB ± 0%    4.23kB ± 0%   -0.07%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=4096-8     4.25kB ± 0%    4.25kB ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=16384-8    4.46kB ± 0%    4.46kB ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=32768-8    5.02kB ± 0%    5.02kB ± 0%     ~     (all equal)

name                                      old allocs/op  new allocs/op  delta
MergeJoiner/rows=1024-8                       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
MergeJoiner/rows=4096-8                       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
MergeJoiner/rows=16384-8                      4.00 ± 0%      4.00 ± 0%     ~     (all equal)
MergeJoiner/rows=1048576-8                    6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8         4.00 ± 0%      4.00 ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=4096-8         4.00 ± 0%      4.00 ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=16384-8        4.00 ± 0%      4.00 ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=1048576-8      6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=4096-8       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=16384-8      4.00 ± 0%      4.00 ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=32768-8      4.00 ± 0%      4.00 ± 0%     ~     (all equal)

```

Release note: None