### PR TITLE
storage: fix deadlock due to inconsistent lock ordering

### DIFF
--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -686,10 +686,14 @@ func (r *Replica) handleReplicatedEvalResult(
 			// that the other nodes have finished this command as well (since
 			// processing the removal from the queue looks up the Range at the
 			// lease holder, being too early here turns this into a no-op).
-			if _, err := r.store.replicaGCQueue.Add(r, replicaGCPriorityRemoved); err != nil {
-				// Log the error; the range should still be GC'd eventually.
-				log.Errorf(ctx, "unable to add to replica GC queue: %s", err)
-			}
+			// Lock ordering dictates that we don't hold any mutexes when adding,
+			// so we fire it off in a task.
+			_ = r.store.stopper.RunAsyncTask(ctx, "add-to-replicag-queue", func(ctx context.Context) {
+				if _, err := r.store.replicaGCQueue.Add(r, replicaGCPriorityRemoved); err != nil {
+					// Log the error; the range should still be GC'd eventually.
+					log.Errorf(ctx, "unable to add to replica GC queue: %s", err)
+				}
+			})
 		}
 		rResult.ChangeReplicas = nil
 	}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -440,8 +440,8 @@ type Store struct {
 	draining atomic.Value
 
 	// Locking notes: To avoid deadlocks, the following lock order must be
-	// obeyed: Replica.raftMu < Replica.readOnlyCmdMu < Store.mu < Replica.mu
-	// < Replica.unreachablesMu < Store.coalescedMu < Store.scheduler.mu.
+	// obeyed: baseQueue.mu < Replica.raftMu < Replica.readOnlyCmdMu < Store.mu
+	// < Replica.mu < Replica.unreachablesMu < Store.coalescedMu < Store.scheduler.mu.
 	// (It is not required to acquire every lock in sequence, but when multiple
 	// locks are held at the same time, it is incorrect to acquire a lock with
 	// "lesser" value in this sequence after one with "greater" value).
@@ -491,6 +491,11 @@ type Store struct {
 	//   (which copies the timestamp cache) while still allowing
 	//   multiple reads in parallel (#3148). TODO(bdarnell): this lock
 	//   only needs to be held during splitTrigger, not all triggers.
+	//
+	// * baseQueue.mu: The mutex contained in each of the store's queues (such
+	//   as the replicate queue, replica GC queue, GC queue, ...). The mutex is
+	//   typically acquired when deciding whether to add a replica to the respective
+	//   queue.
 	//
 	// * Store.mu: Protects the Store's map of its Replicas. Acquired and
 	//   released briefly at the start of each request; metadata operations like

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -589,11 +589,16 @@ func (s *Store) canApplySnapshotLocked(
 			if inactive(exReplica) {
 				gcPriority = replicaGCPriorityCandidate
 			}
-			if _, err := s.replicaGCQueue.Add(exReplica, gcPriority); err != nil {
-				log.Errorf(ctx, "%s: unable to add replica to GC queue: %s", exReplica, err)
-			} else {
-				msg += "; initiated GC:"
-			}
+
+			msg += "; initiated GC:"
+			_ = s.stopper.RunAsyncTask(ctx, "add-to-replicagc-queue", func(ctx context.Context) {
+				// We can't hold any mutexes while adding to queues, so we have to do it in a task. This
+				// is especially important since we hold the store mutex in the surrounding method, which
+				// we wouldn't want to block even if it were legal.
+				if _, err := s.replicaGCQueue.Add(exReplica, gcPriority); err != nil {
+					log.Errorf(ctx, "%s: unable to add replica to GC queue: %s", exReplica, err)
+				}
+			})
 		}
 		return nil, errors.Errorf("%s %v (incoming %v)", msg, exReplica, snapHeader.State.Desc.RSpan()) // exReplica can be nil
 	}


### PR DESCRIPTION
This is a WIP because I want to see if there are other opinions on
how to solve this problem first.

The full analysis is in https://github.com/cockroachdb/cockroach/issues/36413.

The TL;DR is that we don't have a lock ordering for `baseQueue.mu`. We
have callers that acquire it while `Store.mu` is held, and we sometimes
acquire `raftMu` while holding `baseQueue.mu`. This violates the lock
order constraint `raftMu < Store.mu`.

Since `raftMu` is also the lock the has to be acquired first for all
locks mentioned in the existing lock order, we'll need to acquire
`baseQueue.mu` before `raftMu` -- or -- we make it illegal for
`baseQueue` to acquire `raftMu`.

I think the more idiomatic change is to remove the `raftMu` acquisition
from baseQueue. This isn't what I've done in this change, though. The
acquisition was added recently by myself when we started using the
queues as a paced method for initializing Raft groups:

https://github.com/cockroachdb/cockroach/blame/447fe7d6023a3db7473445944ae3693f0f286d17/pkg/storage/queue.go#L437-L439

In hindsight, that was a bad idea since it opened this can of worms.
We can replace this call to `maybeInitializeRaftGroup` with a check
verifying that the Raft group is initialized, and delegate the actual
initialization to a background thread.

On the other hand, maybe the queue should get to assume that no lock
is held when it inspects replicas. This will in turn affect most of
the "reactive" call sites where replicas are offered to the queue
proactively, and some mutex is typically held. This is the solution
explored here (though other call sites need to be changed, and it
will be easy to regress here).

On the positive side,

    make test PKG=./pkg/storage/ TESTFLAGS=-v TAGS=deadlock

fails before this PR and passes after.

Release note (bug fix): Prevent a deadlock related to store queue
processing.