### PR TITLE
coldata: fix Slice when slicing up to batch.Length()

### DIFF
--- a/pkg/sql/exec/coldata/vec_test.go
+++ b/pkg/sql/exec/coldata/vec_test.go
@@ -42,7 +42,7 @@ func TestMemColumnSlice(t *testing.T) {
 	endSlice := uint16(0)
 	for startSlice > endSlice {
 		startSlice = uint16(rng.Intn(BatchSize))
-		endSlice = uint16(rng.Intn(BatchSize))
+		endSlice = uint16(1 + rng.Intn(BatchSize))
 	}
 
 	slice := c.Slice(types.Int64, uint64(startSlice), uint64(endSlice))

--- a/pkg/sql/exec/coldata/vec_tmpl.go
+++ b/pkg/sql/exec/coldata/vec_tmpl.go
@@ -258,7 +258,10 @@ func (m *memColumn) Slice(colType types.T, start uint64, end uint64) Vec {
 		if m.hasNulls {
 			mod := start % 64
 			startIdx := start >> 6
-			endIdx := end>>6 + 1
+			// end is exclusive, so translate that to an exclusive index in nulls by
+			// figuring out which index the last accessible null should be in and add
+			// 1.
+			endIdx := (end-1)>>6 + 1
 			nulls = m.nulls[startIdx:endIdx]
 			if mod != 0 {
 				// If start is not a multiple of 64, we need to shift over the bitmap


### PR DESCRIPTION
A panic occured because we weren't treating the end slice index as
exclusive, resulting in an out of bounds panic when attempting to slice
the nulls slice.

Release note: None