### PR TITLE
release-19.1: storage: avoid copying marshalled RaftCommand when encoding

### DIFF
--- a/pkg/storage/replica_raft_quiesce.go
+++ b/pkg/storage/replica_raft_quiesce.go
@@ -97,7 +97,8 @@ func (r *Replica) unquiesceAndWakeLeaderLocked() {
 		r.store.unquiescedReplicas.Unlock()
 		r.maybeCampaignOnWakeLocked(ctx)
 		// Propose an empty command which will wake the leader.
-		_ = r.mu.internalRaftGroup.Propose(encodeRaftCommandV1(makeIDKey(), nil))
+		data := encodeRaftCommand(raftVersionStandard, makeIDKey(), nil)
+		_ = r.mu.internalRaftGroup.Propose(data)
 	}
 }
 

--- a/pkg/storage/split_delay_helper.go
+++ b/pkg/storage/split_delay_helper.go
@@ -52,7 +52,8 @@ func (sdh *splitDelayHelper) ProposeEmptyCommand(ctx context.Context) {
 	_ = r.withRaftGroup(true /* campaignOnWake */, func(rawNode *raft.RawNode) (bool, error) {
 		// NB: intentionally ignore the error (which can be ErrProposalDropped
 		// when there's an SST inflight).
-		_ = rawNode.Propose(encodeRaftCommandV1(makeIDKey(), nil))
+		data := encodeRaftCommand(raftVersionStandard, makeIDKey(), nil)
+		_ = rawNode.Propose(data)
 		// NB: we need to unquiesce as the group might be quiesced.
 		return true /* unquiesceAndWakeLeader */, nil
 	})


### PR DESCRIPTION
Backport 1/1 commits from #36392.

/cc @cockroachdb/release

---

Informs #36347.

This change avoids the unnecessary allocation and memory copy present in
Raft command encoding. This extra work is expensive for large commands
like `AddSSTable` requests. Even for smaller requests, this work was
still a serious problem because it took place under heavily contended
locks. For instance, the encoding in `defaultSubmitProposalLocked` took
place under the Replica mutex, which serializes all Raft proposals for
a Range. The other two locations fixed took place under the Raft mutex.
While less heavily contended, this was still slowing down the Raft
processing goroutine.

This is a less dramatic version of a change I've been working on. The
full change lifts the slice allocation and most of the RaftCommand proto
marshalling all the way out of `defaultSubmitProposalLocked` and out of
the `Replica.mu` critical section. This commit gets us part of the way
there sets the stage for the rest of the change.

Release note: None
