### PR TITLE
sql: Fix cases where ColumnType is unnecessarily passed by value (patch 6/)

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -480,7 +480,7 @@ func (r *avroDataRecord) rowFromNative(native interface{}) (sqlbase.EncDatumRow,
 		if err != nil {
 			return nil, err
 		}
-		row[r.colIdxByFieldIdx[fieldIdx]] = sqlbase.DatumToEncDatum(field.typ, decoded)
+		row[r.colIdxByFieldIdx[fieldIdx]] = sqlbase.DatumToEncDatum(&field.typ, decoded)
 	}
 	return row, nil
 }

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -85,7 +85,7 @@ func parseValues(tableDesc *sqlbase.TableDescriptor, values string) ([]sqlbase.E
 			if err != nil {
 				return nil, errors.Wrap(err, typedExpr.String())
 			}
-			row = append(row, sqlbase.DatumToEncDatum(col.Type, datum))
+			row = append(row, sqlbase.DatumToEncDatum(&col.Type, datum))
 		}
 		rows = append(rows, row)
 	}

--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -289,15 +289,15 @@ func (sp *csvWriter) Run(ctx context.Context) {
 			}
 			res := sqlbase.EncDatumRow{
 				sqlbase.DatumToEncDatum(
-					types.ColumnType{SemanticType: types.STRING},
+					&types.ColumnType{SemanticType: types.STRING},
 					tree.NewDString(filename),
 				),
 				sqlbase.DatumToEncDatum(
-					types.ColumnType{SemanticType: types.INT},
+					&types.ColumnType{SemanticType: types.INT},
 					tree.NewDInt(tree.DInt(rows)),
 				),
 				sqlbase.DatumToEncDatum(
-					types.ColumnType{SemanticType: types.INT},
+					&types.ColumnType{SemanticType: types.INT},
 					tree.NewDInt(tree.DInt(size)),
 				),
 			}

--- a/pkg/ccl/importccl/read_import_proc.go
+++ b/pkg/ccl/importccl/read_import_proc.go
@@ -424,7 +424,7 @@ func (cp *readImportDataProcessor) doRun(ctx context.Context) error {
 		}
 	}
 
-	typeBytes := types.ColumnType{SemanticType: types.BYTES}
+	typeBytes := &types.ColumnType{SemanticType: types.BYTES}
 
 	if format := cp.spec.Format.Format; singleTable == nil && !isMultiTableFormat(format) {
 		return errors.Errorf("%s only supports reading a single, pre-specified table", format.String())

--- a/pkg/ccl/importccl/sst_writer_proc.go
+++ b/pkg/ccl/importccl/sst_writer_proc.go
@@ -229,23 +229,23 @@ func (sp *sstWriter) Run(ctx context.Context) {
 
 					row := sqlbase.EncDatumRow{
 						sqlbase.DatumToEncDatum(
-							types.ColumnType{SemanticType: types.STRING},
+							&types.ColumnType{SemanticType: types.STRING},
 							tree.NewDString(name),
 						),
 						sqlbase.DatumToEncDatum(
-							types.ColumnType{SemanticType: types.BYTES},
+							&types.ColumnType{SemanticType: types.BYTES},
 							tree.NewDBytes(tree.DBytes(countsBytes)),
 						),
 						sqlbase.DatumToEncDatum(
-							types.ColumnType{SemanticType: types.BYTES},
+							&types.ColumnType{SemanticType: types.BYTES},
 							tree.NewDBytes(tree.DBytes(checksum)),
 						),
 						sqlbase.DatumToEncDatum(
-							types.ColumnType{SemanticType: types.BYTES},
+							&types.ColumnType{SemanticType: types.BYTES},
 							tree.NewDBytes(tree.DBytes(sst.span.Key)),
 						),
 						sqlbase.DatumToEncDatum(
-							types.ColumnType{SemanticType: types.BYTES},
+							&types.ColumnType{SemanticType: types.BYTES},
 							tree.NewDBytes(tree.DBytes(end)),
 						),
 					}

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -288,7 +288,7 @@ func skipTableKey(
 // not match the column's type.
 // See the analog, UnmarshalColumnValue, in sqlbase/column_type_encoding.go
 func UnmarshalColumnValueToCol(
-	vec coldata.Vec, idx uint16, typ types.ColumnType, value roachpb.Value,
+	vec coldata.Vec, idx uint16, typ *types.ColumnType, value roachpb.Value,
 ) error {
 	if value.RawBytes == nil {
 		vec.SetNull(idx)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2616,7 +2616,7 @@ func (dsp *DistSQLPlanner) createPlanForValues(
 		datums := n.Values()
 		for j := range n.columns {
 			var err error
-			datum := sqlbase.DatumToEncDatum(types[j], datums[j])
+			datum := sqlbase.DatumToEncDatum(&types[j], datums[j])
 			buf, err = datum.Encode(&types[j], &a, sqlbase.DatumEncoding_VALUE, buf)
 			if err != nil {
 				return PhysicalPlan{}, err

--- a/pkg/sql/distsqlpb/processors.go
+++ b/pkg/sql/distsqlpb/processors.go
@@ -115,7 +115,7 @@ func (spec *WindowerSpec_Frame_Bounds) initFromAST(
 			spec.Start.OffsetType = DatumInfo{Encoding: sqlbase.DatumEncoding_VALUE, Type: typ}
 			var buf []byte
 			var a sqlbase.DatumAlloc
-			datum := sqlbase.DatumToEncDatum(typ, dStartOffset)
+			datum := sqlbase.DatumToEncDatum(&typ, dStartOffset)
 			buf, err = datum.Encode(&typ, &a, sqlbase.DatumEncoding_VALUE, buf)
 			if err != nil {
 				return err
@@ -160,7 +160,7 @@ func (spec *WindowerSpec_Frame_Bounds) initFromAST(
 				spec.End.OffsetType = DatumInfo{Encoding: sqlbase.DatumEncoding_VALUE, Type: typ}
 				var buf []byte
 				var a sqlbase.DatumAlloc
-				datum := sqlbase.DatumToEncDatum(typ, dEndOffset)
+				datum := sqlbase.DatumToEncDatum(&typ, dEndOffset)
 				buf, err = datum.Encode(&typ, &a, sqlbase.DatumEncoding_VALUE, buf)
 				if err != nil {
 					return err

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -592,7 +592,7 @@ func (ag *aggregatorBase) getAggResults(
 			// We can't encode nil into an EncDatum, so we represent it with DNull.
 			result = tree.DNull
 		}
-		ag.row[i] = sqlbase.DatumToEncDatum(ag.outputTypes[i], result)
+		ag.row[i] = sqlbase.DatumToEncDatum(&ag.outputTypes[i], result)
 	}
 	bucket.close(ag.Ctx)
 

--- a/pkg/sql/distsqlrun/aggregator_test.go
+++ b/pkg/sql/distsqlrun/aggregator_test.go
@@ -639,9 +639,9 @@ func makeGroupedIntRows(groupSize, numCols int, groupedCols []int) sqlbase.EncDa
 		for j := 0; j < numCols; j++ {
 			if groupColSet.Contains(j) {
 				rows[i][j] = sqlbase.DatumToEncDatum(
-					sqlbase.IntType, tree.NewDInt(tree.DInt(getGroupedColVal(i, j))))
+					&sqlbase.IntType, tree.NewDInt(tree.DInt(getGroupedColVal(i, j))))
 			} else {
-				rows[i][j] = sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(i+j)))
+				rows[i][j] = sqlbase.DatumToEncDatum(&sqlbase.IntType, tree.NewDInt(tree.DInt(i+j)))
 			}
 		}
 	}

--- a/pkg/sql/distsqlrun/base_test.go
+++ b/pkg/sql/distsqlrun/base_test.go
@@ -88,7 +88,7 @@ func BenchmarkRowChannelPipeline(b *testing.B) {
 			}
 
 			row := sqlbase.EncDatumRow{
-				sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(1))),
+				sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(1))),
 			}
 			b.SetBytes(int64(8 * 1 * 1))
 			for i := 0; i < b.N; i++ {

--- a/pkg/sql/distsqlrun/cluster_test.go
+++ b/pkg/sql/distsqlrun/cluster_test.go
@@ -358,7 +358,7 @@ func TestLimitedBufferingDeadlock(t *testing.T) {
 	leftRows := make(sqlbase.EncDatumRows, 20)
 	for i := range leftRows {
 		leftRows[i] = sqlbase.EncDatumRow{
-			sqlbase.DatumToEncDatum(typs[0], tree.NewDInt(tree.DInt(i))),
+			sqlbase.DatumToEncDatum(&typs[0], tree.NewDInt(tree.DInt(i))),
 		}
 	}
 	leftValuesSpec, err := generateValuesSpec(typs, leftRows, 10 /* rows per chunk */)
@@ -372,7 +372,7 @@ func TestLimitedBufferingDeadlock(t *testing.T) {
 	for i := 1; i <= 20; i++ {
 		for j := 1; j <= 4*rowChannelBufSize; j++ {
 			rightRows = append(rightRows, sqlbase.EncDatumRow{
-				sqlbase.DatumToEncDatum(typs[0], tree.NewDInt(tree.DInt(i))),
+				sqlbase.DatumToEncDatum(&typs[0], tree.NewDInt(tree.DInt(i))),
 			})
 		}
 	}
@@ -606,9 +606,9 @@ func BenchmarkInfrastructure(b *testing.B) {
 						for j := 0; j < numRows; j++ {
 							row := make(sqlbase.EncDatumRow, 3)
 							lastVal += rng.Intn(10)
-							row[0] = sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(lastVal)))
-							row[1] = sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(rng.Intn(100000))))
-							row[2] = sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(rng.Intn(100000))))
+							row[0] = sqlbase.DatumToEncDatum(&sqlbase.IntType, tree.NewDInt(tree.DInt(lastVal)))
+							row[1] = sqlbase.DatumToEncDatum(&sqlbase.IntType, tree.NewDInt(tree.DInt(rng.Intn(100000))))
+							row[2] = sqlbase.DatumToEncDatum(&sqlbase.IntType, tree.NewDInt(tree.DInt(rng.Intn(100000))))
 							if err := se.AddRow(row); err != nil {
 								b.Fatal(err)
 							}

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -32,7 +32,7 @@ func TestDistinct(t *testing.T) {
 
 	v := [15]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(types.ColumnType{SemanticType: types.INT},
+		v[i] = sqlbase.DatumToEncDatum(&types.ColumnType{SemanticType: types.INT},
 			tree.NewDInt(tree.DInt(i)))
 	}
 

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -157,7 +157,7 @@ func TestHashJoinerError(t *testing.T) {
 	columnTypeInt := types.ColumnType{SemanticType: types.INT}
 	v := [10]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(i)))
 	}
 
 	testCases := joinerErrorTestCases()
@@ -274,7 +274,7 @@ func TestHashJoinerDrain(t *testing.T) {
 	columnTypeInt := types.ColumnType{SemanticType: types.INT}
 	v := [10]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(i)))
 	}
 	spec := distsqlpb.HashJoinerSpec{
 		LeftEqColumns:  []uint32{0},
@@ -378,7 +378,7 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 	columnTypeInt := types.ColumnType{SemanticType: types.INT}
 	v := [10]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(i)))
 	}
 	spec := distsqlpb.HashJoinerSpec{
 		LeftEqColumns:  []uint32{0},

--- a/pkg/sql/distsqlrun/inbound_test.go
+++ b/pkg/sql/distsqlrun/inbound_test.go
@@ -104,7 +104,7 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 	// below.
 	consumer.ConsumerDone()
 
-	row := sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(0)))}
+	row := sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(&sqlbase.IntType, tree.NewDInt(tree.DInt(0)))}
 
 	// Now push a row to the outbox's RowChannel and expect the consumer status
 	// returned to be DrainRequested. This is wrapped in a SucceedsSoon because

--- a/pkg/sql/distsqlrun/input_sync_test.go
+++ b/pkg/sql/distsqlrun/input_sync_test.go
@@ -34,7 +34,7 @@ func TestOrderedSync(t *testing.T) {
 	columnTypeInt := &types.ColumnType{SemanticType: types.INT}
 	v := [6]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(*columnTypeInt, tree.NewDInt(tree.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
 	}
 
 	asc := encoding.Ascending
@@ -193,8 +193,8 @@ func TestUnorderedSync(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
 			for j := 1; j <= 100; j++ {
-				a := sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
-				b := sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(j)))
+				a := sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(i)))
+				b := sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(j)))
 				row := sqlbase.EncDatumRow{a, b}
 				if status := mrc.Push(row, nil /* meta */); status != NeedMoreRows {
 					producerErr <- errors.Errorf("producer error: unexpected response: %d", status)
@@ -241,8 +241,8 @@ func TestUnorderedSync(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
 			for j := 1; j <= 100; j++ {
-				a := sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
-				b := sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(j)))
+				a := sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(i)))
+				b := sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(j)))
 				row := sqlbase.EncDatumRow{a, b}
 				if status := mrc.Push(row, nil /* meta */); status != NeedMoreRows {
 					producerErr <- errors.Errorf("producer error: unexpected response: %d", status)

--- a/pkg/sql/distsqlrun/joiner_test.go
+++ b/pkg/sql/distsqlrun/joiner_test.go
@@ -39,7 +39,7 @@ func joinerTestCases() []joinerTestCase {
 	columnTypeInt := types.ColumnType{SemanticType: types.INT}
 	v := [10]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(i)))
 	}
 	null := sqlbase.EncDatum{Datum: tree.DNull}
 
@@ -839,7 +839,7 @@ func joinerErrorTestCases() []joinerErrorTestCase {
 	columnTypeInt := types.ColumnType{SemanticType: types.INT}
 	v := [10]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(i)))
 	}
 
 	testCases := []joinerErrorTestCase{

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -71,11 +71,11 @@ func (jb *joinerBase) init(
 
 	jb.emptyLeft = make(sqlbase.EncDatumRow, len(leftTypes))
 	for i := range jb.emptyLeft {
-		jb.emptyLeft[i] = sqlbase.DatumToEncDatum(leftTypes[i], tree.DNull)
+		jb.emptyLeft[i] = sqlbase.DatumToEncDatum(&leftTypes[i], tree.DNull)
 	}
 	jb.emptyRight = make(sqlbase.EncDatumRow, len(rightTypes))
 	for i := range jb.emptyRight {
-		jb.emptyRight[i] = sqlbase.DatumToEncDatum(rightTypes[i], tree.DNull)
+		jb.emptyRight[i] = sqlbase.DatumToEncDatum(&rightTypes[i], tree.DNull)
 	}
 
 	jb.eqCols[leftSide] = columns(leftEqColumns)

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -285,7 +285,7 @@ func TestJoinReader(t *testing.T) {
 				for rowIdx, row := range c.input {
 					encRow := make(sqlbase.EncDatumRow, len(row))
 					for i, d := range row {
-						encRow[i] = sqlbase.DatumToEncDatum(c.inputTypes[i], d)
+						encRow[i] = sqlbase.DatumToEncDatum(&c.inputTypes[i], d)
 					}
 					encRows[rowIdx] = encRow
 				}
@@ -376,7 +376,7 @@ func TestJoinReaderDrain(t *testing.T) {
 	}
 
 	encRow := make(sqlbase.EncDatumRow, 1)
-	encRow[0] = sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(1))
+	encRow[0] = sqlbase.DatumToEncDatum(&sqlbase.IntType, tree.NewDInt(1))
 
 	// ConsumerClosed verifies that when a joinReader's consumer is closed, the
 	// joinReader finishes gracefully.

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -46,7 +46,7 @@ func TestMergeJoiner(t *testing.T) {
 	columnTypeInt := types.ColumnType{SemanticType: types.INT}
 	v := [10]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(i)))
 	}
 	null := sqlbase.EncDatum{Datum: tree.DNull}
 
@@ -746,7 +746,7 @@ func TestConsumerClosed(t *testing.T) {
 	columnTypeInt := types.ColumnType{SemanticType: types.INT}
 	v := [10]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(i)))
 	}
 
 	spec := distsqlpb.MergeJoinerSpec{

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -83,7 +83,7 @@ func TestOutbox(t *testing.T) {
 	go func() {
 		producerC <- func() error {
 			row := sqlbase.EncDatumRow{
-				sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(0))),
+				sqlbase.DatumToEncDatum(&sqlbase.IntType, tree.NewDInt(tree.DInt(0))),
 			}
 			if consumerStatus := outbox.Push(row, nil /* meta */); consumerStatus != NeedMoreRows {
 				return errors.Errorf("expected status: %d, got: %d", NeedMoreRows, consumerStatus)
@@ -92,7 +92,7 @@ func TestOutbox(t *testing.T) {
 			// Send rows until the drain request is observed.
 			for {
 				row = sqlbase.EncDatumRow{
-					sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(-1))),
+					sqlbase.DatumToEncDatum(&sqlbase.IntType, tree.NewDInt(tree.DInt(-1))),
 				}
 				consumerStatus := outbox.Push(row, nil /* meta */)
 				if consumerStatus == DrainRequested {
@@ -104,7 +104,7 @@ func TestOutbox(t *testing.T) {
 			}
 
 			// Now send another row that the outbox will discard.
-			row = sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(2)))}
+			row = sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(&sqlbase.IntType, tree.NewDInt(tree.DInt(2)))}
 			if consumerStatus := outbox.Push(row, nil /* meta */); consumerStatus != DrainRequested {
 				return errors.Errorf("expected status: %d, got: %d", NeedMoreRows, consumerStatus)
 			}
@@ -516,7 +516,7 @@ func BenchmarkOutbox(b *testing.B) {
 	for _, numCols := range []int{1, 2, 4, 8} {
 		row := sqlbase.EncDatumRow{}
 		for i := 0; i < numCols; i++ {
-			row = append(row, sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(2))))
+			row = append(row, sqlbase.DatumToEncDatum(&sqlbase.IntType, tree.NewDInt(tree.DInt(2))))
 		}
 		b.Run(fmt.Sprintf("numCols=%d", numCols), func(b *testing.B) {
 			flowID := distsqlpb.FlowID{UUID: uuid.MakeV4()}

--- a/pkg/sql/distsqlrun/processor_utils_test.go
+++ b/pkg/sql/distsqlrun/processor_utils_test.go
@@ -55,7 +55,7 @@ type ProcessorTestCaseRows struct {
 }
 
 // toEncDatum converts a go value to an EncDatum.
-func toEncDatum(datumType types.ColumnType, v interface{}) sqlbase.EncDatum {
+func toEncDatum(datumType *types.ColumnType, v interface{}) sqlbase.EncDatum {
 	d := func() tree.Datum {
 		switch concreteType := v.(type) {
 		case int:
@@ -84,7 +84,7 @@ func (r ProcessorTestCaseRows) toEncDatumRows() sqlbase.EncDatumRows {
 		}
 		result[i] = make(sqlbase.EncDatumRow, len(row))
 		for j, col := range row {
-			result[i][j] = toEncDatum(r.Types[j], col)
+			result[i][j] = toEncDatum(&r.Types[j], col)
 		}
 	}
 	return result

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -389,7 +389,7 @@ func (h *ProcOutputHelper) ProcessRow(
 			if err != nil {
 				return nil, false, err
 			}
-			h.outputRow[i] = sqlbase.DatumToEncDatum(h.outputTypes[i], datum)
+			h.outputRow[i] = sqlbase.DatumToEncDatum(&h.outputTypes[i], datum)
 		}
 	} else if h.outputCols != nil {
 		// Projection.

--- a/pkg/sql/distsqlrun/processors_test.go
+++ b/pkg/sql/distsqlrun/processors_test.go
@@ -44,7 +44,7 @@ func TestPostProcess(t *testing.T) {
 
 	v := [10]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(tree.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(&sqlbase.IntType, tree.NewDInt(tree.DInt(i)))
 	}
 
 	// We run the same input rows through various PostProcessSpecs.

--- a/pkg/sql/distsqlrun/project_set.go
+++ b/pkg/sql/distsqlrun/project_set.go
@@ -275,7 +275,7 @@ func (ps *projectSetProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 
 func (ps *projectSetProcessor) toEncDatum(d tree.Datum, colIdx int) sqlbase.EncDatum {
 	generatedColIdx := colIdx - len(ps.input.OutputTypes())
-	ctyp := ps.spec.GeneratedColumns[generatedColIdx]
+	ctyp := &ps.spec.GeneratedColumns[generatedColIdx]
 	return sqlbase.DatumToEncDatum(ctyp, d)
 }
 

--- a/pkg/sql/distsqlrun/routers_test.go
+++ b/pkg/sql/distsqlrun/routers_test.go
@@ -334,9 +334,9 @@ func TestConsumerStatus(t *testing.T) {
 			case *rangeRouter:
 				// Use 0 and MaxInt32 to route rows based on testRangeRouterSpec's spans.
 				d := tree.NewDInt(0)
-				row0 = sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(colTypes[0], d)}
+				row0 = sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(&colTypes[0], d)}
 				d = tree.NewDInt(math.MaxInt32)
-				row1 = sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(colTypes[0], d)}
+				row1 = sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(&colTypes[0], d)}
 			default:
 				rng, _ := randutil.NewPseudoRand()
 				vals := sqlbase.RandEncDatumRowsOfTypes(rng, 1 /* numRows */, colTypes)

--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -285,7 +285,7 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 			var histogram *stats.HistogramData
 			if si.spec.GenerateHistogram && len(s.sr.Get()) != 0 {
 				colIdx := int(si.spec.Columns[0])
-				typ := s.inTypes[colIdx]
+				typ := &s.inTypes[colIdx]
 
 				h, err := generateHistogram(
 					s.evalCtx,
@@ -350,7 +350,7 @@ func generateHistogram(
 	evalCtx *tree.EvalContext,
 	samples []stats.SampledRow,
 	colIdx int,
-	colType types.ColumnType,
+	colType *types.ColumnType,
 	numRows int64,
 	maxBuckets int,
 ) (stats.HistogramData, error) {
@@ -360,7 +360,7 @@ func generateHistogram(
 		ed := &s.Row[colIdx]
 		// Ignore NULLs (they are counted separately).
 		if !ed.IsNull() {
-			if err := ed.EnsureDecoded(&colType, &da); err != nil {
+			if err := ed.EnsureDecoded(colType, &da); err != nil {
 				return stats.HistogramData{}, err
 			}
 			values = append(values, ed.Datum)

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -301,7 +301,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 
 	outRow := make(sqlbase.EncDatumRow, len(s.outTypes))
 	for i := range outRow {
-		outRow[i] = sqlbase.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		outRow[i] = sqlbase.DatumToEncDatum(&s.outTypes[i], tree.DNull)
 	}
 	// Emit the sampled rows.
 	for _, sample := range s.sr.Get() {
@@ -316,7 +316,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 
 	// Emit the sketch rows.
 	for i := range outRow {
-		outRow[i] = sqlbase.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		outRow[i] = sqlbase.DatumToEncDatum(&s.outTypes[i], tree.DNull)
 	}
 
 	for i, si := range s.sketches {

--- a/pkg/sql/distsqlrun/scrub_tablereader.go
+++ b/pkg/sql/distsqlrun/scrub_tablereader.go
@@ -173,15 +173,15 @@ func (tr *scrubTableReader) generateScrubErrorRow(
 	primaryKeyValues := tr.prettyPrimaryKeyValues(row, &tr.tableDesc)
 	return sqlbase.EncDatumRow{
 		sqlbase.DatumToEncDatum(
-			ScrubTypes[0],
+			&ScrubTypes[0],
 			tree.NewDString(scrubErr.Code),
 		),
 		sqlbase.DatumToEncDatum(
-			ScrubTypes[1],
+			&ScrubTypes[1],
 			tree.NewDString(primaryKeyValues),
 		),
 		sqlbase.DatumToEncDatum(
-			ScrubTypes[2],
+			&ScrubTypes[2],
 			detailsJSON,
 		),
 	}, nil

--- a/pkg/sql/distsqlrun/set_op_test.go
+++ b/pkg/sql/distsqlrun/set_op_test.go
@@ -76,7 +76,7 @@ func intersectAllTestCases() []setOpTestCase {
 	columnTypeInt := types.ColumnType{SemanticType: types.INT}
 	var v = [10]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(i)))
 	}
 
 	return []setOpTestCase{
@@ -174,7 +174,7 @@ func exceptAllTestCases() []setOpTestCase {
 	columnTypeInt := types.ColumnType{SemanticType: types.INT}
 	var v = [10]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(i)))
 	}
 
 	return []setOpTestCase{

--- a/pkg/sql/distsqlrun/stream_data_test.go
+++ b/pkg/sql/distsqlrun/stream_data_test.go
@@ -117,7 +117,7 @@ func TestStreamEncodeDecode(t *testing.T) {
 			if rng.Intn(10) != 0 {
 				rows[i].row = make(sqlbase.EncDatumRow, rowLen)
 				for j := range rows[i].row {
-					rows[i].row[j] = sqlbase.DatumToEncDatum(info[j].Type,
+					rows[i].row[j] = sqlbase.DatumToEncDatum(&info[j].Type,
 						sqlbase.RandDatum(rng, info[j].Type, true))
 				}
 			} else {

--- a/pkg/sql/distsqlrun/windower.go
+++ b/pkg/sql/distsqlrun/windower.go
@@ -771,7 +771,7 @@ func (w *windower) populateNextOutputRow() (bool, error) {
 			// We simply pass through columns in [inputColIdx, windowFn.argIdxStart).
 			w.outputRow = append(w.outputRow, inputRow[inputColIdx:windowFn.argIdxStart]...)
 			windowFnRes := w.windowValues[w.partitionIdx][windowFnIdx][rowIdx]
-			encWindowFnRes := sqlbase.DatumToEncDatum(w.outputTypes[len(w.outputRow)], windowFnRes)
+			encWindowFnRes := sqlbase.DatumToEncDatum(&w.outputTypes[len(w.outputRow)], windowFnRes)
 			w.outputRow = append(w.outputRow, encWindowFnRes)
 			// We skip all columns that were arguments to windowFn.
 			inputColIdx = windowFn.argIdxStart + windowFn.argCount

--- a/pkg/sql/distsqlrun/zigzagjoiner_test.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner_test.go
@@ -49,7 +49,7 @@ func intCols(numCols int) []types.ColumnType {
 
 func encInt(i int) sqlbase.EncDatum {
 	typeInt := types.ColumnType{SemanticType: types.INT}
-	return sqlbase.DatumToEncDatum(typeInt, tree.NewDInt(tree.DInt(i)))
+	return sqlbase.DatumToEncDatum(&typeInt, tree.NewDInt(tree.DInt(i)))
 }
 
 func TestZigzagJoiner(t *testing.T) {
@@ -546,8 +546,8 @@ func TestZigzagJoinerDrain(t *testing.T) {
 	for i := range v {
 		v[i] = tree.NewDInt(tree.DInt(i))
 	}
-	encThree := sqlbase.DatumToEncDatum(typeInt, v[3])
-	encSeven := sqlbase.DatumToEncDatum(typeInt, v[7])
+	encThree := sqlbase.DatumToEncDatum(&typeInt, v[3])
+	encSeven := sqlbase.DatumToEncDatum(&typeInt, v[7])
 
 	sqlutils.CreateTable(
 		t,
@@ -568,7 +568,7 @@ func TestZigzagJoinerDrain(t *testing.T) {
 	}
 
 	encRow := make(sqlbase.EncDatumRow, 1)
-	encRow[0] = sqlbase.DatumToEncDatum(sqlbase.IntType, tree.NewDInt(1))
+	encRow[0] = sqlbase.DatumToEncDatum(&sqlbase.IntType, tree.NewDInt(1))
 
 	// ConsumerClosed verifies that when a joinReader's consumer is closed, the
 	// joinReader finishes gracefully.

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -319,12 +319,12 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 					dStringPtrOrNull(column.DefaultExpr),                 // column_default
 					yesOrNoDatum(column.Nullable),                        // is_nullable
 					tree.NewDString(column.Type.InformationSchemaName()), // data_type
-					characterMaximumLength(column.Type),                  // character_maximum_length
-					characterOctetLength(column.Type),                    // character_octet_length
-					numericPrecision(column.Type),                        // numeric_precision
-					numericPrecisionRadix(column.Type),                   // numeric_precision_radix
-					numericScale(column.Type),                            // numeric_scale
-					datetimePrecision(column.Type),                       // datetime_precision
+					characterMaximumLength(&column.Type),                 // character_maximum_length
+					characterOctetLength(&column.Type),                   // character_octet_length
+					numericPrecision(&column.Type),                       // numeric_precision
+					numericPrecisionRadix(&column.Type),                  // numeric_precision_radix
+					numericScale(&column.Type),                           // numeric_scale
+					datetimePrecision(&column.Type),                      // datetime_precision
 					tree.DNull,                                           // character_set_catalog
 					tree.DNull,                                           // character_set_schema
 					tree.DNull,                                           // character_set_name
@@ -374,27 +374,27 @@ CREATE TABLE information_schema.enabled_roles (
 	},
 }
 
-func characterMaximumLength(colType types.ColumnType) tree.Datum {
+func characterMaximumLength(colType *types.ColumnType) tree.Datum {
 	return dIntFnOrNull(colType.MaxCharacterLength)
 }
 
-func characterOctetLength(colType types.ColumnType) tree.Datum {
+func characterOctetLength(colType *types.ColumnType) tree.Datum {
 	return dIntFnOrNull(colType.MaxOctetLength)
 }
 
-func numericPrecision(colType types.ColumnType) tree.Datum {
+func numericPrecision(colType *types.ColumnType) tree.Datum {
 	return dIntFnOrNull(colType.NumericPrecision)
 }
 
-func numericPrecisionRadix(colType types.ColumnType) tree.Datum {
+func numericPrecisionRadix(colType *types.ColumnType) tree.Datum {
 	return dIntFnOrNull(colType.NumericPrecisionRadix)
 }
 
-func numericScale(colType types.ColumnType) tree.Datum {
+func numericScale(colType *types.ColumnType) tree.Datum {
 	return dIntFnOrNull(colType.NumericScale)
 }
 
-func datetimePrecision(colType types.ColumnType) tree.Datum {
+func datetimePrecision(colType *types.ColumnType) tree.Datum {
 	// We currently do not support a datetime precision.
 	return tree.DNull
 }

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -698,7 +698,7 @@ func GenerateInsertRow(
 
 	// Ensure that the values honor the specified column widths.
 	for i := 0; i < len(insertCols); i++ {
-		outVal, err := sqlbase.LimitValueWidth(insertCols[i].Type, rowVals[i], &insertCols[i].Name)
+		outVal, err := sqlbase.LimitValueWidth(&insertCols[i].Type, rowVals[i], &insertCols[i].Name)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -184,7 +184,7 @@ func (p *planNodeToRowSource) Next() (sqlbase.EncDatumRow, *distsqlrun.ProducerM
 
 		for i, datum := range p.node.Values() {
 			if datum != nil {
-				p.row[i] = sqlbase.DatumToEncDatum(p.outputTypes[i], datum)
+				p.row[i] = sqlbase.DatumToEncDatum(&p.outputTypes[i], datum)
 			}
 		}
 		// ProcessRow here is required to deal with projections, which won't be

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -887,7 +887,7 @@ func (rf *CFetcher) processValueSingle(
 			if len(val.RawBytes) == 0 {
 				return prettyKey, "", nil
 			}
-			typ := table.cols[idx].Type
+			typ := &table.cols[idx].Type
 			err := colencoding.UnmarshalColumnValueToCol(rf.machine.colvecs[idx], rf.machine.rowIdx, typ, val)
 			if err != nil {
 				return "", "", err

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -840,7 +840,7 @@ func (rf *Fetcher) processValueSingle(
 			if len(kv.Value.RawBytes) == 0 {
 				return prettyKey, "", nil
 			}
-			typ := table.cols[idx].Type
+			typ := &table.cols[idx].Type
 			// TODO(arjun): The value is a directly marshaled single value, so we
 			// unmarshal it eagerly here. This can potentially be optimized out,
 			// although that would require changing UnmarshalColumnValue to operate

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -275,7 +275,7 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 	)
 	defer d.Close(ctx)
 
-	row := sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(1)))}
+	row := sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(&columnTypeInt, tree.NewDInt(tree.DInt(1)))}
 	err = d.AddRow(ctx, row)
 	if pgErr, ok := pgerror.GetPGCause(err); !(ok && pgErr.Code == pgerror.CodeDiskFullError) {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -526,7 +526,7 @@ func (h *HashDiskRowContainer) Init(
 		// Initialize the last column of the scratch row we use in AddRow() to
 		// be unmarked.
 		h.scratchEncRow[len(h.scratchEncRow)-1] = sqlbase.DatumToEncDatum(
-			types.ColumnType{SemanticType: types.BOOL},
+			&types.ColumnType{SemanticType: types.BOOL},
 			tree.MakeDBool(false),
 		)
 	}

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -175,7 +175,7 @@ func (mc *MemRowContainer) Less(i, j int) bool {
 func (mc *MemRowContainer) EncRow(idx int) sqlbase.EncDatumRow {
 	datums := mc.At(idx)
 	for i, d := range datums {
-		mc.scratchEncRow[i] = sqlbase.DatumToEncDatum(mc.types[i], d)
+		mc.scratchEncRow[i] = sqlbase.DatumToEncDatum(&mc.types[i], d)
 	}
 	return mc.scratchEncRow
 }
@@ -587,7 +587,7 @@ func MakeDiskBackedIndexedRowContainer(
 func (f *DiskBackedIndexedRowContainer) AddRow(ctx context.Context, row sqlbase.EncDatumRow) error {
 	copy(f.scratchEncRow, row)
 	f.scratchEncRow[len(f.scratchEncRow)-1] = sqlbase.DatumToEncDatum(
-		types.ColumnType{SemanticType: types.INT},
+		&types.ColumnType{SemanticType: types.INT},
 		tree.NewDInt(tree.DInt(f.idx)),
 	)
 	f.idx++

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -92,8 +92,8 @@ func TestRowContainerReplaceMax(t *testing.T) {
 			b = append(b, 'a')
 		}
 		return sqlbase.EncDatumRow{
-			sqlbase.DatumToEncDatum(typeInt, tree.NewDInt(tree.DInt(intVal))),
-			sqlbase.DatumToEncDatum(typeStr, tree.NewDString(string(b))),
+			sqlbase.DatumToEncDatum(&typeInt, tree.NewDInt(tree.DInt(intVal))),
+			sqlbase.DatumToEncDatum(&typeStr, tree.NewDString(string(b))),
 		}
 	}
 

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -712,7 +712,7 @@ func MarshalColumnValue(col ColumnDescriptor, val tree.Datum) (roachpb.Value, er
 // by the column. An error is returned if the value's type does not
 // match the column's type.
 func UnmarshalColumnValue(
-	a *DatumAlloc, typ types.ColumnType, value roachpb.Value,
+	a *DatumAlloc, typ *types.ColumnType, value roachpb.Value,
 ) (tree.Datum, error) {
 	if value.RawBytes == nil {
 		return tree.DNull, nil

--- a/pkg/sql/sqlbase/column_type_properties.go
+++ b/pkg/sql/sqlbase/column_type_properties.go
@@ -211,7 +211,7 @@ func coltypeStringVariantToOid(c coltypes.TStringVariant) oid.Oid {
 // then a truncated copy is returned. Otherwise, an error is returned. This
 // method is used by INSERT and UPDATE.
 func LimitValueWidth(
-	typ types.ColumnType, inVal tree.Datum, name *string,
+	typ *types.ColumnType, inVal tree.Datum, name *string,
 ) (outVal tree.Datum, err error) {
 	switch typ.SemanticType {
 	case types.STRING, types.COLLATEDSTRING:
@@ -284,7 +284,7 @@ func LimitValueWidth(
 	case types.ARRAY:
 		if inArr, ok := inVal.(*tree.DArray); ok {
 			var outArr *tree.DArray
-			elementType := *typ.ElementColumnType()
+			elementType := typ.ElementColumnType()
 			for i, inElem := range inArr.Array {
 				outElem, err := LimitValueWidth(elementType, inElem, name)
 				if err != nil {

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -164,7 +164,7 @@ func EncDatumValueFromBufferWithOffsetsAndType(
 }
 
 // DatumToEncDatum initializes an EncDatum with the given Datum.
-func DatumToEncDatum(ctyp types.ColumnType, d tree.Datum) EncDatum {
+func DatumToEncDatum(ctyp *types.ColumnType, d tree.Datum) EncDatum {
 	if d == nil {
 		panic("Cannot convert nil datum to EncDatum")
 	}

--- a/pkg/sql/sqlbase/encoded_datum_test.go
+++ b/pkg/sql/sqlbase/encoded_datum_test.go
@@ -45,7 +45,7 @@ func TestEncDatum(t *testing.T) {
 	}
 
 	typeInt := types.ColumnType{SemanticType: types.INT}
-	x := DatumToEncDatum(typeInt, tree.NewDInt(5))
+	x := DatumToEncDatum(&typeInt, tree.NewDInt(5))
 
 	check := func(x EncDatum) {
 		if x.IsUnset() {
@@ -114,7 +114,7 @@ func TestEncDatum(t *testing.T) {
 	}
 }
 
-func columnTypeCompatibleWithEncoding(typ types.ColumnType, enc DatumEncoding) bool {
+func columnTypeCompatibleWithEncoding(typ *types.ColumnType, enc DatumEncoding) bool {
 	return enc == DatumEncoding_VALUE || columnTypeIsIndexable(typ)
 }
 
@@ -123,7 +123,7 @@ func TestEncDatumNull(t *testing.T) {
 
 	// Verify DNull is null.
 	typeInt := types.ColumnType{SemanticType: types.INT}
-	n := DatumToEncDatum(typeInt, tree.DNull)
+	n := DatumToEncDatum(&typeInt, tree.DNull)
 	if !n.IsNull() {
 		t.Error("DNull not null")
 	}
@@ -137,7 +137,7 @@ func TestEncDatumNull(t *testing.T) {
 		a, typ := RandEncDatum(rng)
 
 		for enc := range DatumEncoding_name {
-			if !columnTypeCompatibleWithEncoding(typ, DatumEncoding(enc)) {
+			if !columnTypeCompatibleWithEncoding(&typ, DatumEncoding(enc)) {
 				continue
 			}
 			encoded, err := a.Encode(&typ, &alloc, DatumEncoding(enc), nil)
@@ -233,8 +233,8 @@ func TestEncDatumCompare(t *testing.T) {
 				break
 			}
 		}
-		v1 := DatumToEncDatum(typ, d1)
-		v2 := DatumToEncDatum(typ, d2)
+		v1 := DatumToEncDatum(&typ, d1)
+		v2 := DatumToEncDatum(&typ, d2)
 
 		if val, err := v1.Compare(&typ, a, evalCtx, &v2); err != nil {
 			t.Fatal(err)
@@ -292,7 +292,7 @@ func TestEncDatumFromBuffer(t *testing.T) {
 				enc[i] = DatumEncoding_VALUE
 			} else {
 				enc[i] = RandDatumEncoding(rng)
-				for !columnTypeCompatibleWithEncoding(types[i], enc[i]) {
+				for !columnTypeCompatibleWithEncoding(&types[i], enc[i]) {
 					enc[i] = RandDatumEncoding(rng)
 				}
 			}
@@ -332,7 +332,7 @@ func TestEncDatumRowCompare(t *testing.T) {
 	typeInt := types.ColumnType{SemanticType: types.INT}
 	v := [5]EncDatum{}
 	for i := range v {
-		v[i] = DatumToEncDatum(typeInt, tree.NewDInt(tree.DInt(i)))
+		v[i] = DatumToEncDatum(&typeInt, tree.NewDInt(tree.DInt(i)))
 	}
 
 	asc := encoding.Ascending
@@ -457,7 +457,7 @@ func TestEncDatumRowAlloc(t *testing.T) {
 				in[i] = make(EncDatumRow, cols)
 				for j := 0; j < cols; j++ {
 					datum := RandDatum(rng, colTypes[j], true /* nullOk */)
-					in[i][j] = DatumToEncDatum(colTypes[j], datum)
+					in[i][j] = DatumToEncDatum(&colTypes[j], datum)
 				}
 			}
 			var alloc EncDatumRowAlloc
@@ -572,7 +572,7 @@ func TestEncDatumSize(t *testing.T) {
 		},
 		{
 			encDatum: DatumToEncDatum(
-				types.ColumnType{SemanticType: types.INT}, tree.NewDInt(123)),
+				&types.ColumnType{SemanticType: types.INT}, tree.NewDInt(123)),
 			expectedSize: EncDatumOverhead + DIntSize,
 		},
 		{
@@ -593,7 +593,7 @@ func TestEncDatumSize(t *testing.T) {
 		},
 		{
 			encDatum: DatumToEncDatum(
-				types.ColumnType{SemanticType: types.FLOAT}, tree.NewDFloat(123)),
+				&types.ColumnType{SemanticType: types.FLOAT}, tree.NewDFloat(123)),
 			expectedSize: EncDatumOverhead + DFloatSize,
 		},
 		{
@@ -614,7 +614,7 @@ func TestEncDatumSize(t *testing.T) {
 		},
 		{
 			encDatum: DatumToEncDatum(
-				types.ColumnType{SemanticType: types.DECIMAL}, dec12300),
+				&types.ColumnType{SemanticType: types.DECIMAL}, dec12300),
 			expectedSize: EncDatumOverhead + decimalSize,
 		},
 		{
@@ -635,7 +635,7 @@ func TestEncDatumSize(t *testing.T) {
 		},
 		{
 			encDatum: DatumToEncDatum(
-				types.ColumnType{SemanticType: types.STRING}, tree.NewDString("12")),
+				&types.ColumnType{SemanticType: types.STRING}, tree.NewDString("12")),
 			expectedSize: EncDatumOverhead + DStringSize + 2,
 		},
 		{

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1728,13 +1728,13 @@ func fitColumnToFamily(desc *MutableTableDescriptor, col ColumnDescriptor) (int,
 }
 
 // columnTypeIsIndexable returns whether the type t is valid as an indexed column.
-func columnTypeIsIndexable(t types.ColumnType) bool {
+func columnTypeIsIndexable(t *types.ColumnType) bool {
 	return !MustBeValueEncoded(t.SemanticType)
 }
 
 // columnTypeIsInvertedIndexable returns whether the type t is valid to be indexed
 // using an inverted index.
-func columnTypeIsInvertedIndexable(t types.ColumnType) bool {
+func columnTypeIsInvertedIndexable(t *types.ColumnType) bool {
 	return t.SemanticType == types.JSON
 }
 
@@ -1771,7 +1771,7 @@ func checkColumnsValidForIndex(tableDesc *MutableTableDescriptor, indexColNames 
 	for _, indexCol := range indexColNames {
 		for _, col := range tableDesc.AllNonDropColumns() {
 			if col.Name == indexCol {
-				if !columnTypeIsIndexable(col.Type) {
+				if !columnTypeIsIndexable(&col.Type) {
 					invalidColumns = append(invalidColumns, col)
 				}
 			}
@@ -1793,7 +1793,7 @@ func checkColumnsValidForInvertedIndex(
 	for _, indexCol := range indexColNames {
 		for _, col := range tableDesc.AllNonDropColumns() {
 			if col.Name == indexCol {
-				if !columnTypeIsInvertedIndexable(col.Type) {
+				if !columnTypeIsInvertedIndexable(&col.Type) {
 					invalidColumns = append(invalidColumns, col)
 				}
 			}

--- a/pkg/sql/sqlbase/testutils.go
+++ b/pkg/sql/sqlbase/testutils.go
@@ -314,7 +314,7 @@ func RandDatumEncoding(rng *rand.Rand) DatumEncoding {
 func RandEncDatum(rng *rand.Rand) (EncDatum, types.ColumnType) {
 	typ := RandColumnType(rng)
 	datum := RandDatum(rng, typ, true /* nullOk */)
-	return DatumToEncDatum(typ, datum), typ
+	return DatumToEncDatum(&typ, datum), typ
 }
 
 // RandSortingEncDatumSlice generates a slice of random EncDatum values of the
@@ -323,7 +323,7 @@ func RandSortingEncDatumSlice(rng *rand.Rand, numVals int) ([]EncDatum, types.Co
 	typ := RandSortingColumnType(rng)
 	vals := make([]EncDatum, numVals)
 	for i := range vals {
-		vals[i] = DatumToEncDatum(typ, RandDatum(rng, typ, true))
+		vals[i] = DatumToEncDatum(&typ, RandDatum(rng, typ, true))
 	}
 	return vals, typ
 }
@@ -346,7 +346,7 @@ func RandSortingEncDatumSlices(
 func RandEncDatumRowOfTypes(rng *rand.Rand, types []types.ColumnType) EncDatumRow {
 	vals := make([]EncDatum, len(types))
 	for i, typ := range types {
-		vals[i] = DatumToEncDatum(typ, RandDatum(rng, typ, true))
+		vals[i] = DatumToEncDatum(&typ, RandDatum(rng, typ, true))
 	}
 	return vals
 }

--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -119,7 +119,7 @@ func (sr *SampleReservoir) copyRow(dst, src sqlbase.EncDatumRow) error {
 		if err := src[i].EnsureDecoded(&sr.colTypes[i], &sr.da); err != nil {
 			return err
 		}
-		dst[i] = sqlbase.DatumToEncDatum(sr.colTypes[i], src[i].Datum)
+		dst[i] = sqlbase.DatumToEncDatum(&sr.colTypes[i], src[i].Datum)
 	}
 	return nil
 }

--- a/pkg/sql/stats/row_sampling_test.go
+++ b/pkg/sql/stats/row_sampling_test.go
@@ -33,7 +33,7 @@ func runSampleTest(t *testing.T, numSamples int, ranks []int) {
 	var sr SampleReservoir
 	sr.Init(numSamples, []types.ColumnType{typeInt})
 	for _, r := range ranks {
-		d := sqlbase.DatumToEncDatum(typeInt, tree.NewDInt(tree.DInt(r)))
+		d := sqlbase.DatumToEncDatum(&typeInt, tree.NewDInt(tree.DInt(r)))
 		if err := sr.SampleRow(sqlbase.EncDatumRow{d}, uint64(r)); err != nil {
 			t.Errorf("%v", err)
 		}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -926,7 +926,7 @@ func enforceLocalColumnConstraints(row tree.Datums, cols []sqlbase.ColumnDescrip
 		if !col.Nullable && row[i] == tree.DNull {
 			return sqlbase.NewNonNullViolationError(col.Name)
 		}
-		outVal, err := sqlbase.LimitValueWidth(col.Type, row[i], &col.Name)
+		outVal, err := sqlbase.LimitValueWidth(&col.Type, row[i], &col.Name)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Split from #36598 cc @andy-kimball 

ColumnType is a rather big struct, and it should almost never be passed by
value. Update most usages to pass by ref rather than by value.

Release note: None