### PR TITLE
changefeedccl: log more details when returning with non-retryable errors

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -456,11 +456,11 @@ func (b *changefeedResumer) Resume(
 			return nil
 		}
 		if !IsRetryableError(err) {
-			log.Warningf(ctx, `CHANGEFEED job %d returning with error: %v`, jobID, err)
+			log.Warningf(ctx, `CHANGEFEED job %d returning with error: %+v`, jobID, err)
 			return err
 		}
 
-		log.Warningf(ctx, `CHANGEFEED job %d encountered retryable error: %+v`, jobID, err)
+		log.Warningf(ctx, `CHANGEFEED job %d encountered retryable error: %v`, jobID, err)
 		if metrics, ok := execCfg.JobRegistry.MetricsStruct().Changefeed.(*Metrics); ok {
 			metrics.ErrorRetries.Inc(1)
 		}


### PR DESCRIPTION
The `%v` and `%+v` were switched from what I intended in the line that
logs retryable errors and the one that handles non-retryable errors.

Release note: None