### PR TITLE
release-19.1: storage: remove optimization to use in-memory RaftCommand when sideloading SSTs

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -296,8 +296,14 @@ type Replica struct {
 		//
 		// The *ProposalData in the map are "owned" by it. Elements from the
 		// map must only be referenced while Replica.mu is held, except if the
-		// element is removed from the map first. The notable exception is the
-		// contained RaftCommand, which we treat as immutable.
+		// element is removed from the map first.
+		//
+		// Due to Raft reproposals, multiple in-flight Raft entries can have
+		// the same CmdIDKey, all corresponding to the same KV request. However,
+		// not all Raft entries with a given command ID will correspond directly
+		// to the *RaftCommand contained in its associated *ProposalData. This
+		// is because the *RaftCommand can be mutated during reproposals by
+		// Replica.tryReproposeWithNewLeaseIndex.
 		proposals         map[storagebase.CmdIDKey]*ProposalData
 		internalRaftGroup *raft.RawNode
 		// The ID of the replica within the Raft group. May be 0 if the replica has

--- a/pkg/storage/replica_raft.go
+++ b/pkg/storage/replica_raft.go
@@ -2054,6 +2054,8 @@ func (r *Replica) processRaftCommand(
 		// a new one. This is important for pipelined writes, since they
 		// don't have a client watching to retry, so a failure to
 		// eventually apply the proposal would be a user-visible error.
+		// TODO(nvanbenschoten): This reproposal is not tracked by the
+		// quota pool. We should fix that.
 		if proposalRetry == proposalIllegalLeaseIndex && r.tryReproposeWithNewLeaseIndex(proposal) {
 			return false
 		}
@@ -2090,7 +2092,9 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(proposal *ProposalData) bool {
 		// can happen if there are multiple copies of the command in the
 		// logs; see TestReplicaRefreshMultiple). We must not create
 		// multiple copies with multiple lease indexes, so don't repropose
-		// it again.
+		// it again. This ensures that at any time, there is only up to a
+		// single lease index that has a chance of succeeding in the Raft
+		// log for a given command.
 		//
 		// Note that the caller has already removed the current version of
 		// the proposal from the pending proposals map. We must re-add it


### PR DESCRIPTION
Backport 1/1 commits from #36939.

/cc @cockroachdb/release

---

Fixes #36861.

This optimization relied on the fact that `RaftCommands` in `Replica.mu.proposals` were immutable over the lifetime of a Raft proposal. This invariant was violated by #35261, which allowed a lease index error to trigger an immediate reproposal. This reproposal mutated the corresponding `RaftCommand` in `Replica.mu.proposals`. Combined with aliasing between multiple Raft proposals due to reproposals from ticks, this resulted in cases where a leaseholder's Raft logs could diverge from its followers and cause Raft groups to become inconsistent.

We can justify the new cost of unmarshalling `RaftCommands` in `maybeInlineSideloadedRaftCommand` on leaseholders because https://github.com/cockroachdb/cockroach/pull/36670/files#diff-8a33b5571aa9ab154d4f3c2a16724697R230 just landed. That change removes an equally sized allocation and memory copy from the function on both leaseholders and followers.

Release note: None
