### PR TITLE
testutils: add a helper for removing setup code from -memprofile

### DIFF
--- a/pkg/testutils/pprof.go
+++ b/pkg/testutils/pprof.go
@@ -1,0 +1,66 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testutils
+
+import (
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"testing"
+)
+
+// WriteProfile serialized the pprof profile with the given name to a file at
+// the given path.
+func WriteProfile(t testing.TB, name string, path string) {
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := pprof.Lookup(name).WriteTo(f, 0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// AllocProfileDiff writes two alloc profiles, one before running closure and
+// one after. This is similar in spirit to passing the -memprofile flag to a
+// test or benchmark, but make it possible to subtract out setup code, which
+// -memprofile does not.
+//
+// Example usage:
+//     setupCode()
+//     AllocProfileDiff(t, "mem.before", "mem.after", func() {
+//       interestingCode()
+//     })
+//
+// The resulting profiles are then diffed via:
+//     go tool pprof -base mem.before mem.after
+func AllocProfileDiff(t testing.TB, beforePath, afterPath string, fn func()) {
+	// Use "allocs" instead of "heap" to match what -memprofile does. Also run
+	// runtime.GC immediately before grabbing the profile because the allocs
+	// profile is materialized on gc, so this makes sure we have the latest data.
+	//
+	// https://github.com/golang/go/blob/go1.12.4/src/testing/testing.go#L1264-L1269
+	runtime.GC()
+	WriteProfile(t, "allocs", beforePath)
+	fn()
+	runtime.GC()
+	WriteProfile(t, "allocs", afterPath)
+	t.Logf("to use your alloc profiles: go tool pprof -base %s %s", beforePath, afterPath)
+}
+
+// Make the unused linter happy.
+var _ = WriteProfile
+var _ = AllocProfileDiff


### PR DESCRIPTION
AllocProfileDiff writes two alloc profiles, one before running closure and
one after. This is similar in spirit to passing the -memprofile flag to a
test or benchmark, but make it possible to subtract out setup code, which
-memprofile does not.

Example usage:
    setupCode()
    AllocProfileDiff(t, "mem.before", "mem.after", func() {
      interestingCode()
    })

The resulting profiles are then diffed via:
    go tool pprof -base mem.before mem.after

I've wanted this a number of times when working on bulkio stuff, but it
was recently so useful that I decided to clean it up and check it in.

The result of -memprofile on BenchmarkImportWorkload/AddSSTable:

    (pprof) top10
    Showing nodes accounting for 1921.59MB, 74.06% of 2594.70MB total
    Dropped 496 nodes (cum <= 12.97MB)
    Showing top 10 nodes out of 119
          flat  flat%   sum%        cum   cum%
      463.28MB 17.85% 17.85%   463.28MB 17.85%  github.com/cockroachdb/cockroach/pkg/ccl/workloadccl/format.ToSSTable.func2
      266.46MB 10.27% 28.12%   415.37MB 16.01%  github.com/cockroachdb/cockroach/vendor/github.com/golang/leveldb/table.(*Reader).readBlock
      256.60MB  9.89% 38.01%   289.10MB 11.14%  github.com/cockroachdb/cockroach/pkg/sql.GenerateInsertRow
      241.35MB  9.30% 47.32%   241.35MB  9.30%  github.com/cockroachdb/cockroach/pkg/storage.defaultSubmitProposalLocked
      239.81MB  9.24% 56.56%   239.81MB  9.24%  github.com/cockroachdb/cockroach/pkg/storage/storagepb.(*ReplicatedEvalResult_AddSSTable).Unmarshal
      148.91MB  5.74% 62.30%   148.91MB  5.74%  github.com/cockroachdb/cockroach/vendor/github.com/golang/snappy.Decode
       79.94MB  3.08% 65.38%    79.94MB  3.08%  github.com/cockroachdb/cockroach/pkg/storage/engine.gobytes
       78.72MB  3.03% 68.41%    78.72MB  3.03%  github.com/cockroachdb/cockroach/pkg/ccl/importccl.(*rowConverter).sendBatch
       77.51MB  2.99% 71.40%    84.61MB  3.26%  github.com/cockroachdb/cockroach/pkg/workload/tpcc.(*tpcc).tpccOrderLineInitialRowBatch
       69.02MB  2.66% 74.06%    69.02MB  2.66%  github.com/cockroachdb/cockroach/pkg/roachpb.(*Value).SetTuple

The result of using this and diffing the profiles:

    (pprof) top10
    Showing nodes accounting for 299.54MB, 99.02% of 302.50MB total
    Dropped 9 nodes (cum <= 1.51MB)
    Showing top 10 nodes out of 66
          flat  flat%   sum%        cum   cum%
          95MB 31.40% 31.40%   139.67MB 46.17%  github.com/cockroachdb/cockroach/vendor/github.com/golang/leveldb/table.(*Reader).readBlock
       79.94MB 26.43% 57.83%    79.94MB 26.43%  github.com/cockroachdb/cockroach/pkg/storage.defaultSubmitProposalLocked
       79.94MB 26.43% 84.26%    79.94MB 26.43%  github.com/cockroachdb/cockroach/pkg/storage/storagepb.(*ReplicatedEvalResult_AddSSTable).Unmarshal
       44.67MB 14.77% 99.02%    44.67MB 14.77%  github.com/cockroachdb/cockroach/vendor/github.com/golang/snappy.Decode
             0     0% 99.02%     2.45MB  0.81%  github.com/cockroachdb/cockroach/pkg/ccl/importccl_test.BenchmarkImportWorkload.func1.1
             0     0% 99.02%     2.45MB  0.81%  github.com/cockroachdb/cockroach/pkg/ccl/importccl_test.benchmarkAddSSTable
             0     0% 99.02%    63.22MB 20.90%  github.com/cockroachdb/cockroach/pkg/ccl/importccl_test.benchmarkAddSSTable.func1
             0     0% 99.02%    79.94MB 26.43%  github.com/cockroachdb/cockroach/pkg/internal/client.(*CrossRangeTxnWrapperSender).Send
             0     0% 99.02%    79.94MB 26.43%  github.com/cockroachdb/cockroach/pkg/internal/client.(*DB).AddSSTable
             0     0% 99.02%    79.94MB 26.43%  github.com/cockroachdb/cockroach/pkg/internal/client.(*DB).Run

Release note: None