### PR TITLE
exec: add cancellation check to operators

### DIFF
--- a/pkg/sql/exec/cancel_checker.go
+++ b/pkg/sql/exec/cancel_checker.go
@@ -1,0 +1,74 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// CancelChecker is an Operator that checks whether query cancellation has
+// occurred. The check happens on every batch.
+type CancelChecker struct {
+	Operator
+
+	// Number of times check() has been called since last context cancellation
+	// check.
+	callsSinceLastCheck uint32
+}
+
+var _ Operator = &CancelChecker{}
+
+// NewCancelChecker creates a new CancelChecker.
+func NewCancelChecker(op Operator) *CancelChecker {
+	return &CancelChecker{Operator: op}
+}
+
+// Next is part of Operator interface.
+func (c *CancelChecker) Next(ctx context.Context) coldata.Batch {
+	c.checkEveryCall(ctx)
+	return c.Operator.Next(ctx)
+}
+
+// Interval of check() calls to wait between checks for context cancellation.
+// The value is a power of 2 to allow the compiler to use bitwise AND instead
+// of division.
+const cancelCheckInterval = 1024
+
+// check panics with a query canceled error if the associated query has been
+// canceled. The check is performed on every cancelCheckInterval'th call. This
+// should be used only during long-running operations.
+func (c *CancelChecker) check(ctx context.Context) {
+	if c.callsSinceLastCheck%cancelCheckInterval == 0 {
+		c.checkEveryCall(ctx)
+	}
+
+	// Increment. This may rollover when the 32-bit capacity is reached, but
+	// that's all right.
+	c.callsSinceLastCheck++
+}
+
+// checkEveryCall panics with query canceled error (which will be caught at the
+// materializer level and will be propagated forward as metadata) if the
+// associated query has been canceled. The check is performed on every call.
+func (c *CancelChecker) checkEveryCall(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+		panic(sqlbase.QueryCanceledError)
+	default:
+	}
+}

--- a/pkg/sql/exec/cancel_checker_test.go
+++ b/pkg/sql/exec/cancel_checker_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/exec/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCancelChecker verifies that CancelChecker panics with appropriate error
+// when the context is canceled.
+func TestCancelChecker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	batch := coldata.NewMemBatch([]types.T{types.Int64})
+	op := NewCancelChecker(NewNoop(newRepeatableBatchSource(batch)))
+	cancel()
+	require.PanicsWithValue(t, sqlbase.QueryCanceledError, func() {
+		op.Next(ctx)
+	})
+}

--- a/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/hashjoiner_gen.go
@@ -42,8 +42,8 @@ func genHashJoiner(wr io.Writer) error {
 	assignHash := makeFunctionRegex("_ASSIGN_HASH", 2)
 	s = assignHash.ReplaceAllString(s, `{{.Global.UnaryAssign "$1" "$2"}}`)
 
-	rehash := makeFunctionRegex("_REHASH_BODY", 4)
-	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "SelInd" $4}}`)
+	rehash := makeFunctionRegex("_REHASH_BODY", 6)
+	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "SelInd" $6}}`)
 
 	checkCol := makeFunctionRegex("_CHECK_COL_WITH_NULLS", 7)
 	s = checkCol.ReplaceAllString(s, `{{template "checkColWithNulls" buildDict "Global" . "SelInd" $7}}`)

--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -25,6 +25,7 @@ package exec
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"reflect"
 	"unsafe"
@@ -139,9 +140,17 @@ func _CHECK_COL_WITH_NULLS(
 	// {{/*
 }
 
-func _REHASH_BODY(buckets []uint64, keys []interface{}, nKeys uint64, _SEL_STRING string) { // */}}
+func _REHASH_BODY(
+	ctx context.Context,
+	ht *hashTable,
+	buckets []uint64,
+	keys []interface{},
+	nKeys uint64,
+	_SEL_STRING string,
+) { // */}}
 	// {{define "rehashBody"}}
 	for i := uint64(0); i < nKeys; i++ {
+		ht.cancelChecker.check(ctx)
 		v := keys[_SEL_IND]
 		p := uintptr(buckets[i])
 		_ASSIGN_HASH(p, v)
@@ -254,16 +263,22 @@ func _DISTINCT_COLLECT_NO_OUTER(
 // column values) at a given column and computes a new hash by applying a
 // transformation to the existing hash.
 func (ht *hashTable) rehash(
-	buckets []uint64, keyIdx int, t types.T, col coldata.Vec, nKeys uint64, sel []uint16,
+	ctx context.Context,
+	buckets []uint64,
+	keyIdx int,
+	t types.T,
+	col coldata.Vec,
+	nKeys uint64,
+	sel []uint16,
 ) {
 	switch t {
 	// {{range $hashType := .HashTemplate}}
 	case _TYPES_T:
 		keys := col._TemplateType()
 		if sel != nil {
-			_REHASH_BODY(buckets, keys, nKeys, "sel[i]")
+			_REHASH_BODY(ctx, ht, buckets, keys, nKeys, "sel[i]")
 		} else {
-			_REHASH_BODY(buckets, keys, nKeys, "i")
+			_REHASH_BODY(ctx, ht, buckets, keys, nKeys, "i")
 		}
 
 	// {{end}}

--- a/pkg/sql/exec/quicksort_tmpl.go
+++ b/pkg/sql/exec/quicksort_tmpl.go
@@ -8,6 +8,8 @@
 
 package exec
 
+import "context"
+
 // This file is copied from the the Go standard library's sort
 // implementation, found in https://golang.org/src/sort/sort.go. The only
 // modifications are to template each function into each sort_* struct, so
@@ -56,13 +58,14 @@ func (p *sort_TYPE_DIROp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sort_TYPE_DIROp) heapSort(a, b int) {
+func (p *sort_TYPE_DIROp) heapSort(ctx context.Context, a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
+		p.cancelChecker.check(ctx)
 		p.siftDown(i, hi, first)
 	}
 
@@ -186,21 +189,22 @@ func (p *sort_TYPE_DIROp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sort_TYPE_DIROp) quickSort(a, b, maxDepth int) {
+func (p *sort_TYPE_DIROp) quickSort(ctx context.Context, a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(a, b)
+			p.heapSort(ctx, a, b)
 			return
 		}
 		maxDepth--
+		p.cancelChecker.check(ctx)
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(a, mlo, maxDepth)
+			p.quickSort(ctx, a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(mhi, b, maxDepth)
+			p.quickSort(ctx, mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}

--- a/pkg/sql/exec/routers.go
+++ b/pkg/sql/exec/routers.go
@@ -371,7 +371,7 @@ func (r *hashRouter) processNextBatch(ctx context.Context) bool {
 	}
 
 	for _, i := range r.hashCols {
-		r.ht.rehash(r.scratch.buckets, i, r.types[i], b.ColVec(i), uint64(b.Length()), b.Selection())
+		r.ht.rehash(ctx, r.scratch.buckets, i, r.types[i], b.ColVec(i), uint64(b.Length()), b.Selection())
 	}
 
 	// Reset selections.


### PR DESCRIPTION
We introduce a CancelChecker operator that wraps all other operators
and performs a cancellation check on every batch. Also, sorter and
hash joiner do additional checks themselves since they can spend
a lot of time in certain phases of execution.

Release note: None