### PR TITLE
sql: Show more specific types when available (patch 8/)

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -663,22 +663,22 @@ SELECT sum(a) FROM intervals
 3 years 5 mons 7 days 00:00:19
 
 
-query error unknown signature: avg\(string\)
+query error unknown signature: avg\(varchar\)
 SELECT avg(a) FROM abc
 
 query error unknown signature: avg\(bool\)
 SELECT avg(c) FROM abc
 
-query error unknown signature: avg\(tuple{string, bool}\)
+query error unknown signature: avg\(tuple{varchar, bool}\)
 SELECT avg((a,c)) FROM abc
 
-query error unknown signature: sum\(string\)
+query error unknown signature: sum\(varchar\)
 SELECT sum(a) FROM abc
 
 query error unknown signature: sum\(bool\)
 SELECT sum(c) FROM abc
 
-query error unknown signature: sum\(tuple{string, bool}\)
+query error unknown signature: sum\(tuple{varchar, bool}\)
 SELECT sum((a,c)) FROM abc
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -534,7 +534,7 @@ subtest regression_26742
 statement ok
 CREATE TABLE ct(x INT, derived INT AS (x+1) STORED)
 
-statement error value type string doesn't match type INT8 of column "x"
+statement error value type varchar doesn't match type INT8 of column "x"
 INSERT INTO ct(x) SELECT c FROM sw
 
 subtest contraint_check_validation_ordering

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -182,7 +182,7 @@ query error no data source matches pattern: bar.kv.\*
 SELECT bar.kv.* FROM kv
 
 # Don't panic with invalid names (#8024)
-query error cannot subscript type tuple\{string AS k, string AS v\} because it is not an array
+query error cannot subscript type tuple\{char AS k, char AS v\} because it is not an array
 SELECT kv.*[1] FROM kv
 
 query T colnames

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -2332,7 +2332,7 @@ SELECT sum(price) OVER (ORDER BY ptimestamptz RANGE BETWEEN 123 PRECEDING AND CU
 statement error could not parse "1 days" as type decimal
 SELECT sum(price) OVER (ORDER BY price RANGE BETWEEN 123.4 PRECEDING AND '1 days' FOLLOWING) FROM products
 
-statement error RANGE with offset PRECEDING/FOLLOWING is not supported for column type string
+statement error RANGE with offset PRECEDING/FOLLOWING is not supported for column type varchar
 SELECT sum(price) OVER (ORDER BY product_name RANGE 'foo' PRECEDING) FROM products
 
 query TTRR

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -298,13 +298,13 @@ CREATE TABLE abc (
 query TTTTT
 EXPLAIN (TYPES) SELECT min(a) FROM abc
 ----
-group      ·            ·                (min string)  ·
- │         aggregate 0  any_not_null(a)  ·             ·
- │         scalar       ·                ·             ·
- └── scan  ·            ·                (a string)    ·
-·          table        abc@primary      ·             ·
-·          spans        ALL              ·             ·
-·          limit        1                ·             ·
+group      ·            ·                (min char)  ·
+ │         aggregate 0  any_not_null(a)  ·           ·
+ │         scalar       ·                ·           ·
+ └── scan  ·            ·                (a char)    ·
+·          table        abc@primary      ·           ·
+·          spans        ALL              ·           ·
+·          limit        1                ·           ·
 
 statement ok
 CREATE TABLE xyz (

--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -121,24 +121,24 @@ CREATE TABLE t (
 ----
 TABLE t
  ├── a int not null
- ├── b string not null
+ ├── b char not null
  ├── c int
- ├── d string
+ ├── d char
  ├── INDEX primary
  │    ├── a int not null
- │    └── b string not null
+ │    └── b char not null
  ├── INDEX bc
- │    ├── b string not null
+ │    ├── b char not null
  │    ├── c int
  │    └── a int not null
  ├── INDEX dc
- │    ├── d string
+ │    ├── d char
  │    ├── c int
  │    ├── a int not null
- │    └── b string not null
+ │    └── b char not null
  ├── INDEX a_desc
  │    ├── a int not null desc
- │    └── b string not null
+ │    └── b char not null
  ├── FAMILY family1 (a, b)
  ├── FAMILY family2 (c)
  └── FAMILY family3 (d)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -731,14 +731,14 @@ TABLE lineitem
  ├── l_extendedprice float not null
  ├── l_discount float not null
  ├── l_tax float not null
- ├── l_returnflag string not null
- ├── l_linestatus string not null
+ ├── l_returnflag char not null
+ ├── l_linestatus char not null
  ├── l_shipdate date not null
  ├── l_commitdate date not null
  ├── l_receiptdate date not null
- ├── l_shipinstruct string not null
- ├── l_shipmode string not null
- ├── l_comment string not null
+ ├── l_shipinstruct char not null
+ ├── l_shipmode char not null
+ ├── l_comment varchar not null
  ├── INDEX primary
  │    ├── l_orderkey int not null
  │    └── l_linenumber int not null
@@ -786,7 +786,7 @@ WHERE
     AND l_shipdate < DATE '1995-10-01';
 ----
 index-join lineitem
- ├── columns: l_orderkey:1(int!null) l_partkey:2(int!null) l_suppkey:3(int!null) l_linenumber:4(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(string!null) l_linestatus:10(string!null) l_shipdate:11(date!null) l_commitdate:12(date!null) l_receiptdate:13(date!null) l_shipinstruct:14(string!null) l_shipmode:15(string!null) l_comment:16(string!null)
+ ├── columns: l_orderkey:1(int!null) l_partkey:2(int!null) l_suppkey:3(int!null) l_linenumber:4(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null) l_commitdate:12(date!null) l_receiptdate:13(date!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null) l_comment:16(varchar!null)
  ├── stats: [rows=111.111111, distinct(1)=69.2053852, null(1)=0, distinct(2)=69.2053852, null(2)=0, distinct(3)=69.2053852, null(3)=0, distinct(4)=69.2053852, null(4)=0, distinct(5)=69.2053852, null(5)=0, distinct(6)=69.2053852, null(6)=0, distinct(7)=69.2053852, null(7)=0, distinct(8)=69.2053852, null(8)=0, distinct(9)=69.2053852, null(9)=0, distinct(10)=69.2053852, null(10)=0, distinct(11)=69.2053852, null(11)=0, distinct(12)=69.2053852, null(12)=0, distinct(13)=69.2053852, null(13)=0, distinct(14)=69.2053852, null(14)=0, distinct(15)=69.2053852, null(15)=0, distinct(16)=69.2053852, null(16)=0]
  ├── key: (1,4)
  ├── fd: (1,4)-->(2,3,5-16)
@@ -805,7 +805,7 @@ WHERE
     AND l_shipdate::timestamptz < DATE '1995-10-01';
 ----
 index-join lineitem
- ├── columns: l_orderkey:1(int!null) l_partkey:2(int!null) l_suppkey:3(int!null) l_linenumber:4(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(string!null) l_linestatus:10(string!null) l_shipdate:11(date!null) l_commitdate:12(date!null) l_receiptdate:13(date!null) l_shipinstruct:14(string!null) l_shipmode:15(string!null) l_comment:16(string!null)
+ ├── columns: l_orderkey:1(int!null) l_partkey:2(int!null) l_suppkey:3(int!null) l_linenumber:4(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null) l_commitdate:12(date!null) l_receiptdate:13(date!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null) l_comment:16(varchar!null)
  ├── stats: [rows=111.111111, distinct(1)=69.2053852, null(1)=0, distinct(2)=69.2053852, null(2)=0, distinct(3)=69.2053852, null(3)=0, distinct(4)=69.2053852, null(4)=0, distinct(5)=69.2053852, null(5)=0, distinct(6)=69.2053852, null(6)=0, distinct(7)=69.2053852, null(7)=0, distinct(8)=69.2053852, null(8)=0, distinct(9)=69.2053852, null(9)=0, distinct(10)=69.2053852, null(10)=0, distinct(11)=69.2053852, null(11)=0, distinct(12)=69.2053852, null(12)=0, distinct(13)=69.2053852, null(13)=0, distinct(14)=69.2053852, null(14)=0, distinct(15)=69.2053852, null(15)=0, distinct(16)=69.2053852, null(16)=0]
  ├── key: (1,4)
  ├── fd: (1,4)-->(2,3,5-16)

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -444,8 +444,8 @@ build
 SELECT x::VARCHAR(2) FROM b
 ----
 project
- ├── columns: x:3(string)
+ ├── columns: x:3(varchar)
  ├── scan b
  │    └── columns: b.x:1(string!null) z:2(decimal!null)
  └── projections
-      └── b.x::VARCHAR(2) [type=string]
+      └── b.x::VARCHAR(2) [type=varchar]

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -160,7 +160,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: i:7(int) arr:8(int[]) jsonb:9(jsonb!null) bit:10(varbit) s:11(string)
+ ├── columns: i:7(int) arr:8(int[]) jsonb:9(jsonb!null) bit:10(bit) s:11(string)
  ├── fd: ()-->(9,10)
  ├── scan a
  │    └── columns: a.i:2(int) a.s:4(string) a.arr:6(int[])
@@ -168,7 +168,7 @@ project
       ├── variable: a.i [type=int, outer=(2)]
       ├── variable: a.arr [type=int[], outer=(6)]
       ├── const: '[1, 2]' [type=jsonb]
-      ├── null [type=varbit]
+      ├── null [type=bit]
       └── variable: a.s [type=string, outer=(4)]
 
 # Shouldn't eliminate these casts.
@@ -185,7 +185,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: i:7(float) arr:8(decimal[]) s:9(jsonb) s:10(string) i:11(int) s:12(string) array:13(oid[]) array:14(int[])
+ ├── columns: i:7(float) arr:8(decimal[]) s:9(jsonb) s:10(varchar) i:11(int) s:12(varchar) array:13(oid[]) array:14(int2[])
  ├── fd: ()-->(13,14)
  ├── scan a
  │    └── columns: a.i:2(int) a.s:4(string) a.arr:6(int[])
@@ -193,11 +193,11 @@ project
       ├── a.i::FLOAT8 [type=float, outer=(2)]
       ├── a.arr::DECIMAL[] [type=decimal[], outer=(6)]
       ├── a.s::JSONB [type=jsonb, outer=(4)]
-      ├── a.s::VARCHAR(2) [type=string, outer=(4)]
-      ├── a.i::INT2 [type=int, outer=(2)]
-      ├── a.s::CHAR::VARCHAR [type=string, outer=(4)]
+      ├── a.s::VARCHAR(2) [type=varchar, outer=(4)]
+      ├── a.i::INT2 [type=int2, outer=(2)]
+      ├── a.s::CHAR::VARCHAR [type=varchar, outer=(4)]
       ├── ARRAY[1,2]::OIDVECTOR [type=oid[]]
-      └── ARRAY[1,2]::INT2VECTOR [type=int[]]
+      └── ARRAY[1,2]::INT2VECTOR [type=int2[]]
 
 # --------------------------------------------------
 # FoldNullCast
@@ -211,11 +211,11 @@ SELECT
     null::int2vector
 ----
 values
- ├── columns: int8:1(int) timestamptz:2(timestamptz) char:3(string) oidvector:4(oid[]) int2vector:5(int[])
+ ├── columns: int8:1(int) timestamptz:2(timestamptz) char:3(char) oidvector:4(oid[]) int2vector:5(int2[])
  ├── cardinality: [1 - 1]
  ├── key: ()
  ├── fd: ()-->(1-5)
- └── (NULL, NULL, NULL, NULL, NULL) [type=tuple{int, timestamptz, string, oid[], int[]}]
+ └── (NULL, NULL, NULL, NULL, NULL) [type=tuple{int, timestamptz, char, oid[], int2[]}]
 
 # --------------------------------------------------
 # FoldNullUnary

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -1250,12 +1250,12 @@ CREATE TABLE abc (
 )
 ----
 TABLE abc
- ├── a string not null
+ ├── a char not null
  ├── b float
  ├── c bool
  ├── d decimal
  └── INDEX primary
-      └── a string not null
+      └── a char not null
 
 build
 SELECT min(a), min(b), min(c), min(d) FROM abc
@@ -1263,10 +1263,10 @@ SELECT min(a), min(b), min(c), min(d) FROM abc
 scalar-group-by
  ├── columns: min:5(string) min:6(float) min:7(bool) min:8(decimal)
  ├── scan abc
- │    └── columns: a:1(string!null) b:2(float) c:3(bool) d:4(decimal)
+ │    └── columns: a:1(char!null) b:2(float) c:3(bool) d:4(decimal)
  └── aggregations
-      ├── min [type=string]
-      │    └── variable: a [type=string]
+      ├── min [type=char]
+      │    └── variable: a [type=char]
       ├── min [type=float]
       │    └── variable: b [type=float]
       ├── min [type=bool]
@@ -1280,10 +1280,10 @@ SELECT max(a), max(b), max(c), max(d) FROM abc
 scalar-group-by
  ├── columns: max:5(string) max:6(float) max:7(bool) max:8(decimal)
  ├── scan abc
- │    └── columns: a:1(string!null) b:2(float) c:3(bool) d:4(decimal)
+ │    └── columns: a:1(char!null) b:2(float) c:3(bool) d:4(decimal)
  └── aggregations
-      ├── max [type=string]
-      │    └── variable: a [type=string]
+      ├── max [type=char]
+      │    └── variable: a [type=char]
       ├── max [type=float]
       │    └── variable: b [type=float]
       ├── max [type=bool]
@@ -1299,7 +1299,7 @@ scalar-group-by
  ├── project
  │    ├── columns: b:2(float) d:4(decimal)
  │    └── scan abc
- │         └── columns: a:1(string!null) b:2(float) c:3(bool) d:4(decimal)
+ │         └── columns: a:1(char!null) b:2(float) c:3(bool) d:4(decimal)
  └── aggregations
       ├── avg [type=float]
       │    └── variable: b [type=float]
@@ -1335,7 +1335,7 @@ scalar-group-by
 build
 SELECT avg(a) FROM abc
 ----
-error (42883): unknown signature: avg(string)
+error (42883): unknown signature: avg(char)
 
 build
 SELECT avg(c) FROM abc
@@ -1345,12 +1345,12 @@ error (42883): unknown signature: avg(bool)
 build
 SELECT avg((a,c)) FROM abc
 ----
-error (42883): unknown signature: avg(tuple{string, bool})
+error (42883): unknown signature: avg(tuple{char, bool})
 
 build
 SELECT sum(a) FROM abc
 ----
-error (42883): unknown signature: sum(string)
+error (42883): unknown signature: sum(char)
 
 build
 SELECT sum(c) FROM abc
@@ -1360,7 +1360,7 @@ error (42883): unknown signature: sum(bool)
 build
 SELECT sum((a,c)) FROM abc
 ----
-error (42883): unknown signature: sum(tuple{string, bool})
+error (42883): unknown signature: sum(tuple{char, bool})
 
 exec-ddl
 CREATE TABLE xyz (
@@ -2179,15 +2179,15 @@ project
  │    └── project
  │         ├── columns: column9:9(bool) b2.b:3(bool)
  │         ├── inner-join
- │         │    ├── columns: b1.b:1(bool) b1.rowid:2(int!null) b2.b:3(bool) b2.rowid:4(int!null) a:5(string!null) abc.b:6(float) c:7(bool) d:8(decimal)
+ │         │    ├── columns: b1.b:1(bool) b1.rowid:2(int!null) b2.b:3(bool) b2.rowid:4(int!null) a:5(char!null) abc.b:6(float) c:7(bool) d:8(decimal)
  │         │    ├── scan b1
  │         │    │    └── columns: b1.b:1(bool) b1.rowid:2(int!null)
  │         │    ├── inner-join
- │         │    │    ├── columns: b2.b:3(bool) b2.rowid:4(int!null) a:5(string!null) abc.b:6(float) c:7(bool) d:8(decimal)
+ │         │    │    ├── columns: b2.b:3(bool) b2.rowid:4(int!null) a:5(char!null) abc.b:6(float) c:7(bool) d:8(decimal)
  │         │    │    ├── scan b2
  │         │    │    │    └── columns: b2.b:3(bool) b2.rowid:4(int!null)
  │         │    │    ├── scan abc
- │         │    │    │    └── columns: a:5(string!null) abc.b:6(float) c:7(bool) d:8(decimal)
+ │         │    │    │    └── columns: a:5(char!null) abc.b:6(float) c:7(bool) d:8(decimal)
  │         │    │    └── filters (true)
  │         │    └── filters (true)
  │         └── projections
@@ -2215,15 +2215,15 @@ project
  │    └── project
  │         ├── columns: column9:9(bool) b2.b:3(bool)
  │         ├── inner-join
- │         │    ├── columns: b1.b:1(bool) b1.rowid:2(int!null) b2.b:3(bool) b2.rowid:4(int!null) a:5(string!null) abc.b:6(float) c:7(bool) d:8(decimal)
+ │         │    ├── columns: b1.b:1(bool) b1.rowid:2(int!null) b2.b:3(bool) b2.rowid:4(int!null) a:5(char!null) abc.b:6(float) c:7(bool) d:8(decimal)
  │         │    ├── scan b1
  │         │    │    └── columns: b1.b:1(bool) b1.rowid:2(int!null)
  │         │    ├── inner-join
- │         │    │    ├── columns: b2.b:3(bool) b2.rowid:4(int!null) a:5(string!null) abc.b:6(float) c:7(bool) d:8(decimal)
+ │         │    │    ├── columns: b2.b:3(bool) b2.rowid:4(int!null) a:5(char!null) abc.b:6(float) c:7(bool) d:8(decimal)
  │         │    │    ├── scan b2
  │         │    │    │    └── columns: b2.b:3(bool) b2.rowid:4(int!null)
  │         │    │    ├── scan abc
- │         │    │    │    └── columns: a:5(string!null) abc.b:6(float) c:7(bool) d:8(decimal)
+ │         │    │    │    └── columns: a:5(char!null) abc.b:6(float) c:7(bool) d:8(decimal)
  │         │    │    └── filters (true)
  │         │    └── filters (true)
  │         └── projections
@@ -2267,25 +2267,25 @@ SELECT concat(concat(s, a), a) FROM kv, abc GROUP BY concat(s, a), a
 project
  ├── columns: concat:10(string)
  ├── group-by
- │    ├── columns: a:5(string!null) column9:9(string)
- │    ├── grouping columns: a:5(string!null) column9:9(string)
+ │    ├── columns: a:5(char!null) column9:9(string)
+ │    ├── grouping columns: a:5(char!null) column9:9(string)
  │    └── project
- │         ├── columns: column9:9(string) a:5(string!null)
+ │         ├── columns: column9:9(string) a:5(char!null)
  │         ├── inner-join
- │         │    ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) a:5(string!null) b:6(float) c:7(bool) d:8(decimal)
+ │         │    ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) a:5(char!null) b:6(float) c:7(bool) d:8(decimal)
  │         │    ├── scan kv
  │         │    │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
  │         │    ├── scan abc
- │         │    │    └── columns: a:5(string!null) b:6(float) c:7(bool) d:8(decimal)
+ │         │    │    └── columns: a:5(char!null) b:6(float) c:7(bool) d:8(decimal)
  │         │    └── filters (true)
  │         └── projections
  │              └── function: concat [type=string]
  │                   ├── variable: s [type=string]
- │                   └── variable: a [type=string]
+ │                   └── variable: a [type=char]
  └── projections
       └── function: concat [type=string]
            ├── variable: column9 [type=string]
-           └── variable: a [type=string]
+           └── variable: a [type=char]
 
 build
 SELECT concat(concat(s, a), s) FROM kv, abc GROUP BY concat(s, a), a
@@ -2600,11 +2600,11 @@ project
       ├── project
       │    ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) d:8(decimal!null)
       │    └── inner-join
-      │         ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) a:5(string!null) b:6(float) c:7(bool) d:8(decimal!null)
+      │         ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) a:5(char!null) b:6(float) c:7(bool) d:8(decimal!null)
       │         ├── scan kv
       │         │    └── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
       │         ├── scan abc
-      │         │    └── columns: a:5(string!null) b:6(float) c:7(bool) d:8(decimal)
+      │         │    └── columns: a:5(char!null) b:6(float) c:7(bool) d:8(decimal)
       │         └── filters
       │              └── ge [type=bool]
       │                   ├── variable: k [type=int]
@@ -2621,7 +2621,7 @@ scalar-group-by
  ├── project
  │    ├── columns: d:4(decimal)
  │    └── scan abc
- │         └── columns: a:1(string!null) b:2(float) c:3(bool) d:4(decimal)
+ │         └── columns: a:1(char!null) b:2(float) c:3(bool) d:4(decimal)
  └── aggregations
       └── sum [type=decimal]
            └── agg-distinct [type=decimal]
@@ -2637,7 +2637,7 @@ scalar-group-by
  ├── project
  │    ├── columns: column5:5(bool) d:4(decimal)
  │    ├── scan abc
- │    │    └── columns: a:1(string!null) b:2(float) c:3(bool) d:4(decimal)
+ │    │    └── columns: a:1(char!null) b:2(float) c:3(bool) d:4(decimal)
  │    └── projections
  │         └── gt [type=bool]
  │              ├── variable: d [type=decimal]

--- a/pkg/sql/opt/optbuilder/testdata/inner-join
+++ b/pkg/sql/opt/optbuilder/testdata/inner-join
@@ -23,7 +23,7 @@ CREATE TABLE c (x INT, y FLOAT, z VARCHAR, CONSTRAINT fk_x_ref_a FOREIGN KEY (x)
 TABLE c
  ├── x int
  ├── y float
- ├── z string
+ ├── z varchar
  ├── rowid int not null (hidden)
  ├── INDEX primary
  │    └── rowid int not null (hidden)
@@ -68,13 +68,13 @@ build
 SELECT * FROM c, b, a WHERE c.x = a.x AND b.x = a.x
 ----
 project
- ├── columns: x:1(int!null) y:2(float) z:3(string) x:5(int!null) y:6(float) x:8(int!null) y:9(float)
+ ├── columns: x:1(int!null) y:2(float) z:3(varchar) x:5(int!null) y:6(float) x:8(int!null) y:9(float)
  └── select
-      ├── columns: c.x:1(int!null) c.y:2(float) z:3(string) c.rowid:4(int!null) b.x:5(int!null) b.y:6(float) b.rowid:7(int!null) a.x:8(int!null) a.y:9(float)
+      ├── columns: c.x:1(int!null) c.y:2(float) z:3(varchar) c.rowid:4(int!null) b.x:5(int!null) b.y:6(float) b.rowid:7(int!null) a.x:8(int!null) a.y:9(float)
       ├── inner-join
-      │    ├── columns: c.x:1(int) c.y:2(float) z:3(string) c.rowid:4(int!null) b.x:5(int) b.y:6(float) b.rowid:7(int!null) a.x:8(int!null) a.y:9(float)
+      │    ├── columns: c.x:1(int) c.y:2(float) z:3(varchar) c.rowid:4(int!null) b.x:5(int) b.y:6(float) b.rowid:7(int!null) a.x:8(int!null) a.y:9(float)
       │    ├── scan c
-      │    │    └── columns: c.x:1(int) c.y:2(float) z:3(string) c.rowid:4(int!null)
+      │    │    └── columns: c.x:1(int) c.y:2(float) z:3(varchar) c.rowid:4(int!null)
       │    ├── inner-join
       │    │    ├── columns: b.x:5(int) b.y:6(float) b.rowid:7(int!null) a.x:8(int!null) a.y:9(float)
       │    │    ├── scan b

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -600,7 +600,7 @@ TABLE abc
  ├── a int not null
  ├── b int not null
  ├── c int not null
- ├── d string
+ ├── d char
  ├── INDEX primary
  │    ├── a int not null
  │    ├── b int not null
@@ -626,21 +626,21 @@ build
 SELECT d FROM abc ORDER BY lower(d)
 ----
 sort
- ├── columns: d:4(string)  [hidden: column5:5(string)]
+ ├── columns: d:4(char)  [hidden: column5:5(string)]
  ├── ordering: +5
  └── project
-      ├── columns: column5:5(string) d:4(string)
+      ├── columns: column5:5(string) d:4(char)
       ├── scan abc
-      │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+      │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
       └── projections
            └── function: lower [type=string]
-                └── variable: d [type=string]
+                └── variable: d [type=char]
 
 build
 SELECT * FROM abc ORDER BY a
 ----
 scan abc
- ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
  └── ordering: +1
 
 build
@@ -652,7 +652,7 @@ sort
  └── project
       ├── columns: a:1(int!null) b:2(int!null)
       └── scan abc
-           └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+           └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
 
 build
 SELECT a, b FROM abc ORDER BY b, c
@@ -663,7 +663,7 @@ sort
  └── project
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       └── scan abc
-           └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+           └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
 
 build
 SELECT a, b FROM abc ORDER BY b, c, a DESC
@@ -672,10 +672,10 @@ project
  ├── columns: a:1(int!null) b:2(int!null)  [hidden: c:3(int!null)]
  ├── ordering: +2,+3,-1
  └── sort
-      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
       ├── ordering: +2,+3
       └── scan abc
-           └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+           └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
 
 build
 SELECT a FROM abc ORDER BY a DESC
@@ -684,7 +684,7 @@ project
  ├── columns: a:1(int!null)
  ├── ordering: -1
  └── scan abc,rev
-      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+      ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
       └── ordering: -1
 
 build
@@ -698,7 +698,7 @@ limit
  │    ├── columns: a:1(int!null)
  │    ├── ordering: -1
  │    └── scan abc,rev
- │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+ │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
  │         └── ordering: -1
  └── const: 1 [type=int]
 
@@ -713,7 +713,7 @@ offset
  │    ├── columns: a:1(int!null)
  │    ├── ordering: -1
  │    └── scan abc,rev
- │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+ │         ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
  │         └── ordering: -1
  └── const: 1 [type=int]
 
@@ -726,9 +726,9 @@ sort
  └── project
       ├── columns: c:3(int!null)
       └── select
-           ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+           ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
            ├── scan abc
-           │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+           │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
            └── filters
                 └── eq [type=bool]
                      ├── variable: b [type=int]
@@ -743,9 +743,9 @@ sort
  └── project
       ├── columns: c:3(int!null)
       └── select
-           ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+           ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
            ├── scan abc
-           │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+           │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
            └── filters
                 └── eq [type=bool]
                      ├── variable: b [type=int]
@@ -761,10 +761,10 @@ project
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       ├── ordering: +2,+3 opt(1)
       └── select
-           ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+           ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
            ├── ordering: +2,+3 opt(1)
            ├── scan abc
-           │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+           │    ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
            │    └── ordering: +2,+3 opt(1)
            └── filters
                 └── eq [type=bool]
@@ -780,7 +780,7 @@ sort
  └── project
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null)
       └── scan abc
-           └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+           └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(char)
 
 build
 SELECT a FROM abc ORDER BY PRIMARY KEY a

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -740,7 +740,7 @@ concat [type=int[]]
  ├── array: [type=int[]]
  │    ├── const: 1 [type=int]
  │    └── const: 2 [type=int]
- └── cast: INT2 [type=int]
+ └── cast: INT2 [type=int2]
       └── null [type=unknown]
 
 build-scalar

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -188,22 +188,22 @@ exec-ddl
 CREATE TABLE kv (k CHAR PRIMARY KEY, v CHAR)
 ----
 TABLE kv
- ├── k string not null
- ├── v string
+ ├── k char not null
+ ├── v char
  └── INDEX primary
-      └── k string not null
+      └── k char not null
 
 build
 SELECT * FROM kv
 ----
 scan kv
- └── columns: k:1(string!null) v:2(string)
+ └── columns: k:1(char!null) v:2(char)
 
 build
 SELECT k,v FROM kv
 ----
 scan kv
- └── columns: k:1(string!null) v:2(string)
+ └── columns: k:1(char!null) v:2(char)
 
 build
 SELECT v||'foo' AS r FROM kv
@@ -211,10 +211,10 @@ SELECT v||'foo' AS r FROM kv
 project
  ├── columns: r:3(string)
  ├── scan kv
- │    └── columns: k:1(string!null) v:2(string)
+ │    └── columns: k:1(char!null) v:2(char)
  └── projections
       └── concat [type=string]
-           ├── variable: v [type=string]
+           ├── variable: v [type=char]
            └── const: 'foo' [type=string]
 
 build
@@ -223,42 +223,42 @@ SELECT lower(v) FROM kv
 project
  ├── columns: lower:3(string)
  ├── scan kv
- │    └── columns: k:1(string!null) v:2(string)
+ │    └── columns: k:1(char!null) v:2(char)
  └── projections
       └── function: lower [type=string]
-           └── variable: v [type=string]
+           └── variable: v [type=char]
 
 build
 SELECT k FROM kv
 ----
 project
- ├── columns: k:1(string!null)
+ ├── columns: k:1(char!null)
  └── scan kv
-      └── columns: k:1(string!null) v:2(string)
+      └── columns: k:1(char!null) v:2(char)
 
 build
 SELECT kv.K,KV.v FROM kv
 ----
 scan kv
- └── columns: k:1(string!null) v:2(string)
+ └── columns: k:1(char!null) v:2(char)
 
 build
 SELECT kv.* FROM kv
 ----
 scan kv
- └── columns: k:1(string!null) v:2(string)
+ └── columns: k:1(char!null) v:2(char)
 
 build
 SELECT (kv.*) AS r FROM kv
 ----
 project
- ├── columns: r:3(tuple{string AS k, string AS v})
+ ├── columns: r:3(tuple{char AS k, char AS v})
  ├── scan kv
- │    └── columns: k:1(string!null) v:2(string)
+ │    └── columns: k:1(char!null) v:2(char)
  └── projections
-      └── tuple [type=tuple{string AS k, string AS v}]
-           ├── variable: k [type=string]
-           └── variable: v [type=string]
+      └── tuple [type=tuple{char AS k, char AS v}]
+           ├── variable: k [type=char]
+           └── variable: v [type=char]
 
 build
 SELECT foo.* FROM kv
@@ -284,7 +284,7 @@ error (42P01): no data source matches pattern: bar.kv.*
 build
 SELECT kv.*[1] FROM kv
 ----
-error (42804): cannot subscript type tuple{string AS k, string AS v} because it is not an array
+error (42804): cannot subscript type tuple{char AS k, char AS v} because it is not an array
 
 build
 SELECT ARRAY[]
@@ -295,28 +295,28 @@ build
 SELECT FOO.k FROM kv AS foo WHERE foo.k = 'a'
 ----
 project
- ├── columns: k:1(string!null)
+ ├── columns: k:1(char!null)
  └── select
-      ├── columns: k:1(string!null) v:2(string)
+      ├── columns: k:1(char!null) v:2(char)
       ├── scan foo
-      │    └── columns: k:1(string!null) v:2(string)
+      │    └── columns: k:1(char!null) v:2(char)
       └── filters
            └── eq [type=bool]
-                ├── variable: k [type=string]
+                ├── variable: k [type=char]
                 └── const: 'a' [type=string]
 
 build
 SELECT "foo"."v" FROM kv AS foo WHERE foo.k = 'a'
 ----
 project
- ├── columns: v:2(string)
+ ├── columns: v:2(char)
  └── select
-      ├── columns: k:1(string!null) v:2(string)
+      ├── columns: k:1(char!null) v:2(char)
       ├── scan foo
-      │    └── columns: k:1(string!null) v:2(string)
+      │    └── columns: k:1(char!null) v:2(char)
       └── filters
            └── eq [type=bool]
-                ├── variable: k [type=string]
+                ├── variable: k [type=char]
                 └── const: 'a' [type=string]
 
 exec-ddl

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -186,7 +186,7 @@ TABLE abcde
  ├── a string not null
  ├── b uuid not null
  ├── c uuid not null
- ├── d string not null
+ ├── d varchar not null
  ├── e string not null
  ├── INDEX primary
  │    ├── a string not null
@@ -195,13 +195,13 @@ TABLE abcde
  ├── INDEX idx_abd
  │    ├── a string not null
  │    ├── b uuid not null
- │    ├── d string not null
+ │    ├── d varchar not null
  │    └── c uuid not null (storing)
  └── INDEX idx_abcd
       ├── a string not null
       ├── b uuid not null
       ├── c uuid not null
-      └── d string not null
+      └── d varchar not null
 
 exec-ddl
 ALTER TABLE abcde INJECT STATISTICS '[
@@ -280,7 +280,7 @@ ORDER BY d
 LIMIT 10
 ----
 project
- ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null)  [hidden: d:8(string!null)]
+ ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null)  [hidden: d:8(varchar!null)]
  ├── cardinality: [0 - 10]
  ├── stats: [rows=10]
  ├── cost: 164278.036
@@ -288,7 +288,7 @@ project
  ├── fd: ()-->(1,2), (3)-->(4,8), (8)-->(3,4)
  ├── ordering: +8 opt(1,2) [actual: +8]
  └── limit
-      ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) a:5(string!null) b:6(uuid!null) c:7(uuid!null) d:8(string!null)
+      ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) a:5(string!null) b:6(uuid!null) c:7(uuid!null) d:8(varchar!null)
       ├── internal-ordering: +8 opt(1,2,5,6)
       ├── cardinality: [0 - 10]
       ├── stats: [rows=10]
@@ -297,14 +297,14 @@ project
       ├── fd: ()-->(1,2,5,6), (3)-->(4), (7)-->(8), (8)-->(7), (1)==(5), (5)==(1), (2)==(6), (6)==(2), (3)==(7), (7)==(3)
       ├── ordering: +8 opt(1,2,5,6) [actual: +8]
       ├── sort
-      │    ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) a:5(string!null) b:6(uuid!null) c:7(uuid!null) d:8(string!null)
+      │    ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) a:5(string!null) b:6(uuid!null) c:7(uuid!null) d:8(varchar!null)
       │    ├── stats: [rows=50048.8759, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=2500, null(3)=0, distinct(4)=1000, null(4)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0, distinct(7)=2500, null(7)=0, distinct(8)=38781.1698, null(8)=0]
       │    ├── cost: 164277.816
       │    ├── key: (7)
       │    ├── fd: ()-->(1,2,5,6), (3)-->(4), (7)-->(8), (8)-->(7), (1)==(5), (5)==(1), (2)==(6), (6)==(2), (3)==(7), (7)==(3)
       │    ├── ordering: +8 opt(1,2,5,6) [actual: +8]
       │    └── inner-join (merge)
-      │         ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) a:5(string!null) b:6(uuid!null) c:7(uuid!null) d:8(string!null)
+      │         ├── columns: w:1(string!null) x:2(uuid!null) y:3(uuid!null) z:4(string!null) a:5(string!null) b:6(uuid!null) c:7(uuid!null) d:8(varchar!null)
       │         ├── left ordering: +1,+2,+3
       │         ├── right ordering: +5,+6,+7
       │         ├── stats: [rows=50048.8759, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=2500, null(3)=0, distinct(4)=1000, null(4)=0, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0, distinct(7)=2500, null(7)=0, distinct(8)=38781.1698, null(8)=0]
@@ -320,7 +320,7 @@ project
       │         │    ├── fd: ()-->(1,2), (3)-->(4)
       │         │    └── ordering: +3 opt(1,2) [actual: +3]
       │         ├── scan abcde@idx_abcd
-      │         │    ├── columns: a:5(string!null) b:6(uuid!null) c:7(uuid!null) d:8(string!null)
+      │         │    ├── columns: a:5(string!null) b:6(uuid!null) c:7(uuid!null) d:8(varchar!null)
       │         │    ├── constraint: /5/6/7/8: [/'foo'/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'foo'/'2ab23800-06b1-4e19-a3bb-df3768b808d2']
       │         │    ├── stats: [rows=125000, distinct(5)=1, null(5)=0, distinct(6)=1, null(6)=0, distinct(7)=24975.5859, null(7)=0, distinct(8)=93750, null(8)=0]
       │         │    ├── cost: 135000.01

--- a/pkg/sql/opt/xform/testdata/external/customer
+++ b/pkg/sql/opt/xform/testdata/external/customer
@@ -262,10 +262,10 @@ TABLE leaderboard_record
  ├── id bytes not null
  ├── leaderboard_id bytes not null
  ├── owner_id bytes not null
- ├── handle string not null
- ├── lang string not null
- ├── location string
- ├── timezone string
+ ├── handle varchar not null
+ ├── lang varchar not null
+ ├── location varchar
+ ├── timezone varchar
  ├── rank_value int not null
  ├── score int not null
  ├── num_score int not null

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -28,9 +28,9 @@ create table Phone (
 ----
 TABLE phone
  ├── id int not null
- ├── number string
+ ├── number varchar
  ├── since timestamp
- ├── type int
+ ├── type int4
  └── INDEX primary
       └── id int not null
 
@@ -76,16 +76,16 @@ inner join Phone unidirecti1_
 where phoneregis0_.phone_id=1;
 ----
 project
- ├── columns: phone_id1_2_0_:1(int!null) person_i2_2_0_:2(int!null) formula159_0_:11(timestamp) id1_1_1_:3(int!null) number2_1_1_:4(string) since3_1_1_:5(timestamp) type4_1_1_:6(int)
+ ├── columns: phone_id1_2_0_:1(int!null) person_i2_2_0_:2(int!null) formula159_0_:11(timestamp) id1_1_1_:3(int!null) number2_1_1_:4(varchar) since3_1_1_:5(timestamp) type4_1_1_:6(int4)
  ├── key: (3)
  ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (2)-->(11)
  ├── inner-join (lookup phone)
- │    ├── columns: phone_id:1(int!null) person_id:2(int!null) unidirecti1_.id:3(int!null) unidirecti1_.number:4(string) unidirecti1_.since:5(timestamp) unidirecti1_.type:6(int) a10.id:7(int!null) a10.since:9(timestamp)
+ │    ├── columns: phone_id:1(int!null) person_id:2(int!null) unidirecti1_.id:3(int!null) unidirecti1_.number:4(varchar) unidirecti1_.since:5(timestamp) unidirecti1_.type:6(int4) a10.id:7(int!null) a10.since:9(timestamp)
  │    ├── key columns: [2] = [7]
  │    ├── key: (7)
  │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3,7), (3)==(2,7), (7)-->(9), (7)==(2,3)
  │    ├── inner-join (lookup phone)
- │    │    ├── columns: phone_id:1(int!null) person_id:2(int!null) unidirecti1_.id:3(int!null) unidirecti1_.number:4(string) unidirecti1_.since:5(timestamp) unidirecti1_.type:6(int)
+ │    │    ├── columns: phone_id:1(int!null) person_id:2(int!null) unidirecti1_.id:3(int!null) unidirecti1_.number:4(varchar) unidirecti1_.since:5(timestamp) unidirecti1_.type:6(int4)
  │    │    ├── key columns: [2] = [3]
  │    │    ├── key: (3)
  │    │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
@@ -124,11 +124,11 @@ create table Person (
 ----
 TABLE person
  ├── id int not null
- ├── address string
+ ├── address varchar
  ├── createdon timestamp
- ├── name string
- ├── nickname string
- ├── version int not null
+ ├── name varchar
+ ├── nickname varchar
+ ├── version int4 not null
  └── INDEX primary
       └── id int not null
 
@@ -142,11 +142,11 @@ create table Person_addresses (
 ----
 TABLE person_addresses
  ├── person_id int not null
- ├── addresses string
- ├── addresses_key string not null
+ ├── addresses varchar
+ ├── addresses_key varchar not null
  └── INDEX primary
       ├── person_id int not null
-      └── addresses_key string not null
+      └── addresses_key varchar not null
 
 exec-ddl
 create table Phone (
@@ -160,10 +160,10 @@ create table Phone (
 ----
 TABLE phone
  ├── id int not null
- ├── phone_number string
- ├── phone_type string
+ ├── phone_number varchar
+ ├── phone_type varchar
  ├── person_id int
- ├── order_id int
+ ├── order_id int4
  └── INDEX primary
       └── id int not null
 
@@ -178,7 +178,7 @@ create table phone_call (
 ----
 TABLE phone_call
  ├── id int not null
- ├── duration int not null
+ ├── duration int4 not null
  ├── call_timestamp timestamp
  ├── phone_id int
  └── INDEX primary
@@ -194,8 +194,8 @@ create table Partner (
 ----
 TABLE partner
  ├── id int not null
- ├── name string
- ├── version int not null
+ ├── name varchar
+ ├── version int4 not null
  └── INDEX primary
       └── id int not null
 
@@ -236,15 +236,15 @@ where
     )
 ----
 inner-join
- ├── columns: id1_6_0_:1(int!null) id1_4_1_:6(int!null) phone_nu2_6_0_:2(string) person_i4_6_0_:4(int!null) phone_ty3_6_0_:3(string) person_i1_5_0__:12(int!null) addresse2_5_0__:13(string) addresse3_0__:14(string!null) address2_4_1_:7(string) createdo3_4_1_:8(timestamp) name4_4_1_:9(string) nickname5_4_1_:10(string) version6_4_1_:11(int!null) person_i1_5_0__:12(int!null) addresse2_5_0__:13(string) addresse3_0__:14(string!null)
+ ├── columns: id1_6_0_:1(int!null) id1_4_1_:6(int!null) phone_nu2_6_0_:2(varchar) person_i4_6_0_:4(int!null) phone_ty3_6_0_:3(varchar) person_i1_5_0__:12(int!null) addresse2_5_0__:13(varchar) addresse3_0__:14(varchar!null) address2_4_1_:7(varchar) createdo3_4_1_:8(timestamp) name4_4_1_:9(varchar) nickname5_4_1_:10(varchar) version6_4_1_:11(int4!null) person_i1_5_0__:12(int!null) addresse2_5_0__:13(varchar) addresse3_0__:14(varchar!null)
  ├── key: (1,14)
  ├── fd: (1)-->(2-4), (6)-->(7-11), (4)==(6,12), (6)==(4,12), (12,14)-->(13), (12)==(4,6)
  ├── semi-join
- │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int)
+ │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) phone0_.person_id:4(int)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    ├── scan phone0_
- │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int)
+ │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) phone0_.person_id:4(int)
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-4)
  │    ├── scan calls3_
@@ -254,18 +254,18 @@ inner-join
  │    └── filters
  │         └── phone0_.id = phone_id [type=bool, outer=(1,18), constraints=(/1: (/NULL - ]; /18: (/NULL - ]), fd=(1)==(18), (18)==(1)]
  ├── inner-join (merge)
- │    ├── columns: person1_.id:6(int!null) address:7(string) createdon:8(timestamp) name:9(string) nickname:10(string) version:11(int!null) addresses2_.person_id:12(int!null) addresses:13(string) addresses_key:14(string!null)
+ │    ├── columns: person1_.id:6(int!null) address:7(varchar) createdon:8(timestamp) name:9(varchar) nickname:10(varchar) version:11(int4!null) addresses2_.person_id:12(int!null) addresses:13(varchar) addresses_key:14(varchar!null)
  │    ├── left ordering: +6
  │    ├── right ordering: +12
  │    ├── key: (12,14)
  │    ├── fd: (6)-->(7-11), (12,14)-->(13), (6)==(12), (12)==(6)
  │    ├── scan person1_
- │    │    ├── columns: person1_.id:6(int!null) address:7(string) createdon:8(timestamp) name:9(string) nickname:10(string) version:11(int!null)
+ │    │    ├── columns: person1_.id:6(int!null) address:7(varchar) createdon:8(timestamp) name:9(varchar) nickname:10(varchar) version:11(int4!null)
  │    │    ├── key: (6)
  │    │    ├── fd: (6)-->(7-11)
  │    │    └── ordering: +6
  │    ├── scan addresses2_
- │    │    ├── columns: addresses2_.person_id:12(int!null) addresses:13(string) addresses_key:14(string!null)
+ │    │    ├── columns: addresses2_.person_id:12(int!null) addresses:13(varchar) addresses_key:14(varchar!null)
  │    │    ├── key: (12,14)
  │    │    ├── fd: (12,14)-->(13)
  │    │    └── ordering: +12
@@ -298,17 +298,17 @@ where
     )
 ----
 project
- ├── columns: id1_6_:1(int!null) phone_nu2_6_:2(string) person_i4_6_:4(int!null) phone_ty3_6_:3(string)
+ ├── columns: id1_6_:1(int!null) phone_nu2_6_:2(varchar) person_i4_6_:4(int!null) phone_ty3_6_:3(varchar)
  ├── fd: (1)-->(2-4)
  └── inner-join
-      ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int!null) person1_.id:6(int!null) addresses2_.person_id:12(int!null)
+      ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) phone0_.person_id:4(int!null) person1_.id:6(int!null) addresses2_.person_id:12(int!null)
       ├── fd: (1)-->(2-4), (4)==(6,12), (6)==(4,12), (12)==(4,6)
       ├── semi-join
-      │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int)
+      │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) phone0_.person_id:4(int)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4)
       │    ├── scan phone0_
-      │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) phone0_.person_id:4(int)
+      │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) phone0_.person_id:4(int)
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2-4)
       │    ├── scan calls3_
@@ -366,22 +366,22 @@ where
     and partner1_.version=0
 ----
 inner-join
- ├── columns: id1_4_0_:1(int!null) id1_2_1_:7(int!null) address2_4_0_:2(string!null) createdo3_4_0_:3(timestamp) name4_4_0_:4(string) nickname5_4_0_:5(string) version6_4_0_:6(int!null) name2_2_1_:8(string!null) version3_2_1_:9(int!null)
+ ├── columns: id1_4_0_:1(int!null) id1_2_1_:7(int!null) address2_4_0_:2(varchar!null) createdo3_4_0_:3(timestamp) name4_4_0_:4(varchar) nickname5_4_0_:5(varchar) version6_4_0_:6(int4!null) name2_2_1_:8(varchar!null) version3_2_1_:9(int4!null)
  ├── has-placeholder
  ├── key: (1,7)
  ├── fd: ()-->(9), (1)-->(2-6), (7)-->(8)
  ├── semi-join
- │    ├── columns: person0_.id:1(int!null) address:2(string!null) createdon:3(timestamp) person0_.name:4(string) nickname:5(string) person0_.version:6(int!null)
+ │    ├── columns: person0_.id:1(int!null) address:2(varchar!null) createdon:3(timestamp) person0_.name:4(varchar) nickname:5(varchar) person0_.version:6(int4!null)
  │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-6)
  │    ├── select
- │    │    ├── columns: person0_.id:1(int!null) address:2(string!null) createdon:3(timestamp) person0_.name:4(string) nickname:5(string) person0_.version:6(int!null)
+ │    │    ├── columns: person0_.id:1(int!null) address:2(varchar!null) createdon:3(timestamp) person0_.name:4(varchar) nickname:5(varchar) person0_.version:6(int4!null)
  │    │    ├── has-placeholder
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-6)
  │    │    ├── scan person0_
- │    │    │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) person0_.name:4(string) nickname:5(string) person0_.version:6(int!null)
+ │    │    │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) person0_.name:4(varchar) nickname:5(varchar) person0_.version:6(int4!null)
  │    │    │    ├── key: (1)
  │    │    │    └── fd: (1)-->(2-6)
  │    │    └── filters
@@ -393,12 +393,12 @@ inner-join
  │    └── filters
  │         └── person0_.id = person_id [type=bool, outer=(1,13), constraints=(/1: (/NULL - ]; /13: (/NULL - ]), fd=(1)==(13), (13)==(1)]
  ├── select
- │    ├── columns: partner1_.id:7(int!null) partner1_.name:8(string!null) partner1_.version:9(int!null)
+ │    ├── columns: partner1_.id:7(int!null) partner1_.name:8(varchar!null) partner1_.version:9(int4!null)
  │    ├── has-placeholder
  │    ├── key: (7)
  │    ├── fd: ()-->(9), (7)-->(8)
  │    ├── scan partner1_
- │    │    ├── columns: partner1_.id:7(int!null) partner1_.name:8(string) partner1_.version:9(int!null)
+ │    │    ├── columns: partner1_.id:7(int!null) partner1_.name:8(varchar) partner1_.version:9(int4!null)
  │    │    ├── key: (7)
  │    │    └── fd: (7)-->(8,9)
  │    └── filters
@@ -427,14 +427,14 @@ create table Customer_AUD (
 ----
 TABLE customer_aud
  ├── id int not null
- ├── rev int not null
- ├── revtype int
+ ├── rev int4 not null
+ ├── revtype int2
  ├── created_on timestamp
- ├── firstname string
- ├── lastname string
+ ├── firstname varchar
+ ├── lastname varchar
  └── INDEX primary
       ├── id int not null
-      └── rev int not null
+      └── rev int4 not null
 
 opt
 select
@@ -459,64 +459,64 @@ where
     and defaultaud0_.REVTYPE<>$2
 ----
 project
- ├── columns: id1_1_:1(int!null) rev2_1_:2(int!null) revtype3_1_:3(int) created_4_1_:4(timestamp) firstnam5_1_:5(string) lastname6_1_:6(string)
+ ├── columns: id1_1_:1(int!null) rev2_1_:2(int4!null) revtype3_1_:3(int2) created_4_1_:4(timestamp) firstnam5_1_:5(varchar) lastname6_1_:6(varchar)
  ├── has-placeholder
  ├── key: (1,2)
  ├── fd: (1,2)-->(3-6)
  └── select
-      ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int!null) defaultaud0_.revtype:3(int) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(string) defaultaud0_.lastname:6(string) max:13(int!null)
+      ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int4!null) defaultaud0_.revtype:3(int2) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(varchar) defaultaud0_.lastname:6(varchar) max:13(int!null)
       ├── has-placeholder
       ├── key: (1,2)
       ├── fd: (1,2)-->(3-6,13), (2)==(13), (13)==(2)
       ├── group-by
-      │    ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int!null) defaultaud0_.revtype:3(int) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(string) defaultaud0_.lastname:6(string) max:13(int)
-      │    ├── grouping columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int!null)
+      │    ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int4!null) defaultaud0_.revtype:3(int2) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(varchar) defaultaud0_.lastname:6(varchar) max:13(int)
+      │    ├── grouping columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int4!null)
       │    ├── has-placeholder
       │    ├── key: (1,2)
       │    ├── fd: (1,2)-->(3-6,13)
       │    ├── inner-join (merge)
-      │    │    ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int!null) defaultaud0_.revtype:3(int!null) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(string) defaultaud0_.lastname:6(string) defaultaud1_.id:7(int!null) defaultaud1_.rev:8(int!null)
+      │    │    ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int4!null) defaultaud0_.revtype:3(int2!null) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(varchar) defaultaud0_.lastname:6(varchar) defaultaud1_.id:7(int!null) defaultaud1_.rev:8(int4!null)
       │    │    ├── left ordering: +1
       │    │    ├── right ordering: +7
       │    │    ├── has-placeholder
       │    │    ├── key: (2,7,8)
       │    │    ├── fd: (1,2)-->(3-6), (1)==(7), (7)==(1)
       │    │    ├── select
-      │    │    │    ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int!null) defaultaud0_.revtype:3(int!null) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(string) defaultaud0_.lastname:6(string)
+      │    │    │    ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int4!null) defaultaud0_.revtype:3(int2!null) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(varchar) defaultaud0_.lastname:6(varchar)
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: (1,2)
       │    │    │    ├── fd: (1,2)-->(3-6)
       │    │    │    ├── ordering: +1
       │    │    │    ├── scan defaultaud0_
-      │    │    │    │    ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int!null) defaultaud0_.revtype:3(int) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(string) defaultaud0_.lastname:6(string)
+      │    │    │    │    ├── columns: defaultaud0_.id:1(int!null) defaultaud0_.rev:2(int4!null) defaultaud0_.revtype:3(int2) defaultaud0_.created_on:4(timestamp) defaultaud0_.firstname:5(varchar) defaultaud0_.lastname:6(varchar)
       │    │    │    │    ├── key: (1,2)
       │    │    │    │    ├── fd: (1,2)-->(3-6)
       │    │    │    │    └── ordering: +1
       │    │    │    └── filters
       │    │    │         └── defaultaud0_.revtype != $2 [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
       │    │    ├── select
-      │    │    │    ├── columns: defaultaud1_.id:7(int!null) defaultaud1_.rev:8(int!null)
+      │    │    │    ├── columns: defaultaud1_.id:7(int!null) defaultaud1_.rev:8(int4!null)
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: (7,8)
       │    │    │    ├── ordering: +7
       │    │    │    ├── scan defaultaud1_
-      │    │    │    │    ├── columns: defaultaud1_.id:7(int!null) defaultaud1_.rev:8(int!null)
+      │    │    │    │    ├── columns: defaultaud1_.id:7(int!null) defaultaud1_.rev:8(int4!null)
       │    │    │    │    ├── key: (7,8)
       │    │    │    │    └── ordering: +7
       │    │    │    └── filters
       │    │    │         └── defaultaud1_.rev <= $1 [type=bool, outer=(8), constraints=(/8: (/NULL - ])]
       │    │    └── filters (true)
       │    └── aggregations
-      │         ├── max [type=int, outer=(8)]
-      │         │    └── variable: defaultaud1_.rev [type=int]
-      │         ├── const-agg [type=int, outer=(3)]
-      │         │    └── variable: defaultaud0_.revtype [type=int]
+      │         ├── max [type=int4, outer=(8)]
+      │         │    └── variable: defaultaud1_.rev [type=int4]
+      │         ├── const-agg [type=int2, outer=(3)]
+      │         │    └── variable: defaultaud0_.revtype [type=int2]
       │         ├── const-agg [type=timestamp, outer=(4)]
       │         │    └── variable: defaultaud0_.created_on [type=timestamp]
-      │         ├── const-agg [type=string, outer=(5)]
-      │         │    └── variable: defaultaud0_.firstname [type=string]
-      │         └── const-agg [type=string, outer=(6)]
-      │              └── variable: defaultaud0_.lastname [type=string]
+      │         ├── const-agg [type=varchar, outer=(5)]
+      │         │    └── variable: defaultaud0_.firstname [type=varchar]
+      │         └── const-agg [type=varchar, outer=(6)]
+      │              └── variable: defaultaud0_.lastname [type=varchar]
       └── filters
            └── defaultaud0_.rev = max [type=bool, outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
 
@@ -543,16 +543,16 @@ create table Customer_AUD (
 ----
 TABLE customer_aud
  ├── id int not null
- ├── rev int not null
- ├── revtype int
- ├── revend int
+ ├── rev int4 not null
+ ├── revtype int2
+ ├── revend int4
  ├── created_on timestamp
- ├── firstname string
- ├── lastname string
+ ├── firstname varchar
+ ├── lastname varchar
  ├── address_id int
  └── INDEX primary
       ├── id int not null
-      └── rev int not null
+      └── rev int4 not null
 
 opt
 select
@@ -580,65 +580,65 @@ order by
     queryaudit0_.REV asc
 ----
 sort
- ├── columns: id1_3_:1(int!null) rev2_3_:2(int!null) revtype3_3_:3(int) revend4_3_:4(int) created_5_3_:5(timestamp) firstnam6_3_:6(string) lastname7_3_:7(string) address_8_3_:8(int)
+ ├── columns: id1_3_:1(int!null) rev2_3_:2(int4!null) revtype3_3_:3(int2) revend4_3_:4(int4) created_5_3_:5(timestamp) firstnam6_3_:6(varchar) lastname7_3_:7(varchar) address_8_3_:8(int)
  ├── has-placeholder
  ├── key: (1,2)
  ├── fd: (1,2)-->(3-8)
  ├── ordering: +2
  └── project
-      ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int!null) queryaudit0_.revtype:3(int) queryaudit0_.revend:4(int) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(string) queryaudit0_.lastname:7(string) queryaudit0_.address_id:8(int)
+      ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int4!null) queryaudit0_.revtype:3(int2) queryaudit0_.revend:4(int4) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(varchar) queryaudit0_.lastname:7(varchar) queryaudit0_.address_id:8(int)
       ├── has-placeholder
       ├── key: (1,2)
       ├── fd: (1,2)-->(3-8)
       └── select
-           ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int!null) queryaudit0_.revtype:3(int) queryaudit0_.revend:4(int) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(string) queryaudit0_.lastname:7(string) queryaudit0_.address_id:8(int) max:17(int!null)
+           ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int4!null) queryaudit0_.revtype:3(int2) queryaudit0_.revend:4(int4) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(varchar) queryaudit0_.lastname:7(varchar) queryaudit0_.address_id:8(int) max:17(int!null)
            ├── has-placeholder
            ├── key: (1,2)
            ├── fd: (1,2)-->(3-8,17), (2)==(17), (17)==(2)
            ├── group-by
-           │    ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int!null) queryaudit0_.revtype:3(int) queryaudit0_.revend:4(int) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(string) queryaudit0_.lastname:7(string) queryaudit0_.address_id:8(int) max:17(int)
-           │    ├── grouping columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int!null)
+           │    ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int4!null) queryaudit0_.revtype:3(int2) queryaudit0_.revend:4(int4) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(varchar) queryaudit0_.lastname:7(varchar) queryaudit0_.address_id:8(int) max:17(int)
+           │    ├── grouping columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int4!null)
            │    ├── has-placeholder
            │    ├── key: (1,2)
            │    ├── fd: (1,2)-->(3-8,17)
            │    ├── inner-join (merge)
-           │    │    ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int!null) queryaudit0_.revtype:3(int!null) queryaudit0_.revend:4(int) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(string) queryaudit0_.lastname:7(string) queryaudit0_.address_id:8(int) queryaudit1_.id:9(int!null) queryaudit1_.rev:10(int!null)
+           │    │    ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int4!null) queryaudit0_.revtype:3(int2!null) queryaudit0_.revend:4(int4) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(varchar) queryaudit0_.lastname:7(varchar) queryaudit0_.address_id:8(int) queryaudit1_.id:9(int!null) queryaudit1_.rev:10(int4!null)
            │    │    ├── left ordering: +1
            │    │    ├── right ordering: +9
            │    │    ├── has-placeholder
            │    │    ├── key: (2,9,10)
            │    │    ├── fd: (1,2)-->(3-8), (1)==(9), (9)==(1)
            │    │    ├── select
-           │    │    │    ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int!null) queryaudit0_.revtype:3(int!null) queryaudit0_.revend:4(int) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(string) queryaudit0_.lastname:7(string) queryaudit0_.address_id:8(int)
+           │    │    │    ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int4!null) queryaudit0_.revtype:3(int2!null) queryaudit0_.revend:4(int4) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(varchar) queryaudit0_.lastname:7(varchar) queryaudit0_.address_id:8(int)
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1,2)
            │    │    │    ├── fd: (1,2)-->(3-8)
            │    │    │    ├── ordering: +1
            │    │    │    ├── scan queryaudit0_
-           │    │    │    │    ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int!null) queryaudit0_.revtype:3(int) queryaudit0_.revend:4(int) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(string) queryaudit0_.lastname:7(string) queryaudit0_.address_id:8(int)
+           │    │    │    │    ├── columns: queryaudit0_.id:1(int!null) queryaudit0_.rev:2(int4!null) queryaudit0_.revtype:3(int2) queryaudit0_.revend:4(int4) queryaudit0_.created_on:5(timestamp) queryaudit0_.firstname:6(varchar) queryaudit0_.lastname:7(varchar) queryaudit0_.address_id:8(int)
            │    │    │    │    ├── key: (1,2)
            │    │    │    │    ├── fd: (1,2)-->(3-8)
            │    │    │    │    └── ordering: +1
            │    │    │    └── filters
            │    │    │         └── queryaudit0_.revtype != $1 [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
            │    │    ├── scan queryaudit1_
-           │    │    │    ├── columns: queryaudit1_.id:9(int!null) queryaudit1_.rev:10(int!null)
+           │    │    │    ├── columns: queryaudit1_.id:9(int!null) queryaudit1_.rev:10(int4!null)
            │    │    │    ├── key: (9,10)
            │    │    │    └── ordering: +9
            │    │    └── filters (true)
            │    └── aggregations
-           │         ├── max [type=int, outer=(10)]
-           │         │    └── variable: queryaudit1_.rev [type=int]
-           │         ├── const-agg [type=int, outer=(3)]
-           │         │    └── variable: queryaudit0_.revtype [type=int]
-           │         ├── const-agg [type=int, outer=(4)]
-           │         │    └── variable: queryaudit0_.revend [type=int]
+           │         ├── max [type=int4, outer=(10)]
+           │         │    └── variable: queryaudit1_.rev [type=int4]
+           │         ├── const-agg [type=int2, outer=(3)]
+           │         │    └── variable: queryaudit0_.revtype [type=int2]
+           │         ├── const-agg [type=int4, outer=(4)]
+           │         │    └── variable: queryaudit0_.revend [type=int4]
            │         ├── const-agg [type=timestamp, outer=(5)]
            │         │    └── variable: queryaudit0_.created_on [type=timestamp]
-           │         ├── const-agg [type=string, outer=(6)]
-           │         │    └── variable: queryaudit0_.firstname [type=string]
-           │         ├── const-agg [type=string, outer=(7)]
-           │         │    └── variable: queryaudit0_.lastname [type=string]
+           │         ├── const-agg [type=varchar, outer=(6)]
+           │         │    └── variable: queryaudit0_.firstname [type=varchar]
+           │         ├── const-agg [type=varchar, outer=(7)]
+           │         │    └── variable: queryaudit0_.lastname [type=varchar]
            │         └── const-agg [type=int, outer=(8)]
            │              └── variable: queryaudit0_.address_id [type=int]
            └── filters
@@ -682,10 +682,10 @@ create table Phone (
 ----
 TABLE phone
  ├── id int not null
- ├── phone_number string
- ├── phone_type string
+ ├── phone_number varchar
+ ├── phone_type varchar
  ├── person_id int
- ├── order_id int
+ ├── order_id int4
  └── INDEX primary
       └── id int not null
 
@@ -700,7 +700,7 @@ create table phone_call (
 ----
 TABLE phone_call
  ├── id int not null
- ├── duration int not null
+ ├── duration int4 not null
  ├── call_timestamp timestamp
  ├── phone_id int
  └── INDEX primary
@@ -719,11 +719,11 @@ create table Person (
 ----
 TABLE person
  ├── id int not null
- ├── address string
+ ├── address varchar
  ├── createdon timestamp
- ├── name string
- ├── nickname string
- ├── version int not null
+ ├── name varchar
+ ├── nickname varchar
+ ├── version int4 not null
  └── INDEX primary
       └── id int not null
 
@@ -750,11 +750,11 @@ create table Person_addresses (
 ----
 TABLE person_addresses
  ├── person_id int not null
- ├── addresses string
- ├── addresses_key string not null
+ ├── addresses varchar
+ ├── addresses_key varchar not null
  └── INDEX primary
       ├── person_id int not null
-      └── addresses_key string not null
+      └── addresses_key varchar not null
 
 opt
 select
@@ -783,12 +783,12 @@ where
     )
 ----
 distinct-on
- ├── columns: id1_2_:10(int!null) address2_2_:11(string) createdo3_2_:12(timestamp) name4_2_:13(string) nickname5_2_:14(string) version6_2_:15(int)
+ ├── columns: id1_2_:10(int!null) address2_2_:11(varchar) createdo3_2_:12(timestamp) name4_2_:13(varchar) nickname5_2_:14(varchar) version6_2_:15(int4)
  ├── grouping columns: person2_.id:10(int!null)
  ├── key: (10)
  ├── fd: (10)-->(11-15)
  ├── inner-join
- │    ├── columns: phone0_.id:1(int!null) person_id:4(int!null) calls1_.phone_id:9(int!null) person2_.id:10(int!null) address:11(string) createdon:12(timestamp) name:13(string) nickname:14(string) version:15(int!null)
+ │    ├── columns: phone0_.id:1(int!null) person_id:4(int!null) calls1_.phone_id:9(int!null) person2_.id:10(int!null) address:11(varchar) createdon:12(timestamp) name:13(varchar) nickname:14(varchar) version:15(int4!null)
  │    ├── fd: (1)-->(4), (1)==(9), (9)==(1), (10)-->(11-15), (4)==(10), (10)==(4)
  │    ├── inner-join
  │    │    ├── columns: phone0_.id:1(int!null) person_id:4(int) calls1_.phone_id:9(int!null)
@@ -802,9 +802,9 @@ distinct-on
  │    │    │    │    ├── key: (1)
  │    │    │    │    └── fd: (1)-->(4)
  │    │    │    ├── select
- │    │    │    │    ├── columns: call3_.duration:17(int!null) call3_.phone_id:19(int)
+ │    │    │    │    ├── columns: call3_.duration:17(int4!null) call3_.phone_id:19(int)
  │    │    │    │    ├── scan call3_
- │    │    │    │    │    └── columns: call3_.duration:17(int!null) call3_.phone_id:19(int)
+ │    │    │    │    │    └── columns: call3_.duration:17(int4!null) call3_.phone_id:19(int)
  │    │    │    │    └── filters
  │    │    │    │         └── (call3_.duration >= 50) IS NOT false [type=bool, outer=(17)]
  │    │    │    └── filters
@@ -814,22 +814,22 @@ distinct-on
  │    │    └── filters
  │    │         └── phone0_.id = calls1_.phone_id [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    ├── scan person2_
- │    │    ├── columns: person2_.id:10(int!null) address:11(string) createdon:12(timestamp) name:13(string) nickname:14(string) version:15(int!null)
+ │    │    ├── columns: person2_.id:10(int!null) address:11(varchar) createdon:12(timestamp) name:13(varchar) nickname:14(varchar) version:15(int4!null)
  │    │    ├── key: (10)
  │    │    └── fd: (10)-->(11-15)
  │    └── filters
  │         └── person_id = person2_.id [type=bool, outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
  └── aggregations
-      ├── const-agg [type=string, outer=(11)]
-      │    └── variable: address [type=string]
+      ├── const-agg [type=varchar, outer=(11)]
+      │    └── variable: address [type=varchar]
       ├── const-agg [type=timestamp, outer=(12)]
       │    └── variable: createdon [type=timestamp]
-      ├── const-agg [type=string, outer=(13)]
-      │    └── variable: name [type=string]
-      ├── const-agg [type=string, outer=(14)]
-      │    └── variable: nickname [type=string]
-      └── const-agg [type=int, outer=(15)]
-           └── variable: version [type=int]
+      ├── const-agg [type=varchar, outer=(13)]
+      │    └── variable: name [type=varchar]
+      ├── const-agg [type=varchar, outer=(14)]
+      │    └── variable: nickname [type=varchar]
+      └── const-agg [type=int4, outer=(15)]
+           └── variable: version [type=int4]
 
 opt
 select
@@ -850,26 +850,26 @@ where
     )=$1
 ----
 project
- ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(string) person_i4_4_:4(int) phone_ty3_4_:3(string)
+ ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(varchar) person_i4_4_:4(int) phone_ty3_4_:3(varchar)
  ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  └── select
-      ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) person_id:4(int) max:10(int!null)
+      ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) person_id:4(int) max:10(int!null)
       ├── has-placeholder
       ├── key: (1)
       ├── fd: (1)-->(2-4,10)
       ├── group-by
-      │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) person_id:4(int) max:10(int)
+      │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) person_id:4(int) max:10(int)
       │    ├── grouping columns: phone0_.id:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4,10)
       │    ├── inner-join
-      │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) person_id:4(int) calls1_.id:6(int!null) phone_id:9(int!null)
+      │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) person_id:4(int) calls1_.id:6(int!null) phone_id:9(int!null)
       │    │    ├── key: (6)
       │    │    ├── fd: (1)-->(2-4), (6)-->(9), (1)==(9), (9)==(1)
       │    │    ├── scan phone0_
-      │    │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) person_id:4(int)
+      │    │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) person_id:4(int)
       │    │    │    ├── key: (1)
       │    │    │    └── fd: (1)-->(2-4)
       │    │    ├── scan calls1_
@@ -881,10 +881,10 @@ project
       │    └── aggregations
       │         ├── max [type=int, outer=(6)]
       │         │    └── variable: calls1_.id [type=int]
-      │         ├── const-agg [type=string, outer=(2)]
-      │         │    └── variable: phone_number [type=string]
-      │         ├── const-agg [type=string, outer=(3)]
-      │         │    └── variable: phone_type [type=string]
+      │         ├── const-agg [type=varchar, outer=(2)]
+      │         │    └── variable: phone_number [type=varchar]
+      │         ├── const-agg [type=varchar, outer=(3)]
+      │         │    └── variable: phone_type [type=varchar]
       │         └── const-agg [type=int, outer=(4)]
       │              └── variable: person_id [type=int]
       └── filters
@@ -911,23 +911,23 @@ where
     )=2
 ----
 project
- ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int)
+ ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4)
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  └── select
-      ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int) count:12(int!null)
+      ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4) count:12(int!null)
       ├── key: (1)
       ├── fd: ()-->(12), (1)-->(2-6)
       ├── group-by
-      │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int) count:12(int)
+      │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4) count:12(int)
       │    ├── grouping columns: person0_.id:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-6,12)
       │    ├── left-join
-      │    │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null) person_id:10(int)
+      │    │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null) person_id:10(int)
       │    │    ├── fd: (1)-->(2-6)
       │    │    ├── scan person0_
-      │    │    │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
+      │    │    │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null)
       │    │    │    ├── key: (1)
       │    │    │    └── fd: (1)-->(2-6)
       │    │    ├── scan phones1_
@@ -937,16 +937,16 @@ project
       │    └── aggregations
       │         ├── count [type=int, outer=(10)]
       │         │    └── variable: person_id [type=int]
-      │         ├── const-agg [type=string, outer=(2)]
-      │         │    └── variable: address [type=string]
+      │         ├── const-agg [type=varchar, outer=(2)]
+      │         │    └── variable: address [type=varchar]
       │         ├── const-agg [type=timestamp, outer=(3)]
       │         │    └── variable: createdon [type=timestamp]
-      │         ├── const-agg [type=string, outer=(4)]
-      │         │    └── variable: name [type=string]
-      │         ├── const-agg [type=string, outer=(5)]
-      │         │    └── variable: nickname [type=string]
-      │         └── const-agg [type=int, outer=(6)]
-      │              └── variable: version [type=int]
+      │         ├── const-agg [type=varchar, outer=(4)]
+      │         │    └── variable: name [type=varchar]
+      │         ├── const-agg [type=varchar, outer=(5)]
+      │         │    └── variable: nickname [type=varchar]
+      │         └── const-agg [type=int4, outer=(6)]
+      │              └── variable: version [type=int4]
       └── filters
            └── count = 2 [type=bool, outer=(12), constraints=(/12: [/2 - /2]; tight), fd=()-->(12)]
 
@@ -969,26 +969,26 @@ where
     )=$1
 ----
 project
- ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(string) person_i4_4_:4(int) phone_ty3_4_:3(string)
+ ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(varchar) person_i4_4_:4(int) phone_ty3_4_:3(varchar)
  ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  └── select
-      ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) person_id:4(int) min:10(int!null)
+      ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) person_id:4(int) min:10(int!null)
       ├── has-placeholder
       ├── key: (1)
       ├── fd: (1)-->(2-4,10)
       ├── group-by
-      │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) person_id:4(int) min:10(int)
+      │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) person_id:4(int) min:10(int)
       │    ├── grouping columns: phone0_.id:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4,10)
       │    ├── inner-join
-      │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) person_id:4(int) calls1_.id:6(int!null) phone_id:9(int!null)
+      │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) person_id:4(int) calls1_.id:6(int!null) phone_id:9(int!null)
       │    │    ├── key: (6)
       │    │    ├── fd: (1)-->(2-4), (6)-->(9), (1)==(9), (9)==(1)
       │    │    ├── scan phone0_
-      │    │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) person_id:4(int)
+      │    │    │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) person_id:4(int)
       │    │    │    ├── key: (1)
       │    │    │    └── fd: (1)-->(2-4)
       │    │    ├── scan calls1_
@@ -1000,10 +1000,10 @@ project
       │    └── aggregations
       │         ├── min [type=int, outer=(6)]
       │         │    └── variable: calls1_.id [type=int]
-      │         ├── const-agg [type=string, outer=(2)]
-      │         │    └── variable: phone_number [type=string]
-      │         ├── const-agg [type=string, outer=(3)]
-      │         │    └── variable: phone_type [type=string]
+      │         ├── const-agg [type=varchar, outer=(2)]
+      │         │    └── variable: phone_number [type=varchar]
+      │         ├── const-agg [type=varchar, outer=(3)]
+      │         │    └── variable: phone_type [type=varchar]
       │         └── const-agg [type=int, outer=(4)]
       │              └── variable: person_id [type=int]
       └── filters
@@ -1030,46 +1030,46 @@ where
     )=0
 ----
 project
- ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int)
+ ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4)
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  └── select
-      ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int) max:12(int!null)
+      ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4) max:12(int!null)
       ├── key: (1)
       ├── fd: ()-->(12), (1)-->(2-6)
       ├── group-by
-      │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int) max:12(int)
+      │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4) max:12(int)
       │    ├── grouping columns: person0_.id:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-6,12)
       │    ├── inner-join
-      │    │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null) person_id:10(int!null) order_id:11(int!null)
+      │    │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null) person_id:10(int!null) order_id:11(int4!null)
       │    │    ├── fd: (1)-->(2-6), (1)==(10), (10)==(1)
       │    │    ├── scan person0_
-      │    │    │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
+      │    │    │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null)
       │    │    │    ├── key: (1)
       │    │    │    └── fd: (1)-->(2-6)
       │    │    ├── select
-      │    │    │    ├── columns: person_id:10(int) order_id:11(int!null)
+      │    │    │    ├── columns: person_id:10(int) order_id:11(int4!null)
       │    │    │    ├── scan phones1_
-      │    │    │    │    └── columns: person_id:10(int) order_id:11(int)
+      │    │    │    │    └── columns: person_id:10(int) order_id:11(int4)
       │    │    │    └── filters
       │    │    │         └── order_id IS NOT NULL [type=bool, outer=(11), constraints=(/11: (/NULL - ]; tight)]
       │    │    └── filters
       │    │         └── person0_.id = person_id [type=bool, outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
       │    └── aggregations
-      │         ├── max [type=int, outer=(11)]
-      │         │    └── variable: order_id [type=int]
-      │         ├── const-agg [type=string, outer=(2)]
-      │         │    └── variable: address [type=string]
+      │         ├── max [type=int4, outer=(11)]
+      │         │    └── variable: order_id [type=int4]
+      │         ├── const-agg [type=varchar, outer=(2)]
+      │         │    └── variable: address [type=varchar]
       │         ├── const-agg [type=timestamp, outer=(3)]
       │         │    └── variable: createdon [type=timestamp]
-      │         ├── const-agg [type=string, outer=(4)]
-      │         │    └── variable: name [type=string]
-      │         ├── const-agg [type=string, outer=(5)]
-      │         │    └── variable: nickname [type=string]
-      │         └── const-agg [type=int, outer=(6)]
-      │              └── variable: version [type=int]
+      │         ├── const-agg [type=varchar, outer=(4)]
+      │         │    └── variable: name [type=varchar]
+      │         ├── const-agg [type=varchar, outer=(5)]
+      │         │    └── variable: nickname [type=varchar]
+      │         └── const-agg [type=int4, outer=(6)]
+      │              └── variable: version [type=int4]
       └── filters
            └── max = 0 [type=bool, outer=(12), constraints=(/12: [/0 - /0]; tight), fd=()-->(12)]
 
@@ -1094,12 +1094,12 @@ where
     )
 ----
 semi-join
- ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
+ ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person0_
- │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
+ │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  ├── select
@@ -1137,12 +1137,12 @@ where
     )
 ----
 semi-join
- ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
+ ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person0_
- │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
+ │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  ├── select
@@ -1180,11 +1180,11 @@ where
     )
 ----
 semi-join
- ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
+ ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person0_
- │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
+ │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  ├── scan phones1_
@@ -1213,12 +1213,12 @@ where
     )
 ----
 anti-join
- ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(string) person_i4_4_:4(int) phone_ty3_4_:3(string)
+ ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(varchar) person_i4_4_:4(int) phone_ty3_4_:3(varchar)
  ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── scan phone0_
- │    ├── columns: id:1(int!null) phone_number:2(string) phone_type:3(string) person_id:4(int)
+ │    ├── columns: id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) person_id:4(int)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4)
  ├── select
@@ -1252,25 +1252,25 @@ where
     )
 ----
 semi-join (merge)
- ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
+ ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── left ordering: +1
  ├── right ordering: +10
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person0_
- │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
+ │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-6)
  │    └── ordering: +1
  ├── sort
- │    ├── columns: person_id:10(int) order_id:11(int!null)
+ │    ├── columns: person_id:10(int) order_id:11(int4!null)
  │    ├── fd: ()-->(11)
  │    ├── ordering: +10 opt(11) [actual: +10]
  │    └── select
- │         ├── columns: person_id:10(int) order_id:11(int!null)
+ │         ├── columns: person_id:10(int) order_id:11(int4!null)
  │         ├── fd: ()-->(11)
  │         ├── scan phones1_
- │         │    └── columns: person_id:10(int) order_id:11(int)
+ │         │    └── columns: person_id:10(int) order_id:11(int4)
  │         └── filters
  │              └── order_id = 1 [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight), fd=()-->(11)]
  └── filters (true)
@@ -1300,37 +1300,37 @@ where
     and phones2_.phone_type='LAND_LINE'
 ----
 project
- ├── columns: id1_2_:1(int) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int)
+ ├── columns: id1_2_:1(int) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4)
  ├── fd: (1)-->(2-6)
  └── select
-      ├── columns: person0_.id:1(int) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int) phones2_.id:7(int!null) phones2_.order_id:11(int!null) max:17(int!null)
+      ├── columns: person0_.id:1(int) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4) phones2_.id:7(int!null) phones2_.order_id:11(int4!null) max:17(int!null)
       ├── key: (7)
       ├── fd: (1)-->(2-6), (7)-->(1-6,11,17), (11)==(17), (17)==(11)
       ├── group-by
-      │    ├── columns: person0_.id:1(int) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int) phones2_.id:7(int!null) phones2_.order_id:11(int) max:17(int)
+      │    ├── columns: person0_.id:1(int) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4) phones2_.id:7(int!null) phones2_.order_id:11(int4) max:17(int)
       │    ├── grouping columns: phones2_.id:7(int!null)
       │    ├── key: (7)
       │    ├── fd: (1)-->(2-6), (7)-->(1-6,11,17)
       │    ├── inner-join
-      │    │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null) phones2_.id:7(int!null) phones2_.phone_type:9(string!null) phones2_.person_id:10(int!null) phones2_.order_id:11(int) phones1_.person_id:15(int!null) phones1_.order_id:16(int!null)
+      │    │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null) phones2_.id:7(int!null) phones2_.phone_type:9(varchar!null) phones2_.person_id:10(int!null) phones2_.order_id:11(int4) phones1_.person_id:15(int!null) phones1_.order_id:16(int4!null)
       │    │    ├── fd: ()-->(9), (1)-->(2-6), (7)-->(10,11), (1)==(10,15), (10)==(1,15), (15)==(1,10)
       │    │    ├── select
-      │    │    │    ├── columns: phones1_.person_id:15(int) phones1_.order_id:16(int!null)
+      │    │    │    ├── columns: phones1_.person_id:15(int) phones1_.order_id:16(int4!null)
       │    │    │    ├── scan phones1_
-      │    │    │    │    └── columns: phones1_.person_id:15(int) phones1_.order_id:16(int)
+      │    │    │    │    └── columns: phones1_.person_id:15(int) phones1_.order_id:16(int4)
       │    │    │    └── filters
       │    │    │         └── phones1_.order_id IS NOT NULL [type=bool, outer=(16), constraints=(/16: (/NULL - ]; tight)]
       │    │    ├── inner-join (lookup person)
-      │    │    │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null) phones2_.id:7(int!null) phones2_.phone_type:9(string!null) phones2_.person_id:10(int!null) phones2_.order_id:11(int)
+      │    │    │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null) phones2_.id:7(int!null) phones2_.phone_type:9(varchar!null) phones2_.person_id:10(int!null) phones2_.order_id:11(int4)
       │    │    │    ├── key columns: [10] = [1]
       │    │    │    ├── key: (7)
       │    │    │    ├── fd: ()-->(9), (1)-->(2-6), (7)-->(10,11), (1)==(10), (10)==(1)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: phones2_.id:7(int!null) phones2_.phone_type:9(string!null) phones2_.person_id:10(int) phones2_.order_id:11(int)
+      │    │    │    │    ├── columns: phones2_.id:7(int!null) phones2_.phone_type:9(varchar!null) phones2_.person_id:10(int) phones2_.order_id:11(int4)
       │    │    │    │    ├── key: (7)
       │    │    │    │    ├── fd: ()-->(9), (7)-->(10,11)
       │    │    │    │    ├── scan phones2_
-      │    │    │    │    │    ├── columns: phones2_.id:7(int!null) phones2_.phone_type:9(string) phones2_.person_id:10(int) phones2_.order_id:11(int)
+      │    │    │    │    │    ├── columns: phones2_.id:7(int!null) phones2_.phone_type:9(varchar) phones2_.person_id:10(int) phones2_.order_id:11(int4)
       │    │    │    │    │    ├── key: (7)
       │    │    │    │    │    └── fd: (7)-->(9-11)
       │    │    │    │    └── filters
@@ -1339,20 +1339,20 @@ project
       │    │    └── filters
       │    │         └── person0_.id = phones1_.person_id [type=bool, outer=(1,15), constraints=(/1: (/NULL - ]; /15: (/NULL - ]), fd=(1)==(15), (15)==(1)]
       │    └── aggregations
-      │         ├── max [type=int, outer=(16)]
-      │         │    └── variable: phones1_.order_id [type=int]
-      │         ├── const-agg [type=int, outer=(11)]
-      │         │    └── variable: phones2_.order_id [type=int]
-      │         ├── const-agg [type=string, outer=(2)]
-      │         │    └── variable: address [type=string]
+      │         ├── max [type=int4, outer=(16)]
+      │         │    └── variable: phones1_.order_id [type=int4]
+      │         ├── const-agg [type=int4, outer=(11)]
+      │         │    └── variable: phones2_.order_id [type=int4]
+      │         ├── const-agg [type=varchar, outer=(2)]
+      │         │    └── variable: address [type=varchar]
       │         ├── const-agg [type=timestamp, outer=(3)]
       │         │    └── variable: createdon [type=timestamp]
-      │         ├── const-agg [type=string, outer=(4)]
-      │         │    └── variable: name [type=string]
-      │         ├── const-agg [type=string, outer=(5)]
-      │         │    └── variable: nickname [type=string]
-      │         ├── const-agg [type=int, outer=(6)]
-      │         │    └── variable: version [type=int]
+      │         ├── const-agg [type=varchar, outer=(4)]
+      │         │    └── variable: name [type=varchar]
+      │         ├── const-agg [type=varchar, outer=(5)]
+      │         │    └── variable: nickname [type=varchar]
+      │         ├── const-agg [type=int4, outer=(6)]
+      │         │    └── variable: version [type=int4]
       │         └── const-agg [type=int, outer=(1)]
       │              └── variable: person0_.id [type=int]
       └── filters
@@ -1377,11 +1377,11 @@ where
         person0_.id=phones1_.person_id))
 ----
 anti-join
- ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
+ ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person0_
- │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
+ │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  ├── scan phones1_
@@ -1412,11 +1412,11 @@ where
     )
 ----
 semi-join
- ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
+ ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person0_
- │    ├── columns: person0_.id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
+ │    ├── columns: person0_.id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6)
  ├── scan phones1_
@@ -1443,11 +1443,11 @@ where
         phone0_.id=calls1_.phone_id))
 ----
 anti-join
- ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(string) person_i4_4_:4(int) phone_ty3_4_:3(string)
+ ├── columns: id1_4_:1(int!null) phone_nu2_4_:2(varchar) person_i4_4_:4(int) phone_ty3_4_:3(varchar)
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── scan phone0_
- │    ├── columns: phone0_.id:1(int!null) phone_number:2(string) phone_type:3(string) person_id:4(int)
+ │    ├── columns: phone0_.id:1(int!null) phone_number:2(varchar) phone_type:3(varchar) person_id:4(int)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4)
  ├── scan calls1_
@@ -1478,22 +1478,22 @@ where
     )
 ----
 semi-join (merge)
- ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
+ ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── left ordering: +1
  ├── right ordering: +7
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person0_
- │    ├── columns: id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
+ │    ├── columns: id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-6)
  │    └── ordering: +1
  ├── select
- │    ├── columns: person_id:7(int!null) addresses:8(string!null)
+ │    ├── columns: person_id:7(int!null) addresses:8(varchar!null)
  │    ├── fd: ()-->(8)
  │    ├── ordering: +7 opt(8) [actual: +7]
  │    ├── scan addresses1_
- │    │    ├── columns: person_id:7(int!null) addresses:8(string)
+ │    │    ├── columns: person_id:7(int!null) addresses:8(varchar)
  │    │    └── ordering: +7 opt(8) [actual: +7]
  │    └── filters
  │         └── addresses = 'Home address' [type=bool, outer=(8), constraints=(/8: [/'Home address' - /'Home address']; tight), fd=()-->(8)]
@@ -1520,21 +1520,21 @@ where
     )
 ----
 anti-join (merge)
- ├── columns: id1_2_:1(int!null) address2_2_:2(string) createdo3_2_:3(timestamp) name4_2_:4(string) nickname5_2_:5(string) version6_2_:6(int!null)
+ ├── columns: id1_2_:1(int!null) address2_2_:2(varchar) createdo3_2_:3(timestamp) name4_2_:4(varchar) nickname5_2_:5(varchar) version6_2_:6(int4!null)
  ├── left ordering: +1
  ├── right ordering: +7
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  ├── scan person0_
- │    ├── columns: id:1(int!null) address:2(string) createdon:3(timestamp) name:4(string) nickname:5(string) version:6(int!null)
+ │    ├── columns: id:1(int!null) address:2(varchar) createdon:3(timestamp) name:4(varchar) nickname:5(varchar) version:6(int4!null)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-6)
  │    └── ordering: +1
  ├── select
- │    ├── columns: person_id:7(int!null) addresses:8(string)
+ │    ├── columns: person_id:7(int!null) addresses:8(varchar)
  │    ├── ordering: +7
  │    ├── scan addresses1_
- │    │    ├── columns: person_id:7(int!null) addresses:8(string)
+ │    │    ├── columns: person_id:7(int!null) addresses:8(varchar)
  │    │    └── ordering: +7
  │    └── filters
  │         └── (addresses = 'Home address') IS NOT false [type=bool, outer=(8)]
@@ -1557,7 +1557,7 @@ create table EMPLOYEE (
 ----
 TABLE employee
  ├── id int not null
- ├── email string
+ ├── email varchar
  ├── currentproject_id int
  └── INDEX primary
       └── id int not null
@@ -1570,7 +1570,7 @@ create table Employee_phones (
 ----
 TABLE employee_phones
  ├── employee_id int not null
- ├── phone_number string
+ ├── phone_number varchar
  ├── rowid int not null (hidden)
  └── INDEX primary
       └── rowid int not null (hidden)
@@ -1593,23 +1593,23 @@ where
     )=1
 ----
 project
- ├── columns: id1_0_:1(int!null) email2_0_:2(string) currentp3_0_:3(int)
+ ├── columns: id1_0_:1(int!null) email2_0_:2(varchar) currentp3_0_:3(int)
  ├── key: (1)
  ├── fd: (1)-->(2,3)
  └── select
-      ├── columns: id:1(int!null) email:2(string) currentproject_id:3(int) count:7(int!null)
+      ├── columns: id:1(int!null) email:2(varchar) currentproject_id:3(int) count:7(int!null)
       ├── key: (1)
       ├── fd: ()-->(7), (1)-->(2,3)
       ├── group-by
-      │    ├── columns: id:1(int!null) email:2(string) currentproject_id:3(int) count:7(int)
+      │    ├── columns: id:1(int!null) email:2(varchar) currentproject_id:3(int) count:7(int)
       │    ├── grouping columns: id:1(int!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,3,7)
       │    ├── left-join
-      │    │    ├── columns: id:1(int!null) email:2(string) currentproject_id:3(int) employee_id:4(int)
+      │    │    ├── columns: id:1(int!null) email:2(varchar) currentproject_id:3(int) employee_id:4(int)
       │    │    ├── fd: (1)-->(2,3)
       │    │    ├── scan componenti0_
-      │    │    │    ├── columns: id:1(int!null) email:2(string) currentproject_id:3(int)
+      │    │    │    ├── columns: id:1(int!null) email:2(varchar) currentproject_id:3(int)
       │    │    │    ├── key: (1)
       │    │    │    └── fd: (1)-->(2,3)
       │    │    ├── scan phones1_
@@ -1619,8 +1619,8 @@ project
       │    └── aggregations
       │         ├── count [type=int, outer=(4)]
       │         │    └── variable: employee_id [type=int]
-      │         ├── const-agg [type=string, outer=(2)]
-      │         │    └── variable: email [type=string]
+      │         ├── const-agg [type=varchar, outer=(2)]
+      │         │    └── variable: email [type=varchar]
       │         └── const-agg [type=int, outer=(3)]
       │              └── variable: currentproject_id [type=int]
       └── filters
@@ -1692,8 +1692,8 @@ create table Location (
 ----
 TABLE location
  ├── id int not null
- ├── address string
- ├── zip int not null
+ ├── address varchar
+ ├── zip int4 not null
  └── INDEX primary
       └── id int not null
 
@@ -1730,7 +1730,7 @@ where
         and employees1_.employees_id=employee2_.id))
 ----
 left-join
- ├── columns: id1_0_0_:1(int!null) id1_8_1_:3(int) location2_0_0_:2(int) address2_8_1_:4(string) zip3_8_1_:5(int)
+ ├── columns: id1_0_0_:1(int!null) id1_8_1_:3(int) location2_0_0_:2(int) address2_8_1_:4(varchar) zip3_8_1_:5(int4)
  ├── key: (1,3)
  ├── fd: (1)-->(2), (3)-->(4,5)
  ├── anti-join
@@ -1774,7 +1774,7 @@ left-join
  │    └── filters
  │         └── company0_.id = company_id [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  ├── scan location3_
- │    ├── columns: location3_.id:3(int!null) address:4(string) zip:5(int!null)
+ │    ├── columns: location3_.id:3(int!null) address:4(varchar) zip:5(int4!null)
  │    ├── key: (3)
  │    └── fd: (3)-->(4,5)
  └── filters
@@ -1798,11 +1798,11 @@ create table News (
 )
 ----
 TABLE news
- ├── news_id int not null
- ├── detail string
- ├── title string
+ ├── news_id int4 not null
+ ├── detail varchar
+ ├── title varchar
  └── INDEX primary
-      └── news_id int not null
+      └── news_id int4 not null
 
 exec-ddl
 create table Newspaper (
@@ -1812,10 +1812,10 @@ create table Newspaper (
 )
 ----
 TABLE newspaper
- ├── id int not null
- ├── name string
+ ├── id int4 not null
+ ├── name varchar
  └── INDEX primary
-      └── id int not null
+      └── id int4 not null
 
 exec-ddl
 create table Newspaper_News (
@@ -1825,11 +1825,11 @@ create table Newspaper_News (
 )
 ----
 TABLE newspaper_news
- ├── newspaper_id int not null
- ├── news_news_id int not null
+ ├── newspaper_id int4 not null
+ ├── news_news_id int4 not null
  └── INDEX primary
-      ├── newspaper_id int not null
-      └── news_news_id int not null
+      ├── newspaper_id int4 not null
+      └── news_news_id int4 not null
 
 opt
 select
@@ -1853,27 +1853,27 @@ where
     news0_.Newspaper_id=1
 ----
 project
- ├── columns: newspape1_23_0_:1(int!null) news_new2_23_0_:2(int!null) formula140_0_:9(string) news_id1_21_1_:3(int!null) detail2_21_1_:4(string) title3_21_1_:5(string)
+ ├── columns: newspape1_23_0_:1(int4!null) news_new2_23_0_:2(int4!null) formula140_0_:9(varchar) news_id1_21_1_:3(int4!null) detail2_21_1_:4(varchar) title3_21_1_:5(varchar)
  ├── fd: ()-->(1), (3)-->(4,5), (2)==(3), (3)==(2)
  ├── left-join (lookup news)
- │    ├── columns: newspaper_id:1(int!null) news_news_id:2(int!null) news1_.news_id:3(int!null) news1_.detail:4(string) news1_.title:5(string) a0.news_id:6(int) a0.title:8(string)
+ │    ├── columns: newspaper_id:1(int4!null) news_news_id:2(int4!null) news1_.news_id:3(int4!null) news1_.detail:4(varchar) news1_.title:5(varchar) a0.news_id:6(int4) a0.title:8(varchar)
  │    ├── key columns: [2] = [6]
  │    ├── key: (3,6)
  │    ├── fd: ()-->(1), (3)-->(4,5), (2)==(3), (3)==(2), (6)-->(8)
  │    ├── inner-join (lookup news)
- │    │    ├── columns: newspaper_id:1(int!null) news_news_id:2(int!null) news1_.news_id:3(int!null) news1_.detail:4(string) news1_.title:5(string)
+ │    │    ├── columns: newspaper_id:1(int4!null) news_news_id:2(int4!null) news1_.news_id:3(int4!null) news1_.detail:4(varchar) news1_.title:5(varchar)
  │    │    ├── key columns: [2] = [3]
  │    │    ├── key: (3)
  │    │    ├── fd: ()-->(1), (3)-->(4,5), (2)==(3), (3)==(2)
  │    │    ├── scan news0_
- │    │    │    ├── columns: newspaper_id:1(int!null) news_news_id:2(int!null)
+ │    │    │    ├── columns: newspaper_id:1(int4!null) news_news_id:2(int4!null)
  │    │    │    ├── constraint: /1/2: [/1 - /1]
  │    │    │    ├── key: (2)
  │    │    │    └── fd: ()-->(1)
  │    │    └── filters (true)
  │    └── filters (true)
  └── projections
-      └── variable: a0.title [type=string, outer=(8)]
+      └── variable: a0.title [type=varchar, outer=(8)]
 
 exec-ddl
 drop table News, Newspaper, Newspaper_News;
@@ -1893,12 +1893,12 @@ create table GenerationGroup (
 )
 ----
 TABLE generationgroup
- ├── id int not null
- ├── age string
- ├── culture string
- ├── description string
+ ├── id int4 not null
+ ├── age varchar
+ ├── culture varchar
+ ├── description varchar
  └── INDEX primary
-      └── id int not null
+      └── id int4 not null
 
 exec-ddl
 create table GenerationUser (
@@ -1907,9 +1907,9 @@ create table GenerationUser (
 )
 ----
 TABLE generationuser
- ├── id int not null
+ ├── id int4 not null
  └── INDEX primary
-      └── id int not null
+      └── id int4 not null
 
 exec-ddl
 create table GenerationUser_GenerationGroup (
@@ -1919,11 +1919,11 @@ create table GenerationUser_GenerationGroup (
 )
 ----
 TABLE generationuser_generationgroup
- ├── generationuser_id int not null
- ├── ref_id int not null
+ ├── generationuser_id int4 not null
+ ├── ref_id int4 not null
  └── INDEX primary
-      ├── generationuser_id int not null
-      └── ref_id int not null
+      ├── generationuser_id int4 not null
+      └── ref_id int4 not null
 
 opt
 SELECT ref0_.generationuser_id AS generati1_2_0_
@@ -1947,30 +1947,30 @@ INNER JOIN generationgroup AS generation1_
 WHERE ref0_.generationuser_id = 1;
 ----
 project
- ├── columns: generati1_2_0_:1(int!null) ref_id2_2_0_:2(int!null) formula131_0_:19(string) formula132_0_:20(string) formula133_0_:21(string) id1_0_1_:3(int!null) age2_0_1_:4(string) culture3_0_1_:5(string) descript4_0_1_:6(string)
+ ├── columns: generati1_2_0_:1(int4!null) ref_id2_2_0_:2(int4!null) formula131_0_:19(varchar) formula132_0_:20(varchar) formula133_0_:21(varchar) id1_0_1_:3(int4!null) age2_0_1_:4(varchar) culture3_0_1_:5(varchar) descript4_0_1_:6(varchar)
  ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
  ├── left-join (lookup generationgroup)
- │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generation1_.id:3(int!null) generation1_.age:4(string) generation1_.culture:5(string) generation1_.description:6(string) a13.id:7(int) a13.age:8(string) a15.id:11(int) a15.culture:13(string) a13.id:15(int) a13.description:18(string)
+ │    ├── columns: generationuser_id:1(int4!null) ref_id:2(int4!null) generation1_.id:3(int4!null) generation1_.age:4(varchar) generation1_.culture:5(varchar) generation1_.description:6(varchar) a13.id:7(int4) a13.age:8(varchar) a15.id:11(int4) a15.culture:13(varchar) a13.id:15(int4) a13.description:18(varchar)
  │    ├── key columns: [2] = [15]
  │    ├── key: (3,7,11,15)
  │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (7)-->(8), (11)-->(13), (15)-->(18)
  │    ├── left-join (lookup generationgroup)
- │    │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generation1_.id:3(int!null) generation1_.age:4(string) generation1_.culture:5(string) generation1_.description:6(string) a13.id:7(int) a13.age:8(string) a15.id:11(int) a15.culture:13(string)
+ │    │    ├── columns: generationuser_id:1(int4!null) ref_id:2(int4!null) generation1_.id:3(int4!null) generation1_.age:4(varchar) generation1_.culture:5(varchar) generation1_.description:6(varchar) a13.id:7(int4) a13.age:8(varchar) a15.id:11(int4) a15.culture:13(varchar)
  │    │    ├── key columns: [2] = [11]
  │    │    ├── key: (3,7,11)
  │    │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (7)-->(8), (11)-->(13)
  │    │    ├── left-join (lookup generationgroup)
- │    │    │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generation1_.id:3(int!null) generation1_.age:4(string) generation1_.culture:5(string) generation1_.description:6(string) a13.id:7(int) a13.age:8(string)
+ │    │    │    ├── columns: generationuser_id:1(int4!null) ref_id:2(int4!null) generation1_.id:3(int4!null) generation1_.age:4(varchar) generation1_.culture:5(varchar) generation1_.description:6(varchar) a13.id:7(int4) a13.age:8(varchar)
  │    │    │    ├── key columns: [2] = [7]
  │    │    │    ├── key: (3,7)
  │    │    │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2), (7)-->(8)
  │    │    │    ├── inner-join (lookup generationgroup)
- │    │    │    │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null) generation1_.id:3(int!null) generation1_.age:4(string) generation1_.culture:5(string) generation1_.description:6(string)
+ │    │    │    │    ├── columns: generationuser_id:1(int4!null) ref_id:2(int4!null) generation1_.id:3(int4!null) generation1_.age:4(varchar) generation1_.culture:5(varchar) generation1_.description:6(varchar)
  │    │    │    │    ├── key columns: [2] = [3]
  │    │    │    │    ├── key: (3)
  │    │    │    │    ├── fd: ()-->(1), (3)-->(4-6), (2)==(3), (3)==(2)
  │    │    │    │    ├── scan ref0_
- │    │    │    │    │    ├── columns: generationuser_id:1(int!null) ref_id:2(int!null)
+ │    │    │    │    │    ├── columns: generationuser_id:1(int4!null) ref_id:2(int4!null)
  │    │    │    │    │    ├── constraint: /1/2: [/1 - /1]
  │    │    │    │    │    ├── key: (2)
  │    │    │    │    │    └── fd: ()-->(1)
@@ -1979,9 +1979,9 @@ project
  │    │    └── filters (true)
  │    └── filters (true)
  └── projections
-      ├── variable: a13.age [type=string, outer=(8)]
-      ├── variable: a15.culture [type=string, outer=(13)]
-      └── variable: a13.description [type=string, outer=(18)]
+      ├── variable: a13.age [type=varchar, outer=(8)]
+      ├── variable: a15.culture [type=varchar, outer=(13)]
+      └── variable: a13.description [type=varchar, outer=(18)]
 
 exec-ddl
 drop table GenerationGroup, GenerationUser, GenerationUser_GenerationGroup;
@@ -2002,7 +2002,7 @@ create table TAuction2 (
 ----
 TABLE tauction2
  ├── id int not null
- ├── description string
+ ├── description varchar
  ├── enddatetime timestamp
  ├── successfulbid int
  └── INDEX primary
@@ -2108,11 +2108,11 @@ CREATE TABLE customer (
 );
 ----
 TABLE customer
- ├── customerid string not null
- ├── name string not null
- ├── address string not null
+ ├── customerid varchar not null
+ ├── name varchar not null
+ ├── address varchar not null
  └── INDEX primary
-      └── customerid string not null
+      └── customerid varchar not null
 
 exec-ddl
 CREATE TABLE customerorder (
@@ -2123,12 +2123,12 @@ CREATE TABLE customerorder (
 );
 ----
 TABLE customerorder
- ├── customerid string not null
- ├── ordernumber int not null
+ ├── customerid varchar not null
+ ├── ordernumber int4 not null
  ├── orderdate date not null
  └── INDEX primary
-      ├── customerid string not null
-      └── ordernumber int not null
+      ├── customerid varchar not null
+      └── ordernumber int4 not null
 
 exec-ddl
 CREATE TABLE lineitem (
@@ -2140,14 +2140,14 @@ CREATE TABLE lineitem (
 );
 ----
 TABLE lineitem
- ├── customerid string not null
- ├── ordernumber int not null
- ├── productid string not null
- ├── quantity int
+ ├── customerid varchar not null
+ ├── ordernumber int4 not null
+ ├── productid varchar not null
+ ├── quantity int4
  └── INDEX primary
-      ├── customerid string not null
-      ├── ordernumber int not null
-      └── productid string not null
+      ├── customerid varchar not null
+      ├── ordernumber int4 not null
+      └── productid varchar not null
 
 exec-ddl
 CREATE TABLE product (
@@ -2159,12 +2159,12 @@ CREATE TABLE product (
 );
 ----
 TABLE product
- ├── productid string not null
- ├── description string not null
+ ├── productid varchar not null
+ ├── description varchar not null
  ├── cost decimal
- ├── numberavailable int
+ ├── numberavailable int4
  └── INDEX primary
-      └── productid string not null
+      └── productid varchar not null
 
 opt
 SELECT
@@ -2199,29 +2199,29 @@ WHERE
   order0_.customerid = 'c111' AND order0_.ordernumber = 0;
 ----
 project
- ├── columns: customer1_1_0_:1(string) ordernum2_1_0_:2(int) orderdat3_1_0_:3(date) formula101_0_:18(decimal) customer1_2_1_:4(string) ordernum2_2_1_:5(int) producti3_2_1_:6(string) customer1_2_2_:4(string) ordernum2_2_2_:5(int) producti3_2_2_:6(string) quantity4_2_2_:7(int)
+ ├── columns: customer1_1_0_:1(varchar) ordernum2_1_0_:2(int4) orderdat3_1_0_:3(date) formula101_0_:18(decimal) customer1_2_1_:4(varchar) ordernum2_2_1_:5(int4) producti3_2_1_:6(varchar) customer1_2_2_:4(varchar) ordernum2_2_2_:5(int4) producti3_2_2_:6(varchar) quantity4_2_2_:7(int4)
  ├── key: (6)
  ├── fd: ()-->(1-3), (6)-->(4,5,7,18), ()~~>(4,5)
  ├── group-by
- │    ├── columns: order0_.customerid:1(string) order0_.ordernumber:2(int) orderdate:3(date) lineitems1_.customerid:4(string) lineitems1_.ordernumber:5(int) lineitems1_.productid:6(string) lineitems1_.quantity:7(int) sum:17(decimal)
- │    ├── grouping columns: lineitems1_.productid:6(string)
+ │    ├── columns: order0_.customerid:1(varchar) order0_.ordernumber:2(int4) orderdate:3(date) lineitems1_.customerid:4(varchar) lineitems1_.ordernumber:5(int4) lineitems1_.productid:6(varchar) lineitems1_.quantity:7(int4) sum:17(decimal)
+ │    ├── grouping columns: lineitems1_.productid:6(varchar)
  │    ├── key: (6)
  │    ├── fd: ()-->(1-3), (6)-->(1-5,7,17), ()~~>(4,5)
  │    ├── right-join
- │    │    ├── columns: order0_.customerid:1(string!null) order0_.ordernumber:2(int!null) orderdate:3(date!null) lineitems1_.customerid:4(string) lineitems1_.ordernumber:5(int) lineitems1_.productid:6(string) lineitems1_.quantity:7(int) li.customerid:8(string) li.ordernumber:9(int) column16:16(decimal)
+ │    │    ├── columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null) orderdate:3(date!null) lineitems1_.customerid:4(varchar) lineitems1_.ordernumber:5(int4) lineitems1_.productid:6(varchar) lineitems1_.quantity:7(int4) li.customerid:8(varchar) li.ordernumber:9(int4) column16:16(decimal)
  │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
  │    │    ├── project
- │    │    │    ├── columns: column16:16(decimal) li.customerid:8(string!null) li.ordernumber:9(int!null)
+ │    │    │    ├── columns: column16:16(decimal) li.customerid:8(varchar!null) li.ordernumber:9(int4!null)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: li.customerid:8(string!null) li.ordernumber:9(int!null) li.productid:10(string!null) li.quantity:11(int) p.productid:12(string!null) cost:14(decimal)
+ │    │    │    │    ├── columns: li.customerid:8(varchar!null) li.ordernumber:9(int4!null) li.productid:10(varchar!null) li.quantity:11(int4) p.productid:12(varchar!null) cost:14(decimal)
  │    │    │    │    ├── key: (8,9,12)
  │    │    │    │    ├── fd: (8-10)-->(11), (12)-->(14), (10)==(12), (12)==(10)
  │    │    │    │    ├── scan li
- │    │    │    │    │    ├── columns: li.customerid:8(string!null) li.ordernumber:9(int!null) li.productid:10(string!null) li.quantity:11(int)
+ │    │    │    │    │    ├── columns: li.customerid:8(varchar!null) li.ordernumber:9(int4!null) li.productid:10(varchar!null) li.quantity:11(int4)
  │    │    │    │    │    ├── key: (8-10)
  │    │    │    │    │    └── fd: (8-10)-->(11)
  │    │    │    │    ├── scan p
- │    │    │    │    │    ├── columns: p.productid:12(string!null) cost:14(decimal)
+ │    │    │    │    │    ├── columns: p.productid:12(varchar!null) cost:14(decimal)
  │    │    │    │    │    ├── key: (12)
  │    │    │    │    │    └── fd: (12)-->(14)
  │    │    │    │    └── filters
@@ -2229,19 +2229,19 @@ project
  │    │    │    └── projections
  │    │    │         └── li.quantity * cost [type=decimal, outer=(11,14)]
  │    │    ├── left-join (merge)
- │    │    │    ├── columns: order0_.customerid:1(string!null) order0_.ordernumber:2(int!null) orderdate:3(date!null) lineitems1_.customerid:4(string) lineitems1_.ordernumber:5(int) lineitems1_.productid:6(string) lineitems1_.quantity:7(int)
+ │    │    │    ├── columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null) orderdate:3(date!null) lineitems1_.customerid:4(varchar) lineitems1_.ordernumber:5(int4) lineitems1_.productid:6(varchar) lineitems1_.quantity:7(int4)
  │    │    │    ├── left ordering: +1,+2
  │    │    │    ├── right ordering: +4,+5
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
  │    │    │    ├── scan order0_
- │    │    │    │    ├── columns: order0_.customerid:1(string!null) order0_.ordernumber:2(int!null) orderdate:3(date!null)
+ │    │    │    │    ├── columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null) orderdate:3(date!null)
  │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
  │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    ├── key: ()
  │    │    │    │    └── fd: ()-->(1-3)
  │    │    │    ├── scan lineitems1_
- │    │    │    │    ├── columns: lineitems1_.customerid:4(string!null) lineitems1_.ordernumber:5(int!null) lineitems1_.productid:6(string!null) lineitems1_.quantity:7(int)
+ │    │    │    │    ├── columns: lineitems1_.customerid:4(varchar!null) lineitems1_.ordernumber:5(int4!null) lineitems1_.productid:6(varchar!null) lineitems1_.quantity:7(int4)
  │    │    │    │    ├── constraint: /4/5/6: [/'c111'/0 - /'c111'/0]
  │    │    │    │    ├── key: (6)
  │    │    │    │    └── fd: ()-->(4,5), (6)-->(7)
@@ -2252,18 +2252,18 @@ project
  │    └── aggregations
  │         ├── sum [type=decimal, outer=(16)]
  │         │    └── variable: column16 [type=decimal]
- │         ├── const-agg [type=string, outer=(1)]
- │         │    └── variable: order0_.customerid [type=string]
- │         ├── const-agg [type=int, outer=(2)]
- │         │    └── variable: order0_.ordernumber [type=int]
+ │         ├── const-agg [type=varchar, outer=(1)]
+ │         │    └── variable: order0_.customerid [type=varchar]
+ │         ├── const-agg [type=int4, outer=(2)]
+ │         │    └── variable: order0_.ordernumber [type=int4]
  │         ├── const-agg [type=date, outer=(3)]
  │         │    └── variable: orderdate [type=date]
- │         ├── const-agg [type=string, outer=(4)]
- │         │    └── variable: lineitems1_.customerid [type=string]
- │         ├── const-agg [type=int, outer=(5)]
- │         │    └── variable: lineitems1_.ordernumber [type=int]
- │         └── const-agg [type=int, outer=(7)]
- │              └── variable: lineitems1_.quantity [type=int]
+ │         ├── const-agg [type=varchar, outer=(4)]
+ │         │    └── variable: lineitems1_.customerid [type=varchar]
+ │         ├── const-agg [type=int4, outer=(5)]
+ │         │    └── variable: lineitems1_.ordernumber [type=int4]
+ │         └── const-agg [type=int4, outer=(7)]
+ │              └── variable: lineitems1_.quantity [type=int4]
  └── projections
       └── variable: sum [type=decimal, outer=(17)]
 
@@ -2320,75 +2320,75 @@ FROM
   LEFT JOIN product AS product3_ ON lineitems2_.productid = product3_.productid;
 ----
 project
- ├── columns: customer1_0_0_:1(string!null) customer1_1_1_:4(string) ordernum2_1_1_:5(int) customer1_2_2_:7(string) ordernum2_2_2_:8(int) producti3_2_2_:9(string) producti1_3_3_:11(string) name2_0_0_:2(string) address3_0_0_:3(string) orderdat3_1_1_:6(date) formula103_1_:30(decimal) customer1_1_0__:4(string) ordernum2_1_0__:5(int) ordernum2_0__:5(int) quantity4_2_2_:10(int) customer1_2_1__:7(string) ordernum2_2_1__:8(int) producti3_2_1__:9(string) descript2_3_3_:12(string) cost3_3_3_:13(decimal) numberav4_3_3_:14(int) formula104_3_:31(decimal)
+ ├── columns: customer1_0_0_:1(varchar!null) customer1_1_1_:4(varchar) ordernum2_1_1_:5(int4) customer1_2_2_:7(varchar) ordernum2_2_2_:8(int4) producti3_2_2_:9(varchar) producti1_3_3_:11(varchar) name2_0_0_:2(varchar) address3_0_0_:3(varchar) orderdat3_1_1_:6(date) formula103_1_:30(decimal) customer1_1_0__:4(varchar) ordernum2_1_0__:5(int4) ordernum2_0__:5(int4) quantity4_2_2_:10(int4) customer1_2_1__:7(varchar) ordernum2_2_1__:8(int4) producti3_2_1__:9(varchar) descript2_3_3_:12(varchar) cost3_3_3_:13(decimal) numberav4_3_3_:14(int4) formula104_3_:31(decimal)
  ├── key: (1,4,5,7-9,11)
  ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,30,31)
  ├── group-by
- │    ├── columns: customer0_.customerid:1(string!null) name:2(string) address:3(string) orders1_.customerid:4(string) orders1_.ordernumber:5(int) orderdate:6(date) lineitems2_.customerid:7(string) lineitems2_.ordernumber:8(int) lineitems2_.productid:9(string) lineitems2_.quantity:10(int) product3_.productid:11(string) product3_.description:12(string) product3_.cost:13(decimal) product3_.numberavailable:14(int) sum:24(decimal) sum:29(decimal)
- │    ├── grouping columns: customer0_.customerid:1(string!null) orders1_.customerid:4(string) orders1_.ordernumber:5(int) lineitems2_.customerid:7(string) lineitems2_.ordernumber:8(int) lineitems2_.productid:9(string) product3_.productid:11(string)
+ │    ├── columns: customer0_.customerid:1(varchar!null) name:2(varchar) address:3(varchar) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) orderdate:6(date) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) lineitems2_.quantity:10(int4) product3_.productid:11(varchar) product3_.description:12(varchar) product3_.cost:13(decimal) product3_.numberavailable:14(int4) sum:24(decimal) sum:29(decimal)
+ │    ├── grouping columns: customer0_.customerid:1(varchar!null) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) product3_.productid:11(varchar)
  │    ├── key: (1,4,5,7-9,11)
  │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24,29)
  │    ├── left-join
- │    │    ├── columns: customer0_.customerid:1(string!null) name:2(string) address:3(string) orders1_.customerid:4(string) orders1_.ordernumber:5(int) orderdate:6(date) lineitems2_.customerid:7(string) lineitems2_.ordernumber:8(int) lineitems2_.productid:9(string) lineitems2_.quantity:10(int) product3_.productid:11(string) product3_.description:12(string) product3_.cost:13(decimal) product3_.numberavailable:14(int) sum:24(decimal) li.productid:27(string) li.quantity:28(int)
+ │    │    ├── columns: customer0_.customerid:1(varchar!null) name:2(varchar) address:3(varchar) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) orderdate:6(date) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) lineitems2_.quantity:10(int4) product3_.productid:11(varchar) product3_.description:12(varchar) product3_.cost:13(decimal) product3_.numberavailable:14(int4) sum:24(decimal) li.productid:27(varchar) li.quantity:28(int4)
  │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24)
  │    │    ├── group-by
- │    │    │    ├── columns: customer0_.customerid:1(string!null) name:2(string) address:3(string) orders1_.customerid:4(string) orders1_.ordernumber:5(int) orderdate:6(date) lineitems2_.customerid:7(string) lineitems2_.ordernumber:8(int) lineitems2_.productid:9(string) lineitems2_.quantity:10(int) product3_.productid:11(string) product3_.description:12(string) product3_.cost:13(decimal) product3_.numberavailable:14(int) sum:24(decimal)
- │    │    │    ├── grouping columns: customer0_.customerid:1(string!null) orders1_.customerid:4(string) orders1_.ordernumber:5(int) lineitems2_.customerid:7(string) lineitems2_.ordernumber:8(int) lineitems2_.productid:9(string) product3_.productid:11(string)
+ │    │    │    ├── columns: customer0_.customerid:1(varchar!null) name:2(varchar) address:3(varchar) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) orderdate:6(date) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) lineitems2_.quantity:10(int4) product3_.productid:11(varchar) product3_.description:12(varchar) product3_.cost:13(decimal) product3_.numberavailable:14(int4) sum:24(decimal)
+ │    │    │    ├── grouping columns: customer0_.customerid:1(varchar!null) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) product3_.productid:11(varchar)
  │    │    │    ├── key: (1,4,5,7-9,11)
  │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14), (1,4,5,7-9,11)-->(2,3,6,10,12-14,24)
  │    │    │    ├── left-join
- │    │    │    │    ├── columns: customer0_.customerid:1(string!null) name:2(string!null) address:3(string!null) orders1_.customerid:4(string) orders1_.ordernumber:5(int) orderdate:6(date) lineitems2_.customerid:7(string) lineitems2_.ordernumber:8(int) lineitems2_.productid:9(string) lineitems2_.quantity:10(int) product3_.productid:11(string) product3_.description:12(string) product3_.cost:13(decimal) product3_.numberavailable:14(int) li.customerid:15(string) li.ordernumber:16(int) column23:23(decimal)
+ │    │    │    │    ├── columns: customer0_.customerid:1(varchar!null) name:2(varchar!null) address:3(varchar!null) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) orderdate:6(date) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) lineitems2_.quantity:10(int4) product3_.productid:11(varchar) product3_.description:12(varchar) product3_.cost:13(decimal) product3_.numberavailable:14(int4) li.customerid:15(varchar) li.ordernumber:16(int4) column23:23(decimal)
  │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14)
  │    │    │    │    ├── left-join
- │    │    │    │    │    ├── columns: customer0_.customerid:1(string!null) name:2(string!null) address:3(string!null) orders1_.customerid:4(string) orders1_.ordernumber:5(int) orderdate:6(date) lineitems2_.customerid:7(string) lineitems2_.ordernumber:8(int) lineitems2_.productid:9(string) lineitems2_.quantity:10(int) product3_.productid:11(string) product3_.description:12(string) product3_.cost:13(decimal) product3_.numberavailable:14(int)
+ │    │    │    │    │    ├── columns: customer0_.customerid:1(varchar!null) name:2(varchar!null) address:3(varchar!null) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) orderdate:6(date) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) lineitems2_.quantity:10(int4) product3_.productid:11(varchar) product3_.description:12(varchar) product3_.cost:13(decimal) product3_.numberavailable:14(int4)
  │    │    │    │    │    ├── key: (1,4,5,7-9,11)
  │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10), (11)-->(12-14)
  │    │    │    │    │    ├── left-join
- │    │    │    │    │    │    ├── columns: customer0_.customerid:1(string!null) name:2(string!null) address:3(string!null) orders1_.customerid:4(string) orders1_.ordernumber:5(int) orderdate:6(date) lineitems2_.customerid:7(string) lineitems2_.ordernumber:8(int) lineitems2_.productid:9(string) lineitems2_.quantity:10(int)
+ │    │    │    │    │    │    ├── columns: customer0_.customerid:1(varchar!null) name:2(varchar!null) address:3(varchar!null) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) orderdate:6(date) lineitems2_.customerid:7(varchar) lineitems2_.ordernumber:8(int4) lineitems2_.productid:9(varchar) lineitems2_.quantity:10(int4)
  │    │    │    │    │    │    ├── key: (1,4,5,7-9)
  │    │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6), (7-9)-->(10)
  │    │    │    │    │    │    ├── left-join (merge)
- │    │    │    │    │    │    │    ├── columns: customer0_.customerid:1(string!null) name:2(string!null) address:3(string!null) orders1_.customerid:4(string) orders1_.ordernumber:5(int) orderdate:6(date)
+ │    │    │    │    │    │    │    ├── columns: customer0_.customerid:1(varchar!null) name:2(varchar!null) address:3(varchar!null) orders1_.customerid:4(varchar) orders1_.ordernumber:5(int4) orderdate:6(date)
  │    │    │    │    │    │    │    ├── left ordering: +1
  │    │    │    │    │    │    │    ├── right ordering: +4
  │    │    │    │    │    │    │    ├── key: (1,4,5)
  │    │    │    │    │    │    │    ├── fd: (1)-->(2,3), (4,5)-->(6)
  │    │    │    │    │    │    │    ├── scan customer0_
- │    │    │    │    │    │    │    │    ├── columns: customer0_.customerid:1(string!null) name:2(string!null) address:3(string!null)
+ │    │    │    │    │    │    │    │    ├── columns: customer0_.customerid:1(varchar!null) name:2(varchar!null) address:3(varchar!null)
  │    │    │    │    │    │    │    │    ├── key: (1)
  │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3)
  │    │    │    │    │    │    │    │    └── ordering: +1
  │    │    │    │    │    │    │    ├── scan orders1_
- │    │    │    │    │    │    │    │    ├── columns: orders1_.customerid:4(string!null) orders1_.ordernumber:5(int!null) orderdate:6(date!null)
+ │    │    │    │    │    │    │    │    ├── columns: orders1_.customerid:4(varchar!null) orders1_.ordernumber:5(int4!null) orderdate:6(date!null)
  │    │    │    │    │    │    │    │    ├── key: (4,5)
  │    │    │    │    │    │    │    │    ├── fd: (4,5)-->(6)
  │    │    │    │    │    │    │    │    └── ordering: +4
  │    │    │    │    │    │    │    └── filters (true)
  │    │    │    │    │    │    ├── scan lineitems2_
- │    │    │    │    │    │    │    ├── columns: lineitems2_.customerid:7(string!null) lineitems2_.ordernumber:8(int!null) lineitems2_.productid:9(string!null) lineitems2_.quantity:10(int)
+ │    │    │    │    │    │    │    ├── columns: lineitems2_.customerid:7(varchar!null) lineitems2_.ordernumber:8(int4!null) lineitems2_.productid:9(varchar!null) lineitems2_.quantity:10(int4)
  │    │    │    │    │    │    │    ├── key: (7-9)
  │    │    │    │    │    │    │    └── fd: (7-9)-->(10)
  │    │    │    │    │    │    └── filters
  │    │    │    │    │    │         ├── orders1_.customerid = lineitems2_.customerid [type=bool, outer=(4,7), constraints=(/4: (/NULL - ]; /7: (/NULL - ]), fd=(4)==(7), (7)==(4)]
  │    │    │    │    │    │         └── orders1_.ordernumber = lineitems2_.ordernumber [type=bool, outer=(5,8), constraints=(/5: (/NULL - ]; /8: (/NULL - ]), fd=(5)==(8), (8)==(5)]
  │    │    │    │    │    ├── scan product3_
- │    │    │    │    │    │    ├── columns: product3_.productid:11(string!null) product3_.description:12(string!null) product3_.cost:13(decimal) product3_.numberavailable:14(int)
+ │    │    │    │    │    │    ├── columns: product3_.productid:11(varchar!null) product3_.description:12(varchar!null) product3_.cost:13(decimal) product3_.numberavailable:14(int4)
  │    │    │    │    │    │    ├── key: (11)
  │    │    │    │    │    │    └── fd: (11)-->(12-14)
  │    │    │    │    │    └── filters
  │    │    │    │    │         └── lineitems2_.productid = product3_.productid [type=bool, outer=(9,11), constraints=(/9: (/NULL - ]; /11: (/NULL - ]), fd=(9)==(11), (11)==(9)]
  │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: column23:23(decimal) li.customerid:15(string!null) li.ordernumber:16(int!null)
+ │    │    │    │    │    ├── columns: column23:23(decimal) li.customerid:15(varchar!null) li.ordernumber:16(int4!null)
  │    │    │    │    │    ├── inner-join
- │    │    │    │    │    │    ├── columns: li.customerid:15(string!null) li.ordernumber:16(int!null) li.productid:17(string!null) li.quantity:18(int) p.productid:19(string!null) p.cost:21(decimal)
+ │    │    │    │    │    │    ├── columns: li.customerid:15(varchar!null) li.ordernumber:16(int4!null) li.productid:17(varchar!null) li.quantity:18(int4) p.productid:19(varchar!null) p.cost:21(decimal)
  │    │    │    │    │    │    ├── key: (15,16,19)
  │    │    │    │    │    │    ├── fd: (15-17)-->(18), (19)-->(21), (17)==(19), (19)==(17)
  │    │    │    │    │    │    ├── scan li
- │    │    │    │    │    │    │    ├── columns: li.customerid:15(string!null) li.ordernumber:16(int!null) li.productid:17(string!null) li.quantity:18(int)
+ │    │    │    │    │    │    │    ├── columns: li.customerid:15(varchar!null) li.ordernumber:16(int4!null) li.productid:17(varchar!null) li.quantity:18(int4)
  │    │    │    │    │    │    │    ├── key: (15-17)
  │    │    │    │    │    │    │    └── fd: (15-17)-->(18)
  │    │    │    │    │    │    ├── scan p
- │    │    │    │    │    │    │    ├── columns: p.productid:19(string!null) p.cost:21(decimal)
+ │    │    │    │    │    │    │    ├── columns: p.productid:19(varchar!null) p.cost:21(decimal)
  │    │    │    │    │    │    │    ├── key: (19)
  │    │    │    │    │    │    │    └── fd: (19)-->(21)
  │    │    │    │    │    │    └── filters
@@ -2401,41 +2401,41 @@ project
  │    │    │    └── aggregations
  │    │    │         ├── sum [type=decimal, outer=(23)]
  │    │    │         │    └── variable: column23 [type=decimal]
- │    │    │         ├── const-agg [type=string, outer=(2)]
- │    │    │         │    └── variable: name [type=string]
- │    │    │         ├── const-agg [type=string, outer=(3)]
- │    │    │         │    └── variable: address [type=string]
+ │    │    │         ├── const-agg [type=varchar, outer=(2)]
+ │    │    │         │    └── variable: name [type=varchar]
+ │    │    │         ├── const-agg [type=varchar, outer=(3)]
+ │    │    │         │    └── variable: address [type=varchar]
  │    │    │         ├── const-agg [type=date, outer=(6)]
  │    │    │         │    └── variable: orderdate [type=date]
- │    │    │         ├── const-agg [type=int, outer=(10)]
- │    │    │         │    └── variable: lineitems2_.quantity [type=int]
- │    │    │         ├── const-agg [type=string, outer=(12)]
- │    │    │         │    └── variable: product3_.description [type=string]
+ │    │    │         ├── const-agg [type=int4, outer=(10)]
+ │    │    │         │    └── variable: lineitems2_.quantity [type=int4]
+ │    │    │         ├── const-agg [type=varchar, outer=(12)]
+ │    │    │         │    └── variable: product3_.description [type=varchar]
  │    │    │         ├── const-agg [type=decimal, outer=(13)]
  │    │    │         │    └── variable: product3_.cost [type=decimal]
- │    │    │         └── const-agg [type=int, outer=(14)]
- │    │    │              └── variable: product3_.numberavailable [type=int]
+ │    │    │         └── const-agg [type=int4, outer=(14)]
+ │    │    │              └── variable: product3_.numberavailable [type=int4]
  │    │    ├── scan li
- │    │    │    └── columns: li.productid:27(string!null) li.quantity:28(int)
+ │    │    │    └── columns: li.productid:27(varchar!null) li.quantity:28(int4)
  │    │    └── filters
  │    │         └── li.productid = product3_.productid [type=bool, outer=(11,27), constraints=(/11: (/NULL - ]; /27: (/NULL - ]), fd=(11)==(27), (27)==(11)]
  │    └── aggregations
  │         ├── sum [type=decimal, outer=(28)]
- │         │    └── variable: li.quantity [type=int]
- │         ├── const-agg [type=string, outer=(2)]
- │         │    └── variable: name [type=string]
- │         ├── const-agg [type=string, outer=(3)]
- │         │    └── variable: address [type=string]
+ │         │    └── variable: li.quantity [type=int4]
+ │         ├── const-agg [type=varchar, outer=(2)]
+ │         │    └── variable: name [type=varchar]
+ │         ├── const-agg [type=varchar, outer=(3)]
+ │         │    └── variable: address [type=varchar]
  │         ├── const-agg [type=date, outer=(6)]
  │         │    └── variable: orderdate [type=date]
- │         ├── const-agg [type=int, outer=(10)]
- │         │    └── variable: lineitems2_.quantity [type=int]
- │         ├── const-agg [type=string, outer=(12)]
- │         │    └── variable: product3_.description [type=string]
+ │         ├── const-agg [type=int4, outer=(10)]
+ │         │    └── variable: lineitems2_.quantity [type=int4]
+ │         ├── const-agg [type=varchar, outer=(12)]
+ │         │    └── variable: product3_.description [type=varchar]
  │         ├── const-agg [type=decimal, outer=(13)]
  │         │    └── variable: product3_.cost [type=decimal]
- │         ├── const-agg [type=int, outer=(14)]
- │         │    └── variable: product3_.numberavailable [type=int]
+ │         ├── const-agg [type=int4, outer=(14)]
+ │         │    └── variable: product3_.numberavailable [type=int4]
  │         └── const-agg [type=decimal, outer=(24)]
  │              └── variable: sum [type=decimal]
  └── projections
@@ -2475,29 +2475,29 @@ WHERE
   order0_.customerid = 'c111' AND order0_.ordernumber = 0;
 ----
 project
- ├── columns: customer1_1_0_:1(string) ordernum2_1_0_:2(int) orderdat3_1_0_:3(date) formula105_0_:18(decimal) customer1_2_1_:4(string) ordernum2_2_1_:5(int) producti3_2_1_:6(string) customer1_2_2_:4(string) ordernum2_2_2_:5(int) producti3_2_2_:6(string) quantity4_2_2_:7(int)
+ ├── columns: customer1_1_0_:1(varchar) ordernum2_1_0_:2(int4) orderdat3_1_0_:3(date) formula105_0_:18(decimal) customer1_2_1_:4(varchar) ordernum2_2_1_:5(int4) producti3_2_1_:6(varchar) customer1_2_2_:4(varchar) ordernum2_2_2_:5(int4) producti3_2_2_:6(varchar) quantity4_2_2_:7(int4)
  ├── key: (6)
  ├── fd: ()-->(1-3), (6)-->(4,5,7,18), ()~~>(4,5)
  ├── group-by
- │    ├── columns: order0_.customerid:1(string) order0_.ordernumber:2(int) orderdate:3(date) lineitems1_.customerid:4(string) lineitems1_.ordernumber:5(int) lineitems1_.productid:6(string) lineitems1_.quantity:7(int) sum:17(decimal)
- │    ├── grouping columns: lineitems1_.productid:6(string)
+ │    ├── columns: order0_.customerid:1(varchar) order0_.ordernumber:2(int4) orderdate:3(date) lineitems1_.customerid:4(varchar) lineitems1_.ordernumber:5(int4) lineitems1_.productid:6(varchar) lineitems1_.quantity:7(int4) sum:17(decimal)
+ │    ├── grouping columns: lineitems1_.productid:6(varchar)
  │    ├── key: (6)
  │    ├── fd: ()-->(1-3), (6)-->(1-5,7,17), ()~~>(4,5)
  │    ├── right-join
- │    │    ├── columns: order0_.customerid:1(string!null) order0_.ordernumber:2(int!null) orderdate:3(date!null) lineitems1_.customerid:4(string) lineitems1_.ordernumber:5(int) lineitems1_.productid:6(string) lineitems1_.quantity:7(int) li.customerid:8(string) li.ordernumber:9(int) column16:16(decimal)
+ │    │    ├── columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null) orderdate:3(date!null) lineitems1_.customerid:4(varchar) lineitems1_.ordernumber:5(int4) lineitems1_.productid:6(varchar) lineitems1_.quantity:7(int4) li.customerid:8(varchar) li.ordernumber:9(int4) column16:16(decimal)
  │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
  │    │    ├── project
- │    │    │    ├── columns: column16:16(decimal) li.customerid:8(string!null) li.ordernumber:9(int!null)
+ │    │    │    ├── columns: column16:16(decimal) li.customerid:8(varchar!null) li.ordernumber:9(int4!null)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: li.customerid:8(string!null) li.ordernumber:9(int!null) li.productid:10(string!null) li.quantity:11(int) p.productid:12(string!null) cost:14(decimal)
+ │    │    │    │    ├── columns: li.customerid:8(varchar!null) li.ordernumber:9(int4!null) li.productid:10(varchar!null) li.quantity:11(int4) p.productid:12(varchar!null) cost:14(decimal)
  │    │    │    │    ├── key: (8,9,12)
  │    │    │    │    ├── fd: (8-10)-->(11), (12)-->(14), (10)==(12), (12)==(10)
  │    │    │    │    ├── scan li
- │    │    │    │    │    ├── columns: li.customerid:8(string!null) li.ordernumber:9(int!null) li.productid:10(string!null) li.quantity:11(int)
+ │    │    │    │    │    ├── columns: li.customerid:8(varchar!null) li.ordernumber:9(int4!null) li.productid:10(varchar!null) li.quantity:11(int4)
  │    │    │    │    │    ├── key: (8-10)
  │    │    │    │    │    └── fd: (8-10)-->(11)
  │    │    │    │    ├── scan p
- │    │    │    │    │    ├── columns: p.productid:12(string!null) cost:14(decimal)
+ │    │    │    │    │    ├── columns: p.productid:12(varchar!null) cost:14(decimal)
  │    │    │    │    │    ├── key: (12)
  │    │    │    │    │    └── fd: (12)-->(14)
  │    │    │    │    └── filters
@@ -2505,19 +2505,19 @@ project
  │    │    │    └── projections
  │    │    │         └── li.quantity * cost [type=decimal, outer=(11,14)]
  │    │    ├── left-join (merge)
- │    │    │    ├── columns: order0_.customerid:1(string!null) order0_.ordernumber:2(int!null) orderdate:3(date!null) lineitems1_.customerid:4(string) lineitems1_.ordernumber:5(int) lineitems1_.productid:6(string) lineitems1_.quantity:7(int)
+ │    │    │    ├── columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null) orderdate:3(date!null) lineitems1_.customerid:4(varchar) lineitems1_.ordernumber:5(int4) lineitems1_.productid:6(varchar) lineitems1_.quantity:7(int4)
  │    │    │    ├── left ordering: +1,+2
  │    │    │    ├── right ordering: +4,+5
  │    │    │    ├── key: (6)
  │    │    │    ├── fd: ()-->(1-3), (6)-->(4,5,7), ()~~>(4,5)
  │    │    │    ├── scan order0_
- │    │    │    │    ├── columns: order0_.customerid:1(string!null) order0_.ordernumber:2(int!null) orderdate:3(date!null)
+ │    │    │    │    ├── columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null) orderdate:3(date!null)
  │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
  │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    ├── key: ()
  │    │    │    │    └── fd: ()-->(1-3)
  │    │    │    ├── scan lineitems1_
- │    │    │    │    ├── columns: lineitems1_.customerid:4(string!null) lineitems1_.ordernumber:5(int!null) lineitems1_.productid:6(string!null) lineitems1_.quantity:7(int)
+ │    │    │    │    ├── columns: lineitems1_.customerid:4(varchar!null) lineitems1_.ordernumber:5(int4!null) lineitems1_.productid:6(varchar!null) lineitems1_.quantity:7(int4)
  │    │    │    │    ├── constraint: /4/5/6: [/'c111'/0 - /'c111'/0]
  │    │    │    │    ├── key: (6)
  │    │    │    │    └── fd: ()-->(4,5), (6)-->(7)
@@ -2528,18 +2528,18 @@ project
  │    └── aggregations
  │         ├── sum [type=decimal, outer=(16)]
  │         │    └── variable: column16 [type=decimal]
- │         ├── const-agg [type=string, outer=(1)]
- │         │    └── variable: order0_.customerid [type=string]
- │         ├── const-agg [type=int, outer=(2)]
- │         │    └── variable: order0_.ordernumber [type=int]
+ │         ├── const-agg [type=varchar, outer=(1)]
+ │         │    └── variable: order0_.customerid [type=varchar]
+ │         ├── const-agg [type=int4, outer=(2)]
+ │         │    └── variable: order0_.ordernumber [type=int4]
  │         ├── const-agg [type=date, outer=(3)]
  │         │    └── variable: orderdate [type=date]
- │         ├── const-agg [type=string, outer=(4)]
- │         │    └── variable: lineitems1_.customerid [type=string]
- │         ├── const-agg [type=int, outer=(5)]
- │         │    └── variable: lineitems1_.ordernumber [type=int]
- │         └── const-agg [type=int, outer=(7)]
- │              └── variable: lineitems1_.quantity [type=int]
+ │         ├── const-agg [type=varchar, outer=(4)]
+ │         │    └── variable: lineitems1_.customerid [type=varchar]
+ │         ├── const-agg [type=int4, outer=(5)]
+ │         │    └── variable: lineitems1_.ordernumber [type=int4]
+ │         └── const-agg [type=int4, outer=(7)]
+ │              └── variable: lineitems1_.quantity [type=int4]
  └── projections
       └── variable: sum [type=decimal, outer=(17)]
 
@@ -2563,33 +2563,33 @@ FROM
   customerorder AS order0_;
 ----
 project
- ├── columns: customer1_10_:1(string!null) ordernum2_10_:2(int!null) orderdat3_10_:3(date) formula273_:14(decimal)
+ ├── columns: customer1_10_:1(varchar!null) ordernum2_10_:2(int4!null) orderdat3_10_:3(date) formula273_:14(decimal)
  ├── key: (1,2)
  ├── fd: (1,2)-->(3,14)
  ├── group-by
- │    ├── columns: order0_.customerid:1(string!null) order0_.ordernumber:2(int!null) orderdate:3(date) sum:13(decimal)
- │    ├── grouping columns: order0_.customerid:1(string!null) order0_.ordernumber:2(int!null)
+ │    ├── columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null) orderdate:3(date) sum:13(decimal)
+ │    ├── grouping columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null)
  │    ├── key: (1,2)
  │    ├── fd: (1,2)-->(3,13)
  │    ├── left-join
- │    │    ├── columns: order0_.customerid:1(string!null) order0_.ordernumber:2(int!null) orderdate:3(date!null) li.customerid:4(string) li.ordernumber:5(int) column12:12(decimal)
+ │    │    ├── columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null) orderdate:3(date!null) li.customerid:4(varchar) li.ordernumber:5(int4) column12:12(decimal)
  │    │    ├── fd: (1,2)-->(3)
  │    │    ├── scan order0_
- │    │    │    ├── columns: order0_.customerid:1(string!null) order0_.ordernumber:2(int!null) orderdate:3(date!null)
+ │    │    │    ├── columns: order0_.customerid:1(varchar!null) order0_.ordernumber:2(int4!null) orderdate:3(date!null)
  │    │    │    ├── key: (1,2)
  │    │    │    └── fd: (1,2)-->(3)
  │    │    ├── project
- │    │    │    ├── columns: column12:12(decimal) li.customerid:4(string!null) li.ordernumber:5(int!null)
+ │    │    │    ├── columns: column12:12(decimal) li.customerid:4(varchar!null) li.ordernumber:5(int4!null)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: li.customerid:4(string!null) li.ordernumber:5(int!null) li.productid:6(string!null) quantity:7(int) p.productid:8(string!null) cost:10(decimal)
+ │    │    │    │    ├── columns: li.customerid:4(varchar!null) li.ordernumber:5(int4!null) li.productid:6(varchar!null) quantity:7(int4) p.productid:8(varchar!null) cost:10(decimal)
  │    │    │    │    ├── key: (4,5,8)
  │    │    │    │    ├── fd: (4-6)-->(7), (8)-->(10), (6)==(8), (8)==(6)
  │    │    │    │    ├── scan li
- │    │    │    │    │    ├── columns: li.customerid:4(string!null) li.ordernumber:5(int!null) li.productid:6(string!null) quantity:7(int)
+ │    │    │    │    │    ├── columns: li.customerid:4(varchar!null) li.ordernumber:5(int4!null) li.productid:6(varchar!null) quantity:7(int4)
  │    │    │    │    │    ├── key: (4-6)
  │    │    │    │    │    └── fd: (4-6)-->(7)
  │    │    │    │    ├── scan p
- │    │    │    │    │    ├── columns: p.productid:8(string!null) cost:10(decimal)
+ │    │    │    │    │    ├── columns: p.productid:8(varchar!null) cost:10(decimal)
  │    │    │    │    │    ├── key: (8)
  │    │    │    │    │    └── fd: (8)-->(10)
  │    │    │    │    └── filters
@@ -2627,10 +2627,10 @@ CREATE TABLE student (
 ----
 TABLE student
  ├── studentid int not null
- ├── name string not null
- ├── address_city string
- ├── address_state string
- ├── preferredcoursecode string
+ ├── name varchar not null
+ ├── address_city varchar
+ ├── address_state varchar
+ ├── preferredcoursecode varchar
  └── INDEX primary
       └── studentid int not null
 
@@ -2645,12 +2645,12 @@ CREATE TABLE enrolment (
 ----
 TABLE enrolment
  ├── studentid int not null
- ├── coursecode string not null
- ├── semester int not null
- ├── year int not null
+ ├── coursecode varchar not null
+ ├── semester int2 not null
+ ├── year int2 not null
  └── INDEX primary
       ├── studentid int not null
-      └── coursecode string not null
+      └── coursecode varchar not null
 
 opt
 SELECT
@@ -2680,62 +2680,62 @@ WHERE
   );
 ----
 group-by
- ├── columns: studenti1_26_0_:1(int!null) name2_26_0_:2(string) address_3_26_0_:3(string) address_4_26_0_:4(string) preferre5_26_0_:5(string)
+ ├── columns: studenti1_26_0_:1(int!null) name2_26_0_:2(varchar) address_3_26_0_:3(varchar) address_4_26_0_:4(varchar) preferre5_26_0_:5(varchar)
  ├── grouping columns: this_.studentid:1(int!null)
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── select
- │    ├── columns: this_.studentid:1(int!null) name:2(string) address_city:3(string) address_state:4(string) preferredcoursecode:5(string) enrolment_.studentid:6(int!null) enrolment_.coursecode:7(string!null) enrolment_.year:9(int!null) max:14(int!null)
+ │    ├── columns: this_.studentid:1(int!null) name:2(varchar) address_city:3(varchar) address_state:4(varchar) preferredcoursecode:5(varchar) enrolment_.studentid:6(int!null) enrolment_.coursecode:7(varchar!null) enrolment_.year:9(int2!null) max:14(int!null)
  │    ├── key: (1,6,7)
  │    ├── fd: (1)-->(2-5), (6,7)-->(9), (1,6,7)-->(2-5,9,14), (9)==(14), (14)==(9)
  │    ├── group-by
- │    │    ├── columns: this_.studentid:1(int!null) name:2(string) address_city:3(string) address_state:4(string) preferredcoursecode:5(string) enrolment_.studentid:6(int!null) enrolment_.coursecode:7(string!null) enrolment_.year:9(int) max:14(int)
- │    │    ├── grouping columns: this_.studentid:1(int!null) enrolment_.studentid:6(int!null) enrolment_.coursecode:7(string!null)
+ │    │    ├── columns: this_.studentid:1(int!null) name:2(varchar) address_city:3(varchar) address_state:4(varchar) preferredcoursecode:5(varchar) enrolment_.studentid:6(int!null) enrolment_.coursecode:7(varchar!null) enrolment_.year:9(int2) max:14(int)
+ │    │    ├── grouping columns: this_.studentid:1(int!null) enrolment_.studentid:6(int!null) enrolment_.coursecode:7(varchar!null)
  │    │    ├── key: (1,6,7)
  │    │    ├── fd: (1)-->(2-5), (6,7)-->(9), (1,6,7)-->(2-5,9,14)
  │    │    ├── inner-join
- │    │    │    ├── columns: this_.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string!null) enrolment_.studentid:6(int!null) enrolment_.coursecode:7(string!null) enrolment_.year:9(int!null) maxstudentenrolment_.coursecode:11(string!null) maxstudentenrolment_.year:13(int!null)
+ │    │    │    ├── columns: this_.studentid:1(int!null) name:2(varchar!null) address_city:3(varchar) address_state:4(varchar) preferredcoursecode:5(varchar!null) enrolment_.studentid:6(int!null) enrolment_.coursecode:7(varchar!null) enrolment_.year:9(int2!null) maxstudentenrolment_.coursecode:11(varchar!null) maxstudentenrolment_.year:13(int2!null)
  │    │    │    ├── fd: (1)-->(2-5), (6,7)-->(9), (5)==(11), (11)==(5)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: this_.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string!null) maxstudentenrolment_.coursecode:11(string!null) maxstudentenrolment_.year:13(int!null)
+ │    │    │    │    ├── columns: this_.studentid:1(int!null) name:2(varchar!null) address_city:3(varchar) address_state:4(varchar) preferredcoursecode:5(varchar!null) maxstudentenrolment_.coursecode:11(varchar!null) maxstudentenrolment_.year:13(int2!null)
  │    │    │    │    ├── fd: (1)-->(2-5), (5)==(11), (11)==(5)
  │    │    │    │    ├── scan maxstudentenrolment_
- │    │    │    │    │    └── columns: maxstudentenrolment_.coursecode:11(string!null) maxstudentenrolment_.year:13(int!null)
+ │    │    │    │    │    └── columns: maxstudentenrolment_.coursecode:11(varchar!null) maxstudentenrolment_.year:13(int2!null)
  │    │    │    │    ├── scan this_
- │    │    │    │    │    ├── columns: this_.studentid:1(int!null) name:2(string!null) address_city:3(string) address_state:4(string) preferredcoursecode:5(string)
+ │    │    │    │    │    ├── columns: this_.studentid:1(int!null) name:2(varchar!null) address_city:3(varchar) address_state:4(varchar) preferredcoursecode:5(varchar)
  │    │    │    │    │    ├── key: (1)
  │    │    │    │    │    └── fd: (1)-->(2-5)
  │    │    │    │    └── filters
  │    │    │    │         └── preferredcoursecode = maxstudentenrolment_.coursecode [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
  │    │    │    ├── scan enrolment_
- │    │    │    │    ├── columns: enrolment_.studentid:6(int!null) enrolment_.coursecode:7(string!null) enrolment_.year:9(int!null)
+ │    │    │    │    ├── columns: enrolment_.studentid:6(int!null) enrolment_.coursecode:7(varchar!null) enrolment_.year:9(int2!null)
  │    │    │    │    ├── key: (6,7)
  │    │    │    │    └── fd: (6,7)-->(9)
  │    │    │    └── filters (true)
  │    │    └── aggregations
- │    │         ├── max [type=int, outer=(13)]
- │    │         │    └── variable: maxstudentenrolment_.year [type=int]
- │    │         ├── const-agg [type=int, outer=(9)]
- │    │         │    └── variable: enrolment_.year [type=int]
- │    │         ├── const-agg [type=string, outer=(2)]
- │    │         │    └── variable: name [type=string]
- │    │         ├── const-agg [type=string, outer=(3)]
- │    │         │    └── variable: address_city [type=string]
- │    │         ├── const-agg [type=string, outer=(4)]
- │    │         │    └── variable: address_state [type=string]
- │    │         └── const-agg [type=string, outer=(5)]
- │    │              └── variable: preferredcoursecode [type=string]
+ │    │         ├── max [type=int2, outer=(13)]
+ │    │         │    └── variable: maxstudentenrolment_.year [type=int2]
+ │    │         ├── const-agg [type=int2, outer=(9)]
+ │    │         │    └── variable: enrolment_.year [type=int2]
+ │    │         ├── const-agg [type=varchar, outer=(2)]
+ │    │         │    └── variable: name [type=varchar]
+ │    │         ├── const-agg [type=varchar, outer=(3)]
+ │    │         │    └── variable: address_city [type=varchar]
+ │    │         ├── const-agg [type=varchar, outer=(4)]
+ │    │         │    └── variable: address_state [type=varchar]
+ │    │         └── const-agg [type=varchar, outer=(5)]
+ │    │              └── variable: preferredcoursecode [type=varchar]
  │    └── filters
  │         └── enrolment_.year = max [type=bool, outer=(9,14), constraints=(/9: (/NULL - ]; /14: (/NULL - ]), fd=(9)==(14), (14)==(9)]
  └── aggregations
-      ├── const-agg [type=string, outer=(2)]
-      │    └── variable: name [type=string]
-      ├── const-agg [type=string, outer=(3)]
-      │    └── variable: address_city [type=string]
-      ├── const-agg [type=string, outer=(4)]
-      │    └── variable: address_state [type=string]
-      └── const-agg [type=string, outer=(5)]
-           └── variable: preferredcoursecode [type=string]
+      ├── const-agg [type=varchar, outer=(2)]
+      │    └── variable: name [type=varchar]
+      ├── const-agg [type=varchar, outer=(3)]
+      │    └── variable: address_city [type=varchar]
+      ├── const-agg [type=varchar, outer=(4)]
+      │    └── variable: address_state [type=varchar]
+      └── const-agg [type=varchar, outer=(5)]
+           └── variable: preferredcoursecode [type=varchar]
 
 exec-ddl
 drop table student, enrolment
@@ -2750,10 +2750,10 @@ exec-ddl
 CREATE TABLE t_name (id INT4 NOT NULL, c_name VARCHAR(255), PRIMARY KEY (id));
 ----
 TABLE t_name
- ├── id int not null
- ├── c_name string
+ ├── id int4 not null
+ ├── c_name varchar
  └── INDEX primary
-      └── id int not null
+      └── id int4 not null
 
 opt
 SELECT
@@ -2765,22 +2765,22 @@ FROM
   t_name AS this_;
 ----
 project
- ├── columns: id1_0_0_:1(int!null) c_name2_0_0_:2(string) formula0_0_:6(int)
+ ├── columns: id1_0_0_:1(int4!null) c_name2_0_0_:2(varchar) formula0_0_:6(int)
  ├── key: (1)
  ├── fd: (1)-->(2), (2)-->(6)
  ├── inner-join (merge)
- │    ├── columns: this_.id:1(int!null) this_.c_name:2(string) t_name.id:3(int!null)
+ │    ├── columns: this_.id:1(int4!null) this_.c_name:2(varchar) t_name.id:3(int4!null)
  │    ├── left ordering: +1
  │    ├── right ordering: +3
  │    ├── key: (3)
  │    ├── fd: (1)-->(2), (1)==(3), (3)==(1)
  │    ├── scan this_
- │    │    ├── columns: this_.id:1(int!null) this_.c_name:2(string)
+ │    │    ├── columns: this_.id:1(int4!null) this_.c_name:2(varchar)
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
  │    │    └── ordering: +1
  │    ├── scan t_name
- │    │    ├── columns: t_name.id:3(int!null)
+ │    │    ├── columns: t_name.id:3(int4!null)
  │    │    ├── key: (3)
  │    │    └── ordering: +3
  │    └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -14,12 +14,12 @@ CREATE TABLE warehouse
 ----
 TABLE warehouse
  ├── w_id int not null
- ├── w_name string
- ├── w_street_1 string
- ├── w_street_2 string
- ├── w_city string
- ├── w_state string
- ├── w_zip string
+ ├── w_name varchar
+ ├── w_street_1 varchar
+ ├── w_street_2 varchar
+ ├── w_city varchar
+ ├── w_state char
+ ├── w_zip char
  ├── w_tax decimal
  ├── w_ytd decimal
  └── INDEX primary
@@ -114,12 +114,12 @@ CREATE TABLE district
 TABLE district
  ├── d_id int not null
  ├── d_w_id int not null
- ├── d_name string
- ├── d_street_1 string
- ├── d_street_2 string
- ├── d_city string
- ├── d_state string
- ├── d_zip string
+ ├── d_name varchar
+ ├── d_street_1 varchar
+ ├── d_street_2 varchar
+ ├── d_city varchar
+ ├── d_state char
+ ├── d_zip char
  ├── d_tax decimal
  ├── d_ytd decimal
  ├── d_next_o_id int
@@ -243,24 +243,24 @@ TABLE customer
  ├── c_id int not null
  ├── c_d_id int not null
  ├── c_w_id int not null
- ├── c_first string
- ├── c_middle string
- ├── c_last string
- ├── c_street_1 string
- ├── c_street_2 string
- ├── c_city string
- ├── c_state string
- ├── c_zip string
- ├── c_phone string
+ ├── c_first varchar
+ ├── c_middle char
+ ├── c_last varchar
+ ├── c_street_1 varchar
+ ├── c_street_2 varchar
+ ├── c_city varchar
+ ├── c_state char
+ ├── c_zip char
+ ├── c_phone char
  ├── c_since timestamp
- ├── c_credit string
+ ├── c_credit char
  ├── c_credit_lim decimal
  ├── c_discount decimal
  ├── c_balance decimal
  ├── c_ytd_payment decimal
  ├── c_payment_cnt int
  ├── c_delivery_cnt int
- ├── c_data string
+ ├── c_data varchar
  ├── INDEX primary
  │    ├── c_w_id int not null
  │    ├── c_d_id int not null
@@ -268,8 +268,8 @@ TABLE customer
  ├── INDEX customer_idx
  │    ├── c_w_id int not null
  │    ├── c_d_id int not null
- │    ├── c_last string
- │    ├── c_first string
+ │    ├── c_last varchar
+ │    ├── c_first varchar
  │    └── c_id int not null
  └── FOREIGN KEY (c_w_id, c_d_id) REFERENCES t.public.district (d_w_id, d_id)
 
@@ -452,7 +452,7 @@ TABLE history
  ├── h_w_id int
  ├── h_date timestamp
  ├── h_amount decimal
- ├── h_data string
+ ├── h_data varchar
  ├── INDEX primary
  │    └── rowid uuid not null
  ├── INDEX secondary
@@ -696,9 +696,9 @@ CREATE TABLE item
 TABLE item
  ├── i_id int not null
  ├── i_im_id int
- ├── i_name string
+ ├── i_name varchar
  ├── i_price decimal
- ├── i_data string
+ ├── i_data varchar
  └── INDEX primary
       └── i_id int not null
 
@@ -772,20 +772,20 @@ TABLE stock
  ├── s_i_id int not null
  ├── s_w_id int not null
  ├── s_quantity int
- ├── s_dist_01 string
- ├── s_dist_02 string
- ├── s_dist_03 string
- ├── s_dist_04 string
- ├── s_dist_05 string
- ├── s_dist_06 string
- ├── s_dist_07 string
- ├── s_dist_08 string
- ├── s_dist_09 string
- ├── s_dist_10 string
+ ├── s_dist_01 char
+ ├── s_dist_02 char
+ ├── s_dist_03 char
+ ├── s_dist_04 char
+ ├── s_dist_05 char
+ ├── s_dist_06 char
+ ├── s_dist_07 char
+ ├── s_dist_08 char
+ ├── s_dist_09 char
+ ├── s_dist_10 char
  ├── s_ytd int
  ├── s_order_cnt int
  ├── s_remote_cnt int
- ├── s_data string
+ ├── s_data varchar
  ├── INDEX primary
  │    ├── s_w_id int not null
  │    └── s_i_id int not null
@@ -948,7 +948,7 @@ TABLE order_line
  ├── ol_delivery_d timestamp
  ├── ol_quantity int
  ├── ol_amount decimal
- ├── ol_dist_info string
+ ├── ol_dist_info char
  ├── INDEX primary
  │    ├── ol_w_id int not null
  │    ├── ol_d_id int not null
@@ -1077,7 +1077,7 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
- ├── columns: c_discount:16(decimal) c_last:6(string) c_credit:14(string)
+ ├── columns: c_discount:16(decimal) c_last:6(varchar) c_credit:14(char)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1]
  ├── cost: 1.3
@@ -1085,7 +1085,7 @@ project
  ├── fd: ()-->(6,14,16)
  ├── prune: (6,14,16)
  └── scan customer
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_last:6(string) c_credit:14(string) c_discount:16(decimal)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_last:6(varchar) c_credit:14(char) c_discount:16(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
@@ -1102,7 +1102,7 @@ WHERE i_id IN (125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300)
 ORDER BY i_id
 ----
 scan item
- ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)  [hidden: i_id:1(int!null)]
+ ├── columns: i_price:4(decimal) i_name:3(varchar) i_data:5(varchar)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
  ├── stats: [rows=11.8491602, distinct(1)=11.8491602, null(1)=0]
  ├── cost: 12.9255846
@@ -1119,7 +1119,7 @@ WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
 ORDER BY s_i_id
 ----
 project
- ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)  [hidden: s_i_id:1(int!null)]
+ ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar) s_dist_05:8(char)  [hidden: s_i_id:1(int!null)]
  ├── stats: [rows=4.93715008]
  ├── cost: 6.2408091
  ├── key: (1)
@@ -1128,7 +1128,7 @@ project
  ├── prune: (1,3,8,14-17)
  ├── interesting orderings: (+1)
  └── scan stock
-      ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(string) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string)
+      ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(char) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar)
       ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
       ├── stats: [rows=4.93715008, distinct(1)=4.93715008, null(1)=0, distinct(2)=1, null(2)=0]
       ├── cost: 6.1814376
@@ -1154,7 +1154,7 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1(int!null)  [hidden: c_first:4(string)]
+ ├── columns: c_id:1(int!null)  [hidden: c_first:4(varchar)]
  ├── stats: [rows=3]
  ├── cost: 3.35
  ├── key: (1)
@@ -1162,7 +1162,7 @@ project
  ├── ordering: +4
  ├── prune: (1,4)
  └── scan customer@customer_idx
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_last:6(varchar!null)
       ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
       ├── stats: [rows=3, distinct(1)=2.998502, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0]
       ├── cost: 3.31
@@ -1187,7 +1187,7 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
- ├── columns: c_balance:17(decimal) c_first:4(string) c_middle:5(string) c_last:6(string)
+ ├── columns: c_balance:17(decimal) c_first:4(varchar) c_middle:5(char) c_last:6(varchar)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1]
  ├── cost: 1.31
@@ -1195,7 +1195,7 @@ project
  ├── fd: ()-->(4-6,17)
  ├── prune: (4-6,17)
  └── scan customer
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_middle:5(string) c_last:6(string) c_balance:17(decimal)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_middle:5(char) c_last:6(varchar) c_balance:17(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
@@ -1212,7 +1212,7 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(string) c_middle:5(string)
+ ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(varchar) c_middle:5(char)
  ├── stats: [rows=3]
  ├── cost: 16.23
  ├── key: (1)
@@ -1220,7 +1220,7 @@ project
  ├── ordering: +4
  ├── prune: (1,4,5,17)
  └── index-join customer
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_middle:5(string) c_last:6(string!null) c_balance:17(decimal)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_middle:5(char) c_last:6(varchar!null) c_balance:17(decimal)
       ├── stats: [rows=3, distinct(1)=2.998502, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0]
       ├── cost: 16.19
       ├── key: (1)
@@ -1228,7 +1228,7 @@ project
       ├── ordering: +4 opt(2,3,6) [actual: +4]
       ├── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
       └── scan customer@customer_idx
-           ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
+           ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_last:6(varchar!null)
            ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
            ├── stats: [rows=3, distinct(1)=2.998502, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0]
            ├── cost: 3.31
@@ -2712,7 +2712,7 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
- ├── columns: c_discount:16(decimal) c_last:6(string) c_credit:14(string)
+ ├── columns: c_discount:16(decimal) c_last:6(varchar) c_credit:14(char)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1]
  ├── cost: 1.3
@@ -2720,7 +2720,7 @@ project
  ├── fd: ()-->(6,14,16)
  ├── prune: (6,14,16)
  └── scan customer
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_last:6(string) c_credit:14(string) c_discount:16(decimal)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_last:6(varchar) c_credit:14(char) c_discount:16(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
@@ -2737,7 +2737,7 @@ WHERE i_id IN (125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300)
 ORDER BY i_id
 ----
 scan item
- ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)  [hidden: i_id:1(int!null)]
+ ├── columns: i_price:4(decimal) i_name:3(varchar) i_data:5(varchar)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
  ├── stats: [rows=11.8491602, distinct(1)=11.8491602, null(1)=0]
  ├── cost: 12.9255846
@@ -2754,7 +2754,7 @@ WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
 ORDER BY s_i_id
 ----
 project
- ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)  [hidden: s_i_id:1(int!null)]
+ ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar) s_dist_05:8(char)  [hidden: s_i_id:1(int!null)]
  ├── stats: [rows=4.93715008]
  ├── cost: 6.2408091
  ├── key: (1)
@@ -2763,7 +2763,7 @@ project
  ├── prune: (1,3,8,14-17)
  ├── interesting orderings: (+1)
  └── scan stock
-      ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(string) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string)
+      ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(char) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar)
       ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
       ├── stats: [rows=4.93715008, distinct(1)=4.93715008, null(1)=0, distinct(2)=1, null(2)=0]
       ├── cost: 6.1814376
@@ -2789,7 +2789,7 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1(int!null)  [hidden: c_first:4(string)]
+ ├── columns: c_id:1(int!null)  [hidden: c_first:4(varchar)]
  ├── stats: [rows=3]
  ├── cost: 3.35
  ├── key: (1)
@@ -2797,7 +2797,7 @@ project
  ├── ordering: +4
  ├── prune: (1,4)
  └── scan customer@customer_idx
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_last:6(varchar!null)
       ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
       ├── stats: [rows=3, distinct(1)=2.99851548, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0]
       ├── cost: 3.31
@@ -2822,7 +2822,7 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
- ├── columns: c_balance:17(decimal) c_first:4(string) c_middle:5(string) c_last:6(string)
+ ├── columns: c_balance:17(decimal) c_first:4(varchar) c_middle:5(char) c_last:6(varchar)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1]
  ├── cost: 1.31
@@ -2830,7 +2830,7 @@ project
  ├── fd: ()-->(4-6,17)
  ├── prune: (4-6,17)
  └── scan customer
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_middle:5(string) c_last:6(string) c_balance:17(decimal)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_middle:5(char) c_last:6(varchar) c_balance:17(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
@@ -2847,7 +2847,7 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(string) c_middle:5(string)
+ ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(varchar) c_middle:5(char)
  ├── stats: [rows=3]
  ├── cost: 16.23
  ├── key: (1)
@@ -2855,7 +2855,7 @@ project
  ├── ordering: +4
  ├── prune: (1,4,5,17)
  └── index-join customer
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_middle:5(string) c_last:6(string!null) c_balance:17(decimal)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_middle:5(char) c_last:6(varchar!null) c_balance:17(decimal)
       ├── stats: [rows=3, distinct(1)=2.99851548, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0]
       ├── cost: 16.19
       ├── key: (1)
@@ -2863,7 +2863,7 @@ project
       ├── ordering: +4 opt(2,3,6) [actual: +4]
       ├── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
       └── scan customer@customer_idx
-           ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
+           ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_last:6(varchar!null)
            ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
            ├── stats: [rows=3, distinct(1)=2.99851548, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0]
            ├── cost: 3.31

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -14,12 +14,12 @@ CREATE TABLE warehouse
 ----
 TABLE warehouse
  ├── w_id int not null
- ├── w_name string
- ├── w_street_1 string
- ├── w_street_2 string
- ├── w_city string
- ├── w_state string
- ├── w_zip string
+ ├── w_name varchar
+ ├── w_street_1 varchar
+ ├── w_street_2 varchar
+ ├── w_city varchar
+ ├── w_state char
+ ├── w_zip char
  ├── w_tax decimal
  ├── w_ytd decimal
  └── INDEX primary
@@ -46,12 +46,12 @@ CREATE TABLE district
 TABLE district
  ├── d_id int not null
  ├── d_w_id int not null
- ├── d_name string
- ├── d_street_1 string
- ├── d_street_2 string
- ├── d_city string
- ├── d_state string
- ├── d_zip string
+ ├── d_name varchar
+ ├── d_street_1 varchar
+ ├── d_street_2 varchar
+ ├── d_city varchar
+ ├── d_state char
+ ├── d_zip char
  ├── d_tax decimal
  ├── d_ytd decimal
  ├── d_next_o_id int
@@ -93,24 +93,24 @@ TABLE customer
  ├── c_id int not null
  ├── c_d_id int not null
  ├── c_w_id int not null
- ├── c_first string
- ├── c_middle string
- ├── c_last string
- ├── c_street_1 string
- ├── c_street_2 string
- ├── c_city string
- ├── c_state string
- ├── c_zip string
- ├── c_phone string
+ ├── c_first varchar
+ ├── c_middle char
+ ├── c_last varchar
+ ├── c_street_1 varchar
+ ├── c_street_2 varchar
+ ├── c_city varchar
+ ├── c_state char
+ ├── c_zip char
+ ├── c_phone char
  ├── c_since timestamp
- ├── c_credit string
+ ├── c_credit char
  ├── c_credit_lim decimal
  ├── c_discount decimal
  ├── c_balance decimal
  ├── c_ytd_payment decimal
  ├── c_payment_cnt int
  ├── c_delivery_cnt int
- ├── c_data string
+ ├── c_data varchar
  ├── INDEX primary
  │    ├── c_w_id int not null
  │    ├── c_d_id int not null
@@ -118,8 +118,8 @@ TABLE customer
  ├── INDEX customer_idx
  │    ├── c_w_id int not null
  │    ├── c_d_id int not null
- │    ├── c_last string
- │    ├── c_first string
+ │    ├── c_last varchar
+ │    ├── c_first varchar
  │    └── c_id int not null
  └── FOREIGN KEY (c_w_id, c_d_id) REFERENCES t.public.district (d_w_id, d_id)
 
@@ -150,7 +150,7 @@ TABLE history
  ├── h_w_id int
  ├── h_date timestamp
  ├── h_amount decimal
- ├── h_data string
+ ├── h_data varchar
  ├── INDEX primary
  │    └── rowid uuid not null
  ├── INDEX secondary
@@ -239,9 +239,9 @@ CREATE TABLE item
 TABLE item
  ├── i_id int not null
  ├── i_im_id int
- ├── i_name string
+ ├── i_name varchar
  ├── i_price decimal
- ├── i_data string
+ ├── i_data varchar
  └── INDEX primary
       └── i_id int not null
 
@@ -275,20 +275,20 @@ TABLE stock
  ├── s_i_id int not null
  ├── s_w_id int not null
  ├── s_quantity int
- ├── s_dist_01 string
- ├── s_dist_02 string
- ├── s_dist_03 string
- ├── s_dist_04 string
- ├── s_dist_05 string
- ├── s_dist_06 string
- ├── s_dist_07 string
- ├── s_dist_08 string
- ├── s_dist_09 string
- ├── s_dist_10 string
+ ├── s_dist_01 char
+ ├── s_dist_02 char
+ ├── s_dist_03 char
+ ├── s_dist_04 char
+ ├── s_dist_05 char
+ ├── s_dist_06 char
+ ├── s_dist_07 char
+ ├── s_dist_08 char
+ ├── s_dist_09 char
+ ├── s_dist_10 char
  ├── s_ytd int
  ├── s_order_cnt int
  ├── s_remote_cnt int
- ├── s_data string
+ ├── s_data varchar
  ├── INDEX primary
  │    ├── s_w_id int not null
  │    └── s_i_id int not null
@@ -327,7 +327,7 @@ TABLE order_line
  ├── ol_delivery_d timestamp
  ├── ol_quantity int
  ├── ol_amount decimal
- ├── ol_dist_info string
+ ├── ol_dist_info char
  ├── INDEX primary
  │    ├── ol_w_id int not null
  │    ├── ol_d_id int not null
@@ -381,7 +381,7 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
- ├── columns: c_discount:16(decimal) c_last:6(string) c_credit:14(string)
+ ├── columns: c_discount:16(decimal) c_last:6(varchar) c_credit:14(char)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=0.001]
  ├── cost: 0.02128
@@ -389,7 +389,7 @@ project
  ├── fd: ()-->(6,14,16)
  ├── prune: (6,14,16)
  └── scan customer
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_last:6(string) c_credit:14(string) c_discount:16(decimal)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_last:6(varchar) c_credit:14(char) c_discount:16(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=0.001, distinct(1)=0.001, null(1)=0, distinct(2)=0.001, null(2)=0, distinct(3)=0.001, null(3)=0]
@@ -406,7 +406,7 @@ WHERE i_id IN (125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300)
 ORDER BY i_id
 ----
 scan item
- ├── columns: i_price:4(decimal) i_name:3(string) i_data:5(string)  [hidden: i_id:1(int!null)]
+ ├── columns: i_price:4(decimal) i_name:3(varchar) i_data:5(varchar)  [hidden: i_id:1(int!null)]
  ├── constraint: /1: [/25 - /25] [/50 - /50] [/75 - /75] [/100 - /100] [/125 - /125] [/150 - /150] [/175 - /175] [/200 - /200] [/225 - /225] [/250 - /250] [/275 - /275] [/300 - /300]
  ├── stats: [rows=12, distinct(1)=12, null(1)=0]
  ├── cost: 13.09
@@ -423,7 +423,7 @@ WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
 ORDER BY s_i_id
 ----
 project
- ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string) s_dist_05:8(string)  [hidden: s_i_id:1(int!null)]
+ ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar) s_dist_05:8(char)  [hidden: s_i_id:1(int!null)]
  ├── stats: [rows=0.5]
  ├── cost: 0.65
  ├── key: (1)
@@ -432,7 +432,7 @@ project
  ├── prune: (1,3,8,14-17)
  ├── interesting orderings: (+1)
  └── scan stock
-      ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(string) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(string)
+      ├── columns: s_i_id:1(int!null) s_w_id:2(int!null) s_quantity:3(int) s_dist_05:8(char) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar)
       ├── constraint: /2/1: [/4/900 - /4/900] [/4/1000 - /4/1000] [/4/1100 - /4/1100] [/4/1400 - /4/1400] [/4/1500 - /4/1500]
       ├── stats: [rows=0.5, distinct(1)=0.5, null(1)=0, distinct(2)=0.5, null(2)=0]
       ├── cost: 0.635
@@ -458,7 +458,7 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1(int!null)  [hidden: c_first:4(string)]
+ ├── columns: c_id:1(int!null)  [hidden: c_first:4(varchar)]
  ├── stats: [rows=0.00099]
  ├── cost: 0.0210989
  ├── key: (1)
@@ -466,7 +466,7 @@ project
  ├── ordering: +4
  ├── prune: (1,4)
  └── scan customer@customer_idx
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_last:6(varchar!null)
       ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
       ├── stats: [rows=0.00099, distinct(1)=0.00099, null(1)=0, distinct(2)=0.00099, null(2)=0, distinct(3)=0.00099, null(3)=0, distinct(6)=0.00099, null(6)=0]
       ├── cost: 0.011089
@@ -491,7 +491,7 @@ FROM customer
 WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
 ----
 project
- ├── columns: c_balance:17(decimal) c_first:4(string) c_middle:5(string) c_last:6(string)
+ ├── columns: c_balance:17(decimal) c_first:4(varchar) c_middle:5(char) c_last:6(varchar)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=0.001]
  ├── cost: 0.02129
@@ -499,7 +499,7 @@ project
  ├── fd: ()-->(4-6,17)
  ├── prune: (4-6,17)
  └── scan customer
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_middle:5(string) c_last:6(string) c_balance:17(decimal)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_middle:5(char) c_last:6(varchar) c_balance:17(decimal)
       ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=0.001, distinct(1)=0.001, null(1)=0, distinct(2)=0.001, null(2)=0, distinct(3)=0.001, null(3)=0]
@@ -516,7 +516,7 @@ WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
 ORDER BY c_first ASC
 ----
 project
- ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(string) c_middle:5(string)
+ ├── columns: c_id:1(int!null) c_balance:17(decimal) c_first:4(varchar) c_middle:5(char)
  ├── stats: [rows=0.00099]
  ├── cost: 0.035346
  ├── key: (1)
@@ -524,7 +524,7 @@ project
  ├── ordering: +4
  ├── prune: (1,4,5,17)
  └── index-join customer
-      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_middle:5(string) c_last:6(string!null) c_balance:17(decimal)
+      ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_middle:5(char) c_last:6(varchar!null) c_balance:17(decimal)
       ├── stats: [rows=0.00099, distinct(1)=0.00099, null(1)=0, distinct(2)=0.00099, null(2)=0, distinct(3)=0.00099, null(3)=0, distinct(6)=0.00099, null(6)=0]
       ├── cost: 0.0253361
       ├── key: (1)
@@ -532,7 +532,7 @@ project
       ├── ordering: +4 opt(2,3,6) [actual: +4]
       ├── interesting orderings: (+3,+2,+1) (+3,+2,+6,+4,+1)
       └── scan customer@customer_idx
-           ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(string) c_last:6(string!null)
+           ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_last:6(varchar!null)
            ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
            ├── stats: [rows=0.00099, distinct(1)=0.00099, null(1)=0, distinct(2)=0.00099, null(2)=0, distinct(3)=0.00099, null(3)=0, distinct(6)=0.00099, null(6)=0]
            ├── cost: 0.011089

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -8,8 +8,8 @@ CREATE TABLE public.region
 ----
 TABLE region
  ├── r_regionkey int not null
- ├── r_name string not null
- ├── r_comment string
+ ├── r_name char not null
+ ├── r_comment varchar
  └── INDEX primary
       └── r_regionkey int not null
 
@@ -37,9 +37,9 @@ CREATE TABLE public.nation
 ----
 TABLE nation
  ├── n_nationkey int not null
- ├── n_name string not null
+ ├── n_name char not null
  ├── n_regionkey int not null
- ├── n_comment string
+ ├── n_comment varchar
  ├── INDEX primary
  │    └── n_nationkey int not null
  ├── INDEX n_rk
@@ -80,12 +80,12 @@ CREATE TABLE public.supplier
 ----
 TABLE supplier
  ├── s_suppkey int not null
- ├── s_name string not null
- ├── s_address string not null
+ ├── s_name char not null
+ ├── s_address varchar not null
  ├── s_nationkey int not null
- ├── s_phone string not null
+ ├── s_phone char not null
  ├── s_acctbal float not null
- ├── s_comment string not null
+ ├── s_comment varchar not null
  ├── INDEX primary
  │    └── s_suppkey int not null
  ├── INDEX s_nk
@@ -126,14 +126,14 @@ CREATE TABLE public.part
 ----
 TABLE part
  ├── p_partkey int not null
- ├── p_name string not null
- ├── p_mfgr string not null
- ├── p_brand string not null
- ├── p_type string not null
+ ├── p_name varchar not null
+ ├── p_mfgr char not null
+ ├── p_brand char not null
+ ├── p_type varchar not null
  ├── p_size int not null
- ├── p_container string not null
+ ├── p_container char not null
  ├── p_retailprice float not null
- ├── p_comment string not null
+ ├── p_comment varchar not null
  └── INDEX primary
       └── p_partkey int not null
 
@@ -167,7 +167,7 @@ TABLE partsupp
  ├── ps_suppkey int not null
  ├── ps_availqty int not null
  ├── ps_supplycost float not null
- ├── ps_comment string not null
+ ├── ps_comment varchar not null
  ├── INDEX primary
  │    ├── ps_partkey int not null
  │    └── ps_suppkey int not null
@@ -211,13 +211,13 @@ CREATE TABLE public.customer
 ----
 TABLE customer
  ├── c_custkey int not null
- ├── c_name string not null
- ├── c_address string not null
+ ├── c_name varchar not null
+ ├── c_address varchar not null
  ├── c_nationkey int not null
- ├── c_phone string not null
+ ├── c_phone char not null
  ├── c_acctbal float not null
- ├── c_mktsegment string not null
- ├── c_comment string not null
+ ├── c_mktsegment char not null
+ ├── c_comment varchar not null
  ├── INDEX primary
  │    └── c_custkey int not null
  ├── INDEX c_nk
@@ -262,13 +262,13 @@ CREATE TABLE public.orders
 TABLE orders
  ├── o_orderkey int not null
  ├── o_custkey int not null
- ├── o_orderstatus string not null
+ ├── o_orderstatus char not null
  ├── o_totalprice float not null
  ├── o_orderdate date not null
- ├── o_orderpriority string not null
- ├── o_clerk string not null
+ ├── o_orderpriority char not null
+ ├── o_clerk char not null
  ├── o_shippriority int not null
- ├── o_comment string not null
+ ├── o_comment varchar not null
  ├── INDEX primary
  │    └── o_orderkey int not null
  ├── INDEX o_ck
@@ -345,14 +345,14 @@ TABLE lineitem
  ├── l_extendedprice float not null
  ├── l_discount float not null
  ├── l_tax float not null
- ├── l_returnflag string not null
- ├── l_linestatus string not null
+ ├── l_returnflag char not null
+ ├── l_linestatus char not null
  ├── l_shipdate date not null
  ├── l_commitdate date not null
  ├── l_receiptdate date not null
- ├── l_shipinstruct string not null
- ├── l_shipmode string not null
- ├── l_comment string not null
+ ├── l_shipinstruct char not null
+ ├── l_shipmode char not null
+ ├── l_comment varchar not null
  ├── INDEX primary
  │    ├── l_orderkey int not null
  │    └── l_linenumber int not null
@@ -473,20 +473,20 @@ ORDER BY
     l_linestatus;
 ----
 group-by
- ├── columns: l_returnflag:9(string!null) l_linestatus:10(string!null) sum_qty:17(float) sum_base_price:18(float) sum_disc_price:20(float) sum_charge:22(float) avg_qty:23(float) avg_price:24(float) avg_disc:25(float) count_order:26(int)
- ├── grouping columns: l_returnflag:9(string!null) l_linestatus:10(string!null)
+ ├── columns: l_returnflag:9(char!null) l_linestatus:10(char!null) sum_qty:17(float) sum_base_price:18(float) sum_disc_price:20(float) sum_charge:22(float) avg_qty:23(float) avg_price:24(float) avg_disc:25(float) count_order:26(int)
+ ├── grouping columns: l_returnflag:9(char!null) l_linestatus:10(char!null)
  ├── key: (9,10)
  ├── fd: (9,10)-->(17,18,20,22-26)
  ├── ordering: +9,+10
  ├── sort
- │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_returnflag:9(string!null) l_linestatus:10(string!null) column19:19(float) column21:21(float)
+ │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) column19:19(float) column21:21(float)
  │    ├── ordering: +9,+10
  │    └── project
- │         ├── columns: column19:19(float) column21:21(float) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_returnflag:9(string!null) l_linestatus:10(string!null)
+ │         ├── columns: column19:19(float) column21:21(float) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null)
  │         ├── select
- │         │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(string!null) l_linestatus:10(string!null) l_shipdate:11(date!null)
+ │         │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null)
  │         │    ├── scan lineitem
- │         │    │    └── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(string!null) l_linestatus:10(string!null) l_shipdate:11(date!null)
+ │         │    │    └── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null)
  │         │    └── filters
  │         │         └── l_shipdate <= '1998-09-02' [type=bool, outer=(11), constraints=(/11: (/NULL - /'1998-09-02']; tight)]
  │         └── projections
@@ -576,37 +576,37 @@ ORDER BY
 LIMIT 100;
 ----
 project
- ├── columns: s_acctbal:15(float) s_name:11(string) n_name:23(string) p_partkey:1(int) p_mfgr:3(string) s_address:12(string) s_phone:14(string) s_comment:16(string)
+ ├── columns: s_acctbal:15(float) s_name:11(char) n_name:23(char) p_partkey:1(int) p_mfgr:3(char) s_address:12(varchar) s_phone:14(char) s_comment:16(varchar)
  ├── cardinality: [0 - 100]
  ├── fd: (1)-->(3)
  ├── ordering: -15,+23,+11,+1
  └── limit
-      ├── columns: p_partkey:1(int) p_mfgr:3(string) s_name:11(string) s_address:12(string) s_phone:14(string) s_acctbal:15(float) s_comment:16(string) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(string) min:48(float!null)
+      ├── columns: p_partkey:1(int) p_mfgr:3(char) s_name:11(char) s_address:12(varchar) s_phone:14(char) s_acctbal:15(float) s_comment:16(varchar) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(char) min:48(float!null)
       ├── internal-ordering: -15,+23,+11,+(1|17)
       ├── cardinality: [0 - 100]
       ├── key: (17,18)
       ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
       ├── ordering: -15,+23,+11,+(1|17) [actual: -15,+23,+11,+1]
       ├── sort
-      │    ├── columns: p_partkey:1(int) p_mfgr:3(string) s_name:11(string) s_address:12(string) s_phone:14(string) s_acctbal:15(float) s_comment:16(string) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(string) min:48(float!null)
+      │    ├── columns: p_partkey:1(int) p_mfgr:3(char) s_name:11(char) s_address:12(varchar) s_phone:14(char) s_acctbal:15(float) s_comment:16(varchar) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(char) min:48(float!null)
       │    ├── key: (17,18)
       │    ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
       │    ├── ordering: -15,+23,+11,+(1|17) [actual: -15,+23,+11,+1]
       │    └── select
-      │         ├── columns: p_partkey:1(int) p_mfgr:3(string) s_name:11(string) s_address:12(string) s_phone:14(string) s_acctbal:15(float) s_comment:16(string) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(string) min:48(float!null)
+      │         ├── columns: p_partkey:1(int) p_mfgr:3(char) s_name:11(char) s_address:12(varchar) s_phone:14(char) s_acctbal:15(float) s_comment:16(varchar) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(char) min:48(float!null)
       │         ├── key: (17,18)
       │         ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
       │         ├── group-by
-      │         │    ├── columns: p_partkey:1(int) p_mfgr:3(string) s_name:11(string) s_address:12(string) s_phone:14(string) s_acctbal:15(float) s_comment:16(string) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float) n_name:23(string) min:48(float)
+      │         │    ├── columns: p_partkey:1(int) p_mfgr:3(char) s_name:11(char) s_address:12(varchar) s_phone:14(char) s_acctbal:15(float) s_comment:16(varchar) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float) n_name:23(char) min:48(float)
       │         │    ├── grouping columns: ps_partkey:17(int!null) ps_suppkey:18(int!null)
       │         │    ├── key: (17,18)
       │         │    ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23)
       │         │    ├── inner-join
-      │         │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null) ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null) ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    ├── key: (18,29,34)
       │         │    │    ├── fd: ()-->(6,27,46), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17,29), (17)==(1,29), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30), (29)==(1,17)
       │         │    │    ├── inner-join
-      │         │    │    │    ├── columns: ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    │    ├── columns: ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    ├── key: (29,34)
       │         │    │    │    ├── fd: ()-->(46), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30)
       │         │    │    │    ├── scan partsupp
@@ -614,7 +614,7 @@ project
       │         │    │    │    │    ├── key: (29,30)
       │         │    │    │    │    └── fd: (29,30)-->(32)
       │         │    │    │    ├── inner-join (merge)
-      │         │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    │    ├── left ordering: +37
       │         │    │    │    │    ├── right ordering: +41
       │         │    │    │    │    ├── key: (34)
@@ -625,12 +625,12 @@ project
       │         │    │    │    │    │    ├── fd: (34)-->(37)
       │         │    │    │    │    │    └── ordering: +37
       │         │    │    │    │    ├── sort
-      │         │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    │    │    ├── key: (41)
       │         │    │    │    │    │    ├── fd: ()-->(46), (41)-->(43), (43)==(45), (45)==(43)
       │         │    │    │    │    │    ├── ordering: +41 opt(46) [actual: +41]
       │         │    │    │    │    │    └── inner-join (merge)
-      │         │    │    │    │    │         ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    │    │    │         ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    │    │         ├── left ordering: +43
       │         │    │    │    │    │         ├── right ordering: +45
       │         │    │    │    │    │         ├── key: (41)
@@ -641,12 +641,12 @@ project
       │         │    │    │    │    │         │    ├── fd: (41)-->(43)
       │         │    │    │    │    │         │    └── ordering: +43
       │         │    │    │    │    │         ├── select
-      │         │    │    │    │    │         │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    │    │    │         │    ├── columns: r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    │    │         │    ├── key: (45)
       │         │    │    │    │    │         │    ├── fd: ()-->(46)
       │         │    │    │    │    │         │    ├── ordering: +45 opt(46) [actual: +45]
       │         │    │    │    │    │         │    ├── scan region
-      │         │    │    │    │    │         │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    │    │    │         │    │    ├── columns: r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    │    │         │    │    ├── key: (45)
       │         │    │    │    │    │         │    │    ├── fd: (45)-->(46)
       │         │    │    │    │    │         │    │    └── ordering: +45 opt(46) [actual: +45]
@@ -657,11 +657,11 @@ project
       │         │    │    │    └── filters
       │         │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ]), fd=(30)==(34), (34)==(30)]
       │         │    │    ├── inner-join
-      │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    ├── key: (17,18)
       │         │    │    │    ├── fd: ()-->(6,27), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17), (17)==(1)
       │         │    │    │    ├── inner-join
-      │         │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    ├── fd: ()-->(27), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13)
       │         │    │    │    │    ├── scan partsupp
@@ -669,27 +669,27 @@ project
       │         │    │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    │    └── fd: (17,18)-->(20)
       │         │    │    │    │    ├── inner-join
-      │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    ├── key: (10)
       │         │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24), (10)-->(11-16), (13)==(22), (22)==(13)
       │         │    │    │    │    │    ├── scan supplier
-      │         │    │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null)
+      │         │    │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null)
       │         │    │    │    │    │    │    ├── key: (10)
       │         │    │    │    │    │    │    └── fd: (10)-->(11-16)
       │         │    │    │    │    │    ├── inner-join
-      │         │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    │    ├── key: (22)
       │         │    │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24)
       │         │    │    │    │    │    │    ├── scan nation
-      │         │    │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null)
+      │         │    │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null)
       │         │    │    │    │    │    │    │    ├── key: (22)
       │         │    │    │    │    │    │    │    └── fd: (22)-->(23,24)
       │         │    │    │    │    │    │    ├── select
-      │         │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    │    │    ├── key: (26)
       │         │    │    │    │    │    │    │    ├── fd: ()-->(27)
       │         │    │    │    │    │    │    │    ├── scan region
-      │         │    │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    │    │    │    ├── key: (26)
       │         │    │    │    │    │    │    │    │    └── fd: (26)-->(27)
       │         │    │    │    │    │    │    │    └── filters
@@ -701,11 +701,11 @@ project
       │         │    │    │    │    └── filters
       │         │    │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(10,18), constraints=(/10: (/NULL - ]; /18: (/NULL - ]), fd=(10)==(18), (18)==(10)]
       │         │    │    │    ├── select
-      │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null)
+      │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null)
       │         │    │    │    │    ├── key: (1)
       │         │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5)
       │         │    │    │    │    ├── scan part
-      │         │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null)
+      │         │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null)
       │         │    │    │    │    │    ├── key: (1)
       │         │    │    │    │    │    └── fd: (1)-->(3,5,6)
       │         │    │    │    │    └── filters
@@ -718,22 +718,22 @@ project
       │         │    └── aggregations
       │         │         ├── min [type=float, outer=(32)]
       │         │         │    └── variable: ps_supplycost [type=float]
-      │         │         ├── const-agg [type=string, outer=(11)]
-      │         │         │    └── variable: s_name [type=string]
-      │         │         ├── const-agg [type=string, outer=(12)]
-      │         │         │    └── variable: s_address [type=string]
-      │         │         ├── const-agg [type=string, outer=(14)]
-      │         │         │    └── variable: s_phone [type=string]
+      │         │         ├── const-agg [type=char, outer=(11)]
+      │         │         │    └── variable: s_name [type=char]
+      │         │         ├── const-agg [type=varchar, outer=(12)]
+      │         │         │    └── variable: s_address [type=varchar]
+      │         │         ├── const-agg [type=char, outer=(14)]
+      │         │         │    └── variable: s_phone [type=char]
       │         │         ├── const-agg [type=float, outer=(15)]
       │         │         │    └── variable: s_acctbal [type=float]
-      │         │         ├── const-agg [type=string, outer=(16)]
-      │         │         │    └── variable: s_comment [type=string]
+      │         │         ├── const-agg [type=varchar, outer=(16)]
+      │         │         │    └── variable: s_comment [type=varchar]
       │         │         ├── const-agg [type=float, outer=(20)]
       │         │         │    └── variable: ps_supplycost [type=float]
-      │         │         ├── const-agg [type=string, outer=(23)]
-      │         │         │    └── variable: n_name [type=string]
-      │         │         ├── const-agg [type=string, outer=(3)]
-      │         │         │    └── variable: p_mfgr [type=string]
+      │         │         ├── const-agg [type=char, outer=(23)]
+      │         │         │    └── variable: n_name [type=char]
+      │         │         ├── const-agg [type=char, outer=(3)]
+      │         │         │    └── variable: p_mfgr [type=char]
       │         │         └── const-agg [type=int, outer=(1)]
       │         │              └── variable: p_partkey [type=int]
       │         └── filters
@@ -797,25 +797,25 @@ limit
  │         │    ├── columns: column34:34(float) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null)
  │         │    ├── fd: (18)-->(13,16)
  │         │    ├── inner-join (lookup lineitem)
- │         │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
+ │         │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
  │         │    │    ├── key columns: [9] = [18]
  │         │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
  │         │    │    ├── inner-join (lookup orders)
- │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
  │         │    │    │    ├── key columns: [9] = [9]
  │         │    │    │    ├── key: (9)
  │         │    │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (1)==(10), (10)==(1)
  │         │    │    │    ├── inner-join (lookup orders@o_ck)
- │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null)
+ │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null) o_orderkey:9(int!null) o_custkey:10(int!null)
  │         │    │    │    │    ├── key columns: [1] = [10]
  │         │    │    │    │    ├── key: (9)
  │         │    │    │    │    ├── fd: ()-->(7), (9)-->(10), (1)==(10), (10)==(1)
  │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
+ │         │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null)
  │         │    │    │    │    │    ├── key: (1)
  │         │    │    │    │    │    ├── fd: ()-->(7)
  │         │    │    │    │    │    ├── scan customer
- │         │    │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
+ │         │    │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null)
  │         │    │    │    │    │    │    ├── key: (1)
  │         │    │    │    │    │    │    └── fd: (1)-->(7)
  │         │    │    │    │    │    └── filters
@@ -871,21 +871,21 @@ ORDER BY
     o_orderpriority;
 ----
 sort
- ├── columns: o_orderpriority:6(string!null) order_count:26(int)
+ ├── columns: o_orderpriority:6(char!null) order_count:26(int)
  ├── key: (6)
  ├── fd: (6)-->(26)
  ├── ordering: +6
  └── group-by
-      ├── columns: o_orderpriority:6(string!null) count_rows:26(int)
-      ├── grouping columns: o_orderpriority:6(string!null)
+      ├── columns: o_orderpriority:6(char!null) count_rows:26(int)
+      ├── grouping columns: o_orderpriority:6(char!null)
       ├── key: (6)
       ├── fd: (6)-->(26)
       ├── semi-join
-      │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(string!null)
+      │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(5,6)
       │    ├── index-join orders
-      │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(string!null)
+      │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(5,6)
       │    │    └── scan orders@o_od
@@ -948,30 +948,30 @@ ORDER BY
     revenue DESC;
 ----
 sort
- ├── columns: n_name:42(string!null) revenue:49(float)
+ ├── columns: n_name:42(char!null) revenue:49(float)
  ├── key: (42)
  ├── fd: (42)-->(49)
  ├── ordering: -49
  └── group-by
-      ├── columns: n_name:42(string!null) sum:49(float)
-      ├── grouping columns: n_name:42(string!null)
+      ├── columns: n_name:42(char!null) sum:49(float)
+      ├── grouping columns: n_name:42(char!null)
       ├── key: (42)
       ├── fd: (42)-->(49)
       ├── project
-      │    ├── columns: column48:48(float) n_name:42(string!null)
+      │    ├── columns: column48:48(float) n_name:42(char!null)
       │    ├── inner-join
-      │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    ├── fd: ()-->(46), (1)-->(4), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(4,41), (41)==(4,37), (20)==(34), (34)==(20), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(37,41)
       │    │    ├── inner-join
-      │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    ├── fd: ()-->(46), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20), (9)==(18), (18)==(9)
       │    │    │    ├── inner-join
-      │    │    │    │    ├── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    ├── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20)
       │    │    │    │    ├── scan lineitem
       │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null)
       │    │    │    │    ├── inner-join (merge)
-      │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    ├── left ordering: +37
       │    │    │    │    │    ├── right ordering: +41
       │    │    │    │    │    ├── key: (34)
@@ -982,24 +982,24 @@ sort
       │    │    │    │    │    │    ├── fd: (34)-->(37)
       │    │    │    │    │    │    └── ordering: +37
       │    │    │    │    │    ├── sort
-      │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    │    ├── key: (41)
       │    │    │    │    │    │    ├── fd: ()-->(46), (41)-->(42,43), (43)==(45), (45)==(43)
       │    │    │    │    │    │    ├── ordering: +41 opt(46) [actual: +41]
       │    │    │    │    │    │    └── inner-join
-      │    │    │    │    │    │         ├── columns: n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    │         ├── columns: n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    │         ├── key: (41)
       │    │    │    │    │    │         ├── fd: ()-->(46), (41)-->(42,43), (43)==(45), (45)==(43)
       │    │    │    │    │    │         ├── scan nation
-      │    │    │    │    │    │         │    ├── columns: n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null)
+      │    │    │    │    │    │         │    ├── columns: n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null)
       │    │    │    │    │    │         │    ├── key: (41)
       │    │    │    │    │    │         │    └── fd: (41)-->(42,43)
       │    │    │    │    │    │         ├── select
-      │    │    │    │    │    │         │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    │         │    ├── columns: r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    │         │    ├── key: (45)
       │    │    │    │    │    │         │    ├── fd: ()-->(46)
       │    │    │    │    │    │         │    ├── scan region
-      │    │    │    │    │    │         │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    │         │    │    ├── columns: r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    │         │    │    ├── key: (45)
       │    │    │    │    │    │         │    │    └── fd: (45)-->(46)
       │    │    │    │    │    │         │    └── filters
@@ -1140,25 +1140,25 @@ ORDER BY
     l_year;
 ----
 sort
- ├── columns: supp_nation:42(string!null) cust_nation:46(string!null) l_year:49(int) revenue:51(float)
+ ├── columns: supp_nation:42(char!null) cust_nation:46(char!null) l_year:49(int) revenue:51(float)
  ├── key: (42,46,49)
  ├── fd: (42,46,49)-->(51)
  ├── ordering: +42,+46,+49
  └── group-by
-      ├── columns: n1.n_name:42(string!null) n2.n_name:46(string!null) l_year:49(int) sum:51(float)
-      ├── grouping columns: n1.n_name:42(string!null) n2.n_name:46(string!null) l_year:49(int)
+      ├── columns: n1.n_name:42(char!null) n2.n_name:46(char!null) l_year:49(int) sum:51(float)
+      ├── grouping columns: n1.n_name:42(char!null) n2.n_name:46(char!null) l_year:49(int)
       ├── key: (42,46,49)
       ├── fd: (42,46,49)-->(51)
       ├── project
-      │    ├── columns: l_year:49(int) volume:50(float) n1.n_name:42(string!null) n2.n_name:46(string!null)
+      │    ├── columns: l_year:49(int) volume:50(float) n1.n_name:42(char!null) n2.n_name:46(char!null)
       │    ├── inner-join
-      │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+      │    │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    ├── fd: (1)-->(4), (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(41), (41)==(4)
       │    │    ├── inner-join
-      │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+      │    │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8)
       │    │    │    ├── inner-join
-      │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+      │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    │    │    ├── key: (24,41)
       │    │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25)
       │    │    │    │    ├── scan orders@o_ck
@@ -1166,7 +1166,7 @@ sort
       │    │    │    │    │    ├── key: (24)
       │    │    │    │    │    └── fd: (24)-->(25)
       │    │    │    │    ├── inner-join (merge)
-      │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+      │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    │    │    │    ├── left ordering: +36
       │    │    │    │    │    ├── right ordering: +45
       │    │    │    │    │    ├── key: (33,41)
@@ -1177,20 +1177,20 @@ sort
       │    │    │    │    │    │    ├── fd: (33)-->(36)
       │    │    │    │    │    │    └── ordering: +36
       │    │    │    │    │    ├── sort
-      │    │    │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+      │    │    │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    │    │    │    │    ├── key: (41,45)
       │    │    │    │    │    │    ├── fd: (41)-->(42), (45)-->(46)
       │    │    │    │    │    │    ├── ordering: +45
       │    │    │    │    │    │    └── inner-join
-      │    │    │    │    │    │         ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+      │    │    │    │    │    │         ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    │    │    │    │         ├── key: (41,45)
       │    │    │    │    │    │         ├── fd: (41)-->(42), (45)-->(46)
       │    │    │    │    │    │         ├── scan n1
-      │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null)
+      │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(char!null)
       │    │    │    │    │    │         │    ├── key: (41)
       │    │    │    │    │    │         │    └── fd: (41)-->(42)
       │    │    │    │    │    │         ├── scan n2
-      │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+      │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
       │    │    │    │    │    │         │    ├── key: (45)
       │    │    │    │    │    │         │    └── fd: (45)-->(46)
       │    │    │    │    │    │         └── filters
@@ -1294,24 +1294,24 @@ project
  │    │    └── project
  │    │         ├── columns: column63:63(float) o_year:61(int) volume:62(float)
  │    │         ├── project
- │    │         │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(string!null)
+ │    │         │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(char!null)
  │    │         │    ├── inner-join
- │    │         │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
  │    │         │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
  │    │         │    │    ├── inner-join
- │    │         │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
  │    │         │    │    │    ├── fd: ()-->(59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13)
  │    │         │    │    │    ├── inner-join
- │    │         │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
  │    │         │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17)
  │    │         │    │    │    │    ├── scan lineitem
  │    │         │    │    │    │    │    └── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null)
  │    │         │    │    │    │    ├── inner-join
- │    │         │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
  │    │         │    │    │    │    │    ├── key: (33,54)
  │    │         │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
  │    │         │    │    │    │    │    ├── inner-join (merge)
- │    │         │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
  │    │         │    │    │    │    │    │    ├── left ordering: +45
  │    │         │    │    │    │    │    │    ├── right ordering: +50
  │    │         │    │    │    │    │    │    ├── key: (42,54)
@@ -1322,31 +1322,31 @@ project
  │    │         │    │    │    │    │    │    │    ├── fd: (42)-->(45)
  │    │         │    │    │    │    │    │    │    └── ordering: +45
  │    │         │    │    │    │    │    │    ├── sort
- │    │         │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
  │    │         │    │    │    │    │    │    │    ├── key: (50,54)
  │    │         │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
  │    │         │    │    │    │    │    │    │    ├── ordering: +50 opt(59) [actual: +50]
  │    │         │    │    │    │    │    │    │    └── inner-join
- │    │         │    │    │    │    │    │    │         ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    │    │    │    │         ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
  │    │         │    │    │    │    │    │    │         ├── key: (50,54)
  │    │         │    │    │    │    │    │    │         ├── fd: ()-->(59), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52)
  │    │         │    │    │    │    │    │    │         ├── scan n2
- │    │         │    │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null)
+ │    │         │    │    │    │    │    │    │         │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(char!null)
  │    │         │    │    │    │    │    │    │         │    ├── key: (54)
  │    │         │    │    │    │    │    │    │         │    └── fd: (54)-->(55)
  │    │         │    │    │    │    │    │    │         ├── inner-join (merge)
- │    │         │    │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    │    │    │    │         │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(char!null)
  │    │         │    │    │    │    │    │    │         │    ├── left ordering: +58
  │    │         │    │    │    │    │    │    │         │    ├── right ordering: +52
  │    │         │    │    │    │    │    │    │         │    ├── key: (50)
  │    │         │    │    │    │    │    │    │         │    ├── fd: ()-->(59), (50)-->(52), (52)==(58), (58)==(52)
  │    │         │    │    │    │    │    │    │         │    ├── select
- │    │         │    │    │    │    │    │    │         │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    │    │    │    │         │    │    ├── columns: r_regionkey:58(int!null) r_name:59(char!null)
  │    │         │    │    │    │    │    │    │         │    │    ├── key: (58)
  │    │         │    │    │    │    │    │    │         │    │    ├── fd: ()-->(59)
  │    │         │    │    │    │    │    │    │         │    │    ├── ordering: +58 opt(59) [actual: +58]
  │    │         │    │    │    │    │    │    │         │    │    ├── scan region
- │    │         │    │    │    │    │    │    │         │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
+ │    │         │    │    │    │    │    │    │         │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(char!null)
  │    │         │    │    │    │    │    │    │         │    │    │    ├── key: (58)
  │    │         │    │    │    │    │    │    │         │    │    │    ├── fd: (58)-->(59)
  │    │         │    │    │    │    │    │    │         │    │    │    └── ordering: +58 opt(59) [actual: +58]
@@ -1381,11 +1381,11 @@ project
  │    │         │    │    │         ├── s_suppkey = l_suppkey [type=bool, outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
  │    │         │    │    │         └── s_nationkey = n2.n_nationkey [type=bool, outer=(13,54), constraints=(/13: (/NULL - ]; /54: (/NULL - ]), fd=(13)==(54), (54)==(13)]
  │    │         │    │    ├── select
- │    │         │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null)
+ │    │         │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null)
  │    │         │    │    │    ├── key: (1)
  │    │         │    │    │    ├── fd: ()-->(5)
  │    │         │    │    │    ├── scan part
- │    │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null)
+ │    │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null)
  │    │         │    │    │    │    ├── key: (1)
  │    │         │    │    │    │    └── fd: (1)-->(5)
  │    │         │    │    │    └── filters
@@ -1459,26 +1459,26 @@ ORDER BY
     o_year DESC;
 ----
 sort
- ├── columns: nation:48(string!null) o_year:51(int) sum_profit:53(float)
+ ├── columns: nation:48(char!null) o_year:51(int) sum_profit:53(float)
  ├── key: (48,51)
  ├── fd: (48,51)-->(53)
  ├── ordering: +48,-51
  └── group-by
-      ├── columns: n_name:48(string!null) o_year:51(int) sum:53(float)
-      ├── grouping columns: n_name:48(string!null) o_year:51(int)
+      ├── columns: n_name:48(char!null) o_year:51(int) sum:53(float)
+      ├── grouping columns: n_name:48(char!null) o_year:51(int)
       ├── key: (48,51)
       ├── fd: (48,51)-->(53)
       ├── project
-      │    ├── columns: o_year:51(int) amount:52(float) n_name:48(string!null)
+      │    ├── columns: o_year:51(int) amount:52(float) n_name:48(char!null)
       │    ├── inner-join (lookup part)
-      │    │    ├── columns: p_partkey:1(int!null) p_name:2(string!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
+      │    │    ├── columns: p_partkey:1(int!null) p_name:2(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    ├── key columns: [18] = [1]
       │    │    ├── fd: (1)-->(2), (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(1,33), (33)==(1,18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13), (1)==(18,33)
       │    │    ├── inner-join
-      │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
+      │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    │    ├── fd: (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(33), (33)==(18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13)
       │    │    │    ├── inner-join
-      │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
+      │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    │    │    ├── fd: (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(34), (34)==(19), (18)==(33), (33)==(18), (17)==(38), (38)==(17)
       │    │    │    │    ├── inner-join (lookup orders)
       │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null)
@@ -1501,7 +1501,7 @@ sort
       │    │    │    │    │    │    └── filters (true)
       │    │    │    │    │    └── filters (true)
       │    │    │    │    ├── scan nation
-      │    │    │    │    │    ├── columns: n_nationkey:47(int!null) n_name:48(string!null)
+      │    │    │    │    │    ├── columns: n_nationkey:47(int!null) n_name:48(char!null)
       │    │    │    │    │    ├── key: (47)
       │    │    │    │    │    └── fd: (47)-->(48)
       │    │    │    │    └── filters (true)
@@ -1570,38 +1570,38 @@ ORDER BY
 LIMIT 20;
 ----
 limit
- ├── columns: c_custkey:1(int!null) c_name:2(string) revenue:39(float) c_acctbal:6(float) n_name:35(string) c_address:3(string) c_phone:5(string) c_comment:8(string)
+ ├── columns: c_custkey:1(int!null) c_name:2(varchar) revenue:39(float) c_acctbal:6(float) n_name:35(char) c_address:3(varchar) c_phone:5(char) c_comment:8(varchar)
  ├── internal-ordering: -39
  ├── cardinality: [0 - 20]
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,6,8,35,39)
  ├── ordering: -39
  ├── sort
- │    ├── columns: c_custkey:1(int!null) c_name:2(string) c_address:3(string) c_phone:5(string) c_acctbal:6(float) c_comment:8(string) n_name:35(string) sum:39(float)
+ │    ├── columns: c_custkey:1(int!null) c_name:2(varchar) c_address:3(varchar) c_phone:5(char) c_acctbal:6(float) c_comment:8(varchar) n_name:35(char) sum:39(float)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3,5,6,8,35,39)
  │    ├── ordering: -39
  │    └── group-by
- │         ├── columns: c_custkey:1(int!null) c_name:2(string) c_address:3(string) c_phone:5(string) c_acctbal:6(float) c_comment:8(string) n_name:35(string) sum:39(float)
+ │         ├── columns: c_custkey:1(int!null) c_name:2(varchar) c_address:3(varchar) c_phone:5(char) c_acctbal:6(float) c_comment:8(varchar) n_name:35(char) sum:39(float)
  │         ├── grouping columns: c_custkey:1(int!null)
  │         ├── key: (1)
  │         ├── fd: (1)-->(2,3,5,6,8,35,39)
  │         ├── project
- │         │    ├── columns: column38:38(float) c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) n_name:35(string!null)
+ │         │    ├── columns: column38:38(float) c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) n_name:35(char!null)
  │         │    ├── fd: (1)-->(2,3,5,6,8,35)
  │         │    ├── inner-join
- │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
+ │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null) n_nationkey:34(int!null) n_name:35(char!null)
  │         │    │    ├── fd: ()-->(26), (1)-->(2-6,8), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(34), (34)==(4)
  │         │    │    ├── scan nation
- │         │    │    │    ├── columns: n_nationkey:34(int!null) n_name:35(string!null)
+ │         │    │    │    ├── columns: n_nationkey:34(int!null) n_name:35(char!null)
  │         │    │    │    ├── key: (34)
  │         │    │    │    └── fd: (34)-->(35)
  │         │    │    ├── inner-join (lookup customer)
- │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
  │         │    │    │    ├── key columns: [10] = [1]
  │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9), (1)-->(2-6,8), (1)==(10), (10)==(1)
  │         │    │    │    ├── inner-join (lookup lineitem)
- │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
+ │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
  │         │    │    │    │    ├── key columns: [9] = [18]
  │         │    │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9)
  │         │    │    │    │    ├── index-join orders
@@ -1623,18 +1623,18 @@ limit
  │         └── aggregations
  │              ├── sum [type=float, outer=(38)]
  │              │    └── variable: column38 [type=float]
- │              ├── const-agg [type=string, outer=(2)]
- │              │    └── variable: c_name [type=string]
- │              ├── const-agg [type=string, outer=(3)]
- │              │    └── variable: c_address [type=string]
- │              ├── const-agg [type=string, outer=(5)]
- │              │    └── variable: c_phone [type=string]
+ │              ├── const-agg [type=varchar, outer=(2)]
+ │              │    └── variable: c_name [type=varchar]
+ │              ├── const-agg [type=varchar, outer=(3)]
+ │              │    └── variable: c_address [type=varchar]
+ │              ├── const-agg [type=char, outer=(5)]
+ │              │    └── variable: c_phone [type=char]
  │              ├── const-agg [type=float, outer=(6)]
  │              │    └── variable: c_acctbal [type=float]
- │              ├── const-agg [type=string, outer=(8)]
- │              │    └── variable: c_comment [type=string]
- │              └── const-agg [type=string, outer=(35)]
- │                   └── variable: n_name [type=string]
+ │              ├── const-agg [type=varchar, outer=(8)]
+ │              │    └── variable: c_comment [type=varchar]
+ │              └── const-agg [type=char, outer=(35)]
+ │                   └── variable: n_name [type=char]
  └── const: 20 [type=int]
 
 # --------------------------------------------------
@@ -1693,7 +1693,7 @@ sort
       │    ├── project
       │    │    ├── columns: column17:17(float) ps_partkey:1(int!null)
       │    │    ├── inner-join
-      │    │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) ps_availqty:3(int!null) ps_supplycost:4(float!null) s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(string!null)
+      │    │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) ps_availqty:3(int!null) ps_supplycost:4(float!null) s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(char!null)
       │    │    │    ├── key: (1,6)
       │    │    │    ├── fd: ()-->(14), (1,2)-->(3,4), (6)-->(9), (9)==(13), (13)==(9), (2)==(6), (6)==(2)
       │    │    │    ├── scan partsupp
@@ -1701,16 +1701,16 @@ sort
       │    │    │    │    ├── key: (1,2)
       │    │    │    │    └── fd: (1,2)-->(3,4)
       │    │    │    ├── inner-join (lookup supplier@s_nk)
-      │    │    │    │    ├── columns: s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(string!null)
+      │    │    │    │    ├── columns: s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(char!null)
       │    │    │    │    ├── key columns: [13] = [9]
       │    │    │    │    ├── key: (6)
       │    │    │    │    ├── fd: ()-->(14), (6)-->(9), (9)==(13), (13)==(9)
       │    │    │    │    ├── select
-      │    │    │    │    │    ├── columns: n_nationkey:13(int!null) n_name:14(string!null)
+      │    │    │    │    │    ├── columns: n_nationkey:13(int!null) n_name:14(char!null)
       │    │    │    │    │    ├── key: (13)
       │    │    │    │    │    ├── fd: ()-->(14)
       │    │    │    │    │    ├── scan nation
-      │    │    │    │    │    │    ├── columns: n_nationkey:13(int!null) n_name:14(string!null)
+      │    │    │    │    │    │    ├── columns: n_nationkey:13(int!null) n_name:14(char!null)
       │    │    │    │    │    │    ├── key: (13)
       │    │    │    │    │    │    └── fd: (13)-->(14)
       │    │    │    │    │    └── filters
@@ -1740,21 +1740,21 @@ sort
                           │    ├── project
                           │    │    ├── columns: column35:35(float)
                           │    │    ├── inner-join
-                          │    │    │    ├── columns: ps_suppkey:20(int!null) ps_availqty:21(int!null) ps_supplycost:22(float!null) s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(string!null)
+                          │    │    │    ├── columns: ps_suppkey:20(int!null) ps_availqty:21(int!null) ps_supplycost:22(float!null) s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(char!null)
                           │    │    │    ├── fd: ()-->(32), (24)-->(27), (27)==(31), (31)==(27), (20)==(24), (24)==(20)
                           │    │    │    ├── scan partsupp
                           │    │    │    │    └── columns: ps_suppkey:20(int!null) ps_availqty:21(int!null) ps_supplycost:22(float!null)
                           │    │    │    ├── inner-join (lookup supplier@s_nk)
-                          │    │    │    │    ├── columns: s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(string!null)
+                          │    │    │    │    ├── columns: s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(char!null)
                           │    │    │    │    ├── key columns: [31] = [27]
                           │    │    │    │    ├── key: (24)
                           │    │    │    │    ├── fd: ()-->(32), (24)-->(27), (27)==(31), (31)==(27)
                           │    │    │    │    ├── select
-                          │    │    │    │    │    ├── columns: n_nationkey:31(int!null) n_name:32(string!null)
+                          │    │    │    │    │    ├── columns: n_nationkey:31(int!null) n_name:32(char!null)
                           │    │    │    │    │    ├── key: (31)
                           │    │    │    │    │    ├── fd: ()-->(32)
                           │    │    │    │    │    ├── scan nation
-                          │    │    │    │    │    │    ├── columns: n_nationkey:31(int!null) n_name:32(string!null)
+                          │    │    │    │    │    │    ├── columns: n_nationkey:31(int!null) n_name:32(char!null)
                           │    │    │    │    │    │    ├── key: (31)
                           │    │    │    │    │    │    └── fd: (31)-->(32)
                           │    │    │    │    │    └── filters
@@ -1815,26 +1815,26 @@ ORDER BY
     l_shipmode;
 ----
 group-by
- ├── columns: l_shipmode:24(string!null) high_line_count:27(decimal) low_line_count:29(decimal)
- ├── grouping columns: l_shipmode:24(string!null)
+ ├── columns: l_shipmode:24(char!null) high_line_count:27(decimal) low_line_count:29(decimal)
+ ├── grouping columns: l_shipmode:24(char!null)
  ├── key: (24)
  ├── fd: (24)-->(27,29)
  ├── ordering: +24
  ├── project
- │    ├── columns: column26:26(int) column28:28(int) l_shipmode:24(string!null)
+ │    ├── columns: column26:26(int) column28:28(int) l_shipmode:24(char!null)
  │    ├── ordering: +24
  │    ├── inner-join (lookup orders)
- │    │    ├── columns: o_orderkey:1(int!null) o_orderpriority:6(string!null) l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
+ │    │    ├── columns: o_orderkey:1(int!null) o_orderpriority:6(char!null) l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
  │    │    ├── key columns: [10] = [1]
  │    │    ├── fd: (1)-->(6), (1)==(10), (10)==(1)
  │    │    ├── ordering: +24
  │    │    ├── sort
- │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
+ │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
  │    │    │    ├── ordering: +24
  │    │    │    └── select
- │    │    │         ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
+ │    │    │         ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
  │    │    │         ├── index-join lineitem
- │    │    │         │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
+ │    │    │         │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
  │    │    │         │    └── scan lineitem@l_rd
  │    │    │         │         ├── columns: l_orderkey:10(int!null) l_linenumber:13(int!null) l_receiptdate:22(date!null)
  │    │    │         │         ├── constraint: /22/10/13: [/'1994-01-01' - /'1994-12-31']
@@ -1902,15 +1902,15 @@ sort
       │    ├── key: (1)
       │    ├── fd: (1)-->(18)
       │    ├── right-join
-      │    │    ├── columns: c_custkey:1(int!null) o_orderkey:9(int) o_custkey:10(int) o_comment:17(string)
+      │    │    ├── columns: c_custkey:1(int!null) o_orderkey:9(int) o_custkey:10(int) o_comment:17(varchar)
       │    │    ├── key: (1,9)
       │    │    ├── fd: (9)-->(10,17)
       │    │    ├── select
-      │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(string!null)
+      │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(varchar!null)
       │    │    │    ├── key: (9)
       │    │    │    ├── fd: (9)-->(10,17)
       │    │    │    ├── scan orders
-      │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(string!null)
+      │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(varchar!null)
       │    │    │    │    ├── key: (9)
       │    │    │    │    └── fd: (9)-->(10,17)
       │    │    │    └── filters
@@ -1966,7 +1966,7 @@ project
  │    ├── project
  │    │    ├── columns: column26:26(float) column28:28(float)
  │    │    ├── inner-join
- │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(string!null)
+ │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(varchar!null)
  │    │    │    ├── fd: (17)-->(21), (2)==(17), (17)==(2)
  │    │    │    ├── index-join lineitem
  │    │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null)
@@ -1976,7 +1976,7 @@ project
  │    │    │    │         ├── key: (1,4)
  │    │    │    │         └── fd: (1,4)-->(11)
  │    │    │    ├── scan part
- │    │    │    │    ├── columns: p_partkey:17(int!null) p_type:21(string!null)
+ │    │    │    │    ├── columns: p_partkey:17(int!null) p_type:21(varchar!null)
  │    │    │    │    ├── key: (17)
  │    │    │    │    └── fd: (17)-->(21)
  │    │    │    └── filters
@@ -2041,19 +2041,19 @@ ORDER BY
     s_suppkey;
 ----
 project
- ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_phone:5(string!null) total_revenue:25(float!null)
+ ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_phone:5(char!null) total_revenue:25(float!null)
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,25)
  ├── ordering: +1
  └── inner-join (merge)
-      ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_phone:5(string!null) l_suppkey:10(int!null) sum:25(float!null)
+      ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_phone:5(char!null) l_suppkey:10(int!null) sum:25(float!null)
       ├── left ordering: +1
       ├── right ordering: +10
       ├── key: (10)
       ├── fd: (1)-->(2,3,5), (10)-->(25), (1)==(10), (10)==(1)
       ├── ordering: +(1|10) [actual: +1]
       ├── scan supplier
-      │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_phone:5(string!null)
+      │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_phone:5(char!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,3,5)
       │    └── ordering: +1
@@ -2165,17 +2165,17 @@ ORDER BY
     p_size;
 ----
 sort
- ├── columns: p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null) supplier_cnt:22(int)
+ ├── columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null) supplier_cnt:22(int)
  ├── key: (9-11)
  ├── fd: (9-11)-->(22)
  ├── ordering: -22,+9,+10,+11
  └── group-by
-      ├── columns: p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null) count:22(int)
-      ├── grouping columns: p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
+      ├── columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null) count:22(int)
+      ├── grouping columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       ├── key: (9-11)
       ├── fd: (9-11)-->(22)
       ├── inner-join
-      │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
+      │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       │    ├── key: (2,6)
       │    ├── fd: (6)-->(9-11), (1)==(6), (6)==(1)
       │    ├── anti-join (merge)
@@ -2188,12 +2188,12 @@ sort
       │    │    │    ├── key: (1,2)
       │    │    │    └── ordering: +2
       │    │    ├── select
-      │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(string!null)
+      │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(varchar!null)
       │    │    │    ├── key: (15)
       │    │    │    ├── fd: (15)-->(21)
       │    │    │    ├── ordering: +15
       │    │    │    ├── scan supplier
-      │    │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(string!null)
+      │    │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(varchar!null)
       │    │    │    │    ├── key: (15)
       │    │    │    │    ├── fd: (15)-->(21)
       │    │    │    │    └── ordering: +15
@@ -2201,11 +2201,11 @@ sort
       │    │    │         └── s_comment LIKE '%Customer%Complaints%' [type=bool, outer=(21), constraints=(/21: (/NULL - ])]
       │    │    └── filters (true)
       │    ├── select
-      │    │    ├── columns: p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
+      │    │    ├── columns: p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       │    │    ├── key: (6)
       │    │    ├── fd: (6)-->(9-11)
       │    │    ├── scan part
-      │    │    │    ├── columns: p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
+      │    │    │    ├── columns: p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       │    │    │    ├── key: (6)
       │    │    │    └── fd: (6)-->(9-11)
       │    │    └── filters
@@ -2285,23 +2285,23 @@ project
  │    │    │    │    │    ├── key: (17)
  │    │    │    │    │    ├── fd: (17)-->(42)
  │    │    │    │    │    ├── left-join (lookup lineitem)
- │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null) l_partkey:27(int) l_quantity:30(float)
+ │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_container:23(char!null) l_partkey:27(int) l_quantity:30(float)
  │    │    │    │    │    │    ├── key columns: [26 29] = [26 29]
  │    │    │    │    │    │    ├── fd: ()-->(20,23)
  │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [actual: +17]
  │    │    │    │    │    │    ├── left-join (lookup lineitem@l_pk)
- │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null) l_orderkey:26(int) l_partkey:27(int) l_linenumber:29(int)
+ │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_container:23(char!null) l_orderkey:26(int) l_partkey:27(int) l_linenumber:29(int)
  │    │    │    │    │    │    │    ├── key columns: [17] = [27]
  │    │    │    │    │    │    │    ├── key: (17,26,29)
  │    │    │    │    │    │    │    ├── fd: ()-->(20,23), (26,29)-->(27)
  │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [actual: +17]
  │    │    │    │    │    │    │    ├── select
- │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null)
+ │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_container:23(char!null)
  │    │    │    │    │    │    │    │    ├── key: (17)
  │    │    │    │    │    │    │    │    ├── fd: ()-->(20,23)
  │    │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [actual: +17]
  │    │    │    │    │    │    │    │    ├── scan part
- │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null)
+ │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_container:23(char!null)
  │    │    │    │    │    │    │    │    │    ├── key: (17)
  │    │    │    │    │    │    │    │    │    ├── fd: (17)-->(20,23)
  │    │    │    │    │    │    │    │    │    └── ordering: +17 opt(20,23) [actual: +17]
@@ -2371,29 +2371,29 @@ ORDER BY
 LIMIT 100;
 ----
 limit
- ├── columns: c_name:2(string) c_custkey:1(int) o_orderkey:9(int!null) o_orderdate:13(date) o_totalprice:12(float) sum:51(float)
+ ├── columns: c_name:2(varchar) c_custkey:1(int) o_orderkey:9(int!null) o_orderdate:13(date) o_totalprice:12(float) sum:51(float)
  ├── internal-ordering: -12,+13
  ├── cardinality: [0 - 100]
  ├── key: (9)
  ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
  ├── ordering: -12,+13
  ├── sort
- │    ├── columns: c_custkey:1(int) c_name:2(string) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) sum:51(float)
+ │    ├── columns: c_custkey:1(int) c_name:2(varchar) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) sum:51(float)
  │    ├── key: (9)
  │    ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
  │    ├── ordering: -12,+13
  │    └── group-by
- │         ├── columns: c_custkey:1(int) c_name:2(string) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) sum:51(float)
+ │         ├── columns: c_custkey:1(int) c_name:2(varchar) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) sum:51(float)
  │         ├── grouping columns: o_orderkey:9(int!null)
  │         ├── key: (9)
  │         ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
  │         ├── inner-join
- │         │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
+ │         │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
  │         │    ├── fd: (1)-->(2), (9)-->(10,12,13), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
  │         │    ├── scan lineitem
  │         │    │    └── columns: l_orderkey:18(int!null) l_quantity:22(float!null)
  │         │    ├── inner-join
- │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
+ │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null)
  │         │    │    ├── key: (9)
  │         │    │    ├── fd: (9)-->(10,12,13), (1)-->(2), (1)==(10), (10)==(1)
  │         │    │    ├── semi-join (merge)
@@ -2428,7 +2428,7 @@ limit
  │         │    │    │    │         └── sum > 300.0 [type=bool, outer=(50), constraints=(/50: [/300.00000000000006 - ]; tight)]
  │         │    │    │    └── filters (true)
  │         │    │    ├── scan customer
- │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null)
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null)
  │         │    │    │    ├── key: (1)
  │         │    │    │    └── fd: (1)-->(2)
  │         │    │    └── filters
@@ -2440,8 +2440,8 @@ limit
  │              │    └── variable: l_quantity [type=float]
  │              ├── const-agg [type=int, outer=(1)]
  │              │    └── variable: c_custkey [type=int]
- │              ├── const-agg [type=string, outer=(2)]
- │              │    └── variable: c_name [type=string]
+ │              ├── const-agg [type=varchar, outer=(2)]
+ │              │    └── variable: c_name [type=varchar]
  │              ├── const-agg [type=float, outer=(12)]
  │              │    └── variable: o_totalprice [type=float]
  │              └── const-agg [type=date, outer=(13)]
@@ -2505,14 +2505,14 @@ scalar-group-by
  ├── project
  │    ├── columns: column26:26(float)
  │    ├── inner-join (lookup part)
- │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(string!null) l_shipmode:15(string!null) p_partkey:17(int!null) p_brand:20(string!null) p_size:22(int!null) p_container:23(string!null)
+ │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null) p_partkey:17(int!null) p_brand:20(char!null) p_size:22(int!null) p_container:23(char!null)
  │    │    ├── key columns: [2] = [17]
  │    │    ├── fd: ()-->(14), (17)-->(20,22,23), (2)==(17), (17)==(2)
  │    │    ├── select
- │    │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(string!null) l_shipmode:15(string!null)
+ │    │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null)
  │    │    │    ├── fd: ()-->(14)
  │    │    │    ├── scan lineitem
- │    │    │    │    └── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(string!null) l_shipmode:15(string!null)
+ │    │    │    │    └── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null)
  │    │    │    └── filters
  │    │    │         ├── l_shipmode IN ('AIR', 'AIR REG') [type=bool, outer=(15), constraints=(/15: [/'AIR' - /'AIR'] [/'AIR REG' - /'AIR REG']; tight)]
  │    │    │         └── l_shipinstruct = 'DELIVER IN PERSON' [type=bool, outer=(14), constraints=(/14: [/'DELIVER IN PERSON' - /'DELIVER IN PERSON']; tight), fd=()-->(14)]
@@ -2579,20 +2579,20 @@ ORDER BY
     s_name;
 ----
 sort
- ├── columns: s_name:2(string!null) s_address:3(string!null)
+ ├── columns: s_name:2(char!null) s_address:3(varchar!null)
  ├── ordering: +2
  └── project
-      ├── columns: s_name:2(string!null) s_address:3(string!null)
+      ├── columns: s_name:2(char!null) s_address:3(varchar!null)
       └── inner-join
-           ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_nationkey:4(int!null) n_nationkey:8(int!null) n_name:9(string!null)
+           ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null) n_nationkey:8(int!null) n_name:9(char!null)
            ├── key: (1)
            ├── fd: ()-->(9), (1)-->(2-4), (4)==(8), (8)==(4)
            ├── semi-join
-           │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_nationkey:4(int!null)
+           │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-4)
            │    ├── scan supplier
-           │    │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_nationkey:4(int!null)
+           │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
            │    │    ├── key: (1)
            │    │    └── fd: (1)-->(2-4)
            │    ├── semi-join
@@ -2635,11 +2635,11 @@ sort
            │    │    │         └── filters
            │    │    │              └── ps_availqty > (sum * 0.5) [type=bool, outer=(14,42), constraints=(/14: (/NULL - ])]
            │    │    ├── select
-           │    │    │    ├── columns: p_partkey:17(int!null) p_name:18(string!null)
+           │    │    │    ├── columns: p_partkey:17(int!null) p_name:18(varchar!null)
            │    │    │    ├── key: (17)
            │    │    │    ├── fd: (17)-->(18)
            │    │    │    ├── scan part
-           │    │    │    │    ├── columns: p_partkey:17(int!null) p_name:18(string!null)
+           │    │    │    │    ├── columns: p_partkey:17(int!null) p_name:18(varchar!null)
            │    │    │    │    ├── key: (17)
            │    │    │    │    └── fd: (17)-->(18)
            │    │    │    └── filters
@@ -2649,11 +2649,11 @@ sort
            │    └── filters
            │         └── s_suppkey = ps_suppkey [type=bool, outer=(1,13), constraints=(/1: (/NULL - ]; /13: (/NULL - ]), fd=(1)==(13), (13)==(1)]
            ├── select
-           │    ├── columns: n_nationkey:8(int!null) n_name:9(string!null)
+           │    ├── columns: n_nationkey:8(int!null) n_name:9(char!null)
            │    ├── key: (8)
            │    ├── fd: ()-->(9)
            │    ├── scan nation
-           │    │    ├── columns: n_nationkey:8(int!null) n_name:9(string!null)
+           │    │    ├── columns: n_nationkey:8(int!null) n_name:9(char!null)
            │    │    ├── key: (8)
            │    │    └── fd: (8)-->(9)
            │    └── filters
@@ -2714,41 +2714,41 @@ ORDER BY
 LIMIT 100;
 ----
 limit
- ├── columns: s_name:2(string!null) numwait:69(int)
+ ├── columns: s_name:2(char!null) numwait:69(int)
  ├── internal-ordering: -69,+2
  ├── cardinality: [0 - 100]
  ├── key: (2)
  ├── fd: (2)-->(69)
  ├── ordering: -69,+2
  ├── sort
- │    ├── columns: s_name:2(string!null) count_rows:69(int)
+ │    ├── columns: s_name:2(char!null) count_rows:69(int)
  │    ├── key: (2)
  │    ├── fd: (2)-->(69)
  │    ├── ordering: -69,+2
  │    └── group-by
- │         ├── columns: s_name:2(string!null) count_rows:69(int)
- │         ├── grouping columns: s_name:2(string!null)
+ │         ├── columns: s_name:2(char!null) count_rows:69(int)
+ │         ├── grouping columns: s_name:2(char!null)
  │         ├── key: (2)
  │         ├── fd: (2)-->(69)
  │         ├── inner-join
- │         │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
+ │         │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(char!null) n_nationkey:33(int!null) n_name:34(char!null)
  │         │    ├── fd: ()-->(26,34), (1)-->(2,4), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(33), (33)==(4)
  │         │    ├── inner-join (lookup supplier)
- │         │    │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(char!null)
  │         │    │    ├── key columns: [10] = [1]
  │         │    │    ├── fd: ()-->(26), (8)==(24), (24)==(8), (1)-->(2,4), (1)==(10), (10)==(1)
  │         │    │    ├── inner-join (merge)
- │         │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(char!null)
  │         │    │    │    ├── left ordering: +24
  │         │    │    │    ├── right ordering: +8
  │         │    │    │    ├── fd: ()-->(26), (8)==(24), (24)==(8)
  │         │    │    │    ├── select
- │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(char!null)
  │         │    │    │    │    ├── key: (24)
  │         │    │    │    │    ├── fd: ()-->(26)
  │         │    │    │    │    ├── ordering: +24 opt(26) [actual: +24]
  │         │    │    │    │    ├── scan orders
- │         │    │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(char!null)
  │         │    │    │    │    │    ├── key: (24)
  │         │    │    │    │    │    ├── fd: (24)-->(26)
  │         │    │    │    │    │    └── ordering: +24 opt(26) [actual: +24]
@@ -2773,12 +2773,12 @@ limit
  │         │    │    │    │    │    │    └── filters
  │         │    │    │    │    │    │         └── l1.l_receiptdate > l1.l_commitdate [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
  │         │    │    │    │    │    ├── select
- │         │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(string!null) l3.l_linestatus:62(string!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(string!null) l3.l_shipmode:67(string!null) l3.l_comment:68(string!null)
+ │         │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(char!null) l3.l_linestatus:62(char!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(char!null) l3.l_shipmode:67(char!null) l3.l_comment:68(varchar!null)
  │         │    │    │    │    │    │    ├── key: (53,56)
  │         │    │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
  │         │    │    │    │    │    │    ├── ordering: +53
  │         │    │    │    │    │    │    ├── scan l3
- │         │    │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(string!null) l3.l_linestatus:62(string!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(string!null) l3.l_shipmode:67(string!null) l3.l_comment:68(string!null)
+ │         │    │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(char!null) l3.l_linestatus:62(char!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(char!null) l3.l_shipmode:67(char!null) l3.l_comment:68(varchar!null)
  │         │    │    │    │    │    │    │    ├── key: (53,56)
  │         │    │    │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
  │         │    │    │    │    │    │    │    └── ordering: +53
@@ -2787,7 +2787,7 @@ limit
  │         │    │    │    │    │    └── filters
  │         │    │    │    │    │         └── l3.l_suppkey != l1.l_suppkey [type=bool, outer=(10,55), constraints=(/10: (/NULL - ]; /55: (/NULL - ])]
  │         │    │    │    │    ├── scan l2
- │         │    │    │    │    │    ├── columns: l2.l_orderkey:37(int!null) l2.l_partkey:38(int!null) l2.l_suppkey:39(int!null) l2.l_linenumber:40(int!null) l2.l_quantity:41(float!null) l2.l_extendedprice:42(float!null) l2.l_discount:43(float!null) l2.l_tax:44(float!null) l2.l_returnflag:45(string!null) l2.l_linestatus:46(string!null) l2.l_shipdate:47(date!null) l2.l_commitdate:48(date!null) l2.l_receiptdate:49(date!null) l2.l_shipinstruct:50(string!null) l2.l_shipmode:51(string!null) l2.l_comment:52(string!null)
+ │         │    │    │    │    │    ├── columns: l2.l_orderkey:37(int!null) l2.l_partkey:38(int!null) l2.l_suppkey:39(int!null) l2.l_linenumber:40(int!null) l2.l_quantity:41(float!null) l2.l_extendedprice:42(float!null) l2.l_discount:43(float!null) l2.l_tax:44(float!null) l2.l_returnflag:45(char!null) l2.l_linestatus:46(char!null) l2.l_shipdate:47(date!null) l2.l_commitdate:48(date!null) l2.l_receiptdate:49(date!null) l2.l_shipinstruct:50(char!null) l2.l_shipmode:51(char!null) l2.l_comment:52(varchar!null)
  │         │    │    │    │    │    ├── key: (37,40)
  │         │    │    │    │    │    ├── fd: (37,40)-->(38,39,41-52)
  │         │    │    │    │    │    └── ordering: +37
@@ -2796,11 +2796,11 @@ limit
  │         │    │    │    └── filters (true)
  │         │    │    └── filters (true)
  │         │    ├── select
- │         │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
+ │         │    │    ├── columns: n_nationkey:33(int!null) n_name:34(char!null)
  │         │    │    ├── key: (33)
  │         │    │    ├── fd: ()-->(34)
  │         │    │    ├── scan nation
- │         │    │    │    ├── columns: n_nationkey:33(int!null) n_name:34(string!null)
+ │         │    │    │    ├── columns: n_nationkey:33(int!null) n_name:34(char!null)
  │         │    │    │    ├── key: (33)
  │         │    │    │    └── fd: (33)-->(34)
  │         │    │    └── filters
@@ -2873,18 +2873,18 @@ sort
       ├── project
       │    ├── columns: cntrycode:27(string) c_acctbal:6(float!null)
       │    ├── anti-join (merge)
-      │    │    ├── columns: c_custkey:1(int!null) c_phone:5(string!null) c_acctbal:6(float!null)
+      │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
       │    │    ├── left ordering: +1
       │    │    ├── right ordering: +19
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(5,6)
       │    │    ├── select
-      │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(string!null) c_acctbal:6(float!null)
+      │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
       │    │    │    ├── key: (1)
       │    │    │    ├── fd: (1)-->(5,6)
       │    │    │    ├── ordering: +1
       │    │    │    ├── scan customer
-      │    │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(string!null) c_acctbal:6(float!null)
+      │    │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
       │    │    │    │    ├── key: (1)
       │    │    │    │    ├── fd: (1)-->(5,6)
       │    │    │    │    └── ordering: +1
@@ -2899,9 +2899,9 @@ sort
       │    │    │                        ├── key: ()
       │    │    │                        ├── fd: ()-->(17)
       │    │    │                        ├── select
-      │    │    │                        │    ├── columns: c_phone:13(string!null) c_acctbal:14(float!null)
+      │    │    │                        │    ├── columns: c_phone:13(char!null) c_acctbal:14(float!null)
       │    │    │                        │    ├── scan customer
-      │    │    │                        │    │    └── columns: c_phone:13(string!null) c_acctbal:14(float!null)
+      │    │    │                        │    │    └── columns: c_phone:13(char!null) c_acctbal:14(float!null)
       │    │    │                        │    └── filters
       │    │    │                        │         ├── c_acctbal > 0.0 [type=bool, outer=(14), constraints=(/14: [/5e-324 - ]; tight)]
       │    │    │                        │         └── substring(c_phone, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(13)]

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -8,8 +8,8 @@ CREATE TABLE public.region
 ----
 TABLE region
  ├── r_regionkey int not null
- ├── r_name string not null
- ├── r_comment string
+ ├── r_name char not null
+ ├── r_comment varchar
  └── INDEX primary
       └── r_regionkey int not null
 
@@ -26,9 +26,9 @@ CREATE TABLE public.nation
 ----
 TABLE nation
  ├── n_nationkey int not null
- ├── n_name string not null
+ ├── n_name char not null
  ├── n_regionkey int not null
- ├── n_comment string
+ ├── n_comment varchar
  ├── INDEX primary
  │    └── n_nationkey int not null
  ├── INDEX n_rk
@@ -52,12 +52,12 @@ CREATE TABLE public.supplier
 ----
 TABLE supplier
  ├── s_suppkey int not null
- ├── s_name string not null
- ├── s_address string not null
+ ├── s_name char not null
+ ├── s_address varchar not null
  ├── s_nationkey int not null
- ├── s_phone string not null
+ ├── s_phone char not null
  ├── s_acctbal float not null
- ├── s_comment string not null
+ ├── s_comment varchar not null
  ├── INDEX primary
  │    └── s_suppkey int not null
  ├── INDEX s_nk
@@ -81,14 +81,14 @@ CREATE TABLE public.part
 ----
 TABLE part
  ├── p_partkey int not null
- ├── p_name string not null
- ├── p_mfgr string not null
- ├── p_brand string not null
- ├── p_type string not null
+ ├── p_name varchar not null
+ ├── p_mfgr char not null
+ ├── p_brand char not null
+ ├── p_type varchar not null
  ├── p_size int not null
- ├── p_container string not null
+ ├── p_container char not null
  ├── p_retailprice float not null
- ├── p_comment string not null
+ ├── p_comment varchar not null
  └── INDEX primary
       └── p_partkey int not null
 
@@ -111,7 +111,7 @@ TABLE partsupp
  ├── ps_suppkey int not null
  ├── ps_availqty int not null
  ├── ps_supplycost float not null
- ├── ps_comment string not null
+ ├── ps_comment varchar not null
  ├── INDEX primary
  │    ├── ps_partkey int not null
  │    └── ps_suppkey int not null
@@ -138,13 +138,13 @@ CREATE TABLE public.customer
 ----
 TABLE customer
  ├── c_custkey int not null
- ├── c_name string not null
- ├── c_address string not null
+ ├── c_name varchar not null
+ ├── c_address varchar not null
  ├── c_nationkey int not null
- ├── c_phone string not null
+ ├── c_phone char not null
  ├── c_acctbal float not null
- ├── c_mktsegment string not null
- ├── c_comment string not null
+ ├── c_mktsegment char not null
+ ├── c_comment varchar not null
  ├── INDEX primary
  │    └── c_custkey int not null
  ├── INDEX c_nk
@@ -172,13 +172,13 @@ CREATE TABLE public.orders
 TABLE orders
  ├── o_orderkey int not null
  ├── o_custkey int not null
- ├── o_orderstatus string not null
+ ├── o_orderstatus char not null
  ├── o_totalprice float not null
  ├── o_orderdate date not null
- ├── o_orderpriority string not null
- ├── o_clerk string not null
+ ├── o_orderpriority char not null
+ ├── o_clerk char not null
  ├── o_shippriority int not null
- ├── o_comment string not null
+ ├── o_comment varchar not null
  ├── INDEX primary
  │    └── o_orderkey int not null
  ├── INDEX o_ck
@@ -232,14 +232,14 @@ TABLE lineitem
  ├── l_extendedprice float not null
  ├── l_discount float not null
  ├── l_tax float not null
- ├── l_returnflag string not null
- ├── l_linestatus string not null
+ ├── l_returnflag char not null
+ ├── l_linestatus char not null
  ├── l_shipdate date not null
  ├── l_commitdate date not null
  ├── l_receiptdate date not null
- ├── l_shipinstruct string not null
- ├── l_shipmode string not null
- ├── l_comment string not null
+ ├── l_shipinstruct char not null
+ ├── l_shipmode char not null
+ ├── l_comment varchar not null
  ├── INDEX primary
  │    ├── l_orderkey int not null
  │    └── l_linenumber int not null
@@ -318,20 +318,20 @@ ORDER BY
     l_linestatus;
 ----
 group-by
- ├── columns: l_returnflag:9(string!null) l_linestatus:10(string!null) sum_qty:17(float) sum_base_price:18(float) sum_disc_price:20(float) sum_charge:22(float) avg_qty:23(float) avg_price:24(float) avg_disc:25(float) count_order:26(int)
- ├── grouping columns: l_returnflag:9(string!null) l_linestatus:10(string!null)
+ ├── columns: l_returnflag:9(char!null) l_linestatus:10(char!null) sum_qty:17(float) sum_base_price:18(float) sum_disc_price:20(float) sum_charge:22(float) avg_qty:23(float) avg_price:24(float) avg_disc:25(float) count_order:26(int)
+ ├── grouping columns: l_returnflag:9(char!null) l_linestatus:10(char!null)
  ├── key: (9,10)
  ├── fd: (9,10)-->(17,18,20,22-26)
  ├── ordering: +9,+10
  ├── sort
- │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_returnflag:9(string!null) l_linestatus:10(string!null) column19:19(float) column21:21(float)
+ │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) column19:19(float) column21:21(float)
  │    ├── ordering: +9,+10
  │    └── project
- │         ├── columns: column19:19(float) column21:21(float) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_returnflag:9(string!null) l_linestatus:10(string!null)
+ │         ├── columns: column19:19(float) column21:21(float) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null)
  │         ├── select
- │         │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(string!null) l_linestatus:10(string!null) l_shipdate:11(date!null)
+ │         │    ├── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null)
  │         │    ├── scan lineitem
- │         │    │    └── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(string!null) l_linestatus:10(string!null) l_shipdate:11(date!null)
+ │         │    │    └── columns: l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_tax:8(float!null) l_returnflag:9(char!null) l_linestatus:10(char!null) l_shipdate:11(date!null)
  │         │    └── filters
  │         │         └── l_shipdate <= '1998-09-02' [type=bool, outer=(11), constraints=(/11: (/NULL - /'1998-09-02']; tight)]
  │         └── projections
@@ -421,37 +421,37 @@ ORDER BY
 LIMIT 100;
 ----
 project
- ├── columns: s_acctbal:15(float) s_name:11(string) n_name:23(string) p_partkey:1(int) p_mfgr:3(string) s_address:12(string) s_phone:14(string) s_comment:16(string)
+ ├── columns: s_acctbal:15(float) s_name:11(char) n_name:23(char) p_partkey:1(int) p_mfgr:3(char) s_address:12(varchar) s_phone:14(char) s_comment:16(varchar)
  ├── cardinality: [0 - 100]
  ├── fd: (1)-->(3)
  ├── ordering: -15,+23,+11,+1
  └── limit
-      ├── columns: p_partkey:1(int) p_mfgr:3(string) s_name:11(string) s_address:12(string) s_phone:14(string) s_acctbal:15(float) s_comment:16(string) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(string) min:48(float!null)
+      ├── columns: p_partkey:1(int) p_mfgr:3(char) s_name:11(char) s_address:12(varchar) s_phone:14(char) s_acctbal:15(float) s_comment:16(varchar) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(char) min:48(float!null)
       ├── internal-ordering: -15,+23,+11,+(1|17)
       ├── cardinality: [0 - 100]
       ├── key: (17,18)
       ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
       ├── ordering: -15,+23,+11,+(1|17) [actual: -15,+23,+11,+1]
       ├── sort
-      │    ├── columns: p_partkey:1(int) p_mfgr:3(string) s_name:11(string) s_address:12(string) s_phone:14(string) s_acctbal:15(float) s_comment:16(string) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(string) min:48(float!null)
+      │    ├── columns: p_partkey:1(int) p_mfgr:3(char) s_name:11(char) s_address:12(varchar) s_phone:14(char) s_acctbal:15(float) s_comment:16(varchar) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(char) min:48(float!null)
       │    ├── key: (17,18)
       │    ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
       │    ├── ordering: -15,+23,+11,+(1|17) [actual: -15,+23,+11,+1]
       │    └── select
-      │         ├── columns: p_partkey:1(int) p_mfgr:3(string) s_name:11(string) s_address:12(string) s_phone:14(string) s_acctbal:15(float) s_comment:16(string) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(string) min:48(float!null)
+      │         ├── columns: p_partkey:1(int) p_mfgr:3(char) s_name:11(char) s_address:12(varchar) s_phone:14(char) s_acctbal:15(float) s_comment:16(varchar) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_name:23(char) min:48(float!null)
       │         ├── key: (17,18)
       │         ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23), (20)==(48), (48)==(20)
       │         ├── group-by
-      │         │    ├── columns: p_partkey:1(int) p_mfgr:3(string) s_name:11(string) s_address:12(string) s_phone:14(string) s_acctbal:15(float) s_comment:16(string) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float) n_name:23(string) min:48(float)
+      │         │    ├── columns: p_partkey:1(int) p_mfgr:3(char) s_name:11(char) s_address:12(varchar) s_phone:14(char) s_acctbal:15(float) s_comment:16(varchar) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float) n_name:23(char) min:48(float)
       │         │    ├── grouping columns: ps_partkey:17(int!null) ps_suppkey:18(int!null)
       │         │    ├── key: (17,18)
       │         │    ├── fd: (1)-->(3), (17,18)-->(1,3,11,12,14-16,20,23,48), (1)==(17), (17)==(1), (18)-->(11,12,14-16,23)
       │         │    ├── inner-join
-      │         │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null) ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null) ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    ├── key: (18,29,34)
       │         │    │    ├── fd: ()-->(6,27,46), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17,29), (17)==(1,29), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30), (29)==(1,17)
       │         │    │    ├── inner-join
-      │         │    │    │    ├── columns: ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    │    ├── columns: ps_partkey:29(int!null) ps_suppkey:30(int!null) ps_supplycost:32(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    ├── key: (29,34)
       │         │    │    │    ├── fd: ()-->(46), (29,30)-->(32), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (30)==(34), (34)==(30)
       │         │    │    │    ├── scan partsupp
@@ -459,7 +459,7 @@ project
       │         │    │    │    │    ├── key: (29,30)
       │         │    │    │    │    └── fd: (29,30)-->(32)
       │         │    │    │    ├── inner-join
-      │         │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    │    ├── key: (34)
       │         │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(43), (43)==(45), (45)==(43), (37)==(41), (41)==(37)
       │         │    │    │    │    ├── scan supplier@s_nk
@@ -467,16 +467,16 @@ project
       │         │    │    │    │    │    ├── key: (34)
       │         │    │    │    │    │    └── fd: (34)-->(37)
       │         │    │    │    │    ├── inner-join (lookup nation@n_rk)
-      │         │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    │    │    ├── key columns: [45] = [43]
       │         │    │    │    │    │    ├── key: (41)
       │         │    │    │    │    │    ├── fd: ()-->(46), (41)-->(43), (43)==(45), (45)==(43)
       │         │    │    │    │    │    ├── select
-      │         │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    │    │    │    ├── key: (45)
       │         │    │    │    │    │    │    ├── fd: ()-->(46)
       │         │    │    │    │    │    │    ├── scan region
-      │         │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
+      │         │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(char!null)
       │         │    │    │    │    │    │    │    ├── key: (45)
       │         │    │    │    │    │    │    │    └── fd: (45)-->(46)
       │         │    │    │    │    │    │    └── filters
@@ -487,11 +487,11 @@ project
       │         │    │    │    └── filters
       │         │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(30,34), constraints=(/30: (/NULL - ]; /34: (/NULL - ]), fd=(30)==(34), (34)==(30)]
       │         │    │    ├── inner-join
-      │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null) s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    ├── key: (17,18)
       │         │    │    │    ├── fd: ()-->(6,27), (1)-->(3,5), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13), (1)==(17), (17)==(1)
       │         │    │    │    ├── inner-join
-      │         │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) ps_partkey:17(int!null) ps_suppkey:18(int!null) ps_supplycost:20(float!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    ├── fd: ()-->(27), (10)-->(11-16), (17,18)-->(20), (22)-->(23,24), (24)==(26), (26)==(24), (10)==(18), (18)==(10), (13)==(22), (22)==(13)
       │         │    │    │    │    ├── scan partsupp
@@ -499,29 +499,29 @@ project
       │         │    │    │    │    │    ├── key: (17,18)
       │         │    │    │    │    │    └── fd: (17,18)-->(20)
       │         │    │    │    │    ├── inner-join
-      │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null) n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null) n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    ├── key: (10)
       │         │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24), (10)-->(11-16), (13)==(22), (22)==(13)
       │         │    │    │    │    │    ├── scan supplier
-      │         │    │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(string!null) s_address:12(string!null) s_nationkey:13(int!null) s_phone:14(string!null) s_acctbal:15(float!null) s_comment:16(string!null)
+      │         │    │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_name:11(char!null) s_address:12(varchar!null) s_nationkey:13(int!null) s_phone:14(char!null) s_acctbal:15(float!null) s_comment:16(varchar!null)
       │         │    │    │    │    │    │    ├── key: (10)
       │         │    │    │    │    │    │    └── fd: (10)-->(11-16)
       │         │    │    │    │    │    ├── inner-join (lookup nation)
-      │         │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(string!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_name:23(char!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    │    ├── key columns: [22] = [22]
       │         │    │    │    │    │    │    ├── key: (22)
       │         │    │    │    │    │    │    ├── fd: ()-->(27), (22)-->(23,24), (24)==(26), (26)==(24)
       │         │    │    │    │    │    │    ├── inner-join (lookup nation@n_rk)
-      │         │    │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    │    │    ├── columns: n_nationkey:22(int!null) n_regionkey:24(int!null) r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    │    │    ├── key columns: [26] = [24]
       │         │    │    │    │    │    │    │    ├── key: (22)
       │         │    │    │    │    │    │    │    ├── fd: ()-->(27), (22)-->(24), (24)==(26), (26)==(24)
       │         │    │    │    │    │    │    │    ├── select
-      │         │    │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    │    │    │    ├── key: (26)
       │         │    │    │    │    │    │    │    │    ├── fd: ()-->(27)
       │         │    │    │    │    │    │    │    │    ├── scan region
-      │         │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(string!null)
+      │         │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:26(int!null) r_name:27(char!null)
       │         │    │    │    │    │    │    │    │    │    ├── key: (26)
       │         │    │    │    │    │    │    │    │    │    └── fd: (26)-->(27)
       │         │    │    │    │    │    │    │    │    └── filters
@@ -533,11 +533,11 @@ project
       │         │    │    │    │    └── filters
       │         │    │    │    │         └── s_suppkey = ps_suppkey [type=bool, outer=(10,18), constraints=(/10: (/NULL - ]; /18: (/NULL - ]), fd=(10)==(18), (18)==(10)]
       │         │    │    │    ├── select
-      │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null)
+      │         │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null)
       │         │    │    │    │    ├── key: (1)
       │         │    │    │    │    ├── fd: ()-->(6), (1)-->(3,5)
       │         │    │    │    │    ├── scan part
-      │         │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(string!null) p_type:5(string!null) p_size:6(int!null)
+      │         │    │    │    │    │    ├── columns: p_partkey:1(int!null) p_mfgr:3(char!null) p_type:5(varchar!null) p_size:6(int!null)
       │         │    │    │    │    │    ├── key: (1)
       │         │    │    │    │    │    └── fd: (1)-->(3,5,6)
       │         │    │    │    │    └── filters
@@ -550,22 +550,22 @@ project
       │         │    └── aggregations
       │         │         ├── min [type=float, outer=(32)]
       │         │         │    └── variable: ps_supplycost [type=float]
-      │         │         ├── const-agg [type=string, outer=(11)]
-      │         │         │    └── variable: s_name [type=string]
-      │         │         ├── const-agg [type=string, outer=(12)]
-      │         │         │    └── variable: s_address [type=string]
-      │         │         ├── const-agg [type=string, outer=(14)]
-      │         │         │    └── variable: s_phone [type=string]
+      │         │         ├── const-agg [type=char, outer=(11)]
+      │         │         │    └── variable: s_name [type=char]
+      │         │         ├── const-agg [type=varchar, outer=(12)]
+      │         │         │    └── variable: s_address [type=varchar]
+      │         │         ├── const-agg [type=char, outer=(14)]
+      │         │         │    └── variable: s_phone [type=char]
       │         │         ├── const-agg [type=float, outer=(15)]
       │         │         │    └── variable: s_acctbal [type=float]
-      │         │         ├── const-agg [type=string, outer=(16)]
-      │         │         │    └── variable: s_comment [type=string]
+      │         │         ├── const-agg [type=varchar, outer=(16)]
+      │         │         │    └── variable: s_comment [type=varchar]
       │         │         ├── const-agg [type=float, outer=(20)]
       │         │         │    └── variable: ps_supplycost [type=float]
-      │         │         ├── const-agg [type=string, outer=(23)]
-      │         │         │    └── variable: n_name [type=string]
-      │         │         ├── const-agg [type=string, outer=(3)]
-      │         │         │    └── variable: p_mfgr [type=string]
+      │         │         ├── const-agg [type=char, outer=(23)]
+      │         │         │    └── variable: n_name [type=char]
+      │         │         ├── const-agg [type=char, outer=(3)]
+      │         │         │    └── variable: p_mfgr [type=char]
       │         │         └── const-agg [type=int, outer=(1)]
       │         │              └── variable: p_partkey [type=int]
       │         └── filters
@@ -629,25 +629,25 @@ limit
  │         │    ├── columns: column34:34(float) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null)
  │         │    ├── fd: (18)-->(13,16)
  │         │    ├── inner-join (lookup lineitem)
- │         │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
+ │         │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_shipdate:28(date!null)
  │         │    │    ├── key columns: [9] = [18]
  │         │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
  │         │    │    ├── inner-join (lookup orders)
- │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) o_shippriority:16(int!null)
  │         │    │    │    ├── key columns: [9] = [9]
  │         │    │    │    ├── key: (9)
  │         │    │    │    ├── fd: ()-->(7), (9)-->(10,13,16), (1)==(10), (10)==(1)
  │         │    │    │    ├── inner-join (lookup orders@o_ck)
- │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null) o_orderkey:9(int!null) o_custkey:10(int!null)
+ │         │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null) o_orderkey:9(int!null) o_custkey:10(int!null)
  │         │    │    │    │    ├── key columns: [1] = [10]
  │         │    │    │    │    ├── key: (9)
  │         │    │    │    │    ├── fd: ()-->(7), (9)-->(10), (1)==(10), (10)==(1)
  │         │    │    │    │    ├── select
- │         │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
+ │         │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null)
  │         │    │    │    │    │    ├── key: (1)
  │         │    │    │    │    │    ├── fd: ()-->(7)
  │         │    │    │    │    │    ├── scan customer
- │         │    │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(string!null)
+ │         │    │    │    │    │    │    ├── columns: c_custkey:1(int!null) c_mktsegment:7(char!null)
  │         │    │    │    │    │    │    ├── key: (1)
  │         │    │    │    │    │    │    └── fd: (1)-->(7)
  │         │    │    │    │    │    └── filters
@@ -703,21 +703,21 @@ ORDER BY
     o_orderpriority;
 ----
 sort
- ├── columns: o_orderpriority:6(string!null) order_count:26(int)
+ ├── columns: o_orderpriority:6(char!null) order_count:26(int)
  ├── key: (6)
  ├── fd: (6)-->(26)
  ├── ordering: +6
  └── group-by
-      ├── columns: o_orderpriority:6(string!null) count_rows:26(int)
-      ├── grouping columns: o_orderpriority:6(string!null)
+      ├── columns: o_orderpriority:6(char!null) count_rows:26(int)
+      ├── grouping columns: o_orderpriority:6(char!null)
       ├── key: (6)
       ├── fd: (6)-->(26)
       ├── semi-join
-      │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(string!null)
+      │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
       │    ├── key: (1)
       │    ├── fd: (1)-->(5,6)
       │    ├── index-join orders
-      │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(string!null)
+      │    │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(5,6)
       │    │    └── scan orders@o_od
@@ -780,30 +780,30 @@ ORDER BY
     revenue DESC;
 ----
 sort
- ├── columns: n_name:42(string!null) revenue:49(float)
+ ├── columns: n_name:42(char!null) revenue:49(float)
  ├── key: (42)
  ├── fd: (42)-->(49)
  ├── ordering: -49
  └── group-by
-      ├── columns: n_name:42(string!null) sum:49(float)
-      ├── grouping columns: n_name:42(string!null)
+      ├── columns: n_name:42(char!null) sum:49(float)
+      ├── grouping columns: n_name:42(char!null)
       ├── key: (42)
       ├── fd: (42)-->(49)
       ├── project
-      │    ├── columns: column48:48(float) n_name:42(string!null)
+      │    ├── columns: column48:48(float) n_name:42(char!null)
       │    ├── inner-join
-      │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    ├── columns: c_custkey:1(int!null) c_nationkey:4(int!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    ├── fd: ()-->(46), (1)-->(4), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(4,41), (41)==(4,37), (20)==(34), (34)==(20), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(37,41)
       │    │    ├── inner-join
-      │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    ├── fd: ()-->(46), (9)-->(10,13), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20), (9)==(18), (18)==(9)
       │    │    │    ├── inner-join
-      │    │    │    │    ├── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    ├── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37), (20)==(34), (34)==(20)
       │    │    │    │    ├── scan lineitem
       │    │    │    │    │    └── columns: l_orderkey:18(int!null) l_suppkey:20(int!null) l_extendedprice:23(float!null) l_discount:24(float!null)
       │    │    │    │    ├── inner-join
-      │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    ├── columns: s_suppkey:34(int!null) s_nationkey:37(int!null) n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    ├── key: (34)
       │    │    │    │    │    ├── fd: ()-->(46), (34)-->(37), (41)-->(42,43), (43)==(45), (45)==(43), (37)==(41), (41)==(37)
       │    │    │    │    │    ├── scan supplier@s_nk
@@ -811,21 +811,21 @@ sort
       │    │    │    │    │    │    ├── key: (34)
       │    │    │    │    │    │    └── fd: (34)-->(37)
       │    │    │    │    │    ├── inner-join (lookup nation)
-      │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_name:42(string!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_name:42(char!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    │    ├── key columns: [41] = [41]
       │    │    │    │    │    │    ├── key: (41)
       │    │    │    │    │    │    ├── fd: ()-->(46), (41)-->(42,43), (43)==(45), (45)==(43)
       │    │    │    │    │    │    ├── inner-join (lookup nation@n_rk)
-      │    │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    │    │    ├── columns: n_nationkey:41(int!null) n_regionkey:43(int!null) r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    │    │    ├── key columns: [45] = [43]
       │    │    │    │    │    │    │    ├── key: (41)
       │    │    │    │    │    │    │    ├── fd: ()-->(46), (41)-->(43), (43)==(45), (45)==(43)
       │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    │    │    │    ├── key: (45)
       │    │    │    │    │    │    │    │    ├── fd: ()-->(46)
       │    │    │    │    │    │    │    │    ├── scan region
-      │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(string!null)
+      │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:45(int!null) r_name:46(char!null)
       │    │    │    │    │    │    │    │    │    ├── key: (45)
       │    │    │    │    │    │    │    │    │    └── fd: (45)-->(46)
       │    │    │    │    │    │    │    │    └── filters
@@ -967,38 +967,38 @@ ORDER BY
     l_year;
 ----
 group-by
- ├── columns: supp_nation:42(string!null) cust_nation:46(string!null) l_year:49(int) revenue:51(float)
- ├── grouping columns: n1.n_name:42(string!null) n2.n_name:46(string!null) l_year:49(int)
+ ├── columns: supp_nation:42(char!null) cust_nation:46(char!null) l_year:49(int) revenue:51(float)
+ ├── grouping columns: n1.n_name:42(char!null) n2.n_name:46(char!null) l_year:49(int)
  ├── key: (42,46,49)
  ├── fd: (42,46,49)-->(51)
  ├── ordering: +42,+46,+49
  ├── sort
- │    ├── columns: n1.n_name:42(string!null) n2.n_name:46(string!null) l_year:49(int) volume:50(float)
+ │    ├── columns: n1.n_name:42(char!null) n2.n_name:46(char!null) l_year:49(int) volume:50(float)
  │    ├── ordering: +42,+46,+49
  │    └── project
- │         ├── columns: l_year:49(int) volume:50(float) n1.n_name:42(string!null) n2.n_name:46(string!null)
+ │         ├── columns: l_year:49(int) volume:50(float) n1.n_name:42(char!null) n2.n_name:46(char!null)
  │         ├── inner-join
- │         │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    ├── columns: s_suppkey:1(int!null) s_nationkey:4(int!null) l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
  │         │    ├── fd: (1)-->(4), (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(41), (41)==(4)
  │         │    ├── inner-join
- │         │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    │    ├── columns: l_orderkey:8(int!null) l_suppkey:10(int!null) l_extendedprice:13(float!null) l_discount:14(float!null) l_shipdate:18(date!null) o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
  │         │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25), (8)==(24), (24)==(8)
  │         │    │    ├── inner-join
- │         │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(string!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n1.n_nationkey:41(int!null) n1.n_name:42(char!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
  │         │    │    │    ├── key: (24,41)
  │         │    │    │    ├── fd: (24)-->(25), (33)-->(36), (41)-->(42), (45)-->(46), (36)==(45), (45)==(36), (25)==(33), (33)==(25)
  │         │    │    │    ├── inner-join
- │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_custkey:25(int!null) c_custkey:33(int!null) c_nationkey:36(int!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
  │         │    │    │    │    ├── key: (24)
  │         │    │    │    │    ├── fd: (45)-->(46), (33)-->(36), (36)==(45), (45)==(36), (24)-->(25), (25)==(33), (33)==(25)
  │         │    │    │    │    ├── inner-join (merge)
- │         │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null) n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    │    │    │    │    ├── columns: c_custkey:33(int!null) c_nationkey:36(int!null) n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
  │         │    │    │    │    │    ├── left ordering: +45
  │         │    │    │    │    │    ├── right ordering: +36
  │         │    │    │    │    │    ├── key: (33)
  │         │    │    │    │    │    ├── fd: (45)-->(46), (33)-->(36), (36)==(45), (45)==(36)
  │         │    │    │    │    │    ├── scan n2
- │         │    │    │    │    │    │    ├── columns: n2.n_nationkey:45(int!null) n2.n_name:46(string!null)
+ │         │    │    │    │    │    │    ├── columns: n2.n_nationkey:45(int!null) n2.n_name:46(char!null)
  │         │    │    │    │    │    │    ├── key: (45)
  │         │    │    │    │    │    │    ├── fd: (45)-->(46)
  │         │    │    │    │    │    │    └── ordering: +45
@@ -1015,7 +1015,7 @@ group-by
  │         │    │    │    │    └── filters
  │         │    │    │    │         └── c_custkey = o_custkey [type=bool, outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
  │         │    │    │    ├── scan n1
- │         │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(string!null)
+ │         │    │    │    │    ├── columns: n1.n_nationkey:41(int!null) n1.n_name:42(char!null)
  │         │    │    │    │    ├── key: (41)
  │         │    │    │    │    └── fd: (41)-->(42)
  │         │    │    │    └── filters
@@ -1117,31 +1117,31 @@ sort
       │    ├── project
       │    │    ├── columns: column63:63(float) o_year:61(int) volume:62(float)
       │    │    ├── project
-      │    │    │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(string!null)
+      │    │    │    ├── columns: o_year:61(int) volume:62(float) n2.n_name:55(char!null)
       │    │    │    ├── inner-join (lookup part)
-      │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(string!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    ├── columns: p_partkey:1(int!null) p_type:5(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    ├── key columns: [18] = [1]
       │    │    │    │    ├── fd: ()-->(5,59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13), (1)==(18), (18)==(1)
       │    │    │    │    ├── inner-join
-      │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    ├── fd: ()-->(59), (10)-->(13), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17), (10)==(19), (19)==(10), (13)==(54), (54)==(13)
       │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_extendedprice:22(float!null) l_discount:23(float!null) o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34), (17)==(33), (33)==(17)
       │    │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    ├── columns: o_orderkey:33(int!null) o_custkey:34(int!null) o_orderdate:37(date!null) c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    ├── key: (33,54)
       │    │    │    │    │    │    │    ├── fd: ()-->(59), (33)-->(34,37), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45), (34)==(42), (42)==(34)
       │    │    │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(string!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) n2.n_nationkey:54(int!null) n2.n_name:55(char!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    │    ├── key: (42,54)
       │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (42)-->(45), (50)-->(52), (54)-->(55), (52)==(58), (58)==(52), (45)==(50), (50)==(45)
       │    │    │    │    │    │    │    │    ├── scan n2
-      │    │    │    │    │    │    │    │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(string!null)
+      │    │    │    │    │    │    │    │    │    ├── columns: n2.n_nationkey:54(int!null) n2.n_name:55(char!null)
       │    │    │    │    │    │    │    │    │    ├── key: (54)
       │    │    │    │    │    │    │    │    │    └── fd: (54)-->(55)
       │    │    │    │    │    │    │    │    ├── inner-join
-      │    │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    │    ├── columns: c_custkey:42(int!null) c_nationkey:45(int!null) n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    │    │    ├── key: (42)
       │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (52)==(58), (58)==(52), (42)-->(45), (45)==(50), (50)==(45)
       │    │    │    │    │    │    │    │    │    ├── scan customer@c_nk
@@ -1149,16 +1149,16 @@ sort
       │    │    │    │    │    │    │    │    │    │    ├── key: (42)
       │    │    │    │    │    │    │    │    │    │    └── fd: (42)-->(45)
       │    │    │    │    │    │    │    │    │    ├── inner-join (lookup nation@n_rk)
-      │    │    │    │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    │    │    ├── columns: n1.n_nationkey:50(int!null) n1.n_regionkey:52(int!null) r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    │    │    │    ├── key columns: [58] = [52]
       │    │    │    │    │    │    │    │    │    │    ├── key: (50)
       │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59), (50)-->(52), (52)==(58), (58)==(52)
       │    │    │    │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    │    │    │    │    ├── key: (58)
       │    │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(59)
       │    │    │    │    │    │    │    │    │    │    │    ├── scan region
-      │    │    │    │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(string!null)
+      │    │    │    │    │    │    │    │    │    │    │    │    ├── columns: r_regionkey:58(int!null) r_name:59(char!null)
       │    │    │    │    │    │    │    │    │    │    │    │    ├── key: (58)
       │    │    │    │    │    │    │    │    │    │    │    │    └── fd: (58)-->(59)
       │    │    │    │    │    │    │    │    │    │    │    └── filters
@@ -1258,29 +1258,29 @@ ORDER BY
     o_year DESC;
 ----
 sort
- ├── columns: nation:48(string!null) o_year:51(int) sum_profit:53(float)
+ ├── columns: nation:48(char!null) o_year:51(int) sum_profit:53(float)
  ├── key: (48,51)
  ├── fd: (48,51)-->(53)
  ├── ordering: +48,-51
  └── group-by
-      ├── columns: n_name:48(string!null) o_year:51(int) sum:53(float)
-      ├── grouping columns: n_name:48(string!null) o_year:51(int)
+      ├── columns: n_name:48(char!null) o_year:51(int) sum:53(float)
+      ├── grouping columns: n_name:48(char!null) o_year:51(int)
       ├── key: (48,51)
       ├── fd: (48,51)-->(53)
       ├── project
-      │    ├── columns: o_year:51(int) amount:52(float) n_name:48(string!null)
+      │    ├── columns: o_year:51(int) amount:52(float) n_name:48(char!null)
       │    ├── inner-join (lookup part)
-      │    │    ├── columns: p_partkey:1(int!null) p_name:2(string!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
+      │    │    ├── columns: p_partkey:1(int!null) p_name:2(varchar!null) s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    ├── key columns: [18] = [1]
       │    │    ├── fd: (1)-->(2), (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(1,33), (33)==(1,18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13), (1)==(18,33)
       │    │    ├── inner-join
-      │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
+      │    │    │    ├── columns: s_suppkey:10(int!null) s_nationkey:13(int!null) l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    │    ├── fd: (10)-->(13), (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(10,34), (34)==(10,19), (18)==(33), (33)==(18), (17)==(38), (38)==(17), (10)==(19,34), (13)==(47), (47)==(13)
       │    │    │    ├── inner-join
-      │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(string!null)
+      │    │    │    │    ├── columns: l_orderkey:17(int!null) l_partkey:18(int!null) l_suppkey:19(int!null) l_quantity:21(float!null) l_extendedprice:22(float!null) l_discount:23(float!null) ps_partkey:33(int!null) ps_suppkey:34(int!null) ps_supplycost:36(float!null) o_orderkey:38(int!null) o_orderdate:42(date!null) n_nationkey:47(int!null) n_name:48(char!null)
       │    │    │    │    ├── fd: (33,34)-->(36), (38)-->(42), (47)-->(48), (19)==(34), (34)==(19), (18)==(33), (33)==(18), (17)==(38), (38)==(17)
       │    │    │    │    ├── scan nation
-      │    │    │    │    │    ├── columns: n_nationkey:47(int!null) n_name:48(string!null)
+      │    │    │    │    │    ├── columns: n_nationkey:47(int!null) n_name:48(char!null)
       │    │    │    │    │    ├── key: (47)
       │    │    │    │    │    └── fd: (47)-->(48)
       │    │    │    │    ├── inner-join (lookup orders)
@@ -1366,35 +1366,35 @@ ORDER BY
 LIMIT 20;
 ----
 limit
- ├── columns: c_custkey:1(int!null) c_name:2(string) revenue:39(float) c_acctbal:6(float) n_name:35(string) c_address:3(string) c_phone:5(string) c_comment:8(string)
+ ├── columns: c_custkey:1(int!null) c_name:2(varchar) revenue:39(float) c_acctbal:6(float) n_name:35(char) c_address:3(varchar) c_phone:5(char) c_comment:8(varchar)
  ├── internal-ordering: -39
  ├── cardinality: [0 - 20]
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,6,8,35,39)
  ├── ordering: -39
  ├── sort
- │    ├── columns: c_custkey:1(int!null) c_name:2(string) c_address:3(string) c_phone:5(string) c_acctbal:6(float) c_comment:8(string) n_name:35(string) sum:39(float)
+ │    ├── columns: c_custkey:1(int!null) c_name:2(varchar) c_address:3(varchar) c_phone:5(char) c_acctbal:6(float) c_comment:8(varchar) n_name:35(char) sum:39(float)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3,5,6,8,35,39)
  │    ├── ordering: -39
  │    └── group-by
- │         ├── columns: c_custkey:1(int!null) c_name:2(string) c_address:3(string) c_phone:5(string) c_acctbal:6(float) c_comment:8(string) n_name:35(string) sum:39(float)
+ │         ├── columns: c_custkey:1(int!null) c_name:2(varchar) c_address:3(varchar) c_phone:5(char) c_acctbal:6(float) c_comment:8(varchar) n_name:35(char) sum:39(float)
  │         ├── grouping columns: c_custkey:1(int!null)
  │         ├── key: (1)
  │         ├── fd: (1)-->(2,3,5,6,8,35,39)
  │         ├── project
- │         │    ├── columns: column38:38(float) c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) n_name:35(string!null)
+ │         │    ├── columns: column38:38(float) c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) n_name:35(char!null)
  │         │    ├── fd: (1)-->(2,3,5,6,8,35)
  │         │    ├── inner-join (lookup nation)
- │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null) n_nationkey:34(int!null) n_name:35(string!null)
+ │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null) n_nationkey:34(int!null) n_name:35(char!null)
  │         │    │    ├── key columns: [4] = [34]
  │         │    │    ├── fd: ()-->(26), (1)-->(2-6,8), (9)-->(10,13), (34)-->(35), (9)==(18), (18)==(9), (1)==(10), (10)==(1), (4)==(34), (34)==(4)
  │         │    │    ├── inner-join (lookup customer)
- │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) c_address:3(string!null) c_nationkey:4(int!null) c_phone:5(string!null) c_acctbal:6(float!null) c_comment:8(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
+ │         │    │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) c_address:3(varchar!null) c_nationkey:4(int!null) c_phone:5(char!null) c_acctbal:6(float!null) c_comment:8(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
  │         │    │    │    ├── key columns: [10] = [1]
  │         │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9), (1)-->(2-6,8), (1)==(10), (10)==(1)
  │         │    │    │    ├── inner-join (lookup lineitem)
- │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(string!null)
+ │         │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_extendedprice:23(float!null) l_discount:24(float!null) l_returnflag:26(char!null)
  │         │    │    │    │    ├── key columns: [9] = [18]
  │         │    │    │    │    ├── fd: ()-->(26), (9)-->(10,13), (9)==(18), (18)==(9)
  │         │    │    │    │    ├── index-join orders
@@ -1415,18 +1415,18 @@ limit
  │         └── aggregations
  │              ├── sum [type=float, outer=(38)]
  │              │    └── variable: column38 [type=float]
- │              ├── const-agg [type=string, outer=(2)]
- │              │    └── variable: c_name [type=string]
- │              ├── const-agg [type=string, outer=(3)]
- │              │    └── variable: c_address [type=string]
- │              ├── const-agg [type=string, outer=(5)]
- │              │    └── variable: c_phone [type=string]
+ │              ├── const-agg [type=varchar, outer=(2)]
+ │              │    └── variable: c_name [type=varchar]
+ │              ├── const-agg [type=varchar, outer=(3)]
+ │              │    └── variable: c_address [type=varchar]
+ │              ├── const-agg [type=char, outer=(5)]
+ │              │    └── variable: c_phone [type=char]
  │              ├── const-agg [type=float, outer=(6)]
  │              │    └── variable: c_acctbal [type=float]
- │              ├── const-agg [type=string, outer=(8)]
- │              │    └── variable: c_comment [type=string]
- │              └── const-agg [type=string, outer=(35)]
- │                   └── variable: n_name [type=string]
+ │              ├── const-agg [type=varchar, outer=(8)]
+ │              │    └── variable: c_comment [type=varchar]
+ │              └── const-agg [type=char, outer=(35)]
+ │                   └── variable: n_name [type=char]
  └── const: 20 [type=int]
 
 # --------------------------------------------------
@@ -1485,7 +1485,7 @@ sort
       │    ├── project
       │    │    ├── columns: column17:17(float) ps_partkey:1(int!null)
       │    │    ├── inner-join
-      │    │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) ps_availqty:3(int!null) ps_supplycost:4(float!null) s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(string!null)
+      │    │    │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) ps_availqty:3(int!null) ps_supplycost:4(float!null) s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(char!null)
       │    │    │    ├── key: (1,6)
       │    │    │    ├── fd: ()-->(14), (1,2)-->(3,4), (6)-->(9), (9)==(13), (13)==(9), (2)==(6), (6)==(2)
       │    │    │    ├── scan partsupp
@@ -1493,16 +1493,16 @@ sort
       │    │    │    │    ├── key: (1,2)
       │    │    │    │    └── fd: (1,2)-->(3,4)
       │    │    │    ├── inner-join (lookup supplier@s_nk)
-      │    │    │    │    ├── columns: s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(string!null)
+      │    │    │    │    ├── columns: s_suppkey:6(int!null) s_nationkey:9(int!null) n_nationkey:13(int!null) n_name:14(char!null)
       │    │    │    │    ├── key columns: [13] = [9]
       │    │    │    │    ├── key: (6)
       │    │    │    │    ├── fd: ()-->(14), (6)-->(9), (9)==(13), (13)==(9)
       │    │    │    │    ├── select
-      │    │    │    │    │    ├── columns: n_nationkey:13(int!null) n_name:14(string!null)
+      │    │    │    │    │    ├── columns: n_nationkey:13(int!null) n_name:14(char!null)
       │    │    │    │    │    ├── key: (13)
       │    │    │    │    │    ├── fd: ()-->(14)
       │    │    │    │    │    ├── scan nation
-      │    │    │    │    │    │    ├── columns: n_nationkey:13(int!null) n_name:14(string!null)
+      │    │    │    │    │    │    ├── columns: n_nationkey:13(int!null) n_name:14(char!null)
       │    │    │    │    │    │    ├── key: (13)
       │    │    │    │    │    │    └── fd: (13)-->(14)
       │    │    │    │    │    └── filters
@@ -1532,21 +1532,21 @@ sort
                           │    ├── project
                           │    │    ├── columns: column35:35(float)
                           │    │    ├── inner-join
-                          │    │    │    ├── columns: ps_suppkey:20(int!null) ps_availqty:21(int!null) ps_supplycost:22(float!null) s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(string!null)
+                          │    │    │    ├── columns: ps_suppkey:20(int!null) ps_availqty:21(int!null) ps_supplycost:22(float!null) s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(char!null)
                           │    │    │    ├── fd: ()-->(32), (24)-->(27), (27)==(31), (31)==(27), (20)==(24), (24)==(20)
                           │    │    │    ├── scan partsupp
                           │    │    │    │    └── columns: ps_suppkey:20(int!null) ps_availqty:21(int!null) ps_supplycost:22(float!null)
                           │    │    │    ├── inner-join (lookup supplier@s_nk)
-                          │    │    │    │    ├── columns: s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(string!null)
+                          │    │    │    │    ├── columns: s_suppkey:24(int!null) s_nationkey:27(int!null) n_nationkey:31(int!null) n_name:32(char!null)
                           │    │    │    │    ├── key columns: [31] = [27]
                           │    │    │    │    ├── key: (24)
                           │    │    │    │    ├── fd: ()-->(32), (24)-->(27), (27)==(31), (31)==(27)
                           │    │    │    │    ├── select
-                          │    │    │    │    │    ├── columns: n_nationkey:31(int!null) n_name:32(string!null)
+                          │    │    │    │    │    ├── columns: n_nationkey:31(int!null) n_name:32(char!null)
                           │    │    │    │    │    ├── key: (31)
                           │    │    │    │    │    ├── fd: ()-->(32)
                           │    │    │    │    │    ├── scan nation
-                          │    │    │    │    │    │    ├── columns: n_nationkey:31(int!null) n_name:32(string!null)
+                          │    │    │    │    │    │    ├── columns: n_nationkey:31(int!null) n_name:32(char!null)
                           │    │    │    │    │    │    ├── key: (31)
                           │    │    │    │    │    │    └── fd: (31)-->(32)
                           │    │    │    │    │    └── filters
@@ -1607,26 +1607,26 @@ ORDER BY
     l_shipmode;
 ----
 group-by
- ├── columns: l_shipmode:24(string!null) high_line_count:27(decimal) low_line_count:29(decimal)
- ├── grouping columns: l_shipmode:24(string!null)
+ ├── columns: l_shipmode:24(char!null) high_line_count:27(decimal) low_line_count:29(decimal)
+ ├── grouping columns: l_shipmode:24(char!null)
  ├── key: (24)
  ├── fd: (24)-->(27,29)
  ├── ordering: +24
  ├── project
- │    ├── columns: column26:26(int) column28:28(int) l_shipmode:24(string!null)
+ │    ├── columns: column26:26(int) column28:28(int) l_shipmode:24(char!null)
  │    ├── ordering: +24
  │    ├── inner-join (lookup orders)
- │    │    ├── columns: o_orderkey:1(int!null) o_orderpriority:6(string!null) l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
+ │    │    ├── columns: o_orderkey:1(int!null) o_orderpriority:6(char!null) l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
  │    │    ├── key columns: [10] = [1]
  │    │    ├── fd: (1)-->(6), (1)==(10), (10)==(1)
  │    │    ├── ordering: +24
  │    │    ├── sort
- │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
+ │    │    │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
  │    │    │    ├── ordering: +24
  │    │    │    └── select
- │    │    │         ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
+ │    │    │         ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
  │    │    │         ├── index-join lineitem
- │    │    │         │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(string!null)
+ │    │    │         │    ├── columns: l_orderkey:10(int!null) l_shipdate:20(date!null) l_commitdate:21(date!null) l_receiptdate:22(date!null) l_shipmode:24(char!null)
  │    │    │         │    └── scan lineitem@l_rd
  │    │    │         │         ├── columns: l_orderkey:10(int!null) l_linenumber:13(int!null) l_receiptdate:22(date!null)
  │    │    │         │         ├── constraint: /22/10/13: [/'1994-01-01' - /'1994-12-31']
@@ -1694,18 +1694,18 @@ sort
       │    ├── key: (1)
       │    ├── fd: (1)-->(18)
       │    ├── left-join
-      │    │    ├── columns: c_custkey:1(int!null) o_orderkey:9(int) o_custkey:10(int) o_comment:17(string)
+      │    │    ├── columns: c_custkey:1(int!null) o_orderkey:9(int) o_custkey:10(int) o_comment:17(varchar)
       │    │    ├── key: (1,9)
       │    │    ├── fd: (9)-->(10,17)
       │    │    ├── scan customer@c_nk
       │    │    │    ├── columns: c_custkey:1(int!null)
       │    │    │    └── key: (1)
       │    │    ├── select
-      │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(string!null)
+      │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(varchar!null)
       │    │    │    ├── key: (9)
       │    │    │    ├── fd: (9)-->(10,17)
       │    │    │    ├── scan orders
-      │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(string!null)
+      │    │    │    │    ├── columns: o_orderkey:9(int!null) o_custkey:10(int!null) o_comment:17(varchar!null)
       │    │    │    │    ├── key: (9)
       │    │    │    │    └── fd: (9)-->(10,17)
       │    │    │    └── filters
@@ -1758,7 +1758,7 @@ project
  │    ├── project
  │    │    ├── columns: column26:26(float) column28:28(float)
  │    │    ├── inner-join (lookup part)
- │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(string!null)
+ │    │    │    ├── columns: l_partkey:2(int!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipdate:11(date!null) p_partkey:17(int!null) p_type:21(varchar!null)
  │    │    │    ├── key columns: [2] = [17]
  │    │    │    ├── fd: (17)-->(21), (2)==(17), (17)==(2)
  │    │    │    ├── index-join lineitem
@@ -1829,16 +1829,16 @@ ORDER BY
     s_suppkey;
 ----
 sort
- ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_phone:5(string!null) total_revenue:25(float!null)
+ ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_phone:5(char!null) total_revenue:25(float!null)
  ├── key: (1)
  ├── fd: (1)-->(2,3,5,25)
  ├── ordering: +1
  └── project
-      ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_phone:5(string!null) sum:25(float!null)
+      ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_phone:5(char!null) sum:25(float!null)
       ├── key: (1)
       ├── fd: (1)-->(2,3,5,25)
       └── inner-join (lookup supplier)
-           ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_phone:5(string!null) l_suppkey:10(int!null) sum:25(float!null)
+           ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_phone:5(char!null) l_suppkey:10(int!null) sum:25(float!null)
            ├── key columns: [10] = [1]
            ├── key: (10)
            ├── fd: (1)-->(2,3,5), (10)-->(25), (1)==(10), (10)==(1)
@@ -1945,17 +1945,17 @@ ORDER BY
     p_size;
 ----
 sort
- ├── columns: p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null) supplier_cnt:22(int)
+ ├── columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null) supplier_cnt:22(int)
  ├── key: (9-11)
  ├── fd: (9-11)-->(22)
  ├── ordering: -22,+9,+10,+11
  └── group-by
-      ├── columns: p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null) count:22(int)
-      ├── grouping columns: p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
+      ├── columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null) count:22(int)
+      ├── grouping columns: p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       ├── key: (9-11)
       ├── fd: (9-11)-->(22)
       ├── inner-join
-      │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
+      │    ├── columns: ps_partkey:1(int!null) ps_suppkey:2(int!null) p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       │    ├── key: (2,6)
       │    ├── fd: (6)-->(9-11), (1)==(6), (6)==(1)
       │    ├── anti-join (merge)
@@ -1968,12 +1968,12 @@ sort
       │    │    │    ├── key: (1,2)
       │    │    │    └── ordering: +2
       │    │    ├── select
-      │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(string!null)
+      │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(varchar!null)
       │    │    │    ├── key: (15)
       │    │    │    ├── fd: (15)-->(21)
       │    │    │    ├── ordering: +15
       │    │    │    ├── scan supplier
-      │    │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(string!null)
+      │    │    │    │    ├── columns: s_suppkey:15(int!null) s_comment:21(varchar!null)
       │    │    │    │    ├── key: (15)
       │    │    │    │    ├── fd: (15)-->(21)
       │    │    │    │    └── ordering: +15
@@ -1981,11 +1981,11 @@ sort
       │    │    │         └── s_comment LIKE '%Customer%Complaints%' [type=bool, outer=(21), constraints=(/21: (/NULL - ])]
       │    │    └── filters (true)
       │    ├── select
-      │    │    ├── columns: p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
+      │    │    ├── columns: p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       │    │    ├── key: (6)
       │    │    ├── fd: (6)-->(9-11)
       │    │    ├── scan part
-      │    │    │    ├── columns: p_partkey:6(int!null) p_brand:9(string!null) p_type:10(string!null) p_size:11(int!null)
+      │    │    │    ├── columns: p_partkey:6(int!null) p_brand:9(char!null) p_type:10(varchar!null) p_size:11(int!null)
       │    │    │    ├── key: (6)
       │    │    │    └── fd: (6)-->(9-11)
       │    │    └── filters
@@ -2065,23 +2065,23 @@ project
  │    │    │    │    │    ├── key: (17)
  │    │    │    │    │    ├── fd: (17)-->(42)
  │    │    │    │    │    ├── left-join (lookup lineitem)
- │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null) l_partkey:27(int) l_quantity:30(float)
+ │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_container:23(char!null) l_partkey:27(int) l_quantity:30(float)
  │    │    │    │    │    │    ├── key columns: [26 29] = [26 29]
  │    │    │    │    │    │    ├── fd: ()-->(20,23)
  │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [actual: +17]
  │    │    │    │    │    │    ├── left-join (lookup lineitem@l_pk)
- │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null) l_orderkey:26(int) l_partkey:27(int) l_linenumber:29(int)
+ │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_container:23(char!null) l_orderkey:26(int) l_partkey:27(int) l_linenumber:29(int)
  │    │    │    │    │    │    │    ├── key columns: [17] = [27]
  │    │    │    │    │    │    │    ├── key: (17,26,29)
  │    │    │    │    │    │    │    ├── fd: ()-->(20,23), (26,29)-->(27)
  │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [actual: +17]
  │    │    │    │    │    │    │    ├── select
- │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null)
+ │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_container:23(char!null)
  │    │    │    │    │    │    │    │    ├── key: (17)
  │    │    │    │    │    │    │    │    ├── fd: ()-->(20,23)
  │    │    │    │    │    │    │    │    ├── ordering: +17 opt(20,23) [actual: +17]
  │    │    │    │    │    │    │    │    ├── scan part
- │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(string!null) p_container:23(string!null)
+ │    │    │    │    │    │    │    │    │    ├── columns: p_partkey:17(int!null) p_brand:20(char!null) p_container:23(char!null)
  │    │    │    │    │    │    │    │    │    ├── key: (17)
  │    │    │    │    │    │    │    │    │    ├── fd: (17)-->(20,23)
  │    │    │    │    │    │    │    │    │    └── ordering: +17 opt(20,23) [actual: +17]
@@ -2151,27 +2151,27 @@ ORDER BY
 LIMIT 100;
 ----
 limit
- ├── columns: c_name:2(string) c_custkey:1(int) o_orderkey:9(int!null) o_orderdate:13(date) o_totalprice:12(float) sum:51(float)
+ ├── columns: c_name:2(varchar) c_custkey:1(int) o_orderkey:9(int!null) o_orderdate:13(date) o_totalprice:12(float) sum:51(float)
  ├── internal-ordering: -12,+13
  ├── cardinality: [0 - 100]
  ├── key: (9)
  ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
  ├── ordering: -12,+13
  ├── sort
- │    ├── columns: c_custkey:1(int) c_name:2(string) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) sum:51(float)
+ │    ├── columns: c_custkey:1(int) c_name:2(varchar) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) sum:51(float)
  │    ├── key: (9)
  │    ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
  │    ├── ordering: -12,+13
  │    └── group-by
- │         ├── columns: c_custkey:1(int) c_name:2(string) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) sum:51(float)
+ │         ├── columns: c_custkey:1(int) c_name:2(varchar) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) sum:51(float)
  │         ├── grouping columns: o_orderkey:9(int!null)
  │         ├── key: (9)
  │         ├── fd: (1)-->(2), (9)-->(1,2,12,13,51)
  │         ├── inner-join
- │         │    ├── columns: c_custkey:1(int!null) c_name:2(string!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
+ │         │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:9(int!null) o_custkey:10(int!null) o_totalprice:12(float!null) o_orderdate:13(date!null) l_orderkey:18(int!null) l_quantity:22(float!null)
  │         │    ├── fd: (1)-->(2), (9)-->(10,12,13), (9)==(18), (18)==(9), (1)==(10), (10)==(1)
  │         │    ├── scan customer
- │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(string!null)
+ │         │    │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null)
  │         │    │    ├── key: (1)
  │         │    │    └── fd: (1)-->(2)
  │         │    ├── inner-join (merge)
@@ -2222,8 +2222,8 @@ limit
  │              │    └── variable: l_quantity [type=float]
  │              ├── const-agg [type=int, outer=(1)]
  │              │    └── variable: c_custkey [type=int]
- │              ├── const-agg [type=string, outer=(2)]
- │              │    └── variable: c_name [type=string]
+ │              ├── const-agg [type=varchar, outer=(2)]
+ │              │    └── variable: c_name [type=varchar]
  │              ├── const-agg [type=float, outer=(12)]
  │              │    └── variable: o_totalprice [type=float]
  │              └── const-agg [type=date, outer=(13)]
@@ -2287,14 +2287,14 @@ scalar-group-by
  ├── project
  │    ├── columns: column26:26(float)
  │    ├── inner-join (lookup part)
- │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(string!null) l_shipmode:15(string!null) p_partkey:17(int!null) p_brand:20(string!null) p_size:22(int!null) p_container:23(string!null)
+ │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null) p_partkey:17(int!null) p_brand:20(char!null) p_size:22(int!null) p_container:23(char!null)
  │    │    ├── key columns: [2] = [17]
  │    │    ├── fd: ()-->(14), (17)-->(20,22,23), (2)==(17), (17)==(2)
  │    │    ├── select
- │    │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(string!null) l_shipmode:15(string!null)
+ │    │    │    ├── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null)
  │    │    │    ├── fd: ()-->(14)
  │    │    │    ├── scan lineitem
- │    │    │    │    └── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(string!null) l_shipmode:15(string!null)
+ │    │    │    │    └── columns: l_partkey:2(int!null) l_quantity:5(float!null) l_extendedprice:6(float!null) l_discount:7(float!null) l_shipinstruct:14(char!null) l_shipmode:15(char!null)
  │    │    │    └── filters
  │    │    │         ├── l_shipmode IN ('AIR', 'AIR REG') [type=bool, outer=(15), constraints=(/15: [/'AIR' - /'AIR'] [/'AIR REG' - /'AIR REG']; tight)]
  │    │    │         └── l_shipinstruct = 'DELIVER IN PERSON' [type=bool, outer=(14), constraints=(/14: [/'DELIVER IN PERSON' - /'DELIVER IN PERSON']; tight), fd=()-->(14)]
@@ -2361,20 +2361,20 @@ ORDER BY
     s_name;
 ----
 sort
- ├── columns: s_name:2(string!null) s_address:3(string!null)
+ ├── columns: s_name:2(char!null) s_address:3(varchar!null)
  ├── ordering: +2
  └── project
-      ├── columns: s_name:2(string!null) s_address:3(string!null)
+      ├── columns: s_name:2(char!null) s_address:3(varchar!null)
       └── inner-join
-           ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_nationkey:4(int!null) n_nationkey:8(int!null) n_name:9(string!null)
+           ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null) n_nationkey:8(int!null) n_name:9(char!null)
            ├── key: (1)
            ├── fd: ()-->(9), (1)-->(2-4), (4)==(8), (8)==(4)
            ├── semi-join
-           │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_nationkey:4(int!null)
+           │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
            │    ├── key: (1)
            │    ├── fd: (1)-->(2-4)
            │    ├── scan supplier
-           │    │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_address:3(string!null) s_nationkey:4(int!null)
+           │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_address:3(varchar!null) s_nationkey:4(int!null)
            │    │    ├── key: (1)
            │    │    └── fd: (1)-->(2-4)
            │    ├── semi-join
@@ -2417,11 +2417,11 @@ sort
            │    │    │         └── filters
            │    │    │              └── ps_availqty > (sum * 0.5) [type=bool, outer=(14,42), constraints=(/14: (/NULL - ])]
            │    │    ├── select
-           │    │    │    ├── columns: p_partkey:17(int!null) p_name:18(string!null)
+           │    │    │    ├── columns: p_partkey:17(int!null) p_name:18(varchar!null)
            │    │    │    ├── key: (17)
            │    │    │    ├── fd: (17)-->(18)
            │    │    │    ├── scan part
-           │    │    │    │    ├── columns: p_partkey:17(int!null) p_name:18(string!null)
+           │    │    │    │    ├── columns: p_partkey:17(int!null) p_name:18(varchar!null)
            │    │    │    │    ├── key: (17)
            │    │    │    │    └── fd: (17)-->(18)
            │    │    │    └── filters
@@ -2431,11 +2431,11 @@ sort
            │    └── filters
            │         └── s_suppkey = ps_suppkey [type=bool, outer=(1,13), constraints=(/1: (/NULL - ]; /13: (/NULL - ]), fd=(1)==(13), (13)==(1)]
            ├── select
-           │    ├── columns: n_nationkey:8(int!null) n_name:9(string!null)
+           │    ├── columns: n_nationkey:8(int!null) n_name:9(char!null)
            │    ├── key: (8)
            │    ├── fd: ()-->(9)
            │    ├── scan nation
-           │    │    ├── columns: n_nationkey:8(int!null) n_name:9(string!null)
+           │    │    ├── columns: n_nationkey:8(int!null) n_name:9(char!null)
            │    │    ├── key: (8)
            │    │    └── fd: (8)-->(9)
            │    └── filters
@@ -2496,42 +2496,42 @@ ORDER BY
 LIMIT 100;
 ----
 limit
- ├── columns: s_name:2(string!null) numwait:69(int)
+ ├── columns: s_name:2(char!null) numwait:69(int)
  ├── internal-ordering: -69,+2
  ├── cardinality: [0 - 100]
  ├── key: (2)
  ├── fd: (2)-->(69)
  ├── ordering: -69,+2
  ├── sort
- │    ├── columns: s_name:2(string!null) count_rows:69(int)
+ │    ├── columns: s_name:2(char!null) count_rows:69(int)
  │    ├── key: (2)
  │    ├── fd: (2)-->(69)
  │    ├── ordering: -69,+2
  │    └── group-by
- │         ├── columns: s_name:2(string!null) count_rows:69(int)
- │         ├── grouping columns: s_name:2(string!null)
+ │         ├── columns: s_name:2(char!null) count_rows:69(int)
+ │         ├── grouping columns: s_name:2(char!null)
  │         ├── key: (2)
  │         ├── fd: (2)-->(69)
  │         ├── inner-join (lookup nation)
- │         │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null) n_nationkey:33(int!null) n_name:34(string!null)
+ │         │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(char!null) n_nationkey:33(int!null) n_name:34(char!null)
  │         │    ├── key columns: [4] = [33]
  │         │    ├── fd: ()-->(26,34), (1)-->(2,4), (8)==(24), (24)==(8), (1)==(10), (10)==(1), (4)==(33), (33)==(4)
  │         │    ├── inner-join (lookup supplier)
- │         │    │    ├── columns: s_suppkey:1(int!null) s_name:2(string!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(char!null)
  │         │    │    ├── key columns: [10] = [1]
  │         │    │    ├── fd: ()-->(26), (8)==(24), (24)==(8), (1)-->(2,4), (1)==(10), (10)==(1)
  │         │    │    ├── inner-join (merge)
- │         │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    │    ├── columns: l1.l_orderkey:8(int!null) l1.l_suppkey:10(int!null) l1.l_commitdate:19(date!null) l1.l_receiptdate:20(date!null) o_orderkey:24(int!null) o_orderstatus:26(char!null)
  │         │    │    │    ├── left ordering: +24
  │         │    │    │    ├── right ordering: +8
  │         │    │    │    ├── fd: ()-->(26), (8)==(24), (24)==(8)
  │         │    │    │    ├── select
- │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(char!null)
  │         │    │    │    │    ├── key: (24)
  │         │    │    │    │    ├── fd: ()-->(26)
  │         │    │    │    │    ├── ordering: +24 opt(26) [actual: +24]
  │         │    │    │    │    ├── scan orders
- │         │    │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(string!null)
+ │         │    │    │    │    │    ├── columns: o_orderkey:24(int!null) o_orderstatus:26(char!null)
  │         │    │    │    │    │    ├── key: (24)
  │         │    │    │    │    │    ├── fd: (24)-->(26)
  │         │    │    │    │    │    └── ordering: +24 opt(26) [actual: +24]
@@ -2556,12 +2556,12 @@ limit
  │         │    │    │    │    │    │    └── filters
  │         │    │    │    │    │    │         └── l1.l_receiptdate > l1.l_commitdate [type=bool, outer=(19,20), constraints=(/19: (/NULL - ]; /20: (/NULL - ])]
  │         │    │    │    │    │    ├── select
- │         │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(string!null) l3.l_linestatus:62(string!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(string!null) l3.l_shipmode:67(string!null) l3.l_comment:68(string!null)
+ │         │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(char!null) l3.l_linestatus:62(char!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(char!null) l3.l_shipmode:67(char!null) l3.l_comment:68(varchar!null)
  │         │    │    │    │    │    │    ├── key: (53,56)
  │         │    │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
  │         │    │    │    │    │    │    ├── ordering: +53
  │         │    │    │    │    │    │    ├── scan l3
- │         │    │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(string!null) l3.l_linestatus:62(string!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(string!null) l3.l_shipmode:67(string!null) l3.l_comment:68(string!null)
+ │         │    │    │    │    │    │    │    ├── columns: l3.l_orderkey:53(int!null) l3.l_partkey:54(int!null) l3.l_suppkey:55(int!null) l3.l_linenumber:56(int!null) l3.l_quantity:57(float!null) l3.l_extendedprice:58(float!null) l3.l_discount:59(float!null) l3.l_tax:60(float!null) l3.l_returnflag:61(char!null) l3.l_linestatus:62(char!null) l3.l_shipdate:63(date!null) l3.l_commitdate:64(date!null) l3.l_receiptdate:65(date!null) l3.l_shipinstruct:66(char!null) l3.l_shipmode:67(char!null) l3.l_comment:68(varchar!null)
  │         │    │    │    │    │    │    │    ├── key: (53,56)
  │         │    │    │    │    │    │    │    ├── fd: (53,56)-->(54,55,57-68)
  │         │    │    │    │    │    │    │    └── ordering: +53
@@ -2570,7 +2570,7 @@ limit
  │         │    │    │    │    │    └── filters
  │         │    │    │    │    │         └── l3.l_suppkey != l1.l_suppkey [type=bool, outer=(10,55), constraints=(/10: (/NULL - ]; /55: (/NULL - ])]
  │         │    │    │    │    ├── scan l2
- │         │    │    │    │    │    ├── columns: l2.l_orderkey:37(int!null) l2.l_partkey:38(int!null) l2.l_suppkey:39(int!null) l2.l_linenumber:40(int!null) l2.l_quantity:41(float!null) l2.l_extendedprice:42(float!null) l2.l_discount:43(float!null) l2.l_tax:44(float!null) l2.l_returnflag:45(string!null) l2.l_linestatus:46(string!null) l2.l_shipdate:47(date!null) l2.l_commitdate:48(date!null) l2.l_receiptdate:49(date!null) l2.l_shipinstruct:50(string!null) l2.l_shipmode:51(string!null) l2.l_comment:52(string!null)
+ │         │    │    │    │    │    ├── columns: l2.l_orderkey:37(int!null) l2.l_partkey:38(int!null) l2.l_suppkey:39(int!null) l2.l_linenumber:40(int!null) l2.l_quantity:41(float!null) l2.l_extendedprice:42(float!null) l2.l_discount:43(float!null) l2.l_tax:44(float!null) l2.l_returnflag:45(char!null) l2.l_linestatus:46(char!null) l2.l_shipdate:47(date!null) l2.l_commitdate:48(date!null) l2.l_receiptdate:49(date!null) l2.l_shipinstruct:50(char!null) l2.l_shipmode:51(char!null) l2.l_comment:52(varchar!null)
  │         │    │    │    │    │    ├── key: (37,40)
  │         │    │    │    │    │    ├── fd: (37,40)-->(38,39,41-52)
  │         │    │    │    │    │    └── ordering: +37
@@ -2646,18 +2646,18 @@ sort
       ├── project
       │    ├── columns: cntrycode:27(string) c_acctbal:6(float!null)
       │    ├── anti-join (merge)
-      │    │    ├── columns: c_custkey:1(int!null) c_phone:5(string!null) c_acctbal:6(float!null)
+      │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
       │    │    ├── left ordering: +1
       │    │    ├── right ordering: +19
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(5,6)
       │    │    ├── select
-      │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(string!null) c_acctbal:6(float!null)
+      │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
       │    │    │    ├── key: (1)
       │    │    │    ├── fd: (1)-->(5,6)
       │    │    │    ├── ordering: +1
       │    │    │    ├── scan customer
-      │    │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(string!null) c_acctbal:6(float!null)
+      │    │    │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
       │    │    │    │    ├── key: (1)
       │    │    │    │    ├── fd: (1)-->(5,6)
       │    │    │    │    └── ordering: +1
@@ -2672,9 +2672,9 @@ sort
       │    │    │                        ├── key: ()
       │    │    │                        ├── fd: ()-->(17)
       │    │    │                        ├── select
-      │    │    │                        │    ├── columns: c_phone:13(string!null) c_acctbal:14(float!null)
+      │    │    │                        │    ├── columns: c_phone:13(char!null) c_acctbal:14(float!null)
       │    │    │                        │    ├── scan customer
-      │    │    │                        │    │    └── columns: c_phone:13(string!null) c_acctbal:14(float!null)
+      │    │    │                        │    │    └── columns: c_phone:13(char!null) c_acctbal:14(float!null)
       │    │    │                        │    └── filters
       │    │    │                        │         ├── c_acctbal > 0.0 [type=bool, outer=(14), constraints=(/14: [/5e-324 - ]; tight)]
       │    │    │                        │         └── substring(c_phone, 1, 2) IN ('13', '17', '18', '23', '29', '30', '31') [type=bool, outer=(13)]

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -7,12 +7,12 @@ CREATE TABLE abc (
 )
 ----
 TABLE abc
- ├── a string not null
+ ├── a char not null
  ├── b float
  ├── c bool
  ├── d decimal
  └── INDEX primary
-      └── a string not null
+      └── a char not null
 
 exec-ddl
 CREATE TABLE xyz (
@@ -95,13 +95,13 @@ scalar-group-by
  ├── key: ()
  ├── fd: ()-->(5)
  ├── scan abc
- │    ├── columns: a:1(string!null)
+ │    ├── columns: a:1(char!null)
  │    ├── limit: 1
  │    ├── key: ()
  │    └── fd: ()-->(1)
  └── aggregations
-      └── const-agg [type=string, outer=(1)]
-           └── variable: a [type=string]
+      └── const-agg [type=char, outer=(1)]
+           └── variable: a [type=char]
 
 # Verify the rule still fires even if DISTINCT is used.
 opt
@@ -113,13 +113,13 @@ scalar-group-by
  ├── key: ()
  ├── fd: ()-->(5)
  ├── scan abc
- │    ├── columns: a:1(string!null)
+ │    ├── columns: a:1(char!null)
  │    ├── limit: 1
  │    ├── key: ()
  │    └── fd: ()-->(1)
  └── aggregations
-      └── const-agg [type=string, outer=(1)]
-           └── variable: a [type=string]
+      └── const-agg [type=char, outer=(1)]
+           └── variable: a [type=char]
 
 opt
 SELECT min(b) FROM abc
@@ -647,13 +647,13 @@ scalar-group-by
  ├── key: ()
  ├── fd: ()-->(5)
  ├── scan abc,rev
- │    ├── columns: a:1(string!null)
+ │    ├── columns: a:1(char!null)
  │    ├── limit: 1(rev)
  │    ├── key: ()
  │    └── fd: ()-->(1)
  └── aggregations
-      └── const-agg [type=string, outer=(1)]
-           └── variable: a [type=string]
+      └── const-agg [type=char, outer=(1)]
+           └── variable: a [type=char]
 
 # Verify the rule still fires even if DISTINCT is used.
 opt
@@ -665,13 +665,13 @@ scalar-group-by
  ├── key: ()
  ├── fd: ()-->(5)
  ├── scan abc,rev
- │    ├── columns: a:1(string!null)
+ │    ├── columns: a:1(char!null)
  │    ├── limit: 1(rev)
  │    ├── key: ()
  │    └── fd: ()-->(1)
  └── aggregations
-      └── const-agg [type=string, outer=(1)]
-           └── variable: a [type=string]
+      └── const-agg [type=char, outer=(1)]
+           └── variable: a [type=char]
 
 opt
 SELECT max(b) FROM abc

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -363,7 +363,7 @@ TABLE abc
  ├── a int not null
  ├── b int not null
  ├── c int not null
- ├── d string
+ ├── d char
  ├── INDEX primary
  │    ├── a int not null
  │    ├── b int not null

--- a/pkg/sql/sem/types/types.go
+++ b/pkg/sql/sem/types/types.go
@@ -437,33 +437,48 @@ func (t *ColumnType) DebugString() string {
 	return (*InternalColumnType)(t).String()
 }
 
-func (t *ColumnType) String() string {
-	switch t.Oid() {
-	case oid.T_name:
-		return "name"
-	}
-
+// Name returns a single word description of the type that describes it
+// succinctly, but without all the details, such as width, locale, etc. The name
+// is sometimes the same as the name returned by SQLStandardName, but is more
+// CRDB friendly.
+//
+// TODO(andyk): Should these be changed to be the same as SQLStandardName?
+func (t *ColumnType) Name() string {
 	switch t.SemanticType {
 	case NULL:
 		return "unknown"
 	case BOOL:
 		return "bool"
 	case INT:
+		switch t.Width {
+		case 16:
+			return "int2"
+		case 32:
+			return "int4"
+		}
 		return "int"
-	case STRING:
+	case STRING, COLLATEDSTRING:
+		switch t.Oid() {
+		case oid.T_bpchar:
+			return "char"
+		case oid.T_char:
+			// Yes, that's the name. The ways of PostgreSQL are inscrutable.
+			return `"char"`
+		case oid.T_varchar:
+			return "varchar"
+		case oid.T_name:
+			return "name"
+		}
 		return "string"
 	case BIT:
-		return "varbit"
+		if t.Oid() == oid.T_varbit {
+			return "varbit"
+		}
+		return "bit"
 	case FLOAT:
 		return "float"
 	case DECIMAL:
 		return "decimal"
-	case COLLATEDSTRING:
-		if *t.Locale == "" {
-			// Used in telemetry.
-			return "collatedstring{*}"
-		}
-		return fmt.Sprintf("collatedstring{%s}", *t.Locale)
 	case BYTES:
 		return "bytes"
 	case DATE:
@@ -483,6 +498,29 @@ func (t *ColumnType) String() string {
 	case INET:
 		return "inet"
 	case TUPLE:
+		// TUPLE is currently an anonymous type, with no name.
+		return ""
+	case ARRAY:
+		return t.ArrayContents.String() + "[]"
+	case ANY:
+		return "anyelement"
+	case OID:
+		return t.SQLStandardName()
+	}
+
+	panic(pgerror.NewAssertionErrorf("unexpected SemanticType: %s", t.SemanticType))
+}
+
+func (t *ColumnType) String() string {
+	switch t.SemanticType {
+	case COLLATEDSTRING:
+		if *t.Locale == "" {
+			// Used in telemetry.
+			return fmt.Sprintf("collated%s{*}", t.Name())
+		}
+		return fmt.Sprintf("collated%s{%s}", t.Name(), *t.Locale)
+
+	case TUPLE:
 		var buf bytes.Buffer
 		buf.WriteString("tuple")
 		if len(t.TupleContents) != 0 && !IsWildcardTupleType(t) {
@@ -500,15 +538,8 @@ func (t *ColumnType) String() string {
 			buf.WriteByte('}')
 		}
 		return buf.String()
-	case ARRAY:
-		return t.ArrayContents.String() + "[]"
-	case ANY:
-		return "anyelement"
-	case OID:
-		return t.SQLStandardName()
 	}
-
-	panic(pgerror.NewAssertionErrorf("unexpected SemanticType: %s", t.SemanticType))
+	return t.Name()
 }
 
 var (


### PR DESCRIPTION
Split from #36598 cc @andy-kimball 

Update the String() method on types.T to show a type name that is closer to what
coltypes.T shows. For example, varchar and bit are currently never returned by
types.T, which instead maps them to string and varbit, respectively.

This commit prepares for unification of types.T and coltypes.T.

Release note: None