### PR TITLE
[wip] roachtest: use `check-store` in roachtest

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -1203,6 +1203,7 @@ func (r *registry) runAsync(
 				c.l.Printf("failed to download logs: %s", err)
 			}
 		}()
+		defer c.PrintCheckStore(ctx, t)
 		// Detect replica divergence (i.e. ranges in which replicas have arrived
 		// at the same log position with different states).
 		defer c.FailOnReplicaDivergence(ctx, t)


### PR DESCRIPTION
WIP because it still finds stuff that I think is benign, and because
I need to figure out a better UX for how the result is printed/stored
in roachtest.

----

This is motivated by a couple of things:

1. makes sure the command is actually useful and works
2. gives us confidence that nothing fishy is going on
3. gives us a convenient place to look for outliers (stats, log size).

I think it's fine to run this command against a running node (at least
this works like a charm locally), which is required for easy roachtest
integration. Perhaps @ajkr can confirm that this is fine.

PS I'm seeing the annoying message

> 190411 12:48:01.858427 1 storage/engine/rocksdb.go:127  [rocksdb] [/Users/tschottdorf/go/src/github.com/cockroachdb/cockroach/c-deps/rocksdb/db/version_set.cc:2566] More existing levels in DB than needed. max_bytes_for_level_multiplier may not be guaranteed.

again in this context. We need to silence that or customer support
will get asked about it all the time.

Release note: None