### PR TITLE
opt: prototype for support of delegated queries

### DIFF
--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -1,0 +1,45 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package delegate
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// Certain statements (most SHOW variants) are just syntactic sugar for a more
+// complicated underlying query.
+//
+// This package contains the logic to convert the AST of such a statement to the
+// AST of the equivalent query to be planned.
+
+// TryDelegate takes a statement and checks if it is one of the statements that
+// can be rewritten as a lower level query. If it can, returns a new AST which
+// is equivalent to the original statement. Otherwise, returns nil.
+func TryDelegate(stmt tree.Statement, catalog cat.Catalog) (tree.Statement, error) {
+	switch t := stmt.(type) {
+	case *tree.ShowDatabases:
+		return delegateShowDatabases(t)
+
+	default:
+		return nil, nil
+	}
+}
+
+func parse(sql string) (tree.Statement, error) {
+	s, err := parser.ParseOne(sql)
+	return s.AST, err
+}

--- a/pkg/sql/delegate/show_databases.go
+++ b/pkg/sql/delegate/show_databases.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Cockroach Authors.
+// Copyright 2019 The Cockroach Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,14 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sql
+package delegate
 
-import (
-	"context"
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-)
-
-// ShowDatabases returns all the databases.
-// Privileges: None.
-//   Notes: postgres does not have a "show databases"
-//          mysql has a "SHOW DATABASES" permission, but we have no system-level permissions.
-func (p *planner) ShowDatabases(ctx context.Context, n *tree.ShowDatabases) (planNode, error) {
-	return p.delegateQuery(ctx, "SHOW DATABASES",
+func delegateShowDatabases(stmt *tree.ShowDatabases) (tree.Statement, error) {
+	return parse(
 		`SELECT DISTINCT catalog_name AS database_name
-       FROM "".information_schema.schemata
-      ORDER BY 1`,
-		nil, nil)
+     FROM "".information_schema.schemata
+     ORDER BY 1`,
+	)
 }

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -101,7 +101,7 @@ SELECT * FROM [SHOW ZONE CONFIGURATION FOR TABLE system.users] LIMIT 0
 ----
 zone_name  config_sql
 
-query T colnames
+query T colnames,rowsort
 SELECT * FROM [SHOW DATABASES]
 ----
 database_name
@@ -110,7 +110,7 @@ postgres
 system
 test
 
-query TTTTT colnames
+query TTTTT colnames,rowsort
 SELECT * FROM [SHOW GRANTS ON system.descriptor]
 ----
 database_name  schema_name  table_name  grantee  privilege_type

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -137,12 +137,13 @@ drop table  ·  ·
 query TTT
 SELECT * FROM [EXPLAIN SHOW DATABASES] WHERE field != 'size'
 ----
-distinct               ·          ·
- │                     order key  database_name
- └── sort              ·          ·
-      │                order      +database_name
-      └── render       ·          ·
-           └── values  ·          ·
+sort                          ·            ·
+ │                            order        +database_name
+ └── distinct                 ·            ·
+      │                       distinct on  database_name
+      └── render              ·            ·
+           └── virtual table  ·            ·
+·                             source       ·
 
 query TTT
 SELECT * FROM [EXPLAIN SHOW TABLES] WHERE field != 'size'

--- a/pkg/sql/opt/optbuilder/testdata/delegate
+++ b/pkg/sql/opt/optbuilder/testdata/delegate
@@ -1,0 +1,13 @@
+build
+SHOW DATABASES
+----
+sort
+ ├── columns: database_name:1(string)
+ ├── ordering: +1
+ └── distinct-on
+      ├── columns: catalog_name:1(string)
+      ├── grouping columns: catalog_name:1(string)
+      └── project
+           ├── columns: catalog_name:1(string)
+           └── virtual-scan t.information_schema.schemata
+                └── columns: catalog_name:1(string) schema_name:2(string) default_character_set_name:3(string) sql_path:4(string)


### PR DESCRIPTION
Most of the SHOW variants delegate to a more complicated query
involving internal virtual tables. This prototype proposes to move
this logic into a `sql/delegate` subpackage where both the HP and
optbuilder can use it.

We migrate one very simple statement (`SHOW DATABASES`) as a proof of
concept. Note that many statements need to look up a table before
creating the delegated query, hence why the new interface takes a
`cat.Catalog`; we will need to add more functionality to the catalog:
like `ResolveUncachedTableDescriptor`, `CheckAnyPrivilege`.

Also note that not all uses of `delegateQuery` can be migrated to this
infrastructure, like those using an `initialCheck`.

Release note: None