### PR TITLE
txnwait: increase TxnLivenessThreshold significantly, reduce txn aborts under load

### DIFF
--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -2440,7 +2441,7 @@ func TestStoreScanIntentsFromTwoTxns(t *testing.T) {
 	// Now, expire the transactions by moving the clock forward. This will
 	// result in the subsequent scan operation pushing both transactions
 	// in a single batch.
-	manualClock.Increment(2*base.DefaultHeartbeatInterval.Nanoseconds() + 1)
+	manualClock.Increment(txnwait.TxnLivenessThreshold.Nanoseconds() + 1)
 
 	// Scan the range and verify empty result (expired txn is aborted,
 	// cleaning up intents).
@@ -2491,7 +2492,7 @@ func TestStoreScanMultipleIntents(t *testing.T) {
 	// Now, expire the transactions by moving the clock forward. This will
 	// result in the subsequent scan operation pushing both transactions
 	// in a single batch.
-	manual.Increment(2*base.DefaultHeartbeatInterval.Nanoseconds() + 1)
+	manual.Increment(txnwait.TxnLivenessThreshold.Nanoseconds() + 1)
 
 	// Query the range with a single INCONSISTENT scan, which should
 	// cause all intents to be resolved.

--- a/pkg/storage/txn_recovery_integration_test.go
+++ b/pkg/storage/txn_recovery_integration_test.go
@@ -103,11 +103,11 @@ func TestTxnRecoveryFromStaging(t *testing.T) {
 		}
 
 		// Pretend the transaction coordinator for the parallel commit died at this point.
-		// Wait for twice the TxnLivenessThreshold and then issue a read on one of the
-		// keys that the transaction wrote. This will result in a transaction push and
+		// Wait for longer than the TxnLivenessThreshold and then issue a read on one of
+		// the keys that the transaction wrote. This will result in a transaction push and
 		// eventually a full transaction recovery in order to resolve the indeterminate
 		// commit.
-		manual.Increment(2 * txnwait.TxnLivenessThreshold.Nanoseconds())
+		manual.Increment(txnwait.TxnLivenessThreshold.Nanoseconds() + 1)
 
 		gArgs := getArgs(keyA)
 		gReply, pErr := client.SendWrapped(ctx, store.TestSender(), &gArgs)

--- a/pkg/storage/txnwait/txnqueue.go
+++ b/pkg/storage/txnwait/txnqueue.go
@@ -35,10 +35,14 @@ import (
 
 const maxWaitForQueryTxn = 50 * time.Millisecond
 
+// TxnLivenessHeartbeatMultiplier specifies what multiple the transaction
+// liveness threshold should be of the transaction heartbeat internval.
+const TxnLivenessHeartbeatMultiplier = 5
+
 // TxnLivenessThreshold is the maximum duration between transaction heartbeats
 // before the transaction is considered expired by Queue. It is exposed and
 // mutable to allow tests to override it.
-var TxnLivenessThreshold = 2 * base.DefaultHeartbeatInterval
+var TxnLivenessThreshold = TxnLivenessHeartbeatMultiplier * base.DefaultHeartbeatInterval
 
 // ShouldPushImmediately returns whether the PushTxn request should
 // proceed without queueing. This is true for pushes which are neither


### PR DESCRIPTION
This change increases the duration between transaction heartbeats before a transaction is considered expired from 2 seconds to 5 seconds. This has been found to dramatically reduce the frequency of transaction aborts when a cluster is under significant load. This is not expected to noticeably hurt cluster availability in the presence of dead nodes because we already have availability loss on the order of 9 seconds due to the epoch-based lease duration.

This is especially important now that the hack in #25034 is gone. That hack was hiding some of this badness and giving transactions a bit more room to avoid being aborted.

Here's some testing with TPC-C 2300 on AWS with 3 `c5d.4xlarge` machines. I first ran with the the 2 second TxnLivenessThreshold and then with the 5 second:

<img width="872" alt="Screen Shot 2019-04-10 at 4 51 28 PM" src="https://user-images.githubusercontent.com/5438456/55926033-ae332c00-5bdd-11e9-8d6d-184ba1d5ffcd.png">

The top graph is transaction aborts and the bottom graph is p99 service latency. During my tests I actually saw an even bigger difference most of the time. In this trial, leases were still moving around because I didn't use a ramp period (which skews the txn aborts when it stops). I ran another 15 minute run again half an hour later once the leases had balanced (again with a 5 second TxnLivenessThreshold) and saw the latencies I was more accustomed to seeing with the change:

<img width="869" alt="Screen Shot 2019-04-10 at 5 59 19 PM" src="https://user-images.githubusercontent.com/5438456/55926104-09651e80-5bde-11e9-9540-9d7c697a9181.png">

cc. @danhhz, who picked this up back in January when monitoring the performance of an alpha release. I dug into the changes made in 8143b45814590ef5d98d4ef65614e799938cb66c that seemed to be causing issues with transaction aborts but never developed a good theory for what could be causing them and had trouble reliably reproducing them. Little did I know that it wasn't what was added in 8143b45814590ef5d98d4ef65614e799938cb66c that made the difference, it was what [was removed](https://github.com/cockroachdb/cockroach/pull/33396/commits/8143b45814590ef5d98d4ef65614e799938cb66c#diff-3c31a6497771c33db423a4cead092979L130).

The first commit is from #36729 and seems like a generally good change to make. There's no reason we should be sending async aborts if we already know that the transaction was finalized. This was probably also made a little worse by 8143b45814590ef5d98d4ef65614e799938cb66c because we now check to see whether a transaction is commitable when its record is missing when evaluating a `HeartbeatTxn` requests. Before we would simply return a `TransactionNotFoundStatusError`, which was ignored.