### PR TITLE
sql/sem/pretty: fix the formatting of table joins

### DIFF
--- a/pkg/sql/sem/tree/testdata/pretty/4.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/4.align-deindent.golden
@@ -38,18 +38,14 @@ SELECT
 FROM
 	phone
 		AS phone0_
-	INNER JOIN
-		person
-			AS person1_
-	ON
-		phone0_.person_id
-		= person1_.id
-	INNER JOIN
-		person_addresses
-			AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
+	INNER JOIN person
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -98,76 +94,14 @@ SELECT phone0_.id
 		AS addresse3_0__
   FROM phone
 		AS phone0_
-       INNER JOIN
-		person
-			AS person1_
-       ON
-		phone0_.person_id
-		= person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON
-		person1_.id
-		= addresses2_.person_id
- WHERE EXISTS(
-		SELECT
-			calls3_.id
-		FROM
-			phone_call
-				AS calls3_
-		WHERE
-			phone0_.id
-			= calls3_.phone_id
-       )
-
-21:
----------------------
-SELECT phone0_.id
-		AS id1_6_0_,
-       person1_.id
-		AS id1_4_1_,
-       phone0_.phone_number
-		AS phone_nu2_6_0_,
-       phone0_.person_id
-		AS person_i4_6_0_,
-       phone0_.phone_type
-		AS phone_ty3_6_0_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__,
-       person1_.address
-		AS address2_4_1_,
-       person1_.createdon
-		AS createdo3_4_1_,
-       person1_.name
-		AS name4_4_1_,
-       person1_.nickname
-		AS nickname5_4_1_,
-       person1_.version
-		AS version6_4_1_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__
-  FROM phone
-		AS phone0_
-       INNER JOIN
-		person
-			AS person1_
-       ON
-		phone0_.person_id
-		= person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+       INNER JOIN person
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT
 			calls3_.id
@@ -214,73 +148,14 @@ SELECT phone0_.id
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN
-		person
-			AS person1_
-       ON
-		phone0_.person_id
-		= person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
- WHERE EXISTS(
-		SELECT
-			calls3_.id
-		FROM
-			phone_call
-				AS calls3_
-		WHERE
-			phone0_.id
-			= calls3_.phone_id
-       )
-
-24:
-------------------------
-SELECT phone0_.id
-		AS id1_6_0_,
-       person1_.id
-		AS id1_4_1_,
-       phone0_.phone_number
-		AS phone_nu2_6_0_,
-       phone0_.person_id
-		AS person_i4_6_0_,
-       phone0_.phone_type
-		AS phone_ty3_6_0_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__,
-       person1_.address
-		AS address2_4_1_,
-       person1_.createdon
-		AS createdo3_4_1_,
-       person1_.name
-		AS name4_4_1_,
-       person1_.nickname
-		AS nickname5_4_1_,
-       person1_.version
-		AS version6_4_1_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__
-  FROM phone AS phone0_
        INNER JOIN person
-					AS person1_
-       ON
-		phone0_.person_id
-		= person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT
 			calls3_.id
@@ -328,67 +203,13 @@ SELECT phone0_.id
 		AS addresse3_0__
   FROM phone AS phone0_
        INNER JOIN person
-					AS person1_
-       ON
-		phone0_.person_id
-		= person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
- WHERE EXISTS(
-		SELECT calls3_.id
-		  FROM phone_call
-				AS calls3_
-		 WHERE phone0_.id
-		       = calls3_.phone_id
-       )
-
-27:
----------------------------
-SELECT phone0_.id
-		AS id1_6_0_,
-       person1_.id
-		AS id1_4_1_,
-       phone0_.phone_number
-		AS phone_nu2_6_0_,
-       phone0_.person_id
-		AS person_i4_6_0_,
-       phone0_.phone_type
-		AS phone_ty3_6_0_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__,
-       person1_.address
-		AS address2_4_1_,
-       person1_.createdon
-		AS createdo3_4_1_,
-       person1_.name
-		AS name4_4_1_,
-       person1_.nickname
-		AS nickname5_4_1_,
-       person1_.version
-		AS version6_4_1_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__
-  FROM phone AS phone0_
-       INNER JOIN person
-					AS person1_
-       ON phone0_.person_id
-          = person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call
@@ -432,14 +253,13 @@ SELECT phone0_.id AS id1_6_0_,
 		AS addresse3_0__
   FROM phone AS phone0_
        INNER JOIN person
-					AS person1_
-       ON phone0_.person_id
-          = person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call
@@ -482,63 +302,13 @@ SELECT phone0_.id AS id1_6_0_,
 		AS addresse3_0__
   FROM phone AS phone0_
        INNER JOIN person
-					AS person1_
-       ON phone0_.person_id
-          = person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
- WHERE EXISTS(
-		SELECT calls3_.id
-		  FROM phone_call
-				AS calls3_
-		 WHERE phone0_.id
-		       = calls3_.phone_id
-       )
-
-34:
-----------------------------------
-SELECT phone0_.id AS id1_6_0_,
-       person1_.id AS id1_4_1_,
-       phone0_.phone_number
-		AS phone_nu2_6_0_,
-       phone0_.person_id
-		AS person_i4_6_0_,
-       phone0_.phone_type
-		AS phone_ty3_6_0_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__,
-       person1_.address
-		AS address2_4_1_,
-       person1_.createdon
-		AS createdo3_4_1_,
-       person1_.name
-		AS name4_4_1_,
-       person1_.nickname
-		AS nickname5_4_1_,
-       person1_.version
-		AS version6_4_1_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__
-  FROM phone AS phone0_
-       INNER JOIN person
-					AS person1_
-       ON phone0_.person_id
-          = person1_.id
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call
@@ -580,13 +350,13 @@ SELECT phone0_.id AS id1_6_0_,
 		AS addresse3_0__
   FROM phone AS phone0_
        INNER JOIN person
-					AS person1_
-       ON phone0_.person_id
-          = person1_.id
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call
@@ -627,13 +397,60 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id
-          = person1_.id
+       INNER JOIN person
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
+ WHERE EXISTS(
+		SELECT calls3_.id
+		  FROM phone_call AS calls3_
+		 WHERE phone0_.id
+		       = calls3_.phone_id
+       )
+
+39:
+---------------------------------------
+SELECT phone0_.id AS id1_6_0_,
+       person1_.id AS id1_4_1_,
+       phone0_.phone_number
+		AS phone_nu2_6_0_,
+       phone0_.person_id
+		AS person_i4_6_0_,
+       phone0_.phone_type
+		AS phone_ty3_6_0_,
+       addresses2_.person_id
+		AS person_i1_5_0__,
+       addresses2_.addresses
+		AS addresse2_5_0__,
+       addresses2_.addresses_key
+		AS addresse3_0__,
+       person1_.address
+		AS address2_4_1_,
+       person1_.createdon
+		AS createdo3_4_1_,
+       person1_.name AS name4_4_1_,
+       person1_.nickname
+		AS nickname5_4_1_,
+       person1_.version
+		AS version6_4_1_,
+       addresses2_.person_id
+		AS person_i1_5_0__,
+       addresses2_.addresses
+		AS addresse2_5_0__,
+       addresses2_.addresses_key
+		AS addresse3_0__
+  FROM phone AS phone0_
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -671,12 +488,12 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id
+			= person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -712,12 +529,11 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -751,49 +567,11 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
- WHERE EXISTS(
-		SELECT calls3_.id
-		  FROM phone_call AS calls3_
-		 WHERE phone0_.id = calls3_.phone_id
-       )
-
-45:
----------------------------------------------
-SELECT phone0_.id AS id1_6_0_,
-       person1_.id AS id1_4_1_,
-       phone0_.phone_number
-		AS phone_nu2_6_0_,
-       phone0_.person_id AS person_i4_6_0_,
-       phone0_.phone_type AS phone_ty3_6_0_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__,
-       person1_.address AS address2_4_1_,
-       person1_.createdon AS createdo3_4_1_,
-       person1_.name AS name4_4_1_,
-       person1_.nickname AS nickname5_4_1_,
-       person1_.version AS version6_4_1_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__
-  FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
-       INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id = addresses2_.person_id
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -825,11 +603,11 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id = addresses2_.person_id
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -857,11 +635,11 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id = addresses2_.person_id
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -888,10 +666,11 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses AS addresse2_5_0__,
        addresses2_.addresses_key AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
-       INNER JOIN person_addresses AS addresses2_
-       ON person1_.id = addresses2_.person_id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -917,10 +696,98 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses AS addresse2_5_0__,
        addresses2_.addresses_key AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
-       INNER JOIN person_addresses AS addresses2_
-       ON person1_.id = addresses2_.person_id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
+ WHERE EXISTS(
+		SELECT calls3_.id
+		  FROM phone_call AS calls3_
+		 WHERE phone0_.id = calls3_.phone_id
+       )
+
+52:
+----------------------------------------------------
+SELECT phone0_.id AS id1_6_0_,
+       person1_.id AS id1_4_1_,
+       phone0_.phone_number AS phone_nu2_6_0_,
+       phone0_.person_id AS person_i4_6_0_,
+       phone0_.phone_type AS phone_ty3_6_0_,
+       addresses2_.person_id AS person_i1_5_0__,
+       addresses2_.addresses AS addresse2_5_0__,
+       addresses2_.addresses_key AS addresse3_0__,
+       person1_.address AS address2_4_1_,
+       person1_.createdon AS createdo3_4_1_,
+       person1_.name AS name4_4_1_,
+       person1_.nickname AS nickname5_4_1_,
+       person1_.version AS version6_4_1_,
+       addresses2_.person_id AS person_i1_5_0__,
+       addresses2_.addresses AS addresse2_5_0__,
+       addresses2_.addresses_key AS addresse3_0__
+  FROM phone AS phone0_
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
+       INNER JOIN person_addresses AS addresses2_ ON
+			person1_.id = addresses2_.person_id
+ WHERE EXISTS(
+		SELECT calls3_.id
+		  FROM phone_call AS calls3_
+		 WHERE phone0_.id = calls3_.phone_id
+       )
+
+57:
+---------------------------------------------------------
+SELECT phone0_.id AS id1_6_0_,
+       person1_.id AS id1_4_1_,
+       phone0_.phone_number AS phone_nu2_6_0_,
+       phone0_.person_id AS person_i4_6_0_,
+       phone0_.phone_type AS phone_ty3_6_0_,
+       addresses2_.person_id AS person_i1_5_0__,
+       addresses2_.addresses AS addresse2_5_0__,
+       addresses2_.addresses_key AS addresse3_0__,
+       person1_.address AS address2_4_1_,
+       person1_.createdon AS createdo3_4_1_,
+       person1_.name AS name4_4_1_,
+       person1_.nickname AS nickname5_4_1_,
+       person1_.version AS version6_4_1_,
+       addresses2_.person_id AS person_i1_5_0__,
+       addresses2_.addresses AS addresse2_5_0__,
+       addresses2_.addresses_key AS addresse3_0__
+  FROM phone AS phone0_
+       INNER JOIN person AS person1_ ON phone0_.person_id
+		                                        = person1_.id
+       INNER JOIN person_addresses AS addresses2_ ON
+			person1_.id = addresses2_.person_id
+ WHERE EXISTS(
+		SELECT calls3_.id
+		  FROM phone_call AS calls3_
+		 WHERE phone0_.id = calls3_.phone_id
+       )
+
+64:
+----------------------------------------------------------------
+SELECT phone0_.id AS id1_6_0_,
+       person1_.id AS id1_4_1_,
+       phone0_.phone_number AS phone_nu2_6_0_,
+       phone0_.person_id AS person_i4_6_0_,
+       phone0_.phone_type AS phone_ty3_6_0_,
+       addresses2_.person_id AS person_i1_5_0__,
+       addresses2_.addresses AS addresse2_5_0__,
+       addresses2_.addresses_key AS addresse3_0__,
+       person1_.address AS address2_4_1_,
+       person1_.createdon AS createdo3_4_1_,
+       person1_.name AS name4_4_1_,
+       person1_.nickname AS nickname5_4_1_,
+       person1_.version AS version6_4_1_,
+       addresses2_.person_id AS person_i1_5_0__,
+       addresses2_.addresses AS addresse2_5_0__,
+       addresses2_.addresses_key AS addresse3_0__
+  FROM phone AS phone0_
+       INNER JOIN person AS person1_ ON phone0_.person_id
+		                                        = person1_.id
+       INNER JOIN person_addresses AS addresses2_ ON person1_.id
+		                                                     = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -947,8 +814,8 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key AS addresse3_0__
   FROM phone AS phone0_
        INNER JOIN person AS person1_ ON phone0_.person_id = person1_.id
-       INNER JOIN person_addresses AS addresses2_
-       ON person1_.id = addresses2_.person_id
+       INNER JOIN person_addresses AS addresses2_ ON person1_.id
+		                                                     = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_

--- a/pkg/sql/sem/tree/testdata/pretty/4.align-deindent.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/4.align-deindent.golden.short
@@ -32,13 +32,13 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id
-          = person1_.id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id
+			= person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_

--- a/pkg/sql/sem/tree/testdata/pretty/4.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/4.align-only.golden
@@ -38,18 +38,14 @@ SELECT
 FROM
 	phone
 		AS phone0_
-	INNER JOIN
-		person
-			AS person1_
-	ON
-		phone0_.person_id
-		= person1_.id
-	INNER JOIN
-		person_addresses
-			AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
+	INNER JOIN person
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -98,76 +94,14 @@ SELECT phone0_.id
 		AS addresse3_0__
   FROM phone
 		AS phone0_
-       INNER JOIN
-		person
-			AS person1_
-       ON
-		phone0_.person_id
-		= person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON
-		person1_.id
-		= addresses2_.person_id
- WHERE EXISTS(
-		SELECT
-			calls3_.id
-		FROM
-			phone_call
-				AS calls3_
-		WHERE
-			phone0_.id
-			= calls3_.phone_id
-       )
-
-21:
----------------------
-SELECT phone0_.id
-		AS id1_6_0_,
-       person1_.id
-		AS id1_4_1_,
-       phone0_.phone_number
-		AS phone_nu2_6_0_,
-       phone0_.person_id
-		AS person_i4_6_0_,
-       phone0_.phone_type
-		AS phone_ty3_6_0_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__,
-       person1_.address
-		AS address2_4_1_,
-       person1_.createdon
-		AS createdo3_4_1_,
-       person1_.name
-		AS name4_4_1_,
-       person1_.nickname
-		AS nickname5_4_1_,
-       person1_.version
-		AS version6_4_1_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__
-  FROM phone
-		AS phone0_
-       INNER JOIN
-		person
-			AS person1_
-       ON
-		phone0_.person_id
-		= person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+       INNER JOIN person
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT
 			calls3_.id
@@ -214,73 +148,14 @@ SELECT phone0_.id
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN
-		person
-			AS person1_
-       ON
-		phone0_.person_id
-		= person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
- WHERE EXISTS(
-		SELECT
-			calls3_.id
-		FROM
-			phone_call
-				AS calls3_
-		WHERE
-			phone0_.id
-			= calls3_.phone_id
-       )
-
-24:
-------------------------
-SELECT phone0_.id
-		AS id1_6_0_,
-       person1_.id
-		AS id1_4_1_,
-       phone0_.phone_number
-		AS phone_nu2_6_0_,
-       phone0_.person_id
-		AS person_i4_6_0_,
-       phone0_.phone_type
-		AS phone_ty3_6_0_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__,
-       person1_.address
-		AS address2_4_1_,
-       person1_.createdon
-		AS createdo3_4_1_,
-       person1_.name
-		AS name4_4_1_,
-       person1_.nickname
-		AS nickname5_4_1_,
-       person1_.version
-		AS version6_4_1_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__
-  FROM phone AS phone0_
        INNER JOIN person
-					AS person1_
-       ON
-		phone0_.person_id
-		= person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT
 			calls3_.id
@@ -328,67 +203,13 @@ SELECT phone0_.id
 		AS addresse3_0__
   FROM phone AS phone0_
        INNER JOIN person
-					AS person1_
-       ON
-		phone0_.person_id
-		= person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
- WHERE EXISTS(
-		SELECT calls3_.id
-		  FROM phone_call
-				AS calls3_
-		 WHERE phone0_.id
-		       = calls3_.phone_id
-       )
-
-27:
----------------------------
-SELECT phone0_.id
-		AS id1_6_0_,
-       person1_.id
-		AS id1_4_1_,
-       phone0_.phone_number
-		AS phone_nu2_6_0_,
-       phone0_.person_id
-		AS person_i4_6_0_,
-       phone0_.phone_type
-		AS phone_ty3_6_0_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__,
-       person1_.address
-		AS address2_4_1_,
-       person1_.createdon
-		AS createdo3_4_1_,
-       person1_.name
-		AS name4_4_1_,
-       person1_.nickname
-		AS nickname5_4_1_,
-       person1_.version
-		AS version6_4_1_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__
-  FROM phone AS phone0_
-       INNER JOIN person
-					AS person1_
-       ON phone0_.person_id
-          = person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call
@@ -432,14 +253,13 @@ SELECT phone0_.id AS id1_6_0_,
 		AS addresse3_0__
   FROM phone AS phone0_
        INNER JOIN person
-					AS person1_
-       ON phone0_.person_id
-          = person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call
@@ -482,63 +302,13 @@ SELECT phone0_.id AS id1_6_0_,
 		AS addresse3_0__
   FROM phone AS phone0_
        INNER JOIN person
-					AS person1_
-       ON phone0_.person_id
-          = person1_.id
-       INNER JOIN
-		person_addresses
-			AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
- WHERE EXISTS(
-		SELECT calls3_.id
-		  FROM phone_call
-				AS calls3_
-		 WHERE phone0_.id
-		       = calls3_.phone_id
-       )
-
-34:
-----------------------------------
-SELECT phone0_.id AS id1_6_0_,
-       person1_.id AS id1_4_1_,
-       phone0_.phone_number
-		AS phone_nu2_6_0_,
-       phone0_.person_id
-		AS person_i4_6_0_,
-       phone0_.phone_type
-		AS phone_ty3_6_0_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__,
-       person1_.address
-		AS address2_4_1_,
-       person1_.createdon
-		AS createdo3_4_1_,
-       person1_.name
-		AS name4_4_1_,
-       person1_.nickname
-		AS nickname5_4_1_,
-       person1_.version
-		AS version6_4_1_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__
-  FROM phone AS phone0_
-       INNER JOIN person
-					AS person1_
-       ON phone0_.person_id
-          = person1_.id
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call
@@ -580,13 +350,13 @@ SELECT phone0_.id AS id1_6_0_,
 		AS addresse3_0__
   FROM phone AS phone0_
        INNER JOIN person
-					AS person1_
-       ON phone0_.person_id
-          = person1_.id
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call
@@ -627,13 +397,60 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id
-          = person1_.id
+       INNER JOIN person
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
+ WHERE EXISTS(
+		SELECT calls3_.id
+		  FROM phone_call AS calls3_
+		 WHERE phone0_.id
+		       = calls3_.phone_id
+       )
+
+39:
+---------------------------------------
+SELECT phone0_.id AS id1_6_0_,
+       person1_.id AS id1_4_1_,
+       phone0_.phone_number
+		AS phone_nu2_6_0_,
+       phone0_.person_id
+		AS person_i4_6_0_,
+       phone0_.phone_type
+		AS phone_ty3_6_0_,
+       addresses2_.person_id
+		AS person_i1_5_0__,
+       addresses2_.addresses
+		AS addresse2_5_0__,
+       addresses2_.addresses_key
+		AS addresse3_0__,
+       person1_.address
+		AS address2_4_1_,
+       person1_.createdon
+		AS createdo3_4_1_,
+       person1_.name AS name4_4_1_,
+       person1_.nickname
+		AS nickname5_4_1_,
+       person1_.version
+		AS version6_4_1_,
+       addresses2_.person_id
+		AS person_i1_5_0__,
+       addresses2_.addresses
+		AS addresse2_5_0__,
+       addresses2_.addresses_key
+		AS addresse3_0__
+  FROM phone AS phone0_
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -671,12 +488,12 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id
+			= person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -712,12 +529,11 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -751,49 +567,11 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
- WHERE EXISTS(
-		SELECT calls3_.id
-		  FROM phone_call AS calls3_
-		 WHERE phone0_.id = calls3_.phone_id
-       )
-
-45:
----------------------------------------------
-SELECT phone0_.id AS id1_6_0_,
-       person1_.id AS id1_4_1_,
-       phone0_.phone_number
-		AS phone_nu2_6_0_,
-       phone0_.person_id AS person_i4_6_0_,
-       phone0_.phone_type AS phone_ty3_6_0_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__,
-       person1_.address AS address2_4_1_,
-       person1_.createdon AS createdo3_4_1_,
-       person1_.name AS name4_4_1_,
-       person1_.nickname AS nickname5_4_1_,
-       person1_.version AS version6_4_1_,
-       addresses2_.person_id
-		AS person_i1_5_0__,
-       addresses2_.addresses
-		AS addresse2_5_0__,
-       addresses2_.addresses_key
-		AS addresse3_0__
-  FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
-       INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id = addresses2_.person_id
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -825,11 +603,11 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id = addresses2_.person_id
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -857,11 +635,11 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id = addresses2_.person_id
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -888,10 +666,11 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses AS addresse2_5_0__,
        addresses2_.addresses_key AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
-       INNER JOIN person_addresses AS addresses2_
-       ON person1_.id = addresses2_.person_id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -917,10 +696,98 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses AS addresse2_5_0__,
        addresses2_.addresses_key AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id = person1_.id
-       INNER JOIN person_addresses AS addresses2_
-       ON person1_.id = addresses2_.person_id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
+       INNER JOIN person_addresses
+			AS addresses2_ ON person1_.id
+		                  = addresses2_.person_id
+ WHERE EXISTS(
+		SELECT calls3_.id
+		  FROM phone_call AS calls3_
+		 WHERE phone0_.id = calls3_.phone_id
+       )
+
+52:
+----------------------------------------------------
+SELECT phone0_.id AS id1_6_0_,
+       person1_.id AS id1_4_1_,
+       phone0_.phone_number AS phone_nu2_6_0_,
+       phone0_.person_id AS person_i4_6_0_,
+       phone0_.phone_type AS phone_ty3_6_0_,
+       addresses2_.person_id AS person_i1_5_0__,
+       addresses2_.addresses AS addresse2_5_0__,
+       addresses2_.addresses_key AS addresse3_0__,
+       person1_.address AS address2_4_1_,
+       person1_.createdon AS createdo3_4_1_,
+       person1_.name AS name4_4_1_,
+       person1_.nickname AS nickname5_4_1_,
+       person1_.version AS version6_4_1_,
+       addresses2_.person_id AS person_i1_5_0__,
+       addresses2_.addresses AS addresse2_5_0__,
+       addresses2_.addresses_key AS addresse3_0__
+  FROM phone AS phone0_
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
+       INNER JOIN person_addresses AS addresses2_ ON
+			person1_.id = addresses2_.person_id
+ WHERE EXISTS(
+		SELECT calls3_.id
+		  FROM phone_call AS calls3_
+		 WHERE phone0_.id = calls3_.phone_id
+       )
+
+57:
+---------------------------------------------------------
+SELECT phone0_.id AS id1_6_0_,
+       person1_.id AS id1_4_1_,
+       phone0_.phone_number AS phone_nu2_6_0_,
+       phone0_.person_id AS person_i4_6_0_,
+       phone0_.phone_type AS phone_ty3_6_0_,
+       addresses2_.person_id AS person_i1_5_0__,
+       addresses2_.addresses AS addresse2_5_0__,
+       addresses2_.addresses_key AS addresse3_0__,
+       person1_.address AS address2_4_1_,
+       person1_.createdon AS createdo3_4_1_,
+       person1_.name AS name4_4_1_,
+       person1_.nickname AS nickname5_4_1_,
+       person1_.version AS version6_4_1_,
+       addresses2_.person_id AS person_i1_5_0__,
+       addresses2_.addresses AS addresse2_5_0__,
+       addresses2_.addresses_key AS addresse3_0__
+  FROM phone AS phone0_
+       INNER JOIN person AS person1_ ON phone0_.person_id
+		                                        = person1_.id
+       INNER JOIN person_addresses AS addresses2_ ON
+			person1_.id = addresses2_.person_id
+ WHERE EXISTS(
+		SELECT calls3_.id
+		  FROM phone_call AS calls3_
+		 WHERE phone0_.id = calls3_.phone_id
+       )
+
+64:
+----------------------------------------------------------------
+SELECT phone0_.id AS id1_6_0_,
+       person1_.id AS id1_4_1_,
+       phone0_.phone_number AS phone_nu2_6_0_,
+       phone0_.person_id AS person_i4_6_0_,
+       phone0_.phone_type AS phone_ty3_6_0_,
+       addresses2_.person_id AS person_i1_5_0__,
+       addresses2_.addresses AS addresse2_5_0__,
+       addresses2_.addresses_key AS addresse3_0__,
+       person1_.address AS address2_4_1_,
+       person1_.createdon AS createdo3_4_1_,
+       person1_.name AS name4_4_1_,
+       person1_.nickname AS nickname5_4_1_,
+       person1_.version AS version6_4_1_,
+       addresses2_.person_id AS person_i1_5_0__,
+       addresses2_.addresses AS addresse2_5_0__,
+       addresses2_.addresses_key AS addresse3_0__
+  FROM phone AS phone0_
+       INNER JOIN person AS person1_ ON phone0_.person_id
+		                                        = person1_.id
+       INNER JOIN person_addresses AS addresses2_ ON person1_.id
+		                                                     = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_
@@ -947,8 +814,8 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key AS addresse3_0__
   FROM phone AS phone0_
        INNER JOIN person AS person1_ ON phone0_.person_id = person1_.id
-       INNER JOIN person_addresses AS addresses2_
-       ON person1_.id = addresses2_.person_id
+       INNER JOIN person_addresses AS addresses2_ ON person1_.id
+		                                                     = addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_

--- a/pkg/sql/sem/tree/testdata/pretty/4.align-only.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/4.align-only.golden.short
@@ -32,13 +32,13 @@ SELECT phone0_.id AS id1_6_0_,
        addresses2_.addresses_key
 		AS addresse3_0__
   FROM phone AS phone0_
-       INNER JOIN person AS person1_
-       ON phone0_.person_id
-          = person1_.id
+       INNER JOIN person AS person1_ ON
+			phone0_.person_id
+			= person1_.id
        INNER JOIN person_addresses
-					AS addresses2_
-       ON person1_.id
-          = addresses2_.person_id
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
  WHERE EXISTS(
 		SELECT calls3_.id
 		  FROM phone_call AS calls3_

--- a/pkg/sql/sem/tree/testdata/pretty/4.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/4.ref.golden
@@ -38,18 +38,14 @@ SELECT
 FROM
 	phone
 		AS phone0_
-	INNER JOIN
-		person
-			AS person1_
-	ON
-		phone0_.person_id
-		= person1_.id
-	INNER JOIN
-		person_addresses
-			AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
+	INNER JOIN person
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -99,78 +95,14 @@ SELECT
 		AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN
-		person
-			AS person1_
-	ON
-		phone0_.person_id
-		= person1_.id
-	INNER JOIN
-		person_addresses
-			AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
-WHERE
-	EXISTS(
-		SELECT
-			calls3_.id
-		FROM
-			phone_call
-				AS calls3_
-		WHERE
-			phone0_.id
-			= calls3_.phone_id
-	)
-
-26:
---------------------------
-SELECT
-	phone0_.id
-		AS id1_6_0_,
-	person1_.id
-		AS id1_4_1_,
-	phone0_.phone_number
-		AS phone_nu2_6_0_,
-	phone0_.person_id
-		AS person_i4_6_0_,
-	phone0_.phone_type
-		AS phone_ty3_6_0_,
-	addresses2_.person_id
-		AS person_i1_5_0__,
-	addresses2_.addresses
-		AS addresse2_5_0__,
-	addresses2_.addresses_key
-		AS addresse3_0__,
-	person1_.address
-		AS address2_4_1_,
-	person1_.createdon
-		AS createdo3_4_1_,
-	person1_.name
-		AS name4_4_1_,
-	person1_.nickname
-		AS nickname5_4_1_,
-	person1_.version
-		AS version6_4_1_,
-	addresses2_.person_id
-		AS person_i1_5_0__,
-	addresses2_.addresses
-		AS addresse2_5_0__,
-	addresses2_.addresses_key
-		AS addresse3_0__
-FROM
-	phone AS phone0_
-	INNER JOIN
-		person AS person1_
-	ON
-		phone0_.person_id
-		= person1_.id
-	INNER JOIN
-		person_addresses
-			AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
+	INNER JOIN person
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -219,17 +151,14 @@ SELECT
 		AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN
-		person AS person1_
-	ON
-		phone0_.person_id
-		= person1_.id
-	INNER JOIN
-		person_addresses
-			AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
+	INNER JOIN person
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -277,17 +206,14 @@ SELECT
 		AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN
-		person AS person1_
-	ON
-		phone0_.person_id
-		= person1_.id
-	INNER JOIN
-		person_addresses
-			AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
+	INNER JOIN person
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -334,17 +260,14 @@ SELECT
 		AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN
-		person AS person1_
-	ON
-		phone0_.person_id
-		= person1_.id
-	INNER JOIN
-		person_addresses
-			AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
+	INNER JOIN person
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -391,16 +314,66 @@ SELECT
 		AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN person AS person1_
-	ON
-		phone0_.person_id
-		= person1_.id
-	INNER JOIN
-		person_addresses
-			AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
+	INNER JOIN person
+			AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
+WHERE
+	EXISTS(
+		SELECT
+			calls3_.id
+		FROM
+			phone_call AS calls3_
+		WHERE
+			phone0_.id
+			= calls3_.phone_id
+	)
+
+36:
+------------------------------------
+SELECT
+	phone0_.id AS id1_6_0_,
+	person1_.id AS id1_4_1_,
+	phone0_.phone_number
+		AS phone_nu2_6_0_,
+	phone0_.person_id
+		AS person_i4_6_0_,
+	phone0_.phone_type
+		AS phone_ty3_6_0_,
+	addresses2_.person_id
+		AS person_i1_5_0__,
+	addresses2_.addresses
+		AS addresse2_5_0__,
+	addresses2_.addresses_key
+		AS addresse3_0__,
+	person1_.address
+		AS address2_4_1_,
+	person1_.createdon
+		AS createdo3_4_1_,
+	person1_.name AS name4_4_1_,
+	person1_.nickname
+		AS nickname5_4_1_,
+	person1_.version
+		AS version6_4_1_,
+	addresses2_.person_id
+		AS person_i1_5_0__,
+	addresses2_.addresses
+		AS addresse2_5_0__,
+	addresses2_.addresses_key
+		AS addresse3_0__
+FROM
+	phone AS phone0_
+	INNER JOIN person AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -444,64 +417,13 @@ SELECT
 		AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN person AS person1_
-	ON phone0_.person_id = person1_.id
-	INNER JOIN
-		person_addresses
-			AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
-WHERE
-	EXISTS(
-		SELECT
-			calls3_.id
-		FROM
-			phone_call AS calls3_
-		WHERE
-			phone0_.id
-			= calls3_.phone_id
-	)
-
-39:
----------------------------------------
-SELECT
-	phone0_.id AS id1_6_0_,
-	person1_.id AS id1_4_1_,
-	phone0_.phone_number
-		AS phone_nu2_6_0_,
-	phone0_.person_id
-		AS person_i4_6_0_,
-	phone0_.phone_type
-		AS phone_ty3_6_0_,
-	addresses2_.person_id
-		AS person_i1_5_0__,
-	addresses2_.addresses
-		AS addresse2_5_0__,
-	addresses2_.addresses_key
-		AS addresse3_0__,
-	person1_.address AS address2_4_1_,
-	person1_.createdon
-		AS createdo3_4_1_,
-	person1_.name AS name4_4_1_,
-	person1_.nickname
-		AS nickname5_4_1_,
-	person1_.version AS version6_4_1_,
-	addresses2_.person_id
-		AS person_i1_5_0__,
-	addresses2_.addresses
-		AS addresse2_5_0__,
-	addresses2_.addresses_key
-		AS addresse3_0__
-FROM
-	phone AS phone0_
-	INNER JOIN person AS person1_
-	ON phone0_.person_id = person1_.id
-	INNER JOIN
-		person_addresses AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
+	INNER JOIN person AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -543,13 +465,13 @@ SELECT
 		AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN person AS person1_
-	ON phone0_.person_id = person1_.id
-	INNER JOIN
-		person_addresses AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
+	INNER JOIN person AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -589,56 +511,13 @@ SELECT
 		AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN person AS person1_
-	ON phone0_.person_id = person1_.id
-	INNER JOIN
-		person_addresses AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
-WHERE
-	EXISTS(
-		SELECT
-			calls3_.id
-		FROM
-			phone_call AS calls3_
-		WHERE
-			phone0_.id = calls3_.phone_id
-	)
-
-42:
-------------------------------------------
-SELECT
-	phone0_.id AS id1_6_0_,
-	person1_.id AS id1_4_1_,
-	phone0_.phone_number
-		AS phone_nu2_6_0_,
-	phone0_.person_id AS person_i4_6_0_,
-	phone0_.phone_type AS phone_ty3_6_0_,
-	addresses2_.person_id
-		AS person_i1_5_0__,
-	addresses2_.addresses
-		AS addresse2_5_0__,
-	addresses2_.addresses_key
-		AS addresse3_0__,
-	person1_.address AS address2_4_1_,
-	person1_.createdon AS createdo3_4_1_,
-	person1_.name AS name4_4_1_,
-	person1_.nickname AS nickname5_4_1_,
-	person1_.version AS version6_4_1_,
-	addresses2_.person_id
-		AS person_i1_5_0__,
-	addresses2_.addresses
-		AS addresse2_5_0__,
-	addresses2_.addresses_key
-		AS addresse3_0__
-FROM
-	phone AS phone0_
-	INNER JOIN person AS person1_
-	ON phone0_.person_id = person1_.id
-	INNER JOIN
-		person_addresses AS addresses2_
-	ON person1_.id = addresses2_.person_id
+	INNER JOIN person AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -676,11 +555,12 @@ SELECT
 		AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN person AS person1_
-	ON phone0_.person_id = person1_.id
-	INNER JOIN
-		person_addresses AS addresses2_
-	ON person1_.id = addresses2_.person_id
+	INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -714,11 +594,12 @@ SELECT
 		AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN person AS person1_
-	ON phone0_.person_id = person1_.id
-	INNER JOIN
-		person_addresses AS addresses2_
-	ON person1_.id = addresses2_.person_id
+	INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -751,10 +632,12 @@ SELECT
 	addresses2_.addresses_key AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN person AS person1_
-	ON phone0_.person_id = person1_.id
-	INNER JOIN person_addresses AS addresses2_
-	ON person1_.id = addresses2_.person_id
+	INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -786,10 +669,46 @@ SELECT
 	addresses2_.addresses_key AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN person AS person1_
-	ON phone0_.person_id = person1_.id
-	INNER JOIN person_addresses AS addresses2_
-	ON person1_.id = addresses2_.person_id
+	INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id = addresses2_.person_id
+WHERE
+	EXISTS(
+		SELECT
+			calls3_.id
+		FROM
+			phone_call AS calls3_
+		WHERE
+			phone0_.id = calls3_.phone_id
+	)
+
+49:
+-------------------------------------------------
+SELECT
+	phone0_.id AS id1_6_0_,
+	person1_.id AS id1_4_1_,
+	phone0_.phone_number AS phone_nu2_6_0_,
+	phone0_.person_id AS person_i4_6_0_,
+	phone0_.phone_type AS phone_ty3_6_0_,
+	addresses2_.person_id AS person_i1_5_0__,
+	addresses2_.addresses AS addresse2_5_0__,
+	addresses2_.addresses_key AS addresse3_0__,
+	person1_.address AS address2_4_1_,
+	person1_.createdon AS createdo3_4_1_,
+	person1_.name AS name4_4_1_,
+	person1_.nickname AS nickname5_4_1_,
+	person1_.version AS version6_4_1_,
+	addresses2_.person_id AS person_i1_5_0__,
+	addresses2_.addresses AS addresse2_5_0__,
+	addresses2_.addresses_key AS addresse3_0__
+FROM
+	phone AS phone0_
+	INNER JOIN person AS person1_ ON
+			phone0_.person_id = person1_.id
+	INNER JOIN person_addresses AS addresses2_ ON
+			person1_.id = addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT
@@ -822,8 +741,8 @@ SELECT
 FROM
 	phone AS phone0_
 	INNER JOIN person AS person1_ ON phone0_.person_id = person1_.id
-	INNER JOIN person_addresses AS addresses2_
-	ON person1_.id = addresses2_.person_id
+	INNER JOIN person_addresses AS addresses2_ ON
+			person1_.id = addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT

--- a/pkg/sql/sem/tree/testdata/pretty/4.ref.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/4.ref.golden.short
@@ -30,13 +30,13 @@ SELECT
 		AS addresse3_0__
 FROM
 	phone AS phone0_
-	INNER JOIN person AS person1_
-	ON phone0_.person_id = person1_.id
-	INNER JOIN
-		person_addresses AS addresses2_
-	ON
-		person1_.id
-		= addresses2_.person_id
+	INNER JOIN person AS person1_ ON
+			phone0_.person_id
+			= person1_.id
+	INNER JOIN person_addresses
+			AS addresses2_ ON
+			person1_.id
+			= addresses2_.person_id
 WHERE
 	EXISTS(
 		SELECT

--- a/pkg/sql/sem/tree/testdata/pretty/create_table.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/create_table.align-deindent.golden
@@ -68,6 +68,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -161,6 +162,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -254,6 +256,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -344,6 +347,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -432,6 +436,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -519,6 +524,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -605,6 +611,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -690,6 +697,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -774,6 +782,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -857,6 +866,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -938,6 +948,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -1018,6 +1029,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -1097,6 +1109,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -1176,6 +1189,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -1253,6 +1267,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -1325,6 +1340,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
@@ -1392,6 +1408,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
@@ -1453,6 +1470,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
@@ -1513,7 +1531,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price
@@ -1571,7 +1590,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price
@@ -1628,7 +1648,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price
@@ -1686,7 +1707,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price
@@ -1739,7 +1761,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price
@@ -1792,7 +1815,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price >= min_price
@@ -1844,7 +1868,59 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
+	INVERTED INDEX details (misc),
+	CONSTRAINT price_check CHECK (
+							list_price >= min_price
+	                       ),
+	CONSTRAINT supplied_id_fk FOREIGN KEY (
+								supplier_id
+	                          )
+	                          REFERENCES suppliers (
+								id
+	                          )
+	                          ON UPDATE CASCADE,
+	FOREIGN KEY (category_id) REFERENCES categories (
+								id
+	                          )
+) 
+
+54:
+------------------------------------------------------
+CREATE TABLE product_information (
+	product_id INT8 NOT NULL PRIMARY KEY,
+	product_name STRING(50) NOT NULL UNIQUE,
+	product_description STRING(2000),
+	category_id STRING(1)
+	            NOT NULL
+	            CHECK (
+					category_id IN ('A', 'B', 'C')
+	            ),
+	weight_class INT8,
+	warranty_period INT8
+	                CONSTRAINT valid_warranty CHECK (
+						warranty_period BETWEEN 0 AND 24
+	                ),
+	supplier_id INT8,
+	product_status STRING(20),
+	list_price DECIMAL(8,2),
+	min_price DECIMAL(8,2),
+	catalog_url STRING(50) UNIQUE,
+	date_added DATE DEFAULT current_date(),
+	misc JSONB,
+	full_name STRING
+	          AS (
+				concat(first_name, ' ', last_name)
+	          ) STORED,
+	INDEX date_added_idx (date_added),
+	INDEX supp_id_prod_status_idx (
+		supplier_id,
+		product_status
+	),
+	customer_id INT8
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price >= min_price
@@ -1892,9 +1968,8 @@ CREATE TABLE product_information (
 		product_status
 	),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price >= min_price
@@ -1938,9 +2013,8 @@ CREATE TABLE product_information (
 		product_status
 	),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price >= min_price
@@ -1982,9 +2056,8 @@ CREATE TABLE product_information (
 		product_status
 	),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2022,9 +2095,8 @@ CREATE TABLE product_information (
 		product_status
 	),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2059,9 +2131,8 @@ CREATE TABLE product_information (
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2095,9 +2166,8 @@ CREATE TABLE product_information (
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2129,72 +2199,8 @@ CREATE TABLE product_information (
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
-	INVERTED INDEX details (misc),
-	CONSTRAINT price_check CHECK (list_price >= min_price),
-	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
-	                          REFERENCES suppliers (id)
-	                          ON UPDATE CASCADE,
-	FOREIGN KEY (category_id) REFERENCES categories (id)
-) 
-
-80:
---------------------------------------------------------------------------------
-CREATE TABLE product_information (
-	product_id INT8 NOT NULL PRIMARY KEY,
-	product_name STRING(50) NOT NULL UNIQUE,
-	product_description STRING(2000),
-	category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')),
-	weight_class INT8,
-	warranty_period INT8
-	                CONSTRAINT valid_warranty CHECK (
-						warranty_period BETWEEN 0 AND 24
-	                ),
-	supplier_id INT8,
-	product_status STRING(20),
-	list_price DECIMAL(8,2),
-	min_price DECIMAL(8,2),
-	catalog_url STRING(50) UNIQUE,
-	date_added DATE DEFAULT current_date(),
-	misc JSONB,
-	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
-	INDEX date_added_idx (date_added),
-	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8
-	            REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
-	INVERTED INDEX details (misc),
-	CONSTRAINT price_check CHECK (list_price >= min_price),
-	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
-	                          REFERENCES suppliers (id)
-	                          ON UPDATE CASCADE,
-	FOREIGN KEY (category_id) REFERENCES categories (id)
-) 
-
-85:
--------------------------------------------------------------------------------------
-CREATE TABLE product_information (
-	product_id INT8 NOT NULL PRIMARY KEY,
-	product_name STRING(50) NOT NULL UNIQUE,
-	product_description STRING(2000),
-	category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')),
-	weight_class INT8,
-	warranty_period INT8
-	                CONSTRAINT valid_warranty CHECK (
-						warranty_period BETWEEN 0 AND 24
-	                ),
-	supplier_id INT8,
-	product_status STRING(20),
-	list_price DECIMAL(8,2),
-	min_price DECIMAL(8,2),
-	catalog_url STRING(50) UNIQUE,
-	date_added DATE DEFAULT current_date(),
-	misc JSONB,
-	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
-	INDEX date_added_idx (date_added),
-	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2223,7 +2229,39 @@ CREATE TABLE product_information (
 	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	customer_id INT8
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
+	INVERTED INDEX details (misc),
+	CONSTRAINT price_check CHECK (list_price >= min_price),
+	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
+	                          REFERENCES suppliers (id)
+	                          ON UPDATE CASCADE,
+	FOREIGN KEY (category_id) REFERENCES categories (id)
+) 
+
+91:
+-------------------------------------------------------------------------------------------
+CREATE TABLE product_information (
+	product_id INT8 NOT NULL PRIMARY KEY,
+	product_name STRING(50) NOT NULL UNIQUE,
+	product_description STRING(2000),
+	category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')),
+	weight_class INT8,
+	warranty_period INT8
+	                CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24),
+	supplier_id INT8,
+	product_status STRING(20),
+	list_price DECIMAL(8,2),
+	min_price DECIMAL(8,2),
+	catalog_url STRING(50) UNIQUE,
+	date_added DATE DEFAULT current_date(),
+	misc JSONB,
+	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
+	INDEX date_added_idx (date_added),
+	INDEX supp_id_prod_status_idx (supplier_id, product_status),
+	customer_id INT8
+	            REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2251,7 +2289,36 @@ CREATE TABLE product_information (
 	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	customer_id INT8
+	            REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
+	INVERTED INDEX details (misc),
+	CONSTRAINT price_check CHECK (list_price >= min_price),
+	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
+	                          REFERENCES suppliers (id)
+	                          ON UPDATE CASCADE,
+	FOREIGN KEY (category_id) REFERENCES categories (id)
+) 
+
+96:
+------------------------------------------------------------------------------------------------
+CREATE TABLE product_information (
+	product_id INT8 NOT NULL PRIMARY KEY,
+	product_name STRING(50) NOT NULL UNIQUE,
+	product_description STRING(2000),
+	category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')),
+	weight_class INT8,
+	warranty_period INT8 CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24),
+	supplier_id INT8,
+	product_status STRING(20),
+	list_price DECIMAL(8,2),
+	min_price DECIMAL(8,2),
+	catalog_url STRING(50) UNIQUE,
+	date_added DATE DEFAULT current_date(),
+	misc JSONB,
+	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
+	INDEX date_added_idx (date_added),
+	INDEX supp_id_prod_status_idx (supplier_id, product_status),
+	customer_id INT8 REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2279,15 +2346,15 @@ CREATE TABLE product_information (
 	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	customer_id INT8 REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE,
 	FOREIGN KEY (category_id) REFERENCES categories (id)
 ) 
 
-984:
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-CREATE TABLE product_information (product_id INT8 NOT NULL PRIMARY KEY, product_name STRING(50) NOT NULL UNIQUE, product_description STRING(2000), category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')), weight_class INT8, warranty_period INT8 CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24), supplier_id INT8, product_status STRING(20), list_price DECIMAL(8,2), min_price DECIMAL(8,2), catalog_url STRING(50) UNIQUE, date_added DATE DEFAULT current_date(), misc JSONB, full_name STRING AS (concat(first_name, ' ', last_name)) STORED, INDEX date_added_idx (date_added), INDEX supp_id_prod_status_idx (supplier_id, product_status), customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE, INVERTED INDEX details (misc), CONSTRAINT price_check CHECK (list_price >= min_price), CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE, FOREIGN KEY (category_id) REFERENCES categories (id)) 
+995:
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+CREATE TABLE product_information (product_id INT8 NOT NULL PRIMARY KEY, product_name STRING(50) NOT NULL UNIQUE, product_description STRING(2000), category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')), weight_class INT8, warranty_period INT8 CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24), supplier_id INT8, product_status STRING(20), list_price DECIMAL(8,2), min_price DECIMAL(8,2), catalog_url STRING(50) UNIQUE, date_added DATE DEFAULT current_date(), misc JSONB, full_name STRING AS (concat(first_name, ' ', last_name)) STORED, INDEX date_added_idx (date_added), INDEX supp_id_prod_status_idx (supplier_id, product_status), customer_id INT8 REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE, INVERTED INDEX details (misc), CONSTRAINT price_check CHECK (list_price >= min_price), CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE, FOREIGN KEY (category_id) REFERENCES categories (id)) 
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/create_table.align-deindent.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/create_table.align-deindent.golden.short
@@ -45,7 +45,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price

--- a/pkg/sql/sem/tree/testdata/pretty/create_table.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/create_table.align-only.golden
@@ -68,6 +68,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -161,6 +162,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -254,6 +256,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -344,6 +347,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -432,6 +436,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -519,6 +524,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -605,6 +611,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -690,6 +697,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -774,6 +782,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -857,6 +866,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -938,6 +948,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -1018,6 +1029,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -1097,6 +1109,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -1176,6 +1189,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -1253,6 +1267,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -1325,6 +1340,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
@@ -1392,6 +1408,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
@@ -1453,6 +1470,7 @@ CREATE TABLE product_information (
 	            REFERENCES customers_2 (
 					id
 	            )
+					MATCH FULL
 					ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
@@ -1513,7 +1531,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price
@@ -1571,7 +1590,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price
@@ -1628,7 +1648,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price
@@ -1686,7 +1707,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price
@@ -1739,7 +1761,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price
@@ -1792,7 +1815,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price >= min_price
@@ -1844,7 +1868,59 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
+	INVERTED INDEX details (misc),
+	CONSTRAINT price_check CHECK (
+							list_price >= min_price
+	                       ),
+	CONSTRAINT supplied_id_fk FOREIGN KEY (
+								supplier_id
+	                          )
+	                          REFERENCES suppliers (
+								id
+	                          )
+	                          ON UPDATE CASCADE,
+	FOREIGN KEY (category_id) REFERENCES categories (
+								id
+	                          )
+) 
+
+54:
+------------------------------------------------------
+CREATE TABLE product_information (
+	product_id INT8 NOT NULL PRIMARY KEY,
+	product_name STRING(50) NOT NULL UNIQUE,
+	product_description STRING(2000),
+	category_id STRING(1)
+	            NOT NULL
+	            CHECK (
+					category_id IN ('A', 'B', 'C')
+	            ),
+	weight_class INT8,
+	warranty_period INT8
+	                CONSTRAINT valid_warranty CHECK (
+						warranty_period BETWEEN 0 AND 24
+	                ),
+	supplier_id INT8,
+	product_status STRING(20),
+	list_price DECIMAL(8,2),
+	min_price DECIMAL(8,2),
+	catalog_url STRING(50) UNIQUE,
+	date_added DATE DEFAULT current_date(),
+	misc JSONB,
+	full_name STRING
+	          AS (
+				concat(first_name, ' ', last_name)
+	          ) STORED,
+	INDEX date_added_idx (date_added),
+	INDEX supp_id_prod_status_idx (
+		supplier_id,
+		product_status
+	),
+	customer_id INT8
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price >= min_price
@@ -1892,9 +1968,8 @@ CREATE TABLE product_information (
 		product_status
 	),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price >= min_price
@@ -1938,9 +2013,8 @@ CREATE TABLE product_information (
 		product_status
 	),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price >= min_price
@@ -1982,9 +2056,8 @@ CREATE TABLE product_information (
 		product_status
 	),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2022,9 +2095,8 @@ CREATE TABLE product_information (
 		product_status
 	),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2059,9 +2131,8 @@ CREATE TABLE product_information (
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2095,9 +2166,8 @@ CREATE TABLE product_information (
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2129,72 +2199,8 @@ CREATE TABLE product_information (
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
 	customer_id INT8
-	            REFERENCES customers_2 (
-					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
-	INVERTED INDEX details (misc),
-	CONSTRAINT price_check CHECK (list_price >= min_price),
-	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
-	                          REFERENCES suppliers (id)
-	                          ON UPDATE CASCADE,
-	FOREIGN KEY (category_id) REFERENCES categories (id)
-) 
-
-80:
---------------------------------------------------------------------------------
-CREATE TABLE product_information (
-	product_id INT8 NOT NULL PRIMARY KEY,
-	product_name STRING(50) NOT NULL UNIQUE,
-	product_description STRING(2000),
-	category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')),
-	weight_class INT8,
-	warranty_period INT8
-	                CONSTRAINT valid_warranty CHECK (
-						warranty_period BETWEEN 0 AND 24
-	                ),
-	supplier_id INT8,
-	product_status STRING(20),
-	list_price DECIMAL(8,2),
-	min_price DECIMAL(8,2),
-	catalog_url STRING(50) UNIQUE,
-	date_added DATE DEFAULT current_date(),
-	misc JSONB,
-	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
-	INDEX date_added_idx (date_added),
-	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8
-	            REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
-	INVERTED INDEX details (misc),
-	CONSTRAINT price_check CHECK (list_price >= min_price),
-	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
-	                          REFERENCES suppliers (id)
-	                          ON UPDATE CASCADE,
-	FOREIGN KEY (category_id) REFERENCES categories (id)
-) 
-
-85:
--------------------------------------------------------------------------------------
-CREATE TABLE product_information (
-	product_id INT8 NOT NULL PRIMARY KEY,
-	product_name STRING(50) NOT NULL UNIQUE,
-	product_description STRING(2000),
-	category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')),
-	weight_class INT8,
-	warranty_period INT8
-	                CONSTRAINT valid_warranty CHECK (
-						warranty_period BETWEEN 0 AND 24
-	                ),
-	supplier_id INT8,
-	product_status STRING(20),
-	list_price DECIMAL(8,2),
-	min_price DECIMAL(8,2),
-	catalog_url STRING(50) UNIQUE,
-	date_added DATE DEFAULT current_date(),
-	misc JSONB,
-	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
-	INDEX date_added_idx (date_added),
-	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2223,7 +2229,39 @@ CREATE TABLE product_information (
 	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	customer_id INT8
+	            REFERENCES customers_2 (id) MATCH FULL
+	                                        ON DELETE CASCADE ON UPDATE CASCADE,
+	INVERTED INDEX details (misc),
+	CONSTRAINT price_check CHECK (list_price >= min_price),
+	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
+	                          REFERENCES suppliers (id)
+	                          ON UPDATE CASCADE,
+	FOREIGN KEY (category_id) REFERENCES categories (id)
+) 
+
+91:
+-------------------------------------------------------------------------------------------
+CREATE TABLE product_information (
+	product_id INT8 NOT NULL PRIMARY KEY,
+	product_name STRING(50) NOT NULL UNIQUE,
+	product_description STRING(2000),
+	category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')),
+	weight_class INT8,
+	warranty_period INT8
+	                CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24),
+	supplier_id INT8,
+	product_status STRING(20),
+	list_price DECIMAL(8,2),
+	min_price DECIMAL(8,2),
+	catalog_url STRING(50) UNIQUE,
+	date_added DATE DEFAULT current_date(),
+	misc JSONB,
+	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
+	INDEX date_added_idx (date_added),
+	INDEX supp_id_prod_status_idx (supplier_id, product_status),
+	customer_id INT8
+	            REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2251,7 +2289,36 @@ CREATE TABLE product_information (
 	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	customer_id INT8
+	            REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
+	INVERTED INDEX details (misc),
+	CONSTRAINT price_check CHECK (list_price >= min_price),
+	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
+	                          REFERENCES suppliers (id)
+	                          ON UPDATE CASCADE,
+	FOREIGN KEY (category_id) REFERENCES categories (id)
+) 
+
+96:
+------------------------------------------------------------------------------------------------
+CREATE TABLE product_information (
+	product_id INT8 NOT NULL PRIMARY KEY,
+	product_name STRING(50) NOT NULL UNIQUE,
+	product_description STRING(2000),
+	category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')),
+	weight_class INT8,
+	warranty_period INT8 CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24),
+	supplier_id INT8,
+	product_status STRING(20),
+	list_price DECIMAL(8,2),
+	min_price DECIMAL(8,2),
+	catalog_url STRING(50) UNIQUE,
+	date_added DATE DEFAULT current_date(),
+	misc JSONB,
+	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
+	INDEX date_added_idx (date_added),
+	INDEX supp_id_prod_status_idx (supplier_id, product_status),
+	customer_id INT8 REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id)
@@ -2279,15 +2346,15 @@ CREATE TABLE product_information (
 	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	customer_id INT8 REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE,
 	FOREIGN KEY (category_id) REFERENCES categories (id)
 ) 
 
-984:
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-CREATE TABLE product_information (product_id INT8 NOT NULL PRIMARY KEY, product_name STRING(50) NOT NULL UNIQUE, product_description STRING(2000), category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')), weight_class INT8, warranty_period INT8 CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24), supplier_id INT8, product_status STRING(20), list_price DECIMAL(8,2), min_price DECIMAL(8,2), catalog_url STRING(50) UNIQUE, date_added DATE DEFAULT current_date(), misc JSONB, full_name STRING AS (concat(first_name, ' ', last_name)) STORED, INDEX date_added_idx (date_added), INDEX supp_id_prod_status_idx (supplier_id, product_status), customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE, INVERTED INDEX details (misc), CONSTRAINT price_check CHECK (list_price >= min_price), CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE, FOREIGN KEY (category_id) REFERENCES categories (id)) 
+995:
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+CREATE TABLE product_information (product_id INT8 NOT NULL PRIMARY KEY, product_name STRING(50) NOT NULL UNIQUE, product_description STRING(2000), category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')), weight_class INT8, warranty_period INT8 CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24), supplier_id INT8, product_status STRING(20), list_price DECIMAL(8,2), min_price DECIMAL(8,2), catalog_url STRING(50) UNIQUE, date_added DATE DEFAULT current_date(), misc JSONB, full_name STRING AS (concat(first_name, ' ', last_name)) STORED, INDEX date_added_idx (date_added), INDEX supp_id_prod_status_idx (supplier_id, product_status), customer_id INT8 REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE, INVERTED INDEX details (misc), CONSTRAINT price_check CHECK (list_price >= min_price), CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE, FOREIGN KEY (category_id) REFERENCES categories (id)) 
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/create_table.align-only.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/create_table.align-only.golden.short
@@ -45,7 +45,8 @@ CREATE TABLE product_information (
 	customer_id INT8
 	            REFERENCES customers_2 (
 					id
-	            ) ON DELETE CASCADE ON UPDATE CASCADE,
+	            ) MATCH FULL
+	              ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (
 							list_price

--- a/pkg/sql/sem/tree/testdata/pretty/create_table.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/create_table.ref.golden
@@ -68,6 +68,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -161,6 +162,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -253,6 +255,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -344,6 +347,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -434,6 +438,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -523,6 +528,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -611,6 +617,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -699,6 +706,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -780,6 +788,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -861,6 +870,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (
 		misc
@@ -935,6 +945,7 @@ CREATE TABLE product_information (
 		REFERENCES customers_2 (
 			id
 		)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1001,6 +1012,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1065,6 +1077,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1128,6 +1141,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1189,6 +1203,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1250,6 +1265,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1308,6 +1324,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1365,6 +1382,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1421,6 +1439,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1476,6 +1495,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1527,6 +1547,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1576,6 +1597,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1623,6 +1645,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1670,6 +1693,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check
@@ -1716,7 +1740,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
-			ON DELETE CASCADE ON UPDATE CASCADE,
+			MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk
@@ -1760,7 +1784,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
-			ON DELETE CASCADE ON UPDATE CASCADE,
+			MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk
@@ -1801,7 +1825,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
-			ON DELETE CASCADE ON UPDATE CASCADE,
+			MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk
@@ -1840,7 +1864,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
-			ON DELETE CASCADE ON UPDATE CASCADE,
+			MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk
@@ -1878,44 +1902,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
-			ON DELETE CASCADE ON UPDATE CASCADE,
-	INVERTED INDEX details (misc),
-	CONSTRAINT price_check CHECK (list_price >= min_price),
-	CONSTRAINT supplied_id_fk
-		FOREIGN KEY (supplier_id)
-		REFERENCES suppliers (id)
-		ON UPDATE CASCADE,
-	FOREIGN KEY (category_id) REFERENCES categories (id)
-)
-	
-
-72:
-------------------------------------------------------------------------
-CREATE TABLE product_information (
-	product_id INT8 NOT NULL PRIMARY KEY,
-	product_name STRING(50) NOT NULL UNIQUE,
-	product_description STRING(2000),
-	category_id
-		STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')),
-	weight_class INT8,
-	warranty_period
-		INT8
-		CONSTRAINT valid_warranty CHECK (
-			warranty_period BETWEEN 0 AND 24
-		),
-	supplier_id INT8,
-	product_status STRING(20),
-	list_price DECIMAL(8,2),
-	min_price DECIMAL(8,2),
-	catalog_url STRING(50) UNIQUE,
-	date_added DATE DEFAULT current_date(),
-	misc JSONB,
-	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
-	INDEX date_added_idx (date_added),
-	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id
-		INT8
-		REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+			MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk
@@ -1951,7 +1938,8 @@ CREATE TABLE product_information (
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
 	customer_id
 		INT8
-		REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+		REFERENCES customers_2 (id)
+			MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk
@@ -1985,40 +1973,8 @@ CREATE TABLE product_information (
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
 	customer_id
 		INT8
-		REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
-	INVERTED INDEX details (misc),
-	CONSTRAINT price_check CHECK (list_price >= min_price),
-	CONSTRAINT supplied_id_fk
-		FOREIGN KEY (supplier_id)
-		REFERENCES suppliers (id)
-		ON UPDATE CASCADE,
-	FOREIGN KEY (category_id) REFERENCES categories (id)
-)
-	
-
-77:
------------------------------------------------------------------------------
-CREATE TABLE product_information (
-	product_id INT8 NOT NULL PRIMARY KEY,
-	product_name STRING(50) NOT NULL UNIQUE,
-	product_description STRING(2000),
-	category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')),
-	weight_class INT8,
-	warranty_period
-		INT8
-		CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24),
-	supplier_id INT8,
-	product_status STRING(20),
-	list_price DECIMAL(8,2),
-	min_price DECIMAL(8,2),
-	catalog_url STRING(50) UNIQUE,
-	date_added DATE DEFAULT current_date(),
-	misc JSONB,
-	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
-	INDEX date_added_idx (date_added),
-	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id
-		INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+		REFERENCES customers_2 (id)
+			MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk
@@ -2051,7 +2007,9 @@ CREATE TABLE product_information (
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
 	customer_id
-		INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+		INT8
+		REFERENCES customers_2 (id)
+			MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk
@@ -2081,7 +2039,9 @@ CREATE TABLE product_information (
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
 	customer_id
-		INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+		INT8
+		REFERENCES customers_2 (id)
+			MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk
@@ -2090,8 +2050,8 @@ CREATE TABLE product_information (
 )
 	
 
-85:
--------------------------------------------------------------------------------------
+83:
+-----------------------------------------------------------------------------------
 CREATE TABLE product_information (
 	product_id INT8 NOT NULL PRIMARY KEY,
 	product_name STRING(50) NOT NULL UNIQUE,
@@ -2110,7 +2070,39 @@ CREATE TABLE product_information (
 	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	customer_id
+		INT8
+		REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
+	INVERTED INDEX details (misc),
+	CONSTRAINT price_check CHECK (list_price >= min_price),
+	CONSTRAINT supplied_id_fk
+		FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE,
+	FOREIGN KEY (category_id) REFERENCES categories (id)
+)
+	
+
+88:
+----------------------------------------------------------------------------------------
+CREATE TABLE product_information (
+	product_id INT8 NOT NULL PRIMARY KEY,
+	product_name STRING(50) NOT NULL UNIQUE,
+	product_description STRING(2000),
+	category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')),
+	weight_class INT8,
+	warranty_period
+		INT8 CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24),
+	supplier_id INT8,
+	product_status STRING(20),
+	list_price DECIMAL(8,2),
+	min_price DECIMAL(8,2),
+	catalog_url STRING(50) UNIQUE,
+	date_added DATE DEFAULT current_date(),
+	misc JSONB,
+	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
+	INDEX date_added_idx (date_added),
+	INDEX supp_id_prod_status_idx (supplier_id, product_status),
+	customer_id
+		INT8 REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk
@@ -2138,7 +2130,36 @@ CREATE TABLE product_information (
 	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	customer_id
+		INT8 REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
+	INVERTED INDEX details (misc),
+	CONSTRAINT price_check CHECK (list_price >= min_price),
+	CONSTRAINT supplied_id_fk
+		FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE,
+	FOREIGN KEY (category_id) REFERENCES categories (id)
+)
+	
+
+96:
+------------------------------------------------------------------------------------------------
+CREATE TABLE product_information (
+	product_id INT8 NOT NULL PRIMARY KEY,
+	product_name STRING(50) NOT NULL UNIQUE,
+	product_description STRING(2000),
+	category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')),
+	weight_class INT8,
+	warranty_period INT8 CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24),
+	supplier_id INT8,
+	product_status STRING(20),
+	list_price DECIMAL(8,2),
+	min_price DECIMAL(8,2),
+	catalog_url STRING(50) UNIQUE,
+	date_added DATE DEFAULT current_date(),
+	misc JSONB,
+	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
+	INDEX date_added_idx (date_added),
+	INDEX supp_id_prod_status_idx (supplier_id, product_status),
+	customer_id INT8 REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk
@@ -2166,7 +2187,7 @@ CREATE TABLE product_information (
 	full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
 	INDEX date_added_idx (date_added),
 	INDEX supp_id_prod_status_idx (supplier_id, product_status),
-	customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	customer_id INT8 REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check CHECK (list_price >= min_price),
 	CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE,
@@ -2174,13 +2195,13 @@ CREATE TABLE product_information (
 )
 	
 
-983:
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-CREATE TABLE product_information (product_id INT8 NOT NULL PRIMARY KEY, product_name STRING(50) NOT NULL UNIQUE, product_description STRING(2000), category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')), weight_class INT8, warranty_period INT8 CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24), supplier_id INT8, product_status STRING(20), list_price DECIMAL(8,2), min_price DECIMAL(8,2), catalog_url STRING(50) UNIQUE, date_added DATE DEFAULT current_date(), misc JSONB, full_name STRING AS (concat(first_name, ' ', last_name)) STORED, INDEX date_added_idx (date_added), INDEX supp_id_prod_status_idx (supplier_id, product_status), customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE, INVERTED INDEX details (misc), CONSTRAINT price_check CHECK (list_price >= min_price), CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE, FOREIGN KEY (category_id) REFERENCES categories (id))
+994:
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+CREATE TABLE product_information (product_id INT8 NOT NULL PRIMARY KEY, product_name STRING(50) NOT NULL UNIQUE, product_description STRING(2000), category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')), weight_class INT8, warranty_period INT8 CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24), supplier_id INT8, product_status STRING(20), list_price DECIMAL(8,2), min_price DECIMAL(8,2), catalog_url STRING(50) UNIQUE, date_added DATE DEFAULT current_date(), misc JSONB, full_name STRING AS (concat(first_name, ' ', last_name)) STORED, INDEX date_added_idx (date_added), INDEX supp_id_prod_status_idx (supplier_id, product_status), customer_id INT8 REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE, INVERTED INDEX details (misc), CONSTRAINT price_check CHECK (list_price >= min_price), CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE, FOREIGN KEY (category_id) REFERENCES categories (id))
 	
 
-984:
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-CREATE TABLE product_information (product_id INT8 NOT NULL PRIMARY KEY, product_name STRING(50) NOT NULL UNIQUE, product_description STRING(2000), category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')), weight_class INT8, warranty_period INT8 CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24), supplier_id INT8, product_status STRING(20), list_price DECIMAL(8,2), min_price DECIMAL(8,2), catalog_url STRING(50) UNIQUE, date_added DATE DEFAULT current_date(), misc JSONB, full_name STRING AS (concat(first_name, ' ', last_name)) STORED, INDEX date_added_idx (date_added), INDEX supp_id_prod_status_idx (supplier_id, product_status), customer_id INT8 REFERENCES customers_2 (id) ON DELETE CASCADE ON UPDATE CASCADE, INVERTED INDEX details (misc), CONSTRAINT price_check CHECK (list_price >= min_price), CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE, FOREIGN KEY (category_id) REFERENCES categories (id)) 
+995:
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+CREATE TABLE product_information (product_id INT8 NOT NULL PRIMARY KEY, product_name STRING(50) NOT NULL UNIQUE, product_description STRING(2000), category_id STRING(1) NOT NULL CHECK (category_id IN ('A', 'B', 'C')), weight_class INT8, warranty_period INT8 CONSTRAINT valid_warranty CHECK (warranty_period BETWEEN 0 AND 24), supplier_id INT8, product_status STRING(20), list_price DECIMAL(8,2), min_price DECIMAL(8,2), catalog_url STRING(50) UNIQUE, date_added DATE DEFAULT current_date(), misc JSONB, full_name STRING AS (concat(first_name, ' ', last_name)) STORED, INDEX date_added_idx (date_added), INDEX supp_id_prod_status_idx (supplier_id, product_status), customer_id INT8 REFERENCES customers_2 (id) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE, INVERTED INDEX details (misc), CONSTRAINT price_check CHECK (list_price >= min_price), CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id) REFERENCES suppliers (id) ON UPDATE CASCADE, FOREIGN KEY (category_id) REFERENCES categories (id)) 
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/create_table.ref.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/create_table.ref.golden.short
@@ -46,6 +46,7 @@ CREATE TABLE product_information (
 	customer_id
 		INT8
 		REFERENCES customers_2 (id)
+			MATCH FULL
 			ON DELETE CASCADE ON UPDATE CASCADE,
 	INVERTED INDEX details (misc),
 	CONSTRAINT price_check

--- a/pkg/sql/sem/tree/testdata/pretty/create_table.sql
+++ b/pkg/sql/sem/tree/testdata/pretty/create_table.sql
@@ -15,9 +15,9 @@ CREATE TABLE product_information (
     full_name STRING AS (concat(first_name, ' ', last_name)) STORED,
     INDEX date_added_idx (date_added),
     INDEX supp_id_prod_status_idx (supplier_id, product_status),
-    customer_id INT REFERENCES customers_2(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    customer_id INT REFERENCES customers_2(id) MATCH FULL ON UPDATE CASCADE ON DELETE CASCADE,
     INVERTED INDEX details (misc),
     CONSTRAINT price_check CHECK (list_price >= min_price),
     CONSTRAINT supplied_id_fk FOREIGN KEY (supplier_id) REFERENCES suppliers(id) ON UPDATE CASCADE,
-	FOREIGN KEY (category_id) REFERENCES categories(id)
+    FOREIGN KEY (category_id) REFERENCES categories(id)
 )

--- a/pkg/sql/sem/tree/testdata/pretty/create_view.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/create_view.align-deindent.golden
@@ -13,11 +13,9 @@ CREATE VIEW startrek.quotes_per_season (
 		)
 	FROM
 		startrek.quotes
-		JOIN
-			startrek.episodes
-		ON
-			startrek.quotes.episode
-			= startrek.episodes.id
+		JOIN startrek.episodes ON
+				startrek.quotes.episode
+				= startrek.episodes.id
 	GROUP BY
 		startrek.episodes.season
 
@@ -32,46 +30,9 @@ CREATE VIEW startrek.quotes_per_season (
 		count(*)
 	FROM
 		startrek.quotes
-		JOIN
-			startrek.episodes
-		ON
-			startrek.quotes.episode
-			= startrek.episodes.id
-	GROUP BY
-		startrek.episodes.season
-
-30:
-------------------------------
-CREATE VIEW startrek.quotes_per_season (
-	season,
-	quotes
-) AS
-	SELECT
-		startrek.episodes.season,
-		count(*)
-	FROM
-		startrek.quotes
-		JOIN startrek.episodes
-		ON
-			startrek.quotes.episode
-			= startrek.episodes.id
-	GROUP BY
-		startrek.episodes.season
-
-34:
-----------------------------------
-CREATE VIEW startrek.quotes_per_season (
-	season,
-	quotes
-) AS
-	SELECT
-		startrek.episodes.season,
-		count(*)
-	FROM
-		startrek.quotes
-		JOIN startrek.episodes
-		ON startrek.quotes.episode
-		   = startrek.episodes.id
+		JOIN startrek.episodes ON
+				startrek.quotes.episode
+				= startrek.episodes.id
 	GROUP BY
 		startrek.episodes.season
 
@@ -84,24 +45,9 @@ CREATE VIEW startrek.quotes_per_season (
 	  SELECT startrek.episodes.season,
 	         count(*)
 	    FROM startrek.quotes
-	         JOIN startrek.episodes
-	         ON
+	    JOIN startrek.episodes ON
 				startrek.quotes.episode
 				= startrek.episodes.id
-	GROUP BY startrek.episodes.season
-
-39:
----------------------------------------
-CREATE VIEW startrek.quotes_per_season (
-	season,
-	quotes
-) AS
-	  SELECT startrek.episodes.season,
-	         count(*)
-	    FROM startrek.quotes
-	         JOIN startrek.episodes
-	         ON startrek.quotes.episode
-	            = startrek.episodes.id
 	GROUP BY startrek.episodes.season
 
 40:
@@ -112,9 +58,9 @@ CREATE VIEW startrek.quotes_per_season (
 ) AS   SELECT startrek.episodes.season,
               count(*)
          FROM startrek.quotes
-              JOIN startrek.episodes
-              ON startrek.quotes.episode
-                 = startrek.episodes.id
+         JOIN startrek.episodes ON
+				startrek.quotes.episode
+				= startrek.episodes.id
      GROUP BY startrek.episodes.season
 
 48:
@@ -124,20 +70,20 @@ CREATE VIEW startrek.quotes_per_season (
 	quotes
 ) AS   SELECT startrek.episodes.season, count(*)
          FROM startrek.quotes
-              JOIN startrek.episodes
-              ON startrek.quotes.episode
-                 = startrek.episodes.id
+         JOIN startrek.episodes ON
+				startrek.quotes.episode
+				= startrek.episodes.id
      GROUP BY startrek.episodes.season
 
-63:
----------------------------------------------------------------
+58:
+----------------------------------------------------------
 CREATE VIEW startrek.quotes_per_season (
 	season,
 	quotes
 ) AS   SELECT startrek.episodes.season, count(*)
          FROM startrek.quotes
-              JOIN startrek.episodes
-              ON startrek.quotes.episode = startrek.episodes.id
+         JOIN startrek.episodes ON startrek.quotes.episode
+                                   = startrek.episodes.id
      GROUP BY startrek.episodes.season
 
 65:
@@ -149,11 +95,9 @@ CREATE VIEW startrek.quotes_per_season (season, quotes) AS SELECT
 															)
                                                            FROM
 															startrek.quotes
-															JOIN
-																startrek.episodes
-															ON
-																startrek.quotes.episode
-																= startrek.episodes.id
+															JOIN startrek.episodes ON
+																	startrek.quotes.episode
+																	= startrek.episodes.id
                                                            GROUP BY
 															startrek.episodes.season
 
@@ -164,38 +108,9 @@ CREATE VIEW startrek.quotes_per_season (season, quotes) AS SELECT
 															count(*)
                                                            FROM
 															startrek.quotes
-															JOIN
-																startrek.episodes
-															ON
-																startrek.quotes.episode
-																= startrek.episodes.id
-                                                           GROUP BY
-															startrek.episodes.season
-
-82:
-----------------------------------------------------------------------------------
-CREATE VIEW startrek.quotes_per_season (season, quotes) AS SELECT
-															startrek.episodes.season,
-															count(*)
-                                                           FROM
-															startrek.quotes
-															JOIN startrek.episodes
-															ON
-																startrek.quotes.episode
-																= startrek.episodes.id
-                                                           GROUP BY
-															startrek.episodes.season
-
-86:
---------------------------------------------------------------------------------------
-CREATE VIEW startrek.quotes_per_season (season, quotes) AS SELECT
-															startrek.episodes.season,
-															count(*)
-                                                           FROM
-															startrek.quotes
-															JOIN startrek.episodes
-															ON startrek.quotes.episode
-															   = startrek.episodes.id
+															JOIN startrek.episodes ON
+																	startrek.quotes.episode
+																	= startrek.episodes.id
                                                            GROUP BY
 															startrek.episodes.season
 
@@ -204,44 +119,33 @@ CREATE VIEW startrek.quotes_per_season (season, quotes) AS SELECT
 CREATE VIEW startrek.quotes_per_season (season, quotes) AS   SELECT startrek.episodes.season,
                                                                     count(*)
                                                                FROM startrek.quotes
-                                                                    JOIN startrek.episodes
-                                                                    ON
+                                                               JOIN startrek.episodes ON
 																		startrek.quotes.episode
 																		= startrek.episodes.id
-                                                           GROUP BY startrek.episodes.season
-
-94:
-----------------------------------------------------------------------------------------------
-CREATE VIEW startrek.quotes_per_season (season, quotes) AS   SELECT startrek.episodes.season,
-                                                                    count(*)
-                                                               FROM startrek.quotes
-                                                                    JOIN startrek.episodes
-                                                                    ON startrek.quotes.episode
-                                                                       = startrek.episodes.id
                                                            GROUP BY startrek.episodes.season
 
 102:
 ------------------------------------------------------------------------------------------------------
 CREATE VIEW startrek.quotes_per_season (season, quotes) AS   SELECT startrek.episodes.season, count(*)
                                                                FROM startrek.quotes
-                                                                    JOIN startrek.episodes
-                                                                    ON startrek.quotes.episode
-                                                                       = startrek.episodes.id
+                                                               JOIN startrek.episodes ON
+																		startrek.quotes.episode
+																		= startrek.episodes.id
                                                            GROUP BY startrek.episodes.season
 
-117:
----------------------------------------------------------------------------------------------------------------------
+112:
+----------------------------------------------------------------------------------------------------------------
 CREATE VIEW startrek.quotes_per_season (season, quotes) AS   SELECT startrek.episodes.season, count(*)
                                                                FROM startrek.quotes
-                                                                    JOIN startrek.episodes
-                                                                    ON startrek.quotes.episode = startrek.episodes.id
+                                                               JOIN startrek.episodes ON startrek.quotes.episode
+                                                                                         = startrek.episodes.id
                                                            GROUP BY startrek.episodes.season
 
-140:
---------------------------------------------------------------------------------------------------------------------------------------------
+135:
+---------------------------------------------------------------------------------------------------------------------------------------
 CREATE VIEW startrek.quotes_per_season (season, quotes) AS   SELECT startrek.episodes.season, count(*)
                                                                FROM startrek.quotes
-                                                                    JOIN startrek.episodes ON startrek.quotes.episode = startrek.episodes.id
+                                                               JOIN startrek.episodes ON startrek.quotes.episode = startrek.episodes.id
                                                            GROUP BY startrek.episodes.season
 
 156:

--- a/pkg/sql/sem/tree/testdata/pretty/create_view.align-deindent.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/create_view.align-deindent.golden.short
@@ -8,9 +8,9 @@ CREATE VIEW startrek.quotes_per_season (
 ) AS   SELECT startrek.episodes.season,
               count(*)
          FROM startrek.quotes
-              JOIN startrek.episodes
-              ON startrek.quotes.episode
-                 = startrek.episodes.id
+         JOIN startrek.episodes ON
+				startrek.quotes.episode
+				= startrek.episodes.id
      GROUP BY startrek.episodes.season
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/create_view.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/create_view.align-only.golden
@@ -13,11 +13,9 @@ CREATE VIEW startrek.quotes_per_season (
 		)
 	FROM
 		startrek.quotes
-		JOIN
-			startrek.episodes
-		ON
-			startrek.quotes.episode
-			= startrek.episodes.id
+		JOIN startrek.episodes ON
+				startrek.quotes.episode
+				= startrek.episodes.id
 	GROUP BY
 		startrek.episodes.season
 
@@ -32,46 +30,9 @@ CREATE VIEW startrek.quotes_per_season (
 		count(*)
 	FROM
 		startrek.quotes
-		JOIN
-			startrek.episodes
-		ON
-			startrek.quotes.episode
-			= startrek.episodes.id
-	GROUP BY
-		startrek.episodes.season
-
-30:
-------------------------------
-CREATE VIEW startrek.quotes_per_season (
-	season,
-	quotes
-) AS
-	SELECT
-		startrek.episodes.season,
-		count(*)
-	FROM
-		startrek.quotes
-		JOIN startrek.episodes
-		ON
-			startrek.quotes.episode
-			= startrek.episodes.id
-	GROUP BY
-		startrek.episodes.season
-
-34:
-----------------------------------
-CREATE VIEW startrek.quotes_per_season (
-	season,
-	quotes
-) AS
-	SELECT
-		startrek.episodes.season,
-		count(*)
-	FROM
-		startrek.quotes
-		JOIN startrek.episodes
-		ON startrek.quotes.episode
-		   = startrek.episodes.id
+		JOIN startrek.episodes ON
+				startrek.quotes.episode
+				= startrek.episodes.id
 	GROUP BY
 		startrek.episodes.season
 
@@ -84,24 +45,9 @@ CREATE VIEW startrek.quotes_per_season (
 	  SELECT startrek.episodes.season,
 	         count(*)
 	    FROM startrek.quotes
-	         JOIN startrek.episodes
-	         ON
-				startrek.quotes.episode
-				= startrek.episodes.id
-	GROUP BY startrek.episodes.season
-
-39:
----------------------------------------
-CREATE VIEW startrek.quotes_per_season (
-	season,
-	quotes
-) AS
-	  SELECT startrek.episodes.season,
-	         count(*)
-	    FROM startrek.quotes
-	         JOIN startrek.episodes
-	         ON startrek.quotes.episode
-	            = startrek.episodes.id
+	         JOIN startrek.episodes ON
+					startrek.quotes.episode
+					= startrek.episodes.id
 	GROUP BY startrek.episodes.season
 
 40:
@@ -112,9 +58,9 @@ CREATE VIEW startrek.quotes_per_season (
 ) AS   SELECT startrek.episodes.season,
               count(*)
          FROM startrek.quotes
-              JOIN startrek.episodes
-              ON startrek.quotes.episode
-                 = startrek.episodes.id
+              JOIN startrek.episodes ON
+					startrek.quotes.episode
+					= startrek.episodes.id
      GROUP BY startrek.episodes.season
 
 48:
@@ -124,9 +70,9 @@ CREATE VIEW startrek.quotes_per_season (
 	quotes
 ) AS   SELECT startrek.episodes.season, count(*)
          FROM startrek.quotes
-              JOIN startrek.episodes
-              ON startrek.quotes.episode
-                 = startrek.episodes.id
+              JOIN startrek.episodes ON
+					startrek.quotes.episode
+					= startrek.episodes.id
      GROUP BY startrek.episodes.season
 
 63:
@@ -136,8 +82,8 @@ CREATE VIEW startrek.quotes_per_season (
 	quotes
 ) AS   SELECT startrek.episodes.season, count(*)
          FROM startrek.quotes
-              JOIN startrek.episodes
-              ON startrek.quotes.episode = startrek.episodes.id
+              JOIN startrek.episodes ON startrek.quotes.episode
+				                                        = startrek.episodes.id
      GROUP BY startrek.episodes.season
 
 65:
@@ -149,11 +95,9 @@ CREATE VIEW startrek.quotes_per_season (season, quotes) AS SELECT
 															)
                                                            FROM
 															startrek.quotes
-															JOIN
-																startrek.episodes
-															ON
-																startrek.quotes.episode
-																= startrek.episodes.id
+															JOIN startrek.episodes ON
+																	startrek.quotes.episode
+																	= startrek.episodes.id
                                                            GROUP BY
 															startrek.episodes.season
 
@@ -164,38 +108,9 @@ CREATE VIEW startrek.quotes_per_season (season, quotes) AS SELECT
 															count(*)
                                                            FROM
 															startrek.quotes
-															JOIN
-																startrek.episodes
-															ON
-																startrek.quotes.episode
-																= startrek.episodes.id
-                                                           GROUP BY
-															startrek.episodes.season
-
-82:
-----------------------------------------------------------------------------------
-CREATE VIEW startrek.quotes_per_season (season, quotes) AS SELECT
-															startrek.episodes.season,
-															count(*)
-                                                           FROM
-															startrek.quotes
-															JOIN startrek.episodes
-															ON
-																startrek.quotes.episode
-																= startrek.episodes.id
-                                                           GROUP BY
-															startrek.episodes.season
-
-86:
---------------------------------------------------------------------------------------
-CREATE VIEW startrek.quotes_per_season (season, quotes) AS SELECT
-															startrek.episodes.season,
-															count(*)
-                                                           FROM
-															startrek.quotes
-															JOIN startrek.episodes
-															ON startrek.quotes.episode
-															   = startrek.episodes.id
+															JOIN startrek.episodes ON
+																	startrek.quotes.episode
+																	= startrek.episodes.id
                                                            GROUP BY
 															startrek.episodes.season
 
@@ -204,37 +119,26 @@ CREATE VIEW startrek.quotes_per_season (season, quotes) AS SELECT
 CREATE VIEW startrek.quotes_per_season (season, quotes) AS   SELECT startrek.episodes.season,
                                                                     count(*)
                                                                FROM startrek.quotes
-                                                                    JOIN startrek.episodes
-                                                                    ON
-																		startrek.quotes.episode
-																		= startrek.episodes.id
-                                                           GROUP BY startrek.episodes.season
-
-94:
-----------------------------------------------------------------------------------------------
-CREATE VIEW startrek.quotes_per_season (season, quotes) AS   SELECT startrek.episodes.season,
-                                                                    count(*)
-                                                               FROM startrek.quotes
-                                                                    JOIN startrek.episodes
-                                                                    ON startrek.quotes.episode
-                                                                       = startrek.episodes.id
+                                                                    JOIN startrek.episodes ON
+																			startrek.quotes.episode
+																			= startrek.episodes.id
                                                            GROUP BY startrek.episodes.season
 
 102:
 ------------------------------------------------------------------------------------------------------
 CREATE VIEW startrek.quotes_per_season (season, quotes) AS   SELECT startrek.episodes.season, count(*)
                                                                FROM startrek.quotes
-                                                                    JOIN startrek.episodes
-                                                                    ON startrek.quotes.episode
-                                                                       = startrek.episodes.id
+                                                                    JOIN startrek.episodes ON
+																			startrek.quotes.episode
+																			= startrek.episodes.id
                                                            GROUP BY startrek.episodes.season
 
 117:
 ---------------------------------------------------------------------------------------------------------------------
 CREATE VIEW startrek.quotes_per_season (season, quotes) AS   SELECT startrek.episodes.season, count(*)
                                                                FROM startrek.quotes
-                                                                    JOIN startrek.episodes
-                                                                    ON startrek.quotes.episode = startrek.episodes.id
+                                                                    JOIN startrek.episodes ON startrek.quotes.episode
+																		                                                                                              = startrek.episodes.id
                                                            GROUP BY startrek.episodes.season
 
 140:

--- a/pkg/sql/sem/tree/testdata/pretty/create_view.align-only.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/create_view.align-only.golden.short
@@ -8,9 +8,9 @@ CREATE VIEW startrek.quotes_per_season (
 ) AS   SELECT startrek.episodes.season,
               count(*)
          FROM startrek.quotes
-              JOIN startrek.episodes
-              ON startrek.quotes.episode
-                 = startrek.episodes.id
+              JOIN startrek.episodes ON
+					startrek.quotes.episode
+					= startrek.episodes.id
      GROUP BY startrek.episodes.season
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/create_view.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/create_view.ref.golden
@@ -13,11 +13,9 @@ CREATE VIEW startrek.quotes_per_season (
 		)
 	FROM
 		startrek.quotes
-		JOIN
-			startrek.episodes
-		ON
-			startrek.quotes.episode
-			= startrek.episodes.id
+		JOIN startrek.episodes ON
+				startrek.quotes.episode
+				= startrek.episodes.id
 	GROUP BY
 		startrek.episodes.season
 
@@ -32,29 +30,9 @@ CREATE VIEW startrek.quotes_per_season (
 		count(*)
 	FROM
 		startrek.quotes
-		JOIN
-			startrek.episodes
-		ON
-			startrek.quotes.episode
-			= startrek.episodes.id
-	GROUP BY
-		startrek.episodes.season
-
-30:
-------------------------------
-CREATE VIEW startrek.quotes_per_season (
-	season,
-	quotes
-) AS
-	SELECT
-		startrek.episodes.season,
-		count(*)
-	FROM
-		startrek.quotes
-		JOIN startrek.episodes
-		ON
-			startrek.quotes.episode
-			= startrek.episodes.id
+		JOIN startrek.episodes ON
+				startrek.quotes.episode
+				= startrek.episodes.id
 	GROUP BY
 		startrek.episodes.season
 
@@ -68,25 +46,9 @@ CREATE VIEW startrek.quotes_per_season (
 		startrek.episodes.season, count(*)
 	FROM
 		startrek.quotes
-		JOIN startrek.episodes
-		ON
-			startrek.quotes.episode
-			= startrek.episodes.id
-	GROUP BY
-		startrek.episodes.season
-
-57:
----------------------------------------------------------
-CREATE VIEW startrek.quotes_per_season (
-	season,
-	quotes
-) AS
-	SELECT
-		startrek.episodes.season, count(*)
-	FROM
-		startrek.quotes
-		JOIN startrek.episodes
-		ON startrek.quotes.episode = startrek.episodes.id
+		JOIN startrek.episodes ON
+				startrek.quotes.episode
+				= startrek.episodes.id
 	GROUP BY
 		startrek.episodes.season
 
@@ -97,8 +59,21 @@ CREATE VIEW startrek.quotes_per_season (season, quotes) AS
 		startrek.episodes.season, count(*)
 	FROM
 		startrek.quotes
-		JOIN startrek.episodes
-		ON startrek.quotes.episode = startrek.episodes.id
+		JOIN startrek.episodes ON
+				startrek.quotes.episode
+				= startrek.episodes.id
+	GROUP BY
+		startrek.episodes.season
+
+62:
+--------------------------------------------------------------
+CREATE VIEW startrek.quotes_per_season (season, quotes) AS
+	SELECT
+		startrek.episodes.season, count(*)
+	FROM
+		startrek.quotes
+		JOIN startrek.episodes ON
+				startrek.quotes.episode = startrek.episodes.id
 	GROUP BY
 		startrek.episodes.season
 

--- a/pkg/sql/sem/tree/testdata/pretty/create_view.ref.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/create_view.ref.golden.short
@@ -11,10 +11,9 @@ CREATE VIEW startrek.quotes_per_season (
 		count(*)
 	FROM
 		startrek.quotes
-		JOIN startrek.episodes
-		ON
-			startrek.quotes.episode
-			= startrek.episodes.id
+		JOIN startrek.episodes ON
+				startrek.quotes.episode
+				= startrek.episodes.id
 	GROUP BY
 		startrek.episodes.season
 

--- a/pkg/sql/sem/tree/testdata/pretty/explain.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/explain.align-deindent.golden
@@ -15,9 +15,7 @@ FROM
 			FROM
 				kv
 					AS a
-				JOIN
-					kv
-				USING (k)
+				JOIN kv USING (k)
 			WHERE
 				a.v
 				> 3
@@ -39,9 +37,7 @@ SELECT "Level",
 			FROM
 				kv
 					AS a
-				JOIN
-					kv
-				USING (k)
+				JOIN kv USING (k)
 			WHERE
 				a.v
 				> 3
@@ -62,9 +58,7 @@ SELECT "Level",
 		  FROM
 			kv
 				AS a
-			JOIN
-				kv
-			USING (k)
+			JOIN kv USING (k)
 		  WHERE
 			a.v
 			> 3
@@ -84,8 +78,7 @@ SELECT "Level",
 			*
 		  FROM
 			kv AS a
-			JOIN kv
-			USING (k)
+			JOIN kv USING (k)
 		  WHERE
 			a.v > 3
 		  ORDER BY
@@ -103,9 +96,7 @@ SELECT "Level",
 		)   SELECT *
 		      FROM kv
 					AS a
-		           JOIN
-					kv
-		           USING (k)
+		      JOIN kv USING (k)
 		     WHERE a.v
 		           > 3
 		  ORDER BY a.v
@@ -121,9 +112,7 @@ SELECT "Level", "Type"
 		)   SELECT *
 		      FROM kv
 					AS a
-		           JOIN
-					kv
-		           USING (k)
+		      JOIN kv USING (k)
 		     WHERE a.v
 		           > 3
 		  ORDER BY a.v
@@ -138,8 +127,7 @@ SELECT "Level", "Type"
 			VERBOSE
 		)   SELECT *
 		      FROM kv AS a
-		           JOIN kv
-		           USING (k)
+		      JOIN kv USING (k)
 		     WHERE a.v > 3
 		  ORDER BY a.v
 					DESC
@@ -153,8 +141,7 @@ SELECT "Level", "Type"
 			VERBOSE
 		)   SELECT *
 		      FROM kv AS a
-		           JOIN kv
-		           USING (k)
+		      JOIN kv USING (k)
 		     WHERE a.v > 3
 		  ORDER BY a.v DESC
        ]
@@ -168,9 +155,7 @@ SELECT "Level", "Type"
 		                  FROM
 							kv
 								AS a
-							JOIN
-								kv
-							USING (k)
+							JOIN kv USING (k)
 		                  WHERE
 							a.v
 							> 3
@@ -187,8 +172,7 @@ SELECT "Level", "Type"
 							*
 		                  FROM
 							kv AS a
-							JOIN kv
-							USING (k)
+							JOIN kv USING (k)
 		                  WHERE
 							a.v > 3
 		                  ORDER BY
@@ -203,9 +187,7 @@ SELECT "Level", "Type"
 		EXPLAIN (VERBOSE)   SELECT *
 		                      FROM kv
 									AS a
-		                           JOIN
-									kv
-		                           USING (k)
+		                      JOIN kv USING (k)
 		                     WHERE a.v
 		                           > 3
 		                  ORDER BY a.v
@@ -218,8 +200,7 @@ SELECT "Level", "Type"
   FROM [
 		EXPLAIN (VERBOSE)   SELECT *
 		                      FROM kv AS a
-		                           JOIN kv
-		                           USING (k)
+		                      JOIN kv USING (k)
 		                     WHERE a.v > 3
 		                  ORDER BY a.v
 									DESC
@@ -231,19 +212,7 @@ SELECT "Level", "Type"
   FROM [
 		EXPLAIN (VERBOSE)   SELECT *
 		                      FROM kv AS a
-		                           JOIN kv
-		                           USING (k)
-		                     WHERE a.v > 3
-		                  ORDER BY a.v DESC
-       ]
-
-52:
-----------------------------------------------------
-SELECT "Level", "Type"
-  FROM [
-		EXPLAIN (VERBOSE)   SELECT *
-		                      FROM kv AS a
-		                           JOIN kv USING (k)
+		                      JOIN kv USING (k)
 		                     WHERE a.v > 3
 		                  ORDER BY a.v DESC
        ]

--- a/pkg/sql/sem/tree/testdata/pretty/explain.align-deindent.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/explain.align-deindent.golden.short
@@ -7,9 +7,7 @@ SELECT "Level", "Type"
 		EXPLAIN (VERBOSE)   SELECT *
 		                      FROM kv
 									AS a
-		                           JOIN
-									kv
-		                           USING (k)
+		                      JOIN kv USING (k)
 		                     WHERE a.v
 		                           > 3
 		                  ORDER BY a.v

--- a/pkg/sql/sem/tree/testdata/pretty/explain.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/explain.align-only.golden
@@ -15,9 +15,7 @@ FROM
 			FROM
 				kv
 					AS a
-				JOIN
-					kv
-				USING (k)
+				JOIN kv USING (k)
 			WHERE
 				a.v
 				> 3
@@ -39,9 +37,7 @@ SELECT "Level",
 			FROM
 				kv
 					AS a
-				JOIN
-					kv
-				USING (k)
+				JOIN kv USING (k)
 			WHERE
 				a.v
 				> 3
@@ -62,9 +58,7 @@ SELECT "Level",
 		  FROM
 			kv
 				AS a
-			JOIN
-				kv
-			USING (k)
+			JOIN kv USING (k)
 		  WHERE
 			a.v
 			> 3
@@ -84,8 +78,7 @@ SELECT "Level",
 			*
 		  FROM
 			kv AS a
-			JOIN kv
-			USING (k)
+			JOIN kv USING (k)
 		  WHERE
 			a.v > 3
 		  ORDER BY
@@ -103,9 +96,7 @@ SELECT "Level",
 		)   SELECT *
 		      FROM kv
 					AS a
-		           JOIN
-					kv
-		           USING (k)
+		           JOIN kv USING (k)
 		     WHERE a.v
 		           > 3
 		  ORDER BY a.v
@@ -121,9 +112,7 @@ SELECT "Level", "Type"
 		)   SELECT *
 		      FROM kv
 					AS a
-		           JOIN
-					kv
-		           USING (k)
+		           JOIN kv USING (k)
 		     WHERE a.v
 		           > 3
 		  ORDER BY a.v
@@ -138,8 +127,7 @@ SELECT "Level", "Type"
 			VERBOSE
 		)   SELECT *
 		      FROM kv AS a
-		           JOIN kv
-		           USING (k)
+		           JOIN kv USING (k)
 		     WHERE a.v > 3
 		  ORDER BY a.v
 					DESC
@@ -153,8 +141,7 @@ SELECT "Level", "Type"
 			VERBOSE
 		)   SELECT *
 		      FROM kv AS a
-		           JOIN kv
-		           USING (k)
+		           JOIN kv USING (k)
 		     WHERE a.v > 3
 		  ORDER BY a.v DESC
        ]
@@ -168,9 +155,7 @@ SELECT "Level", "Type"
 		                  FROM
 							kv
 								AS a
-							JOIN
-								kv
-							USING (k)
+							JOIN kv USING (k)
 		                  WHERE
 							a.v
 							> 3
@@ -187,8 +172,7 @@ SELECT "Level", "Type"
 							*
 		                  FROM
 							kv AS a
-							JOIN kv
-							USING (k)
+							JOIN kv USING (k)
 		                  WHERE
 							a.v > 3
 		                  ORDER BY
@@ -203,9 +187,7 @@ SELECT "Level", "Type"
 		EXPLAIN (VERBOSE)   SELECT *
 		                      FROM kv
 									AS a
-		                           JOIN
-									kv
-		                           USING (k)
+		                           JOIN kv USING (k)
 		                     WHERE a.v
 		                           > 3
 		                  ORDER BY a.v
@@ -218,8 +200,7 @@ SELECT "Level", "Type"
   FROM [
 		EXPLAIN (VERBOSE)   SELECT *
 		                      FROM kv AS a
-		                           JOIN kv
-		                           USING (k)
+		                           JOIN kv USING (k)
 		                     WHERE a.v > 3
 		                  ORDER BY a.v
 									DESC
@@ -227,18 +208,6 @@ SELECT "Level", "Type"
 
 43:
 -------------------------------------------
-SELECT "Level", "Type"
-  FROM [
-		EXPLAIN (VERBOSE)   SELECT *
-		                      FROM kv AS a
-		                           JOIN kv
-		                           USING (k)
-		                     WHERE a.v > 3
-		                  ORDER BY a.v DESC
-       ]
-
-52:
-----------------------------------------------------
 SELECT "Level", "Type"
   FROM [
 		EXPLAIN (VERBOSE)   SELECT *

--- a/pkg/sql/sem/tree/testdata/pretty/explain.align-only.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/explain.align-only.golden.short
@@ -7,9 +7,7 @@ SELECT "Level", "Type"
 		EXPLAIN (VERBOSE)   SELECT *
 		                      FROM kv
 									AS a
-		                           JOIN
-									kv
-		                           USING (k)
+		                           JOIN kv USING (k)
 		                     WHERE a.v
 		                           > 3
 		                  ORDER BY a.v

--- a/pkg/sql/sem/tree/testdata/pretty/explain.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/explain.ref.golden
@@ -15,9 +15,7 @@ FROM
 			FROM
 				kv
 					AS a
-				JOIN
-					kv
-				USING (k)
+				JOIN kv USING (k)
 			WHERE
 				a.v
 				> 3
@@ -40,9 +38,7 @@ FROM
 			FROM
 				kv
 					AS a
-				JOIN
-					kv
-				USING (k)
+				JOIN kv USING (k)
 			WHERE
 				a.v
 				> 3
@@ -64,8 +60,7 @@ FROM
 				*
 			FROM
 				kv AS a
-				JOIN kv
-				USING (k)
+				JOIN kv USING (k)
 			WHERE
 				a.v > 3
 			ORDER BY
@@ -86,8 +81,7 @@ FROM
 				*
 			FROM
 				kv AS a
-				JOIN kv
-				USING (k)
+				JOIN kv USING (k)
 			WHERE
 				a.v > 3
 			ORDER BY
@@ -96,25 +90,6 @@ FROM
 
 25:
 -------------------------
-SELECT
-	"Level", "Type"
-FROM
-	[
-		EXPLAIN (VERBOSE)
-			SELECT
-				*
-			FROM
-				kv AS a
-				JOIN kv
-				USING (k)
-			WHERE
-				a.v > 3
-			ORDER BY
-				a.v DESC
-	]
-
-33:
----------------------------------
 SELECT
 	"Level", "Type"
 FROM

--- a/pkg/sql/sem/tree/testdata/pretty/join2.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/join2.align-deindent.golden
@@ -18,20 +18,15 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON
-		ct.oid
-		= a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid
+			= a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -44,83 +39,15 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum
-		= (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-WHERE
-	true
-	AND ct.relname
-		= 'j'
-	AND i.indisprimary
-ORDER BY
-	table_name,
-	pk_name,
-	key_seq
-
-9:
----------
-SELECT
-	NULL
-		AS table_cat,
-	n.nspname
-		AS table_schem,
-	ct.relname
-		AS table_name,
-	a.attname
-		AS column_name,
-	(i.keys).n
-		AS key_seq,
-	ci.relname
-		AS pk_name
-FROM
-	pg_catalog.pg_class
-		AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON
-		ct.oid
-		= a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
-			SELECT
-				i.indexrelid,
-				i.indrelid,
-				i.indisprimary,
-				information_schema._pg_expandarray(
-					i.indkey
-				)
-					AS keys
-			FROM
-				pg_catalog.pg_index
-					AS i
-		) AS i
-	ON
-		a.attnum
-		= (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
+			AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
 WHERE
 	true
 	AND ct.relname
@@ -149,18 +76,14 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON
-		ct.oid
-		= a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid
+			= a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
 	JOIN (
 			SELECT
 				i.indexrelid,
@@ -173,18 +96,15 @@ FROM
 			FROM
 				pg_catalog.pg_index
 					AS i
-	     ) AS i
-	ON
-		a.attnum
-		= (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
+		) AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
 WHERE
 	true
 	AND ct.relname
@@ -211,218 +131,35 @@ ORDER BY
 			AS pk_name
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON
+    JOIN pg_catalog.pg_attribute
+			AS a ON
 			ct.oid
 			= a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
+    JOIN pg_catalog.pg_namespace
+			AS n ON
 			ct.relnamespace
 			= n.oid
-         JOIN
-			(
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-			) AS i
-         ON
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indisprimary,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON
 			a.attnum
 			= (i.keys).x
 			AND a.attrelid
 				= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON
+    JOIN pg_catalog.pg_class
+			AS ci ON
 			ci.oid
 			= i.indexrelid
-   WHERE true
-     AND ct.relname
-         = 'j'
-     AND i.indisprimary
-ORDER BY table_name,
-         pk_name,
-         key_seq
-
-15:
----------------
-  SELECT NULL
-			AS table_cat,
-         n.nspname
-			AS table_schem,
-         ct.relname
-			AS table_name,
-         a.attname
-			AS column_name,
-         (i.keys).n
-			AS key_seq,
-         ci.relname
-			AS pk_name
-    FROM pg_catalog.pg_class
-			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON
-			ct.oid
-			= a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON
-			a.attnum
-			= (i.keys).x
-			AND a.attrelid
-				= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON
-			ci.oid
-			= i.indexrelid
-   WHERE true
-     AND ct.relname
-         = 'j'
-     AND i.indisprimary
-ORDER BY table_name,
-         pk_name,
-         key_seq
-
-18:
-------------------
-  SELECT NULL
-			AS table_cat,
-         n.nspname
-			AS table_schem,
-         ct.relname
-			AS table_name,
-         a.attname
-			AS column_name,
-         (i.keys).n
-			AS key_seq,
-         ci.relname
-			AS pk_name
-    FROM pg_catalog.pg_class
-			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid
-            = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON
-			a.attnum
-			= (i.keys).x
-			AND a.attrelid
-				= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-   WHERE true
-     AND ct.relname
-         = 'j'
-     AND i.indisprimary
-ORDER BY table_name,
-         pk_name,
-         key_seq
-
-20:
---------------------
-  SELECT NULL
-			AS table_cat,
-         n.nspname
-			AS table_schem,
-         ct.relname
-			AS table_name,
-         a.attname
-			AS column_name,
-         (i.keys).n
-			AS key_seq,
-         ci.relname
-			AS pk_name
-    FROM pg_catalog.pg_class
-			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid
-            = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum
-            = (i.keys).x
-        AND a.attrelid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
    WHERE true
      AND ct.relname
          = 'j'
@@ -447,39 +184,86 @@ ORDER BY table_name,
 			AS pk_name
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid
-            = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
+    JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid
+			= a.attrelid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
 			ct.relnamespace
 			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum
-            = (i.keys).x
-        AND a.attrelid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indisprimary,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+   WHERE true
+     AND ct.relname = 'j'
+     AND i.indisprimary
+ORDER BY table_name,
+         pk_name,
+         key_seq
+
+26:
+--------------------------
+  SELECT NULL
+			AS table_cat,
+         n.nspname
+			AS table_schem,
+         ct.relname
+			AS table_name,
+         a.attname
+			AS column_name,
+         (i.keys).n
+			AS key_seq,
+         ci.relname
+			AS pk_name
+    FROM pg_catalog.pg_class
+			AS ct
+    JOIN pg_catalog.pg_attribute
+			AS a ON ct.oid
+        = a.attrelid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indisprimary,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
    WHERE true
      AND ct.relname = 'j'
      AND i.indisprimary
@@ -502,38 +286,32 @@ ORDER BY table_name,
 			AS pk_name
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid
-            = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum
-            = (i.keys).x
-        AND a.attrelid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
+    JOIN pg_catalog.pg_attribute
+			AS a ON ct.oid
+        = a.attrelid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indisprimary,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON a.attnum
+                   = (i.keys).x
+               AND a.attrelid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
    WHERE true
      AND ct.relname = 'j'
      AND i.indisprimary
@@ -555,38 +333,32 @@ ORDER BY table_name,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid
-            = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum
-            = (i.keys).x
-        AND a.attrelid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
+    JOIN pg_catalog.pg_attribute
+			AS a ON ct.oid
+        = a.attrelid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indisprimary,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON a.attnum
+                   = (i.keys).x
+               AND a.attrelid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
    WHERE true
      AND ct.relname = 'j'
      AND i.indisprimary
@@ -607,37 +379,32 @@ ORDER BY table_name,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum
-            = (i.keys).x
-        AND a.attrelid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
+    JOIN pg_catalog.pg_attribute
+			AS a ON ct.oid
+        = a.attrelid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indisprimary,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON a.attnum
+                   = (i.keys).x
+               AND a.attrelid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
    WHERE true
      AND ct.relname = 'j'
      AND i.indisprimary
@@ -645,8 +412,8 @@ ORDER BY table_name,
          pk_name,
          key_seq
 
-33:
----------------------------------
+32:
+--------------------------------
   SELECT NULL AS table_cat,
          n.nspname
 			AS table_schem,
@@ -658,34 +425,30 @@ ORDER BY table_name,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-        AND a.attrelid
-            = i.indrelid
-         JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute
+			AS a ON ct.oid
+        = a.attrelid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON a.attnum
+                   = (i.keys).x
+               AND a.attrelid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
    WHERE true
      AND ct.relname = 'j'
      AND i.indisprimary
@@ -702,34 +465,30 @@ ORDER BY table_name,
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-        AND a.attrelid
-            = i.indrelid
-         JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute
+			AS a ON ct.oid
+        = a.attrelid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON a.attnum
+                   = (i.keys).x
+               AND a.attrelid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
    WHERE true
      AND ct.relname = 'j'
      AND i.indisprimary
@@ -746,72 +505,29 @@ ORDER BY table_name,
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-        AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
-   WHERE true
-     AND ct.relname = 'j'
-     AND i.indisprimary
-ORDER BY table_name,
-         pk_name,
-         key_seq
-
-36:
-------------------------------------
-  SELECT NULL AS table_cat,
-         n.nspname AS table_schem,
-         ct.relname AS table_name,
-         a.attname AS column_name,
-         (i.keys).n AS key_seq,
-         ci.relname AS pk_name
-    FROM pg_catalog.pg_class AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-        AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute
+			AS a ON ct.oid
+        = a.attrelid
+    JOIN pg_catalog.pg_namespace
+			AS n ON ct.relnamespace
+        = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON a.attnum
+                   = (i.keys).x
+               AND a.attrelid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
    WHERE true
      AND ct.relname = 'j'
      AND i.indisprimary
@@ -828,28 +544,28 @@ ORDER BY table_name,
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-        AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute
+			AS a ON ct.oid
+        = a.attrelid
+    JOIN pg_catalog.pg_namespace
+			AS n ON ct.relnamespace
+        = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON a.attnum
+                   = (i.keys).x
+               AND a.attrelid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
    WHERE true
      AND ct.relname = 'j'
      AND i.indisprimary
@@ -864,27 +580,60 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-        AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute
+			AS a ON ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace
+			AS n ON ct.relnamespace
+        = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON a.attnum
+                   = (i.keys).x
+               AND a.attrelid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+   WHERE true
+     AND ct.relname = 'j'
+     AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+40:
+----------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         a.attname AS column_name,
+         (i.keys).n AS key_seq,
+         ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+    JOIN pg_catalog.pg_attribute AS a ON
+			ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON a.attnum = (i.keys).x
+               AND a.attrelid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
    WHERE true
      AND ct.relname = 'j'
      AND i.indisprimary
@@ -899,25 +648,86 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-        AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON
+			ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON a.attnum = (i.keys).x
+               AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+   WHERE true
+     AND ct.relname = 'j'
+     AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+43:
+-------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         a.attname AS column_name,
+         (i.keys).n AS key_seq,
+         ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+    JOIN pg_catalog.pg_attribute AS a ON
+			ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x
+               AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+   WHERE true
+     AND ct.relname = 'j'
+     AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+44:
+--------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         a.attname AS column_name,
+         (i.keys).n AS key_seq,
+         ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+    JOIN pg_catalog.pg_attribute AS a ON
+			ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x
+               AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid
+                                      = i.indexrelid
    WHERE true
      AND ct.relname = 'j'
      AND i.indisprimary
@@ -932,24 +742,23 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-        AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid
+                                         = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x
+               AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid
+                                      = i.indexrelid
    WHERE true
      AND ct.relname = 'j'
      AND i.indisprimary
@@ -964,29 +773,28 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-        AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid
+                                         = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x
+               AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid
+                                      = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
-58:
-----------------------------------------------------------
+54:
+------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -994,28 +802,27 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       ) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-        AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid
+                                         = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x
+               AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid
+                                      = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
-61:
--------------------------------------------------------------
+56:
+--------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -1023,22 +830,75 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       ) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid
+                                         = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace
+                                         = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x
+               AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid
+                                      = i.indexrelid
+   WHERE true AND ct.relname = 'j' AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+59:
+-----------------------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         a.attname AS column_name,
+         (i.keys).n AS key_seq,
+         ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid
+                                         = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace
+                                         = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x
+               AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+   WHERE true AND ct.relname = 'j' AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+60:
+------------------------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         a.attname AS column_name,
+         (i.keys).n AS key_seq,
+         ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace
+                                         = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x
+               AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
@@ -1051,26 +911,24 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       ) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x
+               AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
-65:
------------------------------------------------------------------
+68:
+--------------------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -1078,25 +936,23 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       ) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
-69:
----------------------------------------------------------------------
+71:
+-----------------------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -1104,24 +960,21 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       ) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(i.indkey) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
-75:
----------------------------------------------------------------------------
+113:
+-----------------------------------------------------------------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -1129,22 +982,18 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(i.indkey) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
-117:
----------------------------------------------------------------------------------------------------------------------
+143:
+-----------------------------------------------------------------------------------------------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -1152,33 +1001,12 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-   WHERE true AND ct.relname = 'j' AND i.indisprimary
-ORDER BY table_name, pk_name, key_seq
-
-147:
----------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT NULL AS table_cat,
-         n.nspname AS table_schem,
-         ct.relname AS table_name,
-         a.attname AS column_name,
-         (i.keys).n AS key_seq,
-         ci.relname AS pk_name
-    FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i
+         ) AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
@@ -1186,36 +1014,61 @@ ORDER BY table_name, pk_name, key_seq
 ------------------------------------------------------------------------------------------------------------------------------------------------------
   SELECT NULL AS table_cat, n.nspname AS table_schem, ct.relname AS table_name, a.attname AS column_name, (i.keys).n AS key_seq, ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON
+			a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
-152:
---------------------------------------------------------------------------------------------------------------------------------------------------------
+159:
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
   SELECT NULL AS table_cat, n.nspname AS table_schem, ct.relname AS table_name, a.attname AS column_name, (i.keys).n AS key_seq, ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON a.attnum
+                                                                                                                                                       = (i.keys).x
+                                                                                                                                                   AND a.attrelid
+                                                                                                                                                       = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
-205:
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+172:
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   SELECT NULL AS table_cat, n.nspname AS table_schem, ct.relname AS table_name, a.attname AS column_name, (i.keys).n AS key_seq, ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON a.attnum = (i.keys).x
+                                                                                                                                                   AND a.attrelid
+                                                                                                                                                       = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+   WHERE true AND ct.relname = 'j' AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+174:
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT NULL AS table_cat, n.nspname AS table_schem, ct.relname AS table_name, a.attname AS column_name, (i.keys).n AS key_seq, ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON a.attnum = (i.keys).x
+                                                                                                                                                   AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+   WHERE true AND ct.relname = 'j' AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+200:
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT NULL AS table_cat, n.nspname AS table_schem, ct.relname AS table_name, a.attname AS column_name, (i.keys).n AS key_seq, ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+    JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 

--- a/pkg/sql/sem/tree/testdata/pretty/join2.align-deindent.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/join2.align-deindent.golden.short
@@ -9,27 +9,25 @@
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indisprimary,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-        AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_attribute AS a ON
+			ct.oid = a.attrelid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indisprimary,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON a.attnum = (i.keys).x
+               AND a.attrelid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
    WHERE true
      AND ct.relname = 'j'
      AND i.indisprimary

--- a/pkg/sql/sem/tree/testdata/pretty/join2.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/join2.align-only.golden
@@ -18,20 +18,15 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON
-		ct.oid
-		= a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid
+			= a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -44,83 +39,15 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum
-		= (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-WHERE
-	true
-	AND ct.relname
-		= 'j'
-	AND i.indisprimary
-ORDER BY
-	table_name,
-	pk_name,
-	key_seq
-
-9:
----------
-SELECT
-	NULL
-		AS table_cat,
-	n.nspname
-		AS table_schem,
-	ct.relname
-		AS table_name,
-	a.attname
-		AS column_name,
-	(i.keys).n
-		AS key_seq,
-	ci.relname
-		AS pk_name
-FROM
-	pg_catalog.pg_class
-		AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON
-		ct.oid
-		= a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
-			SELECT
-				i.indexrelid,
-				i.indrelid,
-				i.indisprimary,
-				information_schema._pg_expandarray(
-					i.indkey
-				)
-					AS keys
-			FROM
-				pg_catalog.pg_index
-					AS i
-		) AS i
-	ON
-		a.attnum
-		= (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
+			AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
 WHERE
 	true
 	AND ct.relname
@@ -149,18 +76,14 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON
-		ct.oid
-		= a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid
+			= a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
 	JOIN (
 			SELECT
 				i.indexrelid,
@@ -173,18 +96,15 @@ FROM
 			FROM
 				pg_catalog.pg_index
 					AS i
-	     ) AS i
-	ON
-		a.attnum
-		= (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
+		) AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
 WHERE
 	true
 	AND ct.relname
@@ -211,20 +131,15 @@ ORDER BY
 			AS pk_name
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON
-			ct.oid
-			= a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
-         JOIN
-			(
+         JOIN pg_catalog.pg_attribute
+				AS a ON
+				ct.oid
+				= a.attrelid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
+         JOIN (
 				SELECT
 					i.indexrelid,
 					i.indrelid,
@@ -236,18 +151,16 @@ ORDER BY
 				FROM
 					pg_catalog.pg_index
 						AS i
-			) AS i
-         ON
-			a.attnum
-			= (i.keys).x
-			AND a.attrelid
-				= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON
-			ci.oid
-			= i.indexrelid
+			)
+				AS i ON
+				a.attnum
+				= (i.keys).x
+				AND a.attrelid
+					= i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
    WHERE true
          AND ct.relname
 			= 'j'
@@ -272,18 +185,14 @@ ORDER BY table_name,
 			AS pk_name
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON
-			ct.oid
-			= a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
+         JOIN pg_catalog.pg_attribute
+				AS a ON
+				ct.oid
+				= a.attrelid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -296,133 +205,15 @@ ORDER BY table_name,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON
-			a.attnum
-			= (i.keys).x
-			AND a.attrelid
-				= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON
-			ci.oid
-			= i.indexrelid
-   WHERE true
-         AND ct.relname
-			= 'j'
-         AND i.indisprimary
-ORDER BY table_name,
-         pk_name,
-         key_seq
-
-18:
-------------------
-  SELECT NULL
-			AS table_cat,
-         n.nspname
-			AS table_schem,
-         ct.relname
-			AS table_name,
-         a.attname
-			AS column_name,
-         (i.keys).n
-			AS key_seq,
-         ci.relname
-			AS pk_name
-    FROM pg_catalog.pg_class
-			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid
-            = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON
-			a.attnum
-			= (i.keys).x
-			AND a.attrelid
-				= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-   WHERE true
-         AND ct.relname
-			= 'j'
-         AND i.indisprimary
-ORDER BY table_name,
-         pk_name,
-         key_seq
-
-20:
---------------------
-  SELECT NULL
-			AS table_cat,
-         n.nspname
-			AS table_schem,
-         ct.relname
-			AS table_name,
-         a.attname
-			AS column_name,
-         (i.keys).n
-			AS key_seq,
-         ci.relname
-			AS pk_name
-    FROM pg_catalog.pg_class
-			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid
-            = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum
-            = (i.keys).x
-            AND a.attrelid
-				= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
+			) AS i ON
+				a.attnum
+				= (i.keys).x
+				AND a.attrelid
+					= i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
    WHERE true
          AND ct.relname
 			= 'j'
@@ -446,16 +237,14 @@ ORDER BY table_name,
 			AS pk_name
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid
-            = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
+         JOIN pg_catalog.pg_attribute
+				AS a ON
+				ct.oid
+				= a.attrelid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -468,16 +257,15 @@ ORDER BY table_name,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON a.attnum
-            = (i.keys).x
-            AND a.attrelid
-				= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
+			) AS i ON
+				a.attnum
+				= (i.keys).x
+				AND a.attrelid
+					= i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
    WHERE true
          AND ct.relname
 			= 'j'
@@ -501,16 +289,14 @@ ORDER BY table_name,
 			AS pk_name
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid
-            = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
+         JOIN pg_catalog.pg_attribute
+				AS a ON
+				ct.oid
+				= a.attrelid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -523,16 +309,15 @@ ORDER BY table_name,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON a.attnum
-            = (i.keys).x
-            AND a.attrelid
-				= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
+			) AS i ON
+				a.attnum
+				= (i.keys).x
+				AND a.attrelid
+					= i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
    WHERE true
          AND ct.relname = 'j'
          AND i.indisprimary
@@ -554,16 +339,13 @@ ORDER BY table_name,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid
-            = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
+         JOIN pg_catalog.pg_attribute
+				AS a ON ct.oid
+			        = a.attrelid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -576,16 +358,14 @@ ORDER BY table_name,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON a.attnum
-            = (i.keys).x
-            AND a.attrelid
-				= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
+			) AS i ON a.attnum
+			          = (i.keys).x
+			          AND a.attrelid
+						= i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
    WHERE true
          AND ct.relname = 'j'
          AND i.indisprimary
@@ -606,15 +386,13 @@ ORDER BY table_name,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
+         JOIN pg_catalog.pg_attribute
+				AS a ON ct.oid
+			        = a.attrelid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -627,64 +405,13 @@ ORDER BY table_name,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON a.attnum
-            = (i.keys).x
-            AND a.attrelid
-				= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-   WHERE true
-         AND ct.relname = 'j'
-         AND i.indisprimary
-ORDER BY table_name,
-         pk_name,
-         key_seq
-
-33:
----------------------------------
-  SELECT NULL AS table_cat,
-         n.nspname
-			AS table_schem,
-         ct.relname
-			AS table_name,
-         a.attname
-			AS column_name,
-         (i.keys).n AS key_seq,
-         ci.relname AS pk_name
-    FROM pg_catalog.pg_class
-			AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-            AND a.attrelid
-				= i.indrelid
+			) AS i ON a.attnum
+			          = (i.keys).x
+			          AND a.attrelid
+						= i.indrelid
          JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
+				AS ci ON ci.oid
+			         = i.indexrelid
    WHERE true
          AND ct.relname = 'j'
          AND i.indisprimary
@@ -701,15 +428,13 @@ ORDER BY table_name,
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
+         JOIN pg_catalog.pg_attribute
+				AS a ON ct.oid
+			        = a.attrelid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -722,56 +447,13 @@ ORDER BY table_name,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-            AND a.attrelid
-				= i.indrelid
+			) AS i ON a.attnum
+			          = (i.keys).x
+			          AND a.attrelid
+						= i.indrelid
          JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
-   WHERE true
-         AND ct.relname = 'j'
-         AND i.indisprimary
-ORDER BY table_name,
-         pk_name,
-         key_seq
-
-35:
------------------------------------
-  SELECT NULL AS table_cat,
-         n.nspname AS table_schem,
-         ct.relname AS table_name,
-         a.attname AS column_name,
-         (i.keys).n AS key_seq,
-         ci.relname AS pk_name
-    FROM pg_catalog.pg_class AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indisprimary,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-            AND a.attrelid
-				= i.indrelid
-         JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
+				AS ci ON ci.oid
+			         = i.indexrelid
    WHERE true
          AND ct.relname = 'j'
          AND i.indisprimary
@@ -788,14 +470,13 @@ ORDER BY table_name,
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN
-			pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_attribute
+				AS a ON ct.oid
+			        = a.attrelid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -806,13 +487,13 @@ ORDER BY table_name,
 						AS keys
 				  FROM pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-            AND a.attrelid
-				= i.indrelid
+			) AS i ON a.attnum
+			          = (i.keys).x
+			          AND a.attrelid
+						= i.indrelid
          JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
+				AS ci ON ci.oid
+			         = i.indexrelid
    WHERE true
          AND ct.relname = 'j'
          AND i.indisprimary
@@ -830,11 +511,12 @@ ORDER BY table_name,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
          JOIN pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
+				AS a ON ct.oid
+			        = a.attrelid
          JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -845,13 +527,13 @@ ORDER BY table_name,
 						AS keys
 				  FROM pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-            AND a.attrelid
-				= i.indrelid
+			) AS i ON a.attnum
+			          = (i.keys).x
+			          AND a.attrelid
+						= i.indrelid
          JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
+				AS ci ON ci.oid
+			         = i.indexrelid
    WHERE true
          AND ct.relname = 'j'
          AND i.indisprimary
@@ -867,11 +549,11 @@ ORDER BY table_name, pk_name, key_seq
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
          JOIN pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
+				AS a ON ct.oid
+			        = a.attrelid
          JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
+				AS n ON ct.relnamespace
+			        = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -882,11 +564,13 @@ ORDER BY table_name, pk_name, key_seq
 						AS keys
 				  FROM pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-            AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+			) AS i ON a.attnum
+			          = (i.keys).x
+			          AND a.attrelid
+						= i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON ci.oid
+			         = i.indexrelid
    WHERE true
          AND ct.relname = 'j'
          AND i.indisprimary
@@ -901,10 +585,12 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_attribute
+				AS a ON ct.oid
+			        = a.attrelid
+         JOIN pg_catalog.pg_namespace
+				AS n ON ct.relnamespace
+			        = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -915,11 +601,79 @@ ORDER BY table_name, pk_name, key_seq
 						AS keys
 				  FROM pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-            AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+			) AS i ON a.attnum
+			          = (i.keys).x
+			          AND a.attrelid
+						= i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON
+				ci.oid = i.indexrelid
+   WHERE true
+         AND ct.relname = 'j'
+         AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+43:
+-------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         a.attname AS column_name,
+         (i.keys).n AS key_seq,
+         ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_attribute
+				AS a ON ct.oid = a.attrelid
+         JOIN pg_catalog.pg_namespace
+				AS n ON ct.relnamespace
+			        = n.oid
+         JOIN (
+				SELECT i.indexrelid,
+				       i.indrelid,
+				       i.indisprimary,
+				       information_schema._pg_expandarray(
+						i.indkey
+				       )
+						AS keys
+				  FROM pg_catalog.pg_index
+						AS i
+			) AS i ON a.attnum = (i.keys).x
+			          AND a.attrelid
+						= i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON
+				ci.oid = i.indexrelid
+   WHERE true
+         AND ct.relname = 'j'
+         AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+45:
+---------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         a.attname AS column_name,
+         (i.keys).n AS key_seq,
+         ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_attribute AS a ON
+				ct.oid = a.attrelid
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
+         JOIN (
+				SELECT i.indexrelid,
+				       i.indrelid,
+				       i.indisprimary,
+				       information_schema._pg_expandarray(
+						i.indkey
+				       )
+						AS keys
+				  FROM pg_catalog.pg_index
+						AS i
+			) AS i ON a.attnum = (i.keys).x
+			          AND a.attrelid
+						= i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON
+				ci.oid = i.indexrelid
    WHERE true
          AND ct.relname = 'j'
          AND i.indisprimary
@@ -934,10 +688,10 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_attribute AS a ON
+				ct.oid = a.attrelid
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -947,11 +701,73 @@ ORDER BY table_name, pk_name, key_seq
 				       )
 						AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-            AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+			) AS i ON a.attnum = (i.keys).x
+			          AND a.attrelid
+						= i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON
+				ci.oid = i.indexrelid
+   WHERE true
+         AND ct.relname = 'j'
+         AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+49:
+-------------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         a.attname AS column_name,
+         (i.keys).n AS key_seq,
+         ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_attribute AS a ON
+				ct.oid = a.attrelid
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
+         JOIN (
+				SELECT i.indexrelid,
+				       i.indrelid,
+				       i.indisprimary,
+				       information_schema._pg_expandarray(
+						i.indkey
+				       )
+						AS keys
+				  FROM pg_catalog.pg_index AS i
+			) AS i ON a.attnum = (i.keys).x
+			          AND a.attrelid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid
+			                                           = i.indexrelid
+   WHERE true
+         AND ct.relname = 'j'
+         AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+52:
+----------------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         a.attname AS column_name,
+         (i.keys).n AS key_seq,
+         ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_attribute AS a ON ct.oid
+			                                              = a.attrelid
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
+         JOIN (
+				SELECT i.indexrelid,
+				       i.indrelid,
+				       i.indisprimary,
+				       information_schema._pg_expandarray(
+						i.indkey
+				       )
+						AS keys
+				  FROM pg_catalog.pg_index AS i
+			) AS i ON a.attnum = (i.keys).x
+			          AND a.attrelid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid
+			                                           = i.indexrelid
    WHERE true
          AND ct.relname = 'j'
          AND i.indisprimary
@@ -966,10 +782,10 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_attribute AS a ON ct.oid
+			                                              = a.attrelid
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -979,11 +795,10 @@ ORDER BY table_name, pk_name, key_seq
 				       )
 						AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-            AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+			) AS i ON a.attnum = (i.keys).x
+			          AND a.attrelid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid
+			                                           = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
@@ -996,10 +811,10 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_attribute AS a ON ct.oid
+			                                              = a.attrelid
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -1008,11 +823,10 @@ ORDER BY table_name, pk_name, key_seq
 						i.indkey
 				       ) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-            AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+			) AS i ON a.attnum = (i.keys).x
+			          AND a.attrelid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid
+			                                           = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
@@ -1025,10 +839,10 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_attribute AS a ON ct.oid
+			                                              = a.attrelid
+         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace
+			                                              = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -1037,10 +851,10 @@ ORDER BY table_name, pk_name, key_seq
 						i.indkey
 				       ) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+			) AS i ON a.attnum = (i.keys).x
+			          AND a.attrelid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid
+			                                           = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
@@ -1053,10 +867,10 @@ ORDER BY table_name, pk_name, key_seq
          (i.keys).n AS key_seq,
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_attribute AS a
-         ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_attribute AS a ON ct.oid
+			                                              = a.attrelid
+         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace
+			                                              = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -1065,8 +879,8 @@ ORDER BY table_name, pk_name, key_seq
 						i.indkey
 				       ) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+			) AS i ON a.attnum = (i.keys).x
+			          AND a.attrelid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
@@ -1081,8 +895,8 @@ ORDER BY table_name, pk_name, key_seq
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
          JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace
+			                                              = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -1091,8 +905,8 @@ ORDER BY table_name, pk_name, key_seq
 						i.indkey
 				       ) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+			) AS i ON a.attnum = (i.keys).x
+			          AND a.attrelid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
@@ -1116,8 +930,32 @@ ORDER BY table_name, pk_name, key_seq
 						i.indkey
 				       ) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+			) AS i ON a.attnum = (i.keys).x
+			          AND a.attrelid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+   WHERE true AND ct.relname = 'j' AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+71:
+-----------------------------------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         a.attname AS column_name,
+         (i.keys).n AS key_seq,
+         ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+         JOIN (
+				SELECT i.indexrelid,
+				       i.indrelid,
+				       i.indisprimary,
+				       information_schema._pg_expandarray(
+						i.indkey
+				       ) AS keys
+				  FROM pg_catalog.pg_index AS i
+			) AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
@@ -1139,8 +977,7 @@ ORDER BY table_name, pk_name, key_seq
 				       i.indisprimary,
 				       information_schema._pg_expandarray(i.indkey) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+			) AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
@@ -1159,8 +996,7 @@ ORDER BY table_name, pk_name, key_seq
          JOIN (
 				SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+			) AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
@@ -1178,8 +1014,7 @@ ORDER BY table_name, pk_name, key_seq
          JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
          JOIN (
 				SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+			) AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
@@ -1192,20 +1027,58 @@ ORDER BY table_name, pk_name, key_seq
          JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
          JOIN (
 				SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+			) AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq
 
-152:
---------------------------------------------------------------------------------------------------------------------------------------------------------
+155:
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
   SELECT NULL AS table_cat, n.nspname AS table_schem, ct.relname AS table_name, a.attname AS column_name, (i.keys).n AS key_seq, ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
          JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
          JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i
-         ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+         JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON
+				a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+   WHERE true AND ct.relname = 'j' AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+164:
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT NULL AS table_cat, n.nspname AS table_schem, ct.relname AS table_name, a.attname AS column_name, (i.keys).n AS key_seq, ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+         JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON a.attnum
+			                                                                                                                                                            = (i.keys).x
+			                                                                                                                                                            AND a.attrelid
+																																											= i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+   WHERE true AND ct.relname = 'j' AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+177:
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT NULL AS table_cat, n.nspname AS table_schem, ct.relname AS table_name, a.attname AS column_name, (i.keys).n AS key_seq, ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+         JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON a.attnum = (i.keys).x
+			                                                                                                                                                            AND a.attrelid
+																																											= i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+   WHERE true AND ct.relname = 'j' AND i.indisprimary
+ORDER BY table_name, pk_name, key_seq
+
+195:
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT NULL AS table_cat, n.nspname AS table_schem, ct.relname AS table_name, a.attname AS column_name, (i.keys).n AS key_seq, ci.relname AS pk_name
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+         JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON a.attnum = (i.keys).x
+			                                                                                                                                                            AND a.attrelid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
    WHERE true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY table_name, pk_name, key_seq

--- a/pkg/sql/sem/tree/testdata/pretty/join2.align-only.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/join2.align-only.golden.short
@@ -10,11 +10,11 @@
          ci.relname AS pk_name
     FROM pg_catalog.pg_class AS ct
          JOIN pg_catalog.pg_attribute
-				AS a
-         ON ct.oid = a.attrelid
+				AS a ON ct.oid
+			        = a.attrelid
          JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
+				AS n ON ct.relnamespace
+			        = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -25,11 +25,13 @@
 						AS keys
 				  FROM pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON a.attnum = (i.keys).x
-            AND a.attrelid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+			) AS i ON a.attnum
+			          = (i.keys).x
+			          AND a.attrelid
+						= i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON ci.oid
+			         = i.indexrelid
    WHERE true
          AND ct.relname = 'j'
          AND i.indisprimary

--- a/pkg/sql/sem/tree/testdata/pretty/join2.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/join2.ref.golden
@@ -18,20 +18,15 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON
-		ct.oid
-		= a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid
+			= a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -44,18 +39,15 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum
-		= (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
+			AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
 WHERE
 	true
 	AND ct.relname
@@ -83,20 +75,15 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON
-		ct.oid
-		= a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid
+			= a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -109,18 +96,15 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum
-		= (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
+			AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
 WHERE
 	true
 	AND ct.relname
@@ -148,20 +132,15 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON
-		ct.oid
-		= a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid
+			= a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -174,18 +153,15 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum
-		= (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
+			AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
 WHERE
 	true
 	AND ct.relname = 'j'
@@ -211,20 +187,15 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON
-		ct.oid
-		= a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid
+			= a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -237,18 +208,15 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum
-		= (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
+			AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
 WHERE
 	true
 	AND ct.relname = 'j'
@@ -273,18 +241,15 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON ct.oid = a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid
+			= a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -297,76 +262,15 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum
-		= (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-WHERE
-	true
-	AND ct.relname = 'j'
-	AND i.indisprimary
-ORDER BY
-	table_name,
-	pk_name,
-	key_seq
-
-28:
-----------------------------
-SELECT
-	NULL AS table_cat,
-	n.nspname
-		AS table_schem,
-	ct.relname
-		AS table_name,
-	a.attname
-		AS column_name,
-	(i.keys).n AS key_seq,
-	ci.relname AS pk_name
-FROM
-	pg_catalog.pg_class
-		AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON ct.oid = a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
-			SELECT
-				i.indexrelid,
-				i.indrelid,
-				i.indisprimary,
-				information_schema._pg_expandarray(
-					i.indkey
-				)
-					AS keys
-			FROM
-				pg_catalog.pg_index
-					AS i
-		)
-			AS i
-	ON
-		a.attnum
-		= (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
 WHERE
 	true
 	AND ct.relname = 'j'
@@ -387,18 +291,15 @@ SELECT
 	ci.relname AS pk_name
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON ct.oid = a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid
+			= a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -411,15 +312,15 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum = (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
 WHERE
 	true
 	AND ct.relname = 'j'
@@ -429,8 +330,8 @@ ORDER BY
 	pk_name,
 	key_seq
 
-30:
-------------------------------
+31:
+-------------------------------
 SELECT
 	NULL AS table_cat,
 	n.nspname AS table_schem,
@@ -440,16 +341,14 @@ SELECT
 	ci.relname AS pk_name
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON ct.oid = a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -462,15 +361,15 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum = (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
 WHERE
 	true
 	AND ct.relname = 'j'
@@ -491,16 +390,14 @@ SELECT
 	ci.relname AS pk_name
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON ct.oid = a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -513,15 +410,15 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum = (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON
+			a.attnum
+			= (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
 WHERE
 	true
 	AND ct.relname = 'j'
@@ -540,16 +437,14 @@ SELECT
 	ci.relname AS pk_name
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON ct.oid = a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -562,61 +457,13 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum = (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN
-		pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-WHERE
-	true
-	AND ct.relname = 'j'
-	AND i.indisprimary
-ORDER BY
-	table_name, pk_name, key_seq
-
-34:
-----------------------------------
-SELECT
-	NULL AS table_cat,
-	n.nspname AS table_schem,
-	ct.relname AS table_name,
-	a.attname AS column_name,
-	(i.keys).n AS key_seq,
-	ci.relname AS pk_name
-FROM
-	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON ct.oid = a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
-			SELECT
-				i.indexrelid,
-				i.indrelid,
-				i.indisprimary,
-				information_schema._pg_expandarray(
-					i.indkey
-				)
-					AS keys
-			FROM
-				pg_catalog.pg_index
-					AS i
-		)
-			AS i
-	ON
-		a.attnum = (i.keys).x
-		AND a.attrelid
-			= i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON
+			a.attnum = (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid = i.indexrelid
 WHERE
 	true
 	AND ct.relname = 'j'
@@ -635,16 +482,13 @@ SELECT
 	ci.relname AS pk_name
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_attribute
-			AS a
-	ON ct.oid = a.attrelid
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -657,56 +501,13 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum = (i.keys).x
-		AND a.attrelid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-WHERE
-	true
-	AND ct.relname = 'j'
-	AND i.indisprimary
-ORDER BY
-	table_name, pk_name, key_seq
-
-36:
-------------------------------------
-SELECT
-	NULL AS table_cat,
-	n.nspname AS table_schem,
-	ct.relname AS table_name,
-	a.attname AS column_name,
-	(i.keys).n AS key_seq,
-	ci.relname AS pk_name
-FROM
-	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_attribute AS a
-	ON ct.oid = a.attrelid
-	JOIN
-		pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
-			SELECT
-				i.indexrelid,
-				i.indrelid,
-				i.indisprimary,
-				information_schema._pg_expandarray(
-					i.indkey
-				)
-					AS keys
-			FROM
-				pg_catalog.pg_index
-					AS i
-		)
-			AS i
-	ON
-		a.attnum = (i.keys).x
-		AND a.attrelid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON
+			a.attnum = (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid = i.indexrelid
 WHERE
 	true
 	AND ct.relname = 'j'
@@ -725,12 +526,13 @@ SELECT
 	ci.relname AS pk_name
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_attribute AS a
-	ON ct.oid = a.attrelid
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute
+			AS a ON
+			ct.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -743,12 +545,53 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		a.attnum = (i.keys).x
-		AND a.attrelid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON
+			a.attnum = (i.keys).x
+			AND a.attrelid
+				= i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+WHERE
+	true
+	AND ct.relname = 'j'
+	AND i.indisprimary
+ORDER BY
+	table_name, pk_name, key_seq
+
+39:
+---------------------------------------
+SELECT
+	NULL AS table_cat,
+	n.nspname AS table_schem,
+	ct.relname AS table_name,
+	a.attname AS column_name,
+	(i.keys).n AS key_seq,
+	ci.relname AS pk_name
+FROM
+	pg_catalog.pg_class AS ct
+	JOIN pg_catalog.pg_attribute
+			AS a ON ct.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indisprimary,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+		)
+			AS i ON
+			a.attnum = (i.keys).x
+			AND a.attrelid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
 WHERE
 	true
 	AND ct.relname = 'j'
@@ -767,12 +610,11 @@ SELECT
 	ci.relname AS pk_name
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_attribute AS a
-	ON ct.oid = a.attrelid
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute AS a ON
+			ct.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -784,12 +626,11 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON
-		a.attnum = (i.keys).x
-		AND a.attrelid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON
+			a.attnum = (i.keys).x
+			AND a.attrelid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
 WHERE
 	true
 	AND ct.relname = 'j'
@@ -808,12 +649,11 @@ SELECT
 	ci.relname AS pk_name
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_attribute AS a
-	ON ct.oid = a.attrelid
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute AS a ON
+			ct.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -825,49 +665,11 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON
-		a.attnum = (i.keys).x
-		AND a.attrelid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-WHERE
-	true AND ct.relname = 'j' AND i.indisprimary
-ORDER BY
-	table_name, pk_name, key_seq
-
-56:
---------------------------------------------------------
-SELECT
-	NULL AS table_cat,
-	n.nspname AS table_schem,
-	ct.relname AS table_name,
-	a.attname AS column_name,
-	(i.keys).n AS key_seq,
-	ci.relname AS pk_name
-FROM
-	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_attribute AS a
-	ON ct.oid = a.attrelid
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
-			SELECT
-				i.indexrelid,
-				i.indrelid,
-				i.indisprimary,
-				information_schema._pg_expandarray(
-					i.indkey
-				)
-					AS keys
-			FROM
-				pg_catalog.pg_index AS i
-		)
-			AS i
-	ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON
+			a.attnum = (i.keys).x
+			AND a.attrelid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
 WHERE
 	true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY
@@ -884,12 +686,11 @@ SELECT
 	ci.relname AS pk_name
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_attribute AS a
-	ON ct.oid = a.attrelid
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute AS a ON
+			ct.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -901,8 +702,9 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+			AS i ON
+			a.attnum = (i.keys).x
+			AND a.attrelid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 WHERE
 	true AND ct.relname = 'j' AND i.indisprimary
@@ -921,10 +723,9 @@ SELECT
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -934,8 +735,41 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+			AS i ON
+			a.attnum = (i.keys).x
+			AND a.attrelid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+WHERE
+	true AND ct.relname = 'j' AND i.indisprimary
+ORDER BY
+	table_name, pk_name, key_seq
+
+61:
+-------------------------------------------------------------
+SELECT
+	NULL AS table_cat,
+	n.nspname AS table_schem,
+	ct.relname AS table_name,
+	a.attname AS column_name,
+	(i.keys).n AS key_seq,
+	ci.relname AS pk_name
+FROM
+	pg_catalog.pg_class AS ct
+	JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indisprimary,
+				information_schema._pg_expandarray(i.indkey)
+					AS keys
+			FROM
+				pg_catalog.pg_index AS i
+		)
+			AS i ON
+			a.attnum = (i.keys).x AND a.attrelid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 WHERE
 	true AND ct.relname = 'j' AND i.indisprimary
@@ -955,8 +789,7 @@ FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -966,8 +799,8 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+			AS i ON
+			a.attnum = (i.keys).x AND a.attrelid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 WHERE
 	true AND ct.relname = 'j' AND i.indisprimary
@@ -987,8 +820,7 @@ FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -997,8 +829,37 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+			AS i ON
+			a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+WHERE
+	true AND ct.relname = 'j' AND i.indisprimary
+ORDER BY
+	table_name, pk_name, key_seq
+
+69:
+---------------------------------------------------------------------
+SELECT
+	NULL AS table_cat,
+	n.nspname AS table_schem,
+	ct.relname AS table_name,
+	a.attname AS column_name,
+	(i.keys).n AS key_seq,
+	ci.relname AS pk_name
+FROM
+	pg_catalog.pg_class AS ct
+	JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+	JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indisprimary,
+				information_schema._pg_expandarray(i.indkey) AS keys
+			FROM
+				pg_catalog.pg_index AS i
+		)
+			AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 WHERE
 	true AND ct.relname = 'j' AND i.indisprimary
@@ -1018,23 +879,21 @@ FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN (
 			SELECT
 				i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+			AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 WHERE
 	true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY
 	table_name, pk_name, key_seq
 
-141:
----------------------------------------------------------------------------------------------------------------------------------------------
+142:
+----------------------------------------------------------------------------------------------------------------------------------------------
 SELECT
 	NULL AS table_cat,
 	n.nspname AS table_schem,
@@ -1046,10 +905,8 @@ FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i)
-			AS i
-	ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+	JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i)
+			AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 WHERE
 	true AND ct.relname = 'j' AND i.indisprimary
@@ -1064,43 +921,24 @@ FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i)
-			AS i
-	ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+	JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i)
+			AS i ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 WHERE
 	true AND ct.relname = 'j' AND i.indisprimary
 ORDER BY
 	table_name, pk_name, key_seq
 
-146:
---------------------------------------------------------------------------------------------------------------------------------------------------
+150:
+------------------------------------------------------------------------------------------------------------------------------------------------------
 SELECT
 	NULL AS table_cat, n.nspname AS table_schem, ct.relname AS table_name, a.attname AS column_name, (i.keys).n AS key_seq, ci.relname AS pk_name
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i
-	ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-WHERE
-	true AND ct.relname = 'j' AND i.indisprimary
-ORDER BY
-	table_name, pk_name, key_seq
-
-147:
----------------------------------------------------------------------------------------------------------------------------------------------------
-SELECT
-	NULL AS table_cat, n.nspname AS table_schem, ct.relname AS table_name, a.attname AS column_name, (i.keys).n AS key_seq, ci.relname AS pk_name
-FROM
-	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_attribute AS a ON ct.oid = a.attrelid
-	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i
-	ON a.attnum = (i.keys).x AND a.attrelid = i.indrelid
+	JOIN (SELECT i.indexrelid, i.indrelid, i.indisprimary, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON
+			a.attnum = (i.keys).x AND a.attrelid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 WHERE
 	true AND ct.relname = 'j' AND i.indisprimary

--- a/pkg/sql/sem/tree/testdata/pretty/join2.ref.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/join2.ref.golden.short
@@ -11,12 +11,11 @@ SELECT
 	ci.relname AS pk_name
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_attribute AS a
-	ON ct.oid = a.attrelid
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_attribute AS a ON
+			ct.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -28,12 +27,11 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON
-		a.attnum = (i.keys).x
-		AND a.attrelid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON
+			a.attnum = (i.keys).x
+			AND a.attrelid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
 WHERE
 	true
 	AND ct.relname = 'j'

--- a/pkg/sql/sem/tree/testdata/pretty/join3.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/join3.align-deindent.golden
@@ -60,14 +60,11 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -84,22 +81,17 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -171,14 +163,11 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -195,132 +184,17 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
-WHERE
-	true
-	AND n.nspname
-		= 'public'
-	AND ct.relname
-		= 'j'
-ORDER BY
-	non_unique,
-	type,
-	index_name,
-	ordinal_position
-
-9:
----------
-SELECT
-	NULL
-		AS table_cat,
-	n.nspname
-		AS table_schem,
-	ct.relname
-		AS table_name,
-	NOT
-		i.indisunique AS non_unique,
-	NULL
-		AS index_qualifier,
-	ci.relname
-		AS index_name,
-	CASE i.indisclustered
-	WHEN true
-	THEN 1
-	ELSE CASE am.amname
-	WHEN 'hash'
-	THEN 2
-	ELSE 3
-	END
-	END
-		AS type,
-	(i.keys).n
-		AS ordinal_position,
-	btrim(
-		pg_catalog.pg_get_indexdef(
-			ci.oid,
-			(i.keys).n,
-			false
-		),
-		'"'
-	)
-		AS column_name,
-	CASE am.amcanorder
-	WHEN true
-	THEN CASE i.indoption[(i.keys).n - 1]
-	& 1
-	WHEN 1
-	THEN 'D'
-	ELSE 'A'
-	END
-	ELSE NULL
-	END
-		AS asc_or_desc,
-	ci.reltuples
-		AS cardinality,
-	ci.relpages
-		AS pages,
-	pg_catalog.pg_get_expr(
-		i.indpred,
-		i.indrelid
-	)
-		AS filter_condition
-FROM
-	pg_catalog.pg_class
-		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
-			SELECT
-				i.indexrelid,
-				i.indrelid,
-				i.indoption,
-				i.indisunique,
-				i.indisclustered,
-				i.indpred,
-				i.indexprs,
-				information_schema._pg_expandarray(
-					i.indkey
-				)
-					AS keys
-			FROM
-				pg_catalog.pg_index
-					AS i
-		) AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -391,12 +265,10 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
 	JOIN (
 			SELECT
 				i.indexrelid,
@@ -413,22 +285,17 @@ FROM
 			FROM
 				pg_catalog.pg_index
 					AS i
-	     ) AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
+		) AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -498,43 +365,35 @@ ORDER BY
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
+    JOIN pg_catalog.pg_namespace
+			AS n ON
 			ct.relnamespace
 			= n.oid
-         JOIN
-			(
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-			) AS i
-         ON
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indoption,
+				i.indisunique,
+				i.indisclustered,
+				i.indpred,
+				i.indexprs,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON
 			ct.oid
 			= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON
+    JOIN pg_catalog.pg_class
+			AS ci ON
 			ci.oid
 			= i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON
+    JOIN pg_catalog.pg_am
+			AS am ON
 			ci.relam
 			= am.oid
    WHERE true
@@ -603,247 +462,37 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
+    JOIN pg_catalog.pg_namespace
+			AS n ON
 			ct.relnamespace
 			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indoption,
+				i.indisunique,
+				i.indisclustered,
+				i.indpred,
+				i.indexprs,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON
 			ct.oid
 			= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON
+    JOIN pg_catalog.pg_class
+			AS ci ON
 			ci.oid
 			= i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON
+    JOIN pg_catalog.pg_am
+			AS am ON
 			ci.relam
 			= am.oid
-   WHERE true
-     AND n.nspname
-         = 'public'
-     AND ct.relname
-         = 'j'
-ORDER BY non_unique,
-         type,
-         index_name,
-         ordinal_position
-
-18:
-------------------
-  SELECT NULL
-			AS table_cat,
-         n.nspname
-			AS table_schem,
-         ct.relname
-			AS table_name,
-         NOT
-			i.indisunique AS non_unique,
-         NULL
-			AS index_qualifier,
-         ci.relname
-			AS index_name,
-         CASE i.indisclustered
-         WHEN true
-         THEN 1
-         ELSE CASE am.amname
-         WHEN 'hash'
-         THEN 2
-         ELSE 3
-         END
-         END
-			AS type,
-         (i.keys).n
-			AS ordinal_position,
-         btrim(
-			pg_catalog.pg_get_indexdef(
-				ci.oid,
-				(i.keys).n,
-				false
-			),
-			'"'
-         ) AS column_name,
-         CASE am.amcanorder
-         WHEN true
-         THEN CASE i.indoption[(i.keys).n - 1]
-         & 1
-         WHEN 1
-         THEN 'D'
-         ELSE 'A'
-         END
-         ELSE NULL
-         END
-			AS asc_or_desc,
-         ci.reltuples
-			AS cardinality,
-         ci.relpages
-			AS pages,
-         pg_catalog.pg_get_expr(
-			i.indpred,
-			i.indrelid
-         )
-			AS filter_condition
-    FROM pg_catalog.pg_class
-			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON
-			ci.relam
-			= am.oid
-   WHERE true
-     AND n.nspname
-         = 'public'
-     AND ct.relname
-         = 'j'
-ORDER BY non_unique,
-         type,
-         index_name,
-         ordinal_position
-
-20:
---------------------
-  SELECT NULL
-			AS table_cat,
-         n.nspname
-			AS table_schem,
-         ct.relname
-			AS table_name,
-         NOT
-			i.indisunique AS non_unique,
-         NULL
-			AS index_qualifier,
-         ci.relname
-			AS index_name,
-         CASE i.indisclustered
-         WHEN true
-         THEN 1
-         ELSE CASE am.amname
-         WHEN 'hash'
-         THEN 2
-         ELSE 3
-         END
-         END
-			AS type,
-         (i.keys).n
-			AS ordinal_position,
-         btrim(
-			pg_catalog.pg_get_indexdef(
-				ci.oid,
-				(i.keys).n,
-				false
-			),
-			'"'
-         ) AS column_name,
-         CASE am.amcanorder
-         WHEN true
-         THEN CASE i.indoption[(i.keys).n - 1]
-         & 1
-         WHEN 1
-         THEN 'D'
-         ELSE 'A'
-         END
-         ELSE NULL
-         END
-			AS asc_or_desc,
-         ci.reltuples
-			AS cardinality,
-         ci.relpages
-			AS pages,
-         pg_catalog.pg_get_expr(
-			i.indpred,
-			i.indrelid
-         )
-			AS filter_condition
-    FROM pg_catalog.pg_class
-			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON ci.relam
-            = am.oid
    WHERE true
      AND n.nspname
          = 'public'
@@ -909,41 +558,37 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
+    JOIN pg_catalog.pg_namespace
+			AS n ON
 			ct.relnamespace
 			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON ci.relam
-            = am.oid
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indoption,
+				i.indisunique,
+				i.indisclustered,
+				i.indpred,
+				i.indexprs,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON
+			ct.oid
+			= i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+    JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
    WHERE true
      AND n.nspname
          = 'public'
@@ -1008,41 +653,36 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
+    JOIN pg_catalog.pg_namespace
+			AS n ON
 			ct.relnamespace
 			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON ci.relam
-            = am.oid
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indoption,
+				i.indisunique,
+				i.indisclustered,
+				i.indpred,
+				i.indexprs,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+    JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
    WHERE true
      AND n.nspname
          = 'public'
@@ -1103,40 +743,35 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON ci.relam
-            = am.oid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indoption,
+				i.indisunique,
+				i.indisclustered,
+				i.indpred,
+				i.indexprs,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
+    JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
    WHERE true
      AND n.nspname
          = 'public'
@@ -1197,39 +832,34 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indoption,
+				i.indisunique,
+				i.indisclustered,
+				i.indpred,
+				i.indexprs,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
+    JOIN pg_catalog.pg_am
+			AS am ON ci.relam
+         = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -1287,126 +917,34 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
-   WHERE true
-     AND n.nspname = 'public'
-     AND ct.relname = 'j'
-ORDER BY non_unique,
-         type,
-         index_name,
-         ordinal_position
-
-31:
--------------------------------
-  SELECT NULL AS table_cat,
-         n.nspname
-			AS table_schem,
-         ct.relname
-			AS table_name,
-         NOT
-			i.indisunique AS non_unique,
-         NULL
-			AS index_qualifier,
-         ci.relname
-			AS index_name,
-         CASE i.indisclustered
-         WHEN true THEN 1
-         ELSE CASE am.amname
-         WHEN 'hash' THEN 2
-         ELSE 3
-         END
-         END AS type,
-         (i.keys).n
-			AS ordinal_position,
-         btrim(
-			pg_catalog.pg_get_indexdef(
-				ci.oid,
-				(i.keys).n,
-				false
-			),
-			'"'
-         ) AS column_name,
-         CASE am.amcanorder
-         WHEN true
-         THEN CASE i.indoption[(i.keys).n - 1]
-         & 1
-         WHEN 1 THEN 'D'
-         ELSE 'A'
-         END
-         ELSE NULL
-         END AS asc_or_desc,
-         ci.reltuples
-			AS cardinality,
-         ci.relpages AS pages,
-         pg_catalog.pg_get_expr(
-			i.indpred,
-			i.indrelid
-         )
-			AS filter_condition
-    FROM pg_catalog.pg_class
-			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+    JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indoption,
+				i.indisunique,
+				i.indisclustered,
+				i.indpred,
+				i.indexprs,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
+    JOIN pg_catalog.pg_am
+			AS am ON ci.relam
+         = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -1463,37 +1001,32 @@ ORDER BY non_unique,
          ) AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
+    JOIN pg_catalog.pg_am
+			AS am ON ci.relam
+         = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -1549,35 +1082,32 @@ ORDER BY non_unique,
          ) AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
+    JOIN pg_catalog.pg_am
+			AS am ON ci.relam
+         = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -1629,35 +1159,31 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -1709,110 +1235,30 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
-   WHERE true
-     AND n.nspname = 'public'
-     AND ct.relname = 'j'
-ORDER BY non_unique,
-         type,
-         index_name,
-         ordinal_position
-
-36:
-------------------------------------
-  SELECT NULL AS table_cat,
-         n.nspname AS table_schem,
-         ct.relname AS table_name,
-         NOT
-			i.indisunique AS non_unique,
-         NULL AS index_qualifier,
-         ci.relname AS index_name,
-         CASE i.indisclustered
-         WHEN true THEN 1
-         ELSE CASE am.amname
-         WHEN 'hash' THEN 2
-         ELSE 3
-         END
-         END AS type,
-         (i.keys).n
-			AS ordinal_position,
-         btrim(
-			pg_catalog.pg_get_indexdef(
-				ci.oid,
-				(i.keys).n,
-				false
-			),
-			'"'
-         ) AS column_name,
-         CASE am.amcanorder
-         WHEN true
-         THEN CASE i.indoption[(i.keys).n - 1]
-         & 1
-         WHEN 1 THEN 'D'
-         ELSE 'A'
-         END
-         ELSE NULL
-         END AS asc_or_desc,
-         ci.reltuples
-			AS cardinality,
-         ci.relpages AS pages,
-         pg_catalog.pg_get_expr(
-			i.indpred,
-			i.indrelid
-         ) AS filter_condition
-    FROM pg_catalog.pg_class AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace
+			AS n ON ct.relnamespace
+        = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class
+			AS ci ON ci.oid
+         = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -1863,30 +1309,29 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace
+			AS n ON ct.relnamespace
+        = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid
+                   = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -1895,8 +1340,8 @@ ORDER BY non_unique,
          index_name,
          ordinal_position
 
-39:
----------------------------------------
+38:
+--------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -1937,29 +1382,28 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace
+			AS n ON ct.relnamespace
+        = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -2009,29 +1453,27 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -2080,29 +1522,27 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -2111,8 +1551,8 @@ ORDER BY non_unique,
          index_name,
          ordinal_position
 
-42:
-------------------------------------------
+43:
+-------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -2151,28 +1591,26 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam
+                                   = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -2181,8 +1619,8 @@ ORDER BY non_unique,
          index_name,
          ordinal_position
 
-47:
------------------------------------------------
+44:
+--------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -2221,27 +1659,26 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid
+                                      = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam
+                                   = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -2289,27 +1726,157 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid
+                                      = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam
+                                   = am.oid
+   WHERE true
+     AND n.nspname = 'public'
+     AND ct.relname = 'j'
+ORDER BY non_unique,
+         type,
+         index_name,
+         ordinal_position
+
+52:
+----------------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         NOT i.indisunique AS non_unique,
+         NULL AS index_qualifier,
+         ci.relname AS index_name,
+         CASE i.indisclustered
+         WHEN true THEN 1
+         ELSE CASE am.amname
+         WHEN 'hash' THEN 2
+         ELSE 3
+         END
+         END AS type,
+         (i.keys).n AS ordinal_position,
+         btrim(
+			pg_catalog.pg_get_indexdef(
+				ci.oid,
+				(i.keys).n,
+				false
+			),
+			'"'
+         ) AS column_name,
+         CASE am.amcanorder
+         WHEN true
+         THEN CASE i.indoption[(i.keys).n - 1] & 1
+         WHEN 1 THEN 'D'
+         ELSE 'A'
+         END
+         ELSE NULL
+         END AS asc_or_desc,
+         ci.reltuples AS cardinality,
+         ci.relpages AS pages,
+         pg_catalog.pg_get_expr(
+			i.indpred,
+			i.indrelid
+         ) AS filter_condition
+    FROM pg_catalog.pg_class AS ct
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid
+                                      = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+   WHERE true
+     AND n.nspname = 'public'
+     AND ct.relname = 'j'
+ORDER BY non_unique,
+         type,
+         index_name,
+         ordinal_position
+
+54:
+------------------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         NOT i.indisunique AS non_unique,
+         NULL AS index_qualifier,
+         ci.relname AS index_name,
+         CASE i.indisclustered
+         WHEN true THEN 1
+         ELSE CASE am.amname
+         WHEN 'hash' THEN 2
+         ELSE 3
+         END
+         END AS type,
+         (i.keys).n AS ordinal_position,
+         btrim(
+			pg_catalog.pg_get_indexdef(
+				ci.oid,
+				(i.keys).n,
+				false
+			),
+			'"'
+         ) AS column_name,
+         CASE am.amcanorder
+         WHEN true
+         THEN CASE i.indoption[(i.keys).n - 1] & 1
+         WHEN 1 THEN 'D'
+         ELSE 'A'
+         END
+         ELSE NULL
+         END AS asc_or_desc,
+         ci.reltuples AS cardinality,
+         ci.relpages AS pages,
+         pg_catalog.pg_get_expr(
+			i.indpred,
+			i.indrelid
+         ) AS filter_condition
+    FROM pg_catalog.pg_class AS ct
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid
+                                      = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -2357,34 +1924,31 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid
+                                      = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
-57:
----------------------------------------------------------
+56:
+--------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -2422,26 +1986,24 @@ ORDER BY non_unique, type, index_name, ordinal_position
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace
+                                         = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid
+                                      = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -2483,25 +2045,24 @@ ORDER BY non_unique, type, index_name, ordinal_position
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       ) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace
+                                         = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid
+                                      = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'
@@ -2543,25 +2104,23 @@ ORDER BY non_unique, type, index_name, ordinal_position
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       ) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace
+                                         = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
@@ -2601,24 +2160,22 @@ ORDER BY non_unique, type, index_name, ordinal_position
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       ) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
@@ -2654,29 +2211,27 @@ ORDER BY non_unique, type, index_name, ordinal_position
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       ) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       ) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
-69:
----------------------------------------------------------------------
+71:
+-----------------------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -2707,23 +2262,20 @@ ORDER BY non_unique, type, index_name, ordinal_position
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       ) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(i.indkey) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
@@ -2756,70 +2308,20 @@ ORDER BY non_unique, type, index_name, ordinal_position
          ci.relpages AS pages,
          pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       ) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
-   WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
-ORDER BY non_unique, type, index_name, ordinal_position
-
-75:
----------------------------------------------------------------------------
-  SELECT NULL AS table_cat,
-         n.nspname AS table_schem,
-         ct.relname AS table_name,
-         NOT i.indisunique AS non_unique,
-         NULL AS index_qualifier,
-         ci.relname AS index_name,
-         CASE i.indisclustered
-         WHEN true THEN 1
-         ELSE CASE am.amname WHEN 'hash' THEN 2 ELSE 3 END
-         END AS type,
-         (i.keys).n AS ordinal_position,
-         btrim(
-			pg_catalog.pg_get_indexdef(ci.oid, (i.keys).n, false),
-			'"'
-         ) AS column_name,
-         CASE am.amcanorder
-         WHEN true
-         THEN CASE i.indoption[(i.keys).n - 1] & 1
-         WHEN 1 THEN 'D'
-         ELSE 'A'
-         END
-         ELSE NULL
-         END AS asc_or_desc,
-         ci.reltuples AS cardinality,
-         ci.relpages AS pages,
-         pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
-    FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(i.indkey) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(i.indkey) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
@@ -2849,21 +2351,20 @@ ORDER BY non_unique, type, index_name, ordinal_position
          ci.relpages AS pages,
          pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(i.indkey) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(i.indkey) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
@@ -2892,21 +2393,20 @@ ORDER BY non_unique, type, index_name, ordinal_position
          ci.relpages AS pages,
          pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(i.indkey) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(i.indkey) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
@@ -2932,21 +2432,20 @@ ORDER BY non_unique, type, index_name, ordinal_position
          ci.relpages AS pages,
          pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(i.indkey) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(i.indkey) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
@@ -2969,21 +2468,20 @@ ORDER BY non_unique, type, index_name, ordinal_position
          ci.relpages AS pages,
          pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(i.indkey) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(i.indkey) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
@@ -3003,26 +2501,25 @@ ORDER BY non_unique, type, index_name, ordinal_position
          ci.relpages AS pages,
          pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(i.indkey) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(i.indkey) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
-170:
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+166:
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -3037,19 +2534,18 @@ ORDER BY non_unique, type, index_name, ordinal_position
          ci.relpages AS pages,
          pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys
-				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys
+			  FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
-200:
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+196:
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -3064,18 +2560,17 @@ ORDER BY non_unique, type, index_name, ordinal_position
          ci.relpages AS pages,
          pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
-205:
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+203:
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -3090,16 +2585,16 @@ ORDER BY non_unique, type, index_name, ordinal_position
          ci.relpages AS pages,
          pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON
+			ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
-228:
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+210:
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -3114,10 +2609,34 @@ ORDER BY non_unique, type, index_name, ordinal_position
          ci.relpages AS pages,
          pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON ct.oid
+                                                                                                                                                                                                            = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+   WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
+ORDER BY non_unique, type, index_name, ordinal_position
+
+223:
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         NOT i.indisunique AS non_unique,
+         NULL AS index_qualifier,
+         ci.relname AS index_name,
+         CASE i.indisclustered WHEN true THEN 1 ELSE CASE am.amname WHEN 'hash' THEN 2 ELSE 3 END END AS type,
+         (i.keys).n AS ordinal_position,
+         btrim(pg_catalog.pg_get_indexdef(ci.oid, (i.keys).n, false), '"') AS column_name,
+         CASE am.amcanorder WHEN true THEN CASE i.indoption[(i.keys).n - 1] & 1 WHEN 1 THEN 'D' ELSE 'A' END ELSE NULL END AS asc_or_desc,
+         ci.reltuples AS cardinality,
+         ci.relpages AS pages,
+         pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
+    FROM pg_catalog.pg_class AS ct
+    JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+    JOIN (SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 

--- a/pkg/sql/sem/tree/testdata/pretty/join3.align-deindent.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/join3.align-deindent.golden.short
@@ -41,29 +41,27 @@
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT i.indexrelid,
-				       i.indrelid,
-				       i.indoption,
-				       i.indisunique,
-				       i.indisclustered,
-				       i.indpred,
-				       i.indexprs,
-				       information_schema._pg_expandarray(
-						i.indkey
-				       )
-						AS keys
-				  FROM pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+    JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+    JOIN (
+			SELECT i.indexrelid,
+			       i.indrelid,
+			       i.indoption,
+			       i.indisunique,
+			       i.indisclustered,
+			       i.indpred,
+			       i.indexprs,
+			       information_schema._pg_expandarray(
+					i.indkey
+			       )
+					AS keys
+			  FROM pg_catalog.pg_index
+					AS i
+         ) AS i ON ct.oid = i.indrelid
+    JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+    JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
    WHERE true
      AND n.nspname = 'public'
      AND ct.relname = 'j'

--- a/pkg/sql/sem/tree/testdata/pretty/join3.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/join3.align-only.golden
@@ -60,14 +60,11 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -84,22 +81,17 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -171,14 +163,11 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -195,132 +184,17 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
-WHERE
-	true
-	AND n.nspname
-		= 'public'
-	AND ct.relname
-		= 'j'
-ORDER BY
-	non_unique,
-	type,
-	index_name,
-	ordinal_position
-
-9:
----------
-SELECT
-	NULL
-		AS table_cat,
-	n.nspname
-		AS table_schem,
-	ct.relname
-		AS table_name,
-	NOT
-		i.indisunique AS non_unique,
-	NULL
-		AS index_qualifier,
-	ci.relname
-		AS index_name,
-	CASE i.indisclustered
-	WHEN true
-	THEN 1
-	ELSE CASE am.amname
-	WHEN 'hash'
-	THEN 2
-	ELSE 3
-	END
-	END
-		AS type,
-	(i.keys).n
-		AS ordinal_position,
-	btrim(
-		pg_catalog.pg_get_indexdef(
-			ci.oid,
-			(i.keys).n,
-			false
-		),
-		'"'
-	)
-		AS column_name,
-	CASE am.amcanorder
-	WHEN true
-	THEN CASE i.indoption[(i.keys).n - 1]
-	& 1
-	WHEN 1
-	THEN 'D'
-	ELSE 'A'
-	END
-	ELSE NULL
-	END
-		AS asc_or_desc,
-	ci.reltuples
-		AS cardinality,
-	ci.relpages
-		AS pages,
-	pg_catalog.pg_get_expr(
-		i.indpred,
-		i.indrelid
-	)
-		AS filter_condition
-FROM
-	pg_catalog.pg_class
-		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
-			SELECT
-				i.indexrelid,
-				i.indrelid,
-				i.indoption,
-				i.indisunique,
-				i.indisclustered,
-				i.indpred,
-				i.indexprs,
-				information_schema._pg_expandarray(
-					i.indkey
-				)
-					AS keys
-			FROM
-				pg_catalog.pg_index
-					AS i
-		) AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -391,12 +265,10 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
 	JOIN (
 			SELECT
 				i.indexrelid,
@@ -413,22 +285,17 @@ FROM
 			FROM
 				pg_catalog.pg_index
 					AS i
-	     ) AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
+		) AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -498,14 +365,11 @@ ORDER BY
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
-         JOIN
-			(
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
+         JOIN (
 				SELECT
 					i.indexrelid,
 					i.indrelid,
@@ -521,22 +385,18 @@ ORDER BY
 				FROM
 					pg_catalog.pg_index
 						AS i
-			) AS i
-         ON
-			ct.oid
-			= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON
-			ci.oid
-			= i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON
-			ci.relam
-			= am.oid
+			)
+				AS i ON
+				ct.oid
+				= i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
+         JOIN pg_catalog.pg_am
+				AS am ON
+				ci.relam
+				= am.oid
    WHERE true
          AND n.nspname
 			= 'public'
@@ -603,12 +463,10 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -625,225 +483,17 @@ ORDER BY non_unique,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON
-			ct.oid
-			= i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON
-			ci.oid
-			= i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON
-			ci.relam
-			= am.oid
-   WHERE true
-         AND n.nspname
-			= 'public'
-         AND ct.relname
-			= 'j'
-ORDER BY non_unique,
-         type,
-         index_name,
-         ordinal_position
-
-18:
-------------------
-  SELECT NULL
-			AS table_cat,
-         n.nspname
-			AS table_schem,
-         ct.relname
-			AS table_name,
-         NOT
-			i.indisunique AS non_unique,
-         NULL
-			AS index_qualifier,
-         ci.relname
-			AS index_name,
-         CASE i.indisclustered
-         WHEN true
-         THEN 1
-         ELSE CASE am.amname
-         WHEN 'hash'
-         THEN 2
-         ELSE 3
-         END
-         END
-			AS type,
-         (i.keys).n
-			AS ordinal_position,
-         btrim(
-			pg_catalog.pg_get_indexdef(
-				ci.oid,
-				(i.keys).n,
-				false
-			),
-			'"'
-         ) AS column_name,
-         CASE am.amcanorder
-         WHEN true
-         THEN CASE i.indoption[(i.keys).n - 1]
-         & 1
-         WHEN 1
-         THEN 'D'
-         ELSE 'A'
-         END
-         ELSE NULL
-         END
-			AS asc_or_desc,
-         ci.reltuples
-			AS cardinality,
-         ci.relpages
-			AS pages,
-         pg_catalog.pg_get_expr(
-			i.indpred,
-			i.indrelid
-         )
-			AS filter_condition
-    FROM pg_catalog.pg_class
-			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON
-			ci.relam
-			= am.oid
-   WHERE true
-         AND n.nspname
-			= 'public'
-         AND ct.relname
-			= 'j'
-ORDER BY non_unique,
-         type,
-         index_name,
-         ordinal_position
-
-20:
---------------------
-  SELECT NULL
-			AS table_cat,
-         n.nspname
-			AS table_schem,
-         ct.relname
-			AS table_name,
-         NOT
-			i.indisunique AS non_unique,
-         NULL
-			AS index_qualifier,
-         ci.relname
-			AS index_name,
-         CASE i.indisclustered
-         WHEN true
-         THEN 1
-         ELSE CASE am.amname
-         WHEN 'hash'
-         THEN 2
-         ELSE 3
-         END
-         END
-			AS type,
-         (i.keys).n
-			AS ordinal_position,
-         btrim(
-			pg_catalog.pg_get_indexdef(
-				ci.oid,
-				(i.keys).n,
-				false
-			),
-			'"'
-         ) AS column_name,
-         CASE am.amcanorder
-         WHEN true
-         THEN CASE i.indoption[(i.keys).n - 1]
-         & 1
-         WHEN 1
-         THEN 'D'
-         ELSE 'A'
-         END
-         ELSE NULL
-         END
-			AS asc_or_desc,
-         ci.reltuples
-			AS cardinality,
-         ci.relpages
-			AS pages,
-         pg_catalog.pg_get_expr(
-			i.indpred,
-			i.indrelid
-         )
-			AS filter_condition
-    FROM pg_catalog.pg_class
-			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON ci.relam
-            = am.oid
+			) AS i ON
+				ct.oid
+				= i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
+         JOIN pg_catalog.pg_am
+				AS am ON
+				ci.relam
+				= am.oid
    WHERE true
          AND n.nspname
 			= 'public'
@@ -909,12 +559,10 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -931,19 +579,17 @@ ORDER BY non_unique,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON ci.relam
-            = am.oid
+			) AS i ON
+				ct.oid
+				= i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
+         JOIN pg_catalog.pg_am
+				AS am ON
+				ci.relam
+				= am.oid
    WHERE true
          AND n.nspname
 			= 'public'
@@ -1008,12 +654,10 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON
-			ct.relnamespace
-			= n.oid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -1030,19 +674,17 @@ ORDER BY non_unique,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON ci.relam
-            = am.oid
+			) AS i ON
+				ct.oid
+				= i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
+         JOIN pg_catalog.pg_am
+				AS am ON
+				ci.relam
+				= am.oid
    WHERE true
          AND n.nspname
 			= 'public'
@@ -1104,11 +746,10 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -1125,19 +766,108 @@ ORDER BY non_unique,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON ci.relam
-            = am.oid
+			) AS i ON
+				ct.oid
+				= i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
+         JOIN pg_catalog.pg_am
+				AS am ON
+				ci.relam
+				= am.oid
+   WHERE true
+         AND n.nspname
+			= 'public'
+         AND ct.relname
+			= 'j'
+ORDER BY non_unique,
+         type,
+         index_name,
+         ordinal_position
+
+28:
+----------------------------
+  SELECT NULL AS table_cat,
+         n.nspname
+			AS table_schem,
+         ct.relname
+			AS table_name,
+         NOT
+			i.indisunique AS non_unique,
+         NULL
+			AS index_qualifier,
+         ci.relname
+			AS index_name,
+         CASE i.indisclustered
+         WHEN true THEN 1
+         ELSE CASE am.amname
+         WHEN 'hash' THEN 2
+         ELSE 3
+         END
+         END
+			AS type,
+         (i.keys).n
+			AS ordinal_position,
+         btrim(
+			pg_catalog.pg_get_indexdef(
+				ci.oid,
+				(i.keys).n,
+				false
+			),
+			'"'
+         ) AS column_name,
+         CASE am.amcanorder
+         WHEN true
+         THEN CASE i.indoption[(i.keys).n - 1]
+         & 1
+         WHEN 1 THEN 'D'
+         ELSE 'A'
+         END
+         ELSE NULL
+         END AS asc_or_desc,
+         ci.reltuples
+			AS cardinality,
+         ci.relpages
+			AS pages,
+         pg_catalog.pg_get_expr(
+			i.indpred,
+			i.indrelid
+         )
+			AS filter_condition
+    FROM pg_catalog.pg_class
+			AS ct
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
+         JOIN (
+				SELECT
+					i.indexrelid,
+					i.indrelid,
+					i.indoption,
+					i.indisunique,
+					i.indisclustered,
+					i.indpred,
+					i.indexprs,
+					information_schema._pg_expandarray(
+						i.indkey
+					)
+						AS keys
+				FROM
+					pg_catalog.pg_index
+						AS i
+			) AS i ON ct.oid
+			          = i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
+         JOIN pg_catalog.pg_am
+				AS am ON
+				ci.relam
+				= am.oid
    WHERE true
          AND n.nspname
 			= 'public'
@@ -1199,11 +929,10 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -1220,18 +949,16 @@ ORDER BY non_unique,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
-         JOIN
-			pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
+			) AS i ON ct.oid
+			          = i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
+         JOIN pg_catalog.pg_am
+				AS am ON
+				ci.relam
+				= am.oid
    WHERE true
          AND n.nspname
 			= 'public'
@@ -1290,11 +1017,10 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -1311,17 +1037,16 @@ ORDER BY non_unique,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid
-            = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
+			) AS i ON ct.oid
+			          = i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON
+				ci.oid
+				= i.indexrelid
          JOIN pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
+				AS am ON
+				ci.relam
+				= am.oid
    WHERE true
          AND n.nspname
 			= 'public'
@@ -1380,11 +1105,10 @@ ORDER BY non_unique,
 			AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -1401,16 +1125,15 @@ ORDER BY non_unique,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
+			) AS i ON ct.oid
+			          = i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON ci.oid
+			         = i.indexrelid
          JOIN pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
+				AS am ON
+				ci.relam
+				= am.oid
    WHERE true
          AND n.nspname
 			= 'public'
@@ -1468,11 +1191,10 @@ ORDER BY non_unique,
          ) AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -1489,16 +1211,15 @@ ORDER BY non_unique,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN
-			pg_catalog.pg_class
-				AS ci
-         ON ci.oid
-            = i.indexrelid
+			) AS i ON ct.oid
+			          = i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON ci.oid
+			         = i.indexrelid
          JOIN pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
+				AS am ON
+				ci.relam
+				= am.oid
    WHERE true
          AND n.nspname
 			= 'public'
@@ -1555,11 +1276,10 @@ ORDER BY non_unique,
          ) AS filter_condition
     FROM pg_catalog.pg_class
 			AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -1576,14 +1296,14 @@ ORDER BY non_unique,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid
+			          = i.indrelid
          JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
+				AS ci ON ci.oid
+			         = i.indexrelid
          JOIN pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
+				AS am ON ci.relam
+			         = am.oid
    WHERE true
          AND n.nspname = 'public'
          AND ct.relname = 'j'
@@ -1635,11 +1355,10 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace
-            = n.oid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT
 					i.indexrelid,
@@ -1656,93 +1375,14 @@ ORDER BY non_unique,
 				FROM
 					pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid
+			          = i.indrelid
          JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
+				AS ci ON ci.oid
+			         = i.indexrelid
          JOIN pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
-   WHERE true
-         AND n.nspname = 'public'
-         AND ct.relname = 'j'
-ORDER BY non_unique,
-         type,
-         index_name,
-         ordinal_position
-
-35:
------------------------------------
-  SELECT NULL AS table_cat,
-         n.nspname AS table_schem,
-         ct.relname AS table_name,
-         NOT
-			i.indisunique AS non_unique,
-         NULL AS index_qualifier,
-         ci.relname AS index_name,
-         CASE i.indisclustered
-         WHEN true THEN 1
-         ELSE CASE am.amname
-         WHEN 'hash' THEN 2
-         ELSE 3
-         END
-         END AS type,
-         (i.keys).n
-			AS ordinal_position,
-         btrim(
-			pg_catalog.pg_get_indexdef(
-				ci.oid,
-				(i.keys).n,
-				false
-			),
-			'"'
-         ) AS column_name,
-         CASE am.amcanorder
-         WHEN true
-         THEN CASE i.indoption[(i.keys).n - 1]
-         & 1
-         WHEN 1 THEN 'D'
-         ELSE 'A'
-         END
-         ELSE NULL
-         END AS asc_or_desc,
-         ci.reltuples
-			AS cardinality,
-         ci.relpages AS pages,
-         pg_catalog.pg_get_expr(
-			i.indpred,
-			i.indrelid
-         ) AS filter_condition
-    FROM pg_catalog.pg_class AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
-         JOIN (
-				SELECT
-					i.indexrelid,
-					i.indrelid,
-					i.indoption,
-					i.indisunique,
-					i.indisclustered,
-					i.indpred,
-					i.indexprs,
-					information_schema._pg_expandarray(
-						i.indkey
-					)
-						AS keys
-				FROM
-					pg_catalog.pg_index
-						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am
-				AS am
-         ON ci.relam = am.oid
+				AS am ON ci.relam
+			         = am.oid
    WHERE true
          AND n.nspname = 'public'
          AND ct.relname = 'j'
@@ -1794,10 +1434,10 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN
-			pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_namespace
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -1812,13 +1452,14 @@ ORDER BY non_unique,
 						AS keys
 				  FROM pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid
+			          = i.indrelid
          JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+				AS ci ON ci.oid
+			         = i.indexrelid
+         JOIN pg_catalog.pg_am
+				AS am ON ci.relam
+			         = am.oid
    WHERE true
          AND n.nspname = 'public'
          AND ct.relname = 'j'
@@ -1870,8 +1511,9 @@ ORDER BY non_unique,
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
          JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
+				AS n ON
+				ct.relnamespace
+				= n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -1886,13 +1528,14 @@ ORDER BY non_unique,
 						AS keys
 				  FROM pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid
+			          = i.indrelid
          JOIN pg_catalog.pg_class
-				AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+				AS ci ON ci.oid
+			         = i.indexrelid
+         JOIN pg_catalog.pg_am
+				AS am ON ci.relam
+			         = am.oid
    WHERE true
          AND n.nspname = 'public'
          AND ct.relname = 'j'
@@ -1944,8 +1587,8 @@ ORDER BY non_unique,
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
          JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
+				AS n ON ct.relnamespace
+			        = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -1960,12 +1603,13 @@ ORDER BY non_unique,
 						AS keys
 				  FROM pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+			) AS i ON ct.oid
+			          = i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON ci.oid
+			         = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON
+				ci.relam = am.oid
    WHERE true
          AND n.nspname = 'public'
          AND ct.relname = 'j'
@@ -2016,8 +1660,8 @@ ORDER BY non_unique,
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
          JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
+				AS n ON ct.relnamespace
+			        = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -2032,12 +1676,13 @@ ORDER BY non_unique,
 						AS keys
 				  FROM pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+			) AS i ON ct.oid
+			          = i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON ci.oid
+			         = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON
+				ci.relam = am.oid
    WHERE true
          AND n.nspname = 'public'
          AND ct.relname = 'j'
@@ -2087,8 +1732,8 @@ ORDER BY non_unique,
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
          JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
+				AS n ON ct.relnamespace
+			        = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -2103,12 +1748,12 @@ ORDER BY non_unique,
 						AS keys
 				  FROM pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+			) AS i ON ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON ci.oid
+			         = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON
+				ci.relam = am.oid
    WHERE true
          AND n.nspname = 'public'
          AND ct.relname = 'j'
@@ -2157,8 +1802,9 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_namespace
+				AS n ON ct.relnamespace
+			        = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -2173,12 +1819,80 @@ ORDER BY non_unique,
 						AS keys
 				  FROM pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+			) AS i ON ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON
+				ci.oid = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON
+				ci.relam = am.oid
+   WHERE true
+         AND n.nspname = 'public'
+         AND ct.relname = 'j'
+ORDER BY non_unique,
+         type,
+         index_name,
+         ordinal_position
+
+45:
+---------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         NOT i.indisunique AS non_unique,
+         NULL AS index_qualifier,
+         ci.relname AS index_name,
+         CASE i.indisclustered
+         WHEN true THEN 1
+         ELSE CASE am.amname
+         WHEN 'hash' THEN 2
+         ELSE 3
+         END
+         END AS type,
+         (i.keys).n AS ordinal_position,
+         btrim(
+			pg_catalog.pg_get_indexdef(
+				ci.oid,
+				(i.keys).n,
+				false
+			),
+			'"'
+         ) AS column_name,
+         CASE am.amcanorder
+         WHEN true
+         THEN CASE i.indoption[(i.keys).n - 1]
+         & 1
+         WHEN 1 THEN 'D'
+         ELSE 'A'
+         END
+         ELSE NULL
+         END AS asc_or_desc,
+         ci.reltuples AS cardinality,
+         ci.relpages AS pages,
+         pg_catalog.pg_get_expr(
+			i.indpred,
+			i.indrelid
+         ) AS filter_condition
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
+         JOIN (
+				SELECT i.indexrelid,
+				       i.indrelid,
+				       i.indoption,
+				       i.indisunique,
+				       i.indisclustered,
+				       i.indpred,
+				       i.indexprs,
+				       information_schema._pg_expandarray(
+						i.indkey
+				       )
+						AS keys
+				  FROM pg_catalog.pg_index
+						AS i
+			) AS i ON ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON
+				ci.oid = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON
+				ci.relam = am.oid
    WHERE true
          AND n.nspname = 'public'
          AND ct.relname = 'j'
@@ -2227,8 +1941,8 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -2242,12 +1956,147 @@ ORDER BY non_unique,
 				       )
 						AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+			) AS i ON ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON
+				ci.oid = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON
+				ci.relam = am.oid
+   WHERE true
+         AND n.nspname = 'public'
+         AND ct.relname = 'j'
+ORDER BY non_unique,
+         type,
+         index_name,
+         ordinal_position
+
+48:
+------------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         NOT i.indisunique AS non_unique,
+         NULL AS index_qualifier,
+         ci.relname AS index_name,
+         CASE i.indisclustered
+         WHEN true THEN 1
+         ELSE CASE am.amname
+         WHEN 'hash' THEN 2
+         ELSE 3
+         END
+         END AS type,
+         (i.keys).n AS ordinal_position,
+         btrim(
+			pg_catalog.pg_get_indexdef(
+				ci.oid,
+				(i.keys).n,
+				false
+			),
+			'"'
+         ) AS column_name,
+         CASE am.amcanorder
+         WHEN true
+         THEN CASE i.indoption[(i.keys).n - 1]
+         & 1
+         WHEN 1 THEN 'D'
+         ELSE 'A'
+         END
+         ELSE NULL
+         END AS asc_or_desc,
+         ci.reltuples AS cardinality,
+         ci.relpages AS pages,
+         pg_catalog.pg_get_expr(
+			i.indpred,
+			i.indrelid
+         ) AS filter_condition
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
+         JOIN (
+				SELECT i.indexrelid,
+				       i.indrelid,
+				       i.indoption,
+				       i.indisunique,
+				       i.indisclustered,
+				       i.indpred,
+				       i.indexprs,
+				       information_schema._pg_expandarray(
+						i.indkey
+				       )
+						AS keys
+				  FROM pg_catalog.pg_index AS i
+			) AS i ON ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON
+				ci.oid = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON ci.relam
+			                                        = am.oid
+   WHERE true
+         AND n.nspname = 'public'
+         AND ct.relname = 'j'
+ORDER BY non_unique,
+         type,
+         index_name,
+         ordinal_position
+
+49:
+-------------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         NOT i.indisunique AS non_unique,
+         NULL AS index_qualifier,
+         ci.relname AS index_name,
+         CASE i.indisclustered
+         WHEN true THEN 1
+         ELSE CASE am.amname
+         WHEN 'hash' THEN 2
+         ELSE 3
+         END
+         END AS type,
+         (i.keys).n AS ordinal_position,
+         btrim(
+			pg_catalog.pg_get_indexdef(
+				ci.oid,
+				(i.keys).n,
+				false
+			),
+			'"'
+         ) AS column_name,
+         CASE am.amcanorder
+         WHEN true
+         THEN CASE i.indoption[(i.keys).n - 1]
+         & 1
+         WHEN 1 THEN 'D'
+         ELSE 'A'
+         END
+         ELSE NULL
+         END AS asc_or_desc,
+         ci.reltuples AS cardinality,
+         ci.relpages AS pages,
+         pg_catalog.pg_get_expr(
+			i.indpred,
+			i.indrelid
+         ) AS filter_condition
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
+         JOIN (
+				SELECT i.indexrelid,
+				       i.indrelid,
+				       i.indoption,
+				       i.indisunique,
+				       i.indisclustered,
+				       i.indpred,
+				       i.indexprs,
+				       information_schema._pg_expandarray(
+						i.indkey
+				       )
+						AS keys
+				  FROM pg_catalog.pg_index AS i
+			) AS i ON ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid
+			                                           = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON ci.relam
+			                                        = am.oid
    WHERE true
          AND n.nspname = 'public'
          AND ct.relname = 'j'
@@ -2295,8 +2144,8 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -2310,12 +2159,11 @@ ORDER BY non_unique,
 				       )
 						AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+			) AS i ON ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid
+			                                           = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON ci.relam
+			                                        = am.oid
    WHERE true
          AND n.nspname = 'public'
          AND ct.relname = 'j'
@@ -2363,8 +2211,8 @@ ORDER BY non_unique,
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -2378,12 +2226,11 @@ ORDER BY non_unique,
 				       )
 						AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+			) AS i ON ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid
+			                                           = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON ci.relam
+			                                        = am.oid
    WHERE true
          AND n.nspname = 'public'
          AND ct.relname = 'j'
@@ -2428,8 +2275,8 @@ ORDER BY non_unique, type, index_name, ordinal_position
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -2443,10 +2290,9 @@ ORDER BY non_unique, type, index_name, ordinal_position
 				       )
 						AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+			) AS i ON ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid
+			                                           = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true
          AND n.nspname = 'public'
@@ -2489,8 +2335,8 @@ ORDER BY non_unique, type, index_name, ordinal_position
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -2503,10 +2349,9 @@ ORDER BY non_unique, type, index_name, ordinal_position
 						i.indkey
 				       ) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+			) AS i ON ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid
+			                                           = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true
          AND n.nspname = 'public'
@@ -2549,8 +2394,8 @@ ORDER BY non_unique, type, index_name, ordinal_position
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_namespace AS n ON
+				ct.relnamespace = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -2563,10 +2408,66 @@ ORDER BY non_unique, type, index_name, ordinal_position
 						i.indkey
 				       ) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
+			) AS i ON ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid
+			                                           = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+   WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
+ORDER BY non_unique, type, index_name, ordinal_position
+
+61:
+-------------------------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         NOT i.indisunique AS non_unique,
+         NULL AS index_qualifier,
+         ci.relname AS index_name,
+         CASE i.indisclustered
+         WHEN true THEN 1
+         ELSE CASE am.amname WHEN 'hash' THEN 2 ELSE 3 END
+         END AS type,
+         (i.keys).n AS ordinal_position,
+         btrim(
+			pg_catalog.pg_get_indexdef(
+				ci.oid,
+				(i.keys).n,
+				false
+			),
+			'"'
+         ) AS column_name,
+         CASE am.amcanorder
+         WHEN true
+         THEN CASE i.indoption[(i.keys).n - 1] & 1
+         WHEN 1 THEN 'D'
+         ELSE 'A'
+         END
+         ELSE NULL
+         END AS asc_or_desc,
+         ci.reltuples AS cardinality,
+         ci.relpages AS pages,
+         pg_catalog.pg_get_expr(
+			i.indpred,
+			i.indrelid
+         ) AS filter_condition
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace
+			                                              = n.oid
+         JOIN (
+				SELECT i.indexrelid,
+				       i.indrelid,
+				       i.indoption,
+				       i.indisunique,
+				       i.indisclustered,
+				       i.indpred,
+				       i.indexprs,
+				       information_schema._pg_expandarray(
+						i.indkey
+				       ) AS keys
+				  FROM pg_catalog.pg_index AS i
+			) AS i ON ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid
+			                                           = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
@@ -2607,8 +2508,8 @@ ORDER BY non_unique, type, index_name, ordinal_position
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace
+			                                              = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -2621,8 +2522,7 @@ ORDER BY non_unique, type, index_name, ordinal_position
 						i.indkey
 				       ) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
@@ -2660,8 +2560,8 @@ ORDER BY non_unique, type, index_name, ordinal_position
 			i.indrelid
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
-         JOIN pg_catalog.pg_namespace AS n
-         ON ct.relnamespace = n.oid
+         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace
+			                                              = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -2674,8 +2574,7 @@ ORDER BY non_unique, type, index_name, ordinal_position
 						i.indkey
 				       ) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
@@ -2726,8 +2625,7 @@ ORDER BY non_unique, type, index_name, ordinal_position
 						i.indkey
 				       ) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
@@ -2775,8 +2673,7 @@ ORDER BY non_unique, type, index_name, ordinal_position
 						i.indkey
 				       ) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
@@ -2822,8 +2719,7 @@ ORDER BY non_unique, type, index_name, ordinal_position
 				       i.indexprs,
 				       information_schema._pg_expandarray(i.indkey) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
@@ -2866,8 +2762,7 @@ ORDER BY non_unique, type, index_name, ordinal_position
 				       i.indexprs,
 				       information_schema._pg_expandarray(i.indkey) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
@@ -2909,8 +2804,7 @@ ORDER BY non_unique, type, index_name, ordinal_position
 				       i.indexprs,
 				       information_schema._pg_expandarray(i.indkey) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
@@ -2949,8 +2843,7 @@ ORDER BY non_unique, type, index_name, ordinal_position
 				       i.indexprs,
 				       information_schema._pg_expandarray(i.indkey) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
@@ -2986,8 +2879,7 @@ ORDER BY non_unique, type, index_name, ordinal_position
 				       i.indexprs,
 				       information_schema._pg_expandarray(i.indkey) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
@@ -3020,8 +2912,7 @@ ORDER BY non_unique, type, index_name, ordinal_position
 				       i.indexprs,
 				       information_schema._pg_expandarray(i.indkey) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
@@ -3047,8 +2938,7 @@ ORDER BY non_unique, type, index_name, ordinal_position
          JOIN (
 				SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys
 				  FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
@@ -3073,15 +2963,14 @@ ORDER BY non_unique, type, index_name, ordinal_position
          JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
          JOIN (
 				SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i
-              ) AS i
-         ON ct.oid = i.indrelid
+			) AS i ON ct.oid = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
 ORDER BY non_unique, type, index_name, ordinal_position
 
-205:
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+208:
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   SELECT NULL AS table_cat,
          n.nspname AS table_schem,
          ct.relname AS table_name,
@@ -3097,8 +2986,32 @@ ORDER BY non_unique, type, index_name, ordinal_position
          pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
     FROM pg_catalog.pg_class AS ct
          JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-         JOIN (SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i
-         ON ct.oid = i.indrelid
+         JOIN (SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON
+				ct.oid = i.indrelid
+         JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
+   WHERE true AND n.nspname = 'public' AND ct.relname = 'j'
+ORDER BY non_unique, type, index_name, ordinal_position
+
+215:
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT NULL AS table_cat,
+         n.nspname AS table_schem,
+         ct.relname AS table_name,
+         NOT i.indisunique AS non_unique,
+         NULL AS index_qualifier,
+         ci.relname AS index_name,
+         CASE i.indisclustered WHEN true THEN 1 ELSE CASE am.amname WHEN 'hash' THEN 2 ELSE 3 END END AS type,
+         (i.keys).n AS ordinal_position,
+         btrim(pg_catalog.pg_get_indexdef(ci.oid, (i.keys).n, false), '"') AS column_name,
+         CASE am.amcanorder WHEN true THEN CASE i.indoption[(i.keys).n - 1] & 1 WHEN 1 THEN 'D' ELSE 'A' END ELSE NULL END AS asc_or_desc,
+         ci.reltuples AS cardinality,
+         ci.relpages AS pages,
+         pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
+    FROM pg_catalog.pg_class AS ct
+         JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
+         JOIN (SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON ct.oid
+			                                                                                                                                                                                                                 = i.indrelid
          JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
          JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
    WHERE true AND n.nspname = 'public' AND ct.relname = 'j'

--- a/pkg/sql/sem/tree/testdata/pretty/join3.align-only.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/join3.align-only.golden.short
@@ -42,8 +42,8 @@
          ) AS filter_condition
     FROM pg_catalog.pg_class AS ct
          JOIN pg_catalog.pg_namespace
-				AS n
-         ON ct.relnamespace = n.oid
+				AS n ON ct.relnamespace
+			        = n.oid
          JOIN (
 				SELECT i.indexrelid,
 				       i.indrelid,
@@ -58,12 +58,13 @@
 						AS keys
 				  FROM pg_catalog.pg_index
 						AS i
-              ) AS i
-         ON ct.oid = i.indrelid
-         JOIN pg_catalog.pg_class AS ci
-         ON ci.oid = i.indexrelid
-         JOIN pg_catalog.pg_am AS am
-         ON ci.relam = am.oid
+			) AS i ON ct.oid
+			          = i.indrelid
+         JOIN pg_catalog.pg_class
+				AS ci ON ci.oid
+			         = i.indexrelid
+         JOIN pg_catalog.pg_am AS am ON
+				ci.relam = am.oid
    WHERE true
          AND n.nspname = 'public'
          AND ct.relname = 'j'

--- a/pkg/sql/sem/tree/testdata/pretty/join3.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/join3.ref.golden
@@ -60,14 +60,11 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -84,22 +81,17 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -171,14 +163,11 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -195,22 +184,17 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -281,14 +265,11 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -305,22 +286,17 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -390,14 +366,11 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -414,22 +387,17 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -497,14 +465,11 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -521,22 +486,17 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON
-		ci.relam
-		= am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -604,14 +564,11 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -628,20 +585,17 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON ci.relam = am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -707,14 +661,11 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -731,121 +682,17 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON
-		ct.oid
-		= i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON ci.relam = am.oid
-WHERE
-	true
-	AND n.nspname
-		= 'public'
-	AND ct.relname = 'j'
-ORDER BY
-	non_unique,
-	type,
-	index_name,
-	ordinal_position
-
-26:
---------------------------
-SELECT
-	NULL AS table_cat,
-	n.nspname
-		AS table_schem,
-	ct.relname
-		AS table_name,
-	NOT i.indisunique
-		AS non_unique,
-	NULL
-		AS index_qualifier,
-	ci.relname
-		AS index_name,
-	CASE i.indisclustered
-	WHEN true THEN 1
-	ELSE CASE am.amname
-	WHEN 'hash' THEN 2
-	ELSE 3
-	END
-	END
-		AS type,
-	(i.keys).n
-		AS ordinal_position,
-	btrim(
-		pg_catalog.pg_get_indexdef(
-			ci.oid,
-			(i.keys).n,
-			false
-		),
-		'"'
-	)
-		AS column_name,
-	CASE am.amcanorder
-	WHEN true
-	THEN CASE i.indoption[(i.keys).n - 1]
-	& 1
-	WHEN 1 THEN 'D'
-	ELSE 'A'
-	END
-	ELSE NULL
-	END
-		AS asc_or_desc,
-	ci.reltuples
-		AS cardinality,
-	ci.relpages AS pages,
-	pg_catalog.pg_get_expr(
-		i.indpred,
-		i.indrelid
-	)
-		AS filter_condition
-FROM
-	pg_catalog.pg_class
-		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
-			SELECT
-				i.indexrelid,
-				i.indrelid,
-				i.indoption,
-				i.indisunique,
-				i.indisclustered,
-				i.indpred,
-				i.indexprs,
-				information_schema._pg_expandarray(
-					i.indkey
-				)
-					AS keys
-			FROM
-				pg_catalog.pg_index
-					AS i
-		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON
-		ci.oid
-		= i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON ci.relam = am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname
@@ -910,14 +757,11 @@ SELECT
 FROM
 	pg_catalog.pg_class
 		AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -934,16 +778,17 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON ci.oid = i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON ci.relam = am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam
+			= am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -1003,14 +848,11 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON
-		ct.relnamespace
-		= n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -1027,106 +869,16 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON ci.oid = i.indexrelid
-	JOIN
-		pg_catalog.pg_am
-			AS am
-	ON ci.relam = am.oid
-WHERE
-	true
-	AND n.nspname = 'public'
-	AND ct.relname = 'j'
-ORDER BY
-	non_unique,
-	type,
-	index_name,
-	ordinal_position
-
-30:
-------------------------------
-SELECT
-	NULL AS table_cat,
-	n.nspname AS table_schem,
-	ct.relname AS table_name,
-	NOT i.indisunique
-		AS non_unique,
-	NULL AS index_qualifier,
-	ci.relname AS index_name,
-	CASE i.indisclustered
-	WHEN true THEN 1
-	ELSE CASE am.amname
-	WHEN 'hash' THEN 2
-	ELSE 3
-	END
-	END
-		AS type,
-	(i.keys).n
-		AS ordinal_position,
-	btrim(
-		pg_catalog.pg_get_indexdef(
-			ci.oid,
-			(i.keys).n,
-			false
-		),
-		'"'
-	)
-		AS column_name,
-	CASE am.amcanorder
-	WHEN true
-	THEN CASE i.indoption[(i.keys).n - 1]
-	& 1
-	WHEN 1 THEN 'D'
-	ELSE 'A'
-	END
-	ELSE NULL
-	END
-		AS asc_or_desc,
-	ci.reltuples
-		AS cardinality,
-	ci.relpages AS pages,
-	pg_catalog.pg_get_expr(
-		i.indpred,
-		i.indrelid
-	)
-		AS filter_condition
-FROM
-	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
-			SELECT
-				i.indexrelid,
-				i.indrelid,
-				i.indoption,
-				i.indisunique,
-				i.indisclustered,
-				i.indpred,
-				i.indexprs,
-				information_schema._pg_expandarray(
-					i.indkey
-				)
-					AS keys
-			FROM
-				pg_catalog.pg_index
-					AS i
-		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON ci.oid = i.indexrelid
-	JOIN
-		pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON
+			ct.oid
+			= i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -1186,12 +938,11 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -1208,14 +959,15 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON
+			ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -1274,12 +1026,11 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -1296,14 +1047,15 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN
-		pg_catalog.pg_class
-			AS ci
-	ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON
+			ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid
+			= i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -1362,12 +1114,11 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -1384,13 +1135,14 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN
-		pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON
+			ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid = i.indexrelid
+	JOIN pg_catalog.pg_am
+			AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -1449,12 +1201,11 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace
+			= n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -1471,12 +1222,13 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON
+			ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid = i.indexrelid
+	JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -1534,12 +1286,10 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_namespace
-			AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -1556,12 +1306,13 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON
+			ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid = i.indexrelid
+	JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -1618,11 +1369,10 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN
-		pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -1639,12 +1389,13 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON
+			ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class
+			AS ci ON
+			ci.oid = i.indexrelid
+	JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -1701,10 +1452,10 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -1721,12 +1472,93 @@ FROM
 				pg_catalog.pg_index
 					AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON
+			ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+	JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
+WHERE
+	true
+	AND n.nspname = 'public'
+	AND ct.relname = 'j'
+ORDER BY
+	non_unique,
+	type,
+	index_name,
+	ordinal_position
+
+39:
+---------------------------------------
+SELECT
+	NULL AS table_cat,
+	n.nspname AS table_schem,
+	ct.relname AS table_name,
+	NOT i.indisunique AS non_unique,
+	NULL AS index_qualifier,
+	ci.relname AS index_name,
+	CASE i.indisclustered
+	WHEN true THEN 1
+	ELSE CASE am.amname
+	WHEN 'hash' THEN 2
+	ELSE 3
+	END
+	END
+		AS type,
+	(i.keys).n AS ordinal_position,
+	btrim(
+		pg_catalog.pg_get_indexdef(
+			ci.oid,
+			(i.keys).n,
+			false
+		),
+		'"'
+	)
+		AS column_name,
+	CASE am.amcanorder
+	WHEN true
+	THEN CASE i.indoption[(i.keys).n - 1]
+	& 1
+	WHEN 1 THEN 'D'
+	ELSE 'A'
+	END
+	ELSE NULL
+	END
+		AS asc_or_desc,
+	ci.reltuples AS cardinality,
+	ci.relpages AS pages,
+	pg_catalog.pg_get_expr(
+		i.indpred,
+		i.indrelid
+	)
+		AS filter_condition
+FROM
+	pg_catalog.pg_class AS ct
+	JOIN pg_catalog.pg_namespace
+			AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
+			SELECT
+				i.indexrelid,
+				i.indrelid,
+				i.indoption,
+				i.indisunique,
+				i.indisclustered,
+				i.indpred,
+				i.indexprs,
+				information_schema._pg_expandarray(
+					i.indkey
+				)
+					AS keys
+			FROM
+				pg_catalog.pg_index
+					AS i
+		)
+			AS i ON ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+	JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -1783,10 +1615,9 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -1802,12 +1633,11 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+	JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -1863,10 +1693,9 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -1882,12 +1711,11 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+	JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -1940,10 +1768,9 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -1959,12 +1786,11 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+	JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -2017,10 +1843,9 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2036,12 +1861,11 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+	JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'
@@ -2091,10 +1915,9 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2110,10 +1933,9 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
 	true
@@ -2161,10 +1983,9 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2180,10 +2001,9 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
 	true
@@ -2231,10 +2051,9 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2250,10 +2069,9 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
+			AS i ON ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
 	true AND n.nspname = 'public' AND ct.relname = 'j'
@@ -2299,10 +2117,9 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2318,8 +2135,7 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2366,10 +2182,9 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2383,8 +2198,7 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2427,10 +2241,9 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2444,8 +2257,7 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2489,8 +2301,7 @@ SELECT
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2504,8 +2315,7 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2549,8 +2359,7 @@ SELECT
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2563,8 +2372,7 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2604,8 +2412,7 @@ SELECT
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2618,8 +2425,7 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2656,8 +2462,7 @@ SELECT
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2670,8 +2475,7 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2707,8 +2511,7 @@ SELECT
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2721,8 +2524,7 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2757,8 +2559,7 @@ SELECT
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2771,8 +2572,7 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2803,8 +2603,7 @@ SELECT
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2817,8 +2616,7 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2845,8 +2643,7 @@ SELECT
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -2859,8 +2656,7 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2887,15 +2683,13 @@ SELECT
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN (
 			SELECT
 				i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2903,8 +2697,8 @@ WHERE
 ORDER BY
 	non_unique, type, index_name, ordinal_position
 
-194:
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+195:
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 SELECT
 	NULL AS table_cat,
 	n.nspname AS table_schem,
@@ -2922,10 +2716,8 @@ SELECT
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i)
-			AS i
-	ON ct.oid = i.indrelid
+	JOIN (SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i)
+			AS i ON ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE
@@ -2933,8 +2725,8 @@ WHERE
 ORDER BY
 	non_unique, type, index_name, ordinal_position
 
-199:
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+203:
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 SELECT
 	NULL AS table_cat,
 	n.nspname AS table_schem,
@@ -2952,37 +2744,8 @@ SELECT
 FROM
 	pg_catalog.pg_class AS ct
 	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN
-		(SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
-WHERE
-	true AND n.nspname = 'public' AND ct.relname = 'j'
-ORDER BY
-	non_unique, type, index_name, ordinal_position
-
-200:
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-SELECT
-	NULL AS table_cat,
-	n.nspname AS table_schem,
-	ct.relname AS table_name,
-	NOT i.indisunique AS non_unique,
-	NULL AS index_qualifier,
-	ci.relname AS index_name,
-	CASE i.indisclustered WHEN true THEN 1 ELSE CASE am.amname WHEN 'hash' THEN 2 ELSE 3 END END AS type,
-	(i.keys).n AS ordinal_position,
-	btrim(pg_catalog.pg_get_indexdef(ci.oid, (i.keys).n, false), '"') AS column_name,
-	CASE am.amcanorder WHEN true THEN CASE i.indoption[(i.keys).n - 1] & 1 WHEN 1 THEN 'D' ELSE 'A' END ELSE NULL END AS asc_or_desc,
-	ci.reltuples AS cardinality,
-	ci.relpages AS pages,
-	pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS filter_condition
-FROM
-	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n ON ct.relnamespace = n.oid
-	JOIN (SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i
-	ON ct.oid = i.indrelid
+	JOIN (SELECT i.indexrelid, i.indrelid, i.indoption, i.indisunique, i.indisclustered, i.indpred, i.indexprs, information_schema._pg_expandarray(i.indkey) AS keys FROM pg_catalog.pg_index AS i) AS i ON
+			ct.oid = i.indrelid
 	JOIN pg_catalog.pg_class AS ci ON ci.oid = i.indexrelid
 	JOIN pg_catalog.pg_am AS am ON ci.relam = am.oid
 WHERE

--- a/pkg/sql/sem/tree/testdata/pretty/join3.ref.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/join3.ref.golden.short
@@ -46,10 +46,9 @@ SELECT
 		AS filter_condition
 FROM
 	pg_catalog.pg_class AS ct
-	JOIN pg_catalog.pg_namespace AS n
-	ON ct.relnamespace = n.oid
-	JOIN
-		(
+	JOIN pg_catalog.pg_namespace AS n ON
+			ct.relnamespace = n.oid
+	JOIN (
 			SELECT
 				i.indexrelid,
 				i.indrelid,
@@ -65,12 +64,11 @@ FROM
 			FROM
 				pg_catalog.pg_index AS i
 		)
-			AS i
-	ON ct.oid = i.indrelid
-	JOIN pg_catalog.pg_class AS ci
-	ON ci.oid = i.indexrelid
-	JOIN pg_catalog.pg_am AS am
-	ON ci.relam = am.oid
+			AS i ON ct.oid = i.indrelid
+	JOIN pg_catalog.pg_class AS ci ON
+			ci.oid = i.indexrelid
+	JOIN pg_catalog.pg_am AS am ON
+			ci.relam = am.oid
 WHERE
 	true
 	AND n.nspname = 'public'

--- a/pkg/sql/sem/tree/testdata/pretty/join4.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/join4.align-deindent.golden
@@ -6,17 +6,12 @@ SELECT
 	*
 FROM
 	a
-	JOIN
-		b
-	USING (c),
+	JOIN b USING (c),
 	a
-	NATURAL JOIN
-		b,
+	NATURAL JOIN b,
 	a
-	JOIN
-		b
-	ON
-		c
+	JOIN b ON
+			c
 WHERE
 	true
 
@@ -24,83 +19,23 @@ WHERE
 --------
 SELECT *
   FROM a
-       JOIN
-		b
-       USING (c),
+  JOIN b USING (c),
        a
-       NATURAL JOIN
-		b,
+       NATURAL JOIN b,
        a
-       JOIN
-		b
-       ON
+  JOIN b ON
 		c
- WHERE true
-
-11:
------------
-SELECT *
-  FROM a
-       JOIN
-		b
-       USING (c),
-       a
-       NATURAL JOIN
-		b,
-       a
-       JOIN
-		b
-       ON c
  WHERE true
 
 13:
 -------------
 SELECT *
   FROM a
-       JOIN b
-       USING (c),
-       a
-       NATURAL JOIN
-		b,
-       a
-       JOIN b
-       ON c
- WHERE true
-
-18:
-------------------
-SELECT *
-  FROM a
-       JOIN b
-       USING (c),
-       a
-       NATURAL JOIN
-		b,
-       a
-       JOIN b ON c
- WHERE true
-
-22:
-----------------------
-SELECT *
-  FROM a
-       JOIN b
-       USING (c),
+  JOIN b USING (c),
        a
        NATURAL JOIN b,
        a
-       JOIN b ON c
- WHERE true
-
-24:
-------------------------
-SELECT *
-  FROM a
-       JOIN b USING (c),
-       a
-       NATURAL JOIN b,
-       a
-       JOIN b ON c
+  JOIN b ON c
  WHERE true
 
 58:

--- a/pkg/sql/sem/tree/testdata/pretty/join4.align-deindent.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/join4.align-deindent.golden.short
@@ -4,11 +4,11 @@
 -
 SELECT *
   FROM a
-       JOIN b USING (c),
+  JOIN b USING (c),
        a
        NATURAL JOIN b,
        a
-       JOIN b ON c
+  JOIN b ON c
  WHERE true
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/join4.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/join4.align-only.golden
@@ -6,17 +6,12 @@ SELECT
 	*
 FROM
 	a
-	JOIN
-		b
-	USING (c),
+	JOIN b USING (c),
 	a
-	NATURAL JOIN
-		b,
+	NATURAL JOIN b,
 	a
-	JOIN
-		b
-	ON
-		c
+	JOIN b ON
+			c
 WHERE
 	true
 
@@ -24,76 +19,16 @@ WHERE
 --------
 SELECT *
   FROM a
-       JOIN
-		b
-       USING (c),
+       JOIN b USING (c),
        a
-       NATURAL JOIN
-		b,
+       NATURAL JOIN b,
        a
-       JOIN
-		b
-       ON
-		c
- WHERE true
-
-11:
------------
-SELECT *
-  FROM a
-       JOIN
-		b
-       USING (c),
-       a
-       NATURAL JOIN
-		b,
-       a
-       JOIN
-		b
-       ON c
- WHERE true
-
-13:
--------------
-SELECT *
-  FROM a
-       JOIN b
-       USING (c),
-       a
-       NATURAL JOIN
-		b,
-       a
-       JOIN b
-       ON c
+       JOIN b ON
+			c
  WHERE true
 
 18:
 ------------------
-SELECT *
-  FROM a
-       JOIN b
-       USING (c),
-       a
-       NATURAL JOIN
-		b,
-       a
-       JOIN b ON c
- WHERE true
-
-22:
-----------------------
-SELECT *
-  FROM a
-       JOIN b
-       USING (c),
-       a
-       NATURAL JOIN b,
-       a
-       JOIN b ON c
- WHERE true
-
-24:
-------------------------
 SELECT *
   FROM a
        JOIN b USING (c),

--- a/pkg/sql/sem/tree/testdata/pretty/join4.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/join4.ref.golden
@@ -6,89 +6,17 @@ SELECT
 	*
 FROM
 	a
-	JOIN
-		b
-	USING (c),
+	JOIN b USING (c),
 	a
-	NATURAL JOIN
-		b,
+	NATURAL JOIN b,
 	a
-	JOIN
-		b
-	ON
-		c
-WHERE
-	true
-
-8:
---------
-SELECT
-	*
-FROM
-	a
-	JOIN
-		b
-	USING (c),
-	a
-	NATURAL JOIN
-		b,
-	a
-	JOIN
-		b
-	ON c
-WHERE
-	true
-
-10:
-----------
-SELECT
-	*
-FROM
-	a
-	JOIN b
-	USING (c),
-	a
-	NATURAL JOIN
-		b,
-	a
-	JOIN b
-	ON c
+	JOIN b ON
+			c
 WHERE
 	true
 
 15:
 ---------------
-SELECT
-	*
-FROM
-	a
-	JOIN b
-	USING (c),
-	a
-	NATURAL JOIN
-		b,
-	a
-	JOIN b ON c
-WHERE
-	true
-
-19:
--------------------
-SELECT
-	*
-FROM
-	a
-	JOIN b
-	USING (c),
-	a
-	NATURAL JOIN b,
-	a
-	JOIN b ON c
-WHERE
-	true
-
-21:
----------------------
 SELECT
 	*
 FROM

--- a/pkg/sql/sem/tree/testdata/pretty/join5.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/join5.align-deindent.golden
@@ -6,14 +6,11 @@ SELECT
 	*
 FROM
 	a
-	CROSS JOIN
-		b,
+	CROSS JOIN b,
 	a
-	CROSS JOIN
-		(
+	CROSS JOIN (
 			c
-			CROSS JOIN
-				d
+			CROSS JOIN d
 		),
 	d,
 	(
@@ -31,14 +28,11 @@ FROM
 --------
 SELECT *
   FROM a
-       CROSS JOIN
-		b,
+       CROSS JOIN b,
        a
-       CROSS JOIN
-		(
+       CROSS JOIN (
 			c
-			CROSS JOIN
-				d
+			CROSS JOIN d
 		),
        d,
        (
@@ -56,14 +50,11 @@ SELECT *
 ---------------
 SELECT *
   FROM a
-       CROSS JOIN
-		b,
+       CROSS JOIN b,
        a
-       CROSS JOIN
-		(
+       CROSS JOIN (
 			c
-			CROSS JOIN
-				d
+			CROSS JOIN d
 		),
        d,
        (
@@ -80,14 +71,11 @@ SELECT *
 -----------------
 SELECT *
   FROM a
-       CROSS JOIN
-		b,
+       CROSS JOIN b,
        a
-       CROSS JOIN
-		(
+       CROSS JOIN (
 			c
-			CROSS JOIN
-				d
+			CROSS JOIN d
 		),
        d,
        (TABLE x),
@@ -102,52 +90,12 @@ SELECT *
 ------------------
 SELECT *
   FROM a
-       CROSS JOIN
-		b,
-       a
-       CROSS JOIN
-		(
-			c
-			CROSS JOIN
-				d
-		),
-       d,
-       (TABLE x),
-       (
-		   TABLE e
-		ORDER BY f
-       )
-
-19:
--------------------
-SELECT *
-  FROM a
-       CROSS JOIN
-		b,
-       a
-       CROSS JOIN (
-					c
-					CROSS JOIN
-						d
-                  ),
-       d,
-       (TABLE x),
-       (
-		   TABLE e
-		ORDER BY f
-       )
-
-20:
---------------------
-SELECT *
-  FROM a
        CROSS JOIN b,
        a
        CROSS JOIN (
-					c
-					CROSS JOIN
-						d
-                  ),
+			c
+			CROSS JOIN d
+		),
        d,
        (TABLE x),
        (
@@ -162,10 +110,9 @@ SELECT *
        CROSS JOIN b,
        a
        CROSS JOIN (
-					c
-					CROSS JOIN
-						d
-                  ),
+			c
+			CROSS JOIN d
+		),
        d,
        (TABLE x),
        (
@@ -179,24 +126,9 @@ SELECT *
        CROSS JOIN b,
        a
        CROSS JOIN (
-					c
-					CROSS JOIN
-						d
-                  ),
-       d,
-       (TABLE x),
-       (TABLE e ORDER BY f)
-
-32:
---------------------------------
-SELECT *
-  FROM a
-       CROSS JOIN b,
-       a
-       CROSS JOIN (
-					c
-					CROSS JOIN d
-                  ),
+			c
+			CROSS JOIN d
+		),
        d,
        (TABLE x),
        (TABLE e ORDER BY f)

--- a/pkg/sql/sem/tree/testdata/pretty/join5.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/join5.align-only.golden
@@ -6,14 +6,11 @@ SELECT
 	*
 FROM
 	a
-	CROSS JOIN
-		b,
+	CROSS JOIN b,
 	a
-	CROSS JOIN
-		(
+	CROSS JOIN (
 			c
-			CROSS JOIN
-				d
+			CROSS JOIN d
 		),
 	d,
 	(
@@ -31,14 +28,11 @@ FROM
 --------
 SELECT *
   FROM a
-       CROSS JOIN
-		b,
+       CROSS JOIN b,
        a
-       CROSS JOIN
-		(
+       CROSS JOIN (
 			c
-			CROSS JOIN
-				d
+			CROSS JOIN d
 		),
        d,
        (
@@ -56,14 +50,11 @@ SELECT *
 ---------------
 SELECT *
   FROM a
-       CROSS JOIN
-		b,
+       CROSS JOIN b,
        a
-       CROSS JOIN
-		(
+       CROSS JOIN (
 			c
-			CROSS JOIN
-				d
+			CROSS JOIN d
 		),
        d,
        (
@@ -80,14 +71,11 @@ SELECT *
 -----------------
 SELECT *
   FROM a
-       CROSS JOIN
-		b,
+       CROSS JOIN b,
        a
-       CROSS JOIN
-		(
+       CROSS JOIN (
 			c
-			CROSS JOIN
-				d
+			CROSS JOIN d
 		),
        d,
        (TABLE x),
@@ -102,52 +90,12 @@ SELECT *
 ------------------
 SELECT *
   FROM a
-       CROSS JOIN
-		b,
-       a
-       CROSS JOIN
-		(
-			c
-			CROSS JOIN
-				d
-		),
-       d,
-       (TABLE x),
-       (
-		   TABLE e
-		ORDER BY f
-       )
-
-19:
--------------------
-SELECT *
-  FROM a
-       CROSS JOIN
-		b,
-       a
-       CROSS JOIN (
-					c
-					CROSS JOIN
-						d
-                  ),
-       d,
-       (TABLE x),
-       (
-		   TABLE e
-		ORDER BY f
-       )
-
-20:
---------------------
-SELECT *
-  FROM a
        CROSS JOIN b,
        a
        CROSS JOIN (
-					c
-					CROSS JOIN
-						d
-                  ),
+			c
+			CROSS JOIN d
+		),
        d,
        (TABLE x),
        (
@@ -162,10 +110,9 @@ SELECT *
        CROSS JOIN b,
        a
        CROSS JOIN (
-					c
-					CROSS JOIN
-						d
-                  ),
+			c
+			CROSS JOIN d
+		),
        d,
        (TABLE x),
        (
@@ -179,24 +126,9 @@ SELECT *
        CROSS JOIN b,
        a
        CROSS JOIN (
-					c
-					CROSS JOIN
-						d
-                  ),
-       d,
-       (TABLE x),
-       (TABLE e ORDER BY f)
-
-32:
---------------------------------
-SELECT *
-  FROM a
-       CROSS JOIN b,
-       a
-       CROSS JOIN (
-					c
-					CROSS JOIN d
-                  ),
+			c
+			CROSS JOIN d
+		),
        d,
        (TABLE x),
        (TABLE e ORDER BY f)

--- a/pkg/sql/sem/tree/testdata/pretty/join5.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/join5.ref.golden
@@ -6,14 +6,11 @@ SELECT
 	*
 FROM
 	a
-	CROSS JOIN
-		b,
+	CROSS JOIN b,
 	a
-	CROSS JOIN
-		(
+	CROSS JOIN (
 			c
-			CROSS JOIN
-				d
+			CROSS JOIN d
 		),
 	d,
 	(
@@ -33,37 +30,11 @@ SELECT
 	*
 FROM
 	a
-	CROSS JOIN
-		b,
-	a
-	CROSS JOIN
-		(
-			c
-			CROSS JOIN
-				d
-		),
-	d,
-	(TABLE x),
-	(
-		TABLE
-			e
-		ORDER BY
-			f
-	)
-
-17:
------------------
-SELECT
-	*
-FROM
-	a
 	CROSS JOIN b,
 	a
-	CROSS JOIN
-		(
+	CROSS JOIN (
 			c
-			CROSS JOIN
-				d
+			CROSS JOIN d
 		),
 	d,
 	(TABLE x),
@@ -82,25 +53,10 @@ FROM
 	a
 	CROSS JOIN b,
 	a
-	CROSS JOIN
-		(
+	CROSS JOIN (
 			c
 			CROSS JOIN d
 		),
-	d,
-	(TABLE x),
-	(TABLE e ORDER BY f)
-
-25:
--------------------------
-SELECT
-	*
-FROM
-	a
-	CROSS JOIN b,
-	a
-	CROSS JOIN
-		(c CROSS JOIN d),
 	d,
 	(TABLE x),
 	(TABLE e ORDER BY f)


### PR DESCRIPTION
(first commit from #36796)

The formatting for NATURAL was broken. Also this clarifies the joins by adjusting the spacing.

Before:

```
SELECT def.oid, c.relname, pg_catalog.pg_get_expr(def.adbin, def.adrelid)
  FROM pg_catalog.pg_attrdef AS def
       JOIN pg_catalog.pg_class AS c ON def.adrelid = c.oid
       JOIN pg_catalog.pg_namespace AS n ON c.relnamespace = n.oid;
--
SELECT def.oid,
       c.relname,
       pg_catalog.pg_get_expr(
          def.adbin,
          def.adrelid
       )
  FROM pg_catalog.pg_attrdef AS def
       JOIN pg_catalog.pg_class AS c
       ON def.adrelid = c.oid
       JOIN pg_catalog.pg_namespace AS n
       ON c.relnamespace = n.oid;
```

After:

```
SELECT def.oid, c.relname, pg_catalog.pg_get_expr(def.adbin, def.adrelid)
  FROM pg_catalog.pg_attrdef AS def
  JOIN pg_catalog.pg_class AS c ON def.adrelid = c.oid
  JOIN pg_catalog.pg_namespace AS n ON c.relnamespace = n.oid;
--
SELECT def.oid,
       c.relname,
       pg_catalog.pg_get_expr(
		def.adbin,
		def.adrelid
       )
  FROM pg_catalog.pg_attrdef AS def
  JOIN pg_catalog.pg_class AS c ON
		def.adrelid = c.oid
  JOIN pg_catalog.pg_namespace AS n ON
		c.relnamespace = n.oid;
```

Release note: None