### PR TITLE
storage: kick slow closed timestamps being used by rangefeed

### DIFF
--- a/pkg/storage/closedts/closedts.go
+++ b/pkg/storage/closedts/closedts.go
@@ -94,6 +94,9 @@ type Storage interface {
 	// Add merges the given Entry into the state for the given NodeID. The first
 	// Entry passed in for any given Entry.Epoch must have Entry.Full set.
 	Add(roachpb.NodeID, ctpb.Entry)
+	// Clear removes all closed timestamp information from the Storage. It can
+	// be used to simulate the loss of information caused by a process restart.
+	Clear()
 }
 
 // A Notifyee is a sink for closed timestamp updates.

--- a/pkg/storage/closedts/container/noop.go
+++ b/pkg/storage/closedts/container/noop.go
@@ -68,6 +68,7 @@ func (noopEverything) Track(
 func (noopEverything) VisitAscending(roachpb.NodeID, func(ctpb.Entry) (done bool))  {}
 func (noopEverything) VisitDescending(roachpb.NodeID, func(ctpb.Entry) (done bool)) {}
 func (noopEverything) Add(roachpb.NodeID, ctpb.Entry)                               {}
+func (noopEverything) Clear()                                                       {}
 func (noopEverything) Notify(roachpb.NodeID) chan<- ctpb.Entry {
 	return nil // will explode when used, but nobody would use this
 }

--- a/pkg/storage/closedts/provider/testutils/storage.go
+++ b/pkg/storage/closedts/provider/testutils/storage.go
@@ -71,6 +71,13 @@ func (s *TestStorage) Add(nodeID roachpb.NodeID, entry ctpb.Entry) {
 	})
 }
 
+// Clear implements closedts.Storage.
+func (s *TestStorage) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m = nil
+}
+
 // Snapshot returns a copy of the data contain within the TestStorage.
 func (s *TestStorage) Snapshot() map[roachpb.NodeID][]ctpb.Entry {
 	s.mu.Lock()

--- a/pkg/storage/closedts/storage/storage.go
+++ b/pkg/storage/closedts/storage/storage.go
@@ -67,6 +67,8 @@ type SingleStorage interface {
 	// recent bucket and remaining buckets are rotated as indicated by their age
 	// relative to the newly added Entry.
 	Add(ctpb.Entry)
+	// Clear removes all Entries from this storage.
+	Clear()
 }
 
 type entry struct {
@@ -121,6 +123,14 @@ func (ms *MultiStorage) VisitDescending(nodeID roachpb.NodeID, f func(ctpb.Entry
 func (ms *MultiStorage) Add(nodeID roachpb.NodeID, entry ctpb.Entry) {
 	ss := ms.getOrCreate(nodeID)
 	ss.Add(entry)
+}
+
+// Clear implements closedts.Storage.
+func (ms *MultiStorage) Clear() {
+	ms.m.Range(func(_ int64, p unsafe.Pointer) bool {
+		(*entry)(p).SingleStorage.Clear()
+		return true // continue
+	})
 }
 
 // String prints a tabular rundown of the contents of the MultiStorage.

--- a/pkg/storage/closedts/storage/storage_mem.go
+++ b/pkg/storage/closedts/storage/storage_mem.go
@@ -164,6 +164,14 @@ func (m *memStorage) VisitDescending(f func(ctpb.Entry) (done bool)) {
 	}
 }
 
+func (m *memStorage) Clear() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i := 0; i < len(m.mu.buckets); i++ {
+		m.mu.buckets[i] = ctpb.Entry{}
+	}
+}
+
 func merge(e, ee ctpb.Entry) ctpb.Entry {
 	// TODO(tschottdorf): if either of these hit, check that what we're
 	// returning has Full set. If we make it past, check that either of

--- a/pkg/storage/closedts/storage/storage_test.go
+++ b/pkg/storage/closedts/storage/storage_test.go
@@ -123,6 +123,10 @@ func ExampleSingleStorage() {
 	fmt.Println("This would resolve itself if reasonably spaced updates kept coming in.")
 	fmt.Println(s)
 
+	fmt.Println("Finally, when the storage is cleared, all buckets are reset.")
+	s.Clear()
+	fmt.Println(s)
+
 	// Output:
 	// The empty storage renders as below:
 	// +--+---------------------+----------------------+----------------------+----------------------+
@@ -241,6 +245,14 @@ func ExampleSingleStorage() {
 	//   r8                   711                    711                       711
 	//   r9                  2020                   2020                      2020                    2020
 	// +----+---------------------+----------------------+-------------------------+-----------------------+
+	//
+	// Finally, when the storage is cleared, all buckets are reset.
+	// +--+---------------------+----------------------+----------------------+----------------------+
+	//         0.000000000,0         0.000000000,0          0.000000000,0          0.000000000,0
+	//      age=0s (target ≤0s)   age=0s (target ≤10s)   age=0s (target ≤20s)   age=0s (target ≤40s)
+	//            epoch=0               epoch=0                epoch=0                epoch=0
+	// +--+---------------------+----------------------+----------------------+----------------------+
+	// +--+---------------------+----------------------+----------------------+----------------------+
 }
 
 func ExampleMultiStorage_epoch() {

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -173,6 +173,12 @@ func (s *Store) ReservationCount() int {
 	return len(s.snapshotApplySem)
 }
 
+// ClearClosedTimestampStorage clears the closed timestamp storage of all
+// knowledge about closed timestamps.
+func (s *Store) ClearClosedTimestampStorage() {
+	s.cfg.ClosedTimestamp.Storage.Clear()
+}
+
 // AssertInvariants verifies that the store's bookkeping is self-consistent. It
 // is only valid to call this method when there is no in-flight traffic to the
 // store (e.g., after the store is shut down).

--- a/pkg/storage/rangefeed/metrics.go
+++ b/pkg/storage/rangefeed/metrics.go
@@ -14,7 +14,13 @@
 
 package rangefeed
 
-import "github.com/cockroachdb/cockroach/pkg/util/metric"
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
+)
 
 var (
 	metaRangeFeedCatchupScanNanos = metric.Metadata{
@@ -28,6 +34,9 @@ var (
 // Metrics are for production monitoring of RangeFeeds.
 type Metrics struct {
 	RangeFeedCatchupScanNanos *metric.Counter
+
+	RangeFeedSlowClosedTimestampLogN  log.EveryN
+	RangeFeedSlowClosedTimestampNudge *singleflight.Group
 }
 
 // MetricStruct implements the metric.Struct interface.
@@ -36,6 +45,8 @@ func (*Metrics) MetricStruct() {}
 // NewMetrics makes the metrics for RangeFeeds monitoring.
 func NewMetrics() *Metrics {
 	return &Metrics{
-		RangeFeedCatchupScanNanos: metric.NewCounter(metaRangeFeedCatchupScanNanos),
+		RangeFeedCatchupScanNanos:         metric.NewCounter(metaRangeFeedCatchupScanNanos),
+		RangeFeedSlowClosedTimestampLogN:  log.Every(5 * time.Second),
+		RangeFeedSlowClosedTimestampNudge: &singleflight.Group{},
 	}
 }

--- a/pkg/storage/replica_rangefeed_test.go
+++ b/pkg/storage/replica_rangefeed_test.go
@@ -24,10 +24,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
 	"google.golang.org/grpc/metadata"
@@ -649,4 +651,112 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		pErr := <-streamErrC
 		assertRangefeedRetryErr(t, pErr, roachpb.RangeFeedRetryError_REASON_LOGICAL_OPS_MISSING)
 	})
+}
+
+// TestReplicaRangefeedNudgeSlowClosedTimestamp tests that rangefeed detects
+// that its closed timestamp updates have stalled and requests new information
+// from its Range's leaseholder. This is a regression test for #35142.
+func TestReplicaRangefeedNudgeSlowClosedTimestamp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc, db, desc, repls := setupTestClusterForClosedTimestampTesting(ctx, t, testingTargetDuration)
+	defer tc.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+	// While we're here, drop the target duration. This was set to
+	// testingTargetDuration above, but this is higher then it needs to be now
+	// that cluster and schema setup is complete.
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'`)
+
+	// Make sure all the nodes have gotten the rangefeed enabled setting from
+	// gossip, so that they will immediately be able to accept RangeFeeds. The
+	// target_duration one is just to speed up the test, we don't care if it has
+	// propagated everywhere yet.
+	testutils.SucceedsSoon(t, func() error {
+		for i := 0; i < tc.NumServers(); i++ {
+			var enabled bool
+			if err := tc.ServerConn(i).QueryRow(
+				`SHOW CLUSTER SETTING kv.rangefeed.enabled`,
+			).Scan(&enabled); err != nil {
+				return err
+			}
+			if !enabled {
+				return errors.Errorf(`waiting for rangefeed to be enabled on node %d`, i)
+			}
+		}
+		return nil
+	})
+
+	ts1 := tc.Server(0).Clock().Now()
+	rangeFeedCtx, rangeFeedCancel := context.WithCancel(ctx)
+	defer rangeFeedCancel()
+	rangeFeedChs := make([]chan *roachpb.RangeFeedEvent, len(repls))
+	rangeFeedErrC := make(chan error, len(repls))
+	for i := range repls {
+		ds := tc.Server(i).DistSender()
+		rangeFeedCh := make(chan *roachpb.RangeFeedEvent)
+		rangeFeedChs[i] = rangeFeedCh
+		go func() {
+			req := roachpb.RangeFeedRequest{
+				Header: roachpb.Header{Timestamp: ts1},
+				Span: roachpb.Span{
+					Key: desc.StartKey.AsRawKey(), EndKey: desc.EndKey.AsRawKey(),
+				},
+			}
+			rangeFeedErrC <- ds.RangeFeed(rangeFeedCtx, &req, rangeFeedCh)
+		}()
+	}
+
+	// Wait for a RangeFeed checkpoint on each RangeFeed after the RangeFeed
+	// initial scan time (which is the timestamp passed in the request) to make
+	// sure everything is set up. We intentionally don't care about the spans in
+	// the checkpoints, just verifying that something has made it past the
+	// initial scan and is running.
+	waitForCheckpoint := func(ts hlc.Timestamp) {
+		t.Helper()
+		for _, rangeFeedCh := range rangeFeedChs {
+			checkpointed := false
+			for !checkpointed {
+				select {
+				case event := <-rangeFeedCh:
+					if c := event.Checkpoint; c != nil && ts.Less(c.ResolvedTS) {
+						checkpointed = true
+					}
+				case err := <-rangeFeedErrC:
+					t.Fatal(err)
+				}
+			}
+		}
+	}
+	waitForCheckpoint(ts1)
+
+	// Clear the closed timestamp storage on each server. This simulates the case
+	// where a closed timestamp message is lost or a node restarts. To recover,
+	// the servers will need to request an update from the leaseholder.
+	for i := 0; i < tc.NumServers(); i++ {
+		stores := tc.Server(i).GetStores().(*storage.Stores)
+		err := stores.VisitStores(func(s *storage.Store) error {
+			s.ClearClosedTimestampStorage()
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+	// Wait for another RangeFeed checkpoint after the store was cleared. Without
+	// RangeFeed nudging closed timestamps, this doesn't happen on its own. Again,
+	// we intentionally don't care about the spans in the checkpoints, just
+	// verifying that something has made it past the cleared time.
+	ts2 := tc.Server(0).Clock().Now()
+	waitForCheckpoint(ts2)
+
+	// Make sure the RangeFeed hasn't errored yet.
+	select {
+	case err := <-rangeFeedErrC:
+		t.Fatal(err)
+	default:
+	}
+	// Now cancel it and wait for it to shut down.
+	rangeFeedCancel()
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1627,7 +1627,7 @@ func (s *Store) startClosedTimestampRangefeedSubscriber(ctx context.Context) {
 					if err != nil {
 						continue
 					}
-					repl.handleClosedTimestampUpdate()
+					repl.handleClosedTimestampUpdate(ctx)
 				}
 				replIDs = replIDs[:0]
 			case <-s.stopper.ShouldQuiesce():
@@ -3110,7 +3110,7 @@ func (s *Store) RangeFeed(
 			},
 		})
 	}
-	return repl.RangeFeed(args, stream, s.limiters.ConcurrentRangefeedIters)
+	return repl.RangeFeed(args, stream)
 }
 
 // maybeWaitForPushee potentially diverts the incoming request to

--- a/pkg/util/every_n.go
+++ b/pkg/util/every_n.go
@@ -24,6 +24,9 @@ import (
 // given event has occurred so that it can determine whether it's worth
 // handling again.
 //
+// The zero value for EveryN is usable and is equivalent to Every(0), meaning
+// that all calls to ShouldProcess will return true.
+//
 // NOTE: If you specifically care about log messages, you should use the
 // version of this in the log package, as it integrates with the verbosity
 // flags.


### PR DESCRIPTION
Changefeeds and, more proximately, RangeFeeds need closed timestamps to
keep advancing to make progress, but sometimes we have bugs that lead to
closed timestamps getting stuck. We should and will fix the bugs, but
given that even one stuck closed timestamp will stall changefeed-wide
progress, this commit introduces a fallback to try kicking the closed
timestamp when it's behind. Since these are unexected, we also log them
and keep a metric.

Touches #35142

Release note (bug fix): Made `CHANGEFEED`s more resilient to a class of
bugs which manifest as stalls.