### PR TITLE
exec: templatize the LIKE operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -743,6 +743,7 @@ EXECGEN_TARGETS = \
   pkg/sql/exec/coldata/vec.eg.go \
   pkg/sql/exec/distinct.eg.go \
   pkg/sql/exec/hashjoiner.eg.go \
+  pkg/sql/exec/like_ops.eg.go \
   pkg/sql/exec/mergejoiner.eg.go \
   pkg/sql/exec/projection_ops.eg.go \
   pkg/sql/exec/quicksort.eg.go \

--- a/pkg/sql/exec/.gitignore
+++ b/pkg/sql/exec/.gitignore
@@ -12,3 +12,4 @@ colvec.eg.go
 distinct.eg.go
 mergejoiner.eg.go
 any_not_null_agg.eg.go
+like_ops.eg.go

--- a/pkg/sql/exec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/like_ops_gen.go
@@ -1,0 +1,89 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"text/template"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+)
+
+// likeTemplate depends on the selConstOp template from selection_ops_gen. We
+// handle LIKE operators separately from the other selection operators because
+// there are several different implementations which may be chosen depending on
+// the complexity of the LIKE pattern.
+const likeTemplate = `
+package exec
+
+import (
+	"bytes"
+	"regexp"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+)
+
+{{range .}}
+{{template "selConstOp" .}}
+{{end}}
+`
+
+func genLikeOps(wr io.Writer) error {
+	tmpl := template.New("like_ops")
+	var err error
+	tmpl, err = tmpl.Parse(selTemplate)
+	if err != nil {
+		return err
+	}
+	tmpl, err = tmpl.Parse(likeTemplate)
+	if err != nil {
+		return err
+	}
+	overloads := []overload{
+		{
+			Name:    "Prefix",
+			LTyp:    types.Bytes,
+			RTyp:    types.Bytes,
+			RGoType: "[]byte",
+			AssignFunc: func(_ overload, target, l, r string) string {
+				return fmt.Sprintf("%s = bytes.HasPrefix(%s, %s)", target, l, r)
+			},
+		},
+		{
+			Name:    "Suffix",
+			LTyp:    types.Bytes,
+			RTyp:    types.Bytes,
+			RGoType: "[]byte",
+			AssignFunc: func(_ overload, target, l, r string) string {
+				return fmt.Sprintf("%s = bytes.HasSuffix(%s, %s)", target, l, r)
+			},
+		},
+		{
+			Name:    "Regexp",
+			LTyp:    types.Bytes,
+			RTyp:    types.Bytes,
+			RGoType: "*regexp.Regexp",
+			AssignFunc: func(_ overload, target, l, r string) string {
+				return fmt.Sprintf("%s = %s.Match(%s)", target, r, l)
+			},
+		},
+	}
+	return tmpl.Execute(wr, overloads)
+}
+
+func init() {
+	registerGenerator(genLikeOps, "like_ops.eg.go")
+}

--- a/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
@@ -39,11 +39,7 @@ import (
 {{define "opConstName"}}sel{{.Name}}{{.LTyp}}{{.RTyp}}ConstOp{{end}}
 {{define "opName"}}sel{{.Name}}{{.LTyp}}{{.RTyp}}Op{{end}}
 
-{{/* The outer range is a types.T, and the inner is the overloads associated
-     with that type. */}}
-{{range .}}
-{{range .}}
-
+{{define "selConstOp"}}
 type {{template "opConstName" .}} struct {
 	input Operator
 
@@ -93,6 +89,14 @@ func (p *{{template "opConstName" .}}) Next() coldata.Batch {
 func (p {{template "opConstName" .}}) Init() {
 	p.input.Init()
 }
+{{end}}
+
+{{/* The outer range is a types.T, and the inner is the overloads associated
+     with that type. */}}
+{{range .}}
+{{range .}}
+
+{{template "selConstOp" .}}
 
 type {{template "opName" .}} struct {
 	input Operator

--- a/pkg/sql/exec/like_ops.go
+++ b/pkg/sql/exec/like_ops.go
@@ -15,11 +15,8 @@
 package exec
 
 import (
-	"bytes"
-	"regexp"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -43,17 +40,17 @@ func GetLikeOperator(
 	if len(pattern) > 1 && !strings.ContainsAny(pattern[1:len(pattern)-1], "_%") {
 		// Special cases for patterns which are just a prefix or suffix.
 		if pattern[0] == '%' {
-			return &selBytesSuffixOp{
-				input:  input,
-				colIdx: colIdx,
-				suffix: []byte(pattern[1:]),
+			return &selSuffixBytesBytesConstOp{
+				input:    input,
+				colIdx:   colIdx,
+				constArg: []byte(pattern[1:]),
 			}, nil
 		}
 		if pattern[len(pattern)-1] == '%' {
-			return &selBytesPrefixOp{
-				input:  input,
-				colIdx: colIdx,
-				prefix: []byte(pattern[:len(pattern)-1]),
+			return &selPrefixBytesBytesConstOp{
+				input:    input,
+				colIdx:   colIdx,
+				constArg: []byte(pattern[:len(pattern)-1]),
 			}, nil
 		}
 	}
@@ -62,158 +59,9 @@ func GetLikeOperator(
 	if err != nil {
 		return nil, err
 	}
-	return &selBytesRegexpOp{
-		input:   input,
-		colIdx:  colIdx,
-		pattern: re,
+	return &selRegexpBytesBytesConstOp{
+		input:    input,
+		colIdx:   colIdx,
+		constArg: re,
 	}, nil
-}
-
-// TODO(solon): The following operators should ideally be templated along with
-// the other selection operators in selection_ops_gen.go. This is a bit awkward
-// to do because they don't map one-to-one onto ComparisonOperators like the
-// other operators.
-
-type selBytesPrefixOp struct {
-	input Operator
-
-	colIdx int
-	prefix []byte
-}
-
-func (p selBytesPrefixOp) Init() {
-	p.input.Init()
-}
-
-func (p *selBytesPrefixOp) Next() coldata.Batch {
-	for {
-		batch := p.input.Next()
-		if batch.Length() == 0 {
-			return batch
-		}
-
-		coldata := batch.ColVec(p.colIdx).Bytes()[:coldata.BatchSize]
-		var idx uint16
-		n := batch.Length()
-		if sel := batch.Selection(); sel != nil {
-			sel = sel[:n]
-			for _, i := range sel {
-				cmp := bytes.HasPrefix(coldata[i], p.prefix)
-				if cmp {
-					sel[idx] = i
-					idx++
-				}
-			}
-		} else {
-			batch.SetSelection(true)
-			sel := batch.Selection()
-			for i := uint16(0); i < n; i++ {
-				cmp := bytes.HasPrefix(coldata[i], p.prefix)
-				if cmp {
-					sel[idx] = i
-					idx++
-				}
-			}
-		}
-		if idx > 0 {
-			batch.SetLength(idx)
-			return batch
-		}
-	}
-}
-
-type selBytesSuffixOp struct {
-	input Operator
-
-	colIdx int
-	suffix []byte
-}
-
-func (p selBytesSuffixOp) Init() {
-	p.input.Init()
-}
-
-func (p *selBytesSuffixOp) Next() coldata.Batch {
-	for {
-		batch := p.input.Next()
-		if batch.Length() == 0 {
-			return batch
-		}
-
-		coldata := batch.ColVec(p.colIdx).Bytes()[:coldata.BatchSize]
-		var idx uint16
-		n := batch.Length()
-		if sel := batch.Selection(); sel != nil {
-			sel = sel[:n]
-			for _, i := range sel {
-				cmp := bytes.HasSuffix(coldata[i], p.suffix)
-				if cmp {
-					sel[idx] = i
-					idx++
-				}
-			}
-		} else {
-			batch.SetSelection(true)
-			sel := batch.Selection()
-			for i := uint16(0); i < n; i++ {
-				cmp := bytes.HasSuffix(coldata[i], p.suffix)
-				if cmp {
-					sel[idx] = i
-					idx++
-				}
-			}
-		}
-		if idx > 0 {
-			batch.SetLength(idx)
-			return batch
-		}
-	}
-}
-
-type selBytesRegexpOp struct {
-	input Operator
-
-	colIdx  int
-	pattern *regexp.Regexp
-}
-
-func (p selBytesRegexpOp) Init() {
-	p.input.Init()
-}
-
-func (p *selBytesRegexpOp) Next() coldata.Batch {
-	for {
-		batch := p.input.Next()
-		if batch.Length() == 0 {
-			return batch
-		}
-
-		coldata := batch.ColVec(p.colIdx).Bytes()[:coldata.BatchSize]
-		var idx uint16
-		n := batch.Length()
-		if sel := batch.Selection(); sel != nil {
-			sel = sel[:n]
-			for _, i := range sel {
-				cmp := p.pattern.Match(coldata[i])
-				if cmp {
-					sel[idx] = i
-					idx++
-				}
-			}
-		} else {
-			batch.SetSelection(true)
-			sel := batch.Selection()
-			for i := uint16(0); i < n; i++ {
-				cmp := p.pattern.Match(coldata[i])
-				if cmp {
-					sel[idx] = i
-					idx++
-				}
-			}
-		}
-		if idx > 0 {
-			batch.SetLength(idx)
-			return batch
-		}
-	}
 }

--- a/pkg/sql/exec/like_ops_test.go
+++ b/pkg/sql/exec/like_ops_test.go
@@ -24,13 +24,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
-func TestSelBytesPrefix(t *testing.T) {
+func TestSelPrefixBytesBytesConstOp(t *testing.T) {
 	tups := tuples{{"abc"}, {"def"}, {"ghi"}}
 	runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
-		op := selBytesPrefixOp{
-			input:  input[0],
-			colIdx: 0,
-			prefix: []byte("de"),
+		op := selPrefixBytesBytesConstOp{
+			input:    input[0],
+			colIdx:   0,
+			constArg: []byte("de"),
 		}
 		op.Init()
 		out := newOpTestOutput(&op, []int{0}, tuples{{"def"}})
@@ -40,13 +40,13 @@ func TestSelBytesPrefix(t *testing.T) {
 	})
 }
 
-func TestSelBytesSuffix(t *testing.T) {
+func TestSelSuffixBytesBytesConstOp(t *testing.T) {
 	tups := tuples{{"abc"}, {"def"}, {"ghi"}}
 	runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
-		op := selBytesSuffixOp{
-			input:  input[0],
-			colIdx: 0,
-			suffix: []byte("ef"),
+		op := selSuffixBytesBytesConstOp{
+			input:    input[0],
+			colIdx:   0,
+			constArg: []byte("ef"),
 		}
 		op.Init()
 		out := newOpTestOutput(&op, []int{0}, tuples{{"def"}})
@@ -56,17 +56,17 @@ func TestSelBytesSuffix(t *testing.T) {
 	})
 }
 
-func TestSelBytesRegexpOp(t *testing.T) {
+func TestSelRegexpBytesBytesConstOp(t *testing.T) {
 	tups := tuples{{"abc"}, {"def"}, {"ghi"}}
 	pattern, err := regexp.Compile(".e.")
 	if err != nil {
 		t.Fatal(err)
 	}
 	runTests(t, []tuples{tups}, func(t *testing.T, input []Operator) {
-		op := selBytesRegexpOp{
-			input:   input[0],
-			colIdx:  0,
-			pattern: pattern,
+		op := selRegexpBytesBytesConstOp{
+			input:    input[0],
+			colIdx:   0,
+			constArg: pattern,
 		}
 		op.Init()
 		out := newOpTestOutput(&op, []int{0}, tuples{{"def"}})
@@ -99,30 +99,30 @@ func BenchmarkLikeOps(b *testing.B) {
 	source := newRepeatableBatchSource(batch)
 	source.Init()
 
-	prefixOp := &selBytesPrefixOp{
-		input:  source,
-		colIdx: 0,
-		prefix: []byte(prefix),
+	prefixOp := &selPrefixBytesBytesConstOp{
+		input:    source,
+		colIdx:   0,
+		constArg: []byte(prefix),
 	}
-	suffixOp := &selBytesSuffixOp{
-		input:  source,
-		colIdx: 0,
-		suffix: []byte(suffix),
+	suffixOp := &selSuffixBytesBytesConstOp{
+		input:    source,
+		colIdx:   0,
+		constArg: []byte(suffix),
 	}
 	pattern := fmt.Sprintf("^%s.*%s$", prefix, suffix)
-	regexpOp := &selBytesRegexpOp{
-		input:   source,
-		colIdx:  0,
-		pattern: regexp.MustCompile(pattern),
+	regexpOp := &selRegexpBytesBytesConstOp{
+		input:    source,
+		colIdx:   0,
+		constArg: regexp.MustCompile(pattern),
 	}
 
 	testCases := []struct {
 		name string
 		op   Operator
 	}{
-		{name: "selBytesPrefixOp", op: prefixOp},
-		{name: "selBytesSuffixOp", op: suffixOp},
-		{name: "selBytesRegexpOp", op: regexpOp},
+		{name: "selPrefixBytesBytesConstOp", op: prefixOp},
+		{name: "selSuffixBytesBytesConstOp", op: suffixOp},
+		{name: "selRegexpBytesBytesConstOp", op: regexpOp},
 	}
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {


### PR DESCRIPTION
The LIKE operators now make use of the existing selection ops template.
I defined a separate template for the constant selection operator so it
could be reused in like_ops_gen.

Refers #34498

Release note: None