### PR TITLE
storage/bulk: use slab buffer for kv pairs

### DIFF
--- a/pkg/storage/bulk/buffering_adder.go
+++ b/pkg/storage/bulk/buffering_adder.go
@@ -15,6 +15,7 @@
 package bulk
 
 import (
+	"bytes"
 	"context"
 	"sort"
 

--- a/pkg/storage/bulk/buffering_adder.go
+++ b/pkg/storage/bulk/buffering_adder.go
@@ -15,7 +15,6 @@
 package bulk
 
 import (
-	"bytes"
 	"context"
 	"sort"
 
@@ -35,24 +34,18 @@ type BufferingAdder struct {
 	sink SSTBatcher
 	// timestamp applied to mvcc keys created from keys during SST construction.
 	timestamp hlc.Timestamp
-	// skips duplicates (iff they are buffered together).
-	skipDuplicates bool
 
 	// threshold at which buffered entries will be flushed to SSTBatcher.
-	flushSize int64
+	flushSize int
 
 	// currently buffered kvs.
-	curBuf kvsByKey
-	// estimated memory usage of curBuf.
-	curBufSize int64
+	curBuf kvBuf
 
 	flushCounts struct {
 		total      int
 		bufferSize int
 	}
 }
-
-const kvOverhead = 24 + 24 // 2 slice headers, each assuming each is 8 + 8 + 8.
 
 // MakeBulkAdder makes a storagebase.BulkAdder that buffers and sorts K/Vs passed
 // to add into SSTs that are then ingested.
@@ -68,7 +61,7 @@ func MakeBulkAdder(
 	b := &BufferingAdder{
 		sink:      SSTBatcher{db: db, maxSize: sstBytes, rc: rangeCache},
 		timestamp: timestamp,
-		flushSize: flushBytes,
+		flushSize: int(flushBytes),
 	}
 	return b, nil
 }
@@ -91,17 +84,13 @@ func (b *BufferingAdder) Close(ctx context.Context) {
 
 // Add adds a key to the buffer and checks if it needs to flush.
 func (b *BufferingAdder) Add(ctx context.Context, key roachpb.Key, value []byte) error {
-	if len(b.curBuf) == 0 {
-		if err := b.sink.Reset(); err != nil {
-			return err
-		}
+	if err := b.curBuf.append(key, value); err != nil {
+		return err
 	}
-	b.curBuf = append(b.curBuf, kvPair{key, value})
-	b.curBufSize += int64(cap(key)+cap(value)) + kvOverhead
 
-	if b.curBufSize > b.flushSize {
+	if b.curBuf.MemSize > b.flushSize {
 		b.flushCounts.bufferSize++
-		log.VEventf(ctx, 3, "buffer size triggering flush of %s buffer", sz(b.curBufSize))
+		log.VEventf(ctx, 3, "buffer size triggering flush of %s buffer", sz(b.curBuf.MemSize))
 		return b.Flush(ctx)
 	}
 	return nil
@@ -109,23 +98,28 @@ func (b *BufferingAdder) Add(ctx context.Context, key roachpb.Key, value []byte)
 
 // CurrentBufferFill returns the current buffer fill percentage.
 func (b *BufferingAdder) CurrentBufferFill() float32 {
-	return float32(b.curBufSize) / float32(b.flushSize)
+	return float32(b.curBuf.MemSize) / float32(b.flushSize)
 }
 
 // Flush flushes any buffered kvs to the batcher.
 func (b *BufferingAdder) Flush(ctx context.Context) error {
-	if len(b.curBuf) == 0 {
+	if b.curBuf.Len() == 0 {
 		return nil
+	}
+	if err := b.sink.Reset(); err != nil {
+		return err
 	}
 	b.flushCounts.total++
 
 	before := b.sink.flushCounts
 	beforeSize := b.sink.totalRows.DataSize
 
-	sort.Sort(b.curBuf)
-	for i, kv := range b.curBuf {
+	sort.Sort(&b.curBuf)
+	mvccKey := engine.MVCCKey{Timestamp: b.timestamp}
 
-		if err := b.sink.AddMVCCKey(ctx, engine.MVCCKey{Key: kv.key, Timestamp: b.timestamp}, kv.value); err != nil {
+	for i := range b.curBuf.entries {
+		mvccKey.Key = b.curBuf.Key(i)
+		if err := b.sink.AddMVCCKey(ctx, mvccKey, b.curBuf.Value(i)); err != nil {
 			return err
 		}
 	}
@@ -141,12 +135,11 @@ func (b *BufferingAdder) Flush(ctx context.Context) error {
 
 		log.Infof(ctx,
 			"flushing %s buffer wrote %d SSTs (avg: %s) with %d for splits, %d for size",
-			sz(b.curBufSize), files, sz(written/int64(files)), dueToSplits, dueToSize,
+			sz(b.curBuf.MemSize), files, sz(written/int64(files)), dueToSplits, dueToSize,
 		)
 	}
 
-	b.curBufSize = 0
-	b.curBuf = b.curBuf[:0]
+	b.curBuf.Reset()
 	return nil
 }
 
@@ -154,28 +147,3 @@ func (b *BufferingAdder) Flush(ctx context.Context) error {
 func (b *BufferingAdder) GetSummary() roachpb.BulkOpSummary {
 	return b.sink.GetSummary()
 }
-
-// kvPair is a bytes -> bytes kv pair.
-type kvPair struct {
-	key   roachpb.Key
-	value []byte
-}
-
-type kvsByKey []kvPair
-
-// Len implements sort.Interface.
-func (kvs kvsByKey) Len() int {
-	return len(kvs)
-}
-
-// Less implements sort.Interface.
-func (kvs kvsByKey) Less(i, j int) bool {
-	return bytes.Compare(kvs[i].key, kvs[j].key) < 0
-}
-
-// Swap implements sort.Interface.
-func (kvs kvsByKey) Swap(i, j int) {
-	kvs[i], kvs[j] = kvs[j], kvs[i]
-}
-
-var _ sort.Interface = kvsByKey{}

--- a/pkg/storage/bulk/kv_buf.go
+++ b/pkg/storage/bulk/kv_buf.go
@@ -1,0 +1,95 @@
+package bulk
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// kvBuf collects []byte key-value pairs in a sortable buffer.
+//
+// the actual content is stored in a single large slab, instead of individual
+// key and value byte slices, reducing the slice header overhead from 48b/pair
+// to 16b/pair. The total buffer size cannot be more than 32gb and no one key
+// or value may be larger than 512mb.
+type kvBuf struct {
+	entries []kvBufEntry
+	slab    []byte
+	MemSize int // size of buffered data including per-entry overhead
+}
+
+// each entry in the buffer has a key and value -- the actual bytes of these are
+// stored in the large slab, so the entry only records the offset and length in
+// the slab, packing these together into a uint64 for each. The length is stored
+// in the lower `lenBits` and the offset in the higher `64-lenBits`.
+type kvBufEntry struct {
+	keySpan uint64
+	valSpan uint64
+}
+
+const entryOverhead = 16
+
+const (
+	lenBits, lenMask  = 28, 1<<lenBits - 1 // 512mb item limit, 32gb buffer limit.
+	maxLen, maxOffset = lenMask, 1<<(64-lenBits) - 1
+)
+
+func (b *kvBuf) append(k, v []byte) {
+	if len(b.slab) > maxOffset {
+		panic(fmt.Sprintf("buffer size %d exceeds limit %d", len(b.slab), maxOffset))
+	}
+	if len(k) > maxLen {
+		panic(fmt.Sprintf("length %d exceeds limit %d", len(k), maxLen))
+	}
+	if len(v) > maxLen {
+		panic(fmt.Sprintf("length %d exceeds limit %d", len(v), maxLen))
+	}
+
+	b.MemSize += len(k) + len(v) + entryOverhead
+	var e kvBufEntry
+	e.keySpan = uint64(len(b.slab)<<lenBits) | uint64(len(k)&lenMask)
+	b.slab = append(b.slab, k...)
+	e.valSpan = uint64(len(b.slab)<<lenBits) | uint64(len(v)&lenMask)
+	b.slab = append(b.slab, v...)
+
+	b.entries = append(b.entries, e)
+}
+
+func (b *kvBuf) read(span uint64) []byte {
+	length := span & lenMask
+	if length == 0 {
+		return nil
+	}
+	offset := span >> lenBits
+	return b.slab[offset : offset+length]
+}
+
+func (b *kvBuf) Key(i int) roachpb.Key {
+	return b.read(b.entries[i].keySpan)
+}
+
+func (b *kvBuf) Value(i int) []byte {
+	return b.read(b.entries[i].valSpan)
+}
+
+// Len implements sort.Interface.
+func (b *kvBuf) Len() int {
+	return len(b.entries)
+}
+
+// Less implements sort.Interface.
+func (b *kvBuf) Less(i, j int) bool {
+	return bytes.Compare(b.read(b.entries[i].keySpan), b.read(b.entries[j].keySpan)) < 0
+}
+
+// Swap implements sort.Interface.
+func (b *kvBuf) Swap(i, j int) {
+	b.entries[i], b.entries[j] = b.entries[j], b.entries[i]
+}
+
+func (b *kvBuf) Reset() {
+	b.slab = b.slab[:0]
+	b.entries = b.entries[:0]
+	b.MemSize = 0
+}

--- a/pkg/storage/bulk/kv_buf_test.go
+++ b/pkg/storage/bulk/kv_buf_test.go
@@ -1,0 +1,71 @@
+package bulk
+
+import (
+	"bytes"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func makeTestData(num int) (kvs []kvPair, totalSize int) {
+	kvs = make([]kvPair, num)
+	r, _ := randutil.NewPseudoRand()
+	alloc := make([]byte, num*500)
+	randutil.ReadTestdataBytes(r, alloc)
+	for i := range kvs {
+		if len(alloc) < 1500 {
+			const refill = 15000
+			alloc = make([]byte, refill)
+			randutil.ReadTestdataBytes(r, alloc)
+		}
+		kvs[i].key = alloc[:randutil.RandIntInRange(r, 2, 100)]
+		alloc = alloc[len(kvs[i].key):]
+		kvs[i].value = alloc[:randutil.RandIntInRange(r, 0, 1000)]
+		alloc = alloc[len(kvs[i].value):]
+		totalSize += len(kvs[i].key) + len(kvs[i].value)
+	}
+	return kvs, totalSize
+}
+
+func TestKvBuf(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	src, totalSize := makeTestData(50000)
+
+	// Write everything to our buf.
+	b := kvBuf{}
+	for i := range src {
+		b.append(src[i].key, src[i].value)
+	}
+
+	// Sanity check our buf has right size.
+	if expected, actual := len(src), b.Len(); expected != actual {
+		t.Fatalf("expected len %d got %d", expected, actual)
+	}
+	if expected, actual := totalSize+len(src)*16, b.MemSize; expected != actual {
+		t.Fatalf("expected len %d got %d", expected, actual)
+	}
+
+	// Read back what we wrote.
+	for i := range src {
+		if expected, actual := src[i].key, b.Key(i); !bytes.Equal(expected, actual) {
+			t.Fatalf("expected %s\ngot %s", expected, actual)
+		}
+		if expected, actual := src[i].value, b.Value(i); !bytes.Equal(expected, actual) {
+			t.Fatalf("expected %s\ngot %s", expected, actual)
+		}
+	}
+	// Sort both and then ensure they match.
+	sort.Slice(src, func(i, j int) bool { return bytes.Compare(src[i].key, src[j].key) < 0 })
+	sort.Sort(&b)
+	for i := range src {
+		if expected, actual := src[i].key, b.Key(i); !bytes.Equal(expected, actual) {
+			t.Fatalf("expected %s\ngot %s", expected, actual)
+		}
+		if expected, actual := src[i].value, b.Value(i); !bytes.Equal(expected, actual) {
+			t.Fatalf("expected %s\ngot %s", expected, actual)
+		}
+	}
+}

--- a/pkg/storage/bulk/kv_buf_test.go
+++ b/pkg/storage/bulk/kv_buf_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 The Cockroach Authors.
+//
+/// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package bulk
 
 import (
@@ -5,9 +19,16 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
+
+// kvPair is a bytes -> bytes kv pair.
+type kvPair struct {
+	key   roachpb.Key
+	value []byte
+}
 
 func makeTestData(num int) (kvs []kvPair, totalSize int) {
 	kvs = make([]kvPair, num)
@@ -37,7 +58,9 @@ func TestKvBuf(t *testing.T) {
 	// Write everything to our buf.
 	b := kvBuf{}
 	for i := range src {
-		b.append(src[i].key, src[i].value)
+		if err := b.append(src[i].key, src[i].value); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// Sanity check our buf has right size.

--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -48,6 +48,7 @@ type SSTBatcher struct {
 	flushKey        roachpb.Key
 	rc              *kv.RangeDescriptorCache
 
+	// skips duplicates (iff they are buffered together).
 	skipDuplicates bool
 
 	maxSize int64

--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
@@ -46,6 +47,8 @@ type SSTBatcher struct {
 	flushKeyChecked bool
 	flushKey        roachpb.Key
 	rc              *kv.RangeDescriptorCache
+
+	skipDuplicates bool
 
 	maxSize int64
 	// rows written in the current batch.
@@ -75,6 +78,15 @@ func MakeSSTBatcher(ctx context.Context, db *client.DB, flushBytes int64) (*SSTB
 // keys -- like RESTORE where we want the restored data to look the like backup.
 // Keys must be added in order.
 func (b *SSTBatcher) AddMVCCKey(ctx context.Context, key engine.MVCCKey, value []byte) error {
+	if len(b.batchEndKey) > 0 && bytes.Equal(b.batchEndKey, key.Key) {
+		if b.skipDuplicates {
+			return nil
+		}
+		var err storagebase.DuplicateKeyError
+		err.Key = append(err.Key, key.Key...)
+		err.Value = append(err.Value, value...)
+		return err
+	}
 	// Check if we need to flush current batch *before* adding the next k/v --
 	// the batcher may want to flush the keys it already has, either because it
 	// is full or because it wants this key in a separate batch due to splits.
@@ -88,12 +100,11 @@ func (b *SSTBatcher) AddMVCCKey(ctx context.Context, key engine.MVCCKey, value [
 	}
 
 	// Update the range currently represented in this batch, as necessary.
-	if len(b.batchStartKey) == 0 || bytes.Compare(key.Key, b.batchStartKey) < 0 {
+	if len(b.batchStartKey) == 0 {
 		b.batchStartKey = append(b.batchStartKey[:0], key.Key...)
 	}
-	if len(b.batchEndKey) == 0 || bytes.Compare(key.Key, b.batchEndKey) > 0 {
-		b.batchEndKey = append(b.batchEndKey[:0], key.Key...)
-	}
+	b.batchEndKey = append(b.batchEndKey[:0], key.Key...)
+
 	if err := b.rowCounter.Count(key.Key); err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently the BufferingAdder uses a slice kvPair to buffer key value
pairs, where each element has a key and value byte slice. These two
slices mean the overhead per buffered pair is 48 bytes.

This overhead is actually a significant faction -- or even multiple --
of the total size of the buffered data in some cases, particularly in
index encoded data where values are often nil.

This adds a new slab-backed buffer, replacing the key and value slices
in each entry with key and value uint64s, which each index into the
single slab. Each uint64 contains the offset into the slab and legtht of
the key/value, packed together into the high and low bits of the uint64.

This buffer only adds 16b of overhead per k/v pair stored compared to
the 48b of keeping individual slices, and is still sortable by sorting
the slice of offset/len pairs.

The packed offset and len impose a maximum size on those fields -- in
our case the total buffer cannot be more than 32gb and the length of any
single key or value cannot exceed 512mb.

The batcher already needs to track its last key added and takes sorted input,
making checking for duplicates there easy.

While I'm here, given that it takes sorted input, we don't need to be comparing
the key to start and end key to decide if we should update start and end -- if
start is not set, it is the first key and is by definition (given the sorted
input) the start key, and the most recent key is similarly by definition also
the end key.

This uses the slab-backed key/value buffer to store the buffered kvs
instead of individual slices. This cuts the per-pair overhead from 48b
to 16b.

Release note (performance improvement): improved memory efficiency of
bulk ingestion and index backfills buffing.