### PR TITLE
release-19.1: enable the decoding of single-column family columns of both json and array

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1224,3 +1224,52 @@ query B
 SELECT ARRAY[''] = ARRAY[] FROM (VALUES (1)) WHERE ARRAY[B''] != ARRAY[]
 ----
 false
+
+subtest 36477
+
+statement ok
+CREATE TABLE array_single_family (a INT PRIMARY KEY, b INT[], FAMILY fam0(a), FAMILY fam1(b))
+
+statement ok
+INSERT INTO array_single_family VALUES(0,ARRAY[])
+
+statement ok
+INSERT INTO array_single_family VALUES(1,ARRAY[1])
+
+statement ok
+INSERT INTO array_single_family VALUES(2,ARRAY[1,2])
+
+statement ok
+INSERT INTO array_single_family VALUES(3,ARRAY[1,2,NULL])
+
+statement ok
+INSERT INTO array_single_family VALUES(4,ARRAY[NULL,2,3])
+
+statement ok
+INSERT INTO array_single_family VALUES(5,ARRAY[1,NULL,3])
+
+statement ok
+INSERT INTO array_single_family VALUES(6,ARRAY[NULL::INT])
+
+statement ok
+INSERT INTO array_single_family VALUES(7,ARRAY[NULL::INT,NULL::INT])
+
+statement ok
+INSERT INTO array_single_family VALUES(8,ARRAY[NULL::INT,NULL::INT,NULL::INT])
+
+query IT colnames
+SELECT a, b FROM array_single_family ORDER BY a
+----
+a  b
+0  {}
+1  {1}
+2  {1,2}
+3  {1,2,NULL}
+4  {NULL,2,3}
+5  {1,NULL,3}
+6  {NULL}
+7  {NULL,NULL}
+8  {NULL,NULL,NULL}
+
+statement ok
+DROP TABLE array_single_family

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -700,3 +700,24 @@ SELECT '{"b": [], "c": {"a": "b"}}'::JSONB - array['foo', NULL]
 
 statement error pgcode 22P02 a path element is not an integer: foo
 SELECT '{"a": {"b": ["foo"]}}'::JSONB #- ARRAY['a', 'b', 'foo']
+
+subtest single_family_jsonb
+
+statement ok
+CREATE TABLE json_family (a INT PRIMARY KEY, b JSONB, FAMILY fam0(a), FAMILY fam1(b))
+
+statement ok
+INSERT INTO json_family VALUES(0,'{}')
+
+statement ok
+INSERT INTO json_family VALUES(1,'{"a":123,"c":"asdf"}')
+
+query IT colnames
+SELECT a, b FROM json_family ORDER BY a
+----
+a  b
+0  {}
+1  {"a": 123, "c": "asdf"}
+
+statement ok
+DROP TABLE json_family

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -836,6 +836,16 @@ func UnmarshalColumnValue(a *DatumAlloc, typ ColumnType, value roachpb.Value) (t
 		elementType := columnSemanticTypeToDatumType(&ColumnType{}, *typ.ArrayContents)
 		datum, _, err := decodeArrayNoMarshalColumnValue(a, elementType, v)
 		return datum, err
+	case ColumnType_JSONB:
+		v, err := value.GetBytes()
+		if err != nil {
+			return nil, err
+		}
+		_, jsonDatum, err := json.DecodeJSON(v)
+		if err != nil {
+			return nil, err
+		}
+		return tree.NewDJSON(jsonDatum), nil
 	default:
 		return nil, errors.Errorf("unsupported column type: %s", typ.SemanticType)
 	}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: Enable the decoding of single-column family arrays" (#36548)
  * 1/1 commits from "sqlbase: enable the decoding of single-column family jsonb columns" (#36612)

Please see individual PRs for details.

/cc @cockroachdb/release
