### PR TITLE
release-19.1: storage: Avoid RocksDB error log in in-mem DB open

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -179,6 +179,9 @@ DBStatus DBOpen(DBEngine** db, DBSlice dir, DBOptions db_opts) {
     auto memenv = rocksdb::NewMemEnv(rocksdb::Env::Default());
     // Register it for deletion.
     env_mgr->TakeEnvOwnership(memenv);
+    // Create a root directory to suppress error messages that RocksDB would
+    // print if it had to create the DB directory itself.
+    memenv->CreateDir("/");
     // Make it the env that all other Envs must wrap.
     env_mgr->base_env = memenv;
     // Make it the env for rocksdb.


### PR DESCRIPTION
Backport 1/1 commits from #36605.

/cc @cockroachdb/release

---

Since #36408 we are propagating some RocksDB logs to Cockroach logs. One
of the cases RocksDB logs an error is when a DB is opened on a directory
that does not yet exist, even though RocksDB is able to create the
directory and succeed at opening a new DB. To avoid seeing this error
log, though, we can simply create the directory before opening the DB.

Fixes #36568.

Release note: None