### PR TITLE
roachprod: enable dns_hostnames in VPC and re-enable terraform config

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -89,17 +89,19 @@ const (
 
 var defaultConfig = func() (cfg *awsConfig) {
 	cfg = new(awsConfig)
-	if err := json.Unmarshal(MustAsset("old.json"), cfg); err != nil {
+	if err := json.Unmarshal(MustAsset("config.json"), cfg); err != nil {
 		panic(errors.Wrap(err, "failed to embedded configuration"))
 	}
 	return cfg
 }()
 
 var defaultZones = []string{
+	"us-east-2a",
 	"us-east-2b",
 	"us-east-2c",
 	"us-west-2a",
 	"us-west-2b",
+	"us-west-2c",
 	"eu-west-2a",
 	"eu-west-2b",
 	"eu-west-2c",

--- a/pkg/cmd/roachprod/vm/aws/terraform/aws-region/main.tf
+++ b/pkg/cmd/roachprod/vm/aws/terraform/aws-region/main.tf
@@ -32,7 +32,7 @@ output "vpc_info" {
   }
 }
 
-output "extended_vpc_info" {
+output "region_info" {
   value = {
     "region"         = "${var.region}"
     "security_group" = "${aws_security_group.region_security_group.id}"

--- a/pkg/cmd/roachprod/vm/aws/terraform/aws-region/network.tf
+++ b/pkg/cmd/roachprod/vm/aws/terraform/aws-region/network.tf
@@ -58,10 +58,10 @@ data "aws_availability_zone" "zone_detail" {
 
 # One VPC per region, with CIDR 10.<region ID>.0.0/8.
 resource "aws_vpc" "region_vpc" {
-  cidr_block    = "${cidrsubnet("10.0.0.0/8", 8, local.region_number[var.region])}"
-
+  cidr_block           = "${cidrsubnet("10.0.0.0/8", 8, local.region_number[var.region])}"
+  enable_dns_hostnames = true
   tags {
-    Name        = "${var.label}-vpc-${var.region}"
+    Name               = "${var.label}-vpc-${var.region}"
   }
 }
 


### PR DESCRIPTION
It turns out the missing configuration option from the terraform configuration
was using dns hostnames. Now that it's enabled the terraform-created VPCs and
associated configuration works with roachtest. This PR fixes the terraform
config (which has been applied and tested) and sets it back to the default.

Also fixes a broken reference to a renamed terraform output. 

Release note: None