### PR TITLE
roachtest: Shrink scrub workloads

### DIFF
--- a/pkg/cmd/roachtest/scrub.go
+++ b/pkg/cmd/roachtest/scrub.go
@@ -25,13 +25,13 @@ import (
 )
 
 func registerScrubIndexOnlyTPCC(r *registry) {
-	// numScrubRuns is set to 5 assuming a single SCRUB run (index only) takes ~20 min
-	r.Add(makeScrubTPCCTest(5, 1000, time.Hour*2, "index-only", 5))
+	// numScrubRuns is set assuming a single SCRUB run (index only) takes ~1 min
+	r.Add(makeScrubTPCCTest(5, 100, 30*time.Minute, "index-only", 20))
 }
 
 func registerScrubAllChecksTPCC(r *registry) {
-	// numScrubRuns is set to 3 assuming a single SCRUB run (all checks) takes ~35 min
-	r.Add(makeScrubTPCCTest(5, 1000, time.Hour*2, "all-checks", 3))
+	// numScrubRuns is set assuming a single SCRUB run (all checks) takes ~2 min
+	r.Add(makeScrubTPCCTest(5, 100, 30*time.Minute, "all-checks", 10))
 }
 
 func makeScrubTPCCTest(


### PR DESCRIPTION
The scrub roachtest was previously running tpcc-1000 on a cluster of
12 total vcpus, which is not enough (it needs ~double that). This
exposed a lot of interesting issues like #35986, but it's only
incidental to the main purpose of this test (and it's also flaky due
to uninteresting problems associated with overloading).

Switch the test to tpcc-100 so it can be stable; we'll reintroduce a
test dedicated to overload conditions in the future (when we can make
it stable).

Fixes #35985
Fixes #37017

Release note: None