### PR TITLE
backport-19.1: distsqlplan: don't make untyped indexed var

### DIFF
--- a/pkg/sql/distsqlplan/physical_plan.go
+++ b/pkg/sql/distsqlplan/physical_plan.go
@@ -512,7 +512,10 @@ func (p *PhysicalPlan) AddRendering(
 				if post.Projection {
 					internalColIdx = post.OutputColumns[internalColIdx]
 				}
-				newExpr, err := MakeExpression(&tree.IndexedVar{Idx: int(internalColIdx)}, exprCtx, nil)
+				newExpr, err := MakeExpression(tree.NewTypedOrdinalReference(
+					int(internalColIdx),
+					p.ResultTypes[c.ColIdx].ToDatumType()),
+					exprCtx, nil /* indexVarMap */)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/logictest/testdata/logic_test/sqlsmith
+++ b/pkg/sql/logictest/testdata/logic_test/sqlsmith
@@ -29,3 +29,43 @@ statement ok
 INSERT INTO table8 (col1, col2, col4, col6)
 VALUES ('19:06:18.321589', NULL, NULL, NULL)
 UNION ALL (SELECT NULL, NULL, NULL, NULL FROM table5 AS tab_8);
+
+# Regression: #36441 (raw indexed var can't be type checked)
+query TO
+WITH
+    with_20394 (col_162526)
+        AS (
+            SELECT
+                *
+            FROM
+                (
+                    VALUES
+                        (
+                            'd2d225e2-e9be-4420-a645-d1b8f577511c':::UUID
+                        )
+                )
+                    AS tab_25520 (col_162526)
+            UNION ALL
+                SELECT
+                    *
+                FROM
+                    (
+                        VALUES
+                            (
+                                '1d6eaf81-8a2c-43c5-a495-a3b102917ab1':::UUID
+                            )
+                    )
+                        AS tab_25521 (col_162527)
+        )
+SELECT
+    max(with_20394.col_162526::UUID)::UUID AS col_162534,
+    3697877132:::OID AS col_162541
+FROM
+    with_20394
+GROUP BY
+    with_20394.col_162526
+ORDER BY
+    with_20394.col_162526 ASC
+----
+1d6eaf81-8a2c-43c5-a495-a3b102917ab1  3697877132
+d2d225e2-e9be-4420-a645-d1b8f577511c  3697877132


### PR DESCRIPTION
Backport 1/1 commits from #36510.

/cc @cockroachdb/release

---

Making a raw untyped indexed var is no bueno: indexed vars need to have
types at the point that this one is getting created at (after type
checking).

Fixes #36441

Release note (bug fix): fix potential crash when constructing certain
types of aggregations with post projections.
