### PR TITLE
roachprod: ignore errors from gcloud list about unknown zones

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -60,8 +60,9 @@ func runJSONCommand(args []string, parsed interface{}) error {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			stderr = exitErr.Stderr
 		}
-		// TODO(peter): Remove this hack once gcloud is behaving again.
-		if matched, _ := regexp.Match(`europe-north.*Unknown zone`, stderr); !matched {
+		// TODO(peter,ajwerner): Remove this hack once gcloud behaves when adding
+		// new zones.
+		if matched, _ := regexp.Match(`.*Unknown zone`, stderr); !matched {
 			return errors.Errorf("failed to run: gcloud %s: %s\nstdout: %s\nstderr: %s",
 				strings.Join(args, " "), err, bytes.TrimSpace(rawJSON), bytes.TrimSpace(stderr))
 		}


### PR DESCRIPTION
It seems that google exposes new zones to compute list before they
are ready and returns errors about those zones not existing. Apparently
we've encountered this before but this time we're seeing it with
asia-northeast2.

Fortunately this error does not prevent gcloud from returing the expected json
for the other regions. A more complete solution might be to pass an error filter
to the runJSONCommand function as its not clear that this error should be
ignored for all commands, let me know in review if you feel I should do that.

Release note: None