### PR TITLE
opt: fix column names for CREATE TABLE AS when columns are aliased

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -104,3 +104,22 @@ query B
 CREATE TABLE foo4 (x) AS SELECT EXISTS(SELECT * FROM foo3 WHERE x IS NULL); SELECT * FROM foo4
 ----
 true
+
+# Regression test for #36930.
+statement ok
+CREATE TABLE bar AS SELECT 1 AS a, 2 AS b, count(*) AS c FROM foo
+
+query III colnames
+SELECT * FROM bar
+----
+a  b  c
+1  2  4
+
+statement ok
+CREATE TABLE baz (a, b, c) AS SELECT 1, 2, count(*) FROM foo
+
+query III colnames
+SELECT * FROM baz
+----
+a  b  c
+1  2  4

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -1653,9 +1653,16 @@ func (b *Builder) buildCreateTable(ct *memo.CreateTableExpr) (execPlan, error) {
 		if err != nil {
 			return execPlan{}, err
 		}
-		// Impose ordering on input columns, so that they match the order of the
-		// table columns into which values will be inserted.
-		input, err = b.ensureColumns(input, ct.InputCols, nil /* colNames */, nil /* provided */)
+		// Impose ordering and naming on input columns, so that they match the
+		// order and names of the table columns into which values will be
+		// inserted.
+		colList := make(opt.ColList, len(ct.InputCols))
+		colNames := make([]string, len(ct.InputCols))
+		for i := range ct.InputCols {
+			colList[i] = ct.InputCols[i].ID
+			colNames[i] = ct.InputCols[i].Alias
+		}
+		input, err = b.ensureColumns(input, colList, colNames, nil /* provided */)
 		if err != nil {
 			return execPlan{}, err
 		}

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -549,6 +549,14 @@ func (h *hasher) HashZipExpr(val ZipExpr) {
 	}
 }
 
+func (h *hasher) HashPresentation(val physical.Presentation) {
+	for i := range val {
+		col := &val[i]
+		h.HashString(col.Alias)
+		h.HashColumnID(col.ID)
+	}
+}
+
 func (h *hasher) HashPointer(val unsafe.Pointer) {
 	h.HashUint64(uint64(uintptr(val)))
 }
@@ -830,6 +838,18 @@ func (h *hasher) IsZipExprEqual(l, r ZipExpr) bool {
 	}
 	for i := range l {
 		if !l[i].Cols.Equals(r[i].Cols) || l[i].Func != r[i].Func {
+			return false
+		}
+	}
+	return true
+}
+
+func (h *hasher) IsPresentationEqual(l, r physical.Presentation) bool {
+	if len(l) != len(r) {
+		return false
+	}
+	for i := range l {
+		if l[i].ID != r[i].ID || l[i].Alias != r[i].Alias {
 			return false
 		}
 	}

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -191,9 +191,9 @@ define CreateTablePrivate {
     # Schema is the ID of the catalog schema into which the new table goes.
     Schema SchemaID
 
-    # InputCols gives the ordering of input columns. It is only defined when the
-    # AS clause was used in the CREATE TABLE statement.
-    InputCols ColList
+    # InputCols gives the ordering and naming of input columns. It is only
+    # defined when the AS clause was used in the CREATE TABLE statement.
+    InputCols Presentation
 
     # Syntax is the CREATE TABLE AST node.
     Syntax CreateTable

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -176,6 +176,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"FuncProps":      {fullName: "*tree.FunctionProperties", isPointer: true, usePointerIntern: true},
 		"FuncOverload":   {fullName: "*tree.Overload", isPointer: true, usePointerIntern: true},
 		"PhysProps":      {fullName: "*physical.Required", isPointer: true},
+		"Presentation":   {fullName: "physical.Presentation", passByVal: true},
 		"RelProps":       {fullName: "props.Relational"},
 		"RelPropsPtr":    {fullName: "*props.Relational", isPointer: true, usePointerIntern: true},
 		"ScalarProps":    {fullName: "props.Scalar"},


### PR DESCRIPTION
Prior to this patch, the optimizer was ignoring column aliases when
creating column names for tables with the `CREATE TABLE AS` syntax.
For example,
```
  CREATE TABLE bar AS SELECT count(*) AS c FROM foo
```
created a table called bar with a column called `count_rows`. This
commit fixes the error so the column is correctly named `c` instead of
`count_rows`.

Fixes #36930

Release note (bug fix): Corrected the names of some columns for tables
created with CREATE TABLE <name> AS <query>.