### PR TITLE
cli/debug: teach debug raft-log to decode DeleteRange ops

### DIFF
--- a/pkg/cli/debug/print.go
+++ b/pkg/cli/debug/print.go
@@ -139,9 +139,21 @@ func decodeWriteBatch(writeBatch *storagepb.WriteBatch) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			sb.WriteString(fmt.Sprintf("Single delete: %s\n", SprintKey(mvccKey)))
+			sb.WriteString(fmt.Sprintf("Single Delete: %s\n", SprintKey(mvccKey)))
+		case engine.BatchTypeRangeDeletion:
+			mvccStartKey, err := r.MVCCKey()
+			if err != nil {
+				return "", err
+			}
+			mvccEndKey, err := r.MVCCEndKey()
+			if err != nil {
+				return "", err
+			}
+			sb.WriteString(fmt.Sprintf(
+				"Delete Range: [%s, %s)\n", SprintKey(mvccStartKey), SprintKey(mvccEndKey),
+			))
 		default:
-			sb.WriteString(fmt.Sprintf("unsupported batch type: %x\n", r.BatchType()))
+			sb.WriteString(fmt.Sprintf("unsupported batch type: %d\n", r.BatchType()))
 		}
 	}
 	if err := r.Error(); err != nil {


### PR DESCRIPTION
This change extends #35528 to support DeleteRange operations. I was
seeing the following log frequently when running the command:
```
write batch:
failed to decode: unexpected type 15
```

This fixes that.

```
write batch:
Delete Range: [0.000000000,0 /Table/68/1/29/4/2413 (0xcc89a58cf7096d00): , 0.000000000,0 /Table/68/1/31/4/1210 (0xcc89a78cf704ba00): )
Delete: 0.000000000,0 /Table/68/1/29/4/2413 (0xcc89a58cf7096d00):
Delete: 0.000000000,0 /Table/68/1/31/4/1209 (0xcc89a78cf704b900):
```

Release note: None