### PR TITLE
workload/tpcc: improve indexing to permit better partitioning

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -153,7 +153,7 @@ var schemas = [...]string{
 		s_remote_cnt integer,
 		s_data       varchar(50),
 		primary key (s_w_id, s_i_id),
-		index (s_i_id)
+		index stock_item_fk_idx (s_i_id)
 	)
 	`,
 	`
@@ -170,8 +170,8 @@ var schemas = [...]string{
 		ol_amount       decimal(6,2),
 		ol_dist_info    char(24),
 		primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number),
-		index order_line_fk (ol_supply_w_id, ol_d_id),
-		foreign key (ol_supply_w_id, ol_d_id) references stock (s_w_id, s_i_id)
+		index order_line_fk (ol_supply_w_id, ol_i_id),
+		foreign key (ol_supply_w_id, ol_i_id) references stock (s_w_id, s_i_id)
 	)
 	`,
 	`

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -428,15 +428,16 @@ ALTER TABLE customer INJECT STATISTICS '[
 exec-ddl
 CREATE TABLE history
 (
-    rowid    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    h_c_id   integer,
-    h_c_d_id integer,
-    h_c_w_id integer,
-    h_d_id   integer,
-    h_w_id   integer,
+    rowid    uuid    not null default gen_random_uuid(),
+    h_c_id   integer not null,
+    h_c_d_id integer not null,
+    h_c_w_id integer not null,
+    h_d_id   integer not null,
+    h_w_id   integer not null,
     h_date   timestamp,
     h_amount decimal(6,2),
     h_data   varchar(24),
+    primary key (h_w_id, rowid),
     index (h_w_id, h_d_id),
     index (h_c_w_id, h_c_d_id, h_c_id),
     foreign key (h_c_w_id, h_c_d_id, h_c_id) references customer (c_w_id, c_d_id, c_id),
@@ -445,24 +446,26 @@ CREATE TABLE history
 ----
 TABLE history
  ├── rowid uuid not null
- ├── h_c_id int
- ├── h_c_d_id int
- ├── h_c_w_id int
- ├── h_d_id int
- ├── h_w_id int
+ ├── h_c_id int not null
+ ├── h_c_d_id int not null
+ ├── h_c_w_id int not null
+ ├── h_d_id int not null
+ ├── h_w_id int not null
  ├── h_date timestamp
  ├── h_amount decimal
  ├── h_data varchar
  ├── INDEX primary
+ │    ├── h_w_id int not null
  │    └── rowid uuid not null
  ├── INDEX secondary
- │    ├── h_w_id int
- │    ├── h_d_id int
+ │    ├── h_w_id int not null
+ │    ├── h_d_id int not null
  │    └── rowid uuid not null
  ├── INDEX secondary
- │    ├── h_c_w_id int
- │    ├── h_c_d_id int
- │    ├── h_c_id int
+ │    ├── h_c_w_id int not null
+ │    ├── h_c_d_id int not null
+ │    ├── h_c_id int not null
+ │    ├── h_w_id int not null
  │    └── rowid uuid not null
  ├── FOREIGN KEY (h_w_id, h_d_id) REFERENCES t.public.district (d_w_id, d_id)
  └── FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -550,8 +550,7 @@ CREATE TABLE "order"
     o_ol_cnt     integer,
     o_all_local  integer,
     primary key (o_w_id, o_d_id, o_id DESC),
-    unique index order_idx (o_w_id, o_d_id, o_carrier_id, o_id),
-    index (o_w_id, o_d_id, o_c_id),
+    unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC),
     foreign key (o_w_id, o_d_id, o_c_id) references customer (c_w_id, c_d_id, c_id)
 ) interleave in parent district (o_w_id, o_d_id)
 ----
@@ -571,13 +570,8 @@ TABLE order
  ├── INDEX order_idx
  │    ├── o_w_id int not null
  │    ├── o_d_id int not null
- │    ├── o_carrier_id int
- │    └── o_id int not null
- ├── INDEX secondary
- │    ├── o_w_id int not null
- │    ├── o_d_id int not null
  │    ├── o_c_id int
- │    └── o_id int not null
+ │    └── o_id int not null desc
  └── FOREIGN KEY (o_w_id, o_d_id, o_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)
 
 exec-ddl
@@ -1263,17 +1257,17 @@ project
       ├── cost: 5.25
       ├── key: ()
       ├── fd: ()-->(1-6)
-      ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
-      └── scan "order"@secondary,rev
+      ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
+      └── scan "order"@order_idx
            ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
-           ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
-           ├── limit: 1(rev)
+           ├── constraint: /3/2/4/-1: [/10/100/50 - /10/100/50]
+           ├── limit: 1
            ├── stats: [rows=1, distinct(1)=0.999833519, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0]
            ├── cost: 1.09
            ├── key: ()
            ├── fd: ()-->(1-4)
            ├── prune: (1-4)
-           └── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
+           └── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
 
 opt format=hide-qual
 SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
@@ -1708,7 +1702,7 @@ except-all
  ├── left columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
  ├── right columns: o_w_id:6(int) o_d_id:5(int) o_id:4(int)
  ├── stats: [rows=900000]
- ├── cost: 4246800.07
+ ├── cost: 4366800.07
  ├── scan new_order
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
  │    ├── stats: [rows=900000]
@@ -1719,26 +1713,26 @@ except-all
  └── project
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
       ├── stats: [rows=240000]
-      ├── cost: 3272400.04
+      ├── cost: 3392400.04
       ├── key: (4-6)
       ├── prune: (4-6)
       ├── interesting orderings: (+6,+5,-4)
       └── select
            ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            ├── stats: [rows=240000, distinct(4)=3000, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=100, null(6)=0, distinct(9)=1, null(9)=240000]
-           ├── cost: 3270000.03
+           ├── cost: 3390000.03
            ├── key: (4-6)
            ├── fd: ()-->(9)
            ├── prune: (4-6)
-           ├── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
-           ├── scan "order"@order_idx
+           ├── interesting orderings: (+6,+5,-4)
+           ├── scan "order"
            │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            │    ├── stats: [rows=3000000, distinct(4)=3000, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=100, null(6)=0, distinct(9)=10, null(9)=900000]
-           │    ├── cost: 3240000.02
+           │    ├── cost: 3360000.02
            │    ├── key: (4-6)
            │    ├── fd: (4-6)-->(9)
            │    ├── prune: (4-6,9)
-           │    └── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
+           │    └── interesting orderings: (+6,+5,-4)
            └── filters
                 └── is [type=bool, outer=(9), constraints=(/9: [/NULL - /NULL]; tight), fd=()-->(9)]
                      ├── variable: o_carrier_id [type=int]
@@ -1754,30 +1748,30 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── right columns: no_w_id:11(int) no_d_id:10(int) no_o_id:9(int)
  ├── stats: [rows=240000]
- ├── cost: 4240200.07
+ ├── cost: 4360200.07
  ├── project
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=240000]
- │    ├── cost: 3272400.04
+ │    ├── cost: 3392400.04
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    └── select
  │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         ├── stats: [rows=240000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=1, null(6)=240000]
- │         ├── cost: 3270000.03
+ │         ├── cost: 3390000.03
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
- │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
- │         ├── scan "order"@order_idx
+ │         ├── interesting orderings: (+3,+2,-1)
+ │         ├── scan "order"
  │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         │    ├── stats: [rows=3000000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=10, null(6)=900000]
- │         │    ├── cost: 3240000.02
+ │         │    ├── cost: 3360000.02
  │         │    ├── key: (1-3)
  │         │    ├── fd: (1-3)-->(6)
  │         │    ├── prune: (1-3,6)
- │         │    └── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
+ │         │    └── interesting orderings: (+3,+2,-1)
  │         └── filters
  │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
  │                   ├── variable: o_carrier_id [type=int]
@@ -1903,25 +1897,55 @@ scalar-group-by
  ├── columns: count:19(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 39158757.2
+ ├── cost: 39201942.2
  ├── key: ()
  ├── fd: ()-->(19)
  ├── prune: (19)
  ├── select
  │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
  │    ├── stats: [rows=10001995]
- │    ├── cost: 39058737.2
- │    ├── interesting orderings: (+11,+10,-9) (+3,+2,-1)
- │    ├── full-join
+ │    ├── cost: 39101922.2
+ │    ├── full-join (merge)
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
+ │    │    ├── left ordering: +3,+2,-1
+ │    │    ├── right ordering: +11,+10,-9
  │    │    ├── stats: [rows=30005985]
- │    │    ├── cost: 38758677.4
- │    │    ├── reject-nulls: (1-3,9-11)
- │    │    ├── interesting orderings: (+11,+10,-9) (+3,+2,-1)
+ │    │    ├── cost: 38801862.4
+ │    │    ├── project
+ │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
+ │    │    │    ├── stats: [rows=240000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0]
+ │    │    │    ├── cost: 3392400.04
+ │    │    │    ├── key: (1-3)
+ │    │    │    ├── ordering: +3,+2,-1
+ │    │    │    ├── prune: (1-3)
+ │    │    │    ├── interesting orderings: (+3,+2,-1)
+ │    │    │    └── select
+ │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
+ │    │    │         ├── stats: [rows=240000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=1, null(6)=240000]
+ │    │    │         ├── cost: 3390000.03
+ │    │    │         ├── key: (1-3)
+ │    │    │         ├── fd: ()-->(6)
+ │    │    │         ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
+ │    │    │         ├── prune: (1-3)
+ │    │    │         ├── interesting orderings: (+3,+2,-1)
+ │    │    │         ├── scan "order"
+ │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
+ │    │    │         │    ├── stats: [rows=3000000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=10, null(6)=900000]
+ │    │    │         │    ├── cost: 3360000.02
+ │    │    │         │    ├── key: (1-3)
+ │    │    │         │    ├── fd: (1-3)-->(6)
+ │    │    │         │    ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
+ │    │    │         │    ├── prune: (1-3,6)
+ │    │    │         │    └── interesting orderings: (+3,+2,-1)
+ │    │    │         └── filters
+ │    │    │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
+ │    │    │                   ├── variable: o_carrier_id [type=int]
+ │    │    │                   └── null [type=unknown]
  │    │    ├── project
  │    │    │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
  │    │    │    ├── stats: [rows=30005985, distinct(9)=3000, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=100, null(11)=0]
  │    │    │    ├── cost: 34806942.6
+ │    │    │    ├── ordering: +11,+10,-9
  │    │    │    ├── prune: (9-11)
  │    │    │    ├── interesting orderings: (+11,+10,-9)
  │    │    │    └── select
@@ -1929,55 +1953,21 @@ scalar-group-by
  │    │    │         ├── stats: [rows=30005985, distinct(9)=3000, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=100, null(11)=0, distinct(15)=1, null(15)=9003667]
  │    │    │         ├── cost: 34506882.8
  │    │    │         ├── fd: ()-->(15)
+ │    │    │         ├── ordering: +11,+10,-9 opt(15) [actual: +11,+10,-9]
  │    │    │         ├── prune: (9-11)
  │    │    │         ├── interesting orderings: (+11,+10,-9)
  │    │    │         ├── scan order_line
  │    │    │         │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
  │    │    │         │    ├── stats: [rows=30005985, distinct(9)=3000, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=100, null(11)=0, distinct(15)=1, null(15)=9003667]
  │    │    │         │    ├── cost: 34206822.9
+ │    │    │         │    ├── ordering: +11,+10,-9 opt(15) [actual: +11,+10,-9]
  │    │    │         │    ├── prune: (9-11,15)
  │    │    │         │    └── interesting orderings: (+11,+10,-9)
  │    │    │         └── filters
  │    │    │              └── is [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight), fd=()-->(15)]
  │    │    │                   ├── variable: ol_delivery_d [type=timestamp]
  │    │    │                   └── null [type=unknown]
- │    │    ├── project
- │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
- │    │    │    ├── stats: [rows=240000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0]
- │    │    │    ├── cost: 3272400.04
- │    │    │    ├── key: (1-3)
- │    │    │    ├── prune: (1-3)
- │    │    │    ├── interesting orderings: (+3,+2,-1)
- │    │    │    └── select
- │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
- │    │    │         ├── stats: [rows=240000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=1, null(6)=240000]
- │    │    │         ├── cost: 3270000.03
- │    │    │         ├── key: (1-3)
- │    │    │         ├── fd: ()-->(6)
- │    │    │         ├── prune: (1-3)
- │    │    │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
- │    │    │         ├── scan "order"@order_idx
- │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
- │    │    │         │    ├── stats: [rows=3000000, distinct(1)=3000, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=10, null(6)=900000]
- │    │    │         │    ├── cost: 3240000.02
- │    │    │         │    ├── key: (1-3)
- │    │    │         │    ├── fd: (1-3)-->(6)
- │    │    │         │    ├── prune: (1-3,6)
- │    │    │         │    └── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
- │    │    │         └── filters
- │    │    │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
- │    │    │                   ├── variable: o_carrier_id [type=int]
- │    │    │                   └── null [type=unknown]
- │    │    └── filters
- │    │         ├── eq [type=bool, outer=(3,11), constraints=(/3: (/NULL - ]; /11: (/NULL - ]), fd=(3)==(11), (11)==(3)]
- │    │         │    ├── variable: ol_w_id [type=int]
- │    │         │    └── variable: o_w_id [type=int]
- │    │         ├── eq [type=bool, outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
- │    │         │    ├── variable: ol_d_id [type=int]
- │    │         │    └── variable: o_d_id [type=int]
- │    │         └── eq [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
- │    │              ├── variable: ol_o_id [type=int]
- │    │              └── variable: o_id [type=int]
+ │    │    └── filters (true)
  │    └── filters
  │         └── or [type=bool, outer=(1,9)]
  │              ├── is [type=bool]
@@ -2898,17 +2888,17 @@ project
       ├── cost: 5.25
       ├── key: ()
       ├── fd: ()-->(1-6)
-      ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
-      └── scan "order"@secondary,rev
+      ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
+      └── scan "order"@order_idx
            ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
-           ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
-           ├── limit: 1(rev)
+           ├── constraint: /3/2/4/-1: [/10/100/50 - /10/100/50]
+           ├── limit: 1
            ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0]
            ├── cost: 1.09
            ├── key: ()
            ├── fd: ()-->(1-4)
            ├── prune: (1-4)
-           └── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
+           └── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
 
 opt format=hide-qual
 SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
@@ -3343,7 +3333,7 @@ except-all
  ├── left columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
  ├── right columns: o_w_id:6(int) o_d_id:5(int) o_id:4(int)
  ├── stats: [rows=11322]
- ├── cost: 71652571.2
+ ├── cost: 74276759.6
  ├── scan new_order
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
  │    ├── stats: [rows=11322]
@@ -3354,26 +3344,26 @@ except-all
  └── project
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
       ├── stats: [rows=6560471]
-      ├── cost: 71574738.7
+      ├── cost: 74198927.1
       ├── key: (4-6)
       ├── prune: (4-6)
       ├── interesting orderings: (+6,+5,-4)
       └── select
            ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            ├── stats: [rows=6560471, distinct(4)=659230.57, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=10, null(6)=0, distinct(9)=1, null(9)=11322]
-           ├── cost: 71509133.9
+           ├── cost: 74133322.3
            ├── key: (4-6)
            ├── fd: ()-->(9)
            ├── prune: (4-6)
-           ├── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
-           ├── scan "order"@order_idx
+           ├── interesting orderings: (+6,+5,-4)
+           ├── scan "order"
            │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            │    ├── stats: [rows=65604710, distinct(4)=659249, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=10, null(6)=0, distinct(9)=10, null(9)=11322]
-           │    ├── cost: 70853086.8
+           │    ├── cost: 73477275.2
            │    ├── key: (4-6)
            │    ├── fd: (4-6)-->(9)
            │    ├── prune: (4-6,9)
-           │    └── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
+           │    └── interesting orderings: (+6,+5,-4)
            └── filters
                 └── is [type=bool, outer=(9), constraints=(/9: [/NULL - /NULL]; tight), fd=()-->(9)]
                      ├── variable: o_carrier_id [type=int]
@@ -3389,30 +3379,30 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── right columns: no_w_id:11(int) no_d_id:10(int) no_o_id:9(int)
  ├── stats: [rows=6560471]
- ├── cost: 71718062.6
+ ├── cost: 74342251
  ├── project
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=6560471]
- │    ├── cost: 71574738.7
+ │    ├── cost: 74198927.1
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    └── select
  │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         ├── stats: [rows=6560471, distinct(1)=659230.57, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=11322]
- │         ├── cost: 71509133.9
+ │         ├── cost: 74133322.3
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
- │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
- │         ├── scan "order"@order_idx
+ │         ├── interesting orderings: (+3,+2,-1)
+ │         ├── scan "order"
  │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         │    ├── stats: [rows=65604710, distinct(1)=659249, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=10, null(6)=11322]
- │         │    ├── cost: 70853086.8
+ │         │    ├── cost: 73477275.2
  │         │    ├── key: (1-3)
  │         │    ├── fd: (1-3)-->(6)
  │         │    ├── prune: (1-3,6)
- │         │    └── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
+ │         │    └── interesting orderings: (+3,+2,-1)
  │         └── filters
  │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
  │                   ├── variable: o_carrier_id [type=int]
@@ -3538,44 +3528,46 @@ scalar-group-by
  ├── columns: count:19(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 815749348
+ ├── cost: 818357133
  ├── key: ()
  ├── fd: ()-->(19)
  ├── prune: (19)
  ├── select
  │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
  │    ├── stats: [rows=2186906.23]
- │    ├── cost: 815727479
- │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
- │    ├── full-join
+ │    ├── cost: 818335264
+ │    ├── full-join (merge)
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
+ │    │    ├── left ordering: +3,+2,-1
+ │    │    ├── right ordering: +11,+10,-9
  │    │    ├── stats: [rows=6560718.68]
- │    │    ├── cost: 815661872
- │    │    ├── reject-nulls: (1-3,9-11)
- │    │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
+ │    │    ├── cost: 818269657
  │    │    ├── project
  │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    │    │    ├── stats: [rows=6560471, distinct(1)=659230.57, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
- │    │    │    ├── cost: 71574738.7
+ │    │    │    ├── cost: 74198927.1
  │    │    │    ├── key: (1-3)
+ │    │    │    ├── ordering: +3,+2,-1
  │    │    │    ├── prune: (1-3)
  │    │    │    ├── interesting orderings: (+3,+2,-1)
  │    │    │    └── select
  │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         ├── stats: [rows=6560471, distinct(1)=659230.57, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=1, null(6)=11322]
- │    │    │         ├── cost: 71509133.9
+ │    │    │         ├── cost: 74133322.3
  │    │    │         ├── key: (1-3)
  │    │    │         ├── fd: ()-->(6)
+ │    │    │         ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
  │    │    │         ├── prune: (1-3)
- │    │    │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
- │    │    │         ├── scan "order"@order_idx
+ │    │    │         ├── interesting orderings: (+3,+2,-1)
+ │    │    │         ├── scan "order"
  │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         │    ├── stats: [rows=65604710, distinct(1)=659249, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(6)=10, null(6)=11322]
- │    │    │         │    ├── cost: 70853086.8
+ │    │    │         │    ├── cost: 73477275.2
  │    │    │         │    ├── key: (1-3)
  │    │    │         │    ├── fd: (1-3)-->(6)
+ │    │    │         │    ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
  │    │    │         │    ├── prune: (1-3,6)
- │    │    │         │    └── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
+ │    │    │         │    └── interesting orderings: (+3,+2,-1)
  │    │    │         └── filters
  │    │    │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
  │    │    │                   ├── variable: o_carrier_id [type=int]
@@ -3584,6 +3576,7 @@ scalar-group-by
  │    │    │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
  │    │    │    ├── stats: [rows=275.057668, distinct(9)=275.044618, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0]
  │    │    │    ├── cost: 743939515
+ │    │    │    ├── ordering: +11,+10,-9
  │    │    │    ├── prune: (9-11)
  │    │    │    ├── interesting orderings: (+11,+10,-9)
  │    │    │    └── select
@@ -3591,28 +3584,21 @@ scalar-group-by
  │    │    │         ├── stats: [rows=275.057668, distinct(9)=275.044618, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0, distinct(15)=1, null(15)=275.057668]
  │    │    │         ├── cost: 743939513
  │    │    │         ├── fd: ()-->(15)
+ │    │    │         ├── ordering: +11,+10,-9 opt(15) [actual: +11,+10,-9]
  │    │    │         ├── prune: (9-11)
  │    │    │         ├── interesting orderings: (+11,+10,-9)
  │    │    │         ├── scan order_line
  │    │    │         │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
  │    │    │         │    ├── stats: [rows=646903924, distinct(9)=651111, null(9)=0, distinct(10)=10, null(10)=0, distinct(11)=10, null(11)=0, distinct(15)=2351500, null(15)=106092]
  │    │    │         │    ├── cost: 737470473
+ │    │    │         │    ├── ordering: +11,+10,-9 opt(15) [actual: +11,+10,-9]
  │    │    │         │    ├── prune: (9-11,15)
  │    │    │         │    └── interesting orderings: (+11,+10,-9)
  │    │    │         └── filters
  │    │    │              └── is [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight), fd=()-->(15)]
  │    │    │                   ├── variable: ol_delivery_d [type=timestamp]
  │    │    │                   └── null [type=unknown]
- │    │    └── filters
- │    │         ├── eq [type=bool, outer=(3,11), constraints=(/3: (/NULL - ]; /11: (/NULL - ]), fd=(3)==(11), (11)==(3)]
- │    │         │    ├── variable: ol_w_id [type=int]
- │    │         │    └── variable: o_w_id [type=int]
- │    │         ├── eq [type=bool, outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
- │    │         │    ├── variable: ol_d_id [type=int]
- │    │         │    └── variable: o_d_id [type=int]
- │    │         └── eq [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
- │    │              ├── variable: ol_o_id [type=int]
- │    │              └── variable: o_id [type=int]
+ │    │    └── filters (true)
  │    └── filters
  │         └── or [type=bool, outer=(1,9)]
  │              ├── is [type=bool]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -438,8 +438,8 @@ CREATE TABLE history
     h_amount decimal(6,2),
     h_data   varchar(24),
     primary key (h_w_id, rowid),
-    index (h_w_id, h_d_id),
-    index (h_c_w_id, h_c_d_id, h_c_id),
+    index history_customer_fk_idx (h_c_w_id, h_c_d_id, h_c_id),
+    index history_district_fk_idx (h_w_id, h_d_id),
     foreign key (h_c_w_id, h_c_d_id, h_c_id) references customer (c_w_id, c_d_id, c_id),
     foreign key (h_w_id, h_d_id) references district (d_w_id, d_id)
 )
@@ -457,18 +457,18 @@ TABLE history
  ├── INDEX primary
  │    ├── h_w_id int not null
  │    └── rowid uuid not null
- ├── INDEX secondary
- │    ├── h_w_id int not null
- │    ├── h_d_id int not null
- │    └── rowid uuid not null
- ├── INDEX secondary
+ ├── INDEX history_customer_fk_idx
  │    ├── h_c_w_id int not null
  │    ├── h_c_d_id int not null
  │    ├── h_c_id int not null
  │    ├── h_w_id int not null
  │    └── rowid uuid not null
- ├── FOREIGN KEY (h_w_id, h_d_id) REFERENCES t.public.district (d_w_id, d_id)
- └── FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)
+ ├── INDEX history_district_fk_idx
+ │    ├── h_w_id int not null
+ │    ├── h_d_id int not null
+ │    └── rowid uuid not null
+ ├── FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)
+ └── FOREIGN KEY (h_w_id, h_d_id) REFERENCES t.public.district (d_w_id, d_id)
 
 exec-ddl
 ALTER TABLE history INJECT STATISTICS '[
@@ -760,7 +760,7 @@ CREATE TABLE stock
     s_remote_cnt integer,
     s_data       varchar(50),
     primary key (s_w_id, s_i_id),
-    index (s_i_id),
+    index stock_item_fk_idx (s_i_id),
     foreign key (s_w_id) references warehouse (w_id),
     foreign key (s_i_id) references item (i_id)
 ) interleave in parent warehouse (s_w_id)
@@ -786,7 +786,7 @@ TABLE stock
  ├── INDEX primary
  │    ├── s_w_id int not null
  │    └── s_i_id int not null
- ├── INDEX secondary
+ ├── INDEX stock_item_fk_idx
  │    ├── s_i_id int not null
  │    └── s_w_id int not null
  ├── FOREIGN KEY (s_w_id) REFERENCES t.public.warehouse (w_id)
@@ -930,9 +930,9 @@ CREATE TABLE order_line
     ol_amount       decimal(6,2),
     ol_dist_info    char(24),
     primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number),
-    index order_line_fk (ol_supply_w_id, ol_d_id),
+    index order_line_stock_fk_idx (ol_supply_w_id, ol_i_id),
     foreign key (ol_w_id, ol_d_id, ol_o_id) references "order" (o_w_id, o_d_id, o_id),
-    foreign key (ol_supply_w_id, ol_d_id) references stock (s_w_id, s_i_id)
+    foreign key (ol_supply_w_id, ol_i_id) references stock (s_w_id, s_i_id)
 ) interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)
 ----
 TABLE order_line
@@ -951,14 +951,15 @@ TABLE order_line
  │    ├── ol_d_id int not null
  │    ├── ol_o_id int not null desc
  │    └── ol_number int not null
- ├── INDEX order_line_fk
+ ├── INDEX order_line_stock_fk_idx
  │    ├── ol_supply_w_id int
- │    ├── ol_d_id int not null
+ │    ├── ol_i_id int not null
  │    ├── ol_w_id int not null
+ │    ├── ol_d_id int not null
  │    ├── ol_o_id int not null
  │    └── ol_number int not null
  ├── FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES t.public."order" (o_w_id, o_d_id, o_id)
- └── FOREIGN KEY (ol_supply_w_id, ol_d_id) REFERENCES t.public.stock (s_w_id, s_i_id)
+ └── FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES t.public.stock (s_w_id, s_i_id)
 
 exec-ddl
 ALTER TABLE order_line INJECT STATISTICS '[
@@ -1279,7 +1280,7 @@ project
  ├── stats: [rows=10.001995]
  ├── cost: 11.9223741
  ├── prune: (5-9)
- ├── interesting orderings: (+6)
+ ├── interesting orderings: (+6,+5)
  └── scan order_line
       ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_delivery_d:7(timestamp) ol_quantity:8(int) ol_amount:9(decimal)
       ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
@@ -1287,7 +1288,7 @@ project
       ├── cost: 11.8123541
       ├── fd: ()-->(1-3)
       ├── prune: (1-3,5-9)
-      └── interesting orderings: (+3,+2,-1) (+6,+2,+3,+1)
+      └── interesting orderings: (+3,+2,-1) (+6,+5,+3,+2,+1)
 
 # --------------------------------------------------
 # 2.7 The Delivery Transaction
@@ -1670,7 +1671,7 @@ ORDER BY ol_w_id, ol_d_id
 sort
  ├── columns: count:11(int)  [hidden: ol_d_id:2(int!null) ol_w_id:3(int!null)]
  ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
- ├── cost: 33306883.7
+ ├── cost: 33606943.5
  ├── key: (2,3)
  ├── fd: (2,3)-->(11)
  ├── ordering: +3,+2
@@ -1679,14 +1680,14 @@ sort
       ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
       ├── grouping columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
       ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0]
-      ├── cost: 33306653.4
+      ├── cost: 33606713.2
       ├── key: (2,3)
       ├── fd: (2,3)-->(11)
       ├── prune: (11)
-      ├── scan order_line@order_line_fk
+      ├── scan order_line@order_line_stock_fk_idx
       │    ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
       │    ├── stats: [rows=30005985, distinct(2,3)=1000, null(2,3)=0]
-      │    ├── cost: 32106404
+      │    ├── cost: 32406463.8
       │    ├── prune: (2,3)
       │    └── interesting orderings: (+3,+2)
       └── aggregations
@@ -1803,7 +1804,7 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null) o_ol_cnt:7(int)
  ├── right columns: ol_w_id:11(int) ol_d_id:10(int) ol_o_id:9(int) count_rows:19(int)
  ├── stats: [rows=3000000]
- ├── cost: 37386763.1
+ ├── cost: 37686823
  ├── scan "order"
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
  │    ├── stats: [rows=3000000]
@@ -1816,15 +1817,15 @@ except-all
       ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) count_rows:19(int)
       ├── grouping columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
       ├── stats: [rows=3000000, distinct(9-11)=3000000, null(9-11)=0]
-      ├── cost: 33936763.1
+      ├── cost: 34236822.9
       ├── key: (9-11)
       ├── fd: (9-11)-->(19)
       ├── prune: (19)
       ├── interesting orderings: (+11,+10,-9)
-      ├── scan order_line@order_line_fk
+      ├── scan order_line@order_line_stock_fk_idx
       │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
       │    ├── stats: [rows=30005985, distinct(9-11)=3000000, null(9-11)=0]
-      │    ├── cost: 32406463.8
+      │    ├── cost: 32706523.7
       │    ├── prune: (9-11)
       │    └── interesting orderings: (+11,+10,-9)
       └── aggregations
@@ -1849,20 +1850,20 @@ except-all
  ├── left columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count_rows:11(int)
  ├── right columns: o_w_id:14(int) o_d_id:13(int) o_id:12(int) o_ol_cnt:18(int)
  ├── stats: [rows=3000000]
- ├── cost: 37386763.1
+ ├── cost: 37686823
  ├── group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
  │    ├── grouping columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
  │    ├── stats: [rows=3000000, distinct(1-3)=3000000, null(1-3)=0]
- │    ├── cost: 33936763.1
+ │    ├── cost: 34236822.9
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(11)
  │    ├── prune: (11)
  │    ├── interesting orderings: (+3,+2,-1)
- │    ├── scan order_line@order_line_fk
+ │    ├── scan order_line@order_line_stock_fk_idx
  │    │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
  │    │    ├── stats: [rows=30005985, distinct(1-3)=3000000, null(1-3)=0]
- │    │    ├── cost: 32406463.8
+ │    │    ├── cost: 32706523.7
  │    │    ├── prune: (1-3)
  │    │    └── interesting orderings: (+3,+2,-1)
  │    └── aggregations
@@ -2910,7 +2911,7 @@ project
  ├── stats: [rows=9.93538619]
  ├── cost: 11.8431096
  ├── prune: (5-9)
- ├── interesting orderings: (+6)
+ ├── interesting orderings: (+6,+5)
  └── scan order_line
       ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_delivery_d:7(timestamp) ol_quantity:8(int) ol_amount:9(decimal)
       ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
@@ -2918,7 +2919,7 @@ project
       ├── cost: 11.7337557
       ├── fd: ()-->(1-3)
       ├── prune: (1-3,5-9)
-      └── interesting orderings: (+3,+2,-1) (+6,+2,+3,+1)
+      └── interesting orderings: (+3,+2,-1) (+6,+5,+3,+2,+1)
 
 # --------------------------------------------------
 # 2.7 The Delivery Transaction
@@ -3301,7 +3302,7 @@ ORDER BY ol_w_id, ol_d_id
 sort
  ├── columns: count:11(int)  [hidden: ol_d_id:2(int!null) ol_w_id:3(int!null)]
  ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
- ├── cost: 718063373
+ ├── cost: 724532412
  ├── key: (2,3)
  ├── fd: (2,3)-->(11)
  ├── ordering: +3,+2
@@ -3310,14 +3311,14 @@ sort
       ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
       ├── grouping columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
       ├── stats: [rows=100, distinct(2,3)=100, null(2,3)=0]
-      ├── cost: 718063357
+      ├── cost: 724532396
       ├── key: (2,3)
       ├── fd: (2,3)-->(11)
       ├── prune: (11)
-      ├── scan order_line@order_line_fk
+      ├── scan order_line@order_line_stock_fk_idx
       │    ├── columns: ol_d_id:2(int!null) ol_w_id:3(int!null)
       │    ├── stats: [rows=646903924, distinct(2,3)=100, null(2,3)=0]
-      │    ├── cost: 692187199
+      │    ├── cost: 698656238
       │    ├── prune: (2,3)
       │    └── interesting orderings: (+3,+2)
       └── aggregations
@@ -3434,7 +3435,7 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null) o_ol_cnt:7(int)
  ├── right columns: ol_w_id:11(int) ol_d_id:10(int) ol_o_id:9(int) count_rows:19(int)
  ├── stats: [rows=65604710]
- ├── cost: 807093026
+ ├── cost: 813562065
  ├── scan "order"
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
  │    ├── stats: [rows=65604710]
@@ -3447,15 +3448,15 @@ except-all
       ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) count_rows:19(int)
       ├── grouping columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
       ├── stats: [rows=65111100, distinct(9-11)=65111100, null(9-11)=0]
-      ├── cost: 731652545
+      ├── cost: 738121584
       ├── key: (9-11)
       ├── fd: (9-11)-->(19)
       ├── prune: (19)
       ├── interesting orderings: (+11,+10,-9)
-      ├── scan order_line@order_line_fk
+      ├── scan order_line@order_line_stock_fk_idx
       │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
       │    ├── stats: [rows=646903924, distinct(9-11)=65111100, null(9-11)=0]
-      │    ├── cost: 698656238
+      │    ├── cost: 705125277
       │    ├── prune: (9-11)
       │    └── interesting orderings: (+11,+10,-9)
       └── aggregations
@@ -3480,20 +3481,20 @@ except-all
  ├── left columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count_rows:11(int)
  ├── right columns: o_w_id:14(int) o_d_id:13(int) o_id:12(int) o_ol_cnt:18(int)
  ├── stats: [rows=65111100]
- ├── cost: 807088089
+ ├── cost: 813557129
  ├── group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
  │    ├── grouping columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
  │    ├── stats: [rows=65111100, distinct(1-3)=65111100, null(1-3)=0]
- │    ├── cost: 731652545
+ │    ├── cost: 738121584
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(11)
  │    ├── prune: (11)
  │    ├── interesting orderings: (+3,+2,-1)
- │    ├── scan order_line@order_line_fk
+ │    ├── scan order_line@order_line_stock_fk_idx
  │    │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
  │    │    ├── stats: [rows=646903924, distinct(1-3)=65111100, null(1-3)=0]
- │    │    ├── cost: 698656238
+ │    │    ├── cost: 705125277
  │    │    ├── prune: (1-3)
  │    │    └── interesting orderings: (+3,+2,-1)
  │    └── aggregations

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -641,17 +641,19 @@ CREATE TABLE new_order
     no_o_id  integer   not null,
     no_d_id  integer   not null,
     no_w_id  integer   not null,
-    primary key (no_w_id, no_d_id, no_o_id DESC)
+    primary key (no_w_id, no_d_id, no_o_id),
+    foreign key (no_w_id, no_d_id, no_o_id) references "order" (o_w_id, o_d_id, o_id)
 ) interleave in parent "order" (no_w_id, no_d_id, no_o_id)
 ----
 TABLE new_order
  ├── no_o_id int not null
  ├── no_d_id int not null
  ├── no_w_id int not null
- └── INDEX primary
-      ├── no_w_id int not null
-      ├── no_d_id int not null
-      └── no_o_id int not null desc
+ ├── INDEX primary
+ │    ├── no_w_id int not null
+ │    ├── no_d_id int not null
+ │    └── no_o_id int not null
+ └── FOREIGN KEY (no_w_id, no_d_id, no_o_id) REFERENCES t.public."order" (o_w_id, o_d_id, o_id)
 
 exec-ddl
 ALTER TABLE new_order INJECT STATISTICS '[
@@ -1321,16 +1323,16 @@ project
  ├── key: ()
  ├── fd: ()-->(1)
  ├── prune: (1)
- └── scan new_order,rev
+ └── scan new_order
       ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
-      ├── constraint: /3/2/-1: [/10/100 - /10/100]
-      ├── limit: 1(rev)
+      ├── constraint: /3/2/1: [/10/100 - /10/100]
+      ├── limit: 1
       ├── stats: [rows=1]
       ├── cost: 1.07
       ├── key: ()
       ├── fd: ()-->(1-3)
       ├── prune: (1-3)
-      └── interesting orderings: (+3,+2,-1)
+      └── interesting orderings: (+3,+2,+1)
 
 opt format=hide-qual
 SELECT sum(ol_amount)
@@ -1542,7 +1544,7 @@ group-by
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
- │    └── interesting orderings: (+3,+2,-1)
+ │    └── interesting orderings: (+3,+2,+1)
  └── aggregations
       └── max [type=int, outer=(1)]
            └── variable: no_o_id [type=int]
@@ -1617,7 +1619,7 @@ scalar-group-by
  │    │    │    ├── key: (1-3)
  │    │    │    ├── ordering: +3,+2
  │    │    │    ├── prune: (1-3)
- │    │    │    └── interesting orderings: (+3,+2,-1)
+ │    │    │    └── interesting orderings: (+3,+2,+1)
  │    │    └── aggregations
  │    │         ├── max [type=int, outer=(1)]
  │    │         │    └── variable: no_o_id [type=int]
@@ -1710,7 +1712,7 @@ except-all
  │    ├── cost: 954000.02
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
- │    └── interesting orderings: (+3,+2,-1)
+ │    └── interesting orderings: (+3,+2,+1)
  └── project
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
       ├── stats: [rows=240000]
@@ -1783,7 +1785,7 @@ except-all
       ├── cost: 954000.02
       ├── key: (9-11)
       ├── prune: (9-11)
-      └── interesting orderings: (+11,+10,-9)
+      └── interesting orderings: (+11,+10,+9)
 
 opt format=hide-qual
 (
@@ -2952,16 +2954,16 @@ project
  ├── key: ()
  ├── fd: ()-->(1)
  ├── prune: (1)
- └── scan new_order,rev
+ └── scan new_order
       ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
-      ├── constraint: /3/2/-1: [/10/100 - /10/100]
-      ├── limit: 1(rev)
+      ├── constraint: /3/2/1: [/10/100 - /10/100]
+      ├── limit: 1
       ├── stats: [rows=1]
       ├── cost: 1.07
       ├── key: ()
       ├── fd: ()-->(1-3)
       ├── prune: (1-3)
-      └── interesting orderings: (+3,+2,-1)
+      └── interesting orderings: (+3,+2,+1)
 
 opt format=hide-qual
 SELECT sum(ol_amount)
@@ -3173,7 +3175,7 @@ group-by
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
- │    └── interesting orderings: (+3,+2,-1)
+ │    └── interesting orderings: (+3,+2,+1)
  └── aggregations
       └── max [type=int, outer=(1)]
            └── variable: no_o_id [type=int]
@@ -3248,7 +3250,7 @@ scalar-group-by
  │    │    │    ├── key: (1-3)
  │    │    │    ├── ordering: +3,+2
  │    │    │    ├── prune: (1-3)
- │    │    │    └── interesting orderings: (+3,+2,-1)
+ │    │    │    └── interesting orderings: (+3,+2,+1)
  │    │    └── aggregations
  │    │         ├── max [type=int, outer=(1)]
  │    │         │    └── variable: no_o_id [type=int]
@@ -3341,7 +3343,7 @@ except-all
  │    ├── cost: 12001.34
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
- │    └── interesting orderings: (+3,+2,-1)
+ │    └── interesting orderings: (+3,+2,+1)
  └── project
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
       ├── stats: [rows=6560471]
@@ -3414,7 +3416,7 @@ except-all
       ├── cost: 12001.34
       ├── key: (9-11)
       ├── prune: (9-11)
-      └── interesting orderings: (+11,+10,-9)
+      └── interesting orderings: (+11,+10,+9)
 
 opt format=hide-qual
 (

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -136,8 +136,8 @@ CREATE TABLE history
     h_amount decimal(6,2),
     h_data   varchar(24),
     primary key (h_w_id, rowid),
-    index (h_w_id, h_d_id),
-    index (h_c_w_id, h_c_d_id, h_c_id),
+    index history_customer_fk_idx (h_c_w_id, h_c_d_id, h_c_id),
+    index history_district_fk_idx (h_w_id, h_d_id),
     foreign key (h_c_w_id, h_c_d_id, h_c_id) references customer (c_w_id, c_d_id, c_id),
     foreign key (h_w_id, h_d_id) references district (d_w_id, d_id)
 )
@@ -155,18 +155,18 @@ TABLE history
  ├── INDEX primary
  │    ├── h_w_id int not null
  │    └── rowid uuid not null
- ├── INDEX secondary
- │    ├── h_w_id int not null
- │    ├── h_d_id int not null
- │    └── rowid uuid not null
- ├── INDEX secondary
+ ├── INDEX history_customer_fk_idx
  │    ├── h_c_w_id int not null
  │    ├── h_c_d_id int not null
  │    ├── h_c_id int not null
  │    ├── h_w_id int not null
  │    └── rowid uuid not null
- ├── FOREIGN KEY (h_w_id, h_d_id) REFERENCES t.public.district (d_w_id, d_id)
- └── FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)
+ ├── INDEX history_district_fk_idx
+ │    ├── h_w_id int not null
+ │    ├── h_d_id int not null
+ │    └── rowid uuid not null
+ ├── FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)
+ └── FOREIGN KEY (h_w_id, h_d_id) REFERENCES t.public.district (d_w_id, d_id)
 
 exec-ddl
 CREATE TABLE "order"
@@ -263,7 +263,7 @@ CREATE TABLE stock
     s_remote_cnt integer,
     s_data       varchar(50),
     primary key (s_w_id, s_i_id),
-    index (s_i_id),
+    index stock_item_fk_idx (s_i_id),
     foreign key (s_w_id) references warehouse (w_id),
     foreign key (s_i_id) references item (i_id)
 ) interleave in parent warehouse (s_w_id)
@@ -289,7 +289,7 @@ TABLE stock
  ├── INDEX primary
  │    ├── s_w_id int not null
  │    └── s_i_id int not null
- ├── INDEX secondary
+ ├── INDEX stock_item_fk_idx
  │    ├── s_i_id int not null
  │    └── s_w_id int not null
  ├── FOREIGN KEY (s_w_id) REFERENCES t.public.warehouse (w_id)
@@ -309,9 +309,9 @@ CREATE TABLE order_line
     ol_amount       decimal(6,2),
     ol_dist_info    char(24),
     primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number),
-    index order_line_fk (ol_supply_w_id, ol_d_id),
+    index order_line_stock_fk_idx (ol_supply_w_id, ol_i_id),
     foreign key (ol_w_id, ol_d_id, ol_o_id) references "order" (o_w_id, o_d_id, o_id),
-    foreign key (ol_supply_w_id, ol_d_id) references stock (s_w_id, s_i_id)
+    foreign key (ol_supply_w_id, ol_i_id) references stock (s_w_id, s_i_id)
 ) interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)
 ----
 TABLE order_line
@@ -330,14 +330,15 @@ TABLE order_line
  │    ├── ol_d_id int not null
  │    ├── ol_o_id int not null desc
  │    └── ol_number int not null
- ├── INDEX order_line_fk
+ ├── INDEX order_line_stock_fk_idx
  │    ├── ol_supply_w_id int
- │    ├── ol_d_id int not null
+ │    ├── ol_i_id int not null
  │    ├── ol_w_id int not null
+ │    ├── ol_d_id int not null
  │    ├── ol_o_id int not null
  │    └── ol_number int not null
  ├── FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES t.public."order" (o_w_id, o_d_id, o_id)
- └── FOREIGN KEY (ol_supply_w_id, ol_d_id) REFERENCES t.public.stock (s_w_id, s_i_id)
+ └── FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES t.public.stock (s_w_id, s_i_id)
 
 # --------------------------------------------------
 # 2.4 The New Order Transaction
@@ -583,7 +584,7 @@ project
  ├── stats: [rows=0.001]
  ├── cost: 0.02119
  ├── prune: (5-9)
- ├── interesting orderings: (+6)
+ ├── interesting orderings: (+6,+5)
  └── scan order_line
       ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) ol_i_id:5(int!null) ol_supply_w_id:6(int) ol_delivery_d:7(timestamp) ol_quantity:8(int) ol_amount:9(decimal)
       ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
@@ -591,7 +592,7 @@ project
       ├── cost: 0.01118
       ├── fd: ()-->(1-3)
       ├── prune: (1-3,5-9)
-      └── interesting orderings: (+3,+2,-1) (+6,+2,+3,+1)
+      └── interesting orderings: (+3,+2,-1) (+6,+5,+3,+2,+1)
 
 # --------------------------------------------------
 # 2.7 The Delivery Transaction
@@ -1093,7 +1094,7 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null) o_ol_cnt:7(int)
  ├── right columns: ol_w_id:11(int) ol_d_id:10(int) ol_o_id:9(int) count_rows:19(int)
  ├── stats: [rows=1000]
- ├── cost: 2290.06
+ ├── cost: 2300.06
  ├── scan "order"
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_ol_cnt:7(int)
  │    ├── stats: [rows=1000]
@@ -1106,15 +1107,15 @@ except-all
       ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) count_rows:19(int)
       ├── grouping columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
       ├── stats: [rows=1000, distinct(9-11)=1000, null(9-11)=0]
-      ├── cost: 1140.03
+      ├── cost: 1150.03
       ├── key: (9-11)
       ├── fd: (9-11)-->(19)
       ├── prune: (19)
       ├── interesting orderings: (+11,+10,-9)
-      ├── scan order_line@order_line_fk
+      ├── scan order_line@order_line_stock_fk_idx
       │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
       │    ├── stats: [rows=1000, distinct(9-11)=1000, null(9-11)=0]
-      │    ├── cost: 1080.02
+      │    ├── cost: 1090.02
       │    ├── prune: (9-11)
       │    └── interesting orderings: (+11,+10,-9)
       └── aggregations
@@ -1139,20 +1140,20 @@ except-all
  ├── left columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count_rows:11(int)
  ├── right columns: o_w_id:14(int) o_d_id:13(int) o_id:12(int) o_ol_cnt:18(int)
  ├── stats: [rows=1000]
- ├── cost: 2290.06
+ ├── cost: 2300.06
  ├── group-by
  │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null) count_rows:11(int)
  │    ├── grouping columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
  │    ├── stats: [rows=1000, distinct(1-3)=1000, null(1-3)=0]
- │    ├── cost: 1140.03
+ │    ├── cost: 1150.03
  │    ├── key: (1-3)
  │    ├── fd: (1-3)-->(11)
  │    ├── prune: (11)
  │    ├── interesting orderings: (+3,+2,-1)
- │    ├── scan order_line@order_line_fk
+ │    ├── scan order_line@order_line_stock_fk_idx
  │    │    ├── columns: ol_o_id:1(int!null) ol_d_id:2(int!null) ol_w_id:3(int!null)
  │    │    ├── stats: [rows=1000, distinct(1-3)=1000, null(1-3)=0]
- │    │    ├── cost: 1080.02
+ │    │    ├── cost: 1090.02
  │    │    ├── prune: (1-3)
  │    │    └── interesting orderings: (+3,+2,-1)
  │    └── aggregations

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -210,17 +210,19 @@ CREATE TABLE new_order
     no_o_id  integer   not null,
     no_d_id  integer   not null,
     no_w_id  integer   not null,
-    primary key (no_w_id, no_d_id, no_o_id DESC)
+    primary key (no_w_id, no_d_id, no_o_id),
+    foreign key (no_w_id, no_d_id, no_o_id) references "order" (o_w_id, o_d_id, o_id)
 ) interleave in parent "order" (no_w_id, no_d_id, no_o_id)
 ----
 TABLE new_order
  ├── no_o_id int not null
  ├── no_d_id int not null
  ├── no_w_id int not null
- └── INDEX primary
-      ├── no_w_id int not null
-      ├── no_d_id int not null
-      └── no_o_id int not null desc
+ ├── INDEX primary
+ │    ├── no_w_id int not null
+ │    ├── no_d_id int not null
+ │    └── no_o_id int not null
+ └── FOREIGN KEY (no_w_id, no_d_id, no_o_id) REFERENCES t.public."order" (o_w_id, o_d_id, o_id)
 
 exec-ddl
 CREATE TABLE item
@@ -625,16 +627,16 @@ project
  ├── key: ()
  ├── fd: ()-->(1)
  ├── prune: (1)
- └── scan new_order,rev
+ └── scan new_order
       ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
-      ├── constraint: /3/2/-1: [/10/100 - /10/100]
-      ├── limit: 1(rev)
+      ├── constraint: /3/2/1: [/10/100 - /10/100]
+      ├── limit: 1
       ├── stats: [rows=0.1]
       ├── cost: 0.116
       ├── key: ()
       ├── fd: ()-->(1-3)
       ├── prune: (1-3)
-      └── interesting orderings: (+3,+2,-1)
+      └── interesting orderings: (+3,+2,+1)
 
 opt format=hide-qual
 SELECT sum(ol_amount)
@@ -837,7 +839,7 @@ group-by
  │    ├── key: (1-3)
  │    ├── ordering: +3,+2
  │    ├── prune: (1-3)
- │    └── interesting orderings: (+3,+2,-1)
+ │    └── interesting orderings: (+3,+2,+1)
  └── aggregations
       └── max [type=int, outer=(1)]
            └── variable: no_o_id [type=int]
@@ -912,7 +914,7 @@ scalar-group-by
  │    │    │    ├── key: (1-3)
  │    │    │    ├── ordering: +3,+2
  │    │    │    ├── prune: (1-3)
- │    │    │    └── interesting orderings: (+3,+2,-1)
+ │    │    │    └── interesting orderings: (+3,+2,+1)
  │    │    └── aggregations
  │    │         ├── max [type=int, outer=(1)]
  │    │         │    └── variable: no_o_id [type=int]
@@ -1000,7 +1002,7 @@ except-all
  │    ├── cost: 1060.02
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
- │    └── interesting orderings: (+3,+2,-1)
+ │    └── interesting orderings: (+3,+2,+1)
  └── project
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
       ├── stats: [rows=10]
@@ -1073,7 +1075,7 @@ except-all
       ├── cost: 1060.02
       ├── key: (9-11)
       ├── prune: (9-11)
-      └── interesting orderings: (+11,+10,-9)
+      └── interesting orderings: (+11,+10,+9)
 
 opt format=hide-qual
 (

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -180,8 +180,7 @@ CREATE TABLE "order"
     o_ol_cnt     integer,
     o_all_local  integer,
     primary key (o_w_id, o_d_id, o_id DESC),
-    unique index order_idx (o_w_id, o_d_id, o_carrier_id, o_id),
-    index (o_w_id, o_d_id, o_c_id),
+    unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC),
     foreign key (o_w_id, o_d_id, o_c_id) references customer (c_w_id, c_d_id, c_id)
 ) interleave in parent district (o_w_id, o_d_id)
 ----
@@ -201,13 +200,8 @@ TABLE order
  ├── INDEX order_idx
  │    ├── o_w_id int not null
  │    ├── o_d_id int not null
- │    ├── o_carrier_id int
- │    └── o_id int not null
- ├── INDEX secondary
- │    ├── o_w_id int not null
- │    ├── o_d_id int not null
  │    ├── o_c_id int
- │    └── o_id int not null
+ │    └── o_id int not null desc
  └── FOREIGN KEY (o_w_id, o_d_id, o_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)
 
 exec-ddl
@@ -567,17 +561,17 @@ project
       ├── cost: 0.0251777
       ├── key: ()
       ├── fd: ()-->(1-6)
-      ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
-      └── scan "order"@secondary,rev
+      ├── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
+      └── scan "order"@order_idx
            ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_c_id:4(int!null)
-           ├── constraint: /3/2/4/1: [/10/100/50 - /10/100/50]
-           ├── limit: 1(rev)
+           ├── constraint: /3/2/4/-1: [/10/100/50 - /10/100/50]
+           ├── limit: 1
            ├── stats: [rows=0.00099, distinct(1)=0.00099, null(1)=0, distinct(2)=0.00099, null(2)=0, distinct(3)=0.00099, null(3)=0, distinct(4)=0.00099, null(4)=0]
            ├── cost: 0.0110692
            ├── key: ()
            ├── fd: ()-->(1-4)
            ├── prune: (1-4)
-           └── interesting orderings: (+3,+2,-1) (+3,+2,+4,+1)
+           └── interesting orderings: (+3,+2,-1) (+3,+2,+4,-1)
 
 opt format=hide-qual
 SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
@@ -998,7 +992,7 @@ except-all
  ├── left columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
  ├── right columns: o_w_id:6(int) o_d_id:5(int) o_id:4(int)
  ├── stats: [rows=1000]
- ├── cost: 2170.27
+ ├── cost: 2210.27
  ├── scan new_order
  │    ├── columns: no_o_id:1(int!null) no_d_id:2(int!null) no_w_id:3(int!null)
  │    ├── stats: [rows=1000]
@@ -1009,26 +1003,26 @@ except-all
  └── project
       ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null)
       ├── stats: [rows=10]
-      ├── cost: 1090.14
+      ├── cost: 1130.14
       ├── key: (4-6)
       ├── prune: (4-6)
       ├── interesting orderings: (+6,+5,-4)
       └── select
            ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            ├── stats: [rows=10, distinct(4)=9.5617925, null(4)=0, distinct(5)=9.5617925, null(5)=0, distinct(6)=9.5617925, null(6)=0, distinct(9)=1, null(9)=10]
-           ├── cost: 1090.03
+           ├── cost: 1130.03
            ├── key: (4-6)
            ├── fd: ()-->(9)
            ├── prune: (4-6)
-           ├── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
-           ├── scan "order"@order_idx
+           ├── interesting orderings: (+6,+5,-4)
+           ├── scan "order"
            │    ├── columns: o_id:4(int!null) o_d_id:5(int!null) o_w_id:6(int!null) o_carrier_id:9(int)
            │    ├── stats: [rows=1000, distinct(4)=100, null(4)=0, distinct(5)=100, null(5)=0, distinct(6)=100, null(6)=0, distinct(9)=100, null(9)=10]
-           │    ├── cost: 1080.02
+           │    ├── cost: 1120.02
            │    ├── key: (4-6)
            │    ├── fd: (4-6)-->(9)
            │    ├── prune: (4-6,9)
-           │    └── interesting orderings: (+6,+5,-4) (+6,+5,+9,+4)
+           │    └── interesting orderings: (+6,+5,-4)
            └── filters
                 └── is [type=bool, outer=(9), constraints=(/9: [/NULL - /NULL]; tight), fd=()-->(9)]
                      ├── variable: o_carrier_id [type=int]
@@ -1044,30 +1038,30 @@ except-all
  ├── left columns: o_w_id:3(int!null) o_d_id:2(int!null) o_id:1(int!null)
  ├── right columns: no_w_id:11(int) no_d_id:10(int) no_o_id:9(int)
  ├── stats: [rows=10]
- ├── cost: 2160.37
+ ├── cost: 2200.37
  ├── project
  │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    ├── stats: [rows=10]
- │    ├── cost: 1090.14
+ │    ├── cost: 1130.14
  │    ├── key: (1-3)
  │    ├── prune: (1-3)
  │    ├── interesting orderings: (+3,+2,-1)
  │    └── select
  │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         ├── stats: [rows=10, distinct(1)=9.5617925, null(1)=0, distinct(2)=9.5617925, null(2)=0, distinct(3)=9.5617925, null(3)=0, distinct(6)=1, null(6)=10]
- │         ├── cost: 1090.03
+ │         ├── cost: 1130.03
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
  │         ├── prune: (1-3)
- │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
- │         ├── scan "order"@order_idx
+ │         ├── interesting orderings: (+3,+2,-1)
+ │         ├── scan "order"
  │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │         │    ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=100, null(6)=10]
- │         │    ├── cost: 1080.02
+ │         │    ├── cost: 1120.02
  │         │    ├── key: (1-3)
  │         │    ├── fd: (1-3)-->(6)
  │         │    ├── prune: (1-3,6)
- │         │    └── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
+ │         │    └── interesting orderings: (+3,+2,-1)
  │         └── filters
  │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
  │                   ├── variable: o_carrier_id [type=int]
@@ -1193,44 +1187,46 @@ scalar-group-by
  ├── columns: count:19(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
- ├── cost: 2241.084
+ ├── cost: 2280.984
  ├── key: ()
  ├── fd: ()-->(19)
  ├── prune: (19)
  ├── select
  │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
  │    ├── stats: [rows=6.62853719]
- │    ├── cost: 2240.99771
- │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
- │    ├── full-join
+ │    ├── cost: 2280.89771
+ │    ├── full-join (merge)
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:9(int) ol_d_id:10(int) ol_w_id:11(int)
+ │    │    ├── left ordering: +3,+2,-1
+ │    │    ├── right ordering: +11,+10,-9
  │    │    ├── stats: [rows=19.8856116]
- │    │    ├── cost: 2240.78886
- │    │    ├── reject-nulls: (1-3,9-11)
- │    │    ├── interesting orderings: (+3,+2,-1) (+11,+10,-9)
+ │    │    ├── cost: 2280.68886
  │    │    ├── project
  │    │    │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null)
  │    │    │    ├── stats: [rows=10, distinct(1)=9.5617925, null(1)=0, distinct(2)=9.5617925, null(2)=0, distinct(3)=9.5617925, null(3)=0]
- │    │    │    ├── cost: 1090.14
+ │    │    │    ├── cost: 1130.14
  │    │    │    ├── key: (1-3)
+ │    │    │    ├── ordering: +3,+2,-1
  │    │    │    ├── prune: (1-3)
  │    │    │    ├── interesting orderings: (+3,+2,-1)
  │    │    │    └── select
  │    │    │         ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         ├── stats: [rows=10, distinct(1)=9.5617925, null(1)=0, distinct(2)=9.5617925, null(2)=0, distinct(3)=9.5617925, null(3)=0, distinct(6)=1, null(6)=10]
- │    │    │         ├── cost: 1090.03
+ │    │    │         ├── cost: 1130.03
  │    │    │         ├── key: (1-3)
  │    │    │         ├── fd: ()-->(6)
+ │    │    │         ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
  │    │    │         ├── prune: (1-3)
- │    │    │         ├── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
- │    │    │         ├── scan "order"@order_idx
+ │    │    │         ├── interesting orderings: (+3,+2,-1)
+ │    │    │         ├── scan "order"
  │    │    │         │    ├── columns: o_id:1(int!null) o_d_id:2(int!null) o_w_id:3(int!null) o_carrier_id:6(int)
  │    │    │         │    ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(3)=100, null(3)=0, distinct(6)=100, null(6)=10]
- │    │    │         │    ├── cost: 1080.02
+ │    │    │         │    ├── cost: 1120.02
  │    │    │         │    ├── key: (1-3)
  │    │    │         │    ├── fd: (1-3)-->(6)
+ │    │    │         │    ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
  │    │    │         │    ├── prune: (1-3,6)
- │    │    │         │    └── interesting orderings: (+3,+2,-1) (+3,+2,+6,+1)
+ │    │    │         │    └── interesting orderings: (+3,+2,-1)
  │    │    │         └── filters
  │    │    │              └── is [type=bool, outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
  │    │    │                   ├── variable: o_carrier_id [type=int]
@@ -1239,6 +1235,7 @@ scalar-group-by
  │    │    │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null)
  │    │    │    ├── stats: [rows=10, distinct(9)=9.5617925, null(9)=0, distinct(10)=9.5617925, null(10)=0, distinct(11)=9.5617925, null(11)=0]
  │    │    │    ├── cost: 1150.14
+ │    │    │    ├── ordering: +11,+10,-9
  │    │    │    ├── prune: (9-11)
  │    │    │    ├── interesting orderings: (+11,+10,-9)
  │    │    │    └── select
@@ -1246,28 +1243,21 @@ scalar-group-by
  │    │    │         ├── stats: [rows=10, distinct(9)=9.5617925, null(9)=0, distinct(10)=9.5617925, null(10)=0, distinct(11)=9.5617925, null(11)=0, distinct(15)=1, null(15)=10]
  │    │    │         ├── cost: 1150.03
  │    │    │         ├── fd: ()-->(15)
+ │    │    │         ├── ordering: +11,+10,-9 opt(15) [actual: +11,+10,-9]
  │    │    │         ├── prune: (9-11)
  │    │    │         ├── interesting orderings: (+11,+10,-9)
  │    │    │         ├── scan order_line
  │    │    │         │    ├── columns: ol_o_id:9(int!null) ol_d_id:10(int!null) ol_w_id:11(int!null) ol_delivery_d:15(timestamp)
  │    │    │         │    ├── stats: [rows=1000, distinct(9)=100, null(9)=0, distinct(10)=100, null(10)=0, distinct(11)=100, null(11)=0, distinct(15)=100, null(15)=10]
  │    │    │         │    ├── cost: 1140.02
+ │    │    │         │    ├── ordering: +11,+10,-9 opt(15) [actual: +11,+10,-9]
  │    │    │         │    ├── prune: (9-11,15)
  │    │    │         │    └── interesting orderings: (+11,+10,-9)
  │    │    │         └── filters
  │    │    │              └── is [type=bool, outer=(15), constraints=(/15: [/NULL - /NULL]; tight), fd=()-->(15)]
  │    │    │                   ├── variable: ol_delivery_d [type=timestamp]
  │    │    │                   └── null [type=unknown]
- │    │    └── filters
- │    │         ├── eq [type=bool, outer=(3,11), constraints=(/3: (/NULL - ]; /11: (/NULL - ]), fd=(3)==(11), (11)==(3)]
- │    │         │    ├── variable: ol_w_id [type=int]
- │    │         │    └── variable: o_w_id [type=int]
- │    │         ├── eq [type=bool, outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
- │    │         │    ├── variable: ol_d_id [type=int]
- │    │         │    └── variable: o_d_id [type=int]
- │    │         └── eq [type=bool, outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
- │    │              ├── variable: ol_o_id [type=int]
- │    │              └── variable: o_id [type=int]
+ │    │    └── filters (true)
  │    └── filters
  │         └── or [type=bool, outer=(1,9)]
  │              ├── is [type=bool]

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -126,15 +126,16 @@ TABLE customer
 exec-ddl
 CREATE TABLE history
 (
-    rowid    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    h_c_id   integer,
-    h_c_d_id integer,
-    h_c_w_id integer,
-    h_d_id   integer,
-    h_w_id   integer,
+    rowid    uuid    not null default gen_random_uuid(),
+    h_c_id   integer not null,
+    h_c_d_id integer not null,
+    h_c_w_id integer not null,
+    h_d_id   integer not null,
+    h_w_id   integer not null,
     h_date   timestamp,
     h_amount decimal(6,2),
     h_data   varchar(24),
+    primary key (h_w_id, rowid),
     index (h_w_id, h_d_id),
     index (h_c_w_id, h_c_d_id, h_c_id),
     foreign key (h_c_w_id, h_c_d_id, h_c_id) references customer (c_w_id, c_d_id, c_id),
@@ -143,24 +144,26 @@ CREATE TABLE history
 ----
 TABLE history
  ├── rowid uuid not null
- ├── h_c_id int
- ├── h_c_d_id int
- ├── h_c_w_id int
- ├── h_d_id int
- ├── h_w_id int
+ ├── h_c_id int not null
+ ├── h_c_d_id int not null
+ ├── h_c_w_id int not null
+ ├── h_d_id int not null
+ ├── h_w_id int not null
  ├── h_date timestamp
  ├── h_amount decimal
  ├── h_data varchar
  ├── INDEX primary
+ │    ├── h_w_id int not null
  │    └── rowid uuid not null
  ├── INDEX secondary
- │    ├── h_w_id int
- │    ├── h_d_id int
+ │    ├── h_w_id int not null
+ │    ├── h_d_id int not null
  │    └── rowid uuid not null
  ├── INDEX secondary
- │    ├── h_c_w_id int
- │    ├── h_c_d_id int
- │    ├── h_c_id int
+ │    ├── h_c_w_id int not null
+ │    ├── h_c_d_id int not null
+ │    ├── h_c_id int not null
+ │    ├── h_w_id int not null
  │    └── rowid uuid not null
  ├── FOREIGN KEY (h_w_id, h_d_id) REFERENCES t.public.district (d_w_id, d_id)
  └── FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES t.public.customer (c_w_id, c_d_id, c_id)

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -75,17 +75,17 @@ const (
 		index customer_idx (c_w_id, c_d_id, c_last, c_first)
 	)`
 	tpccCustomerSchemaInterleave = ` interleave in parent district (c_w_id, c_d_id)`
-	// No PK necessary for this table.
-	tpccHistorySchema = `(
-		rowid    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-		h_c_id   integer,
-		h_c_d_id integer,
-		h_c_w_id integer,
-		h_d_id   integer,
-		h_w_id   integer,
+	tpccHistorySchema            = `(
+		rowid    uuid    not null default gen_random_uuid(),
+		h_c_id   integer not null,
+		h_c_d_id integer not null,
+		h_c_w_id integer not null,
+		h_d_id   integer not null,
+		h_w_id   integer not null,
 		h_date   timestamp,
 		h_amount decimal(6,2),
 		h_data   varchar(24),
+		primary key (h_w_id, rowid),
 		index (h_w_id, h_d_id),
 		index (h_c_w_id, h_c_d_id, h_c_id)
 	)`

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -98,9 +98,8 @@ const (
 		o_carrier_id integer,
 		o_ol_cnt     integer,
 		o_all_local  integer,
-		primary key (o_w_id, o_d_id, o_id DESC),
-		unique index order_idx (o_w_id, o_d_id, o_carrier_id, o_id),
-		index (o_w_id, o_d_id, o_c_id)
+		primary key  (o_w_id, o_d_id, o_id DESC),
+		unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC)
 	)`
 	tpccOrderSchemaInterleave = ` interleave in parent district (o_w_id, o_d_id)`
 	tpccNewOrderSchema        = `(

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -23,6 +23,7 @@ import (
 )
 
 const (
+	// WAREHOUSE table.
 	tpccWarehouseSchema = `(
 		w_id        integer   not null primary key,
 		w_name      varchar(10),
@@ -34,7 +35,9 @@ const (
 		w_tax       decimal(4,4),
 		w_ytd       decimal(12,2)
 	)`
-	tpccDistrictSchema = `(
+
+	// DISTRICT table.
+	tpccDistrictSchemaBase = `(
 		d_id         integer       not null,
 		d_w_id       integer       not null,
 		d_name       varchar(10),
@@ -48,8 +51,11 @@ const (
 		d_next_o_id  integer,
 		primary key (d_w_id, d_id)
 	)`
-	tpccDistrictSchemaInterleave = ` interleave in parent warehouse (d_w_id)`
-	tpccCustomerSchema           = `(
+	tpccDistrictSchemaInterleaveSuffix = `
+		interleave in parent warehouse (d_w_id)`
+
+	// CUSTOMER table.
+	tpccCustomerSchemaBase = `(
 		c_id           integer        not null,
 		c_d_id         integer        not null,
 		c_w_id         integer        not null,
@@ -74,8 +80,11 @@ const (
 		primary key (c_w_id, c_d_id, c_id),
 		index customer_idx (c_w_id, c_d_id, c_last, c_first)
 	)`
-	tpccCustomerSchemaInterleave = ` interleave in parent district (c_w_id, c_d_id)`
-	tpccHistorySchema            = `(
+	tpccCustomerSchemaInterleaveSuffix = `
+		interleave in parent district (c_w_id, c_d_id)`
+
+	// HISTORY table.
+	tpccHistorySchemaBase = `(
 		rowid    uuid    not null default gen_random_uuid(),
 		h_c_id   integer not null,
 		h_c_d_id integer not null,
@@ -85,11 +94,13 @@ const (
 		h_date   timestamp,
 		h_amount decimal(6,2),
 		h_data   varchar(24),
-		primary key (h_w_id, rowid),
-		index (h_w_id, h_d_id),
-		index (h_c_w_id, h_c_d_id, h_c_id)
-	)`
-	tpccOrderSchema = `(
+		primary key (h_w_id, rowid)`
+	tpccHistorySchemaFkSuffix = `
+		index history_customer_fk_idx (h_c_w_id, h_c_d_id, h_c_id),
+		index history_district_fk_idx (h_w_id, h_d_id)`
+
+	// ORDER table.
+	tpccOrderSchemaBase = `(
 		o_id         integer      not null,
 		o_d_id       integer      not null,
 		o_w_id       integer      not null,
@@ -101,15 +112,24 @@ const (
 		primary key  (o_w_id, o_d_id, o_id DESC),
 		unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC)
 	)`
-	tpccOrderSchemaInterleave = ` interleave in parent district (o_w_id, o_d_id)`
-	tpccNewOrderSchema        = `(
+	tpccOrderSchemaInterleaveSuffix = `
+		interleave in parent district (o_w_id, o_d_id)`
+
+	// NEW-ORDER table.
+	tpccNewOrderSchema = `(
 		no_o_id  integer   not null,
 		no_d_id  integer   not null,
 		no_w_id  integer   not null,
 		primary key (no_w_id, no_d_id, no_o_id)
 	)`
-	tpccNewOrderSchemaInterleave = ` interleave in parent "order" (no_w_id, no_d_id, no_o_id)`
-	tpccItemSchema               = `(
+	// This natural-seeming interleave makes performance worse, because this
+	// table has a ton of churn and produces a lot of MVCC tombstones, which
+	// then will gum up the works of scans over the parent table.
+	// tpccNewOrderSchemaInterleaveSuffix = `
+	// 	interleave in parent "order" (no_w_id, no_d_id, no_o_id)`
+
+	// ITEM table.
+	tpccItemSchema = `(
 		i_id     integer      not null,
 		i_im_id  integer,
 		i_name   varchar(24),
@@ -117,7 +137,9 @@ const (
 		i_data   varchar(50),
 		primary key (i_id)
 	)`
-	tpccStockSchema = `(
+
+	// STOCK table.
+	tpccStockSchemaBase = `(
 		s_i_id       integer       not null,
 		s_w_id       integer       not null,
 		s_quantity   integer,
@@ -135,11 +157,14 @@ const (
 		s_order_cnt  integer,
 		s_remote_cnt integer,
 		s_data       varchar(50),
-		primary key (s_w_id, s_i_id),
-		index (s_i_id)
-	)`
-	tpccStockSchemaInterleave = ` interleave in parent warehouse (s_w_id)`
-	tpccOrderLineSchema       = `(
+		primary key (s_w_id, s_i_id)`
+	tpccStockSchemaFkSuffix = `
+		index stock_item_fk_idx (s_i_id)`
+	tpccStockSchemaInterleaveSuffix = `
+		interleave in parent warehouse (s_w_id)`
+
+	// ORDER-LINE table.
+	tpccOrderLineSchemaBase = `(
 		ol_o_id         integer   not null,
 		ol_d_id         integer   not null,
 		ol_w_id         integer   not null,
@@ -150,11 +175,27 @@ const (
 		ol_quantity     integer,
 		ol_amount       decimal(6,2),
 		ol_dist_info    char(24),
-		primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number),
-		index order_line_fk (ol_supply_w_id, ol_i_id)
-	)`
-	tpccOrderLineSchemaInterleave = ` interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)`
+		primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number)`
+	tpccOrderLineSchemaFkSuffix = `
+		index order_line_stock_fk_idx (ol_supply_w_id, ol_i_id)`
+	tpccOrderLineSchemaInterleaveSuffix = `
+		interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)`
 )
+
+func maybeAddFkSuffix(fks bool, base, suffix string) string {
+	const endSchema = "\n\t)"
+	if !fks {
+		return base + endSchema
+	}
+	return base + "," + suffix + endSchema
+}
+
+func maybeAddInterleaveSuffix(interleave bool, base, suffix string) string {
+	if !interleave {
+		return base
+	}
+	return base + suffix
+}
 
 func scatterRanges(db *gosql.DB) error {
 	tables := []string{

--- a/pkg/workload/tpcc/generate.go
+++ b/pkg/workload/tpcc/generate.go
@@ -65,9 +65,6 @@ var (
 const (
 	numWarehousesPerRange = 10
 	numItemsPerRange      = 100
-
-	historyRanges                 = 1000
-	numHistoryValsPerRange uint64 = math.MaxUint64 / historyRanges
 )
 
 type generateLocals struct {

--- a/pkg/workload/tpcc/partition.go
+++ b/pkg/workload/tpcc/partition.go
@@ -240,10 +240,7 @@ func partitionOrder(db *gosql.DB, wPart *partitioner, zones []string) error {
 	if err := partitionTable(db, wPart, zones, `"order"`, "o_w_id", 0); err != nil {
 		return err
 	}
-	if err := partitionIndex(db, wPart, zones, `"order"`, "order_idx", "o_w_id", 1); err != nil {
-		return err
-	}
-	return partitionIndex(db, wPart, zones, `"order"`, "order_o_w_id_o_d_id_o_c_id_idx", "o_w_id", 2)
+	return partitionIndex(db, wPart, zones, `"order"`, "order_idx", "o_w_id", 1)
 }
 
 func partitionOrderLine(db *gosql.DB, wPart *partitioner, zones []string) error {

--- a/pkg/workload/tpcc/partition.go
+++ b/pkg/workload/tpcc/partition.go
@@ -247,14 +247,14 @@ func partitionOrderLine(db *gosql.DB, wPart *partitioner, zones []string) error 
 	if err := partitionTable(db, wPart, zones, "order_line", "ol_w_id", 0); err != nil {
 		return err
 	}
-	return partitionIndex(db, wPart, zones, "order_line", "order_line_fk", "ol_supply_w_id", 1)
+	return partitionIndex(db, wPart, zones, "order_line", "order_line_stock_fk_idx", "ol_supply_w_id", 1)
 }
 
 func partitionStock(db *gosql.DB, wPart, iPart *partitioner, zones []string) error {
 	if err := partitionTable(db, wPart, zones, "stock", "s_w_id", 0); err != nil {
 		return err
 	}
-	return partitionIndex(db, iPart, zones, "stock", "stock_s_i_id_idx", "s_i_id", 1)
+	return partitionIndex(db, iPart, zones, "stock", "stock_item_fk_idx", "s_i_id", 1)
 }
 
 func partitionCustomer(db *gosql.DB, wPart *partitioner, zones []string) error {
@@ -268,10 +268,10 @@ func partitionHistory(db *gosql.DB, wPart *partitioner, zones []string) error {
 	if err := partitionTable(db, wPart, zones, "history", "h_w_id", 0); err != nil {
 		return err
 	}
-	if err := partitionIndex(db, wPart, zones, "history", "history_h_w_id_h_d_id_idx", "h_w_id", 1); err != nil {
+	if err := partitionIndex(db, wPart, zones, "history", "history_customer_fk_idx", "h_c_w_id", 1); err != nil {
 		return err
 	}
-	return partitionIndex(db, wPart, zones, "history", "history_h_c_w_id_h_c_d_id_h_c_id_idx", "h_c_w_id", 2)
+	return partitionIndex(db, wPart, zones, "history", "history_district_fk_idx", "h_w_id", 2)
 }
 
 func partitionItem(db *gosql.DB, iPart *partitioner, zones []string) error {

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -96,16 +96,13 @@ var tpccMeta = workload.Meta{
 	Name: `tpcc`,
 	Description: `TPC-C simulates a transaction processing workload` +
 		` using a rich schema of multiple tables`,
-	// TODO(anyone): when bumping this version and regenerating fixtures, please
-	// address the TODO in PostLoad.
-	Version:      `2.0.1`,
+	Version:      `2.1.0`,
 	PublicFacing: true,
 	New: func() workload.Generator {
 		g := &tpcc{}
 		g.flags.FlagSet = pflag.NewFlagSet(`tpcc`, pflag.ContinueOnError)
 		g.flags.Meta = map[string]workload.FlagMeta{
 			`db`:                 {RuntimeOnly: true},
-			`fks`:                {RuntimeOnly: true},
 			`mix`:                {RuntimeOnly: true},
 			`partitions`:         {RuntimeOnly: true},
 			`partition-affinity`: {RuntimeOnly: true},
@@ -122,19 +119,15 @@ var tpccMeta = workload.Meta{
 
 		g.flags.Uint64Var(&g.seed, `seed`, 1, `Random number generator seed`)
 		g.flags.IntVar(&g.warehouses, `warehouses`, 1, `Number of warehouses for loading`)
+		g.flags.BoolVar(&g.fks, `fks`, true, `Add the foreign keys`)
 		g.flags.BoolVar(&g.interleaved, `interleaved`, false, `Use interleaved tables`)
-		// Hardcode this since it doesn't seem like anyone will want to change
-		// it and it's really noisy in the generated fixture paths.
-		g.nowString = []byte(`2006-01-02 15:04:05`)
 
 		g.flags.StringVar(&g.mix, `mix`,
 			`newOrder=10,payment=10,orderStatus=1,delivery=1,stockLevel=1`,
 			`Weights for the transaction mix. The default matches the TPCC spec.`)
-
 		g.flags.BoolVar(&g.doWaits, `wait`, true, `Run in wait mode (include think/keying sleeps)`)
 		g.flags.StringVar(&g.dbOverride, `db`, ``,
 			`Override for the SQL database to use. If empty, defaults to the generator name`)
-
 		g.flags.IntVar(&g.workers, `workers`, 0, fmt.Sprintf(
 			`Number of concurrent workers. Defaults to --warehouses * %d`, numWorkersPerWarehouse,
 		))
@@ -142,8 +135,6 @@ var tpccMeta = workload.Meta{
 			`Number of connections. Defaults to --warehouses * %d (except in nowait mode, where it defaults to --workers`,
 			numConnsPerWarehouse,
 		))
-
-		g.flags.BoolVar(&g.fks, `fks`, true, `Add the foreign keys`)
 		g.flags.IntVar(&g.partitions, `partitions`, 1, `Partition tables (requires split)`)
 		g.flags.IntVar(&g.affinityPartition, `partition-affinity`, -1, `Run load generator against specific partition (requires partitions)`)
 		g.flags.IntVar(&g.activeWarehouses, `active-warehouses`, 0, `Run the load generator against a specific number of warehouses. Defaults to --warehouses'`)
@@ -151,9 +142,12 @@ var tpccMeta = workload.Meta{
 		g.flags.BoolVar(&g.serializable, `serializable`, false, `Force serializable mode`)
 		g.flags.BoolVar(&g.split, `split`, false, `Split tables`)
 		g.flags.StringSliceVar(&g.zones, "zones", []string{}, "Zones for partitioning, the number of zones should match the number of partitions and the zones used to start cockroach.")
-
 		g.flags.BoolVar(&g.expensiveChecks, `expensive-checks`, false, `Run expensive checks`)
 		g.connFlags = workload.NewConnFlags(&g.flags)
+
+		// Hardcode this since it doesn't seem like anyone will want to change
+		// it and it's really noisy in the generated fixture paths.
+		g.nowString = []byte(`2006-01-02 15:04:05`)
 		return g
 	},
 }
@@ -240,34 +234,7 @@ func (w *tpcc) Hooks() workload.Hooks {
 					`alter table stock add foreign key (s_w_id) references warehouse (w_id)`,
 					`alter table stock add foreign key (s_i_id) references item (i_id)`,
 					`alter table order_line add foreign key (ol_w_id, ol_d_id, ol_o_id) references "order" (o_w_id, o_d_id, o_id)`,
-				}
-
-				// TODO(anyone): Remove this check. Once fixtures are
-				// regenerated and the meta version is bumped on this workload,
-				// we won't need it anymore.
-				{
-					const q = `SELECT column_name
-						       FROM information_schema.statistics
-						       WHERE index_name = 'order_line_fk'
-						         AND seq_in_index = 2`
-					var fkCol string
-					if err := db.QueryRow(q).Scan(&fkCol); err != nil {
-						return err
-					}
-					var fkStmt string
-					switch fkCol {
-					case "ol_i_id":
-						// The corrected column. When the TODO above is addressed,
-						// this should be moved into fkStmts.
-						fkStmt = `alter table order_line add foreign key (ol_supply_w_id, ol_i_id) references stock (s_w_id, s_i_id)`
-					case "ol_d_id":
-						// The old, incorrect column. When the TODO above is addressed,
-						// this should be removed entirely.
-						fkStmt = `alter table order_line add foreign key (ol_supply_w_id, ol_d_id) references stock (s_w_id, s_i_id)`
-					default:
-						return errors.Errorf("unexpected column %q in order_line_fk", fkCol)
-					}
-					fkStmts = append(fkStmts, fkStmt)
+					`alter table order_line add foreign key (ol_supply_w_id, ol_i_id) references stock (s_w_id, s_i_id)`,
 				}
 
 				for _, fkStmt := range fkStmts {
@@ -372,8 +339,12 @@ func (w *tpcc) Tables() []workload.Table {
 		)),
 	}
 	district := workload.Table{
-		Name:   `district`,
-		Schema: tpccDistrictSchema,
+		Name: `district`,
+		Schema: maybeAddInterleaveSuffix(
+			w.interleaved,
+			tpccDistrictSchemaBase,
+			tpccDistrictSchemaInterleaveSuffix,
+		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numDistrictsPerWarehouse * w.warehouses,
 			FillBatch:  w.tpccDistrictInitialRowBatch,
@@ -386,8 +357,12 @@ func (w *tpcc) Tables() []workload.Table {
 		)),
 	}
 	customer := workload.Table{
-		Name:   `customer`,
-		Schema: tpccCustomerSchema,
+		Name: `customer`,
+		Schema: maybeAddInterleaveSuffix(
+			w.interleaved,
+			tpccCustomerSchemaBase,
+			tpccCustomerSchemaInterleaveSuffix,
+		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numCustomersPerWarehouse * w.warehouses,
 			FillBatch:  w.tpccCustomerInitialRowBatch,
@@ -395,8 +370,12 @@ func (w *tpcc) Tables() []workload.Table {
 		Stats: w.tpccCustomerStats(),
 	}
 	history := workload.Table{
-		Name:   `history`,
-		Schema: tpccHistorySchema,
+		Name: `history`,
+		Schema: maybeAddFkSuffix(
+			w.fks,
+			tpccHistorySchemaBase,
+			tpccHistorySchemaFkSuffix,
+		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numHistoryPerWarehouse * w.warehouses,
 			FillBatch:  w.tpccHistoryInitialRowBatch,
@@ -409,8 +388,12 @@ func (w *tpcc) Tables() []workload.Table {
 		)),
 	}
 	order := workload.Table{
-		Name:   `order`,
-		Schema: tpccOrderSchema,
+		Name: `order`,
+		Schema: maybeAddInterleaveSuffix(
+			w.interleaved,
+			tpccOrderSchemaBase,
+			tpccOrderSchemaInterleaveSuffix,
+		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numOrdersPerWarehouse * w.warehouses,
 			FillBatch:  w.tpccOrderInitialRowBatch,
@@ -441,8 +424,16 @@ func (w *tpcc) Tables() []workload.Table {
 		Stats: w.tpccItemStats(),
 	}
 	stock := workload.Table{
-		Name:   `stock`,
-		Schema: tpccStockSchema,
+		Name: `stock`,
+		Schema: maybeAddInterleaveSuffix(
+			w.interleaved,
+			maybeAddFkSuffix(
+				w.fks,
+				tpccStockSchemaBase,
+				tpccStockSchemaFkSuffix,
+			),
+			tpccStockSchemaInterleaveSuffix,
+		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numStockPerWarehouse * w.warehouses,
 			FillBatch:  w.tpccStockInitialRowBatch,
@@ -450,24 +441,21 @@ func (w *tpcc) Tables() []workload.Table {
 		Stats: w.tpccStockStats(),
 	}
 	orderLine := workload.Table{
-		Name:   `order_line`,
-		Schema: tpccOrderLineSchema,
+		Name: `order_line`,
+		Schema: maybeAddInterleaveSuffix(
+			w.interleaved,
+			maybeAddFkSuffix(
+				w.fks,
+				tpccOrderLineSchemaBase,
+				tpccOrderLineSchemaFkSuffix,
+			),
+			tpccOrderLineSchemaInterleaveSuffix,
+		),
 		InitialRows: workload.BatchedTuples{
 			NumBatches: numOrdersPerWarehouse * w.warehouses,
 			FillBatch:  w.tpccOrderLineInitialRowBatch,
 		},
 		Stats: w.tpccOrderLineStats(),
-	}
-	if w.interleaved {
-		district.Schema += tpccDistrictSchemaInterleave
-		customer.Schema += tpccCustomerSchemaInterleave
-		order.Schema += tpccOrderSchemaInterleave
-		stock.Schema += tpccStockSchemaInterleave
-		orderLine.Schema += tpccOrderLineSchemaInterleave
-		// This natural-seeming interleave makes performance worse, because this
-		// table has a ton of churn and produces a lot of MVCC tombstones, which
-		// then will gum up the works of scans over the parent table.
-		_ = tpccNewOrderSchemaInterleave
 	}
 	return []workload.Table{
 		warehouse, district, customer, history, order, newOrder, item, stock, orderLine,

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -231,6 +231,7 @@ func (w *tpcc) Hooks() workload.Hooks {
 					`alter table history add foreign key (h_c_w_id, h_c_d_id, h_c_id) references customer (c_w_id, c_d_id, c_id)`,
 					`alter table history add foreign key (h_w_id, h_d_id) references district (d_w_id, d_id)`,
 					`alter table "order" add foreign key (o_w_id, o_d_id, o_c_id) references customer (c_w_id, c_d_id, c_id)`,
+					`alter table new_order add foreign key (no_w_id, no_d_id, no_o_id) references "order" (o_w_id, o_d_id, o_id)`,
 					`alter table stock add foreign key (s_w_id) references warehouse (w_id)`,
 					`alter table stock add foreign key (s_i_id) references item (i_id)`,
 					`alter table order_line add foreign key (ol_w_id, ol_d_id, ol_o_id) references "order" (o_w_id, o_d_id, o_id)`,

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -27,8 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uint128"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/jackc/pgx"
@@ -404,10 +402,9 @@ func (w *tpcc) Tables() []workload.Table {
 			FillBatch:  w.tpccHistoryInitialRowBatch,
 		},
 		Splits: splits(workload.Tuples(
-			historyRanges-1,
+			numBatches(w.warehouses, numWarehousesPerRange),
 			func(i int) []interface{} {
-				at := uint128.FromInts(uint64(i+1)*numHistoryValsPerRange, 0)
-				return []interface{}{uuid.FromUint128(at).String()}
+				return []interface{}{(i + 1) * numWarehousesPerRange}
 			},
 		)),
 	}

--- a/pkg/workload/tpcc/worker.go
+++ b/pkg/workload/tpcc/worker.go
@@ -183,9 +183,7 @@ func (w *worker) run(ctx context.Context) error {
 	w.permIdx++
 
 	warehouseID := w.warehouse
-	if !w.config.doWaits {
-		warehouseID = rand.Intn(w.config.warehouses)
-	} else {
+	if w.config.doWaits {
 		// Wait out the entire keying and think time even if the context is
 		// expired. This prevents all workers from immediately restarting when
 		// the workload's ramp period expires, which can overload a cluster.


### PR DESCRIPTION
This PR contains a number of incremental improvements to TPC-C that allow it to be more effectively partitioned. The changes focus on migrating indexes to all be partitionable by warehouse and removing indexes that are only needed for foreign keys when fks are not enabled. This is all a precursor to a follow-up PR: #36855.

I'm assigning @jordanlewis and @danhhz as reviewers because between the two of you most of the changes here have already been agreed upon.

This PR will require me to regenerate all TPC-C fixtures. I intend to do so before it is merged.