### PR TITLE
release-2.1: enable the decoding of single-column family columns of both json and array

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1194,3 +1194,52 @@ query T
 SELECT * FROM v WHERE y = ARRAY(SELECT x FROM u ORDER BY x);
 ----
 {1,2}
+
+subtest 36477
+
+statement ok
+CREATE TABLE array_single_family (a INT PRIMARY KEY, b INT[], FAMILY fam0(a), FAMILY fam1(b))
+
+statement ok
+INSERT INTO array_single_family VALUES(0,ARRAY[])
+
+statement ok
+INSERT INTO array_single_family VALUES(1,ARRAY[1])
+
+statement ok
+INSERT INTO array_single_family VALUES(2,ARRAY[1,2])
+
+statement ok
+INSERT INTO array_single_family VALUES(3,ARRAY[1,2,NULL])
+
+statement ok
+INSERT INTO array_single_family VALUES(4,ARRAY[NULL,2,3])
+
+statement ok
+INSERT INTO array_single_family VALUES(5,ARRAY[1,NULL,3])
+
+statement ok
+INSERT INTO array_single_family VALUES(6,ARRAY[NULL::INT])
+
+statement ok
+INSERT INTO array_single_family VALUES(7,ARRAY[NULL::INT,NULL::INT])
+
+statement ok
+INSERT INTO array_single_family VALUES(8,ARRAY[NULL::INT,NULL::INT,NULL::INT])
+
+query IT colnames
+SELECT a, b FROM array_single_family ORDER BY a
+----
+a  b
+0  {}
+1  {1}
+2  {1,2}
+3  {1,2,NULL}
+4  {NULL,2,3}
+5  {1,NULL,3}
+6  {NULL}
+7  {NULL,NULL}
+8  {NULL,NULL,NULL}
+
+statement ok
+DROP TABLE array_single_family

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -672,3 +672,24 @@ SELECT '{"b": [], "c": {"a": "b"}}'::JSONB - array['a'];
 
 statement error pgcode 22P02 a path element is not an integer: foo
 SELECT '{"a": {"b": ["foo"]}}'::JSONB #- ARRAY['a', 'b', 'foo']
+
+subtest single_family_jsonb
+
+statement ok
+CREATE TABLE json_family (a INT PRIMARY KEY, b JSONB, FAMILY fam0(a), FAMILY fam1(b))
+
+statement ok
+INSERT INTO json_family VALUES(0,'{}')
+
+statement ok
+INSERT INTO json_family VALUES(1,'{"a":123,"c":"asdf"}')
+
+query IT colnames
+SELECT a, b FROM json_family ORDER BY a
+----
+a  b
+0  {}
+1  {"a": 123, "c": "asdf"}
+
+statement ok
+DROP TABLE json_family

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -807,6 +807,16 @@ func UnmarshalColumnValue(a *DatumAlloc, typ ColumnType, value roachpb.Value) (t
 		elementType := columnSemanticTypeToDatumType(&ColumnType{}, *typ.ArrayContents)
 		datum, _, err := decodeArrayNoMarshalColumnValue(a, elementType, v)
 		return datum, err
+	case ColumnType_JSONB:
+		v, err := value.GetBytes()
+		if err != nil {
+			return nil, err
+		}
+		_, jsonDatum, err := json.DecodeJSON(v)
+		if err != nil {
+			return nil, err
+		}
+		return tree.NewDJSON(jsonDatum), nil
 	default:
 		return nil, errors.Errorf("unsupported column type: %s", typ.SemanticType)
 	}

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -799,6 +799,14 @@ func UnmarshalColumnValue(a *DatumAlloc, typ ColumnType, value roachpb.Value) (t
 			return nil, err
 		}
 		return a.NewDOid(tree.MakeDOid(tree.DInt(v))), nil
+	case ColumnType_ARRAY:
+		v, err := value.GetBytes()
+		if err != nil {
+			return nil, err
+		}
+		elementType := columnSemanticTypeToDatumType(&ColumnType{}, *typ.ArrayContents)
+		datum, _, err := decodeArrayNoMarshalColumnValue(a, elementType, v)
+		return datum, err
 	default:
 		return nil, errors.Errorf("unsupported column type: %s", typ.SemanticType)
 	}
@@ -893,6 +901,14 @@ func decodeArray(a *DatumAlloc, elementType types.T, b []byte) (tree.Datum, []by
 	if err != nil {
 		return nil, b, err
 	}
+	return decodeArrayNoMarshalColumnValue(a, elementType, b)
+}
+
+// decodeArrayNoMarshalColumnValue skips the step where the MarshalColumnValue
+// is stripped from the bytes. This is required for single-column family arrays.
+func decodeArrayNoMarshalColumnValue(
+	a *DatumAlloc, elementType types.T, b []byte,
+) (tree.Datum, []byte, error) {
 	header, b, err := decodeArrayHeader(b)
 	if err != nil {
 		return nil, b, err


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: Enable the decoding of single-column family arrays" (#36548)
  * 1/1 commits from "sqlbase: enable the decoding of single-column family jsonb columns" (#36612)

Please see individual PRs for details.

/cc @cockroachdb/release
