### PR TITLE
release-19.1: build: Allow go 1.12 again

### DIFF
--- a/build/go-version-check.sh
+++ b/build/go-version-check.sh
@@ -26,9 +26,3 @@ if (( version_major != required_version_major )) || (( version_minor < minimum_v
   echo "go$required_version_major.$minimum_version_minor+ required (detected go$version)" >&2
   exit 1
 fi
-
-# Pending resolution of #35637
-if [ $version_minor -ge 12 ]; then
-  echo "go 1.12+ is known to produce invalid crdb builds, see https://github.com/cockroachdb/cockroach/issues/35637" >&2
-  exit 1
-fi


### PR DESCRIPTION
Backport 1/1 commits from #36389.

/cc @cockroachdb/release

---

Fears of invalid builds have been resolved, so we no longer need to
prohibit this.

Note that it is difficult to be lint-clean with both 1.11 and 1.12
simultaneously, so we'll have to wait to fix the new lint issues until
we move to 1.12 as the minimum version (post CRDB 19.1)

Updates #35637

Release note: None
