### PR TITLE
roachprod: fix nil pointer panic when uploading a key pair

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/keys.go
+++ b/pkg/cmd/roachprod/vm/aws/keys.go
@@ -75,7 +75,7 @@ func (p *Provider) sshKeyImport(keyName string, region string) error {
 	err = p.runJSONCommand(args, &data)
 	// If two roachprod instances run at the same time with the same key, they may
 	// race to upload the key pair.
-	if strings.Contains(err.Error(), "InvalidKeyPair.Duplicate") {
+	if err == nil || strings.Contains(err.Error(), "InvalidKeyPair.Duplicate") {
 		return nil
 	}
 	return err


### PR DESCRIPTION
In #36488 I sloppily added in a check to deal with races uploading keys which I clearly did not test.

Fixes cause of a skipped AWS test https://teamcity.cockroachdb.com/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=1220242&_focus=4713 from last night. 