### PR TITLE
workload: minor optimizations to randString

### DIFF
--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -202,9 +202,8 @@ func randStringLetters(rng rand.Source, buf []byte) {
 	const lettersLen = uint64(len(letters))
 	const lettersCharsPerRand = uint64(11) // floor(log(math.MaxUint64)/log(lettersLen))
 
-	r := rng.Uint64()
-	charsLeft := lettersCharsPerRand
-	for i := range buf {
+	var r, charsLeft uint64
+	for i := 0; i < len(buf); i++ {
 		if charsLeft == 0 {
 			r = rng.Uint64()
 			charsLeft = lettersCharsPerRand

--- a/pkg/workload/tpcc/random.go
+++ b/pkg/workload/tpcc/random.go
@@ -99,7 +99,7 @@ func randOriginalString(rng *rand.Rand, a *bufalloc.ByteAllocator) string {
 	return randAString(rng, a, 26, 50)
 }
 
-// randNString generates a random numeric string of length between min anx max
+// randNString generates a random numeric string of length between min and max
 // inclusive. See 4.3.2.2.
 func randNString(rng *rand.Rand, a *bufalloc.ByteAllocator, min, max int) string {
 	return randStringFromAlphabet(rng, a, min, max, randStringNumbers)
@@ -164,9 +164,8 @@ func randStringLetters(rng rand.Source, buf []byte) {
 	const lettersLen = uint64(len(letters))
 	const lettersCharsPerRand = uint64(13) // floor(log(math.MaxUint64)/log(lettersLen))
 
-	r := rng.Uint64()
-	charsLeft := lettersCharsPerRand
-	for i := range buf {
+	var r, charsLeft uint64
+	for i := 0; i < len(buf); i++ {
 		if charsLeft == 0 {
 			r = rng.Uint64()
 			charsLeft = lettersCharsPerRand
@@ -182,9 +181,8 @@ func randStringNumbers(rng rand.Source, buf []byte) {
 	const numbersLen = uint64(len(numbers))
 	const numbersCharsPerRand = uint64(19) // floor(log(math.MaxUint64)/log(numbersLen))
 
-	r := rng.Uint64()
-	charsLeft := numbersCharsPerRand
-	for i := range buf {
+	var r, charsLeft uint64
+	for i := 0; i < len(buf); i++ {
 		if charsLeft == 0 {
 			r = rng.Uint64()
 			charsLeft = numbersCharsPerRand
@@ -200,9 +198,8 @@ func randStringAChars(rng rand.Source, buf []byte) {
 	const aCharsLen = uint64(len(aChars))
 	const aCharsCharsPerRand = uint64(10) // floor(log(math.MaxUint64)/log(aCharsLen))
 
-	r := rng.Uint64()
-	charsLeft := aCharsCharsPerRand
-	for i := range buf {
+	var r, charsLeft uint64
+	for i := 0; i < len(buf); i++ {
 		if charsLeft == 0 {
 			r = rng.Uint64()
 			charsLeft = aCharsCharsPerRand


### PR DESCRIPTION
This commit includes two minor optimizations to the randString
functions:
1. remove the initial call to `rng.Uint64()` and start with `charsLeft = 0`.
   This reduces the size of the function.
2. replace the `for range` loop with a `for i := 0; ...; i++ {` loop.
   Surprisingly, this made the biggest difference. I'm not sure why. Either
   way, there are no bounds checks in the function (which is very impressive).

```
name                      old time/op   new time/op   delta
RandStringFast/letters-4   72.0ns ± 0%   68.5ns ± 0%  -4.87%  (p=0.000 n=8+9)
RandStringFast/numbers-4   73.1ns ± 1%   70.0ns ± 0%  -4.32%  (p=0.000 n=9+9)
RandStringFast/aChars-4    83.7ns ± 2%   83.1ns ± 2%  -0.74%  (p=0.020 n=10+9)

name                      old speed     new speed     delta
RandStringFast/letters-4  361MB/s ± 0%  379MB/s ± 0%  +5.10%  (p=0.000 n=8+9)
RandStringFast/numbers-4  356MB/s ± 1%  372MB/s ± 0%  +4.51%  (p=0.000 n=9+9)
RandStringFast/aChars-4   311MB/s ± 2%  313MB/s ± 2%  +0.73%  (p=0.028 n=10+9)
```

Release note: None