### PR TITLE
roachtest: skip cdc/crdb-chaos and cdc/sink-chaos

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -516,6 +516,7 @@ func registerCDC(r *registry) {
 	})
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("cdc/sink-chaos/rangefeed=%t", useRangeFeed),
+		Skip:       `#36432`,
 		MinVersion: "v2.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -532,6 +533,7 @@ func registerCDC(r *registry) {
 	})
 	r.Add(testSpec{
 		Name:       fmt.Sprintf("cdc/crdb-chaos/rangefeed=%t", useRangeFeed),
+		Skip:       `#36432`,
 		MinVersion: "v2.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Run: func(ctx context.Context, t *test, c *cluster) {


### PR DESCRIPTION
As #36432 mentions, we know what's wrong. We're not getting any new data
from running these, so stop spamming failures until we get a chance to
fix them.

Release note: None