### PR TITLE
storage: avoid double-ingest of same SST on re-apply

### DIFF
--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/kr/pretty"
@@ -404,6 +405,7 @@ func addSSTablePreApply(
 	} else {
 		ingestPath := path + ".ingested"
 
+		canLinkToRaftFile := false
 		// The SST may already be on disk, thanks to the sideloading mechanism.  If
 		// so we can try to add that file directly, via a new hardlink if the file-
 		// system support it, rather than writing a new copy of it. However, this is
@@ -413,7 +415,21 @@ func addSSTablePreApply(
 		// tell Rocks that it is not allowed to modify the file, in which case it
 		// will return and error if it would have tried to do so, at which point we
 		// can fall back to writing a new copy for Rocks to ingest.
-		if _, err := os.Stat(path); err == nil {
+		if _, links, err := sysutil.StatAndLinkCount(path); err == nil {
+			// HACK: RocksDB does not like ingesting the same file (by inode) twice.
+			// See facebook/rocksdb#5133. We can tell that we have tried to ingest
+			// this file already if it has more than one link – one from the file raft
+			// wrote and one from rocks. In that case, we should not try to give
+			// rocks a link to the same file again.
+			if links == 1 {
+				canLinkToRaftFile = true
+			} else {
+				log.Warningf(ctx, "SSTable at index %d term %d may have already been ingested (link count %d) -- falling back to ingesting a copy",
+					index, term, links)
+			}
+		}
+
+		if canLinkToRaftFile {
 			// If the fs supports it, make a hard-link for rocks to ingest. We cannot
 			// pass it the path in the sideload store as it deletes the passed path on
 			// success.

--- a/pkg/util/sysutil/sysutil_unix.go
+++ b/pkg/util/sysutil/sysutil_unix.go
@@ -21,6 +21,8 @@ package sysutil
 import (
 	"fmt"
 	"math"
+	"os"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 )
@@ -54,4 +56,19 @@ func StatFS(path string) (*FSInfo, error) {
 		TotalBlocks: int64(fs.Blocks),
 		BlockSize:   int64(fs.Bsize),
 	}, nil
+}
+
+// StatAndLinkCount wraps os.Stat, returning its result and, if the platform
+// supports it, the link-count from the returned file info.
+func StatAndLinkCount(path string) (os.FileInfo, int64, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return stat, 0, err
+	}
+	if sys := stat.Sys(); sys != nil {
+		if s, ok := sys.(*syscall.Stat_t); ok {
+			return stat, int64(s.Nlink), nil
+		}
+	}
+	return stat, 0, nil
 }

--- a/pkg/util/sysutil/sysutil_windows.go
+++ b/pkg/util/sysutil/sysutil_windows.go
@@ -19,6 +19,7 @@ package sysutil
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/user"
 )
 
@@ -36,4 +37,10 @@ func ProcessIdentity() string {
 // supported on Unix-like platforms.
 func StatFS(path string) (*FSInfo, error) {
 	return nil, errors.New("unsupported on Windows")
+}
+
+// StatAndLinkCount wraps os.Stat, returning its result and a zero link count.
+func StatAndLinkCount(path string) (os.FileInfo, int64, error) {
+	stat, err := os.Stat(path)
+	return stat, 0, err
 }


### PR DESCRIPTION
If an AddSSTable is re-applied when using the no-copy, hard-link only ingest, the second ingest
passes a link to the same underlying file (by inode) to rocks. Due to https://github.com/facebook/rocksdb/issues/5133,
this then causes the ingestion to fail.

This avoids that by checking if the file we're about to ingest already has moore than one link.
If so, we do not allow ingesting the raft file directly and instead make a copy.

Release note: none.