### PR TITLE
storage: deflake TestEagerReplication

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -424,6 +425,13 @@ type Replica struct {
 		// not have all the log entries.
 		draining bool
 	}
+
+	// Throttle how often we offer this Replica to the split and merge queues.
+	// We have triggers downstream of Raft that do so based on limited
+	// information and without explicit throttling some replicas will offer once
+	// per applied Raft command, which is silly and also clogs up the queues'
+	// semaphores.
+	splitQueueThrottle, mergeQueueThrottle util.EveryN
 
 	// loadBasedSplitter keeps information about load-based splitting.
 	loadBasedSplitter split.Decider

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -535,6 +535,11 @@ func (r *Replica) handleReplicatedEvalResult(
 		r.store.splitQueue.MaybeAddAsync(ctx, r, r.store.Clock().Now())
 	}
 	if r.store.mergeQueue != nil && needsMergeBySize { // the bootstrap store has a nil merge queue
+		// TODO(tbg): for ranges which are small but protected from merges by
+		// other means (zone configs etc), this is called on every command, and
+		// fires off a goroutine each time. Make this trigger (and potentially
+		// the split one above, though it hasn't been observed to be as
+		// bothersome) less aggressive.
 		r.store.mergeQueue.MaybeAddAsync(ctx, r, r.store.Clock().Now())
 	}
 

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -531,10 +531,15 @@ func (r *Replica) handleReplicatedEvalResult(
 	r.store.metrics.addMVCCStats(deltaStats)
 	rResult.Delta = enginepb.MVCCStatsDelta{}
 
-	if r.store.splitQueue != nil && needsSplitBySize { // the bootstrap store has a nil split queue
+	// NB: the bootstrap store has a nil split queue.
+	// TODO(tbg): the above is probably a lie now.
+	if r.store.splitQueue != nil && needsSplitBySize && r.splitQueueThrottle.ShouldProcess(timeutil.Now()) {
 		r.store.splitQueue.MaybeAddAsync(ctx, r, r.store.Clock().Now())
 	}
-	if r.store.mergeQueue != nil && needsMergeBySize { // the bootstrap store has a nil merge queue
+
+	// The bootstrap store has a nil merge queue.
+	// TODO(tbg): the above is probably a lie now.
+	if r.store.mergeQueue != nil && needsMergeBySize && r.mergeQueueThrottle.ShouldProcess(timeutil.Now()) {
 		// TODO(tbg): for ranges which are small but protected from merges by
 		// other means (zone configs etc), this is called on every command, and
 		// fires off a goroutine each time. Make this trigger (and potentially

--- a/pkg/storage/replicate_test.go
+++ b/pkg/storage/replicate_test.go
@@ -30,13 +30,12 @@ import (
 func TestEagerReplication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/36663")
-
 	ctx := context.Background()
 	storeCfg := storage.TestStoreConfig(nil /* clock */)
 	// Disable the replica scanner so that we rely on the eager replication code
 	// path that occurs after splits.
 	storeCfg.TestingKnobs.DisableScanner = true
+
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
@@ -46,6 +45,7 @@ func TestEagerReplication(t *testing.T) {
 	// replication cannot succeed).
 	purgatoryStartCount := store.ReplicateQueuePurgatoryLength()
 
+	t.Logf("purgatory start count is %d", purgatoryStartCount)
 	// Perform a split and check that there's one more range in the purgatory.
 
 	key := roachpb.Key("a")


### PR DESCRIPTION
This wasn't actually the test's fault but another brain fart on my end,
namely using the wrong parameter for the semaphores used for MaybeAdd
and Add. We wanted size 500 and 100 respectively, but ended up using 1.

Fixes #36663.
Fixes #36821.

Release note: None