### PR TITLE
exec: add col direction support to vectorized merge joiner

### DIFF
--- a/pkg/sql/distsqlrun/column_exec_setup.go
+++ b/pkg/sql/distsqlrun/column_exec_setup.go
@@ -284,17 +284,6 @@ func newColOperator(
 		nLeftCols := uint32(len(leftTypes))
 		nRightCols := uint32(len(rightTypes))
 
-		leftEqCols := make([]uint32, 0, nLeftCols)
-		rightEqCols := make([]uint32, 0, nRightCols)
-
-		for _, oCol := range core.MergeJoiner.LeftOrdering.Columns {
-			leftEqCols = append(leftEqCols, oCol.ColIdx)
-		}
-
-		for _, oCol := range core.MergeJoiner.RightOrdering.Columns {
-			rightEqCols = append(rightEqCols, oCol.ColIdx)
-		}
-
 		leftOutCols := make([]uint32, 0, nLeftCols)
 		rightOutCols := make([]uint32, 0, nRightCols)
 
@@ -323,8 +312,8 @@ func newColOperator(
 			rightOutCols,
 			leftTypes,
 			rightTypes,
-			leftEqCols,
-			rightEqCols,
+			core.MergeJoiner.LeftOrdering.Columns,
+			core.MergeJoiner.RightOrdering.Columns,
 		)
 
 		columnTypes = make([]sqlbase.ColumnType, nLeftCols+nRightCols)

--- a/pkg/sql/distsqlrun/columnar_operators_test.go
+++ b/pkg/sql/distsqlrun/columnar_operators_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func TestSorterAgainstProcessor(t *testing.T) {
@@ -33,7 +33,7 @@ func TestSorterAgainstProcessor(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
-	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	rng, _ := randutil.NewPseudoRand()
 
 	nRows := 100
 	maxCols := 5
@@ -51,7 +51,7 @@ func TestSorterAgainstProcessor(t *testing.T) {
 		// Note: we're only generating column orderings on all nCols columns since
 		// if there are columns not in the ordering, the results are not fully
 		// deterministic.
-		orderingCols := generateColumnOrdering(rng, nCols, nCols, true)
+		orderingCols := generateColumnOrdering(rng, nCols, nCols)
 		sorterSpec := &distsqlpb.SorterSpec{
 			OutputOrdering: distsqlpb.Ordering{Columns: orderingCols},
 		}
@@ -59,7 +59,7 @@ func TestSorterAgainstProcessor(t *testing.T) {
 			Input: []distsqlpb.InputSyncSpec{{ColumnTypes: inputTypes}},
 			Core:  distsqlpb.ProcessorCoreUnion{Sorter: sorterSpec},
 		}
-		if err := verifyColOperator(false, [][]sqlbase.ColumnType{inputTypes}, []sqlbase.EncDatumRows{rows}, inputTypes, pspec); err != nil {
+		if err := verifyColOperator(false /* anyOrder */, [][]sqlbase.ColumnType{inputTypes}, []sqlbase.EncDatumRows{rows}, inputTypes, pspec); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -71,7 +71,7 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
-	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	rng, _ := randutil.NewPseudoRand()
 
 	nRows := 100
 	maxCols := 5
@@ -87,7 +87,7 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 		// Note: we're only generating column orderings on all nCols columns since
 		// if there are columns not in the ordering, the results are not fully
 		// deterministic.
-		orderingCols := generateColumnOrdering(rng, nCols, nCols, true)
+		orderingCols := generateColumnOrdering(rng, nCols, nCols)
 		for matchLen := 1; matchLen <= nCols; matchLen++ {
 			rows := sqlbase.MakeRandIntRowsInRange(rng, nRows, nCols, maxNum, nullProbability)
 			matchedCols := distsqlpb.ConvertToColumnOrdering(distsqlpb.Ordering{Columns: orderingCols[:matchLen]})
@@ -108,7 +108,7 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 				Input: []distsqlpb.InputSyncSpec{{ColumnTypes: inputTypes}},
 				Core:  distsqlpb.ProcessorCoreUnion{Sorter: sorterSpec},
 			}
-			if err := verifyColOperator(false, [][]sqlbase.ColumnType{inputTypes}, []sqlbase.EncDatumRows{rows}, inputTypes, pspec); err != nil {
+			if err := verifyColOperator(false /* anyOrder */, [][]sqlbase.ColumnType{inputTypes}, []sqlbase.EncDatumRows{rows}, inputTypes, pspec); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -118,10 +118,9 @@ func TestSortChunksAgainstProcessor(t *testing.T) {
 func TestMergeJoinerAgainstProcessor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var da sqlbase.DatumAlloc
-	st := cluster.MakeTestingClusterSettings()
-	evalCtx := tree.MakeTestingEvalContext(st)
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
-	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	rng, _ := randutil.NewPseudoRand()
 
 	nRows := 100
 	maxCols := 5
@@ -137,8 +136,12 @@ func TestMergeJoinerAgainstProcessor(t *testing.T) {
 		// Note: we're only generating column orderings on all nCols columns since
 		// if there are columns not in the ordering, the results are not fully
 		// deterministic.
-		lOrderingCols := generateColumnOrdering(rng, nCols, nCols, false)
-		rOrderingCols := generateColumnOrdering(rng, nCols, nCols, false)
+		lOrderingCols := generateColumnOrdering(rng, nCols, nCols)
+		rOrderingCols := generateColumnOrdering(rng, nCols, nCols)
+		// Set the directions of both columns to be the same.
+		for i, lCol := range lOrderingCols {
+			rOrderingCols[i].Direction = lCol.Direction
+		}
 
 		lRows := sqlbase.MakeRandIntRowsInRange(rng, nRows, nCols, maxNum, nullProbability)
 		rRows := sqlbase.MakeRandIntRowsInRange(rng, nRows, nCols, maxNum, nullProbability)
@@ -167,7 +170,7 @@ func TestMergeJoinerAgainstProcessor(t *testing.T) {
 			Input: []distsqlpb.InputSyncSpec{{ColumnTypes: inputTypes}, {ColumnTypes: inputTypes}},
 			Core:  distsqlpb.ProcessorCoreUnion{MergeJoiner: mjSpec},
 		}
-		if err := verifyColOperator(false, [][]sqlbase.ColumnType{inputTypes, inputTypes}, []sqlbase.EncDatumRows{lRows, rRows}, append(inputTypes, inputTypes...), pspec); err != nil {
+		if err := verifyColOperator(false /* anyOrder */, [][]sqlbase.ColumnType{inputTypes, inputTypes}, []sqlbase.EncDatumRows{lRows, rRows}, append(inputTypes, inputTypes...), pspec); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -175,21 +178,20 @@ func TestMergeJoinerAgainstProcessor(t *testing.T) {
 
 // generateColumnOrdering produces a random ordering of nOrderingCols columns
 // on a table with nCols columns, so nOrderingCols must be not greater than
-// nCols.
+// nCols
 func generateColumnOrdering(
-	rng *rand.Rand, nCols int, nOrderingCols int, randomizeDirection bool,
+	rng *rand.Rand, nCols int, nOrderingCols int,
 ) []distsqlpb.Ordering_Column {
 	if nOrderingCols > nCols {
 		panic("nOrderingCols > nCols in generateColumnOrdering")
 	}
+
 	orderingCols := make([]distsqlpb.Ordering_Column, nOrderingCols)
 	for i, col := range rng.Perm(nCols)[:nOrderingCols] {
-		// TODO (georgeutsin) refactor this to accept a directions slice.
-		direction := distsqlpb.Ordering_Column_Direction(0)
-		if randomizeDirection {
-			direction = distsqlpb.Ordering_Column_Direction(rng.Intn(2))
+		orderingCols[i] = distsqlpb.Ordering_Column{
+			ColIdx:    uint32(col),
+			Direction: distsqlpb.Ordering_Column_Direction(rng.Intn(2)),
 		}
-		orderingCols[i] = distsqlpb.Ordering_Column{ColIdx: uint32(col), Direction: direction}
 	}
 	return orderingCols
 }


### PR DESCRIPTION
Noticed a bug using the row vs col op comparator, where the
vectorized merge joiner incorrectly handles DESC column orders
due to the fact that the comparison always incremented the left
probe idx if it was less, which is not the case with descending
columns.

This fix adds some templated methods to switch between the ASC
and DESC cases.

Some benchmarks:

```
name                                      old time/op    new time/op    delta
MergeJoiner/rows=1024-8                     39.6µs ± 1%    40.3µs ± 1%   +1.86%  (p=0.000 n=9+10)
MergeJoiner/rows=4096-8                      152µs ± 1%     150µs ± 1%   -1.83%  (p=0.000 n=10+10)
MergeJoiner/rows=16384-8                     589µs ± 1%     585µs ± 0%   -0.68%  (p=0.001 n=9+9)
MergeJoiner/rows=1048576-8                  37.4ms ± 8%    36.7ms ± 0%     ~     (p=0.190 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8       40.7µs ± 2%    40.7µs ± 2%     ~     (p=0.971 n=10+10)
MergeJoiner/oneSideRepeat-rows=4096-8        158µs ± 4%     152µs ± 4%   -4.33%  (p=0.001 n=9+10)
MergeJoiner/oneSideRepeat-rows=16384-8       601µs ± 2%     578µs ± 3%   -3.82%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1048576-8    37.7ms ± 6%    36.7ms ± 6%     ~     (p=0.211 n=10+9)
MergeJoiner/bothSidesRepeat-rows=1024-8     42.7µs ± 1%    41.9µs ± 2%   -1.83%  (p=0.002 n=8+9)
MergeJoiner/bothSidesRepeat-rows=4096-8      191µs ± 1%     189µs ± 2%   -0.96%  (p=0.019 n=9+9)
MergeJoiner/bothSidesRepeat-rows=16384-8    1.51ms ± 2%    1.40ms ± 1%   -7.54%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=32768-8    5.56ms ± 5%    4.75ms ± 1%  -14.60%  (p=0.000 n=10+10)

name                                      old speed      new speed      delta
MergeJoiner/rows=1024-8                   1.66GB/s ± 1%  1.63GB/s ± 1%   -1.83%  (p=0.000 n=9+10)
MergeJoiner/rows=4096-8                   1.72GB/s ± 1%  1.75GB/s ± 1%   +1.86%  (p=0.000 n=10+10)
MergeJoiner/rows=16384-8                  1.78GB/s ± 1%  1.79GB/s ± 0%   +0.68%  (p=0.001 n=9+9)
MergeJoiner/rows=1048576-8                1.80GB/s ± 8%  1.83GB/s ± 0%     ~     (p=0.190 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8     1.61GB/s ± 2%  1.61GB/s ± 2%     ~     (p=0.971 n=10+10)
MergeJoiner/oneSideRepeat-rows=4096-8     1.64GB/s ± 8%  1.73GB/s ± 4%   +5.49%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=16384-8    1.74GB/s ± 2%  1.81GB/s ± 2%   +3.96%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1048576-8  1.78GB/s ± 6%  1.82GB/s ± 7%     ~     (p=0.393 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8   1.54GB/s ± 1%  1.57GB/s ± 2%   +1.87%  (p=0.002 n=8+9)
MergeJoiner/bothSidesRepeat-rows=4096-8   1.37GB/s ± 1%  1.39GB/s ± 2%   +0.98%  (p=0.019 n=9+9)
MergeJoiner/bothSidesRepeat-rows=16384-8   693MB/s ± 2%   750MB/s ± 1%   +8.15%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=32768-8   377MB/s ± 5%   442MB/s ± 1%  +17.02%  (p=0.000 n=10+10)

name                                      old alloc/op   new alloc/op   delta
MergeJoiner/rows=1024-8                      5.00B ± 0%     9.00B ± 0%  +80.00%  (p=0.000 n=8+8)
MergeJoiner/rows=4096-8                      27.0B ± 0%     27.0B ± 0%     ~     (all equal)
MergeJoiner/rows=16384-8                      104B ±31%       90B ± 0%     ~     (p=0.211 n=10+10)
MergeJoiner/rows=1048576-8                  5.45kB ± 0%    5.45kB ± 0%   +0.02%  (p=0.000 n=9+10)
MergeJoiner/oneSideRepeat-rows=1024-8        9.00B ± 0%     9.00B ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=4096-8        27.0B ± 0%     27.0B ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=16384-8       90.0B ± 0%    103.8B ±31%     ~     (p=0.294 n=8+10)
MergeJoiner/oneSideRepeat-rows=1048576-8    6.54kB ±39%    5.45kB ± 0%     ~     (p=0.119 n=10+9)
MergeJoiner/bothSidesRepeat-rows=1024-8      9.00B ± 0%     9.00B ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=4096-8      27.0B ± 0%     27.0B ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=16384-8      272B ± 0%      272B ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=32768-8      907B ± 0%      908B ± 0%   +0.11%  (p=0.000 n=9+10)

name                                      old allocs/op  new allocs/op  delta
MergeJoiner/rows=1024-8                       0.00           0.00          ~     (all equal)
MergeJoiner/rows=4096-8                       0.00           0.00          ~     (all equal)
MergeJoiner/rows=16384-8                      0.00           0.00          ~     (all equal)
MergeJoiner/rows=1048576-8                    1.00 ± 0%      1.00 ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=1024-8         0.00           0.00          ~     (all equal)
MergeJoiner/oneSideRepeat-rows=4096-8         0.00           0.00          ~     (all equal)
MergeJoiner/oneSideRepeat-rows=16384-8        0.00           0.00          ~     (all equal)
MergeJoiner/oneSideRepeat-rows=1048576-8      1.30 ±54%      1.00 ± 0%     ~     (p=0.173 n=10+9)
MergeJoiner/bothSidesRepeat-rows=1024-8       0.00           0.00          ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=4096-8       0.00           0.00          ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=16384-8      0.00           0.00          ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=32768-8      0.00           0.00          ~     (all equal)
```

Release note: None