### PR TITLE
roachtest: Reduce tpcc/w=max targets

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -156,9 +156,9 @@ func registerTPCC(r *registry) {
 			var warehouses int
 			switch cloud {
 			case "gce":
-				warehouses = 1350
+				warehouses = 1250
 			case "aws":
-				warehouses = 2300
+				warehouses = 2100
 			default:
 				t.Fatalf("unknown cloud: %q", cloud)
 			}


### PR DESCRIPTION
Make large cuts to deflake the test until we can get enough data to
put a tighter bound on it. The AWS case does not appear to have passed
since its introduction.

Closes #35337
Updates #36097

Release note: None