### PR TITLE
changefeedccl,storage: better debugging for changefeeds that have fallen behind

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -952,6 +952,14 @@ var (
 		Measurement: "Encryption At Rest",
 		Unit:        metric.Unit_CONST,
 	}
+
+	// Closed timestamp metrics.
+	metaClosedTimestampMaxBehindNanos = metric.Metadata{
+		Name:        "kv.closed_timestamp.max_behind_nanos",
+		Help:        "Largest latency between realtime and replica max closed timestamp",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 )
 
 // StoreMetrics is the set of metrics for a given store.
@@ -1157,6 +1165,9 @@ type StoreMetrics struct {
 	// RangeFeed counts.
 	RangeFeedMetrics *rangefeed.Metrics
 
+	// Closed timestamp metrics.
+	ClosedTimestampMaxBehindNanos *metric.Gauge
+
 	// Stats for efficient merges.
 	mu struct {
 		syncutil.Mutex
@@ -1358,6 +1369,9 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 
 		// RangeFeed counters.
 		RangeFeedMetrics: rangefeed.NewMetrics(),
+
+		// Closed timestamp metrics.
+		ClosedTimestampMaxBehindNanos: metric.NewGauge(metaClosedTimestampMaxBehindNanos),
 	}
 
 	sm.raftRcvdMessages[raftpb.MsgProp] = sm.RaftRcvdMsgProp


### PR DESCRIPTION
changefeedccl: consider closedts interval in slow log threshold

This was currently only tied to the cluster setting that controls poller
responsiveness, but we've switched to rangefeed by default. These two
cluster setting values represent the target responsiveness of poller and
range feed. The cluster setting for switching between poller and
rangefeed is only checked at changefeed start/resume, so instead of
switching on it here, just add them. Also add 1 second in case both
these settings are set really low (as they are in unit tests).

Closes #34690

----

storage: add kv.closed_timestamp.max_behind_nanos metric

Largest latency between realtime and replica max closed timestamp

Will help debug things like #35142