### PR TITLE
roachprod: distribute authorized keys file for shared ubuntu user on gce

### DIFF
--- a/pkg/cmd/roachprod/cloud/cluster_cloud.go
+++ b/pkg/cmd/roachprod/cloud/cluster_cloud.go
@@ -150,16 +150,6 @@ func (c *Cluster) IsLocal() bool {
 	return c.Name == config.Local
 }
 
-// HasProvider returns true if there is a vm in VMs with the given provider.
-func (c *Cluster) HasProvider(provider string) bool {
-	for i := range c.VMs {
-		if c.VMs[i].Provider == provider {
-			return true
-		}
-	}
-	return false
-}
-
 func namesFromVM(v vm.VM) (string, string, error) {
 	if v.IsLocal() {
 		return config.Local, config.Local, nil


### PR DESCRIPTION
This PR removes the aws specific logic for setting up the ubuntu user for shared
use on roachprod hosts. It also fixes a bug introduced in
1d821eab5841d88434e16b4b0151e1f3daae67a3 which inadvertently omitted the writing
of key_data to the authorized_keys file. I tested that this is working on both providers.

This is the first step in moving to a shared user model in roachprod for gcloud
like we already do in aws.

See https://github.com/cockroachdb/cockroach/pull/36795#issuecomment-483249613

Release note: None