### PR TITLE
release-19.1: storage: fix panic in ensureClosedTimestampStarted

### DIFF
--- a/pkg/storage/replica_rangefeed.go
+++ b/pkg/storage/replica_rangefeed.go
@@ -489,6 +489,15 @@ func (r *Replica) ensureClosedTimestampStarted(ctx context.Context) *roachpb.Err
 		r.EmitMLAI()
 		return nil
 	} else if lErr, ok := err.GetDetail().(*roachpb.NotLeaseHolderError); ok {
+		if lErr.LeaseHolder == nil {
+			// It's possible for redirectOnOrAcquireLease to return
+			// NotLeaseHolderErrors with LeaseHolder unset, but these should be
+			// transient conditions. If this method is being called by RangeFeed to
+			// nudge a stuck closedts, then essentially all we can do here is nothing
+			// and assume that redirectOnOrAcquireLease will do something different
+			// the next time it's called.
+			return nil
+		}
 		leaseholderNodeID = lErr.LeaseHolder.NodeID
 	} else {
 		return err


### PR DESCRIPTION
Backport 1/1 commits from #36853.

/cc @cockroachdb/release

---

When I introduced this method in #36684, I copied the usage of the
LeaseHolder field from canServeFollowerRead but missed the part where it
first checks that the field is set. Noticed by seeing this panic with a
nil pointer dereference in a roachtest.

Release note (bug fix): fixes a panic that can happen while RangeFeeds
are active
