### PR TITLE
release-19.1: sql: avoid data race on appStats.stmts

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -351,11 +351,11 @@ func (s *sqlStats) getStmtStats(
 	var ret []roachpb.CollectedStatementStatistics
 	salt := ClusterSecret.Get(&s.st.SV)
 	for appName, a := range s.apps {
+		a.Lock()
 		if cap(ret) == 0 {
 			// guesstimate that we'll need apps*(queries-per-app).
 			ret = make([]roachpb.CollectedStatementStatistics, 0, len(a.stmts)*len(s.apps))
 		}
-		a.Lock()
 		for q, stats := range a.stmts {
 			maybeScrubbed := q.stmt
 			maybeHashedAppName := appName


### PR DESCRIPTION
Backport 1/1 commits from #36686.

Closes #36863.

/cc @cockroachdb/release

---

Fixes #33678.

I think the issue reported the wrong stack trace for the "Previous write"
goroutine. A race appears possible because `appStats` was not being locked while
reading `len(appStats.stmts)`. Not all callers of `getStatsForStmtWithKey`,
which mutates `appStats.stmts`, also hold a lock on `sqlStats` (the container
which holds a collection of `appStats`). For instance, we do not hold the lock
on `appStats` while mutating the map in `crdbInternalStmtStatsTable.populate`.

Release note: None
