### PR TITLE
roachprod: add missing space when setting up authorized_keys

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -688,7 +688,7 @@ echo "${keys_data}" >> "${tmp1}"
 sort -u < "${tmp1}" > "${tmp2}"
 sudo install --mode 0600 --owner ` + sharedUser +
 				` --group ` + sharedUser +
-				`"${tmp2}" ~` + sharedUser + `/.ssh/authorized_keys`
+				` "${tmp2}" ~` + sharedUser + `/.ssh/authorized_keys`
 			if out, err := sess.CombinedOutput(cmd); err != nil {
 				return nil, errors.Wrapf(err, "~ %s\n%s", cmd, out)
 			}


### PR DESCRIPTION
I shouldn't have re-wrapped this code after testing.