### PR TITLE
 exec: add conversion from coldata.Batches to Arrow arrays and back

### DIFF
--- a/pkg/sql/exec/coldata/vec.go
+++ b/pkg/sql/exec/coldata/vec.go
@@ -135,6 +135,11 @@ type Nulls interface {
 	UnsetNulls()
 	// SetNulls sets the column to have only null values.
 	SetNulls()
+
+	// NullBitmap returns the null bitmap.
+	NullBitmap() []uint64
+	// SetNullBitmap sets the null bitmap.
+	SetNullBitmap([]uint64)
 }
 
 var _ Vec = &memColumn{}

--- a/pkg/sql/exec/coldata/vec_tmpl.go
+++ b/pkg/sql/exec/coldata/vec_tmpl.go
@@ -340,3 +340,18 @@ func (m *memColumn) ExtendNullsWithSel(
 		}
 	}
 }
+
+func (m *memColumn) NullBitmap() []uint64 {
+	return m.nulls
+}
+
+func (m *memColumn) SetNullBitmap(bm []uint64) {
+	m.nulls = bm
+	m.hasNulls = false
+	for _, i := range bm {
+		if i != 0 {
+			m.hasNulls = true
+			return
+		}
+	}
+}

--- a/pkg/sql/exec/colserde/arrowbatchconverter.go
+++ b/pkg/sql/exec/colserde/arrowbatchconverter.go
@@ -1,0 +1,313 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package colserde
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"unsafe"
+
+	"github.com/apache/arrow/go/arrow"
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/apache/arrow/go/arrow/memory"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/pkg/errors"
+)
+
+// ArrowBatchConverter converts batches to arrow column data
+// ([]*array.Data) and back again.
+type ArrowBatchConverter struct {
+	typs []types.T
+
+	// builders are the set of builders that need to be kept around in order to
+	// construct arrow representations of certain types when they cannot be simply
+	// cast from our current data representation.
+	builders struct {
+		// boolBuilder builds arrow bool columns as a bitmap from a bool slice.
+		boolBuilder *array.BooleanBuilder
+		// binaryBuilder builds arrow []byte columns as one []byte slice with
+		// accompanying offsets from a [][]byte slice.
+		binaryBuilder *array.BinaryBuilder
+	}
+
+	scratch struct {
+		// batch and arrowData are used as scratch space returned as the corresponding
+		// conversion result.
+		batch     coldata.Batch
+		arrowData []*array.Data
+		// buffers is scratch space for exactly two buffers per element in
+		// arrowData.
+		buffers [][]*memory.Buffer
+	}
+}
+
+// NewArrowBatchConverter converts coldata.Batches to []*array.Data and back
+// again according to the schema specified by typs. Converting data that does
+// not conform to typs results in undefined behavior.
+func NewArrowBatchConverter(typs []types.T) *ArrowBatchConverter {
+	c := &ArrowBatchConverter{typs: typs}
+	c.builders.boolBuilder = array.NewBooleanBuilder(memory.DefaultAllocator)
+	c.builders.binaryBuilder = array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+	c.scratch.batch = coldata.NewMemBatch(typs)
+	c.scratch.arrowData = make([]*array.Data, len(typs))
+	c.scratch.buffers = make([][]*memory.Buffer, len(typs))
+	for i := range c.scratch.buffers {
+		// Only primitive types are directly constructed, therefore we only need
+		// two buffers: one for the nulls, the other for the values.
+		c.scratch.buffers[i] = make([]*memory.Buffer, 2)
+	}
+	return c
+}
+
+const (
+	sizeOfInt8    = int(unsafe.Sizeof(int8(0)))
+	sizeOfInt16   = int(unsafe.Sizeof(int16(0)))
+	sizeOfInt32   = int(unsafe.Sizeof(int32(0)))
+	sizeOfInt64   = int(unsafe.Sizeof(int64(0)))
+	sizeOfUint64  = int(unsafe.Sizeof(uint64(0)))
+	sizeOfFloat32 = int(unsafe.Sizeof(float32(0)))
+	sizeOfFloat64 = int(unsafe.Sizeof(float64(0)))
+)
+
+// BatchToArrow converts the first batch.Length elements of the batch into an
+// arrow []*array.Data. It is assumed that the batch is not larger than
+// coldata.BatchSize. The returned []*array.Data may only be used until the
+// next call to BatchToArrow.
+func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, error) {
+	if batch.Width() != len(c.typs) {
+		return nil, errors.Errorf("mismatched batch width and schema length: %d != %d", batch.Width(), len(c.typs))
+	}
+	n := int(batch.Length())
+	for i, typ := range c.typs {
+		vec := batch.ColVec(i)
+
+		var arrowBitmap []byte
+		if vec.HasNulls() {
+			// Cast null bitmap.
+			vecBitmap := vec.NullBitmap()
+			vecBitmapHeader := (*reflect.SliceHeader)(unsafe.Pointer(&vecBitmap))
+			arrowBitmapHeader := (*reflect.SliceHeader)(unsafe.Pointer(&arrowBitmap))
+			arrowBitmapHeader.Data = vecBitmapHeader.Data
+			arrowBitmapHeader.Len = vecBitmapHeader.Len * sizeOfUint64
+			arrowBitmapHeader.Cap = vecBitmapHeader.Cap * sizeOfUint64
+
+			// Per the arrow spec, null bitmaps represent a null value as an unset
+			// bit, which is the opposite of what we do, so invert the bitmap.
+			// TODO(asubiotto): Transition to using arrow bitmap semantics.
+			for i := range arrowBitmap {
+				arrowBitmap[i] = arrowBitmap[i] ^ math.MaxUint8
+			}
+		}
+
+		if typ == types.Bool || typ == types.Bytes {
+			// Bools and Bytes are handled differently from other types. Refer to the
+			// comment on ArrowBatchConverter.builders for more information.
+			var data *array.Data
+			switch typ {
+			case types.Bool:
+				c.builders.boolBuilder.AppendValues(vec.Bool()[:n], nil /* valid */)
+				data = c.builders.boolBuilder.NewBooleanArray().Data()
+			case types.Bytes:
+				c.builders.binaryBuilder.AppendValues(vec.Bytes()[:n], nil /* valid */)
+				data = c.builders.binaryBuilder.NewBinaryArray().Data()
+			default:
+				panic(fmt.Sprintf("unexpected type %s", typ))
+			}
+			if arrowBitmap != nil {
+				// Overwrite empty null bitmap with the true bitmap.
+				data.Buffers()[0] = memory.NewBufferBytes(arrowBitmap)
+			}
+			c.scratch.arrowData[i] = data
+			continue
+		}
+
+		var (
+			values []byte
+			// dataHeader is the reflect.SliceHeader of the coldata.Vec's underlying
+			// data slice that we are casting to bytes.
+			dataHeader *reflect.SliceHeader
+			// datumSize is the size of one datum that we are casting to a byte slice.
+			datumSize int
+		)
+
+		switch typ {
+		case types.Int8:
+			ints := vec.Int8()[:n]
+			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&ints))
+			datumSize = sizeOfInt8
+		case types.Int16:
+			ints := vec.Int16()[:n]
+			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&ints))
+			datumSize = sizeOfInt16
+		case types.Int32:
+			ints := vec.Int32()[:n]
+			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&ints))
+			datumSize = sizeOfInt32
+		case types.Int64:
+			ints := vec.Int64()[:n]
+			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&ints))
+			datumSize = sizeOfInt64
+		case types.Float32:
+			floats := vec.Float32()[:n]
+			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&floats))
+			datumSize = sizeOfFloat32
+		case types.Float64:
+			floats := vec.Float64()[:n]
+			dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&floats))
+			datumSize = sizeOfFloat64
+		default:
+			panic(fmt.Sprintf("unsupported type for conversion to arrow data %s", typ))
+		}
+
+		// Cast values.
+		valuesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&values))
+		valuesHeader.Data = dataHeader.Data
+		valuesHeader.Len = dataHeader.Len * datumSize
+		valuesHeader.Cap = dataHeader.Cap * datumSize
+
+		// Construct the underlying arrow buffers.
+		// WARNING: The ordering of construction is critical.
+		c.scratch.buffers[i][0] = memory.NewBufferBytes(arrowBitmap)
+		c.scratch.buffers[i][1] = memory.NewBufferBytes(values)
+
+		// Create the data from the buffers. It might be surprising that we don't
+		// set a type or a null count, but these fields are not used in the way that
+		// we're using array.Data. The part we care about are the buffers. Type
+		// information is inferred from the ArrowBatchConverter schema, null count
+		// is an optimization we can use when working with nulls, and childData is
+		// only used for nested types like Lists, Structs, or Unions.
+		c.scratch.arrowData[i] = array.NewData(
+			nil /* dtype */, n, c.scratch.buffers[i], nil /* childData */, 0 /* nulls */, 0, /* offset */
+		)
+	}
+	return c.scratch.arrowData, nil
+}
+
+// ArrowToBatch converts []*array.Data to a coldata.Batch. There must not be
+// more than coldata.BatchSize elements in data. The returned batch may only be
+// used until the next call to ArrowToBatch.
+func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data) (coldata.Batch, error) {
+	if len(data) != len(c.typs) {
+		return nil, errors.Errorf("mismatched data and schema length: %d != %d", len(data), len(c.typs))
+	}
+	// Assume > 0 length data.
+	n := data[0].Len()
+	for i, typ := range c.typs {
+		vec := c.scratch.batch.ColVec(i)
+		d := data[i]
+
+		var arr array.Interface
+		if typ == types.Bool || typ == types.Bytes {
+			switch typ {
+			case types.Bool:
+				boolArr := array.NewBooleanData(d)
+				vecArr := vec.Bool()
+				for i := 0; i < boolArr.Len(); i++ {
+					vecArr[i] = boolArr.Value(i)
+				}
+				arr = boolArr
+			case types.Bytes:
+				bytesArr := array.NewBinaryData(d)
+				bytes := bytesArr.ValueBytes()
+				if bytes == nil {
+					// All bytes values are empty, so the representation is solely with the
+					// offsets slice, so create an empty slice so that the conversion
+					// corresponds.
+					bytes = make([]byte, 0)
+				}
+				offsets := bytesArr.ValueOffsets()
+				vecArr := vec.Bytes()
+				for i := 0; i < len(offsets)-1; i++ {
+					vecArr[i] = bytes[offsets[i]:offsets[i+1]]
+				}
+				arr = bytesArr
+			default:
+				panic(fmt.Sprintf("unexpected type %s", typ))
+			}
+		} else {
+			var col interface{}
+			switch typ {
+			case types.Int8:
+				intArr := array.NewInt8Data(d)
+				col = intArr.Int8Values()
+				arr = intArr
+			case types.Int16:
+				intArr := array.NewInt16Data(d)
+				col = intArr.Int16Values()
+				arr = intArr
+			case types.Int32:
+				intArr := array.NewInt32Data(d)
+				col = intArr.Int32Values()
+				arr = intArr
+			case types.Int64:
+				intArr := array.NewInt64Data(d)
+				col = intArr.Int64Values()
+				arr = intArr
+			case types.Float32:
+				floatArr := array.NewFloat32Data(d)
+				col = floatArr.Float32Values()
+				arr = floatArr
+			case types.Float64:
+				floatArr := array.NewFloat64Data(d)
+				col = floatArr.Float64Values()
+				arr = floatArr
+			default:
+				panic(
+					fmt.Sprintf("unsupported type for conversion to column batch %s", d.DataType().Name()),
+				)
+			}
+			vec.SetCol(col)
+		}
+
+		// TODO(asubiotto): We can skip the rest of this logic if arr.NullN() == 0.
+		// However, we don't keep track of the number of nulls in coldata.Vec yet,
+		// so cannot set the number of nulls properly on []*array.Data. Therefore,
+		// arr.NullN() on a converted coldata.Vec is meaningless.
+
+		arrowBitmap := arr.NullBitmapBytes()
+		if arrowBitmap != nil {
+			if n > 1 {
+				// Similar to BatchToArrow, our bitmap representations are currently the
+				// inverse of arrow, so convert them back.
+				// TODO(asubiotto): Transition to using arrow bitmap semantics.
+				endIdx := ((n - 1) >> 3) + 1
+				for i := range arrowBitmap[:endIdx] {
+					arrowBitmap[i] = arrowBitmap[i] ^ math.MaxUint8
+				}
+				// After n elements, the bitmap is unset, so we have to clear the
+				// remaining bits in the last element we iterated over.
+				mod := n & 7
+				if mod != 0 {
+					arrowBitmap[endIdx-1] = arrowBitmap[endIdx-1] ^ (math.MaxUint8 << uint8(mod))
+				}
+			}
+
+			var vecBitmap []uint64
+			arrowBitmapHeader := (*reflect.SliceHeader)(unsafe.Pointer(&arrowBitmap))
+			vecBitmapHeader := (*reflect.SliceHeader)(unsafe.Pointer(&vecBitmap))
+			vecBitmapHeader.Data = arrowBitmapHeader.Data
+			vecBitmapHeader.Len = arrowBitmapHeader.Len / sizeOfUint64
+			vecBitmapHeader.Cap = arrowBitmapHeader.Cap / sizeOfUint64
+
+			vec.SetNullBitmap(vecBitmap)
+		}
+	}
+	c.scratch.batch.SetLength(uint16(n))
+	// No selection, all values are valid.
+	c.scratch.batch.SetSelection(false)
+	return c.scratch.batch, nil
+}

--- a/pkg/sql/exec/colserde/arrowbatchconverter_test.go
+++ b/pkg/sql/exec/colserde/arrowbatchconverter_test.go
@@ -1,0 +1,154 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package colserde
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArrowBatchConverterRandom(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const maxTyps = 16
+
+	rng, _ := randutil.NewPseudoRand()
+
+	availableTyps := make([]types.T, 0, len(types.AllTypes))
+	for _, typ := range types.AllTypes {
+		// TODO(asubiotto): We do not support decimal conversion yet.
+		if typ == types.Decimal {
+			continue
+		}
+		availableTyps = append(availableTyps, typ)
+	}
+	typs := make([]types.T, rng.Intn(maxTyps)+1)
+	for i := range typs {
+		typs[i] = availableTyps[rng.Intn(len(availableTyps))]
+	}
+
+	b := exec.RandomBatch(rng, typs, rng.Intn(coldata.BatchSize)+1, rng.Float64())
+	c := NewArrowBatchConverter(typs)
+
+	arrowData, err := c.BatchToArrow(b)
+	require.NoError(t, err)
+	result, err := c.ArrowToBatch(arrowData)
+	require.NoError(t, err)
+	if result.Selection() != nil {
+		t.Fatal("violated invariant that batches have no selection vectors")
+	}
+	require.Equal(t, b.Length(), result.Length())
+	require.Equal(t, b.Width(), result.Width())
+	for i, typ := range typs {
+		// Verify equality of ColVecs (this includes nulls). Since the coldata.Vec
+		// backing array is always of coldata.BatchSize due to the scratch batch
+		// that the converter keeps around, the coldata.Vec needs to be sliced to
+		// the first length elements to match on length, otherwise the check will
+		// fail.
+		require.Equal(
+			t,
+			b.ColVec(i).Slice(typ, 0, uint64(b.Length())),
+			result.ColVec(i).Slice(typ, 0, uint64(result.Length())),
+		)
+	}
+}
+
+func BenchmarkArrowBatchConverter(b *testing.B) {
+	// fixedLen specifies how many bytes we should fit variable length data types
+	// to in order to reduce benchmark noise.
+	const fixedLen = 64
+
+	rng, _ := randutil.NewPseudoRand()
+
+	typs := []types.T{types.Bool, types.Bytes, types.Int64}
+	// numBytes corresponds 1:1 to typs and specifies how many bytes we are
+	// converting on one iteration of the benchmark for the corresponding type in
+	// typs.
+	numBytes := []int64{coldata.BatchSize, fixedLen * coldata.BatchSize, 8 * coldata.BatchSize}
+	// Run a benchmark on every type we care about.
+	for typIdx, typ := range typs {
+		batch := exec.RandomBatch(rng, []types.T{typ}, coldata.BatchSize, 0 /* nullProbability */)
+		if batch.Width() != 1 {
+			b.Fatalf("unexpected batch width: %d", batch.Width())
+		}
+		if typ == types.Bytes {
+			// This type has variable length elements, fit all of them to be fixedLen
+			// bytes long.
+			bytes := batch.ColVec(0).Bytes()
+			for i := range bytes {
+				diff := len(bytes[i]) - fixedLen
+				if diff < 0 {
+					bytes[i] = append(bytes[i], make([]byte, -diff)...)
+				} else if diff > 0 {
+					bytes[i] = bytes[i][:fixedLen]
+				}
+			}
+		}
+		c := NewArrowBatchConverter([]types.T{typ})
+		nullFractions := []float64{0, 0.25, 0.5}
+		setNullFraction := func(batch coldata.Batch, nullFraction float64) {
+			vec := batch.ColVec(0)
+			vec.UnsetNulls()
+			numNulls := uint16(int(nullFraction * float64(batch.Length())))
+			// Set the first numNulls elements to null.
+			for i := uint16(0); i < batch.Length() && i < numNulls; i++ {
+				vec.SetNull(i)
+			}
+		}
+		for _, nullFraction := range nullFractions {
+			setNullFraction(batch, nullFraction)
+			testPrefix := fmt.Sprintf("%s/nullFraction=%0.2f", typ.String(), nullFraction)
+			var data []*array.Data
+			b.Run(testPrefix+"/BatchToArrow", func(b *testing.B) {
+				b.SetBytes(numBytes[typIdx])
+				for i := 0; i < b.N; i++ {
+					data, _ = c.BatchToArrow(batch)
+					if len(data) != 1 {
+						b.Fatal("expected arrow batch of length 1")
+					}
+					if data[0].Len() != coldata.BatchSize {
+						b.Fatal("unexpected number of elements")
+					}
+				}
+			})
+		}
+		for _, nullFraction := range nullFractions {
+			setNullFraction(batch, nullFraction)
+			data, err := c.BatchToArrow(batch)
+			require.NoError(b, err)
+			testPrefix := fmt.Sprintf("%s/nullFraction=%0.2f", typ.String(), nullFraction)
+			b.Run(testPrefix+"/ArrowToBatch", func(b *testing.B) {
+				b.SetBytes(numBytes[typIdx])
+				for i := 0; i < b.N; i++ {
+					result, _ := c.ArrowToBatch(data)
+					if result.Width() != 1 {
+						b.Fatal("expected one column")
+					}
+					if result.Length() != coldata.BatchSize {
+						b.Fatal("unexpected number of elements")
+					}
+				}
+			})
+		}
+	}
+}

--- a/pkg/sql/exec/random_testutils.go
+++ b/pkg/sql/exec/random_testutils.go
@@ -38,8 +38,9 @@ func randomTypes(rng *rand.Rand, n int) []types.T {
 	return typs
 }
 
-// randomVec populates vec with n random values of typ. It is assumed that n is
-// in bounds of the given vec.
+// randomVec populates vec with n random values of typ, setting each value to
+// null with a probability of nullProbability. It is assumed that n is in bounds
+// of the given vec.
 func randomVec(rng *rand.Rand, typ types.T, vec coldata.Vec, n int, nullProbability float64) {
 	switch typ {
 	case types.Bool:
@@ -109,10 +110,10 @@ func randomVec(rng *rand.Rand, typ types.T, vec coldata.Vec, n int, nullProbabil
 	}
 }
 
-// randomBatch returns an n-length batch of the given typs where each value will
+// RandomBatch returns an n-length batch of the given typs where each value will
 // be null with a probability of nullProbability. The returned batch will have
 // no selection vector.
-func randomBatch(rng *rand.Rand, typs []types.T, n int, nullProbability float64) coldata.Batch {
+func RandomBatch(rng *rand.Rand, typs []types.T, n int, nullProbability float64) coldata.Batch {
 	batch := coldata.NewMemBatchWithSize(typs, n)
 	for i, typ := range typs {
 		randomVec(rng, typ, batch.ColVec(i), n, nullProbability)
@@ -158,14 +159,14 @@ var (
 	_ = randomBatchWithSel
 )
 
-// randomBatchWithSel is equivalent to randomBatch, but will also add a
+// randomBatchWithSel is equivalent to RandomBatch, but will also add a
 // selection vector to the batch where each row is selected with probability
 // selProbability. If selProbability is 1, all the rows will be selected, if
 // selProbability is 0, none will.
 func randomBatchWithSel(
 	rng *rand.Rand, typs []types.T, n int, nullProbability float64, selProbability float64,
 ) coldata.Batch {
-	batch := randomBatch(rng, typs, n, nullProbability)
+	batch := RandomBatch(rng, typs, n, nullProbability)
 	batch.SetSelection(true)
 	copy(batch.Selection(), randomSel(rng, uint16(n), 1-selProbability))
 	return batch


### PR DESCRIPTION
NOTE: Decimals are not converted yet. This will come later as the
conversion is a bit more involved.

This commit adds code to convert from coldata.Batches to []*array.Data
which can be easily serialized. This is mostly done by casting the data
slices with the exception of Bool and Bytes types.

Bools and Bytes have different representations in arrow. Bools are
represented by a bitmap while we represent them as a []bool and Bytes
are represented using one byte slice with accompanying offsets while we
represent them as [][]byte. We therefore defer to the array.Builders to
not think about the conversion. However this comes with performance
costs since the builders are not good at reusing memory and there is an
extra conversion step. The Boolean builder throughput is worse because
there is more overhead per byte.

In the future, it is very likely that we will construct memory.Buffers
ourselves for these types to avoid performance costs as we can directly
cast bools to bytes since there is no need for well formed
memory.Buffers and there is nothing fancy to do re: offsets for the
[]byte representation of [][]byte.

Release note: None

Benchmarks:
```
BenchmarkArrowBatchConverter/Bool/nullFraction=0.00/BatchToArrow-8         	  500000	      2536 ns/op	 403.63 MB/s	    1136 B/op	       8 allocs/op
BenchmarkArrowBatchConverter/Bool/nullFraction=0.25/BatchToArrow-8         	  500000	      2615 ns/op	 391.46 MB/s	    1200 B/op	       9 allocs/op
BenchmarkArrowBatchConverter/Bool/nullFraction=0.50/BatchToArrow-8         	  500000	      2607 ns/op	 392.77 MB/s	    1200 B/op	       9 allocs/op
BenchmarkArrowBatchConverter/Bool/nullFraction=0.00/ArrowToBatch-8         	 1000000	      1877 ns/op	 545.31 MB/s	      64 B/op	       1 allocs/op
BenchmarkArrowBatchConverter/Bool/nullFraction=0.25/ArrowToBatch-8         	 1000000	      1872 ns/op	 546.74 MB/s	      64 B/op	       1 allocs/op
BenchmarkArrowBatchConverter/Bool/nullFraction=0.50/ArrowToBatch-8         	 1000000	      1860 ns/op	 550.29 MB/s	      64 B/op	       1 allocs/op
BenchmarkArrowBatchConverter/Bytes/nullFraction=0.00/BatchToArrow-8        	   30000	     52196 ns/op	1255.57 MB/s	  162208 B/op	      18 allocs/op
BenchmarkArrowBatchConverter/Bytes/nullFraction=0.25/BatchToArrow-8        	   30000	     52549 ns/op	1247.12 MB/s	  162272 B/op	      19 allocs/op
BenchmarkArrowBatchConverter/Bytes/nullFraction=0.50/BatchToArrow-8        	   30000	     51311 ns/op	1277.22 MB/s	  162272 B/op	      19 allocs/op
BenchmarkArrowBatchConverter/Bytes/nullFraction=0.00/ArrowToBatch-8        	  500000	      2652 ns/op	24706.72 MB/s	      96 B/op	       1 allocs/op
BenchmarkArrowBatchConverter/Bytes/nullFraction=0.25/ArrowToBatch-8        	  500000	      2666 ns/op	24577.69 MB/s	      96 B/op	       1 allocs/op
BenchmarkArrowBatchConverter/Bytes/nullFraction=0.50/ArrowToBatch-8        	  500000	      2647 ns/op	24750.81 MB/s	      96 B/op	       1 allocs/op
BenchmarkArrowBatchConverter/Int64/nullFraction=0.00/BatchToArrow-8        	10000000	       215 ns/op	37930.60 MB/s	     224 B/op	       3 allocs/op
BenchmarkArrowBatchConverter/Int64/nullFraction=0.25/BatchToArrow-8        	10000000	       220 ns/op	37120.18 MB/s	     224 B/op	       3 allocs/op
BenchmarkArrowBatchConverter/Int64/nullFraction=0.50/BatchToArrow-8        	10000000	       221 ns/op	36927.31 MB/s	     224 B/op	       3 allocs/op
BenchmarkArrowBatchConverter/Int64/nullFraction=0.00/ArrowToBatch-8        	10000000	       149 ns/op	54863.43 MB/s	      96 B/op	       2 allocs/op
BenchmarkArrowBatchConverter/Int64/nullFraction=0.25/ArrowToBatch-8        	10000000	       156 ns/op	52341.90 MB/s	      96 B/op	       2 allocs/op
BenchmarkArrowBatchConverter/Int64/nullFraction=0.50/ArrowToBatch-8        	10000000	       156 ns/op	52350.79 MB/s	      96 B/op	       2 allocs/op
```
These benchmarks show the performance difference between using builders with few/many bytes per conversion vs directly casting.

As stated in the commit message bools have worse throughput due to more overhead per number of bytes. This could be improved by casting with the downside of not having arrow-compatible buffers. Thought I'd just use the builder for now and then change when we make the decision of how we want to represent data.

Note that decimal support will be added later, but since it can be encapsulated as its own change, I though it'd be better to do that separately once this is in.

Addresses #36661 