### PR TITLE
exec: convert Nulls from interface to struct

### DIFF
--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -159,7 +159,7 @@ func decodeTableKeyToCol(
 	}
 	var isNull bool
 	if key, isNull = encoding.DecodeIfNull(key); isNull {
-		vec.SetNull(idx)
+		vec.Nulls().SetNull(idx)
 		return key, nil
 	}
 	var rkey []byte
@@ -287,7 +287,7 @@ func UnmarshalColumnValueToCol(
 	vec coldata.Vec, idx uint16, typ *types.T, value roachpb.Value,
 ) error {
 	if value.RawBytes == nil {
-		vec.SetNull(idx)
+		vec.Nulls().SetNull(idx)
 	}
 
 	var err error

--- a/pkg/sql/colencoding/value_encoding.go
+++ b/pkg/sql/colencoding/value_encoding.go
@@ -30,7 +30,7 @@ func DecodeTableValueToCol(
 ) ([]byte, error) {
 	// NULL is special because it is a valid value for any type.
 	if typ == encoding.Null {
-		vec.SetNull(idx)
+		vec.Nulls().SetNull(idx)
 		return b[dataOffset:], nil
 	}
 	// Bool is special because the value is stored in the value tag.

--- a/pkg/sql/distsqlrun/materializer.go
+++ b/pkg/sql/distsqlrun/materializer.go
@@ -135,7 +135,7 @@ func (m *materializer) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 		typs := m.OutputTypes()
 		for outIdx, cIdx := range m.outputToInputColIdx {
 			col := m.batch.ColVec(cIdx)
-			if col.NullAt(rowIdx) {
+			if col.Nulls().NullAt(rowIdx) {
 				m.row[outIdx].Datum = tree.DNull
 				continue
 			}

--- a/pkg/sql/exec/coldata/nulls.go
+++ b/pkg/sql/exec/coldata/nulls.go
@@ -1,0 +1,234 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package coldata
+
+// zeroedNulls is a zeroed out slice representing a bitmap of size BatchSize.
+// This is copied to efficiently clear a nulls slice.
+var zeroedNulls [(BatchSize-1)>>6 + 1]uint64
+
+// filledNulls is a slice representing a bitmap of size BatchSize with every
+// single bit set.
+var filledNulls [(BatchSize-1)>>6 + 1]uint64
+
+// onesMask is a max uint64, where every bit is set to 1.
+const onesMask = ^uint64(0)
+
+func init() {
+	// Initializes filledNulls to the desired slice.
+	for i := range filledNulls {
+		filledNulls[i] = onesMask
+	}
+}
+
+// Nulls represents a list of potentially nullable values.
+type Nulls struct {
+	nulls []uint64
+	// hasNulls represents whether or not the memColumn has any null values set.
+	hasNulls bool
+}
+
+// NewNulls returns a new nulls vector, initialized with a length.
+func NewNulls(len int) Nulls {
+	if len > 0 {
+		return Nulls{
+			nulls: make([]uint64, (len-1)>>6+1),
+		}
+	}
+	return Nulls{
+		nulls: make([]uint64, 0),
+	}
+}
+
+// HasNulls returns true if the column has any null values.
+func (n *Nulls) HasNulls() bool {
+	return n.hasNulls
+}
+
+// NullAt returns true if the ith value of the column is null.
+func (n *Nulls) NullAt(i uint16) bool {
+	return n.NullAt64(uint64(i))
+}
+
+// SetNull sets the ith value of the column to null.
+func (n *Nulls) SetNull(i uint16) {
+	n.SetNull64(uint64(i))
+}
+
+// SetNullRange sets all the values in [start, end) to null.
+func (n *Nulls) SetNullRange(start uint64, end uint64) {
+	if start >= end {
+		return
+	}
+
+	n.hasNulls = true
+	sIdx := start >> 6
+	eIdx := end >> 6
+
+	// Case where mask only spans one uint64.
+	if sIdx == eIdx {
+		mask := onesMask << (start % 64)
+		mask = mask & (onesMask >> (64 - (end % 64)))
+		n.nulls[sIdx] |= mask
+		return
+	}
+
+	// Case where mask spans at least two uint64s.
+	if sIdx < eIdx {
+		mask := onesMask << (start % 64)
+		n.nulls[sIdx] |= mask
+
+		mask = onesMask >> (64 - (end % 64))
+		n.nulls[eIdx] |= mask
+
+		for i := sIdx + 1; i < eIdx; i++ {
+			n.nulls[i] |= onesMask
+		}
+	}
+}
+
+// UnsetNulls sets the column to have no null values.
+func (n *Nulls) UnsetNulls() {
+	n.hasNulls = false
+
+	startIdx := 0
+	for startIdx < len(n.nulls) {
+		startIdx += copy(n.nulls[startIdx:], zeroedNulls[:])
+	}
+}
+
+// SetNulls sets the column to have only null values.
+func (n *Nulls) SetNulls() {
+	n.hasNulls = true
+
+	startIdx := 0
+	for startIdx < len(n.nulls) {
+		startIdx += copy(n.nulls[startIdx:], filledNulls[:])
+	}
+}
+
+// NullAt64 returns true if the ith value of the column is null.
+func (n *Nulls) NullAt64(i uint64) bool {
+	intIdx := i >> 6
+	return ((n.nulls[intIdx] >> (i % 64)) & 1) == 1
+}
+
+// SetNull64 sets the ith value of the column to null.
+func (n *Nulls) SetNull64(i uint64) {
+	n.hasNulls = true
+	intIdx := i >> 6
+	n.nulls[intIdx] |= 1 << (i % 64)
+}
+
+// Extend extends the nulls vector with the next toAppend values from src,
+// starting at srcStartIdx.
+func (n *Nulls) Extend(src *Nulls, destStartIdx uint64, srcStartIdx uint16, toAppend uint16) {
+	if toAppend == 0 {
+		return
+	}
+	outputLen := destStartIdx + uint64(toAppend)
+	// We will need ceil(outputLen/64) uint64s to encode the combined nulls.
+	needed := (outputLen-1)/64 + 1
+	current := uint64(len(n.nulls))
+	if current < needed {
+		n.nulls = append(n.nulls, make([]uint64, needed-current)...)
+	}
+	if src.HasNulls() {
+		for i := uint16(0); i < toAppend; i++ {
+			// TODO(yuzefovich): this can be done more efficiently with a bitwise OR:
+			// like n.nulls[i] |= vec.nulls[i].
+			if src.NullAt(srcStartIdx + i) {
+				n.SetNull64(destStartIdx + uint64(i))
+			}
+		}
+	}
+}
+
+// ExtendWithSel extends the nulls vector with the next toAppend values from
+// src, starting at srcStartIdx and using the provided selection vector.
+func (n *Nulls) ExtendWithSel(
+	src *Nulls, destStartIdx uint64, srcStartIdx uint16, toAppend uint16, sel []uint16,
+) {
+	if toAppend == 0 {
+		return
+	}
+	outputLen := destStartIdx + uint64(toAppend)
+	// We will need ceil(outputLen/64) uint64s to encode the combined nulls.
+	needed := (outputLen-1)/64 + 1
+	current := uint64(len(n.nulls))
+	if current < needed {
+		n.nulls = append(n.nulls, make([]uint64, needed-current)...)
+	}
+	if src.HasNulls() {
+		for i := uint16(0); i < toAppend; i++ {
+			// TODO(yuzefovich): this can be done more efficiently with a bitwise OR:
+			// like n.nulls[i] |= vec.nulls[i].
+			if src.NullAt(sel[srcStartIdx+i]) {
+				n.SetNull64(destStartIdx + uint64(i))
+			}
+		}
+	}
+}
+
+// Slice returns a new Nulls representing a slice of the current Nulls from
+// [start, end).
+func (n *Nulls) Slice(start uint64, end uint64) Nulls {
+	if !n.hasNulls {
+		return NewNulls(int(end - start))
+	}
+	mod := start % 64
+	startIdx := start >> 6
+	// end is exclusive, so translate that to an exclusive index in nulls by
+	// figuring out which index the last accessible null should be in and add
+	// 1.
+	endIdx := (end-1)>>6 + 1
+	nulls := n.nulls[startIdx:endIdx]
+	if mod != 0 {
+		// If start is not a multiple of 64, we need to shift over the bitmap
+		// to have the first index correspond. Allocate new null bitmap as we
+		// want to keep the original bitmap safe for reuse.
+		nulls = make([]uint64, len(nulls))
+		for i, j := startIdx, 0; i < endIdx-1; i, j = i+1, j+1 {
+			// Bring the first null to the beginning.
+			nulls[j] = n.nulls[i] >> mod
+			// And now bitwise or the remaining bits with the bits we want to
+			// bring over from the next index, note that we handle endIdx-1
+			// separately.
+			nulls[j] |= (n.nulls[i+1] << (64 - mod))
+		}
+		// Get the first bits to where we want them for endIdx-1.
+		nulls[len(nulls)-1] = n.nulls[endIdx-1] >> mod
+	}
+	return Nulls{
+		nulls:    nulls,
+		hasNulls: true,
+	}
+}
+
+// NullBitmap returns the null bitmap.
+func (n *Nulls) NullBitmap() []uint64 {
+	return n.nulls
+}
+
+// SetNullBitmap sets the null bitmap.
+func (n *Nulls) SetNullBitmap(bm []uint64) {
+	n.nulls = bm
+	n.hasNulls = false
+	for _, i := range bm {
+		if i != 0 {
+			n.hasNulls = true
+			return
+		}
+	}
+}

--- a/pkg/sql/exec/coldata/vec.go
+++ b/pkg/sql/exec/coldata/vec.go
@@ -27,8 +27,6 @@ type column interface{}
 // Vec is an interface that represents a column vector that's accessible by
 // Go native types.
 type Vec interface {
-	Nulls
-
 	// TODO(jordan): is a bitmap or slice of bools better?
 	// Bool returns a bool list.
 	Bool() []bool
@@ -100,86 +98,25 @@ type Vec interface {
 	// It uses the reflect package and is not suitable for calling in hot paths.
 	PrettyValueAt(idx uint16, colType types.T) string
 
-	// ExtendNulls extends the null member of a Vec to accommodate toAppend tuples
-	// and sets the right indexes to null, needed when the length of the underlying column changes.
-	ExtendNulls(vec Vec, destStartIdx uint64, srcStartIdx uint16, toAppend uint16)
-
-	// ExtendNullsWithSel extends the null member of a Vec to accommodate toAppend tuples
-	// and sets the right indexes to null with the selection vector in mind, needed when the
-	// length of the underlying column changes.
-	ExtendNullsWithSel(vec Vec, destStartIdx uint64, srcStartIdx uint16, toAppend uint16, sel []uint16)
-}
-
-// Nulls represents a list of potentially nullable values.
-type Nulls interface {
 	// HasNulls returns true if the column has any null values.
 	HasNulls() bool
 
-	// NullAt takes in a uint16 and returns true if the ith value of the column is
-	// null.
-	NullAt(i uint16) bool
-	// SetNull takes in a uint16 and sets the ith value of the column to null.
-	SetNull(i uint16)
-
-	// NullAt64 takes in a uint64 and returns true if the ith value of the column
-	// is null.
-	NullAt64(i uint64) bool
-	// SetNull64 takes in a uint64 and sets the ith value of the column to null.
-	SetNull64(i uint64)
-
-	// SetNullRange takes a start uint64 and an end uint64 index, and sets all the values
-	// in [start, end) to null.
-	SetNullRange(start uint64, end uint64)
-
-	// UnsetNulls sets the column to have 0 null values.
-	UnsetNulls()
-	// SetNulls sets the column to have only null values.
-	SetNulls()
-
-	// NullBitmap returns the null bitmap.
-	NullBitmap() []uint64
-	// SetNullBitmap sets the null bitmap.
-	SetNullBitmap([]uint64)
+	// Nulls returns the nulls vector for the column.
+	Nulls() *Nulls
 }
 
 var _ Vec = &memColumn{}
 
-// zeroedNulls is a zeroed out slice representing a bitmap of size BatchSize.
-// This is copied to efficiently clear a nulls slice.
-var zeroedNulls [(BatchSize-1)>>6 + 1]uint64
-
-// filledNulls is a slice representing a bitmap of size BatchSize with every
-// single bit set.
-var filledNulls [(BatchSize-1)>>6 + 1]uint64
-
-// onesMask is a max uint64, where every bit is set to 1.
-const onesMask = ^uint64(0)
-
-func init() {
-	// Initializes filledNulls to the desired slice.
-	for i := range filledNulls {
-		filledNulls[i] = onesMask
-	}
-}
-
 // memColumn is a simple pass-through implementation of Vec that just casts
 // a generic interface{} to the proper type when requested.
 type memColumn struct {
-	col column
-
-	nulls []uint64
-	// hasNulls represents whether or not the memColumn has any null values set.
-	hasNulls bool
+	col   column
+	nulls Nulls
 }
 
 // NewMemColumn returns a new memColumn, initialized with a length.
 func NewMemColumn(t types.T, n int) Vec {
-	var nulls []uint64
-	if n > 0 {
-		nulls = make([]uint64, (n-1)>>6+1)
-	} else {
-		nulls = make([]uint64, 0)
-	}
+	nulls := NewNulls(n)
 
 	switch t {
 	case types.Bool:
@@ -205,80 +142,8 @@ func NewMemColumn(t types.T, n int) Vec {
 	}
 }
 
-func (m *memColumn) HasNulls() bool {
-	return m.hasNulls
-}
-
-func (m *memColumn) NullAt(i uint16) bool {
-	return m.NullAt64(uint64(i))
-}
-
-func (m *memColumn) SetNull(i uint16) {
-	m.SetNull64(uint64(i))
-}
-
 func (m *memColumn) SetCol(col interface{}) {
 	m.col = col
-}
-
-func (m *memColumn) UnsetNulls() {
-	m.hasNulls = false
-
-	startIdx := 0
-	for startIdx < len(m.nulls) {
-		startIdx += copy(m.nulls[startIdx:], zeroedNulls[:])
-	}
-}
-
-func (m *memColumn) SetNulls() {
-	m.hasNulls = true
-
-	startIdx := 0
-	for startIdx < len(m.nulls) {
-		startIdx += copy(m.nulls[startIdx:], filledNulls[:])
-	}
-}
-
-func (m *memColumn) NullAt64(i uint64) bool {
-	intIdx := i >> 6
-	return ((m.nulls[intIdx] >> (i % 64)) & 1) == 1
-}
-
-func (m *memColumn) SetNull64(i uint64) {
-	m.hasNulls = true
-	intIdx := i >> 6
-	m.nulls[intIdx] |= 1 << (i % 64)
-}
-
-func (m *memColumn) SetNullRange(start uint64, end uint64) {
-	if start >= end {
-		return
-	}
-
-	m.hasNulls = true
-	sIdx := start >> 6
-	eIdx := end >> 6
-
-	// Case where mask only spans one uint64.
-	if sIdx == eIdx {
-		mask := onesMask << (start % 64)
-		mask = mask & (onesMask >> (64 - (end % 64)))
-		m.nulls[sIdx] |= mask
-		return
-	}
-
-	// Case where mask spans at least two uint64s.
-	if sIdx < eIdx {
-		mask := onesMask << (start % 64)
-		m.nulls[sIdx] |= mask
-
-		mask = onesMask >> (64 - (end % 64))
-		m.nulls[eIdx] |= mask
-
-		for i := sIdx + 1; i < eIdx; i++ {
-			m.nulls[i] |= onesMask
-		}
-	}
 }
 
 func (m *memColumn) Bool() []bool {
@@ -323,4 +188,12 @@ func (m *memColumn) Col() interface{} {
 
 func (m *memColumn) _TemplateType() []interface{} {
 	panic("don't call this from non template code")
+}
+
+func (m *memColumn) HasNulls() bool {
+	return m.nulls.hasNulls
+}
+
+func (m *memColumn) Nulls() *Nulls {
+	return &m.nulls
 }

--- a/pkg/sql/exec/coldata/vec_test.go
+++ b/pkg/sql/exec/coldata/vec_test.go
@@ -34,7 +34,7 @@ func TestMemColumnSlice(t *testing.T) {
 		ints[i] = int64(i)
 		if i%2 == 0 {
 			// Set every other value to null.
-			c.SetNull(i)
+			c.Nulls().SetNull(i)
 		}
 	}
 
@@ -50,7 +50,7 @@ func TestMemColumnSlice(t *testing.T) {
 	// Verify that every other value is null.
 	for i, j := startSlice, uint16(0); i < endSlice; i, j = i+1, j+1 {
 		if i%2 == 0 {
-			if !slice.NullAt(j) {
+			if !slice.Nulls().NullAt(j) {
 				t.Fatalf("expected null at %d (original index: %d)", j, i)
 			}
 			continue
@@ -117,16 +117,16 @@ func TestNullRanges(t *testing.T) {
 
 	c := NewMemColumn(types.Int64, BatchSize)
 	for _, tc := range tcs {
-		c.UnsetNulls()
-		c.SetNullRange(tc.start, tc.end)
+		c.Nulls().UnsetNulls()
+		c.Nulls().SetNullRange(tc.start, tc.end)
 
 		for i := uint64(0); i < BatchSize; i++ {
 			if i >= tc.start && i < tc.end {
-				if !c.NullAt64(i) {
+				if !c.Nulls().NullAt64(i) {
 					t.Fatalf("expected null at %d, start: %d end: %d", i, tc.start, tc.end)
 				}
 			} else {
-				if c.NullAt64(i) {
+				if c.Nulls().NullAt64(i) {
 					t.Fatalf("expected non-null at %d, start: %d end: %d", i, tc.start, tc.end)
 				}
 			}

--- a/pkg/sql/exec/colserde/arrowbatchconverter.go
+++ b/pkg/sql/exec/colserde/arrowbatchconverter.go
@@ -98,7 +98,7 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 		var arrowBitmap []byte
 		if vec.HasNulls() {
 			// Cast null bitmap.
-			vecBitmap := vec.NullBitmap()
+			vecBitmap := vec.Nulls().NullBitmap()
 			vecBitmapHeader := (*reflect.SliceHeader)(unsafe.Pointer(&vecBitmap))
 			arrowBitmapHeader := (*reflect.SliceHeader)(unsafe.Pointer(&arrowBitmap))
 			arrowBitmapHeader.Data = vecBitmapHeader.Data
@@ -303,7 +303,7 @@ func (c *ArrowBatchConverter) ArrowToBatch(data []*array.Data) (coldata.Batch, e
 			vecBitmapHeader.Len = arrowBitmapHeader.Len / sizeOfUint64
 			vecBitmapHeader.Cap = arrowBitmapHeader.Cap / sizeOfUint64
 
-			vec.SetNullBitmap(vecBitmap)
+			vec.Nulls().SetNullBitmap(vecBitmap)
 		}
 	}
 	c.scratch.batch.SetLength(uint16(n))

--- a/pkg/sql/exec/colserde/arrowbatchconverter_test.go
+++ b/pkg/sql/exec/colserde/arrowbatchconverter_test.go
@@ -108,11 +108,11 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 		nullFractions := []float64{0, 0.25, 0.5}
 		setNullFraction := func(batch coldata.Batch, nullFraction float64) {
 			vec := batch.ColVec(0)
-			vec.UnsetNulls()
+			vec.Nulls().UnsetNulls()
 			numNulls := uint16(int(nullFraction * float64(batch.Length())))
 			// Set the first numNulls elements to null.
 			for i := uint16(0); i < batch.Length() && i < numNulls; i++ {
-				vec.SetNull(i)
+				vec.Nulls().SetNull(i)
 			}
 		}
 		for _, nullFraction := range nullFractions {

--- a/pkg/sql/exec/const_tmpl.go
+++ b/pkg/sql/exec/const_tmpl.go
@@ -127,7 +127,7 @@ func (c constNullOp) Next(ctx context.Context) coldata.Batch {
 	if batch.Width() == c.outputIdx {
 		batch.AppendCol(types.Int8)
 		col := batch.ColVec(c.outputIdx)
-		col.SetNulls()
+		col.Nulls().SetNulls()
 	}
 	return batch
 }

--- a/pkg/sql/exec/hashjoiner.go
+++ b/pkg/sql/exec/hashjoiner.go
@@ -275,7 +275,7 @@ func (hj *hashJoinEqOp) initEmitting() {
 	// Set all elements in the probe columns of the output batch to null.
 	for _, colIdx := range hj.prober.spec.outCols {
 		outCol := hj.prober.batch.ColVec(int(colIdx + hj.prober.probeColOffset))
-		outCol.SetNulls()
+		outCol.Nulls().SetNulls()
 	}
 }
 

--- a/pkg/sql/exec/hashjoiner_test.go
+++ b/pkg/sql/exec/hashjoiner_test.go
@@ -776,12 +776,12 @@ func BenchmarkHashJoiner(b *testing.B) {
 			if hasNulls {
 				for colIdx := 0; colIdx < nCols; colIdx++ {
 					vec := batch.ColVec(colIdx)
-					vec.SetNull(0)
+					vec.Nulls().SetNull(0)
 				}
 			} else {
 				for colIdx := 0; colIdx < nCols; colIdx++ {
 					vec := batch.ColVec(colIdx)
-					vec.UnsetNulls()
+					vec.Nulls().UnsetNulls()
 				}
 			}
 

--- a/pkg/sql/exec/hashjoiner_tmpl.go
+++ b/pkg/sql/exec/hashjoiner_tmpl.go
@@ -102,9 +102,9 @@ func _CHECK_COL_BODY(
 			// found.
 
 			/* {{if .ProbeHasNulls }} */
-			if probeVec.NullAt(_SEL_IND) {
+			if probeVec.Nulls().NullAt(_SEL_IND) {
 				ht.groupID[ht.toCheck[i]] = 0
-			} else /*{{end}} {{if .BuildHasNulls}} */ if buildVec.NullAt64(keyID - 1) {
+			} else /*{{end}} {{if .BuildHasNulls}} */ if buildVec.Nulls().NullAt64(keyID - 1) {
 				ht.differs[ht.toCheck[i]] = true
 			} else /*{{end}} */ {
 				_CHECK_COL_MAIN(ht, buildKeys, probeKeys, keyID, i)

--- a/pkg/sql/exec/mergejoiner_test.go
+++ b/pkg/sql/exec/mergejoiner_test.go
@@ -1141,7 +1141,7 @@ func newBatchOfIntRows(nCols int, batch coldata.Batch) coldata.Batch {
 
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		vec := batch.ColVec(colIdx)
-		vec.UnsetNulls()
+		vec.Nulls().UnsetNulls()
 	}
 	return batch
 }
@@ -1158,7 +1158,7 @@ func newBatchOfRepeatedIntRows(nCols int, batch coldata.Batch, numRepeats int) c
 
 	for colIdx := 0; colIdx < nCols; colIdx++ {
 		vec := batch.ColVec(colIdx)
-		vec.UnsetNulls()
+		vec.Nulls().UnsetNulls()
 	}
 	return batch
 }

--- a/pkg/sql/exec/mergejoiner_tmpl.go
+++ b/pkg/sql/exec/mergejoiner_tmpl.go
@@ -94,13 +94,13 @@ func _PROBE_SWITCH(sel selPermutation, lHasNulls bool, rHasNulls bool, asc bool)
 			for curLIdx < curLLength && curRIdx < curRLength {
 				// TODO(georgeutsin): change null check logic for non INNER joins.
 				// {{ if $.LNull }}
-				if lVec.NullAt64(uint64(_L_SEL_IND)) {
+				if lVec.Nulls().NullAt64(uint64(_L_SEL_IND)) {
 					curLIdx++
 					continue
 				}
 				// {{ end }}
 				// {{ if $.RNull }}
-				if rVec.NullAt64(uint64(_R_SEL_IND)) {
+				if rVec.Nulls().NullAt64(uint64(_R_SEL_IND)) {
 					curRIdx++
 					continue
 				}
@@ -128,7 +128,7 @@ func _PROBE_SWITCH(sel selPermutation, lHasNulls bool, rHasNulls bool, asc bool)
 						for curLIdx < curLLength {
 							// TODO(georgeutsin): change null check logic for non INNER joins.
 							// {{ if $.LNull }}
-							if lVec.NullAt64(uint64(_L_SEL_IND)) {
+							if lVec.Nulls().NullAt64(uint64(_L_SEL_IND)) {
 								lComplete = true
 								break
 							}
@@ -151,7 +151,7 @@ func _PROBE_SWITCH(sel selPermutation, lHasNulls bool, rHasNulls bool, asc bool)
 						for curRIdx < curRLength {
 							// TODO(georgeutsin): change null check logic for non INNER joins.
 							// {{ if $.RNull }}
-							if rVec.NullAt64(uint64(_R_SEL_IND)) {
+							if rVec.Nulls().NullAt64(uint64(_R_SEL_IND)) {
 								rComplete = true
 								break
 							}
@@ -290,8 +290,8 @@ func _LEFT_SWITCH(isSel bool, hasNulls bool) { // */}}
 				}
 
 				// {{ if $.HasNulls }}
-				if src.NullAt64(uint64(srcStartIdx)) {
-					out.SetNullRange(uint64(outStartIdx), uint64(outStartIdx+toAppend))
+				if src.Nulls().NullAt64(uint64(srcStartIdx)) {
+					out.Nulls().SetNullRange(uint64(outStartIdx), uint64(outStartIdx+toAppend))
 				}
 				// {{ end }}
 
@@ -408,7 +408,7 @@ func _RIGHT_SWITCH(isSel bool, hasNulls bool) { // */}}
 				}
 
 				// {{ if $.HasNulls }}
-				out.ExtendNulls(src, uint64(outStartIdx), uint16(o.builderState.right.curSrcStartIdx), uint16(toAppend))
+				out.Nulls().Extend(src.Nulls(), uint64(outStartIdx), uint16(o.builderState.right.curSrcStartIdx), uint16(toAppend))
 				// {{ end }}
 
 				// Optimization in the case that group length is 1, use assign instead of copy.
@@ -541,13 +541,13 @@ func (o *mergeJoinOp) isGroupFinished(
 			var curVal _GOTYPE
 			if sel != nil {
 				// TODO (georgeutsin): Potentially update this logic for non INNER joins.
-				if bat.ColVec(int(colIdx)).HasNulls() && bat.ColVec(int(colIdx)).NullAt64(uint64(sel[rowIdx])) {
+				if bat.ColVec(int(colIdx)).HasNulls() && bat.ColVec(int(colIdx)).Nulls().NullAt64(uint64(sel[rowIdx])) {
 					return true
 				}
 				curVal = bat.ColVec(int(colIdx))._TemplateType()[sel[rowIdx]]
 			} else {
 				// TODO (georgeutsin): Potentially update this logic for non INNER joins.
-				if bat.ColVec(int(colIdx)).HasNulls() && bat.ColVec(int(colIdx)).NullAt64(uint64(rowIdx)) {
+				if bat.ColVec(int(colIdx)).HasNulls() && bat.ColVec(int(colIdx)).Nulls().NullAt64(uint64(rowIdx)) {
 					return true
 				}
 				curVal = bat.ColVec(int(colIdx))._TemplateType()[rowIdx]

--- a/pkg/sql/exec/random_testutils.go
+++ b/pkg/sql/exec/random_testutils.go
@@ -98,14 +98,14 @@ func randomVec(rng *rand.Rand, typ types.T, vec coldata.Vec, n int, nullProbabil
 	default:
 		panic(fmt.Sprintf("unhandled type %s", typ))
 	}
-	vec.UnsetNulls()
+	vec.Nulls().UnsetNulls()
 	if nullProbability == 0 {
 		return
 	}
 
 	for i := 0; i < n; i++ {
 		if rng.Float64() < nullProbability {
-			vec.SetNull(uint16(i))
+			vec.Nulls().SetNull(uint16(i))
 		}
 	}
 }

--- a/pkg/sql/exec/rowstovec_tmpl.go
+++ b/pkg/sql/exec/rowstovec_tmpl.go
@@ -61,7 +61,7 @@ func _ROWS_TO_COL_VEC(
 		}
 		datum := row[columnIdx].Datum
 		if datum == tree.DNull {
-			vec.SetNull(uint16(i))
+			vec.Nulls().SetNull(uint16(i))
 		} else {
 			v, err := datumToPhysicalFn(datum)
 			if err != nil {

--- a/pkg/sql/exec/utils_test.go
+++ b/pkg/sql/exec/utils_test.go
@@ -202,14 +202,14 @@ func (s *opTestInput) Next(context.Context) coldata.Batch {
 
 	for i := range s.typs {
 		vec := s.batch.ColVec(i)
-		vec.UnsetNulls()
+		vec.Nulls().UnsetNulls()
 		// Automatically convert the Go values into exec.Type slice elements using
 		// reflection. This is slow, but acceptable for tests.
 		col := reflect.ValueOf(vec.Col())
 		for j := uint16(0); j < batchSize; j++ {
 			outputIdx := s.selection[j]
 			if tups[j][i] == nil {
-				vec.SetNull(outputIdx)
+				vec.Nulls().SetNull(outputIdx)
 			} else {
 				col.Index(int(outputIdx)).Set(
 					reflect.ValueOf(tups[j][i]).Convert(reflect.TypeOf(vec.Col()).Elem()))
@@ -283,13 +283,13 @@ func (s *opFixedSelTestInput) Init() {
 		// selection vector later in Next().
 		for i := range s.typs {
 			vec := s.batch.ColVec(i)
-			vec.UnsetNulls()
+			vec.Nulls().UnsetNulls()
 			// Automatically convert the Go values into exec.Type slice elements using
 			// reflection. This is slow, but acceptable for tests.
 			col := reflect.ValueOf(vec.Col())
 			for j := 0; j < len(s.tuples); j++ {
 				if s.tuples[j][i] == nil {
-					vec.SetNull(uint16(j))
+					vec.Nulls().SetNull(uint16(j))
 				} else {
 					col.Index(j).Set(
 						reflect.ValueOf(s.tuples[j][i]).Convert(reflect.TypeOf(vec.Col()).Elem()))
@@ -311,13 +311,13 @@ func (s *opFixedSelTestInput) Next(context.Context) coldata.Batch {
 		// into the current batch (keeping the s.idx in mind).
 		for i := range s.typs {
 			vec := s.batch.ColVec(i)
-			vec.UnsetNulls()
+			vec.Nulls().UnsetNulls()
 			// Automatically convert the Go values into exec.Type slice elements using
 			// reflection. This is slow, but acceptable for tests.
 			col := reflect.ValueOf(vec.Col())
 			for j := uint16(0); j < batchSize; j++ {
 				if s.tuples[s.idx+j][i] == nil {
-					vec.SetNull(j)
+					vec.Nulls().SetNull(j)
 				} else {
 					col.Index(int(j)).Set(
 						reflect.ValueOf(s.tuples[s.idx+j][i]).Convert(reflect.TypeOf(vec.Col()).Elem()))
@@ -383,7 +383,7 @@ func (r *opTestOutput) next(ctx context.Context) tuple {
 	}
 	for outIdx, colIdx := range r.cols {
 		vec := r.batch.ColVec(colIdx)
-		if vec.NullAt(curIdx) {
+		if vec.Nulls().NullAt(curIdx) {
 			ret[outIdx] = nil
 		} else {
 			col := reflect.ValueOf(vec.Col())

--- a/pkg/sql/row/cfetcher.go
+++ b/pkg/sql/row/cfetcher.go
@@ -569,7 +569,7 @@ func (rf *CFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 
 		case stateResetBatch:
 			for i := range rf.machine.colvecs {
-				rf.machine.colvecs[i].UnsetNulls()
+				rf.machine.colvecs[i].Nulls().UnsetNulls()
 			}
 			rf.machine.batch.SetSelection(false)
 			rf.shiftState()
@@ -1026,7 +1026,7 @@ func (rf *CFetcher) fillNulls() error {
 					strings.Join(table.index.ColumnNames, ","), strings.Join(indexColValues, ",")))
 			}
 		}
-		rf.machine.colvecs[i].SetNull(rf.machine.rowIdx)
+		rf.machine.colvecs[i].Nulls().SetNull(rf.machine.rowIdx)
 	}
 	return nil
 }


### PR DESCRIPTION
The fact that `Nulls` was an interface prevented inlining and thus made
calls to functions like `NullAt` and `SetNull` unnecessarily sluggish,
especially when used in tight loops. I converted it to a struct which is
accessed via `Vec.Nulls()`. This will also allow us to pull some more
optimization tricks later like ORing the null bitmaps together to
combine two columns.

Release note: None