### PR TITLE
backport-19.1: server: make engine stall checker warn, not fatal, by default

### DIFF
--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -108,7 +108,8 @@ func runDiskStalledDetection(
 	go func() {
 		t.WorkerStatus("running server")
 		out, err := c.RunWithBuffer(ctx, l, n,
-			fmt.Sprintf("timeout --signal 9 %ds env COCKROACH_ENGINE_MAX_SYNC_DURATION=%s COCKROACH_LOG_MAX_SYNC_DURATION=%s "+
+			fmt.Sprintf("timeout --signal 9 %ds env COCKROACH_ENGINE_MAX_SYNC_DURATION_FATAL=true "+
+				"COCKROACH_ENGINE_MAX_SYNC_DURATION=%s COCKROACH_LOG_MAX_SYNC_DURATION=%s "+
 				"./cockroach start --insecure --logtostderr=INFO --store {store-dir}/%s --log-dir {store-dir}/%s",
 				int(dur.Seconds()), maxDataSync, maxLogSync, dataDir, logDir,
 			),


### PR DESCRIPTION
Backport 1/1 commits from #36484.

/cc @cockroachdb/release

---

The environment variable will allows us to go back to testing the
absence of stalls, though we may also chose to do something more
programmatic based on RocksDB's internal tracking of write stalls.

Release note: None
