### PR TITLE
distsqlplan: reset MergeOrdering if windower is planned

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3245,6 +3245,11 @@ func (dsp *DistSQLPlanner) createPlanForWindow(
 	// possibly adding rendering because it is used there.
 	plan.PlanToStreamColMap = identityMap(plan.PlanToStreamColMap, len(plan.ResultTypes))
 
+	// windowers do not guarantee maintaining the order at the moment, so we
+	// reset MergeOrdering. There shouldn't be an ordering here, but we reset it
+	// defensively (see #35179).
+	plan.SetMergeOrdering(distsqlpb.Ordering{})
+
 	// After all window functions are computed, we might need to add rendering.
 	if renderingAdded, err := windowPlanState.addRenderingIfNecessary(); err != nil {
 		return PhysicalPlan{}, err


### PR DESCRIPTION
Windower doesn't guarantee maintaining the order, so merge ordering
of the plan should be set to empty.

Fixes: #35179.

Release note: None