### PR TITLE
sql: restrict statements that can be used as row sources

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1827,7 +1827,7 @@ table_ref ::=
 	| '(' joined_table ')' opt_ordinality alias_clause
 	| func_table opt_ordinality opt_alias_clause
 	| 'LATERAL' func_table opt_ordinality opt_alias_clause
-	| '[' preparable_stmt ']' opt_ordinality opt_alias_clause
+	| '[' row_source_extension_stmt ']' opt_ordinality opt_alias_clause
 
 all_or_distinct ::=
 	'ALL'
@@ -2054,6 +2054,15 @@ alias_clause ::=
 func_table ::=
 	func_expr_windowless
 	| 'ROWS' 'FROM' '(' rowsfrom_list ')'
+
+row_source_extension_stmt ::=
+	delete_stmt
+	| explain_stmt
+	| insert_stmt
+	| select_stmt
+	| show_stmt
+	| update_stmt
+	| upsert_stmt
 
 opt_column ::=
 	'COLUMN'

--- a/docs/generated/sql/bnf/table_ref.bnf
+++ b/docs/generated/sql/bnf/table_ref.bnf
@@ -6,4 +6,4 @@ table_ref ::=
 	| '(' joined_table ')' ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
 	| func_application ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
 	| 'LATERAL' func_application ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
-	| '[' preparable_stmt ']' ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )
+	| '[' row_source_extension_stmt ']' ( 'WITH' 'ORDINALITY' |  ) ( ( 'AS' table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) | table_alias_name ( '(' ( ( name ) ( ( ',' name ) )* ) ')' |  ) ) |  )

--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -177,26 +177,6 @@ func TestStatementReuses(t *testing.T) {
 			})
 		}
 	})
-	t.Run("SELECT * FROM <src>", func(t *testing.T) {
-		for _, test := range testData {
-			t.Run(test, func(t *testing.T) {
-				rows, err := db.Query("EXPLAIN SELECT * FROM [" + test + "]")
-				if err != nil {
-					if testutils.IsError(err, "statement source .* does not return any columns") {
-						// This error is acceptable and does not constitute a test failure.
-						return
-					}
-					t.Fatal(err)
-				}
-				defer rows.Close()
-				for rows.Next() {
-				}
-				if err := rows.Err(); err != nil {
-					t.Fatal(err)
-				}
-			})
-		}
-	})
 	t.Run("PREPARE EXPLAIN", func(t *testing.T) {
 		for _, test := range testData {
 			t.Run(test, func(t *testing.T) {

--- a/pkg/sql/opt/optbuilder/testdata/create_table
+++ b/pkg/sql/opt/optbuilder/testdata/create_table
@@ -54,12 +54,6 @@ CREATE TABLE ab (a, b) AS SELECT 1, 2, 3
 ----
 error (42601): CREATE TABLE specifies 2 column names, but data source has 3 columns
 
-# Try to use CREATE TABLE in FROM clause.
-build
-SELECT * FROM [CREATE TABLE ab (a, b) AS SELECT 1, 2]
-----
-error (42703): statement source "CREATE TABLE ab (a, b) AS SELECT 1, 2" does not return any columns
-
 # Non-existent column.
 build
 CREATE TABLE ab (a, b) AS SELECT a


### PR DESCRIPTION
We currently support all preparable statements as row sources using
the `SELECT FROM [ ... ]` syntax. Many of these statements are not
really useful here and each one will require work when we deprecate
the heuristic planner.

This change restricts the set of statements that can be used as row
sources to DML statements, SHOW statements, and EXPLAIN. There were no
specific tests for this functionality for any of the statements that
were removed. If we find that we need any of them, we can add them
back on a case-by-case basis.

Release note (sql change): Only SELECT, INSERT, UPDATE, UPSERT,
DELETE, SHOW, EXPLAIN are supported as data sources using the `SELECT
...  FROM [ ... ]` syntax.

Informs #34848.