### PR TITLE
sql: Rename DOIDWrapper to DTypeWrapper (patch 12/)

### DIFF
--- a/pkg/sql/exec/types/conv/conv.go
+++ b/pkg/sql/exec/types/conv/conv.go
@@ -147,7 +147,7 @@ func GetDatumToPhysicalFn(ct *semtypes.T) func(tree.Datum) (interface{}, error) 
 	case semtypes.STRING:
 		return func(datum tree.Datum) (interface{}, error) {
 			// Handle other STRING-related OID types, like oid.T_name.
-			wrapper, ok := datum.(*tree.DOidWrapper)
+			wrapper, ok := datum.(*tree.DTypeWrapper)
 			if ok {
 				datum = wrapper.Wrapped
 			}

--- a/pkg/sql/sem/tree/datum_invariants_test.go
+++ b/pkg/sql/sem/tree/datum_invariants_test.go
@@ -21,7 +21,10 @@ import (
 )
 
 func TestAllTypesCastableToString(t *testing.T) {
-	for _, typ := range types.Scalar {
+	for _, typ := range types.OidToType {
+		if typ.IsAmbiguous() {
+			continue
+		}
 		if ok, _ := isCastDeepValid(typ, types.String); !ok {
 			t.Errorf("%s is not castable to STRING, all types should be", typ)
 		}
@@ -29,7 +32,10 @@ func TestAllTypesCastableToString(t *testing.T) {
 }
 
 func TestAllTypesCastableFromString(t *testing.T) {
-	for _, typ := range types.Scalar {
+	for _, typ := range types.OidToType {
+		if typ.IsAmbiguous() {
+			continue
+		}
 		if ok, _ := isCastDeepValid(types.String, typ); !ok {
 			t.Errorf("%s is not castable from STRING, all types should be", typ)
 		}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3537,8 +3537,8 @@ func (expr *IndirectionExpr) Eval(ctx *EvalContext) (Datum, error) {
 	arr := MustBeDArray(d)
 
 	// VECTOR types use 0-indexing.
-	if w, ok := d.(*DOidWrapper); ok {
-		switch w.Oid {
+	if w, ok := d.(*DTypeWrapper); ok {
+		switch w.Type.Oid() {
 		case oid.T_oidvector, oid.T_int2vector:
 			subscriptIdx++
 		}
@@ -4065,7 +4065,7 @@ func (t *DOid) Eval(_ *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
-func (t *DOidWrapper) Eval(_ *EvalContext) (Datum, error) {
+func (t *DTypeWrapper) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }
 

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1699,7 +1699,7 @@ func (node *DTimestampTZ) String() string     { return AsString(node) }
 func (node *DTuple) String() string           { return AsString(node) }
 func (node *DArray) String() string           { return AsString(node) }
 func (node *DOid) String() string             { return AsString(node) }
-func (node *DOidWrapper) String() string      { return AsString(node) }
+func (node *DTypeWrapper) String() string     { return AsString(node) }
 func (node *Exprs) String() string            { return AsString(node) }
 func (node *ArrayFlatten) String() string     { return AsString(node) }
 func (node *FuncExpr) String() string         { return AsString(node) }

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1421,7 +1421,7 @@ func (d *DOid) TypeCheck(_ *SemaContext, _ *types.T) (TypedExpr, error) { return
 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
 // identity function for Datum.
-func (d *DOidWrapper) TypeCheck(_ *SemaContext, _ *types.T) (TypedExpr, error) { return d, nil }
+func (d *DTypeWrapper) TypeCheck(_ *SemaContext, _ *types.T) (TypedExpr, error) { return d, nil }
 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
 // identity function for Datum.

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -668,7 +668,7 @@ func (expr *DArray) Walk(_ Visitor) Expr { return expr }
 func (expr *DOid) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr *DOidWrapper) Walk(_ Visitor) Expr { return expr }
+func (expr *DTypeWrapper) Walk(_ Visitor) Expr { return expr }
 
 // WalkExpr traverses the nodes in an expression.
 //


### PR DESCRIPTION
Split from #36598 cc @andy-kimball 

Generalize DOIDWrapper so that it can wrap a Datum with any types.T rather
than an OID. This enables it to represent any type, such as "VARCHAR(20)",
rather than just "VARCHAR".

Release note: None