### PR TITLE
backport-19.1: storage: skip TestStoreRangeRemoveDead, TestLeaseNotUsedAfterRestart

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2851,6 +2851,9 @@ func TestStoreRangeMoveDecommissioning(t *testing.T) {
 // ReplicateQueue will notice and remove any replicas on it.
 func TestStoreRangeRemoveDead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/34081")
+
 	sc := storage.TestStoreConfig(nil)
 	sc.TestingKnobs.DisableReplicaRebalancing = true
 	mtc := &multiTestContext{

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1078,6 +1078,9 @@ func TestLeaseMetricsOnSplitAndTransfer(t *testing.T) {
 // See replica.mu.minLeaseProposedTS for the reasons why this isn't allowed.
 func TestLeaseNotUsedAfterRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/34111")
+
 	ctx := context.Background()
 
 	sc := storage.TestStoreConfig(nil)


### PR DESCRIPTION
Backport 1/1 commits from #36328.

/cc @cockroachdb/release

---

We need to investigate both (in particular the former), but for now
minimize disruption.

Release note: None
