### PR TITLE
bitarray: fix a bug in the right shift logic

### DIFF
--- a/pkg/util/bitarray/bitarray.go
+++ b/pkg/util/bitarray/bitarray.go
@@ -248,6 +248,11 @@ func (d BitArray) LeftShiftAny(n int64) BitArray {
 			r.words[j] |= d.words[i] << (numBitsPerWord - srcShift)
 			j++
 		}
+		// Erase the trailing bits that are not used any more.
+		// See #36606.
+		if len(r.words) > 0 {
+			r.words[len(r.words)-1] &= ^word(0) << (numBitsPerWord - r.lastBitsUsed)
+		}
 	}
 
 	return r


### PR DESCRIPTION
Fixes #36606.

When shifting by a number of bits smaller than 64, the resulting word
array was not canonical - it would contain leftover bits from the
original value in the last slot, beyond `lastBitsUsed`.

This patch ensures these bits get cleared.

Release note (bug fix): CockroachDB now computes the result of
shifting bit arrays to the right properly and avoids generating
invalid bit arrays.