### PR TITLE
sql: move gossipccl.DisableMerges to gossip, call during idx backfill

### DIFF
--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -16,7 +16,6 @@ import (
 	"sort"
 	"sync/atomic"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/gossipccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/intervalccl"
@@ -1076,7 +1075,7 @@ func restore(
 		}
 		disableCtx, cancel := context.WithCancel(restoreCtx)
 		defer cancel()
-		gossipccl.DisableMerges(disableCtx, gossip, tableIDs)
+		gossip.DisableMerges(disableCtx, tableIDs)
 	}
 
 	// Get TableRekeys to use when importing raw data.

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
-	"github.com/cockroachdb/cockroach/pkg/ccl/gossipccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -1079,7 +1078,7 @@ func (r *importResumer) Resume(
 		}
 		disableCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		gossipccl.DisableMerges(disableCtx, p.ExecCfg().Gossip, tableIDs)
+		p.ExecCfg().Gossip.DisableMerges(disableCtx, tableIDs)
 	}
 
 	res, err := doDistributedCSVTransform(

--- a/pkg/gossip/disable_merges.go
+++ b/pkg/gossip/disable_merges.go
@@ -1,18 +1,23 @@
 // Copyright 2018 The Cockroach Authors.
 //
-// Licensed as a CockroachDB Enterprise file under the Cockroach Community
-// License (the "License"); you may not use this file except in compliance with
-// the License. You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
 
-package gossipccl
+package gossip
 
 import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -23,7 +28,7 @@ const (
 // DisableMerges starts a goroutine which periodically gossips keys that
 // disable merging for the specified table IDs. The goroutine until the
 // associated context is done (usually via cancellation).
-func DisableMerges(ctx context.Context, g *gossip.Gossip, tableIDs []uint32) {
+func (g *Gossip) DisableMerges(ctx context.Context, tableIDs []uint32) {
 	if len(tableIDs) == 0 {
 		// Nothing to do.
 		return
@@ -31,7 +36,7 @@ func DisableMerges(ctx context.Context, g *gossip.Gossip, tableIDs []uint32) {
 
 	disable := func() {
 		for _, id := range tableIDs {
-			key := gossip.MakeTableDisableMergesKey(id)
+			key := MakeTableDisableMergesKey(id)
 			err := g.AddInfo(key, nil /* value */, disableMergesInterval*2 /* ttl */)
 			if err != nil {
 				log.Infof(ctx, "failed to gossip: %s: %v", key, err)

--- a/pkg/gossip/disable_merges_test.go
+++ b/pkg/gossip/disable_merges_test.go
@@ -1,18 +1,23 @@
 // Copyright 2018 The Cockroach Authors.
 //
-// Licensed as a CockroachDB Enterprise file under the Cockroach Community
-// License (the "License"); you may not use this file except in compliance with
-// the License. You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
 
-package gossipccl
+package gossip
 
 import (
 	"context"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -32,14 +37,14 @@ func TestDisableMerges(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			g := gossip.NewTest(1, nil /* rpcContext */, nil, /* grpcServer */
+			g := NewTest(1, nil /* rpcContext */, nil, /* grpcServer */
 				stopper, metric.NewRegistry())
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			DisableMerges(ctx, g, c.tableIDs)
+			g.DisableMerges(ctx, c.tableIDs)
 			for _, id := range c.tableIDs {
-				key := gossip.MakeTableDisableMergesKey(id)
+				key := MakeTableDisableMergesKey(id)
 				if _, err := g.GetInfo(key); err != nil {
 					t.Fatalf("expected to find %s, but got %v", key, err)
 				}


### PR DESCRIPTION
This moves the DisableMerges helper from gossipccl to gossip, and adds a call to it during index backfills.

Release note: none.