### PR TITLE
backupccl: skip TestBackupRestoreCheckpointing

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -615,6 +615,8 @@ func TestBackupRestoreSystemJobsProgress(t *testing.T) {
 func TestBackupRestoreCheckpointing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/33357")
+
 	defer func(oldInterval time.Duration) {
 		backupccl.BackupCheckpointInterval = oldInterval
 	}(backupccl.BackupCheckpointInterval)


### PR DESCRIPTION
It's too flaky and I haven't seen any signs of bulkio working on it.

Touches https://github.com/cockroachdb/cockroach/pull/36948.

Release note: None