### PR TITLE
 distsqlrun: allow processing more than one Span per run of chunkBackfiller execution

### DIFF
--- a/pkg/roachpb/merge_spans.go
+++ b/pkg/roachpb/merge_spans.go
@@ -109,7 +109,8 @@ func MergeSpans(spans []Span) ([]Span, bool) {
 // covered by the minuend but not the subtrahend. For example, given a single
 // minuend span [0, 10) and a subspan subtrahend [4,5) yields: [0, 4), [5, 10).
 //
-// Both inputs are mutated during execution and are not safe for reuse after.
+// The todo input is mutated during execution and is not safe for reuse after.
+// The done input is left as-is and is safe for later reuse.
 //
 // Internally the minuend and subtrahend are labeled as "todo" and "done", i.e.
 // conceptually it discusses them as a set of spans "to do" with a subset that

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -62,7 +62,7 @@ const (
 
 	// checkpointInterval is the interval after which a checkpoint of the
 	// schema change is posted.
-	checkpointInterval = 1 * time.Minute
+	checkpointInterval = 2 * time.Minute
 )
 
 var indexBulkBackfillChunkSize = settings.RegisterIntSetting(

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -558,8 +558,11 @@ func (sc *SchemaChanger) distBackfill(
 	extendLeases := make(chan struct{})
 	g := ctxgroup.WithContext(ctx)
 	g.GoCtx(func(ctx context.Context) error {
-		tick := time.NewTicker(schemaChangeLeaseDuration.Get(&sc.settings.SV) / time.Duration(4))
-		defer tick.Stop()
+		tickLease := time.NewTicker(schemaChangeLeaseDuration.Get(&sc.settings.SV) / time.Duration(4))
+		defer tickLease.Stop()
+		const checkCancelFreq = time.Second * 30
+		tickJobCancel := time.NewTicker(checkCancelFreq)
+		defer tickJobCancel.Stop()
 		ctxDone := ctx.Done()
 		for {
 			select {
@@ -567,7 +570,11 @@ func (sc *SchemaChanger) distBackfill(
 				return nil
 			case <-ctxDone:
 				return nil
-			case <-tick.C:
+			case <-tickJobCancel.C:
+				if err := sc.job.CheckStatus(ctx); err != nil {
+					return jobs.SimplifyInvalidStatusError(err)
+				}
+			case <-tickLease.C:
 				if err := sc.ExtendLease(ctx, lease); err != nil {
 					return err
 				}
@@ -595,7 +602,6 @@ func (sc *SchemaChanger) distBackfill(
 			if len(spans) <= 0 {
 				break
 			}
-
 			log.VEventf(ctx, 2, "backfill: process %+v spans", spans)
 			if err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 				// Report schema change progress. We define progress at this point
@@ -667,6 +673,7 @@ func (sc *SchemaChanger) distBackfill(
 					evalCtx.Tracing,
 				)
 				defer recv.Release()
+
 				planCtx := sc.distSQLPlanner.NewPlanningCtx(ctx, evalCtx, txn)
 				plan, err := sc.distSQLPlanner.createBackfiller(
 					planCtx, backfillType, *tableDesc.TableDesc(), duration, chunkSize, spans, otherTableDescs, readAsOf,

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -120,46 +120,66 @@ func (b *backfiller) mainLoop(ctx context.Context) error {
 		len(b.spec.Spans) == 0 {
 		return errors.Errorf("completed processing all spans for %s backfill (%d, %d)", b.name, desc.ID, mutationID)
 	}
-	work := b.spec.Spans[0].Span
 
 	// Backfill the mutations for all the rows.
 	chunkSize := b.spec.ChunkSize
-	start := timeutil.Now()
 
 	if err := b.chunks.prepare(ctx); err != nil {
 		return err
 	}
 	defer b.chunks.close(ctx)
 
-	finished := work
-	sp := work
-	var nChunks, row = 0, int64(0)
-	for ; sp.Key != nil; nChunks, row = nChunks+1, row+chunkSize {
-		if log.V(2) {
-			log.Infof(ctx, "%s backfill (%d, %d) at row: %d, span: %s",
-				b.name, desc.ID, mutationID, row, sp)
+	start := timeutil.Now()
+	totalChunks := 0
+	totalSpans := 0
+	var finishedSpans roachpb.Spans
+
+	for i := range b.spec.Spans {
+		log.VEventf(ctx, 2, "%s backfiller starting span %d of %d: %s",
+			b.name, i+1, len(b.spec.Spans), b.spec.Spans[i].Span)
+		chunks := 0
+		todo := b.spec.Spans[i].Span
+		for todo.Key != nil {
+			log.VEventf(ctx, 3, "%s backfiller starting chunk %d: %s", b.name, chunks, todo)
+			var err error
+			todo.Key, err = b.chunks.runChunk(ctx, mutations, todo, chunkSize, b.spec.ReadAsOf)
+			if err != nil {
+				return err
+			}
+			chunks++
+			if timeutil.Since(start) > b.spec.Duration {
+				break
+			}
 		}
-		var err error
-		sp.Key, err = b.chunks.runChunk(ctx, mutations, sp, chunkSize, b.spec.ReadAsOf)
-		if err != nil {
-			return err
-		}
-		if timeutil.Since(start) > b.spec.Duration && sp.Key != nil {
-			finished.EndKey = sp.Key
+		totalChunks += chunks
+
+		// If we exited the loop with a non-nil resume key, we ran out of time.
+		if todo.Key != nil {
+			log.VEventf(ctx, 2,
+				"%s backfiller ran out of time on span %d of %d, will resume it at %s next time",
+				b.name, i+1, len(b.spec.Spans), todo)
+			finishedSpans = append(finishedSpans, roachpb.Span{Key: b.spec.Spans[i].Span.Key, EndKey: todo.Key})
 			break
 		}
+		log.VEventf(ctx, 2, "%s backfiller finished span %d of %d: %s",
+			b.name, i+1, len(b.spec.Spans), b.spec.Spans[i].Span)
+		totalSpans++
+		finishedSpans = append(finishedSpans, b.spec.Spans[i].Span)
 	}
+
+	log.VEventf(ctx, 3, "%s backfiller flushing...", b.name)
 	if err := b.chunks.flush(ctx); err != nil {
 		return err
 	}
+	log.VEventf(ctx, 2, "%s backfiller finished %d spans in %d chunks in %s",
+		b.name, totalSpans, totalChunks, timeutil.Since(start))
 
-	log.VEventf(ctx, 2, "processed %d rows in %d chunks", row, nChunks)
 	return WriteResumeSpan(ctx,
 		b.flowCtx.ClientDB,
 		b.spec.Table.ID,
 		mutationID,
 		b.filter,
-		roachpb.Spans{finished},
+		finishedSpans,
 		b.flowCtx.JobRegistry,
 	)
 }

--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -77,6 +77,9 @@ func (cb *columnBackfiller) prepare(ctx context.Context) error {
 func (cb *columnBackfiller) flush(ctx context.Context) error {
 	return nil
 }
+func (cb *columnBackfiller) CurrentBufferFill() float32 {
+	return 0
+}
 
 // runChunk implements the chunkBackfiller interface.
 func (cb *columnBackfiller) runChunk(

--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -101,6 +101,10 @@ func (ib *indexBackfiller) flush(ctx context.Context) error {
 	return ib.wrapDupError(ctx, ib.adder.Flush(ctx))
 }
 
+func (ib *indexBackfiller) CurrentBufferFill() float32 {
+	return ib.adder.CurrentBufferFill()
+}
+
 func (ib *indexBackfiller) wrapDupError(ctx context.Context, orig error) error {
 	if orig == nil {
 		return nil

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3572,6 +3572,7 @@ func TestCancelSchemaChange(t *testing.T) {
 	var enableAsyncSchemaChanges uint32
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			WriteCheckpointInterval: time.Nanosecond, // checkpoint after every chunk.
 			AsyncExecNotification: func() error {
 				if enable := atomic.LoadUint32(&enableAsyncSchemaChanges); enable == 0 {
 					return errors.New("async schema changes are disabled")

--- a/pkg/storage/bulk/buffering_adder.go
+++ b/pkg/storage/bulk/buffering_adder.go
@@ -104,6 +104,11 @@ func (b *BufferingAdder) Add(ctx context.Context, key roachpb.Key, value []byte)
 	return nil
 }
 
+// CurrentBufferFill returns the current buffer fill percentage.
+func (b *BufferingAdder) CurrentBufferFill() float32 {
+	return float32(b.curBufSize) / float32(b.flushSize)
+}
+
 // Flush flushes any buffered kvs to the batcher.
 func (b *BufferingAdder) Flush(ctx context.Context) error {
 	if len(b.curBuf) == 0 {

--- a/pkg/storage/bulk/buffering_adder.go
+++ b/pkg/storage/bulk/buffering_adder.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
 )
 
 // BufferingAdder is a wrapper for an SSTBatcher that allows out-of-order calls
@@ -62,6 +63,9 @@ func MakeBulkAdder(
 	flushBytes, sstBytes int64,
 	timestamp hlc.Timestamp,
 ) (*BufferingAdder, error) {
+	if flushBytes <= 0 || sstBytes <= 0 {
+		return nil, errors.Errorf("flush size and sst bytes must be > 0")
+	}
 	b := &BufferingAdder{
 		sink:      SSTBatcher{db: db, maxSize: sstBytes, rc: rangeCache},
 		timestamp: timestamp,

--- a/pkg/storage/storagebase/bulk_adder.go
+++ b/pkg/storage/storagebase/bulk_adder.go
@@ -34,6 +34,8 @@ type BulkAdder interface {
 	Add(ctx context.Context, key roachpb.Key, value []byte) error
 	// Flush explicitly flushes anything remaining in the adder's buffer.
 	Flush(ctx context.Context) error
+	// CurrentBufferFill returns how full the configured buffer is.
+	CurrentBufferFill() float32
 	// GetSummary returns a summary of rows/bytes/etc written by this batcher.
 	GetSummary() roachpb.BulkOpSummary
 	// Close closes the underlying buffers/writers.


### PR DESCRIPTION
Previously the backfiller mainloop only processed the chunks for the first span until it either finished that span
or ran out of the configured time. This meant that very small spans, e.g. in a very well scattered table, would
make it flush, write the updated job record and exit after doing very little work.

This could result in flushing underfilled buffers and thus make more small, overlapping SSTs and generarte excessive
revisions to the job record by updating it after every span.

This changes the mainLoop to process spans until it runs out of time or spans.

Note that it still exits after reaching the configured time. A futher change might try making it long-lived, and simply
pause to checkpoint mid-loop. That is left to a followup change.

The second commit here _does_ increase the configured time from one minute to two minutes, and adds an opportunistic flush and checkpoint in the last 20% of the duration if the buffer becomes full enough (>90%). This should help avoid forcing a flush due to time right after performing one due to size.