### PR TITLE
exec: optimize builder in vectorized merge joiner

### DIFF
--- a/pkg/sql/exec/execgen/cmd/execgen/mergejoiner_gen.go
+++ b/pkg/sql/exec/execgen/cmd/execgen/mergejoiner_gen.go
@@ -62,9 +62,6 @@ func genMergeJoinOps(wr io.Writer) error {
 	s = strings.Replace(s, "_IS_R_SEL", "{{$sel.IsRSel}}", -1)
 	s = strings.Replace(s, "_SEL_ARG", "$sel", -1)
 
-	copyWithSel := makeFunctionRegex("_COPY_WITH_SEL", 5)
-	s = copyWithSel.ReplaceAllString(s, `{{template "copyWithSel" . }}`)
-
 	probeSwitch := makeFunctionRegex("_PROBE_SWITCH", 4)
 	s = probeSwitch.ReplaceAllString(s, `{{template "probeSwitch" buildDict "Global" $ "Sel" $1 "LNull" $2 "RNull" $3 "Asc" $4}}`)
 

--- a/pkg/sql/exec/mergejoiner.go
+++ b/pkg/sql/exec/mergejoiner.go
@@ -588,7 +588,7 @@ func (o *mergeJoinOp) Next(ctx context.Context) coldata.Batch {
 			o.build()
 
 			// If both builders had output and they didn't finish at the same time, panic.
-			if (len(o.left.outCols) > 0 && len(o.right.outCols) > 0) && o.builderState.left.finished != o.builderState.right.finished {
+			if len(o.left.outCols) > 0 && len(o.right.outCols) > 0 && o.builderState.left.finished != o.builderState.right.finished {
 				panic("unexpected builder state, both left and right should finish at the same time")
 			}
 


### PR DESCRIPTION
Since every row in the a left group expansion is the same, we can
store the value to be copied in a local variable outside the tight
loop, which increases efficiency in the case of an n:n join.

This also makes the code more readable, as the logic that switches
between selection and not selection becomes a one line difference.

Also optimized the right builder in the selection vector case,
since we no longer need to use a generic function when copying
values from one selection mapped colvec to another.

Some benchmarks:
```
name                                      old time/op    new time/op    delta
MergeJoiner/rows=1024-8                     41.3µs ± 5%    41.6µs ± 4%     ~     (p=0.497 n=9+10)
MergeJoiner/rows=4096-8                      151µs ± 1%     155µs ± 2%   +3.07%  (p=0.000 n=9+10)
MergeJoiner/rows=16384-8                     589µs ± 2%     603µs ± 1%   +2.26%  (p=0.000 n=10+9)
MergeJoiner/rows=1048576-8                  37.7ms ± 7%    37.8ms ± 2%     ~     (p=0.247 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8       41.2µs ± 4%    41.0µs ± 3%     ~     (p=0.739 n=10+10)
MergeJoiner/oneSideRepeat-rows=4096-8        150µs ± 0%     152µs ± 0%   +1.39%  (p=0.000 n=9+10)
MergeJoiner/oneSideRepeat-rows=16384-8       574µs ± 0%     585µs ± 0%   +1.95%  (p=0.000 n=8+9)
MergeJoiner/oneSideRepeat-rows=1048576-8    37.1ms ± 8%    36.5ms ± 1%     ~     (p=0.400 n=10+9)
MergeJoiner/bothSidesRepeat-rows=1024-8     42.4µs ± 1%    42.5µs ± 0%   +0.34%  (p=0.014 n=9+9)
MergeJoiner/bothSidesRepeat-rows=4096-8      191µs ± 1%     179µs ± 3%   -6.29%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=16384-8    1.47ms ± 2%    1.07ms ± 3%  -27.26%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=32768-8    4.88ms ± 0%    3.17ms ± 3%  -35.18%  (p=0.000 n=10+10)

name                                      old speed      new speed      delta
MergeJoiner/rows=1024-8                   1.59GB/s ± 5%  1.57GB/s ± 4%     ~     (p=0.497 n=9+10)
MergeJoiner/rows=4096-8                   1.74GB/s ± 1%  1.69GB/s ± 2%   -2.96%  (p=0.000 n=9+10)
MergeJoiner/rows=16384-8                  1.78GB/s ± 2%  1.74GB/s ± 1%   -2.22%  (p=0.000 n=10+9)
MergeJoiner/rows=1048576-8                1.78GB/s ± 7%  1.77GB/s ± 2%     ~     (p=0.247 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8     1.59GB/s ± 4%  1.60GB/s ± 3%     ~     (p=0.739 n=10+10)
MergeJoiner/oneSideRepeat-rows=4096-8     1.74GB/s ± 0%  1.72GB/s ± 0%   -1.37%  (p=0.000 n=9+10)
MergeJoiner/oneSideRepeat-rows=16384-8    1.83GB/s ± 0%  1.79GB/s ± 0%   -1.92%  (p=0.000 n=8+9)
MergeJoiner/oneSideRepeat-rows=1048576-8  1.81GB/s ± 8%  1.84GB/s ± 1%     ~     (p=0.400 n=10+9)
MergeJoiner/bothSidesRepeat-rows=1024-8   1.55GB/s ± 1%  1.54GB/s ± 0%   -0.34%  (p=0.014 n=9+9)
MergeJoiner/bothSidesRepeat-rows=4096-8   1.37GB/s ± 1%  1.46GB/s ± 3%   +6.73%  (p=0.000 n=10+10)
MergeJoiner/bothSidesRepeat-rows=16384-8   716MB/s ± 2%   984MB/s ± 2%  +37.48%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=32768-8   429MB/s ± 0%   663MB/s ± 3%  +54.30%  (p=0.000 n=10+10)

name                                      old alloc/op   new alloc/op   delta
MergeJoiner/rows=1024-8                      9.00B ± 0%     9.00B ± 0%     ~     (all equal)
MergeJoiner/rows=4096-8                      27.0B ± 0%     27.0B ± 0%     ~     (all equal)
MergeJoiner/rows=16384-8                     90.0B ± 0%    113.0B ±20%  +25.56%  (p=0.043 n=9+10)
MergeJoiner/rows=1048576-8                  6.54kB ±39%    6.90kB ±32%     ~     (p=1.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8        9.00B ± 0%     9.00B ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=4096-8        27.0B ± 0%     27.0B ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=16384-8       90.0B ± 0%     90.0B ± 0%     ~     (all equal)
MergeJoiner/oneSideRepeat-rows=1048576-8    5.45kB ± 0%    5.45kB ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=1024-8      9.00B ± 0%     9.00B ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=4096-8      27.0B ± 0%     27.0B ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=16384-8      272B ± 0%      136B ± 0%  -50.00%  (p=0.000 n=10+9)
MergeJoiner/bothSidesRepeat-rows=32768-8      908B ± 0%      544B ± 0%  -40.09%  (p=0.000 n=10+10)

name                                      old allocs/op  new allocs/op  delta
MergeJoiner/rows=1024-8                       0.00           0.00          ~     (all equal)
MergeJoiner/rows=4096-8                       0.00           0.00          ~     (all equal)
MergeJoiner/rows=16384-8                      0.00           0.00          ~     (all equal)
MergeJoiner/rows=1048576-8                    1.30 ±54%      1.40 ±43%     ~     (p=1.000 n=10+10)
MergeJoiner/oneSideRepeat-rows=1024-8         0.00           0.00          ~     (all equal)
MergeJoiner/oneSideRepeat-rows=4096-8         0.00           0.00          ~     (all equal)
MergeJoiner/oneSideRepeat-rows=16384-8        0.00           0.00          ~     (all equal)
MergeJoiner/oneSideRepeat-rows=1048576-8      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=1024-8       0.00           0.00          ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=4096-8       0.00           0.00          ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=16384-8      0.00           0.00          ~     (all equal)
MergeJoiner/bothSidesRepeat-rows=32768-8      0.00           0.00          ~     (all equal)
```
Release note: None