### PR TITLE
bulk: change AddSSTTable to not be recursive

### DIFF
--- a/pkg/storage/bulk/sst_batcher.go
+++ b/pkg/storage/bulk/sst_batcher.go
@@ -189,57 +189,95 @@ func (b *SSTBatcher) GetSummary() roachpb.BulkOpSummary {
 	return b.totalRows
 }
 
+type sender interface {
+	AddSSTable(ctx context.Context, begin, end interface{}, data []byte) error
+}
+
+type sstSpan struct {
+	start, end roachpb.Key
+	sstBytes   []byte
+}
+
 // AddSSTable retries db.AddSSTable if retryable errors occur, including if the
 // SST spans a split, in which case it is iterated and split into two SSTs, one
 // for each side of the split in the error, and each are retried.
-func AddSSTable(ctx context.Context, db *client.DB, start, end roachpb.Key, sstBytes []byte) error {
+func AddSSTable(ctx context.Context, db sender, start, end roachpb.Key, sstBytes []byte) error {
+	work := []*sstSpan{{start: start, end: end, sstBytes: sstBytes}}
+	// Create an iterator that iterates over the top level SST to produce all the splits.
+	var iter engine.SimpleIterator
+	defer func() {
+		if iter != nil {
+			iter.Close()
+		}
+	}()
 	const maxAddSSTableRetries = 10
-	var err error
-	for i := 0; i < maxAddSSTableRetries; i++ {
-		log.VEventf(ctx, 2, "sending %s AddSSTable [%s,%s)", sz(len(sstBytes)), start, end)
-		// This will fail if the range has split but we'll check for that below.
-		err = db.AddSSTable(ctx, start, end, sstBytes)
-		if err == nil {
-			return nil
+	for len(work) > 0 {
+		item := work[0]
+		work = work[1:]
+		if err := func() error {
+			var err error
+			for i := 0; i < maxAddSSTableRetries; i++ {
+				log.VEventf(ctx, 2, "sending %s AddSSTable [%s,%s)", sz(len(sstBytes)), start, end)
+				// This will fail if the range has split but we'll check for that below.
+				err = db.AddSSTable(ctx, item.start, item.end, item.sstBytes)
+				if err == nil {
+					return nil
+				}
+				// This range has split -- we need to split the SST to try again.
+				if m, ok := errors.Cause(err).(*roachpb.RangeKeyMismatchError); ok {
+					if iter == nil {
+						iter, err = engine.NewMemSSTIterator(sstBytes, false)
+						if err != nil {
+							return err
+						}
+					}
+					split := m.MismatchedRange.EndKey.AsRawKey()
+					log.Infof(ctx, "SSTable cannot be added spanning range bounds %v, retrying...", split)
+					left, right, err := createSplitSSTable(ctx, db, item.start, split, iter)
+					if err != nil {
+						return err
+					}
+					// Add more work.
+					work = append([]*sstSpan{left, right}, work...)
+					return nil
+				}
+				// Retry on AmbiguousResult.
+				if _, ok := err.(*roachpb.AmbiguousResultError); ok {
+					log.Warningf(ctx, "addsstable [%s,%s) attempt %d failed: %+v", start, end, i, err)
+					continue
+				}
+			}
+			return errors.Wrapf(err, "addsstable [%s,%s)", item.start, item.end)
+		}(); err != nil {
+			return err
 		}
-		// This range has split -- we need to split the SST to try again.
-		if m, ok := errors.Cause(err).(*roachpb.RangeKeyMismatchError); ok {
-			split := m.MismatchedRange.EndKey.AsRawKey()
-			log.Infof(ctx, "SSTable cannot be added spanning range bounds %v, retrying...", split)
-			return addSplitSSTable(ctx, db, sstBytes, start, split)
-		}
-		// Retry on AmbiguousResult.
-		if _, ok := err.(*roachpb.AmbiguousResultError); ok {
-			log.Warningf(ctx, "addsstable [%s,%s) attempt %d failed: %+v", start, end, i, err)
-			continue
-		}
+		// explicitly deallocate SST. This will not deallocate the
+		// top level SST which is kept around to iterate over.
+		item.sstBytes = nil
 	}
-	return errors.Wrapf(err, "addsstable [%s,%s)", start, end)
+
+	return nil
 }
 
-// addSplitSSTable is a helper for splitting up and retrying AddSStable calls.
-func addSplitSSTable(
-	ctx context.Context, db *client.DB, sstBytes []byte, start, splitKey roachpb.Key,
-) error {
-	iter, err := engine.NewMemSSTIterator(sstBytes, false)
-	if err != nil {
-		return err
-	}
-	defer iter.Close()
-
+// createSplitSSTable is a helper for splitting up SSTs. The iterator
+// passed in is over the top level SST passed into AddSSTTable().
+func createSplitSSTable(
+	ctx context.Context, db sender, start, splitKey roachpb.Key, iter engine.SimpleIterator,
+) (*sstSpan, *sstSpan, error) {
 	w, err := engine.MakeRocksDBSstFileWriter()
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	defer w.Close()
 
 	split := false
 	var first, last roachpb.Key
+	var left, right *sstSpan
 
 	iter.Seek(engine.MVCCKey{Key: start})
 	for {
 		if ok, err := iter.Valid(); err != nil {
-			return err
+			return nil, nil, err
 		} else if !ok {
 			break
 		}
@@ -249,15 +287,18 @@ func addSplitSSTable(
 		if !split && key.Key.Compare(splitKey) >= 0 {
 			res, err := w.Finish()
 			if err != nil {
-				return err
+				return nil, nil, err
 			}
-			if err := AddSSTable(ctx, db, first, last.PrefixEnd(), res); err != nil {
-				return err
+			left = &sstSpan{
+				start:    first,
+				end:      last.PrefixEnd(),
+				sstBytes: res,
 			}
+
 			w.Close()
 			w, err = engine.MakeRocksDBSstFileWriter()
 			if err != nil {
-				return err
+				return nil, nil, err
 			}
 
 			split = true
@@ -271,7 +312,7 @@ func addSplitSSTable(
 		last = append(last[:0], key.Key...)
 
 		if err := w.Add(engine.MVCCKeyValue{Key: key, Value: iter.UnsafeValue()}); err != nil {
-			return err
+			return nil, nil, err
 		}
 
 		iter.Next()
@@ -279,7 +320,12 @@ func addSplitSSTable(
 
 	res, err := w.Finish()
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	return AddSSTable(ctx, db, first, last.PrefixEnd(), res)
+	right = &sstSpan{
+		start:    first,
+		end:      last.PrefixEnd(),
+		sstBytes: res,
+	}
+	return left, right, nil
 }


### PR DESCRIPTION
AddSSTTable was recursive to deal with range splits.
Unfortunately the recursive call would create new SSTs
without freeing the older ones creating a memory buildup
that was quadratic. We've seen memory buildup on the order
of GBs due to this recursion.

fixes #36769
fixes #36381

Release note: None