### PR TITLE
backport-19.1: debug zip improvements

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -47,6 +48,7 @@ import (
 	// register some workloads for TestWorkload
 	_ "github.com/cockroachdb/cockroach/pkg/workload/examples"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 type cliTest struct {
@@ -1879,9 +1881,7 @@ Use "cockroach [command] --help" for more information about a command.
 			}
 			got := strings.Join(final, "\n")
 
-			if got != test.expected {
-				t.Errorf("got:\n%s\n----\nexpected:\n%s", got, test.expected)
-			}
+			assert.Equal(t, test.expected, got)
 		})
 	}
 }
@@ -2288,6 +2288,54 @@ func TestJunkPositionalArguments(t *testing.T) {
 	}
 }
 
+// TestZipContainsAllInternalTables verifies that we don't add new internal tables
+// without also taking them into account in a `debug zip`. If this test fails,
+// add your table to either of the []string slices referenced in the test (which
+// are used by `debug zip`) or add it as an exception after having verified that
+// it indeed should not be collected (this is rare).
+// NB: if you're adding a new one, you'll also have to update TestZip.
+func TestZipContainsAllInternalTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	rows, err := db.Query(`
+SELECT concat('crdb_internal.', table_name) as name FROM [ SHOW TABLES FROM crdb_internal ] WHERE
+    table_name NOT IN (
+-- whitelisted tables that don't need to be in debug zip
+'backward_dependencies',
+'builtin_functions',
+'create_statements',
+'forward_dependencies',
+'index_columns',
+'table_columns',
+'table_indexes',
+'ranges',
+'ranges_no_leases',
+'predefined_comments',
+'session_trace',
+'session_variables',
+'tables'
+)
+ORDER BY name ASC`)
+	assert.NoError(t, err)
+
+	var tables []string
+	for rows.Next() {
+		var table string
+		assert.NoError(t, rows.Scan(&table))
+		tables = append(tables, table)
+	}
+
+	var exp []string
+	exp = append(exp, debugZipTablesPerNode...)
+	exp = append(exp, debugZipTablesPerCluster...)
+	sort.Strings(exp)
+
+	assert.Equal(t, exp, tables)
+}
+
 func TestZip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -2306,16 +2354,28 @@ writing ` + os.DevNull + `
   debug/liveness.json
   debug/settings.json
   debug/reports/problemranges.json
+  debug/crdb_internal.cluster_queries.txt
+  debug/crdb_internal.cluster_sessions.txt
+  debug/crdb_internal.cluster_settings.txt
   debug/crdb_internal.jobs.txt
+  debug/crdb_internal.kv_node_status.txt
+  debug/crdb_internal.kv_store_status.txt
   debug/crdb_internal.schema_changes.txt
+  debug/crdb_internal.partitions.txt
+  debug/crdb_internal.zones.txt
   debug/nodes/1/status.json
+  debug/nodes/1/crdb_internal.feature_usage.txt
+  debug/nodes/1/crdb_internal.gossip_alerts.txt
   debug/nodes/1/crdb_internal.gossip_liveness.txt
   debug/nodes/1/crdb_internal.gossip_network.txt
   debug/nodes/1/crdb_internal.gossip_nodes.txt
+  debug/nodes/1/crdb_internal.leases.txt
+  debug/nodes/1/crdb_internal.node_statement_statistics.txt
+  debug/nodes/1/crdb_internal.node_build_info.txt
   debug/nodes/1/crdb_internal.node_metrics.txt
-  debug/nodes/1/crdb_internal.gossip_alerts.txt
-  debug/nodes/1/queries.txt
-  debug/nodes/1/sessions.txt
+  debug/nodes/1/crdb_internal.node_queries.txt
+  debug/nodes/1/crdb_internal.node_runtime_info.txt
+  debug/nodes/1/crdb_internal.node_sessions.txt
   debug/nodes/1/details.json
   debug/nodes/1/gossip.json
   debug/nodes/1/stacks.txt
@@ -2360,9 +2420,7 @@ writing ` + os.DevNull + `
   debug/schema/system/zones.json
 `
 
-	if out != expected {
-		t.Errorf("expected:\n%s\ngot:\n%s", expected, out)
-	}
+	assert.Equal(t, expected, out)
 }
 
 func TestWorkload(t *testing.T) {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -231,6 +231,12 @@ func init() {
 		if strings.HasPrefix(flag.Name, "lightstep_") {
 			flag.Hidden = true
 		}
+		if strings.HasPrefix(flag.Name, "httptest.") {
+			// If we test the cli commands in tests, we may end up transitively
+			// importing httptest, for example via `testify/assert`. Make sure
+			// it doesn't show up in the output or it will confuse tests.
+			flag.Hidden = true
+		}
 		switch flag.Name {
 		case logflags.NoRedirectStderrName:
 			flag.Hidden = true

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -50,6 +50,17 @@ import (
 
 const crdbInternalName = "crdb_internal"
 
+// Naming convention:
+// - if the response is served from memory, prefix with node_
+// - if the response is served via a kv request, prefix with kv_
+// - if the response is not from kv requests but is cluster-wide (i.e. the
+//    answer isn't specific to the sql connection being used, prefix with cluster_.
+//
+// Adding something new here will require an update to `pkg/cli` for inclusion in
+// a `debug zip`; the unit tests will guide you.
+//
+// Many existing tables don't follow the conventions above, but please apply
+// them to future additions.
 var crdbInternal = virtualSchema{
 	name: crdbInternalName,
 	tableDefs: map[sqlbase.ID]virtualSchemaDef{
@@ -91,6 +102,7 @@ var crdbInternal = virtualSchema{
 	validWithNoDatabaseContext: true,
 }
 
+// TODO(tbg): prefix with node_.
 var crdbInternalBuildInfoTable = virtualSchemaTable{
 	comment: `detailed identification strings (RAM, local node only)`,
 	schema: `
@@ -124,6 +136,7 @@ CREATE TABLE crdb_internal.node_build_info (
 	},
 }
 
+// TODO(tbg): prefix with node_.
 var crdbInternalRuntimeInfoTable = virtualSchemaTable{
 	comment: `server parameters, useful to construct connection URLs (RAM, local node only)`,
 	schema: `
@@ -183,6 +196,7 @@ CREATE TABLE crdb_internal.node_runtime_info (
 	},
 }
 
+// TODO(tbg): prefix with kv_.
 var crdbInternalTablesTable = virtualSchemaTable{
 	comment: `table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)`,
 	schema: `
@@ -285,6 +299,7 @@ CREATE TABLE crdb_internal.tables (
 	},
 }
 
+// TODO(tbg): prefix with kv_.
 var crdbInternalSchemaChangesTable = virtualSchemaTable{
 	comment: `ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)`,
 	schema: `
@@ -348,6 +363,7 @@ CREATE TABLE crdb_internal.schema_changes (
 	},
 }
 
+// TODO(tbg): prefix with node_.
 var crdbInternalLeasesTable = virtualSchemaTable{
 	comment: `acquired table leases (RAM; local node only)`,
 	schema: `
@@ -416,6 +432,7 @@ func tsOrNull(micros int64) tree.Datum {
 	return tree.MakeDTimestamp(ts, time.Microsecond)
 }
 
+// TODO(tbg): prefix with kv_.
 var crdbInternalJobsTable = virtualSchemaTable{
 	comment: `decoded job metadata from system.jobs (KV scan)`,
 	schema: `
@@ -550,6 +567,7 @@ func (s stmtList) Less(i, j int) bool {
 	return s[i].stmt < s[j].stmt
 }
 
+// TODO(tbg): prefix with node_.
 var crdbInternalStmtStatsTable = virtualSchemaTable{
 	comment: `statement statistics (RAM; local node only)`,
 	schema: `
@@ -662,6 +680,8 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 
 // crdbInternalSessionTraceTable exposes the latest trace collected on this
 // session (via SET TRACING={ON/OFF})
+//
+// TODO(tbg): prefix with node_.
 var crdbInternalSessionTraceTable = virtualSchemaTable{
 	comment: `session trace accumulated so far (RAM)`,
 	schema: `
@@ -695,6 +715,8 @@ CREATE TABLE crdb_internal.session_trace (
 
 // crdbInternalClusterSettingsTable exposes the list of current
 // cluster settings.
+//
+// TODO(tbg): prefix with node_.
 var crdbInternalClusterSettingsTable = virtualSchemaTable{
 	comment: `cluster settings (RAM)`,
 	schema: `
@@ -1068,6 +1090,8 @@ CREATE TABLE crdb_internal.builtin_functions (
 
 // crdbInternalCreateStmtsTable exposes the CREATE TABLE/CREATE VIEW
 // statements.
+//
+// TODO(tbg): prefix with kv_.
 var crdbInternalCreateStmtsTable = virtualSchemaTable{
 	comment: `CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)`,
 	schema: `
@@ -1179,6 +1203,8 @@ CREATE TABLE crdb_internal.create_statements (
 }
 
 // crdbInternalTableColumnsTable exposes the column descriptors.
+//
+// TODO(tbg): prefix with kv_.
 var crdbInternalTableColumnsTable = virtualSchemaTable{
 	comment: "details for all columns accessible by current user in current database (KV scan)",
 	schema: `
@@ -1222,6 +1248,8 @@ CREATE TABLE crdb_internal.table_columns (
 }
 
 // crdbInternalTableIndexesTable exposes the index descriptors.
+//
+// TODO(tbg): prefix with kv_.
 var crdbInternalTableIndexesTable = virtualSchemaTable{
 	comment: "indexes accessible by current user in current database (KV scan)",
 	schema: `
@@ -1269,6 +1297,8 @@ CREATE TABLE crdb_internal.table_indexes (
 }
 
 // crdbInternalIndexColumnsTable exposes the index columns.
+//
+// TODO(tbg): prefix with kv_.
 var crdbInternalIndexColumnsTable = virtualSchemaTable{
 	comment: "index columns for all indexes accessible by current user in current database (KV scan)",
 	schema: `
@@ -1382,6 +1412,8 @@ CREATE TABLE crdb_internal.index_columns (
 
 // crdbInternalBackwardDependenciesTable exposes the backward
 // inter-descriptor dependencies.
+//
+// TODO(tbg): prefix with kv_.
 var crdbInternalBackwardDependenciesTable = virtualSchemaTable{
 	comment: "backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)",
 	schema: `
@@ -1521,6 +1553,8 @@ CREATE TABLE crdb_internal.feature_usage (
 
 // crdbInternalForwardDependenciesTable exposes the forward
 // inter-descriptor dependencies.
+//
+// TODO(tbg): prefix with kv_.
 var crdbInternalForwardDependenciesTable = virtualSchemaTable{
 	comment: "forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)",
 	schema: `
@@ -1656,8 +1690,10 @@ FROM crdb_internal.ranges_no_leases
 	},
 }
 
-// crdbInternalRangesNoLeasesTable exposes system ranges without the
+// crdbInternalRangesNoLeasesTable exposes all ranges in the system without the
 // `lease_holder` information.
+//
+// TODO(tbg): prefix with kv_.
 var crdbInternalRangesNoLeasesTable = virtualSchemaTable{
 	comment: `range metadata without leaseholder details (KV join; expensive!)`,
 	schema: `
@@ -1769,6 +1805,8 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 // The cli_specifier column is deprecated and only exists to be used
 // as a hidden field by the CLI for backwards compatibility. Use zone_name
 // instead.
+//
+// TODO(tbg): prefix with kv_.
 var crdbInternalZonesTable = virtualSchemaTable{
 	comment: "decoded zone configurations from system.zones (KV scan)",
 	schema: `
@@ -2202,6 +2240,8 @@ func addPartitioningRows(
 
 // crdbInternalPartitionsTable decodes and exposes the partitions of each
 // table.
+//
+// TODO(tbg): prefix with cluster_.
 var crdbInternalPartitionsTable = virtualSchemaTable{
 	comment: "defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)",
 	schema: `
@@ -2225,6 +2265,8 @@ CREATE TABLE crdb_internal.partitions (
 }
 
 // crdbInternalKVNodeStatusTable exposes information from the status server about the cluster nodes.
+//
+// TODO(tbg): s/kv_/cluster_/
 var crdbInternalKVNodeStatusTable = virtualSchemaTable{
 	comment: "node details across the entire cluster (cluster RPC; expensive!)",
 	schema: `
@@ -2339,6 +2381,8 @@ CREATE TABLE crdb_internal.kv_node_status (
 }
 
 // crdbInternalKVStoreStatusTable exposes information about the cluster stores.
+//
+// TODO(tbg): s/kv_/cluster_/
 var crdbInternalKVStoreStatusTable = virtualSchemaTable{
 	comment: "store details and status (cluster RPC; expensive!)",
 	schema: `
@@ -2455,6 +2499,8 @@ CREATE TABLE crdb_internal.kv_store_status (
 // comments for virtual tables. This is used by SHOW TABLES WITH COMMENT
 // as fall-back when system.comments is silent.
 // TODO(knz): extend this with vtable column comments.
+//
+// TODO(tbg): prefix with node_.
 var crdbInternalPredefinedCommentsTable = virtualSchemaTable{
 	comment: `comments for predefined virtual tables (RAM/static)`,
 	schema: `


### PR DESCRIPTION
Backport:
  * 1/1 commits from "cli: actually fetch per-node tables from nodes" (#36167)
  * 1/1 commits from "cli: enforce inclusion of new crdb_internal tables in debug zip" (#36281)

Please see individual PRs for details.

/cc @cockroachdb/release
