### PR TITLE
storage: remove optimization to use in-memory RaftCommand when sideloading SSTs

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -332,7 +332,21 @@ func registerTPCC(r *registry) {
 		CPUs:  4,
 
 		LoadWarehouses: 1000,
-		EstimatedMax:   300,
+		EstimatedMax:   gceOrAws(cloud, 400, 600),
+	})
+	registerTPCCBenchSpec(r, tpccBenchSpec{
+		Nodes: 3,
+		CPUs:  16,
+
+		LoadWarehouses: gceOrAws(cloud, 2000, 2500),
+		EstimatedMax:   gceOrAws(cloud, 1600, 2300),
+	})
+	registerTPCCBenchSpec(r, tpccBenchSpec{
+		Nodes: 12,
+		CPUs:  16,
+
+		LoadWarehouses: gceOrAws(cloud, 8000, 10000),
+		EstimatedMax:   gceOrAws(cloud, 7000, 7000),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:        6,
@@ -368,6 +382,13 @@ func maxVersion(vers ...string) string {
 		return ""
 	}
 	return max.String()
+}
+
+func gceOrAws(cloud string, gce, aws int) int {
+	if cloud == "aws" {
+		return aws
+	}
+	return gce
 }
 
 func maybeMinVersionForFixturesImport(cloud string) string {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -297,8 +297,14 @@ type Replica struct {
 		//
 		// The *ProposalData in the map are "owned" by it. Elements from the
 		// map must only be referenced while Replica.mu is held, except if the
-		// element is removed from the map first. The notable exception is the
-		// contained RaftCommand, which we treat as immutable.
+		// element is removed from the map first.
+		//
+		// Due to Raft reproposals, multiple in-flight Raft entries can have
+		// the same CmdIDKey, all corresponding to the same KV request. However,
+		// not all Raft entries with a given command ID will correspond directly
+		// to the *RaftCommand contained in its associated *ProposalData. This
+		// is because the *RaftCommand can be mutated during reproposals by
+		// Replica.tryReproposeWithNewLeaseIndex.
 		proposals         map[storagebase.CmdIDKey]*ProposalData
 		internalRaftGroup *raft.RawNode
 		// The ID of the replica within the Raft group. May be 0 if the replica has


### PR DESCRIPTION
Fixes #36861.

This optimization relied on the fact that `RaftCommands` in `Replica.mu.proposals` were immutable over the lifetime of a Raft proposal. This invariant was violated by #35261, which allowed a lease index error to trigger an immediate reproposal. This reproposal mutated the corresponding `RaftCommand` in `Replica.mu.proposals`. Combined with aliasing between multiple Raft proposals due to reproposals from ticks, this resulted in cases where a leaseholder's Raft logs could diverge from its followers and cause Raft groups to become inconsistent.

We can justify the new cost of unmarshalling `RaftCommands` in `maybeInlineSideloadedRaftCommand` on leaseholders because https://github.com/cockroachdb/cockroach/pull/36670/files#diff-8a33b5571aa9ab154d4f3c2a16724697R230 just landed. That change removes an equally sized allocation and memory copy from the function on both leaseholders and followers.

Release note: None