### PR TITLE
roachtest: misc fixes

### DIFF
--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -28,8 +28,9 @@ import (
 func registerBackup(r *registry) {
 	backup2TBSpec := makeClusterSpec(10)
 	r.Add(testSpec{
-		Name:    fmt.Sprintf("backup2TB/%s", backup2TBSpec),
-		Cluster: backup2TBSpec,
+		Name:       fmt.Sprintf("backup2TB/%s", backup2TBSpec),
+		Cluster:    backup2TBSpec,
+		MinVersion: "v19.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			rows := 65104166
 			dest := c.name


### PR DESCRIPTION
roachtest: run backup test on 19.1 and upwards only

Fixes #36978.

roachtest: really skip version-upgrade on 2.1 (via hack)

The hack is necessary since subtests silently ignore the MinVersion field.

See #36752.

acceptance: add debugging to acceptance/cli/node-status

Closes #36596.

Release note: None