### PR TITLE
roachtest: update canary latest release tag fetcher with custom regexes

### DIFF
--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -19,9 +19,12 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 )
+
+var hibernateReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
 
 // This test runs hibernate-core's full test suite against a single cockroach
 // node.
@@ -41,12 +44,11 @@ func registerHibernate(r *registry) {
 		c.Start(ctx, t, c.All())
 
 		t.Status("cloning hibernate and installing prerequisites")
-		latestTag, err := repeatGetLatestTag(ctx, c, "hibernate", "hibernate-orm")
+		latestTag, err := repeatGetLatestTag(
+			ctx, c, "hibernate", "hibernate-orm", hibernateReleaseTagRegex,
+		)
 		if err != nil {
 			t.Fatal(err)
-		}
-		if len(latestTag) == 0 {
-			t.Fatal(fmt.Sprintf("did not get a latest tag"))
 		}
 		c.l.Printf("Latest Hibernate release is %s.", latestTag)
 

--- a/pkg/cmd/roachtest/psycopg.go
+++ b/pkg/cmd/roachtest/psycopg.go
@@ -26,6 +26,7 @@ import (
 )
 
 var psycopgResultRegex = regexp.MustCompile(`(?P<name>.*) \((?P<class>.*)\) \.\.\. (?P<result>[^ ']*)(?: ['"](?P<reason>.*)['"])?`)
+var psycopgReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)(?:_(?P<minor>\d+)(?:_(?P<point>\d+)(?:_(?P<subpoint>\d+))?)?)?$`)
 
 // This test runs psycopg full test suite against a single cockroach node.
 
@@ -44,12 +45,9 @@ func registerPsycopg(r *registry) {
 		c.Start(ctx, t, c.All())
 
 		t.Status("cloning psycopg and installing prerequisites")
-		latestTag, err := repeatGetLatestTag(ctx, c, "psycopg", "psycopg2")
+		latestTag, err := repeatGetLatestTag(ctx, c, "psycopg", "psycopg2", psycopgReleaseTagRegex)
 		if err != nil {
 			t.Fatal(err)
-		}
-		if len(latestTag) == 0 {
-			t.Fatal(fmt.Sprintf("did not get a latest tag"))
 		}
 		c.l.Printf("Latest Psycopg release is %s.", latestTag)
 

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -18,7 +18,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"regexp"
 )
+
+var typeORMReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
 
 // This test runs TypeORM's full test suite against a single cockroach node.
 func registerTypeORM(r *registry) {
@@ -36,12 +39,9 @@ func registerTypeORM(r *registry) {
 		c.Start(ctx, t, c.All())
 
 		t.Status("cloning TypeORM and installing prerequisites")
-		latestTag, err := repeatGetLatestTag(ctx, c, "typeorm", "typeorm")
+		latestTag, err := repeatGetLatestTag(ctx, c, "typeorm", "typeorm", typeORMReleaseTagRegex)
 		if err != nil {
 			t.Fatal(err)
-		}
-		if len(latestTag) == 0 {
-			t.Fatal(fmt.Sprintf("did not get a latest tag"))
 		}
 		c.l.Printf("Latest TypeORM release is %s.", latestTag)
 


### PR DESCRIPTION
This adds proper sorting on a per repo basis.  Sadly, most projects do not
conform to release naming that a string sort would be able correctly order.

Release note: None