### PR TITLE
release-2.0: pgwire: cancel authentication work when the network connection is closed

### DIFF
--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -28,6 +28,7 @@ type TestingKnobs struct {
 	SQLExecutor         ModuleTestingKnobs
 	SQLLeaseManager     ModuleTestingKnobs
 	SQLSchemaChanger    ModuleTestingKnobs
+	PGWireTestingKnobs  ModuleTestingKnobs
 	SQLMigrationManager ModuleTestingKnobs
 	DistSQL             ModuleTestingKnobs
 	SQLEvalContext      ModuleTestingKnobs

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -24,8 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
@@ -56,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/pkg/errors"
 )
 
 // ClusterOrganization is the organization name.
@@ -271,6 +270,7 @@ type ExecutorConfig struct {
 	AuditLogger     *log.SecondaryLogger
 
 	TestingKnobs              *ExecutorTestingKnobs
+	PGWireTestingKnobs        *PGWireTestingKnobs
 	SchemaChangerTestingKnobs *SchemaChangerTestingKnobs
 	EvalContextTestingKnobs   tree.EvalContextTestingKnobs
 	// HistogramWindowInterval is (server.Config).HistogramWindowInterval.
@@ -295,6 +295,18 @@ var _ base.ModuleTestingKnobs = &ExecutorTestingKnobs{}
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
 func (*ExecutorTestingKnobs) ModuleTestingKnobs() {}
+
+// PGWireTestingKnobs contains knobs for the pgwire module.
+type PGWireTestingKnobs struct {
+	// AuthHook is used to override the normal authentication handling on new
+	// connections.
+	AuthHook func(context.Context) error
+}
+
+var _ base.ModuleTestingKnobs = &PGWireTestingKnobs{}
+
+// ModuleTestingKnobs implements the base.ModuleTestingKnobs interface.
+func (*PGWireTestingKnobs) ModuleTestingKnobs() {}
 
 // StatementFilter is the type of callback that
 // ExecutorTestingKnobs.StatementFilter takes.

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -27,9 +27,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/lib/pq/oid"
-	"github.com/pkg/errors"
-
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -44,6 +41,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/lib/pq/oid"
+	"github.com/pkg/errors"
 )
 
 // conn implements a pgwire network connection (version 3 of the protocol,
@@ -85,6 +84,12 @@ type conn struct {
 
 	readBuf    pgwirebase.ReadBuffer
 	msgBuilder *writeBuffer
+}
+
+type authOptions struct {
+	skipAuth bool                            // test-only
+	authHook func(ctx context.Context) error // test-only
+	insecure bool
 }
 
 // serveConn creates a conn that will serve the netConn. It returns once the
@@ -134,9 +139,9 @@ func serveConn(
 	sqlServer *sql.Server,
 	draining func() bool,
 	execCfg *sql.ExecutorConfig,
+	authOpt authOptions,
 	stopper *stop.Stopper,
-	insecure bool,
-) error {
+) {
 	sArgs.RemoteAddr = netConn.RemoteAddr()
 
 	if log.V(2) {
@@ -145,15 +150,8 @@ func serveConn(
 
 	c := newConn(netConn, sArgs, metrics, execCfg)
 
-	if err := c.handleAuthentication(ctx, insecure); err != nil {
-		_ = c.conn.Close()
-		reserved.Close(ctx)
-		return err
-	}
-
 	// Do the reading of commands from the network.
-	readingErr := c.serveImpl(ctx, draining, sqlServer, reserved, stopper)
-	return readingErr
+	c.serveImpl(ctx, draining, sqlServer, reserved, authOpt, stopper)
 }
 
 func newConn(
@@ -188,10 +186,12 @@ func (c *conn) GetErr() error {
 }
 
 // serveImpl continuously reads from the network connection and pushes execution
-// instructions into a sql.StmtBuf.
+// instructions into a sql.StmtBuf, from where they'll be processed by a command
+// "processor" goroutine (a connExecutor).
 // The method returns when the pgwire termination message is received, when
 // network communication fails, when the server is draining or when ctx is
-// canceled (which also happens when draining, but not from the get-go).
+// canceled (which also happens when draining (but not from the get-go), and
+// when the processor encounters a fatal error).
 //
 // serveImpl always closes the network connection before returning.
 //
@@ -203,73 +203,89 @@ func (c *conn) serveImpl(
 	draining func() bool,
 	sqlServer *sql.Server,
 	reserved mon.BoundAccount,
+	authOpt authOptions,
 	stopper *stop.Stopper,
-) error {
+) {
 	defer func() { _ = c.conn.Close() }()
 
 	// NOTE: We're going to write a few messages to the connection in this method,
 	// for the handshake. After that, all writes are done async, in the
 	// startWriter() goroutine.
 
-	for key, value := range statusReportParams {
-		c.msgBuilder.initMsg(pgwirebase.ServerMsgParameterStatus)
-		c.msgBuilder.writeTerminatedString(key)
-		c.msgBuilder.writeTerminatedString(value)
-		if err := c.msgBuilder.finishMsg(c.conn); err != nil {
-			return err
-		}
-	}
-
-	// An initial readyForQuery message is part of the handshake.
-	c.msgBuilder.initMsg(pgwirebase.ServerMsgReady)
-	c.msgBuilder.writeByte(byte(sql.IdleTxnBlock))
-	if err := c.msgBuilder.finishMsg(c.conn); err != nil {
-		return err
-	}
-
 	ctx = log.WithLogTagStr(ctx, "user", c.sessionArgs.User)
-	ctx, stopReader := context.WithCancel(ctx)
-	defer stopReader() // This calms the linter that wants these callbacks to always be called.
-	var ctxCanceled bool
+	ctx, cancelConn := context.WithCancel(ctx)
+	defer cancelConn() // This calms the linter that wants these callbacks to always be called.
 
-	// Once a session has been set up, the underlying net.Conn is switched to
-	// a conn that exits if the session's context is canceled.
+	var sentDrainSignal bool
+	// The net.Conn is switched to a conn that exits if the ctx is canceled.
 	c.conn = newReadTimeoutConn(c.conn, func() error {
-		// If the context was closed, it's time to bail. Either a higher-level
-		// server or the command processor have canceled us.
+		// If the context was canceled, it's time to stop reading. Either a
+		// higher-level server or the command processor have canceled us.
 		if ctx.Err() != nil {
-			ctxCanceled = true
 			return ctx.Err()
 		}
 		// If the server is draining, we'll let the processor know by pushing a
 		// DrainRequest. This will make the processor quit whenever it finds a good
 		// time.
-		if draining() {
+		if !sentDrainSignal && draining() {
 			_ /* err */ = c.stmtBuf.Push(ctx, sql.DrainRequest{})
+			sentDrainSignal = true
 		}
 		return nil
 	})
 	c.rd = *bufio.NewReader(c.conn)
 
-	var wg sync.WaitGroup
-	var writerErr error
-	processorCtx, stopProcessor := context.WithCancel(ctx)
+	// We'll build an authPipe to communicate with the authentication process.
+	authPipe := newAuthPipe(c)
+	var authenticator authenticator = authPipe
+
+	// procCh is the channel on which we'll receive the termination signal from
+	// the command processor.
+	var procCh <-chan error
+
 	if sqlServer != nil {
-		wg.Add(1)
-		go func() {
-			writerErr = sqlServer.ServeConn(
-				processorCtx, c.sessionArgs, c.stmtBuf, c, reserved, &c.metrics.SQLMemMetrics)
-			// TODO(andrei): Should we sometimes transmit the writerErr's to the
-			// client?
-			wg.Done()
-			stopReader()
-		}()
+		// Spawn the command processing goroutine, which also handles connection
+		// authentication). It will notify us when it's done through procCh, and
+		// we'll also interact with the authentication process through ac.
+		var ac AuthConn = authPipe
+		procCh = c.processCommandsAsync(ctx, authOpt, ac, sqlServer, reserved, cancelConn)
+	} else {
+		// sqlServer == nil means we are in a local test. In this case
+		// we only need the minimum to make pgx happy.
+		var err error
+		for key, value := range statusReportParams {
+			c.msgBuilder.initMsg(pgwirebase.ServerMsgParameterStatus)
+			c.msgBuilder.writeTerminatedString(key)
+			c.msgBuilder.writeTerminatedString(value)
+			if err := c.msgBuilder.finishMsg(c.conn); err != nil {
+				break
+			}
+		}
+		if err != nil {
+			reserved.Close(ctx)
+			return
+		}
+
+		var ac AuthConn = authPipe
+		// Simulate auth succeeding.
+		ac.AuthOK()
+		dummyCh := make(chan error)
+		close(dummyCh)
+		procCh = dummyCh
+		// An initial readyForQuery message is part of the handshake.
+		c.msgBuilder.initMsg(pgwirebase.ServerMsgReady)
+		c.msgBuilder.writeByte(byte(sql.IdleTxnBlock))
+		if err := c.msgBuilder.finishMsg(c.conn); err != nil {
+			reserved.Close(ctx)
+			return
+		}
 	}
 
 	var err error
 	var terminateSeen bool
 	var doingExtendedQueryMessage bool
 
+	var authDone bool
 Loop:
 	for {
 		var typ pgwirebase.ClientMessageType
@@ -279,11 +295,39 @@ Loop:
 		if err != nil {
 			break Loop
 		}
-		if log.V(2) {
-			log.Infof(ctx, "pgwire: processing %s", typ)
-		}
 		timeReceived := timeutil.Now()
+		log.VEventf(ctx, 2, "pgwire: processing %s", typ)
+
+		if !authDone {
+			if typ == pgwirebase.ClientMsgPassword {
+				var pwd []byte
+				if pwd, err = c.readBuf.GetBytes(n - 4); err != nil {
+					break Loop
+				}
+				// Pass the data to the authenticator. This hopefully causes it to finish
+				// authentication in the background and give us an intSizer when we loop
+				// around.
+				if err = authenticator.sendPwdData(pwd); err != nil {
+					break Loop
+				}
+				continue
+			}
+			// Wait for the auth result.
+			err = authenticator.authResult()
+			if err != nil {
+				// The error has already been sent to the client.
+				break Loop
+			} else {
+				authDone = true
+			}
+		}
+
 		switch typ {
+		case pgwirebase.ClientMsgPassword:
+			// This messages are only acceptable during the auth phase, handled above.
+			err = pgwirebase.NewProtocolViolationErrorf("unexpected authentication data")
+			_ /* err */ = writeErr(err, c.msgBuilder, &c.writerState.buf)
+			break Loop
 		case pgwirebase.ClientMsgSimpleQuery:
 			if doingExtendedQueryMessage {
 				if err = c.stmtBuf.Push(
@@ -355,31 +399,137 @@ Loop:
 		}
 	}
 
+	// We're done reading data from the client, so make the communication
+	// goroutine stop. Depending on what that goroutine is currently doing (or
+	// blocked on), we cancel and close all the possible channels to make sure we
+	// tickle it in the right way.
+
 	// Signal command processing to stop. It might be the case that the processor
 	// canceled our context and that's how we got here; in that case, this will
 	// be a no-op.
 	c.stmtBuf.Close()
-	stopProcessor()
-	wg.Wait()
+	// Cancel the processor's context.
+	cancelConn()
+	// In case the authenticator is blocked on waiting for data from the client,
+	// tell it that there's no more data coming. This is a no-op if authentication
+	// was completed already.
+	authenticator.noMorePwdData()
+
+	// Wait for the processor goroutine to finish, if it hasn't already. We're
+	// ignoring the error we get from it, as we have no use for it. It might be a
+	// connection error, or a context cancelation error case this goroutine is the
+	// one that triggered the execution to stop.
+	<-procCh
 
 	if terminateSeen {
-		return nil
+		return
 	}
 	// If we're draining, let the client know by piling on an AdminShutdownError
 	// and flushing the buffer.
-	if ctxCanceled || draining() {
+	if draining() {
+		// TODO(andrei): I think sending this extra error to the client if we also
+		// sent another error for the last query (like a context canceled) is a bad
+		// idead; see #22630. I think we should find a way to return the
+		// AdminShutdown error as the only result of the query.
 		_ /* err */ = writeErr(
 			newAdminShutdownErr(err), c.msgBuilder, &c.writerState.buf)
 		_ /* n */, _ /* err */ = c.writerState.buf.WriteTo(c.conn)
+	}
+}
 
-		// Swallow whatever error we might have gotten from the writer. If we're
-		// draining, it's probably a canceled context error.
-		return nil
-	}
-	if writerErr != nil {
-		return writerErr
-	}
-	return nil
+// processCommandsAsync spawns a goroutine that authenticates the connection and
+// then processes commands from c.stmtBuf.
+//
+// It returns a channel that will be signaled when this goroutine is done.
+// Whatever error is returned on that channel has already been written to the
+// client connection, if applicable.
+//
+// If authentication fails, this goroutine finishes and, as always, cancelConn
+// is called.
+//
+// Args:
+// ac: An interface used by the authentication process to receive password data
+//   and to ultimately declare the authentication successful.
+// reserved: Reserved memory. This method takes ownership.
+// cancelConn: A function to be called when this goroutine exits. Its goal is to
+//   cancel the connection's context, thus stopping the connection's goroutine.
+//   The returned channel is also closed before this goroutine dies, but the
+//   connection's goroutine is not expected to be reading from that channel
+//   (instead, it's expected to always be monitoring the network connection).
+func (c *conn) processCommandsAsync(
+	ctx context.Context,
+	authOpt authOptions,
+	ac AuthConn,
+	sqlServer *sql.Server,
+	reserved mon.BoundAccount,
+	cancelConn func(),
+) <-chan error {
+	// reservedOwned is true while we own reserved, false when we pass ownership
+	// away.
+	reservedOwned := true
+	retCh := make(chan error, 1)
+	go func() {
+		var retErr error
+		var authOK bool
+		defer func() {
+			// Release resources, if we still own them.
+			if reservedOwned {
+				reserved.Close(ctx)
+			}
+			// Notify the connection's goroutine that we're terminating. The
+			// connection might know already, as it might have triggered this
+			// goroutine's finish, but it also might be us that we're triggering the
+			// connection's death. This context cancelation serves to interrupt a
+			// network read on the connection's goroutine.
+			cancelConn()
+
+			if !authOK {
+				ac.AuthFail(retErr)
+			}
+			// Inform the connection goroutine of success or failure.
+			retCh <- retErr
+		}()
+
+		// Authenticate the connection.
+		if !authOpt.skipAuth {
+			if authOpt.authHook != nil {
+				if retErr = authOpt.authHook(ctx); retErr != nil {
+					return
+				}
+			} else {
+				if retErr = c.handleAuthentication(ctx, ac, authOpt.insecure); retErr != nil {
+					return
+				}
+			}
+		}
+
+		ac.AuthOK()
+		authOK = true
+
+		// Send some status params.
+		for key, value := range statusReportParams {
+			c.msgBuilder.initMsg(pgwirebase.ServerMsgParameterStatus)
+			c.msgBuilder.writeTerminatedString(key)
+			c.msgBuilder.writeTerminatedString(value)
+			if err := c.msgBuilder.finishMsg(c.conn); err != nil {
+				retErr = err
+				return
+			}
+		}
+		// An initial readyForQuery message is part of the handshake.
+		c.msgBuilder.initMsg(pgwirebase.ServerMsgReady)
+		c.msgBuilder.writeByte(byte(sql.IdleTxnBlock))
+		if err := c.msgBuilder.finishMsg(c.conn); err != nil {
+			retErr = err
+			return
+		}
+
+		// Now actually process commands.
+		reservedOwned = false // We're about to pass ownership away.
+		retErr = sqlServer.ServeConn(
+			ctx, c.sessionArgs, c.stmtBuf, c, reserved, &c.metrics.SQLMemMetrics)
+	}()
+	return retCh
 }
 
 // An error is returned iff the statement buffer has been closed. In that case,
@@ -1210,13 +1360,13 @@ func (r *pgwireReader2) ReadByte() (byte, error) {
 	return b, err
 }
 
-// handleAuthentication should discuss with the client to arrange
-// authentication and update c.sessionArgs with the authenticated user's
-// name, if different from the one given initially. Note: at this
-// point the sql.Session does not exist yet! If need exists to access the
-// database to look up authentication data, use the internal executor.
-func (c *conn) handleAuthentication(ctx context.Context, insecure bool) error {
-
+// handleAuthentication checks the connection's user. Errors are sent to the
+// client and also returned.
+//
+// TODO(knz): handleAuthentication should discuss with the client to arrange
+// authentication and update c.sessionArgs with the authenticated user's name,
+// if different from the one given initially.
+func (c *conn) handleAuthentication(ctx context.Context, ac AuthConn, insecure bool) error {
 	sendError := func(err error) error {
 		_ /* err */ = writeErr(err, c.msgBuilder, c.conn)
 		return err
@@ -1234,14 +1384,14 @@ func (c *conn) handleAuthentication(ctx context.Context, insecure bool) error {
 		return sendError(errors.Errorf("user %s does not exist", c.sessionArgs.User))
 	}
 
-	if tlsConn, ok := c.conn.(*tls.Conn); ok {
+	if tlsConn, ok := c.conn.(*readTimeoutConn).Conn.(*tls.Conn); ok {
 		var authenticationHook security.UserAuthHook
 
 		tlsState := tlsConn.ConnectionState()
 		// If no certificates are provided, default to password
 		// authentication.
 		if len(tlsState.PeerCertificates) == 0 {
-			password, err := c.sendAuthPasswordRequest()
+			password, err := c.sendAuthPasswordRequest(ac)
 			if err != nil {
 				return sendError(err)
 			}
@@ -1272,22 +1422,133 @@ func (c *conn) handleAuthentication(ctx context.Context, insecure bool) error {
 
 // sendAuthPasswordRequest requests a cleartext password from the client and
 // returns it.
-func (c *conn) sendAuthPasswordRequest() (string, error) {
+func (c *conn) sendAuthPasswordRequest(ac AuthConn) (string, error) {
 	c.msgBuilder.initMsg(pgwirebase.ServerMsgAuth)
 	c.msgBuilder.putInt32(authCleartextPassword)
 	if err := c.msgBuilder.finishMsg(c.conn); err != nil {
 		return "", err
 	}
 
-	typ, n, err := c.readBuf.ReadTypedMsg(&c.rd)
-	c.metrics.BytesInCount.Inc(int64(n))
+	pwdData, err := ac.GetPwdData()
 	if err != nil {
 		return "", err
 	}
-
-	if typ != pgwirebase.ClientMsgPassword {
-		return "", errors.Errorf("invalid response to authentication request: %s", typ)
+	password, err := passwordString(pwdData)
+	if err != nil {
+		return "", err
 	}
+	return password, nil
+}
 
-	return c.readBuf.GetString()
+// authenticator is the interface used by the connection to pass password data
+// to the authenticator and expect an authentication decision from it.
+type authenticator interface {
+	// sendPwdData is used to push authentication data into the authenticator.
+	// This call is blocking; authenticators are supposed to consume data hastily
+	// once they've requested it.
+	sendPwdData(data []byte) error
+	// noMorePwdData is used to inform the authenticator that the client is not
+	// sending any more authentication data. This method can be called multiple
+	// times.
+	noMorePwdData()
+	// authResult blocks for an authentication decision. This call also informs
+	// the authenticator that no more auth data is coming from the client;
+	// noMorePwdData() is called internally.
+	authResult() error
+}
+
+// AuthConn is the interface used by the authenticator for interacting with the
+// pgwire connection.
+type AuthConn interface {
+	// GetPwdData returns authentication info that was previously requested with
+	// SendAuthRequest. The call blocks until such data is available.
+	// An error is returned if the client connection dropped or if the client
+	// didn't respect the protocol. After an error has been returned, GetPwdData()
+	// cannot be called any more.
+	GetPwdData() ([]byte, error)
+	// AuthOK declares that authentication succeeded. Future
+	// authenticator.sendPwdData() calls fail.
+	AuthOK()
+	// AuthFail declares that authentication has failed and provides an error to
+	// be returned by authenticator.authResult(). Future
+	// authenticator.sendPwdData() calls fail. The error has already been written
+	// to the client connection.
+	AuthFail(err error)
+}
+
+// authPipe is the implementation for the authenticator and AuthConn interfaces.
+// A single authPipe will serve as both an AuthConn and an authenticator; the
+// two represent the two "ends" of the pipe and we'll pass data between them.
+type authPipe struct {
+	c *conn // Only used for writing, not for reading.
+
+	ch chan []byte
+	// writerDone is a channel closed by noMorePwdData().
+	// Nil if noMorePwdData().
+	writerDone chan struct{}
+	readerDone chan error
+}
+
+func newAuthPipe(c *conn) *authPipe {
+	ap := &authPipe{
+		c:          c,
+		ch:         make(chan []byte),
+		writerDone: make(chan struct{}),
+		readerDone: make(chan error, 1),
+	}
+	return ap
+}
+
+var _ authenticator = &authPipe{}
+var _ AuthConn = &authPipe{}
+
+func (p *authPipe) sendPwdData(data []byte) error {
+	select {
+	case p.ch <- data:
+		return nil
+	case <-p.readerDone:
+		return pgwirebase.NewProtocolViolationErrorf("unexpected auth data")
+	}
+}
+
+func (p *authPipe) noMorePwdData() {
+	if p.writerDone == nil {
+		return
+	}
+	// A reader blocked in GetPwdData() gets unblocked with an error.
+	close(p.writerDone)
+	p.writerDone = nil
+}
+
+// GetPwdData is part of the AuthConn interface.
+func (p *authPipe) GetPwdData() ([]byte, error) {
+	select {
+	case data := <-p.ch:
+		return data, nil
+	case <-p.writerDone:
+		return nil, pgwirebase.NewProtocolViolationErrorf("client didn't send required auth data")
+	}
+}
+
+// AuthOK is part of the AuthConn interface.
+func (p *authPipe) AuthOK() {
+	p.readerDone <- nil
+}
+
+func (p *authPipe) AuthFail(err error) {
+	p.readerDone <- err
+}
+
+// authResult is part of the authenticator interface.
+func (p *authPipe) authResult() error {
+	p.noMorePwdData()
+	return <-p.readerDone
+}
+
+func passwordString(pwdData []byte) (string, error) {
+	// Make a string out of the byte array.
+	if bytes.IndexByte(pwdData, 0) != len(pwdData)-1 {
+		return "", fmt.Errorf("expected 0-terminated byte array")
+	}
+	return string(pwdData[:len(pwdData)-1]), nil
 }

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -32,9 +32,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lib/pq"
-	"github.com/pkg/errors"
-
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -47,6 +44,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
 )
 
 // https://golang.org/cl/38533 and https://golang.org/cl/91115 changed the


### PR DESCRIPTION
Backport of #36231 (which is itself a backport of #35776) into release-2.0.
cc @cockroachdb/release 

Before this patch we would not react to a pgwire connection closing
while we were in the process of authenticating the connection's user.
That's bad particularly when authentication is blocked forever because
of data unavailability. Before this patch, goroutines blocked on
authentication would just leak if the client closed the corresponding
connection, leading to OOMs for folks.
Generally, we react to connection cancelation: a dedicated goroutine is
constantly responsible for reading from the network and canceling the
command processor's context if the connection drops. However,
authentication was special in that it happened before the connection
entered this reader/processor-goroutine mode. Authentication did it's
own reading and writing from the net conn.

This patch extends authentication to fit into the 2-goroutine model. The
conn goroutine takes responsibility for reading all the password
information and passing it to an authenticator which runs on the command
processing goroutine. As in all other cases, if the connection is
dropped, the authenticator's ctx will be canceled.
This required abstracting the conn's interaction with the authenticator
through an interface. The authenticator's interactions with the
connection were already abstracted through an interface for GSS API
reasons. That interface is adapted. A "pipe" metaphor is used to model
the interactions between the conn and the authenticator.

Release note (bug fix): memory and goroutines used for authenticating
connections opened while the cluster is unavailable (e.g. network
partition) no longer leak when the client closes said connections.