### PR TITLE
Makefile: fix roachprod-stressrace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -908,7 +908,7 @@ roachprod-stress roachprod-stressrace: bin/roachprod-stress
 	@if [ -z "$(CLUSTER)" ]; then \
 	  echo "ERROR: missing or empty CLUSTER"; \
 	else \
-	  bin/roachprod-stress $(CLUSTER) $(STRESSFLAGS) ./$(notdir $(PKG)).test \
+	  bin/roachprod-stress $(CLUSTER) $(STRESSFLAGS) ./$(notdir $(patsubst %/,%,$(PKG))).test \
 	    -test.run "$(TESTS)" $(filter-out -v,$(TESTFLAGS)) -test.v -test.timeout $(TESTTIMEOUT); \
 	fi
 


### PR DESCRIPTION
I think 47d26211bd24947130b8a83caeb06a4e207fcad3 broke this. I suspect
that it was tested when that change was made, but that an errant `.test`
file was still around and made it seem like it worked.

Release note: None