### PR TITLE
backfill: lower default backfiller batch size to 5000

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -58,7 +58,7 @@
 <tr><td><code>rocksdb.min_wal_sync_interval</code></td><td>duration</td><td><code>0s</code></td><td>minimum duration between syncs of the RocksDB WAL</td></tr>
 <tr><td><code>schemachanger.backfiller.buffer_size</code></td><td>byte size</td><td><code>196 MiB</code></td><td>amount to buffer in memory during backfills</td></tr>
 <tr><td><code>schemachanger.backfiller.max_sst_size</code></td><td>byte size</td><td><code>16 MiB</code></td><td>target size for ingested files during backfills</td></tr>
-<tr><td><code>schemachanger.bulk_index_backfill.batch_size</code></td><td>integer</td><td><code>5000000</code></td><td>number of rows to process at a time during bulk index backfill</td></tr>
+<tr><td><code>schemachanger.bulk_index_backfill.batch_size</code></td><td>integer</td><td><code>5000</code></td><td>number of rows to process at a time during bulk index backfill</td></tr>
 <tr><td><code>schemachanger.bulk_index_backfill.enabled</code></td><td>boolean</td><td><code>true</code></td><td>backfill indexes in bulk via addsstable</td></tr>
 <tr><td><code>schemachanger.lease.duration</code></td><td>duration</td><td><code>5m0s</code></td><td>the duration of a schema change lease</td></tr>
 <tr><td><code>schemachanger.lease.renew_fraction</code></td><td>float</td><td><code>0.5</code></td><td>the fraction of schemachanger.lease_duration remaining to trigger a renew of the lease</td></tr>

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -68,7 +68,7 @@ const (
 var indexBulkBackfillChunkSize = settings.RegisterIntSetting(
 	"schemachanger.bulk_index_backfill.batch_size",
 	"number of rows to process at a time during bulk index backfill",
-	5000000,
+	5000,
 )
 
 var _ sort.Interface = columnsByID{}


### PR DESCRIPTION
Lower `schemachanger.bulk_index_backfill.batch_size` from 5000000 to 5000 to
reduce memory allocation when buffering KVs during index backfills, now that
KVs are buffered and sorted in BulkAdder instead of being sorted in every
batch.

Release note: None