### PR TITLE
opt: add support for LATERAL in FROM clause

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1820,9 +1820,11 @@ distinct_on_clause ::=
 table_ref ::=
 	relation_expr opt_index_flags opt_ordinality opt_alias_clause
 	| select_with_parens opt_ordinality opt_alias_clause
+	| 'LATERAL' select_with_parens opt_ordinality opt_alias_clause
 	| joined_table
 	| '(' joined_table ')' opt_ordinality alias_clause
 	| func_table opt_ordinality opt_alias_clause
+	| 'LATERAL' func_table opt_ordinality opt_alias_clause
 	| '[' preparable_stmt ']' opt_ordinality opt_alias_clause
 
 all_or_distinct ::=

--- a/docs/generated/sql/bnf/table_ref.bnf
+++ b/docs/generated/sql/bnf/table_ref.bnf
@@ -1,7 +1,9 @@
 table_ref ::=
 	table_name ( '@' index_name | ) ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
 	| '(' select_stmt ')' ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
+	| 'LATERAL' '(' select_stmt ')' ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
 	| joined_table
 	| '(' joined_table ')' ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
 	| func_application ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
+	| 'LATERAL' func_application ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
 	| '[' preparable_stmt ']' ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -166,6 +166,9 @@ func (p *planner) getDataSource(
 
 	case *tree.AliasedTableExpr:
 		// Alias clause: source AS alias(cols...)
+		if t.Lateral {
+			return planDataSource{}, pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError, "LATERAL is not supported")
+		}
 
 		if t.IndexFlags != nil {
 			indexFlags = t.IndexFlags

--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -988,6 +988,27 @@ Group 1	{"name": "admin", "type": "USER"}
 Group 1	{"name": "user", "type": "USER"}
 Group 2	{"name": "admin2", "type": "USER"}
 
+query TT
+SELECT
+    data->>'name',
+    members
+FROM
+    groups AS g,
+    jsonb_array_elements(
+        (
+            SELECT
+                gg.data->'members' AS members
+            FROM
+                groups AS gg
+            WHERE
+                gg.data->>'name' = g.data->>'name'
+        )
+    ) AS members
+----
+Group 1  {"name": "admin", "type": "USER"}
+Group 1  {"name": "user", "type": "USER"}
+Group 2  {"name": "admin2", "type": "USER"}
+
 # ------------------------------------------------------------------------------
 # Regression test cases.
 # ------------------------------------------------------------------------------

--- a/pkg/sql/logictest/testdata/planner_test/select
+++ b/pkg/sql/logictest/testdata/planner_test/select
@@ -643,3 +643,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message IN
 querying next range at /Table/63/1/0
 === SPAN START: kv.DistSender: sending partial batch ===
 querying next range at /Table/63/1/10
+
+# Ensure that the heuristic planner correctly rejects LATERAL joins.
+statement error LATERAL is not supported
+SELECT a.a FROM a, LATERAL (SELECT * FROM b.a WHERE a.a = b.a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -325,87 +325,61 @@ SELECT level, node_type, field, description FROM [EXPLAIN (VERBOSE) SELECT
 2   ·              render 12  relname
 3   hash-join      ·          ·
 3   ·              type       inner
-3   ·              equality   (oid) = (attrelid)
-3   ·              pred       confrelid = oid
+3   ·              equality   (refobjid) = (oid)
 4   hash-join      ·          ·
 4   ·              type       inner
-4   ·              equality   (relnamespace) = (oid)
-5   virtual table  ·          ·
-5   ·              source     ·
-5   virtual table  ·          ·
-5   ·              source     ·
-4   hash-join      ·          ·
-4   ·              type       inner
-4   ·              equality   (attnum) = (column167)
-5   virtual table  ·          ·
-5   ·              source     ·
-5   render         ·          ·
-5   ·              render 0   confkey[generate_series]
-5   ·              render 1   nspname
-5   ·              render 2   relname
-5   ·              render 3   attname
-5   ·              render 4   conname
-5   ·              render 5   condeferrable
-5   ·              render 6   condeferred
-5   ·              render 7   confrelid
-5   ·              render 8   confupdtype
-5   ·              render 9   confdeltype
-5   ·              render 10  generate_series
-5   ·              render 11  relname
+4   ·              equality   (oid) = (objid)
+5   hash-join      ·          ·
+5   ·              type       inner
+5   ·              pred       (attnum = confkey[generate_series]) AND (attnum = conkey[generate_series])
 6   hash-join      ·          ·
 6   ·              type       inner
-6   ·              equality   (conrelid, column166) = (oid, attnum)
-7   render         ·          ·
-7   ·              render 0   conkey[generate_series]
-7   ·              render 1   conname
-7   ·              render 2   condeferrable
-7   ·              render 3   condeferred
-7   ·              render 4   conrelid
-7   ·              render 5   confrelid
-7   ·              render 6   confupdtype
-7   ·              render 7   confdeltype
-7   ·              render 8   confkey
-7   ·              render 9   generate_series
-7   ·              render 10  relname
-8   hash-join      ·          ·
-8   ·              type       cross
-9   hash-join      ·          ·
-9   ·              type       inner
-9   ·              equality   (objid) = (oid)
-10  hash-join      ·          ·
-10  ·              type       inner
-10  ·              equality   (refobjid) = (oid)
-11  filter         ·          ·
-11  ·              filter     (classid = 4294967232) AND (refclassid = 4294967234)
-12  virtual table  ·          ·
-12  ·              source     ·
-11  filter         ·          ·
-11  ·              filter     relkind = 'i'
-12  virtual table  ·          ·
-12  ·              source     ·
-10  filter         ·          ·
-10  ·              filter     contype = 'f'
-11  virtual table  ·          ·
-11  ·              source     ·
-9   project set    ·          ·
-9   ·              render 0   generate_series(1, 32)
-10  emptyrow       ·          ·
+6   ·              equality   (oid, oid) = (confrelid, conrelid)
 7   hash-join      ·          ·
 7   ·              type       inner
-7   ·              equality   (attrelid) = (oid)
-8   virtual table  ·          ·
-8   ·              source     ·
+7   ·              equality   (oid) = (attrelid)
 8   hash-join      ·          ·
 8   ·              type       inner
-8   ·              equality   (relnamespace) = (oid)
+8   ·              equality   (oid) = (relnamespace)
+9   hash-join      ·          ·
+9   ·              type       inner
+9   ·              equality   (oid) = (attrelid)
+10  hash-join      ·          ·
+10  ·              type       inner
+10  ·              equality   (oid) = (relnamespace)
+11  virtual table  ·          ·
+11  ·              source     ·
+11  virtual table  ·          ·
+11  ·              source     ·
+10  hash-join      ·          ·
+10  ·              type       cross
+11  virtual table  ·          ·
+11  ·              source     ·
+11  filter         ·          ·
+11  ·              filter     nspname = 'public'
+12  virtual table  ·          ·
+12  ·              source     ·
 9   filter         ·          ·
 9   ·              filter     relname = 'orders'
 10  virtual table  ·          ·
 10  ·              source     ·
-9   filter         ·          ·
-9   ·              filter     nspname = 'public'
-10  virtual table  ·          ·
-10  ·              source     ·
+8   virtual table  ·          ·
+8   ·              source     ·
+7   filter         ·          ·
+7   ·              filter     contype = 'f'
+8   virtual table  ·          ·
+8   ·              source     ·
+6   project set    ·          ·
+6   ·              render 0   generate_series(1, 32)
+7   emptyrow       ·          ·
+5   filter         ·          ·
+5   ·              filter     (classid = 4294967232) AND (refclassid = 4294967234)
+6   virtual table  ·          ·
+6   ·              source     ·
+4   filter         ·          ·
+4   ·              filter     relkind = 'i'
+5   virtual table  ·          ·
+5   ·              source     ·
 
 # Ensure that left joins on non-null foreign keys turn into inner joins
 statement ok

--- a/pkg/sql/opt/optbuilder/testdata/inner-join
+++ b/pkg/sql/opt/optbuilder/testdata/inner-join
@@ -137,6 +137,18 @@ SELECT * FROM a, a
 ----
 error (42712): source name "a" specified more than once (missing AS clause)
 
+# TODO(justin): this case should be rejected for having a name specified twice.
+build fully-qualify-names
+SELECT * FROM a, (SELECT * FROM a) AS a
+----
+inner-join
+ ├── columns: x:1(int!null) y:2(float) x:3(int!null) y:4(float)
+ ├── scan t.public.a
+ │    └── columns: t.public.a.x:1(int!null) t.public.a.y:2(float)
+ ├── scan t.public.a
+ │    └── columns: t.public.a.x:3(int!null) t.public.a.y:4(float)
+ └── filters (true)
+
 build fully-qualify-names
 SELECT * FROM t.a, a
 ----

--- a/pkg/sql/opt/optbuilder/testdata/lateral
+++ b/pkg/sql/opt/optbuilder/testdata/lateral
@@ -1,0 +1,306 @@
+exec-ddl
+CREATE TABLE x (a INT PRIMARY KEY)
+----
+TABLE x
+ ├── a int not null
+ └── INDEX primary
+      └── a int not null
+
+exec-ddl
+CREATE TABLE y (b INT PRIMARY KEY)
+----
+TABLE y
+ ├── b int not null
+ └── INDEX primary
+      └── b int not null
+
+exec-ddl
+CREATE TABLE z (c INT PRIMARY KEY)
+----
+TABLE z
+ ├── c int not null
+ └── INDEX primary
+      └── c int not null
+
+build
+SELECT * FROM x, y, z
+----
+inner-join
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── scan x
+ │    └── columns: a:1(int!null)
+ ├── inner-join
+ │    ├── columns: b:2(int!null) c:3(int!null)
+ │    ├── scan y
+ │    │    └── columns: b:2(int!null)
+ │    ├── scan z
+ │    │    └── columns: c:3(int!null)
+ │    └── filters (true)
+ └── filters (true)
+
+build
+SELECT * FROM x, LATERAL (SELECT * FROM y WHERE b = a)
+----
+inner-join-apply
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── scan x
+ │    └── columns: a:1(int!null)
+ ├── select
+ │    ├── columns: b:2(int!null)
+ │    ├── scan y
+ │    │    └── columns: b:2(int!null)
+ │    └── filters
+ │         └── eq [type=bool]
+ │              ├── variable: b [type=int]
+ │              └── variable: a [type=int]
+ └── filters (true)
+
+build
+SELECT * FROM x, (SELECT * FROM y WHERE b = a)
+----
+error (42703): column "a" does not exist
+
+# Ensure that the presence of LATERAL properly affects name resolution.
+
+build
+SELECT
+  (SELECT b FROM (SELECT c AS a FROM z), LATERAL (SELECT * FROM y WHERE b = a))
+FROM x
+----
+project
+ ├── columns: b:4(int)
+ ├── scan x
+ │    └── columns: a:1(int!null)
+ └── projections
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: y.b:3(int!null)
+                └── project
+                     ├── columns: y.b:3(int!null)
+                     └── inner-join-apply
+                          ├── columns: c:2(int!null) y.b:3(int!null)
+                          ├── scan z
+                          │    └── columns: c:2(int!null)
+                          ├── select
+                          │    ├── columns: y.b:3(int!null)
+                          │    ├── scan y
+                          │    │    └── columns: y.b:3(int!null)
+                          │    └── filters
+                          │         └── eq [type=bool]
+                          │              ├── variable: y.b [type=int]
+                          │              └── variable: c [type=int]
+                          └── filters (true)
+
+build
+SELECT
+  (SELECT b FROM (SELECT c AS a FROM z), (SELECT * FROM y WHERE b = a))
+FROM x
+----
+project
+ ├── columns: b:4(int)
+ ├── scan x
+ │    └── columns: a:1(int!null)
+ └── projections
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: y.b:3(int!null)
+                └── project
+                     ├── columns: y.b:3(int!null)
+                     └── inner-join
+                          ├── columns: c:2(int!null) y.b:3(int!null)
+                          ├── scan z
+                          │    └── columns: c:2(int!null)
+                          ├── select
+                          │    ├── columns: y.b:3(int!null)
+                          │    ├── scan y
+                          │    │    └── columns: y.b:3(int!null)
+                          │    └── filters
+                          │         └── eq [type=bool]
+                          │              ├── variable: y.b [type=int]
+                          │              └── variable: a [type=int]
+                          └── filters (true)
+
+build
+SELECT * FROM x AS o WHERE EXISTS(SELECT * FROM x, LATERAL (SELECT * FROM y WHERE b = x.a AND o.a = x.a))
+----
+select
+ ├── columns: a:1(int!null)
+ ├── scan o
+ │    └── columns: o.a:1(int!null)
+ └── filters
+      └── exists [type=bool]
+           └── inner-join-apply
+                ├── columns: x.a:2(int!null) b:3(int!null)
+                ├── scan x
+                │    └── columns: x.a:2(int!null)
+                ├── select
+                │    ├── columns: b:3(int!null)
+                │    ├── scan y
+                │    │    └── columns: b:3(int!null)
+                │    └── filters
+                │         └── and [type=bool]
+                │              ├── eq [type=bool]
+                │              │    ├── variable: b [type=int]
+                │              │    └── variable: x.a [type=int]
+                │              └── eq [type=bool]
+                │                   ├── variable: o.a [type=int]
+                │                   └── variable: x.a [type=int]
+                └── filters (true)
+
+build
+SELECT * FROM x, LATERAL (SELECT * FROM y WHERE b = a), z
+----
+inner-join-apply
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
+ ├── inner-join-apply
+ │    ├── columns: a:1(int!null) b:2(int!null)
+ │    ├── scan x
+ │    │    └── columns: a:1(int!null)
+ │    ├── select
+ │    │    ├── columns: b:2(int!null)
+ │    │    ├── scan y
+ │    │    │    └── columns: b:2(int!null)
+ │    │    └── filters
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: b [type=int]
+ │    │              └── variable: a [type=int]
+ │    └── filters (true)
+ ├── scan z
+ │    └── columns: c:3(int!null)
+ └── filters (true)
+
+build
+SELECT * FROM x, LATERAL (SELECT * FROM y WHERE b = a), x
+----
+error (42712): source name "x" specified more than once (missing AS clause)
+
+exec-ddl
+CREATE TABLE j (
+  id INT PRIMARY KEY,
+  j JSONB
+)
+----
+TABLE j
+ ├── id int not null
+ ├── j jsonb
+ └── INDEX primary
+      └── id int not null
+
+build
+SELECT * FROM j, jsonb_array_elements(j.j->'foo')
+----
+inner-join-apply
+ ├── columns: id:1(int!null) j:2(jsonb) jsonb_array_elements:3(jsonb)
+ ├── scan j
+ │    └── columns: id:1(int!null) j:2(jsonb)
+ ├── project-set
+ │    ├── columns: jsonb_array_elements:3(jsonb)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: jsonb_array_elements [type=jsonb]
+ │              └── fetch-val [type=jsonb]
+ │                   ├── variable: j [type=jsonb]
+ │                   └── const: 'foo' [type=string]
+ └── filters (true)
+
+# Explicit LATERAL makes no difference for SRFs.
+
+build
+SELECT * FROM j, LATERAL jsonb_array_elements(j.j->'foo')
+----
+inner-join-apply
+ ├── columns: id:1(int!null) j:2(jsonb) jsonb_array_elements:3(jsonb)
+ ├── scan j
+ │    └── columns: id:1(int!null) j:2(jsonb)
+ ├── project-set
+ │    ├── columns: jsonb_array_elements:3(jsonb)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: jsonb_array_elements [type=jsonb]
+ │              └── fetch-val [type=jsonb]
+ │                   ├── variable: j [type=jsonb]
+ │                   └── const: 'foo' [type=string]
+ └── filters (true)
+
+# Referencing a lateral SRF from a lateral SRF.
+
+build
+SELECT * FROM j, jsonb_array_elements(j.j->'foo') AS e, jsonb_array_elements(e.e->'bar')
+----
+inner-join-apply
+ ├── columns: id:1(int!null) j:2(jsonb) e:3(jsonb) jsonb_array_elements:4(jsonb)
+ ├── inner-join-apply
+ │    ├── columns: id:1(int!null) j:2(jsonb) jsonb_array_elements:3(jsonb)
+ │    ├── scan j
+ │    │    └── columns: id:1(int!null) j:2(jsonb)
+ │    ├── project-set
+ │    │    ├── columns: jsonb_array_elements:3(jsonb)
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple]
+ │    │    └── zip
+ │    │         └── function: jsonb_array_elements [type=jsonb]
+ │    │              └── fetch-val [type=jsonb]
+ │    │                   ├── variable: j [type=jsonb]
+ │    │                   └── const: 'foo' [type=string]
+ │    └── filters (true)
+ ├── project-set
+ │    ├── columns: jsonb_array_elements:4(jsonb)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: jsonb_array_elements [type=jsonb]
+ │              └── fetch-val [type=jsonb]
+ │                   ├── variable: jsonb_array_elements [type=jsonb]
+ │                   └── const: 'bar' [type=string]
+ └── filters (true)
+
+build
+SELECT
+    *
+FROM
+    j,
+    jsonb_array_elements(
+        (
+            SELECT
+                j2.j->'members' AS members
+            FROM
+                j AS j2
+            WHERE
+                j2.j->>'name' = j.j->>'name'
+        )
+    )
+----
+inner-join-apply
+ ├── columns: id:1(int!null) j:2(jsonb) jsonb_array_elements:6(jsonb)
+ ├── scan j
+ │    └── columns: j.id:1(int!null) j.j:2(jsonb)
+ ├── project-set
+ │    ├── columns: jsonb_array_elements:6(jsonb)
+ │    ├── values
+ │    │    └── tuple [type=tuple]
+ │    └── zip
+ │         └── function: jsonb_array_elements [type=jsonb]
+ │              └── subquery [type=jsonb]
+ │                   └── max1-row
+ │                        ├── columns: members:5(jsonb)
+ │                        └── project
+ │                             ├── columns: members:5(jsonb)
+ │                             ├── select
+ │                             │    ├── columns: j2.id:3(int!null) j2.j:4(jsonb)
+ │                             │    ├── scan j2
+ │                             │    │    └── columns: j2.id:3(int!null) j2.j:4(jsonb)
+ │                             │    └── filters
+ │                             │         └── eq [type=bool]
+ │                             │              ├── fetch-text [type=string]
+ │                             │              │    ├── variable: j2.j [type=jsonb]
+ │                             │              │    └── const: 'name' [type=string]
+ │                             │              └── fetch-text [type=string]
+ │                             │                   ├── variable: j.j [type=jsonb]
+ │                             │                   └── const: 'name' [type=string]
+ │                             └── projections
+ │                                  └── fetch-val [type=jsonb]
+ │                                       ├── variable: j2.j [type=jsonb]
+ │                                       └── const: 'members' [type=string]
+ └── filters (true)

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -17,7 +17,7 @@ project-set
 build
 SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ----
-inner-join
+inner-join-apply
  ├── columns: generate_series:1(int) generate_series:2(int)
  ├── project-set
  │    ├── columns: generate_series:1(int)
@@ -120,34 +120,34 @@ SELECT t.*, u.*, a.*, b.* FROM t, u, generate_series(1, 2) AS a, generate_series
 ----
 project
  ├── columns: a:1(string) b:3(string) a:5(int) b:6(int)
- └── inner-join
+ └── inner-join-apply
       ├── columns: a:1(string) t.rowid:2(int!null) b:3(string) u.rowid:4(int!null) generate_series:5(int) generate_series:6(int)
-      ├── scan t
-      │    └── columns: a:1(string) t.rowid:2(int!null)
-      ├── inner-join
-      │    ├── columns: b:3(string) u.rowid:4(int!null) generate_series:5(int) generate_series:6(int)
-      │    ├── scan u
-      │    │    └── columns: b:3(string) u.rowid:4(int!null)
-      │    ├── inner-join
-      │    │    ├── columns: generate_series:5(int) generate_series:6(int)
-      │    │    ├── project-set
-      │    │    │    ├── columns: generate_series:5(int)
-      │    │    │    ├── values
-      │    │    │    │    └── tuple [type=tuple]
-      │    │    │    └── zip
-      │    │    │         └── function: generate_series [type=int]
-      │    │    │              ├── const: 1 [type=int]
-      │    │    │              └── const: 2 [type=int]
-      │    │    ├── project-set
-      │    │    │    ├── columns: generate_series:6(int)
-      │    │    │    ├── values
-      │    │    │    │    └── tuple [type=tuple]
-      │    │    │    └── zip
-      │    │    │         └── function: generate_series [type=int]
-      │    │    │              ├── const: 3 [type=int]
-      │    │    │              └── const: 4 [type=int]
+      ├── inner-join-apply
+      │    ├── columns: a:1(string) t.rowid:2(int!null) b:3(string) u.rowid:4(int!null) generate_series:5(int)
+      │    ├── inner-join-apply
+      │    │    ├── columns: a:1(string) t.rowid:2(int!null) b:3(string) u.rowid:4(int!null)
+      │    │    ├── scan t
+      │    │    │    └── columns: a:1(string) t.rowid:2(int!null)
+      │    │    ├── scan u
+      │    │    │    └── columns: b:3(string) u.rowid:4(int!null)
       │    │    └── filters (true)
+      │    ├── project-set
+      │    │    ├── columns: generate_series:5(int)
+      │    │    ├── values
+      │    │    │    └── tuple [type=tuple]
+      │    │    └── zip
+      │    │         └── function: generate_series [type=int]
+      │    │              ├── const: 1 [type=int]
+      │    │              └── const: 2 [type=int]
       │    └── filters (true)
+      ├── project-set
+      │    ├── columns: generate_series:6(int)
+      │    ├── values
+      │    │    └── tuple [type=tuple]
+      │    └── zip
+      │         └── function: generate_series [type=int]
+      │              ├── const: 3 [type=int]
+      │              └── const: 4 [type=int]
       └── filters (true)
 
 build
@@ -483,18 +483,18 @@ SELECT a.*, b.*, c.* FROM generate_series(1,1) a, unnest(ARRAY[1]) b, pg_get_key
 ----
 limit
  ├── columns: a:1(int) b:2(int) word:3(string) catcode:4(string) catdesc:5(string)
- ├── inner-join
+ ├── inner-join-apply
  │    ├── columns: generate_series:1(int) unnest:2(int) word:3(string) catcode:4(string) catdesc:5(string)
- │    ├── project-set
- │    │    ├── columns: generate_series:1(int)
- │    │    ├── values
- │    │    │    └── tuple [type=tuple]
- │    │    └── zip
- │    │         └── function: generate_series [type=int]
- │    │              ├── const: 1 [type=int]
- │    │              └── const: 1 [type=int]
- │    ├── inner-join
- │    │    ├── columns: unnest:2(int) word:3(string) catcode:4(string) catdesc:5(string)
+ │    ├── inner-join-apply
+ │    │    ├── columns: generate_series:1(int) unnest:2(int)
+ │    │    ├── project-set
+ │    │    │    ├── columns: generate_series:1(int)
+ │    │    │    ├── values
+ │    │    │    │    └── tuple [type=tuple]
+ │    │    │    └── zip
+ │    │    │         └── function: generate_series [type=int]
+ │    │    │              ├── const: 1 [type=int]
+ │    │    │              └── const: 1 [type=int]
  │    │    ├── project-set
  │    │    │    ├── columns: unnest:2(int)
  │    │    │    ├── values
@@ -503,13 +503,13 @@ limit
  │    │    │         └── function: unnest [type=int]
  │    │    │              └── array: [type=int[]]
  │    │    │                   └── const: 1 [type=int]
- │    │    ├── project-set
- │    │    │    ├── columns: word:3(string) catcode:4(string) catdesc:5(string)
- │    │    │    ├── values
- │    │    │    │    └── tuple [type=tuple]
- │    │    │    └── zip
- │    │    │         └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
  │    │    └── filters (true)
+ │    ├── project-set
+ │    │    ├── columns: word:3(string) catcode:4(string) catdesc:5(string)
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple]
+ │    │    └── zip
+ │    │         └── function: pg_get_keywords [type=tuple{string AS word, string AS catcode, string AS catdesc}]
  │    └── filters (true)
  └── const: 0 [type=int]
 

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -753,6 +753,8 @@ func TestParse(t *testing.T) {
 		{`SELECT a FROM (SELECT 1 FROM t) WITH ORDINALITY AS bar`},
 		{`SELECT a FROM ROWS FROM (a(x), b(y), c(z))`},
 		{`SELECT a FROM t1, t2`},
+		{`SELECT a FROM t1, LATERAL (SELECT * FROM t2 WHERE a = b)`},
+		{`SELECT a FROM t1, LATERAL ROWS FROM (generate_series(1, t1.x))`},
 		{`SELECT a FROM t AS t1`},
 		{`SELECT a FROM t AS t1 (c1)`},
 		{`SELECT a FROM t AS t1 (c1, c2, c3, c4)`},
@@ -1630,6 +1632,8 @@ func TestParse2(t *testing.T) {
 			`SELECT a FROM ROWS FROM (generate_series(1, 32)) AS s (x)`},
 		{`SELECT a FROM generate_series(1, 32) WITH ORDINALITY AS s (x)`,
 			`SELECT a FROM ROWS FROM (generate_series(1, 32)) WITH ORDINALITY AS s (x)`},
+		{`SELECT a FROM LATERAL generate_series(1, 32)`,
+			`SELECT a FROM LATERAL ROWS FROM (generate_series(1, 32))`},
 
 		// Tuples
 		{`SELECT 1 IN (b)`, `SELECT 1 IN (b,)`},
@@ -2900,8 +2904,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`INSERT INTO foo(a, a.b) VALUES (1,2)`, 27792, ``},
 		{`INSERT INTO foo VALUES (1,2) ON CONFLICT ON CONSTRAINT a DO NOTHING`, 28161, ``},
 
-		{`SELECT * FROM ab, LATERAL (SELECT * FROM kv)`, 24560, `select`},
-		{`SELECT * FROM ab, LATERAL foo(a)`, 24560, `srf`},
 		{`SELECT max(a ORDER BY b) FROM ab`, 23620, ``},
 
 		{`SELECT * FROM a FOR UPDATE`, 6583, ``},

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -631,6 +631,12 @@ func (node *Subquery) doc(p *PrettyCfg) pretty.Doc {
 
 func (node *AliasedTableExpr) doc(p *PrettyCfg) pretty.Doc {
 	d := p.Doc(node.Expr)
+	if node.Lateral {
+		d = pretty.Concat(
+			p.keywordWithText("", "LATERAL", " "),
+			d,
+		)
+	}
 	if node.IndexFlags != nil {
 		d = pretty.Concat(
 			d,

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -365,11 +365,15 @@ type AliasedTableExpr struct {
 	Expr       TableExpr
 	IndexFlags *IndexFlags
 	Ordinality bool
+	Lateral    bool
 	As         AliasClause
 }
 
 // Format implements the NodeFormatter interface.
 func (node *AliasedTableExpr) Format(ctx *FmtCtx) {
+	if node.Lateral {
+		ctx.WriteString("LATERAL ")
+	}
 	ctx.FormatNode(node.Expr)
 	if node.IndexFlags != nil {
 		ctx.FormatNode(node.IndexFlags)


### PR DESCRIPTION
Fixes #24676.
Partial fix for #24560.

This commit adds support for LATERAL in the FROM clause of a SELECT.
LATERAL allows a subquery or SRF to refer to columns in tables earlier
in the FROM clause. This is semantically an inner apply join.

A hiccup with this is that we build join trees in a FROM clause
right-deep, but the semantics of LATERAL force the tree to be left-deep.
Changing the default to be left-deep could cause some hand-optimized
queries to become slower, so we only change the order if there is a
LATERAL subquery. Note that SRFs are always implicitly LATERAL.

This commit does *not* add support for LATERAL as a keyword to explicit
`JOIN` expressions.

Release note (sql change): the LATERAL keyword in a FROM clause is now
supported.