### PR TITLE
release-19.1: roachtest: Reduce tpcc/w=max targets

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -155,9 +155,9 @@ func registerTPCC(r *registry) {
 			var warehouses int
 			switch cloud {
 			case "gce":
-				warehouses = 1350
+				warehouses = 1250
 			case "aws":
-				warehouses = 2300
+				warehouses = 2100
 			default:
 				t.Fatalf("unknown cloud: %q", cloud)
 			}


### PR DESCRIPTION
Backport 1/1 commits from #36401.

/cc @cockroachdb/release

---

Make large cuts to deflake the test until we can get enough data to
put a tighter bound on it. The AWS case does not appear to have passed
since its introduction.

Closes #35337
Updates #36097

Release note: None
