### PR TITLE
pgdate: check for overflow during date creation

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1250,3 +1250,11 @@ SELECT
     '1971-03-18'::DATE + 300866802885581286
 ----
 108672393952-01-22 00:00:00 +0000 +0000
+
+subtest year_overflow
+
+statement error field year value 12634756214869554 is out of range
+SELECT '12634756214869554-01-01'::date
+
+statement error field year value 12634756214869554 is out of range
+SELECT '12634756214869554-01-01'::timestamp

--- a/pkg/util/timeutil/pgdate/field_extract_test.go
+++ b/pkg/util/timeutil/pgdate/field_extract_test.go
@@ -98,7 +98,9 @@ func TestExtractSentinels(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if fe.MakeTimestamp() != tc.expected {
+			if res, err := fe.MakeTimestamp(); err != nil {
+				t.Fatal(err)
+			} else if res != tc.expected {
 				t.Fatal("did not get expected sentinel value")
 			}
 		})

--- a/pkg/util/timeutil/pgdate/parsing.go
+++ b/pkg/util/timeutil/pgdate/parsing.go
@@ -100,7 +100,7 @@ func ParseDate(now time.Time, mode ParseMode, s string) (time.Time, error) {
 	if err := fe.Extract(s); err != nil {
 		return TimeEpoch, parseError(err, "date", s)
 	}
-	return fe.MakeDate(), nil
+	return fe.MakeDate()
 }
 
 // ParseTime converts a string into a time value on the epoch day.
@@ -125,7 +125,7 @@ func ParseTime(now time.Time, mode ParseMode, s string) (time.Time, error) {
 			return TimeEpoch, parseError(err, "time", s)
 		}
 	}
-	return fe.MakeTime(), nil
+	return fe.MakeTime()
 }
 
 // ParseTimestamp converts a string into a timestamp.
@@ -142,7 +142,7 @@ func ParseTimestamp(now time.Time, mode ParseMode, s string) (time.Time, error) 
 	if err := fe.Extract(s); err != nil {
 		return TimeEpoch, parseError(err, "timestamp", s)
 	}
-	return fe.MakeTimestamp(), nil
+	return fe.MakeTimestamp()
 }
 
 // badFieldPrefixError constructs a CodeInvalidDatetimeFormatError pgerror.

--- a/pkg/util/timeutil/pgdate/parsing_test.go
+++ b/pkg/util/timeutil/pgdate/parsing_test.go
@@ -376,6 +376,10 @@ var dateTestData = []timeData{
 		s:   "121212",
 		exp: time.Date(2012, 12, 12, 0, 0, 0, 0, time.UTC),
 	},
+	{
+		s:   "1462356043380-01-01",
+		err: true,
+	},
 }
 
 var timeTestData = []timeData{


### PR DESCRIPTION
The year field especially is liable to overflow the underlying int64 of
nanos in the time.Time.

Release note (bug fix): Check for overflow during date and timestamp
creation.