### PR TITLE
requestbatcher,intentresolver: add timeout in requestbatcher and adopt

### DIFF
--- a/pkg/storage/intentresolver/intent_resolver.go
+++ b/pkg/storage/intentresolver/intent_resolver.go
@@ -61,6 +61,11 @@ const (
 	// (this helps avoid deadlocks during test shutdown).
 	intentResolverTimeout = 30 * time.Second
 
+	// gcTimeout is the timeout when processing gc of a batch of txn records.
+	// Since processing txn records is best effort, we'd rather give up than
+	// wait too long (this helps avoid deadlocks during test shutdown).
+	gcTimeout = 30 * time.Second
+
 	// intentResolverBatchSize is the maximum number of intents that will be
 	// resolved in a single batch. Batches that span many ranges (which is
 	// possible for the commit of a transaction that spans many ranges) will be
@@ -199,6 +204,7 @@ func New(c Config) *IntentResolver {
 		MaxIdle:         c.MaxGCBatchIdle,
 		Stopper:         c.Stopper,
 		Sender:          c.DB.NonTransactionalSender(),
+		BatchTimeout:    gcTimeout,
 	})
 	batchSize := intentResolverBatchSize
 	if c.TestingKnobs.MaxIntentResolutionBatchSize > 0 {
@@ -211,6 +217,7 @@ func New(c Config) *IntentResolver {
 		MaxIdle:         c.MaxIntentResolutionBatchIdle,
 		Stopper:         c.Stopper,
 		Sender:          c.DB.NonTransactionalSender(),
+		BatchTimeout:    intentResolverTimeout,
 	})
 	return ir
 }

--- a/pkg/util/contextutil/context.go
+++ b/pkg/util/contextutil/context.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
 )
 
 // WithCancel adds an info log to context.WithCancel's CancelFunc.
@@ -88,7 +87,7 @@ func RunWithTimeout(
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	err := fn(ctx)
-	if errors.Cause(err) == context.DeadlineExceeded {
+	if err != nil && ctx.Err() == context.DeadlineExceeded {
 		return TimeoutError{
 			operation: op,
 			duration:  timeout,


### PR DESCRIPTION
This PR adds a configuration option for a timeout for batch request sends in
the request batcher and adopts this option in the intent resolver. Prior to
the introduction of batching in #34803 intent resolution was performed with a
maximum timeout of 30s. This PR uses that same constant and additionally
applies it to batches of requests to gc transaction records.

Informs #36806.

Release note: None