### PR TITLE
exec: add null ranges and optimize nulls in the vect. merge joiner

### DIFF
--- a/pkg/sql/exec/coldata/vec_test.go
+++ b/pkg/sql/exec/coldata/vec_test.go
@@ -60,3 +60,76 @@ func TestMemColumnSlice(t *testing.T) {
 		}
 	}
 }
+
+func TestNullRanges(t *testing.T) {
+	tcs := []struct {
+		start uint64
+		end   uint64
+	}{
+		{
+			start: 1,
+			end:   1,
+		},
+		{
+			start: 50,
+			end:   0,
+		},
+		{
+			start: 0,
+			end:   50,
+		},
+		{
+			start: 0,
+			end:   64,
+		},
+		{
+			start: 25,
+			end:   50,
+		},
+		{
+			start: 0,
+			end:   80,
+		},
+		{
+			start: 20,
+			end:   80,
+		},
+		{
+			start: 0,
+			end:   387,
+		},
+		{
+			start: 385,
+			end:   387,
+		},
+		{
+			start: 0,
+			end:   1023,
+		},
+		{
+			start: 1022,
+			end:   1023,
+		}, {
+			start: 1023,
+			end:   1023,
+		},
+	}
+
+	c := NewMemColumn(types.Int64, BatchSize)
+	for _, tc := range tcs {
+		c.UnsetNulls()
+		c.SetNullRange(tc.start, tc.end)
+
+		for i := uint64(0); i < BatchSize; i++ {
+			if i >= tc.start && i < tc.end {
+				if !c.NullAt64(i) {
+					t.Fatalf("expected null at %d, start: %d end: %d", i, tc.start, tc.end)
+				}
+			} else {
+				if c.NullAt64(i) {
+					t.Fatalf("expected non-null at %d, start: %d end: %d", i, tc.start, tc.end)
+				}
+			}
+		}
+	}
+}

--- a/pkg/sql/exec/coldata/vec_tmpl.go
+++ b/pkg/sql/exec/coldata/vec_tmpl.go
@@ -52,7 +52,7 @@ func (m *memColumn) Append(vec Vec, colType types.T, toLength uint64, fromLength
 	}
 
 	if fromLength > 0 {
-		m.nulls = append(m.nulls, make([]int64, (fromLength-1)>>6+1)...)
+		m.nulls = append(m.nulls, make([]uint64, (fromLength-1)>>6+1)...)
 
 		if vec.HasNulls() {
 			for i := uint16(0); i < fromLength; i++ {
@@ -106,7 +106,7 @@ func (m *memColumn) AppendWithSel(
 	}
 
 	if batchSize > 0 {
-		m.nulls = append(m.nulls, make([]int64, (batchSize-1)>>6+1)...)
+		m.nulls = append(m.nulls, make([]uint64, (batchSize-1)>>6+1)...)
 		for i := uint16(0); i < batchSize; i++ {
 			if vec.NullAt(sel[i]) {
 				m.SetNull64(toLength + uint64(i))
@@ -254,7 +254,7 @@ func (m *memColumn) Slice(colType types.T, start uint64, end uint64) Vec {
 	// {{range .}}
 	case _TYPES_T:
 		col := m._TemplateType()
-		var nulls []int64
+		var nulls []uint64
 		if m.hasNulls {
 			mod := start % 64
 			startIdx := start >> 6
@@ -267,7 +267,7 @@ func (m *memColumn) Slice(colType types.T, start uint64, end uint64) Vec {
 				// If start is not a multiple of 64, we need to shift over the bitmap
 				// to have the first index correspond. Allocate new null bitmap as we
 				// want to keep the original bitmap safe for reuse.
-				nulls = make([]int64, len(nulls))
+				nulls = make([]uint64, len(nulls))
 				for i, j := startIdx, 0; i < endIdx-1; i, j = i+1, j+1 {
 					// Bring the first null to the beginning.
 					nulls[j] = m.nulls[i] >> mod
@@ -310,7 +310,7 @@ func (m *memColumn) ExtendNulls(vec Vec, destStartIdx uint64, srcStartIdx uint16
 	if uint64(cap(m.nulls)) < outputLen/64 {
 		// (batchSize-1)>>6+1 is the number of Int64s needed to encode the additional elements/nulls in the Vec.
 		// This is equivalent to ceil(batchSize/64).
-		m.nulls = append(m.nulls, make([]int64, (toAppend-1)>>6+1)...)
+		m.nulls = append(m.nulls, make([]uint64, (toAppend-1)>>6+1)...)
 	}
 	if vec.HasNulls() {
 		for i := uint16(0); i < toAppend; i++ {
@@ -330,7 +330,7 @@ func (m *memColumn) ExtendNullsWithSel(
 	if uint64(cap(m.nulls)) < outputLen/64 {
 		// (batchSize-1)>>6+1 is the number of Int64s needed to encode the additional elements/nulls in the Vec.
 		// This is equivalent to ceil(batchSize/64).
-		m.nulls = append(m.nulls, make([]int64, (toAppend-1)>>6+1)...)
+		m.nulls = append(m.nulls, make([]uint64, (toAppend-1)>>6+1)...)
 	}
 	for i := uint16(0); i < toAppend; i++ {
 		// TODO(yuzefovich): this can be done more efficiently with a bitwise OR:


### PR DESCRIPTION
Added a new member function to coldata.Nulls to allow setting a
range of null values, given a start and end index. This is useful
for example in the merge joiner when we are building the left
groups, since it is faster to write nulls using a bitwise operation
compared to setting each row to null one by one.

This required refactoring Nulls to use a slice of uint64 instead
of int64 for the null bitmap under the hood, since right shifting
a mask (commonly -1) doesn't work as expected for a signed number,
as the sign digit does not get shifted.

Some benchmarks:
```
name                                      old time/op    new time/op    delta
MergeJoiner/rows=1024-8                     40.0µs ± 1%    39.8µs ± 1%  -0.57%  (p=0.023 n=10+10)
MergeJoiner/rows=4096-8                      152µs ± 0%     150µs ± 1%  -1.12%  (p=0.000 n=10+10)
MergeJoiner/rows=16384-8                     591µs ± 3%     580µs ± 1%  -1.88%  (p=0.000 n=9+10)
MergeJoiner/rows=1048576-8                  37.1ms ± 3%    35.4ms ± 2%  -4.48%  (p=0.000 n=9+10)
MergeJoiner/oneSideRepeat-rows=1024-8       41.3µs ± 3%    40.2µs ± 0%  -2.49%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=4096-8        154µs ± 1%     150µs ± 1%  -2.21%  (p=0.000 n=9+10)
MergeJoiner/oneSideRepeat-rows=16384-8       592µs ± 1%     587µs ± 1%  -0.76%  (p=0.008 n=9+10)
MergeJoiner/oneSideRepeat-rows=1048576-8    37.6ms ± 7%    37.4ms ± 3%    ~     (p=0.853 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8     43.0µs ± 0%    42.7µs ± 0%  -0.87%  (p=0.000 n=8+9)
MergeJoiner/bothSidesRepeat-rows=4096-8      189µs ± 1%     186µs ± 1%  -1.59%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=16384-8    1.42ms ± 2%    1.39ms ± 0%  -2.03%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=32768-8    4.86ms ± 2%    4.80ms ± 1%  -1.26%  (p=0.001 n=10+10)

name                                      old speed      new speed      delta
MergeJoiner/rows=1024-8                   1.64GB/s ± 1%  1.65GB/s ± 1%  +0.58%  (p=0.023 n=10+10)
MergeJoiner/rows=4096-8                   1.73GB/s ± 0%  1.75GB/s ± 1%  +1.14%  (p=0.000 n=10+10)
MergeJoiner/rows=16384-8                  1.77GB/s ± 3%  1.81GB/s ± 1%  +1.90%  (p=0.000 n=9+10)
MergeJoiner/rows=1048576-8                1.81GB/s ± 3%  1.89GB/s ± 2%  +4.68%  (p=0.000 n=9+10)
MergeJoiner/oneSideRepeat-rows=1024-8     1.59GB/s ± 3%  1.63GB/s ± 0%  +2.53%  (p=0.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=4096-8     1.71GB/s ± 1%  1.75GB/s ± 1%  +2.25%  (p=0.000 n=9+10)
MergeJoiner/oneSideRepeat-rows=16384-8    1.77GB/s ± 1%  1.79GB/s ± 1%  +0.76%  (p=0.008 n=9+10)
MergeJoiner/oneSideRepeat-rows=1048576-8  1.79GB/s ± 6%  1.80GB/s ± 3%    ~     (p=0.853 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8   1.52GB/s ± 0%  1.54GB/s ± 0%  +0.88%  (p=0.000 n=8+9)
MergeJoiner/bothSidesRepeat-rows=4096-8   1.38GB/s ± 1%  1.41GB/s ± 1%  +1.61%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=16384-8   738MB/s ± 2%   753MB/s ± 0%  +2.07%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=32768-8   431MB/s ± 2%   437MB/s ± 1%  +1.26%  (p=0.001 n=10+10)

name                                      old alloc/op   new alloc/op   delta
MergeJoiner/rows=1024-8                      7.40B ±32%     6.20B ±45%    ~     (p=0.370 n=10+10)
MergeJoiner/rows=4096-8                      27.0B ± 0%     27.0B ± 0%    ~     (all equal)
MergeJoiner/rows=16384-8                      104B ±31%       90B ± 0%    ~     (p=0.211 n=10+10)
MergeJoiner/rows=1048576-8                  5.45kB ± 0%    5.45kB ± 0%    ~     (all equal)
MergeJoiner/oneSideRepeat-rows=1024-8        9.00B ± 0%     9.00B ± 0%    ~     (all equal)
MergeJoiner/oneSideRepeat-rows=4096-8        27.0B ± 0%     27.0B ± 0%    ~     (all equal)
MergeJoiner/oneSideRepeat-rows=16384-8       90.0B ± 0%     90.0B ± 0%    ~     (all equal)
MergeJoiner/oneSideRepeat-rows=1048576-8    6.90kB ±32%    5.45kB ± 0%    ~     (p=0.087 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8      9.00B ± 0%     9.00B ± 0%    ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=4096-8      27.0B ± 0%     27.0B ± 0%    ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=16384-8      272B ± 0%      272B ± 0%    ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=32768-8      908B ± 0%      908B ± 0%    ~     (all equal)

name                                      old allocs/op  new allocs/op  delta
MergeJoiner/rows=1024-8                       0.00           0.00         ~     (all equal)
MergeJoiner/rows=4096-8                       0.00           0.00         ~     (all equal)
MergeJoiner/rows=16384-8                      0.00           0.00         ~     (all equal)
MergeJoiner/rows=1048576-8                    1.00 ± 0%      1.00 ± 0%    ~     (all equal)
MergeJoiner/oneSideRepeat-rows=1024-8         0.00           0.00         ~     (all equal)
MergeJoiner/oneSideRepeat-rows=4096-8         0.00           0.00         ~     (all equal)
MergeJoiner/oneSideRepeat-rows=16384-8        0.00           0.00         ~     (all equal)
MergeJoiner/oneSideRepeat-rows=1048576-8      1.40 ±43%      1.00 ± 0%    ~     (p=0.087 n=10+10)
MergeJoiner/bothSidesRepeat-rows=1024-8       0.00           0.00         ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=4096-8       0.00           0.00         ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=16384-8      0.00           0.00         ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=32768-8      0.00           0.00         ~     (all equal)
```

Release note: None