### PR TITLE
storage: use finer locks and async methods for queuing ranges

### DIFF
--- a/pkg/storage/merge_queue.go
+++ b/pkg/storage/merge_queue.go
@@ -310,7 +310,7 @@ func (mq *mergeQueue) process(
 		// On seeing a ConditionFailedError, don't return an error and enqueue
 		// this replica again in case it still needs to be merged.
 		log.Infof(ctx, "merge saw concurrent descriptor modification; maybe retrying")
-		mq.MaybeAdd(lhsRepl, mq.store.Clock().Now())
+		mq.MaybeAddAsync(ctx, lhsRepl, mq.store.Clock().Now())
 	default:
 		// While range merges are unstable, be extra cautious and mark every error
 		// as purgatory-worthy.

--- a/pkg/storage/queue_helpers_testutil.go
+++ b/pkg/storage/queue_helpers_testutil.go
@@ -1,0 +1,141 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
+)
+
+// Code in this file is for testing usage only. It is exported only because it
+// is called from outside of the package.
+
+func (bq *baseQueue) testingAdd(
+	ctx context.Context, repl *Replica, priority float64,
+) (bool, error) {
+	return bq.addInternal(ctx, repl.Desc(), true, priority)
+}
+
+func forceScanAndProcess(s *Store, q *baseQueue) error {
+	// Check that the system config is available. It is needed by many queues. If
+	// it's not available, some queues silently fail to process any replicas,
+	// which is undesirable for this method.
+	if cfg := s.Gossip().GetSystemConfig(); cfg == nil {
+		return errors.Errorf("system config not available in gossip")
+	}
+
+	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
+		q.maybeAdd(context.Background(), repl, s.cfg.Clock.Now())
+		return true
+	})
+
+	q.DrainQueue(s.stopper)
+	return nil
+}
+
+func mustForceScanAndProcess(ctx context.Context, s *Store, q *baseQueue) {
+	if err := forceScanAndProcess(s, q); err != nil {
+		log.Fatal(ctx, err)
+	}
+}
+
+// ForceReplicationScanAndProcess iterates over all ranges and
+// enqueues any that need to be replicated.
+func (s *Store) ForceReplicationScanAndProcess() error {
+	return forceScanAndProcess(s, s.replicateQueue.baseQueue)
+}
+
+// MustForceReplicaGCScanAndProcess iterates over all ranges and enqueues any that
+// may need to be GC'd.
+func (s *Store) MustForceReplicaGCScanAndProcess() {
+	mustForceScanAndProcess(context.TODO(), s, s.replicaGCQueue.baseQueue)
+}
+
+// MustForceMergeScanAndProcess iterates over all ranges and enqueues any that
+// may need to be merged.
+func (s *Store) MustForceMergeScanAndProcess() {
+	mustForceScanAndProcess(context.TODO(), s, s.mergeQueue.baseQueue)
+}
+
+// ForceSplitScanAndProcess iterates over all ranges and enqueues any that
+// may need to be split.
+func (s *Store) ForceSplitScanAndProcess() error {
+	return forceScanAndProcess(s, s.splitQueue.baseQueue)
+}
+
+// MustForceRaftLogScanAndProcess iterates over all ranges and enqueues any that
+// need their raft logs truncated and then process each of them.
+func (s *Store) MustForceRaftLogScanAndProcess() {
+	mustForceScanAndProcess(context.TODO(), s, s.raftLogQueue.baseQueue)
+}
+
+// ForceTimeSeriesMaintenanceQueueProcess iterates over all ranges, enqueuing
+// any that need time series maintenance, then processes the time series
+// maintenance queue.
+func (s *Store) ForceTimeSeriesMaintenanceQueueProcess() error {
+	return forceScanAndProcess(s, s.tsMaintenanceQueue.baseQueue)
+}
+
+// ForceRaftSnapshotQueueProcess iterates over all ranges, enqueuing
+// any that need raft snapshots, then processes the raft snapshot
+// queue.
+func (s *Store) ForceRaftSnapshotQueueProcess() error {
+	return forceScanAndProcess(s, s.raftSnapshotQueue.baseQueue)
+}
+
+// ForceConsistencyQueueProcess runs all the ranges through the consistency
+// queue.
+func (s *Store) ForceConsistencyQueueProcess() error {
+	return forceScanAndProcess(s, s.consistencyQueue.baseQueue)
+}
+
+// The methods below can be used to control a store's queues. Stopping a queue
+// is only meant to happen in tests.
+
+func (s *Store) setGCQueueActive(active bool) {
+	s.gcQueue.SetDisabled(!active)
+}
+func (s *Store) setMergeQueueActive(active bool) {
+	s.mergeQueue.SetDisabled(!active)
+}
+func (s *Store) setRaftLogQueueActive(active bool) {
+	s.raftLogQueue.SetDisabled(!active)
+}
+func (s *Store) setReplicaGCQueueActive(active bool) {
+	s.replicaGCQueue.SetDisabled(!active)
+}
+
+// SetReplicateQueueActive controls the replication queue. Only
+// intended for tests.
+func (s *Store) SetReplicateQueueActive(active bool) {
+	s.replicateQueue.SetDisabled(!active)
+}
+func (s *Store) setSplitQueueActive(active bool) {
+	s.splitQueue.SetDisabled(!active)
+}
+func (s *Store) setTimeSeriesMaintenanceQueueActive(active bool) {
+	s.tsMaintenanceQueue.SetDisabled(!active)
+}
+func (s *Store) setRaftSnapshotQueueActive(active bool) {
+	s.raftSnapshotQueue.SetDisabled(!active)
+}
+func (s *Store) setConsistencyQueueActive(active bool) {
+	s.consistencyQueue.SetDisabled(!active)
+}
+func (s *Store) setScannerActive(active bool) {
+	s.scanner.SetDisabled(!active)
+}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1170,7 +1170,7 @@ func (r *Replica) beginCmds(
 			return *boundarySpan
 		})
 		if shouldInitSplit {
-			r.store.splitQueue.MaybeAdd(r, r.store.Clock().Now())
+			r.store.splitQueue.MaybeAddAsync(ctx, r, r.store.Clock().Now())
 		}
 	}
 

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -321,9 +321,7 @@ func (rgcq *replicaGCQueue) process(
 					leftDesc, leftReplyDesc)
 				// Chances are that the left replica needs to be GC'd. Since we don't
 				// have definitive proof, queue it with a low priority.
-				if _, err := rgcq.Add(leftRepl, replicaGCPriorityDefault); err != nil {
-					log.Errorf(ctx, "unable to add %s to replica GC queue: %s", leftRepl, err)
-				}
+				rgcq.AddAsync(ctx, leftRepl, replicaGCPriorityDefault)
 				return nil
 			}
 		}

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -840,7 +840,7 @@ func testRaftSSTableSideloadingProposal(t *testing.T, engineInMem, mockSideloade
 		}
 	}
 
-	if _, err := tc.store.raftLogQueue.Add(tc.repl, 99.99 /* priority */); err != nil {
+	if _, err := tc.store.raftLogQueue.testingAdd(ctx, tc.repl, 99.99 /* priority */); err != nil {
 		t.Fatal(err)
 	}
 	tc.store.MustForceRaftLogScanAndProcess()

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -268,7 +268,7 @@ func (rq *replicateQueue) process(
 			return err
 		} else if requeue {
 			// Enqueue this replica again to see if there are more changes to be made.
-			rq.MaybeAdd(repl, rq.store.Clock().Now())
+			rq.MaybeAddAsync(ctx, repl, rq.store.Clock().Now())
 		}
 		if testingAggressiveConsistencyChecks {
 			if err := rq.store.consistencyQueue.process(ctx, repl, sysCfg); err != nil {

--- a/pkg/storage/scanner.go
+++ b/pkg/storage/scanner.go
@@ -38,7 +38,7 @@ type replicaQueue interface {
 	// MaybeAdd adds the replica to the queue if the replica meets
 	// the queue's inclusion criteria and the queue is not already
 	// too full, etc.
-	MaybeAdd(*Replica, hlc.Timestamp)
+	MaybeAddAsync(context.Context, *Replica, hlc.Timestamp)
 	// MaybeRemove removes the replica from the queue if it is present.
 	MaybeRemove(roachpb.RangeID)
 	// Name returns the name of the queue.
@@ -232,7 +232,7 @@ func (rs *replicaScanner) waitAndProcess(
 				log.Infof(ctx, "replica scanner processing %s", repl)
 			}
 			for _, q := range rs.queues {
-				q.MaybeAdd(repl, rs.clock.Now())
+				q.MaybeAddAsync(ctx, repl, rs.clock.Now())
 			}
 			return false
 

--- a/pkg/storage/scanner_test.go
+++ b/pkg/storage/scanner_test.go
@@ -144,7 +144,8 @@ func (tq *testQueue) Start(stopper *stop.Stopper) {
 	})
 }
 
-func (tq *testQueue) MaybeAdd(repl *Replica, now hlc.Timestamp) {
+// NB: MaybeAddAsync on a testQueue is actually synchronous.
+func (tq *testQueue) MaybeAddAsync(ctx context.Context, repl *Replica, now hlc.Timestamp) {
 	tq.Lock()
 	defer tq.Unlock()
 	if index := tq.indexOf(repl.RangeID); index == -1 {

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -146,7 +146,7 @@ func (sq *splitQueue) process(ctx context.Context, r *Replica, sysCfg *config.Sy
 		// On seeing a ConditionFailedError, don't return an error and enqueue
 		// this replica again in case it still needs to be split.
 		log.Infof(ctx, "split saw concurrent descriptor modification; maybe retrying")
-		sq.MaybeAdd(r, sq.store.Clock().Now())
+		sq.MaybeAddAsync(ctx, r, sq.store.Clock().Now())
 	default:
 		return err
 	}

--- a/pkg/storage/split_trigger_helper.go
+++ b/pkg/storage/split_trigger_helper.go
@@ -41,7 +41,7 @@ func (rd *replicaMsgAppDropper) ShouldDrop(startKey roachpb.RKey) (fmt.Stringer,
 	if lhsRepl == nil {
 		return nil, false
 	}
-	_, _ = lhsRepl.store.gcQueue.Add(lhsRepl, replicaGCPriorityDefault)
+	lhsRepl.store.gcQueue.AddAsync(context.Background(), lhsRepl, replicaGCPriorityDefault)
 	return lhsRepl, true
 }
 

--- a/pkg/storage/store_snapshot.go
+++ b/pkg/storage/store_snapshot.go
@@ -591,14 +591,7 @@ func (s *Store) canApplySnapshotLocked(
 			}
 
 			msg += "; initiated GC:"
-			_ = s.stopper.RunAsyncTask(ctx, "add-to-replicagc-queue", func(ctx context.Context) {
-				// We can't hold any mutexes while adding to queues, so we have to do it in a task. This
-				// is especially important since we hold the store mutex in the surrounding method, which
-				// we wouldn't want to block even if it were legal.
-				if _, err := s.replicaGCQueue.Add(exReplica, gcPriority); err != nil {
-					log.Errorf(ctx, "%s: unable to add replica to GC queue: %s", exReplica, err)
-				}
-			})
+			s.replicaGCQueue.AddAsync(ctx, exReplica, gcPriority)
 		}
 		return nil, errors.Errorf("%s %v (incoming %v)", msg, exReplica, snapHeader.State.Desc.RSpan()) // exReplica can be nil
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2591,7 +2591,7 @@ func (fq *fakeRangeQueue) Start(_ *stop.Stopper) {
 	// Do nothing
 }
 
-func (fq *fakeRangeQueue) MaybeAdd(_ *Replica, _ hlc.Timestamp) {
+func (fq *fakeRangeQueue) MaybeAddAsync(context.Context, *Replica, hlc.Timestamp) {
 	// Do nothing
 }
 


### PR DESCRIPTION
baseQueue.mu locks were held unnecessarily long, and in particular across
`shouldQueue` invocations which in turn can acquire various Replica locks,
complicating the lock ordering story.

Sidestep this issue by never holding baseQueue.mu across any operation that
can touch the Replica.

The remaining issue here is that callers of `Add` or `MaybeAdd` may be
holding locks on the Replica object already which could also lead to
deadlock. This is because the queue calls into
`repl.maybeInitializeRaftGroup()` (which can end up acquiring the raftMu)
but also because it calls the various `shouldQueue` methods doing the
queue-specific checks; those almost always acquire locks, too. This problem
should be exclusive to `raftMu`; I doubt we hold `Replica.mu` while calling
`Add/MaybeAdd` or at least it should be easy to avoid that.

Working around this is left to the second commit, which avoids having to worry
about lock ordering if a replica is added to a queue while holding mutexes.
Primarly, this affects calls to add a replica to a queue from within the raft
processing goroutines, where the replica's raftMu is held. Adding a replica to
a queue can in turn require acquisition of the raftMu, leading to potential
deadlock.

This hasn't been observed in practice, but let's be prudent and avoid this
problem. Queues act asynchronously by their very nature, so we lose very
little by not offering replicas to a queue synchronously, except during
unit tests, where we'll simply have work around it.

Touches #36413.