### PR TITLE
sql: fix COMMENT ON crash with -vmodule

### DIFF
--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -140,6 +140,8 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *valuesNode:
 	case *virtualTableNode:
 	case *zeroNode:
+	case *commentOnTableNode:
+	case *commentOnColumnNode:
 	default:
 		panic(fmt.Sprintf("unhandled node type: %T", plan))
 	}


### PR DESCRIPTION
Fixes a crash that happens when `COMMENT ON` is executed with a high V
level.

Fixes #36822.

Release note (bug fix): Fixed a crash caused by running `COMMENT ON`
with verbose logging turned on.