### PR TITLE
opt: fix inappropriate SRF column rename

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -375,6 +375,36 @@ SELECT a.*, b.*, c.* FROM generate_series(1,1) a, unnest(ARRAY[1]) b, pg_get_key
 ----
 a  b  word  catcode  catdesc
 
+# Regression for #36501: the column from a single-column SRF should not be
+# renamed because of a higher-level table alias.
+query I colnames
+SELECT * FROM (SELECT * FROM generate_series(1, 2)) AS a
+----
+generate_series
+1
+2
+
+query I colnames
+SELECT * FROM (SELECT unnest(ARRAY[1])) AS tablealias
+----
+unnest
+1
+
+query I colnames
+SELECT * FROM (SELECT unnest(ARRAY[1]) AS colalias) AS tablealias
+----
+colalias
+1
+
+query II
+SELECT * FROM
+  (SELECT unnest(ARRAY[1]) AS filter_id2) AS uq
+JOIN
+  (SELECT unnest(ARRAY[1]) AS filter_id) AS ab
+ON uq.filter_id2 = ab.filter_id
+----
+1  1
+
 # Beware of multi-valued SRFs in render position (#19149)
 query TTT colnames
 SELECT 'a' AS a, pg_get_keywords(), 'c' AS c LIMIT 1

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -68,6 +68,10 @@ type scope struct {
 	// the replaceSRF() function for more details.
 	replaceSRFs bool
 
+	// singleSRFColumn is true if this scope has a single column that comes from
+	// an SRF. The flag is used to allow renaming the column to the table alias.
+	singleSRFColumn bool
+
 	// srfs contains all the SRFs that were replaced in this scope. It will be
 	// used by the Builder to convert the input from the FROM clause to a lateral
 	// cross join between the input and a Zip of all the srfs in this slice.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -206,12 +206,8 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 		// names, then use the specified table name both as the column name and
 		// table name.
 		noColNameSpecified := len(colAlias) == 0
-		if scope.isAnonymousTable() && noColNameSpecified {
-			// SRFs and scalar functions used as a data source are always wrapped in
-			// a ProjectSet operation.
-			if ps, ok := scope.expr.(*memo.ProjectSetExpr); ok && ps.Relational().OutputCols.Len() == 1 {
-				colAlias = tree.NameList{as.Alias}
-			}
+		if scope.isAnonymousTable() && noColNameSpecified && scope.singleSRFColumn {
+			colAlias = tree.NameList{as.Alias}
 		}
 
 		// If an alias was specified, use that to qualify the column names.

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -119,6 +119,9 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 		ID:   b.factory.Metadata().NextValuesID(),
 	})
 	outScope.expr = b.factory.ConstructProjectSet(input, zip)
+	if len(outScope.cols) == 1 {
+		outScope.singleSRFColumn = true
+	}
 	return outScope
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -283,6 +283,63 @@ project
       └── function: ascii [type=int]
            └── variable: unnest [type=string]
 
+# Regression test for #36501: don't rename the SRF column because of a
+# higher-level table alias.
+build
+SELECT * FROM (SELECT unnest(ARRAY[1])) AS tablealias
+----
+project-set
+ ├── columns: unnest:1(int)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      └── function: unnest [type=int]
+           └── array: [type=int[]]
+                └── const: 1 [type=int]
+
+build
+SELECT * FROM (SELECT unnest(ARRAY[1]) AS colalias) AS tablealias
+----
+project-set
+ ├── columns: colalias:1(int)
+ ├── values
+ │    └── tuple [type=tuple]
+ └── zip
+      └── function: unnest [type=int]
+           └── array: [type=int[]]
+                └── const: 1 [type=int]
+
+build
+SELECT * FROM
+  (SELECT unnest(ARRAY[1]) AS filter_id2) AS uq
+JOIN
+  (SELECT unnest(ARRAY[1]) AS filter_id) AS ab
+ON uq.filter_id2 = ab.filter_id
+----
+inner-join
+ ├── columns: filter_id2:1(int!null) filter_id:2(int!null)
+ ├── project-set
+ │    ├── columns: unnest:1(int)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: unnest [type=int]
+ │              └── array: [type=int[]]
+ │                   └── const: 1 [type=int]
+ ├── project-set
+ │    ├── columns: unnest:2(int)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: unnest [type=int]
+ │              └── array: [type=int[]]
+ │                   └── const: 1 [type=int]
+ └── filters
+      └── eq [type=bool]
+           ├── variable: unnest [type=int]
+           └── variable: unnest [type=int]
+
+
 # nested_SRF
 # See #20511
 


### PR DESCRIPTION
When we use a single-column SRF as a data source and use a table alias
(e.g. `SELECT * FROM generate_series(1,2) AS a`), the column is
renamed to the table alias.

The optbuilder does exactly this, however it also does it when the
table alias is "indirect", e.g.
`SELECT * FROM (SELECT * FROM generate_series(1,2)) AS a`.

This commit fixes this by keeping track if a scope has a single column
where this renaming is appropriate, instead of peeking inside the
expression we built, which is in direct violation of Andy's No-peeking
Principle™.

Fixes #36501.

Release note (bug fix): Fixed inappropriate column renaming in some
cases involving single-column SRFs.