### PR TITLE
storage/engine: fix handling of 0-length varstrings in RocksDBBatchReader

### DIFF
--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -369,7 +369,7 @@ func rocksDBBatchVarString(repr []byte) (s []byte, orepr []byte, err error) {
 	}
 	repr = repr[n:]
 	if v == 0 {
-		return nil, nil, nil
+		return nil, repr, nil
 	}
 	if v > uint64(len(repr)) {
 		return nil, nil, fmt.Errorf("malformed varstring, expected %d bytes, but only %d remaining",


### PR DESCRIPTION
Previously, 0-length varstrings inadvertently cuased the reader to
truncate the batch repr which would usually result in a call to `Next`
complaining about the batch containing an unexpected number of
entries. So far, it looks like the only effect of this would be "invalid
batch" errors while using `cockroach debug` commands. It is possible
there is a more serious effect, though.

See #36937

Release note (bug fix): Fixed a bug in write batch decoding that could
cause "invalid batch" errors while using `cockroach debug` commands to
analyze data.