### PR TITLE
storage: drop stack trace from "slow commit" warning

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2022,8 +2022,8 @@ func (r *rocksDBBatch) commitInternal(sync bool) error {
 
 	warnLargeBatches := r.parent.cfg.WarnLargeBatchThreshold > 0
 	if elapsed := timeutil.Since(start); warnLargeBatches && (elapsed >= r.parent.cfg.WarnLargeBatchThreshold) {
-		log.Warningf(context.TODO(), "batch [%d/%d/%d] commit took %s (>%s):\n%s",
-			count, size, r.flushes, elapsed, r.parent.cfg.WarnLargeBatchThreshold, debug.Stack())
+		log.Warningf(context.TODO(), "batch [%d/%d/%d] commit took %s (>= warning threshold %s)",
+			count, size, r.flushes, elapsed, r.parent.cfg.WarnLargeBatchThreshold)
 	}
 
 	return nil


### PR DESCRIPTION
We've long stopped caring about the caller eating the slow commit
latency, and the stack traces in the logs are confusing.

Release note: None