### PR TITLE
rsg: import and unblock CCL code in RSG tests

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -28,6 +28,9 @@ import (
 	"testing"
 	"time"
 
+	// Enable CCL statements.
+	_ "github.com/cockroachdb/cockroach/pkg/ccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/rsg"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -545,6 +548,7 @@ func testRandomSyntax(
 		t.Skip("enable with '-rsg <duration>'")
 	}
 	ctx := context.Background()
+	defer utilccl.TestingEnableEnterprise()()
 
 	params, _ := tests.CreateTestServerParams()
 	params.UseDatabase = "ident"


### PR DESCRIPTION
Fixes #36479

Release note: None