### PR TITLE
exec: add vectorized merge joiner logic and comparison tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/exec_merge_join
+++ b/pkg/sql/logictest/testdata/logic_test/exec_merge_join
@@ -1,0 +1,28 @@
+# LogicTest: local-vec
+
+# Basic tables, no nulls
+
+statement ok
+CREATE TABLE t1 (k INT PRIMARY KEY, v INT)
+
+statement ok
+INSERT INTO t1 VALUES  (-1, -1), (0, 4), (2, 1), (3, 4), (5, 4)
+
+statement ok
+CREATE INDEX on t1 (k);
+
+statement ok
+CREATE TABLE t2 (x INT, y INT)
+
+statement ok
+INSERT INTO t2 VALUES (0, 5), (1, 3), (1, 4), (3, 2), (3, 3), (4, 6)
+
+statement ok
+CREATE INDEX on t2 (x);
+
+query IIII
+SELECT k, v, x, y FROM t1 INNER MERGE JOIN t2 ON k = x;
+----
+0 4 0 5
+3 4 3 2
+3 4 3 3


### PR DESCRIPTION
Added tests that compare the row by row merge joiner to the
vectorized one on randomized input data. This mainly tests the
column orderings to make sure that different permutations of
columns are handled properly.

Also added some basic logic tests that can be extended in the
future.

Release note: None