### PR TITLE
exec: eliminate a few bounds checks in selection

### DIFF
--- a/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
@@ -55,14 +55,14 @@ func (p *{{template "opConstName" .}}) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 
-		coldata := batch.ColVec(p.colIdx).{{.LTyp}}()[:coldata.BatchSize]
+		col := batch.ColVec(p.colIdx).{{.LTyp}}()[:coldata.BatchSize]
 		var idx uint16
 		n := batch.Length()
 		if sel := batch.Selection(); sel != nil {
-			sel := sel[:n]
+			sel = sel[:n]
 			for _, i := range sel {
 				var cmp bool
-				{{(.Assign "cmp" "coldata[i]" "p.constArg")}}
+				{{(.Assign "cmp" "col[i]" "p.constArg")}}
 				if cmp {
 					sel[idx] = i
 					idx++
@@ -71,11 +71,12 @@ func (p *{{template "opConstName" .}}) Next(ctx context.Context) coldata.Batch {
 		} else {
 			batch.SetSelection(true)
 			sel := batch.Selection()
-			for i := uint16(0); i < n; i++ {
+			col = col[:n]
+			for i := range col {
 				var cmp bool
-				{{(.Assign "cmp" "coldata[i]" "p.constArg")}}
+				{{(.Assign "cmp" "col[i]" "p.constArg")}}
 				if cmp {
-					sel[idx] = i
+					sel[idx] = uint16(i)
 					idx++
 				}
 			}
@@ -119,7 +120,7 @@ func (p *{{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 
 		var idx uint16
 		if sel := batch.Selection(); sel != nil {
-			sel := sel[:n]
+			sel = sel[:n]
 			for _, i := range sel {
 				var cmp bool
 				{{(.Assign "cmp" "col1[i]" "col2[i]")}}
@@ -131,11 +132,13 @@ func (p *{{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 		} else {
 			batch.SetSelection(true)
 			sel := batch.Selection()
-			for i := uint16(0); i < n; i++ {
+			col1 = col1[:n]
+			col2 = col2[:len(col1)]
+			for i := range col1 {
 				var cmp bool
 				{{(.Assign "cmp" "col1[i]" "col2[i]")}}
 				if cmp {
-					sel[idx] = i
+					sel[idx] = uint16(i)
 					idx++
 				}
 			}


### PR DESCRIPTION
Our selection ops had a few avoidable bounds checks which I eliminated.
I also added benchmarks for the cases where the input has a selection
vector.

Benchmarks:
```
name                                         old time/op    new time/op    delta
SelLTInt64Int64ConstOp-4                        772ns ±16%     703ns ±14%     ~     (p=0.421 n=5+5)
SelLTInt64Int64ConstOpWithSelectionVector-4     720ns ±16%     693ns ±11%     ~     (p=0.690 n=5+5)
SelLTInt64Int64Op-4                             711ns ± 2%     544ns ± 3%  -23.47%  (p=0.008 n=5+5)
SelLTInt64Int64OpWithSelectionVector-4          786ns ± 1%     780ns ± 3%     ~     (p=0.413 n=5+5)

name                                         old speed      new speed      delta
SelLTInt64Int64ConstOp-4                     10.7GB/s ±15%  11.8GB/s ±13%     ~     (p=0.421 n=5+5)
SelLTInt64Int64ConstOpWithSelectionVector-4  11.5GB/s ±15%  11.9GB/s ±11%     ~     (p=0.690 n=5+5)
SelLTInt64Int64Op-4                          23.0GB/s ± 2%  30.1GB/s ± 3%  +30.61%  (p=0.008 n=5+5)
SelLTInt64Int64OpWithSelectionVector-4       20.8GB/s ± 0%  21.0GB/s ± 3%     ~     (p=0.310 n=5+5)
```

Release note: None