### PR TITLE
exec: plumb through contexts as an argument to Next

### DIFF
--- a/pkg/sql/distsqlrun/colbatch_scan.go
+++ b/pkg/sql/distsqlrun/colbatch_scan.go
@@ -49,8 +49,8 @@ func (s *colBatchScan) Init() {
 	}
 }
 
-func (s *colBatchScan) Next() coldata.Batch {
-	bat, err := s.rf.NextBatch(s.ctx)
+func (s *colBatchScan) Next(ctx context.Context) coldata.Batch {
+	bat, err := s.rf.NextBatch(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/distsqlrun/colbatch_scan_test.go
+++ b/pkg/sql/distsqlrun/colbatch_scan_test.go
@@ -80,7 +80,7 @@ func BenchmarkColBatchScan(b *testing.B) {
 					b.Fatal(err)
 				}
 				for {
-					bat := tr.Next()
+					bat := tr.Next(ctx)
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/pkg/sql/distsqlrun/columnarizer.go
+++ b/pkg/sql/distsqlrun/columnarizer.go
@@ -38,6 +38,8 @@ type columnarizer struct {
 	accumulatedMeta []ProducerMetadata
 }
 
+var _ exec.Operator = &columnarizer{}
+
 // newColumnarizer returns a new columnarizer.
 func newColumnarizer(flowCtx *FlowCtx, processorID int32, input RowSource) (*columnarizer, error) {
 	c := &columnarizer{
@@ -70,7 +72,7 @@ func (c *columnarizer) Init() {
 	c.input.Start(context.TODO())
 }
 
-func (c *columnarizer) Next() coldata.Batch {
+func (c *columnarizer) Next(context.Context) coldata.Batch {
 	// Buffer up n rows.
 	nRows := uint16(0)
 	columnTypes := c.OutputTypes()

--- a/pkg/sql/distsqlrun/columnarizer_test.go
+++ b/pkg/sql/distsqlrun/columnarizer_test.go
@@ -49,7 +49,7 @@ func BenchmarkColumnarize(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		foundRows := 0
 		for {
-			batch := c.Next()
+			batch := c.Next(ctx)
 			if batch.Length() == 0 {
 				break
 			}

--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -102,7 +102,7 @@ func newMaterializer(
 		flowCtx,
 		processorID,
 		output,
-		nil,
+		nil, /* memMonitor */
 		ProcStateOpts{
 			TrailingMetaCallback: func(ctx context.Context) []ProducerMetadata {
 				var trailingMeta []ProducerMetadata
@@ -121,6 +121,7 @@ func newMaterializer(
 
 func (m *materializer) Start(ctx context.Context) context.Context {
 	m.input.Init()
+	m.Ctx = ctx
 	return ctx
 }
 
@@ -128,7 +129,7 @@ func (m *materializer) Start(ctx context.Context) context.Context {
 // The purpose of having this function is to not create an anonymous function
 // on every call to Next().
 func (m *materializer) nextBatch() {
-	m.batch = m.input.Next()
+	m.batch = m.input.Next(m.Ctx)
 }
 
 func (m *materializer) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {

--- a/pkg/sql/distsqlrun/vectorized_error_propagation_test.go
+++ b/pkg/sql/distsqlrun/vectorized_error_propagation_test.go
@@ -166,12 +166,12 @@ func (e *testNonVectorizedErrorEmitter) Init() {
 }
 
 // Next is part of exec.Operator interface.
-func (e *testNonVectorizedErrorEmitter) Next() coldata.Batch {
+func (e *testNonVectorizedErrorEmitter) Next(ctx context.Context) coldata.Batch {
 	if !e.emitBatch {
 		e.emitBatch = true
 		panic(errors.New("An error from distsqlrun package"))
 	}
 
 	e.emitBatch = false
-	return e.input.Next()
+	return e.input.Next(ctx)
 }

--- a/pkg/sql/exec/aggregator.go
+++ b/pkg/sql/exec/aggregator.go
@@ -15,6 +15,8 @@
 package exec
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
@@ -232,7 +234,7 @@ func (a *orderedAggregator) Init() {
 	a.initWithBatchSize(coldata.BatchSize, coldata.BatchSize)
 }
 
-func (a *orderedAggregator) Next() coldata.Batch {
+func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 	if a.done {
 		a.scratch.SetLength(0)
 		return a.scratch
@@ -257,7 +259,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 	}
 
 	for a.scratch.resumeIdx < a.scratch.outputSize {
-		batch := a.input.Next()
+		batch := a.input.Next(ctx)
 		for i, fn := range a.aggregateFuncs {
 			fn.Compute(batch, a.aggCols[i])
 		}

--- a/pkg/sql/exec/bool_vec_to_sel.go
+++ b/pkg/sql/exec/bool_vec_to_sel.go
@@ -14,7 +14,11 @@
 
 package exec
 
-import "github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+)
 
 // boolVecToSelOp transforms a boolean column into a selection vector by adding
 // an index to the selection for each true value in the boolean column.
@@ -30,11 +34,11 @@ var _ Operator = &boolVecToSelOp{}
 
 var zeroBoolVec = make([]bool, coldata.BatchSize)
 
-func (p *boolVecToSelOp) Next() coldata.Batch {
+func (p *boolVecToSelOp) Next(ctx context.Context) coldata.Batch {
 	// Loop until we have non-zero amount of output to return, or our input's been
 	// exhausted.
 	for {
-		batch := p.input.Next()
+		batch := p.input.Next(ctx)
 		if batch.Length() == 0 {
 			return batch
 		}

--- a/pkg/sql/exec/coalescer.go
+++ b/pkg/sql/exec/coalescer.go
@@ -15,6 +15,8 @@
 package exec
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
@@ -46,7 +48,7 @@ func (p *coalescerOp) Init() {
 	p.buffer = coldata.NewMemBatch(p.inputTypes)
 }
 
-func (p *coalescerOp) Next() coldata.Batch {
+func (p *coalescerOp) Next(ctx context.Context) coldata.Batch {
 	tempBatch := p.group
 	p.group = p.buffer
 
@@ -55,7 +57,7 @@ func (p *coalescerOp) Next() coldata.Batch {
 
 	for p.group.Length() < coldata.BatchSize {
 		leftover := coldata.BatchSize - p.group.Length()
-		batch := p.input.Next()
+		batch := p.input.Next(ctx)
 		batchSize := batch.Length()
 
 		if batchSize == 0 {

--- a/pkg/sql/exec/coalescer_test.go
+++ b/pkg/sql/exec/coalescer_test.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -72,6 +73,7 @@ func TestCoalescer(t *testing.T) {
 }
 
 func BenchmarkCoalescer(b *testing.B) {
+	ctx := context.Background()
 	// The input operator to the coalescer returns a batch of random size from [1,
 	// col.BatchSize) each time.
 	nCols := 4
@@ -105,7 +107,7 @@ func BenchmarkCoalescer(b *testing.B) {
 				co.Init()
 
 				for i := 0; i < nBatches; i++ {
-					co.Next()
+					co.Next(ctx)
 				}
 			}
 		})

--- a/pkg/sql/exec/count.go
+++ b/pkg/sql/exec/count.go
@@ -15,6 +15,8 @@
 package exec
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
@@ -30,6 +32,8 @@ type countOp struct {
 	done          bool
 	count         int64
 }
+
+var _ Operator = &countOp{}
 
 // NewCountOp returns a new count operator that counts the rows in its input.
 func NewCountOp(input Operator) Operator {
@@ -48,13 +52,13 @@ func (c *countOp) Init() {
 	c.done = false
 }
 
-func (c *countOp) Next() coldata.Batch {
+func (c *countOp) Next(ctx context.Context) coldata.Batch {
 	if c.done {
 		c.internalBatch.SetLength(0)
 		return c.internalBatch
 	}
 	for {
-		bat := c.input.Next()
+		bat := c.input.Next(ctx)
 		length := bat.Length()
 		if length == 0 {
 			c.done = true

--- a/pkg/sql/exec/deselector.go
+++ b/pkg/sql/exec/deselector.go
@@ -15,6 +15,8 @@
 package exec
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
@@ -46,8 +48,8 @@ func (p *deselectorOp) Init() {
 	p.output = coldata.NewMemBatch(p.inputTypes)
 }
 
-func (p *deselectorOp) Next() coldata.Batch {
-	batch := p.input.Next()
+func (p *deselectorOp) Next(ctx context.Context) coldata.Batch {
+	batch := p.input.Next(ctx)
 	if batch.Selection() == nil {
 		return batch
 	}

--- a/pkg/sql/exec/deselector_test.go
+++ b/pkg/sql/exec/deselector_test.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -76,6 +77,7 @@ func TestDeselector(t *testing.T) {
 
 func BenchmarkDeselector(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
 
 	nCols := 1
 	inputTypes := make([]types.T, nCols)
@@ -109,7 +111,7 @@ func BenchmarkDeselector(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					input.resetBatchesToReturn(nBatches)
-					for b := op.Next(); b.Length() != 0; b = op.Next() {
+					for b := op.Next(ctx); b.Length() != 0; b = op.Next(ctx) {
 					}
 					// We don't need to reset the deselector because it doesn't keep any
 					// state. We do, however, want to keep its already allocated memory

--- a/pkg/sql/exec/distinct_test.go
+++ b/pkg/sql/exec/distinct_test.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
@@ -87,6 +88,7 @@ func TestSortedDistinct(t *testing.T) {
 
 func BenchmarkSortedDistinct(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
 
 	batch := coldata.NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
 	aCol := batch.ColVec(1).Int64()
@@ -116,6 +118,6 @@ func BenchmarkSortedDistinct(b *testing.B) {
 	// don't count the artificial zeroOp'd column in the throughput
 	b.SetBytes(int64(8 * coldata.BatchSize * 3))
 	for i := 0; i < b.N; i++ {
-		distinct.Next()
+		distinct.Next(ctx)
 	}
 }

--- a/pkg/sql/exec/distinct_tmpl.go
+++ b/pkg/sql/exec/distinct_tmpl.go
@@ -25,6 +25,7 @@ package exec
 
 import (
 	"bytes"
+	"context"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
@@ -168,8 +169,8 @@ func (p *sortedDistinct_TYPEOp) reset() {
 	}
 }
 
-func (p *sortedDistinct_TYPEOp) Next() coldata.Batch {
-	batch := p.input.Next()
+func (p *sortedDistinct_TYPEOp) Next(ctx context.Context) coldata.Batch {
+	batch := p.input.Next(ctx)
 	if batch.Length() == 0 {
 		return batch
 	}

--- a/pkg/sql/exec/error.go
+++ b/pkg/sql/exec/error.go
@@ -16,6 +16,7 @@ package exec
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"runtime/debug"
 	"strings"
@@ -94,12 +95,12 @@ func (e *TestVectorizedErrorEmitter) Init() {
 }
 
 // Next is part of Operator interface.
-func (e *TestVectorizedErrorEmitter) Next() coldata.Batch {
+func (e *TestVectorizedErrorEmitter) Next(ctx context.Context) coldata.Batch {
 	if !e.emitBatch {
 		e.emitBatch = true
 		panic(errors.New("a panic from exec package"))
 	}
 
 	e.emitBatch = false
-	return e.input.Next()
+	return e.input.Next(ctx)
 }

--- a/pkg/sql/exec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/like_ops_gen.go
@@ -31,6 +31,7 @@ package exec
 
 import (
 	"bytes"
+  "context"
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"

--- a/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/projection_ops_gen.go
@@ -26,6 +26,7 @@ package exec
 
 import (
 	"bytes"
+  "context"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
@@ -54,8 +55,8 @@ type {{template "opRConstName" .}} struct {
 	outputIdx int
 }
 
-func (p *{{template "opRConstName" .}}) Next() coldata.Batch {
-	batch := p.input.Next()
+func (p *{{template "opRConstName" .}}) Next(ctx context.Context) coldata.Batch {
+	batch := p.input.Next(ctx)
 	if p.outputIdx == batch.Width() {
 		batch.AppendCol(types.{{.RetTyp}})
 	}
@@ -88,8 +89,8 @@ type {{template "opLConstName" .}} struct {
 	outputIdx int
 }
 
-func (p *{{template "opLConstName" .}}) Next() coldata.Batch {
-	batch := p.input.Next()
+func (p *{{template "opLConstName" .}}) Next(ctx context.Context) coldata.Batch {
+	batch := p.input.Next(ctx)
 	if p.outputIdx == batch.Width() {
 		batch.AppendCol(types.{{.RetTyp}})
 	}
@@ -122,8 +123,8 @@ type {{template "opName" .}} struct {
 	outputIdx int
 }
 
-func (p *{{template "opName" .}}) Next() coldata.Batch {
-	batch := p.input.Next()
+func (p *{{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
+	batch := p.input.Next(ctx)
 	if p.outputIdx == batch.Width() {
 		batch.AppendCol(types.{{.RetTyp}})
 	}

--- a/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/selection_ops_gen.go
@@ -26,6 +26,7 @@ package exec
 
 import (
 	"bytes"
+  "context"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
@@ -47,9 +48,9 @@ type {{template "opConstName" .}} struct {
 	constArg {{.RGoType}}
 }
 
-func (p *{{template "opConstName" .}}) Next() coldata.Batch {
+func (p *{{template "opConstName" .}}) Next(ctx context.Context) coldata.Batch {
 	for {
-		batch := p.input.Next()
+		batch := p.input.Next(ctx)
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -105,9 +106,9 @@ type {{template "opName" .}} struct {
 	col2Idx int
 }
 
-func (p *{{template "opName" .}}) Next() coldata.Batch {
+func (p *{{template "opName" .}}) Next(ctx context.Context) coldata.Batch {
 	for {
-		batch := p.input.Next()
+		batch := p.input.Next(ctx)
 		if batch.Length() == 0 {
 			return batch
 		}

--- a/pkg/sql/exec/hash_aggregator.go
+++ b/pkg/sql/exec/hash_aggregator.go
@@ -15,6 +15,8 @@
 package exec
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
@@ -165,12 +167,12 @@ func (ag *hashAggregator) Init() {
 	ag.orderedAgg.Init()
 }
 
-func (ag *hashAggregator) Next() coldata.Batch {
+func (ag *hashAggregator) Next(ctx context.Context) coldata.Batch {
 	if !ag.buildFinished {
-		ag.build()
+		ag.build(ctx)
 	}
 
-	return ag.orderedAgg.Next()
+	return ag.orderedAgg.Next(ctx)
 }
 
 // Reset resets the hashAggregator for another run. Primarily used for
@@ -181,8 +183,8 @@ func (ag *hashAggregator) reset() {
 	ag.orderedAgg.reset()
 }
 
-func (ag *hashAggregator) build() {
-	ag.builder.exec()
+func (ag *hashAggregator) build(ctx context.Context) {
+	ag.builder.exec(ctx)
 	ag.buildFinished = true
 }
 
@@ -240,7 +242,7 @@ func makeHashAggregatorBatchOp(ht *hashTable, distinctCol []bool) Operator {
 
 func (op *hashAggregatorBatchOp) Init() {}
 
-func (op *hashAggregatorBatchOp) Next() coldata.Batch {
+func (op *hashAggregatorBatchOp) Next(context.Context) coldata.Batch {
 	// The selection vector needs to be populated before any batching can be
 	// done.
 	if op.sel == nil {

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -750,6 +751,7 @@ func TestHashJoinerInt64(t *testing.T) {
 }
 
 func BenchmarkHashJoiner(b *testing.B) {
+	ctx := context.Background()
 	nCols := 4
 	sourceTypes := make([]types.T, nCols)
 
@@ -826,7 +828,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 										for i := 0; i < nBatches; i++ {
 											// Technically, the non-distinct hash join will produce much more
 											// than nBatches of output.
-											hj.Next()
+											hj.Next(ctx)
 										}
 									}
 								})

--- a/pkg/sql/exec/like_ops_test.go
+++ b/pkg/sql/exec/like_ops_test.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -78,6 +79,7 @@ func TestSelRegexpBytesBytesConstOp(t *testing.T) {
 
 func BenchmarkLikeOps(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
 
 	batch := coldata.NewMemBatch([]types.T{types.Bytes})
 	col := batch.ColVec(0).Bytes()
@@ -129,7 +131,7 @@ func BenchmarkLikeOps(b *testing.B) {
 			tc.op.Init()
 			b.SetBytes(int64(width * coldata.BatchSize))
 			for i := 0; i < b.N; i++ {
-				tc.op.Next()
+				tc.op.Next(ctx)
 			}
 		})
 	}

--- a/pkg/sql/exec/limit.go
+++ b/pkg/sql/exec/limit.go
@@ -14,7 +14,11 @@
 
 package exec
 
-import "github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+)
 
 // limitOp is an operator that implements limit, returning only the first n
 // tuples from its input.
@@ -30,6 +34,8 @@ type limitOp struct {
 	done bool
 }
 
+var _ Operator = &limitOp{}
+
 // NewLimitOp returns a new limit operator with the given limit.
 func NewLimitOp(input Operator, limit uint64) Operator {
 	c := &limitOp{
@@ -44,12 +50,12 @@ func (c *limitOp) Init() {
 	c.input.Init()
 }
 
-func (c *limitOp) Next() coldata.Batch {
+func (c *limitOp) Next(ctx context.Context) coldata.Batch {
 	if c.done {
 		c.internalBatch.SetLength(0)
 		return c.internalBatch
 	}
-	bat := c.input.Next()
+	bat := c.input.Next(ctx)
 	length := bat.Length()
 	if length == 0 {
 		return bat

--- a/pkg/sql/exec/offset.go
+++ b/pkg/sql/exec/offset.go
@@ -14,7 +14,11 @@
 
 package exec
 
-import "github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+)
 
 // offsetOp is an operator that implements offset, returning everything
 // after the first n tuples in its input.
@@ -27,6 +31,8 @@ type offsetOp struct {
 	// seen is the number of tuples seen so far.
 	seen uint64
 }
+
+var _ Operator = &offsetOp{}
 
 // NewOffsetOp returns a new offset operator with the given offset.
 func NewOffsetOp(input Operator, offset uint64) Operator {
@@ -42,9 +48,9 @@ func (c *offsetOp) Init() {
 	c.input.Init()
 }
 
-func (c *offsetOp) Next() coldata.Batch {
+func (c *offsetOp) Next(ctx context.Context) coldata.Batch {
 	for {
-		bat := c.input.Next()
+		bat := c.input.Next(ctx)
 		length := bat.Length()
 		if length == 0 {
 			return bat

--- a/pkg/sql/exec/offset_test.go
+++ b/pkg/sql/exec/offset_test.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
@@ -67,6 +68,7 @@ func TestOffset(t *testing.T) {
 }
 
 func BenchmarkOffset(b *testing.B) {
+	ctx := context.Background()
 	batch := coldata.NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
 	batch.SetLength(coldata.BatchSize)
 	source := newRepeatableBatchSource(batch)
@@ -77,6 +79,6 @@ func BenchmarkOffset(b *testing.B) {
 	b.SetBytes(2 * coldata.BatchSize)
 	for i := 0; i < b.N; i++ {
 		o.(*offsetOp).Reset()
-		o.Next()
+		o.Next(ctx)
 	}
 }

--- a/pkg/sql/exec/one_shot.go
+++ b/pkg/sql/exec/one_shot.go
@@ -14,7 +14,11 @@
 
 package exec
 
-import "github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+)
 
 // oneShotOp is an operator that does an arbitrary operation on the first batch
 // that it gets, then deletes itself from the operator tree. This is useful for
@@ -27,12 +31,14 @@ type oneShotOp struct {
 	fn func(batch coldata.Batch)
 }
 
+var _ Operator = &oneShotOp{}
+
 func (o *oneShotOp) Init() {
 	o.input.Init()
 }
 
-func (o *oneShotOp) Next() coldata.Batch {
-	batch := o.input.Next()
+func (o *oneShotOp) Next(ctx context.Context) coldata.Batch {
+	batch := o.input.Next(ctx)
 
 	// Do our one-time work.
 	o.fn(batch)

--- a/pkg/sql/exec/operator.go
+++ b/pkg/sql/exec/operator.go
@@ -14,7 +14,11 @@
 
 package exec
 
-import "github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+)
 
 // Operator is a column vector operator that produces a Batch as output.
 type Operator interface {
@@ -29,7 +33,7 @@ type Operator interface {
 	//
 	// Calling Next may invalidate the contents of the last Batch returned by
 	// Next.
-	Next() coldata.Batch
+	Next(context.Context) coldata.Batch
 }
 
 // resetter is an interface that operators can implement if they can be reset
@@ -59,8 +63,8 @@ func (n *noopOperator) Init() {
 	n.input.Init()
 }
 
-func (n *noopOperator) Next() coldata.Batch {
-	return n.input.Next()
+func (n *noopOperator) Next(ctx context.Context) coldata.Batch {
+	return n.input.Next(ctx)
 }
 
 func (n *noopOperator) reset() {
@@ -84,9 +88,9 @@ func (s *zeroOperator) Init() {
 	s.input.Init()
 }
 
-func (s *zeroOperator) Next() coldata.Batch {
+func (s *zeroOperator) Next(ctx context.Context) coldata.Batch {
 	// TODO(solon): Can we avoid calling Next on the input at all?
-	next := s.input.Next()
+	next := s.input.Next(ctx)
 	next.SetLength(0)
 	return next
 }

--- a/pkg/sql/exec/projection_ops_test.go
+++ b/pkg/sql/exec/projection_ops_test.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -59,6 +60,7 @@ func TestProjPlusInt64Int64Op(t *testing.T) {
 
 func BenchmarkProjPlusInt64Int64ConstOp(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
 
 	batch := coldata.NewMemBatch([]types.T{types.Int64, types.Int64})
 	col := batch.ColVec(0).Int64()
@@ -79,7 +81,7 @@ func BenchmarkProjPlusInt64Int64ConstOp(b *testing.B) {
 
 	b.SetBytes(int64(8 * coldata.BatchSize))
 	for i := 0; i < b.N; i++ {
-		plusOp.Next()
+		plusOp.Next(ctx)
 	}
 }
 
@@ -130,6 +132,7 @@ func TestGetProjectionOperator(t *testing.T) {
 
 func BenchmarkProjPlusInt64Int64Op(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
 
 	batch := coldata.NewMemBatch([]types.T{types.Int64, types.Int64, types.Int64})
 	col1 := batch.ColVec(0).Int64()
@@ -152,6 +155,6 @@ func BenchmarkProjPlusInt64Int64Op(b *testing.B) {
 
 	b.SetBytes(int64(8 * coldata.BatchSize * 2))
 	for i := 0; i < b.N; i++ {
-		plusOp.Next()
+		plusOp.Next(ctx)
 	}
 }

--- a/pkg/sql/exec/selection_ops_test.go
+++ b/pkg/sql/exec/selection_ops_test.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -97,6 +98,7 @@ func TestGetSelectionOperator(t *testing.T) {
 
 func BenchmarkSelLTInt64Int64ConstOp(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
 
 	batch := coldata.NewMemBatch([]types.T{types.Int64})
 	col := batch.ColVec(0).Int64()
@@ -116,12 +118,13 @@ func BenchmarkSelLTInt64Int64ConstOp(b *testing.B) {
 
 	b.SetBytes(int64(8 * coldata.BatchSize))
 	for i := 0; i < b.N; i++ {
-		plusOp.Next()
+		plusOp.Next(ctx)
 	}
 }
 
 func BenchmarkSelLTInt64Int64Op(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
 
 	batch := coldata.NewMemBatch([]types.T{types.Int64, types.Int64})
 	col1 := batch.ColVec(0).Int64()
@@ -143,6 +146,6 @@ func BenchmarkSelLTInt64Int64Op(b *testing.B) {
 
 	b.SetBytes(int64(8 * coldata.BatchSize * 2))
 	for i := 0; i < b.N; i++ {
-		plusOp.Next()
+		plusOp.Next(ctx)
 	}
 }

--- a/pkg/sql/exec/simple_project.go
+++ b/pkg/sql/exec/simple_project.go
@@ -15,6 +15,8 @@
 package exec
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
 )
@@ -26,6 +28,8 @@ type simpleProjectOp struct {
 
 	batch *projectingBatch
 }
+
+var _ Operator = &simpleProjectOp{}
 
 // projectingBatch is a Batch that applies a simple projection to another,
 // underlying batch, discarding all columns but the ones in its projection
@@ -73,8 +77,8 @@ func (d *simpleProjectOp) Init() {
 	d.input.Init()
 }
 
-func (d *simpleProjectOp) Next() coldata.Batch {
-	batch := d.input.Next()
+func (d *simpleProjectOp) Next(ctx context.Context) coldata.Batch {
+	batch := d.input.Next(ctx)
 	d.batch.Batch = batch
 
 	return d.batch

--- a/pkg/sql/exec/sort_chunks_test.go
+++ b/pkg/sql/exec/sort_chunks_test.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"testing"
@@ -253,6 +254,7 @@ func TestSortChunksRandomized(t *testing.T) {
 
 func BenchmarkSortChunks(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
 
 	sorterConstructors := []func(Operator, []types.T, []distsqlpb.Ordering_Column, int) (Operator, error){
 		NewSortChunks,
@@ -316,7 +318,7 @@ func BenchmarkSortChunks(b *testing.B) {
 									sorter.Init()
 									rowsEmitted := 0
 									for rowsEmitted < rowsTotal {
-										out := sorter.Next()
+										out := sorter.Next(ctx)
 										if out.Length() == 0 {
 											b.Fail()
 										}

--- a/pkg/sql/exec/sort_test.go
+++ b/pkg/sql/exec/sort_test.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -224,7 +225,7 @@ func TestAllSpooler(t *testing.T) {
 		runTests(t, []tuples{tc.tuples}, func(t *testing.T, input []Operator) {
 			allSpooler := newAllSpooler(input[0], tc.typ)
 			allSpooler.init()
-			allSpooler.spool()
+			allSpooler.spool(context.Background())
 			if len(tc.tuples) != int(allSpooler.getNumTuples()) {
 				t.Fatal(fmt.Sprintf("allSpooler spooled wrong number of tuples: expected %d, but received %d", len(tc.tuples), allSpooler.getNumTuples()))
 			}
@@ -246,6 +247,7 @@ func TestAllSpooler(t *testing.T) {
 
 func BenchmarkSort(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
 
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
 		for _, nCols := range []int{1, 2, 4} {
@@ -279,7 +281,7 @@ func BenchmarkSort(b *testing.B) {
 
 					sort.Init()
 					for i := 0; i < nBatches; i++ {
-						out := sort.Next()
+						out := sort.Next(ctx)
 						if out.Length() == 0 {
 							b.Fail()
 						}
@@ -292,6 +294,7 @@ func BenchmarkSort(b *testing.B) {
 
 func BenchmarkAllSpooler(b *testing.B) {
 	rng, _ := randutil.NewPseudoRand()
+	ctx := context.Background()
 
 	for _, nBatches := range []int{1 << 1, 1 << 4, 1 << 8} {
 		for _, nCols := range []int{1, 2, 4} {
@@ -316,7 +319,7 @@ func BenchmarkAllSpooler(b *testing.B) {
 					source := newFiniteBatchSource(batch, nBatches)
 					allSpooler := newAllSpooler(source, typs)
 					allSpooler.init()
-					allSpooler.spool()
+					allSpooler.spool(ctx)
 				}
 			})
 		}

--- a/pkg/sql/exec/stats.go
+++ b/pkg/sql/exec/stats.go
@@ -15,6 +15,8 @@
 package exec
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/execpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -66,7 +68,7 @@ func (vsc *VectorizedStatsCollector) SetOutputWatch(outputWatch *timeutil.StopWa
 }
 
 // Next is part of Operator interface.
-func (vsc *VectorizedStatsCollector) Next() coldata.Batch {
+func (vsc *VectorizedStatsCollector) Next(ctx context.Context) coldata.Batch {
 	if vsc.outputWatch != nil {
 		// vsc.outputWatch is non-nil which means that this Operator is outputting
 		// the batches into another one. In order to avoid double counting the time
@@ -81,7 +83,7 @@ func (vsc *VectorizedStatsCollector) Next() coldata.Batch {
 		// Operator, and we need to start the stop watch ourselves.
 		vsc.inputWatch.Start()
 	}
-	batch = vsc.Operator.Next()
+	batch = vsc.Operator.Next(ctx)
 	if batch.Length() > 0 {
 		vsc.NumBatches++
 		vsc.NumTuples += int64(batch.Length())

--- a/pkg/sql/exec/stats_test.go
+++ b/pkg/sql/exec/stats_test.go
@@ -15,6 +15,7 @@
 package exec
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -32,7 +33,7 @@ func TestNumBatches(t *testing.T) {
 	vsc := NewVectorizedStatsCollector(noop, 0 /* id */, true /* isStall */, timeutil.NewStopWatch())
 	vsc.Init()
 	for {
-		b := vsc.Next()
+		b := vsc.Next(context.Background())
 		if b.Length() == 0 {
 			break
 		}
@@ -48,7 +49,7 @@ func TestNumTuples(t *testing.T) {
 		vsc := NewVectorizedStatsCollector(noop, 0 /* id */, true /* isStall */, timeutil.NewStopWatch())
 		vsc.Init()
 		for {
-			b := vsc.Next()
+			b := vsc.Next(context.Background())
 			if b.Length() == 0 {
 				break
 			}
@@ -104,7 +105,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 		mjStatsCollector.Init()
 		batchCount := 0
 		for {
-			b := mjStatsCollector.Next()
+			b := mjStatsCollector.Next(context.Background())
 			if b.Length() == 0 {
 				break
 			}
@@ -148,8 +149,8 @@ func (o *timeAdvancingOperator) Init() {
 	o.input.Init()
 }
 
-func (o *timeAdvancingOperator) Next() coldata.Batch {
-	b := o.input.Next()
+func (o *timeAdvancingOperator) Next(ctx context.Context) coldata.Batch {
+	b := o.input.Next(ctx)
 	if b.Length() > 0 {
 		o.timeSource.Advance()
 	}


### PR DESCRIPTION
We need to have access to contexts from the operators (one use case
is cancellation checking, probably there are others as well). There
appears to be two ways of how to go about it - either embedding it
into the operators or passing through as an argument. This commit
implements the latter.

Release note: None