### PR TITLE
exec: support NOT LIKE

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -478,8 +478,10 @@ func planExpressionOperators(
 		}
 		typ := ct[leftIdx]
 		if constArg, ok := t.Right.(tree.Datum); ok {
-			if t.Operator == tree.Like {
-				op, err := exec.GetLikeOperator(ctx, leftOp, leftIdx, string(tree.MustBeDString(constArg)))
+			if t.Operator == tree.Like || t.Operator == tree.NotLike {
+				negate := t.Operator == tree.NotLike
+				op, err := exec.GetLikeOperator(
+					ctx, leftOp, leftIdx, string(tree.MustBeDString(constArg)), negate)
 				return op, resultIdx, ct, err
 			}
 			op, err := exec.GetSelectionConstOperator(typ, cmpOp, leftOp, leftIdx, constArg)

--- a/pkg/sql/exec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/like_ops_gen.go
@@ -80,6 +80,33 @@ func genLikeOps(wr io.Writer) error {
 				return fmt.Sprintf("%s = %s.Match(%s)", target, r, l)
 			},
 		},
+		{
+			Name:    "NotPrefix",
+			LTyp:    types.Bytes,
+			RTyp:    types.Bytes,
+			RGoType: "[]byte",
+			AssignFunc: func(_ overload, target, l, r string) string {
+				return fmt.Sprintf("%s = !bytes.HasPrefix(%s, %s)", target, l, r)
+			},
+		},
+		{
+			Name:    "NotSuffix",
+			LTyp:    types.Bytes,
+			RTyp:    types.Bytes,
+			RGoType: "[]byte",
+			AssignFunc: func(_ overload, target, l, r string) string {
+				return fmt.Sprintf("%s = !bytes.HasSuffix(%s, %s)", target, l, r)
+			},
+		},
+		{
+			Name:    "NotRegexp",
+			LTyp:    types.Bytes,
+			RTyp:    types.Bytes,
+			RGoType: "*regexp.Regexp",
+			AssignFunc: func(_ overload, target, l, r string) string {
+				return fmt.Sprintf("%s = !%s.Match(%s)", target, r, l)
+			},
+		},
 	}
 	return tmpl.Execute(wr, overloads)
 }

--- a/pkg/sql/exec/like_ops.go
+++ b/pkg/sql/exec/like_ops.go
@@ -21,12 +21,19 @@ import (
 )
 
 // GetLikeOperator returns a selection operator which applies the specified LIKE
-// pattern. The implementation varies depending on the complexity of the
-// pattern.
+// pattern, or NOT LIKE if the negate argument is true. The implementation
+// varies depending on the complexity of the pattern.
 func GetLikeOperator(
-	ctx *tree.EvalContext, input Operator, colIdx int, pattern string,
+	ctx *tree.EvalContext, input Operator, colIdx int, pattern string, negate bool,
 ) (Operator, error) {
 	if pattern == "" {
+		if negate {
+			return &selNEBytesBytesConstOp{
+				input:    input,
+				colIdx:   colIdx,
+				constArg: []byte{},
+			}, nil
+		}
 		return &selEQBytesBytesConstOp{
 			input:    input,
 			colIdx:   colIdx,
@@ -34,12 +41,23 @@ func GetLikeOperator(
 		}, nil
 	}
 	if pattern == "%" {
+		if negate {
+			return NewZeroOp(input), nil
+		}
 		// Matches everything.
+		// TODO(solon): Replace this with a NOT NULL operator.
 		return NewNoop(input), nil
 	}
 	if len(pattern) > 1 && !strings.ContainsAny(pattern[1:len(pattern)-1], "_%") {
 		// Special cases for patterns which are just a prefix or suffix.
 		if pattern[0] == '%' {
+			if negate {
+				return &selNotSuffixBytesBytesConstOp{
+					input:    input,
+					colIdx:   colIdx,
+					constArg: []byte(pattern[1:]),
+				}, nil
+			}
 			return &selSuffixBytesBytesConstOp{
 				input:    input,
 				colIdx:   colIdx,
@@ -47,6 +65,13 @@ func GetLikeOperator(
 			}, nil
 		}
 		if pattern[len(pattern)-1] == '%' {
+			if negate {
+				return &selNotPrefixBytesBytesConstOp{
+					input:    input,
+					colIdx:   colIdx,
+					constArg: []byte(pattern[:len(pattern)-1]),
+				}, nil
+			}
 			return &selPrefixBytesBytesConstOp{
 				input:    input,
 				colIdx:   colIdx,
@@ -58,6 +83,13 @@ func GetLikeOperator(
 	re, err := tree.ConvertLikeToRegexp(ctx, pattern, false, '\\')
 	if err != nil {
 		return nil, err
+	}
+	if negate {
+		return &selNotRegexpBytesBytesConstOp{
+			input:    input,
+			colIdx:   colIdx,
+			constArg: re,
+		}, nil
 	}
 	return &selRegexpBytesBytesConstOp{
 		input:    input,

--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -68,3 +68,25 @@ func (n *noopOperator) reset() {
 		r.reset()
 	}
 }
+
+type zeroOperator struct {
+	input Operator
+}
+
+var _ Operator = &zeroOperator{}
+
+// NewZeroOp creates a new operator which just returns an empty batch.
+func NewZeroOp(input Operator) Operator {
+	return &zeroOperator{input: input}
+}
+
+func (s *zeroOperator) Init() {
+	s.input.Init()
+}
+
+func (s *zeroOperator) Next() coldata.Batch {
+	// TODO(solon): Can we avoid calling Next on the input at all?
+	next := s.input.Next()
+	next.SetLength(0)
+	return next
+}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -223,10 +223,20 @@ SELECT * FROM e WHERE x LIKE ''
 ----
 
 query T
+SELECT * FROM e WHERE x NOT LIKE '' ORDER BY 1
+----
+abc
+xyz
+
+query T
 SELECT * FROM e WHERE x LIKE '%' ORDER BY 1
 ----
 abc
 xyz
+
+query T
+SELECT * FROM e WHERE x NOT LIKE '%'
+----
 
 query T
 SELECT * FROM e WHERE x LIKE 'ab%'
@@ -234,14 +244,29 @@ SELECT * FROM e WHERE x LIKE 'ab%'
 abc
 
 query T
+SELECT * FROM e WHERE x NOT LIKE 'ab%'
+----
+xyz
+
+query T
 SELECT * FROM e WHERE x LIKE '%bc'
 ----
 abc
 
 query T
+SELECT * FROM e WHERE x NOT LIKE '%bc'
+----
+xyz
+
+query T
 SELECT * FROM e WHERE x LIKE 'a%c'
 ----
 abc
+
+query T
+SELECT * FROM e WHERE x NOT LIKE 'a%c'
+----
+xyz
 
 statement ok
 RESET optimizer; RESET experimental_vectorize


### PR DESCRIPTION
like_ops_gen.go now also generates the negated version of its operators
for use with NOT LIKE.

Refers #34498

Release note: None