### PR TITLE
release-19.1: opt: ensure null count is not larger than row count in GROUP BY

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -1413,8 +1413,8 @@ func (sb *statisticsBuilder) colStatGroupBy(
 	} else {
 		inputRowCount := sb.statsFromChild(groupNode, 0 /* childIdx */).RowCount
 		colStat.NullCount = ((colStat.DistinctCount + 1) / inputRowCount) * inputColStat.NullCount
-		colStat.NullCount = min(s.RowCount, colStat.NullCount)
 	}
+	colStat.NullCount = min(s.RowCount, colStat.NullCount)
 
 	if colSet.SubsetOf(relProps.NotNullCols) {
 		colStat.NullCount = 0

--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -466,3 +466,52 @@ select
  │              └── variable: x [type=int]
  └── filters
       └── sum = 5 [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
+
+# Regression test for #36442.
+norm
+WITH q (a, b) AS (SELECT * FROM (VALUES (true, NULL), (false, NULL), (true, 5)))
+  SELECT 1
+    FROM q
+   WHERE q.a
+GROUP BY q.b
+  HAVING bool_or(q.a)
+----
+project
+ ├── columns: "?column?":4(int!null)
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=0]
+ ├── fd: ()-->(4)
+ ├── select
+ │    ├── columns: column2:2(int) bool_or:3(bool!null)
+ │    ├── cardinality: [0 - 3]
+ │    ├── stats: [rows=0, distinct(3)=0, null(3)=0]
+ │    ├── key: (2)
+ │    ├── fd: ()-->(3)
+ │    ├── group-by
+ │    │    ├── columns: column2:2(int) bool_or:3(bool)
+ │    │    ├── grouping columns: column2:2(int)
+ │    │    ├── cardinality: [0 - 3]
+ │    │    ├── stats: [rows=0.875, distinct(2)=0.875, null(2)=0.875, distinct(3)=0.875, null(3)=0.875]
+ │    │    ├── key: (2)
+ │    │    ├── fd: (2)-->(3)
+ │    │    ├── select
+ │    │    │    ├── columns: column1:1(bool!null) column2:2(int)
+ │    │    │    ├── cardinality: [0 - 3]
+ │    │    │    ├── stats: [rows=1.5, distinct(1)=1, null(1)=0, distinct(2)=0.875, null(2)=1]
+ │    │    │    ├── fd: ()-->(1)
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:1(bool) column2:2(int)
+ │    │    │    │    ├── cardinality: [3 - 3]
+ │    │    │    │    ├── stats: [rows=3, distinct(1)=2, null(1)=0, distinct(2)=1, null(2)=2]
+ │    │    │    │    ├── (true, NULL) [type=tuple{bool, int}]
+ │    │    │    │    ├── (false, NULL) [type=tuple{bool, int}]
+ │    │    │    │    └── (true, 5) [type=tuple{bool, int}]
+ │    │    │    └── filters
+ │    │    │         └── variable: column1 [type=bool, outer=(1), constraints=(/1: [/true - /true]; tight), fd=()-->(1)]
+ │    │    └── aggregations
+ │    │         └── bool-or [type=bool, outer=(1)]
+ │    │              └── variable: column1 [type=bool]
+ │    └── filters
+ │         └── variable: bool_or [type=bool, outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+ └── projections
+      └── const: 1 [type=int]


### PR DESCRIPTION
Backport 1/1 commits from #36497.

/cc @cockroachdb/release

---

This commit fixes an edge case in the `GROUP BY` statistics logic where
the estimated null count could be larger than the row count if there
was a single grouping column and the row count was less than 1.

Fixes #36442

Release note (bug fix): Fixed a planning error that occured with some
GROUP BY queries due to errors in null count estimation.
