### PR TITLE
distsqlrun: don't double-drain in count_rows agg

### DIFF
--- a/pkg/sql/distsqlrun/countrows.go
+++ b/pkg/sql/distsqlrun/countrows.go
@@ -93,10 +93,12 @@ func (ag *countAggregator) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			return nil, meta
 		}
 		if row == nil {
-			ag.MoveToDraining(nil /* err */)
 			ret := make(sqlbase.EncDatumRow, 1)
 			ret[0] = sqlbase.EncDatum{Datum: tree.NewDInt(tree.DInt(ag.count))}
-			return ag.ProcessRowHelper(ret), nil
+			rendered, _, err := ag.out.ProcessRow(ag.Ctx, ret)
+			// We're done as soon as we process our one output row.
+			ag.MoveToDraining(err)
+			return rendered, nil
 		}
 		ag.count++
 	}

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1756,3 +1756,9 @@ SELECT u, v, array_agg(w) AS s FROM (SELECT * FROM uvw ORDER BY w) GROUP BY u, v
 ----
 3  2  {1,3}
 1  2  {3,3}
+
+# Regression test for #36433: don't panic with count_agg if a post-render produces an error.
+
+query error lpad
+SELECT count(*)::TEXT||lpad('foo', 23984729388383834723984) FROM (VALUES(1));
+


### PR DESCRIPTION
Previously, the count_rows aggregator had a bug that caused it to double
drain (and cause a panic) if it encountered an error while rendering
after it had consumed all of its rows.

Fixes #36433 

Release note (bug fix): prevent panic when running a render expression
that produces an error at the very end of a count_rows aggregate.