### PR TITLE
roachtest: streamline debug collection

### DIFF
--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -274,7 +274,7 @@ func TestRegistryRunClusterExpired(t *testing.T) {
 	local, clusterName = true, "local"
 
 	var buf syncedBuffer
-	expiredRE := regexp.MustCompile(`(?m)^.*cluster expired \(.*\)$`)
+	expiredRE := regexp.MustCompile(`(?m)^.*cluster is already expired \(.*\)$`)
 
 	r := newRegistry()
 	r.config.skipClusterValidationOnAttach = true


### PR DESCRIPTION
Inspired by [1].

The case in which a test hit an error and the case in which a test
times out were handled differently and I had little confidence that
it was working as intended.

This simplifies by not running the test in the main goroutine, but
reserving the main goroutine for defering the debug and cleanup
actions while the test itself is now running in a child goroutine.

I tested this running `tpcc/nodes=3/w=headroom` locally (where it
runs with one warehouse and only for a minute) in the passing case
and in the case in which it fails with an artificially low timeout.

[1]: https://github.com/cockroachdb/cockroach/issues/36094#issuecomment-480189693

Release note: None