### PR TITLE
exprgen: support for fake relational op

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1711,3 +1711,7 @@ func (h *joinPropsHelper) cardinality() props.Cardinality {
 		return innerJoinCard
 	}
 }
+
+func (b *logicalPropsBuilder) buildFakeRelProps(fake *FakeRelExpr, rel *props.Relational) {
+	*rel = *fake.Props
+}

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -347,6 +347,9 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet, e RelExpr) *props.Column
 	case opt.ExplainOp, opt.ShowTraceForSessionOp:
 		relProps := e.Relational()
 		return sb.colStatLeaf(colSet, &relProps.Stats, &relProps.FuncDeps, relProps.NotNullCols)
+
+	case opt.FakeRelOp:
+		panic(pgerror.NewAssertionErrorf("FakeRelOp does not contain col stat for %v", colSet))
 	}
 
 	panic(pgerror.NewAssertionErrorf("unrecognized relational expression type: %v", log.Safe(e.Op())))

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1322,3 +1322,41 @@ project
       │    └── fd: (3)-->(1,2)
       └── filters
            └── y = 3 [type=bool, outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+
+# Sample testcase using exprgen.
+expr colstat=1 colstat=2
+(Select 
+  (FakeRel
+    [
+      (OutputCols [ (NewColumn "a" "int") (NewColumn "b" "int") (NewColumn "c" "int")] )
+      (Cardinality "-")
+      (Stats `[
+        {
+          "columns": ["a"],
+          "distinct_count": 100,
+          "null_count": 0, 
+          "row_count": 100, 
+          "created_at": "2018-01-01 1:00:00.00000+00:00"
+        },
+        {
+          "columns": ["b"],
+          "distinct_count": 20,
+          "null_count": 5, 
+          "row_count": 100, 
+          "created_at": "2018-01-01 1:00:00.00000+00:00"
+        }
+      ]`)
+    ]
+  )
+  [ (Eq (Var "b") (Const 1)) ]
+)
+----
+select
+ ├── columns: a:1(int) b:2(int!null) c:3(int)
+ ├── stats: [rows=4.75, distinct(1)=4.75, null(1)=0, distinct(2)=1, null(2)=0]
+ ├── fd: ()-->(2)
+ ├── fake-rel
+ │    ├── columns: a:1(int) b:2(int) c:3(int)
+ │    └── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=20, null(2)=5]
+ └── filters
+      └── b = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -832,3 +832,16 @@ define ProjectSet {
     Input RelExpr
     Zip   ZipExpr
 }
+
+# FakeRel is a mock relational operator used for testing; its logical properties
+# are pre-determined and stored in the private. It can be used as the child of
+# an operator for which we are calculating properties or statistics.
+[Relational]
+define FakeRel {
+    _ FakeRelPrivate
+}
+
+[Private]
+define FakeRelPrivate {
+    Props RelPropsPtr
+}

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -177,6 +177,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"FuncOverload":   {fullName: "*tree.Overload", isPointer: true, usePointerIntern: true},
 		"PhysProps":      {fullName: "*physical.Required", isPointer: true},
 		"RelProps":       {fullName: "props.Relational"},
+		"RelPropsPtr":    {fullName: "*props.Relational", isPointer: true, usePointerIntern: true},
 		"ScalarProps":    {fullName: "props.Scalar"},
 	}
 

--- a/pkg/sql/opt/optgen/exprgen/expr_gen.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen.go
@@ -184,7 +184,7 @@ func (eg *exprGen) eval(expr lang.Expr) interface{} {
 		return string(*expr)
 
 	default:
-		panic(errorf("unsupported expression %s", expr.Op()))
+		panic(errorf("unsupported expression %s: %v", expr.Op(), expr))
 	}
 }
 

--- a/pkg/sql/opt/optgen/exprgen/private.go
+++ b/pkg/sql/opt/optgen/exprgen/private.go
@@ -17,11 +17,14 @@ package exprgen
 import (
 	"context"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -39,6 +42,13 @@ import (
 func (eg *exprGen) evalPrivate(privType reflect.Type, expr lang.Expr) interface{} {
 	if expr.Op() != lang.ListOp {
 		panic(errorf("private must be a list of the form [ (FieldName Value) ... ]"))
+	}
+
+	// Special case for FakeRelPrivate; we want to specify the Relational fields
+	// directly.
+	if privType == reflect.TypeOf(memo.FakeRelPrivate{}) {
+		props := eg.evalPrivate(reflect.TypeOf(props.Relational{}), expr).(*props.Relational)
+		return &memo.FakeRelPrivate{Props: props}
 	}
 
 	items := expr.(*lang.ListExpr).Items
@@ -81,6 +91,9 @@ func (eg *exprGen) convertPrivateFieldValue(
 
 		case reflect.TypeOf(opt.Operator(0)):
 			return eg.opFromStr(str)
+
+		case reflect.TypeOf(props.Cardinality{}):
+			return eg.cardinalityFromStr(str)
 		}
 	}
 
@@ -141,4 +154,29 @@ func (eg *exprGen) opFromStr(str string) opt.Operator {
 		}
 	}
 	panic(errorf("unknown operator %s", str))
+}
+
+func (eg *exprGen) cardinalityFromStr(str string) props.Cardinality {
+	pieces := strings.SplitN(str, "-", 2)
+	if len(pieces) != 2 {
+		panic(errorf("cardinality must be of the form \"[<min>] - [<max>]\": %s", str))
+	}
+	a := strings.Trim(pieces[0], " ")
+	b := strings.Trim(pieces[1], " ")
+	c := props.AnyCardinality
+	if a != "" {
+		c.Min = uint32(eg.intFromStr(a))
+	}
+	if b != "" {
+		c.Max = uint32(eg.intFromStr(b))
+	}
+	return c
+}
+
+func (eg *exprGen) intFromStr(str string) int {
+	val, err := strconv.Atoi(str)
+	if err != nil {
+		panic(errorf("expected number: %s (error: %v)", str, err))
+	}
+	return val
 }

--- a/pkg/sql/opt/optgen/exprgen/testdata/fake
+++ b/pkg/sql/opt/optgen/exprgen/testdata/fake
@@ -19,3 +19,77 @@ fake-rel
  ├── columns: a:1(int!null) b:2(int!null) c:3(int)
  ├── stats: [rows=0]
  └── cost: 0.01
+
+expr
+(FakeRel
+  [
+    (OutputCols [ (NewColumn "a" "int") (NewColumn "b" "int") (NewColumn "c" "int")] )
+    (Cardinality "5 - 1000")
+    (Stats `[
+      {
+        "columns": ["a"],
+        "distinct_count": 100,
+        "null_count": 0, 
+        "row_count": 100, 
+        "created_at": "2018-01-01 1:00:00.00000+00:00"
+      },
+      {
+        "columns": ["b"],
+        "distinct_count": 20,
+        "null_count": 5, 
+        "row_count": 100, 
+        "created_at": "2018-01-01 1:00:00.00000+00:00"
+      }
+    ]`)
+  ]
+)
+----
+fake-rel
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── cardinality: [5 - 1000]
+ ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=20, null(2)=5]
+ └── cost: 0.01
+
+# Verify that newer stats are preferred.
+expr
+(FakeRel
+  [
+    (OutputCols [ (NewColumn "a" "int") (NewColumn "b" "int") (NewColumn "c" "int")] )
+    (Cardinality "-")
+    (Stats `[
+      {
+        "columns": ["a"],
+        "distinct_count": 100,
+        "null_count": 0, 
+        "row_count": 100, 
+        "created_at": "2018-01-01 1:00:00.00000+00:00"
+      },
+      {
+        "columns": ["a"],
+        "distinct_count": 110,
+        "null_count": 0, 
+        "row_count": 110, 
+        "created_at": "2018-01-02 1:00:00.00000+00:00"
+      },
+      {
+        "columns": ["b"],
+        "distinct_count": 20,
+        "null_count": 5, 
+        "row_count": 100, 
+        "created_at": "2018-01-01 1:00:00.00000+00:00"
+      },
+      {
+        "columns": ["b"],
+        "distinct_count": 22,
+        "null_count": 5, 
+        "row_count": 120, 
+        "created_at": "2018-01-03 1:00:00.00000+00:00"
+      }
+    ]`)
+  ]
+)
+----
+fake-rel
+ ├── columns: a:1(int) b:2(int) c:3(int)
+ ├── stats: [rows=120, distinct(1)=110, null(1)=0, distinct(2)=22, null(2)=5]
+ └── cost: 0.01

--- a/pkg/sql/opt/optgen/exprgen/testdata/fake
+++ b/pkg/sql/opt/optgen/exprgen/testdata/fake
@@ -1,0 +1,21 @@
+expr
+(FakeRel [])
+----
+fake-rel
+ ├── cardinality: [0 - 0]
+ ├── stats: [rows=0]
+ └── cost: 0.01
+
+expr
+(FakeRel
+  [
+    (OutputCols [ (NewColumn "a" "int") (NewColumn "b" "int") (NewColumn "c" "int")] )
+    (NotNullCols "a,b")
+    (Cardinality "-")
+  ]
+)
+----
+fake-rel
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+ ├── stats: [rows=0]
+ └── cost: 0.01

--- a/pkg/sql/opt/optgen/lang/scanner.go
+++ b/pkg/sql/opt/optgen/lang/scanner.go
@@ -244,7 +244,11 @@ func (s *Scanner) Scan() Token {
 
 	case '"':
 		s.unread()
-		return s.scanStringLiteral()
+		return s.scanStringLiteral('"', false /* multiLine */)
+
+	case '`':
+		s.unread()
+		return s.scanStringLiteral('`', true /* multiLine */)
 
 	case '#':
 		s.unread()
@@ -371,7 +375,7 @@ func (s *Scanner) scanIdentifier() Token {
 	return s.tok
 }
 
-func (s *Scanner) scanStringLiteral() Token {
+func (s *Scanner) scanStringLiteral(endChar rune, multiLine bool) Token {
 	// Create a buffer and read the current character into it.
 	var buf bytes.Buffer
 	buf.WriteRune(s.read())
@@ -380,7 +384,7 @@ func (s *Scanner) scanStringLiteral() Token {
 	// newline, or EOF is read.
 	for {
 		ch := s.read()
-		if ch == errRune || ch == eofRune || ch == '\n' {
+		if ch == errRune || ch == eofRune || (!multiLine && ch == '\n') {
 			s.unread()
 			s.tok = ILLEGAL
 			break
@@ -388,7 +392,7 @@ func (s *Scanner) scanStringLiteral() Token {
 
 		buf.WriteRune(ch)
 
-		if ch == '"' {
+		if ch == endChar {
 			s.tok = STRING
 			break
 		}


### PR DESCRIPTION
Fixes #30273.
Closes #32103.

#### exprgen: add FakeRelOp

This commit adds a "fake" relational operator which contains all the
logical properties in its private, along with partial exprgen support.

This operator is intended to use as a child when testing the
derivation of logical props of a target operator.

Release note: None

#### optgen: support multi-line strings

Add support for multi-line strings using backquote. Will be useful for
exprgen, to include json statistics.

Release note: None

#### exprgen: json stats for fake ops

Support specifying FakeRel stats using the same JSON format we use for
`INJECT STATS`.

Release note: None
