### PR TITLE
storage,closedts: make minprop.Tracker epoch aware

### DIFF
--- a/pkg/storage/closedts/container/noop.go
+++ b/pkg/storage/closedts/container/noop.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/closedts"
 	"github.com/cockroachdb/cockroach/pkg/storage/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -57,13 +58,13 @@ func NoopContainer() *Container {
 func (noopEverything) Get(client ctpb.InboundClient) error {
 	return errors.New("closed timestamps disabled")
 }
-func (noopEverything) Close(next hlc.Timestamp) (hlc.Timestamp, map[roachpb.RangeID]ctpb.LAI) {
-	return hlc.Timestamp{}, nil
+func (noopEverything) Close(
+	next hlc.Timestamp, expCurEpoch ctpb.Epoch,
+) (hlc.Timestamp, map[roachpb.RangeID]ctpb.LAI, bool) {
+	return hlc.Timestamp{}, nil, false
 }
-func (noopEverything) Track(
-	ctx context.Context,
-) (hlc.Timestamp, func(context.Context, roachpb.RangeID, ctpb.LAI)) {
-	return hlc.Timestamp{}, func(context.Context, roachpb.RangeID, ctpb.LAI) {}
+func (noopEverything) Track(ctx context.Context) (hlc.Timestamp, closedts.ReleaseFunc) {
+	return hlc.Timestamp{}, func(context.Context, ctpb.Epoch, roachpb.RangeID, ctpb.LAI) {}
 }
 func (noopEverything) VisitAscending(roachpb.NodeID, func(ctpb.Entry) (done bool))  {}
 func (noopEverything) VisitDescending(roachpb.NodeID, func(ctpb.Entry) (done bool)) {}

--- a/pkg/storage/closedts/minprop/doc_test.go
+++ b/pkg/storage/closedts/minprop/doc_test.go
@@ -29,7 +29,7 @@ func Example() {
 	ctx := context.TODO()
 
 	tracker := NewTracker()
-
+	const ep1 ctpb.Epoch = 1
 	fmt.Println("The newly initialized tracker has a zero closed timestamp:")
 	fmt.Println(tracker)
 
@@ -44,15 +44,15 @@ func Example() {
 	fmt.Println(tracker)
 
 	fmt.Println("The command on r1 finishes evaluating at Lease Applied Index 10 and lets the Tracker know.")
-	done2(ctx, 1, 10)
+	done2(ctx, ep1, 1, 10)
 	fmt.Println(tracker)
 
 	fmt.Println("The command on r12 also finishes quickly, at LAI 77.")
-	done3(ctx, 12, 77)
+	done3(ctx, ep1, 12, 77)
 	fmt.Println(tracker)
 
 	fmt.Println("The system closes out a timestamp (registering 1000 as the next timestamp to close out).")
-	closed1, mlai1 := tracker.Close(hlc.Timestamp{WallTime: 1E9})
+	closed1, mlai1, _ := tracker.Close(hlc.Timestamp{WallTime: 1E9}, ep1)
 	fmt.Println("No problem: nothing is tracked on the left side; returns:", closed1, "and", mlaiString(mlai1))
 	fmt.Println("Note how the items on the right have moved to the left, as they are relevant for the")
 	fmt.Println("next call to Close.")
@@ -60,23 +60,23 @@ func Example() {
 
 	fmt.Println("Nothing happens for a while until the system tries to close out the next timestamp.")
 	fmt.Println("However, the very first proposal is still tracked and blocks progress.")
-	closed2, mlai2 := tracker.Close(hlc.Timestamp{WallTime: 2E9})
+	closed2, mlai2, _ := tracker.Close(hlc.Timestamp{WallTime: 2E9}, ep1)
 	fmt.Println("The call returns a no-op in the form", closed2, mlaiString(mlai2), ".")
 	fmt.Println(tracker)
 
 	ts4, done4 := tracker.Track(ctx)
 	fmt.Println("A new command gets tracked on r12 (and is forwarded to", ts4, "(if necessary).")
 	fmt.Println("It terminates quickly, leaving an MLAI entry of 78 behind.")
-	done4(ctx, 12, 78)
+	done4(ctx, ep1, 12, 78)
 	fmt.Println(tracker)
 
 	fmt.Println("Finally! The slow evaluation finishes and the command gets proposed at index 79.")
 	fmt.Println("Note that the right now tracks a smaller value of 78. Consumers have to keep the")
 	fmt.Println("maximum they've seen.")
-	done1(ctx, 12, 79)
+	done1(ctx, ep1, 12, 79)
 	fmt.Println(tracker)
 
-	closed3, mlai3 := tracker.Close(hlc.Timestamp{WallTime: 3E9})
+	closed3, mlai3, _ := tracker.Close(hlc.Timestamp{WallTime: 3E9}, ep1)
 	fmt.Println("The next call to Close() is successful and returns:", closed3, "and", mlaiString(mlai3))
 	fmt.Println(tracker)
 
@@ -87,6 +87,7 @@ func Example() {
 	//       |            next=0.000000000,1
 	//       |          left | right
 	//       |             0 # 0
+	//       |             1 e 1
 	//       v               v
 	// ---------------------------------------------------------> time
 	//
@@ -97,6 +98,7 @@ func Example() {
 	//       |            next=0.000000000,1
 	//       |          left | right
 	//       |             0 # 1
+	//       |             1 e 1
 	//       v               v
 	// ---------------------------------------------------------> time
 	//
@@ -106,6 +108,7 @@ func Example() {
 	//       |            next=0.000000000,1
 	//       |          left | right
 	//       |             0 # 3
+	//       |             1 e 1
 	//       v               v
 	// ---------------------------------------------------------> time
 	//
@@ -115,6 +118,7 @@ func Example() {
 	//       |            next=0.000000000,1
 	//       |          left | right
 	//       |             0 # 2
+	//       |             1 e 1
 	//       |               @ 10     (r1)
 	//       v               v
 	// ---------------------------------------------------------> time
@@ -125,6 +129,7 @@ func Example() {
 	//       |            next=0.000000000,1
 	//       |          left | right
 	//       |             0 # 1
+	//       |             1 e 1
 	//       |               @ 10     (r1)
 	//       |               @ 77     (r12)
 	//       v               v
@@ -139,6 +144,7 @@ func Example() {
 	//       |            next=1.000000000,0
 	//       |          left | right
 	//       |             1 # 0
+	//       |             1 e 1
 	//       |            10 @        (r1)
 	//       |            77 @        (r12)
 	//       v               v
@@ -152,6 +158,7 @@ func Example() {
 	//       |            next=1.000000000,0
 	//       |          left | right
 	//       |             1 # 0
+	//       |             1 e 1
 	//       |            10 @        (r1)
 	//       |            77 @        (r12)
 	//       v               v
@@ -164,6 +171,7 @@ func Example() {
 	//       |            next=1.000000000,0
 	//       |          left | right
 	//       |             1 # 0
+	//       |             1 e 1
 	//       |            10 @        (r1)
 	//       |            77 @        (r12)
 	//       |               @ 78     (r12)
@@ -178,6 +186,7 @@ func Example() {
 	//       |            next=1.000000000,0
 	//       |          left | right
 	//       |             0 # 0
+	//       |             1 e 1
 	//       |            10 @        (r1)
 	//       |               @ 78     (r12)
 	//       |            79 @        (r12)
@@ -190,6 +199,7 @@ func Example() {
 	//       |            next=3.000000000,0
 	//       |          left | right
 	//       |             0 # 0
+	//       |             1 e 1
 	//       |            78 @        (r12)
 	//       v               v
 	// ---------------------------------------------------------> time

--- a/pkg/storage/closedts/minprop/tracker.go
+++ b/pkg/storage/closedts/minprop/tracker.go
@@ -32,7 +32,8 @@ type Tracker struct {
 	mu struct {
 		syncutil.Mutex
 		// closed is the most recently closed timestamp.
-		closed hlc.Timestamp
+		closed      hlc.Timestamp
+		closedEpoch ctpb.Epoch
 
 		// The variables below track required information for the next closed
 		// timestamp and beyond. First, `next` is the timestamp that will be
@@ -63,10 +64,28 @@ type Tracker struct {
 		// `leftRef` has been drained (i.e. has dropped to zero); new proposals
 		// are always forced above `next` and consequently count towards
 		// `rightRef`.
+		//
+		// Epochs track the highest liveness epoch observed for any released
+		// proposals. Tracking a max epoch allows the MPT to provide some MLAI
+		// information about the current epoch when calls to Close straddle multiple
+		// different epochs. Before epoch tracking was added the client of the MPT
+		// was forced to assume that the MLAI information from the current call to
+		// Close corresponded to the highest known epoch as of the previous call to
+		// Close. This is problematic in cases where an epoch change leads to a
+		// lease change for an otherwise quiescent range. If this mechanism were
+		// not in place then the client would never learn about an MLAI for the
+		// current epoch. Clients provide their view of the current epoch to calls
+		// to Close which use this information to determine whether the current
+		// state should be moved and whether the caller can make use of the
+		// currently tracked data. Each side tracks data which corresponds exactly
+		// to the side's epoch value. Releasing a proposal into the tracker at a
+		// later epoch than is currently tracked will result in the current data
+		// corresponding to the prior epoch to be evicted.
 
-		next                hlc.Timestamp
-		leftMLAI, rightMLAI map[roachpb.RangeID]ctpb.LAI
-		leftRef, rightRef   int
+		next                  hlc.Timestamp
+		leftMLAI, rightMLAI   map[roachpb.RangeID]ctpb.LAI
+		leftRef, rightRef     int
+		leftEpoch, rightEpoch ctpb.Epoch
 	}
 }
 
@@ -76,10 +95,13 @@ var _ closedts.TrackerI = (*Tracker)(nil)
 // a next closed timestamp of one logical tick past zero.
 func NewTracker() *Tracker {
 	t := &Tracker{}
+	const initialEpoch = 1
+	t.mu.closedEpoch = initialEpoch
+	t.mu.leftEpoch = initialEpoch
+	t.mu.rightEpoch = initialEpoch
 	t.mu.next = hlc.Timestamp{Logical: 1}
 	t.mu.leftMLAI = map[roachpb.RangeID]ctpb.LAI{}
 	t.mu.rightMLAI = map[roachpb.RangeID]ctpb.LAI{}
-
 	return t
 }
 
@@ -89,6 +111,7 @@ func (t *Tracker) String() string {
 	defer t.mu.Unlock()
 	closed, next := t.mu.closed, t.mu.next
 	leftRef, rightRef := t.mu.leftRef, t.mu.rightRef
+	leftEpoch, rightEpoch := t.mu.leftEpoch, t.mu.rightEpoch
 
 	type item struct {
 		rangeID roachpb.RangeID
@@ -115,7 +138,7 @@ func (t *Tracker) String() string {
 	for _, item := range lais {
 		var format string
 		if !item.left {
-			format = `      |               @ %d     (r%d)
+			format = `      |               @ %-2d     (r%d)
 `
 		} else {
 			format = `      |   %11d @        (r%d)
@@ -129,11 +152,12 @@ func (t *Tracker) String() string {
       |            next=%s
       |          left | right
       |           %3d # %d
+      |           %3d e %d
 `+lines+
 		`      v               v
 ---------------------------------------------------------> time
 `,
-		closed, next, leftRef, rightRef,
+		closed, next, leftRef, rightRef, leftEpoch, rightEpoch,
 	)
 }
 
@@ -148,20 +172,52 @@ func (t *Tracker) String() string {
 // like a successful call that happens to not return any new information).
 // Similarly, failure to provide a timestamp strictly larger than that to be
 // closed out next results in the same "idempotent" return values.
-func (t *Tracker) Close(next hlc.Timestamp) (hlc.Timestamp, map[roachpb.RangeID]ctpb.LAI) {
+//
+// Callers additionally provide the current expected epoch value, the liveness
+// epoch at which the caller intends to advertise this closed timestamp. The
+// caller must know that it is live at a timestamp greater than or equal to the
+// timestamp which the tracker will close. For correctness purposes this will
+// be the case if the caller knows that it is live at next and calls to Close()
+// pass monontic calues for next. If the current expected epoch is older than
+// the currently tracked data then the timestamp will fail to be closed. If the
+// expected epoch value is older than the epoch tracked on the left but
+// corresponds to the epoch of the previous successful close then the previous
+// closed timestamp is returned along with a nil map. This situation is just
+// like the unsuccessful close scenario due to unreleased proposals. This
+// behavior enables the caller to successfully obtain the tracked data at the
+// newer epoch in a later query after its epoch has updated. If the caller's
+// expected epoch is even older than the previously returned epoch then zero
+// values are returned. If the caller's expected epoch is newer than that of
+// tracked data the state of the tracker is progressed but zero values are
+// returned.
+func (t *Tracker) Close(
+	next hlc.Timestamp, expCurEpoch ctpb.Epoch,
+) (ts hlc.Timestamp, mlai map[roachpb.RangeID]ctpb.LAI, ok bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	var closed hlc.Timestamp
-	var mlai map[roachpb.RangeID]ctpb.LAI
 	if log.V(3) {
-		log.Infof(context.TODO(), "close: leftRef=%d rightRef=%d next=%s closed=%s new=%s", t.mu.leftRef, t.mu.rightRef, t.mu.next, t.mu.closed, next)
+		log.Infof(context.TODO(),
+			"close: leftRef=%d (ep: %d) rightRef=%d (ep: %d) next=%s closed=%s@ (ep: %d) new=%s (ep: %d)",
+			t.mu.leftRef, t.mu.leftEpoch, t.mu.rightRef, t.mu.rightEpoch, t.mu.next,
+			t.mu.closed, t.mu.closedEpoch, next, expCurEpoch)
 	}
 
 	// Make sure to not let `t.mu.next` regress, or we'll accept proposals
 	// that violate earlier closed timestamps. (And if it stayed the same
 	// the logic in the closure returned from Track would fall apart).
-	if t.mu.leftRef == 0 && t.mu.next.Less(next) {
+	canClose := t.mu.leftRef == 0 && t.mu.next.Less(next)
+
+	// NB: the expected closed epoch may not match the epoch for the timestamp we
+	// are currently closing. If the expected closed epoch is earlier than the
+	// epoch tracked on the left then the caller likely read its liveness just
+	// before an epoch change and we should not move the tracker state as the
+	// caller will likely visit again with the new epoch and would like the
+	// tracked information. If the expCurEpoch is greater than or equal to the
+	// current epoch, proceed with closing out the current timestamp, deferring
+	// the decision regarding whether to return the updated state based on epoch
+	// until after updating the data.
+	if canClose && t.mu.leftEpoch <= expCurEpoch {
 		// NB: if rightRef is also zero, then nothing is in flight right now and
 		// we could theoretically close out `next`. However, we'd also have to
 		// merge the left and right MLAI maps, and would force followers to
@@ -169,21 +225,37 @@ func (t *Tracker) Close(next hlc.Timestamp) (hlc.Timestamp, map[roachpb.RangeID]
 		// them. If we want to make use of this optimization, we should emit
 		// two closed timestamp updates for this case.
 		t.mu.closed = t.mu.next
-		mlai = t.mu.leftMLAI // hold on to left MLAIs as return value
+		t.mu.closedEpoch = t.mu.leftEpoch
+		mlai = t.mu.leftMLAI
+
+		// NB: if the expCurEpoch is after the epoch tracked on the right, we'll
+		// never be able to use that information so clear it. The below logic is
+		// not required for correctness but adds an invariant that after a call to
+		// Close with a give expCurEpoch no state corresponding to an earlier epoch
+		// will be tracked on either side. Without this logic, subsequent proposals
+		// or Close calls at the later epoch would lead to this data being
+		// discarded at that point.
+		if t.mu.rightEpoch < expCurEpoch {
+			t.mu.rightEpoch = expCurEpoch
+			clearMLAIMap(t.mu.rightMLAI)
+		}
 
 		// `next` moves forward to the provided timestamp, and picks up the
 		// right refcount and MLAIs (so that it is now responsible for tracking
 		// everything that's in-flight).
 		t.mu.leftMLAI = t.mu.rightMLAI
 		t.mu.leftRef = t.mu.rightRef
+		t.mu.leftEpoch = t.mu.rightEpoch
 		t.mu.rightMLAI = map[roachpb.RangeID]ctpb.LAI{}
 		t.mu.rightRef = 0
 
 		t.mu.next = next
 	}
-	closed = t.mu.closed
 
-	return closed, mlai
+	if t.mu.closedEpoch != expCurEpoch {
+		return hlc.Timestamp{}, nil, false
+	}
+	return t.mu.closed, mlai, true
 }
 
 // Track is called before evaluating a proposal. It returns the minimum
@@ -195,11 +267,9 @@ func (t *Tracker) Close(next hlc.Timestamp) (hlc.Timestamp, map[roachpb.RangeID]
 // b) with zero arguments if the command won't end up being proposed (i.e. hit
 //    an error during evaluation).
 //
-// The closure is not thread safe. For convenience, it may be called with zero
-// arguments once after a regular call.
-func (t *Tracker) Track(
-	ctx context.Context,
-) (hlc.Timestamp, func(context.Context, roachpb.RangeID, ctpb.LAI)) {
+// The ReleaseFunc is not thread safe. For convenience, it may be called with
+// zero arguments once after a regular call.
+func (t *Tracker) Track(ctx context.Context) (hlc.Timestamp, closedts.ReleaseFunc) {
 	shouldLog := log.V(3)
 
 	t.mu.Lock()
@@ -212,7 +282,7 @@ func (t *Tracker) Track(
 	}
 
 	var calls int
-	release := func(ctx context.Context, rangeID roachpb.RangeID, lai ctpb.LAI) {
+	release := func(ctx context.Context, epoch ctpb.Epoch, rangeID roachpb.RangeID, lai ctpb.LAI) {
 		calls++
 		if calls != 1 {
 			if lai != 0 || rangeID != 0 || calls > 2 {
@@ -220,42 +290,91 @@ func (t *Tracker) Track(
 			}
 			return
 		}
-
-		t.mu.Lock()
-		defer t.mu.Unlock()
-		if minProp == t.mu.closed.Next() {
-			if shouldLog {
-				log.Infof(ctx, "release: minprop %s on r%d@%d tracked on the left", minProp, rangeID, lai)
-			}
-			t.mu.leftRef--
-			if t.mu.leftRef < 0 {
-				log.Fatalf(ctx, "min proposal left ref count < 0")
-			}
-			if rangeID == 0 {
-				return
-			}
-
-			if curLAI, found := t.mu.leftMLAI[rangeID]; !found || curLAI < lai {
-				t.mu.leftMLAI[rangeID] = lai
-			}
-		} else if minProp == t.mu.next.Next() {
-			if shouldLog {
-				log.Infof(ctx, "release: minprop %s on r%d@%d tracked on the right", minProp, rangeID, lai)
-			}
-			t.mu.rightRef--
-			if t.mu.rightRef < 0 {
-				log.Fatalf(ctx, "min proposal right ref count < 0")
-			}
-			if rangeID == 0 {
-				return
-			}
-			if curLAI, found := t.mu.rightMLAI[rangeID]; !found || curLAI < lai {
-				t.mu.rightMLAI[rangeID] = lai
-			}
-		} else {
-			log.Fatalf(ctx, "min proposal %s not tracked under closed (%s) or next (%s) timestamp", minProp, t.mu.closed, t.mu.next)
-		}
+		t.release(ctx, minProp, epoch, rangeID, lai, shouldLog)
 	}
 
 	return minProp, release
+}
+
+// release is the business logic to release properly account for the release of
+// a tracked proposal. It is called from the ReleaseFunc closure returned from
+// Track.
+func (t *Tracker) release(
+	ctx context.Context,
+	minProp hlc.Timestamp,
+	epoch ctpb.Epoch,
+	rangeID roachpb.RangeID,
+	lai ctpb.LAI,
+	shouldLog bool,
+) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var left bool
+	if minProp == t.mu.closed.Next() {
+		left = true
+	} else if minProp == t.mu.next.Next() {
+		left = false
+	} else {
+		log.Fatalf(ctx, "min proposal %s not tracked under closed (%s) or next (%s) timestamp", minProp, t.mu.closed, t.mu.next)
+	}
+	// If the update is from the left side, clear all existing MLAIs from the left
+	// to uphold the invariant that all tracked MLAIs belong to the same (and
+	// largest seen) epoch. It would not violate correctness to clear the data on
+	// the left even if the proposal being released is tracked on the right; it is
+	// likely that the next call to close will observe the later epoch and thus
+	// not read this data but the code chooses to retain it.
+	if left && epoch > t.mu.leftEpoch {
+		t.mu.leftEpoch = epoch
+		clearMLAIMap(t.mu.leftMLAI)
+	}
+	// The right side is bumped and cleared when the epoch increases without
+	// taking into account which side the current proposal is tracked under
+	// because bumping the left side implies that the information from the right
+	// side will never be retrieved by the client (as epochs only ever go up and
+	// the current left will be emitted before the current right side).
+	if epoch > t.mu.rightEpoch {
+		t.mu.rightEpoch = epoch
+		clearMLAIMap(t.mu.rightMLAI)
+	}
+	if left {
+		releaseProposal(ctx, "left", shouldLog, minProp, rangeID, lai,
+			&t.mu.leftRef, t.mu.leftMLAI, t.mu.leftEpoch != epoch)
+	} else {
+		releaseProposal(ctx, "right", shouldLog, minProp, rangeID, lai,
+			&t.mu.rightRef, t.mu.rightMLAI, t.mu.rightEpoch != epoch)
+	}
+}
+
+func clearMLAIMap(m map[roachpb.RangeID]ctpb.LAI) {
+	for rangeID := range m {
+		delete(m, rangeID)
+	}
+}
+
+func releaseProposal(
+	ctx context.Context,
+	side string,
+	shouldLog bool,
+	minProp hlc.Timestamp,
+	rangeID roachpb.RangeID,
+	lai ctpb.LAI,
+	refs *int,
+	mlaiMap map[roachpb.RangeID]ctpb.LAI,
+	fromPreviousEpoch bool,
+) {
+	if shouldLog {
+		log.Infof(ctx, "release: minprop %s on r%d@%d tracked on the %s", minProp, rangeID, lai, side)
+	}
+	*refs--
+	if *refs < 0 {
+		log.Fatalf(ctx, "min proposal %s ref count < 0", side)
+	}
+	if rangeID == 0 {
+		return
+	}
+	if !fromPreviousEpoch {
+		if curLAI, found := mlaiMap[rangeID]; !found || curLAI < lai {
+			mlaiMap[rangeID] = lai
+		}
+	}
 }

--- a/pkg/storage/closedts/provider/provider.go
+++ b/pkg/storage/closedts/provider/provider.go
@@ -130,7 +130,6 @@ func (p *Provider) runCloser(ctx context.Context) {
 
 	var t timeutil.Timer
 	defer t.Stop()
-	var lastEpoch ctpb.Epoch
 	for {
 		closeFraction := closedts.CloseFraction.Get(&p.cfg.Settings.SV)
 		targetDuration := float64(closedts.TargetDuration.Get(&p.cfg.Settings.SV))
@@ -148,8 +147,7 @@ func (p *Provider) runCloser(ctx context.Context) {
 			continue
 		}
 
-		next, epoch, err := p.cfg.Clock(p.cfg.NodeID)
-
+		next, liveAtEpoch, err := p.cfg.Clock(p.cfg.NodeID)
 		next.WallTime -= int64(targetDuration)
 		if err != nil {
 			if p.everyClockLog.ShouldLog() {
@@ -159,19 +157,25 @@ func (p *Provider) runCloser(ctx context.Context) {
 			// loop to check their client's context.
 			p.mu.Broadcast()
 		} else {
-			closed, m := p.cfg.Close(next)
+			// Close may fail if the data being closed does not correspond to the
+			// current liveAtEpoch.
+			closed, m, ok := p.cfg.Close(next, liveAtEpoch)
+			if !ok {
+				if log.V(1) {
+					log.Infof(ctx, "failed to close %v due to liveness epoch mismatch at %v",
+						next, liveAtEpoch)
+				}
+				continue
+			}
 			if log.V(1) {
-				log.Infof(ctx, "closed ts=%s with %+v, next closed timestamp should be %s", closed, m, next)
+				log.Infof(ctx, "closed ts=%s with %+v, next closed timestamp should be %s",
+					closed, m, next)
 			}
 			entry := ctpb.Entry{
-				Epoch:           lastEpoch,
+				Epoch:           liveAtEpoch,
 				ClosedTimestamp: closed,
 				MLAI:            m,
 			}
-			// TODO(tschottdorf): this one-off between the epoch is awkward. Clock() gives us the epoch for `next`
-			// but the entry wants the epoch for the current closed timestamp. Better to pass both into Close and
-			// to get both back from it as well.
-			lastEpoch = epoch
 
 			// Simulate a subscription to the local node, so that the new information
 			// is added to the storage (and thus becomes available to future subscribers

--- a/pkg/storage/closedts/provider/provider_test.go
+++ b/pkg/storage/closedts/provider/provider_test.go
@@ -67,7 +67,7 @@ func TestProviderSubscribeNotify(t *testing.T) {
 			}
 			return hlc.Timestamp{}, ctpb.Epoch(1), errors.New("injected clock error")
 		},
-		Close: func(next hlc.Timestamp) (hlc.Timestamp, map[roachpb.RangeID]ctpb.LAI) {
+		Close: func(next hlc.Timestamp, expCurEpoch ctpb.Epoch) (hlc.Timestamp, map[roachpb.RangeID]ctpb.LAI, bool) {
 			panic("should never be called")
 		},
 	}
@@ -258,12 +258,12 @@ func TestProviderSubscribeConcurrent(t *testing.T) {
 		Clock: func(roachpb.NodeID) (hlc.Timestamp, ctpb.Epoch, error) {
 			return hlc.Timestamp{}, 1, nil
 		},
-		Close: func(next hlc.Timestamp) (hlc.Timestamp, map[roachpb.RangeID]ctpb.LAI) {
+		Close: func(next hlc.Timestamp, expCurEpoch ctpb.Epoch) (hlc.Timestamp, map[roachpb.RangeID]ctpb.LAI, bool) {
 			return hlc.Timestamp{
 					WallTime: atomic.AddInt64(&ts, 1),
 				}, map[roachpb.RangeID]ctpb.LAI{
 					1: ctpb.LAI(atomic.LoadInt64(&ts)),
-				}
+				}, true
 		},
 	}
 

--- a/pkg/storage/replica_closedts.go
+++ b/pkg/storage/replica_closedts.go
@@ -29,9 +29,10 @@ func (r *Replica) EmitMLAI() {
 	if r.mu.state.LeaseAppliedIndex > lai {
 		lai = r.mu.state.LeaseAppliedIndex
 	}
+	epoch := r.mu.state.Lease.Epoch
 	r.mu.Unlock()
 
 	ctx := r.AnnotateCtx(context.Background())
 	_, untrack := r.store.cfg.ClosedTimestamp.Tracker.Track(ctx)
-	untrack(ctx, r.RangeID, ctpb.LAI(lai))
+	untrack(ctx, ctpb.Epoch(epoch), r.RangeID, ctpb.LAI(lai))
 }

--- a/pkg/storage/replica_write.go
+++ b/pkg/storage/replica_write.go
@@ -154,7 +154,9 @@ func (r *Replica) executeWriteBatch(
 		return nil, pErr
 	}
 	// A max lease index of zero is returned when no proposal was made or a lease was proposed.
-	// In both cases, we don't need to communicate a MLAI.
+	// In both cases, we don't need to communicate a MLAI. Furthermore, for lease proposals we
+	// cannot communicate under the lease's epoch. Instead the code calls EmitMLAI explicitly
+	// as a side effect of stepping up as leaseholder.
 	if maxLeaseIndex != 0 {
 		untrack(ctx, ctpb.Epoch(lease.Epoch), r.RangeID, ctpb.LAI(maxLeaseIndex))
 	}

--- a/pkg/storage/replica_write.go
+++ b/pkg/storage/replica_write.go
@@ -114,7 +114,7 @@ func (r *Replica) executeWriteBatch(
 	r.limitTxnMaxTimestamp(ctx, &ba, status)
 
 	minTS, untrack := r.store.cfg.ClosedTimestamp.Tracker.Track(ctx)
-	defer untrack(ctx, 0, 0) // covers all error returns below
+	defer untrack(ctx, 0, 0, 0) // covers all error returns below
 
 	// Examine the read and write timestamp caches for preceding
 	// commands which require this command to move its timestamp
@@ -156,7 +156,7 @@ func (r *Replica) executeWriteBatch(
 	// A max lease index of zero is returned when no proposal was made or a lease was proposed.
 	// In both cases, we don't need to communicate a MLAI.
 	if maxLeaseIndex != 0 {
-		untrack(ctx, r.RangeID, ctpb.LAI(maxLeaseIndex))
+		untrack(ctx, ctpb.Epoch(lease.Epoch), r.RangeID, ctpb.LAI(maxLeaseIndex))
 	}
 
 	// After the command is proposed to Raft, invoking endCmds.done is now the


### PR DESCRIPTION
This PR adds epoch information to the minprop.Tracker's state. Before
this PR the MPT did not know anything about the epoch in which
proposals occurred. In order to ensure that LAI values from a previous
epoch were not recorded in to a later epoch the closedts.Provider
would report MLAI information from Tracker.Close calls as
corresponding to an epoch value that existed prior to the beginning of
the current interval. When the interval straddles more than one epoch
this behavior is too conservative and leads to emitted MLAI
information for the later epoch not ever being reported.

Informs #35142.

Release note: None