### PR TITLE
roachtest: restart node at end of upgrade/mixedWith

### DIFF
--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -179,7 +179,7 @@ func registerUpgrade(r *registry) {
 			t.Fatal("cluster setting version shouldn't be upgraded before all non-decommissioned nodes are alive")
 		}
 
-		// Now decommission and stop the second last node.
+		// Now decommission and stop n3.
 		// The decommissioned nodes should not prevent auto upgrade.
 		if err := decommissionAndStop(nodes - 2); err != nil {
 			t.Fatal(err)
@@ -260,6 +260,9 @@ func registerUpgrade(r *registry) {
 		if downgradeVersion != "" {
 			t.Fatalf("cluster setting cluster.preserve_downgrade_option is %s, should be an empty string", downgradeVersion)
 		}
+
+		// Start n3 again to satisfy the dead node detector.
+		c.Start(ctx, t, c.Node(nodes-2))
 	}
 
 	mixedWithVersion := r.PredecessorVersion()


### PR DESCRIPTION
This one slipped the cracks because it only ran on release-2.1 (which
has no frequent nightlies) until the other day, when I added the
PredecessorVersion() for 19.1.

Fixes #36593.

Release note: None