### PR TITLE
roachtest: create new import/tpcc/warehouses=4000/geo test

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -94,6 +94,16 @@ func registerImportTPCC(r *registry) {
 			},
 		})
 	}
+	const geoWarehouses = 4000
+	const geoZones = "europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b"
+	r.Add(testSpec{
+		Name:    fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses),
+		Cluster: makeClusterSpec(8, cpu(16), geo(), zones(geoZones)),
+		Timeout: 5 * time.Hour,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runImportTPCC(ctx, t, c, geoWarehouses)
+		},
+	})
 	r.Add(testSpec{
 		Name:       `import/experimental-direct-ingestion`,
 		Skip:       `bricks cluster`,


### PR DESCRIPTION
Closes #36861.

This test runs a geo-distributed import in the same configuration
as the one we saw cause issues with #36861.

I'm testing now to see if this will actually trigger the consistency
failure without the fix from #36939.

Release note: None