### PR TITLE
storage: don't fatal on sync intent resolution error

### DIFF
--- a/pkg/storage/batcheval/cmd_end_transaction.go
+++ b/pkg/storage/batcheval/cmd_end_transaction.go
@@ -492,7 +492,7 @@ func resolveLocalIntents(
 			}
 			return nil
 		}(); err != nil {
-			log.Fatalf(ctx, "error resolving intent at %s on end transaction [%s]: %s", span, txn.Status, err)
+			return nil, errors.Wrapf(err, "resolving intent at %s on end transaction [%s]", span, txn.Status)
 		}
 	}
 	// If the poison arg is set, make sure to set the abort span entry.


### PR DESCRIPTION
Fixes #36882.

We've seen a few of these fly-by and said that fatal-ing is the desired
behavior (#36603, #34346, etc.), but I'm confused why. This is during
batch evaluation, so we can always return an error to the client and
force it to deal with it. The errors here will mostly be due to filesystem
problems, which are severe, but crashing when we don't have to still
doesn't seem like the right thing to do. I think it's better to reserve
crashing for places that need to (downstream of Raft) and to throw
errors wherever else we can.

Release note: None