### PR TITLE
sqlbase: add randomized tests for key and value encoding

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1009,6 +1009,17 @@
   version = "v0.1.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:ed8219bed9a7adf8f0450a97b278fde8b289a5285b580fda20f6c23087fcce41"
+  name = "github.com/leanovate/gopter"
+  packages = [
+    ".",
+    "prop",
+  ]
+  pruneopts = "UT"
+  revision = "634a59d12406abc51545000deab7cf43ebc32378"
+
+[[projects]]
   digest = "1:8ef506fc2bb9ced9b151dafa592d4046063d744c646c1bbe801982ce87e4bc24"
   name = "github.com/lib/pq"
   packages = [
@@ -1861,6 +1872,8 @@
     "github.com/knz/strtime",
     "github.com/kr/pretty",
     "github.com/kr/text",
+    "github.com/leanovate/gopter",
+    "github.com/leanovate/gopter/prop",
     "github.com/lib/pq",
     "github.com/lib/pq/oid",
     "github.com/lightstep/lightstep-tracer-go",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -106,6 +106,11 @@ ignored = [
   name = "honnef.co/go/tools"
   version = "=2017.2.2"
 
+# Test util - don't need to pin.
+[[constraint]]
+  name = "github.com/leanovate/gopter"
+  branch = "master"
+
 # github.com/openzipkin-contrib/zipkin-go-opentracing requires a newer
 # version of thrift than is currently present in a release.
 [[override]]

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -328,7 +328,7 @@ func DecodeTableKey(
 		}
 		return a.NewDOid(tree.MakeDOid(tree.DInt(i))), rkey, err
 	default:
-		return nil, nil, errors.Errorf("TODO(pmattis): decoded index key: %s", valType)
+		return nil, nil, errors.Errorf("unable to decode table key: %s", valType)
 	}
 }
 
@@ -396,8 +396,9 @@ func EncodeTableValue(
 		return encoding.EncodeBytesValue(appendTo, uint32(colID), []byte(t.Contents)), nil
 	case *tree.DOid:
 		return encoding.EncodeIntValue(appendTo, uint32(colID), int64(t.DInt)), nil
+	default:
+		return nil, errors.Errorf("unable to encode table value: %T", t)
 	}
-	return nil, errors.Errorf("unable to encode table value: %T", val)
 }
 
 // DecodeTableValue decodes a value encoded by EncodeTableValue.
@@ -1097,7 +1098,7 @@ func checkElementType(paramType *types.T, elemType *types.T) error {
 // encodeArrayElement appends the encoded form of one array element to
 // the target byte buffer.
 func encodeArrayElement(b []byte, d tree.Datum) ([]byte, error) {
-	switch t := d.(type) {
+	switch t := tree.UnwrapDatum(nil, d).(type) {
 	case *tree.DInt:
 		return encoding.EncodeUntaggedIntValue(b, int64(*t)), nil
 	case *tree.DString:
@@ -1134,6 +1135,7 @@ func encodeArrayElement(b []byte, d tree.Datum) ([]byte, error) {
 		return encoding.EncodeUntaggedIntValue(b, int64(t.DInt)), nil
 	case *tree.DCollatedString:
 		return encoding.EncodeUntaggedBytesValue(b, []byte(t.Contents)), nil
+	default:
+		return nil, errors.Errorf("don't know how to encode %s (%T)", d, d)
 	}
-	return nil, errors.Errorf("don't know how to encode %s", d)
 }

--- a/pkg/sql/sqlbase/column_type_encoding_test.go
+++ b/pkg/sql/sqlbase/column_type_encoding_test.go
@@ -1,0 +1,180 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlbase
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/prop"
+)
+
+func genColumnType() gopter.Gen {
+	return func(genParams *gopter.GenParameters) *gopter.GenResult {
+		columnType := RandColumnType(genParams.Rng)
+		return gopter.NewGenResult(columnType, gopter.NoShrinker)
+	}
+}
+
+func genDatum() gopter.Gen {
+	return func(genParams *gopter.GenParameters) *gopter.GenResult {
+		return gopter.NewGenResult(RandDatum(genParams.Rng, RandColumnType(genParams.Rng),
+			false), gopter.NoShrinker)
+	}
+}
+
+func genDatumWithType(columnType interface{}) gopter.Gen {
+	return func(genParams *gopter.GenParameters) *gopter.GenResult {
+		datum := RandDatum(genParams.Rng, columnType.(*types.T), false)
+		return gopter.NewGenResult(datum, gopter.NoShrinker)
+	}
+}
+
+func genEncodingDirection() gopter.Gen {
+	return func(genParams *gopter.GenParameters) *gopter.GenResult {
+		return gopter.NewGenResult(
+			encoding.Direction((genParams.Rng.Int()%int(encoding.Descending))+1),
+			gopter.NoShrinker)
+	}
+}
+
+func hasKeyEncoding(typ *types.T) bool {
+	// Only some types are round-trip key encodable.
+	switch typ.Family() {
+	case types.JsonFamily, types.ArrayFamily, types.CollatedStringFamily, types.TupleFamily, types.DecimalFamily:
+		return false
+	}
+	return true
+}
+
+func TestEncodeTableValue(t *testing.T) {
+	a := &DatumAlloc{}
+	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	parameters := gopter.DefaultTestParameters()
+	parameters.MinSuccessfulTests = 10000
+	properties := gopter.NewProperties(parameters)
+	var scratch []byte
+	properties.Property("roundtrip", prop.ForAll(
+		func(d tree.Datum) string {
+			b, err := EncodeTableValue(nil, 0, d, scratch)
+			if err != nil {
+				return "error: " + err.Error()
+			}
+			newD, leftoverBytes, err := DecodeTableValue(a, d.ResolvedType(), b)
+			if len(leftoverBytes) > 0 {
+				return "Leftover bytes"
+			}
+			if err != nil {
+				return "error: " + err.Error()
+			}
+			if newD.Compare(ctx, d) != 0 {
+				return "unequal"
+			}
+			return ""
+		},
+		genDatum(),
+	))
+	properties.TestingRun(t)
+}
+
+func TestEncodeTableKey(t *testing.T) {
+	a := &DatumAlloc{}
+	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	parameters := gopter.DefaultTestParameters()
+	parameters.MinSuccessfulTests = 10000
+	properties := gopter.NewProperties(parameters)
+	properties.Property("roundtrip", prop.ForAll(
+		func(d tree.Datum, dir encoding.Direction) string {
+			b, err := EncodeTableKey(nil, d, dir)
+			if err != nil {
+				return "error: " + err.Error()
+			}
+			newD, leftoverBytes, err := DecodeTableKey(a, d.ResolvedType(), b, dir)
+			if len(leftoverBytes) > 0 {
+				return "Leftover bytes"
+			}
+			if err != nil {
+				return "error: " + err.Error()
+			}
+			if newD.Compare(ctx, d) != 0 {
+				return "unequal"
+			}
+			return ""
+		},
+		genColumnType().
+			SuchThat(hasKeyEncoding).
+			FlatMap(genDatumWithType, reflect.TypeOf((*tree.Datum)(nil)).Elem()),
+		genEncodingDirection(),
+	))
+	properties.Property("order-preserving", prop.ForAll(
+		func(datums []tree.Datum, dir encoding.Direction) string {
+			d1 := datums[0]
+			d2 := datums[1]
+			b1, err := EncodeTableKey(nil, d1, dir)
+			if err != nil {
+				return "error: " + err.Error()
+			}
+			b2, err := EncodeTableKey(nil, d2, dir)
+			if err != nil {
+				return "error: " + err.Error()
+			}
+
+			expectedCmp := d1.Compare(ctx, d2)
+			cmp := bytes.Compare(b1, b2)
+
+			if expectedCmp == 0 {
+				if cmp != 0 {
+					return fmt.Sprintf("equal inputs produced inequal outputs: \n%v\n%v", b1, b2)
+				}
+				// If the inputs are equal and so are the outputs, no more checking to do.
+				return ""
+			}
+
+			cmpsMatch := expectedCmp == cmp
+			dirIsAscending := dir == encoding.Ascending
+
+			if cmpsMatch != dirIsAscending {
+				return fmt.Sprintf("non-order preserving encoding: \n%v\n%v", b1, b2)
+			}
+			return ""
+		},
+		// For each column type, generate two datums of that type.
+		genColumnType().
+			SuchThat(hasKeyEncoding).
+			FlatMap(
+				func(t interface{}) gopter.Gen {
+					colTyp := t.(*types.T)
+					return gopter.CombineGens(
+						genDatumWithType(colTyp),
+						genDatumWithType(colTyp))
+				}, reflect.TypeOf([]interface{}{})).
+			Map(func(datums []interface{}) []tree.Datum {
+				ret := make([]tree.Datum, len(datums))
+				for i, d := range datums {
+					ret[i] = d.(tree.Datum)
+				}
+				return ret
+			}),
+		genEncodingDirection(),
+	))
+	properties.TestingRun(t)
+}


### PR DESCRIPTION
This uses `gopter`, a property-based testing framework. More of a POC of how that framework works than anything, though I don't think we have tests that do this work yet so it'll be good to add in any event.

Release note: None