### PR TITLE
sql: Do not quote locale name in COLLATE clauses (patch 17/)

### DIFF
--- a/pkg/sql/lex/encode.go
+++ b/pkg/sql/lex/encode.go
@@ -181,6 +181,21 @@ func encodeEscapedSQLIdent(buf *bytes.Buffer, s string) {
 	buf.WriteByte('"')
 }
 
+// EncodeLocaleName writes the locale identifier in s to buf. Any dash
+// characters are mapped to underscore characters. Underscore characters do not
+// need to be quoted, and they are considered equivalent to dash characters by
+// the CLDR standard: http://cldr.unicode.org/.
+func EncodeLocaleName(buf *bytes.Buffer, s string) {
+	for i, n := 0, len(s); i < n; i++ {
+		ch := s[i]
+		if ch == '-' {
+			buf.WriteByte('_')
+		} else {
+			buf.WriteByte(ch)
+		}
+	}
+}
+
 // EncodeSQLBytes encodes the SQL byte array in 'in' to buf, to a
 // format suitable for re-scanning. We don't use a straightforward hex
 // encoding here with x'...'  because the result would be less

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -319,3 +319,26 @@ query T
 SELECT * FROM foo WHERE a = 'abcd' COLLATE en_u_ks_level2
 ----
 aBcD
+
+# Test quoted collations.
+
+statement ok
+CREATE TABLE quoted_coll (
+  a STRING COLLATE "en",
+  b STRING COLLATE "en_US",
+  c STRING COLLATE "en-Us" DEFAULT ('c' COLLATE "en-Us"),
+  d STRING COLLATE "en-u-ks-level1" DEFAULT ('d'::STRING COLLATE "en-u-ks-level1"),
+  e STRING COLLATE "en-us" AS (a COLLATE "en-us") STORED
+)
+
+query TT
+SHOW CREATE TABLE quoted_coll
+----
+quoted_coll  CREATE TABLE quoted_coll (
+  a STRING COLLATE en NULL,
+  b STRING COLLATE en_US NULL,
+  c STRING COLLATE en_Us NULL DEFAULT 'c':::STRING COLLATE en_Us,
+  d STRING COLLATE en_u_ks_level1 NULL DEFAULT 'd':::STRING::STRING COLLATE en_u_ks_level1,
+  e STRING COLLATE en_us NULL AS (a COLLATE en_us) STORED,
+  FAMILY "primary" (a, b, c, d, e, rowid)
+)

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -637,7 +637,7 @@ func TestParse(t *testing.T) {
 		{`SELECT ((() AS a)).*`},
 		{`SELECT (TABLE a)`},
 		{`SELECT 0x1`},
-		{`SELECT 'Deutsch' COLLATE "DE"`},
+		{`SELECT 'Deutsch' COLLATE de`},
 		{`SELECT a @> b`},
 		{`SELECT a <@ b`},
 		{`SELECT a ? b`},

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1186,7 +1186,7 @@ func (*DCollatedString) AmbiguousFormat() bool { return false }
 func (d *DCollatedString) Format(ctx *FmtCtx) {
 	lex.EncodeSQLString(&ctx.Buffer, d.Contents)
 	ctx.WriteString(" COLLATE ")
-	lex.EncodeUnrestrictedSQLIdent(&ctx.Buffer, d.Locale, lex.EncNoFlags)
+	lex.EncodeLocaleName(&ctx.Buffer, d.Locale)
 }
 
 // ResolvedType implements the TypedExpr interface.

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1462,7 +1462,7 @@ func (node *CastExpr) Format(ctx *FmtCtx) {
 			)
 			ctx.WriteString(strTyp.SQLString())
 			ctx.WriteString(") COLLATE ")
-			lex.EncodeUnrestrictedSQLIdent(&ctx.Buffer, node.Type.Locale(), lex.EncNoFlags)
+			lex.EncodeLocaleName(&ctx.Buffer, node.Type.Locale())
 		} else {
 			ctx.WriteString(node.Type.SQLString())
 			ctx.WriteByte(')')
@@ -1624,7 +1624,7 @@ type CollateExpr struct {
 func (node *CollateExpr) Format(ctx *FmtCtx) {
 	exprFmtWithParen(ctx, node.Expr)
 	ctx.WriteString(" COLLATE ")
-	lex.EncodeUnrestrictedSQLIdent(&ctx.Buffer, node.Locale, lex.EncNoFlags)
+	lex.EncodeLocaleName(&ctx.Buffer, node.Locale)
 }
 
 // TupleStar represents (E).* expressions.

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1671,7 +1671,7 @@ func (t *T) collatedStringTypeSQL(isArray bool) string {
 	} else {
 		buf.WriteString(" COLLATE ")
 	}
-	lex.EncodeUnrestrictedSQLIdent(&buf, t.Locale(), lex.EncNoFlags)
+	lex.EncodeLocaleName(&buf, t.Locale())
 	return buf.String()
 }
 


### PR DESCRIPTION
Currently, locale strings are quoted when they contain underscore or
dash characters. The Unicode CLDR standard treats those characters as
equivalent. Furthermore, SQL identifiers don't need to be quoted. So
this commit introduces a new EncodeLocaleName method that maps dash
characters to underscore characters so that locale names do not need
to be quoted when printed as part of SQL syntax.

This change resolves a compatibility issue with the TypeORM driver,
which does not handle quoted locale names.

Release note (sql change): Locale names in COLLATE clauses have dash
characters mapped to underscore when printed as part of SQL syntax.