### PR TITLE
opt: clean up buildAggregation in optbuilder

### DIFF
--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -898,7 +898,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 // replaceSRF also stores a pointer to the new srf struct in this scope's srfs
 // slice. The slice is used later by the Builder to convert the input from
 // the FROM clause to a lateral cross join between the input and a Zip of all
-// the srfs in the s.srfs slice. See Builder.constructProjectSet in srfs.go for
+// the srfs in the s.srfs slice. See Builder.buildProjectSet in srfs.go for
 // more details.
 func (s *scope) replaceSRF(f *tree.FuncExpr, def *tree.FunctionDefinition) *srf {
 	// We need to save and restore the previous value of the field in

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -646,17 +646,28 @@ func (b *Builder) buildSelectClause(
 	orderByScope := b.analyzeOrderBy(orderBy, fromScope, projectionsScope)
 	distinctOnScope := b.analyzeDistinctOnArgs(sel.DistinctOn, fromScope, projectionsScope)
 
-	if b.needsAggregation(sel, fromScope) {
-		outScope = b.buildAggregation(
-			sel, havingExpr, fromScope, projectionsScope, orderByScope, distinctOnScope,
-		)
+	var groupingCols []scopeColumn
+	var having opt.ScalarExpr
+	needsAgg := b.needsAggregation(sel, fromScope)
+	if needsAgg {
+		// Grouping columns must be built before building the projection list so
+		// we can check that any column references that appear in the SELECT list
+		// outside of aggregate functions are present in the grouping list.
+		groupingCols = b.buildGroupingColumns(sel, fromScope)
+		having = b.buildHaving(havingExpr, fromScope)
+	}
+
+	b.buildProjectionList(fromScope, projectionsScope)
+	b.buildOrderBy(fromScope, projectionsScope, orderByScope)
+	b.buildDistinctOnArgs(fromScope, projectionsScope, distinctOnScope)
+	b.buildProjectSet(fromScope)
+
+	if needsAgg {
+		// We must wait to build the aggregation until after the above block since
+		// any SRFs found in the SELECT list will change the FROM scope (they
+		// create an implicit lateral join).
+		outScope = b.buildAggregation(groupingCols, having, fromScope)
 	} else {
-		b.buildProjectionList(fromScope, projectionsScope)
-		b.buildOrderBy(fromScope, projectionsScope, orderByScope)
-		b.buildDistinctOnArgs(fromScope, projectionsScope, distinctOnScope)
-		if len(fromScope.srfs) > 0 {
-			fromScope.expr = b.constructProjectSet(fromScope.expr, fromScope.srfs)
-		}
 		outScope = fromScope
 	}
 

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -148,23 +148,27 @@ func (b *Builder) finishBuildGeneratorFunction(
 	return fn
 }
 
-// constructProjectSet constructs a ProjectSet, which is a lateral cross join
+// buildProjectSet builds a ProjectSet, which is a lateral cross join
 // between the given input expression and a functional zip constructed from the
 // given srfs.
 //
-// This function is called at most once per SELECT clause, and it is only
-// called if at least one SRF was discovered in the SELECT list. The ProjectSet
-// is necessary in case some of the SRFs depend on the input. For example,
-// consider this query:
+// This function is called at most once per SELECT clause, and updates
+// inScope.expr if at least one SRF was discovered in the SELECT list. The
+// ProjectSet is necessary in case some of the SRFs depend on the input.
+// For example, consider this query:
 //
 //   SELECT generate_series(t.a, t.a + 1) FROM t
 //
 // In this case, the inputs to generate_series depend on table t, so during
 // execution, generate_series will be called once for each row of t.
-func (b *Builder) constructProjectSet(in memo.RelExpr, srfs []*srf) memo.RelExpr {
+func (b *Builder) buildProjectSet(inScope *scope) {
+	if len(inScope.srfs) == 0 {
+		return
+	}
+
 	// Get the output columns and function expressions of the zip.
-	zip := make(memo.ZipExpr, len(srfs))
-	for i, srf := range srfs {
+	zip := make(memo.ZipExpr, len(inScope.srfs))
+	for i, srf := range inScope.srfs {
 		zip[i].Func = srf.fn
 		zip[i].Cols = make(opt.ColList, len(srf.cols))
 		for j := range srf.cols {
@@ -172,5 +176,5 @@ func (b *Builder) constructProjectSet(in memo.RelExpr, srfs []*srf) memo.RelExpr
 		}
 	}
 
-	return b.factory.ConstructProjectSet(in, zip)
+	inScope.expr = b.factory.ConstructProjectSet(inScope.expr, zip)
 }


### PR DESCRIPTION
`buildAggregation` in `opt/optbuilder/groupby.go` was a monster of a function
with a lot of parameters. This commit splits it into a few logical pieces
to improve maintainability.

Closes #29215

Release note: None