### PR TITLE
tree: permit NULL sequences to be typed as desired

### DIFF
--- a/pkg/sql/distsqlrun/expr_test.go
+++ b/pkg/sql/distsqlrun/expr_test.go
@@ -83,8 +83,9 @@ func TestProcessExpressionConstantEval(t *testing.T) {
 	}
 
 	expected := &tree.DArray{
-		ParamTyp: types.Int,
-		Array:    tree.Datums{tree.NewDInt(1), tree.NewDInt(2)},
+		ParamTyp:    types.Int,
+		Array:       tree.Datums{tree.NewDInt(1), tree.NewDInt(2)},
+		HasNonNulls: true,
 	}
 	if !reflect.DeepEqual(expr, expected) {
 		t.Errorf("invalid expr '%v', expected '%v'", expr, expected)

--- a/pkg/sql/logictest/testdata/logic_test/sqlsmith
+++ b/pkg/sql/logictest/testdata/logic_test/sqlsmith
@@ -76,3 +76,70 @@ CREATE TABLE table9 (a INT8);
 
 statement ok
 INSERT INTO table9 SELECT lag(a) OVER (PARTITION BY a) FROM table9;
+
+# Regression: #36607 (can't serialize or type-check arrays of NULL properly)
+query TTTT
+WITH
+    with_194015 (col_1548014)
+        AS (
+            SELECT
+                *
+            FROM
+                (
+                    VALUES
+                        (('-28 years -2 mons -677 days -11:53:30.528699':::INTERVAL::INTERVAL + '11:55:41.419498':::TIME::TIME)::TIME + '1973-01-24':::DATE::DATE),
+                        ('1970-01-11 01:38:09.000155+00:00':::TIMESTAMP),
+                        ('1970-01-09 07:04:13.000247+00:00':::TIMESTAMP),
+                        ('1970-01-07 14:19:52.000951+00:00':::TIMESTAMP),
+                        (NULL)
+                )
+                    AS tab_240443 (col_1548014)
+        ),
+    with_194016 (col_1548015, col_1548016, col_1548017)
+        AS (
+            SELECT
+                *
+            FROM
+                (
+                    VALUES
+                        (
+                            '160.182.25.199/22':::INET::INET << 'c2af:30cb:5db8:bb79:4d11:2d0:1de8:bcea/59':::INET::INET,
+                            '09:14:05.761109':::TIME::TIME + '4 years 7 mons 345 days 23:43:13.325036':::INTERVAL::INTERVAL,
+                            B'0101010110101011101001111010100011001111001110001000101100011001101'
+                        ),
+                        (false, '14:36:41.282187':::TIME, B'011111111011001100000001101101011111110110010011110100110111100')
+                )
+                    AS tab_240444 (col_1548015, col_1548016, col_1548017)
+        ),
+    with_194017 (col_1548018)
+        AS (SELECT * FROM (VALUES ('43a30bc5-e412-426d-b99a-65783a7ed445':::UUID), (NULL), (crdb_internal.cluster_id()::UUID)) AS tab_240445 (col_1548018))
+SELECT
+    CASE
+    WHEN false THEN age('1970-01-09 08:48:24.000568+00:00':::TIMESTAMPTZ::TIMESTAMPTZ, '1970-01-07 08:40:45.000483+00:00':::TIMESTAMPTZ::TIMESTAMPTZ)::INTERVAL
+    ELSE (
+        (
+            (-0.02805450661234963150):::DECIMAL::DECIMAL
+            * array_position(
+                    (gen_random_uuid()::UUID::UUID || (NULL::UUID || NULL::UUID[])::UUID[])::UUID[],
+                    '5f29920d-7db1-4efc-b1cc-d1a7d0bcf145':::UUID::UUID
+                )::INT8::INT8
+        )::DECIMAL
+        * age('1970-01-04 07:17:45.000268+00:00':::TIMESTAMPTZ::TIMESTAMPTZ, NULL::TIMESTAMPTZ)::INTERVAL::INTERVAL
+    )
+    END::INTERVAL
+    + '-21 years -10 mons -289 days -13:27:05.205069':::INTERVAL::INTERVAL
+        AS col_1548019,
+    '1984-01-07':::DATE AS col_1548020,
+    NULL AS col_1548021,
+    'f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2':::UUID AS col_1548022
+FROM
+    with_194015
+ORDER BY
+    with_194015.col_1548014 DESC
+LIMIT
+    4:::INT8;
+----
+NULL  1984-01-07 00:00:00 +0000 +0000  NULL  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
+NULL  1984-01-07 00:00:00 +0000 +0000  NULL  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
+NULL  1984-01-07 00:00:00 +0000 +0000  NULL  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2
+NULL  1984-01-07 00:00:00 +0000 +0000  NULL  f96fd19a-d2a9-4d98-81dd-97e3fc2a45d2

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -93,6 +93,8 @@ func ExtractConstDatum(e opt.Expr) tree.Datum {
 			a.Array[i] = ExtractConstDatum(t.Elems[i])
 			if a.Array[i] == tree.DNull {
 				a.HasNulls = true
+			} else {
+				a.HasNonNulls = true
 			}
 		}
 		return a

--- a/pkg/sql/opt/norm/custom_funcs.go
+++ b/pkg/sql/opt/norm/custom_funcs.go
@@ -1484,6 +1484,8 @@ func (c *CustomFuncs) FoldArray(elems memo.ScalarListExpr, typ *types.T) opt.Sca
 		a.Array[i] = memo.ExtractConstDatum(elems[i])
 		if a.Array[i] == tree.DNull {
 			a.HasNulls = true
+		} else {
+			a.HasNonNulls = true
 		}
 	}
 	return c.f.ConstructConst(a)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3040,11 +3040,10 @@ may increase either contention or retry errors, or both.`,
 					}
 				}
 				if newArr != nil {
-					return &tree.DArray{
-						ParamTyp: value.ParamTyp,
-						Array:    newArr,
-						HasNulls: value.HasNulls,
-					}, nil
+					ret := &tree.DArray{}
+					*ret = *value
+					ret.Array = newArr
+					return ret, nil
 				}
 				return value, nil
 			},

--- a/pkg/sql/sem/tree/constant_eval_test.go
+++ b/pkg/sql/sem/tree/constant_eval_test.go
@@ -51,8 +51,9 @@ func TestConstantEvalArrayComparison(t *testing.T) {
 		ColumnName: "a",
 	}
 	right := tree.DArray{
-		ParamTyp: types.Int,
-		Array:    tree.Datums{tree.NewDInt(1), tree.NewDInt(2)},
+		ParamTyp:    types.Int,
+		Array:       tree.Datums{tree.NewDInt(1), tree.NewDInt(2)},
+		HasNonNulls: true,
 	}
 	expected := tree.NewTypedComparisonExpr(tree.EQ, &left, &right)
 	if !reflect.DeepEqual(expr, expected) {

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -51,9 +51,8 @@ func TestEval(t *testing.T) {
 				// expr.TypeCheck to avoid constant folding.
 				typedExpr, err := expr.TypeCheck(nil, types.Any)
 				if err != nil {
-					t.Fatalf("%s: %v", d.Input, err)
+					t.Fatalf("%s %s: %v", path, d.Input, err)
 				}
-				t.Logf("Type checked expression: %s", typedExpr)
 
 				e, err := getExpr(typedExpr)
 				if err != nil {

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -310,6 +310,16 @@ func TestFormatExpr2(t *testing.T) {
 			tree.FmtParsable,
 			`(NULL, 'foo':::STRING)`,
 		},
+		{&tree.DArray{
+			ParamTyp: types.Int,
+			Array:    tree.Datums{tree.DNull, tree.DNull},
+			HasNulls: true,
+		},
+			tree.FmtParsable,
+			`ARRAY[NULL,NULL]:::INT8[]`,
+		},
+
+		// Ensure that nulls get properly type annotated when printed in an
 	}
 
 	for i, test := range testData {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1446,7 +1446,26 @@ func (d *DTuple) TypeCheck(_ *SemaContext, _ *types.T) (TypedExpr, error) { retu
 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
 // identity function for Datum.
-func (d *DArray) TypeCheck(_ *SemaContext, _ *types.T) (TypedExpr, error) { return d, nil }
+func (d *DArray) TypeCheck(_ *SemaContext, desired *types.T) (TypedExpr, error) {
+	// Type-checking arrays is different from normal datums, since there are
+	// situations in which an array's type is ambiguous without a desired type.
+	// Consider the following examples. They're typed as `unknown[]` until
+	// something asserts otherwise. In these circumstances, we're allowed to just
+	// mark the array's type as the desired one.
+	// ARRAY[]
+	// ARRAY[NULL, NULL]
+	if (d.ParamTyp == types.Unknown || d.ParamTyp == types.Any) && (!d.HasNonNulls) {
+		if desired.Family() != types.ArrayFamily {
+			// We can't desire a non-array type here.
+			return d, nil
+		}
+		dCopy := &DArray{}
+		*dCopy = *d
+		dCopy.ParamTyp = desired.ArrayContents()
+		return dCopy, nil
+	}
+	return d, nil
+}
 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
 // identity function for Datum.
@@ -1782,7 +1801,13 @@ func TypeCheckSameTypedExprs(
 		if err != nil {
 			return nil, nil, err
 		}
-		return []TypedExpr{typedExpr}, typedExpr.ResolvedType(), nil
+		typ := typedExpr.ResolvedType()
+		if typ == types.Unknown && desired != types.Any {
+			// The expression had a NULL type, so we can return the desired type as
+			// the expression type.
+			typ = desired
+		}
+		return []TypedExpr{typedExpr}, typ, nil
 	}
 
 	// Handle tuples, which will in turn call into this function recursively for each element.
@@ -1830,6 +1855,7 @@ func TypeCheckSameTypedExprs(
 		}
 
 		if firstValidType.Family() == types.UnknownFamily {
+			// We got to the end without finding a non-null expression.
 			switch {
 			case len(constIdxs) > 0:
 				return typeCheckConstsAndPlaceholdersWithDesired(s, desired)
@@ -1837,6 +1863,9 @@ func TypeCheckSameTypedExprs(
 				p := s.exprs[placeholderIdxs[0]].(*Placeholder)
 				return nil, nil, placeholderTypeAmbiguityError{p.Idx}
 			default:
+				if desired != types.Any {
+					return typedExprs, desired, nil
+				}
 				return typedExprs, types.Unknown, nil
 			}
 		}

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -88,6 +88,8 @@ func TestTypeCheck(t *testing.T) {
 		{`ARRAY['a', 'b', 'c']`, `ARRAY['a':::STRING, 'b':::STRING, 'c':::STRING]`},
 		{`ARRAY[1.5, 2.5, 3.5]`, `ARRAY[1.5:::DECIMAL, 2.5:::DECIMAL, 3.5:::DECIMAL]`},
 		{`ARRAY[NULL]`, `ARRAY[NULL]`},
+		{`ARRAY[NULL]:::int[]`, `ARRAY[NULL]`},
+		{`ARRAY[NULL, NULL]:::int[]`, `ARRAY[NULL, NULL]`},
 		{`1 = ANY ARRAY[1.5, 2.5, 3.5]`, `1:::DECIMAL = ANY ARRAY[1.5:::DECIMAL, 2.5:::DECIMAL, 3.5:::DECIMAL]`},
 		{`true = SOME (ARRAY[true, false])`, `true = SOME ARRAY[true, false]`},
 		{`1.3 = ALL ARRAY[1, 2, 3]`, `1.3:::DECIMAL = ALL ARRAY[1:::DECIMAL, 2:::DECIMAL, 3:::DECIMAL]`},

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -938,6 +938,7 @@ func decodeArrayNoMarshalColumnValue(
 			result.Array[i] = tree.DNull
 			result.HasNulls = true
 		} else {
+			result.HasNonNulls = true
 			val, b, err = decodeUntaggedDatum(a, elementType, b)
 			if err != nil {
 				return nil, b, err

--- a/pkg/sql/sqlbase/column_type_properties.go
+++ b/pkg/sql/sqlbase/column_type_properties.go
@@ -111,11 +111,9 @@ func LimitValueWidth(typ *types.T, inVal tree.Datum, name *string) (outVal tree.
 				}
 				if outElem != inElem {
 					if outArr == nil {
-						outArr = &tree.DArray{
-							ParamTyp: inArr.ParamTyp,
-							Array:    make(tree.Datums, len(inArr.Array)),
-							HasNulls: inArr.HasNulls,
-						}
+						outArr = &tree.DArray{}
+						*outArr = *inArr
+						outArr.Array = make(tree.Datums, len(inArr.Array))
 						copy(outArr.Array, inArr.Array[:i])
 					}
 				}


### PR DESCRIPTION
Fixes #36607.

Previously, expressions that contained a sequence of expressions
(anything that uses `TypeCheckSameTypedExprs`) would fail to coerce
those expressions to a desired type if all of those expressions were
statically typed as `NULL`. Concretely, this led to expressions like

```
ARRAY[NULL, NULL]:::int[]
```

to not be type-checkable.

Also, make sure that arrays that contain only null are serialized
properly, by ensuring that they get a type annotation to prevent
ambiguity.

Release note (bug fix): permit arrays and other sequences to be
type-checkable in certain contexts when all of their elements are null.