### PR TITLE
roachpb: formalize observed timestamp preconditions, talk about leaseholders

### DIFF
--- a/pkg/roachpb/data.pb.go
+++ b/pkg/roachpb/data.pb.go
@@ -89,7 +89,7 @@ func (x ValueType) String() string {
 	return proto.EnumName(ValueType_name, int32(x))
 }
 func (ValueType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{0}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{0}
 }
 
 // ReplicaChangeType is a parameter of ChangeReplicasTrigger.
@@ -113,7 +113,7 @@ func (x ReplicaChangeType) String() string {
 	return proto.EnumName(ReplicaChangeType_name, int32(x))
 }
 func (ReplicaChangeType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{1}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{1}
 }
 
 // TransactionStatus specifies possible states for a transaction.
@@ -165,7 +165,7 @@ func (x TransactionStatus) String() string {
 	return proto.EnumName(TransactionStatus_name, int32(x))
 }
 func (TransactionStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{2}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{2}
 }
 
 // Span is a key range with an inclusive start Key and an exclusive end Key.
@@ -184,7 +184,7 @@ type Span struct {
 func (m *Span) Reset()      { *m = Span{} }
 func (*Span) ProtoMessage() {}
 func (*Span) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{0}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{0}
 }
 func (m *Span) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -236,7 +236,7 @@ func (m *Value) Reset()         { *m = Value{} }
 func (m *Value) String() string { return proto.CompactTextString(m) }
 func (*Value) ProtoMessage()    {}
 func (*Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{1}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{1}
 }
 func (m *Value) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -274,7 +274,7 @@ func (m *KeyValue) Reset()         { *m = KeyValue{} }
 func (m *KeyValue) String() string { return proto.CompactTextString(m) }
 func (*KeyValue) ProtoMessage()    {}
 func (*KeyValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{2}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{2}
 }
 func (m *KeyValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -314,7 +314,7 @@ func (m *StoreIdent) Reset()         { *m = StoreIdent{} }
 func (m *StoreIdent) String() string { return proto.CompactTextString(m) }
 func (*StoreIdent) ProtoMessage()    {}
 func (*StoreIdent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{3}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{3}
 }
 func (m *StoreIdent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -356,7 +356,7 @@ func (m *SplitTrigger) Reset()         { *m = SplitTrigger{} }
 func (m *SplitTrigger) String() string { return proto.CompactTextString(m) }
 func (*SplitTrigger) ProtoMessage()    {}
 func (*SplitTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{4}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{4}
 }
 func (m *SplitTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -406,7 +406,7 @@ func (m *MergeTrigger) Reset()         { *m = MergeTrigger{} }
 func (m *MergeTrigger) String() string { return proto.CompactTextString(m) }
 func (*MergeTrigger) ProtoMessage()    {}
 func (*MergeTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{5}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{5}
 }
 func (m *MergeTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -445,7 +445,7 @@ type ChangeReplicasTrigger struct {
 func (m *ChangeReplicasTrigger) Reset()      { *m = ChangeReplicasTrigger{} }
 func (*ChangeReplicasTrigger) ProtoMessage() {}
 func (*ChangeReplicasTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{6}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{6}
 }
 func (m *ChangeReplicasTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -489,7 +489,7 @@ func (m *ModifiedSpanTrigger) Reset()         { *m = ModifiedSpanTrigger{} }
 func (m *ModifiedSpanTrigger) String() string { return proto.CompactTextString(m) }
 func (*ModifiedSpanTrigger) ProtoMessage()    {}
 func (*ModifiedSpanTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{7}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{7}
 }
 func (m *ModifiedSpanTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -529,7 +529,7 @@ func (m *InternalCommitTrigger) Reset()         { *m = InternalCommitTrigger{} }
 func (m *InternalCommitTrigger) String() string { return proto.CompactTextString(m) }
 func (*InternalCommitTrigger) ProtoMessage()    {}
 func (*InternalCommitTrigger) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{8}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{8}
 }
 func (m *InternalCommitTrigger) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -593,7 +593,7 @@ func (m *ObservedTimestamp) Reset()         { *m = ObservedTimestamp{} }
 func (m *ObservedTimestamp) String() string { return proto.CompactTextString(m) }
 func (*ObservedTimestamp) ProtoMessage()    {}
 func (*ObservedTimestamp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{9}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{9}
 }
 func (m *ObservedTimestamp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -672,40 +672,67 @@ type Transaction struct {
 	RefreshedTimestamp hlc.Timestamp `protobuf:"bytes,15,opt,name=refreshed_timestamp,json=refreshedTimestamp,proto3" json:"refreshed_timestamp"`
 	// A list of <NodeID, timestamp> pairs. The list maps NodeIDs to timestamps
 	// as observed from their local clock during this transaction. The purpose of
-	// this map is to avoid uncertainty related restarts which normally occur
+	// this list is to avoid uncertainty related restarts which normally occur
 	// when reading a value in the near future as per the max_timestamp field.
 	//
-	// Morally speaking, having an entry for a node in this map means that this
+	// Morally speaking, having an entry for a node in this list means that this
 	// node has been visited before, and that no more uncertainty restarts are
 	// expected for operations served from it. However, this is not entirely
 	// accurate. For example, say a txn starts with orig_timestamp=1 (and some
 	// large max_timestamp). It then reads key "a" from node A, registering an
 	// entry `A -> 5` in the process (`5` happens to be a timestamp taken off
-	// that node's clock at the end of the read).
+	// that node's clock at the start of the read).
+	//
 	// Now assume that some other transaction writes and commits a value at key "b"
 	// and timestamp 4 (again, served by node A), and our transaction attempts to
 	// read that key. Since there is an entry in its observed_timestamps for A,
 	// our uncertainty window is `[orig_timestamp, 5) = [1, 5)` but the value at
 	// key "b" is in that window, and so we will restart. However, we will restart
-	// with a timestamp that is at least high as our entry in the map for node A,
+	// with a timestamp that is at least high as our entry in the list for node A,
 	// so no future operation on node A will be uncertain.
 	//
-	// Thus, expressed properly, you could say that when a node has been read from
-	// successfully before, uncertainty on that node is restricted to values with
-	// timestamps in the interval [orig_timestamp, first_visit_timestamp), and
-	// that no node will trigger restarts more than once (and in fact, usually
-	// the first restart also bumps the txn timestamp enough to clear all other
-	// nodes).
+	// Thus, expressed properly, we can say that when a node has been read from
+	// successfully before by a transaction, uncertainty for values written by a
+	// leaseholder on that node is restricted to values with timestamps in the
+	// interval [orig_timestamp, first_visit_timestamp). An upper bound can be
+	// placed on the uncertainty window because we are guaranteed that at the time
+	// that the transaction first visited the node, none of the Ranges that it was
+	// a leaseholder for had served any writes at higher timestamps than the clock
+	// reading we observe. This implies that any writes that the transaction may
+	// later see written by leaseholders on this node at higher timestamps than
+	// the observed timestamp could not have taken place causally before this
+	// transaction and can be ignored for the purposes of uncertainty.
 	//
-	// When this list holds a corresponding entry for the node the current
-	// request is executing on, we can run the command with the map's timestamp
-	// as the top boundary of our uncertainty interval, limiting (and often
-	// avoiding) uncertainty restarts.
+	// There are two invariants necessary for this guarantee to hold:
+	// 1. a leaseholder's clock must always be equal to or greater than the timestamp
+	//    of all writes that it has served. This is trivial to enforce for
+	//    non-transactional writes. It is more complicated for transactional writes
+	//    which may move their commit timestamp forward over their lifetime before
+	//    committing, even after writing intents on remote Ranges. To accommodate
+	//    this situation, transactions ensure that at the time of their commit, any
+	//    leaseholder for a Range that contains one of its intent has an HLC clock
+	//    with an equal or greater timestamp than the transaction's commit timestamp.
+	//    TODO(nvanbenschoten): This is violated by txn refreshes. See #36431.
+	// 2. a leaseholder's clock must always be equal to or greater than the timestamp
+	//    of all writes that previous leaseholders for its Range have served. We
+	//    enforce that when a Replica acquires a lease it bumps its node's clock to a
+	//    time higher than the previous leaseholder's clock when it stopped serving
+	//    writes. This is accomplished cooperatively for lease transfers and through
+	//    a statis period before lease expiration for lease acquisitions. It then
+	//    follows by induction that, in conjunction with the previous invariant, this
+	//    invariant holds for all leaseholders, given that a Range's initial
+	//    leaseholder assumes responsibility for an empty range with no writes.
+	//
+	//
+	// When this list holds a corresponding entry for the node who owns that lease
+	// that the current request is executing under, we can run the command with
+	// the list's timestamp as the top boundary of our uncertainty interval,
+	// limiting (and often avoiding) uncertainty restarts.
 	//
 	// When a transaction is first initialized on a node, it may use a timestamp
 	// from the local hybrid logical clock to initialize the corresponding entry
-	// in the map. In particular, if `orig_timestamp` is taken from that node's
-	// clock, we may add that to the map, which eliminates read uncertainty for
+	// in the list. In particular, if `orig_timestamp` is taken from that node's
+	// clock, we may add that to the list, which eliminates read uncertainty for
 	// reads on that node.
 	//
 	// The slice of observed timestamps is kept sorted by NodeID. Use
@@ -777,7 +804,7 @@ type Transaction struct {
 func (m *Transaction) Reset()      { *m = Transaction{} }
 func (*Transaction) ProtoMessage() {}
 func (*Transaction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{10}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{10}
 }
 func (m *Transaction) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -834,7 +861,7 @@ func (m *TransactionRecord) Reset()         { *m = TransactionRecord{} }
 func (m *TransactionRecord) String() string { return proto.CompactTextString(m) }
 func (*TransactionRecord) ProtoMessage()    {}
 func (*TransactionRecord) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{11}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{11}
 }
 func (m *TransactionRecord) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -872,7 +899,7 @@ func (m *Intent) Reset()         { *m = Intent{} }
 func (m *Intent) String() string { return proto.CompactTextString(m) }
 func (*Intent) ProtoMessage()    {}
 func (*Intent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{12}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{12}
 }
 func (m *Intent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -913,7 +940,7 @@ func (m *SequencedWrite) Reset()         { *m = SequencedWrite{} }
 func (m *SequencedWrite) String() string { return proto.CompactTextString(m) }
 func (*SequencedWrite) ProtoMessage()    {}
 func (*SequencedWrite) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{13}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{13}
 }
 func (m *SequencedWrite) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -979,7 +1006,7 @@ type Lease struct {
 func (m *Lease) Reset()      { *m = Lease{} }
 func (*Lease) ProtoMessage() {}
 func (*Lease) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{14}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{14}
 }
 func (m *Lease) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1026,7 +1053,7 @@ func (m *AbortSpanEntry) Reset()         { *m = AbortSpanEntry{} }
 func (m *AbortSpanEntry) String() string { return proto.CompactTextString(m) }
 func (*AbortSpanEntry) ProtoMessage()    {}
 func (*AbortSpanEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{15}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{15}
 }
 func (m *AbortSpanEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1097,7 +1124,7 @@ func (m *TxnCoordMeta) Reset()         { *m = TxnCoordMeta{} }
 func (m *TxnCoordMeta) String() string { return proto.CompactTextString(m) }
 func (*TxnCoordMeta) ProtoMessage()    {}
 func (*TxnCoordMeta) Descriptor() ([]byte, []int) {
-	return fileDescriptor_data_d188257a74e0026d, []int{16}
+	return fileDescriptor_data_16e2e632a95b5e7e, []int{16}
 }
 func (m *TxnCoordMeta) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -6103,9 +6130,9 @@ var (
 	ErrIntOverflowData   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("roachpb/data.proto", fileDescriptor_data_d188257a74e0026d) }
+func init() { proto.RegisterFile("roachpb/data.proto", fileDescriptor_data_16e2e632a95b5e7e) }
 
-var fileDescriptor_data_d188257a74e0026d = []byte{
+var fileDescriptor_data_16e2e632a95b5e7e = []byte{
 	// 2069 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xdc, 0x58, 0xcd, 0x6f, 0xdb, 0xc8,
 	0x15, 0x37, 0x45, 0xca, 0xa2, 0x9e, 0x3e, 0x4c, 0x8f, 0xe3, 0x44, 0xcd, 0xa2, 0x56, 0x56, 0x5b,

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -306,40 +306,67 @@ message Transaction {
   util.hlc.Timestamp refreshed_timestamp = 15 [(gogoproto.nullable) = false];
   // A list of <NodeID, timestamp> pairs. The list maps NodeIDs to timestamps
   // as observed from their local clock during this transaction. The purpose of
-  // this map is to avoid uncertainty related restarts which normally occur
+  // this list is to avoid uncertainty related restarts which normally occur
   // when reading a value in the near future as per the max_timestamp field.
   //
-  // Morally speaking, having an entry for a node in this map means that this
+  // Morally speaking, having an entry for a node in this list means that this
   // node has been visited before, and that no more uncertainty restarts are
   // expected for operations served from it. However, this is not entirely
   // accurate. For example, say a txn starts with orig_timestamp=1 (and some
   // large max_timestamp). It then reads key "a" from node A, registering an
   // entry `A -> 5` in the process (`5` happens to be a timestamp taken off
-  // that node's clock at the end of the read).
+  // that node's clock at the start of the read).
+  //
   // Now assume that some other transaction writes and commits a value at key "b"
   // and timestamp 4 (again, served by node A), and our transaction attempts to
   // read that key. Since there is an entry in its observed_timestamps for A,
   // our uncertainty window is `[orig_timestamp, 5) = [1, 5)` but the value at
   // key "b" is in that window, and so we will restart. However, we will restart
-  // with a timestamp that is at least high as our entry in the map for node A,
+  // with a timestamp that is at least high as our entry in the list for node A,
   // so no future operation on node A will be uncertain.
   //
-  // Thus, expressed properly, you could say that when a node has been read from
-  // successfully before, uncertainty on that node is restricted to values with
-  // timestamps in the interval [orig_timestamp, first_visit_timestamp), and
-  // that no node will trigger restarts more than once (and in fact, usually
-  // the first restart also bumps the txn timestamp enough to clear all other
-  // nodes).
+  // Thus, expressed properly, we can say that when a node has been read from
+  // successfully before by a transaction, uncertainty for values written by a
+  // leaseholder on that node is restricted to values with timestamps in the
+  // interval [orig_timestamp, first_visit_timestamp). An upper bound can be
+  // placed on the uncertainty window because we are guaranteed that at the time
+  // that the transaction first visited the node, none of the Ranges that it was
+  // a leaseholder for had served any writes at higher timestamps than the clock
+  // reading we observe. This implies that any writes that the transaction may
+  // later see written by leaseholders on this node at higher timestamps than
+  // the observed timestamp could not have taken place causally before this
+  // transaction and can be ignored for the purposes of uncertainty.
   //
-  // When this list holds a corresponding entry for the node the current
-  // request is executing on, we can run the command with the map's timestamp
-  // as the top boundary of our uncertainty interval, limiting (and often
-  // avoiding) uncertainty restarts.
+  // There are two invariants necessary for this guarantee to hold:
+  // 1. a leaseholder's clock must always be equal to or greater than the timestamp
+  //    of all writes that it has served. This is trivial to enforce for
+  //    non-transactional writes. It is more complicated for transactional writes
+  //    which may move their commit timestamp forward over their lifetime before
+  //    committing, even after writing intents on remote Ranges. To accommodate
+  //    this situation, transactions ensure that at the time of their commit, any
+  //    leaseholder for a Range that contains one of its intent has an HLC clock
+  //    with an equal or greater timestamp than the transaction's commit timestamp.
+  //    TODO(nvanbenschoten): This is violated by txn refreshes. See #36431.
+  // 2. a leaseholder's clock must always be equal to or greater than the timestamp
+  //    of all writes that previous leaseholders for its Range have served. We
+  //    enforce that when a Replica acquires a lease it bumps its node's clock to a
+  //    time higher than the previous leaseholder's clock when it stopped serving
+  //    writes. This is accomplished cooperatively for lease transfers and through
+  //    a statis period before lease expiration for lease acquisitions. It then
+  //    follows by induction that, in conjunction with the previous invariant, this
+  //    invariant holds for all leaseholders, given that a Range's initial
+  //    leaseholder assumes responsibility for an empty range with no writes.
+  //
+  //
+  // When this list holds a corresponding entry for the node who owns that lease
+  // that the current request is executing under, we can run the command with
+  // the list's timestamp as the top boundary of our uncertainty interval,
+  // limiting (and often avoiding) uncertainty restarts.
   //
   // When a transaction is first initialized on a node, it may use a timestamp
   // from the local hybrid logical clock to initialize the corresponding entry
-  // in the map. In particular, if `orig_timestamp` is taken from that node's
-  // clock, we may add that to the map, which eliminates read uncertainty for
+  // in the list. In particular, if `orig_timestamp` is taken from that node's
+  // clock, we may add that to the list, which eliminates read uncertainty for
   // reads on that node.
   //
   // The slice of observed timestamps is kept sorted by NodeID. Use

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1333,6 +1333,7 @@ func (r *Replica) limitTxnMaxTimestamp(
 	// a timestamp on file for this Node which is smaller than MaxTimestamp,
 	// we can lower MaxTimestamp accordingly. If MaxTimestamp drops below
 	// OrigTimestamp, we effectively can't see uncertainty restarts anymore.
+	// TODO(nvanbenschoten): This should use the lease's node id.
 	obsTS, ok := ba.Txn.GetObservedTimestamp(ba.Replica.NodeID)
 	if !ok {
 		return
@@ -1342,6 +1343,8 @@ func (r *Replica) limitTxnMaxTimestamp(
 	// ensures we avoid incorrect assumptions about when data was
 	// written, in absolute time on a different node, which held the
 	// lease before this replica acquired it.
+	// TODO(nvanbenschoten): Do we ever need to call this when
+	//   status.State != VALID?
 	if status.State == storagepb.LeaseState_VALID {
 		obsTS.Forward(status.Lease.Start)
 	}


### PR DESCRIPTION
This PR is an initial reaction to #36431 and to `limitTxnMaxTimestamp` being
broken for follower reads (PR for that coming soon). To start, we were missing
any real documentation on what makes the observed timestamp mechanism safe and
what invariants need to hold in order for a clock reading on a node to imply an
absence of causality on any values later read at higher timestamp on that node.
The PR addresses this by discussing the invariants necessary for observed
timestamps to be used to bound a transaction's uncertainty window.

In doing so, the PR also attempts to address a second issue, which is that the
documentation conflated a node serving reads and writes with leaseholders
serving reads and writes. At the time that this was all written, these were
equivalent. Now that we have follower reads, the omission of a discussion about
leaseholders made this all hard to think about (e.g. "whose observed timestamp
do we care about when performing a follower read?"). The PR addresses this by
adjusting the wording around nodes and leaseholders. This would have come in
handy in reasoning about #23749.

Release note: None