### PR TITLE
roachprod: rationalize refreshing of DNS entries

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -661,3 +661,8 @@ func (p *Provider) runInstance(name string, zone string, opts vm.CreateOpts) err
 
 	return p.runJSONCommand(args, &data)
 }
+
+// Active is part of the vm.Provider interface.
+func (p *Provider) Active() bool {
+	return true
+}

--- a/pkg/cmd/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/cmd/roachprod/vm/flagstub/flagstub.go
@@ -80,3 +80,8 @@ func (p *provider) List() (vm.List, error) {
 func (p *provider) Name() string {
 	return p.delegate.Name()
 }
+
+// Active is part of the vm.Provider interface.
+func (p *provider) Active() bool {
+	return false
+}

--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -41,6 +41,11 @@ const (
 	ProviderName = "gce"
 )
 
+// DefaultProject returns the default GCE project.
+func DefaultProject() string {
+	return defaultProject
+}
+
 // init will inject the GCE provider into vm.Providers, but only if the gcloud tool is available on the local path.
 func init() {
 	var p vm.Provider = &Provider{}
@@ -190,9 +195,14 @@ func (o *providerOpts) ConfigureClusterFlags(flags *pflag.FlagSet) {
 		"Project to manage cluster in")
 }
 
-// Provider TODO(peter): document
+// Provider is the GCE implementation of the vm.Provider interface.
 type Provider struct {
 	opts providerOpts
+}
+
+// Project returns the GCE project that we're operating on.
+func (p *Provider) Project() string {
+	return p.opts.Project
 }
 
 // CleanSSH TODO(peter): document
@@ -420,4 +430,9 @@ func (p *Provider) List() (vm.List, error) {
 // Name TODO(peter): document
 func (p *Provider) Name() string {
 	return ProviderName
+}
+
+// Active is part of the vm.Provider interface.
+func (p *Provider) Active() bool {
+	return true
 }

--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -139,11 +139,8 @@ func writeStartupScript(extraMountOpts string) (string, error) {
 }
 
 // SyncDNS replaces the configured DNS zone with the supplied hosts.
-func SyncDNS(names vm.List) error {
+func SyncDNS(vms vm.List) error {
 	if Subdomain == "" {
-		return nil
-	}
-	if p, ok := vm.Providers[ProviderName].(*Provider); !ok || p.opts.Project != defaultProject {
 		return nil
 	}
 
@@ -157,7 +154,7 @@ func SyncDNS(names vm.List) error {
 			fmt.Fprintf(os.Stderr, "removing %s failed: %v", f.Name(), err)
 		}
 	}()
-	for _, vm := range names {
+	for _, vm := range vms {
 		fmt.Fprintf(f, "%s 60 IN A %s\n", vm.Name, vm.PublicIP)
 	}
 	f.Close()

--- a/pkg/cmd/roachprod/vm/local/local.go
+++ b/pkg/cmd/roachprod/vm/local/local.go
@@ -135,3 +135,8 @@ func (p *Provider) List() (ret vm.List, _ error) {
 func (p *Provider) Name() string {
 	return ProviderName
 }
+
+// Active is part of the vm.Provider interface.
+func (p *Provider) Active() bool {
+	return true
+}

--- a/pkg/cmd/roachprod/vm/vm.go
+++ b/pkg/cmd/roachprod/vm/vm.go
@@ -157,6 +157,14 @@ type Provider interface {
 	List() (List, error)
 	// The name of the Provider, which will also surface in the top-level Providers map.
 	Name() string
+
+	// Active returns true if the provider is properly installed and capable of
+	// operating, false if it's just a stub. This allows one to test whether a
+	// particular provider is functioning properly by doin, for example,
+	// Providers[gce.ProviderName].Active. Note that just looking at
+	// Providers[gce.ProviderName] != nil doesn't work because
+	// Providers[gce.ProviderName] can be a stub.
+	Active() bool
 }
 
 // Providers contains all known Provider instances. This is initialized by subpackage init() functions.


### PR DESCRIPTION
Before this patch, the DNS entries were refreshed even if we hadn't
properly listed the AWS clusters, which would cause their DNS entries to
be removed inadvertently.
This patch lifts the decision about whether to refresh or not out of the
GCE code and into the top level.

Release note: None