### PR TITLE
opt: support arguments to window functions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -98,7 +98,7 @@ ALTER TABLE test DROP COLUMN v;
 
 # Don't fall back to heuristic planner in ALWAYS mode.
 query error unsupported window function
-SELECT avg(k) OVER () FROM t ORDER BY 1
+SELECT avg(k) OVER (ORDER BY k) FROM t ORDER BY 1
 
 statement ok
 SET OPTIMIZER = LOCAL

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -506,7 +506,7 @@ statement error aggregate functions are not allowed in UPDATE SET
 UPDATE t32477 SET x = count(x)
 
 statement error window functions are not allowed in UPDATE SET
-UPDATE t32477 SET x = rank(x) OVER ()
+UPDATE t32477 SET x = rank() OVER ()
 
 statement error generator functions are not allowed in UPDATE SET
 UPDATE t32477 SET x = generate_series(1,2)

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -265,13 +265,25 @@ SELECT avg(k) OVER (PARTITION BY a) FROM kv
 query error column "a" does not exist
 SELECT avg(k) OVER (ORDER BY a) FROM kv
 
-query error pgcode 42803 aggregate function calls cannot contain window function calls
+# TODO(justin): this should have pgcode 42803 but CBO currently doesn't get
+# it right.
+query error window functions are not allowed in aggregate
 SELECT avg(avg(k) OVER ()) FROM kv ORDER BY 1
 
 query R
 SELECT avg(avg(k)) OVER () FROM kv ORDER BY 1
 ----
 5
+
+query RR
+SELECT avg(k) OVER (), avg(v) OVER () FROM kv ORDER BY 1
+----
+5  2.3333333333333333333
+5  2.3333333333333333333
+5  2.3333333333333333333
+5  2.3333333333333333333
+5  2.3333333333333333333
+5  2.3333333333333333333
 
 query error OVER specified, but now\(\) is neither a window function nor an aggregate function
 SELECT now() OVER () FROM kv ORDER BY 1
@@ -3026,3 +3038,8 @@ FROM
     (SELECT 1 AS a)
 ----
 1 1
+
+query T
+SELECT string_agg('foo', s) OVER () FROM (SELECT * FROM kv LIMIT 1)
+----
+foo

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -769,4 +769,4 @@ sort
 
 # Test with an unsupported statement.
 statement error unsupported window function
-EXPLAIN (OPT) SELECT avg(x) OVER () FROM (VALUES (1)) AS t(x)
+EXPLAIN (OPT) SELECT avg(x) OVER (ORDER BY x) FROM (VALUES (1)) AS t(x)

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -55,24 +55,50 @@ output row: [3 3.5355339059327376220]
 output row: [8 3.5355339059327376220]
 
 query TTTTT
-EXPLAIN (VERBOSE) SELECT avg(k), max(v), min(w), 2 + row_number() OVER () FROM kv ORDER BY 1
+EXPLAIN (VERBOSE) SELECT ntile(1) OVER () FROM kv
 ----
-render               ·            ·                     (avg, max, min, "?column?")  ·
- │                   render 0     avg                   ·                            ·
- │                   render 1     max                   ·                            ·
- │                   render 2     min                   ·                            ·
- │                   render 3     row_number + 2        ·                            ·
- └── window          ·            ·                     (avg, max, min, row_number)  ·
-      │              window 0     row_number() OVER ()  ·                            ·
-      │              render 3     row_number() OVER ()  ·                            ·
-      └── group      ·            ·                     (agg0, agg1, agg2)           ·
-           │         aggregate 0  avg(k)                ·                            ·
-           │         aggregate 1  max(v)                ·                            ·
-           │         aggregate 2  min(w)                ·                            ·
-           │         scalar       ·                     ·                            ·
-           └── scan  ·            ·                     (k, v, w)                    ·
-·                    table        kv@primary            ·                            ·
-·                    spans        ALL                   ·                            ·
+render               ·         ·                  (ntile)                              ·
+ │                   render 0  ntile              ·                                    ·
+ └── window          ·         ·                  (k, v, w, f, d, s, b, ntile)         ·
+      │              window 0  ntile(@8) OVER ()  ·                                    ·
+      │              render 7  ntile(@8) OVER ()  ·                                    ·
+      └── render     ·         ·                  (k, v, w, f, d, s, b, ntile_1_arg1)  ·
+           │         render 0  k                  ·                                    ·
+           │         render 1  v                  ·                                    ·
+           │         render 2  w                  ·                                    ·
+           │         render 3  f                  ·                                    ·
+           │         render 4  d                  ·                                    ·
+           │         render 5  s                  ·                                    ·
+           │         render 6  b                  ·                                    ·
+           │         render 7  1                  ·                                    ·
+           └── scan  ·         ·                  (k, v, w, f, d, s, b)                ·
+·                    table     kv@primary         ·                                    ·
+·                    spans     ALL                ·                                    ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT nth_value(1, 2) OVER () FROM kv
+----
+render               ·         ·                          (nth_value)                                                ·
+ │                   render 0  nth_value                  ·                                                          ·
+ └── window          ·         ·                          (k, v, w, f, d, s, b, nth_value)                           ·
+      │              window 0  nth_value(@8, @9) OVER ()  ·                                                          ·
+      │              render 7  nth_value(@8, @9) OVER ()  ·                                                          ·
+      └── render     ·         ·                          (k, v, w, f, d, s, b, nth_value_1_arg1, nth_value_1_arg2)  ·
+           │         render 0  k                          ·                                                          ·
+           │         render 1  v                          ·                                                          ·
+           │         render 2  w                          ·                                                          ·
+           │         render 3  f                          ·                                                          ·
+           │         render 4  d                          ·                                                          ·
+           │         render 5  s                          ·                                                          ·
+           │         render 6  b                          ·                                                          ·
+           │         render 7  1                          ·                                                          ·
+           │         render 8  2                          ·                                                          ·
+           └── scan  ·         ·                          (k, v, w, f, d, s, b)                                      ·
+·                    table     kv@primary                 ·                                                          ·
+·                    spans     ALL                        ·                                                          ·
+
+statement error column "v" must appear in the GROUP BY clause or be used in an aggregate function
+EXPLAIN (VERBOSE) SELECT max(v) OVER (), min(v) FROM kv ORDER BY 1
 
 query TTT
 EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -928,20 +928,22 @@ func (b *logicalPropsBuilder) buildWindowProps(window *WindowExpr, rel *props.Re
 
 	// Output Columns
 	// --------------
-	// Output columns are all passed through with the addition of one extra
-	// column.
-	rel.OutputCols = inputProps.OutputCols.Copy()
+	// Output columns are all the passthrough columns with the addition of the
+	// window function column.
+	rel.OutputCols = window.Passthrough.Copy()
 	rel.OutputCols.Add(int(window.ColID))
 
 	// Not Null Columns
 	// ----------------
 	// Inherit not null columns from input.
 	// TODO(justin): in many cases the added column may not be nullable.
-	rel.NotNullCols = inputProps.NotNullCols.Copy()
+	rel.NotNullCols = inputProps.NotNullCols.Intersection(rel.OutputCols)
 
 	// Outer Columns
 	// -------------
-	// Outer columns were derived by BuildSharedProps.
+	// Outer columns were derived by BuildSharedProps; remove any that are bound
+	// by input columns.
+	rel.OuterCols.DifferenceWith(inputProps.OutputCols)
 
 	// Functional Dependencies
 	// -----------------------

--- a/pkg/sql/opt/memo/testdata/logprops/window
+++ b/pkg/sql/opt/memo/testdata/logprops/window
@@ -116,3 +116,48 @@ project
                           └── plus [type=int, outer=(8,9)]
                                ├── variable: rank [type=int]
                                └── variable: x [type=int]
+
+build
+SELECT lag('foo'::string) OVER (), lag(1) OVER () FROM kv
+----
+project
+ ├── columns: lag:8(string) lag:9(int)
+ ├── prune: (8,9)
+ └── window
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) lag:8(string) lag:9(int)
+      ├── key: (1)
+      ├── fd: ()-->(10-15), (1)-->(2-7)
+      ├── window
+      │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) lag:8(string) lag_2_arg1:13(int!null) lag_2_arg2:14(int!null) lag_2_arg3:15(int)
+      │    ├── key: (1)
+      │    ├── fd: ()-->(10-15), (1)-->(2-7)
+      │    ├── project
+      │    │    ├── columns: lag_1_arg1:10(string) lag_1_arg2:11(int!null) lag_1_arg3:12(string) lag_2_arg1:13(int!null) lag_2_arg2:14(int!null) lag_2_arg3:15(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    ├── key: (1)
+      │    │    ├── fd: ()-->(10-15), (1)-->(2-7)
+      │    │    ├── prune: (1-7,10-15)
+      │    │    ├── interesting orderings: (+1)
+      │    │    ├── scan kv
+      │    │    │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2-7)
+      │    │    │    ├── prune: (1-7)
+      │    │    │    └── interesting orderings: (+1)
+      │    │    └── projections
+      │    │         ├── cast: STRING [type=string]
+      │    │         │    └── const: 'foo' [type=string]
+      │    │         ├── const: 1 [type=int]
+      │    │         ├── cast: STRING [type=string]
+      │    │         │    └── null [type=unknown]
+      │    │         ├── const: 1 [type=int]
+      │    │         ├── const: 1 [type=int]
+      │    │         └── cast: INT8 [type=int]
+      │    │              └── null [type=unknown]
+      │    └── lag [type=string]
+      │         ├── variable: lag_1_arg1 [type=string]
+      │         ├── variable: lag_1_arg2 [type=int]
+      │         └── variable: lag_1_arg3 [type=string]
+      └── lag [type=int]
+           ├── variable: lag_2_arg1 [type=int]
+           ├── variable: lag_2_arg2 [type=int]
+           └── variable: lag_2_arg3 [type=int]

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -205,6 +205,12 @@ var WindowOpReverseMap = map[Operator]string{
 	DenseRankOp:   "dense_rank",
 	PercentRankOp: "percent_rank",
 	CumeDistOp:    "cume_dist",
+	NtileOp:       "ntile",
+	LagOp:         "lag",
+	LeadOp:        "lead",
+	FirstValueOp:  "first_value",
+	LastValueOp:   "last_value",
+	NthValueOp:    "nth_value",
 }
 
 // NegateOpMap maps from a comparison operator type to its negated operator

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -847,6 +847,9 @@ define ProjectSet {
 [Relational]
 define Window {
     Input    RelExpr
+
+    # Function contains the window function being computed. It will always be
+    # a member of the Window class and its arguments will always be Variables.
     Function ScalarExpr
 
     _ WindowPrivate
@@ -856,6 +859,13 @@ define Window {
 define WindowPrivate {
     # ColID holds the id of the column introduced by this operator.
     ColID ColumnID
+
+    # Passthrough is the set of columns the window function passes through
+    # unchanged. Note the only columns pruned by a Window operator are the
+    # window function's arguments.
+    # TODO(justin): This could be derived from the input's output columns and
+    # the function itself.
+    Passthrough ColSet
 }
 
 # FakeRel is a mock relational operator used for testing; its logical properties

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -890,6 +890,16 @@ define AggDistinct {
     Input ScalarExpr
 }
 
+# AggFilter is used as a modifier that wraps the input of an aggregate
+# function. It causes only rows for which the filter expression is true
+# to be processed. AggFilter should always occur on top of AggDistinct
+# if they are both present.
+[Scalar]
+define AggFilter {
+    Input  ScalarExpr
+    Filter ScalarExpr
+}
+
 # Rank computes the position of a row relative to an ordering, with same-valued
 # rows receiving the same value.
 [Scalar, Window]
@@ -918,14 +928,52 @@ define PercentRank {
 define CumeDist {
 }
 
-# AggFilter is used as a modifier that wraps the input of an aggregate
-# function. It causes only rows for which the filter expression is true
-# to be processed. AggFilter should always occur on top of AggDistinct
-# if they are both present.
-[Scalar]
-define AggFilter {
-    Input  ScalarExpr
-    Filter ScalarExpr
+# Ntile builds a histogram with the specified number of buckets and evaluates
+# to which bucket the row falls in.
+[Scalar, Window]
+define Ntile {
+    NumBuckets ScalarExpr
+}
+
+# Lag returns Value evaluated at the row Offset rows before this one. If no
+# such row exists, returns Def.
+[Scalar, Window]
+define Lag {
+    Value  ScalarExpr
+    Offset ScalarExpr
+    # Def is the default value.
+    Def    ScalarExpr
+}
+
+# Lead returns Value evaluated at the row Offset rows after this one. If no
+# such row exists, returns Def.
+[Scalar, Window]
+define Lead {
+    Value  ScalarExpr
+    Offset ScalarExpr
+    # Def is the default value.
+    Def    ScalarExpr
+}
+
+# FirstValue returns Value evaluated at the first row in the row's frame.
+# TODO(justin): can this be unified with FirstAgg?
+[Scalar, Window]
+define FirstValue {
+    Value ScalarExpr
+}
+
+# LastValue returns Value evaluated at the last row in the row's frame.
+[Scalar, Window]
+define LastValue {
+    Value ScalarExpr
+}
+
+# NthValue returns Value evaluated at the nth row in the row's frame.
+# Out-of-bounds references evaluate to NULL.
+[Scalar, Window]
+define NthValue {
+    Value ScalarExpr
+    Nth   ScalarExpr
 }
 
 # ScalarList is a list expression that has scalar expression items of type

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -517,6 +517,22 @@ func (b *Builder) constructWindowFn(name string, args []opt.ScalarExpr) opt.Scal
 		return b.factory.ConstructPercentRank()
 	case "cume_dist":
 		return b.factory.ConstructCumeDist()
+	case "ntile":
+		return b.factory.ConstructNtile(args[0])
+	case "lag":
+		return b.factory.ConstructLag(args[0], args[1], args[2])
+	case "lead":
+		return b.factory.ConstructLead(args[0], args[1], args[2])
+	case "first_value":
+		return b.factory.ConstructFirstValue(args[0])
+	case "last_value":
+		return b.factory.ConstructLastValue(args[0])
+	case "nth_value":
+		return b.factory.ConstructNthValue(args[0], args[1])
+	case "string_agg":
+		// We can handle non-constant second arguments for string_agg in window
+		// fns (but not aggregates).
+		return b.factory.ConstructStringAgg(args[0], args[1])
 	default:
 		return b.constructAggregate(name, args)
 	}

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -36,17 +36,22 @@ error (42P20): rank(): window functions are not allowed in GROUP BY
 build
 SELECT sum(rank() over ()) FROM kv
 ----
-error (42P20): rank(): window functions are not allowed in aggregate
+error (42P20): sum(): rank(): window functions are not allowed in aggregate
 
 build
 SELECT count(w) OVER () FROM kv GROUP BY 1
 ----
-error (0A000): unimplemented: unsupported window function
+error (42P20): count(): window functions are not allowed in GROUP BY
+
+build
+SELECT avg(avg(k) OVER ()) OVER () FROM kv
+----
+error (42P20): avg(): avg(): window function calls cannot be nested
 
 build
 INSERT INTO kv (k, v) VALUES (99, 100) RETURNING sum(v) OVER ()
 ----
-error (0A000): unimplemented: unsupported window function
+error (42P20): sum(): window functions are not allowed in RETURNING
 
 build
 SELECT sum(v) FROM kv GROUP BY k LIMIT sum(v) OVER ()
@@ -61,12 +66,12 @@ error (42P20): window functions are not allowed in OFFSET
 build
 INSERT INTO kv (k, v) VALUES (99, count(1) OVER ())
 ----
-error (0A000): unimplemented: unsupported window function
+error (42P20): count(): window functions are not allowed in VALUES
 
 build
 SELECT k FROM kv WHERE avg(k) OVER () > 1
 ----
-error (0A000): unimplemented: unsupported window function
+error (42P20): avg(): window functions are not allowed in WHERE
 
 build
 SELECT 1 FROM kv GROUP BY 1 HAVING sum(1) OVER (PARTITION BY 1) > 1
@@ -74,14 +79,252 @@ SELECT 1 FROM kv GROUP BY 1 HAVING sum(1) OVER (PARTITION BY 1) > 1
 error (0A000): unimplemented: unsupported window function
 
 build
-SELECT avg(k) OVER () FROM kv ORDER BY 1
+SELECT lag('foo'::string) OVER (), lag(1) OVER () FROM kv
+----
+project
+ ├── columns: lag:8(string) lag:9(int)
+ └── window
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) lag:8(string) lag:9(int)
+      ├── window
+      │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) lag:8(string) lag_2_arg1:13(int!null) lag_2_arg2:14(int!null) lag_2_arg3:15(int)
+      │    ├── project
+      │    │    ├── columns: lag_1_arg1:10(string) lag_1_arg2:11(int!null) lag_1_arg3:12(string) lag_2_arg1:13(int!null) lag_2_arg2:14(int!null) lag_2_arg3:15(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    ├── scan kv
+      │    │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    └── projections
+      │    │         ├── cast: STRING [type=string]
+      │    │         │    └── const: 'foo' [type=string]
+      │    │         ├── const: 1 [type=int]
+      │    │         ├── cast: STRING [type=string]
+      │    │         │    └── null [type=unknown]
+      │    │         ├── const: 1 [type=int]
+      │    │         ├── const: 1 [type=int]
+      │    │         └── cast: INT8 [type=int]
+      │    │              └── null [type=unknown]
+      │    └── lag [type=string]
+      │         ├── variable: lag_1_arg1 [type=string]
+      │         ├── variable: lag_1_arg2 [type=int]
+      │         └── variable: lag_1_arg3 [type=string]
+      └── lag [type=int]
+           ├── variable: lag_2_arg1 [type=int]
+           ├── variable: lag_2_arg2 [type=int]
+           └── variable: lag_2_arg3 [type=int]
+
+build
+SELECT lag((SELECT k FROM kv kv2 WHERE kv2.k = kv.k)) OVER () FROM kv
+----
+project
+ ├── columns: lag:15(int)
+ └── window
+      ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.f:4(float) kv.d:5(decimal) kv.s:6(string) kv.b:7(bool) lag:15(int)
+      ├── project
+      │    ├── columns: lag_1_arg1:16(int) lag_1_arg2:17(int!null) lag_1_arg3:18(int) kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.f:4(float) kv.d:5(decimal) kv.s:6(string) kv.b:7(bool)
+      │    ├── scan kv
+      │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.f:4(float) kv.d:5(decimal) kv.s:6(string) kv.b:7(bool)
+      │    └── projections
+      │         ├── subquery [type=int]
+      │         │    └── max1-row
+      │         │         ├── columns: kv2.k:8(int!null)
+      │         │         └── project
+      │         │              ├── columns: kv2.k:8(int!null)
+      │         │              └── select
+      │         │                   ├── columns: kv2.k:8(int!null) kv2.v:9(int) kv2.w:10(int) kv2.f:11(float) kv2.d:12(decimal) kv2.s:13(string) kv2.b:14(bool)
+      │         │                   ├── scan kv2
+      │         │                   │    └── columns: kv2.k:8(int!null) kv2.v:9(int) kv2.w:10(int) kv2.f:11(float) kv2.d:12(decimal) kv2.s:13(string) kv2.b:14(bool)
+      │         │                   └── filters
+      │         │                        └── eq [type=bool]
+      │         │                             ├── variable: kv2.k [type=int]
+      │         │                             └── variable: kv.k [type=int]
+      │         ├── const: 1 [type=int]
+      │         └── cast: INT8 [type=int]
+      │              └── null [type=unknown]
+      └── lag [type=int]
+           ├── variable: lag_1_arg1 [type=int]
+           ├── variable: lag_1_arg2 [type=int]
+           └── variable: lag_1_arg3 [type=int]
+
+build
+SELECT lag(1) OVER (), lead(1) OVER () FROM kv
+----
+project
+ ├── columns: lag:8(int) lead:9(int)
+ └── window
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) lag:8(int) lead:9(int)
+      ├── window
+      │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) lag:8(int) lead_2_arg1:13(int!null) lead_2_arg2:14(int!null) lead_2_arg3:15(int)
+      │    ├── project
+      │    │    ├── columns: lag_1_arg1:10(int!null) lag_1_arg2:11(int!null) lag_1_arg3:12(int) lead_2_arg1:13(int!null) lead_2_arg2:14(int!null) lead_2_arg3:15(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    ├── scan kv
+      │    │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    └── projections
+      │    │         ├── const: 1 [type=int]
+      │    │         ├── const: 1 [type=int]
+      │    │         ├── cast: INT8 [type=int]
+      │    │         │    └── null [type=unknown]
+      │    │         ├── const: 1 [type=int]
+      │    │         ├── const: 1 [type=int]
+      │    │         └── cast: INT8 [type=int]
+      │    │              └── null [type=unknown]
+      │    └── lag [type=int]
+      │         ├── variable: lag_1_arg1 [type=int]
+      │         ├── variable: lag_1_arg2 [type=int]
+      │         └── variable: lag_1_arg3 [type=int]
+      └── lead [type=int]
+           ├── variable: lead_2_arg1 [type=int]
+           ├── variable: lead_2_arg2 [type=int]
+           └── variable: lead_2_arg3 [type=int]
+
+build
+SELECT lag(1, 2) OVER (), lead(1, 2) OVER () FROM kv
+----
+project
+ ├── columns: lag:8(int) lead:9(int)
+ └── window
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) lag:8(int) lead:9(int)
+      ├── window
+      │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) lag:8(int) lead_2_arg1:13(int!null) lead_2_arg2:14(int!null) lead_2_arg3:15(int)
+      │    ├── project
+      │    │    ├── columns: lag_1_arg1:10(int!null) lag_1_arg2:11(int!null) lag_1_arg3:12(int) lead_2_arg1:13(int!null) lead_2_arg2:14(int!null) lead_2_arg3:15(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    ├── scan kv
+      │    │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    └── projections
+      │    │         ├── const: 1 [type=int]
+      │    │         ├── const: 2 [type=int]
+      │    │         ├── cast: INT8 [type=int]
+      │    │         │    └── null [type=unknown]
+      │    │         ├── const: 1 [type=int]
+      │    │         ├── const: 2 [type=int]
+      │    │         └── cast: INT8 [type=int]
+      │    │              └── null [type=unknown]
+      │    └── lag [type=int]
+      │         ├── variable: lag_1_arg1 [type=int]
+      │         ├── variable: lag_1_arg2 [type=int]
+      │         └── variable: lag_1_arg3 [type=int]
+      └── lead [type=int]
+           ├── variable: lead_2_arg1 [type=int]
+           ├── variable: lead_2_arg2 [type=int]
+           └── variable: lead_2_arg3 [type=int]
+
+build
+SELECT lag(1, 2, 3) OVER (), lead(1, 2, 3) OVER () FROM kv
+----
+project
+ ├── columns: lag:8(int) lead:9(int)
+ └── window
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) lag:8(int) lead:9(int)
+      ├── window
+      │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) lag:8(int) lead_2_arg1:13(int!null) lead_2_arg2:14(int!null) lead_2_arg3:15(int!null)
+      │    ├── project
+      │    │    ├── columns: lag_1_arg1:10(int!null) lag_1_arg2:11(int!null) lag_1_arg3:12(int!null) lead_2_arg1:13(int!null) lead_2_arg2:14(int!null) lead_2_arg3:15(int!null) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    ├── scan kv
+      │    │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    └── projections
+      │    │         ├── const: 1 [type=int]
+      │    │         ├── const: 2 [type=int]
+      │    │         ├── const: 3 [type=int]
+      │    │         ├── const: 1 [type=int]
+      │    │         ├── const: 2 [type=int]
+      │    │         └── const: 3 [type=int]
+      │    └── lag [type=int]
+      │         ├── variable: lag_1_arg1 [type=int]
+      │         ├── variable: lag_1_arg2 [type=int]
+      │         └── variable: lag_1_arg3 [type=int]
+      └── lead [type=int]
+           ├── variable: lead_2_arg1 [type=int]
+           ├── variable: lead_2_arg2 [type=int]
+           └── variable: lead_2_arg3 [type=int]
+
+build
+SELECT avg(k) OVER () FROM kv
+----
+project
+ ├── columns: avg:8(decimal)
+ └── window
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) avg:8(decimal)
+      ├── project
+      │    ├── columns: avg_1_arg1:9(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    ├── scan kv
+      │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    └── projections
+      │         └── variable: k [type=int]
+      └── avg [type=decimal]
+           └── variable: avg_1_arg1 [type=int]
+
+build
+SELECT x FROM (SELECT avg(k) OVER () AS x FROM kv)
+----
+project
+ ├── columns: x:8(decimal)
+ └── window
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) avg:8(decimal)
+      ├── project
+      │    ├── columns: avg_1_arg1:9(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    ├── scan kv
+      │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    └── projections
+      │         └── variable: k [type=int]
+      └── avg [type=decimal]
+           └── variable: avg_1_arg1 [type=int]
+
+build
+SELECT avg(DISTINCT k) OVER () FROM kv
 ----
 error (0A000): unimplemented: unsupported window function
+
+build
+SELECT avg(k) FILTER (WHERE k > 5) OVER () FROM kv
+----
+error (0A000): unimplemented: unsupported window function
+
+build
+SELECT avg(k), max(v) OVER () FROM kv ORDER BY 1
+----
+error (42803): column "v" must appear in the GROUP BY clause or be used in an aggregate function
+
+build
+SELECT avg(k) OVER () FROM kv ORDER BY 1
+----
+sort
+ ├── columns: avg:8(decimal)
+ ├── ordering: +8
+ └── project
+      ├── columns: avg:8(decimal)
+      └── window
+           ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) avg:8(decimal)
+           ├── project
+           │    ├── columns: avg_1_arg1:9(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+           │    ├── scan kv
+           │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+           │    └── projections
+           │         └── variable: k [type=int]
+           └── avg [type=decimal]
+                └── variable: avg_1_arg1 [type=int]
 
 build
 SELECT k, v, w, v - w + 2 + row_number() OVER (PARTITION BY v, k ORDER BY w) FROM kv ORDER BY 1
 ----
 error (0A000): unimplemented: unsupported window function
+
+build
+SELECT k, v, rank() OVER w FROM kv WINDOW w AS ()
+----
+error (0A000): unimplemented: unsupported window function
+
+build
+SELECT k, v, first_value(v) OVER () FROM kv
+----
+project
+ ├── columns: k:1(int!null) v:2(int) first_value:8(int)
+ └── window
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) first_value:8(int)
+      ├── project
+      │    ├── columns: first_value_1_arg1:9(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    ├── scan kv
+      │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    └── projections
+      │         └── variable: v [type=int]
+      └── first-value [type=int]
+           └── variable: first_value_1_arg1 [type=int]
 
 build
 SELECT avg(k), max(v), min(w), 2 + row_number() OVER () FROM kv ORDER BY 1
@@ -187,6 +430,74 @@ SELECT k, v, rank() OVER (ORDER BY k) FROM kv ORDER BY 1
 error (0A000): unimplemented: unsupported window function
 
 build
-SELECT k, v, ntile(1) OVER () FROM kv ORDER BY 1
+SELECT k, v, ntile(1) OVER () FROM kv
 ----
-error (0A000): unimplemented: unsupported window function
+project
+ ├── columns: k:1(int!null) v:2(int) ntile:8(int)
+ └── window
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) ntile:8(int)
+      ├── project
+      │    ├── columns: ntile_1_arg1:9(int!null) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    ├── scan kv
+      │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    └── projections
+      │         └── const: 1 [type=int]
+      └── ntile [type=int]
+           └── variable: ntile_1_arg1 [type=int]
+
+build
+SELECT k, v, ntile(1) OVER (), ntile(50) OVER () FROM kv
+----
+project
+ ├── columns: k:1(int!null) v:2(int) ntile:8(int) ntile:9(int)
+ └── window
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) ntile:8(int) ntile:9(int)
+      ├── window
+      │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) ntile:8(int) ntile_2_arg1:11(int!null)
+      │    ├── project
+      │    │    ├── columns: ntile_1_arg1:10(int!null) ntile_2_arg1:11(int!null) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    ├── scan kv
+      │    │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    │    └── projections
+      │    │         ├── const: 1 [type=int]
+      │    │         └── const: 50 [type=int]
+      │    └── ntile [type=int]
+      │         └── variable: ntile_1_arg1 [type=int]
+      └── ntile [type=int]
+           └── variable: ntile_2_arg1 [type=int]
+
+build
+SELECT k, v, nth_value('foo', 1) OVER () FROM kv
+----
+project
+ ├── columns: k:1(int!null) v:2(int) nth_value:8(string)
+ └── window
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) nth_value:8(string)
+      ├── project
+      │    ├── columns: nth_value_1_arg1:9(string!null) nth_value_1_arg2:10(int!null) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    ├── scan kv
+      │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    └── projections
+      │         ├── const: 'foo' [type=string]
+      │         └── const: 1 [type=int]
+      └── nth-value [type=string]
+           ├── variable: nth_value_1_arg1 [type=string]
+           └── variable: nth_value_1_arg2 [type=int]
+
+build
+SELECT k, v, nth_value(1, k) OVER () FROM kv
+----
+project
+ ├── columns: k:1(int!null) v:2(int) nth_value:8(int)
+ └── window
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) nth_value:8(int)
+      ├── project
+      │    ├── columns: nth_value_1_arg1:9(int!null) nth_value_1_arg2:10(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    ├── scan kv
+      │    │    └── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
+      │    └── projections
+      │         ├── const: 1 [type=int]
+      │         └── variable: k [type=int]
+      └── nth-value [type=int]
+           ├── variable: nth_value_1_arg1 [type=int]
+           └── variable: nth_value_1_arg2 [type=int]

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -15,6 +15,9 @@
 package optbuilder
 
 import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -25,8 +28,7 @@ import (
 type windowInfo struct {
 	*tree.FuncExpr
 
-	def  memo.FunctionPrivate
-	args memo.ScalarListExpr
+	def memo.FunctionPrivate
 
 	// col is the output column of the aggregation.
 	col *scopeColumn
@@ -52,3 +54,99 @@ func (w *windowInfo) Eval(_ *tree.EvalContext) (tree.Datum, error) {
 
 var _ tree.Expr = &windowInfo{}
 var _ tree.TypedExpr = &windowInfo{}
+
+// buildWindow adds any window functions on top of the expression.
+func (b *Builder) buildWindow(outScope *scope, inScope *scope) {
+	if len(inScope.windows) == 0 {
+		return
+	}
+	argLists := make([][]opt.ScalarExpr, len(inScope.windows))
+	argScope := outScope.push()
+	argScope.appendColumnsFromScope(outScope)
+	// The arguments to a given window function need to be columns in the input
+	// relation. Build a projection that produces those values to go underneath
+	// the window functions.
+	// TODO(justin): this is unfortunate in common cases where the arguments are
+	// constant, since we'll be projecting an extra column in every row.  It
+	// would be good if the windower supported being specified with constant
+	// values.
+	// TODO(justin): it's possible we could reuse some projections here, if a
+	// window function takes a column directly.
+	// TODO(justin): would it be better to just introduce a projection beneath
+	// every window operator and then let norm rules push them all down and merge
+	// them at the bottom, rather than building up one projection here?
+	for i := range inScope.windows {
+		w := &inScope.windows[i]
+		argExprs := b.getTypedWindowArgs(w)
+
+		argLists[i] = make(memo.ScalarListExpr, len(argExprs))
+		for j, a := range argExprs {
+			expr := b.buildScalar(a, inScope, nil, nil, nil)
+			col := b.synthesizeColumn(
+				argScope,
+				fmt.Sprintf("%s_%d_arg%d", w.def.Name, i+1, j+1),
+				a.ResolvedType(),
+				a,
+				expr,
+			)
+			argLists[i][j] = b.factory.ConstructVariable(col.id)
+		}
+	}
+
+	b.constructProjectForScope(outScope, argScope)
+	outScope.expr = argScope.expr
+
+	// Maintain the set of columns that the window function must pass through,
+	// since the arguments to the upper window functions must be passed through
+	// the lower window functions.
+	passthroughCols := argScope.colSet()
+	for i := range inScope.windows {
+		w := &inScope.windows[i]
+		// A window function does not pass through its own arguments.
+		for _, a := range argLists[i] {
+			passthroughCols.Remove(int(a.(*memo.VariableExpr).Col))
+		}
+		outScope.expr = b.factory.ConstructWindow(
+			outScope.expr,
+			b.constructWindowFn(w.def.Name, argLists[i]),
+			&memo.WindowPrivate{
+				ColID:       w.col.id,
+				Passthrough: passthroughCols.Copy(),
+			},
+		)
+		passthroughCols.Add(int(w.col.id))
+	}
+}
+
+// getTypedWindowArgs returns the arguments to the window function as
+// a []tree.TypedExpr. In the case of arguments with default values, it
+// fills in the values if they are missing.
+// TODO(justin): this is a bit of a hack to get around the fact that we don't
+// have a good way to represent optional values in the opt tree, figure out
+// a better way to do this. In particular this is bad because it results in us
+// projecting the default argument to some window functions when we could just
+// not do that projection.
+func (b *Builder) getTypedWindowArgs(w *windowInfo) []tree.TypedExpr {
+	argExprs := make([]tree.TypedExpr, len(w.Exprs))
+	for i, pexpr := range w.Exprs {
+		argExprs[i] = pexpr.(tree.TypedExpr)
+	}
+
+	switch w.def.Name {
+	// The second argument of {lead,lag} is 1 by default, and the third argument
+	// is NULL by default.
+	case "lead", "lag":
+		if len(argExprs) < 2 {
+			argExprs = append(argExprs, tree.NewDInt(1))
+		}
+		if len(argExprs) < 3 {
+			null, err := tree.ReType(tree.DNull, argExprs[0].ResolvedType())
+			if err != nil {
+				panic(pgerror.NewAssertionErrorWithWrappedErrf(err, "error calling tree.ReType"))
+			}
+			argExprs = append(argExprs, null)
+		}
+	}
+
+	return argExprs
+}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -822,8 +822,8 @@ func (ef *execFactory) ConstructWindow(root exec.Node, wi exec.WindowInfo) (exec
 
 	holder := &windowFuncHolder{
 		expr:         wi.Expr,
-		args:         nil,
-		argCount:     0,
+		args:         wi.Expr.Exprs,
+		argCount:     len(wi.Expr.Exprs),
 		argIdxStart:  wi.Idx,
 		window:       p,
 		filterColIdx: noFilterIdx,

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -164,7 +164,7 @@ func NewRangeUnavailableError(
 // nested within an aggregate function.
 func NewWindowInAggError() error {
 	return pgerror.New(pgerror.CodeGroupingError,
-		"aggregate function calls cannot contain window function calls")
+		"window functions are not allowed in aggregate")
 }
 
 // NewAggInAggError creates an error for the case when an aggregate function is


### PR DESCRIPTION
A fair bit of complexity here, the main idea is that when building
window functions with arguments we create a projection that introduces
the arguments for the window function to consume.

When execbuilding, we then rearrange the columns to simplify knowing
where columns are going to end up, since in execution, window functions
always put their results in the place they took their arguments from.

I think this commit might be a bit undertested, since a lot of the logic
tests are still blocked on running under the optimizer due to PARTITION
and ORDER BY support, so it's possible that adding those will uncover
some bugs here due to unlocking a lot more of the logic tests.

Release note: None