### PR TITLE
release-19.1: distsqlrun: add missing close call to backfiller

### DIFF
--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -128,6 +128,7 @@ func (b *backfiller) mainLoop(ctx context.Context) error {
 	if err := b.chunks.prepare(ctx); err != nil {
 		return err
 	}
+	defer b.chunks.close(ctx)
 
 	var resume roachpb.Span
 	sp := work


### PR DESCRIPTION
Backport 1/1 commits from #36604.

/cc @cockroachdb/release

---

Release note: none.
