### PR TITLE
release-19.1: cluster: Add final cluster version 19.1

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -116,6 +116,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>2.1-10</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>19.1</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -472,7 +472,7 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 		clusterVersionUpgrade("2.1", true /* manual */),
 
 		binaryVersionUpgrade("HEAD", nodes),
-		clusterVersionUpgrade("", false /* manual */),
+		clusterVersionUpgrade("19.1", false /* manual */),
 	}
 
 	type feature struct {

--- a/pkg/roachpb/version.go
+++ b/pkg/roachpb/version.go
@@ -36,10 +36,19 @@ func (v Version) CanBump(o Version) bool {
 		// placeholder.
 		return false
 	}
+
 	if o.Major == v.Major {
 		return o.Minor <= v.Minor+1
 	}
-	return o.Major == v.Major+1 && o.Minor == 0
+	if o.Major <= 2 {
+		// The semver era, 1.0 to 2.1
+		return o.Major == v.Major+1 && o.Minor == 0
+	} else if v.Major == 2 && o.Major == 19 {
+		// Transitioning from 2.1 to 19.1
+		return v.Minor == 1 && o.Minor == 1
+	}
+	// The calver era, 19.1 and onwards.
+	return o.Major == v.Major+1 && o.Minor == 1
 }
 
 // Less compares two Versions.

--- a/pkg/roachpb/version_test.go
+++ b/pkg/roachpb/version_test.go
@@ -45,13 +45,49 @@ func TestVersionLess(t *testing.T) {
 		{v1: v(1, 0, 0, 0), v2: v(1, 1, 0, 0), less: true},
 		{v1: v(1, 1, 0, 1), v2: v(1, 1, 0, 0), less: false},
 		{v1: v(1, 1, 0, 1), v2: v(1, 2, 0, 0), less: true},
-		{v1: v(2, 0, 0, 0), v2: v(3, 0, 0, 0), less: true},
+		{v1: v(2, 1, 0, 0), v2: v(19, 1, 0, 0), less: true},
+		{v1: v(19, 1, 0, 0), v2: v(19, 2, 0, 0), less: true},
+		{v1: v(19, 2, 0, 0), v2: v(20, 1, 0, 0), less: true},
 	}
 
 	for _, test := range testData {
 		t.Run("", func(t *testing.T) {
 			if a, e := test.v1.Less(test.v2), test.less; a != e {
 				t.Errorf("expected %s < %s? %t; got %t", pretty.Sprint(test.v1), pretty.Sprint(test.v2), e, a)
+			}
+		})
+	}
+}
+
+func TestVersionCanBump(t *testing.T) {
+	v := func(major, minor, patch, unstable int32) Version {
+		return Version{
+			Major:    major,
+			Minor:    minor,
+			Patch:    patch,
+			Unstable: unstable,
+		}
+	}
+	testData := []struct {
+		v1, v2  Version
+		canBump bool
+	}{
+		{v1: v(2, 0, 0, 0), v2: v(2, 1, 0, 0), canBump: true},
+		{v1: v(2, 0, 0, 0), v2: v(19, 1, 0, 0), canBump: false},
+		{v1: v(2, 1, 0, 0), v2: v(19, 1, 0, 0), canBump: true},
+		{v1: v(2, 1, 6, 0), v2: v(19, 1, 0, 0), canBump: true},
+		{v1: v(2, 1, 0, 10), v2: v(19, 1, 0, 0), canBump: true},
+		{v1: v(19, 1, 0, 0), v2: v(19, 2, 0, 0), canBump: true},
+		{v1: v(19, 1, 0, 0), v2: v(19, 3, 0, 0), canBump: false},
+		{v1: v(19, 2, 0, 0), v2: v(20, 1, 0, 0), canBump: true},
+		{v1: v(19, 2, 0, 0), v2: v(20, 2, 0, 0), canBump: false},
+	}
+
+	for _, test := range testData {
+		t.Run("", func(t *testing.T) {
+			if a, e := test.v1.CanBump(test.v2), test.canBump; a != e {
+				t.Errorf("expected %s can bump to %s? %t; got %t",
+					pretty.Sprint(test.v1), pretty.Sprint(test.v2), e, a)
 			}
 		})
 	}

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -66,6 +66,7 @@ const (
 	VersionDirectImport
 	VersionSideloadedStorageNoReplicaID // see versionsSingleton for details
 	VersionPushTxnToInclusive
+	Version19_1
 
 	// Add new versions here (step one of two).
 
@@ -443,6 +444,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		Key:     VersionPushTxnToInclusive,
 		Version: roachpb.Version{Major: 2, Minor: 1, Unstable: 10},
 	},
+	{
+		// Version19_1 is CockroachDB v19.1. It's used for all v19.1.x patch releases.
+		Key:     Version19_1,
+		Version: roachpb.Version{Major: 19, Minor: 1},
+	},
 
 	// Add new versions here (step two of two).
 
@@ -453,7 +459,7 @@ var (
 	// this binary. If this binary is started using a store marked with an older
 	// version than BinaryMinimumSupportedVersion, then the binary will exit with
 	// an error.
-	BinaryMinimumSupportedVersion = VersionByKey(Version2_0)
+	BinaryMinimumSupportedVersion = VersionByKey(Version2_1)
 
 	// BinaryServerVersion is the version of this binary.
 	//

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -267,9 +267,9 @@ select crdb_internal.set_vmodule('')
 0
 
 query T
-select regexp_replace(crdb_internal.node_executable_version()::string, '-\d+', '-x');
+select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');
 ----
-2.1-x
+19.1
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -364,9 +364,9 @@ select * from crdb_internal.gossip_alerts
 
 # Anyone can see the executable version.
 query T
-select regexp_replace(crdb_internal.node_executable_version()::string, '-\d+', '-x');
+select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');
 ----
-2.1-x
+19.1
 
 user root
 


### PR DESCRIPTION
Backport 1/1 commits from #36440.

/cc @cockroachdb/release

---

Also belatedly bump BinaryMinimumSupportedVersion

Release note: None
