### PR TITLE
settings/cluster: Add a version to denote work on v19.2.

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -2,7 +2,7 @@
 <thead><tr><th>Setting</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>changefeed.experimental_poll_interval</code></td><td>duration</td><td><code>1s</code></td><td>polling interval for the prototype changefeed implementation (WARNING: may compromise cluster stability or correctness; do not edit without supervision)</td></tr>
-<tr><td><code>changefeed.push.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, changed are pushed instead of pulled. This requires the kv.rangefeed.enabled setting. See https://www.cockroachlabs.com/docs/v19.1/change-data-capture.html#enable-rangefeeds-to-reduce-latency</td></tr>
+<tr><td><code>changefeed.push.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, changed are pushed instead of pulled. This requires the kv.rangefeed.enabled setting. See https://www.cockroachlabs.com/docs/v19.2/change-data-capture.html#enable-rangefeeds-to-reduce-latency</td></tr>
 <tr><td><code>cloudstorage.gs.default.key</code></td><td>string</td><td><code></code></td><td>if set, JSON key to use during Google Cloud Storage operations</td></tr>
 <tr><td><code>cloudstorage.http.custom_ca</code></td><td>string</td><td><code></code></td><td>custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage</td></tr>
 <tr><td><code>cloudstorage.timeout</code></td><td>duration</td><td><code>10m0s</code></td><td>the timeout for import/export storage operations</td></tr>
@@ -121,6 +121,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>19.1</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>19.1-1</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -293,7 +293,7 @@ func (r *registry) PredecessorVersion() string {
 		// This makes sure the map gets updated. An empty string often means
 		// "use the main binary", and can mean that tests pass even though they
 		// don't test what they want to test.
-		return "no-predecessor-found"
+		return "no-pred"
 	}
 	return v
 }

--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	settings "github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -474,8 +475,12 @@ func runVersionUpgrade(ctx context.Context, t *test, c *cluster) {
 		binaryVersionUpgrade("v2.1.2", nodes),
 		clusterVersionUpgrade("2.1", true /* manual */),
 
-		binaryVersionUpgrade("HEAD", nodes),
+		// TODO(bram): Update this to the full release version once it's out.
+		binaryVersionUpgrade("v19.1.0-rc.3", nodes),
 		clusterVersionUpgrade("19.1", false /* manual */),
+
+		binaryVersionUpgrade("HEAD", nodes),
+		clusterVersionUpgrade(settings.BinaryServerVersion.String(), false /* manual */),
 	}
 
 	type feature struct {

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -68,6 +68,7 @@ const (
 	VersionPushTxnToInclusive
 	VersionSnapshotsWithoutLog
 	Version19_1
+	VersionStart19_2
 
 	// Add new versions here (step one of two).
 
@@ -453,6 +454,10 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// Version19_1 is CockroachDB v19.1. It's used for all v19.1.x patch releases.
 		Key:     Version19_1,
 		Version: roachpb.Version{Major: 19, Minor: 1},
+	}, {
+		// Version19_2_Start demarcates work towards CockroachDB v19.2.
+		Key:     VersionStart19_2,
+		Version: roachpb.Version{Major: 19, Minor: 1, Unstable: 1},
 	},
 
 	// Add new versions here (step two of two).
@@ -464,7 +469,7 @@ var (
 	// this binary. If this binary is started using a store marked with an older
 	// version than BinaryMinimumSupportedVersion, then the binary will exit with
 	// an error.
-	BinaryMinimumSupportedVersion = VersionByKey(Version2_1)
+	BinaryMinimumSupportedVersion = VersionByKey(Version19_1)
 
 	// BinaryServerVersion is the version of this binary.
 	//


### PR DESCRIPTION
Also shrink the name in the upgrade test so that it fits within our cluster
name requirements.

Release note: None