### PR TITLE
[dnm] make `roachprod logs` work

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -998,7 +998,7 @@ func (c *SyncedCluster) Logs(
 			remote = filepath.Join(localHome, src) + "/"
 		} else {
 			logDir := src
-			if !filepath.IsAbs(logDir) && user != "" && user != sshUser {
+			if false && !filepath.IsAbs(logDir) && user != "" && user != sshUser {
 				logDir = "~" + user + "/" + logDir
 			}
 			remote = fmt.Sprintf("%s@%s:%s/", c.user(c.Nodes[idx-1]),
@@ -1011,7 +1011,7 @@ func (c *SyncedCluster) Logs(
 				"-o UserKnownHostsFile=/dev/null "+
 				"-o ControlPersist=2m")
 			// Use rsync-path flag to sudo into user if different from sshUser.
-			if user != "" && user != sshUser {
+			if user != "" && user != sshUser && false {
 				rsyncArgs = append(rsyncArgs, "--rsync-path",
 					fmt.Sprintf("sudo -u %s rsync", user))
 			}
@@ -1025,8 +1025,8 @@ func (c *SyncedCluster) Logs(
 			if ctx.Err() != nil {
 				return nil
 			}
-			return errors.Errorf("failed to rsync from %v to %v: %v\n%s",
-				src, dest, err, stderrBuf.String())
+			return errors.Errorf("failed to rsync from %v to %v with args %v: %v\n%s",
+				src, dest, err, rsyncArgs, stderrBuf.String())
 		}
 		return nil
 	}


### PR DESCRIPTION
This isn't fixing anything globally, but on my local machine both
of these mechanisms that I commented out were doing harm instead
of good.

For context, my local username is `tschottdorf` but I run with
`ROACHPROD_USER=tobias` to match my gce project. My SSH user in
that setup ends up as `tschottdorf` (which I find mildly confusing).
I'd think it would use `tobias` everywhere, but it is what it is.

Honestly I'm probably just going to rename my local user to match
`tobias` to avoid these problems but I thought I'd put this online
in case @ajwerner knows what the right thing to do here is.

Release note: None