### PR TITLE
roachtest: relax passing criteria for kv/contention/nodes=4

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -181,9 +181,9 @@ func registerKVContention(r *registry) {
 
 				// Assert that the average throughput stayed above a certain
 				// threshold. In this case, assert that max throughput only
-				// dipped below 10 qps for 5% of the time.
+				// dipped below 10 qps for 10% of the time.
 				const minQPS = 10
-				verifyTxnPerSecond(ctx, c, t, c.Node(1), start, end, minQPS, 0.05)
+				verifyTxnPerSecond(ctx, c, t, c.Node(1), start, end, minQPS, 0.1)
 				return nil
 			})
 			m.Wait()


### PR DESCRIPTION
Fixes #36089.

We've seen that this test can occasionally dip above 5% of time below
the minimum QPS. This doesn't seem to be indicative of a full QPS stall
and this passing criteria was somewhat arbitrary, so relax it.

Release note: None