### PR TITLE
sql: validate computed columns during ALTER TABLE

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -169,6 +169,12 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 			}
 
+			if d.IsComputed() {
+				if err := validateComputedColumn(n.tableDesc, d, &params.p.semaCtx); err != nil {
+					return err
+				}
+			}
+
 		case *tree.AlterTableAddConstraint:
 			info, err := n.tableDesc.GetConstraintInfo(params.ctx, nil)
 			if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -351,6 +351,16 @@ CREATE TABLE y (
   r INT AS (1) STORED REFERENCES x
 )
 
+# Regression test for #36036.
+statement ok
+CREATE TABLE tt (i INT8 AS (1) STORED)
+
+statement error variable sub-expressions are not allowed in computed column
+ALTER TABLE tt ADD COLUMN c STRING AS ((SELECT NULL)) STORED
+
+statement error computed columns cannot reference other computed columns
+ALTER TABLE tt ADD COLUMN c INT8 AS (i) STORED
+
 # Composite FK.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -739,7 +739,7 @@ statement ok
 ALTER TABLE customers ADD j INT AS (i-1) STORED
 
 statement ok
-ALTER TABLE customers ADD COLUMN d INT DEFAULT 15, ADD COLUMN e INT AS (d + j) STORED
+ALTER TABLE customers ADD COLUMN d INT DEFAULT 15, ADD COLUMN e INT AS (d + (i-1)) STORED
 
 statement ok
 COMMIT
@@ -755,7 +755,7 @@ query TT
 SELECT status, description FROM [SHOW JOBS]
 WHERE job_type = 'SCHEMA CHANGE' ORDER BY job_id DESC LIMIT 1
 ----
-succeeded  ALTER TABLE test.public.customers ADD COLUMN i INT8 DEFAULT 5;ALTER TABLE test.public.customers ADD COLUMN j INT8 AS (i - 1) STORED;ALTER TABLE test.public.customers ADD COLUMN d INT8 DEFAULT 15, ADD COLUMN e INT8 AS (d + j) STORED
+succeeded  ALTER TABLE test.public.customers ADD COLUMN i INT8 DEFAULT 5;ALTER TABLE test.public.customers ADD COLUMN j INT8 AS (i - 1) STORED;ALTER TABLE test.public.customers ADD COLUMN d INT8 DEFAULT 15, ADD COLUMN e INT8 AS (d + (i - 1)) STORED
 
 # VALIDATE CONSTRAINT will not hang when executed in the same txn as
 # a schema change in the same txn #32118


### PR DESCRIPTION
Previously these were only validated during CREATE, allowing the creation
of incorrect columns. validateComputedColumn has removed its dependency
on the tree.CreateTable struct so that the alter code can use it. Because
of this, all FKs must be computed prior to the computed validate checks.

Fixes #36036

Release note (bug fix): Correctly validate computed columns during ALTER
TABLE ADD COLUMN.