### PR TITLE
roachtest: add schemachange/bulkingest test

### DIFF
--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -59,6 +59,7 @@ func registerTests(r *registry) {
 	registerRestore(r)
 	registerRoachmart(r)
 	registerScaleData(r)
+	registerSchemaChangeBulkIngest(r)
 	registerSchemaChangeCancelIndexTPCC1000(r)
 	registerSchemaChangeKV(r)
 	registerSchemaChangeIndexTPCC100(r)


### PR DESCRIPTION
Add a test to index the random `payload` column for the `bulkingest` workload,
to test the index backfiller for an index on randomly ordered values relative
to the primary key.

Release note: None