### PR TITLE
sql: add index entries to the SST as they are generated

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -68,7 +68,7 @@ const (
 var indexBulkBackfillChunkSize = settings.RegisterIntSetting(
 	"schemachanger.bulk_index_backfill.batch_size",
 	"number of rows to process at a time during bulk index backfill",
-	5000,
+	100000,
 )
 
 var _ sort.Interface = columnsByID{}


### PR DESCRIPTION
Before this change we would generate a chunk of index entries
and then add the chunk to the SST. This eliminates the need
to buffer the index entries in a chunk.

Also adjusted schemachanger.bulk_index_backfill.batch_size up
to 100,000 so that the backfill makes infrequent scans.

fixes #36668

Release note: None