### PR TITLE
exec: refactor vectorized merge joiner count

### DIFF
--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -896,7 +896,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 	for _, inputSize := range []int{0, 1 << 2, 1 << 4, 1 << 8, 1 << 12, 1 << 16} {
 		numRepeats := int(math.Sqrt(float64(inputSize)))
 		b.Run(fmt.Sprintf("BothSidesRepeatInputSize=%d", inputSize), func(b *testing.B) {
-			row := sqlbase.MakeRepeatedIntRows(100, numRepeats, numCols)
+			row := sqlbase.MakeRepeatedIntRows(numRepeats, inputSize, numCols)
 			leftInput := NewRepeatableRowSource(sqlbase.OneIntCol, row)
 			rightInput := NewRepeatableRowSource(sqlbase.OneIntCol, row)
 			b.SetBytes(int64(8 * inputSize * numCols * 2))

--- a/pkg/sql/exec/mergejoiner_groups_buffer.go
+++ b/pkg/sql/exec/mergejoiner_groups_buffer.go
@@ -44,8 +44,8 @@ func (b *circularGroupsBuffer) reset(lIdx int, lLength int, rIdx int, rLength in
 	b.bufferEndIdx = 1
 	b.bufferEndIdxForCol = 1
 
-	b.leftGroups[0] = group{lIdx, lLength, 1}
-	b.rightGroups[0] = group{rIdx, rLength, 1}
+	b.leftGroups[0] = group{lIdx, lLength, 1, 0}
+	b.rightGroups[0] = group{rIdx, rLength, 1, 0}
 }
 
 // nextGroupInCol returns whether or not there exists a next group in the current
@@ -73,8 +73,18 @@ func (b *circularGroupsBuffer) nextGroupInCol(lGroup *group, rGroup *group) bool
 func (b *circularGroupsBuffer) addGroupsToNextCol(
 	curLIdx int, lRunLength int, curRIdx int, rRunLength int,
 ) {
-	b.leftGroups[b.bufferEndIdx] = group{curLIdx, curLIdx + lRunLength, rRunLength}
-	b.rightGroups[b.bufferEndIdx] = group{curRIdx, curRIdx + rRunLength, lRunLength}
+	b.leftGroups[b.bufferEndIdx] = group{
+		rowStartIdx: curLIdx,
+		rowEndIdx:   curLIdx + lRunLength,
+		numRepeats:  rRunLength,
+		toBuild:     lRunLength * rRunLength,
+	}
+	b.rightGroups[b.bufferEndIdx] = group{
+		rowStartIdx: curRIdx,
+		rowEndIdx:   curRIdx + rRunLength,
+		numRepeats:  lRunLength,
+		toBuild:     lRunLength * rRunLength,
+	}
 	b.bufferEndIdx++
 
 	// Modulus on every step is more expensive than this check.

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -546,6 +546,8 @@ type finiteBatchSource struct {
 
 var _ Operator = &finiteBatchSource{}
 
+var emptyBatch = coldata.NewMemBatch([]types.T{})
+
 // newFiniteBatchSource returns a new Operator initialized to return its input
 // batch a specified number of times.
 func newFiniteBatchSource(batch coldata.Batch, usableCount int) *finiteBatchSource {
@@ -564,7 +566,7 @@ func (f *finiteBatchSource) Next() coldata.Batch {
 		f.usableCount--
 		return f.repeatableBatch.Next()
 	}
-	return coldata.NewMemBatch([]types.T{})
+	return emptyBatch
 }
 
 // randomLengthBatchSource is an Operator that forever returns the same batch at


### PR DESCRIPTION
Noticed a panic from a sanity check while running a test using the
TPCH dataset. The left and right builders weren't finishing at
the same time because the left had no output columns while the
right did. Before the output count calculation was done using
the left builder code, but this is problematic as the count
shouldn't be dependent on which side has output.

The fix was (yet another) overhaul to the counting code, which
introduces a new toBuild field which is populated when the group
is created, and used to determine the count after the builder
has materialized the rows. In theory, this field should stay in
sync with the builders.

Because of this, we were able to collapse the separate code paths
for COUNT and non COUNT queries by delegating it all to the same
method. Although this uses more memory, the speed remains
unaffected as a few sample queries retain 10x speed improvement on
COUNTs. This also improves the readability of the merge joiner IMO.

Benchmarks:
```
name                                      old time/op    new time/op    delta
MergeJoiner/rows=1024-8                     36.9µs ± 4%    37.3µs ± 2%      ~     (p=0.113 n=10+9)
MergeJoiner/rows=4096-8                      136µs ± 0%     138µs ± 1%    +1.78%  (p=0.000 n=10+10)
MergeJoiner/rows=16384-8                     521µs ± 0%     535µs ± 0%    +2.71%  (p=0.000 n=10+9)
MergeJoiner/rows=1048576-8                  31.9ms ± 2%    33.5ms ± 5%    +4.87%  (p=0.000 n=9+10)
MergeJoiner/oneSideRepeat-rows=1024-8       38.0µs ± 1%    35.7µs ± 1%    -6.21%  (p=0.000 n=10+9)
MergeJoiner/oneSideRepeat-rows=4096-8        140µs ± 1%     139µs ± 2%      ~     (p=0.243 n=10+9)
MergeJoiner/oneSideRepeat-rows=16384-8       542µs ± 0%     538µs ± 1%    -0.67%  (p=0.001 n=9+10)
MergeJoiner/oneSideRepeat-rows=1048576-8    34.3ms ± 1%    35.3ms ± 4%    +3.13%  (p=0.009 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8     38.5µs ± 2%    37.5µs ± 0%    -2.64%  (p=0.000 n=10+8)
MergeJoiner/bothSidesRepeat-rows=4096-8      183µs ± 1%     190µs ± 3%    +3.89%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=16384-8    1.48ms ± 1%    1.46ms ± 3%    -1.51%  (p=0.029 n=10+10)
MergeJoiner/bothSidesRepeat-rows=32768-8    5.28ms ± 0%    5.39ms ± 7%      ~     (p=0.842 n=9+10)

name                                      old speed      new speed      delta
MergeJoiner/rows=1024-8                   1.78GB/s ± 4%  1.75GB/s ± 4%      ~     (p=0.063 n=10+10)
MergeJoiner/rows=4096-8                   1.93GB/s ± 0%  1.90GB/s ± 1%    -1.75%  (p=0.000 n=10+10)
MergeJoiner/rows=16384-8                  2.01GB/s ± 0%  1.96GB/s ± 0%    -2.64%  (p=0.000 n=10+9)
MergeJoiner/rows=1048576-8                2.10GB/s ± 2%  2.01GB/s ± 5%    -4.57%  (p=0.000 n=9+10)
MergeJoiner/oneSideRepeat-rows=1024-8     1.72GB/s ± 1%  1.84GB/s ± 1%    +6.62%  (p=0.000 n=10+9)
MergeJoiner/oneSideRepeat-rows=4096-8     1.87GB/s ± 1%  1.88GB/s ± 2%      ~     (p=0.243 n=10+9)
MergeJoiner/oneSideRepeat-rows=16384-8    1.93GB/s ± 0%  1.95GB/s ± 1%    +0.68%  (p=0.001 n=9+10)
MergeJoiner/oneSideRepeat-rows=1048576-8  1.96GB/s ± 1%  1.90GB/s ± 4%    -2.98%  (p=0.009 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8   1.70GB/s ± 2%  1.75GB/s ± 0%    +2.70%  (p=0.000 n=10+8)
MergeJoiner/bothSidesRepeat-rows=4096-8   1.43GB/s ± 1%  1.38GB/s ± 3%    -3.73%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=16384-8   706MB/s ± 1%   717MB/s ± 3%    +1.56%  (p=0.029 n=10+10)
MergeJoiner/bothSidesRepeat-rows=32768-8   397MB/s ± 0%   390MB/s ± 7%      ~     (p=0.842 n=9+10)

name                                      old alloc/op   new alloc/op   delta
MergeJoiner/rows=1024-8                     4.23kB ± 0%    0.01kB ± 0%   -99.88%  (p=0.000 n=10+10)
MergeJoiner/rows=4096-8                     4.25kB ± 0%    0.03kB ± 0%   -99.36%  (p=0.000 n=10+10)
MergeJoiner/rows=16384-8                    4.30kB ± 0%    0.09kB ± 0%   -97.91%  (p=0.000 n=10+10)
MergeJoiner/rows=1048576-8                  9.02kB ± 0%    5.45kB ± 0%   -39.59%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8       4.23kB ± 0%    0.01kB ± 0%   -99.88%  (p=0.000 n=9+10)
MergeJoiner/oneSideRepeat-rows=4096-8       4.25kB ± 0%    0.03kB ± 0%   -99.36%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=16384-8      4.30kB ± 0%    0.09kB ± 0%   -97.91%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1048576-8    9.02kB ± 0%    5.45kB ± 0%   -39.59%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8     4.23kB ± 0%    0.01kB ± 0%   -99.88%  (p=0.000 n=9+10)
MergeJoiner/bothSidesRepeat-rows=4096-8     4.25kB ± 0%    0.03kB ± 0%   -99.36%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=16384-8    4.46kB ± 0%    0.27kB ± 0%   -93.91%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=32768-8    5.02kB ± 0%    0.91kB ± 0%   -81.94%  (p=0.000 n=10+9)

name                                      old allocs/op  new allocs/op  delta
MergeJoiner/rows=1024-8                       4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
MergeJoiner/rows=4096-8                       4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
MergeJoiner/rows=16384-8                      4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
MergeJoiner/rows=1048576-8                    5.00 ± 0%      1.00 ± 0%   -80.00%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8         4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=4096-8         4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=16384-8        4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1048576-8      5.00 ± 0%      1.00 ± 0%   -80.00%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8       4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=4096-8       4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=16384-8      4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=32768-8      4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)

```

Release note: None