### PR TITLE
release-19.1: storage: decrease default kv.bulk_io_write.max_rate

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -32,7 +32,7 @@
 <tr><td><code>kv.bulk_io_write.concurrent_addsstable_requests</code></td><td>integer</td><td><code>1</code></td><td>number of AddSSTable requests a store will handle concurrently before queuing</td></tr>
 <tr><td><code>kv.bulk_io_write.concurrent_export_requests</code></td><td>integer</td><td><code>3</code></td><td>number of export requests a store will handle concurrently before queuing</td></tr>
 <tr><td><code>kv.bulk_io_write.concurrent_import_requests</code></td><td>integer</td><td><code>1</code></td><td>number of import requests a store will handle concurrently before queuing</td></tr>
-<tr><td><code>kv.bulk_io_write.max_rate</code></td><td>byte size</td><td><code>8.0 EiB</code></td><td>the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops</td></tr>
+<tr><td><code>kv.bulk_io_write.max_rate</code></td><td>byte size</td><td><code>1.0 TiB</code></td><td>the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops</td></tr>
 <tr><td><code>kv.bulk_sst.sync_size</code></td><td>byte size</td><td><code>2.0 MiB</code></td><td>threshold after which non-Rocks SST writes must fsync (0 disables)</td></tr>
 <tr><td><code>kv.closed_timestamp.close_fraction</code></td><td>float</td><td><code>0.2</code></td><td>fraction of closed timestamp target duration specifying how frequently the closed timestamp is advanced</td></tr>
 <tr><td><code>kv.closed_timestamp.follower_reads_enabled</code></td><td>boolean</td><td><code>true</code></td><td>allow (all) replicas to serve consistent historical reads based on closed timestamp information</td></tr>

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -113,7 +113,7 @@ var logSSTInfoTicks = envutil.EnvOrDefaultInt(
 var bulkIOWriteLimit = settings.RegisterByteSizeSetting(
 	"kv.bulk_io_write.max_rate",
 	"the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops",
-	math.MaxInt64,
+	1<<40,
 )
 
 // importRequestsLimit limits concurrent import requests.


### PR DESCRIPTION
Backport 1/1 commits from #36884.

/cc @cockroachdb/release

---

Previously `kv.bulk_io_write.max_rate` had a default value of `MaxInt64`, which
caused rounding problems in the rate limiter due to very small time intervals.
This lowers the default to 1 TB/s.

Fixes #36806.
(See https://github.com/cockroachdb/cockroach/issues/36806#issuecomment-483811059)

Release note (bug fix): The default value of `kv.bulk_io_write.max_rate` is now
1 TB/s, to help prevent incorrect rate limiting behavior due to rounding.
