### PR TITLE
sql: run deleteRange queries in batches

### DIFF
--- a/pkg/sql/logictest/testdata/planner_test/delete_range
+++ b/pkg/sql/logictest/testdata/planner_test/delete_range
@@ -1,0 +1,19 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY)
+
+# Delete range operates in chunks of 600 (defined by sql.TableTruncateChunkSize).
+statement ok
+INSERT INTO a SELECT * FROM generate_series(1,1000)
+
+statement ok
+SET tracing = on,kv; DELETE FROM a; SET tracing = off
+
+# Ensure that DelRange requests are chunked for DELETE FROM...
+query TT
+SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
+WHERE message LIKE '%DelRange%'
+----
+flow                 DelRange /Table/53/1 - /Table/53/2
+flow                 DelRange /Table/53/1/601/0 - /Table/53/2

--- a/pkg/sql/logictest/testdata/planner_test/interleaved
+++ b/pkg/sql/logictest/testdata/planner_test/interleaved
@@ -243,9 +243,11 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 ----
 DelRange /Table/61/1/5 - /Table/61/1/7/NULL
 querying next range at /Table/61/1/5
-r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+r20: sending batch 1 DelRng to (n1,s1):1
 fast path completed
 rows affected: 3
+querying next range at /Table/61/1/5
+r20: sending batch 1 EndTxn to (n1,s1):1
 
 query II colnames
 select * from b order by a_id, b_id
@@ -285,9 +287,11 @@ select message FROM [SHOW KV TRACE FOR SESSION]
 ----
 DelRange /Table/61/1 - /Table/61/3
 querying next range at /Table/61/1
-r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+r20: sending batch 1 DelRng to (n1,s1):1
 fast path completed
 rows affected: 5
+querying next range at /Table/61/1
+r20: sending batch 1 EndTxn to (n1,s1):1
 
 query II colnames
 select * from b order by a_id, b_id

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -243,9 +243,11 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 ----
 DelRange /Table/61/1/5 - /Table/61/1/7/NULL
 querying next range at /Table/61/1/5
-r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+r20: sending batch 1 DelRng to (n1,s1):1
 fast path completed
 rows affected: 3
+querying next range at /Table/61/1/5
+r20: sending batch 1 EndTxn to (n1,s1):1
 
 query II colnames
 select * from b order by a_id, b_id
@@ -285,9 +287,11 @@ select message FROM [SHOW KV TRACE FOR SESSION]
 ----
 DelRange /Table/61/1 - /Table/61/3
 querying next range at /Table/61/1
-r20: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
+r20: sending batch 1 DelRng to (n1,s1):1
 fast path completed
 rows affected: 5
+querying next range at /Table/61/1
+r20: sending batch 1 EndTxn to (n1,s1):1
 
 query II colnames
 select * from b order by a_id, b_id

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -84,7 +84,10 @@ type tableWriter interface {
 
 type autoCommitOpt int
 
-const autoCommitEnabled autoCommitOpt = 1
+const (
+	autoCommitDisabled autoCommitOpt = 0
+	autoCommitEnabled  autoCommitOpt = 1
+)
 
 // extendedTableWriter is a temporary interface introduced
 // until all the tableWriters implement it. When that is achieved, it will be merged into


### PR DESCRIPTION
Fixes #36588.

Previously, a query like `DELETE FROM t` that uses a deleteRangeNode
under the hood would attempt to send a single `DelRange` request for
each span it was responsible for deleting. This led to unlimited memory
usage, since the `DelRange` request must return the keys it deleted in
this context so SQL can know how many rows were affected.

To solve this problem, we send `DelRange` requests with a returned-key
limit in a loop until the range is fully deleted.

Release note (bug fix): prevent unlimited memory usage during SQL range
deletions