### PR TITLE
sql: ensure lease expiration is monotonically increasing

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -87,7 +87,7 @@ const (
 	// DefaultTableDescriptorLeaseJitterFraction is the default factor
 	// that we use to randomly jitter the lease duration when acquiring a
 	// new lease and the lease renewal timeout.
-	DefaultTableDescriptorLeaseJitterFraction = 0.25
+	DefaultTableDescriptorLeaseJitterFraction = 0.05
 
 	// DefaultTableDescriptorLeaseRenewalTimeout is the default time
 	// before a lease expires when acquisition to renew the lease begins.

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -350,6 +350,74 @@ CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
 	}
 }
 
+// Tests that a name cache entry always exists for the latest lease and
+// the lease expiration time is monotonically increasing.
+func TestNameCacheContainsLatestLease(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	removalTracker := NewLeaseRemovalTracker()
+	testingKnobs := base.TestingKnobs{
+		SQLLeaseManager: &LeaseManagerTestingKnobs{
+			LeaseStoreTestingKnobs: LeaseStoreTestingKnobs{
+				LeaseReleasedEvent: removalTracker.LeaseRemovedNotification,
+			},
+		},
+	}
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{Knobs: testingKnobs})
+	defer s.Stopper().Stop(context.TODO())
+	leaseManager := s.LeaseManager().(*LeaseManager)
+
+	const tableName = "test"
+
+	if _, err := db.Exec(fmt.Sprintf(`
+CREATE DATABASE t;
+CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
+`, tableName)); err != nil {
+		t.Fatal(err)
+	}
+
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", tableName)
+
+	// Populate the name cache.
+	if _, err := db.Exec("SELECT * FROM t.test;"); err != nil {
+		t.Fatal(err)
+	}
+
+	// There is a cache entry.
+	lease := leaseManager.tableNames.get(tableDesc.ParentID, tableName, s.Clock().Now())
+	if lease == nil {
+		t.Fatalf("name cache has no unexpired entry for (%d, %s)", tableDesc.ParentID, tableName)
+	}
+
+	tracker := removalTracker.TrackRemoval(&lease.ImmutableTableDescriptor)
+
+	// Acquire another lease.
+	if _, err := acquireNodeLease(context.TODO(), leaseManager, tableDesc.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the name resolves to the new lease.
+	newLease := leaseManager.tableNames.get(tableDesc.ParentID, tableName, s.Clock().Now())
+	if newLease == nil {
+		t.Fatalf("name cache doesn't contain entry for (%d, %s)", tableDesc.ParentID, tableName)
+	}
+	if newLease == lease {
+		t.Fatalf("same lease %s", newLease.expiration.GoTime())
+	}
+
+	if err := leaseManager.Release(&lease.ImmutableTableDescriptor); err != nil {
+		t.Fatal(err)
+	}
+
+	// The first lease acquisition was released.
+	if err := tracker.WaitForRemoval(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := leaseManager.Release(&newLease.ImmutableTableDescriptor); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // Test that table names are treated as case sensitive by the name cache.
 func TestTableNameCaseSensitive(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
This is a fix for both a correctness issue and a performance problem.
1. Correctness issue during schema changes: A node could hand an
expiration time from a lease to a transaction T, and if the
node reacquired a lease for the table at an expiration less than
the existing lease's expiration it could release the existing
lease (with a greater expiration) before the transaction T committed,
thereby invalidating T's deadline.
2. Performance issue: After a lease acquisition if the expiration
time of the new lease was less than the existing lease, it would replace
the table in the cache with the new lease and release the older
lease. But unfortunately it would also not update the table in the
table name cache (the table name cache always uses the lease with
the highest expiration). The table in the table name cache would have
it's lease released rendering the name entry invalid. Therefore until
the node acquired another lease for the same table, the node would be
in a state where there was a table cached but it's name -> table cache
entry invalid, resulting in it making name resolution requests for
every query (but not lease renewals).

It is likely this bug started happening with the addition of more
aggressive lease acquisitions through #28725. I've reduced the value
of DefaultTableDescriptorLeaseJitterFraction to make the logic
ensuring the monotonicity of the lease expiration fire infrequently.

fixes #36044

Release note: None