### PR TITLE
sqlbase: enable the decoding of single-column family jsonb columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -700,3 +700,24 @@ SELECT '{"b": [], "c": {"a": "b"}}'::JSONB - array['foo', NULL]
 
 statement error pgcode 22P02 a path element is not an integer: foo
 SELECT '{"a": {"b": ["foo"]}}'::JSONB #- ARRAY['a', 'b', 'foo']
+
+subtest single_family_jsonb
+
+statement ok
+CREATE TABLE json_family (a INT PRIMARY KEY, b JSONB, FAMILY fam0(a), FAMILY fam1(b))
+
+statement ok
+INSERT INTO json_family VALUES(0,'{}')
+
+statement ok
+INSERT INTO json_family VALUES(1,'{"a":123,"c":"asdf"}')
+
+query IT colnames
+SELECT a, b FROM json_family ORDER BY a
+----
+a  b
+0  {}
+1  {"a": 123, "c": "asdf"}
+
+statement ok
+DROP TABLE json_family

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -836,6 +836,16 @@ func UnmarshalColumnValue(a *DatumAlloc, typ ColumnType, value roachpb.Value) (t
 		elementType := columnSemanticTypeToDatumType(&ColumnType{}, *typ.ArrayContents)
 		datum, _, err := decodeArrayNoMarshalColumnValue(a, elementType, v)
 		return datum, err
+	case ColumnType_JSONB:
+		v, err := value.GetBytes()
+		if err != nil {
+			return nil, err
+		}
+		_, jsonDatum, err := json.DecodeJSON(v)
+		if err != nil {
+			return nil, err
+		}
+		return tree.NewDJSON(jsonDatum), nil
 	default:
 		return nil, errors.Errorf("unsupported column type: %s", typ.SemanticType)
 	}


### PR DESCRIPTION
Similar to #36548, where arrays were not decoded correctly if they were in
a single-column family, jsonb had the same issue.

This fixes that.

Release note (bug fix): Single column family jsonb columns can now be decoded
correctly.
From #36548 (bug fix) Single column family array columns can now be decoded
correctly.